### PR TITLE
fix: Windows環境でのClaude Code起動エラーを改善

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -1,5 +1,6 @@
 import { execa } from 'execa';
 import chalk from 'chalk';
+import { platform } from 'os';
 export class ClaudeError extends Error {
   constructor(message: string, public cause?: unknown) {
     super(message);
@@ -18,20 +19,40 @@ export async function launchClaudeCode(worktreePath: string, skipPermissions = f
       console.log(chalk.yellow('   ⚠️  Skipping permissions check'));
     }
     
+    const isWindows = platform() === 'win32';
+    
     await execa('claude', args, {
       cwd: worktreePath,
-      stdio: 'inherit'
+      stdio: 'inherit',
+      shell: isWindows
     });
-  } catch (error) {
-    throw new ClaudeError('Failed to launch Claude Code', error);
+  } catch (error: any) {
+    const errorMessage = error.code === 'ENOENT' 
+      ? 'Claude Code command not found. Please ensure Claude Code is installed and available in your PATH.'
+      : `Failed to launch Claude Code: ${error.message || 'Unknown error'}`;
+    
+    if (platform() === 'win32') {
+      console.error(chalk.red('\n💡 Windows troubleshooting tips:'));
+      console.error(chalk.yellow('   1. Ensure Claude Code is installed: npm install -g @anthropic/claude-code'));
+      console.error(chalk.yellow('   2. Try restarting your terminal or IDE'));
+      console.error(chalk.yellow('   3. Check if "claude" is available in your PATH'));
+      console.error(chalk.yellow('   4. Try running "where claude" or "npx claude" to test the command'));
+    }
+    
+    throw new ClaudeError(errorMessage, error);
   }
 }
 
 export async function isClaudeCodeAvailable(): Promise<boolean> {
   try {
-    await execa('claude', ['--version']);
+    const isWindows = platform() === 'win32';
+    await execa('claude', ['--version'], { shell: isWindows });
     return true;
-  } catch {
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      console.error(chalk.yellow('\n⚠️  Claude Code not found in PATH'));
+      console.error(chalk.gray('   Please install Claude Code: npm install -g @anthropic/claude-code'));
+    }
     return false;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,9 @@ export async function main(): Promise<void> {
       printError(`Worktree error: ${error.message}`);
     } else if (error instanceof ClaudeError) {
       printError(`Claude Code error: ${error.message}`);
+      if (error.cause && error.cause instanceof Error) {
+        printError(`Cause: ${error.cause.message}`);
+      }
     } else if (error instanceof AppError) {
       printError(`Application error: ${error.message}`);
     } else {


### PR DESCRIPTION
## Summary
- Windows環境で「Failed to launch Claude Code」エラーが発生する問題を修正
- エラー発生時により詳細な情報を表示するように改善
- NPMでインストールされたClaude Codeコマンドに対応

## Changes
- `claude.ts`: Windows環境でのshellオプションを適切に設定
- `claude.ts`: エラーメッセージにnpmインストールコマンドを追加 
- `index.ts`: ClaudeErrorのcause情報も出力するように改善

## Test plan
- [x] Windows環境でclaude-worktreeを実行
- [x] Claude Codeが見つからない場合に適切なエラーメッセージが表示されることを確認
- [x] エラー詳細情報（cause）が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)