### PR TITLE
fix: create-release.ymlをdevelop→main PR作成方式に修正

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,18 +1,19 @@
 ---
-description: developからrelease/vX.Y.Zブランチを作成し、完全自動リリースフローを開始します。
+description: developからmainへのRelease PRを作成し、完全自動リリースフローを開始します。
 tags: [project]
 ---
 
 # リリースコマンド
 
-release-please が Release PR を自動作成し、マージ後に完全自動リリースフローを実行します。
+develop から main への Release PR を作成し、マージ後に完全自動リリースフローを実行します。
 
 ## 実行内容
 
-1. `gh workflow run create-release.yml --ref develop` を実行して release-please が main への Release PR を作成
-2. Release PR に自動マージが有効化される
-3. CI チェック通過後、Release PR が main に自動マージ
-4. GitHub Actions が以下を自動実行:
+1. `gh workflow run create-release.yml --ref develop` を実行
+2. ワークフローが Conventional Commits を解析し、次のバージョンを決定
+3. develop → main の Release PR を作成し、自動マージを有効化
+4. CI チェック通過後、Release PR が main に自動マージ
+5. GitHub Actions が以下を自動実行:
    - **release.yml (main)**: release-please でタグ・GitHub Release を作成
    - **publish.yml (main)**: npm publish（必要に応じて）、main → develop バックマージ
 
@@ -21,7 +22,7 @@ release-please が Release PR を自動作成し、マージ後に完全自動�
 - develop ブランチにリリース対象コミットが揃っていること
 - GitHub CLI (`gh`) が認証済み (`gh auth login`)
 - 最新コミットが Conventional Commits 形式であること
-- release-please がバージョンを決定できる差分が存在すること
+- `feat:` または `fix:` コミットが存在すること
 
 ## コマンド実行
 
@@ -33,7 +34,7 @@ gh workflow run create-release.yml --ref develop
 
 ```bash
 # Release PR を確認
-gh pr list --label "autorelease: pending"
+gh pr list --base main --head develop
 
 # Release PR を手動マージ（自動マージが有効でない場合）
 gh pr merge <PR番号> --merge
@@ -41,6 +42,7 @@ gh pr merge <PR番号> --merge
 
 ## トラブルシューティング
 
+- Release PR が作成されない場合は、`feat:` または `fix:` コミットが存在するか確認してください。
 - Release PR 作成後に release.yml が失敗した場合は、Actions から再実行し、ログを確認してください。
 - main で npm publish が有効な場合は `NPM_TOKEN` が正しく設定されていることを確認してください。
 - Release PR が既に存在する場合は、既存の PR を確認して対応してください。

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Create Release Branch
+name: Create Release PR
 
 on:
   workflow_dispatch:
@@ -8,40 +8,151 @@ permissions:
   pull-requests: write
 
 jobs:
-  release-pr:
-    name: Create release PR (release-please)
+  create-release-pr:
+    name: Create release PR (develop → main)
     runs-on: ubuntu-latest
     steps:
-      - name: Run release-please
-        id: rp
-        uses: googleapis/release-please-action@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
+          ref: develop
+          fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
-          release-type: node
-          manifest-file: .release-please-manifest.json
-          config-file: .release-please-config.json
-          target-branch: main
 
-      - name: Enable auto-merge for release PR
-        if: steps.rp.outputs.pr != ''
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get next version from release-please
+        id: version
         env:
           GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.rp.outputs.pr }}
         run: |
-          gh pr merge "$PR_NUMBER" --auto --merge
+          # Get current version from manifest
+          CURRENT_VERSION=$(jq -r '."."]' .release-please-manifest.json)
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          # Check for conventional commits since last release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --oneline)
+          else
+            COMMITS=$(git log --oneline "${LAST_TAG}..HEAD")
+          fi
+
+          # Determine bump type based on commits
+          if echo "$COMMITS" | grep -qE "^[a-f0-9]+ (feat|feature)(\(.+\))?!:"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE "BREAKING CHANGE"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE "^[a-f0-9]+ (feat|feature)(\(.+\))?:"; then
+            BUMP="minor"
+          elif echo "$COMMITS" | grep -qE "^[a-f0-9]+ (fix|perf)(\(.+\))?:"; then
+            BUMP="patch"
+          else
+            BUMP="none"
+          fi
+
+          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+
+          if [ "$BUMP" = "none" ]; then
+            echo "No releasable commits found"
+            echo "has_release=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Calculate next version
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          case "$BUMP" in
+            major)
+              NEXT_VERSION="$((MAJOR + 1)).0.0"
+              ;;
+            minor)
+              NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
+              ;;
+            patch)
+              NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              ;;
+          esac
+
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "has_release=true" >> $GITHUB_OUTPUT
+          echo "Next version will be: $NEXT_VERSION (bump: $BUMP)"
+
+      - name: Check for existing PR
+        if: steps.version.outputs.has_release == 'true'
+        id: check_pr
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING_PR=$(gh pr list --base main --head develop --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "pr_exists=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$EXISTING_PR" >> $GITHUB_OUTPUT
+            echo "Existing PR found: #$EXISTING_PR"
+          else
+            echo "pr_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create release PR
+        if: steps.version.outputs.has_release == 'true' && steps.check_pr.outputs.pr_exists != 'true'
+        id: create_pr
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+        run: |
+          PR_URL=$(gh pr create \
+            --base main \
+            --head develop \
+            --title "chore(release): v${NEXT_VERSION}" \
+            --body "## Release v${NEXT_VERSION}
+
+          This PR merges develop into main for release.
+
+          After this PR is merged:
+          1. \`release.yml\` will create the Git tag and GitHub Release via release-please
+          2. \`publish.yml\` will handle npm publish and backmerge to develop
+
+          ---
+          🤖 Generated with GitHub Actions")
+
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "Created PR: $PR_URL"
+
+      - name: Enable auto-merge
+        if: steps.version.outputs.has_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.create_pr.outputs.pr_number || steps.check_pr.outputs.pr_number }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr merge "$PR_NUMBER" --auto --merge
+            echo "Auto-merge enabled for PR #$PR_NUMBER"
+          fi
 
       - name: Summary
-        if: steps.rp.outputs.pr != ''
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          if [ "${{ steps.version.outputs.has_release }}" != "true" ]; then
+            cat >> $GITHUB_STEP_SUMMARY <<EOF
+          ## No Release Needed
+
+          No releasable commits (feat/fix) found since last release.
+          EOF
+          else
+            cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Release PR Created/Updated
 
-          - **PR**: #${{ steps.rp.outputs.pr }}
+          - **Next Version**: v${{ steps.version.outputs.next_version }}
+          - **PR**: #${{ steps.create_pr.outputs.pr_number || steps.check_pr.outputs.pr_number }}
           - **Auto-merge**: Enabled
 
-          Next steps:
+          ### Next steps
           1. CI checks will run on the Release PR
           2. Once checks pass, the PR will be auto-merged to main
           3. release.yml will create tag and GitHub Release
           4. publish.yml will handle npm publish and backmerge to develop
           EOF
+          fi


### PR DESCRIPTION
## Summary

- release-please が main ブランチのコミット履歴のみを参照する問題を修正
- `create-release.yml` を gh CLI で develop → main PR を直接作成する方式に変更
- Conventional Commits を解析してバージョンを自動決定

## 問題

前回のリリースワークフロー（#268）では、`create-release.yml` が release-please を使って Release PR を作成しようとしていましたが、release-please は main ブランチのコミット履歴しか参照しないため、develop の変更が main に入る前には動作しませんでした。

## 修正内容

1. `create-release.yml`: gh CLI で develop → main の PR を直接作成
2. Conventional Commits (`feat:`, `fix:`) を解析してバージョンを自動決定
3. `.claude/commands/release.md`: 新しいフローに合わせてドキュメント更新

## 新しいフロー

```
feature/* → develop (Auto Merge)
     ↓
/release コマンド → develop → main の Release PR 作成
     ↓
Release PR マージ → main push
     ↓
release.yml → release-please がタグ・GitHub Release 作成
     ↓
publish.yml → npm publish + main → develop バックマージ
```

## Test plan

- [ ] `gh workflow run create-release.yml --ref develop` で Release PR が作成されることを確認
- [ ] PR タイトルに正しいバージョンが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースプロセスを簡素化しました。develop ブランチから main ブランチへの自動 PR 作成とマージが可能になりました。
  * コミットメッセージの規約に基づいて、バージョン番号が自動的に決定されるようになりました。
  * GitHub Actions のリリースワークフロー処理を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->