### PR TITLE
Codex CLIのweb検索引数をweb_search_requestに更新

### DIFF
--- a/specs/SPEC-473b3d47/spec.md
+++ b/specs/SPEC-473b3d47/spec.md
@@ -243,7 +243,7 @@ Processing... ⠙
 
 #### Codex CLI起動設定
 
-- **FR-037**: システムは、Codex CLIを`bunx @openai/codex@latest`で起動する際に、次の引数を常に付与しなければならない：`--search`、`--model="gpt-5-codex"`、`--sandbox workspace-write`、`-c model_reasoning_effort="high"`、`-c model_reasoning_summaries="detailed"`、`-c sandbox_workspace_write.network_access=true`、`-c shell_environment_policy.inherit=all`、`-c shell_environment_policy.ignore_default_excludes=true`、`-c shell_environment_policy.experimental_use_profile=true`
+- **FR-037**: システムは、Codex CLIを`bunx @openai/codex@latest`で起動する際に、次の引数を常に付与しなければならない：`-c web_search_request=true`、`--model="gpt-5-codex"`、`--sandbox workspace-write`、`-c model_reasoning_effort="high"`、`-c model_reasoning_summaries="detailed"`、`-c sandbox_workspace_write.network_access=true`、`-c shell_environment_policy.inherit=all`、`-c shell_environment_policy.ignore_default_excludes=true`、`-c shell_environment_policy.experimental_use_profile=true`
 
 ### 主要エンティティ
 

--- a/specs/SPEC-c0deba7e/data-model.md
+++ b/specs/SPEC-c0deba7e/data-model.md
@@ -95,9 +95,9 @@ if (extraArgs) {
   args.push(...extraArgs);
 }
 
-args.push('--search');
+args.push('-c', 'web_search_request=true');
 
-// 最終コマンド: bunx @openai/codex@latest [args] --search
+// 最終コマンド: bunx @openai/codex@latest [args] -c web_search_request=true
 ```
 
 ---

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -6,7 +6,8 @@ import { createChildStdio, getTerminalStreams } from "./utils/terminal.js";
 
 const CODEX_CLI_PACKAGE = "@openai/codex@latest";
 const DEFAULT_CODEX_ARGS = [
-  "--search",
+  "-c",
+  "web_search_request=true",
   '--model="gpt-5-codex"',
   "--sandbox",
   "workspace-write",

--- a/tests/unit/codex.test.ts
+++ b/tests/unit/codex.test.ts
@@ -46,7 +46,8 @@ import { launchCodexCLI } from "../../src/codex";
 const mockExeca = execa as ReturnType<typeof vi.fn>;
 
 const DEFAULT_CODEX_ARGS = [
-  "--search",
+  "-c",
+  "web_search_request=true",
   '--model="gpt-5-codex"',
   "--sandbox",
   "workspace-write",


### PR DESCRIPTION
## 概要
- Codex CLI起動時のデフォルト引数をweb_search_requestに変更
- Spec Kitドキュメントの要件とデータモデルを同期
- 単体テストの期待値を更新

## テスト
- bun test
