### PR TITLE
feat: npm公開機能を有効化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,11 @@ jobs:
             echo "is_release=false" >> $GITHUB_OUTPUT
           fi
 
-      # Uncomment when ready to publish to npm
-      # - name: Publish to npm
-      #   if: steps.check_release.outputs.is_release == 'true'
-      #   env:
-      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #   run: npm publish --access public
+      - name: Publish to npm
+        if: steps.check_release.outputs.is_release == 'true'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
   backmerge-to-develop:
     name: Backmerge to develop


### PR DESCRIPTION
## 概要

publish.ymlのnpm publishステップを有効化し、mainブランチへのマージ時に自動的にnpmレジストリへ公開されるようにしました。

## 変更内容

- `.github/workflows/publish.yml`のnpm publishステップのコメントアウトを解除

## 背景

現在、npmパッケージが1.24.2で停止しており、最新版(1.28.2)が公開されていませんでした。
調査の結果、publish.ymlのnpm publishステップがコメントアウトされていたため、有効化しました。

## リリースフロー

unity-mcp-serverと同様の設計:
1. semantic-releaseはrelease/*ブランチで実行（npmPublish: false）
2. npm publishはpublish.ymlでmainブランチで実行

## テスト計画

- [ ] このPRをdevelopにマージ
- [ ] /releaseコマンドでリリース実行
- [ ] npmレジストリで最新版が公開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)