### PR TITLE
fix: ブランチ作成中の待機表示を改善

### DIFF
--- a/src/ui/__tests__/components/screens/BranchCreatorScreen.test.tsx
+++ b/src/ui/__tests__/components/screens/BranchCreatorScreen.test.tsx
@@ -1,25 +1,31 @@
 /**
  * @vitest-environment happy-dom
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render as rtlRender, act } from '@testing-library/react';
 import React from 'react';
 import { BranchCreatorScreen } from '../../../components/screens/BranchCreatorScreen.js';
 import { Window } from 'happy-dom';
+import { render as inkRender } from 'ink-testing-library';
 
 describe('BranchCreatorScreen', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     // Setup happy-dom
     const window = new Window();
     globalThis.window = window as any;
     globalThis.document = window.document as any;
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should render header with title', () => {
     const onBack = vi.fn();
-    const onCreate = vi.fn();
-    const { getByText } = render(
-      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} />
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { getByText } = rtlRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
     );
 
     expect(getByText(/New Branch/i)).toBeDefined();
@@ -27,9 +33,9 @@ describe('BranchCreatorScreen', () => {
 
   it('should render branch type selection initially', () => {
     const onBack = vi.fn();
-    const onCreate = vi.fn();
-    const { getByText } = render(
-      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} />
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { getByText } = rtlRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
     );
 
     expect(getByText(/Select branch type/i)).toBeDefined();
@@ -40,9 +46,9 @@ describe('BranchCreatorScreen', () => {
 
   it('should render footer with actions', () => {
     const onBack = vi.fn();
-    const onCreate = vi.fn();
-    const { getAllByText } = render(
-      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} />
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { getAllByText } = rtlRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
     );
 
     expect(getAllByText(/enter/i).length).toBeGreaterThan(0);
@@ -51,9 +57,9 @@ describe('BranchCreatorScreen', () => {
 
   it('should show branch name input after type selection', () => {
     const onBack = vi.fn();
-    const onCreate = vi.fn();
-    const { container } = render(
-      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} />
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { container } = rtlRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
     );
 
     // Test will verify the screen transitions from type selection to name input
@@ -62,9 +68,9 @@ describe('BranchCreatorScreen', () => {
 
   it('should handle branch creation', () => {
     const onBack = vi.fn();
-    const onCreate = vi.fn();
-    const { container } = render(
-      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} />
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { container } = rtlRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
     );
 
     // Test will verify onCreate is called with correct branch name
@@ -76,9 +82,9 @@ describe('BranchCreatorScreen', () => {
     process.stdout.rows = 30;
 
     const onBack = vi.fn();
-    const onCreate = vi.fn();
-    const { container } = render(
-      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} />
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { container } = rtlRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
     );
 
     expect(container).toBeDefined();
@@ -88,12 +94,122 @@ describe('BranchCreatorScreen', () => {
 
   it('should handle back navigation with ESC key', () => {
     const onBack = vi.fn();
-    const onCreate = vi.fn();
-    const { container } = render(
-      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} />
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { container } = rtlRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
     );
 
     // Test will verify onBack is called when ESC is pressed
     expect(container).toBeDefined();
+  });
+
+  it('should display creating state while waiting for branch creation', async () => {
+    expect.assertions(3);
+    const onBack = vi.fn();
+    let resolveCreate: (() => void) | null = null;
+    const onCreate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCreate = resolve;
+        })
+    );
+    const { stdin, lastFrame } = inkRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
+    );
+
+    // Select default branch type (feature)
+    await act(async () => {
+      stdin.write('\r');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const branchName = 'new-branch';
+    for (const char of branchName) {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Submit branch name
+    await act(async () => {
+      stdin.write('\r');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onCreate).toHaveBeenCalledWith(`feature/${branchName}`);
+    expect(lastFrame()).toContain('Creating branch');
+    expect(lastFrame()).toContain(`feature/${branchName}`);
+
+    await act(async () => {
+      resolveCreate?.();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it('should ignore ESC input while branch creation is in progress', async () => {
+    expect.assertions(2);
+    const onBack = vi.fn();
+    let resolveCreate: (() => void) | null = null;
+    const onCreate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCreate = resolve;
+        })
+    );
+    const { stdin, lastFrame } = inkRender(
+      <BranchCreatorScreen onBack={onBack} onCreate={onCreate} disableAnimation />
+    );
+
+    // Move to name input
+    await act(async () => {
+      stdin.write('\r');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const branchName = 'blocking-branch';
+    for (const char of branchName) {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Attempt to cancel with ESC during creation
+    await act(async () => {
+      stdin.write('\u001B');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onBack).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('Creating branch');
+
+    await act(async () => {
+      resolveCreate?.();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
   });
 });


### PR DESCRIPTION
## 概要
- BranchCreatorScreenでブランチ作成中の進行状況表示とESCロックを追加
- onCreateをPromise対応に変更しテスト用disableAnimationフラグを導入
- Inkテストを拡充して進行中表示と入力ロックを検証

## テスト
- bun test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * ブランチ作成時にローディング表示を追加
  * アニメーション制御オプションを実装

* **改善**
  * ブランチ作成中の入力操作を制限し、ユーザーエクスペリエンスを向上

* **テスト**
  * ブランチ作成画面のテストケースを拡張

<!-- end of auto-generated comment: release notes by coderabbit.ai -->