### PR TITLE
fix: ブランチ一覧のAIツールラベルからNew/Continue/Resumeを削除

### DIFF
--- a/src/cli/ui/__tests__/components/screens/BranchListScreen.test.tsx
+++ b/src/cli/ui/__tests__/components/screens/BranchListScreen.test.tsx
@@ -239,7 +239,7 @@ describe("BranchListScreen", () => {
           model: null,
           timestamp: Date.UTC(2025, 10, 26, 14, 3),
         },
-        lastToolUsageLabel: "Codex | New | 2025-11-26 14:03",
+        lastToolUsageLabel: "Codex | 2025-11-26 14:03",
       },
       {
         name: "feature/without-usage",
@@ -266,7 +266,7 @@ describe("BranchListScreen", () => {
     );
 
     const output = stripAnsi(stripControlSequences(lastFrame() ?? ""));
-    expect(output).toContain("Codex | New | 2025-11-26 14:03");
+    expect(output).toContain("Codex | 2025-11-26 14:03");
     expect(output).toContain("Unknown |");
   });
 

--- a/src/cli/ui/__tests__/utils/branchFormatter.test.ts
+++ b/src/cli/ui/__tests__/utils/branchFormatter.test.ts
@@ -65,7 +65,6 @@ describe("branchFormatter", () => {
       const result = formatBranchItem(branchInfo);
 
       expect(result.lastToolUsageLabel).toContain("Codex");
-      expect(result.lastToolUsageLabel).toContain("New");
       expect(result.lastToolUsageLabel).toContain("2025-11-26");
     });
 

--- a/src/cli/ui/utils/branchFormatter.ts
+++ b/src/cli/ui/utils/branchFormatter.ts
@@ -99,15 +99,6 @@ function mapToolLabel(toolId: string, toolLabel?: string): string {
   return "Custom";
 }
 
-function mapModeLabel(
-  mode?: "normal" | "continue" | "resume" | null,
-): string | null {
-  if (mode === "normal") return "New";
-  if (mode === "continue") return "Continue";
-  if (mode === "resume") return "Resume";
-  return null;
-}
-
 function formatTimestamp(ts: number): string {
   const date = new Date(ts);
   const year = date.getFullYear();
@@ -123,12 +114,8 @@ function buildLastToolUsageLabel(
 ): string | null {
   if (!usage) return null;
   const toolText = mapToolLabel(usage.toolId, usage.toolLabel);
-  const modeText = mapModeLabel(usage.mode);
   const timestamp = usage.timestamp ? formatTimestamp(usage.timestamp) : null;
   const parts = [toolText];
-  if (modeText) {
-    parts.push(modeText);
-  }
   if (timestamp) {
     parts.push(timestamp);
   }


### PR DESCRIPTION
## Summary

- ブランチ選択UIでAIツール名の横に表示されていた「New」「Continue」「Resume」ラベルを削除
- これらのラベルはユーザーにとって有用な情報を提供していなかったため、シンプルに「ツール名 | タイムスタンプ」形式に変更

## Changes

- `src/cli/ui/utils/branchFormatter.ts`: `mapModeLabel()`関数と関連ロジックを削除
- テストファイルの期待値を更新

## Before/After

```
# Before
Codex | New | 2025-12-04 17:16
Claude | Continue | 2025-12-04 16:19

# After
Codex | 2025-12-04 17:16
Claude | 2025-12-04 16:19
```

## Test plan

- [x] ビルド成功 (`bun run build`)
- [x] 関連テスト成功 (`bun test src/cli/ui/__tests__/utils/branchFormatter.test.ts`)
- [x] BranchListScreenテスト成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ブランチリスト画面のツール使用ラベルから不要な表示を削除し、よりシンプルな形式に統一しました。

* **テスト**
  * テストデータとアサーションを更新し、新しいラベル形式に対応させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->