### PR TITLE
feat(ai): AI出力言語を設定可能にする

### DIFF
--- a/crates/gwt-core/src/ai/summary.rs
+++ b/crates/gwt-core/src/ai/summary.rs
@@ -7,8 +7,37 @@ use std::time::SystemTime;
 
 pub const SESSION_SYSTEM_PROMPT_BASE: &str = "You are a helpful assistant summarizing a coding agent session so the user can remember the original request and latest instruction.\nReturn Markdown only with the following format and headings, in this exact order:\n\n## <Purpose heading in the user's language>\n<1 sentence: the original user request + key constraints + explicit exclusions>\n\n## <Summary heading in the user's language>\n<1-2 sentences: current status (use a clear status word) + the latest user instruction; mention if blocked>\n\n## <Highlights heading in the user's language>\n- <Original request: ...>\n- <Latest instruction: ...>\n- <Decisions/constraints: ...>\n- <Exclusions/not doing: ...>\n- <Status: ...>\n- <Progress: ...>\n- <Recent meaningful actions (last 1-3): ...>\n- <Needs user input (as a direct question): ...>\n- <Key words (3 items): ...>\n\nAdd more bullets if there are additional important items, but keep the list concise.\nIf there was no progress, say so and why.\nIf waiting for user input, state the exact question needed.\nDo not guess; if something is unknown, say so explicitly in the user's language.\nUse short labels followed by \":\" for each bullet and translate the labels to the user's language.\nDetect the response language from the session content and respond in that language.\nIf the session contains multiple languages, use the language used by the user messages.\nAll headings and all content must be in the user's language.\nDo not output JSON, code fences, or any extra text.\n\nIgnore operational workflow chatter from this session except for content that changes direction:\n- PR/MR creation, branch operations, test/build/CI activity, and short status updates.\n- Keep summaries focused on user intent, decisions, constraints, outcomes, blockers, or pending actions.\n- Ignore one-line acknowledgements unless they contain a blocking issue or design decision.\nPrioritize substantive conversation over command history.\n\nWhen the session language is Japanese, headings must be exactly in this order:\n- ## 目的\n- ## 要約\n- ## ハイライト\nWhen the session language is English, headings must be exactly in this order:\n- ## Purpose\n- ## Summary\n- ## Highlights.";
 
+const SESSION_SYSTEM_PROMPT_EN: &str = "You are a helpful assistant summarizing a coding agent session so the user can remember the original request and latest instruction.\nRespond in English.\nReturn Markdown only with the following format and headings, in this exact order:\n\n## Purpose\n<1 sentence: the original user request + key constraints + explicit exclusions>\n\n## Summary\n<1-2 sentences: current status (use a clear status word) + the latest user instruction; mention if blocked>\n\n## Highlights\n- <Original request: ...>\n- <Latest instruction: ...>\n- <Decisions/constraints: ...>\n- <Exclusions/not doing: ...>\n- <Status: ...>\n- <Progress: ...>\n- <Recent meaningful actions (last 1-3): ...>\n- <Needs user input (as a direct question): ...>\n- <Key words (3 items): ...>\n\nAdd more bullets if there are additional important items, but keep the list concise.\nIf there was no progress, say so and why.\nIf waiting for user input, state the exact question needed.\nDo not guess; if something is unknown, say so explicitly in English.\nUse short labels followed by \":\" for each bullet.\nAll headings and all content must be in English.\nDo not output JSON, code fences, or any extra text.\n\nIgnore operational workflow chatter from this session except for content that changes direction:\n- PR/MR creation, branch operations, test/build/CI activity, and short status updates.\n- Keep summaries focused on user intent, decisions, constraints, outcomes, blockers, or pending actions.\n- Ignore one-line acknowledgements unless they contain a blocking issue or design decision.\nPrioritize substantive conversation over command history.";
+
+const SESSION_SYSTEM_PROMPT_JA: &str = "You are a helpful assistant summarizing a coding agent session so the user can remember the original request and latest instruction.\nRespond in Japanese.\nReturn Markdown only with the following format and headings, in this exact order:\n\n## 目的\n<1文: 元のユーザー依頼 + 重要な制約 + 明示された除外>\n\n## 要約\n<1-2文: 現在ステータス（明確な状態語を使う）+ 最新のユーザー指示。ブロックされているなら明記>\n\n## ハイライト\n- <元の依頼: ...>\n- <最新指示: ...>\n- <決定事項/制約: ...>\n- <除外/やらないこと: ...>\n- <ステータス: ...>\n- <進捗: ...>\n- <直近の意味のある行動（1-3件）: ...>\n- <ユーザーに必要な入力（質問として）: ...>\n- <キーワード（3つ）: ...>\n\n重要な項目があれば箇条書きを追加してよいが、簡潔にすること。\n進捗がない場合は、その旨と理由を書くこと。\nユーザー入力待ちの場合は、必要な質問をそのまま書くこと。\n推測しない。不明な点は不明と明記すること。\n各箇条書きは短いラベル + \":\" で始め、ラベルも日本語にすること。\n見出しと本文はすべて日本語にすること。\nJSONやコードフェンス、余計なテキストを出力しないこと。\n\n以下の運用的なやり取りは、方向性が変わる内容を除き無視すること:\n- PR/MR作成、ブランチ操作、テスト/ビルド/CI、短いステータス更新\n- 要約はユーザー意図、決定事項、制約、結果、ブロッカー、未完了作業に集中する\n- ブロッキングや設計判断を含まない1行の相槌は無視する\n会話の中身を優先し、コマンド履歴に引っ張られないこと。";
+
 const MAX_MESSAGE_CHARS: usize = 220;
 const MAX_PROMPT_CHARS: usize = 8000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SummaryLanguage {
+    Ja,
+    En,
+}
+
+fn session_system_prompt(language: &str) -> &'static str {
+    match language.trim() {
+        "ja" => SESSION_SYSTEM_PROMPT_JA,
+        "auto" => SESSION_SYSTEM_PROMPT_BASE,
+        _ => SESSION_SYSTEM_PROMPT_EN,
+    }
+}
+
+fn contains_japanese(text: &str) -> bool {
+    text.chars().any(|c| {
+        matches!(
+            c,
+            '\u{3040}'..='\u{309F}' // Hiragana
+                | '\u{30A0}'..='\u{30FF}' // Katakana
+                | '\u{4E00}'..='\u{9FFF}' // CJK Unified Ideographs
+        )
+    })
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct SessionSummary {
@@ -34,6 +63,7 @@ pub struct SessionSummaryCache {
     last_modified: HashMap<String, SystemTime>,
     session_ids: HashMap<String, String>,
     tool_ids: HashMap<String, String>,
+    languages: HashMap<String, String>,
 }
 
 impl SessionSummaryCache {
@@ -58,18 +88,34 @@ impl SessionSummaryCache {
         branch: String,
         tool_id: String,
         session_id: String,
+        language: String,
         summary: SessionSummary,
         mtime: SystemTime,
     ) {
         self.cache.insert(branch.clone(), summary);
         self.last_modified.insert(branch.clone(), mtime);
         self.session_ids.insert(branch.clone(), session_id);
-        self.tool_ids.insert(branch, tool_id);
+        self.tool_ids.insert(branch.clone(), tool_id);
+        self.languages.insert(branch, language);
     }
 
-    pub fn is_stale(&self, branch: &str, session_id: &str, current_mtime: SystemTime) -> bool {
+    pub fn is_stale(
+        &self,
+        branch: &str,
+        session_id: &str,
+        language: &str,
+        current_mtime: SystemTime,
+    ) -> bool {
         if let Some(cached_session_id) = self.session_ids.get(branch) {
             if cached_session_id != session_id {
+                return true;
+            }
+        } else {
+            return true;
+        }
+
+        if let Some(cached_language) = self.languages.get(branch) {
+            if cached_language != language {
                 return true;
             }
         } else {
@@ -90,7 +136,7 @@ struct SessionSummaryFields {
     bullet_points: Vec<String>,
 }
 
-pub fn build_session_prompt(parsed: &ParsedSession) -> Vec<ChatMessage> {
+pub fn build_session_prompt(parsed: &ParsedSession, language: &str) -> Vec<ChatMessage> {
     let mut lines = Vec::new();
     lines.push(format!(
         "Agent: {} (session_id: {})",
@@ -163,7 +209,7 @@ pub fn build_session_prompt(parsed: &ParsedSession) -> Vec<ChatMessage> {
     vec![
         ChatMessage {
             role: "system".to_string(),
-            content: SESSION_SYSTEM_PROMPT_BASE.to_string(),
+            content: session_system_prompt(language).to_string(),
         },
         ChatMessage {
             role: "user".to_string(),
@@ -247,13 +293,14 @@ pub fn summarize_scrollback(
     client: &AIClient,
     scrollback_text: &str,
     branch_name: &str,
+    language: &str,
 ) -> Result<SessionSummary, AIError> {
     let sampled = sample_scrollback_text(scrollback_text);
     let user_prompt = format!("Branch: {branch_name}\nTerminal session output:\n{sampled}");
     let messages = vec![
         ChatMessage {
             role: "system".to_string(),
-            content: SESSION_SYSTEM_PROMPT_BASE.to_string(),
+            content: session_system_prompt(language).to_string(),
         },
         ChatMessage {
             role: "user".to_string(),
@@ -262,7 +309,7 @@ pub fn summarize_scrollback(
     ];
     let content = client.create_response(messages)?;
     let fields = parse_session_summary_fields(&content).unwrap_or_default();
-    let markdown = normalize_session_summary_markdown(&content, &fields)?;
+    let markdown = normalize_session_summary_markdown(&content, &fields, language)?;
     validate_session_summary_markdown(&markdown)?;
 
     let token_count = scrollback_text.chars().count() / 4;
@@ -315,11 +362,12 @@ fn sample_scrollback_text(text: &str) -> String {
 pub fn summarize_session(
     client: &AIClient,
     parsed: &ParsedSession,
+    language: &str,
 ) -> Result<SessionSummary, AIError> {
-    let messages = build_session_prompt(parsed);
+    let messages = build_session_prompt(parsed, language);
     let content = client.create_response(messages)?;
     let fields = parse_session_summary_fields(&content).unwrap_or_default();
-    let markdown = normalize_session_summary_markdown(&content, &fields)?;
+    let markdown = normalize_session_summary_markdown(&content, &fields, language)?;
     validate_session_summary_markdown(&markdown)?;
 
     let metrics = build_metrics(parsed);
@@ -392,51 +440,78 @@ fn parse_session_summary_fields(content: &str) -> Result<SessionSummaryFields, A
 fn normalize_session_summary_markdown(
     content: &str,
     fields: &SessionSummaryFields,
+    language: &str,
 ) -> Result<String, AIError> {
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return Err(AIError::ParseError("Empty summary".to_string()));
     }
 
+    let target = target_summary_language(language, trimmed);
+
     if parse_json_summary(trimmed).is_some() {
-        return Ok(build_markdown_from_fields(fields));
+        return Ok(build_markdown_from_fields(fields, target));
     }
 
     if looks_like_markdown(trimmed) {
-        return Ok(normalize_summary_headings(trimmed));
+        return Ok(normalize_summary_headings(trimmed, target));
     }
 
-    Ok(build_markdown_from_fields(fields))
+    Ok(build_markdown_from_fields(fields, target))
 }
 
 fn validate_session_summary_markdown(markdown: &str) -> Result<(), AIError> {
     let mut stage = SummaryStage::Start;
+    let mut lang: Option<SummaryLanguage> = None;
     let mut has_bullet = false;
 
     for line in markdown.lines() {
         let trimmed = line.trim();
         if let Some(title) = trimmed.strip_prefix("## ") {
             let title = title.trim();
-            if heading_matches(title, &["目的"]) {
-                if stage != SummaryStage::Start {
-                    return Err(AIError::IncompleteSummary);
+            match stage {
+                SummaryStage::Start => {
+                    if heading_matches(title, &["目的"]) {
+                        lang = Some(SummaryLanguage::Ja);
+                        stage = SummaryStage::Purpose;
+                        continue;
+                    }
+                    if heading_matches(title, &["Purpose", "purpose"]) {
+                        lang = Some(SummaryLanguage::En);
+                        stage = SummaryStage::Purpose;
+                        continue;
+                    }
                 }
-                stage = SummaryStage::Purpose;
-                continue;
-            }
-            if heading_matches(title, &["要約", "概要"]) {
-                if stage != SummaryStage::Purpose {
-                    return Err(AIError::IncompleteSummary);
-                }
-                stage = SummaryStage::Summary;
-                continue;
-            }
-            if heading_matches(title, &["ハイライト", "Highlights", "highlights"]) {
-                if stage != SummaryStage::Summary {
-                    return Err(AIError::IncompleteSummary);
-                }
-                stage = SummaryStage::Highlight;
-                continue;
+                SummaryStage::Purpose => match lang.unwrap_or(SummaryLanguage::Ja) {
+                    SummaryLanguage::Ja => {
+                        if heading_matches(title, &["要約", "概要"]) {
+                            stage = SummaryStage::Summary;
+                            continue;
+                        }
+                    }
+                    SummaryLanguage::En => {
+                        if heading_matches(title, &["Summary", "summary"]) {
+                            stage = SummaryStage::Summary;
+                            continue;
+                        }
+                    }
+                },
+                SummaryStage::Summary => match lang.unwrap_or(SummaryLanguage::Ja) {
+                    SummaryLanguage::Ja => {
+                        if heading_matches(title, &["ハイライト"]) {
+                            stage = SummaryStage::Highlight;
+                            continue;
+                        }
+                    }
+                    SummaryLanguage::En => {
+                        if heading_matches(title, &["Highlights", "highlights"]) {
+                            stage = SummaryStage::Highlight;
+                            continue;
+                        }
+                    }
+                },
+                SummaryStage::Highlight => stage = SummaryStage::Done,
+                SummaryStage::Done => {}
             }
             if stage == SummaryStage::Highlight {
                 stage = SummaryStage::Done;
@@ -456,14 +531,47 @@ fn validate_session_summary_markdown(markdown: &str) -> Result<(), AIError> {
     Err(AIError::IncompleteSummary)
 }
 
-fn normalize_summary_headings(markdown: &str) -> String {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeadingKind {
+    Purpose,
+    Summary,
+    Highlights,
+}
+
+fn classify_heading(title: &str) -> Option<HeadingKind> {
+    if heading_matches(title, &["目的", "Purpose", "purpose"]) {
+        return Some(HeadingKind::Purpose);
+    }
+    if heading_matches(title, &["要約", "概要", "Summary", "summary"]) {
+        return Some(HeadingKind::Summary);
+    }
+    if heading_matches(title, &["ハイライト", "Highlights", "highlights"]) {
+        return Some(HeadingKind::Highlights);
+    }
+    None
+}
+
+fn canonical_heading(kind: HeadingKind, lang: SummaryLanguage) -> &'static str {
+    match (kind, lang) {
+        (HeadingKind::Purpose, SummaryLanguage::Ja) => "目的",
+        (HeadingKind::Purpose, SummaryLanguage::En) => "Purpose",
+        (HeadingKind::Summary, SummaryLanguage::Ja) => "要約",
+        (HeadingKind::Summary, SummaryLanguage::En) => "Summary",
+        (HeadingKind::Highlights, SummaryLanguage::Ja) => "ハイライト",
+        (HeadingKind::Highlights, SummaryLanguage::En) => "Highlights",
+    }
+}
+
+fn normalize_summary_headings(markdown: &str, lang: SummaryLanguage) -> String {
     let mut out = String::with_capacity(markdown.len());
     let lines: Vec<&str> = markdown.lines().collect();
     let last_idx = lines.len().saturating_sub(1);
     for (idx, line) in lines.iter().enumerate() {
         let line = *line;
         if let Some(title) = line.trim_start().strip_prefix("## ") {
-            let normalized_title = normalize_summary_heading_title(title);
+            let normalized_title = classify_heading(title)
+                .map(|kind| canonical_heading(kind, lang).to_string())
+                .unwrap_or_else(|| title.trim().to_string());
             out.push_str("## ");
             out.push_str(&normalized_title);
             if idx < last_idx {
@@ -477,19 +585,6 @@ fn normalize_summary_headings(markdown: &str) -> String {
         }
     }
     out
-}
-
-fn normalize_summary_heading_title(title: &str) -> String {
-    if heading_matches(title, &["目的", "Purpose", "purpose"]) {
-        return "目的".to_string();
-    }
-    if heading_matches(title, &["要約", "概要", "Summary", "summary"]) {
-        return "要約".to_string();
-    }
-    if heading_matches(title, &["ハイライト", "Highlights", "highlights"]) {
-        return "ハイライト".to_string();
-    }
-    title.to_string()
 }
 
 fn heading_matches(title: &str, expected: &[&str]) -> bool {
@@ -535,28 +630,43 @@ fn looks_like_markdown(content: &str) -> bool {
         || content.contains("\n1)")
 }
 
-fn build_markdown_from_fields(fields: &SessionSummaryFields) -> String {
+fn build_markdown_from_fields(fields: &SessionSummaryFields, lang: SummaryLanguage) -> String {
     let purpose = fields
         .task_overview
         .as_ref()
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
-        .unwrap_or("(Not available)");
+        .unwrap_or(match lang {
+            SummaryLanguage::Ja => "(不明)",
+            SummaryLanguage::En => "(Not available)",
+        });
     let summary = fields
         .short_summary
         .as_ref()
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
-        .unwrap_or("(Not available)");
+        .unwrap_or(match lang {
+            SummaryLanguage::Ja => "(不明)",
+            SummaryLanguage::En => "(Not available)",
+        });
 
     let mut out = String::new();
-    out.push_str("## 目的\n");
+    out.push_str("## ");
+    out.push_str(canonical_heading(HeadingKind::Purpose, lang));
+    out.push('\n');
     out.push_str(purpose);
-    out.push_str("\n\n## 要約\n");
+    out.push_str("\n\n## ");
+    out.push_str(canonical_heading(HeadingKind::Summary, lang));
+    out.push('\n');
     out.push_str(summary);
-    out.push_str("\n\n## ハイライト\n");
+    out.push_str("\n\n## ");
+    out.push_str(canonical_heading(HeadingKind::Highlights, lang));
+    out.push('\n');
     if fields.bullet_points.is_empty() {
-        out.push_str("- (No highlights)\n");
+        match lang {
+            SummaryLanguage::Ja => out.push_str("- (ハイライトなし)\n"),
+            SummaryLanguage::En => out.push_str("- (No highlights)\n"),
+        }
     } else {
         for bullet in fields.bullet_points.iter().take(3) {
             let line = bullet.trim_start_matches("- ").trim();
@@ -566,6 +676,48 @@ fn build_markdown_from_fields(fields: &SessionSummaryFields) -> String {
         }
     }
     out
+}
+
+fn target_summary_language(requested: &str, content: &str) -> SummaryLanguage {
+    match requested.trim() {
+        "ja" => SummaryLanguage::Ja,
+        "en" => SummaryLanguage::En,
+        "auto" => detect_summary_language(content).unwrap_or_else(|| {
+            if contains_japanese(content) {
+                SummaryLanguage::Ja
+            } else {
+                SummaryLanguage::En
+            }
+        }),
+        _ => SummaryLanguage::En,
+    }
+}
+
+fn detect_summary_language(content: &str) -> Option<SummaryLanguage> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let Some(title) = trimmed.strip_prefix("## ") else {
+            continue;
+        };
+        let title = title.trim();
+        if heading_matches(title, &["目的", "要約", "概要", "ハイライト"]) {
+            return Some(SummaryLanguage::Ja);
+        }
+        if heading_matches(
+            title,
+            &[
+                "Purpose",
+                "purpose",
+                "Summary",
+                "summary",
+                "Highlights",
+                "highlights",
+            ],
+        ) {
+            return Some(SummaryLanguage::En);
+        }
+    }
+    None
 }
 
 fn parse_json_summary(content: &str) -> Option<SessionSummaryFields> {
@@ -763,10 +915,13 @@ mod tests {
             "main".to_string(),
             "codex-cli".to_string(),
             "sess-1".to_string(),
+            "en".to_string(),
             summary,
             now,
         );
-        assert!(cache.is_stale("main", "sess-2", now));
+        assert!(cache.is_stale("main", "sess-2", "en", now));
+        assert!(cache.is_stale("main", "sess-1", "ja", now));
+        assert!(!cache.is_stale("main", "sess-1", "en", now));
     }
 
     #[test]
@@ -789,7 +944,7 @@ mod tests {
             total_turns: 200,
         };
 
-        let prompt = build_session_prompt(&parsed);
+        let prompt = build_session_prompt(&parsed, "auto");
         let user_prompt = prompt
             .iter()
             .find(|msg| msg.role == "user")
@@ -834,7 +989,7 @@ mod tests {
             total_turns: 3,
         };
 
-        let prompt = build_session_prompt(&parsed);
+        let prompt = build_session_prompt(&parsed, "auto");
         let user_prompt = prompt
             .iter()
             .find(|msg| msg.role == "user")
@@ -885,7 +1040,7 @@ mod tests {
             total_turns: 4,
         };
 
-        let prompt = build_session_prompt(&parsed);
+        let prompt = build_session_prompt(&parsed, "auto");
         let user_prompt = prompt
             .iter()
             .find(|msg| msg.role == "user")
@@ -903,7 +1058,8 @@ mod tests {
         let content =
             r#"{"task_overview":"目的文","short_summary":"要約文","bullets":["項目1","項目2"]}"#;
         let fields = parse_session_summary_fields(content).expect("parse fields");
-        let markdown = normalize_session_summary_markdown(content, &fields).expect("markdown");
+        let markdown =
+            normalize_session_summary_markdown(content, &fields, "ja").expect("markdown");
         assert!(markdown.contains("## 目的"));
         assert!(markdown.contains("目的文"));
         assert!(markdown.contains("## 要約"));
@@ -913,10 +1069,22 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_session_summary_markdown_from_json_english_headings() {
+        let content = r#"{"task_overview":"Purpose text","short_summary":"Summary text","bullets":["A","B"]}"#;
+        let fields = parse_session_summary_fields(content).expect("parse fields");
+        let markdown =
+            normalize_session_summary_markdown(content, &fields, "en").expect("markdown");
+        assert!(markdown.contains("## Purpose"));
+        assert!(markdown.contains("## Summary"));
+        assert!(markdown.contains("## Highlights"));
+    }
+
+    #[test]
     fn test_normalize_session_summary_markdown_passthrough() {
         let content = "## 目的\nA\n\n## 要約\nB\n\n## ハイライト\n- C";
         let fields = SessionSummaryFields::default();
-        let markdown = normalize_session_summary_markdown(content, &fields).expect("markdown");
+        let markdown =
+            normalize_session_summary_markdown(content, &fields, "ja").expect("markdown");
         assert_eq!(markdown, content);
     }
 
@@ -924,7 +1092,8 @@ mod tests {
     fn test_normalize_session_summary_markdown_normalizes_alternative_summary_heading() {
         let content = "## 目的\nA\n\n## 概要\nB\n\n## ハイライト\n- C";
         let fields = SessionSummaryFields::default();
-        let markdown = normalize_session_summary_markdown(content, &fields).expect("markdown");
+        let markdown =
+            normalize_session_summary_markdown(content, &fields, "ja").expect("markdown");
         assert_eq!(markdown, "## 目的\nA\n\n## 要約\nB\n\n## ハイライト\n- C");
     }
 
@@ -932,13 +1101,20 @@ mod tests {
     fn test_normalize_session_summary_markdown_normalizes_english_headings() {
         let content = "## Purpose\nA\n\n## Summary\nB\n\n## Highlights\n- C";
         let fields = SessionSummaryFields::default();
-        let markdown = normalize_session_summary_markdown(content, &fields).expect("markdown");
+        let markdown =
+            normalize_session_summary_markdown(content, &fields, "ja").expect("markdown");
         assert_eq!(markdown, "## 目的\nA\n\n## 要約\nB\n\n## ハイライト\n- C");
     }
 
     #[test]
     fn test_validate_session_summary_markdown_accepts_complete() {
         let content = "## 目的\nA\n\n## 要約\nB\n\n## ハイライト\n- C";
+        assert!(validate_session_summary_markdown(content).is_ok());
+    }
+
+    #[test]
+    fn test_validate_session_summary_markdown_accepts_english_headings() {
+        let content = "## Purpose\nA\n\n## Summary\nB\n\n## Highlights\n- C";
         assert!(validate_session_summary_markdown(content).is_ok());
     }
 

--- a/crates/gwt-core/src/config/profile.rs
+++ b/crates/gwt-core/src/config/profile.rs
@@ -90,6 +90,9 @@ pub struct AISettings {
     /// Model name
     #[serde(default = "default_model")]
     pub model: String,
+    /// Output language ("en" | "ja" | "auto")
+    #[serde(default = "default_ai_language")]
+    pub language: String,
     /// Session summary enabled
     #[serde(default = "default_summary_enabled")]
     pub summary_enabled: bool,
@@ -101,6 +104,7 @@ pub struct ResolvedAISettings {
     pub endpoint: String,
     pub api_key: String,
     pub model: String,
+    pub language: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,6 +129,7 @@ impl AISettings {
             endpoint: self.endpoint.trim().to_string(),
             api_key: self.api_key.trim().to_string(),
             model: self.model.trim().to_string(),
+            language: normalize_ai_language(&self.language),
         }
     }
 
@@ -149,8 +154,20 @@ fn default_model() -> String {
     String::new() // No default - must be selected via wizard
 }
 
+fn default_ai_language() -> String {
+    "en".to_string()
+}
+
 fn default_summary_enabled() -> bool {
     true
+}
+
+fn normalize_ai_language(value: &str) -> String {
+    match value.trim().to_lowercase().as_str() {
+        "ja" => "ja".to_string(),
+        "auto" => "auto".to_string(),
+        _ => "en".to_string(),
+    }
 }
 
 /// Profiles configuration stored on disk
@@ -452,6 +469,7 @@ mod tests {
             endpoint: default_endpoint(),
             api_key: String::new(),
             model: model.to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         }
     }
@@ -637,6 +655,7 @@ profiles:
         assert_eq!(resolved.endpoint, "");
         assert_eq!(resolved.model, "");
         assert_eq!(resolved.api_key, "");
+        assert_eq!(resolved.language, "en");
         assert!(!settings.summary_enabled);
     }
 
@@ -649,7 +668,33 @@ profiles:
         assert_eq!(resolved.endpoint, "https://api.openai.com/v1"); // serde default
         assert_eq!(resolved.model, ""); // No default model
         assert_eq!(resolved.api_key, "");
+        assert_eq!(settings.language, "en");
+        assert_eq!(resolved.language, "en");
         assert!(settings.summary_enabled);
+    }
+
+    #[test]
+    fn test_ai_settings_language_normalizes_known_values() {
+        let settings = AISettings {
+            endpoint: "https://api.example.com/v1".to_string(),
+            api_key: "".to_string(),
+            model: "gpt-4o-mini".to_string(),
+            language: "JA".to_string(),
+            summary_enabled: true,
+        };
+        assert_eq!(settings.resolved().language, "ja");
+
+        let settings = AISettings {
+            language: " auto ".to_string(),
+            ..settings
+        };
+        assert_eq!(settings.resolved().language, "auto");
+
+        let settings = AISettings {
+            language: "fr".to_string(),
+            ..settings
+        };
+        assert_eq!(settings.resolved().language, "en");
     }
 
     #[test]
@@ -659,6 +704,7 @@ profiles:
             endpoint: "".to_string(),
             api_key: "".to_string(),
             model: "".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         };
         let resolved = settings.resolved();
@@ -674,6 +720,7 @@ profiles:
             endpoint: "http://localhost:11434/v1".to_string(),
             api_key: "".to_string(),
             model: "llama3.2".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         };
         assert!(settings.is_enabled());
@@ -685,6 +732,7 @@ profiles:
             endpoint: "https://api.example.com/v1".to_string(),
             api_key: "".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         };
         assert!(settings.is_enabled());
@@ -696,6 +744,7 @@ profiles:
             endpoint: "".to_string(),
             api_key: "key".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         };
         assert!(!missing_endpoint.is_enabled());
@@ -704,6 +753,7 @@ profiles:
             endpoint: "https://api.example.com/v1".to_string(),
             api_key: "key".to_string(),
             model: "".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         };
         assert!(!missing_model.is_enabled());
@@ -715,6 +765,7 @@ profiles:
             endpoint: "https://api.example.com/v1".to_string(),
             api_key: "key".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
             summary_enabled: false,
         };
         assert!(!disabled.is_summary_enabled());
@@ -723,6 +774,7 @@ profiles:
             endpoint: "https://api.example.com/v1".to_string(),
             api_key: "key".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         };
         assert!(enabled.is_summary_enabled());

--- a/crates/gwt-tauri/src/commands/sessions.rs
+++ b/crates/gwt-tauri/src/commands/sessions.rs
@@ -718,6 +718,8 @@ struct PersistedSessionSummaryCache {
 struct PersistedBranchSummary {
     pub tool_id: String,
     pub session_id: String,
+    #[serde(default)]
+    pub language: String,
     pub input_mtime_ms: u64,
     pub last_updated_ms: u64,
     pub markdown: Option<String>,
@@ -792,10 +794,17 @@ fn ensure_persisted_session_summary_cache_loaded(
             ..Default::default()
         };
 
+        let language = if entry.language.trim().is_empty() {
+            "en".to_string()
+        } else {
+            entry.language
+        };
+
         cache.set(
             branch,
             entry.tool_id,
             entry.session_id,
+            language,
             summary,
             input_mtime,
         );
@@ -809,6 +818,7 @@ fn persist_session_summary_cache_entry(
     branch: &str,
     tool_id: &str,
     session_id: &str,
+    language: &str,
     input_mtime: SystemTime,
     summary: &SessionSummary,
 ) {
@@ -843,6 +853,7 @@ fn persist_session_summary_cache_entry(
         PersistedBranchSummary {
             tool_id: tool_id.to_string(),
             session_id: session_id.to_string(),
+            language: language.to_string(),
             input_mtime_ms,
             last_updated_ms,
             markdown: summary.markdown.clone(),
@@ -972,6 +983,7 @@ fn scrollback_summary_immediate(
     state: &AppState,
 ) -> (SessionSummaryResult, Option<ScrollbackSummaryJob>) {
     let pane_session = pane_session_id(&candidate.pane_id);
+    let language = settings.language.clone();
 
     let (cached_ok, previous_any) = {
         let cache_guard = match state.session_summary_cache.lock() {
@@ -992,7 +1004,7 @@ fn scrollback_summary_immediate(
         let cached_ok = cache.and_then(|c| {
             c.get(branch)
                 .cloned()
-                .filter(|_| !c.is_stale(branch, &pane_session, candidate.mtime))
+                .filter(|_| !c.is_stale(branch, &pane_session, &language, candidate.mtime))
         });
         let previous_any = cache.and_then(|c| c.get(branch).cloned());
         (cached_ok, previous_any)
@@ -1210,6 +1222,7 @@ fn get_branch_session_summary_immediate(
         }
     };
     let mtime = metadata.modified().unwrap_or_else(|_| SystemTime::now());
+    let language = settings.language.clone();
 
     // Cache lookup (best-effort). Do not hold the mutex while doing network calls.
     let (cached_ok, previous_any) = {
@@ -1221,7 +1234,7 @@ fn get_branch_session_summary_immediate(
         let cached_ok = cache.and_then(|c| {
             c.get(branch)
                 .cloned()
-                .filter(|_| !c.is_stale(branch, &session_id, mtime))
+                .filter(|_| !c.is_stale(branch, &session_id, &language, mtime))
         });
         let previous_any = cache.and_then(|c| c.get(branch).cloned());
         (cached_ok, previous_any)
@@ -1484,7 +1497,7 @@ fn generate_and_cache_session_summary(
         }
     };
 
-    match summarize_session(&client, &parsed) {
+    match summarize_session(&client, &parsed, &job.settings.language) {
         Ok(summary) => {
             // Avoid overwriting the cache if the branch's latest session has changed
             // since the job started (e.g., a new session was recorded).
@@ -1494,6 +1507,7 @@ fn generate_and_cache_session_summary(
                         job.branch.clone(),
                         job.tool_id.clone(),
                         job.session_id.clone(),
+                        job.settings.language.clone(),
                         summary.clone(),
                         job.mtime,
                     );
@@ -1503,6 +1517,7 @@ fn generate_and_cache_session_summary(
                     &job.branch,
                     &job.tool_id,
                     &job.session_id,
+                    &job.settings.language,
                     job.mtime,
                     &summary,
                 );
@@ -1592,7 +1607,7 @@ fn generate_and_cache_scrollback_summary(
         }
     };
 
-    match summarize_scrollback(&client, &scrollback, &job.branch) {
+    match summarize_scrollback(&client, &scrollback, &job.branch, &job.settings.language) {
         Ok(summary) => {
             if is_latest_scrollback_candidate(
                 state,
@@ -1605,6 +1620,7 @@ fn generate_and_cache_scrollback_summary(
                         job.branch.clone(),
                         job.tool_id.clone(),
                         pane_session.clone(),
+                        job.settings.language.clone(),
                         summary.clone(),
                         job.mtime,
                     );
@@ -1614,6 +1630,7 @@ fn generate_and_cache_scrollback_summary(
                     &job.branch,
                     &job.tool_id,
                     &pane_session,
+                    &job.settings.language,
                     job.mtime,
                     &summary,
                 );
@@ -1865,6 +1882,7 @@ mod tests {
             endpoint: "https://api.openai.com/v1".to_string(),
             api_key: "".to_string(),
             model: "gpt-5.2-codex".to_string(),
+            language: "en".to_string(),
             summary_enabled: false,
         });
         config.save().unwrap();
@@ -1899,6 +1917,7 @@ mod tests {
             endpoint: "https://api.openai.com/v1".to_string(),
             api_key: "".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         });
         config.save().unwrap();
@@ -1943,6 +1962,7 @@ mod tests {
             endpoint: "https://api.openai.com/v1".to_string(),
             api_key: "".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
             summary_enabled: true,
         });
         config.save().unwrap();
@@ -1979,6 +1999,7 @@ mod tests {
                 "main".to_string(),
                 "codex-cli".to_string(),
                 "sess-999".to_string(),
+                "en".to_string(),
                 summary,
                 mtime,
             );
@@ -2031,6 +2052,7 @@ mod tests {
             endpoint: "https://api.openai.com/v1".to_string(),
             api_key: "".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
         };
 
         let (out, job) = scrollback_summary_immediate(
@@ -2174,6 +2196,7 @@ bullet_points = ["- A"]
                 "main".to_string(),
                 "codex-cli".to_string(),
                 pane_session_id("pane-xyz"),
+                "en".to_string(),
                 summary,
                 base,
             );
@@ -2188,6 +2211,7 @@ bullet_points = ["- A"]
             endpoint: "https://api.openai.com/v1".to_string(),
             api_key: "".to_string(),
             model: "gpt-4o-mini".to_string(),
+            language: "en".to_string(),
         };
 
         let (out, job) = scrollback_summary_immediate(

--- a/crates/gwt-tauri/src/commands/version_history.rs
+++ b/crates/gwt-tauri/src/commands/version_history.rs
@@ -2,7 +2,7 @@
 //!
 //! This feature does NOT read CHANGELOG.md. It derives version ranges from Git tags
 //! (v*), generates a simple grouped changelog from commit subjects, and (when AI is
-//! configured) generates an English summary.
+//! configured) generates a summary in the configured language.
 
 use crate::commands::project::resolve_repo_path_for_project_root;
 use crate::state::{AppState, VersionHistoryCacheEntry};
@@ -21,6 +21,13 @@ const MAX_SUBJECTS_FOR_CHANGELOG: usize = 400;
 const MAX_SUBJECTS_FOR_AI: usize = 120;
 const MAX_CHANGELOG_LINES_PER_GROUP: usize = 20;
 const MAX_PROMPT_CHARS: usize = 12000;
+
+fn normalize_version_history_language(value: &str) -> &'static str {
+    match value.trim() {
+        "ja" => "ja",
+        _ => "en", // "en" or "auto" (or any invalid value) -> English
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectVersions {
@@ -138,6 +145,8 @@ pub fn get_project_version_history(
         }
     };
 
+    let language = normalize_version_history_language(&settings.language);
+
     // Cache hit
     if let Some(hit) = get_cached_version_history(
         &state,
@@ -145,6 +154,7 @@ pub fn get_project_version_history(
         &version_id,
         range_from_oid.as_deref(),
         &range_to_oid,
+        language,
     ) {
         return Ok(VersionHistoryResult {
             status: "ok".to_string(),
@@ -270,10 +280,15 @@ fn get_cached_version_history(
     version_id: &str,
     range_from_oid: Option<&str>,
     range_to_oid: &str,
+    language: &str,
 ) -> Option<VersionHistoryCacheEntry> {
     let guard = state.project_version_history_cache.lock().ok()?;
     let repo_map = guard.get(repo_key)?;
     let entry = repo_map.get(version_id)?.clone();
+
+    if entry.language != language {
+        return None;
+    }
 
     let from_ok = match (entry.range_from_oid.as_deref(), range_from_oid) {
         (None, None) => true,
@@ -303,6 +318,7 @@ fn generate_and_cache_version_history(
     settings: gwt_core::config::ResolvedAISettings,
     state: &AppState,
 ) -> VersionHistoryResult {
+    let language = normalize_version_history_language(&settings.language);
     let subjects =
         match git_log_subjects(repo_path, range_from, range_to, MAX_SUBJECTS_FOR_CHANGELOG) {
             Ok(v) => v,
@@ -321,7 +337,7 @@ fn generate_and_cache_version_history(
             }
         };
 
-    let simple_changelog = build_simple_changelog_markdown(&subjects);
+    let simple_changelog = build_simple_changelog_markdown(&subjects, language);
 
     let client = match AIClient::new(settings.clone()) {
         Ok(client) => client,
@@ -349,7 +365,7 @@ fn generate_and_cache_version_history(
         &subjects,
     );
 
-    let summary_markdown = match generate_ai_summary(&client, &ai_input) {
+    let summary_markdown = match generate_ai_summary(&client, &ai_input, language) {
         Ok(md) => md,
         Err(err) => {
             return VersionHistoryResult {
@@ -378,6 +394,7 @@ fn generate_and_cache_version_history(
                 range_from_oid: range_from_oid.map(|s| s.to_string()),
                 range_to_oid: range_to_oid.to_string(),
                 commit_count,
+                language: language.to_string(),
                 summary_markdown: summary_markdown.clone(),
                 changelog_markdown: simple_changelog.clone(),
             },
@@ -428,21 +445,40 @@ fn build_ai_input(
     sample_text(&content, MAX_PROMPT_CHARS)
 }
 
-fn generate_ai_summary(client: &AIClient, input: &str) -> Result<String, AIError> {
-    let system = [
-        "You are a release notes assistant.",
-        "Write concise English for end users.",
-        "Do NOT list commit hashes or raw git commands.",
-        "Do NOT copy commit subjects verbatim unless necessary.",
-        "Output MUST be Markdown with these sections in this order:",
-        "## Summary",
-        "## Highlights",
-        "Highlights MUST be 3-5 bullet points.",
-        "Keep it short and practical.",
-    ]
-    .join("\n");
+fn generate_ai_summary(client: &AIClient, input: &str, language: &str) -> Result<String, AIError> {
+    let system = if language == "ja" {
+        [
+            "You are a release notes assistant.",
+            "Write concise Japanese for end users.",
+            "Do NOT list commit hashes or raw git commands.",
+            "Do NOT copy commit subjects verbatim unless necessary.",
+            "Output MUST be Markdown with these sections in this order:",
+            "## 要約",
+            "## ハイライト",
+            "Highlights MUST be 3-5 bullet points.",
+            "Keep it short and practical.",
+        ]
+        .join("\n")
+    } else {
+        [
+            "You are a release notes assistant.",
+            "Write concise English for end users.",
+            "Do NOT list commit hashes or raw git commands.",
+            "Do NOT copy commit subjects verbatim unless necessary.",
+            "Output MUST be Markdown with these sections in this order:",
+            "## Summary",
+            "## Highlights",
+            "Highlights MUST be 3-5 bullet points.",
+            "Keep it short and practical.",
+        ]
+        .join("\n")
+    };
 
-    let user = format!("Summarize the following project changes for this version.\n\n{input}\n");
+    let user = if language == "ja" {
+        format!("次のプロジェクト変更点を、このバージョンのリリースノートとして要約してください。\n\n{input}\n")
+    } else {
+        format!("Summarize the following project changes for this version.\n\n{input}\n")
+    };
 
     let out = client.create_response(vec![
         ChatMessage {
@@ -455,25 +491,29 @@ fn generate_ai_summary(client: &AIClient, input: &str) -> Result<String, AIError
         },
     ])?;
 
-    let markdown = out.trim().to_string();
-    validate_ai_summary_markdown(&markdown)?;
+    let markdown = normalize_ai_summary_markdown(out.trim(), language);
+    validate_ai_summary_markdown(&markdown, language)?;
     Ok(markdown)
 }
 
-fn validate_ai_summary_markdown(markdown: &str) -> Result<(), AIError> {
+fn validate_ai_summary_markdown(markdown: &str, language: &str) -> Result<(), AIError> {
     let mut has_summary = false;
     let mut has_highlights = false;
     let mut highlight_bullets = 0usize;
     let mut in_highlights = false;
 
+    let want_ja = language == "ja";
+
     for line in markdown.lines() {
         let t = line.trim();
-        if t.eq_ignore_ascii_case("## summary") {
+        if (!want_ja && t.eq_ignore_ascii_case("## summary")) || (want_ja && t == "## 要約") {
             has_summary = true;
             in_highlights = false;
             continue;
         }
-        if t.eq_ignore_ascii_case("## highlights") {
+        if (!want_ja && t.eq_ignore_ascii_case("## highlights"))
+            || (want_ja && t == "## ハイライト")
+        {
             has_highlights = true;
             in_highlights = true;
             continue;
@@ -491,6 +531,48 @@ fn validate_ai_summary_markdown(markdown: &str) -> Result<(), AIError> {
     } else {
         Err(AIError::IncompleteSummary)
     }
+}
+
+fn normalize_ai_summary_markdown(markdown: &str, language: &str) -> String {
+    let want_ja = language == "ja";
+    let mut out = String::with_capacity(markdown.len());
+    let lines: Vec<&str> = markdown.lines().collect();
+    let last_idx = lines.len().saturating_sub(1);
+
+    for (idx, line) in lines.iter().enumerate() {
+        let line = *line;
+        let trimmed = line.trim_start();
+        if let Some(title) = trimmed.strip_prefix("## ") {
+            let title = title.trim();
+            let title_l = title.to_ascii_lowercase();
+
+            if title == "要約" || title == "概要" || title_l == "summary" {
+                out.push_str(if want_ja { "## 要約" } else { "## Summary" });
+                if idx < last_idx {
+                    out.push('\n');
+                }
+                continue;
+            }
+            if title == "ハイライト" || title_l == "highlights" {
+                out.push_str(if want_ja {
+                    "## ハイライト"
+                } else {
+                    "## Highlights"
+                });
+                if idx < last_idx {
+                    out.push('\n');
+                }
+                continue;
+            }
+        }
+
+        out.push_str(line);
+        if idx < last_idx {
+            out.push('\n');
+        }
+    }
+
+    out
 }
 
 fn is_bullet_line(line: &str) -> bool {
@@ -516,7 +598,8 @@ fn strip_ordered_prefix(line: &str) -> Option<&str> {
     None
 }
 
-fn build_simple_changelog_markdown(subjects: &[String]) -> String {
+fn build_simple_changelog_markdown(subjects: &[String], language: &str) -> String {
+    let want_ja = language == "ja";
     let mut groups: BTreeMap<&'static str, Vec<String>> = BTreeMap::new();
     for s in subjects {
         let s = s.trim();
@@ -549,7 +632,11 @@ fn build_simple_changelog_markdown(subjects: &[String]) -> String {
             continue;
         }
         out.push_str("### ");
-        out.push_str(name);
+        out.push_str(if want_ja {
+            translate_changelog_group(name)
+        } else {
+            name
+        });
         out.push('\n');
         let mut shown = 0usize;
         for e in entries.iter().take(MAX_CHANGELOG_LINES_PER_GROUP) {
@@ -559,15 +646,38 @@ fn build_simple_changelog_markdown(subjects: &[String]) -> String {
             shown += 1;
         }
         if entries.len() > shown {
-            out.push_str(&format!("- (+{} more)\n", entries.len() - shown));
+            out.push_str(&format!(
+                "- (+{} {})\n",
+                entries.len() - shown,
+                if want_ja { "件" } else { "more" }
+            ));
         }
         out.push('\n');
     }
 
     if out.trim().is_empty() {
-        "(No commits)".to_string()
+        if want_ja {
+            "(コミットなし)".to_string()
+        } else {
+            "(No commits)".to_string()
+        }
     } else {
         out.trim_end().to_string()
+    }
+}
+
+fn translate_changelog_group(name: &str) -> &str {
+    match name {
+        "Features" => "機能",
+        "Bug Fixes" => "バグ修正",
+        "Documentation" => "ドキュメント",
+        "Performance" => "パフォーマンス",
+        "Refactor" => "リファクタ",
+        "Styling" => "スタイル",
+        "Testing" => "テスト",
+        "Miscellaneous Tasks" => "その他タスク",
+        "Other" => "その他",
+        _ => name,
     }
 }
 
@@ -895,7 +1005,7 @@ mod tests {
             "docs: update readme".to_string(),
             "random message".to_string(),
         ];
-        let md = build_simple_changelog_markdown(&subjects);
+        let md = build_simple_changelog_markdown(&subjects, "en");
         assert!(md.contains("### Features"));
         assert!(md.contains("**ui:** add button"));
         assert!(md.contains("### Bug Fixes"));
@@ -906,11 +1016,20 @@ mod tests {
         assert!(md.contains("- random message"));
     }
 
+    #[test]
+    fn simple_changelog_translates_group_headings_in_japanese() {
+        let subjects = vec!["feat: add".to_string(), "fix: bug".to_string()];
+        let md = build_simple_changelog_markdown(&subjects, "ja");
+        assert!(md.contains("### 機能"));
+        assert!(md.contains("### バグ修正"));
+    }
+
     fn ai_settings(summary_enabled: bool) -> AISettings {
         AISettings {
             endpoint: "https://api.openai.com/v1".to_string(),
             api_key: String::new(),
             model: "gpt-5.2-codex".to_string(),
+            language: "en".to_string(),
             summary_enabled,
         }
     }

--- a/crates/gwt-tauri/src/state.rs
+++ b/crates/gwt-tauri/src/state.rs
@@ -47,6 +47,7 @@ pub struct VersionHistoryCacheEntry {
     pub range_from_oid: Option<String>,
     pub range_to_oid: String,
     pub commit_count: u32,
+    pub language: String,
     pub summary_markdown: String,
     pub changelog_markdown: String,
 }

--- a/gwt-gui/src/lib/components/SettingsPanel.svelte
+++ b/gwt-gui/src/lib/components/SettingsPanel.svelte
@@ -418,6 +418,7 @@
             endpoint: "https://api.openai.com/v1",
             api_key: "",
             model: "",
+            language: "en",
             summary_enabled: true,
           },
         }
@@ -428,7 +429,10 @@
     };
   }
 
-  function updateAiField(field: "endpoint" | "api_key" | "model" | "summary_enabled", value: string | boolean) {
+  function updateAiField(
+    field: "endpoint" | "api_key" | "model" | "language" | "summary_enabled",
+    value: string | boolean
+  ) {
     if (!profiles) return;
     const p = currentProfile;
     if (!p || !p.ai) return;
@@ -858,6 +862,18 @@
                     {:else if !aiModelsLoading && aiModels.length === 0 && currentEndpoint}
                       <span class="field-hint">No models returned from /v1/models.</span>
                     {/if}
+                  </div>
+                  <div class="ai-field">
+                    <span class="ai-label">Language</span>
+                    <select
+                      class="select"
+                      value={currentAi?.language ?? "en"}
+                      onchange={(e) => updateAiField("language", (e.target as HTMLSelectElement).value)}
+                    >
+                      <option value="en">English</option>
+                      <option value="ja">Japanese</option>
+                      <option value="auto">Auto</option>
+                    </select>
                   </div>
                   <div class="ai-field">
                     <span class="ai-label">Session Summary</span>

--- a/gwt-gui/src/lib/components/SettingsPanel.test.ts
+++ b/gwt-gui/src/lib/components/SettingsPanel.test.ts
@@ -45,6 +45,7 @@ const profilesFixture: ProfilesConfig = {
         endpoint: "https://api.openai.com/v1",
         api_key: "test-key",
         model: "gpt-4o-mini",
+        language: "en",
         summary_enabled: true,
       },
     },
@@ -356,6 +357,7 @@ describe("SettingsPanel", () => {
         endpoint: "https://api.openai.com/v1",
         api_key: "dev-key",
         model: "gpt-4o-mini",
+        language: "en",
         summary_enabled: true,
       },
     };
@@ -427,6 +429,7 @@ describe("SettingsPanel", () => {
       endpoint: "https://api.openai.com/v1",
       api_key: "test-key",
       model: "custom-model",
+      language: "en",
       summary_enabled: true,
     };
     invokeMock.mockImplementation(async (command: string) => {
@@ -448,6 +451,7 @@ describe("SettingsPanel", () => {
       endpoint: "https://api.openai.com/v1",
       api_key: "test-key",
       model: "",
+      language: "en",
       summary_enabled: true,
     };
     invokeMock.mockImplementation(async (command: string) => {

--- a/gwt-gui/src/lib/types.ts
+++ b/gwt-gui/src/lib/types.ts
@@ -148,6 +148,7 @@ export interface AISettings {
   endpoint: string;
   api_key: string;
   model: string;
+  language: "en" | "ja" | "auto";
   summary_enabled: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Add `language` setting (`en`/`ja`/`auto`, default `en`) to AI settings.
- Generate AI session summaries and Version History summaries in the configured language (branch name suggestion is unchanged).

## Context
- We want AI outputs (session summary, changelog/release-notes style summary, etc.) to follow a user-selected language instead of always being English / auto-detected.

## Changes
- Add `AISettings.language` and propagate it through `ResolvedAISettings`.
- Session summary (including scrollback summary) uses language-specific system prompts and validates both English/Japanese headings.
- Version History AI summary and simple changelog headings switch to Japanese when `language=ja` (otherwise English).
- GUI: Profiles > AI Settings adds a Language selector.

## Testing
- `cargo test`
- `cargo test -p gwt-core`
- `cd gwt-gui && pnpm install && pnpm test`

## Risk / Impact
- Low: backward compatible (missing `language` defaults to `en`).
- Cache keys now include language, so summaries may regenerate when switching languages.

## Deployment
- None

## Screenshots
- None

## Related Issues / Links
- None

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked (`cargo fmt`)
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- For Version History, `auto` is treated as English (ja/en toggle only). Session summary supports `auto` by using the existing auto-detect prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multilingual AI summaries: Japanese and English support with localized headings and placeholders.
  * Language preference added to AI settings (UI select) with auto-detect override.
  * Changelog/version history generation and AI summaries respect the chosen language.
  * Summaries and version-history results cached and retrieved per language for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->