### PR TITLE
feat: リモートブランチ削除を選択可能にする機能を追加

### DIFF
--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -363,3 +363,14 @@ export async function confirmCleanup(targets: CleanupTarget[]): Promise<boolean>
     default: false
   });
 }
+
+export async function confirmRemoteBranchDeletion(targets: CleanupTarget[]): Promise<boolean> {
+  const message = targets.length === 1 && targets[0]
+    ? `Also delete remote branch "${targets[0].branch}"?`
+    : `Also delete ${targets.length} remote branches?`;
+    
+  return await confirm({
+    message,
+    default: false
+  });
+}


### PR DESCRIPTION
## Summary
- Clean up機能でリモートブランチ削除を選択可能にする機能を追加
- リモートブランチ削除前に確認プロンプトを表示するように変更
- ユーザーがリモートブランチ削除をスキップできるようになった

## Changes
- `confirmRemoteBranchDeletion`関数を新規追加
- `handleCleanupMergedPRs`関数でリモートブランチ削除を条件付き実行に変更
- リモートブランチ削除の有無をユーザーが選択できるように改善

## Test plan
- [ ] Clean up機能を実行
- [ ] リモートブランチ削除の確認プロンプトが表示されることを確認
- [ ] 「No」を選択した場合、ローカルブランチのみ削除されることを確認
- [ ] 「Yes」を選択した場合、ローカルとリモート両方のブランチが削除されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)