### PR TITLE
fix: Gemini CLI起動時のTTY描画を維持する

### DIFF
--- a/specs/SPEC-3b0ed29b/spec.md
+++ b/specs/SPEC-3b0ed29b/spec.md
@@ -136,6 +136,7 @@ gwtから各AIツール（Claude Code、Codex、Gemini、Qwen）を起動する�
 - **FR-009**: Quick Startは、選択中のブランチ／ワークツリーごとにツール別最新セッションを表示し、他ブランチのセッションIDを混在させてはならない
 - **FR-010**: Quick Startは、履歴が古い場合でもワークツリー内のセッションファイルを走査し、有効な`session_id`を持つ最新ファイルを優先して表示しなければならない
 - **FR-011**: Quick Startは、Reasoning設定を持たないツール（Claude Code / Gemini / Qwen）ではReasoning表示を出してはならない
+- **FR-012**: 各AIツールは、起動プロセスのstdin/stdout/stderrを親ターミナル（TTY）へ接続し、色表示・ターミナル幅・インタラクティブ描画が失われないように**しなければならない**
 
 #### Claude Code固有要件
 


### PR DESCRIPTION
- gwt経由でGemini CLIを起動すると色/幅が効かない問題を修正
- stdout/stderrをpipeせずTTYを継承
- SPEC-3b0ed29bにFR-012追加、geminiユニットテスト更新

## 動作確認
- gwtでGeminiを起動し、カラー表示とターミナル幅に合わせた描画を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AI ツールの起動時に、ターミナルの色出力、画面幅、インタラクティブなレンダリングが正しく保持されるようになりました。

* **改善**
  * プロセス実行時のターミナル出力処理を最適化し、より安定した対話的な操作体験を実現しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->