### PR TITLE
fix: semantic-release実行に必要なNode.js setupを追加

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,6 +19,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

semantic-releaseの実行に必要なNode.js setupステップを追加しました。

### 問題

先ほどのPRで、すべてのワークフローからnpm依存を削除しましたが、
semantic-releaseはNode.js v22.14.0以上を必要とするため、
create-release.ymlとrelease.ymlでエラーが発生していました。

### 修正内容

- `create-release.yml`に`Setup Node.js`ステップを追加（v22.14.0）
- `release.yml`の`semantic-release`ジョブに`Setup Node.js`ステップを追加（v22.14.0）

bunxでsemantic-releaseを実行するには、適切なバージョンのNode.jsが必要です。

### 動作確認

- [ ] /releaseコマンドが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)