### PR TITLE
hotfix: immediate PR cleanup feedback

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -308,6 +308,15 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
       completionTimerRef.current = null;
     };
 
+    // Provide immediate feedback before fetching targets
+    setCleanupInputLocked(true);
+    setCleanupIndicators({});
+    const initialFrame = getSpinnerFrame(0);
+    setCleanupFooterMessage({ text: `Processing... ${initialFrame}`, color: 'cyan' });
+    setCleanupProcessingBranch(null);
+    spinnerFrameIndexRef.current = 0;
+    setSpinnerFrameIndex(0);
+
     let targets;
     try {
       targets = await getMergedPRWorktrees();
@@ -345,13 +354,11 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
     }, {});
 
     setCleanupIndicators(initialIndicators);
-    setCleanupInputLocked(true);
     const firstTarget = targets.length > 0 ? targets[0] : undefined;
     setCleanupProcessingBranch(firstTarget ? firstTarget.branch : null);
     spinnerFrameIndexRef.current = 0;
     setSpinnerFrameIndex(0);
-    const initialFrame = getSpinnerFrame(0);
-    setCleanupFooterMessage({ text: `Processing... ${initialFrame}`, color: 'cyan' });
+    setCleanupFooterMessage({ text: `Processing... ${getSpinnerFrame(0)}`, color: 'cyan' });
 
     for (let index = 0; index < targets.length; index += 1) {
       const currentTarget = targets[index];


### PR DESCRIPTION
## Summary
- lock input and show spinner immediately when running PR cleanup
- keep UI responsive while processing targets sequentially
- update specs to match new UX

## Testing
- bun run lint
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * クリーンアップフロー中の処理表示のタイミングを調整。スピナーと「処理中...」メッセージが、ターゲット取得前により早期に表示されるようになりました。これにより、ユーザーは処理開始を即座に認識できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->