### PR TITLE
feat(gui): restore agent tabs on project open

### DIFF
--- a/gwt-gui/src/lib/terminal/TerminalView.svelte
+++ b/gwt-gui/src/lib/terminal/TerminalView.svelte
@@ -112,6 +112,7 @@
   onMount(() => {
     const rootEl = containerEl;
     if (!rootEl) return;
+    let cancelled = false;
 
     const term = new Terminal({
       cursorBlink: true,
@@ -217,8 +218,33 @@
       writeToTerminalBytes(Array.from(bytes));
     });
 
-    // Listen to terminal output from backend
-    setupEventListener();
+    // Best-effort: show recent scrollback so restored tabs aren't blank.
+    (async () => {
+      try {
+        const { invoke } = await import("@tauri-apps/api/core");
+        const text = await invoke<string>("capture_scrollback_tail", {
+          paneId,
+          maxBytes: 64 * 1024,
+        });
+        if (text) {
+          term.write(text);
+        }
+      } catch {
+        // Ignore: not available outside Tauri runtime.
+      }
+
+      // Listen to terminal output from backend.
+      const unlistenFn = await setupEventListener(term);
+      if (cancelled) {
+        if (unlistenFn) {
+          unlistenFn();
+        }
+        return;
+      }
+      if (unlistenFn) {
+        unlisten = unlistenFn;
+      }
+    })();
 
     // ResizeObserver for auto-fitting
     const observer = new ResizeObserver(() => {
@@ -248,6 +274,7 @@
     window.addEventListener("gwt-terminal-font-size", handleFontSizeChange);
 
     return () => {
+      cancelled = true;
       if (unlisten) {
         unlisten();
       }
@@ -259,21 +286,22 @@
     };
   });
 
-  async function setupEventListener() {
+  async function setupEventListener(term: Terminal): Promise<(() => void) | null> {
     try {
       const { listen } = await import("@tauri-apps/api/event");
       const unlistenFn = await listen<{ pane_id: string; data: number[] }>(
         "terminal-output",
         (event) => {
-          if (event.payload.pane_id === paneId && terminal) {
+          if (event.payload.pane_id === paneId) {
             const bytes = new Uint8Array(event.payload.data);
-            terminal.write(bytes);
+            term.write(bytes);
           }
         }
       );
-      unlisten = unlistenFn;
+      return unlistenFn;
     } catch (err) {
       console.error("Failed to setup terminal event listener:", err);
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
- Restore previously opened agent tabs (sessions) when opening a project.
- Reduce "blank terminal" on restored tabs by showing recent scrollback tail on mount.

## Context
- Users want the agent tab state to come back after reopening a project.

## Changes
- Persist/restore per-project agent tab state (order + active tab) via localStorage.
- Restore only panes that still exist (verified via `list_terminals`); drop missing panes.
- Guard persistence until hydration completes to avoid overwriting stored state with an empty one.
- `TerminalView` best-effort loads `capture_scrollback_tail` (64KB) before subscribing to live output.

## Testing
- `pnpm -C gwt-gui check`
- `pnpm -C gwt-gui test`
- `cargo test`

## Risk / Impact
- Low/medium: touches tab persistence/rehydration and terminal bootstrapping.
- If localStorage is unavailable/blocked, behavior falls back to current behavior.

## Deployment
- None

## Screenshots
- None

## Related Issues / Links
- None

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- This PR does not auto-relaunch missing panes; it restores only panes still present in the backend.
