### PR TITLE
test: cover protected branch navigation

### DIFF
--- a/specs/SPEC-4e948b89/tasks.md
+++ b/specs/SPEC-4e948b89/tasks.md
@@ -7,10 +7,10 @@
 
 - [x] T101 [P] [US2] `tests/unit/worktree.test.ts` に保護ブランチ拒否の失敗テストを追加（main/develop/master）
 - [x] T102 [P] [US1] `src/ui/screens/__tests__/BranchActionSelectorScreen.test.tsx` に保護ブランチで「Create new branch」が表示されないテストを追加
-- [ ] T103 [ ] [US1] `tests/ui/__tests__/integration/navigation.test.tsx` に保護ブランチ選択時の遷移テストを追加（Codex 2025-11-06 着手予定）
+- [x] T103 [ ] [US1] `tests/ui/__tests__/integration/navigation.test.tsx` に保護ブランチ選択時の遷移テストを追加（Codex 2025-11-07 完了）
 - [x] T104 [ ] [US2] `src/worktree.ts` の `createWorktree` に保護ブランチチェックを実装
 - [x] T105 [ ] [US1] `src/ui/components/App.tsx` と `BranchActionSelectorScreen.tsx` を更新し、遷移/表示ロジックを修正（警告メッセージ含む）※Codex 2025-11-06 完了
 - [x] T106 [ ] [US1] 追加したUIメッセージのスナップショット/表示検証を調整し、関連テストを更新 ※Codex 2025-11-06 完了
-- [x] T107 [ ] [US1/US2] `bun test` 全体を実行して回帰確認（Codex 2025-11-06 実施）
+- [x] T107 [ ] [US1/US2] `bun test` 全体を実行して回帰確認（Codex 2025-11-06/11-07 実施）
 
 > 並列属性 `[P]` はテスト追加タスク間で並行可能であることを示す。

--- a/src/ui/__tests__/integration/navigation.test.tsx
+++ b/src/ui/__tests__/integration/navigation.test.tsx
@@ -4,10 +4,13 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import React from 'react';
 import { App } from '../../components/App.js';
 import { Window } from 'happy-dom';
-import type { BranchInfo } from '../../types.js';
+import type { BranchInfo, BranchItem } from '../../types.js';
+import * as BranchListScreenModule from '../../components/screens/BranchListScreen.js';
+import * as BranchActionSelectorScreenModule from '../../screens/BranchActionSelectorScreen.js';
 
 vi.mock('../../../git.js', () => ({
   __esModule: true,
@@ -30,6 +33,17 @@ vi.mock('../../../worktree.js', () => ({
   switchToProtectedBranch: mockSwitchToProtectedBranch,
 }));
 
+const aiToolScreenProps: unknown[] = [];
+
+vi.mock('../../components/screens/AIToolSelectorScreen.js', () => {
+  return {
+    AIToolSelectorScreen: (props: unknown) => {
+      aiToolScreenProps.push(props);
+      return React.createElement('div');
+    },
+  };
+});
+
 import { getAllBranches, getRepositoryRoot, deleteBranch } from '../../../git.js';
 import {
   listAdditionalWorktrees,
@@ -49,6 +63,9 @@ const mockedGetMergedPRWorktrees = getMergedPRWorktrees as Mock;
 const mockedRemoveWorktree = removeWorktree as Mock;
 const mockedIsProtectedBranchName = mockIsProtectedBranchName as Mock;
 const mockedSwitchToProtectedBranch = mockSwitchToProtectedBranch as Mock;
+const originalBranchListScreen = BranchListScreenModule.BranchListScreen;
+const originalBranchActionSelectorScreen =
+  BranchActionSelectorScreenModule.BranchActionSelectorScreen;
 
 describe('Navigation Integration Tests', () => {
   beforeEach(() => {
@@ -187,6 +204,176 @@ describe('Navigation Integration Tests', () => {
 
     // Test will verify onExit is called
     expect(container).toBeDefined();
+  });
+});
+
+describe('Protected Branch Navigation (T103)', () => {
+  const branchListProps: any[] = [];
+  const branchActionProps: any[] = [];
+  let branchListSpy: ReturnType<typeof vi.spyOn>;
+  let branchActionSpy: ReturnType<typeof vi.spyOn>;
+
+  const baseBranches: BranchInfo[] = [
+    {
+      name: 'main',
+      type: 'local',
+      branchType: 'main',
+      isCurrent: true,
+    },
+    {
+      name: 'feature/test',
+      type: 'local',
+      branchType: 'feature',
+      isCurrent: false,
+    },
+  ];
+
+  beforeEach(() => {
+    const window = new Window();
+    globalThis.window = window as any;
+    globalThis.document = window.document as any;
+    mockedGetAllBranches.mockReset();
+    mockedListAdditionalWorktrees.mockReset();
+    mockedGetRepositoryRoot.mockReset();
+    mockedDeleteBranch.mockReset();
+    mockedCreateWorktree.mockReset();
+    mockedGenerateWorktreePath.mockReset();
+    mockedGetMergedPRWorktrees.mockReset();
+    mockedRemoveWorktree.mockReset();
+    mockedIsProtectedBranchName.mockReset();
+    mockedSwitchToProtectedBranch.mockReset();
+    branchListProps.length = 0;
+    branchActionProps.length = 0;
+    aiToolScreenProps.length = 0;
+    branchListSpy = vi
+      .spyOn(BranchListScreenModule, 'BranchListScreen')
+      .mockImplementation((props: any) => {
+        branchListProps.push(props);
+        return React.createElement(originalBranchListScreen, props);
+      });
+    branchActionSpy = vi
+      .spyOn(BranchActionSelectorScreenModule, 'BranchActionSelectorScreen')
+      .mockImplementation((props: any) => {
+        branchActionProps.push(props);
+        return React.createElement(originalBranchActionSelectorScreen, props);
+      });
+
+    mockedIsProtectedBranchName.mockImplementation((name: string) =>
+      ['main', 'develop', 'origin/main', 'origin/develop'].includes(name)
+    );
+    mockedSwitchToProtectedBranch.mockResolvedValue('local');
+  });
+
+  afterEach(() => {
+    branchListSpy.mockRestore();
+    branchActionSpy.mockRestore();
+  });
+
+  it('switches local protected branches via root workflow and navigates to AI tool', async () => {
+    mockedGetAllBranches.mockResolvedValue(baseBranches);
+    mockedListAdditionalWorktrees.mockResolvedValue([]);
+
+    const onExit = vi.fn();
+    render(<App onExit={onExit} />);
+
+    await waitFor(() => {
+      expect(branchListProps.length).toBeGreaterThan(0);
+    });
+
+    const latestProps = branchListProps.at(-1);
+    const protectedBranch = (latestProps?.branches as BranchItem[]).find(
+      (item) => item.name === 'main'
+    );
+    expect(protectedBranch).toBeDefined();
+
+    await act(async () => {
+      latestProps?.onSelect(protectedBranch);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(branchActionProps.length).toBeGreaterThan(0);
+    });
+
+    const actionProps = branchActionProps.at(-1);
+    expect(actionProps?.mode).toBe('protected');
+    expect(actionProps?.infoMessage).toContain('ルートブランチ');
+
+    await act(async () => {
+      await actionProps?.onUseExisting();
+      await Promise.resolve();
+    });
+
+    expect(mockedSwitchToProtectedBranch).toHaveBeenCalledWith({
+      branchName: 'main',
+      repoRoot: '/repo',
+      remoteRef: null,
+    });
+
+    await waitFor(() => {
+      expect(aiToolScreenProps.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('creates tracking branch for remote protected selections before navigating to AI tool', async () => {
+    const remoteBranches: BranchInfo[] = [
+      {
+        name: 'origin/develop',
+        type: 'remote',
+        branchType: 'develop',
+        isCurrent: false,
+      },
+      {
+        name: 'feature/test',
+        type: 'local',
+        branchType: 'feature',
+        isCurrent: false,
+      },
+    ];
+    mockedGetAllBranches.mockResolvedValue(remoteBranches);
+    mockedListAdditionalWorktrees.mockResolvedValue([]);
+    mockedSwitchToProtectedBranch.mockResolvedValue('remote');
+
+    const onExit = vi.fn();
+    render(<App onExit={onExit} />);
+
+    await waitFor(() => {
+      expect(branchListProps.length).toBeGreaterThan(0);
+    });
+
+    const latestProps = branchListProps.at(-1);
+    const protectedBranch = (latestProps?.branches as BranchItem[]).find(
+      (item) => item.name === 'origin/develop'
+    );
+    expect(protectedBranch).toBeDefined();
+
+    await act(async () => {
+      latestProps?.onSelect(protectedBranch);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(branchActionProps.length).toBeGreaterThan(0);
+    });
+
+    const actionProps = branchActionProps.at(-1);
+    expect(actionProps?.mode).toBe('protected');
+    expect(actionProps?.primaryLabel).toContain('root');
+
+    await act(async () => {
+      await actionProps?.onUseExisting();
+      await Promise.resolve();
+    });
+
+    expect(mockedSwitchToProtectedBranch).toHaveBeenCalledWith({
+      branchName: 'develop',
+      repoRoot: '/repo',
+      remoteRef: 'origin/develop',
+    });
+
+    await waitFor(() => {
+      expect(aiToolScreenProps.length).toBeGreaterThan(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add ink integration coverage so selecting main/develop switches the root worktree per SPEC-4e948b89 T103
- mark SPEC tasks to show T103/T107 completion on 2025-11-07

## Testing
- bun test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 保護されたブランチナビゲーション機能の統合テストを追加しました。ローカルおよびリモートの保護されたブランチの選択動作の検証を含みます。

* **Chores**
  * 内部タスクステータスを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->