### PR TITLE
feat: Git Flow準拠のリリースブランチ機能とユーザー選択オプション

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -439,6 +439,17 @@ export async function deleteRemoteBranch(branchName: string, remote = 'origin'):
   }
 }
 
+export async function getCurrentBranchName(worktreePath: string): Promise<string> {
+  try {
+    const { stdout } = await execa('git', ['branch', '--show-current'], {
+      cwd: worktreePath
+    });
+    return stdout.trim();
+  } catch (error) {
+    throw new GitError('Failed to get current branch name', error);
+  }
+}
+
 export async function pushBranchToRemote(worktreePath: string, branchName: string, remote = 'origin'): Promise<void> {
   try {
     // Check if the remote branch exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,8 @@ import {
   confirmProceedWithoutPush,
   selectSession,
   selectClaudeExecutionMode,
-  selectVersionBumpType
+  selectVersionBumpType,
+  selectReleaseAction
 } from './ui/prompts.js';
 import { 
   displayBranchTable,
@@ -815,24 +816,32 @@ async function handlePostClaudeChanges(worktreePath: string): Promise<void> {
     
     // Check if there are uncommitted changes
     if (!(await hasUncommittedChanges(worktreePath))) {
-      // リリースブランチの場合は、変更がなくてもPR作成を提案
+      // リリースブランチの場合は、変更がなくてもリリースアクションを選択
       if (isReleaseBranch) {
-        printInfo('This is a release branch. You may want to:');
-        printInfo('1. Push changes and create a PR to main');
-        printInfo('2. After merge, create a tag and merge back to develop');
-        const shouldPush = await confirm({
-          message: 'Push release branch and create PR?',
-          default: true
-        });
+        const action = await selectReleaseAction();
         
-        if (shouldPush) {
-          try {
-            await pushBranchToRemote(worktreePath, branchName);
-            printSuccess(`Pushed release branch: ${branchName}`);
-            printInfo('You can now create a PR to main branch using GitHub/GitLab');
-          } catch (error) {
-            printError(`Failed to push: ${error instanceof Error ? error.message : String(error)}`);
-          }
+        switch (action) {
+          case 'complete':
+            try {
+              await pushBranchToRemote(worktreePath, branchName);
+              printSuccess(`Pushed release branch: ${branchName}`);
+              printInfo('\nGit Flow Release Process:');
+              printInfo('1. Create a PR to main branch');
+              printInfo('2. After merge, create a tag on main branch');
+              printInfo('3. Merge back to develop branch');
+              printInfo('\nUse GitHub/GitLab to create the PR.');
+            } catch (error) {
+              printError(`Failed to push: ${error instanceof Error ? error.message : String(error)}`);
+            }
+            break;
+            
+          case 'continue':
+            printInfo('Release branch saved. You can continue working on it later.');
+            break;
+            
+          case 'nothing':
+            // Just exit
+            break;
         }
       }
       return;
@@ -853,25 +862,32 @@ async function handlePostClaudeChanges(worktreePath: string): Promise<void> {
           await commitChanges(worktreePath, commitMessage);
           printSuccess('Changes committed successfully!');
           
-          // リリースブランチの場合は、PR作成を提案
+          // リリースブランチの場合は、リリースアクションを選択
           if (isReleaseBranch) {
-            const shouldPush = await confirm({
-              message: 'Push release branch and create PR to main?',
-              default: true
-            });
+            const action = await selectReleaseAction();
             
-            if (shouldPush) {
-              try {
-                await pushBranchToRemote(worktreePath, branchName);
-                printSuccess(`Pushed release branch: ${branchName}`);
-                printInfo('\nGit Flow Release Process:');
-                printInfo('1. Create a PR to main branch');
-                printInfo('2. After merge, create a tag on main branch');
-                printInfo('3. Merge back to develop branch');
-                printInfo('\nUse GitHub/GitLab to create the PR.');
-              } catch (error) {
-                printError(`Failed to push: ${error instanceof Error ? error.message : String(error)}`);
-              }
+            switch (action) {
+              case 'complete':
+                try {
+                  await pushBranchToRemote(worktreePath, branchName);
+                  printSuccess(`Pushed release branch: ${branchName}`);
+                  printInfo('\nGit Flow Release Process:');
+                  printInfo('1. Create a PR to main branch');
+                  printInfo('2. After merge, create a tag on main branch');
+                  printInfo('3. Merge back to develop branch');
+                  printInfo('\nUse GitHub/GitLab to create the PR.');
+                } catch (error) {
+                  printError(`Failed to push: ${error instanceof Error ? error.message : String(error)}`);
+                }
+                break;
+                
+              case 'continue':
+                printInfo('Release branch saved with your commits. You can continue working on it later.');
+                break;
+                
+              case 'nothing':
+                // Just exit
+                break;
             }
           }
           return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ import {
   GitError,
   getCurrentVersion,
   calculateNewVersion,
-  executeNpmVersionInWorktree
+  executeNpmVersionInWorktree,
+  getCurrentBranchName
 } from './git.js';
 import { 
   listAdditionalWorktrees,
@@ -808,9 +809,9 @@ async function handleCleanupMergedPRs(): Promise<boolean> {
 
 async function handlePostClaudeChanges(worktreePath: string): Promise<void> {
   try {
-    // worktreepathからブランチ名を取得
-    const branchName = path.basename(worktreePath);
-    const isReleaseBranch = branchName.startsWith('release/') || branchName.startsWith('release-');
+    // 正確なブランチ名を取得
+    const branchName = await getCurrentBranchName(worktreePath);
+    const isReleaseBranch = branchName.startsWith('release/');
     
     // Check if there are uncommitted changes
     if (!(await hasUncommittedChanges(worktreePath))) {
@@ -863,10 +864,11 @@ async function handlePostClaudeChanges(worktreePath: string): Promise<void> {
               try {
                 await pushBranchToRemote(worktreePath, branchName);
                 printSuccess(`Pushed release branch: ${branchName}`);
-                printInfo('You can now create a PR to main branch');
-                printInfo('After merge, remember to:');
-                printInfo('1. Create a tag on main branch');
-                printInfo('2. Merge back to develop branch');
+                printInfo('\nGit Flow Release Process:');
+                printInfo('1. Create a PR to main branch');
+                printInfo('2. After merge, create a tag on main branch');
+                printInfo('3. Merge back to develop branch');
+                printInfo('\nUse GitHub/GitLab to create the PR.');
               } catch (error) {
                 printError(`Failed to push: ${error instanceof Error ? error.message : String(error)}`);
               }

--- a/src/ui/prompts.ts
+++ b/src/ui/prompts.ts
@@ -607,6 +607,29 @@ export async function confirmProceedWithoutPush(branchName: string): Promise<boo
   });
 }
 
+export async function selectReleaseAction(): Promise<'complete' | 'continue' | 'nothing'> {
+  return await select({
+    message: 'What would you like to do with this release branch?',
+    choices: [
+      {
+        name: '🚀 Complete release - Push and create PR to main',
+        value: 'complete',
+        description: 'Start the release process'
+      },
+      {
+        name: '⏸️  Save and continue later',
+        value: 'continue',
+        description: 'Keep the branch for future work'
+      },
+      {
+        name: '❌ Exit without action',
+        value: 'nothing',
+        description: 'Just exit'
+      }
+    ]
+  });
+}
+
 export async function selectSession(sessions: SessionData[]): Promise<SessionData | null> {
   if (sessions.length === 0) {
     return null;


### PR DESCRIPTION
## Summary
Git Flowに準拠したリリースブランチ機能を実装し、ユーザーが柔軟にリリースプロセスを管理できるようにしました。

## 主な機能

### 1. Git Flow準拠のリリースブランチ作成
- developブランチから分岐（存在しない場合はmain/masterから）
- バージョンタイプ選択（patch/minor/major）
- `release/X.Y.Z`形式でブランチ自動生成
- worktree内でnpm version実行

### 2. リリースブランチ終了時の選択肢
- **🚀 Complete release** - リリースを完了してPRを作成
- **⏸️ Save and continue later** - 後で作業を続けるために保存
- **❌ Exit without action** - 何もせずに終了

### 3. 修正された問題
- package.jsonが存在しない場合のエラーを解決
- ブランチ名の正確な検出（git branch --show-current使用）
- developブランチがない環境への対応

## 実装内容
- `calculateNewVersion()` - バージョン計算
- `executeNpmVersionInWorktree()` - worktree内でのnpm version実行
- `getCurrentBranchName()` - 正確なブランチ名取得
- `selectReleaseAction()` - リリースアクション選択

## Test plan
- [ ] リリースブランチ作成フローが正しく動作することを確認
- [ ] developブランチがない環境でも動作することを確認
- [ ] リリースブランチ終了時に3つの選択肢が表示されることを確認
- [ ] 各選択肢が期待通りに動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)