### PR TITLE
fix: 履歴表示のUI改善とタイトル抽出バグ修正

### DIFF
--- a/src/claude-history.ts
+++ b/src/claude-history.ts
@@ -226,13 +226,23 @@ async function parseConversationFile(filePath: string): Promise<ClaudeConversati
       if (extractedContent) {
         // Remove system prompts or meta information
         const cleanContent = extractedContent
-          .replace(/^(<.*?>|System:|Assistant:|Human:)/i, '')
+          .replace(/^(<.*?>|System:|Assistant:|Human:|User:)/i, '')  
+          .replace(/<\/[^>]+>/g, '') // Remove closing tags like </local-command-stdout>
+          .replace(/^(Result of calling|Error:|Warning:|DEBUG:|LOG:)/i, '') // Remove system messages
+          .replace(/^(Tool executed|Command executed|Output:)/i, '') // Remove tool output indicators  
+          .replace(/^\s*[-#*•]\s*/gm, '') // Remove list markers
+          .replace(/^https?:\/\/[^\s]+$/gm, '') // Remove standalone URLs
           .trim();
           
         // Extract first meaningful line
         const firstLine = cleanContent.split('\n')[0]?.trim() || '';
         
-        if (firstLine.length > 0) {
+        // Validate that the content is meaningful
+        if (firstLine.length > 5 && 
+            !firstLine.match(/^(no content|undefined|null|\(no content\))$/i) &&
+            !firstLine.includes('</') && // Avoid HTML-like content
+            !firstLine.match(/^[^a-zA-Z]*$/) // Must contain some letters
+        ) {
           title = firstLine.length > 60 ? firstLine.substring(0, 57) + '...' : firstLine;
         }
         


### PR DESCRIPTION
## Summary

前回のPR #48で実装したccresume風表示に対するユーザーフィードバックを受けて、UI表示とタイトル抽出の問題を修正。

## Issues Fixed

### UI表示の問題
- 二重表示問題: 静的な会話リストと選択プロンプトが分離していた問題を解決
- より直感的な単一選択インターフェースに統一

### タイトル抽出のバグ
- `(no content)</local-command-stdout>` などの不正なタイトル表示を修正
- システム出力や HTML タグを適切に除外する厳密なフィルタリングを実装

## Changes

### UI Improvements
- `selectClaudeConversation`関数の二重表示を解消
- 単一の選択プロンプトで直感的な操作を実現
- プレビュー表示を確認画面として分離

### Content Filtering
- `parseConversationFile`関数のタイトル抽出ロジックを強化
- 以下の不要なコンテンツを除外:
  - HTMLタグ (`</local-command-stdout>` など)
  - システムメッセージ (DEBUG, LOG, Error など)
  - ツール出力表示
  - 単独のURL
  - 意味のない文字列

### Validation Logic
- コンテンツの妥当性チェックを追加
- 5文字以上、アルファベットを含む、HTMLタグを含まないコンテンツのみ採用

## Test plan

- [x] TypeScriptコンパイルが成功することを確認
- [x] ESLintエラーがないことを確認
- [x] 二重表示が解消されていることを確認
- [x] 不正なタイトルが表示されないことを確認

## User Feedback Addressed

> "Select a conversation:がありますが、実際にカーソルの移動は、Choose conversation to resume:の方です。"

→ 二重表示を解消し、単一の選択プロンプトに統一

> "(no content)</local-command-stdout>" のようなおかしなタイトルが表示されている

→ 厳密なコンテンツフィルタリングで不正なタイトルを除外

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 会話タイトルの生成がより正確になり、不要な接頭辞やリスト記号、URLなどが自動的に除去されるようになりました。

* **リファクタ**
  * Claude会話の選択画面がシンプルになり、会話選択後にプレビューと確認が表示されるようになりました。選択前のプレビュー表示やリスト表示が削除され、操作が直感的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->