### PR TITLE
refactor: ブランチ作成時のベースブランチ解決ロジックを改善

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -15,7 +15,7 @@ import { useGitData } from '../hooks/useGitData.js';
 import { useScreenState } from '../hooks/useScreenState.js';
 import { formatBranchItems } from '../utils/branchFormatter.js';
 import { calculateStatistics } from '../utils/statisticsCalculator.js';
-import type { BranchItem } from '../types.js';
+import type { BranchItem, SelectedBranchState } from '../types.js';
 import { getRepositoryRoot, deleteBranch } from '../../git.js';
 import {
   createWorktree,
@@ -24,6 +24,10 @@ import {
   removeWorktree,
 } from '../../worktree.js';
 import { getPackageVersion } from '../../utils.js';
+import {
+  resolveBaseBranchLabel,
+  resolveBaseBranchRef,
+} from '../utils/baseBranch.js';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧'];
 const COMPLETION_HOLD_DURATION_MS = 3000;
@@ -51,13 +55,6 @@ export interface AppProps {
   loadingIndicatorDelay?: number;
 }
 
-interface SelectedBranchState {
-  name: string;
-  displayName: string;
-  branchType: 'local' | 'remote';
-  remoteBranch?: string;
-}
-
 /**
  * App - Top-level component for Ink.js UI
  * Integrates ErrorBoundary, data fetching, screen navigation, and all screens
@@ -74,6 +71,7 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
 
   // Selection state (for branch → tool → mode flow)
   const [selectedBranch, setSelectedBranch] = useState<SelectedBranchState | null>(null);
+  const [creationSourceBranch, setCreationSourceBranch] = useState<SelectedBranchState | null>(null);
   const [selectedTool, setSelectedTool] = useState<AITool | null>(null);
 
   // PR cleanup feedback
@@ -223,6 +221,11 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
     return 'main';
   }, [branches]);
 
+  const baseBranchLabel = useMemo(
+    () => resolveBaseBranchLabel(creationSourceBranch, selectedBranch, resolveBaseBranch),
+    [creationSourceBranch, resolveBaseBranch, selectedBranch]
+  );
+
   // Handle branch selection
   const toLocalBranchName = useCallback((remoteName: string) => {
     const segments = remoteName.split('/');
@@ -282,8 +285,9 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
   }, [navigateTo]);
 
   const handleCreateNewBranch = useCallback(() => {
+    setCreationSourceBranch(selectedBranch);
     navigateTo('branch-creator');
-  }, [navigateTo]);
+  }, [navigateTo, selectedBranch]);
 
   // Handle quit
   const handleQuit = useCallback(() => {
@@ -298,7 +302,11 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
         const repoRoot = await getRepositoryRoot();
         const worktreePath = await generateWorktreePath(repoRoot, branchName);
         // Use selectedBranch as base if available, otherwise resolve from repo
-        const baseBranch = selectedBranch?.name ?? resolveBaseBranch();
+        const baseBranch = resolveBaseBranchRef(
+          creationSourceBranch,
+          selectedBranch,
+          resolveBaseBranch,
+        );
 
         await createWorktree({
           branchName,
@@ -309,6 +317,7 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
         });
 
         refresh();
+        setCreationSourceBranch(null);
         setSelectedBranch({
           name: branchName,
           displayName: branchName,
@@ -324,7 +333,14 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
         refresh();
       }
     },
-    [navigateTo, goBack, refresh, resolveBaseBranch, selectedBranch]
+    [
+      navigateTo,
+      goBack,
+      refresh,
+      resolveBaseBranch,
+      selectedBranch,
+      creationSourceBranch,
+    ]
   );
 
   const handleCleanupCommand = useCallback(async () => {
@@ -556,7 +572,7 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
           <BranchCreatorScreen
             onBack={goBack}
             onCreate={handleCreate}
-            {...(selectedBranch?.displayName && { baseBranch: selectedBranch.displayName })}
+            baseBranch={baseBranchLabel}
             version={version}
           />
         );

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -67,6 +67,13 @@ export interface BranchGroup {
   priority: number;
 }
 
+export interface SelectedBranchState {
+  name: string;
+  displayName: string;
+  branchType: "local" | "remote";
+  remoteBranch?: string;
+}
+
 export interface UIFilter {
   showWithWorktree: boolean;
   showWithoutWorktree: boolean;

--- a/src/ui/utils/baseBranch.ts
+++ b/src/ui/utils/baseBranch.ts
@@ -1,0 +1,32 @@
+import type { SelectedBranchState } from "../types.js";
+
+function getBranchRef(branch: SelectedBranchState | null | undefined): string | null {
+  if (!branch) {
+    return null;
+  }
+  return branch.remoteBranch ?? branch.name;
+}
+
+export function resolveBaseBranchRef(
+  creationSource: SelectedBranchState | null,
+  selectedBranch: SelectedBranchState | null,
+  resolveDefault: () => string,
+): string {
+  return (
+    getBranchRef(creationSource) ??
+    getBranchRef(selectedBranch) ??
+    resolveDefault()
+  );
+}
+
+export function resolveBaseBranchLabel(
+  creationSource: SelectedBranchState | null,
+  selectedBranch: SelectedBranchState | null,
+  resolveDefault: () => string,
+): string {
+  return (
+    creationSource?.displayName ??
+    selectedBranch?.displayName ??
+    resolveDefault()
+  );
+}

--- a/tests/unit/utils/baseBranch.test.ts
+++ b/tests/unit/utils/baseBranch.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  resolveBaseBranchRef,
+  resolveBaseBranchLabel,
+} from "../../../src/ui/utils/baseBranch.js";
+import type { SelectedBranchState } from "../../../src/ui/types.js";
+
+const localBranch: SelectedBranchState = {
+  name: "feature/feature1",
+  displayName: "feature/feature1",
+  branchType: "local",
+};
+
+const remoteBranch: SelectedBranchState = {
+  name: "feature/feature1",
+  displayName: "origin/feature/feature1",
+  branchType: "remote",
+  remoteBranch: "origin/feature/feature1",
+};
+
+describe("resolveBaseBranchRef", () => {
+  it("prefers creation source branch reference when available", () => {
+    const fallback = vi.fn(() => "develop");
+
+    const result = resolveBaseBranchRef(localBranch, null, fallback);
+
+    expect(result).toBe("feature/feature1");
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("uses remote reference when creation source branch tracks a remote", () => {
+    const fallback = vi.fn(() => "develop");
+
+    const result = resolveBaseBranchRef(remoteBranch, null, fallback);
+
+    expect(result).toBe("origin/feature/feature1");
+  });
+
+  it("falls back to selected branch when creation source is null", () => {
+    const fallback = vi.fn(() => "develop");
+
+    const result = resolveBaseBranchRef(null, remoteBranch, fallback);
+
+    expect(result).toBe("origin/feature/feature1");
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("uses default resolver when no branch information is available", () => {
+    const fallback = vi.fn(() => "develop");
+
+    const result = resolveBaseBranchRef(null, null, fallback);
+
+    expect(result).toBe("develop");
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveBaseBranchLabel", () => {
+  it("prefers creation source label when provided", () => {
+    const fallback = vi.fn(() => "develop");
+
+    const result = resolveBaseBranchLabel(localBranch, remoteBranch, fallback);
+
+    expect(result).toBe("feature/feature1");
+  });
+
+  it("falls back to selected branch label when creation source is null", () => {
+    const fallback = vi.fn(() => "develop");
+
+    const result = resolveBaseBranchLabel(null, remoteBranch, fallback);
+
+    expect(result).toBe("origin/feature/feature1");
+  });
+
+  it("falls back to default label when neither branch is available", () => {
+    const fallback = vi.fn(() => "develop");
+
+    const result = resolveBaseBranchLabel(null, null, fallback);
+
+    expect(result).toBe("develop");
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `SelectedBranchState`型をtypes.tsに移動して再利用性を向上
- ベースブランチ解決ロジックを専用ユーティリティ関数に分離
- `creationSourceBranch`状態を導入し、ブランチ作成元を明示的に追跡
- `resolveBaseBranchRef`と`resolveBaseBranchLabel`関数を実装
- ユニットテストを追加してロジックの正確性を保証

## 変更内容

### 型定義の整理
- `SelectedBranchState`インターフェースをApp.tsxからtypes.tsに移動し、プロジェクト全体で再利用可能に

### 新規ユーティリティ関数
- `src/ui/utils/baseBranch.ts`を新規作成
  - `resolveBaseBranchRef`: ブランチ作成時のベースブランチ参照を解決
  - `resolveBaseBranchLabel`: ブランチ作成画面に表示するラベルを解決

### 状態管理の改善
- `creationSourceBranch`状態を追加し、ブランチ作成画面に遷移する前に選択されたブランチを保存
- より正確なベースブランチ解決フローを実現

### テストカバレッジ
- `tests/unit/utils/baseBranch.test.ts`を追加
- 7つのテストケースで各種シナリオをカバー

## Test plan

- [x] ビルドが成功することを確認 (`bun run build`)
- [x] ユニットテストが全て通過することを確認 (`bun test`)
- [x] TypeScriptのコンパイルエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)