### PR TITLE
docs: Linuxのnode-gypビルド要件を追記

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -42,6 +42,11 @@ bun add -g @akiojin/gwt
 bunx @akiojin/gwt
 ```
 
+> 注意（Linux）: `node-gyp` のエラー（例: `Error: not found: make`）でインストールに失敗する場合、`node-pty` などのネイティブ依存をビルドするためのツールが不足しています。`linux/arm64` や `node:* -slim` のような最小イメージで起きやすいです。
+>
+> - Debian/Ubuntu: `apt-get update && apt-get install -y build-essential`
+> - Alpine: `apk add --no-cache build-base python3`
+
 ## クイックスタート
 
 任意のGitリポジトリで実行:
@@ -166,6 +171,7 @@ bunx @akiojin/gwt serve
 - **GitHub CLI**: PR クリーンアップ機能に必要（オプション）
 - **Python**: >= 3.11（Spec Kit CLIに必要）
 - **uv**: Pythonパッケージマネージャー（Spec Kit CLIに必要）
+- **ビルドツール**（Linux）: ネイティブ依存がソースビルドに回る場合、`make` と C/C++ ツールチェーンが必要です（`linux/arm64` や最小Dockerイメージで起きやすい）
 
 ## Spec Kit による仕様駆動開発
 
@@ -317,6 +323,7 @@ bun run start
 **権限エラー**: Claude Codeが適切なディレクトリ権限を持っていることを確認  
 **Git ワークツリー競合**: クリーンアップ機能を使用して古いワークツリーを削除  
 **GitHub認証**: PRクリーンアップ機能使用前に`gh auth login`を実行  
+**node-gyp / node-pty ビルドエラー**: `Error: not found: make` の場合は `build-essential`（Debian/Ubuntu）や `build-base`（Alpine）をインストール  
 **Bunバージョン**: `bun --version`でBun >= 1.0.0を確認
 
 ### デバッグモード

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Run without installation using bunx:
 bunx @akiojin/gwt
 ```
 
+> Note (Linux): If installation fails with a `node-gyp` error like `Error: not found: make`, you're missing build tools needed to compile native dependencies (e.g., `node-pty`). This is common on `linux/arm64` and minimal images like `node:* -slim`.
+>
+> - Debian/Ubuntu: `apt-get update && apt-get install -y build-essential`
+> - Alpine: `apk add --no-cache build-base python3`
+
 ## Quick Start
 
 Run in any Git repository:
@@ -189,6 +194,7 @@ For technical details, see [specs/SPEC-cff08403/](specs/SPEC-cff08403/).
 - **GitHub CLI**: Required for PR cleanup features (optional)
 - **Python**: >= 3.11 (for Spec Kit CLI)
 - **uv**: Python package manager (for Spec Kit CLI)
+- **Build tools** (Linux): `make` + a C/C++ toolchain may be required when native dependencies are built from source (common on `linux/arm64` and minimal Docker images)
 
 ## Spec-Driven Development with Spec Kit
 


### PR DESCRIPTION
Dockerなどの最小Linux環境（特に linux/arm64）で node-pty がソースビルドに回る場合、make/C++ツールチェーン不足で node-gyp が失敗することがあるため、READMEに必要なビルドツールとインストール例（Debian/Ubuntu・Alpine）を追記しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント更新

* **Documentation**
  * Linux環境でのネイティブビルドツール要件に関するガイダンスを追加しました。特にarm64やminimalイメージでのnode-gypビルド失敗時の解決方法として、Debian/UbuntuおよびAlpine環境別のインストール手順を記載しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->