### PR TITLE
fix: ウェルカムメッセージの枠線表示を長いバージョン番号に対応

### DIFF
--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -175,22 +175,29 @@ export async function printWelcome(): Promise<void> {
   const versionText = version ? ` v${version}` : '';
   const title = `🌳 Claude Worktree Manager${versionText}`;
   
-  // Box border configuration
-  const borderWidth = 49; // Total width including borders
-  const contentWidth = borderWidth - 2; // Width without borders (47)
-  
   // Calculate title display width
   // 🌳 = 2 columns, rest is normal text
   const emojiWidth = 2;
-  const textLength = title.length - 2; // Subtract emoji bytes
-  const titleDisplayWidth = emojiWidth + textLength;
+  const textAfterEmoji = title.substring(2).length; // Get length of text after emoji
+  const titleDisplayWidth = emojiWidth + textAfterEmoji;
+  
+  // Determine box width dynamically based on title length
+  // Minimum width of 49, or title width + padding
+  const minBorderWidth = 49;
+  const neededWidth = titleDisplayWidth + 4; // +4 for "║ " and " ║"
+  const borderWidth = Math.max(minBorderWidth, neededWidth);
+  const contentWidth = borderWidth - 2; // Width without borders
   
   // Calculate right padding
   const rightPadding = contentWidth - titleDisplayWidth - 1; // -1 for left space
   
-  console.log(chalk.blueBright.bold('╔═══════════════════════════════════════════════╗'));
+  // Create border strings
+  const topBorder = '╔' + '═'.repeat(borderWidth - 2) + '╗';
+  const bottomBorder = '╚' + '═'.repeat(borderWidth - 2) + '╝';
+  
+  console.log(chalk.blueBright.bold(topBorder));
   console.log(chalk.blueBright.bold(`║ ${title}${' '.repeat(rightPadding)} ║`));
-  console.log(chalk.blueBright.bold('╚═══════════════════════════════════════════════╝'));
+  console.log(chalk.blueBright.bold(bottomBorder));
   console.log(chalk.gray('Interactive Git worktree manager for Claude Code'));
   console.log(chalk.gray('Press Ctrl+C to quit anytime'));
   console.log();


### PR DESCRIPTION
## Summary
- ウェルカムメッセージの枠線表示で、長いバージョン番号（例: v1.110.111）でも正しく表示されるよう修正
- 絵文字の表示幅を正確に計算（2カラム分）
- 枠線の幅を動的に調整する実装に変更

## Changes
- 絵文字「🌳」の表示幅を2カラムとして正しく計算
- タイトルの長さに応じて枠線の幅を動的に調整（最小49文字幅を維持）
- 長いバージョン番号でも枠線が崩れない実装

## Test plan
- [x] 通常のバージョン番号（v0.3.0）で正しく表示されることを確認
- [x] 長いバージョン番号（v1.110.111）で正しく表示されることを確認
- [x] 非常に長いバージョン番号（v999.999.999-beta.123456789）で枠線が自動拡張されることを確認
- [x] TypeScript型チェックとESLintが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)