### PR TITLE
fix: リリースブランチ作成フローの修正

### DIFF
--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -334,6 +334,17 @@ export async function confirmWorktreeRemoval(worktreePath: string): Promise<bool
 
 export async function getNewBranchConfig(): Promise<NewBranchConfig> {
   const type = await selectBranchType();
+  
+  // リリースブランチの場合は、バージョン選択後に自動生成されるため、
+  // ここでは仮の値を返す
+  if (type === 'release') {
+    return {
+      type,
+      taskName: 'version-placeholder',
+      branchName: 'release/version-placeholder'
+    };
+  }
+  
   const taskName = await inputBranchName(type);
   const branchName = `${type}/${taskName}`;
   


### PR DESCRIPTION
## Summary
先ほどマージされたPR #55 の修正版です。
リリースブランチ選択時に「Enter release name:」が表示される問題を修正しました。

## 変更内容
- `handleCreateNewBranch`関数を再設計し、ブランチタイプ別に処理を完全に分離
- リリースブランチの処理フロー: タイプ選択 → ベースブランチ選択 → バージョン選択 → npm version実行
- 通常ブランチの処理フロー: タイプ選択 → ブランチ名入力 → ベースブランチ選択
- 不要な`getNewBranchConfig`関数のインポートを削除

## Test plan
- [ ] 新規ブランチ作成でリリースブランチを選択
- [ ] 「Enter release name:」プロンプトが表示されないことを確認
- [ ] patch/minor/majorの選択が正しく表示されることを確認
- [ ] バージョン番号に基づいてブランチ名が自動生成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)