### PR TITLE
fix: カラム名（ヘッダー）が表示されない問題を修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,6 @@ export async function main(): Promise<void> {
 
         // Create and display table
         const choices = await createBranchTable(branches, worktrees);
-        await displayBranchTable();
 
         // Get user selection with statistics
         const selection = await selectFromTable(choices, { branches, worktrees });


### PR DESCRIPTION
## 概要
- カラム名（ヘッダー）が表示されない問題を修正
- ヘッダー行とセパレーター行が正しく表示されるよう改善

## 問題の原因
1. `displayBranchTable()`が画面をクリアしてウェルカムメッセージのみ表示していた
2. テーブルの内容（ヘッダーを含む）は別の場所で表示されていたが、画面クリア後に消えていた
3. カスタムプロンプトでヘッダー行が`disabled: true`のため選択項目として扱われていなかった

## 修正内容
- `src/index.ts`: `displayBranchTable()`の呼び出しを削除
- `src/ui/prompts.ts`: 
  - ヘッダー行とセパレーター行を常に表示するよう改善
  - 選択可能な項目とヘッダー行を分離して管理
  - ウェルカムメッセージを`selectFromTable`内で表示

## テスト
- [x] ビルドが成功すること
- [x] TypeScript型チェックが通ること
- [x] ESLintエラーがないこと
- [x] ヘッダー行が正しく表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)