### PR TITLE
fix: フィルターモードでショートカットを無効化

### DIFF
--- a/src/cli/ui/__tests__/components/screens/BranchListScreen.test.tsx
+++ b/src/cli/ui/__tests__/components/screens/BranchListScreen.test.tsx
@@ -588,16 +588,12 @@ describe("BranchListScreen", () => {
     });
 
     it("should disable other key bindings (m, c, r) while typing in filter", () => {
-      // Note: Input component uses blockKeys prop to prevent c/r/m/f from
-      // triggering shortcuts while typing in the filter field
-      // This test verifies the intended behavior (though KeyboardEvent
-      // may not work correctly in test environment)
       const onSelect = vi.fn();
       const onNavigate = vi.fn();
       const onCleanupCommand = vi.fn();
       const onRefresh = vi.fn();
 
-      const { container } = render(
+      const inkApp = inkRender(
         <BranchListScreen
           branches={mockBranches}
           stats={mockStats}
@@ -608,28 +604,21 @@ describe("BranchListScreen", () => {
         />,
       );
 
-      // Enter filter mode
-      const fKeyEvent = new (globalThis.window as any).KeyboardEvent(
-        "keydown",
-        { key: "f" },
-      );
-      document.dispatchEvent(fKeyEvent);
-
-      // When user types in filter, Input component blocks c/r/m/f keys
-      // Press m, c, r keys (should be blocked by Input's blockKeys)
-      ["m", "c", "r"].forEach((key) => {
-        const keyEvent = new (globalThis.window as any).KeyboardEvent(
-          "keydown",
-          { key },
-        );
-        document.dispatchEvent(keyEvent);
+      act(() => {
+        inkApp.stdin.write("f"); // enter filter mode
       });
 
-      // None of the callbacks should be called (keys are blocked)
-      // Note: This may fail in test environment due to KeyboardEvent limitations
+      act(() => {
+        inkApp.stdin.write("c");
+        inkApp.stdin.write("r");
+        inkApp.stdin.write("m");
+      });
+
       expect(onNavigate).not.toHaveBeenCalled();
       expect(onCleanupCommand).not.toHaveBeenCalled();
       expect(onRefresh).not.toHaveBeenCalled();
+
+      inkApp.unmount();
     });
 
     it("should display match count when filtering", () => {

--- a/src/cli/ui/components/screens/BranchListScreen.tsx
+++ b/src/cli/ui/components/screens/BranchListScreen.tsx
@@ -147,6 +147,11 @@ export function BranchListScreen({
       return;
     }
 
+    // Disable global shortcuts while in filter mode
+    if (filterMode) {
+      return;
+    }
+
     // Global shortcuts (blocked by Input component when typing in filter mode)
     if (input === "m" && onNavigate) {
       onNavigate("worktree-manager");


### PR DESCRIPTION
## Summary
- フィルターモード中はuseInputでショートカット処理を早期リターンし、c/r/mが発火しないように修正
- ショートカット無効化テストをInkのstdin入力ベースに変更し、実際の入力経路で検証

## Testing
- bun run test src/cli/ui/__tests__/components/screens/BranchListScreen.test.tsx
- bun run test（tests/unit/hooks/block-git-branch-ops.test.tsの4ケースが既存の期待値不一致で失敗）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* フィルターモード使用時にキーボードショートカット（m、c、r キーなど）が正しく無効化されるようになりました。フィルター中は検索入力に集中でき、意図しないコマンド実行が防止されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->