### PR TITLE
fix: normalize escaped windows batch command wrappers (#1265)

### DIFF
--- a/crates/gwt-core/src/terminal/pty.rs
+++ b/crates/gwt-core/src/terminal/pty.rs
@@ -92,17 +92,48 @@ fn build_cmd_command_expression(command: &str, args: &[String]) -> String {
     parts.join(" ")
 }
 
+fn strip_wrapping_quotes(value: &str) -> Option<&str> {
+    if value.len() < 2 {
+        return None;
+    }
+
+    let bytes = value.as_bytes();
+    let first = bytes[0];
+    let last = bytes[value.len() - 1];
+    let wrapped = (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'');
+    if wrapped {
+        Some(value[1..value.len() - 1].trim())
+    } else {
+        None
+    }
+}
+
+fn strip_wrapping_escaped_quotes(value: &str) -> Option<&str> {
+    if value.len() < 4 {
+        return None;
+    }
+
+    let wrapped = (value.starts_with("\\\"") && value.ends_with("\\\""))
+        || (value.starts_with("\\'") && value.ends_with("\\'"));
+    if wrapped {
+        Some(value[2..value.len() - 2].trim())
+    } else {
+        None
+    }
+}
+
 fn strip_wrapping_quotes_recursive(value: &str) -> String {
     let mut current = value.trim();
-    while current.len() >= 2 {
-        let bytes = current.as_bytes();
-        let first = bytes[0];
-        let last = bytes[current.len() - 1];
-        let wrapped = (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'');
-        if !wrapped {
-            break;
+    loop {
+        if let Some(next) = strip_wrapping_quotes(current) {
+            current = next;
+            continue;
         }
-        current = current[1..current.len() - 1].trim();
+        if let Some(next) = strip_wrapping_escaped_quotes(current) {
+            current = next;
+            continue;
+        }
+        break;
     }
     current.to_string()
 }
@@ -720,6 +751,14 @@ mod tests {
             strip_wrapping_quotes_recursive("\"C:\\Tools\\npx.cmd\""),
             "C:\\Tools\\npx.cmd"
         );
+        assert_eq!(
+            strip_wrapping_quotes_recursive(r#"'\"C:\Program Files\nodejs\npx.cmd\"'"#),
+            r#"C:\Program Files\nodejs\npx.cmd"#
+        );
+        assert_eq!(
+            strip_wrapping_quotes_recursive(r#"\"C:\Tools\npx.cmd\""#),
+            r#"C:\Tools\npx.cmd"#
+        );
     }
 
     #[test]
@@ -734,6 +773,14 @@ mod tests {
     fn is_windows_batch_command_for_platform_detects_wrapped_cmd_extension() {
         assert!(is_windows_batch_command_for_platform(
             "'\"C:\\Program Files\\nodejs\\npx.cmd\"'",
+            |_| None
+        ));
+    }
+
+    #[test]
+    fn is_windows_batch_command_for_platform_detects_escaped_wrapped_cmd_extension() {
+        assert!(is_windows_batch_command_for_platform(
+            r#"'\"C:\Program Files\nodejs\npx.cmd\"'"#,
             |_| None
         ));
     }
@@ -761,6 +808,28 @@ mod tests {
         let args = vec!["--yes".to_string(), "@openai/codex@latest".to_string()];
         let (program, resolved_args) = resolve_spawn_command_for_platform(
             "'\"C:\\Program Files\\nodejs\\npx.cmd\"'",
+            &args,
+            true,
+            || "pwsh".to_string(),
+            None,
+            false,
+            false,
+        );
+        assert_eq!(program, "cmd.exe");
+        assert_eq!(
+            resolved_args,
+            vec![
+                "/C".to_string(),
+                "\"C:\\Program Files\\nodejs\\npx.cmd\" --yes @openai/codex@latest".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_spawn_command_windows_normalizes_escaped_wrapped_batch_path() {
+        let args = vec!["--yes".to_string(), "@openai/codex@latest".to_string()];
+        let (program, resolved_args) = resolve_spawn_command_for_platform(
+            r#"'\"C:\Program Files\nodejs\npx.cmd\"'"#,
             &args,
             true,
             || "pwsh".to_string(),


### PR DESCRIPTION
## Summary
- Normalize escaped outer quotes in Windows batch command paths so Launch Agent resolves `npx.cmd` reliably.
- Fixes user-facing startup failures where commands like `'\"C:\\Program Files\\nodejs\\npx.cmd\"'` were treated as unknown commands.

## Context
- Issue #1265 reported repeated launch failures on Windows with `npx.cmd` path strings containing escaped wrapping quotes.
- Previous normalization covered plain wrapping quotes, but not escaped wrappers in some launch payloads.

## Changes
- Extended command normalization in `crates/gwt-core/src/terminal/pty.rs`:
- Added helpers to strip both plain wrappers (`'...'`, `"..."`) and escaped wrappers (`\\"...\\"`, `\\'...\\'`) recursively.
- Kept existing `cmd.exe /C` batch routing behavior and non-batch/powershell branches unchanged.
- Added regression tests for escaped wrapped command strings in normalization, batch detection, and spawn resolution.

## Testing
- `cargo test -p gwt-core terminal::pty -- --nocapture` (pass: 36/36)
- `bunx commitlint --from HEAD~1 --to HEAD` (pass)

## Risk / Impact
- Impacted area is limited to Windows PTY command normalization in `gwt-core`.
- Low risk for non-Windows flows; existing branch behavior is preserved and covered by existing tests.

## Deployment
- none

## Screenshots
- none (backend-only change)

## Related Issues / Links
- https://github.com/akiojin/gwt/issues/1265
- `specs/SPEC-1265/spec.md`

## Checklist
- [x] Tests added/updated
- [ ] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- This PR intentionally focuses on escaped-wrapper normalization only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced terminal command parsing to better handle quoted and escaped strings in command execution.
  * Improved Windows batch command resolution and normalization for more reliable command spawning.

* **Tests**
  * Expanded test coverage for quote and escape handling in terminal operations.
  * Added tests validating Windows batch command detection and execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->