### PR TITLE
fix: hookイベント名直指定に対応

### DIFF
--- a/crates/gwt-cli/src/cli.rs
+++ b/crates/gwt-cli/src/cli.rs
@@ -193,8 +193,7 @@ mod tests {
 
     #[test]
     fn test_hook_parses_event_subcommand() {
-        let cli =
-            Cli::try_parse_from(["gwt", "hook", "event", "UserPromptSubmit"]).unwrap();
+        let cli = Cli::try_parse_from(["gwt", "hook", "event", "UserPromptSubmit"]).unwrap();
         match cli.command {
             Some(Commands::Hook {
                 action: HookAction::Event { name },

--- a/crates/gwt-cli/src/main.rs
+++ b/crates/gwt-cli/src/main.rs
@@ -465,9 +465,9 @@ fn cmd_hook(action: HookAction) -> Result<(), GwtError> {
     match action {
         HookAction::Event { name } => handle_hook_event(&name),
         HookAction::EventAlias(args) => {
-            let name = args.first().ok_or_else(|| {
-                GwtError::Internal("Missing hook event name.".to_string())
-            })?;
+            let name = args
+                .first()
+                .ok_or_else(|| GwtError::Internal("Missing hook event name.".to_string()))?;
             if args.len() > 1 {
                 return Err(GwtError::Internal(format!(
                     "Unexpected hook arguments: {}",


### PR DESCRIPTION
## Summary
- Accept direct hook event names like `gwt hook UserPromptSubmit` for Claude Code hooks
- Add CLI parsing tests for hook command variants

## Context
- Issue #709 reports `gwt hook UserPromptSubmit` fails with "unrecognized subcommand"
- Align CLI behavior with SPEC-861d8cdf hook usage expectations

## Changes
- Parse direct hook event names as an external subcommand alias
- Route aliases through existing hook event handler with argument validation
- Add CLI parsing tests for hook commands

## Testing
- `cargo test -p gwt-cli test_hook_parses`

## Risk / Impact
- Low; CLI argument parsing behavior only

## Deployment
- None

## Screenshots
- None

## Related Issues / Links
- #709
- SPEC-861d8cdf

## Checklist
- [x] Tests added/updated
- [ ] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- None
