### PR TITLE
fix(gui): resolve duplicated prefix display in from issue branch name (#1288)

### DIFF
--- a/gwt-gui/src/lib/components/AgentLaunchForm.svelte
+++ b/gwt-gui/src/lib/components/AgentLaunchForm.svelte
@@ -179,10 +179,8 @@
     })()
   );
 
-  let issueBranchName = $derived(
-    selectedIssue
-      ? `${newBranchPrefix}issue-${selectedIssue.number}`
-      : ""
+  let issueBranchSuffix = $derived(
+    selectedIssue ? `issue-${selectedIssue.number}` : ""
   );
 
   let ghCliAvailable = $derived(
@@ -1015,7 +1013,7 @@
       } else {
         if (!newBranchPrefix) return;
         const fullName = issueForLaunch
-          ? issueBranchName
+          ? buildNewBranchName(newBranchPrefix, issueBranchSuffix)
           : newBranchFullName.trim();
         if (!baseBranch.trim() || !fullName) return;
         request.branch = fullName;
@@ -1311,7 +1309,7 @@
                   {/if}
                   <input
                     type="text"
-                    value={issueBranchName}
+                    value={issueBranchSuffix}
                     readonly
                   />
                 </div>

--- a/gwt-gui/src/lib/components/AgentLaunchForm.test.ts
+++ b/gwt-gui/src/lib/components/AgentLaunchForm.test.ts
@@ -953,6 +953,17 @@ describe("AgentLaunchForm", () => {
     const issueButton = rendered.getByRole("button", { name: /#99/i });
     await fireEvent.click(issueButton);
 
+    await waitFor(() => {
+      expect(rendered.getByText("Auto-generated from issue #99")).toBeTruthy();
+    });
+    const issueBranchField = rendered
+      .getByText("Auto-generated from issue #99")
+      .closest(".field") as HTMLElement;
+    const issuePrefixSelect = issueBranchField.querySelector("select") as HTMLSelectElement;
+    const issueBranchInput = issueBranchField.querySelector("input[readonly]") as HTMLInputElement;
+    expect(issuePrefixSelect.value).toBe("bugfix/");
+    expect(issueBranchInput.value).toBe("issue-99");
+
     const launchButton = rendered.getByRole("button", { name: "Launch" }) as HTMLButtonElement;
     await waitFor(() => {
       expect(launchButton.disabled).toBe(false);
@@ -964,6 +975,8 @@ describe("AgentLaunchForm", () => {
     });
 
     const request = onLaunch.mock.calls[0][0] as any;
+    expect(request.branch).toBe("bugfix/issue-99");
+    expect(request.createBranch).toEqual({ name: "bugfix/issue-99", base: "main" });
     expect(request.issueNumber).toBe(99);
     expect(
       invokeMock.mock.calls.some((call: any[]) => call[0] === "link_branch_to_issue")

--- a/specs/SPEC-1288/plan.md
+++ b/specs/SPEC-1288/plan.md
@@ -1,0 +1,43 @@
+# 実装計画: From Issue でブランチ名に prefix が二重表示される
+
+**仕様ID**: `SPEC-1288` | **日付**: 2026-02-27 | **仕様書**: `specs/SPEC-1288/spec.md`
+
+## 目的
+
+- From Issue の Branch Name 表示を prefix/suffix 分離にして視認性を改善し、launch payload の既存仕様を維持する。
+
+## 技術コンテキスト
+
+- **フロントエンド**: Svelte 5 + TypeScript（`gwt-gui/src/lib/components/AgentLaunchForm.svelte`）
+- **バックエンド**: 変更なし
+- **テスト**: `gwt-gui/src/lib/components/AgentLaunchForm.test.ts`
+- **前提**: branch 作成の実体ロジックは変えず、UI 表示と branch 文字列の組み立て箇所のみを調整する
+
+## 実装方針
+
+### Phase 1: TDD（RED）
+
+- From Issue の表示値が `issue-<number>` であることを検証するテストを追加する。
+- Launch request の `branch` / `createBranch.name` が full branch name であることを検証する。
+
+### Phase 2: UI / launch 組み立て修正
+
+- `issueBranchName` を `issueBranchSuffix` に置換し、From Issue の readonly 入力欄は suffix のみ表示する。
+- launch 時は `buildNewBranchName(newBranchPrefix, issueBranchSuffix)` で full branch name を構築する。
+- Manual タブの既存ロジック (`newBranchFullName`) は維持する。
+
+### Phase 3: 検証
+
+- 変更対象テストを実行して pass を確認する。
+- `svelte-check` を実行して型エラーがないことを確認する。
+
+## テスト
+
+### フロントエンド
+
+- `keeps Launch disabled in fromIssue mode until a prefix is selected`
+- `does not link or rollback issue branch before async launch job completion`（表示 + payload 検証を追加）
+
+### バックエンド
+
+- 変更なし

--- a/specs/SPEC-1288/spec.md
+++ b/specs/SPEC-1288/spec.md
@@ -1,0 +1,74 @@
+# バグ修正仕様: From Issue でブランチ名に prefix が二重表示される
+
+**仕様ID**: `SPEC-1288`
+**作成日**: 2026-02-27
+**更新日**: 2026-02-27
+**ステータス**: ドラフト
+**カテゴリ**: GUI
+**依存仕様**:
+
+- SPEC-c6ba640a（GitHub Issue連携によるブランチ作成）
+- SPEC-a2f8e3b1（From Issue ブランチプレフィックスAI判定）
+
+**入力**: ユーザー説明: "Issue #1288を解決して"
+
+## 背景
+
+- Launch Agent の New Branch > From Issue では、prefix 選択ドロップダウンと readonly 入力欄の双方に prefix が含まれ、`bugfix` が二重に見える。
+- 実際に作成される branch 名は正しいが、UI 表示が誤解を招く。
+
+## ユーザーシナリオとテスト *(必須)*
+
+### ユーザーストーリー 1 - From Issue の branch 表示を正しく理解したい (優先度: P0)
+
+ユーザーとして、From Issue の Branch Name で prefix と suffix の役割を明確に見分けたい。
+
+**独立したテスト**: `bug` ラベル付き Issue 選択時、prefix セレクトは `bugfix/`、入力欄は `issue-<number>` のみになること。
+
+**受け入れシナリオ**:
+
+1. **前提条件** From Issue タブで `bug` ラベル付き Issue #99 を選択、**操作** Branch Name 表示を確認、**期待結果** prefix は `bugfix/`、入力欄は `issue-99` を表示する
+2. **前提条件** From Issue タブで prefix を `feature/` から `hotfix/` に変更、**操作** 表示を確認、**期待結果** 入力欄は `issue-<number>` のままで、prefix 側のみ変化する
+
+---
+
+### ユーザーストーリー 2 - 起動時の branch 作成は従来どおり成功したい (優先度: P0)
+
+ユーザーとして、表示修正後も launch payload は従来どおり `{prefix}issue-{number}` で送られてほしい。
+
+**独立したテスト**: From Issue launch の request で `branch` と `createBranch.name` が full branch name であること。
+
+**受け入れシナリオ**:
+
+1. **前提条件** `bugfix/` + Issue #99 を選択済み、**操作** Launch 実行、**期待結果** request.branch は `bugfix/issue-99` で送信される
+2. **前提条件** 同上、**操作** Launch 実行、**期待結果** request.createBranch.name は `bugfix/issue-99` で送信される
+
+## エッジケース
+
+- prefix 未選択（AI 判定失敗等）時は、入力欄に `issue-<number>` を表示したまま Launch を無効化する。
+- Manual タブの Direct / AI Suggest の表示・送信ロジックには影響を与えない。
+
+## 要件 *(必須)*
+
+### 機能要件
+
+- **FR-001**: From Issue の Branch Name 表示は、prefix セレクトと `issue-<number>` の suffix 表示を分離しなければならない。
+- **FR-002**: From Issue の launch 時に送信する branch 名は、`{prefix}issue-{number}` 形式を維持しなければならない。
+- **FR-003**: `request.branch` と `request.createBranch.name` は同一の full branch name を使用しなければならない。
+- **FR-004**: prefix 未選択時の Launch disabled 制御は既存挙動を維持しなければならない。
+
+### 非機能要件
+
+- **NFR-001**: 変更範囲は `AgentLaunchForm` の UI 表示と launch 組み立てに限定し、Tauri command I/F を変更しない。
+- **NFR-002**: 既存 From Issue 回帰を防ぐため、`AgentLaunchForm.test.ts` に表示と payload のテストを追加する。
+
+## 制約と仮定
+
+- ブランチ命名規約 `{prefix}issue-{number}` は既存仕様に従い変更しない。
+- prefix 種別は既存 4 種（`feature/`, `bugfix/`, `hotfix/`, `release/`）を維持する。
+
+## 成功基準 *(必須)*
+
+- **SC-001**: From Issue 選択後、Branch Name の入力欄に prefix が重複表示されない。
+- **SC-002**: Launch payload は表示変更後も `{prefix}issue-{number}` を保持する。
+- **SC-003**: 追加したユニットテストが通過し、既存 From Issue テストに回帰がない。

--- a/specs/SPEC-1288/tasks.md
+++ b/specs/SPEC-1288/tasks.md
@@ -1,0 +1,15 @@
+# タスクリスト: From Issue でブランチ名に prefix が二重表示される
+
+## Phase 1: セットアップ
+
+- [x] T001 [US1] 仕様書を作成し Issue #1288 の受け入れ条件を定義する `specs/SPEC-1288/spec.md`
+- [x] T002 [US1] 実装計画とタスクを作成する `specs/SPEC-1288/plan.md`, `specs/SPEC-1288/tasks.md`
+
+## Phase 2: ストーリー 1
+
+- [x] T003 [US1] From Issue の branch 表示が suffix のみになるテストを追加する `gwt-gui/src/lib/components/AgentLaunchForm.test.ts`
+- [x] T004 [US1] `AgentLaunchForm.svelte` で表示を suffix-only にし launch 時に full branch name を組み立てる `gwt-gui/src/lib/components/AgentLaunchForm.svelte`
+
+## Phase 3: 仕上げ・横断
+
+- [x] T005 [共通] Frontend テストと型チェックを実行して回帰がないことを確認する `gwt-gui/src/lib/components/AgentLaunchForm.test.ts`

--- a/specs/specs.md
+++ b/specs/specs.md
@@ -17,6 +17,7 @@
 
 | SPEC ID | タイトル | 作成日 |
 | --- | --- | --- |
+| [SPEC-1288](SPEC-1288/spec.md) | バグ修正仕様: From Issue でブランチ名に prefix が二重表示される | 2026-02-27 |
 | [SPEC-dc2ef2d3](SPEC-dc2ef2d3/spec.md) | 機能仕様: Worktree詳細ビューでCLAUDE.md/AGENTS.md/GEMINI.mdを確認・修正し編集起動 | 2026-02-27 |
 | [SPEC-54c8e2fa](SPEC-54c8e2fa/spec.md) | 機能仕様: Issue連携ブランチのリンク保証と起動フロー一元化 | 2026-02-26 |
 | [SPEC-9cd50c7c](SPEC-9cd50c7c/spec.md) | 機能仕様: AI自動ブランチ命名モード | 2026-02-26 |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,16 +1,15 @@
-# TODO: Issue #1256 Modal Front Layering
+# TODO: Issue #1288 From Issue Branch Name Display
 
 ## 背景
-Issue #1256「エラーリポートウィンドウを一番手前に表示」を、既存 `SPEC-fabb6678` に追記し、共通モーダル層設計と TDD（Unit + E2E）で修正する。
+Issue #1288「From Issue からブランチ作成時にブランチ名の表示が不自然（prefix が重複して見える）」を、`SPEC-1288` と TDD で修正する。
 
 ## 実装ステップ
-- [x] SPEC-fabb6678（spec/plan/tasks/tdd）へ US10 + FR + 検証計画を追記
-- [x] モーダル共通 z-index トークンを導入し、モーダル関連コンポーネントへ適用
-- [x] ReportDialog 最前面保証の Unit テストを追加
-- [x] モーダル競合時の最前面保証 E2E を追加
-- [x] テスト/チェック実行（ReportDialog unit, dialogs-common e2e, svelte-check）
+- [x] `specs/SPEC-1288/spec.md`, `plan.md`, `tasks.md` を作成して要件を定義
+- [x] `AgentLaunchForm.svelte` の From Issue 表示を suffix-only（`issue-<number>`）に修正
+- [x] Launch 時の branch 名組み立てを full name（`{prefix}issue-{number}`）で固定
+- [x] `AgentLaunchForm.test.ts` に表示と payload の回帰テストを追加
+- [x] テスト/チェック実行（対象 test + svelte-check）
 
 ## 検証結果
-- [x] `cd gwt-gui && pnpm test src/lib/components/ReportDialog.test.ts`（pass: 27 tests）
-- [x] `cd gwt-gui && pnpm exec playwright test e2e/dialogs-common.spec.ts --project=chromium`（pass: 11 tests）
-- [x] `cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json`（0 errors / 1 warning）
+- [x] `cd gwt-gui && pnpm test src/lib/components/AgentLaunchForm.test.ts`（pass: 39 tests）
+- [x] `cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json`（0 errors / 1 warning: 既存 `MergeDialog.svelte`）


### PR DESCRIPTION
## Summary
- Fix duplicated prefix display in Launch Agent > New Branch > From Issue branch name field
- Keep actual launch/create payload unchanged as `{prefix}issue-{number}`

## Context
- Issue #1288 reported that `bugfix` appears duplicated in the From Issue branch name display
- The previous UI rendered prefix selector and a full branch string with prefix, which looked incorrect

## Changes
- Update `AgentLaunchForm` to display suffix-only (`issue-<number>`) in From Issue readonly input
- Build full branch name only at launch time using `buildNewBranchName(newBranchPrefix, issueBranchSuffix)`
- Add regression assertions in `AgentLaunchForm.test.ts` for both UI display and launch payload
- Add SPEC docs for this fix (`SPEC-1288`) and update spec/todo indexes

## Testing
- `cd gwt-gui && pnpm test src/lib/components/AgentLaunchForm.test.ts` (pass: 39 tests)
- `cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json` (0 errors, 1 existing warning in `MergeDialog.svelte`)

## Risk / Impact
- Scope is limited to From Issue branch-name presentation and request assembly in `AgentLaunchForm`
- No Tauri command contract or backend behavior changes

## Deployment
- None

## Screenshots
- N/A (UI-only tweak validated by tests)

## Related Issues / Links
- https://github.com/akiojin/gwt/issues/1288
- `specs/SPEC-1288/spec.md`
- `specs/SPEC-1288/plan.md`
- `specs/SPEC-1288/tasks.md`

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [x] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- This branch also contains prior branch history changes; this PR focuses on Issue #1288 adjustments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed branch prefix duplication in the "From Issue" branch selection flow. Branch prefixes and issue references now display correctly without redundant formatting.

* **Tests**
  * Updated test suite to verify correct branch name construction and display when launching agents from issues.

* **Documentation**
  * Added detailed specifications and implementation planning documentation for branch naming improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->