### PR TITLE
fix: ウェルカムメッセージの枠線表示を修正

### DIFF
--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -176,13 +176,17 @@ export async function printWelcome(): Promise<void> {
   const title = `🌳 Claude Worktree Manager${versionText}`;
   
   // Box border configuration
-  const borderWidth = 51; // Total width including borders
-  const contentWidth = borderWidth - 2; // Width without borders
+  const borderWidth = 49; // Total width including borders
+  const contentWidth = borderWidth - 2; // Width without borders (47)
   
-  // Calculate padding - account for emoji width (2 display columns)
-  const displayLength = 2 + title.length - 1; // 🌳 takes 2 columns, rest is normal
-  const totalPadding = contentWidth - displayLength - 2; // 2 for side spaces
-  const rightPadding = Math.max(0, totalPadding);
+  // Calculate title display width
+  // 🌳 = 2 columns, rest is normal text
+  const emojiWidth = 2;
+  const textLength = title.length - 2; // Subtract emoji bytes
+  const titleDisplayWidth = emojiWidth + textLength;
+  
+  // Calculate right padding
+  const rightPadding = contentWidth - titleDisplayWidth - 1; // -1 for left space
   
   console.log(chalk.blueBright.bold('╔═══════════════════════════════════════════════╗'));
   console.log(chalk.blueBright.bold(`║ ${title}${' '.repeat(rightPadding)} ║`));


### PR DESCRIPTION
## Summary
- ウェルカムメッセージの枠線がズレていた問題を修正
- 絵文字の表示幅を正しく計算するように改善

## Changes
- 枠線の幅を49文字に調整
- 絵文字「🌳」の表示幅（2カラム）を正確に計算
- タイトルと枠線が正しく揃うようにパディング計算を修正

## Test plan
- [x] `npm run build`でビルド成功
- [x] `npm start`で動作確認
- [x] `npm run type-check`で型チェック通過
- [x] `npm run lint`でリントエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)