### PR TITLE
feat: アクセスできないworktreeを明示的に表示し、pnpmへ移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,16 +36,16 @@
 ### ビルドコマンド
 
 ```bash
-npm run build    # TypeScriptコンパイル
-npm run dev      # ウォッチモードでのコンパイル
-npm start        # ビルド済みバイナリの実行
+pnpm run build    # TypeScriptコンパイル
+pnpm run dev      # ウォッチモードでのコンパイル
+pnpm start        # ビルド済みバイナリの実行
 ```
 
 ### テストコマンド
 
 ```bash
-npm run type-check  # TypeScript型チェック
-npm run lint        # ESLint実行
+pnpm run type-check  # TypeScript型チェック
+pnpm run lint        # ESLint実行
 ```
 
 ### 主要な依存関係

--- a/README.ja.md
+++ b/README.ja.md
@@ -139,32 +139,32 @@ git clone https://github.com/akiojin/claude-worktree.git
 cd claude-worktree
 
 # 依存関係をインストール
-npm install
+pnpm install
 
 # プロジェクトをビルド
-npm run build
+pnpm run build
 ```
 
 ### 利用可能なスクリプト
 
 ```bash
 # 自動リビルド付き開発モード
-npm run dev
+pnpm run dev
 
 # プロダクションビルド
-npm run build
+pnpm run build
 
 # 型チェック
-npm run type-check
+pnpm run type-check
 
 # コードリンティング
-npm run lint
+pnpm run lint
 
 # ビルド成果物をクリーン
-npm run clean
+pnpm run clean
 
 # CLIをローカルテスト
-npm run start
+pnpm run start
 ```
 
 ### 開発ワークフロー
@@ -172,8 +172,8 @@ npm run start
 1. **フォークとクローン**: リポジトリをフォークし、あなたのフォークをクローン
 2. **ブランチ作成**: ツール自体を使用してfeatureブランチを作成
 3. **開発**: TypeScriptサポート付きで変更を実施
-4. **テスト**: `npm run start`でCLI機能をテスト
-5. **品質チェック**: `npm run type-check`と`npm run lint`を実行
+4. **テスト**: `pnpm run start`でCLI機能をテスト
+5. **品質チェック**: `pnpm run type-check`と`pnpm run lint`を実行
 6. **プルリクエスト**: 明確な説明付きでPRを提出
 
 ### コード構造

--- a/README.md
+++ b/README.md
@@ -139,32 +139,32 @@ git clone https://github.com/akiojin/claude-worktree.git
 cd claude-worktree
 
 # Install dependencies
-npm install
+pnpm install
 
 # Build the project
-npm run build
+pnpm run build
 ```
 
 ### Available Scripts
 
 ```bash
 # Development mode with auto-rebuild
-npm run dev
+pnpm run dev
 
 # Production build
-npm run build
+pnpm run build
 
 # Type checking
-npm run type-check
+pnpm run type-check
 
 # Code linting
-npm run lint
+pnpm run lint
 
 # Clean build artifacts
-npm run clean
+pnpm run clean
 
 # Test the CLI locally
-npm run start
+pnpm run start
 ```
 
 ### Development Workflow
@@ -172,8 +172,8 @@ npm run start
 1. **Fork and Clone**: Fork the repository and clone your fork
 2. **Create Branch**: Use the tool itself to create a feature branch
 3. **Development**: Make changes with TypeScript support
-4. **Testing**: Test CLI functionality with `npm run start`
-5. **Quality Checks**: Run `npm run type-check` and `npm run lint`
+4. **Testing**: Test CLI functionality with `pnpm run start`
+5. **Quality Checks**: Run `pnpm run type-check` and `pnpm run lint`
 6. **Pull Request**: Submit a PR with clear description
 
 ### Code Structure

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,22 +113,22 @@ Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'E:\claude-worktree\dist\index.
 1. **初回実行時**
    ```bash
    # パッケージを一度アンインストール
-   npm uninstall -g @akiojin/claude-worktree
+   pnpm uninstall -g @akiojin/claude-worktree
    
    # 再インストール（prepareスクリプトが自動実行される）
-   npm install -g @akiojin/claude-worktree
+   pnpm add -g @akiojin/claude-worktree
    ```
 
 2. **ローカル開発時**
    ```bash
    # 依存関係のインストール
-   npm install
+   pnpm install
    
    # ビルドの実行
-   npm run build
+   pnpm run build
    
    # 実行
-   npm start
+   pnpm start
    ```
 
 ### TypeScriptコンパイルエラー
@@ -147,14 +147,14 @@ Windowsの`tsc`コマンドが別のプログラムを参照している
 npx tsc
 
 # または、package.jsonのスクリプトを使用
-npm run build
+pnpm run build
 ```
 
-### npm警告の対処
+### pnpm警告の対処
 
 **症状：**
 ```
-npm warn Unknown project config "shamefully-hoist"...
+pnpm warn Unknown project config "shamefully-hoist"...
 ```
 
 **原因：**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src/**/*.ts",
     "type-check": "tsc --noEmit",
     "clean": "rimraf dist",
-    "prepare": "npm run build"
+    "prepare": "pnpm run build"
   },
   "keywords": [
     "git",

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -39,7 +39,7 @@ export async function launchClaudeCode(worktreePath: string, skipPermissions = f
     
     if (platform() === 'win32') {
       console.error(chalk.red('\n💡 Windows troubleshooting tips:'));
-      console.error(chalk.yellow('   1. Ensure Claude Code is installed: npm install -g @anthropic-ai/claude-code'));
+      console.error(chalk.yellow('   1. Ensure Claude Code is installed: pnpm add -g @anthropic-ai/claude-code'));
       console.error(chalk.yellow('   2. Try restarting your terminal or IDE'));
       console.error(chalk.yellow('   3. Check if "claude" is available in your PATH'));
       console.error(chalk.yellow('   4. Try running "where claude" or "npx claude" to test the command'));
@@ -57,7 +57,7 @@ export async function isClaudeCodeAvailable(): Promise<boolean> {
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       console.error(chalk.yellow('\n⚠️  Claude Code not found in PATH'));
-      console.error(chalk.gray('   Please install Claude Code: npm install -g @anthropic-ai/claude-code'));
+      console.error(chalk.gray('   Please install Claude Code: pnpm add -g @anthropic-ai/claude-code'));
     }
     return false;
   }

--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -1,4 +1,5 @@
 import { select, input, confirm, checkbox } from '@inquirer/prompts';
+import chalk from 'chalk';
 import { 
   BranchInfo, 
   BranchType, 
@@ -233,13 +234,21 @@ export async function confirmSkipPermissions(): Promise<boolean> {
   });
 }
 
-export async function selectWorktreeForManagement(worktrees: Array<{ branch: string; path: string }>): Promise<string | 'back'> {
+export async function selectWorktreeForManagement(worktrees: Array<{ branch: string; path: string; isAccessible?: boolean; invalidReason?: string }>): Promise<string | 'back'> {
   const choices = [
-    ...worktrees.map((w, index) => ({
-      name: `${index + 1}. ${w.branch}`,
-      value: w.branch,
-      description: w.path
-    })),
+    ...worktrees.map((w, index) => {
+      const isInvalid = w.isAccessible === false;
+      return {
+        name: isInvalid 
+          ? chalk.red(`${index + 1}. ✗ ${w.branch}`)
+          : `${index + 1}. ${w.branch}`,
+        value: w.branch,
+        description: isInvalid 
+          ? chalk.red(`${w.path} (${w.invalidReason || 'Inaccessible'})`)
+          : w.path,
+        disabled: isInvalid ? 'Cannot access this worktree' : false
+      };
+    }),
     {
       name: '← Back to main menu',
       value: 'back',

--- a/src/ui/table.ts
+++ b/src/ui/table.ts
@@ -92,15 +92,20 @@ export async function createBranchTable(
     // Get changes count if worktree exists
     let changesText = '';
     if (hasWorktree && worktree) {
-      try {
-        const changedFiles = await getChangedFilesCount(worktree.path);
-        if (changedFiles > 0) {
-          changesText = chalk.yellow(`✎ ${changedFiles}`);
-        } else {
+      // Check if worktree is accessible
+      if (worktree.isAccessible === false) {
+        changesText = chalk.red('✗ Invalid');
+      } else {
+        try {
+          const changedFiles = await getChangedFilesCount(worktree.path);
+          if (changedFiles > 0) {
+            changesText = chalk.yellow(`✎ ${changedFiles}`);
+          } else {
+            changesText = chalk.gray('─');
+          }
+        } catch {
           changesText = chalk.gray('─');
         }
-      } catch {
-        changesText = chalk.gray('─');
       }
     } else {
       changesText = chalk.gray('─');

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -90,6 +90,8 @@ export interface CleanupTarget {
   hasUnpushedCommits: boolean;
   cleanupType: 'worktree-and-branch' | 'branch-only';
   hasRemoteBranch?: boolean;
+  isAccessible?: boolean;
+  invalidReason?: string;
 }
 
 export interface GitHubPRAuthor {


### PR DESCRIPTION
## Summary
- Docker環境と非Docker環境間でアクセスできないworktreeを「不正なworktree」として明示的に表示
- npmからpnpmへの完全移行を実施

## 主な変更点

### 1. 不正なworktreeの検出と表示
- `WorktreeInfo`インターフェースに`isAccessible`と`invalidReason`フィールドを追加
- アクセスできないworktreeをフィルタリングせずに、赤色の「✗」マークで表示
- 統計情報に不正なworktree数を追加

### 2. 操作制限
- 不正なworktreeはClaude Codeで開けないよう制限
- 削除時は特別な確認メッセージを表示し、強制削除（`--force`）で削除可能

### 3. UI改善
- `handleCleanupMergedPRs`でクリーンアップ対象がない場合もユーザー入力を待つよう修正
- ブランチテーブルで「✗ Invalid」として状態表示

### 4. pnpmへの移行
- package.jsonの`prepare`スクリプトを`pnpm run build`に変更
- すべてのドキュメントのnpmコマンドをpnpmに変更
- エラーメッセージのインストールコマンドを`pnpm add -g`に変更

## Test plan
- [ ] Docker環境でWindowsのworktreeが「不正なworktree」として表示されることを確認
- [ ] Windows環境でDockerのworktreeが「不正なworktree」として表示されることを確認
- [ ] 不正なworktreeを削除できることを確認
- [ ] 不正なworktreeをClaude Codeで開こうとするとエラーになることを確認
- [ ] pnpmコマンドが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ワークツリーがアクセス不可の場合、その状態や理由を明示的に表示し、管理・削除時にユーザーへ確認プロンプトを追加しました。
  * 統計やテーブル表示に「無効なワークツリー」数や状態を反映するようになりました。

* **ドキュメント**
  * すべてのコマンド例やセットアップ手順を `npm` から `pnpm` に統一しました。

* **スタイル**
  * ワークツリー選択時の表示やテーブルのエラーステータス表示がより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->