### PR TITLE
feat: ブランチ一覧のソート機能を実装

### DIFF
--- a/src/ui/__tests__/utils/branchFormatter.test.ts
+++ b/src/ui/__tests__/utils/branchFormatter.test.ts
@@ -176,7 +176,7 @@ describe("branchFormatter", () => {
   });
 
   describe("formatBranchItems", () => {
-    it("should format multiple branches", () => {
+    it("should format multiple branches with sorting", () => {
       const branches: BranchInfo[] = [
         {
           name: "main",
@@ -201,11 +201,14 @@ describe("branchFormatter", () => {
       const results = formatBranchItems(branches);
 
       expect(results).toHaveLength(3);
+      // Current branch (main) should be first
       expect(results[0].name).toBe("main");
       expect(results[0].isCurrent).toBe(true);
-      expect(results[1].name).toBe("feature/test");
-      expect(results[2].name).toBe("origin/main");
-      expect(results[2].type).toBe("remote");
+      // origin/main is also main branch, so it comes second
+      expect(results[1].name).toBe("origin/main");
+      expect(results[1].type).toBe("remote");
+      // feature/test comes last
+      expect(results[2].name).toBe("feature/test");
     });
 
     it("should handle empty array", () => {
@@ -214,7 +217,7 @@ describe("branchFormatter", () => {
       expect(results).toHaveLength(0);
     });
 
-    it("should preserve branch order", () => {
+    it("should sort branches alphabetically when no other priority applies", () => {
       const branches: BranchInfo[] = [
         {
           name: "z-branch",
@@ -232,8 +235,295 @@ describe("branchFormatter", () => {
 
       const results = formatBranchItems(branches);
 
-      expect(results[0].name).toBe("z-branch");
-      expect(results[1].name).toBe("a-branch");
+      expect(results[0].name).toBe("a-branch");
+      expect(results[1].name).toBe("z-branch");
+    });
+  });
+
+  describe("formatBranchItems - sorting", () => {
+    it("should prioritize current branch at the top", () => {
+      const branches: BranchInfo[] = [
+        {
+          name: "feature/a",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "feature/current",
+          type: "local",
+          branchType: "feature",
+          isCurrent: true,
+        },
+        {
+          name: "main",
+          type: "local",
+          branchType: "main",
+          isCurrent: false,
+        },
+      ];
+
+      const results = formatBranchItems(branches);
+
+      expect(results[0].name).toBe("feature/current");
+      expect(results[0].isCurrent).toBe(true);
+    });
+
+    it("should prioritize main branch as second (after current)", () => {
+      const branches: BranchInfo[] = [
+        {
+          name: "feature/test",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "main",
+          type: "local",
+          branchType: "main",
+          isCurrent: false,
+        },
+        {
+          name: "develop",
+          type: "local",
+          branchType: "develop",
+          isCurrent: false,
+        },
+      ];
+
+      const results = formatBranchItems(branches);
+
+      expect(results[0].name).toBe("main");
+      expect(results[1].name).toBe("develop");
+    });
+
+    it("should prioritize develop branch after main (when main exists)", () => {
+      const branches: BranchInfo[] = [
+        {
+          name: "feature/test",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "develop",
+          type: "local",
+          branchType: "develop",
+          isCurrent: false,
+        },
+        {
+          name: "main",
+          type: "local",
+          branchType: "main",
+          isCurrent: false,
+        },
+      ];
+
+      const results = formatBranchItems(branches);
+
+      expect(results[0].name).toBe("main");
+      expect(results[1].name).toBe("develop");
+      expect(results[2].name).toBe("feature/test");
+    });
+
+    it("should NOT prioritize develop branch when main does not exist", () => {
+      const branches: BranchInfo[] = [
+        {
+          name: "feature/a",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "develop",
+          type: "local",
+          branchType: "develop",
+          isCurrent: false,
+        },
+        {
+          name: "feature/z",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+      ];
+
+      const results = formatBranchItems(branches);
+
+      // develop should be sorted alphabetically, not prioritized
+      expect(results[0].name).toBe("develop");
+      expect(results[1].name).toBe("feature/a");
+      expect(results[2].name).toBe("feature/z");
+    });
+
+    it("should prioritize branches with worktree", () => {
+      const worktreeMap = new Map([
+        ["feature/with-worktree", {
+          path: "/path/to/worktree",
+          locked: false,
+          prunable: false,
+          isAccessible: true,
+        }],
+      ]);
+
+      const branches: BranchInfo[] = [
+        {
+          name: "feature/no-worktree",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "feature/with-worktree",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+          worktree: {
+            path: "/path/to/worktree",
+            locked: false,
+            prunable: false,
+            isAccessible: true,
+          },
+        },
+      ];
+
+      const results = formatBranchItems(branches, worktreeMap);
+
+      expect(results[0].name).toBe("feature/with-worktree");
+      expect(results[1].name).toBe("feature/no-worktree");
+    });
+
+    it("should prioritize local branches over remote branches", () => {
+      const branches: BranchInfo[] = [
+        {
+          name: "origin/feature/remote",
+          type: "remote",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "feature/local",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+      ];
+
+      const results = formatBranchItems(branches);
+
+      expect(results[0].name).toBe("feature/local");
+      expect(results[0].type).toBe("local");
+      expect(results[1].name).toBe("origin/feature/remote");
+      expect(results[1].type).toBe("remote");
+    });
+
+    it("should apply all sorting rules in correct priority order", () => {
+      const worktreeMap = new Map([
+        ["feature/with-worktree", {
+          path: "/path/to/worktree",
+          locked: false,
+          prunable: false,
+          isAccessible: true,
+        }],
+      ]);
+
+      const branches: BranchInfo[] = [
+        {
+          name: "origin/feature/z-remote",
+          type: "remote",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "feature/with-worktree",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+          worktree: {
+            path: "/path/to/worktree",
+            locked: false,
+            prunable: false,
+            isAccessible: true,
+          },
+        },
+        {
+          name: "feature/z-local-no-worktree",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "feature/a-local-no-worktree",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "develop",
+          type: "local",
+          branchType: "develop",
+          isCurrent: false,
+        },
+        {
+          name: "main",
+          type: "local",
+          branchType: "main",
+          isCurrent: false,
+        },
+        {
+          name: "feature/current",
+          type: "local",
+          branchType: "feature",
+          isCurrent: true,
+        },
+      ];
+
+      const results = formatBranchItems(branches, worktreeMap);
+
+      // Expected order:
+      // 1. Current branch
+      // 2. main
+      // 3. develop (because main exists)
+      // 4. Branches with worktree
+      // 5. Local branches (alphabetically)
+      // 6. Remote branches
+      expect(results[0].name).toBe("feature/current");
+      expect(results[1].name).toBe("main");
+      expect(results[2].name).toBe("develop");
+      expect(results[3].name).toBe("feature/with-worktree");
+      expect(results[4].name).toBe("feature/a-local-no-worktree");
+      expect(results[5].name).toBe("feature/z-local-no-worktree");
+      expect(results[6].name).toBe("origin/feature/z-remote");
+    });
+
+    it("should handle release and hotfix branches without special priority", () => {
+      const branches: BranchInfo[] = [
+        {
+          name: "feature/test",
+          type: "local",
+          branchType: "feature",
+          isCurrent: false,
+        },
+        {
+          name: "hotfix/urgent",
+          type: "local",
+          branchType: "hotfix",
+          isCurrent: false,
+        },
+        {
+          name: "release/v1.0",
+          type: "local",
+          branchType: "release",
+          isCurrent: false,
+        },
+      ];
+
+      const results = formatBranchItems(branches);
+
+      // Should be sorted alphabetically (no special priority)
+      expect(results[0].name).toBe("feature/test");
+      expect(results[1].name).toBe("hotfix/urgent");
+      expect(results[2].name).toBe("release/v1.0");
     });
   });
 });

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -150,10 +150,19 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
   );
 
   // Format branches to BranchItems (memoized for performance)
-  const branchItems: BranchItem[] = useMemo(
-    () => formatBranchItems(visibleBranches),
-    [visibleBranches]
-  );
+  const branchItems: BranchItem[] = useMemo(() => {
+    // Build worktreeMap for sorting
+    const worktreeMap = new Map();
+    for (const wt of worktrees) {
+      worktreeMap.set(wt.branch, {
+        path: wt.path,
+        locked: false,
+        prunable: wt.isAccessible === false,
+        isAccessible: wt.isAccessible ?? true,
+      });
+    }
+    return formatBranchItems(visibleBranches, worktreeMap);
+  }, [visibleBranches, worktrees]);
 
   // Calculate statistics (memoized for performance)
   const stats = useMemo(() => calculateStatistics(visibleBranches), [visibleBranches]);

--- a/src/ui/utils/branchFormatter.ts
+++ b/src/ui/utils/branchFormatter.ts
@@ -3,6 +3,7 @@ import type {
   BranchItem,
   BranchType,
   WorktreeStatus,
+  WorktreeInfo,
 } from "../types.js";
 import stringWidth from "string-width";
 
@@ -130,8 +131,60 @@ export function formatBranchItem(
 }
 
 /**
- * Converts an array of BranchInfo to BranchItem array
+ * Sorts branches according to the priority rules:
+ * 1. Current branch (highest priority)
+ * 2. main branch
+ * 3. develop branch (only if main exists)
+ * 4. Branches with worktree
+ * 5. Local branches
+ * 6. Alphabetical order by name
  */
-export function formatBranchItems(branches: BranchInfo[]): BranchItem[] {
-  return branches.map((branch) => formatBranchItem(branch));
+function sortBranches(
+  branches: BranchInfo[],
+  worktreeMap: Map<string, WorktreeInfo>
+): BranchInfo[] {
+  // Check if main branch exists
+  const hasMainBranch = branches.some((b) => b.branchType === "main");
+
+  return [...branches].sort((a, b) => {
+    // 1. Current branch is highest priority
+    if (a.isCurrent && !b.isCurrent) return -1;
+    if (!a.isCurrent && b.isCurrent) return 1;
+
+    // 2. main branch is second priority
+    if (a.branchType === "main" && b.branchType !== "main") return -1;
+    if (a.branchType !== "main" && b.branchType === "main") return 1;
+
+    // 3. develop branch is third priority (only if main exists)
+    if (hasMainBranch) {
+      if (a.branchType === "develop" && b.branchType !== "develop") return -1;
+      if (a.branchType !== "develop" && b.branchType === "develop") return 1;
+    }
+
+    // 4. Branches with worktree are prioritized
+    const aHasWorktree = worktreeMap.has(a.name) || !!a.worktree;
+    const bHasWorktree = worktreeMap.has(b.name) || !!b.worktree;
+    if (aHasWorktree && !bHasWorktree) return -1;
+    if (!aHasWorktree && bHasWorktree) return 1;
+
+    // 5. Local branches are prioritized over remote-only
+    const aIsLocal = a.type === "local";
+    const bIsLocal = b.type === "local";
+    if (aIsLocal && !bIsLocal) return -1;
+    if (!aIsLocal && bIsLocal) return 1;
+
+    // 6. Alphabetical order by name
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/**
+ * Converts an array of BranchInfo to BranchItem array with sorting
+ */
+export function formatBranchItems(
+  branches: BranchInfo[],
+  worktreeMap: Map<string, WorktreeInfo> = new Map()
+): BranchItem[] {
+  const sortedBranches = sortBranches(branches, worktreeMap);
+  return sortedBranches.map((branch) => formatBranchItem(branch));
 }


### PR DESCRIPTION
## 概要

SPEC-a5ae4916で定義されたブランチ一覧のソート機能を実装しました。
ブランチが6段階の優先順位でソートされ、ユーザーが最も関連性の高いブランチに素早くアクセスできるようになります。

## ソート優先順位

1. **現在のブランチ** - 最優先で最上部に表示
2. **mainブランチ** - 2番目の優先度
3. **developブランチ** - mainが存在する場合のみ3番目の優先度
4. **worktree付きブランチ** - 作業中のブランチを優先表示
5. **ローカルブランチ** - リモートのみのブランチより優先
6. **名前順** - 同じ優先度内ではアルファベット昇順

## 変更内容

- **src/ui/utils/branchFormatter.ts**
  - `sortBranches` 関数を新規追加
  - `formatBranchItems` 関数に `worktreeMap` 引数を追加
  - 6段階のソートロジックを実装

- **src/ui/components/App.tsx**
  - worktreeMapを生成してformatBranchItemsに渡すように修正
  - useMemo依存配列にworktreesを追加

- **src/ui/__tests__/utils/branchFormatter.test.ts**
  - ソート機能の包括的なテストケースを追加（9個の新規テスト）
  - 既存のテストを修正してソート動作に対応

## テスト結果

✅ 全21テストが通過  
✅ ビルドエラーなし  
✅ 型チェックエラーなし

## 仕様書

- SPEC-a5ae4916: ブランチ一覧の表示順序改善
- 場所: `/specs/SPEC-a5ae4916/`

## 備考

- release/hotfixブランチは特別扱いせず、一般的な優先度ルールに従います
- mainブランチが存在しない場合、developブランチは特別扱いされません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブランチリスト表示が改善されました。現在のブランチとmain/developが優先表示され、ワークツリー情報も含まれるようになりました。

* **テスト**
  * ブランチフォーマッタのテストケースを拡張し、新しいソート動作を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->