### PR TITLE
fix(gui): adjust font size input and startup apply

### DIFF
--- a/gwt-gui/src/lib/components/SettingsPanel.svelte
+++ b/gwt-gui/src/lib/components/SettingsPanel.svelte
@@ -984,6 +984,7 @@
     font-size: var(--ui-font-base);
     font-family: monospace;
     outline: none;
+    appearance: textfield;
     -moz-appearance: textfield;
   }
 

--- a/gwt-gui/src/main.ts
+++ b/gwt-gui/src/main.ts
@@ -8,29 +8,25 @@ if (!import.meta.env.DEV) {
   window.addEventListener("contextmenu", (e) => e.preventDefault());
 }
 
-let app: ReturnType<typeof mount>;
-
 // Apply saved font size settings on startup before mounting to reduce flicker
-(async () => {
-  let settings: { ui_font_size: number; terminal_font_size: number } | null = null;
-  try {
-    const { invoke } = await import("@tauri-apps/api/core");
-    settings = await invoke<{ ui_font_size: number; terminal_font_size: number }>("get_settings");
-    if (settings.ui_font_size) {
-      document.documentElement.style.setProperty("--ui-font-base", settings.ui_font_size + "px");
-    }
-    if (settings.terminal_font_size) {
-      (window as any).__gwtTerminalFontSize = settings.terminal_font_size;
-    }
-  } catch {
-    // Settings not available (e.g. dev mode without Tauri runtime)
+let settings: { ui_font_size: number; terminal_font_size: number } | null = null;
+try {
+  const { invoke } = await import("@tauri-apps/api/core");
+  settings = await invoke<{ ui_font_size: number; terminal_font_size: number }>("get_settings");
+  if (settings.ui_font_size) {
+    document.documentElement.style.setProperty("--ui-font-base", settings.ui_font_size + "px");
   }
-
-  app = mount(App, { target: document.getElementById("app")! });
-
-  if (settings?.terminal_font_size) {
-    window.dispatchEvent(new CustomEvent("gwt-terminal-font-size", { detail: settings.terminal_font_size }));
+  if (settings.terminal_font_size) {
+    (window as any).__gwtTerminalFontSize = settings.terminal_font_size;
   }
-})();
+} catch {
+  // Settings not available (e.g. dev mode without Tauri runtime)
+}
+
+const app = mount(App, { target: document.getElementById("app")! });
+
+if (settings?.terminal_font_size) {
+  window.dispatchEvent(new CustomEvent("gwt-terminal-font-size", { detail: settings.terminal_font_size }));
+}
 
 export default app;


### PR DESCRIPTION
## Summary
- フォントサイズ入力のクランプを確定時に行うよう変更
- 起動時にフォント設定を先に適用してチラつきを軽減

## Context
- PR #943 のレビュー指摘（入力のしづらさ/FOUC）対応

## Changes
- SettingsPanel の数値入力を oninput では生値反映、onchange で clamp
- main.ts で設定適用後に mount するフローへ調整

## Testing
- 未実施

## Risk / Impact
- SettingsPanel の入力挙動と初期表示タイミングに影響
- 既存のフォント設定読み込みが失敗する場合は従来通り

## Deployment
- none

## Screenshots
- none

## Related Issues / Links
- PR #943 のレビュー指摘

## Checklist
- [ ] Tests added/updated
- [ ] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font size input validation to prevent invalid or empty values from being saved
  * Enhanced font size settings restoration reliability during application initialization
  * Fixed cross-browser styling inconsistency for font size input controls

* **Improvements**
  * Optimized font size settings loading to occur earlier in the application startup sequence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->