### PR TITLE
fix: run UI with bun runtime

### DIFF
--- a/bin/gwt.js
+++ b/bin/gwt.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 import('../dist/index.js').then(module => {
   if (module.main) {
     return module.main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,11 @@ function performTerminalCleanup(): void {
  * Returns SelectionResult if user made selections, undefined if user quit
  */
 async function mainSolidUI(): Promise<SelectionResult | undefined> {
+  if (!("Bun" in globalThis)) {
+    throw new Error(
+      "OpenTUI requires the Bun runtime. Run with Bun (e.g. bunx @akiojin/gwt@latest).",
+    );
+  }
   const { renderSolidApp } = await import("./opentui/index.solid.js");
   const terminal = getTerminalStreams();
 


### PR DESCRIPTION
## Summary
- run CLI UI with Bun runtime to avoid bun:ffi loader errors
- guard OpenTUI entry when Bun is unavailable

## Testing
- bunx commitlint --from HEAD~1 --to HEAD