### PR TITLE
fix(ci): マージ方法をsquashに変更してCHANGELOG重複を防止

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
-          gh pr merge "${{ github.event.pull_request.number }}" --auto --merge --repo "${{ github.repository }}"
+          gh pr merge "${{ github.event.pull_request.number }}" --auto --squash --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

- auto-merge.ymlで`--merge`を`--squash`に変更
- release-pleaseがマージコミットと元のコミットから同じConventional Commitメッセージを検出してCHANGELOGに重複エントリが生成される問題を解決

## Root Cause

`--merge`オプションでマージすると：
1. 元のコミット: `fix: xxx`
2. マージコミット: `Merge pull request #N` + PRタイトル（`fix: xxx`）

両方にConventional Commit形式のメッセージが含まれるため、release-pleaseが2回検出していた。

## Solution

`--squash`に変更することで、PRの全コミットが1つのコミットにまとまり、重複が発生しなくなる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)