### PR TITLE
docs: README.md/README.ja.mdを最新の実装状態に同期

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,15 +10,17 @@ Claude Code / Codex CLI / Gemini CLI 対応の対話型Gitワークツリーマ�
 
 ## ✨ 主要機能
 
-- 🎯 **対話型ブランチ選択**: ブランチ種別・ワークツリー・変更状態アイコンに加え配置インジケータ枠（左=L, 右=R, リモートのみ=☁）で所在を示し、リモート名の `origin/` を省いたシンプルなリストで判別しやすく、現在の選択は `>` プレフィックスで強調されるため誤操作を防止
+- 🎯 **モダンReactベースUI**: Ink.jsによるスムーズでレスポンシブなターミナルインターフェースとリアルタイム更新
+- 🖼️ **フルスクリーンレイアウト**: 統計情報付きの固定ヘッダー、スクロール可能なブランチリスト、キーボードショートカット付きの常時表示フッター
 - 🌟 **スマートブランチ作成**: ガイド付きプロンプトと自動ベースブランチ選択でfeature、bugfix、hotfix、releaseブランチを作成
 - 🔄 **高度なワークツリー管理**: 作成、クリーンアップ、パス最適化を含む完全なライフサイクル管理
 - 🤖 **Coding Agent 選択**: 起動時の対話型ランチャーで Claude Code / Codex CLI / Gemini CLI を選択
 - 🚀 **Coding Agent 統合**: 選択したコーディングエージェントをワークツリーで起動（Claude Codeは権限設定・変更処理の統合あり）
+- 🔒 **ワークツリーコマンド制限**: PreToolUse hooksによりワークツリー境界を強制し、ディレクトリ移動、ブランチ切替、ワークツリー外のファイル操作をブロック
 - 📊 **GitHub PR統合**: マージされたプルリクエストのブランチとワークツリーの自動クリーンアップ
 - 🛠️ **変更管理**: 開発セッション後のコミット、stash、破棄の内蔵サポート
 - 📦 **ユニバーサルパッケージ**: 一度インストールすれば全プロジェクトで一貫した動作
-- 🔍 **リポジトリ統計**: プロジェクト概要の向上のためのブランチとワークツリー数のリアルタイム表示
+- 🔍 **リアルタイム統計**: 自動ターミナルリサイズ対応でブランチ・ワークツリー数をライブ更新
 
 ## インストール
 
@@ -94,25 +96,46 @@ bunx @akiojin/gwt serve
 
 - Web UI はデフォルトで <http://localhost:3000> で利用できます
 - システムトレイ常駐は現時点では **Windows のみ対応** です（macOS/Linux では自動で無効化されます）
-- ブランチ一覧/検索/Worktree作成など、CLIと同じ体験をブラウザで提供
-- ブランチ一覧カードの「Coding Agentを起動」ボタンでモーダルが開き、エージェント/モード/引数/同期を選んで起動
-- ブランチ詳細ページはセッションの状態確認専用（稼働中セッションのターミナルと履歴を表示）
+- ブランチ一覧はCLIビューと同等で、検索とワークツリー作成を含む
+- ブランチ詳細ページからCoding Agentセッションを直接開始可能
 
 ### カスタム Coding Agent の管理
 
-- ダッシュボード右上の **Config**（または `/config` URL）で `~/.gwt/tools.json` をGUI編集
-- 実行タイプ（path/bunx/command）、defaultArgs、modeArgs、permissionSkipArgs、envをまとめて設定
-- 変更内容はCLIと共有の `tools.json` に保存されるため、CLI/Webのどちらからでも同じコーディングエージェントを利用可能
-- ブランチ一覧モーダルの起動フォームでは以下を指定できます:
-  - 起動するコーディングエージェント（ビルトインを含む）
-  - `normal / continue / resume` モード
-  - 追加引数（スペース区切り）
-  - CLIと同等の `--dangerously-skip-permissions`（確認ダイアログ付き）
-- モーダルから直接 `git fetch --all` + `git pull --ff-only` を実行でき、CLIと同じ安全ガードで divergence を検出します。
+- ダッシュボード右上の **Config**（または `/config` URL）で `~/.gwt/tools.json` を表示・編集
+- 実行タイプ（`path` / `bunx` / `command`）、デフォルト引数、モード別引数、権限スキップ引数、環境変数を追加・編集
+- 変更内容はCLIが使用する同じ `tools.json` ファイルに書き込まれるため、両チャネルで同期
+- ブランチ詳細ページからの起動時に設定可能:
+  - 任意のカスタム Coding Agent を選択
+  - `normal` / `continue` / `resume` モードを選択
+  - 追加引数を追記
+  - CLIと同等の `--dangerously-skip-permissions` フローを有効化（確認付き）
 
-> JSON編集なしでカスタムコーディングエージェントを試せるため、Web UIでパラメータを調整しながらCLIにも即反映できます。
+> ヒント: Web UI を使用してカスタム Coding Agent 定義を素早く調整し、JSON を手動編集せずに CLI またはブラウザから実行できます。
 
 ## 高度なワークフロー
+
+### ブランチ戦略
+
+このリポジトリは構造化されたブランチ戦略に従います：
+
+- **`main`**: 本番環境用コード。リリース専用の保護ブランチ。
+- **`develop`**: 機能統合ブランチ。すべてのfeatureブランチはここにマージ。
+- **`feature/*`**: 新機能と機能強化。**`develop`をベースとし、`develop`をターゲットにする必要があります**。
+- **`hotfix/*`**: 本番環境の緊急修正。`main`をベースとし、ターゲットにする。
+- **`release/*`**: リリース準備ブランチ。
+
+**重要**: featureブランチを作成する際は、常に`develop`をベースブランチとして使用してください：
+
+```bash
+# 正しい方法: develop からfeatureブランチを作成
+git checkout develop
+git pull origin develop
+git checkout -b feature/my-feature
+
+# またはこのツールを使用すると自動的に処理されます
+gwt
+# → 「新規ブランチ作成」を選択 → 「feature」→ 自動的にdevelopをベースとして使用
+```
 
 ### ブランチ作成ワークフロー
 
@@ -219,23 +242,24 @@ Claude Code で以下のコマンドを実行して、仕様駆動開発を活�
 ```
 @akiojin/gwt/
 ├── src/
-│   ├── index.ts          # メインアプリケーションエントリーポイント
-│   ├── git.ts           # Git操作とブランチ管理
-│   ├── worktree.ts      # ワークツリー作成と管理
-│   ├── claude.ts        # Claude Code 統合
-│   ├── codex.ts         # Codex CLI 統合
-│   ├── gemini.ts        # Gemini CLI 統合
-│   ├── github.ts        # GitHub CLI統合
-│   ├── utils.ts         # ユーティリティ関数とエラーハンドリング
-│   └── ui/              # ユーザーインターフェースコンポーネント
-│       ├── display.ts   # コンソール出力フォーマット
-│       ├── prompts.ts   # 対話型プロンプト
-│       ├── table.ts     # ブランチテーブル生成
-│       └── types.ts     # TypeScript型定義
+│   ├── cli/
+│   │   └── ui/          # Ink.js ReactコンポーネントによるターミナルUI
+│   ├── web/             # Web UIサーバー（Express + React）
+│   ├── services/        # コアビジネスロジック
+│   ├── repositories/    # データアクセス層
+│   ├── config/          # 設定管理
+│   ├── logging/         # 構造化ログ（pino）
+│   ├── shared/          # 共有ユーティリティと型
+│   └── types/           # TypeScript型定義
 ├── bin/
 │   └── gwt.js # 実行可能ラッパー
 ├── .claude/             # Claude Code 設定
-│   └── commands/        # Spec Kit スラッシュコマンド
+│   ├── commands/        # Spec Kit スラッシュコマンド
+│   ├── settings.json    # Hook設定
+│   └── hooks/           # コマンド制限用PreToolUse hooks
+│       ├── block-cd-command.sh        # cdコマンドをワークツリー内に制限
+│       ├── block-git-branch-ops.sh    # git ブランチ操作を制御
+│       └── block-file-ops.sh          # ファイル操作をワークツリー内に制限
 ├── .specify/            # Spec Kit スクリプトとテンプレート
 │   ├── memory/          # プロジェクトメモリファイル
 │   ├── scripts/         # 自動化スクリプト

--- a/README.md
+++ b/README.md
@@ -242,19 +242,15 @@ For more details, see the [Spec Kit documentation](https://github.com/akiojin/sp
 ```
 @akiojin/gwt/
 ├── src/
-│   ├── index.ts          # Main application entry point
-│   ├── git.ts           # Git operations and branch management
-│   ├── worktree.ts      # Worktree creation and management
-│   ├── claude.ts        # Claude Code integration
-│   ├── codex.ts         # Codex CLI integration
-│   ├── gemini.ts        # Gemini CLI integration
-│   ├── github.ts        # GitHub CLI integration
-│   ├── utils.ts         # Utility functions and error handling
-│   └── ui/              # User interface components
-│       ├── display.ts   # Console output formatting
-│       ├── prompts.ts   # Interactive prompts
-│       ├── table.ts     # Branch table generation
-│       └── types.ts     # TypeScript type definitions
+│   ├── cli/
+│   │   └── ui/          # Ink.js React components for terminal UI
+│   ├── web/             # Web UI server (Express + React)
+│   ├── services/        # Core business logic
+│   ├── repositories/    # Data access layer
+│   ├── config/          # Configuration management
+│   ├── logging/         # Structured logging (pino)
+│   ├── shared/          # Shared utilities and types
+│   └── types/           # TypeScript type definitions
 ├── bin/
 │   └── gwt.js # Executable wrapper
 ├── .claude/             # Claude Code configuration
@@ -384,18 +380,6 @@ We welcome contributions! Please read our contributing guidelines:
 - **Documentation**: This README and inline code documentation
 - **Issues**: GitHub Issues for bug reports and feature requests
 - **Discussions**: GitHub Discussions for questions and community support
-
-## MCP Configuration
-
-This repo includes `.mcp.json` for local MCP server definitions.
-
-- **External endpoints**: `context7` uses an external SSE endpoint. Review trust, security, and privacy requirements before enabling it in your environment.
-- **Data handling**: MCP clients may send prompts/queries (and possibly repository context depending on your tooling). Confirm compliance/DPA needs and disable the endpoint if external sharing is not permitted.
-- **Overrides**: If your MCP client supports environment expansion, you can override or disable external endpoints via env vars:
-  - `MCP_CONTEXT7_URL` (default: `https://mcp.context7.com/sse`)
-  - `MCP_CONTEXT7_ENABLED` (default: `true`)
-  - `SERENA_MCP_REF` (default: pinned commit in `.mcp.json`)
-- **Local config**: If your client does not expand env vars, generate a local config with `envsubst` and point your client to it.
 
 ### Icon Legend
 


### PR DESCRIPTION
## Summary

- README.md/README.ja.md を最新の実装状態に同期
- MCP Configuration セクション削除（古い情報のため）
- Project Structure を実際のディレクトリ構成に更新
- README.ja.md に不足していたセクションを追加（Branch Strategy、Ink.js UI、PreToolUse hooks）

## Test plan

- [x] markdownlint チェック通過
- [x] commitlint チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)