### PR TITLE
fix: Auto MergeでGraphQLミューテーションを使用

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -37,11 +37,12 @@ jobs:
         id: check
         run: |
           PR_NUMBER=${{ steps.pr.outputs.number }}
-          PR_DATA=$(gh pr view $PR_NUMBER --json mergeable,mergeStateStatus,isDraft)
+          PR_DATA=$(gh pr view $PR_NUMBER --json id,mergeable,mergeStateStatus,isDraft)
 
           MERGEABLE=$(echo "$PR_DATA" | jq -r '.mergeable')
           MERGE_STATE=$(echo "$PR_DATA" | jq -r '.mergeStateStatus')
           IS_DRAFT=$(echo "$PR_DATA" | jq -r '.isDraft')
+          PR_ID=$(echo "$PR_DATA" | jq -r '.id')
 
           if [ "$IS_DRAFT" = "true" ]; then
             echo "PR is a draft, skipping"
@@ -59,6 +60,7 @@ jobs:
           fi
 
           echo "ready=true" >> $GITHUB_OUTPUT
+          echo "id=$PR_ID" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -66,7 +68,8 @@ jobs:
         if: steps.check.outputs.ready == 'true'
         run: |
           PR_NUMBER=${{ steps.pr.outputs.number }}
+          PR_ID=${{ steps.check.outputs.id }}
           echo "Auto-merging PR #$PR_NUMBER"
-          gh pr merge $PR_NUMBER --merge --auto --yes
+          gh api graphql -f query='mutation($pr:ID!){ mergePullRequest(input:{pullRequestId:$pr, mergeMethod:MERGE}) { pullRequest { number }}}' -f pr="$PR_ID"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/specs/SPEC-cff08403/data-model.md
+++ b/specs/SPEC-cff08403/data-model.md
@@ -114,9 +114,9 @@ ELSE:
                                                ↓
                                      shouldMerge == true?
                                          ↙         ↘
-                                      Yes          No
-                                       ↓            ↓
-                                   gh pr merge    Log + Skip
+                                     Yes          No
+                                      ↓            ↓
+                        gh api graphql mergePullRequest    Log + Skip
 ```
 
 ### 2. PRデータ取得フロー

--- a/specs/SPEC-cff08403/quickstart.md
+++ b/specs/SPEC-cff08403/quickstart.md
@@ -95,8 +95,9 @@ jobs:
         if: steps.check.outputs.ready == 'true'
         run: |
           PR_NUMBER=${{ steps.pr.outputs.number }}
+          PR_ID=${{ steps.check.outputs.id }}
           echo "Auto-merging PR #$PR_NUMBER"
-          gh pr merge $PR_NUMBER --merge --auto
+          gh api graphql -f query='mutation($pr:ID!){ mergePullRequest(input:{pullRequestId:$pr, mergeMethod:MERGE}) { pullRequest { number }}}' -f pr="$PR_ID"
         env:
           GH_TOKEN: ${{ github.token }}
 ```

--- a/specs/SPEC-cff08403/tasks.md
+++ b/specs/SPEC-cff08403/tasks.md
@@ -92,7 +92,7 @@ graph TD
 - [x] T003 [P] [US1] ジョブの実行条件を設定（conclusion=success、event=pull_request）し、必要な権限を定義 in .github/workflows/auto-merge.yml
 - [x] T004 [US1] PR番号取得ステップを実装（workflow_run.head_branchからgh pr listで取得）in .github/workflows/auto-merge.yml
 - [x] T005 [US1] マージ可能性チェックステップを実装（mergeable、mergeStateStatusを確認）in .github/workflows/auto-merge.yml
-- [x] T006 [US1] PRマージステップを実装（gh pr merge --merge --autoを使用）in .github/workflows/auto-merge.yml
+- [x] T006 [US1] PRマージステップを実装（gh api graphqlによるmergePullRequest実行）in .github/workflows/auto-merge.yml
 - [ ] T007 [US1] 統合テスト: テストPRを作成し、CI成功後に自動マージされることを確認
 
 ---


### PR DESCRIPTION
## 概要
- gh pr merge の --yes オプションがrunnerのバージョンで未対応だったためワークフローが失敗
- mergePullRequest GraphQLミューテーションを利用してPRを非対話でMerge commitするよう変更
- ドキュメント類もGraphQLベースの手順に更新