### PR TITLE
fix: prevent false Branch Exists from stale remote refs (#1231)

### DIFF
--- a/crates/gwt-core/src/git/issue.rs
+++ b/crates/gwt-core/src/git/issue.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides Issue information using GitHub CLI (gh) for branch creation from issues.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use super::gh_cli::{gh_command, is_gh_available};
@@ -579,12 +580,29 @@ pub fn find_branch_for_issue(
     }
 
     let stdout = String::from_utf8_lossy(&remote_output.stdout);
-    let remote_branch = stdout
+    let mut checked = HashSet::new();
+
+    for remote_branch in stdout
         .lines()
         .map(|line| line.trim())
-        .find(|branch| branch.contains(&pattern));
+        .filter(|branch| branch.contains(&pattern))
+    {
+        let Some((remote_name, branch_name)) = split_remote_tracking_branch(remote_branch) else {
+            continue;
+        };
 
-    Ok(remote_branch.map(|b| strip_remote_prefix(b).to_string()))
+        // Avoid duplicate lookups when remote output contains repeated refs.
+        let key = format!("{remote_name}/{branch_name}");
+        if !checked.insert(key) {
+            continue;
+        }
+
+        if remote_branch_exists_on_remote(repo_path, remote_name, branch_name)? {
+            return Ok(Some(strip_remote_prefix(remote_branch).to_string()));
+        }
+    }
+
+    Ok(None)
 }
 
 /// Strip remote prefix from a remote branch name.
@@ -594,6 +612,38 @@ fn strip_remote_prefix(remote_branch: &str) -> &str {
         .split_once('/')
         .map(|(_, rest)| rest)
         .unwrap_or(remote_branch)
+}
+
+fn split_remote_tracking_branch(remote_branch: &str) -> Option<(&str, &str)> {
+    let (remote_name, branch_name) = remote_branch.split_once('/')?;
+    if remote_name.is_empty() || branch_name.is_empty() || branch_name.contains(" -> ") {
+        return None;
+    }
+    Some((remote_name, branch_name))
+}
+
+fn remote_branch_exists_on_remote(
+    repo_path: &Path,
+    remote_name: &str,
+    branch_name: &str,
+) -> Result<bool, String> {
+    let output = crate::process::command("git")
+        .args(["ls-remote", "--heads", remote_name, branch_name])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute git ls-remote: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git ls-remote failed for remote '{}' and branch '{}': {}",
+            remote_name,
+            branch_name,
+            stderr.trim()
+        ));
+    }
+
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
 /// Generate full branch name from type and issue
@@ -655,6 +705,76 @@ pub fn create_linked_branch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn run_git(repo_path: &Path, args: &[&str]) {
+        let output = crate::process::command("git")
+            .args(args)
+            .current_dir(repo_path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(repo_path: &Path, args: &[&str]) -> String {
+        let output = crate::process::command("git")
+            .args(args)
+            .current_dir(repo_path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn create_test_repo() -> TempDir {
+        let temp = TempDir::new().unwrap();
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["config", "user.email", "test@test.com"]);
+        run_git(temp.path(), &["config", "user.name", "Test"]);
+        std::fs::write(temp.path().join("README.md"), "initial").unwrap();
+        run_git(temp.path(), &["add", "."]);
+        run_git(temp.path(), &["commit", "-m", "initial"]);
+        temp
+    }
+
+    fn current_branch_name(repo_path: &Path) -> String {
+        git_stdout(repo_path, &["rev-parse", "--abbrev-ref", "HEAD"])
+    }
+
+    fn create_repo_with_origin() -> (TempDir, TempDir) {
+        let repo = create_test_repo();
+        let origin = TempDir::new().unwrap();
+        run_git(origin.path(), &["init", "--bare"]);
+        run_git(
+            repo.path(),
+            &["remote", "add", "origin", origin.path().to_str().unwrap()],
+        );
+        let base = current_branch_name(repo.path());
+        run_git(repo.path(), &["push", "-u", "origin", &base]);
+        (repo, origin)
+    }
+
+    fn create_remote_issue_branch_without_local_copy(repo_path: &Path, branch_name: &str) {
+        let base = current_branch_name(repo_path);
+        run_git(repo_path, &["checkout", "-b", branch_name, &base]);
+        std::fs::write(repo_path.join("issue.txt"), branch_name).unwrap();
+        run_git(repo_path, &["add", "."]);
+        run_git(repo_path, &["commit", "-m", "issue branch"]);
+        run_git(repo_path, &["push", "-u", "origin", branch_name]);
+        run_git(repo_path, &["checkout", &base]);
+        run_git(repo_path, &["branch", "-D", branch_name]);
+    }
 
     // ==========================================================
     // FR-007: Display format tests
@@ -1333,10 +1453,68 @@ mod tests {
         assert_eq!(strip_remote_prefix("issue-42"), "issue-42");
     }
 
+    #[test]
+    fn test_split_remote_tracking_branch_parses_valid_ref() {
+        let parsed = split_remote_tracking_branch("origin/feature/issue-42");
+        assert_eq!(parsed, Some(("origin", "feature/issue-42")));
+    }
+
+    #[test]
+    fn test_split_remote_tracking_branch_rejects_symbolic_ref() {
+        let parsed = split_remote_tracking_branch("origin/HEAD -> origin/main");
+        assert!(parsed.is_none());
+    }
+
     // ==========================================================
     // SPEC-rb01a2f3: find_branch_for_issue remote search
     // ==========================================================
 
-    // Note: find_branch_for_issue with remote search requires a git repo,
-    // tested via integration tests (same as local branch search, see line 958)
+    #[test]
+    fn test_find_branch_for_issue_finds_local_branch() {
+        let repo = create_test_repo();
+        let base = current_branch_name(repo.path());
+        run_git(
+            repo.path(),
+            &["checkout", "-b", "feature/issue-1029", &base],
+        );
+
+        let found = find_branch_for_issue(repo.path(), 1029).unwrap();
+        assert_eq!(found.as_deref(), Some("feature/issue-1029"));
+    }
+
+    #[test]
+    fn test_find_branch_for_issue_confirms_remote_branch_with_ls_remote() {
+        let (repo, _origin) = create_repo_with_origin();
+        create_remote_issue_branch_without_local_copy(repo.path(), "bugfix/issue-1029");
+        run_git(repo.path(), &["fetch", "origin"]);
+
+        let remote_tracking = git_stdout(repo.path(), &["branch", "-r", "--list", "*issue-1029*"]);
+        assert!(
+            remote_tracking.contains("origin/bugfix/issue-1029"),
+            "expected remote-tracking ref to exist in test setup"
+        );
+
+        let found = find_branch_for_issue(repo.path(), 1029).unwrap();
+        assert_eq!(found.as_deref(), Some("bugfix/issue-1029"));
+    }
+
+    #[test]
+    fn test_find_branch_for_issue_ignores_stale_remote_tracking_ref() {
+        let (repo, origin) = create_repo_with_origin();
+        create_remote_issue_branch_without_local_copy(repo.path(), "bugfix/issue-1029");
+        run_git(repo.path(), &["fetch", "origin"]);
+
+        let remote_tracking_before =
+            git_stdout(repo.path(), &["branch", "-r", "--list", "*issue-1029*"]);
+        assert!(
+            remote_tracking_before.contains("origin/bugfix/issue-1029"),
+            "expected remote-tracking ref to exist before remote deletion"
+        );
+
+        // Delete directly on remote to leave stale remote-tracking ref in the local clone.
+        run_git(origin.path(), &["branch", "-D", "bugfix/issue-1029"]);
+
+        let found = find_branch_for_issue(repo.path(), 1029).unwrap();
+        assert_eq!(found, None);
+    }
 }

--- a/specs/SPEC-c2df2e7a/plan.md
+++ b/specs/SPEC-c2df2e7a/plan.md
@@ -1,0 +1,51 @@
+# 実装計画: From Issue の Branch Exists 誤判定（stale remote-tracking ref）
+
+**仕様ID**: `SPEC-c2df2e7a` | **日付**: 2026-02-25 | **仕様書**: `specs/SPEC-c2df2e7a/spec.md`
+
+## 目的
+
+- stale remote-tracking ref による `Branch Exists` 誤判定を除去し、From Issue の選択不可誤表示を防止する。
+
+## 技術コンテキスト
+
+- **バックエンド**: Rust 2021（`crates/gwt-core/src/git/issue.rs`）
+- **フロントエンド**: 変更不要（既存API結果を利用）
+- **Git連携**: `git branch --list` / `git branch -r --list` / `git ls-remote --heads`
+- **テスト**: `cargo test -p gwt-core git::issue::tests::`, `cargo clippy -p gwt-core --all-targets -- -D warnings`
+- **前提**: `find_existing_issue_branch` のI/Fは維持し、判定精度のみ改善する
+
+## 実装方針
+
+### Phase 1: TDD（RED）
+
+- `find_branch_for_issue()` の再現テストを追加する。
+1. ローカル branch 優先で検出される
+2. 実リモート branch がある場合に検出される
+3. stale remote-tracking のみの場合は検出されない
+- remote-tracking 解析用ユーティリティのユニットテストを追加する。
+
+### Phase 2: 判定ロジック改修
+
+- `find_branch_for_issue()` の remote 分岐で、候補ごとに `ls-remote` 実在確認を挟む。
+- symbolic ref（`origin/HEAD -> ...`）を候補から除外する。
+- 候補重複時の `ls-remote` 再実行を避ける。
+- `ls-remote` 失敗時はエラー返却し、曖昧な成功を返さない。
+
+### Phase 3: GREEN 検証
+
+- `cargo test -p gwt-core git::issue::tests::` を実行し、追加ケースを含めて全件成功を確認する。
+- `cargo clippy -p gwt-core --all-targets -- -D warnings` を実行し、警告ゼロを確認する。
+
+## テスト
+
+### バックエンド
+
+- `test_find_branch_for_issue_finds_local_branch`
+- `test_find_branch_for_issue_confirms_remote_branch_with_ls_remote`
+- `test_find_branch_for_issue_ignores_stale_remote_tracking_ref`
+- `test_split_remote_tracking_branch_parses_valid_ref`
+- `test_split_remote_tracking_branch_rejects_symbolic_ref`
+
+### フロントエンド
+
+- 変更なし（判定APIの戻り値改善のみ）。既存UIテスト対象外。

--- a/specs/SPEC-c2df2e7a/spec.md
+++ b/specs/SPEC-c2df2e7a/spec.md
@@ -1,0 +1,92 @@
+# バグ修正仕様: From Issue の Branch Exists 誤判定（stale remote-tracking ref）
+
+**仕様ID**: `SPEC-c2df2e7a`
+**作成日**: 2026-02-25
+**更新日**: 2026-02-25
+**ステータス**: 承認済み
+**カテゴリ**: Core / Git Issue
+**依存仕様**:
+
+- `SPEC-c6ba640a`（From Issue UI）
+- `SPEC-rb01a2f3`（remote branch 検出）
+
+**入力**: ユーザー説明: "Issue #1231: Branch Exists false positive caused by stale remote-tracking branch for From Issue"
+
+## 背景
+
+- `find_branch_for_issue()` は remote-tracking branch（`git branch -r`）をそのまま「存在」とみなしている
+- 実リモートから既に削除された stale ref が残っていると、`Branch Exists` が誤表示される
+- 結果として、Issue #1029 のように実ブランチが無いのに From Issue が選択不可になる
+
+## ユーザーシナリオとテスト *(必須)*
+
+### ユーザーストーリー 1 - stale remote-tracking を Exists に含めない (優先度: P0)
+
+開発者として、実リモートに存在しない stale remote-tracking ref では `Branch Exists` 判定にならないようにしたい。
+
+**独立したテスト**: `find_branch_for_issue()` が stale remote-tracking ref のみを持つ状態で `None` を返すこと
+
+**受け入れシナリオ**:
+
+1. **前提条件** `origin/bugfix/issue-1029` が remote-tracking に残り、実リモートには存在しない、**操作** `find_branch_for_issue(repo, 1029)` を呼ぶ、**期待結果** `None` が返る
+2. **前提条件** stale ref が存在する、**操作** Launch Agent > From Issue を開く、**期待結果** Issue は `Branch Exists` で無効化されない
+
+---
+
+### ユーザーストーリー 2 - 実リモート branch は引き続き検出する (優先度: P0)
+
+開発者として、リモートに実在する Issue branch は従来通り `Branch Exists` として検出したい。
+
+**独立したテスト**: 実リモートに `bugfix/issue-1029` があるとき `Some("bugfix/issue-1029")` を返すこと
+
+**受け入れシナリオ**:
+
+1. **前提条件** ローカルには branch がなく、リモートには branch がある、**操作** `find_branch_for_issue(repo, 1029)` を呼ぶ、**期待結果** remote branch 名を返す
+2. **前提条件** remote-tracking と実リモートが一致する、**操作** 判定APIを呼ぶ、**期待結果** 既存 branch として扱う
+
+---
+
+### ユーザーストーリー 3 - ローカル branch 優先は維持する (優先度: P1)
+
+開発者として、ローカル branch がある場合は追加の remote 検証なしで即時検出したい。
+
+**独立したテスト**: ローカル `feature/issue-1029` があるとき `Some("feature/issue-1029")` を返すこと
+
+**受け入れシナリオ**:
+
+1. **前提条件** ローカル branch が存在する、**操作** `find_branch_for_issue(repo, 1029)` を呼ぶ、**期待結果** ローカル branch を返す
+2. **前提条件** 同名 remote branch も存在する、**操作** 判定APIを呼ぶ、**期待結果** ローカル branch 優先を維持する
+
+## エッジケース
+
+- `origin/HEAD -> origin/main` のような symbolic ref 行は branch 候補から除外する
+- 同じ branch 候補が重複して出ても `ls-remote` は重複実行しない
+- `git ls-remote` が失敗した場合は曖昧に成功扱いせずエラーとして呼び出し側へ返す
+
+## 要件 *(必須)*
+
+### 機能要件
+
+- **FR-001**: `find_branch_for_issue()` はローカル branch 検出を最優先で実行しなければならない
+- **FR-002**: remote-tracking branch 候補は remote 名と branch 名へ分離し、symbolic ref を除外しなければならない
+- **FR-003**: remote-tracking branch 候補は `git ls-remote --heads <remote> <branch>` で実在確認しなければならない
+- **FR-004**: 実在確認で空結果だった候補は stale とみなし、`Branch Exists` に含めてはならない
+- **FR-005**: `git ls-remote` 実行失敗時はエラーを返し、誤って `Some(...)` を返してはならない
+- **FR-006 (TDD)**: `find_branch_for_issue()` 修正前に再現テスト（stale/実在/ローカル優先）を追加し、RED→GREEN の順で完了しなければならない
+
+### 非機能要件
+
+- **NFR-001**: 既存のローカル branch 判定の性能特性に退行を生じさせない（local hit 時に追加ネットワーク確認を行わない）
+- **NFR-002**: `cargo test -p gwt-core git::issue::tests::` と `cargo clippy -p gwt-core --all-targets -- -D warnings` を通過する
+
+## 制約と仮定
+
+- `Branch Exists` 判定は `worktree + local + 実在remote` を対象とし、stale remote-tracking は対象外とする
+- remote 実在確認には Git の標準コマンド（`ls-remote --heads`）のみを使用する
+
+## 成功基準 *(必須)*
+
+- **SC-001**: stale remote-tracking のみ存在するケースで `find_branch_for_issue()` が `None` を返す
+- **SC-002**: 実在 remote branch のケースで `find_branch_for_issue()` が `Some(branch)` を返す
+- **SC-003**: ローカル branch 優先ケースで既存動作を維持する
+- **SC-004**: 追加テストを含む `git::issue::tests::` が全件成功する

--- a/specs/SPEC-c2df2e7a/tasks.md
+++ b/specs/SPEC-c2df2e7a/tasks.md
@@ -1,0 +1,31 @@
+# タスクリスト: From Issue の Branch Exists 誤判定（stale remote-tracking ref）
+
+## Phase 1: セットアップ
+
+- [x] T001 [P] [US1] 再現条件（stale remote-tracking による誤判定）を整理し、対象関数を `find_branch_for_issue` に確定する `crates/gwt-core/src/git/issue.rs`
+
+## Phase 2: 基盤
+
+- [x] T002 [US1] remote-tracking 候補の分解ヘルパー（symbolic ref 除外）を追加する `crates/gwt-core/src/git/issue.rs`
+- [x] T003 [US1] remote 実在確認ヘルパー（`git ls-remote --heads`）を追加する `crates/gwt-core/src/git/issue.rs`
+
+## Phase 3: ストーリー 1（stale ref を除外）
+
+- [x] T004 [US1] (RED) stale remote-tracking のみで `None` を期待するテストを追加する `crates/gwt-core/src/git/issue.rs`
+- [x] T005 [US1] (GREEN) `find_branch_for_issue` の remote 判定に `ls-remote` 実在確認を組み込み、stale 候補を無視する `crates/gwt-core/src/git/issue.rs`
+
+## Phase 4: ストーリー 2（実remote検出維持）
+
+- [x] T006 [US2] (RED) 実remote branch で `Some(...)` を期待するテストを追加する `crates/gwt-core/src/git/issue.rs`
+- [x] T007 [US2] (GREEN) 実remote branch を返し、既存 I/F を維持することを確認する `crates/gwt-core/src/git/issue.rs`
+
+## Phase 5: ストーリー 3（ローカル優先維持）
+
+- [x] T008 [US3] (RED) ローカル branch 優先のテストを追加する `crates/gwt-core/src/git/issue.rs`
+- [x] T009 [US3] (GREEN) ローカルヒット時に追加 remote 照会を行わない既存動作を維持する `crates/gwt-core/src/git/issue.rs`
+
+## Phase 6: 仕上げ・横断
+
+- [x] T010 [P] [共通] `spec.md` / `plan.md` / `tasks.md` を作成・更新する `specs/SPEC-c2df2e7a/spec.md` `specs/SPEC-c2df2e7a/plan.md` `specs/SPEC-c2df2e7a/tasks.md`
+- [x] T011 [P] [共通] 仕様索引を更新する `specs/specs.md`
+- [x] T012 [共通] `cargo test -p gwt-core git::issue::tests::` と `cargo clippy -p gwt-core --all-targets -- -D warnings` を実行して成功を確認する `crates/gwt-core/src/git/issue.rs`

--- a/specs/specs.md
+++ b/specs/specs.md
@@ -1,6 +1,6 @@
 # 仕様一覧
 
-**最終更新**: 2026-02-24
+**最終更新**: 2026-02-25
 
 - 現行の仕様・要件: `specs/SPEC-XXXXXXXX/spec.md`
 - 以前までのTUIの仕様・要件（archive）: `specs/archive/SPEC-XXXXXXXX/spec.md`
@@ -17,6 +17,7 @@
 
 | SPEC ID | タイトル | 作成日 |
 | --- | --- | --- |
+| [SPEC-c2df2e7a](SPEC-c2df2e7a/spec.md) | バグ修正仕様: From Issue の Branch Exists 誤判定（stale remote-tracking ref） | 2026-02-25 |
 | [SPEC-25251fb9](SPEC-25251fb9/spec.md) | バグ修正: ターミナル行数増加時のトラックパッドスクロール不能 | 2026-02-24 |
 | [SPEC-434cef4e](SPEC-434cef4e/spec.md) | バグ修正仕様: v7.11.0 起動不能（Issue #1219） | 2026-02-24 |
 | [SPEC-e0e11640](SPEC-e0e11640/spec.md) | バグ修正仕様: macOS リリースの署名/公証を必須化して Gatekeeper エラーを防止 | 2026-02-24 |


### PR DESCRIPTION
## Summary
- Fix false `Branch Exists` detection in Launch Agent > From Issue when only stale remote-tracking refs exist
- Keep existing behavior for local branches and actually existing remote branches

## Context
- This addresses Issue #1231
- `find_branch_for_issue` previously treated `git branch -r` candidates as existing without verifying remote head existence

## Changes
- Updated `find_branch_for_issue` to validate remote-tracking candidates via `git ls-remote --heads <remote> <branch>`
- Added guards to skip symbolic refs (e.g., `origin/HEAD -> origin/main`) and deduplicate repeated remote candidates
- Preserved local-branch-first behavior
- Added regression and behavior tests for:
  - local branch detection
  - real remote-only branch detection
  - stale remote-tracking ref being ignored
- Added and completed spec artifacts for this fix:
  - `specs/SPEC-c2df2e7a/spec.md`
  - `specs/SPEC-c2df2e7a/plan.md`
  - `specs/SPEC-c2df2e7a/tasks.md`
  - updated `specs/specs.md`

## Testing
- `cargo test -p gwt-core git::issue::tests:: -- --nocapture`
- `cargo clippy -p gwt-core --all-targets -- -D warnings`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Risk / Impact
- Impact area: GitHub issue branch existence detection (`find_existing_issue_branch` path)
- Mitigation: explicit remote validation avoids stale-ref false positives; local branch path remains unchanged

## Deployment
- None

## Screenshots
- None (backend + spec/docs change only)

## Related Issues / Links
- Closes #1231
- Spec: `specs/SPEC-c2df2e7a/spec.md`

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [x] Docs updated
- [x] Migration/backfill plan included (not needed)
- [x] Monitoring/alerts updated (not needed)

## Notes
- Existing `SPEC-rb01a2f3` is a legacy non-standard ID and not compatible with Spec Kit scripts (`SPEC-[a-f0-9]{8}`), so this PR tracks the update under `SPEC-c2df2e7a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved false positives in remote branch existence detection by validating branch state against live remote data, preventing stale references from being incorrectly marked as existing.

* **Tests**
  * Added integration tests for remote branch detection and validation scenarios.

* **Chores**
  * Added specification and implementation planning documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->