### PR TITLE
fix(ci): use cmake toolchain file to disable GGML_NATIVE on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,11 @@ jobs:
         run: cargo tauri build
         env:
           # Disable CPU-native optimizations for whisper.cpp/ggml to avoid
-          # ARM i8mm intrinsic errors on macOS CI runners.
-          # whisper-rs-sys passes WHISPER_* env vars as cmake defines;
-          # WHISPER_NATIVE is an alias for GGML_NATIVE in whisper.cpp.
-          WHISPER_NATIVE: ${{ matrix.platform == 'macos' && 'OFF' || 'ON' }}
+          # ARM i8mm intrinsic errors on macOS CI runners (Xcode 16.4 Apple Clang
+          # defines __ARM_FEATURE_MATMUL_INT8 with -mcpu=native+noi8mm).
+          # whisper-rs-sys passes CMAKE_* env vars as cmake defines, so we use
+          # CMAKE_TOOLCHAIN_FILE to inject GGML_NATIVE=OFF before ggml's option().
+          CMAKE_TOOLCHAIN_FILE: ${{ matrix.platform == 'macos' && format('{0}/cmake/ci-disable-native.cmake', github.workspace) || '' }}
       - name: Build Windows installer (.msi)
         if: matrix.platform == 'windows'
         id: package_windows

--- a/cmake/ci-disable-native.cmake
+++ b/cmake/ci-disable-native.cmake
@@ -1,0 +1,7 @@
+# CI toolchain override: disable GGML_NATIVE to avoid ARM i8mm intrinsic
+# compilation errors on macOS GitHub Actions runners.
+#
+# whisper-rs-sys passes CMAKE_* env vars to cmake, so we use
+# CMAKE_TOOLCHAIN_FILE pointing here. The option() call in ggml respects
+# cache variables set by toolchain files, preventing -mcpu=native.
+set(GGML_NATIVE OFF CACHE BOOL "Disable native CPU optimizations for CI" FORCE)


### PR DESCRIPTION
## Summary

- macOS CI で whisper.cpp/ggml の ARM i8mm ビルドエラーを修正
- `CMAKE_TOOLCHAIN_FILE` 経由で `GGML_NATIVE=OFF` を cmake に直接注入

## Root Cause

1. `whisper_option_depr()` は `if(OFF)` を false 評価するため `WHISPER_NATIVE=OFF` が `GGML_NATIVE` にマッピングされない
2. Xcode 16.4 の Apple Clang は `-mcpu=native+noi8mm` でも `__ARM_FEATURE_MATMUL_INT8` を定義してしまう

## Fix

- `cmake/ci-disable-native.cmake` を作成し `GGML_NATIVE=OFF` を FORCE で設定
- whisper-rs-sys が `CMAKE_*` 環境変数を cmake defines にパススルーする仕組みを利用

## Test plan

- [ ] macOS release ビルドが成功すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve compilation stability on macOS CI runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->