### PR TITLE
fix: カーソル位置をグローバル管理に変更して安全状態更新時のリセットを防止

### DIFF
--- a/src/cli/ui/App.solid.tsx
+++ b/src/cli/ui/App.solid.tsx
@@ -258,6 +258,9 @@ export function AppSolid(props: AppSolidProps) {
   const [loading, setLoading] = createSignal(!props.branches);
   const [error, setError] = createSignal<Error | null>(null);
 
+  // ブランチ一覧のカーソル位置（グローバル管理で再マウント時もリセットされない）
+  const [branchCursorPosition, setBranchCursorPosition] = createSignal(0);
+
   const [toolItems, setToolItems] = createSignal<SelectorItem[]>([]);
   const [toolError, setToolError] = createSignal<Error | null>(null);
 
@@ -1449,6 +1452,8 @@ export function AppSolid(props: AppSolidProps) {
           cleanupUI={cleanupUI}
           helpVisible={helpVisible()}
           wizardVisible={wizardVisible()}
+          cursorPosition={branchCursorPosition()}
+          onCursorPositionChange={setBranchCursorPosition}
         />
       );
     }

--- a/src/cli/ui/screens/solid/BranchListScreen.tsx
+++ b/src/cli/ui/screens/solid/BranchListScreen.tsx
@@ -53,6 +53,10 @@ export interface BranchListScreenProps {
   helpVisible?: boolean;
   /** ウィザードポップアップ表示中は入力を無効化 */
   wizardVisible?: boolean;
+  /** カーソル位置（外部から制御する場合） */
+  cursorPosition?: number;
+  /** カーソル位置変更時のコールバック */
+  onCursorPositionChange?: (index: number) => void;
 }
 
 const VIEW_MODES: BranchViewMode[] = ["all", "local", "remote"];
@@ -299,7 +303,21 @@ export function BranchListScreen(props: BranchListScreenProps) {
   const [filterQuery, setFilterQuery] = createSignal("");
   const [filterMode, setFilterMode] = createSignal(false);
   const [viewMode, setViewMode] = createSignal<BranchViewMode>("all");
-  const [selectedIndex, setSelectedIndex] = createSignal(0);
+
+  // カーソル位置: 外部制御（props.cursorPosition）が優先、なければ内部状態を使用
+  const [internalSelectedIndex, setInternalSelectedIndex] = createSignal(
+    props.cursorPosition ?? 0,
+  );
+  const selectedIndex = () => props.cursorPosition ?? internalSelectedIndex();
+  const setSelectedIndex = (
+    value: number | ((prev: number) => number),
+  ): void => {
+    const newValue =
+      typeof value === "function" ? value(selectedIndex()) : value;
+    setInternalSelectedIndex(newValue);
+    props.onCursorPositionChange?.(newValue);
+  };
+
   const [scrollOffset, setScrollOffset] = createSignal(0);
   const [cleanupSpinnerIndex, setCleanupSpinnerIndex] = createSignal(0);
   const [cursorIndex, setCursorIndex] = createSignal(0);


### PR DESCRIPTION
## Summary

- 安全状態確認時にブランチ一覧のカーソル位置がリセットされる問題を修正
- カーソル位置（selectedIndex）を BranchListScreen のローカルシグナルから App.solid.tsx のグローバルシグナルに移動

## Changes

- `BranchListScreenProps` に `cursorPosition` と `onCursorPositionChange` を追加
- `App.solid.tsx` に `branchCursorPosition` シグナルを追加
- 外部から渡された `cursorPosition` を優先、未指定時は内部状態を使用

## Root Cause

前回の修正（PR #539）では `createEffect` に `on()` ヘルパーと `{ defer: true }` を追加したが、これは `filterQuery()` と `viewMode()` の変更のみを対象としており、他の原因パス（cleanupUIオブジェクトの毎回新規作成、setBranchItemsによる配列参照更新）を修正していなかった。

今回の修正では、カーソル位置を App.solid.tsx でグローバルに管理することで、コンポーネント再マウント時のリセットを根本的に解消した。

## Test plan

- [x] `bun run build` - ビルド成功
- [x] `bun test` - テスト成功（7件パス）
- [ ] 手動テスト: ブランチ一覧で安全状態確認中にカーソル移動→確認完了後もカーソル位置保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)