### PR TITLE
fix: Windows環境でエージェント端末の文字化けを抑止

### DIFF
--- a/crates/gwt-core/src/terminal/manager.rs
+++ b/crates/gwt-core/src/terminal/manager.rs
@@ -166,6 +166,7 @@ impl PaneManager {
             env_vars: config.env_vars,
             terminal_shell: config.terminal_shell,
             interactive: config.interactive,
+            windows_force_utf8: config.windows_force_utf8,
         };
         let pane = TerminalPane::new(pane_config)?;
         self.add_pane(pane)?;
@@ -204,6 +205,7 @@ impl PaneManager {
             env_vars: config.env_vars,
             terminal_shell: config.terminal_shell,
             interactive: config.interactive,
+            windows_force_utf8: config.windows_force_utf8,
         };
         let pane = TerminalPane::new(pane_config)?;
         self.add_pane(pane)?;
@@ -351,6 +353,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         })
         .expect("failed to create test pane")
     }
@@ -609,6 +612,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
         let pane_id = mgr.launch_agent(&repo_root, config, 24, 80).unwrap();
         assert!(!pane_id.is_empty());
@@ -634,6 +638,7 @@ mod tests {
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             };
             mgr.launch_agent(&repo_root, config, 24, 80).unwrap();
         }
@@ -675,6 +680,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
         let pane_id1 = mgr.launch_agent(&repo_root, config1, 24, 80).unwrap();
 
@@ -688,6 +694,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
         let pane_id2 = mgr.launch_agent(&repo_root, config2, 24, 80).unwrap();
 
@@ -775,6 +782,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
         mgr.launch_agent(&repo_root, config1, 24, 80).unwrap();
 
@@ -788,6 +796,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
         mgr.launch_agent(&repo_root, config2, 24, 80).unwrap();
 
@@ -844,6 +853,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
         let pane_id = mgr.spawn_shell(config, 24, 80).unwrap();
         assert!(!pane_id.is_empty());
@@ -871,6 +881,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
         let pane_id = mgr.spawn_shell(config, 24, 80).unwrap();
         assert_eq!(mgr.pane_count(), 2);

--- a/crates/gwt-core/src/terminal/mod.rs
+++ b/crates/gwt-core/src/terminal/mod.rs
@@ -48,4 +48,6 @@ pub struct BuiltinLaunchConfig {
     /// Whether this launch is interactive (e.g. spawn_shell).
     /// When true on Windows, the command is not wrapped with PowerShell.
     pub interactive: bool,
+    /// Whether to force UTF-8 terminal initialization on Windows launch.
+    pub windows_force_utf8: bool,
 }

--- a/crates/gwt-core/src/terminal/pane.rs
+++ b/crates/gwt-core/src/terminal/pane.rs
@@ -35,6 +35,8 @@ pub struct PaneConfig {
     pub terminal_shell: Option<String>,
     /// Whether this is an interactive session (e.g. spawn_shell).
     pub interactive: bool,
+    /// Whether to force UTF-8 terminal initialization on Windows launch.
+    pub windows_force_utf8: bool,
 }
 
 /// A terminal pane integrating PTY and scrollback.
@@ -69,6 +71,7 @@ impl TerminalPane {
             cols: config.cols,
             terminal_shell: config.terminal_shell,
             interactive: config.interactive,
+            windows_force_utf8: config.windows_force_utf8,
         };
 
         let pty = PtyHandle::new(pty_config)?;
@@ -273,6 +276,7 @@ mod tests {
             env_vars: HashMap::new(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         }
     }
 

--- a/crates/gwt-core/src/terminal/pty.rs
+++ b/crates/gwt-core/src/terminal/pty.rs
@@ -23,20 +23,33 @@ pub struct PtyConfig {
     /// Whether this is an interactive session (e.g. spawn_shell).
     /// When true on Windows, the command is not wrapped with PowerShell.
     pub interactive: bool,
+    /// Whether to force UTF-8 terminal initialization on Windows launch.
+    pub windows_force_utf8: bool,
 }
 
 fn escape_powershell_single_quoted(value: &str) -> String {
     value.replace('\'', "''")
 }
 
-fn build_windows_powershell_command_expression(command: &str, args: &[String]) -> String {
+fn build_windows_powershell_command_expression(
+    command: &str,
+    args: &[String],
+    windows_force_utf8: bool,
+) -> String {
     let mut parts = Vec::with_capacity(args.len() + 1);
     parts.push(format!("'{}'", escape_powershell_single_quoted(command)));
     parts.extend(
         args.iter()
             .map(|arg| format!("'{}'", escape_powershell_single_quoted(arg))),
     );
-    format!("& {}", parts.join(" "))
+    let invoke = format!("& {}", parts.join(" "));
+    if windows_force_utf8 {
+        format!(
+            "$enc = [System.Text.UTF8Encoding]::new($false); [Console]::InputEncoding = $enc; [Console]::OutputEncoding = $enc; $OutputEncoding = $enc; chcp.com 65001 > $null; {invoke}"
+        )
+    } else {
+        invoke
+    }
 }
 
 fn resolve_windows_shell_with<F>(mut command_exists: F) -> String
@@ -79,6 +92,23 @@ fn build_cmd_command_expression(command: &str, args: &[String]) -> String {
     parts.join(" ")
 }
 
+fn build_cmd_utf8_command_expression(command: &str, args: &[String]) -> String {
+    let expression = build_cmd_command_expression(command, args);
+    format!("chcp 65001 > nul && {expression}")
+}
+
+fn build_powershell_wrapped_args(expression: String) -> Vec<String> {
+    vec![
+        "-NoLogo".to_string(),
+        "-NoProfile".to_string(),
+        "-NonInteractive".to_string(),
+        "-ExecutionPolicy".to_string(),
+        "Bypass".to_string(),
+        "-Command".to_string(),
+        expression,
+    ]
+}
+
 fn resolve_spawn_command_for_platform<F>(
     command: &str,
     args: &[String],
@@ -86,48 +116,70 @@ fn resolve_spawn_command_for_platform<F>(
     mut resolve_windows_shell: F,
     shell: Option<&str>,
     interactive: bool,
+    windows_force_utf8: bool,
 ) -> (String, Vec<String>)
 where
     F: FnMut() -> String,
 {
     if is_windows {
-        let force_powershell_wrap = matches!(shell, Some("powershell"));
-
-        // If an explicit shell override is provided, use it.
         if let Some(shell_id) = shell {
-            if shell_id == "cmd" {
-                let expression = build_cmd_command_expression(command, args);
-                return ("cmd.exe".to_string(), vec!["/C".to_string(), expression]);
+            match shell_id {
+                "cmd" => {
+                    let expression = if windows_force_utf8 {
+                        build_cmd_utf8_command_expression(command, args)
+                    } else {
+                        build_cmd_command_expression(command, args)
+                    };
+                    let cmd_args = if windows_force_utf8 {
+                        vec![
+                            "/D".to_string(),
+                            "/S".to_string(),
+                            "/C".to_string(),
+                            expression,
+                        ]
+                    } else {
+                        vec!["/C".to_string(), expression]
+                    };
+                    return ("cmd.exe".to_string(), cmd_args);
+                }
+                // "wsl": command and args are already set by the caller (launch_with_wsl_pty_write
+                // or resolve_shell_for_spawn), so pass through without wrapping.
+                "wsl" => return (command.to_string(), args.to_vec()),
+                "powershell" => {
+                    let shell = resolve_windows_shell();
+                    let expression = build_windows_powershell_command_expression(
+                        command,
+                        args,
+                        windows_force_utf8,
+                    );
+                    return (shell, build_powershell_wrapped_args(expression));
+                }
+                _ => {}
             }
-            // "wsl": command and args are already set by the caller (launch_with_wsl_pty_write
-            // or resolve_shell_for_spawn), so pass through without wrapping.
-            if shell_id == "wsl" {
-                return (command.to_string(), args.to_vec());
-            }
-            // "powershell" falls through to the default PowerShell path below.
         }
 
         // Interactive sessions (e.g. spawn_shell) must not be wrapped with
         // PowerShell -NonInteractive, as that breaks ConPTY I/O.
-        // Exception: explicit `powershell` selection should keep the wrapper path.
-        if interactive && !force_powershell_wrap {
+        if interactive && !windows_force_utf8 {
             return (command.to_string(), args.to_vec());
         }
 
+        if windows_force_utf8 {
+            let expression = build_cmd_utf8_command_expression(command, args);
+            return (
+                "cmd.exe".to_string(),
+                vec![
+                    "/D".to_string(),
+                    "/S".to_string(),
+                    "/C".to_string(),
+                    expression,
+                ],
+            );
+        }
+
         let shell = resolve_windows_shell();
-        let expression = build_windows_powershell_command_expression(command, args);
-        return (
-            shell,
-            vec![
-                "-NoLogo".to_string(),
-                "-NoProfile".to_string(),
-                "-NonInteractive".to_string(),
-                "-ExecutionPolicy".to_string(),
-                "Bypass".to_string(),
-                "-Command".to_string(),
-                expression,
-            ],
-        );
+        let expression = build_windows_powershell_command_expression(command, args, false);
+        return (shell, build_powershell_wrapped_args(expression));
     }
 
     (command.to_string(), args.to_vec())
@@ -138,6 +190,7 @@ fn resolve_spawn_command(
     args: &[String],
     shell: Option<&str>,
     interactive: bool,
+    windows_force_utf8: bool,
 ) -> (String, Vec<String>) {
     resolve_spawn_command_for_platform(
         command,
@@ -146,6 +199,7 @@ fn resolve_spawn_command(
         resolve_windows_shell,
         shell,
         interactive,
+        windows_force_utf8,
     )
 }
 
@@ -187,6 +241,7 @@ impl PtyHandle {
             &config.args,
             config.terminal_shell.as_deref(),
             config.interactive,
+            config.windows_force_utf8,
         );
 
         let mut cmd = CommandBuilder::new(&spawn_command);
@@ -286,11 +341,20 @@ mod tests {
     #[test]
     fn build_windows_powershell_command_expression_quotes_command_and_args() {
         let args = vec!["--yes".to_string(), "@openai/codex@latest".to_string()];
-        let expr = build_windows_powershell_command_expression("C:\\Tools\\npx.cmd", &args);
+        let expr = build_windows_powershell_command_expression("C:\\Tools\\npx.cmd", &args, false);
         assert_eq!(
             expr,
             "& 'C:\\Tools\\npx.cmd' '--yes' '@openai/codex@latest'"
         );
+    }
+
+    #[test]
+    fn build_windows_powershell_command_expression_utf8_wraps_preamble() {
+        let args = vec!["--version".to_string()];
+        let expr = build_windows_powershell_command_expression("codex", &args, true);
+        assert!(expr.contains("[System.Text.UTF8Encoding]::new($false)"));
+        assert!(expr.contains("chcp.com 65001 > $null"));
+        assert!(expr.ends_with("& 'codex' '--version'"));
     }
 
     #[test]
@@ -314,6 +378,7 @@ mod tests {
             true,
             || "pwsh".to_string(),
             None,
+            false,
             false,
         );
 
@@ -342,6 +407,7 @@ mod tests {
             || "powershell.exe".to_string(),
             None,
             false,
+            false,
         );
         assert_eq!(program, "powershell.exe");
         assert_eq!(
@@ -368,6 +434,7 @@ mod tests {
             || "pwsh".to_string(),
             None,
             false,
+            false,
         );
         assert_eq!(program, "codex");
         assert_eq!(resolved_args, args);
@@ -382,6 +449,7 @@ mod tests {
             true,
             || "pwsh".to_string(),
             Some("cmd"),
+            false,
             false,
         );
         assert_eq!(program, "cmd.exe");
@@ -408,6 +476,7 @@ mod tests {
             || "pwsh".to_string(),
             Some("cmd"),
             false,
+            false,
         );
         assert_eq!(program, "cmd.exe");
         assert_eq!(
@@ -418,6 +487,99 @@ mod tests {
                     .to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn resolve_spawn_command_windows_force_utf8_wraps_with_cmd() {
+        let args = vec!["--version".to_string()];
+        let (program, resolved_args) = resolve_spawn_command_for_platform(
+            "codex",
+            &args,
+            true,
+            || "pwsh".to_string(),
+            None,
+            true,
+            true,
+        );
+        assert_eq!(program, "cmd.exe");
+        assert_eq!(
+            resolved_args,
+            vec![
+                "/D".to_string(),
+                "/S".to_string(),
+                "/C".to_string(),
+                "chcp 65001 > nul && codex --version".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_spawn_command_windows_force_utf8_cmd_shell_uses_cmd_wrapper() {
+        let args = vec!["--version".to_string()];
+        let (program, resolved_args) = resolve_spawn_command_for_platform(
+            "codex",
+            &args,
+            true,
+            || "pwsh".to_string(),
+            Some("cmd"),
+            false,
+            true,
+        );
+        assert_eq!(program, "cmd.exe");
+        assert_eq!(
+            resolved_args,
+            vec![
+                "/D".to_string(),
+                "/S".to_string(),
+                "/C".to_string(),
+                "chcp 65001 > nul && codex --version".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_spawn_command_windows_force_utf8_powershell_shell_keeps_powershell_wrapper() {
+        let args = vec!["--version".to_string()];
+        let (program, resolved_args) = resolve_spawn_command_for_platform(
+            "codex",
+            &args,
+            true,
+            || "pwsh".to_string(),
+            Some("powershell"),
+            false,
+            true,
+        );
+        assert_eq!(program, "pwsh");
+        assert_eq!(
+            &resolved_args[0..6],
+            &[
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
+                "-ExecutionPolicy".to_string(),
+                "Bypass".to_string(),
+                "-Command".to_string(),
+            ]
+        );
+        assert!(resolved_args[6].contains("[System.Text.UTF8Encoding]::new($false)"));
+        assert!(resolved_args[6].contains("chcp.com 65001 > $null"));
+        assert!(resolved_args[6].contains("& 'codex' '--version'"));
+    }
+
+    #[test]
+    fn resolve_spawn_command_windows_force_utf8_wsl_passthrough() {
+        let args = vec!["-e".to_string(), "echo hello".to_string()];
+        let (program, resolved_args) = resolve_spawn_command_for_platform(
+            "wsl.exe",
+            &args,
+            true,
+            || "pwsh".to_string(),
+            Some("wsl"),
+            true,
+            true,
+        );
+        assert_eq!(program, "wsl.exe");
+        assert_eq!(resolved_args, args);
     }
 
     #[test]
@@ -436,6 +598,7 @@ mod tests {
             true,
             || "pwsh".to_string(),
             Some("powershell"),
+            false,
             false,
         );
         assert_eq!(program, "pwsh");
@@ -463,6 +626,7 @@ mod tests {
             || "pwsh".to_string(),
             Some("powershell"),
             true,
+            false,
         );
         assert_eq!(program, "pwsh");
         assert_eq!(
@@ -537,6 +701,7 @@ mod tests {
             cols: 80,
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
 
         let handle = PtyHandle::new(config).expect("Failed to create PTY");
@@ -567,6 +732,7 @@ mod tests {
             cols: 80,
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
 
         let handle = PtyHandle::new(config).expect("Failed to create PTY");
@@ -608,6 +774,7 @@ mod tests {
             cols: 80,
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
 
         let handle = PtyHandle::new(config).expect("Failed to create PTY");
@@ -626,6 +793,7 @@ mod tests {
             cols: 80,
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
 
         let mut handle = PtyHandle::new(config).expect("Failed to create PTY");
@@ -654,6 +822,7 @@ mod tests {
             cols: 80,
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
 
         let result = PtyHandle::new(config);
@@ -682,6 +851,7 @@ mod tests {
             || "pwsh".to_string(),
             None,
             true,
+            false,
         );
         assert_eq!(program, "pwsh");
         assert_eq!(resolved_args, vec!["--version".to_string()]);
@@ -697,6 +867,7 @@ mod tests {
             || "pwsh".to_string(),
             None,
             true,
+            false,
         );
         assert_eq!(program, "/bin/zsh");
         assert_eq!(resolved_args, vec!["-l".to_string()]);
@@ -712,6 +883,7 @@ mod tests {
             || "pwsh".to_string(),
             None,
             true,
+            false,
         );
         assert_eq!(program, "claude");
         assert_eq!(
@@ -733,6 +905,7 @@ mod tests {
             || "pwsh".to_string(),
             None,
             true,
+            false,
         );
         assert_eq!(program, "C:\\Users\\user\\.bun\\bin\\bunx.cmd");
         assert_eq!(
@@ -755,6 +928,7 @@ mod tests {
             cols: 80,
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         };
 
         let result = PtyHandle::new(config);

--- a/crates/gwt-tauri/src/agent_tools.rs
+++ b/crates/gwt-tauri/src/agent_tools.rs
@@ -574,6 +574,7 @@ mod tests {
             env_vars: Default::default(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         })
         .expect("failed to create test pane");
 

--- a/crates/gwt-tauri/src/commands/terminal.rs
+++ b/crates/gwt-tauri/src/commands/terminal.rs
@@ -1902,6 +1902,7 @@ fn launch_with_wsl_pty_write(
         env_vars: HashMap::new(), // WSL login shell handles base env
         terminal_shell: Some("wsl".to_string()),
         interactive: true,
+        windows_force_utf8: false,
     };
 
     let pane_id = {
@@ -1978,6 +1979,7 @@ fn launch_with_wsl_pty_write(
         env_vars: HashMap::new(),
         terminal_shell: Some("wsl".to_string()),
         interactive: false,
+        windows_force_utf8: false,
     };
 
     launch_with_config(&repo_path, fallback_config, meta, state, app_handle)
@@ -2017,6 +2019,7 @@ pub fn launch_terminal(
         env_vars: HashMap::new(),
         terminal_shell: None,
         interactive: true,
+        windows_force_utf8: cfg!(target_os = "windows"),
     };
 
     launch_with_config(&repo_path, config, None, &state, app_handle)
@@ -2169,6 +2172,7 @@ pub fn spawn_shell(
         env_vars: HashMap::new(),
         terminal_shell: terminal_shell_tag,
         interactive: true,
+        windows_force_utf8: false,
     };
 
     let pane_id = {
@@ -2547,6 +2551,7 @@ mod tests {
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             })
             .expect("failed to create test pane");
 
@@ -2608,6 +2613,7 @@ mod tests {
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             })
             .expect("failed to create running pane");
 
@@ -2625,6 +2631,7 @@ mod tests {
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             })
             .expect("failed to create done pane");
 
@@ -2681,6 +2688,7 @@ mod tests {
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             })
             .expect("failed to create test pane");
 
@@ -2723,6 +2731,7 @@ mod tests {
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             })
             .expect("failed to create test pane");
 
@@ -2774,6 +2783,7 @@ mod tests {
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             })
             .expect("failed to create test pane");
 
@@ -3404,6 +3414,7 @@ services:
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             })
             .expect("failed to create test pane");
 
@@ -4324,6 +4335,7 @@ pub(crate) fn launch_agent_for_project_root(
                 env_vars: docker_env.clone(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             }
         }
         DockerExecMode::DockerRun {
@@ -4389,6 +4401,7 @@ pub(crate) fn launch_agent_for_project_root(
                 env_vars: HashMap::new(),
                 terminal_shell: None,
                 interactive: false,
+                windows_force_utf8: false,
             }
         }
         DockerExecMode::None => {
@@ -4439,6 +4452,7 @@ pub(crate) fn launch_agent_for_project_root(
                 env_vars,
                 terminal_shell,
                 interactive: true,
+                windows_force_utf8: cfg!(target_os = "windows"),
             }
         }
     };

--- a/crates/gwt-tauri/src/pty_skills.rs
+++ b/crates/gwt-tauri/src/pty_skills.rs
@@ -242,6 +242,7 @@ mod tests {
             env_vars: Default::default(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         })
         .expect("failed to create test pane");
 
@@ -286,6 +287,7 @@ mod tests {
             env_vars: Default::default(),
             terminal_shell: None,
             interactive: false,
+            windows_force_utf8: false,
         })
         .expect("failed to create test pane");
 


### PR DESCRIPTION
## Summary
- Windows ���� AI �G�[�W�F���g�iCodex �Ȃǁj�N������ UTF-8 ���������s���A���������ETTY �������}�~���܂����B
- �ʏ��̎蓮�^�[�~�i���N���ɂ͉e�����^�����AAI �G�[�W�F���g�N�����̂ݓK�p���܂��B

## Context
- Issue #1257: Windows ���� Codex �^�[�~�i���\�����������������B
- ���������Ƃ��� Windows �̊����R�[�h�y�[�W�icp932�j�� UTF-8 �O���o�͂̕s���v�������A�N������ UTF-8 �������K�v�ł����B

## Changes
- `BuiltinLaunchConfig` / `PaneConfig` / `PtyConfig` �� `windows_force_utf8` ���ǉ����A�N���ݒ��� end-to-end �œ`���B
- Windows �N������ PTY �R�}���h������ UTF-8 �����������ǉ��B
  - `cmd`: `chcp 65001 > nul && ...`
  - `powershell`: Input/OutputEncoding �ݒ� + `chcp.com 65001`
  - `wsl`: �����ǂ��� passthrough
- �K�p�͈͂� AI �G�[�W�F���g�N���ihost ���s�j�Ɍ��肵�A`spawn_shell` / Docker / WSL �ɂ͓K�p���Ȃ��悤�ێ��B
- �֘A���j�b�g�e�X�g���ǉ��E�X�V�B

## Testing
- `cargo fmt --all`
- `cargo check -p gwt-core`
- `cargo test -p gwt-core terminal::pty::tests::resolve_spawn_command_windows_force_utf8_wraps_with_cmd`
- `cargo test -p gwt-core terminal::pty::tests::resolve_spawn_command_windows_force_utf8_cmd_shell_uses_cmd_wrapper`
- `cargo test -p gwt-core terminal::pty::tests::resolve_spawn_command_windows_force_utf8_powershell_shell_keeps_powershell_wrapper`
- `cargo test -p gwt-core terminal::pty::tests::resolve_spawn_command_windows_force_utf8_wsl_passthrough`
- `cargo test -p gwt-core terminal::manager::tests::test_launch_agent_success`

## Risk / Impact
- �e���͈͂� Windows �� AI �G�[�W�F���g�N������ PTY �R�}���h�g�ݗ��ĂɌ����B
- �������������̉��A���X�N�́A�蓮�^�[�~�i���EWSL�EDocker �o�H�����K�p�ɂ��邱�Ƃōŏ����B

## Deployment
- �Ȃ��i�ʏ탊���[�X�t���[�j�B

## Screenshots
- �Ȃ��i���W�b�N�C���̂݁j�B

## Related Issues / Links
- https://github.com/akiojin/gwt/issues/1257

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- `cargo check -p gwt-tauri` �͈ˑ����i`whisper-rs-sys`�j�̊��v���ɂ����A���̊��ł͖������ł��B
  - `libclang` �����o�A�܂��� `WHISPER_DONT_GENERATE_BINDINGS=1` ���� `bindings.rs` const eval �G���[�Ŏ��s�B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows UTF-8 terminal initialization configuration option to terminal pane and launch settings, allowing users to force UTF-8 encoding when launching terminal instances on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->