### PR TITLE
feat: Repository Statisticsの表デザインを改善

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,12 +94,9 @@ export async function main(): Promise<void> {
         // Create and display table
         const choices = await createBranchTable(branches, worktrees);
         displayBranchTable();
-        
-        // Display statistics
-        await printStatistics(branches, worktrees);
 
-        // Get user selection
-        const selection = await selectFromTable(choices);
+        // Get user selection with statistics
+        const selection = await selectFromTable(choices, { branches, worktrees });
 
         // Handle selection
         const shouldContinue = await handleSelection(selection, branches, worktrees, repoRoot);

--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -285,24 +285,24 @@ export async function printStatistics(branches: BranchInfo[], worktrees: Worktre
   
   // Calculate the maximum label width for proper alignment
   const maxLabelWidth = Math.max(...stats.map(s => s.label.length));
-  const valueWidth = 4; // Width for numbers (up to 9999)
-  const padding = 2; // Padding on each side
-  const totalWidth = maxLabelWidth + valueWidth + padding * 2 + 3; // +3 for ": " and spacing
+  const valueWidth = Math.max(...stats.map(s => s.value.toString().length), 3); // Dynamic value width
+  const padding = 1; // Reduced padding
+  const totalWidth = maxLabelWidth + valueWidth + padding * 2 + 2; // +2 for ": "
   
-  // Print the statistics box
+  // Print the compact statistics box
   console.log();
-  console.log(chalk.gray('┌' + '─'.repeat(totalWidth) + '┐'));
-  console.log(chalk.gray('│') + chalk.cyan.bold(' 📊 Repository Statistics'.padEnd(totalWidth - 1)) + chalk.gray('│'));
+  console.log(chalk.gray('╭' + '─'.repeat(totalWidth) + '╮'));
+  console.log(chalk.gray('│') + chalk.cyan.bold(' 📊 Repository Statistics') + chalk.gray(' '.repeat(totalWidth - 25) + '│'));
   console.log(chalk.gray('├' + '─'.repeat(totalWidth) + '┤'));
   
   for (const stat of stats) {
-    const label = chalk.white(stat.label + ':');
-    const value = stat.color(stat.value.toString().padStart(valueWidth));
-    const line = ` ${label.padEnd(maxLabelWidth + 1)} ${value}`;
-    console.log(chalk.gray('│') + line.padEnd(totalWidth) + chalk.gray('│'));
+    const label = `  ${stat.label}:`;
+    const value = stat.color(stat.value.toString());
+    const spacer = ' '.repeat(totalWidth - stringWidth(label) - stringWidth(value.toString()) - 1);
+    console.log(chalk.gray('│') + chalk.white(label) + spacer + value + chalk.gray(' │'));
   }
   
-  console.log(chalk.gray('└' + '─'.repeat(totalWidth) + '┘'));
+  console.log(chalk.gray('╰' + '─'.repeat(totalWidth) + '╯'));
   console.log();
 }
 

--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -6,9 +6,18 @@ import {
   CleanupTarget
 } from './types.js';
 
-export async function selectFromTable(choices: Array<{ name: string; value: string; description?: string }>): Promise<string> {
+export async function selectFromTable(
+  choices: Array<{ name: string; value: string; description?: string }>,
+  statistics?: { branches: BranchInfo[]; worktrees: import('../worktree.js').WorktreeInfo[] }
+): Promise<string> {
   // Filter out separator items for selection
   const selectableChoices = choices.filter(choice => choice.value !== '__separator__');
+  
+  // Display statistics if provided
+  if (statistics) {
+    const { printStatistics } = await import('./display.js');
+    await printStatistics(statistics.branches, statistics.worktrees);
+  }
   
   return await select({
     message: 'Select a branch or action:',


### PR DESCRIPTION
## Summary
- Repository Statisticsの表デザインをよりコンパクトで見やすいものに改善
- 右側の不要な空白を削除し、動的な幅調整を実装
- 統計情報の表示位置を最適化（テーブル選択の直前に移動）

## Changes
- `printStatistics`関数を改善：
  - よりモダンな枠線スタイル（rounded corners）を採用
  - 動的な幅調整により、内容に応じた最適なサイズで表示
  - パディングを削減してよりコンパクトに
- 統計情報の表示位置を`selectFromTable`関数に統合
- テーブル表示の直後、選択プロンプトの直前に統計情報を表示

## Test plan
- [x] ビルド成功確認 (`npm run build`)
- [x] 型チェック通過 (`npm run type-check`)
- [x] Lint通過 (`npm run lint`)
- [ ] 手動テスト：`claude-worktree`コマンドを実行して、統計情報が適切な位置にコンパクトに表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)