### PR TITLE
ci: releaseコミットをcommitlintチェック対象外に

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  ignores: [(message) => message.startsWith("chore(release):")],
   rules: {
     "subject-empty": [2, "never"],
     "subject-max-length": [2, "always", 100],


### PR DESCRIPTION
## 概要
- commitlint が semantic-release が生成する `chore(release): ...` コミットの本文長で失敗する問題を修正
- commitlint に release コミットを無視する ignore ルールを追加

## 背景
- リリース Run: https://github.com/akiojin/claude-worktree/actions/runs/19107703493
- `body-max-line-length` 違反で commit-msg フックが失敗し semantic-release が停止

## テスト
- bun run test src/ui/__tests__/components/common/LoadingIndicator.test.tsx
- bun run test
- bunx --bun markdownlint-cli "**/*.md" --config .markdownlint.json --ignore-path .markdownlintignore
- ※CI成否はマージ後の release ワークフローで確認予定
