### PR TITLE
feat: Claude Codeアカウント切り替え機能の実装

### DIFF
--- a/src/services/claude-account.service.ts
+++ b/src/services/claude-account.service.ts
@@ -170,6 +170,12 @@ export class ClaudeAccountService {
       throw new Error(`Account "${accountName}" not found`);
     }
 
+    console.log(chalk.gray(`[DEBUG] Target account data:`));
+    console.log(chalk.gray(`  Name: ${targetAccount.name}`));
+    console.log(chalk.gray(`  SubscriptionType: ${targetAccount.subscriptionType}`));
+    console.log(chalk.gray(`  Scopes: ${targetAccount.scopes.join(', ')}`));
+    console.log(chalk.gray(`  ExpiresAt: ${new Date(targetAccount.expiresAt).toISOString()}`));
+
     // 現在の認証情報をバックアップ
     await this.backupCurrentCredentials();
 
@@ -184,8 +190,16 @@ export class ClaudeAccountService {
     await claudeConfigService.setActiveAccount(accountName);
 
     console.log(chalk.green(`🔄 Switched to account: ${accountName}`));
-    console.log(chalk.cyan(`   Plan: ${targetAccount.subscriptionType}`));
+    console.log(chalk.cyan(`   Plan: ${targetAccount.subscriptionType || 'Unknown'}`));
     console.log(chalk.cyan(`   Scopes: ${targetAccount.scopes.join(', ')}`));
+
+    // 切り替え後の認証情報を確認
+    const newCredentials = await this.getCurrentCredentials();
+    if (newCredentials) {
+      console.log(chalk.gray(`[DEBUG] New credentials applied:`));
+      console.log(chalk.gray(`  SubscriptionType: ${newCredentials.claudeAiOauth.subscriptionType}`));
+      console.log(chalk.gray(`  Scopes: ${newCredentials.claudeAiOauth.scopes.join(', ')}`));
+    }
   }
 
   /**

--- a/src/ui/account-prompts.ts
+++ b/src/ui/account-prompts.ts
@@ -28,8 +28,20 @@ export async function showCurrentAccountInfo(): Promise<void> {
     }
     
     if (accountInfo) {
-      console.log(chalk.cyan(`📋 Plan: ${accountInfo.subscriptionType}`));
+      // subscriptionTypeの表示（nullの場合の処理を追加）
+      const planDisplay = accountInfo.subscriptionType || 'Unknown';
+      const planColor = accountInfo.subscriptionType === 'max' ? chalk.yellow : 
+                       accountInfo.subscriptionType === 'pro' ? chalk.blue : 
+                       accountInfo.subscriptionType === 'free' ? chalk.gray : chalk.cyan;
+      console.log(planColor(`📋 Plan: ${planDisplay}`));
+      
+      // Scopesの表示
       console.log(chalk.cyan(`🔑 Scopes: ${accountInfo.scopes.join(', ')}`));
+      
+      // user:profileスコープがない場合は警告
+      if (!accountInfo.scopes.includes('user:profile')) {
+        console.log(chalk.yellow('⚠️  Note: user:profile scope is missing. Profile information may be limited.'));
+      }
       
       const expirationDate = new Date(accountInfo.expiresAt);
       const isExpired = accountInfo.isExpired;
@@ -79,7 +91,8 @@ export async function selectAccountToSwitch(): Promise<string | null> {
       const isExpired = account.expiresAt < Date.now();
       
       let name = account.name;
-      let description = `${account.subscriptionType}`;
+      const planDisplay = account.subscriptionType || 'Unknown';
+      let description = `${planDisplay}`;
       
       if (isActive) {
         name = `${name} ${chalk.green('(current)')}`;
@@ -93,6 +106,11 @@ export async function selectAccountToSwitch(): Promise<string | null> {
       
       const savedDate = new Date(account.savedAt).toLocaleDateString('ja-JP');
       description += ` - 保存日 ${savedDate}`;
+      
+      // スコープ情報も追加
+      if (!account.scopes.includes('user:profile')) {
+        description += ` ${chalk.yellow('(limited scopes)')}`;
+      }
       
       return {
         name,
@@ -137,8 +155,13 @@ export async function saveCurrentAccountPrompt(): Promise<string | null> {
     console.log(chalk.gray('Current account details:'));
     
     if (authStatus.accountInfo) {
-      console.log(chalk.cyan(`   Plan: ${authStatus.accountInfo.subscriptionType}`));
+      const planDisplay = authStatus.accountInfo.subscriptionType || 'Unknown';
+      console.log(chalk.cyan(`   Plan: ${planDisplay}`));
       console.log(chalk.cyan(`   Scopes: ${authStatus.accountInfo.scopes.join(', ')}`));
+      
+      if (!authStatus.accountInfo.scopes.includes('user:profile')) {
+        console.log(chalk.yellow('   ⚠️  Note: user:profile scope is missing'));
+      }
     }
 
     const accountName = await input({
@@ -182,7 +205,8 @@ export async function selectAccountToDelete(): Promise<string | null> {
     const choices = accounts.map(account => {
       const isActive = account.name === currentActive;
       let name = account.name;
-      let description = `${account.subscriptionType}`;
+      const planDisplay = account.subscriptionType || 'Unknown';
+      let description = `${planDisplay}`;
       
       if (isActive) {
         name = `${name} ${chalk.yellow('(currently active)')}`;


### PR DESCRIPTION
## 概要
Claude Codeの複数アカウント（Free/Pro/Max）を切り替えて使用できる機能を実装しました。

## 実装内容

### 新機能
- **アカウント管理メニュー**: メインメニューから`a`キーでアクセス可能
- **アカウント保存**: 現在の認証情報に名前を付けて保存
- **アカウント切り替え**: 保存済みアカウント間の切り替え
- **アカウント追加**: 新しいアカウントの認証と保存
- **アカウント削除**: 不要なアカウントの削除

### 技術的な実装
- Claude Code CLIの既存コマンド（`claude setup-token`、`claude config`）を活用
- 認証情報は`~/.claude/.credentials.json`から読み取り
- アカウント情報は`~/.config/claude-worktree/accounts/`に保存
- Claude Configシステムと統合してアクティブアカウントを管理

### UI/UXの改善
- subscriptionTypeがnullの場合は"Unknown"と表示
- Planごとに色分け表示（Max: 黄色、Pro: 青、Free: グレー）
- user:profileスコープがない場合は警告メッセージを表示
- タイムゾーン付きでトークンの有効期限を表示

## 注意事項
- Claude CodeのOAuth認証では、subscriptionTypeがnullで返されることがあります
- user:profileスコープがない場合、プロフィール情報が制限される可能性があります

## テスト方法
1. `pnpm install && pnpm build`
2. `claude-worktree`を実行してメインメニューから`a`キーを押す
3. アカウント管理メニューから各機能をテスト

🤖 Generated with [Claude Code](https://claude.ai/code)