### PR TITLE
fix: AI設定ウィザードでdキーが入力できない問題を修正

### DIFF
--- a/crates/gwt-cli/src/tui/app.rs
+++ b/crates/gwt-cli/src/tui/app.rs
@@ -2884,13 +2884,14 @@ impl Model {
                         } else if c == 'n' || c == 'N' {
                             self.ai_wizard.cancel_delete();
                         }
+                    } else if self.ai_wizard.is_text_input() {
+                        // Text input mode: insert character (including 'd')
+                        self.ai_wizard.insert_char(c);
                     } else if c == 'd' || c == 'D' {
-                        // Show delete confirmation (only in edit mode)
+                        // Show delete confirmation (only in edit mode, non-text-input steps)
                         if self.ai_wizard.is_edit {
                             self.ai_wizard.show_delete();
                         }
-                    } else if self.ai_wizard.is_text_input() {
-                        self.ai_wizard.insert_char(c);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- AI設定ウィザードのホストURL入力時に`d`キーが入力できない問題を修正
- `d`キーが削除ショートカットとして先に処理されていたため、テキスト入力に到達しなかった
- `is_text_input()`のチェック順序を修正し、テキスト入力モードでは`d`を文字として扱うようにした

## Test plan
- [x] `cargo test --lib` - 全298テストパス
- [x] `cargo clippy` - 警告なし
- [ ] AI設定ウィザードでホストURLに`d`を含む文字列（例: `https://api.openai.com/v1`）を入力できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)