### PR TITLE
fix: リモートモードでローカル・リモート両存在ブランチが表示されない問題を修正

### DIFF
--- a/src/cli/ui/components/screens/BranchListScreen.tsx
+++ b/src/cli/ui/components/screens/BranchListScreen.tsx
@@ -274,8 +274,14 @@ export function BranchListScreen({
     let result = branches;
 
     // Apply view mode filter
-    if (viewMode !== "all") {
-      result = result.filter((branch) => branch.type === viewMode);
+    if (viewMode === "local") {
+      result = result.filter((branch) => branch.type === "local");
+    } else if (viewMode === "remote") {
+      // リモート専用ブランチ OR ローカルだがリモートにも存在するブランチ
+      result = result.filter(
+        (branch) =>
+          branch.type === "remote" || branch.hasRemoteCounterpart === true,
+      );
     }
 
     // Apply search filter


### PR DESCRIPTION
## Summary

- ブランチがローカルとリモートの両方に存在する場合、「リモートのみ」表示モードで表示されない問題を修正
- `hasRemoteCounterpart`フラグを活用して、リモートに対応するブランチがあるローカルブランチも表示するように変更

## Changes

- `src/cli/ui/components/screens/BranchListScreen.tsx`: フィルタリングロジックを修正

## Test plan

- [ ] 「リモートのみ」モードで、ローカル・リモート両方に存在するブランチが表示されることを確認
- [ ] 「ローカルのみ」モードで、ローカルブランチのみ表示されることを確認
- [ ] 「すべて」モードで、全ブランチが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)