### PR TITLE
ci: lint/testワークフローをmainブランチPRでも実行するよう修正

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- `lint.yml` と `test.yml` の pull_request トリガーに main ブランチを追加
- main ブランチへの Release PR でも CI チェックが実行されるようになる

## 背景

main ブランチには `Commit Message Lint`, `ESLint & Prettier`, `Test (Bun)`, `Build` が Required チェックとして設定されているため、これらのワークフローが main への PR でも実行される必要がある。

## Test plan

- [ ] PR #272 (Release PR) で lint/test ワークフローが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)