### PR TITLE
fix: Rust移行時に誤って削除されたentrypoint.shを復元

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Git設定（node:22-bookwormにはGitが含まれている）
+# グローバルGit設定（安全なディレクトリを追加）
+git config --global --add safe.directory /gwt
+
+# ユーザー名とメールの設定（環境変数から）
+if [ -n "$GITHUB_USERNAME" ]; then
+    git config --global user.name "$GITHUB_USERNAME"
+fi
+
+if [ -n "$GIT_USER_EMAIL" ]; then
+    git config --global user.email "$GIT_USER_EMAIL"
+fi
+
+# Git認証ファイルを環境変数から作成
+if [ -n "$GITHUB_USERNAME" ] && [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
+    echo "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com" > /root/.git-credentials
+    chmod 600 /root/.git-credentials
+    git config --global credential.helper store
+fi
+
+# GitHub CLIの認証（GITHUB_TOKENが設定されている場合）
+if [ -n "$GITHUB_TOKEN" ] && command -v gh &> /dev/null; then
+    echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null || true
+fi
+
+# .codexディレクトリのセットアップ
+# auth.jsonをホストと同期（クロスプラットフォーム対応）
+if [ -f /root/.codex-host/auth.json ]; then
+    # auth.jsonが誤ってディレクトリとして作成されている場合は削除
+    if [ -d /root/.codex/auth.json ]; then
+        echo "⚠️  Removing incorrectly created auth.json directory"
+        rm -rf /root/.codex/auth.json
+    fi
+
+    # ホストのauth.jsonが存在しない、または空、またはホスト側が新しい場合はコピー
+    if [ ! -f /root/.codex/auth.json ] || [ ! -s /root/.codex/auth.json ] || [ /root/.codex-host/auth.json -nt /root/.codex/auth.json ]; then
+        cp /root/.codex-host/auth.json /root/.codex/auth.json
+        chmod 600 /root/.codex/auth.json
+        echo "✅ Codex auth.json synced from host"
+    else
+        echo "✅ Codex auth.json is up to date"
+    fi
+else
+    echo "ℹ️  INFO: Codex auth.json not found on host (optional)"
+fi
+
+echo "🚀 Docker development environment is ready!"
+echo "   You can now build the project with: bun run build"
+echo "   Or start development with: bun run dev"
+echo ""
+
+# コマンドの実行（デフォルトはbash）
+exec "$@"


### PR DESCRIPTION
## Summary
- Rust移行コミット(2606cbcd)で誤って削除された `scripts/entrypoint.sh` を復元
- Dockerビルドが `COPY scripts/entrypoint.sh` で失敗する問題を修正

## Changes
- `scripts/entrypoint.sh` を削除前の状態から復元

## Test plan
- [ ] `docker compose build --no-cache` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)