### PR TITLE
fix: show agent history for remote-only branches

### DIFF
--- a/crates/gwt-cli/src/tui/app.rs
+++ b/crates/gwt-cli/src/tui/app.rs
@@ -789,13 +789,11 @@ impl Model {
                     item
                 })
                 .collect();
-            branch_items.extend(
-                remote_only_branches.iter().map(|b| {
-                    let mut item = BranchItem::from_branch_minimal(b, &worktrees);
-                    apply_last_tool_usage(&mut item, &repo_root, &tool_usage_map, &agent_history);
-                    item
-                }),
-            );
+            branch_items.extend(remote_only_branches.iter().map(|b| {
+                let mut item = BranchItem::from_branch_minimal(b, &worktrees);
+                apply_last_tool_usage(&mut item, &repo_root, &tool_usage_map, &agent_history);
+                item
+            }));
 
             // Sort branches by timestamp for those with sessions
             branch_items.iter_mut().for_each(|item| {
@@ -5992,12 +5990,7 @@ mod tests {
             .unwrap();
         let tool_usage_map: HashMap<String, ToolSessionEntry> = HashMap::new();
 
-        apply_last_tool_usage(
-            &mut item,
-            Path::new("/tmp/repo"),
-            &tool_usage_map,
-            &history,
-        );
+        apply_last_tool_usage(&mut item, Path::new("/tmp/repo"), &tool_usage_map, &history);
 
         assert_eq!(item.last_tool_usage.as_deref(), Some("Codex@latest"));
         assert_eq!(item.last_tool_id.as_deref(), Some("codex-cli"));


### PR DESCRIPTION
## Summary
- Show last-used agent info for remote-only branches by normalizing branch names
- Apply agent history fallback consistently across branch list entries

## Context
- Worktree deletion should not remove visible agent history (SPEC-2ca73d7d, SPEC-d2f4762a FR-088/090)

## Changes
- Normalize branch names (strip remotes/*) before history lookup
- Apply tool usage or agent history to all branches, including remote-only
- Add unit tests for normalization and remote history fallback

## Testing
- `cargo test -p gwt-cli --quiet`

## Risk / Impact
- Low: read-only display logic for branch list history

## Deployment
- None

## Screenshots
- N/A

## Related Issues / Links
- SPEC-2ca73d7d
- SPEC-d2f4762a

## Checklist
- [x] Tests added/updated
- [ ] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- None
