### PR TITLE
fix(gui): stabilize terminal trackpad fallback when active timing varies

### DIFF
--- a/gwt-gui/src/lib/terminal/TerminalView.svelte
+++ b/gwt-gui/src/lib/terminal/TerminalView.svelte
@@ -126,11 +126,11 @@
     }
   }
 
-  function scrollViewportByWheel(rootEl: HTMLElement, event: WheelEvent) {
+  function scrollViewportByWheel(rootEl: HTMLElement, event: WheelEvent): boolean {
     const viewport = rootEl.querySelector<HTMLElement>(".xterm-viewport");
-    if (!viewport) return;
+    if (!viewport) return false;
 
-    if (event.deltaY === 0) return;
+    if (event.deltaY === 0) return false;
 
     const fontSize =
       typeof terminal?.options.fontSize === "number" ? terminal.options.fontSize : 13;
@@ -147,6 +147,7 @@
 
     const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
     viewport.scrollTop = Math.min(Math.max(viewport.scrollTop + delta, 0), maxScrollTop);
+    return true;
   }
 
   onMount(() => {
@@ -204,13 +205,16 @@
     });
 
     const handleWheel = (event: WheelEvent) => {
-      if (!active || !terminal) return;
       if (event.deltaY === 0) return;
+      if (!terminal) return;
 
       focusTerminalIfNeeded(rootEl, true);
+
+      const didScroll = scrollViewportByWheel(rootEl, event);
+      if (!didScroll) return;
+
       event.preventDefault();
       event.stopImmediatePropagation();
-      scrollViewportByWheel(rootEl, event);
     };
     rootEl.addEventListener("wheel", handleWheel, { passive: false, capture: true });
 

--- a/gwt-gui/src/lib/terminal/TerminalView.test.ts
+++ b/gwt-gui/src/lib/terminal/TerminalView.test.ts
@@ -325,4 +325,48 @@ describe("TerminalView", () => {
     expect(term.focus).toHaveBeenCalled();
     expect(viewport.scrollTop).toBe(150);
   });
+
+  it("still scrolls wheel input when active is false", async () => {
+    const { container } = await renderTerminalView({
+      paneId: "pane-4",
+      active: false,
+    });
+    const rootEl = container.querySelector(".terminal-container");
+    expect(rootEl).not.toBeNull();
+
+    const viewport = document.createElement("div");
+    viewport.className = "xterm-viewport";
+    viewport.style.overflow = "auto";
+    Object.defineProperty(viewport, "clientHeight", {
+      value: 100,
+      configurable: true,
+    });
+    Object.defineProperty(viewport, "scrollHeight", {
+      value: 250,
+      configurable: true,
+    });
+    viewport.scrollTop = 20;
+    rootEl!.appendChild(viewport);
+
+    await fireEvent.wheel(rootEl!, { deltaY: 20, bubbles: true });
+
+    expect(viewport.scrollTop).toBeGreaterThan(20);
+  });
+
+  it("does not prevent default when no viewport is available", async () => {
+    const { container } = await renderTerminalView({
+      paneId: "pane-5",
+      active: true,
+    });
+    const rootEl = container.querySelector(".terminal-container");
+    expect(rootEl).not.toBeNull();
+
+    const event = new WheelEvent("wheel", { deltaY: 20, bubbles: true });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+
+    rootEl!.dispatchEvent(event);
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Make terminal trackpad scroll fallback robust when active-state timing and viewport availability vary.
- Prevent losing scroll when wheel fallback can’t handle the event by only consuming the event on successful fallback.

## Context
- Trackpad scroll sometimes remains unresponsive in Agent tabs after tab switching or initialization.
- Prior fixes removed focus checks in some paths, but failures still reoccurred when fallback conditions changed.

## Changes
- Update `scrollViewportByWheel` to return success/failure explicitly.
- Apply wheel fallback without hard dependency on `active` so quick tab/focus transitions won’t block wheel handling.
- Only call `preventDefault` and `stopImmediatePropagation` when fallback actually scrolls.
- Add coverage for: active=false wheel input and no-viewport wheel handling behavior.

## Testing
- Not run: `pnpm -C gwt-gui test src/lib/terminal/TerminalView.test.ts` (missing local `node_modules`/`vitest`).
- Manual: verify trackpad/wheel scrolling in Agent terminal tab during tab activation and edge timing scenarios.

## Risk / Impact
- Low: only affects terminal wheel event handling fallback path and does not change command handling or terminal output logic.
- Rollback: revert commit `780c1f22`.

## Deployment
- none

## Screenshots
- none

## Related Issues / Links
- Related PR history: #985, #995, #996, #1025

## Checklist
- [x] Tests added/updated
- [ ] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- No functional changes outside terminal wheel fallback path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal viewport scrolling behavior when using the mouse wheel, with better handling of edge cases like missing viewports.

* **Tests**
  * Added tests for scroll behavior across different terminal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->