### PR TITLE
style: 推奨メッセージの色をyellowに変更（警告として目立つように）

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -168,19 +168,19 @@ export async function launchClaudeCode(
           ),
         );
         console.log(
-          chalk.gray(
+          chalk.yellow(
             "   💡 Recommended: Install Claude Code via official method for faster startup",
           ),
         );
         console.log(
-          chalk.gray("      macOS/Linux: brew install --cask claude-code"),
+          chalk.yellow("      macOS/Linux: brew install --cask claude-code"),
         );
         console.log(
-          chalk.gray(
+          chalk.yellow(
             "      or: curl -fsSL https://claude.ai/install.sh | bash",
           ),
         );
-        console.log(chalk.gray(""));
+        console.log("");
         // Wait 2 seconds to let user read the message
         await new Promise((resolve) => setTimeout(resolve, 2000));
         await execa("bunx", [CLAUDE_CLI_PACKAGE, ...args], {


### PR DESCRIPTION
## Summary

bunxフォールバック時の公式インストール推奨メッセージの色を`gray`から`yellow`に変更し、警告として目立つようにしました。

### 変更内容

**変更前**:
```
   🔄 Falling back to bunx @anthropic-ai/claude-code@latest
   💡 Recommended: Install Claude Code via official method for faster startup  (gray)
      macOS/Linux: brew install --cask claude-code  (gray)
      or: curl -fsSL https://claude.ai/install.sh | bash  (gray)
```

**変更後**:
```
   🔄 Falling back to bunx @anthropic-ai/claude-code@latest
   💡 Recommended: Install Claude Code via official method for faster startup  (yellow)
      macOS/Linux: brew install --cask claude-code  (yellow)
      or: curl -fsSL https://claude.ai/install.sh | bash  (yellow)
```

### 変更理由

- grayではメッセージが目立たず、ユーザーが見落とす可能性がある
- yellowにすることで警告として認識しやすくなる
- bunxがフォールバック処理であることを明確に伝える
- 公式インストール方法の重要性を強調

### 技術詳細

#### 変更ファイル
- **src/claude.ts** (171-182行目):
  - `chalk.gray()` → `chalk.yellow()` に変更

### Test plan

- [x] ユニットテスト14件すべて通過
- [x] ビルド成功（`bun run build`）
- [x] フォーマット適用済み

### 関連PR

- #132: Claude Code自動検出機能
- #133: bunxフォールバック時に公式インストール方法を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)