### PR TITLE
docs: Update CLI help to reflect current options

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,7 +13,7 @@ Claude Code / Codex CLI 対応の対話型Gitワークツリーマネージャ�
 - 🎯 **対話型ブランチ選択**: ブランチ種別・ワークツリー・変更状態アイコンに加え配置インジケータ枠（左=L, 右=R, リモートのみ=☁）で所在を示し、リモート名の `origin/` を省いたシンプルなリストで判別しやすく、現在の選択は `>` プレフィックスで強調されるため誤操作を防止
 - 🌟 **スマートブランチ作成**: ガイド付きプロンプトと自動ベースブランチ選択でfeature、hotfix、releaseブランチを作成
 - 🔄 **高度なワークツリー管理**: 作成、クリーンアップ、パス最適化を含む完全なライフサイクル管理
-- 🤖 **AIツール選択**: 起動時に Claude Code / Codex CLI を選択、または `--tool` で直接指定（`--` 以降は各ツールへ引数パススルー）
+- 🤖 **AIツール選択**: 起動時の対話型ランチャーで Claude Code / Codex CLI を選択
 - 🚀 **AIツール統合**: 選択したツールをワークツリーで起動（Claude Codeは権限設定・変更処理の統合あり）
 - 📊 **GitHub PR統合**: マージされたプルリクエストのブランチとワークツリーの自動クリーンアップ
 - 🛠️ **変更管理**: 開発セッション後のコミット、stash、破棄の内蔵サポート
@@ -54,20 +54,10 @@ claude-worktree
 bunx @akiojin/claude-worktree
 ```
 
-### AIツール選択と直接指定
+CLIオプションは現在 `--help` のみサポートされています:
 
 ```bash
-# 対話的にツールを選ぶ（Claude / Codex）
-claude-worktree
-
-# 直接指定
-claude-worktree --tool claude
-claude-worktree --tool codex
-
-# ツール固有オプションを渡す（"--" 以降はツールへパススルー）
-claude-worktree --tool claude -- -r      # Claude Code を resume
-claude-worktree --tool codex -- resume --last  # Codex CLI の直近セッションを再開
-claude-worktree --tool codex -- resume <id>  # Codex CLI の特定セッションを再開
+claude-worktree --help
 ```
 
 ツールは以下のオプションを持つ対話型インターフェースを提供します:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Interactive Git worktree manager with AI tool selection (Claude Code / Codex CLI
 - 🖼️ **Full-screen Layout**: Persistent header with statistics, scrollable branch list, and always-visible footer with keyboard shortcuts
 - 🌟 **Smart Branch Creation**: Create feature, hotfix, or release branches with guided prompts and automatic base branch selection
 - 🔄 **Advanced Worktree Management**: Complete lifecycle management including creation, cleanup, and path optimization
-- 🤖 **AI Tool Selection**: Choose between Claude Code / Codex CLI at launch, or use `--tool` (with `--` to pass arguments through to the tool)
+- 🤖 **AI Tool Selection**: Choose between Claude Code / Codex CLI through the interactive launcher
 - 🚀 **AI Tool Integration**: Launch the selected tool in the worktree (Claude Code includes permission handling and post-change flow)
 - 📊 **GitHub PR Integration**: Automatic cleanup of merged pull request branches and worktrees
 - 🛠️ **Change Management**: Built-in support for committing, stashing, or discarding changes after development sessions
@@ -47,30 +47,21 @@ bunx @akiojin/claude-worktree
 
 Run in any Git repository:
 
-````bash
+```bash
 # If installed globally
 claude-worktree
 
 # Or use bunx for one-time execution
 bunx @akiojin/claude-worktree
+```
 
-### AI Tool Selection and Direct Launch
+The CLI currently supports only the help option:
 
 ```bash
-# Interactive selection (Claude / Codex)
-claude-worktree
+claude-worktree --help
+```
 
-# Direct selection
-claude-worktree --tool claude
-claude-worktree --tool codex
-
-# Pass tool-specific options (after "--")
-claude-worktree --tool claude -- -r          # Resume in Claude Code
-claude-worktree --tool codex -- resume --last  # Resume last Codex session
-claude-worktree --tool codex -- resume <id>  # Resume specific Codex session
-````
-
-````
+To view usage information, run `claude-worktree --help`.
 
 The tool presents an interactive interface with the following options:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -356,25 +356,16 @@ try {
 
 ## CLI Usage
 
-コマンドライン引数:
+現在サポートされているコマンドライン引数:
 
-- `-c, --continue`: 最後のセッションを継続
-- `-r, --resume`: セッションを選択して再開
-- `--tool <tool>`: AIツールを直接指定 (`claude-code` | `codex-cli`)
-- `-- <args>`: AIツールに渡す追加引数
+- `-h, --help`: ヘルプを表示
 
 **例:**
 
 ```bash
-# Claude Codeで新規ワークツリー作成
+# 対話型ランチャーを起動
 claude-worktree
 
-# 最後のセッションを継続
-claude-worktree -c
-
-# 特定のツールを指定
-claude-worktree --tool codex-cli
-
-# ツールに引数を渡す
-claude-worktree --tool claude-code -- --verbose
+# ヘルプを表示
+claude-worktree --help
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,23 +30,11 @@ Worktree Manager
 Usage: claude-worktree [options]
 
 Options:
-  -c              Continue from the last session (automatically open the last used worktree)
-  -r, --resume    Resume a session - interactively select from available sessions
-  --tool <name>   Select AI tool to launch in worktree (claude|codex)
   -h, --help      Show this help message
 
 Description:
   Interactive Git worktree manager with AI tool selection (Claude Code / Codex CLI) and graphical branch selection.
-
-  Without options: Opens the interactive menu to select branches and manage worktrees.
-  With -c option: Automatically continues from where you left off in the last session.
-  With -r option: Shows a list of recent sessions to choose from and resume.
-
-Pass-through:
-  Use "--" to pass additional args directly to the selected tool.
-  Examples:
-    claude-worktree --tool claude -- -r
-    claude-worktree --tool codex -- resume --last
+  Launch without additional options to open the interactive menu.
 `);
 }
 


### PR DESCRIPTION
## 概要
- 現行のCLIがサポートしない // 等の記述をヘルプ・ドキュメントから削除
- README (英/日) と API ドキュメントを更新して、 のみが利用可能であることを明示

## 動作確認
- 
Worktree Manager

Usage: claude-worktree [options]

Options:
  -c              Continue from the last session (automatically open the last used worktree)
  -r, --resume    Resume a session - interactively select from available sessions
  --tool <name>   Select AI tool to launch in worktree (claude|codex)
  -h, --help      Show this help message

Description:
  Interactive Git worktree manager with AI tool selection (Claude Code / Codex CLI) and graphical branch selection.

  Without options: Opens the interactive menu to select branches and manage worktrees.
  With -c option: Automatically continues from where you left off in the last session.
  With -r option: Shows a list of recent sessions to choose from and resume.

Pass-through:
  Use "--" to pass additional args directly to the selected tool.
  Examples:
    claude-worktree --tool claude -- -r
    claude-worktree --tool codex -- resume --last の表示内容がドキュメントと一致することを確認