### PR TITLE
fix: authenticate gh before enabling auto merge

### DIFF
--- a/.github/workflows/auto-enable-automerge.yml
+++ b/.github/workflows/auto-enable-automerge.yml
@@ -34,6 +34,13 @@ jobs:
             echo "token=$AUTO_MERGE_TOKEN" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Authenticate GitHub CLI
+        if: steps.token.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          echo "$GH_TOKEN" | gh auth login --with-token --hostname github.com
+
       - name: Skip when auto-merge already enabled
         id: check
         if: steps.token.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- log in the GitHub CLI within the workflow using the provided token before calling gh commands

## Testing
- n/a