### PR TITLE
fix: Auto Mergeワークフローのトリガー修正

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,9 +5,6 @@ on:
     workflows: ["Test", "Lint"]
     types:
       - completed
-    branches:
-      - main
-      - develop
 
 jobs:
   auto-merge:
@@ -70,6 +67,6 @@ jobs:
         run: |
           PR_NUMBER=${{ steps.pr.outputs.number }}
           echo "Auto-merging PR #$PR_NUMBER"
-          gh pr merge $PR_NUMBER --merge --auto
+          gh pr merge $PR_NUMBER --merge --auto --yes
         env:
           GH_TOKEN: ${{ github.token }}

--- a/specs/SPEC-cff08403/contracts/workflow-run-event.md
+++ b/specs/SPEC-cff08403/contracts/workflow-run-event.md
@@ -14,9 +14,6 @@ on:
     workflows: ["Test", "Lint"]
     types:
       - completed
-    branches:
-      - main
-      - develop
 ```
 
 ## イベントペイロード構造

--- a/specs/SPEC-cff08403/quickstart.md
+++ b/specs/SPEC-cff08403/quickstart.md
@@ -34,9 +34,6 @@ on:
     workflows: ["Test", "Lint"]
     types:
       - completed
-    branches:
-      - main
-      - develop
 
 jobs:
   auto-merge:

--- a/specs/SPEC-cff08403/research.md
+++ b/specs/SPEC-cff08403/research.md
@@ -49,9 +49,6 @@ on:
     workflows: ["Test", "Lint"]
     types:
       - completed
-    branches:
-      - main
-      - develop
 ```
 
 ### 1.3 ブランチ保護ルールとの統合


### PR DESCRIPTION
## 概要
- workflow_run の branches フィルタを削除し、PRのヘッドブランチでも起動するよう修正
- gh pr merge 実行時に --yes を付与し、CI上で非対話実行を保証