### PR TITLE
Fix: Ink UIのTTY制御を再調整

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -138,17 +138,28 @@ export async function launchClaudeCode(
 
     terminal.exitRawMode();
 
-    await execa("bunx", [CLAUDE_CLI_PACKAGE, ...args], {
+    const execaOptions = {
       cwd: worktreePath,
       shell: true,
-      stdin: terminal.stdin,
-      stdout: terminal.stdout,
-      stderr: terminal.stderr,
+      stdin:
+        terminal.usingFallback && terminal.stdinFd !== undefined
+          ? terminal.stdinFd
+          : "inherit",
+      stdout:
+        terminal.usingFallback && terminal.stdoutFd !== undefined
+          ? terminal.stdoutFd
+          : "inherit",
+      stderr:
+        terminal.usingFallback && terminal.stderrFd !== undefined
+          ? terminal.stderrFd
+          : "inherit",
       env:
         isRoot && options.skipPermissions
           ? { ...process.env, IS_SANDBOX: "1" }
           : process.env,
-    });
+    } as const;
+
+    await execa("bunx", [CLAUDE_CLI_PACKAGE, ...args], execaOptions as any);
   } catch (error: any) {
     const errorMessage =
       error.code === "ENOENT"

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -82,13 +82,24 @@ export async function launchCodexCLI(
 
     terminal.exitRawMode();
 
-    await execa("bunx", [CODEX_CLI_PACKAGE, ...args], {
+    const execaOptions = {
       cwd: worktreePath,
       shell: true,
-      stdin: terminal.stdin,
-      stdout: terminal.stdout,
-      stderr: terminal.stderr,
-    });
+      stdin:
+        terminal.usingFallback && terminal.stdinFd !== undefined
+          ? terminal.stdinFd
+          : "inherit",
+      stdout:
+        terminal.usingFallback && terminal.stdoutFd !== undefined
+          ? terminal.stdoutFd
+          : "inherit",
+      stderr:
+        terminal.usingFallback && terminal.stderrFd !== undefined
+          ? terminal.stderrFd
+          : "inherit",
+    } as const;
+
+    await execa("bunx", [CODEX_CLI_PACKAGE, ...args], execaOptions as any);
   } catch (error: any) {
     const errorMessage =
       error.code === "ENOENT"

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -6,6 +6,9 @@ export interface TerminalStreams {
   stdin: NodeJS.ReadStream;
   stdout: NodeJS.WriteStream;
   stderr: NodeJS.WriteStream;
+  stdinFd?: number;
+  stdoutFd?: number;
+  stderrFd?: number;
   usingFallback: boolean;
   exitRawMode: () => void;
 }
@@ -124,6 +127,9 @@ function createTerminalStreams(): TerminalStreams {
       stdin,
       stdout,
       stderr,
+      stdinFd: fdIn,
+      stdoutFd: fdOut,
+      stderrFd: fdErr,
       usingFallback: true,
       exitRawMode,
     };


### PR DESCRIPTION
## 概要
- Ink UI用のTTYユーティリティにフォールバックFDを保持し、raw mode解除手順を整理
- AIツール起動時にTTYフォールバックが存在する場合でも標準入出力を適切に引き渡し
- ユニットテストを拡張し、TTYフォールバック経路を検証

## テスト
- bun run build
- bun run test
