### PR TITLE
fix: update wmi 0.18 API and add fail-fast: false to release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.create-tag.outputs.version }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: linux

--- a/crates/gwt-core/src/system_info.rs
+++ b/crates/gwt-core/src/system_info.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 #[cfg(target_os = "windows")]
 use serde::Deserialize;
 #[cfg(target_os = "windows")]
-use wmi::{COMLibrary, WMIConnection};
+use wmi::WMIConnection;
 
 /// Static GPU information (model name, total VRAM).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -275,10 +275,7 @@ struct Win32VideoController {
 
 #[cfg(target_os = "windows")]
 fn detect_windows_gpus() -> Vec<GpuStaticInfo> {
-    let Ok(com_library) = COMLibrary::new() else {
-        return Vec::new();
-    };
-    let Ok(wmi) = WMIConnection::new(com_library) else {
+    let Ok(wmi) = WMIConnection::new() else {
         return Vec::new();
     };
 


### PR DESCRIPTION
## Summary

- wmi 0.18 API変更に対応（COMLibrary削除、WMIConnection::new()引数変更）
- リリースビルドマトリクスに fail-fast: false を追加

## Test plan

- [ ] Windows ビルドが成功すること
- [ ] macOS ビルドが成功すること（cmake toolchain file による GGML_NATIVE=OFF）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to continue running all build configurations even when one fails, improving test coverage visibility.

* **Refactor**
  * Simplified Windows GPU detection initialization process while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->