### PR TITLE
fix: ログビューア・プロファイル画面のUI改善

### DIFF
--- a/crates/gwt-cli/src/tui/app.rs
+++ b/crates/gwt-cli/src/tui/app.rs
@@ -1520,8 +1520,10 @@ impl Model {
         let footer_height = if footer_text_len > inner_width { 4 } else { 3 };
 
         // Profiles, Environment, and Logs screens don't need header
-        let needs_header =
-            !matches!(base_screen, Screen::Profiles | Screen::Environment | Screen::Logs);
+        let needs_header = !matches!(
+            base_screen,
+            Screen::Profiles | Screen::Environment | Screen::Logs
+        );
         let header_height = if needs_header { 6 } else { 0 };
 
         let chunks = Layout::default()

--- a/crates/gwt-cli/src/tui/screens/logs.rs
+++ b/crates/gwt-cli/src/tui/screens/logs.rs
@@ -262,8 +262,8 @@ pub fn render_logs(state: &LogsState, frame: &mut Frame, area: Rect) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),                  // Header/Filter
-            Constraint::Min(0),                     // Log entries
+            Constraint::Length(3),                 // Header/Filter
+            Constraint::Min(0),                    // Log entries
             Constraint::Length(search_bar_height), // Search bar (only when searching)
         ])
         .split(area);
@@ -401,7 +401,6 @@ fn render_search_bar(state: &LogsState, frame: &mut Frame, area: Rect) {
         area.y + 1,
     ));
 }
-
 
 fn render_detail_view(entry: &LogEntry, frame: &mut Frame, area: Rect) {
     let level_style = match entry.level.as_str() {


### PR DESCRIPTION
## Summary

- ログビューア画面でアプリレベルのヘッダーを非表示に変更
- ログビューア画面のタイトルスタイルをプロファイル画面と統一（BOTTOM borderのみ）
- ログビューア画面のフッター重複を解消（app.rsのフッターに統一）
- 検索バーは検索時のみ表示するよう動的レイアウトに変更

## Test plan

- [ ] TUIを起動してログビューア画面を開き、アプリヘッダーが非表示になっていることを確認
- [ ] ログビューア画面でタイトル「Logs (X/Y) | Filter: ...」が表示されることを確認
- [ ] フッターが1つのみ表示されることを確認
- [ ] `/`キーで検索モードに入り、検索バーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)