### PR TITLE
test: hook setup重複登録防止のテスト追加

### DIFF
--- a/crates/gwt-core/src/config/claude_hooks.rs
+++ b/crates/gwt-core/src/config/claude_hooks.rs
@@ -595,12 +595,20 @@ mod tests {
         // Check UserPromptSubmit is not duplicated
         let user_prompt_hook = settings.hooks.get("UserPromptSubmit").unwrap();
         let arr = user_prompt_hook.as_array().expect("Expected array format");
-        assert_eq!(arr.len(), 1, "Should have exactly one entry, not duplicated");
+        assert_eq!(
+            arr.len(),
+            1,
+            "Should have exactly one entry, not duplicated"
+        );
 
         // Check PreToolUse is not duplicated
         let pre_tool_hook = settings.hooks.get("PreToolUse").unwrap();
         let arr = pre_tool_hook.as_array().expect("Expected array format");
-        assert_eq!(arr.len(), 1, "Should have exactly one entry, not duplicated");
+        assert_eq!(
+            arr.len(),
+            1,
+            "Should have exactly one entry, not duplicated"
+        );
 
         // Verify the original path is preserved (not replaced)
         assert!(content.contains("/path/to/old-gwt"));


### PR DESCRIPTION
## Summary
- 異なる実行可能パスで`gwt hook setup`を複数回実行しても、hookエントリが重複して追加されないことを保証するテストを追加

## Background
グローバル設定（`~/.claude/settings.json`）に古いworktreeパスのhookエントリが蓄積していた問題が発生。現在の実装は正しく重複を防止しているが、その動作を保証するテストが不足していた。

## Changes
- `test_idempotent_registration_with_different_paths`テストを追加
  - 異なるパスで2回登録しても1エントリのみ保持されることを確認
  - 最初のパスが保持され、後のパスは追加されないことを確認

## Test plan
- [x] `cargo test --package gwt-core -- claude_hooks` - 全14テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)