### PR TITLE
fix: Claude Codeのnpmパッケージ名を修正

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -33,7 +33,7 @@ export async function launchClaudeCode(worktreePath: string, skipPermissions = f
     
     if (platform() === 'win32') {
       console.error(chalk.red('\n💡 Windows troubleshooting tips:'));
-      console.error(chalk.yellow('   1. Ensure Claude Code is installed: npm install -g @anthropic/claude-code'));
+      console.error(chalk.yellow('   1. Ensure Claude Code is installed: npm install -g @anthropic-ai/claude-code'));
       console.error(chalk.yellow('   2. Try restarting your terminal or IDE'));
       console.error(chalk.yellow('   3. Check if "claude" is available in your PATH'));
       console.error(chalk.yellow('   4. Try running "where claude" or "npx claude" to test the command'));
@@ -51,7 +51,7 @@ export async function isClaudeCodeAvailable(): Promise<boolean> {
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       console.error(chalk.yellow('\n⚠️  Claude Code not found in PATH'));
-      console.error(chalk.gray('   Please install Claude Code: npm install -g @anthropic/claude-code'));
+      console.error(chalk.gray('   Please install Claude Code: npm install -g @anthropic-ai/claude-code'));
     }
     return false;
   }


### PR DESCRIPTION
## Summary
- Claude Codeの正しいnpmパッケージ名 `@anthropic-ai/claude-code` に修正
- Windows環境やDocker環境でのエラーメッセージが改善されます

## 変更内容
- `@anthropic/claude-code` → `@anthropic-ai/claude-code` に修正
- エラーメッセージとトラブルシューティングガイドの更新

## Test plan
- [x] TypeScriptのビルドが成功すること
- [x] ESLintチェックが通ること
- [x] 型チェックが通ること

🤖 Generated with [Claude Code](https://claude.ai/code)