### PR TITLE
fix: recover from missing registered worktree paths

### DIFF
--- a/specs/SPEC-a70a1ece/spec.md
+++ b/specs/SPEC-a70a1ece/spec.md
@@ -192,6 +192,8 @@ submoduleを含むリポジトリをclone/worktree作成した場合、自動的
 - `git worktree add` が "<path> is a missing but already registered worktree" を返す場合も、staleなworktreeメタデータの可能性がある
   - 安全確認の上で `git worktree prune` を一度だけ実行し、再試行する
   - `git worktree prune --dry-run --verbose` の結果、現在実行中のworktreeメタデータが削除対象に含まれる場合は自動pruneを行わず、手動対応を促す
+- ブランチ名が `<remote>/<branch>` 形式でも、remote名は任意のため誤判定しない
+  - リモートブランチの存在が確認できる場合のみremote refとして扱い、それ以外は通常のブランチ名として扱う
 - ネットワーク接続がない状態でcloneを実行した場合、適切なエラーメッセージを表示する
 - マイグレーション中にlocked worktreeが検出された場合、unlockを促すメッセージを表示してブロックする
 - マイグレーション中にディスク容量が不足した場合、必要容量と空き容量を表示してブロックする


### PR DESCRIPTION
## Summary
- Recover automatically when `git worktree add` fails with "missing but already registered worktree"
- Avoid E1013 during worktree creation by pruning stale worktree metadata when safe

## Context
- Worktree creation can fail if Git keeps a registered worktree path even after the directory is deleted
- This should be treated as a recoverable stale-metadata case, similar to "already checked out at <path>" with a missing path

## Changes
- Detect registered worktree-path conflicts before creating a worktree and attempt `git worktree prune` (safe, once)
- When `git worktree add` returns the "missing but already registered worktree" error, prune+retry once (guarded by safety check)
- Tie "current worktree" safety detection to the target repo's `--git-common-dir` to avoid false positives when running from another repository
- Add tests for normal and bare repos
- Update spec: `specs/SPEC-a70a1ece/spec.md`

## Testing
- `cargo fmt`
- `cargo test -p gwt-core`
- `cargo test -p gwt-cli`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Risk / Impact
- Auto-prune touches Git worktree metadata; it is limited to one attempt and blocked if the current worktree would be pruned

## Deployment
- None

## Screenshots
- None

## Related Issues / Links
- Follow-up to #918

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [x] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic recovery from stale worktree metadata with safe pruning procedures.
  * Idempotent worktree creation—returns existing worktrees instead of prompting when branches already have them.
  * Enhanced conflict detection and resilient error recovery.

* **Bug Fixes**
  * Improved handling of missing or conflicting registered worktrees.

* **Changes**
  * Updated success message format for worktree creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->