### PR TITLE
fix(test): Bun互換性のためのテスト修正

### DIFF
--- a/tests/quality/dist-app-bundle.test.ts
+++ b/tests/quality/dist-app-bundle.test.ts
@@ -10,7 +10,8 @@ const bundlePath = resolve(
 
 describe("Dist bundle integrity", () => {
   it("reflects BranchList cleanup UI implementation", async () => {
-    await expect(access(bundlePath, constants.F_OK)).resolves.toBeUndefined();
+    // Check file exists - access() resolves to undefined/null on success
+    await expect(access(bundlePath, constants.F_OK)).resolves.toBeFalsy();
 
     const content = await readFile(bundlePath, "utf8");
 

--- a/tests/unit/git.test.ts
+++ b/tests/unit/git.test.ts
@@ -883,11 +883,17 @@ describe("git.ts - Branch Operations", () => {
 });
 
 describe("git.ts - Gitignore Operations", () => {
+  // Restore all mocks to ensure fs module is not affected
+  beforeEach(() => {
+    mock.restore();
+  });
+
   describe("ensureGitignoreEntry", () => {
     let tempDir: string;
 
     beforeEach(async () => {
-      // Create temporary directory for tests
+      // Restore mocks and create temporary directory for tests
+      mock.restore();
       tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-test-"));
     });
 


### PR DESCRIPTION
## Summary
- dist-app-bundle.test.ts: access()がnullを返す問題を修正（toBeFalsyに変更）
- git.test.ts: Gitignore Operationsテストでmock.restore()を追加してfs.mkdtempの動作を修復

## Test plan
- [ ] CI テストが通過することを確認
- [ ] v4.11.x の publish workflow が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)