### PR TITLE
bugfix/fix other

### DIFF
--- a/crates/gwt-cli/src/tui/screens/branch_list.rs
+++ b/crates/gwt-cli/src/tui/screens/branch_list.rs
@@ -386,7 +386,7 @@ impl BranchItem {
 
     /// FR-082/FR-083/FR-084/FR-085: Get branch name color based on worktree status and gone status
     /// - White: Worktree exists and active
-    /// - Gray: No Worktree
+    /// - DarkGray: No Worktree
     /// - Red: Worktree path inaccessible OR branch is gone (upstream deleted)
     pub fn branch_name_color(&self) -> Color {
         if self.is_gone {
@@ -395,7 +395,7 @@ impl BranchItem {
         } else {
             match self.worktree_status {
                 WorktreeStatus::Active => Color::White, // FR-082: Active worktree
-                WorktreeStatus::None => Color::Gray,    // FR-083: No worktree
+                WorktreeStatus::None => Color::DarkGray, // FR-083: No worktree
                 WorktreeStatus::Inaccessible => Color::Red, // FR-084: Inaccessible path
             }
         }
@@ -2335,6 +2335,25 @@ mod tests {
         assert_eq!(state.spinner_char(), '/');
         state.spinner_frame = SPINNER_FRAMES.len() * 5;
         assert_eq!(state.spinner_char(), '|');
+    }
+
+    #[test]
+    fn test_branch_name_color_by_worktree_status() {
+        let mut branch = sample_branch("feature/color");
+
+        branch.worktree_status = WorktreeStatus::Active;
+        branch.is_gone = false;
+        assert_eq!(branch.branch_name_color(), Color::White);
+
+        branch.worktree_status = WorktreeStatus::None;
+        assert_eq!(branch.branch_name_color(), Color::DarkGray);
+
+        branch.worktree_status = WorktreeStatus::Inaccessible;
+        assert_eq!(branch.branch_name_color(), Color::Red);
+
+        branch.is_gone = true;
+        branch.worktree_status = WorktreeStatus::None;
+        assert_eq!(branch.branch_name_color(), Color::Red);
     }
 
     #[test]


### PR DESCRIPTION
- **fix: プロファイル画面のスペースキー有効化とフッター折り返し対応**
- **fix: フッター高さを動的に計算してテキスト長に応じて調整**
- **fix: プロファイル・環境変数画面でヘッダーを非表示に**
- **fix: プロファイル画面の重複ヘッダーを削除**
- **fix: プロファイル画面の内部ヘッダーを復元し重複フッターを削除**
- **fix: update deprecated gix work_dir() to workdir()**
- **fix: ログビューア画面のヘッダー非表示とタイトルスタイル統一**
- **fix: ログビューア画面のフッター重複を解消**
- **chore: rustfmtによるコードフォーマット修正**
- **chore: code-simplifierプラグインを追加**
- **fix: upstream未設定ブランチの安全ステータス判定を修正**
- **fix: upstream未設定ブランチをSafetyCheck対象に含める**
- **fix: stdoutを継承してエージェントのTTY検出を修正**
- **fix: Rust移行時に誤って削除されたentrypoint.shを復元**
- **fix: マージ済み判定を git merge-base --is-ancestor に変更**
- **fix: Unpushedアイコンを!から^に変更して区別化**
- **fix: Unpushedアイコン変更の追加修正**
- **fix(tmux): tmuxマルチモードでロケール環境変数を引き継ぐ**
- **fix(tmux): ログインシェルでコマンドを実行してロケール設定を読み込む**
- **fix(tmux): ロケール未設定環境でC.UTF-8をデフォルト適用**
- **fix(tmux): TERM環境変数も引き継いでUnicode文字の表示を修正**
- **fix(tmux): send-keys方式に戻してstdin接続問題を修正**
- **fix(tmux): 利用可能なUTF-8ロケールを自動検出**
- **fix: send-keys経由で環境変数をエクスポートしてDocker+tmux文字化けに対応**
- **docs: Docker+tmuxでのUnicode文字化け解決方法をREADMEに追加**
- **chore: rustfmtによるコードフォーマット修正**
- **fix: gray out branches without worktrees**
