### PR TITLE
fix: ブランチ一覧表示時にリモートブランチをfetchして最新情報を取得

### DIFF
--- a/src/cli/ui/__tests__/integration/navigation.test.tsx
+++ b/src/cli/ui/__tests__/integration/navigation.test.tsx
@@ -61,6 +61,7 @@ import {
   getAllBranches,
   getRepositoryRoot,
   deleteBranch,
+  fetchAllRemotes,
 } from "../../../../git.ts";
 import {
   listAdditionalWorktrees,
@@ -73,6 +74,7 @@ import {
 const mockedGetAllBranches = getAllBranches as Mock;
 const mockedGetRepositoryRoot = getRepositoryRoot as Mock;
 const mockedDeleteBranch = deleteBranch as Mock;
+const mockedFetchAllRemotes = fetchAllRemotes as Mock;
 const mockedListAdditionalWorktrees = listAdditionalWorktrees as Mock;
 const mockedCreateWorktree = createWorktree as Mock;
 const mockedGenerateWorktreePath = generateWorktreePath as Mock;
@@ -96,6 +98,7 @@ describe("Navigation Integration Tests", () => {
     mockedListAdditionalWorktrees.mockReset();
     mockedGetRepositoryRoot.mockReset();
     mockedDeleteBranch.mockReset();
+    mockedFetchAllRemotes.mockReset();
     mockedCreateWorktree.mockReset();
     mockedGenerateWorktreePath.mockReset();
     mockedGetMergedPRWorktrees.mockReset();
@@ -268,6 +271,7 @@ describe("Protected Branch Navigation (T103)", () => {
     mockedListAdditionalWorktrees.mockReset();
     mockedGetRepositoryRoot.mockReset();
     mockedDeleteBranch.mockReset();
+    mockedFetchAllRemotes.mockReset();
     mockedCreateWorktree.mockReset();
     mockedGenerateWorktreePath.mockReset();
     mockedGetMergedPRWorktrees.mockReset();

--- a/src/cli/ui/hooks/useGitData.ts
+++ b/src/cli/ui/hooks/useGitData.ts
@@ -41,9 +41,16 @@ export function useGitData(options?: UseGitDataOptions): UseGitDataResult {
     setError(null);
 
     try {
-      // リモートブランチの最新情報を取得
       const repoRoot = await getRepositoryRoot();
-      await fetchAllRemotes({ cwd: repoRoot });
+
+      // リモートブランチの最新情報を取得（失敗してもローカル表示は継続）
+      try {
+        await fetchAllRemotes({ cwd: repoRoot });
+      } catch (fetchError) {
+        if (process.env.DEBUG) {
+          console.warn("Failed to fetch remote branches", fetchError);
+        }
+      }
 
       const [branchesData, worktreesData] = await Promise.all([
         getAllBranches(),

--- a/src/web/server/services/branches.ts
+++ b/src/web/server/services/branches.ts
@@ -37,9 +37,17 @@ function mapPullRequestState(state: string): "open" | "merged" | "closed" {
  * すべてのブランチ一覧を取得（マージステータスとWorktree情報付き）
  */
 export async function listBranches(): Promise<Branch[]> {
-  // リモートブランチの最新情報を取得
   const repoRoot = await getRepositoryRoot();
-  await fetchAllRemotes({ cwd: repoRoot });
+
+  // リモートブランチの最新情報を取得（失敗してもローカル情報にはフォールバック）
+  try {
+    await fetchAllRemotes({ cwd: repoRoot });
+  } catch (error) {
+    console.warn(
+      "Failed to fetch remote branches for Web UI; falling back to local branches",
+      error,
+    );
+  }
 
   const [branches, worktrees] = await Promise.all([
     getAllBranches(),


### PR DESCRIPTION
## Summary

- ブランチ一覧表示時に`git fetch --all --prune`を実行してリモートブランチの最新情報を取得するように修正
- CLI UI (`useGitData.ts`) と Web UI (`branches.ts`) の両方で対応
- これにより、新しいリモートブランチが一覧に正しく表示されるようになる

## Test plan

- [ ] CLI UIでブランチ一覧を表示し、リモートブランチが全て表示されることを確認
- [ ] Web UIでブランチ一覧を表示し、リモートブランチが全て表示されることを確認
- [ ] 新しいリモートブランチを作成後、一覧をリフレッシュして表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * リモート情報を先に取得・更新することで、ブランチとワークツリーの収集が効率化され、同期状態や未プッシュ表示の精度が向上しました。
* **テスト**
  * 統合テストにリモート取得を模擬するモックを追加し、外部リモート呼び出しを伴わずに挙動を検証できるようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->