### PR TITLE
feat: worktree削除時にローカルブランチをリモートにプッシュする機能を追加

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -237,3 +237,29 @@ export async function deleteRemoteBranch(branchName: string, remote = 'origin'):
     throw new GitError(`Failed to delete remote branch ${remote}/${branchName}`, error);
   }
 }
+
+export async function pushBranchToRemote(worktreePath: string, branchName: string, remote = 'origin'): Promise<void> {
+  try {
+    // Check if the remote branch exists
+    const remoteBranchExists = await checkRemoteBranchExists(branchName, remote);
+    
+    if (remoteBranchExists) {
+      // Push to existing remote branch
+      await execa('git', ['push', remote, branchName], { cwd: worktreePath });
+    } else {
+      // Push and set upstream for new remote branch
+      await execa('git', ['push', '--set-upstream', remote, branchName], { cwd: worktreePath });
+    }
+  } catch (error) {
+    throw new GitError(`Failed to push branch ${branchName} to ${remote}`, error);
+  }
+}
+
+async function checkRemoteBranchExists(branchName: string, remote = 'origin'): Promise<boolean> {
+  try {
+    await execa('git', ['show-ref', '--verify', '--quiet', `refs/remotes/${remote}/${branchName}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -148,7 +148,7 @@ export function displayCleanupTargets(targets: CleanupTarget[]): void {
       console.log(`    ${chalk.red('⚠️  Has uncommitted changes')}`);
     }
     if (target.hasUnpushedCommits) {
-      console.log(`    ${chalk.yellow('⚠️  Has unpushed commits')}`);
+      console.log(`    ${chalk.yellow('⚠️  Has unpushed commits (will be pushed before deletion)')}`);
     }
     console.log();
   }

--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -358,10 +358,8 @@ export async function selectCleanupTargets(targets: CleanupTarget[]): Promise<Cl
     value: target,
     disabled: target.hasUncommittedChanges 
       ? 'Has uncommitted changes' 
-      : target.hasUnpushedCommits
-      ? 'Has unpushed commits'
       : false,
-    checked: !target.hasUncommittedChanges && !target.hasUnpushedCommits
+    checked: !target.hasUncommittedChanges
   }));
   
   const selected = await checkbox({
@@ -392,6 +390,30 @@ export async function confirmRemoteBranchDeletion(targets: CleanupTarget[]): Pro
     
   return await confirm({
     message,
+    default: false
+  });
+}
+
+export async function confirmPushUnpushedCommits(targets: CleanupTarget[]): Promise<boolean> {
+  const branchesWithUnpushed = targets.filter(t => t.hasUnpushedCommits);
+  
+  if (branchesWithUnpushed.length === 0) {
+    return false;
+  }
+  
+  const message = branchesWithUnpushed.length === 1 && branchesWithUnpushed[0]
+    ? `Push unpushed commits in "${branchesWithUnpushed[0].branch}" before deletion?`
+    : `Push unpushed commits in ${branchesWithUnpushed.length} branches before deletion?`;
+    
+  return await confirm({
+    message,
+    default: true
+  });
+}
+
+export async function confirmProceedWithoutPush(branchName: string): Promise<boolean> {
+  return await confirm({
+    message: `Failed to push "${branchName}". Proceed with deletion anyway?`,
     default: false
   });
 }


### PR DESCRIPTION
## Summary

Clean upでworktreeを削除する際に、ローカルブランチにプッシュされていないコミットがある場合、自動的にリモートにプッシュしてからローカルブランチを削除する機能を追加しました。

### 主な変更点

- `git.ts`に`pushBranchToRemote`関数を追加
- `index.ts`のClean up処理でプッシュ機能を統合
- プッシュに関するユーザープロンプトを追加
- UI表示の改善

### 機能詳細

1. **自動プッシュ機能**: プッシュされていないコミットがあるブランチを自動検出
2. **ユーザー確認**: プッシュするかどうかをユーザーに確認
3. **エラーハンドリング**: プッシュ失敗時の継続確認
4. **安全性**: プッシュ後にローカルブランチを削除

## Test plan

- [x] TypeScript型チェック完了
- [x] ESLint実行完了
- [x] ビルド確認完了
- [ ] 手動テスト（プッシュ機能の動作確認）
- [ ] エラーケースのテスト

🤖 Generated with [Claude Code](https://claude.ai/code)