### PR TITLE
fix(core): macOS Apple Silicon GPUをsystem_profilerで検出

### DIFF
--- a/crates/gwt-core/src/system_info.rs
+++ b/crates/gwt-core/src/system_info.rs
@@ -106,7 +106,7 @@ impl SystemMonitor {
 
 #[cfg(target_os = "macos")]
 fn detect_macos_gpu() -> Option<GpuStaticInfo> {
-    let output = std::process::Command::new("system_profiler")
+    let output = crate::process::command("system_profiler")
         .args(["SPDisplaysDataType", "-json"])
         .output()
         .ok()?;


### PR DESCRIPTION
## Summary

- macOS（Apple Silicon）環境で About > System タブに「No GPU detected」と表示されるバグを修正
- `system_profiler SPDisplaysDataType -json` を使用してGPUモデル名を検出
- `OnceLock` でキャッシュし、初回呼び出し時のみコマンドを実行

## Details

`gpu_static_info()` が無条件で `None` を返していたため、macOS 環境では GPU が検出されなかった。
`system_profiler` コマンド（macOS 標準）で JSON 出力を取得し、`sppci_model` フィールドからモデル名を抽出する。

- 追加依存ゼロ（`serde_json` + `std::process::Command` は既存）
- Apple Silicon 全世代（M1〜M4）で動作する安定 API
- 仕様 SPEC-a1b2c3d4 US6-3「Apple Silicon Mac: GPUモデル名が表示される（使用率は非表示）」に対応

## Test plan

- [x] `cargo test -p gwt-core system_info::tests` — 新規テスト3件を含む全7件 GREEN
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 警告なし
- [ ] `cargo tauri dev` → About > System タブで GPU モデル名（例: "Apple M4 Max"）が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS systems now report GPU model info when available.

* **Improvements**
  * GPU info retrieval is cached for faster repeated access.

* **Documentation**
  * Updated GPU detection docs to reflect macOS behavior and caching.

* **Tests**
  * Added macOS-gated unit tests validating detection, parsing, and cache consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->