### PR TITLE
fix: pin node 22 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.14.0
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- switch release workflow to Node.js 22.14.0 to satisfy semantic-release engine requirements

## Testing
- not run