### PR TITLE
fix: CI/CDテスト失敗の修正 - mockのdefault export追加

### DIFF
--- a/tests/integration/session-continue.test.ts
+++ b/tests/integration/session-continue.test.ts
@@ -2,16 +2,27 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as config from "../../src/config/index";
 
 // Mock node:fs/promises
-vi.mock("node:fs/promises", () => ({
-  readFile: vi.fn(),
-  writeFile: vi.fn(),
-  mkdir: vi.fn(),
-  readdir: vi.fn(),
-}));
+vi.mock("node:fs/promises", () => {
+  const readFile = vi.fn();
+  const writeFile = vi.fn();
+  const mkdir = vi.fn();
+  const readdir = vi.fn();
+  return {
+    readFile,
+    writeFile,
+    mkdir,
+    readdir,
+    default: { readFile, writeFile, mkdir, readdir },
+  };
+});
 
-vi.mock("node:os", () => ({
-  homedir: vi.fn(() => "/home/testuser"),
-}));
+vi.mock("node:os", () => {
+  const homedir = vi.fn(() => "/home/testuser");
+  return {
+    homedir,
+    default: { homedir },
+  };
+});
 
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 

--- a/tests/integration/session-resume.test.ts
+++ b/tests/integration/session-resume.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as config from "../../src/config/index";
 
-vi.mock("node:fs/promises", () => ({
-  readFile: vi.fn(),
-  writeFile: vi.fn(),
-  mkdir: vi.fn(),
-  readdir: vi.fn(),
-}));
+vi.mock("node:fs/promises", () => {
+  const readFile = vi.fn();
+  const writeFile = vi.fn();
+  const mkdir = vi.fn();
+  const readdir = vi.fn();
+  return {
+    readFile,
+    writeFile,
+    mkdir,
+    readdir,
+    default: { readFile, writeFile, mkdir, readdir },
+  };
+});
 
 vi.mock("node:os", () => {
   const homedir = vi.fn(() => "/home/testuser");

--- a/tests/unit/claude.test.ts
+++ b/tests/unit/claude.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { launchClaudeCode } from "../../src/claude.js";
 import { existsSync } from "fs";
 
-// Mock execa
-const mockExeca = vi.fn();
+const { mockExeca } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+}));
+
 vi.mock("execa", () => ({
   execa: mockExeca,
+  default: { execa: mockExeca },
 }));
 
 // Mock fs


### PR DESCRIPTION
## 概要

CI/CD環境でのvitest要件に対応し、すべてのmockにdefault exportを追加しました。

## 変更内容

### tests/integration/session-continue.test.ts
- `node:fs/promises` mockにdefault exportを追加
- readFile, writeFile, mkdir, readdirすべてにdefault export対応

### tests/integration/session-resume.test.ts
- `node:fs/promises` mockにdefault exportを追加
- session-continue.test.tsと同じパターンを適用

### tests/unit/claude.test.ts
- `execa` mockにdefault exportを追加
- vi.hoisted()と組み合わせて使用

## 技術詳細

CI環境のvitestでは、以下のnode: protocol importsとESMモジュールにdefault exportが必須：
- node:os
- node:fs/promises
- execa (ESMモジュール)

## テスト

ローカル環境：
- `bun run test` - すべてのテストがパス

CI/CD環境：
- 本PRのCI/CD実行を待ちます

## 関連

- #89 - 元のInk.js UI移行PR（自動マージ済み）
- SPEC-4c2ef107 - Ink.js UI移行仕様

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>