### PR TITLE
fix: release.ymlのコミットメッセージ検出条件を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
     name: Create Tag & GitHub Release
     runs-on: ubuntu-latest
     # Only run for release commits (from Release PR merge)
-    if: startsWith(github.event.head_commit.message, 'chore(release):')
+    # GitHub merge commit format: "Merge pull request #XX from ...\n\nchore(release): vX.Y.Z"
+    if: contains(github.event.head_commit.message, 'chore(release):')
     outputs:
       release_created: ${{ steps.create_release.outputs.release_created }}
       tag_name: ${{ steps.extract_version.outputs.tag_name }}


### PR DESCRIPTION
## Summary

- GitHub のマージ PR コミットメッセージ形式に対応
- `startsWith` から `contains` に変更

## 問題

GitHub でマージ PR を作成すると、コミットメッセージが以下の形式になる:
```
Merge pull request #276 from akiojin/develop

chore(release): v2.7.0
```

`startsWith(github.event.head_commit.message, 'chore(release):')` では検出できない。

## Test plan

- [ ] 手動で release.yml を再実行し、タグと GitHub Release が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)