### PR TITLE
docs: add Icon Legend section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,3 +347,9 @@ We welcome contributions! Please read our contributing guidelines:
 - **Documentation**: This README and inline code documentation
 - **Issues**: GitHub Issues for bug reports and feature requests
 - **Discussions**: GitHub Discussions for questions and community support
+
+### Icon Legend
+
+- First 3 columns: ⚡(main/develop) / ✨(feature) / 🐛(bugfix) / 🔥(hotfix) / 📦(release) / 📌(other), 🟢=has worktree, 🟠=has worktree (inaccessible), ✏️=uncommitted changes, ⚠️=warning, ⭐=current branch
+- Location column: blank=local exists, `☁`=remote only
+- Selection column: In color environments, selection is shown with `>` prefix (with space) instead of background inversion


### PR DESCRIPTION
## Summary

- README.mdにIcon Legend（アイコン凡例）セクションを追加
- README.ja.mdに既存だったセクションを英語版にも追加し、両言語版を同期

## Test plan

- [ ] README.mdにIcon Legendセクションが正しく表示されることを確認
- [ ] markdownlintでエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * README.mdにアイコンレジェンドセクションを新たに追加しました。Git worktreeのユーザーインターフェース内で使用されるシンボルと列の意味を詳細に説明しています。main/developブランチの識別、feature、bugfix、hotfix、releaseのステータス区別、およびworktree/ステータスインジケーターが記載されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->