### PR TITLE
fix: Resumeは各ツールのresume機能に委譲

### DIFF
--- a/src/cli/ui/components/App.tsx
+++ b/src/cli/ui/components/App.tsx
@@ -11,7 +11,6 @@ import { BranchListScreen } from "./screens/BranchListScreen.js";
 import { BranchCreatorScreen } from "./screens/BranchCreatorScreen.js";
 import { BranchActionSelectorScreen } from "../screens/BranchActionSelectorScreen.js";
 import { AIToolSelectorScreen } from "./screens/AIToolSelectorScreen.js";
-import { SessionSelectorScreen } from "./screens/SessionSelectorScreen.js";
 import { ExecutionModeSelectorScreen } from "./screens/ExecutionModeSelectorScreen.js";
 import type { ExecutionMode } from "./screens/ExecutionModeSelectorScreen.js";
 import { BranchQuickStartScreen } from "./screens/BranchQuickStartScreen.js";
@@ -93,13 +92,6 @@ export interface AppProps {
   loadingIndicatorDelay?: number;
 }
 
-export interface SessionOption {
-  sessionId: string;
-  toolLabel: string;
-  branch: string;
-  timestamp: number;
-}
-
 /**
  * App - Top-level component for Ink.js UI
  * Integrates ErrorBoundary, data fetching, screen navigation, and all screens
@@ -119,13 +111,6 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
   // Version state
   const [version, setVersion] = useState<string | null>(null);
   const [repoRoot, setRepoRoot] = useState<string | null>(null);
-  const [sessionOptions, setSessionOptions] = useState<SessionOption[]>([]);
-  const [sessionLoading, setSessionLoading] = useState(false);
-  const [sessionError, setSessionError] = useState<string | null>(null);
-  const [pendingExecution, setPendingExecution] = useState<{
-    mode: ExecutionMode;
-    skipPermissions: boolean;
-  } | null>(null);
   const [continueSessionId, setContinueSessionId] = useState<string | null>(
     null,
   );
@@ -286,53 +271,6 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
       cancelled = true;
     };
   }, [branches, worktrees]);
-
-  // Load available sessions when entering session selector
-  useEffect(() => {
-    if (currentScreen !== "session-selector") {
-      return;
-    }
-    if (!selectedTool || !selectedBranch) {
-      setSessionOptions([]);
-      return;
-    }
-
-    setSessionLoading(true);
-    setSessionError(null);
-
-    (async () => {
-      try {
-        const root = repoRoot ?? (await getRepositoryRoot());
-        if (!repoRoot && root) {
-          setRepoRoot(root);
-        }
-        const sessionData = root ? await loadSession(root) : null;
-        const history = sessionData?.history ?? [];
-
-        const filtered = history
-          .filter(
-            (entry) =>
-              entry.sessionId &&
-              entry.toolId === selectedTool &&
-              entry.branch === selectedBranch.name,
-          )
-          .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))
-          .map((entry) => ({
-            sessionId: entry.sessionId as string,
-            toolLabel: entry.toolLabel,
-            branch: entry.branch,
-            timestamp: entry.timestamp,
-          }));
-
-        setSessionOptions(filtered);
-      } catch (_err) {
-        setSessionOptions([]);
-        setSessionError("セッション一覧の取得に失敗しました");
-      } finally {
-        setSessionLoading(false);
-      }
-    })();
-  }, [currentScreen, selectedTool, selectedBranch, repoRoot]);
 
   // Load quick start options for selected branch (latest per tool)
   useEffect(() => {
@@ -1165,18 +1103,6 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
     ],
   );
 
-  // Handle session selection
-  const handleSessionSelect = useCallback(
-    (session: string) => {
-      const execution = pendingExecution ?? {
-        mode: "resume" as ExecutionMode,
-        skipPermissions: false,
-      };
-      completeSelection(execution.mode, execution.skipPermissions, session);
-    },
-    [pendingExecution, completeSelection],
-  );
-
   const handleQuickStartSelect = useCallback(
     (action: QuickStartAction, toolId?: AITool | null) => {
       if (action === "manual" || !branchQuickStart.length) {
@@ -1228,14 +1154,9 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
   // Handle execution mode and skipPermissions selection
   const handleModeSelect = useCallback(
     (result: { mode: ExecutionMode; skipPermissions: boolean }) => {
-      if (result.mode === "resume") {
-        setPendingExecution(result);
-        navigateTo("session-selector");
-        return;
-      }
       completeSelection(result.mode, result.skipPermissions, null);
     },
-    [completeSelection, navigateTo],
+    [completeSelection],
   );
 
   // Render screen based on currentScreen
@@ -1342,19 +1263,6 @@ export function App({ onExit, loadingIndicatorDelay = 300 }: AppProps) {
             onSelect={handleModelSelect}
             version={version}
             initialSelection={selectedModel}
-          />
-        );
-
-      case "session-selector":
-        // TODO: Implement session data fetching
-        return (
-          <SessionSelectorScreen
-            sessions={sessionOptions}
-            loading={sessionLoading}
-            errorMessage={sessionError}
-            onBack={goBack}
-            onSelect={handleSessionSelect}
-            version={version}
           />
         );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -553,12 +553,12 @@ export async function handleAIToolWorkflow(
       { skipHistory: true },
     );
 
-    // Lookup saved session ID for continue/resume
+    // Lookup saved session ID for Continue (auto attach)
     let resumeSessionId: string | null =
       selectedSessionId && selectedSessionId.length > 0
         ? selectedSessionId
         : null;
-    if (mode === "continue" || mode === "resume") {
+    if (mode === "continue") {
       const existingSession = await loadSession(repoRoot);
       const history = existingSession?.history ?? [];
 

--- a/tests/unit/index.resume-delegation.test.ts
+++ b/tests/unit/index.resume-delegation.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SelectionResult } from "../../src/cli/ui/components/App.js";
+import type { ExecutionMode } from "../../src/cli/ui/components/screens/ExecutionModeSelectorScreen.js";
+
+// Vitest shim for environments lacking vi.hoisted (e.g., bun)
+if (typeof (vi as Record<string, unknown>).hoisted !== "function") {
+  // @ts-expect-error injected shim
+  vi.hoisted = (factory: () => unknown) => factory();
+}
+
+const {
+  ensureWorktreeMock,
+  fetchAllRemotesMock,
+  pullFastForwardMock,
+  getBranchDivergenceStatusesMock,
+  worktreeExistsMock,
+  getRepositoryRootMock,
+  getToolByIdMock,
+  getSharedEnvironmentMock,
+  installDependenciesMock,
+  launchCodexCLIMock,
+  saveSessionMock,
+  loadSessionMock,
+  findLatestCodexSessionMock,
+} = vi.hoisted(() => ({
+  ensureWorktreeMock: vi.fn(async () => "/repo/worktrees/feature/resume"),
+  fetchAllRemotesMock: vi.fn(async () => undefined),
+  pullFastForwardMock: vi.fn(async () => undefined),
+  getBranchDivergenceStatusesMock: vi.fn(async () => []),
+  worktreeExistsMock: vi.fn(async () => null),
+  getRepositoryRootMock: vi.fn(async () => "/repo"),
+  getToolByIdMock: vi.fn(() => ({ id: "codex-cli", displayName: "Codex" })),
+  getSharedEnvironmentMock: vi.fn(async () => ({})),
+  installDependenciesMock: vi.fn(async () => ({
+    skipped: false as const,
+    manager: "bun" as const,
+    lockfile: "/repo/bun.lock",
+  })),
+  launchCodexCLIMock: vi.fn(async () => ({ sessionId: null })),
+  saveSessionMock: vi.fn(async () => undefined),
+  loadSessionMock: vi.fn(async () => ({
+    lastWorktreePath: "/repo/worktrees/feature/resume",
+    lastBranch: "feature/resume",
+    lastUsedTool: "codex-cli",
+    toolLabel: "Codex",
+    mode: "continue",
+    model: null,
+    reasoningLevel: null,
+    skipPermissions: null,
+    timestamp: Date.now(),
+    repositoryRoot: "/repo",
+    lastSessionId: "saved-session-id",
+    history: [
+      {
+        branch: "feature/resume",
+        worktreePath: "/repo/worktrees/feature/resume",
+        toolId: "codex-cli",
+        toolLabel: "Codex",
+        sessionId: "saved-session-id",
+        mode: "continue",
+        model: null,
+        reasoningLevel: null,
+        skipPermissions: null,
+        timestamp: Date.now(),
+      },
+    ],
+  })),
+  findLatestCodexSessionMock: vi.fn(async () => null),
+}));
+
+const waitForUserAcknowledgementMock = vi.hoisted(() =>
+  vi.fn<() => Promise<void>>(),
+);
+
+vi.mock("../../src/git.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../src/git.js")>(
+      "../../src/git.js",
+    );
+  return {
+    ...actual,
+    getRepositoryRoot: getRepositoryRootMock,
+    fetchAllRemotes: fetchAllRemotesMock,
+    pullFastForward: pullFastForwardMock,
+    getBranchDivergenceStatuses: getBranchDivergenceStatusesMock,
+    branchExists: vi.fn(async () => true),
+  };
+});
+
+vi.mock("../../src/worktree.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/worktree.js")>(
+    "../../src/worktree.js",
+  );
+  return {
+    ...actual,
+    worktreeExists: worktreeExistsMock,
+    isProtectedBranchName: vi.fn(() => false),
+    switchToProtectedBranch: vi.fn(async () => "none" as const),
+  };
+});
+
+vi.mock("../../src/services/WorktreeOrchestrator.js", () => ({
+  WorktreeOrchestrator: class {
+    ensureWorktree = ensureWorktreeMock;
+  },
+}));
+
+const DependencyInstallErrorMock = vi.hoisted(
+  () =>
+    class DependencyInstallError extends Error {
+      constructor(message?: string) {
+        super(message);
+        this.name = "DependencyInstallError";
+      }
+    },
+);
+
+vi.mock("../../src/services/dependency-installer.js", () => ({
+  installDependenciesForWorktree: installDependenciesMock,
+  DependencyInstallError: DependencyInstallErrorMock,
+}));
+
+vi.mock("../../src/config/tools.js", () => ({
+  getToolById: getToolByIdMock,
+  getSharedEnvironment: getSharedEnvironmentMock,
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  saveSession: saveSessionMock,
+  loadSession: loadSessionMock,
+}));
+
+vi.mock("../../src/codex.js", () => ({
+  launchCodexCLI: launchCodexCLIMock,
+  CodexError: class CodexError extends Error {
+    constructor(
+      message: string,
+      public cause?: unknown,
+    ) {
+      super(message);
+      this.name = "CodexError";
+    }
+  },
+}));
+
+vi.mock("../../src/utils/session.js", () => ({
+  findLatestCodexSession: findLatestCodexSessionMock,
+  findLatestClaudeSession: vi.fn(async () => null),
+  findLatestGeminiSession: vi.fn(async () => null),
+  findLatestClaudeSessionId: vi.fn(async () => null),
+}));
+
+vi.mock("../../src/utils/terminal.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/utils/terminal.js")
+  >("../../src/utils/terminal.js");
+  return {
+    ...actual,
+    waitForUserAcknowledgement: waitForUserAcknowledgementMock,
+  };
+});
+
+// Import after mocks are set up
+import { handleAIToolWorkflow } from "../../src/index.js";
+
+beforeEach(() => {
+  ensureWorktreeMock.mockClear();
+  fetchAllRemotesMock.mockClear();
+  pullFastForwardMock.mockClear();
+  getBranchDivergenceStatusesMock.mockClear();
+  worktreeExistsMock.mockClear();
+  getRepositoryRootMock.mockClear();
+  getToolByIdMock.mockClear();
+  getSharedEnvironmentMock.mockClear();
+  installDependenciesMock.mockClear();
+  launchCodexCLIMock.mockClear();
+  saveSessionMock.mockClear();
+  loadSessionMock.mockClear();
+  findLatestCodexSessionMock.mockClear();
+  waitForUserAcknowledgementMock.mockClear();
+  waitForUserAcknowledgementMock.mockResolvedValue(undefined);
+});
+
+describe("handleAIToolWorkflow - Resume delegation", () => {
+  const baseSelection: Omit<SelectionResult, "mode"> = {
+    branch: "feature/resume",
+    displayName: "feature/resume",
+    branchType: "local",
+    tool: "codex-cli",
+    skipPermissions: false,
+    model: "gpt-5.1-codex",
+  };
+
+  it("does not auto-resolve sessionId when mode=resume (delegates to tool resume)", async () => {
+    const selection: SelectionResult = {
+      ...baseSelection,
+      mode: "resume" as ExecutionMode,
+      sessionId: null,
+    };
+
+    vi.useFakeTimers();
+    const run = handleAIToolWorkflow(selection);
+    await vi.advanceTimersByTimeAsync(3000);
+    await run;
+    vi.useRealTimers();
+
+    expect(loadSessionMock).not.toHaveBeenCalled();
+    expect(launchCodexCLIMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        mode: "resume",
+        sessionId: null,
+      }),
+    );
+  });
+
+  it("auto-resolves sessionId when mode=continue and none is provided", async () => {
+    const selection: SelectionResult = {
+      ...baseSelection,
+      mode: "continue" as ExecutionMode,
+      sessionId: null,
+    };
+
+    vi.useFakeTimers();
+    const run = handleAIToolWorkflow(selection);
+    await vi.advanceTimersByTimeAsync(3000);
+    await run;
+    vi.useRealTimers();
+
+    expect(loadSessionMock).toHaveBeenCalledTimes(1);
+    expect(launchCodexCLIMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        mode: "continue",
+        sessionId: "saved-session-id",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## 変更内容\n- Execution ModeのResumeはSessionSelectorに遷移せず、各ツールのResume機能で再開する\n- Continueのみ保存済みsessionIdを自動解決（Resumeでは自動補完しない）\n- 仕様(SPEC)更新 + TDD追加\n\n## 確認\n- bun run test\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **改善**
  * Resume機能が簡略化されました。セッション選択画面が削除され、ツール側のResume機能が直接呼び出されるようになります。

* **テスト**
  * Resume機能の委譲パスに関する包括的なユニットテストスイートを追加しました。

* **ドキュメント**
  * Resume機能の動作仕様を最新の実装に合わせて更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->