### PR TITLE
feat: Git Flowに準拠したリリースブランチ自動作成機能の実装

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -418,16 +418,31 @@ export async function executeNpmVersionInWorktree(
       await execa('git', ['commit', '-m', `chore: create package.json with version ${newVersion}`], { cwd: worktreePath });
     } else {
       // worktree内でnpm versionコマンドを実行（既に計算済みのバージョンを使用）
-      await execa('npm', ['version', newVersion, '--no-git-tag-version'], {
-        cwd: worktreePath
-      });
+      try {
+        await execa('npm', ['version', newVersion, '--no-git-tag-version'], {
+          cwd: worktreePath
+        });
+      } catch (npmError) {
+        // npmコマンドが見つからない場合は、手動でpackage.jsonを更新
+        const packageContent = await fs.promises.readFile(packageJsonPath, 'utf-8');
+        const packageData = JSON.parse(packageContent);
+        packageData.version = newVersion;
+        await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageData, null, 2) + '\n');
+      }
       
-      // package.jsonとpackage-lock.jsonの変更をコミット
-      await execa('git', ['add', 'package.json', 'package-lock.json'], { cwd: worktreePath });
+      // package.jsonの変更をコミット（package-lock.jsonは存在する場合のみ）
+      const filesToAdd = ['package.json'];
+      if (fs.existsSync(path.join(worktreePath, 'package-lock.json'))) {
+        filesToAdd.push('package-lock.json');
+      }
+      await execa('git', ['add', ...filesToAdd], { cwd: worktreePath });
       await execa('git', ['commit', '-m', `chore: bump version to ${newVersion}`], { cwd: worktreePath });
     }
   } catch (error) {
-    throw new GitError(`Failed to execute npm version ${newVersion} in worktree`, error);
+    // エラーの詳細情報を含める
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorDetails = error instanceof Error && 'stderr' in error ? ` (${error.stderr})` : '';
+    throw new GitError(`Failed to execute npm version ${newVersion} in worktree: ${errorMessage}${errorDetails}`, error);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,6 +854,22 @@ async function handlePostClaudeChanges(worktreePath: string): Promise<void> {
                 
                 printSuccess('Pull request created successfully!');
                 printInfo(stdout);
+                
+                // リリースブランチのworktreeとローカルブランチを削除
+                printInfo('\nCleaning up release worktree and local branch...');
+                try {
+                  await removeWorktree(worktreePath, true);
+                  printSuccess('Release worktree removed successfully.');
+                  
+                  // ローカルブランチも削除（リモートブランチは残す）
+                  await deleteBranch(branchName, true);
+                  printSuccess(`Local branch ${branchName} deleted successfully.`);
+                  
+                  printInfo('\nRelease process initiated. The PR is ready for review.');
+                  printInfo('Remote branch is preserved for the PR.');
+                } catch (error) {
+                  printWarning('Failed to clean up. Please remove worktree/branch manually.');
+                }
               } catch (error) {
                 printWarning('Failed to create PR automatically. Please create it manually.');
                 printInfo('\nGit Flow Release Process:');


### PR DESCRIPTION
## 概要
Git Flowに準拠したリリースブランチの自動作成機能を実装しました。`npm version`コマンドと連携して、バージョン管理を効率化します。

## 実装内容

### 1. リリースブランチ作成機能
- ブランチタイプ選択時に「Release」オプションを追加
- Git Flowに従い、developブランチから分岐（developがない場合はmain/masterから）
- バージョンバンプタイプ（patch/minor/major）を選択可能
- 自動的に`release/X.Y.Z`形式のブランチ名を生成

### 2. npm versionとの連携
- worktree作成後、自動的に`npm version`を実行
- package.jsonが存在しない場合は自動作成
- バージョン変更を自動コミット

### 3. リリースブランチ終了フロー
- リリースブランチからexitする際に専用の選択肢を表示
  - **Complete release**: 変更をプッシュし、PRを作成、worktreeとローカルブランチを削除
  - **Continue working later**: 現在の状態を保持（後で作業を継続可能）
  - **Do nothing**: 何もせずに終了
- 未コミットの変更がある場合は自動的にコミット

### 4. 自動化機能
- Complete release選択時の自動化：
  - リモートへのプッシュ
  - GitHub CLIを使用したPR作成（タイトル、本文、チェックリスト付き）
  - worktreeの削除
  - ローカルブランチの削除（リモートブランチは保持）

## 関連ファイル
- `src/index.ts`: メインロジックの実装
- `src/git.ts`: バージョン管理関連の関数を追加
- `src/ui/prompts.ts`: UI関連のプロンプトを追加

## テスト結果
- ✅ TypeScriptビルド成功
- ✅ 型チェック成功
- ✅ ESLint警告なし

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>