### PR TITLE
feat: クリーンアップ時にリモートブランチも削除する機能を追加

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -243,3 +243,11 @@ export async function fetchAllRemotes(): Promise<void> {
     throw new GitError('Failed to fetch remote branches', error);
   }
 }
+
+export async function deleteRemoteBranch(branchName: string, remote: string = 'origin'): Promise<void> {
+  try {
+    await execa('git', ['push', remote, '--delete', branchName]);
+  } catch (error) {
+    throw new GitError(`Failed to delete remote branch ${remote}/${branchName}`, error);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   branchExists, 
   getRepositoryRoot,
   deleteBranch,
+  deleteRemoteBranch,
   hasUncommittedChanges,
   showStatus,
   stashChanges,
@@ -374,8 +375,16 @@ async function handleCleanupMergedPRs(): Promise<boolean> {
         printInfo(`Removing worktree: ${target.worktreePath}`);
         await removeWorktree(target.worktreePath, true); // Force remove
         
-        printInfo(`Deleting branch: ${target.branch}`);
+        printInfo(`Deleting local branch: ${target.branch}`);
         await deleteBranch(target.branch, true); // Force delete
+        
+        printInfo(`Deleting remote branch: origin/${target.branch}`);
+        try {
+          await deleteRemoteBranch(target.branch);
+        } catch (error) {
+          // リモートブランチの削除に失敗してもローカルの削除は成功として扱う
+          printWarning(`Failed to delete remote branch: ${error instanceof Error ? error.message : String(error)}`);
+        }
         
         results.push({ target, success: true });
       } catch (error) {


### PR DESCRIPTION
## Summary
- クリーンアップ機能でマージ済みPRのリモートブランチも自動削除されるようになりました
- ローカルブランチ削除後に`git push origin --delete <branch>`を実行します
- リモートブランチ削除が失敗してもローカル削除は成功として扱います

## Changes
- `src/git.ts`: `deleteRemoteBranch`関数を追加
- `src/index.ts`: `handleCleanupMergedPRs`関数でリモートブランチ削除を実装

## Test plan
- [ ] クリーンアップ機能を実行
- [ ] マージ済みPRのworktreeが削除されることを確認
- [ ] ローカルブランチが削除されることを確認
- [ ] リモートブランチも削除されることを確認
- [ ] リモートブランチ削除に失敗してもローカル削除が成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * マージ済みプルリクエストのクリーンアップ時に、対応するリモートブランチも自動的に削除されるようになりました。
* **改善**
  * ログメッセージがより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->