### PR TITLE
fix: reflect ai readiness in agent mode

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,6 +62,18 @@ cd ..
 cargo tauri build
 ```
 
+## AI 設定
+
+Agent Mode やセッション要約を使うには AI 設定が必要です。
+
+手順:
+
+- `Settings` を開く
+- `Profiles` でプロファイルを選択
+- `AI Settings` を有効化
+- `Endpoint` と `Model` を設定（ローカル LLM の場合は API Key 省略可）
+- `Save` をクリック
+
 ## ディレクトリ構成
 
 - `crates/gwt-core/`: コア（Git/worktree/設定/ログ/Docker/PTY）

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ cd ..
 cargo tauri build
 ```
 
+## AI Settings
+
+Agent Mode and features like session summaries require AI settings.
+
+Steps:
+
+- Open `Settings`
+- Select a profile in `Profiles`
+- Enable `AI Settings`
+- Set `Endpoint` and `Model` (API key is optional for local LLMs)
+- Click `Save`
+
 ## Repository Layout
 
 - `crates/gwt-core/`: core logic (Git/worktree/config/logs/docker/pty)


### PR DESCRIPTION
## Summary
- Reflect AI readiness on Agent Mode initial load to avoid false "AI settings are required" warnings
- Document AI settings steps in README (EN/JA)

## Context
- Agent Mode showed the warning even when AI settings were configured

## Changes
- Initialize Agent Mode state using ProfilesConfig AI resolution
- Add AI settings quick steps to README.md and README.ja.md

## Testing
- Not run (not requested)

## Risk / Impact
- Low: uses existing profile config resolution

## Deployment
- None

## Screenshots
- N/A

## Related Issues / Links
- None

## Checklist
- [ ] Tests added/updated
- [ ] Lint/format checked
- [x] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive AI Settings configuration guide detailing how to enable, configure endpoints, models, and manage API keys for cloud and local LLMs in English and Japanese.

* **Bug Fixes**
  * Improved AI settings state initialization to properly handle configuration loading and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->