### PR TITLE
docs: add pnpm and bun installation methods to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,18 +23,40 @@ Claude Code用の対話型Gitワークツリーマネージャー（グラフィ
 
 ### グローバルインストール（推奨）
 
-永続的なアクセスのためにnpmでグローバルインストール:
+永続的なアクセスのためにグローバルインストール:
 
+#### npm
 ```bash
 npm install -g @akiojin/claude-worktree
 ```
 
-### npxでの一回限りの使用
+#### pnpm
+```bash
+pnpm add -g @akiojin/claude-worktree
+```
 
-インストールせずにnpxで実行:
+#### bun
+```bash
+bun add -g @akiojin/claude-worktree
+```
 
+### 一回限りの使用
+
+インストールせずに実行:
+
+#### npx (npm)
 ```bash
 npx @akiojin/claude-worktree
+```
+
+#### pnpx (pnpm)
+```bash
+pnpx @akiojin/claude-worktree
+```
+
+#### bunx (bun)
+```bash
+bunx @akiojin/claude-worktree
 ```
 
 ## クイックスタート

--- a/README.md
+++ b/README.md
@@ -23,18 +23,40 @@ Interactive Git worktree manager for Claude Code with graphical branch selection
 
 ### Global Installation (Recommended)
 
-Install globally via npm for permanent access:
+Install globally for permanent access:
 
+#### npm
 ```bash
 npm install -g @akiojin/claude-worktree
 ```
 
-### One-time Usage with npx
+#### pnpm
+```bash
+pnpm add -g @akiojin/claude-worktree
+```
 
-Run without installation using npx:
+#### bun
+```bash
+bun add -g @akiojin/claude-worktree
+```
 
+### One-time Usage
+
+Run without installation:
+
+#### npx (npm)
 ```bash
 npx @akiojin/claude-worktree
+```
+
+#### pnpx (pnpm)
+```bash
+pnpx @akiojin/claude-worktree
+```
+
+#### bunx (bun)
+```bash
+bunx @akiojin/claude-worktree
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add installation instructions for pnpm and bun package managers
- Update both README.md and README.ja.md
- Support global installation and one-time usage methods

## Changes
- Added pnpm global installation (`pnpm add -g`)
- Added bun global installation (`bun add -g`)
- Added pnpx one-time usage (`pnpx`)
- Added bunx one-time usage (`bunx`)

## Test plan
- [x] README.md formatting verified
- [x] README.ja.md formatting verified
- [x] Type check passed

🤖 Generated with [Claude Code](https://claude.ai/code)