### PR TITLE
fix(terminal): normalize Windows shell cwd injection paths (#1466)

### DIFF
--- a/crates/gwt-core/src/terminal/pty.rs
+++ b/crates/gwt-core/src/terminal/pty.rs
@@ -262,17 +262,23 @@ fn is_powershell_executable(command: &str) -> bool {
     )
 }
 
+fn normalize_windows_working_dir_for_shell(working_dir: &Path) -> String {
+    working_dir.to_string_lossy().replace('/', "\\")
+}
+
 fn cmd_cd_expression(working_dir: &Path) -> String {
     format!(
         "cd /D \"{}\"",
-        escape_cmd_double_quoted(working_dir.to_string_lossy().as_ref())
+        escape_cmd_double_quoted(normalize_windows_working_dir_for_shell(working_dir).as_ref())
     )
 }
 
 fn powershell_set_location_expression(working_dir: &Path) -> String {
     format!(
         "Set-Location -LiteralPath '{}'",
-        escape_powershell_single_quoted(working_dir.to_string_lossy().as_ref())
+        escape_powershell_single_quoted(
+            normalize_windows_working_dir_for_shell(working_dir).as_ref()
+        )
     )
 }
 
@@ -1221,6 +1227,23 @@ mod tests {
     }
 
     #[test]
+    fn inject_windows_working_dir_into_spawn_args_cmd_normalizes_forward_slash_worktree_path() {
+        let mut args = vec!["/C".to_string(), "codex --version".to_string()];
+        inject_windows_working_dir_into_spawn_args(
+            "cmd.exe",
+            &mut args,
+            Path::new("E:/gwt/bugfix/issue-1466"),
+        );
+        assert_eq!(
+            args,
+            vec![
+                "/C".to_string(),
+                "cd /D \"E:\\gwt\\bugfix\\issue-1466\" && codex --version".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn inject_windows_working_dir_into_spawn_args_powershell_prefixes_set_location() {
         let mut args = vec![
             "-NoLogo".to_string(),
@@ -1235,6 +1258,30 @@ mod tests {
         assert_eq!(
             args[6],
             "Set-Location -LiteralPath 'C:\\repo\\it''s'; & 'codex' '--version'".to_string()
+        );
+    }
+
+    #[test]
+    fn inject_windows_working_dir_into_spawn_args_powershell_normalizes_forward_slash_worktree_path(
+    ) {
+        let mut args = vec![
+            "-NoLogo".to_string(),
+            "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
+            "-ExecutionPolicy".to_string(),
+            "Bypass".to_string(),
+            "-Command".to_string(),
+            "& 'codex' '--version'".to_string(),
+        ];
+        inject_windows_working_dir_into_spawn_args(
+            "pwsh",
+            &mut args,
+            Path::new("E:/gwt/bugfix/issue-1466"),
+        );
+        assert_eq!(
+            args[6],
+            "Set-Location -LiteralPath 'E:\\gwt\\bugfix\\issue-1466'; & 'codex' '--version'"
+                .to_string()
         );
     }
 


### PR DESCRIPTION
## Summary

- Normalize Windows shell-injected worktree paths before building `cmd.exe` / PowerShell cwd expressions so `Command Prompt` launches do not fail on `E:/...`-style paths.
- Add regression tests for both `cmd.exe` and PowerShell wrapper injection so the `#1466` path-format bug is covered in `gwt-core`.

## Changes

- `crates/gwt-core/src/terminal/pty.rs`: normalize shell-injected Windows working directory strings from `/` to `\` before composing `cd /D` and `Set-Location`.
- `crates/gwt-core/src/terminal/pty.rs`: add regression tests for `E:/gwt/...` worktree paths in `cmd.exe` and PowerShell wrapper flows.

## Testing

- [x] `cargo test -p gwt-core inject_windows_working_dir_into_spawn_args_ -- --test-threads=1` — new regression tests fail before the fix and pass after the fix.
- [x] `cargo test -p gwt-core terminal::pty -- --test-threads=1` — `terminal::pty` suite passes.
- [x] `cargo fmt --all -- --check` — passes (`rustfmt` nightly-option warnings only).
- [x] `cargo clippy -p gwt-core --all-targets -- -D warnings` — passes.

## Related Issues / Links

- #1466
- #1306

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — backend-only change; Rust checks passed
- [x] Documentation updated (if user-facing change) — N/A: no documentation change required
- [x] Migration/backfill plan included (if schema/data change) — N/A: no schema/data change
- [x] CHANGELOG impact considered (breaking change flagged in commit) — patch-level fix only, no breaking change

## Notes

- Windows GUI での実機再確認はこの環境では未実施です。backend の回帰は `pty.rs` の unit test でカバーしています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows shell working directory path handling to properly format paths for both Command Prompt and PowerShell terminals, ensuring correct directory navigation when launching terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->