### PR TITLE
feat: worktreeに存在しないローカルブランチのクリーンアップ機能を追加

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -67,7 +67,7 @@ async function getCurrentBranch(): Promise<string | null> {
   }
 }
 
-async function getLocalBranches(): Promise<BranchInfo[]> {
+export async function getLocalBranches(): Promise<BranchInfo[]> {
   try {
     const { stdout } = await execa('git', ['branch', '--format=%(refname:short)']);
     return stdout
@@ -255,7 +255,7 @@ export async function pushBranchToRemote(worktreePath: string, branchName: strin
   }
 }
 
-async function checkRemoteBranchExists(branchName: string, remote = 'origin'): Promise<boolean> {
+export async function checkRemoteBranchExists(branchName: string, remote = 'origin'): Promise<boolean> {
   try {
     await execa('git', ['show-ref', '--verify', '--quiet', `refs/remotes/${remote}/${branchName}`]);
     return true;

--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -126,31 +126,68 @@ export async function printStatistics(branches: BranchInfo[], worktrees: Worktre
 }
 
 export function displayCleanupTargets(targets: CleanupTarget[]): void {
-  console.log(chalk.blue.bold('\n🧹 Merged PR Worktrees:'));
-  console.log();
+  const worktreeTargets = targets.filter(t => t.cleanupType === 'worktree-and-branch');
+  const branchOnlyTargets = targets.filter(t => t.cleanupType === 'branch-only');
   
-  for (const target of targets) {
-    const statusIcons = [];
-    if (target.hasUncommittedChanges) {
-      statusIcons.push(chalk.red('●'));
-    }
-    if (target.hasUnpushedCommits) {
-      statusIcons.push(chalk.yellow('↑'));
-    }
-    
-    const status = statusIcons.length > 0 ? ` ${statusIcons.join(' ')}` : '';
-    const prInfo = chalk.gray(`PR #${target.pullRequest.number}: ${target.pullRequest.title}`);
-    
-    console.log(`  ${chalk.green(target.branch)}${status}`);
-    console.log(`    ${prInfo}`);
-    console.log(`    ${chalk.gray(target.worktreePath)}`);
-    if (target.hasUncommittedChanges) {
-      console.log(`    ${chalk.red('⚠️  Has uncommitted changes')}`);
-    }
-    if (target.hasUnpushedCommits) {
-      console.log(`    ${chalk.yellow('⚠️  Has unpushed commits (will be pushed before deletion)')}`);
-    }
+  if (worktreeTargets.length > 0) {
+    console.log(chalk.blue.bold('\n🧹 Merged PR Worktrees (Worktree + Local Branch):'));
     console.log();
+    
+    for (const target of worktreeTargets) {
+      const statusIcons = [];
+      if (target.hasUncommittedChanges) {
+        statusIcons.push(chalk.red('●'));
+      }
+      if (target.hasUnpushedCommits) {
+        statusIcons.push(chalk.yellow('↑'));
+      }
+      if (target.hasRemoteBranch) {
+        statusIcons.push(chalk.blue('🌐'));
+      }
+      
+      const status = statusIcons.length > 0 ? ` ${statusIcons.join(' ')}` : '';
+      const prInfo = chalk.gray(`PR #${target.pullRequest.number}: ${target.pullRequest.title}`);
+      
+      console.log(`  ${chalk.green(target.branch)}${status}`);
+      console.log(`    ${prInfo}`);
+      console.log(`    ${chalk.gray(target.worktreePath)}`);
+      if (target.hasUncommittedChanges) {
+        console.log(`    ${chalk.red('⚠️  Has uncommitted changes')}`);
+      }
+      if (target.hasUnpushedCommits) {
+        console.log(`    ${chalk.yellow('⚠️  Has unpushed commits (will be pushed before deletion)')}`);
+      }
+      if (target.hasRemoteBranch) {
+        console.log(`    ${chalk.blue('ℹ️  Has remote branch (will be deleted if selected)')}`);
+      }
+      console.log();
+    }
+  }
+  
+  if (branchOnlyTargets.length > 0) {
+    console.log(chalk.cyan.bold('\n🌿 Merged PR Local Branches (Local Branch Only):'));
+    console.log();
+    
+    for (const target of branchOnlyTargets) {
+      const statusIcons = [];
+      if (target.hasRemoteBranch) {
+        statusIcons.push(chalk.blue('🌐'));
+      } else {
+        statusIcons.push(chalk.gray('📍'));
+      }
+      
+      const status = statusIcons.length > 0 ? ` ${statusIcons.join(' ')}` : '';
+      const prInfo = chalk.gray(`PR #${target.pullRequest.number}: ${target.pullRequest.title}`);
+      
+      console.log(`  ${chalk.cyan(target.branch)}${status}`);
+      console.log(`    ${prInfo}`);
+      if (target.hasRemoteBranch) {
+        console.log(`    ${chalk.blue('ℹ️  Has remote branch (will be deleted if selected)')}`);
+      } else {
+        console.log(`    ${chalk.gray('ℹ️  Local branch only (no remote)')}`);
+      }
+      console.log();
+    }
   }
 }
 

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -83,11 +83,13 @@ export interface WorktreeWithPR {
 }
 
 export interface CleanupTarget {
-  worktreePath: string;
+  worktreePath: string | null; // null for local branch only cleanup
   branch: string;
   pullRequest: MergedPullRequest;
   hasUncommittedChanges: boolean;
   hasUnpushedCommits: boolean;
+  cleanupType: 'worktree-and-branch' | 'branch-only';
+  hasRemoteBranch?: boolean;
 }
 
 export interface GitHubPRAuthor {


### PR DESCRIPTION
## 概要

worktreeに存在しないローカルブランチが削除対象にならない問題を解決し、マージ済みPRに関連するすべてのローカルブランチを適切にクリーンアップできるようになりました。

## 変更内容

### 🔧 新機能
- **`getOrphanedLocalBranches`関数を追加**
  - worktreeに存在しないローカルブランチを検出してクリーンアップ対象として特定
  - マージ済みPRとの照合機能
  - リモートブランチ存在確認機能

### 🎨 UI改善
- **削除対象の種別表示を強化**
  - 🧹 Worktree + Local Branch: worktreeとローカルブランチの両方を削除
  - 🌿 Local Branch Only: ローカルブランチのみを削除
  - ステータスアイコンでリモートブランチの有無を明示

### 🔄 処理ロジック改善
- **`CleanupTarget`型の拡張**
  - `cleanupType`: 'worktree-and-branch' | 'branch-only'
  - `hasRemoteBranch`: リモートブランチの存在フラグ
  - `worktreePath`: null許可（ローカルブランチのみの場合）

- **削除処理の分岐**
  - worktree + ローカルブランチ削除
  - ローカルブランチのみ削除
  - リモートブランチが存在する場合のみリモート削除を実行

## テスト項目

- [x] 型チェック (`npm run type-check`)
- [x] ESLint (`npm run lint`)
- [x] ビルド確認 (`npm run build`)
- [x] 並列処理の効率化確認
- [x] デバッグ出力での動作確認

## 解決した問題

✅ worktreeに存在しないローカルブランチが削除対象にならない問題を解決
✅ マージ済みPRに関連するすべてのローカルブランチを検出・削除可能
✅ UI上で削除対象の種別を明確に区別表示
✅ リモートブランチの存在状況に応じた適切な削除判定

🤖 Generated with [Claude Code](https://claude.ai/code)