### PR TITLE
docs: Web UI起動手順と設定パスを最新化

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -78,19 +78,23 @@ gwt -v
 ### Web UI の起動
 
 ```bash
-claude-worktree serve
+# CLI を起動すると Web UI もバックグラウンドで自動起動します
+gwt
+
+# Web UI だけ起動したい場合
+gwt serve
 # または
-bunx @akiojin/claude-worktree serve
+bunx @akiojin/gwt serve
 ```
 
-- ブラウザで <http://localhost:3000> を開き、Worktree ダッシュボードにアクセス
+- Web UI はデフォルトで <http://localhost:3000> で利用できます
 - ブランチ一覧/検索/Worktree作成など、CLIと同じ体験をブラウザで提供
 - ブランチ一覧カードの「AIツールを起動」ボタンでモーダルが開き、ツール/モード/引数/同期を選んで起動
 - ブランチ詳細ページはセッションの状態確認専用（稼働中セッションのターミナルと履歴を表示）
 
 ### カスタムAIツールの管理
 
-- ダッシュボード右上の **Config**（または `/config` URL）で `~/.claude-worktree/tools.json` をGUI編集
+- ダッシュボード右上の **Config**（または `/config` URL）で `~/.gwt/tools.json` をGUI編集（旧 `~/.claude-worktree/tools.json` は初回起動時に自動移行）
 - 実行タイプ（path/bunx/command）、defaultArgs、modeArgs、permissionSkipArgs、envをまとめて設定
 - 変更内容はCLIと共有の `tools.json` に保存されるため、CLI/Webのどちらからでも同じツールを利用可能
 - ブランチ一覧モーダルの起動フォームでは以下を指定できます:

--- a/README.md
+++ b/README.md
@@ -80,18 +80,22 @@ The tool presents an interactive interface with the following options:
 ### Launching the Web UI
 
 ```bash
-claude-worktree serve
-# or
-bunx @akiojin/claude-worktree serve
+# Running the CLI also starts the Web UI in the background.
+gwt
+
+# (Optional) start only the Web UI server:
+gwt serve
+# or without global install
+bunx @akiojin/gwt serve
 ```
 
-- Open <http://localhost:3000> to access the Worktree dashboard
+- The Web UI is available by default at <http://localhost:3000>
 - The branch list mirrors the CLI view, including search and worktree creation
 - Detailed branch pages let you start AI tool sessions directly from the browser
 
 ### Managing Custom AI Tools
 
-- Navigate to **Config** (top-right button on the dashboard or `/config`) to view and edit `~/.claude-worktree/tools.json`
+- Navigate to **Config** (top-right button on the dashboard or `/config`) to view and edit `~/.gwt/tools.json` (legacy `~/.claude-worktree/tools.json` is auto-migrated on first run)
 - Add/edit tools with execution type (`path` / `bunx` / `command`), default arguments, mode-specific arguments, permission skip arguments, and environment variables
 - Changes are written to the same `tools.json` file that the CLI uses, so both channels stay in sync
 - When launching from the branch detail page you can:

--- a/docs/WEB_UI.md
+++ b/docs/WEB_UI.md
@@ -15,6 +15,8 @@ bun run start:web
 bunx . serve
 ```
 
+通常の `gwt` 起動でも Web UI はバックグラウンドで自動起動します。CLI なしで Web UI だけを起動したい場合に上記コマンドを使ってください。
+
 デフォルトでは `http://localhost:3000` でアクセス可能です。
 
 ## 機能概要

--- a/src/services/aiToolResolver.ts
+++ b/src/services/aiToolResolver.ts
@@ -227,7 +227,7 @@ export async function resolveCustomToolCommand(
       "CUSTOM_TOOL_NOT_FOUND",
       `Custom tool not found: ${options.toolId}`,
       [
-        "Update ~/.claude-worktree/tools.json to include this ID",
+        "Update ~/.gwt/tools.json to include this ID",
         "Reload the Web UI after editing the tools list",
       ],
     );

--- a/src/web/client/src/pages/ConfigPage.tsx
+++ b/src/web/client/src/pages/ConfigPage.tsx
@@ -228,7 +228,7 @@ export function ConfigPage() {
             <div>
               <h2>登録済みツール</h2>
               <p className="section-card__body">
-                CLI と Web UI は同じ設定を参照します。ここで更新すると ~/.claude-worktree/tools.json に保存されます。
+                CLI と Web UI は同じ設定を参照します。ここで更新すると ~/.gwt/tools.json に保存されます。
               </p>
             </div>
           </header>


### PR DESCRIPTION
- CLI起動時にWeb UIが自動起動する挙動に合わせてドキュメントを更新\n- カスタムツール設定パスを ~/.gwt/tools.json に統一（旧 ~/.claude-worktree は自動移行）\n- UI/エラーメッセージの参照パスも更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 設定ファイルのパスを ~/.gwt/tools.json に更新しました。従来のパスは自動的に移行されます
  * Web UI の起動方法およびデフォルトアクセスについてのドキュメントを改善
  * カスタムツール設定のオプション詳細を充実させました（モード選択、追加引数、権限設定など）

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->