### PR TITLE
chore: テスト時のCLI起動遅延をスキップ

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -306,7 +306,12 @@ export async function launchClaudeCode(
           ),
         );
         console.log("");
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        const shouldSkipDelay =
+          typeof process !== "undefined" &&
+          (process.env?.NODE_ENV === "test" || Boolean(process.env?.VITEST));
+        if (!shouldSkipDelay) {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        }
         if (useNpx && npxLookup?.path) {
           await execInteractive(
             npxLookup.path,

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -201,7 +201,12 @@ export async function launchGeminiCLI(
       );
       console.log(chalk.yellow("      npm install -g @google/gemini-cli"));
       console.log("");
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      const shouldSkipDelay =
+        typeof process !== "undefined" &&
+        (process.env?.NODE_ENV === "test" || Boolean(process.env?.VITEST));
+      if (!shouldSkipDelay) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
       return await run("bunx", [GEMINI_CLI_PACKAGE, ...runArgs]);
     };
 


### PR DESCRIPTION
## 変更内容\n- テスト環境ではClaude/Gemini CLI起動時の2秒待機をスキップ\n\n## 影響範囲\n- テスト実行時のみ\n\n## 動作確認\n- 未実施（vitest が起動待ちで進まず）