### PR TITLE
fix: wire sidebar launch agent and quick start handlers

### DIFF
--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -1376,6 +1376,8 @@
           onBranchSelect={handleBranchSelect}
           onBranchActivate={handleBranchActivate}
           onCleanupRequest={handleCleanupRequest}
+          onLaunchAgent={requestAgentLaunch}
+          onQuickLaunch={handleAgentLaunch}
         />
       {/if}
       <MainArea


### PR DESCRIPTION
## Summary
- Fixes non-responsive actions in the Sidebar Worktree Summary panel by wiring missing callbacks from `App.svelte` into `Sidebar`.
- Restores expected behavior for both `Launch Agent...` and Quick Start `Continue/New` buttons.

## Context
- In the Sidebar branch mode, user interactions in `WorktreeSummaryPanel` were no-ops because `onLaunchAgent` and `onQuickLaunch` were not passed from the app root.
- This caused launch actions to work in some surfaces (e.g. `MainArea`) but not in the Sidebar summary area.

## Changes
- Added missing prop wiring in `gwt-gui/src/App.svelte`:
  - `onLaunchAgent={requestAgentLaunch}`
  - `onQuickLaunch={handleAgentLaunch}`
- Added regression tests in `gwt-gui/src/lib/components/Sidebar.test.ts`:
  - summary panel `Launch Agent...` invokes `onLaunchAgent`
  - Quick Start `Continue` invokes `onQuickLaunch` with `mode: "continue"` and `resumeSessionId`
  - Quick Start `New` invokes `onQuickLaunch` with `mode: "normal"`
  - Quick Start remains safe when `onQuickLaunch` is not provided

## Testing
- `cd gwt-gui && pnpm test -- src/lib/components/Sidebar.test.ts`
- `cd gwt-gui && pnpm check`
- `git push` pre-push hook CI-equivalent checks passed

## Risk / Impact
- Impacted area is limited to GUI callback wiring for Sidebar launch controls.
- Regression risk is low; behavior is covered by targeted component tests.

## Deployment
- none

## Screenshots
- none

## Related Issues / Links
- none

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- Branch: `bugfix/launch-agent-button-not-responsive`
- Commit: `e95f4236`
