### PR TITLE
fix: align branch list headers

### DIFF
--- a/src/cli/ui/components/screens/BranchListScreen.tsx
+++ b/src/cli/ui/components/screens/BranchListScreen.tsx
@@ -112,6 +112,9 @@ export function BranchListScreen({
   testOnFilterQueryChange,
 }: BranchListScreenProps) {
   const { rows } = useTerminalSize();
+  const COLUMN_WIDTH = 2;
+  const SYNC_COLUMN_WIDTH = 6;
+  const headerText = `  ${"Ty".padEnd(COLUMN_WIDTH)}${"Wt".padEnd(COLUMN_WIDTH)}${"St".padEnd(COLUMN_WIDTH)}${"Rm".padEnd(COLUMN_WIDTH)}${"Sync".padEnd(SYNC_COLUMN_WIDTH)}Branch`;
 
   // Filter state - allow test control via props
   const [internalFilterQuery, setInternalFilterQuery] = useState("");
@@ -412,9 +415,7 @@ export function BranchListScreen({
             <>
               {/* Column labels */}
               <Box>
-                <Text dimColor>
-                  {"  Type Wt St Rm Sync  Branch"}
-                </Text>
+                <Text dimColor>{headerText}</Text>
               </Box>
               <Select
                 items={filteredBranches}

--- a/src/cli/ui/types.ts
+++ b/src/cli/ui/types.ts
@@ -1,4 +1,5 @@
 import type { LastToolUsage } from "../../types/api.js";
+export type { LastToolUsage } from "../../types/api.js";
 
 export interface WorktreeInfo {
   path: string;
@@ -9,7 +10,6 @@ export interface WorktreeInfo {
 
 export type AITool = string;
 export type InferenceLevel = "low" | "medium" | "high" | "xhigh";
-export type { LastToolUsage } from "../../types/api.js";
 
 export interface ModelOption {
   id: string;


### PR DESCRIPTION
## Summary
- align branch list header text with column widths (Type/Wt/St/Rm/Sync)
- keep LastToolUsage import/export at top to satisfy review feedback

## Testing
- bun run lint
- bun run test