### PR TITLE
fix: プレビュー表示時の画面クリア機能追加

### DIFF
--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -582,8 +582,11 @@ export async function selectClaudeConversation(worktreePath: string): Promise<im
       return null;
     }
 
+    // Clear screen before showing preview
+    console.clear();
+    
     // Show preview before final confirmation
-    console.log('\n' + chalk.bold.cyan('📖 Conversation Preview'));
+    console.log(chalk.bold.cyan('📖 Conversation Preview'));
     console.log(chalk.gray('─'.repeat(80)));
     console.log();
     
@@ -605,7 +608,8 @@ export async function selectClaudeConversation(worktreePath: string): Promise<im
     if (shouldResume) {
       return selectedConversation;
     } else {
-      // Go back to selection
+      // Clear screen before going back to selection
+      console.clear();
       return await selectClaudeConversation(worktreePath);
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

ユーザーフィードバックを受けて、履歴選択後のプレビュー表示を改善。重複した選択履歴が表示されて見にくい問題を解決。

## Issue Fixed

### 画面表示の問題
> "選択後の画面ですが、キャンセルした内容も表示されており、すごく見にくいです。画面はクリアしてもらいたいです。"

選択履歴やキャンセル履歴が累積表示されて非常に見にくい状態でした：

```
────────────────────────────────────────────────────────────────────────────────
✔ Resume "Conversation (1 messages)"? no
✔ Choose conversation to resume: 💬 Conversation (350 messages)
📖 Conversation Preview
[履歴内容]
✔ Resume "Conversation (350 messages)"? no
✔ Choose conversation to resume: 💬 新しい選択
```

## Changes

### UI Experience Improvements
- **プレビュー表示前に画面クリア**: `console.clear()` を追加してプレビュー画面をクリーンに表示
- **キャンセル時の画面クリア**: 再選択時にも画面をクリアして操作履歴を除去
- **すっきりとした表示**: ユーザーが現在選択中の会話のプレビューのみを表示

### 実装詳細
- `selectClaudeConversation`関数でプレビュー表示前に `console.clear()` を実行
- キャンセル後の再選択時にも画面をクリアして操作をリセット
- 選択履歴の重複表示を完全に防止

## Result

修正後は以下のようなクリーンな表示になります：

```
📖 Conversation Preview
────────────────────────────────────────────────────────────────────────────────

[User] 実際の会話内容...
[Assistant] 回答内容...
... and X more messages above

────────────────────────────────────────────────────────────────────────────────
? Resume "会話タイトル"? (Y/n)
```

## Test plan

- [x] TypeScriptコンパイルが成功することを確認
- [x] ESLintエラーがないことを確認
- [x] プレビュー表示前に画面がクリアされることを確認
- [x] キャンセル時の再選択で画面がクリアされることを確認
- [x] 選択履歴の重複表示が解消されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)