### PR TITLE
chore: develop-to-main初回リリースマージ

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,31 @@
+# Release Command
+
+developブランチの変更をmainブランチにマージし、semantic-releaseによる自動リリースを実行します。
+
+## 実行手順
+
+1. GitHub Actions workflow_dispatchでrelease-triggerワークフローを起動します
+2. gh CLIコマンドを使用: `gh workflow run release-trigger.yml --ref develop -f confirm=release`
+3. ワークフロー実行状態を監視し、ユーザーに結果を報告します
+
+## 実行内容
+
+release-triggerワークフローは以下を自動実行します:
+
+1. developブランチをチェックアウト
+2. developをmainにマージ（可能ならfast-forward、不可能ならmerge commit作成）
+3. mainへpush
+4. mainへのpushトリガーでReleaseワークフローが自動起動
+5. Releaseワークフローがsemantic-releaseを実行:
+   - バージョン判定
+   - CHANGELOG.md生成
+   - npm公開
+   - GitHubリリース作成
+   - package.jsonとCHANGELOG.mdをコミット
+
+## 注意事項
+
+- このコマンドはdevelopブランチで実行する必要があります
+- developとmainに競合がある場合、マージコミットが作成されます
+- リリース可能なコミットがない場合、semantic-releaseは何もしません
+- リリースには`SEMANTIC_RELEASE_TOKEN`と`NPM_TOKEN`のシークレットが必要です

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -1,0 +1,69 @@
+name: Release Trigger
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'release' to confirm release"
+        required: true
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-and-release:
+    name: Merge develop to main
+    runs-on: ubuntu-latest
+    if: github.event.inputs.confirm == 'release'
+
+    steps:
+      - name: Checkout develop branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+
+      - name: Configure git credentials
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+        run: |
+          if [ -z "$GH_RELEASE_TOKEN" ]; then
+            echo "SEMANTIC_RELEASE_TOKEN secret is not configured"
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
+
+      - name: Fetch main branch
+        run: |
+          git fetch origin main:main
+
+      - name: Merge develop into main
+        run: |
+          git checkout main
+          git merge --ff-only develop || {
+            echo "Fast-forward merge failed. Creating merge commit..."
+            git merge develop --no-ff -m "chore: merge develop into main for release"
+          }
+
+      - name: Push to main
+        run: |
+          git push origin main
+          echo "Successfully pushed to main. Release workflow will be triggered automatically."
+
+      - name: Summary
+        run: |
+          echo "## Release Triggered" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "develop branch has been merged into main." >> $GITHUB_STEP_SUMMARY
+          echo "The Release workflow will now automatically:" >> $GITHUB_STEP_SUMMARY
+          echo "- Run tests and build" >> $GITHUB_STEP_SUMMARY
+          echo "- Execute semantic-release" >> $GITHUB_STEP_SUMMARY
+          echo "- Publish to npm" >> $GITHUB_STEP_SUMMARY
+          echo "- Create GitHub release" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check the [Release workflow](https://github.com/${{ github.repository }}/actions/workflows/release.yml) for progress." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,6 @@ name: Release
 on:
   push:
     branches: [main]
-  workflow_run:
-    workflows: ["Auto Merge"]
-    types:
-      - completed
 
 permissions:
   contents: write
@@ -18,11 +14,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main')
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,14 @@
 
 - README.mdには設計などは書いてはいけない。プロジェクトの説明やディレクトリ構成などの説明のみに徹底する。設計などは、適切なファイルへのリンクを書く。
 
+## リリースワークフロー
+
+- リリースは develop → main への手動マージでトリガーされる
+- feature/* ブランチは develop へマージ（Auto Merge）
+- develop での蓄積後、`/release` コマンドで develop → main マージ＋リリース実行
+- リリースコマンド: Claude Code で `/release` 実行、または `gh workflow run release-trigger.yml --ref develop -f confirm=release`
+- mainブランチへのpush時に semantic-release が自動実行され、npm公開とGitHubリリースを作成
+
 ## 最近の変更
 
 ### 2025-01-06: Codex CLI対応機能の計画
@@ -79,3 +87,9 @@
 - worktree起動時にClaude CodeとCodex CLIを選択可能にする機能を計画中
 - 詳細: `/specs/001-codex-cli-worktree/`
 - 技術スタック: Bun 1.0+, TypeScript, inquirer（必要に応じてNode.js 18+を併用）
+
+### 2025-01-06: リリースフロー変更
+
+- develop ブランチを導入し、手動リリースフローに移行
+- feature → develop (Auto Merge) → /release → main → リリース
+- 詳細: `.github/workflows/release-trigger.yml`, `.claude/commands/release.md`

--- a/README.ja.md
+++ b/README.ja.md
@@ -105,15 +105,16 @@ claude-worktree -v
 - **自動マージ**: すべてのCIチェック（Test、Lint）が成功し、競合がない場合、PRを自動的にマージ
 - **マージ方法**: マージコミットを使用して完全なコミット履歴を保持
 - **スマートスキップロジック**: ドラフトPR、競合のあるPR、CI失敗時は自動的にスキップ
-- **対象ブランチ**: `main`および`develop`ブランチへのPRで有効
+- **対象ブランチ**: `develop`ブランチへのPRで有効（機能統合）
 - **安全第一**: ブランチ保護ルールを尊重し、CI成功を必須条件とする
 
 **動作の仕組み:**
 
-1. `main`または`develop`を対象とするPRを作成
+1. `develop`を対象とするPRを作成
 2. CIワークフロー（Test、Lint）が自動実行
-3. すべてのCIチェックが成功し、競合がない場合、PRが自動的にマージされる
-4. 手動介入は不要 - PRを作成してCIに任せるだけ
+3. すべてのCIチェックが成功し、競合がない場合、PRが自動的に`develop`にマージされる
+4. 変更は`develop`に蓄積され、リリース準備ができるまで待機
+5. `/release`コマンドを使用して`develop`を`main`にマージし、semantic-releaseをトリガー
 
 **自動マージの無効化:**
 
@@ -269,6 +270,139 @@ bun run start
   }
 }
 ```
+
+## リリースプロセス
+
+このプロジェクトは **semantic-release** を使用して、自動的なバージョン管理、CHANGELOG生成、npm公開を行っています。リリースプロセスは develop-to-main ワークフローに従い、準備ができたタイミングで手動でトリガーされます。
+
+### リリースワークフロー
+
+```
+feature/* → PR → develop (自動マージ) → テスト/ビルド
+                                        ↓ (手動トリガー)
+                             /release コマンド → develop→main → リリース
+```
+
+### リリースの仕組み
+
+1. **開発**: featureブランチを作成し、PRを通じて`develop`にマージ
+2. **自動マージ**: CIが成功すると、PRは自動的に`develop`にマージされる
+3. **テスト**: `develop`ブランチで変更がテスト・ビルドされる
+4. **手動リリース**: リリース準備ができたら、Claude Codeで`/release`コマンドを実行
+5. **自動処理**: リリースワークフローが以下を実行:
+   - `develop`を`main`にマージ
+   - テストとビルドを実行
+   - semantic-releaseがコミットを分析してバージョンを決定
+     - `feat:` → マイナーバージョン (1.0.0 → 1.1.0)
+     - `fix:` → パッチバージョン (1.0.0 → 1.0.1)
+     - `BREAKING CHANGE:` → メジャーバージョン (1.0.0 → 2.0.0)
+   - CHANGELOG.mdを生成
+   - npmレジストリに公開
+   - リリースノート付きのGitHubリリースを作成
+
+### Conventional Commits
+
+semantic-releaseはコミットメッセージを使用してリリースタイプを決定します:
+
+| タイプ                                                | 説明         | バージョンへの影響        |
+| ----------------------------------------------------- | ------------ | ------------------------- |
+| `feat:`                                               | 新機能       | マイナー (1.0.0 → 1.1.0)  |
+| `fix:`                                                | バグ修正     | パッチ (1.0.0 → 1.0.1)    |
+| `BREAKING CHANGE:`                                    | 破壊的変更   | メジャー (1.0.0 → 2.0.0)  |
+| `chore:`, `docs:`, `style:`, `refactor:`, `test:`    | リリースなし | -                         |
+
+**コミット例**:
+
+```bash
+# 機能追加（マイナーリリース）
+git commit -m "feat: セッション管理機能を追加"
+
+# バグ修正（パッチリリース）
+git commit -m "fix: Dockerパス処理の問題を解決"
+
+# 破壊的変更（メジャーリリース）
+git commit -m "feat!: Bun 1.0+を必須に
+
+BREAKING CHANGE: npxサポートを削除、bunxが必須"
+```
+
+### 設定ファイル
+
+#### .releaserc.json
+
+semantic-releaseの設定ファイルはリリースプロセスを定義します:
+
+```json
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/git",
+    "@semantic-release/github"
+  ]
+}
+```
+
+詳細な設定仕様については、[specs/SPEC-23bb2eed/data-model.md](./specs/SPEC-23bb2eed/data-model.md)を参照してください。
+
+#### GitHub Actionsワークフロー
+
+**リリーストリガーワークフロー** (`.github/workflows/release-trigger.yml`)
+
+`develop`を`main`にマージする手動トリガーワークフロー:
+
+- `/release`コマンド（Claude Code）または`gh workflow run release-trigger.yml --ref develop -f confirm=release`で起動
+- `develop`ブランチを`main`にマージ（可能ならfast-forward、不可能ならマージコミット）
+- `main`へpushし、Releaseワークフローをトリガー
+
+**リリースワークフロー** (`.github/workflows/release.yml`)
+
+`main`にコミットがpushされたときに自動実行:
+
+1. テストを実行 (`bun run test`)
+2. プロジェクトをビルド (`bun run build`)
+3. semantic-releaseを実行（バージョン、CHANGELOG、公開）
+
+> **必要なシークレット:**
+> - `NPM_TOKEN` – `automation`スコープを持つnpm公開トークン
+> - `SEMANTIC_RELEASE_TOKEN` – `repo`スコープを持つGitHub個人アクセストークン（classic）。シークレット登録後、トークン所有ユーザー、または「Allow GitHub Actions to bypass branch protection」を`main`ブランチ保護ルールに設定し、リリースコミットのpushが拒否されないようにしてください。シークレットが存在しない場合、ワークフローは早期に失敗します。
+
+### /releaseコマンドの使用
+
+Claude Codeからリリースプロセスを実行:
+
+1. `develop`ブランチ、またはClaude Codeコマンドにアクセスできる任意のブランチにいることを確認
+2. `/release`コマンドを実行
+3. Claude CodeがGitHub Actionsワークフローをトリガー
+4. GitHub Actions UIでワークフローの進行状況を監視
+5. semantic-releaseがリリース可能なコミットを検出すると、自動的にリリースが公開される
+
+または、gh CLIで手動トリガー:
+
+```bash
+gh workflow run release-trigger.yml --ref develop -f confirm=release
+```
+
+### 手動検証
+
+リリース設定をローカルで検証するには:
+
+```bash
+# 設定をテストするためのドライラン
+node node_modules/semantic-release/bin/semantic-release.js --dry-run
+```
+
+> **注意:** semantic-release v25はプロジェクト自体がBunを使用している場合でもNode.js 22.14+を必要とします。GitHub Actionsワークフローは自動的にこのバージョンをインストールします。上記コマンドを実行する前にローカルでも同じバージョンを使用してください。
+
+### リソース
+
+- [semantic-releaseドキュメント](https://semantic-release.gitbook.io/)
+- [Conventional Commits仕様](https://www.conventionalcommits.org/)
+- [リリースプロセスガイド](./specs/SPEC-23bb2eed/quickstart.md)
 
 ## トラブルシューティング
 

--- a/specs/SPEC-23bb2eed/tasks.md
+++ b/specs/SPEC-23bb2eed/tasks.md
@@ -1,10 +1,20 @@
 ---
-description: "SPEC-23bb2eed実装のためのタスクリスト: semantic-release 設定明示化"
+description: "SPEC-23bb2eed実装のためのタスクリスト: develop-to-main手動リリースフロー"
+status: "✅ 実装完了（2025-01-06）"
 ---
 
-# タスク: semantic-release 設定明示化（現状維持アプローチ）
+# タスク: develop-to-main手動リリースフロー（2025-01-06実装済み）
 
-**入力**: `/specs/SPEC-23bb2eed/` からの設計ドキュメント
+**注**: このタスクリストは旧仕様（semantic-release設定明示化）に基づいています。実際には2025-01-06にdevelop-to-main手動リリースフローとして実装完了しました。
+
+**実装済み内容**:
+- developブランチ作成
+- release-trigger.ymlワークフロー作成
+- /releaseスラッシュコマンド作成
+- release.ymlワークフロー修正（mainプッシュのみトリガー）
+- ドキュメント更新（README.md、README.ja.md、CLAUDE.md）
+
+**入力**: `/specs/SPEC-23bb2eed/` からの設計ドキュメント（2025-01-06更新）
 **前提条件**: plan.md、spec.md、research.md、data-model.md、quickstart.md
 
 **構成**: タスクは実装の論理的な順序でグループ化され、各段階の独立した実装とテストを可能にします。


### PR DESCRIPTION
## 概要

develop-to-main手動リリースフローの初回リリースとして、developブランチをmainにマージします。

## マージ後の動作

このPRがmainにマージされると、以下が自動実行されます：

1. **Releaseワークフロー起動**: mainへのpushがトリガー
2. **semantic-release実行**: コミット解析とバージョン判定
3. **npm公開**: 新バージョンの公開
4. **GitHubリリース作成**: リリースノート自動生成
5. **CHANGELOG更新**: mainブランチにコミット

## 含まれる変更

### 実装（PR #165からdevelopにマージ済み）
- ✅ developブランチ作成
- ✅ release-trigger.ymlワークフロー作成
- ✅ /releaseスラッシュコマンド作成
- ✅ release.ymlワークフロー修正
- ✅ ドキュメント更新
- ✅ Spec Kit仕様更新

### リリース予定の変更
- `feat: develop-to-main手動リリースフローの実装`
- `docs: SPEC-23bb2eedを手動リリースフロー仕様に更新`
- `chore: 開発環境をnpmからpnpmに移行`（PR #164）

## 注意事項

- これは初回リリースのため、手動でPRを作成・マージします
- 次回以降は`/release`コマンドでリリース可能になります
- semantic-releaseがfeat:コミットを検出するため、minorバージョンアップが予想されます

## チェックリスト

- [x] developブランチのCI成功確認
- [x] Spec Kit仕様整備完了
- [x] ドキュメント更新完了
- [ ] mainマージ後のsemantic-release実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 手動リリース機能を追加。`/release`コマンドでリリースを トリガー可能に
  * 開発ブランチ導入。機能ブランチから開発ブランチへの自動マージを実装

* **Documentation**
  * リリースワークフローに関するドキュメントを拡充
  * PRの対象ブランチを開発ブランチに統一。リリースプロセスを明文化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->