### PR TITLE
エラー発生時にユーザー入力を待機するように修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,7 @@ async function handleBranchSelection(branchName: string, repoRoot: string): Prom
 
   } catch (error) {
     printError(`Failed to handle branch selection: ${error instanceof Error ? error.message : String(error)}`);
+    await confirmContinue('Press enter to continue...');
     return true;
   }
 }
@@ -279,6 +280,7 @@ async function handleCreateNewBranch(branches: BranchInfo[], repoRoot: string): 
 
   } catch (error) {
     printError(`Failed to create new branch: ${error instanceof Error ? error.message : String(error)}`);
+    await confirmContinue('Press enter to continue...');
     return true;
   }
 }
@@ -348,6 +350,7 @@ async function handleManageWorktrees(worktrees: WorktreeInfo[]): Promise<boolean
 
   } catch (error) {
     printError(`Failed to manage worktrees: ${error instanceof Error ? error.message : String(error)}`);
+    await confirmContinue('Press enter to continue...');
     return true;
   }
 }
@@ -462,6 +465,7 @@ async function handleCleanupMergedPRs(): Promise<boolean> {
 
   } catch (error) {
     printError(`Failed to cleanup merged PRs: ${error instanceof Error ? error.message : String(error)}`);
+    await confirmContinue('Press enter to continue...');
     return true;
   }
 }
@@ -508,6 +512,7 @@ async function handlePostClaudeChanges(worktreePath: string): Promise<void> {
     }
   } catch (error) {
     printError(`Failed to handle changes: ${error instanceof Error ? error.message : String(error)}`);
+    await confirmContinue('Press enter to continue...');
   }
 }
 


### PR DESCRIPTION
## Summary
- エラーメッセージ表示後、ユーザーがEnterキーを押すまで画面を保持するように修正
- すべてのエラーハンドラーに `confirmContinue` を追加

## Test plan
- [ ] 存在しないブランチを選択してエラーが発生した際、エラーメッセージが表示された後、Enterキーを押すまで画面が保持されることを確認
- [ ] 新規ブランチ作成時にエラーが発生した際も同様の動作を確認
- [ ] worktree管理中のエラー時も同様の動作を確認
- [ ] PR クリーンアップ時のエラーでも同様の動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)