### PR TITLE
feat: マージ済みPRのworktreeとブランチを削除する機能を追加

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -216,3 +216,30 @@ function getBranchType(branchName: string): BranchInfo['branchType'] {
   if (branchName.startsWith('release/')) return 'release';
   return 'other';
 }
+
+export async function hasUnpushedCommits(worktreePath: string, branch: string): Promise<boolean> {
+  try {
+    const { stdout } = await execa('git', ['log', `origin/${branch}..${branch}`, '--oneline'], { cwd: worktreePath });
+    return stdout.trim().length > 0;
+  } catch {
+    // If the branch doesn't exist on remote, consider it has unpushed commits
+    return true;
+  }
+}
+
+export async function isBranchMerged(branch: string, targetBranch: string = 'main'): Promise<boolean> {
+  try {
+    const { stdout } = await execa('git', ['branch', '--merged', targetBranch]);
+    return stdout.includes(branch);
+  } catch (error) {
+    throw new GitError(`Failed to check if branch ${branch} is merged`, error);
+  }
+}
+
+export async function fetchAllRemotes(): Promise<void> {
+  try {
+    await execa('git', ['fetch', '--all', '--prune']);
+  } catch (error) {
+    throw new GitError('Failed to fetch remote branches', error);
+  }
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,99 @@
+import { execa } from 'execa';
+import chalk from 'chalk';
+import type { PullRequest, MergedPullRequest } from './ui/types.js';
+
+export async function isGitHubCLIAvailable(): Promise<boolean> {
+  try {
+    await execa('gh', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getPullRequests(): Promise<PullRequest[]> {
+  try {
+    const { stdout } = await execa('gh', [
+      'pr', 'list',
+      '--state', 'all',
+      '--json', 'number,title,state,headRefName,mergedAt,author',
+      '--limit', '100'
+    ]);
+    
+    const prs = JSON.parse(stdout);
+    return prs.map((pr: any) => ({
+      number: pr.number,
+      title: pr.title,
+      state: pr.state,
+      branch: pr.headRefName,
+      mergedAt: pr.mergedAt,
+      author: pr.author?.login || 'unknown'
+    }));
+  } catch (error) {
+    console.error(chalk.yellow('Warning: Failed to fetch pull requests'));
+    return [];
+  }
+}
+
+export async function getMergedPullRequests(): Promise<MergedPullRequest[]> {
+  try {
+    const { stdout } = await execa('gh', [
+      'pr', 'list',
+      '--state', 'merged',
+      '--json', 'number,title,headRefName,mergedAt,author',
+      '--limit', '100'
+    ]);
+    
+    const prs = JSON.parse(stdout);
+    return prs.map((pr: any) => ({
+      number: pr.number,
+      title: pr.title,
+      branch: pr.headRefName,
+      mergedAt: pr.mergedAt,
+      author: pr.author?.login || 'unknown'
+    }));
+  } catch (error) {
+    console.error(chalk.yellow('Warning: Failed to fetch merged pull requests'));
+    return [];
+  }
+}
+
+export async function getPullRequestByBranch(branchName: string): Promise<PullRequest | null> {
+  try {
+    const { stdout } = await execa('gh', [
+      'pr', 'list',
+      '--head', branchName,
+      '--state', 'all',
+      '--json', 'number,title,state,headRefName,mergedAt,author',
+      '--limit', '1'
+    ]);
+    
+    const prs = JSON.parse(stdout);
+    if (prs.length === 0) {
+      return null;
+    }
+    
+    const pr = prs[0];
+    return {
+      number: pr.number,
+      title: pr.title,
+      state: pr.state,
+      branch: pr.headRefName,
+      mergedAt: pr.mergedAt,
+      author: pr.author?.login || 'unknown'
+    };
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function checkGitHubAuth(): Promise<boolean> {
+  try {
+    await execa('gh', ['auth', 'status']);
+    return true;
+  } catch {
+    console.error(chalk.red('Error: GitHub CLI is not authenticated'));
+    console.log(chalk.yellow('Please run: gh auth login'));
+    return false;
+  }
+}

--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -4,7 +4,8 @@ import {
   BranchInfo, 
   EnhancedBranchChoice, 
   BranchGroup,
-  UIFilter 
+  UIFilter,
+  CleanupTarget 
 } from './types.js';
 import { WorktreeInfo } from '../worktree.js';
 
@@ -277,4 +278,59 @@ export async function printStatistics(branches: BranchInfo[], worktrees: Worktre
   }
   
   console.log();
+}
+
+export function displayCleanupTargets(targets: CleanupTarget[]): void {
+  if (targets.length === 0) {
+    console.log(chalk.gray('No merged PR worktrees found.'));
+    return;
+  }
+  
+  console.log(chalk.blue.bold('\n🧹 Merged PR Worktrees:'));
+  console.log();
+  
+  for (const target of targets) {
+    const statusIcons = [];
+    if (target.hasUncommittedChanges) {
+      statusIcons.push(chalk.red('●'));
+    }
+    if (target.hasUnpushedCommits) {
+      statusIcons.push(chalk.yellow('↑'));
+    }
+    
+    const status = statusIcons.length > 0 ? ` ${statusIcons.join(' ')}` : '';
+    const prInfo = chalk.gray(`PR #${target.pullRequest.number}: ${target.pullRequest.title}`);
+    
+    console.log(`  ${chalk.green(target.branch)}${status}`);
+    console.log(`    ${prInfo}`);
+    console.log(`    ${chalk.gray(target.worktreePath)}`);
+    if (target.hasUncommittedChanges) {
+      console.log(`    ${chalk.red('⚠️  Has uncommitted changes')}`);
+    }
+    if (target.hasUnpushedCommits) {
+      console.log(`    ${chalk.yellow('⚠️  Has unpushed commits')}`);
+    }
+    console.log();
+  }
+}
+
+export function displayCleanupResults(results: Array<{ target: CleanupTarget; success: boolean; error?: string }>): void {
+  console.log(chalk.blue.bold('\n🧹 Cleanup Results:'));
+  console.log();
+  
+  let successCount = 0;
+  let failureCount = 0;
+  
+  for (const result of results) {
+    if (result.success) {
+      successCount++;
+      console.log(chalk.green(`  ✅ ${result.target.branch} - Successfully removed`));
+    } else {
+      failureCount++;
+      console.log(chalk.red(`  ❌ ${result.target.branch} - Failed: ${result.error || 'Unknown error'}`));
+    }
+  }
+  
+  console.log();
+  console.log(chalk.gray(`Summary: ${successCount} succeeded, ${failureCount} failed`));
 }

--- a/src/ui/table.ts
+++ b/src/ui/table.ts
@@ -1,5 +1,3 @@
-import Table from 'cli-table3';
-import chalk from 'chalk';
 import stringWidth from 'string-width';
 import { BranchInfo } from './types.js';
 import { WorktreeInfo } from '../worktree.js';
@@ -48,8 +46,7 @@ export async function createBranchTable(
       branchDisplay = `★ ${branch.name}`;
     }
     
-    // Format type with colors
-    const typeColor = getBranchTypeColor(branch.branchType);
+    // Format type
     const typeText = branch.branchType;
     
     // Format worktree status
@@ -124,58 +121,18 @@ export async function createBranchTable(
   });
 
   choices.push({
+    name: '🧹 Clean up merged PRs',
+    value: '__cleanup_prs__',
+    description: 'Remove worktrees and branches for merged pull requests'
+  });
+
+  choices.push({
     name: '❌ Exit',
     value: '__exit__',
     description: 'Exit the application'
   });
 
   return choices;
-}
-
-function getBranchTypeColor(branchType: BranchInfo['branchType']) {
-  switch (branchType) {
-    case 'main':
-      return chalk.red.bold;
-    case 'develop':
-      return chalk.blue.bold;
-    case 'feature':
-      return chalk.green;
-    case 'hotfix':
-      return chalk.red;
-    case 'release':
-      return chalk.yellow;
-    default:
-      return chalk.gray;
-  }
-}
-
-function truncatePath(path: string, maxLength: number): string {
-  const width = stringWidth(path);
-  if (width <= maxLength) return path;
-  
-  // Show the beginning of the path with ellipsis at the end
-  // Account for '...' which takes 3 display width
-  const ellipsis = '...';
-  const availableWidth = maxLength - stringWidth(ellipsis);
-  
-  // Start from the beginning
-  let result = '';
-  let currentWidth = 0;
-  
-  for (let i = 0; i < path.length; i++) {
-    const char = path[i];
-    if (!char) continue;
-    const charWidth = stringWidth(char);
-    
-    if (currentWidth + charWidth > availableWidth) {
-      break;
-    }
-    
-    result += char;
-    currentWidth += charWidth;
-  }
-  
-  return result + ellipsis;
 }
 
 function padEndUnicode(str: string, targetLength: number, padString: string = ' '): string {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -59,3 +59,34 @@ export interface UIFilter {
   showLocal: boolean;
   showRemote: boolean;
 }
+
+export interface PullRequest {
+  number: number;
+  title: string;
+  state: 'OPEN' | 'CLOSED' | 'MERGED';
+  branch: string;
+  mergedAt: string | null;
+  author: string;
+}
+
+export interface MergedPullRequest {
+  number: number;
+  title: string;
+  branch: string;
+  mergedAt: string;
+  author: string;
+}
+
+export interface WorktreeWithPR {
+  worktreePath: string;
+  branch: string;
+  pullRequest: PullRequest | null;
+}
+
+export interface CleanupTarget {
+  worktreePath: string;
+  branch: string;
+  pullRequest: MergedPullRequest;
+  hasUncommittedChanges: boolean;
+  hasUnpushedCommits: boolean;
+}


### PR DESCRIPTION
## Summary
- GitHub CLI (gh) を使用してマージ済みPRを検出し、対応するworktreeとブランチを削除する機能を追加しました
- メインメニューに「🧹 Clean up merged PRs」オプションを追加
- 安全性のため、未コミット・未プッシュの変更がある場合は削除対象から除外

## 主な変更内容

### 新規ファイル
- `src/github.ts`: GitHub CLI連携機能（PR情報の取得）

### 更新ファイル
- `src/git.ts`: ブランチのマージ状態確認、未プッシュコミット確認機能を追加
- `src/worktree.ts`: PR状態を含むworktree情報取得機能を追加
- `src/ui/types.ts`: PR関連の型定義を追加
- `src/ui/prompts.ts`: クリーンアップ対象選択用のプロンプトを追加
- `src/ui/display.ts`: マージ済みPR情報の表示機能を追加
- `src/ui/table.ts`: メニューに新しいオプションを追加
- `src/index.ts`: クリーンアップ機能のハンドラを実装

## 使用方法
1. メインメニューから「🧹 Clean up merged PRs」を選択
2. GitHub CLIがインストールされ、認証済みであることを確認
3. マージ済みPRに対応するworktreeの一覧が表示される
4. 削除したいworktreeを複数選択可能（スペースキーで選択）
5. 確認後、選択したworktreeとブランチが削除される

## Test plan
- [ ] GitHub CLIがインストールされていない場合のエラーハンドリング
- [ ] GitHub CLIが未認証の場合のエラーハンドリング
- [ ] マージ済みPRがない場合の適切なメッセージ表示
- [ ] 未コミット・未プッシュの変更がある場合の保護機能
- [ ] 複数選択と削除の動作確認
- [ ] 削除成功・失敗時の適切なフィードバック

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * マージ済みプルリクエスト（PR）用ワークツリーとブランチのクリーンアップ機能を追加しました。
  * クリーンアップ対象の選択・確認・実行・結果表示が可能になりました。
  * マージ済みPRワークツリーの状態（未コミット・未プッシュ）を表示します。
  * GitHub CLI連携によるPR情報の取得・認証チェックに対応しました。

* **UIの改善**
  * メニューに「🧹 マージ済みPRのクリーンアップ」オプションを追加しました。
  * クリーンアップ対象や処理結果が分かりやすく表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->