### PR TITLE
feat: テーブル表示にカラムヘッダーを追加

### DIFF
--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -7,10 +7,10 @@ import {
 } from './types.js';
 
 export async function selectFromTable(
-  choices: Array<{ name: string; value: string; description?: string }>,
+  choices: Array<{ name: string; value: string; description?: string; disabled?: boolean }>,
   statistics?: { branches: BranchInfo[]; worktrees: import('../worktree.js').WorktreeInfo[] }
 ): Promise<string> {
-  // Filter branch choices only (exclude action items)
+  // Filter branch choices only (exclude action items and header/separator rows)
   const branchChoices = choices.filter(choice => 
     choice.value !== '__separator__' && 
     choice.value !== '__separator_space__' && 
@@ -20,7 +20,9 @@ export async function selectFromTable(
     choice.value !== '__manage_worktrees__' &&
     choice.value !== '__cleanup_prs__' &&
     choice.value !== '__exit__' &&
-    choice.name.trim() !== ''
+    choice.value !== '__header__' &&
+    choice.name.trim() !== '' &&
+    !choice.disabled
   );
   
   // Display statistics if provided
@@ -33,13 +35,13 @@ export async function selectFromTable(
 }
 
 async function selectBranchWithShortcuts(
-  branchChoices: Array<{ name: string; value: string; description?: string }>
+  branchChoices: Array<{ name: string; value: string; description?: string; disabled?: boolean }>
 ): Promise<string> {
   const { createPrompt, useState, useKeypress, isEnterKey, usePrefix } = await import('@inquirer/core');
   
   const branchSelectPrompt = createPrompt<string, { 
     message: string; 
-    choices: Array<{ name: string; value: string; description?: string }>;
+    choices: Array<{ name: string; value: string; description?: string; disabled?: boolean }>;
     pageSize?: number;
   }>((config, done) => {
     const [selectedIndex, setSelectedIndex] = useState(0);

--- a/src/ui/table.ts
+++ b/src/ui/table.ts
@@ -25,7 +25,40 @@ export async function createBranchTable(
       .map(w => [w.branch, w])
   );
 
-  const choices: Array<{ name: string; value: string; description?: string }> = [];
+  const choices: Array<{ name: string; value: string; description?: string; disabled?: boolean }> = [];
+
+  // Set fixed width for branch name column
+  const branchNameColumnWidth = 32;
+
+  // Add header row
+  const headerRow = [
+    padEndUnicode(chalk.bold.cyan('ブランチ名'), branchNameColumnWidth),
+    padEndUnicode(chalk.bold.cyan('タイプ'), 14),
+    padEndUnicode(chalk.bold.cyan('Worktree'), 10),
+    padEndUnicode(chalk.bold.cyan('ステータス'), 12),
+    chalk.bold.cyan('変更')
+  ].join(' ┃ ');
+
+  choices.push({
+    name: headerRow,
+    value: '__header__',
+    disabled: true
+  });
+
+  // Add separator row
+  const separatorRow = [
+    '─'.repeat(branchNameColumnWidth),
+    '─'.repeat(14),
+    '─'.repeat(10),
+    '─'.repeat(12),
+    '─'.repeat(4)
+  ].join('─┼─');
+
+  choices.push({
+    name: chalk.gray(separatorRow),
+    value: '__separator__',
+    disabled: true
+  });
 
   // Filter out "origin" branch and sort: current first, then by type
   const filteredBranches = branches.filter(b => b.name !== 'origin');
@@ -36,9 +69,6 @@ export async function createBranchTable(
     if (a.branchType !== 'main' && b.branchType === 'main') return 1;
     return a.name.localeCompare(b.name);
   });
-
-  // Set fixed width for branch name column
-  const branchNameColumnWidth = 32;
 
   for (const branch of sortedBranches) {
     const worktree = worktreeMap.get(branch.name);


### PR DESCRIPTION
## 概要
ブランチ一覧テーブルにカラムヘッダーを追加し、ユーザーが各列の意味を理解しやすくしました。

## 変更内容
- ブランチ一覧テーブルにカラム名を表示
  - ブランチ名、タイプ、Worktree、ステータス、変更
- ヘッダー行とセパレーター行をセレクション対象外に設定
- 視覚的にデータとヘッダーを区別するスタイリング（色付け）を追加

## 実装詳細
- `src/ui/table.ts`: ヘッダー行とセパレーター行の追加
- `src/ui/prompts.ts`: ヘッダー行をセレクション対象外にするフィルタリング

## テスト
- TypeScript型チェック ✅
- ESLint ✅  
- ビルドテスト ✅

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ブランチ選択テーブルにヘッダー行と区切り線が追加され、より見やすくなりました。

* **改善**
  * 選択肢に「無効」状態（disabled）が導入され、無効な項目やヘッダー・区切り線が選択肢から除外されるようになりました。
  * ブランチ名の列幅が固定され、表示が整いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->