### PR TITLE
fix(tauri): keep app resident on Cmd+Q and confirm quit when agents run

### DIFF
--- a/crates/gwt-tauri/src/app.rs
+++ b/crates/gwt-tauri/src/app.rs
@@ -9,6 +9,7 @@ use tracing::{info, warn};
 #[cfg(not(test))]
 use gwt_core::config::os_env;
 
+#[cfg(any(not(test), target_os = "macos"))]
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
 fn should_prevent_window_close(is_quitting: bool) -> bool {
@@ -19,6 +20,7 @@ fn should_prevent_exit_request(is_quitting: bool) -> bool {
     !is_quitting
 }
 
+#[cfg(any(not(test), target_os = "macos"))]
 fn has_running_agents(state: &AppState) -> bool {
     let Ok(mut manager) = state.pane_manager.lock() else {
         return false;
@@ -34,6 +36,7 @@ fn has_running_agents(state: &AppState) -> bool {
     false
 }
 
+#[cfg(any(not(test), target_os = "macos"))]
 fn try_begin_exit_confirm(state: &AppState) -> bool {
     state
         .exit_confirm_inflight
@@ -41,6 +44,7 @@ fn try_begin_exit_confirm(state: &AppState) -> bool {
         .is_ok()
 }
 
+#[cfg(any(not(test), target_os = "macos"))]
 fn end_exit_confirm(state: &AppState) {
     state.exit_confirm_inflight.store(false, Ordering::SeqCst);
 }

--- a/crates/gwt-tauri/src/state.rs
+++ b/crates/gwt-tauri/src/state.rs
@@ -87,6 +87,7 @@ pub struct AppState {
     pub launch_jobs: Mutex<HashMap<String, Arc<AtomicBool>>>,
     pub is_quitting: AtomicBool,
     /// Prevent multiple exit confirmation dialogs from showing at once.
+    #[cfg(any(not(test), target_os = "macos"))]
     pub exit_confirm_inflight: AtomicBool,
     pub os_env: Arc<OnceCell<HashMap<String, String>>>,
     pub os_env_source: Arc<OnceCell<EnvSource>>,
@@ -108,6 +109,7 @@ impl AppState {
             pane_launch_meta: Mutex::new(HashMap::new()),
             launch_jobs: Mutex::new(HashMap::new()),
             is_quitting: AtomicBool::new(false),
+            #[cfg(any(not(test), target_os = "macos"))]
             exit_confirm_inflight: AtomicBool::new(false),
             os_env: Arc::new(OnceCell::new()),
             os_env_source: Arc::new(OnceCell::new()),


### PR DESCRIPTION
## Summary
- Prevent macOS Cmd+Q from quitting the entire app when the last window is closed.
- When agents are running, ask for confirmation before quitting or closing the window.

## Context
- Cmd+Q was closing the focused window, which could trigger an all-windows-closed exit path.
- If agents are running, accidental quit/close is disruptive.

## Changes
- Keep the app resident when all windows are closed unless an explicit quit was requested.
- Show exit confirmation dialogs only when agents are running:
  - Tray Quit: confirm quitting the app
  - Cmd+Q (macOS): confirm closing the focused window
- Recreate the main window when the app is resident but has zero windows.

## Testing
- cargo fmt --all
- cargo test -p gwt-tauri

## Risk / Impact
- Window lifecycle behavior changes (macOS Cmd+Q and all-windows-closed handling).
- Added dialogs in exit flows; guarded against multiple dialogs with an inflight flag.

## Deployment
- None

## Screenshots
- None

## Related Issues / Links
- TODO

## Checklist
- [ ] Tests added/updated
- [x] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- quit_app (forced migration refusal) remains force-quit without confirmation.
