### PR TITLE
fix(ci): disable GGML native CPU optimizations for macOS release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
         run: cargo install tauri-cli --version "^2"
       - name: Build Tauri
         run: cargo tauri build
+        env:
+          # Disable CPU-native optimizations for whisper.cpp/ggml to avoid
+          # ARM i8mm intrinsic errors on macOS CI runners
+          CMAKE_ARGS: ${{ matrix.platform == 'macos' && '-DGGML_NATIVE=OFF' || '' }}
       - name: Build Windows installer (.msi)
         if: matrix.platform == 'windows'
         id: package_windows


### PR DESCRIPTION
## Summary

- macOS CI ランナーで whisper.cpp/ggml の ARM `i8mm` intrinsics がサポートされていないため、Tauri macOS ビルドが失敗する問題を修正
- `CMAKE_ARGS="-DGGML_NATIVE=OFF"` を macOS ビルドに設定

## Changes

- `.github/workflows/release.yml`: macOS ビルド時に `GGML_NATIVE=OFF` を設定

## Test plan

- [ ] main マージ後にリリースワークフローが再実行され、macOS ビルドが成功すること
- [ ] v7.11.0 の GitHub Release にバイナリがアップロードされること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted macOS build configuration to improve compatibility on Apple Silicon and Intel-based systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->