### PR TITLE
fix: Project Index files search no-results regression (#1441)

### DIFF
--- a/crates/gwt-tauri/src/commands/project_index.rs
+++ b/crates/gwt-tauri/src/commands/project_index.rs
@@ -568,6 +568,23 @@ mod tests {
     }
 
     #[test]
+    fn chroma_search_has_substring_fallback_for_empty_semantic_results() {
+        assert!(
+            CHROMA_HELPER_SCRIPT.contains("def fallback_substring_search("),
+            "fallback_substring_search helper must exist"
+        );
+        assert!(
+            CHROMA_HELPER_SCRIPT.contains("if not items:"),
+            "search path must branch on empty semantic results"
+        );
+        assert!(
+            CHROMA_HELPER_SCRIPT
+                .contains("items = fallback_substring_search(collection, query, actual_n)"),
+            "search path must invoke fallback_substring_search"
+        );
+    }
+
+    #[test]
     fn chroma_runner_response_deserializes_camel_case_metrics() {
         let json = r#"{
             "ok": true,

--- a/crates/gwt-tauri/src/python/chroma_index_runner.py
+++ b/crates/gwt-tauri/src/python/chroma_index_runner.py
@@ -407,7 +407,57 @@ def action_search(db_path: str, query: str, n_results: int = 10) -> dict:
                 "size": meta.get("size", 0),
             })
 
+    if not items:
+        items = fallback_substring_search(collection, query, actual_n)
+
     return {"ok": True, "results": items}
+
+
+def fallback_substring_search(collection, query: str, n_results: int) -> List[dict]:
+    """Fallback search using case-insensitive substring matching on path/description."""
+    normalized = query.strip().lower()
+    if not normalized or n_results <= 0:
+        return []
+
+    try:
+        snapshot = collection.get(include=["metadatas"])
+    except Exception:
+        return []
+
+    ids = snapshot.get("ids") or []
+    metadatas = snapshot.get("metadatas") or []
+    matches = []
+
+    for idx, file_id in enumerate(ids):
+        meta = metadatas[idx] if idx < len(metadatas) and metadatas[idx] else {}
+        path = str(meta.get("path", file_id))
+        description = str(meta.get("description", ""))
+
+        path_pos = path.lower().find(normalized)
+        desc_pos = description.lower().find(normalized)
+
+        positions = [pos for pos in (path_pos, desc_pos) if pos >= 0]
+        if not positions:
+            continue
+
+        rank = 0 if path_pos >= 0 else 1
+        best_pos = min(positions)
+
+        matches.append((
+            rank,
+            best_pos,
+            path,
+            {
+                "path": path,
+                "description": description,
+                "distance": None,
+                "fileType": meta.get("file_type", ""),
+                "size": meta.get("size", 0),
+            },
+        ))
+
+    matches.sort(key=lambda item: (item[0], item[1], item[2]))
+    return [item[3] for item in matches[:n_results]]
 
 
 def action_index_issues(project_root: str, db_path: str) -> dict:

--- a/gwt-gui/src/lib/components/ProjectIndexPanel.svelte
+++ b/gwt-gui/src/lib/components/ProjectIndexPanel.svelte
@@ -12,6 +12,8 @@
   let query = $state("");
   let results = $state<ProjectIndexSearchResult[]>([]);
   let searching = $state(false);
+  let hasSearched = $state(false);
+  let lastSearchedQuery = $state("");
   let error = $state<string | null>(null);
   let statusError = $state<string | null>(null);
   let indexStatus = $state<{
@@ -46,7 +48,12 @@
 
   async function handleSearch() {
     const q = query.trim();
-    if (!q) return;
+    if (!q) {
+      hasSearched = false;
+      lastSearchedQuery = "";
+      results = [];
+      return;
+    }
 
     searching = true;
     error = null;
@@ -60,6 +67,8 @@
       error = String(e);
       results = [];
     } finally {
+      hasSearched = true;
+      lastSearchedQuery = q;
       searching = false;
     }
   }
@@ -199,7 +208,7 @@
             {/if}
           </div>
         {/each}
-      {:else if !searching && !error && query.trim()}
+      {:else if !searching && !error && hasSearched && lastSearchedQuery === query.trim()}
         <div class="no-results">No results found</div>
       {/if}
     </div>

--- a/gwt-gui/src/lib/components/ProjectIndexPanel.test.ts
+++ b/gwt-gui/src/lib/components/ProjectIndexPanel.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("../openExternalUrl", () => ({
+  openExternalUrl: vi.fn(),
+}));
+
+async function renderProjectIndexPanel(projectPath = "/tmp/project") {
+  const { default: ProjectIndexPanel } = await import("./ProjectIndexPanel.svelte");
+  return render(ProjectIndexPanel, {
+    props: {
+      projectPath,
+    },
+  });
+}
+
+describe("ProjectIndexPanel", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "get_index_status_cmd") {
+        return {
+          indexed: true,
+          totalFiles: 12911,
+          dbSizeBytes: 82_087_321,
+        };
+      }
+
+      if (command === "search_project_index_cmd") {
+        return [];
+      }
+
+      if (command === "index_github_issues_cmd") {
+        return {
+          issuesIndexed: 0,
+          durationMs: 1,
+        };
+      }
+
+      if (command === "search_github_issues_cmd") {
+        return [];
+      }
+
+      throw new Error(`unexpected invoke command: ${command}`);
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not show no-results message before a files search is executed", async () => {
+    const rendered = await renderProjectIndexPanel();
+
+    await waitFor(() => {
+      expect(rendered.getByText("12911 files indexed")).toBeTruthy();
+    });
+
+    const input = rendered.getByPlaceholderText("Search project files...") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "Git" } });
+
+    expect(rendered.queryByText("No results found")).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "search_project_index_cmd",
+      expect.anything(),
+    );
+  });
+
+  it("shows no-results message after a files search returns an empty list", async () => {
+    const rendered = await renderProjectIndexPanel();
+
+    await waitFor(() => {
+      expect(rendered.getByText("12911 files indexed")).toBeTruthy();
+    });
+
+    const input = rendered.getByPlaceholderText("Search project files...") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "Git" } });
+    await fireEvent.click(rendered.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("search_project_index_cmd", {
+        projectRoot: "/tmp/project",
+        query: "Git",
+        nResults: 20,
+      });
+    });
+
+    await waitFor(() => {
+      expect(rendered.getByText("No results found")).toBeTruthy();
+    });
+  });
+
+  it("hides stale no-results message when the query is edited after search", async () => {
+    const rendered = await renderProjectIndexPanel();
+
+    await waitFor(() => {
+      expect(rendered.getByText("12911 files indexed")).toBeTruthy();
+    });
+
+    const input = rendered.getByPlaceholderText("Search project files...") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "Git" } });
+    await fireEvent.click(rendered.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(rendered.getByText("No results found")).toBeTruthy();
+    });
+
+    await fireEvent.input(input, { target: { value: "Rust" } });
+    expect(rendered.queryByText("No results found")).toBeNull();
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,30 @@
 # TODO: GitHub Copilot CLI 対応
 
+---
+
+## TODO: Issue #1441 Project Index Files 検索結果 0 件表示の修正（2026-03-04）
+
+## 背景（Issue #1441）
+
+Project Index の Files タブで `Git` を検索した際に「No results found」と見える不具合。
+根本原因として、未検索状態でも入力文字列があるだけで 0 件表示文言が出る UI 条件と、
+semantic 検索結果が空のときのフォールバック不在を修正する。
+
+## 実装ステップ（Issue #1441）
+
+- [x] T001 フロントエンド回帰テスト追加（未検索時 0 件文言を表示しない）
+- [x] T002 RED 確認（追加テスト失敗を確認）
+- [x] T003 UI 実装修正（検索実行後のみ 0 件文言表示）
+- [x] T004 Python 検索フォールバック追加（semantic 0 件時の部分一致）
+- [x] T005 GREEN 確認（対象テスト実行）
+- [x] T006 追加検証（svelte-check + Rust unit test）
+
+## 検証結果（Issue #1441）
+
+- [x] `cd gwt-gui && pnpm test src/lib/components/ProjectIndexPanel.test.ts`（3 tests passed）
+- [x] `cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json`（0 errors / 1 warning: 既存 `MergeDialog.svelte`）
+- [x] `cargo test -p gwt-tauri project_index -- --test-threads=1`（5 tests passed）
+
 ## 背景（Copilot CLI 対応）
 
 gwt に 5 番目の AI コーディングエージェントとして GitHub Copilot CLI（`copilot` コマンド、npm: `@github/copilot`）を追加する。既存の 4 エージェント（Claude Code / Codex / Gemini / OpenCode）と同じパターンに従い、最小限の変更で統合する。


### PR DESCRIPTION
## Summary
- fix Files tab UI state so `No results found` is shown only after an executed search for the current query
- add `ProjectIndexPanel` regression tests for pre-search state and stale no-results behavior
- add project-index fallback path in `chroma_index_runner.py` for empty semantic results (case-insensitive substring match)
- add Rust guard test to ensure fallback path remains embedded in the helper script

## Verification
- `cd gwt-gui && pnpm test src/lib/components/ProjectIndexPanel.test.ts`
- `cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json`
- `cargo test -p gwt-tauri project_index -- --test-threads=1`

Fixes #1441


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search functionality now includes a fallback substring matching mechanism to display results when semantic search yields no matches.

* **Bug Fixes**
  * Improved handling of empty search states and refined no-results messaging display logic.

* **Tests**
  * Added comprehensive test coverage for search behavior, including empty state handling and result display validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->