### PR TITLE
fix: Goodbye後にプロセスが終了しない問題を修正

### DIFF
--- a/tests/unit/index.webui-startup.test.ts
+++ b/tests/unit/index.webui-startup.test.ts
@@ -264,4 +264,23 @@ describe("main() - Web UI server startup (SPEC-c8e7a5b2)", () => {
 
     expect(closeWebServerMock).toHaveBeenCalledTimes(1);
   });
+
+  it("T021: ポート使用中の場合はcloseが呼ばれない", async () => {
+    setupMocks({ isPortInUse: true });
+
+    const { main } = await import("../../src/index.js");
+    await main();
+
+    expect(closeWebServerMock).not.toHaveBeenCalled();
+  });
+
+  it("T022: startWebServer失敗時はcloseが呼ばれない", async () => {
+    const serverError = new Error("startWebServer failed");
+    setupMocks({ startWebServerError: serverError });
+
+    const { main } = await import("../../src/index.js");
+    await main();
+
+    expect(closeWebServerMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
- Web UIサーバーをbackground起動時にunrefし、終了時にclose()で停止\n- PTY/トレイもクリーンアップ\n- ユニットテスト追加 (T020)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * バックグラウンドでのWeb UIサーバー起動に対応しました。
  * 起動失敗でもアプリがクラッシュしないようログ処理を強化しました。
  * アプリ終了時にバックグラウンドサーバーを確実に停止する順序制御とタイムアウト対応を追加しました。
  * システムリソースのクリーンアップ（トレイやセッション破棄）を改善しました。

* **テスト**
  * Web UIサーバーの起動／停止と関連のシャットダウン挙動を検証するテストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->