### PR TITLE
feat: Claude CodeのPreToolUseフックでgitブランチ操作を禁止

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+(checkout|switch|branch)'; then echo '{\"decision\":\"block\",\"reason\":\"🚫 ブランチ切り替え・作成コマンドは禁止されています / Branch switching and creation commands are not allowed: '\"$cmd\"'\",\"stopReason\":\"Worktreeは起動したブランチで作業を完結させる設計です。git checkout、git switch、git branch 等のブランチ操作は実行できません。\\n\\nReason: Worktree is designed to complete work on the launched branch. Branch operations such as git checkout, git switch, and git branch cannot be executed.\"}'; exit 2; fi"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Claude CodeのPreToolUseフックを使用して、gitブランチ切り替え・作成コマンドを技術的に禁止する機能を実装しました。

## Changes

- `.claude/settings.json` に PreToolUseフックを追加
- Bashツールで実行される `git checkout`、`git switch`、`git branch` コマンドを検出してブロック
- 日英バイリンガルのエラーメッセージでWorktree設計思想を明示

## Motivation

CLAUDE.mdに記載されている以下のルールを技術的に強制するため：

> **ブランチ切り替えは絶対禁止。`git checkout`、`git switch`、`git branch -f` 等のブランチ切り替えコマンドの実行は一切認めない。Worktreeは起動したブランチで作業を完結させる設計である。**

これまでは開発ガイドラインとしてのみ記載されていましたが、Claude Codeが誤ってブランチ操作を試みた際に自動的にブロックされるようになります。

## Technical Details

### フックの仕組み

- **トリガー**: PreToolUse（Bashツール実行前）
- **検出パターン**: 正規表現 `git\s+(checkout|switch|branch)`
- **ブロック方法**: exit code 2 + JSON応答（decision: "block"）

### ブロック対象コマンド

- `git checkout` （全オプション）
- `git switch` （全オプション）
- `git branch` （作成・削除・変更含む）
- `git checkout -b/-B` （新規ブランチ作成）
- `git switch -c/-C` （新規ブランチ作成）
- `git branch -f/-F/--force` （強制変更）
- `git branch -d/-D` （削除）
- `git branch -m/-M` （リネーム）

### エラーメッセージ例

```
🚫 ブランチ切り替え・作成コマンドは禁止されています / Branch switching and creation commands are not allowed: git checkout main

Worktreeは起動したブランチで作業を完結させる設計です。git checkout、git switch、git branch 等のブランチ操作は実行できません。

Reason: Worktree is designed to complete work on the launched branch. Branch operations such as git checkout, git switch, and git branch cannot be executed.
```

## Test Plan

- [x] `.claude/settings.json` の構文チェック（jq validation）
- [x] 設定ファイルのJSON構造確認
- [ ] 実際にClaude Codeで `git checkout` を試みてブロックされることを確認
- [ ] 許可されるgitコマンド（`git status`、`git add`、`git commit` など）は正常に実行できることを確認

## Related

- CLAUDE.md: 開発ワークフロー > 基本ルール
- Claude Code Hooks機能: https://docs.claude.com/en/docs/claude-code/hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)