### PR TITLE
fix: worktree内での実行時の警告表示とパス解決の改善

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   commitChanges,
   fetchAllRemotes,
   pushBranchToRemote,
+  isInWorktree,
   GitError 
 } from './git.js';
 import { 
@@ -79,6 +80,17 @@ export async function main(): Promise<void> {
     if (!(await isGitRepository())) {
       printError('Current directory is not a Git repository.');
       process.exit(1);
+    }
+    
+    // Check if running from a worktree directory
+    if (await isInWorktree()) {
+      printWarning('Running from a worktree directory is not recommended.');
+      printInfo('Please run this command from the main repository root to avoid path issues.');
+      printInfo('You can continue, but some operations may not work correctly.');
+      const shouldContinue = await confirmContinue('Do you want to continue anyway?');
+      if (!shouldContinue) {
+        process.exit(0);
+      }
     }
 
     // Check if Claude Code is available


### PR DESCRIPTION
## Summary
- worktreeディレクトリからの実行時に警告メッセージを表示し、ユーザーに適切な使用方法を案内
- `git rev-parse --git-common-dir`を使用してより確実にメインリポジトリのルートディレクトリを取得
- 存在しないworktreeパスを適切にフィルタリングして、エラーを回避

## 変更内容
### src/git.ts
- `getRepositoryRoot()`: メインリポジトリのルートを確実に取得するように改善
- `getWorkdirStatus()`: 存在しないパスへのアクセスを事前チェック
- `isInWorktree()`: 現在のディレクトリがworktree内かどうかを判定する関数を追加

### src/index.ts
- worktree内からの実行時に警告メッセージを表示
- ユーザーに継続するかどうかの確認を促す

### src/worktree.ts
- `listAdditionalWorktrees()`: 存在しないworktreeパスをフィルタリング
- `getMergedPRWorktrees()`: worktreeパスの存在確認を追加

## Test plan
- [ ] メインリポジトリからの実行が正常に動作すること
- [ ] worktreeディレクトリからの実行時に警告が表示されること
- [ ] 存在しないworktreeパスがある場合でもエラーにならないこと
- [ ] Docker環境での動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)