### PR TITLE
fix(gui): refresh codex auth state after settings save

### DIFF
--- a/gwt-gui/src/lib/components/AgentLaunchForm.svelte
+++ b/gwt-gui/src/lib/components/AgentLaunchForm.svelte
@@ -369,6 +369,17 @@
   });
 
   $effect(() => {
+    const onSettingsUpdated = () => {
+      void detectAgents();
+      void refreshAiConfigured();
+    };
+    window.addEventListener("gwt-settings-updated", onSettingsUpdated);
+    return () => {
+      window.removeEventListener("gwt-settings-updated", onSettingsUpdated);
+    };
+  });
+
+  $effect(() => {
     (async () => {
       try {
         const { invoke } = await import("$lib/tauriInvoke");
@@ -381,21 +392,7 @@
 
   // Check AI configuration (SPEC-9cd50c7c T043-T044)
   $effect(() => {
-    (async () => {
-      try {
-        const { invoke } = await import("$lib/tauriInvoke");
-        const configured = await invoke<boolean>("is_ai_configured");
-        aiConfigured = configured;
-        if (!configured) {
-          aiConfigured = false;
-          if (branchNamingMode === "ai-suggest") {
-            branchNamingMode = "direct";
-          }
-        }
-      } catch {
-        // AI config check failed - keep default mode.
-      }
-    })();
+    void refreshAiConfigured();
   });
 
   $effect(() => {
@@ -892,6 +889,19 @@
       selectedAgent = "";
     } finally {
       loading = false;
+    }
+  }
+
+  async function refreshAiConfigured() {
+    try {
+      const { invoke } = await import("$lib/tauriInvoke");
+      const configured = await invoke<boolean>("is_ai_configured");
+      aiConfigured = configured;
+      if (!configured && branchNamingMode === "ai-suggest") {
+        branchNamingMode = "direct";
+      }
+    } catch {
+      // AI config check failed - keep current mode.
     }
   }
 

--- a/gwt-gui/src/lib/components/AgentLaunchForm.test.ts
+++ b/gwt-gui/src/lib/components/AgentLaunchForm.test.ts
@@ -202,6 +202,59 @@ describe("AgentLaunchForm", () => {
     expect(binaryFallbackNotice).toBeTruthy();
   });
 
+  it("refreshes codex authentication when settings are updated", async () => {
+    let detectCall = 0;
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "detect_agents") {
+        detectCall += 1;
+        return [
+          {
+            id: "codex",
+            name: "Codex",
+            version: "0.0.0",
+            authenticated: detectCall > 1,
+            available: true,
+          },
+        ];
+      }
+      if (cmd === "get_agent_config") {
+        return { version: 1, claude: { provider: "anthropic", glm: {} } };
+      }
+      if (cmd === "is_ai_configured") return true;
+      return [];
+    });
+
+    const onLaunch = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+
+    const rendered = await renderLaunchForm({
+      projectPath: "/tmp/project",
+      selectedBranch: "",
+      onLaunch,
+      onClose,
+    });
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("detect_agents");
+    });
+    await waitFor(() => {
+      expect(rendered.getByText("Not authenticated")).toBeTruthy();
+    });
+
+    window.dispatchEvent(
+      new CustomEvent("gwt-settings-updated", {
+        detail: {},
+      })
+    );
+
+    await waitFor(() => {
+      expect(detectCall).toBeGreaterThanOrEqual(2);
+    });
+    await waitFor(() => {
+      expect(rendered.queryByText("Not authenticated")).toBeNull();
+    });
+  });
+
 
   it("displays new codex model options including gpt-5.3-codex-spark", async () => {
     invokeMock.mockImplementation(async (cmd: string) => {


### PR DESCRIPTION
## Summary

- Refresh Codex authentication state after settings updates so a newly saved API key is reflected immediately in Launch Agent on macOS.
- Reuse a dedicated AI-configuration refresh helper to keep post-save and initial-load behavior consistent for branch naming mode.
- Add a regression test that proves the stale `Not authenticated` hint disappears after the settings-updated event.

## Changes

- `gwt-gui/src/lib/components/AgentLaunchForm.svelte`: listen for `gwt-settings-updated` and re-run `detectAgents` plus AI-config refresh.
- `gwt-gui/src/lib/components/AgentLaunchForm.svelte`: extract `refreshAiConfigured()` and use it from the existing AI configuration effect.
- `gwt-gui/src/lib/components/AgentLaunchForm.test.ts`: add `refreshes codex authentication when settings are updated` regression test.

## Testing

- [x] `pnpm -C gwt-gui test AgentLaunchForm.test.ts -t "refreshes codex authentication when settings are updated"` — target regression test passes.
- [x] `pnpm -C gwt-gui test AgentLaunchForm.test.ts` — full `AgentLaunchForm` test file passes (43/43).

## Related Issues / Links

- https://github.com/akiojin/gwt/pull/1462

## Checklist

- [x] Tests added/updated
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — Not run in this follow-up; scope was targeted GUI test coverage.
- [ ] Documentation updated (if user-facing change) — N/A: no docs page or command contract changed.
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema/data migration.
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — N/A: no breaking change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application now automatically detects when settings are updated and refreshes AI configuration in real-time.
  * Intelligently switches from AI-powered branch naming suggestions to direct mode if AI configuration becomes unavailable.

* **Tests**
  * Added test coverage for settings update handling and AI configuration refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->