### PR TITLE
fix(ci): set CMAKE_OSX_DEPLOYMENT_TARGET to 11.0 for macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,10 @@ jobs:
           CMAKE_TOOLCHAIN_FILE: ${{ matrix.platform == 'macos' && format('{0}/cmake/ci-disable-native.cmake', github.workspace) || '' }}
           # ARM Macs require macOS 11.0+; ggml uses std::filesystem (10.15+).
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'macos' && '11.0' || '' }}
+          # Also pass as cmake define (whisper-rs-sys forwards CMAKE_* env vars).
+          # cmake appends -mmacosx-version-min AFTER CMAKE_C_FLAGS, so the last
+          # flag (from this define) wins over the 10.13 injected by cmake-rs/cc.
+          CMAKE_OSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'macos' && '11.0' || '' }}
       - name: Build Windows installer (.msi)
         if: matrix.platform == 'windows'
         id: package_windows

--- a/cmake/ci-disable-native.cmake
+++ b/cmake/ci-disable-native.cmake
@@ -1,7 +1,16 @@
-# CI toolchain override: disable GGML_NATIVE to avoid ARM i8mm intrinsic
-# compilation errors on macOS GitHub Actions runners.
+# CI toolchain override for macOS GitHub Actions runners.
 #
 # whisper-rs-sys passes CMAKE_* env vars to cmake, so we use
-# CMAKE_TOOLCHAIN_FILE pointing here. The option() call in ggml respects
-# cache variables set by toolchain files, preventing -mcpu=native.
+# CMAKE_TOOLCHAIN_FILE pointing here. Toolchain-file cache variables
+# are applied before project() and take precedence over defaults.
+#
+# 1. Disable GGML_NATIVE to avoid ARM i8mm intrinsic errors
+#    (Xcode 16.4 Apple Clang + -mcpu=native).
 set(GGML_NATIVE OFF CACHE BOOL "Disable native CPU optimizations for CI" FORCE)
+#
+# 2. Set deployment target to macOS 11.0+.
+#    ggml uses std::filesystem (requires 10.15+); ARM Macs need 11.0+.
+#    cmake-rs (via cc crate) may inject -mmacosx-version-min=10.13 into
+#    CMAKE_C_FLAGS, but cmake appends its own flag AFTER those, and
+#    clang uses the last -mmacosx-version-min it sees.
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "macOS 11.0+ for ARM and std::filesystem" FORCE)


### PR DESCRIPTION
## Summary
- Set `CMAKE_OSX_DEPLOYMENT_TARGET=11.0` in cmake toolchain file and as env var
- cmake-rs injects `-mmacosx-version-min=10.13` via cc crate; cmake appends its own flag AFTER, and clang uses the last one

## Context
macOS release build fails because ggml uses `std::filesystem` (requires 10.15+) but cmake-rs forces deployment target to 10.13 regardless of `MACOSX_DEPLOYMENT_TARGET` env var.

## Test plan
- [ ] macOS release build succeeds with `-mmacosx-version-min=11.0`
- [ ] Linux/Windows builds unaffected (empty env values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build configuration for enhanced consistency and reliability. Updated deployment target settings to prevent build inconsistencies and ensure more predictable macOS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->