### PR TITLE
fix: improve URL opener fallbacks

### DIFF
--- a/crates/gwt-cli/src/tui/app.rs
+++ b/crates/gwt-cli/src/tui/app.rs
@@ -1826,16 +1826,15 @@ impl Model {
             }
         }
 
-        if std::env::var_os("TMUX").is_some() {
-            if std::process::Command::new("tmux")
+        if std::env::var_os("TMUX").is_some()
+            && std::process::Command::new("tmux")
                 .args(["set-buffer", "--", url])
                 .spawn()
                 .is_ok()
-            {
-                self.status_message = Some(format!("URL copied to tmux buffer: {}", url));
-                self.status_message_time = Some(Instant::now());
-                return;
-            }
+        {
+            self.status_message = Some(format!("URL copied to tmux buffer: {}", url));
+            self.status_message_time = Some(Instant::now());
+            return;
         }
 
         let mut extra_hint = String::new();
@@ -1843,7 +1842,8 @@ impl Model {
             || std::env::var_os("container").is_some()
             || std::env::var_os("DOCKER_CONTAINER").is_some()
         {
-            if std::fs::write("/tmp/gwt-open-url.txt", url).is_ok() {
+            let write_ok = std::fs::write("/tmp/gwt-open-url.txt", url).is_ok();
+            if write_ok {
                 extra_hint = " URL saved to /tmp/gwt-open-url.txt".to_string();
             }
         }


### PR DESCRIPTION
## Summary
- Fix URL open failures by adding multi-OS fallbacks and clearer errors
- Provide tmux/Docker-safe handling when no GUI opener exists

## Context
- Branch detail link opening failed with "os error 2" when openers were missing

## Changes
- Add fallback openers for Linux and PowerShell fallback for Windows
- Copy URL to tmux buffer or write to `/tmp/gwt-open-url.txt` in containers
- Validate empty URLs and improve error messaging

## Testing
- `cargo build --release`
- `cargo test`

## Risk / Impact
- Low: touch only URL opening path and error handling

## Deployment
- None

## Screenshots
- N/A

## Related Issues / Links
- N/A

## Checklist
- [ ] Tests added/updated
- [ ] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- Container handling writes to `/tmp/gwt-open-url.txt` when openers are unavailable
