### PR TITLE
feat: エージェント起動中のブランチでも選択メニューを表示

### DIFF
--- a/crates/gwt-cli/src/tui/app.rs
+++ b/crates/gwt-cli/src/tui/app.rs
@@ -1742,7 +1742,8 @@ impl Model {
                 skip_permissions: entry.skip_permissions,
             })
             .collect();
-        self.wizard.open_for_branch(&branch_name, history, running_pane_idx);
+        self.wizard
+            .open_for_branch(&branch_name, history, running_pane_idx);
     }
 
     fn handle_branch_list_mouse(&mut self, mouse: MouseEvent) {
@@ -2798,7 +2799,8 @@ impl Model {
                             skip_permissions: entry.skip_permissions,
                         })
                         .collect();
-                    self.wizard.open_for_branch(&branch_name, history, running_pane_idx);
+                    self.wizard
+                        .open_for_branch(&branch_name, history, running_pane_idx);
                 } else {
                     self.status_message = Some("No branch selected".to_string());
                     self.status_message_time = Some(Instant::now());

--- a/crates/gwt-cli/src/tui/screens/wizard.rs
+++ b/crates/gwt-cli/src/tui/screens/wizard.rs
@@ -2080,7 +2080,10 @@ mod tests {
         let mut state = WizardState::new();
         state.open_for_branch("feature/test", vec![], Some(0));
         let options = state.branch_action_options();
-        assert_eq!(options, &["Focus agent pane", "Create new branch from this"]);
+        assert_eq!(
+            options,
+            &["Focus agent pane", "Create new branch from this"]
+        );
     }
 
     #[test]
@@ -2088,7 +2091,10 @@ mod tests {
         let mut state = WizardState::new();
         state.open_for_branch("feature/test", vec![], None);
         let options = state.branch_action_options();
-        assert_eq!(options, &["Use selected branch", "Create new from selected"]);
+        assert_eq!(
+            options,
+            &["Use selected branch", "Create new from selected"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- ブランチ選択時、エージェント起動中でもウィザードを開いて選択肢を表示するよう変更
- エージェント起動中: "Focus agent pane" / "Create new branch from this" を表示
- エージェント未起動: "Use selected branch" / "Create new from selected" を表示

## Changes

### wizard.rs
- `WizardConfirmResult` に `FocusPane(usize)` バリアントを追加
- `WizardState` に `has_running_agent` と `running_agent_pane_idx` フィールドを追加
- `open_for_branch()` に `running_pane_idx` 引数を追加
- `branch_action_options()` ヘルパーメソッドを追加
- `confirm()` でエージェント起動中の処理を追加
- `render_branch_action_step()` で動的な選択肢を表示
- 4つの新しいテストを追加

### app.rs
- `handle_branch_enter()` - 常にウィザードを開くように変更
- `Message::OpenWizard` - `running_pane_idx` を渡すよう変更
- `Message::WizardConfirm` - `FocusPane` をハンドリング

## Test plan

- [x] `cargo build --release` - ビルド成功
- [x] `cargo test` - 全テスト通過 (272 passed)
- [x] `cargo clippy` - 警告なし
- [ ] 手動テスト: エージェント未起動のブランチでEnter → "Use selected branch" / "Create new from selected" が表示
- [ ] 手動テスト: エージェント起動中のブランチでEnter → "Focus agent pane" / "Create new branch from this" が表示
- [ ] 手動テスト: "Focus agent pane" 選択 → ペインにフォーカス、ウィザード閉じる
- [ ] 手動テスト: "Create new branch from this" 選択 → BranchTypeSelect ステップに進む

🤖 Generated with [Claude Code](https://claude.com/claude-code)