### PR TITLE
fix: avoid E1013 by reusing existing worktrees

### DIFF
--- a/crates/gwt-cli/src/commands.rs
+++ b/crates/gwt-cli/src/commands.rs
@@ -114,7 +114,7 @@ fn cmd_add(
         manager.create_for_branch(branch)?
     };
 
-    println!("Created worktree at: {}", wt.path.display());
+    println!("Worktree: {}", wt.path.display());
     println!("Branch: {}", wt.display_name());
 
     Ok(())

--- a/specs/SPEC-a70a1ece/spec.md
+++ b/specs/SPEC-a70a1ece/spec.md
@@ -185,7 +185,10 @@ submoduleを含むリポジトリをclone/worktree作成した場合、自動的
 
 - gitリポジトリでもbareリポジトリでもない空でないディレクトリでgwtを起動した場合、既存ファイルがあることを警告し、ユーザーが続行を選択した場合のみcloneウィザードを表示する
 - 親ディレクトリへの書き込み権限がない場合、worktree作成はエラーとなる
-- 既にworktreeが存在するブランチを選択した場合、既存のworktreeを開くか確認する
+- 既にworktreeが存在するブランチを選択した場合（TUI/CLI/API共通）、新規作成は行わず既存worktreeを返す（冪等）
+- `git worktree add` が "already checked out at <path>" を返すが `<path>` が存在しない場合、staleなworktreeメタデータの可能性がある
+  - 安全確認の上で `git worktree prune` を一度だけ実行し、再試行する
+  - `git worktree prune --dry-run --verbose` の結果、現在実行中のworktreeメタデータが削除対象に含まれる場合は自動pruneを行わず、手動対応を促す
 - ネットワーク接続がない状態でcloneを実行した場合、適切なエラーメッセージを表示する
 - マイグレーション中にlocked worktreeが検出された場合、unlockを促すメッセージを表示してブロックする
 - マイグレーション中にディスク容量が不足した場合、必要容量と空き容量を表示してブロックする


### PR DESCRIPTION
## Summary
- Fix E1013 during worktree creation by making `create_for_branch` idempotent when a worktree already exists for the target branch.
- Add a safe prune-and-retry path for stale worktree metadata that triggers "already checked out".

## Context
- Users hit `[E1013] Git operation failed: worktree add: fatal: '<branch>' is already checked out at '<path>'` while creating worktrees.
- In practice this often means either:
  - The branch already has a worktree and we should reuse it.
  - Or the worktree metadata is stale and needs pruning.

## Changes
- `gwt-core`: `WorktreeManager::create_for_branch` now:
  - Returns an existing worktree for the branch instead of calling `git worktree add` again.
  - Treats `Locked` as an error (`E2008`) and handles `Missing`/`Prunable` by attempting a single safe `git worktree prune` before retrying.
  - Parses the "already checked out at <path>" error to resolve and return the existing worktree when possible.
- `gwt-cli`: `gwt add` output no longer assumes creation; it prints `Worktree: <path>`.
- Spec updated to document the idempotent behavior and prune safety guard.

## Testing
- `cargo test -p gwt-core`
- `cargo test -p gwt-cli`

## Risk / Impact
- Behavior change: callers that previously received an error for an existing worktree will now get success with the existing path.
- Auto-prune is guarded by `git worktree prune --dry-run --verbose` and refuses to prune if it would remove the current worktree metadata.

## Deployment
- None.

## Screenshots
- None.

## Related Issues / Links
- Spec: `specs/SPEC-a70a1ece/spec.md`

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked (`cargo fmt`)
- [x] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- Auto-prune runs at most once per `create_for_branch` call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Worktree creation is now idempotent—selecting an existing branch returns the existing worktree instead of attempting to create a new one.
  * Enhanced remote branch reference resolution for improved multi-worktree management.

* **Bug Fixes**
  * Improved detection and recovery from stale metadata scenarios during worktree operations.
  * Better handling of locked and missing worktrees with safer pruning mechanics.

* **Documentation**
  * Updated specifications with expanded edge case coverage and error handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->