### PR TITLE
feat: npm versionコマンドと連携したリリースブランチ作成機能

### DIFF
--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -251,6 +251,34 @@ export async function selectBranchType(): Promise<BranchType> {
   });
 }
 
+export async function selectVersionBumpType(currentVersion: string): Promise<'patch' | 'minor' | 'major'> {
+  const versionParts = currentVersion.split('.');
+  const major = parseInt(versionParts[0] || '0');
+  const minor = parseInt(versionParts[1] || '0');
+  const patch = parseInt(versionParts[2] || '0');
+  
+  return await select({
+    message: `Current version: ${currentVersion}. Select version bump type:`,
+    choices: [
+      {
+        name: `📌 Patch (${major}.${minor}.${patch + 1})`,
+        value: 'patch',
+        description: 'Bug fixes and minor changes'
+      },
+      {
+        name: `📈 Minor (${major}.${minor + 1}.0)`,
+        value: 'minor',
+        description: 'New features, backwards compatible'
+      },
+      {
+        name: `🚀 Major (${major + 1}.0.0)`,
+        value: 'major',
+        description: 'Breaking changes'
+      }
+    ]
+  });
+}
+
 export async function inputBranchName(type: BranchType): Promise<string> {
   return await input({
     message: `Enter ${type} name:`,


### PR DESCRIPTION
## Summary
- リリースブランチ作成時に`npm version`コマンドを自動実行する機能を追加
- git flowのリリースフローに準拠した実装
- バージョン番号に基づいてブランチ名を自動生成

## 変更内容
- `selectVersionBumpType()`プロンプトを追加 - patch/minor/majorから選択可能
- `executeNpmVersion()`関数を追加 - npm versionコマンドを実行してpackage.jsonを更新
- リリースブランチ作成フローを更新 - バージョン選択後に`release/vX.Y.Z`形式でブランチ名を自動生成

## Test plan
- [ ] 新規ブランチ作成でリリースブランチを選択
- [ ] patch/minor/majorの各オプションで正しくバージョンが更新されることを確認
- [ ] バージョン番号に基づいてブランチ名が自動生成されることを確認
- [ ] package.jsonの更新が自動コミットされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)