### PR TITLE
fix(ci): set MACOSX_DEPLOYMENT_TARGET=11.0 for macOS release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
           # whisper-rs-sys passes CMAKE_* env vars as cmake defines, so we use
           # CMAKE_TOOLCHAIN_FILE to inject GGML_NATIVE=OFF before ggml's option().
           CMAKE_TOOLCHAIN_FILE: ${{ matrix.platform == 'macos' && format('{0}/cmake/ci-disable-native.cmake', github.workspace) || '' }}
+          # ARM Macs require macOS 11.0+; ggml uses std::filesystem (10.15+).
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'macos' && '11.0' || '' }}
       - name: Build Windows installer (.msi)
         if: matrix.platform == 'windows'
         id: package_windows


### PR DESCRIPTION
## Summary

- macOS リリースビルドに `MACOSX_DEPLOYMENT_TARGET=11.0` を設定
- ggml の `std::filesystem` 使用（10.15+）と ARM Mac 要件（11.0+）に対応

## Test plan

- [ ] macOS ビルドが成功すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration to ensure compatibility with macOS 11.0 and later on ARM and Intel processors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->