### PR TITLE
fix(ci): use WHISPER_NATIVE=OFF for macOS release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,10 @@ jobs:
         run: cargo tauri build
         env:
           # Disable CPU-native optimizations for whisper.cpp/ggml to avoid
-          # ARM i8mm intrinsic errors on macOS CI runners
-          CMAKE_ARGS: ${{ matrix.platform == 'macos' && '-DGGML_NATIVE=OFF' || '' }}
+          # ARM i8mm intrinsic errors on macOS CI runners.
+          # whisper-rs-sys passes WHISPER_* env vars as cmake defines;
+          # WHISPER_NATIVE is an alias for GGML_NATIVE in whisper.cpp.
+          WHISPER_NATIVE: ${{ matrix.platform == 'macos' && 'OFF' || 'ON' }}
       - name: Build Windows installer (.msi)
         if: matrix.platform == 'windows'
         id: package_windows


### PR DESCRIPTION
## Summary

- macOS CI ランナーで whisper.cpp/ggml の ARM i8mm intrinsics ビルドエラーを修正
- `WHISPER_NATIVE=OFF` 環境変数を使用（whisper-rs-sys が cmake に渡す GGML_NATIVE のエイリアス）

## Changes

- `.github/workflows/release.yml`: macOS ビルドに `WHISPER_NATIVE=OFF` を設定

## Context

v7.11.0 リリースワークフローで macOS Tauri ビルドが失敗。whisper.cpp/ggml が ARM i8mm 最適化を有効にしようとするが、CI ランナーのコンパイラがサポートしていない。

## Test plan

- [ ] main マージ後にリリースワークフローが再実行され、macOS ビルドが成功すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build optimization configuration to improve platform-specific native compilation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->