### PR TITLE
fix: Improve git hook detection for commands with options

### DIFF
--- a/.claude/hooks/block-git-branch-ops.sh
+++ b/.claude/hooks/block-git-branch-ops.sh
@@ -3,118 +3,27 @@
 # Claude Code PreToolUse Hook: Block git branch operations
 # このスクリプトは git checkout, git switch, git branch, git worktree コマンドをブロックします
 
-# 配列内に値が含まれているかを判定
-contains_element() {
-    local needle="$1"
-    shift
-    for element in "$@"; do
-        if [ "$element" = "$needle" ]; then
-            return 0
-        fi
-    done
-    return 1
-}
-
 # git branch コマンドが参照系かどうかを判定
+# 許可リスト方式：参照系フラグのみ許可、それ以外はブロック
 is_read_only_git_branch() {
     local branch_args="$1"
 
+    # トリム
     branch_args=$(echo "$branch_args" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+
+    # 引数なしは許可（ブランチ一覧表示）
     if [ -z "$branch_args" ]; then
         return 0
     fi
 
-    local -a branch_tokens=()
-    if command -v python3 >/dev/null 2>&1; then
-        local tokens_json
-        tokens_json=$(
-            BRANCH_ARGS="$branch_args" python3 - <<'PY' 2>/dev/null
-import os
-import shlex
-import json
-
-args = os.environ.get("BRANCH_ARGS", "")
-try:
-    tokens = shlex.split(args)
-except ValueError:
-    tokens = []
-
-print(json.dumps(tokens))
-PY
-        )
-        if [ -z "$tokens_json" ]; then
-            tokens_json='[]'
-        fi
-        mapfile -t branch_tokens < <(printf '%s\n' "$tokens_json" | jq -r '.[]')
-    else
-        # Pythonが利用できない環境向けフォールバック
-        read -r -a branch_tokens <<< "$branch_args"
+    # 参照系フラグのみの場合は許可
+    # 許可リスト: --list, --show-current, --all, -a, --remotes, -r, --contains, --merged, --no-merged, --points-at, --format, --sort, --abbrev
+    if echo "$branch_args" | grep -qE '^(--list|--show-current|--all|-a|--remotes|-r|--contains|--merged|--no-merged|--points-at|--format|--sort|--abbrev)'; then
+        return 0
     fi
 
-    local dangerous_flags=(-d -D --delete -m -M --move -c -C --copy --create-reflog --set-upstream-to --unset-upstream --track --no-track --edit-description -f --force)
-    local expect_value_flags=(--list -l --contains --merged --no-merged --points-at --format --sort --abbrev)
-
-    local expect_value=""
-    for token in "${branch_tokens[@]}"; do
-        if [ -z "$token" ]; then
-            continue
-        fi
-
-        if [ -n "$expect_value" ]; then
-            if [[ "$token" == -* ]]; then
-                expect_value=""
-            else
-                expect_value=""
-                continue
-            fi
-        fi
-
-        if [ "$token" = "--" ]; then
-            return 1
-        fi
-
-        if [[ "$token" == -* ]]; then
-            local option_name="$token"
-            local inline_value=""
-
-            if [[ "$token" == *=* ]]; then
-                option_name="${token%%=*}"
-                inline_value="${token#*=}"
-            fi
-
-            if [[ "$option_name" == -* && "$option_name" != --* && ${#option_name} -gt 2 && "$option_name" != -*=* ]]; then
-                local short_flags="${option_name#-}"
-                local i
-                for ((i = 0; i < ${#short_flags}; i++)); do
-                    local short_flag="-${short_flags:i:1}"
-                    if contains_element "$short_flag" "${dangerous_flags[@]}"; then
-                        return 1
-                    fi
-                    if contains_element "$short_flag" "${expect_value_flags[@]}"; then
-                        expect_value="$short_flag"
-                    fi
-                done
-                continue
-            fi
-
-            if contains_element "$option_name" "${dangerous_flags[@]}"; then
-                return 1
-            fi
-
-            if contains_element "$option_name" "${expect_value_flags[@]}"; then
-                if [ -z "$inline_value" ]; then
-                    expect_value="$option_name"
-                fi
-                continue
-            fi
-
-            continue
-        fi
-
-        return 1
-    done
-
-    return 0
+    # その他はブロック（破壊的操作、新規ブランチ作成等）
+    return 1
 }
 
 # stdinからJSON入力を読み取り
@@ -162,28 +71,56 @@ EOF
         fi
     fi
 
-    # ブランチ切り替え/作成/worktreeコマンドをチェック
-    if echo "$trimmed_segment" | grep -qE '^git\s+(checkout|switch|branch|worktree)\b'; then
-        if echo "$trimmed_segment" | grep -qE '^git\s+branch\b'; then
-            branch_args=$(echo "$trimmed_segment" | sed -E 's/^git[[:space:]]+branch//')
+    # ブランチ切り替え/作成/worktreeコマンドをチェック（オプション付きgitコマンドにも対応）
+    # git -C /path checkout, git --work-tree=/path checkout などを検出
+    if echo "$trimmed_segment" | grep -qE '^git\b'; then
+        # checkout/switchは無条件ブロック
+        if echo "$trimmed_segment" | grep -qE '\b(checkout|switch)\b'; then
+            cat <<EOF
+{
+  "decision": "block",
+  "reason": "🚫 Branch switching commands (checkout/switch) are not allowed",
+  "stopReason": "Worktree is designed to complete work on the launched branch. Branch operations such as git checkout and git switch cannot be executed.\n\nBlocked command: $command"
+}
+EOF
+            echo "🚫 Blocked: $command" >&2
+            echo "Reason: Branch switching (checkout/switch) is not allowed in Worktree." >&2
+            exit 2
+        fi
+
+        # branchコマンドは参照系のみ許可
+        if echo "$trimmed_segment" | grep -qE '\bbranch\b'; then
+            # git ... branch の後の引数を抽出（branchより前を全て除去）
+            branch_args=$(echo "$trimmed_segment" | sed -E 's/^.*\bbranch\b//')
             if is_read_only_git_branch "$branch_args"; then
                 continue
             fi
-        fi
-        # JSON応答を返す
-        cat <<EOF
+            # 破壊的操作をブロック
+            cat <<EOF
 {
   "decision": "block",
-  "reason": "🚫 Branch switching, creation, and worktree commands are not allowed",
-  "stopReason": "Worktree is designed to complete work on the launched branch. Branch operations such as git checkout, git switch, git branch, and git worktree cannot be executed.\n\nBlocked command: $command"
+  "reason": "🚫 Branch modification commands are not allowed",
+  "stopReason": "Worktree is designed to complete work on the launched branch. Destructive branch operations such as git branch -d, git branch -m cannot be executed.\n\nBlocked command: $command"
 }
 EOF
+            echo "🚫 Blocked: $command" >&2
+            echo "Reason: Branch modification is not allowed in Worktree." >&2
+            exit 2
+        fi
 
-    # stderrにもメッセージを出力
-    echo "🚫 Blocked: $command" >&2
-    echo "Reason: Worktree is designed to complete work on the launched branch." >&2
-
-    exit 2  # ブロック
+        # worktreeコマンドをブロック
+        if echo "$trimmed_segment" | grep -qE '\bworktree\b'; then
+            cat <<EOF
+{
+  "decision": "block",
+  "reason": "🚫 Worktree commands are not allowed",
+  "stopReason": "Worktree management operations such as git worktree add/remove cannot be executed from within a worktree.\n\nBlocked command: $command"
+}
+EOF
+            echo "🚫 Blocked: $command" >&2
+            echo "Reason: Worktree management is not allowed in Worktree." >&2
+            exit 2
+        fi
     fi
 done <<< "$command_segments"
 


### PR DESCRIPTION
- Change detection pattern from position-dependent to position-independent
- Support git commands with -C, --work-tree, -c options
- Simplify is_read_only_git_branch function (100 lines → 20 lines)
- Remove Python3 dependency
- Reduce total lines from 192 to 130 (32% reduction)

Fixes detection failure for commands like:
- git -C /path checkout feature/xxx
- git -C /path branch --show-current

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ変更**
  * Git ブランチの作成・削除などの変更操作がブロックされるようになりました
  * Git checkout および git switch コマンドの実行がブロックされました
  * ワークツリー管理コマンドが制限されるようになりました
  * インタラクティブ rebase が制限されるようになりました
  * 読み取り専用のブランチ参照コマンドのみが許可されます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->