### PR TITLE
Docker起動時の強制ビルドを削除し開発環境専用に変更

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -58,15 +58,9 @@ else
     echo "   ✅ Dependencies already installed"
 fi
 
-# distディレクトリが存在しない、またはsrcが更新されている場合はビルド
-if [ ! -d "/claude-worktree/dist" ] || [ -n "$(find /claude-worktree/src -type f -newer /claude-worktree/dist 2>/dev/null)" ]; then
-    echo "   Building project..."
-    cd /claude-worktree && bun run build
-else
-    echo "   ✅ Build artifacts up to date"
-fi
-
-echo "🚀 Docker environment is ready!"
+echo "🚀 Docker development environment is ready!"
+echo "   You can now build the project with: bun run build"
+echo "   Or start development with: bun run dev"
 echo ""
 
 # コマンドの実行（デフォルトはbash）


### PR DESCRIPTION
## Summary

- ソースコードにエラーがあるとDockerコンテナが起動しない問題を修正
- entrypoint.shから自動ビルド処理を削除し、開発環境として必要最小限の機能のみに変更
- 開発者がコンテナ内で自由にビルド・テスト・実行できるように改善

## Changes

- `scripts/entrypoint.sh`: ビルド処理（62-67行目）を削除
  - 依存関係のインストール（`bun install`）のみ実行
  - ビルドは開発者が`bun run build`で手動実行可能

## Test plan

- [ ] Dockerコンテナが正常に起動すること
- [ ] コンテナ内で`bun run build`が実行可能であること
- [ ] ソースコードにエラーがある状態でもDockerコンテナが起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker開発環境の初期化メッセージを改善しました。環境の準備完了と、プロジェクトのビルド方法または開発モードでの実行方法に関する明確な指示が表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->