### PR TITLE
test: BranchListScreenのローディング表示を安定化

### DIFF
--- a/src/ui/__tests__/components/screens/BranchListScreen.test.tsx
+++ b/src/ui/__tests__/components/screens/BranchListScreen.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { BranchListScreen } from '../../../components/screens/BranchListScreen.js';
@@ -10,10 +10,15 @@ import { Window } from 'happy-dom';
 
 describe('BranchListScreen', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     // Setup happy-dom
     const window = new Window();
     globalThis.window = window as any;
     globalThis.document = window.document as any;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   const mockBranches: BranchItem[] = [
@@ -121,13 +126,13 @@ describe('BranchListScreen', () => {
     expect(queryByText(/Git情報を読み込んでいます/i)).toBeNull();
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      vi.advanceTimersByTime(5);
     });
 
     expect(queryByText(/Git情報を読み込んでいます/i)).toBeNull();
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 15));
+      vi.advanceTimersByTime(10);
     });
 
     expect(getByText(/Git情報を読み込んでいます/i)).toBeDefined();


### PR DESCRIPTION
## 概要
- BranchListScreenのローディング遅延テストでフェイクタイマーを使用し、CI上でのタイミング依存の失敗を防止
- happy-dom初期化後にタイマーを実テーブルへ戻す後処理を追加

## テスト
- bun run test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト実行時のタイマー処理を改善しました。フェイクタイマーを使用することで、テストの実行速度を向上させました。

**ユーザーへの影響:** このアップデートは内部テスト改善のみで、ユーザーに見える機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->