### PR TITLE
fix(codex): web_search_request を web_search に変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -1341,7 +1341,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2467,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3976,7 +3976,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4027,7 +4027,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5416,7 +5416,7 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5427,9 +5427,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -6116,18 +6116,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.34"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.34"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6202,9 +6202,9 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
 
 [[package]]
 name = "zune-core"

--- a/crates/gwt-core/src/agent/codex.rs
+++ b/crates/gwt-core/src/agent/codex.rs
@@ -231,7 +231,7 @@ pub fn codex_default_args(
 
     let mut args = vec![
         "--enable".to_string(),
-        "web_search_request".to_string(),
+        "web_search".to_string(),
         format!("--model={}", model),
     ];
 
@@ -385,7 +385,7 @@ mod tests {
     fn test_codex_default_args_defaults() {
         let args = codex_default_args(None, None, None, false, false);
         assert!(args.contains(&"--enable".to_string()));
-        assert!(args.contains(&"web_search_request".to_string()));
+        assert!(args.contains(&"web_search".to_string()));
         assert!(args.contains(&"--model=gpt-5.2-codex".to_string()));
         assert!(args.contains(&"model_reasoning_effort=high".to_string()));
     }

--- a/specs/SPEC-3b0ed29b/spec.md
+++ b/specs/SPEC-3b0ed29b/spec.md
@@ -27,7 +27,7 @@ gwtから各コーディングエージェント（Claude Code、Codex、Gemini�
 
 **受け入れシナリオ**:
 
-1. **前提条件** gwtが起動しブランチが選択されている、**操作** エージェント選択画面でCodexを選択して起動、**期待結果** Codexが`--enable web_search_request`、(v0.80.0未満の場合のみ)`--enable skills`、`--sandbox workspace-write`などのデフォルト引数付きで起動する
+1. **前提条件** gwtが起動しブランチが選択されている、**操作** エージェント選択画面でCodexを選択して起動、**期待結果** Codexが`--enable web_search`、(v0.80.0未満の場合のみ)`--enable skills`、`--sandbox workspace-write`などのデフォルト引数付きで起動する
 2. **前提条件** gwtが起動しブランチが選択されている、**操作** エージェント選択画面でClaude Codeを選択して起動、**期待結果** Claude Codeがデフォルト設定で起動し、モデル選択が可能
 3. **前提条件** gwtが起動しブランチが選択されている、**操作** エージェント選択画面でGeminiを選択して起動、**期待結果** Gemini CLIがデフォルト設定で起動する
 4. **前提条件** gwtが起動しブランチが選択されている、**操作** エージェント選択画面でOpenCodeを選択して起動、**期待結果** OpenCodeがデフォルト設定で起動する
@@ -404,7 +404,7 @@ gwtから各コーディングエージェント（Claude Code、Codex、Gemini�
 
 #### Codex固有要件
 
-- **FR-201**: Codexは、デフォルト引数として`--enable web_search_request`を含め**なければならない**
+- **FR-201**: Codexは、デフォルト引数として`--enable web_search`を含め**なければならない**
 - **FR-202**: Codexは、Codex CLIバージョンが0.80.0未満の場合にのみ`--enable skills`を付与し、0.80.0以上またはバージョン判定不能の場合は付与してはならない
 - **FR-203**: Codexは、デフォルト引数として`--sandbox workspace-write`を含め**なければならない**
 - **FR-204**: Codexは、デフォルト引数として推論設定（`-c model_reasoning_effort`、`-c model_reasoning_summaries`）を含め**なければならない**


### PR DESCRIPTION
## Summary

- Codex CLIの非推奨パラメーター `web_search_request` を新しいパラメーター `web_search` に更新
- 仕様書（SPEC-3b0ed29b/spec.md）の該当箇所も同様に更新
- テストコードも新しいパラメーター名に変更

## Changes

- `crates/gwt-core/src/agent/codex.rs`: `--enable web_search_request` → `--enable web_search`
- `specs/SPEC-3b0ed29b/spec.md`: 仕様書の2箇所を更新

## Test Plan

- [x] `cargo test --package gwt-core --lib -- codex` でテスト成功
- [x] `cargo clippy` で警告なし
- [x] `commitlint` で検証成功

Closes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Codex CLI argument flag from "web_search_request" to "web_search" for consistency.

* **Documentation**
  * Updated specifications to reflect the corrected Codex default argument naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->