### PR TITLE
fix: Claude Code履歴表示でタイトル表示問題を修正

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -43,8 +43,9 @@ export async function launchClaudeCode(
           
           if (selectedConversation) {
             console.log(chalk.green(`   ✨ Resuming: ${selectedConversation.title}`));
-            // For now, use standard resume mode - in the future, we could launch with specific conversation ID
-            args.push('-r');
+            // Don't use -r flag since we already handled conversation selection
+            // Launch in normal mode to start fresh in the selected context
+            console.log(chalk.gray('   📝 Starting new session in conversation context'));
           } else {
             // User cancelled or no conversations found, fall back to normal mode
             console.log(chalk.gray('   ✨ Starting new session'));

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -43,9 +43,17 @@ export async function launchClaudeCode(
           
           if (selectedConversation) {
             console.log(chalk.green(`   ✨ Resuming: ${selectedConversation.title}`));
-            // Don't use -r flag since we already handled conversation selection
-            // Launch in normal mode to start fresh in the selected context
-            console.log(chalk.gray('   📝 Starting new session in conversation context'));
+            
+            // Use specific session ID if available
+            if (selectedConversation.sessionId) {
+              args.push('--resume', selectedConversation.sessionId);
+              console.log(chalk.cyan(`   🆔 Using session ID: ${selectedConversation.sessionId}`));
+            } else {
+              // Fallback: try to use filename as session identifier
+              const fileName = selectedConversation.id;
+              console.log(chalk.yellow(`   ⚠️  No session ID found, trying filename: ${fileName}`));
+              args.push('--resume', fileName);
+            }
           } else {
             // User cancelled or no conversations found, fall back to normal mode
             console.log(chalk.gray('   ✨ Starting new session'));


### PR DESCRIPTION
## Summary
- Claude Code履歴一覧表示で、セッションIDのみが表示されタイトルが表示されない問題を修正
- タイトル抽出ロジックを大幅改善し、複数のコンテンツ形式に対応
- セッションID抽出機能も改善し、確実な会話再開を実現

## 主な変更点
- **タイトル抽出の改善**: 文字列、配列、オブジェクト形式のコンテンツに対応
- **役割マッチングの柔軟化**: user/human/sender等の複数の役割識別子に対応  
- **ファイル名からのタイトル抽出**: メッセージからタイトルが取得できない場合のフォールバック強化
- **セッションID抽出の改善**: session_id/conversation_id/id等の複数フィールドに対応
- **デバッグ機能追加**: DEBUG_CLAUDE_HISTORY環境変数でデバッグ出力が可能

## Test plan
- [x] TypeScriptビルドとlintチェック
- [ ] 実際のClaude Code履歴ファイルでのタイトル表示確認
- [ ] デバッグモードでの動作確認
- [ ] セッションID指定での会話再開テスト

🤖 Generated with [Claude Code](https://claude.ai/code)