### PR TITLE
fix: support gwt-v* tag pattern in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: ['v*']
+    tags: ['v*', 'gwt-v*']  # Support both tag patterns (release-please uses gwt-v*)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

release-please が `gwt-v6.0.0` 形式のタグを作成するため、publish.yml のトリガーパターンを更新。

## 変更

- タグパターン: `['v*']` → `['v*', 'gwt-v*']`

## 影響

これにより、次回以降のリリースで publish ワークフローが自動トリガーされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)