### PR TITLE
fix: エラー発生時の入力待機処理を追加

### DIFF
--- a/bin/claude-worktree.js
+++ b/bin/claude-worktree.js
@@ -15,10 +15,53 @@ async function resolveEntry() {
   return pathToFileURL(srcEntry).href;
 }
 
+async function waitForEnter() {
+  const { stdin, stdout } = process;
+
+  if (!stdin || !stdin.isTTY) {
+    return;
+  }
+
+  if (typeof stdin.setRawMode === "function") {
+    try {
+      stdin.setRawMode(false);
+    } catch {
+      // ignore raw mode reset errors
+    }
+  }
+
+  await new Promise((resolve) => {
+    const cleanup = () => {
+      stdin.removeListener("data", onData);
+      if (typeof stdin.pause === "function") {
+        stdin.pause();
+      }
+    };
+
+    const onData = (chunk) => {
+      const data =
+        typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      if (data.includes("\n") || data.includes("\r")) {
+        cleanup();
+        resolve();
+      }
+    };
+
+    stdout?.write?.("\nエラー内容を確認したら Enter キーを押してください。\n");
+
+    if (typeof stdin.resume === "function") {
+      stdin.resume();
+    }
+
+    stdin.on("data", onData);
+  });
+}
+
 const entry = await resolveEntry();
 const { main } = await import(entry);
 
-main().catch((error) => {
+main().catch(async (error) => {
   console.error("Error:", error.message);
+  await waitForEnter();
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- エラー発生時に必ずユーザー入力を待機するハンドリングを追加
- CLI起動直後に失敗した場合でもメッセージを確認できるように調整

## Testing
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エラー発生時にユーザーの確認待機機能を実装し、統一されたエラーハンドリングフローを構築しました

* **改善**
  * エラーメッセージの表示と対応が一貫性を持つよう改善しました
  * 日本語でのエラープロンプト表示に対応しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->