### PR TITLE
fix(tui): TUI起動時の自動orphanクリーンアップを削除

### DIFF
--- a/crates/gwt-cli/src/main.rs
+++ b/crates/gwt-cli/src/main.rs
@@ -67,9 +67,6 @@ fn run() -> Result<(), GwtError> {
         Some(cmd) => handle_command(cmd, &repo_root, &settings),
         None => {
             // Interactive TUI mode
-            if let Ok(manager) = WorktreeManager::new(&repo_root) {
-                let _ = manager.auto_cleanup_orphans();
-            }
             let mut entry: Option<TuiEntryContext> = None;
             loop {
                 let selection = tui::run_with_context(entry.take())?;


### PR DESCRIPTION
## Summary
- TUI起動時に自動実行されていた `auto_cleanup_orphans()` を削除
- ユーザーの意図しない修復が行われる問題を修正
- 修復は明示的に `gwt repair` コマンドを実行したときのみ行われるようになる

## Test plan
- [x] `cargo build --release` でビルド成功を確認
- [x] `cargo test` で全テスト成功を確認
- [x] `cargo clippy --all-targets --all-features -- -D warnings` で警告なしを確認

🤖 Generated with [Claude Code](https://claude.ai/code)