### PR TITLE
fix: remove version constraint from gwt-core path dependency

### DIFF
--- a/crates/gwt-web/Cargo.toml
+++ b/crates/gwt-web/Cargo.toml
@@ -9,7 +9,7 @@ description = "Web server for Git Worktree Manager"
 publish = false  # Not ready for publishing (Phase 4 - future work)
 
 [dependencies]
-gwt-core = { path = "../gwt-core", version = "5.0.0" }
+gwt-core = { path = "../gwt-core" }
 thiserror.workspace = true
 tokio.workspace = true
 axum = { workspace = true, features = ["ws"] }


### PR DESCRIPTION
## Summary

gwt-web の gwt-core 依存関係から version 制約を削除。

## 問題

release-please がバージョンを 6.0.0 に上げた際、gwt-web が `gwt-core = "^5.0.0"` を要求していたため CI が失敗。

## 解決

`publish = false` の crate では path 依存関係に version 制約は不要なので削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)