### PR TITLE
fix: decouple crates.io publish from GitHub Release and npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     environment: release
+    continue-on-error: true  # Don't block other jobs if crates.io publish fails
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -114,7 +115,7 @@ jobs:
 
   upload-release:
     name: Upload to GitHub Release
-    needs: [release-please, build-binaries, publish-crates]
+    needs: [release-please, build-binaries]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Fix the release workflow so that crates.io publish failure doesn't block GitHub Release upload and npm publish.

## Changes

- Remove `publish-crates` from `upload-release` job dependencies
- Add `continue-on-error: true` to `publish-crates` job

This ensures npm publish proceeds even if crates.io Trusted Publishing fails (e.g., due to workflow filename mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)