### PR TITLE
fix(docs): release-pleaseの参照をリリースワークフローに修正

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,7 +107,7 @@ git branch -D branch-name
 
 1. `gh pr checks <PR番号>` で `lint` / `test` の2ジョブが成功しているか確認します。
 2. 失敗したジョブがある場合は GitHub Actions から再実行します（`Re-run all jobs`）。
-3. release-please の処理で失敗した場合はコミットメッセージ（Conventional Commits準拠）とトークン権限を見直し、修正後に再度 `/release` を実行して Release PR を更新します。
+3. リリースワークフローの処理で失敗した場合はコミットメッセージ（Conventional Commits準拠）とトークン権限を見直し、修正後に再度 `/release` を実行して Release PR を更新します。
 
 ### Branch Protection チェックリスト
 


### PR DESCRIPTION
## Summary
- troubleshooting.mdの「release-please」参照を「リリースワークフロー」に修正

## Test Plan
- [ ] lint/test CI パス
- [ ] auto-merge成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * トラブルシューティングドキュメント内のローカライゼーション表記を調整し、用語をより明確に統一しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->