### PR TITLE
fix: Claude Code履歴のタイトル抽出を改善

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -55,8 +55,9 @@ export async function launchClaudeCode(
               args.push('--resume', fileName);
             }
           } else {
-            // User cancelled or no conversations found, fall back to normal mode
-            console.log(chalk.gray('   ✨ Starting new session'));
+            // User cancelled - return without launching Claude
+            console.log(chalk.gray('   ↩️  Selection cancelled, returning to menu'));
+            return;
           }
         } catch (error) {
           console.warn(chalk.yellow('   ⚠️  Failed to load conversation history, using standard resume'));


### PR DESCRIPTION
## Summary
- Claude Codeの実際のメッセージ構造に対応したタイトル抽出機能を実装
- `type='message'` + `userType='user'`形式のメッセージを正しく識別するように修正
- `msg.message.content`からの適切なコンテンツ抽出を実装
- 文字列、配列、オブジェクト形式のメッセージコンテンツに対応

## Test plan
- [ ] Claude Code履歴ファイルからの正常なタイトル抽出
- [ ] 複数のメッセージ形式での動作確認  
- [ ] 既存機能への影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Claude Codeの複数のメッセージ形式に対応し、会話履歴から最後のユーザーメッセージをより正確に抽出できるようになりました。

* **リファクタリング**
  * メッセージ内容の抽出ロジックが統一され、様々な形式のコンテンツからテキストを正しく取得できるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->