### PR TITLE
fix: hooksコマンドに絶対パスを使用

### DIFF
--- a/crates/gwt-core/src/config/claude_hooks.rs
+++ b/crates/gwt-core/src/config/claude_hooks.rs
@@ -158,10 +158,7 @@ pub fn register_gwt_hooks(settings_path: &Path) -> Result<(), GwtError> {
 }
 
 /// Internal function to register hooks with a specified executable path
-fn register_gwt_hooks_with_exe_path(
-    settings_path: &Path,
-    exe_path: &str,
-) -> Result<(), GwtError> {
+fn register_gwt_hooks_with_exe_path(settings_path: &Path, exe_path: &str) -> Result<(), GwtError> {
     // Create parent directory if needed
     if let Some(parent) = settings_path.parent() {
         std::fs::create_dir_all(parent)?;


### PR DESCRIPTION
## Summary

- Claude Code hooks 登録時に絶対パスを使用するように修正
- `std::env::current_exe()` で実行中のバイナリのフルパスを取得
- `gwt` が PATH に含まれていない環境でも hooks が正しく動作

## Problem

Claude Code hooks が以下のエラーで失敗:
```
Stop hook error: Failed with non-blocking status code:
/bin/sh: 1: gwt: not found
```

## Solution

hooks 登録時に相対パス `"gwt hook Stop"` ではなく、絶対パス `"/path/to/gwt hook Stop"` を使用

## Test plan

- [x] 全テストがpass
- [x] clippy警告なし
- [x] `gwt hook uninstall && gwt hook setup` で絶対パスが設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)