### PR TITLE
fix: prioritize filter input over shortcuts

### DIFF
--- a/crates/gwt-cli/src/tui/app.rs
+++ b/crates/gwt-cli/src/tui/app.rs
@@ -4259,9 +4259,7 @@ impl Model {
         } else {
             // Normal key handling
             match (key.code, key.modifiers) {
-                (KeyCode::Char('c'), KeyModifiers::CONTROL) if is_key_press => {
-                    Some(Message::CtrlC)
-                }
+                (KeyCode::Char('c'), KeyModifiers::CONTROL) if is_key_press => Some(Message::CtrlC),
                 (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT)
                     if is_key_press
                         && matches!(self.screen, Screen::BranchList)
@@ -4325,9 +4323,8 @@ impl Model {
                         if self.environment.edit_mode {
                             Some(Message::Char('n'))
                         } else if self.environment.is_ai_only() {
-                            self.status_message = Some(
-                                "AI settings only. Use Enter to edit.".to_string(),
-                            );
+                            self.status_message =
+                                Some("AI settings only. Use Enter to edit.".to_string());
                             self.status_message_time = Some(Instant::now());
                             None
                         } else {
@@ -4354,9 +4351,8 @@ impl Model {
                         if self.environment.edit_mode {
                             Some(Message::Char('r'))
                         } else if self.environment.is_ai_only() {
-                            self.status_message = Some(
-                                "AI settings only. Use Enter to edit.".to_string(),
-                            );
+                            self.status_message =
+                                Some("AI settings only. Use Enter to edit.".to_string());
                             self.status_message_time = Some(Instant::now());
                             None
                         } else {
@@ -4433,9 +4429,8 @@ impl Model {
                         if self.environment.edit_mode {
                             Some(Message::Char('d'))
                         } else if self.environment.is_ai_only() {
-                            self.status_message = Some(
-                                "AI settings only. Use Enter to edit.".to_string(),
-                            );
+                            self.status_message =
+                                Some("AI settings only. Use Enter to edit.".to_string());
                             self.status_message_time = Some(Instant::now());
                             None
                         } else {


### PR DESCRIPTION
## Summary
- Prioritize filter input over shortcuts in BranchList filter mode
- Add regression tests for filter-mode key handling

## Context
- Shortcut keys were firing while typing in filter mode (e.g. `r` refresh), blocking filter input

## Changes
- Route filter-mode character input before shortcut handling
- Refactor key handling into a dedicated handler for clarity
- Add unit tests for filter-mode input and filter toggle

## Testing
- `cargo test -p gwt-cli test_filter_`

## Risk / Impact
- Low: localized to key handling in BranchList filter mode

## Deployment
- None

## Screenshots
- N/A

## Related Issues / Links
- N/A

## Checklist
- [x] Tests added/updated
- [ ] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- Template file `references/pr-body-template.md` not found in repo; used a minimal body.
