### PR TITLE
feat(unity): add Core Models & Config service (#1542)

### DIFF
--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreConfigInstaller.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreConfigInstaller.cs
@@ -1,0 +1,17 @@
+using Gwt.Core.Models;
+using Gwt.Core.Services.Config;
+using Gwt.Shared;
+using VContainer;
+
+namespace Gwt.Core.Installers
+{
+    public class GwtCoreConfigInstaller : IGwtInstaller
+    {
+        public void Install(IContainerBuilder builder)
+        {
+            builder.Register<ConfigService>(Lifetime.Singleton).As<IConfigService>();
+            builder.Register<SessionService>(Lifetime.Singleton).As<ISessionService>();
+            builder.Register<RecentProjectsService>(Lifetime.Singleton);
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreConfigInstaller.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreConfigInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4b565ac4ae940629a7f76ad44631f8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/AITypes.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/AITypes.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class AISettings
+    {
+        public string Endpoint = "";
+        public string ApiKey = "";
+        public string Model = "";
+        public string Language = "en";
+        public bool SummaryEnabled = true;
+    }
+
+    [System.Serializable]
+    public class ResolvedAISettings
+    {
+        public string Endpoint;
+        public string ApiKey;
+        public string Model;
+        public string Language;
+    }
+
+    [System.Serializable]
+    public class Profile
+    {
+        public string Name;
+        public Dictionary<string, string> Env = new();
+        public List<string> DisabledEnv = new();
+        public string Description = "";
+        public AISettings AI;
+        public bool? AIEnabled;
+    }
+
+    [System.Serializable]
+    public class ProfilesConfig
+    {
+        public int Version = 1;
+        public string Active;
+        public AISettings DefaultAI;
+        public Dictionary<string, Profile> Profiles = new();
+    }
+
+    [System.Serializable]
+    public class ChatMessage
+    {
+        public string Role;
+        public string Content;
+    }
+
+    [System.Serializable]
+    public class AIResponse
+    {
+        public string Text;
+        public long? UsageTokens;
+    }
+
+    [System.Serializable]
+    public class SessionSummary
+    {
+        public string TaskOverview;
+        public string ShortSummary;
+        public List<string> BulletPoints = new();
+        public string Markdown;
+        public SessionMetrics Metrics = new();
+    }
+
+    [System.Serializable]
+    public class SessionMetrics
+    {
+        public int? TokenCount;
+        public int ToolExecutionCount;
+        public long? ElapsedSeconds;
+        public int TurnCount;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/AITypes.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/AITypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00582d18c276455bbefd60a9540c3d00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Branch.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Branch.cs
@@ -1,0 +1,26 @@
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class Branch
+    {
+        public string Name;
+        public bool IsCurrent;
+        public bool HasRemote;
+        public string Upstream;
+        public string CommitHash;
+        public int Ahead;
+        public int Behind;
+        public long CommitTimestamp;
+        public bool IsGone;
+    }
+
+    [System.Serializable]
+    public class BranchMeta
+    {
+        public string Upstream;
+        public int Ahead;
+        public int Behind;
+        public long LastCommitTimestamp;
+        public string BaseBranch;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Branch.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Branch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd2fc1b875a24084b9034fd53f06891b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/BranchSummary.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/BranchSummary.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class BranchSummary
+    {
+        public string BranchName;
+        public string WorktreePath;
+        public List<CommitEntry> Commits = new();
+        public ChangeStats Stats;
+        public BranchMeta Meta;
+        public SessionSummary SessionSummary;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/BranchSummary.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/BranchSummary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63525f7c153f4cc6af5003047e0ac4d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Enums.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Enums.cs
@@ -1,0 +1,20 @@
+namespace Gwt.Core.Models
+{
+    public enum WorktreeStatus { Active, Locked, Prunable, Missing }
+    public enum CleanupReason { PathMissing, BranchDeleted, Orphaned }
+    public enum RepoType { Normal, Bare, Worktree, Empty, NonRepo }
+    public enum AgentStatusValue { Unknown, Running, WaitingInput, Stopped }
+    public enum TaskStatus { Pending, Ready, Running, Paused, Completed, Failed, Cancelled }
+    public enum FileChangeKind { Added, Modified, Deleted, Renamed, Copied, Untracked }
+    public enum PrStatus { Open, Closed, Merged, Draft }
+    public enum SessionStatus { Active, Paused, Completed, Failed }
+    public enum AgentType { Claude, Codex, Gemini, OpenCode }
+    public enum DivergenceStatus { UpToDate, Ahead, Behind, Diverged }
+    public enum TestStatus { NotRun, Running, Passed, Failed }
+    public enum WorktreeStrategy { New, Shared }
+    public enum ErrorCategory { Git, Config, Network, Agent, Terminal, AI, System }
+    public enum ErrorSeverity { Info, Warning, Error, Fatal }
+    public enum AIErrorType { Unauthorized, RateLimited, ServerError, NetworkError, ParseError, ConfigError }
+    public enum ActiveAISettingsSource { ActiveProfile, DefaultAI, None }
+    public enum PaneStatus { Running, Completed, Error }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Enums.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Enums.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5942fcc5795d46bc8b4293460cefda9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitHubTypes.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitHubTypes.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class GitHubLabel
+    {
+        public string Name;
+        public string Color;
+    }
+
+    [System.Serializable]
+    public class GitHubAssignee
+    {
+        public string Login;
+        public string AvatarUrl;
+    }
+
+    [System.Serializable]
+    public class GitHubMilestone
+    {
+        public string Title;
+        public int Number;
+    }
+
+    [System.Serializable]
+    public class GitHubIssue
+    {
+        public long Number;
+        public string Title;
+        public string UpdatedAt;
+        public List<GitHubLabel> Labels = new();
+        public string Body;
+        public string State;
+        public string HtmlUrl;
+        public List<GitHubAssignee> Assignees = new();
+        public int CommentsCount;
+        public GitHubMilestone Milestone;
+    }
+
+    [System.Serializable]
+    public class FetchIssuesResult
+    {
+        public List<GitHubIssue> Issues = new();
+        public bool HasNextPage;
+    }
+
+    [System.Serializable]
+    public class PullRequest
+    {
+        public long Number;
+        public string Title;
+        public string HeadBranch;
+        public string State;
+        public string BaseBranch;
+        public string Url;
+        public string UpdatedAt;
+    }
+
+    [System.Serializable]
+    public class WorkflowRunInfo
+    {
+        public string WorkflowName;
+        public long RunId;
+        public string Status;
+        public string Conclusion;
+        public bool? IsRequired;
+    }
+
+    [System.Serializable]
+    public class ReviewInfo
+    {
+        public string Reviewer;
+        public string State;
+    }
+
+    [System.Serializable]
+    public class ReviewComment
+    {
+        public string Author;
+        public string Body;
+        public string FilePath;
+        public long? Line;
+        public string CodeSnippet;
+        public string CreatedAt;
+    }
+
+    [System.Serializable]
+    public class PrStatusInfo
+    {
+        public long Number;
+        public string Title;
+        public string State;
+        public string Url;
+        public string Mergeable;
+        public string Author;
+        public string BaseBranch;
+        public string HeadBranch;
+        public List<string> Labels = new();
+        public List<string> Assignees = new();
+        public string Milestone;
+        public List<long> LinkedIssues = new();
+        public List<WorkflowRunInfo> CheckSuites = new();
+        public List<ReviewInfo> Reviews = new();
+        public List<ReviewComment> ReviewComments = new();
+        public long ChangedFilesCount;
+        public long Additions;
+        public long Deletions;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitHubTypes.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitHubTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 200f1c88a0ff457e83d4de22784a740f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitTypes.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitTypes.cs
@@ -1,0 +1,64 @@
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class CommitEntry
+    {
+        public string Hash;
+        public string Message;
+    }
+
+    [System.Serializable]
+    public class FileChange
+    {
+        public string Path;
+        public FileChangeKind Kind;
+        public int Insertions;
+        public int Deletions;
+    }
+
+    [System.Serializable]
+    public class FileDiff
+    {
+        public string Path;
+        public FileChangeKind Kind;
+        public string OldPath;
+        public int Insertions;
+        public int Deletions;
+    }
+
+    [System.Serializable]
+    public class GitChangeSummary
+    {
+        public System.Collections.Generic.List<FileChange> Files = new();
+        public int Insertions;
+        public int Deletions;
+        public bool HasChanges;
+    }
+
+    [System.Serializable]
+    public class WorkingTreeEntry
+    {
+        public string Path;
+        public string Status;
+        public bool Staged;
+    }
+
+    [System.Serializable]
+    public class ChangeStats
+    {
+        public int FilesChanged;
+        public int Insertions;
+        public int Deletions;
+        public bool HasUncommitted;
+        public bool HasUnpushed;
+    }
+
+    [System.Serializable]
+    public class GitViewCommit
+    {
+        public string Hash;
+        public string Message;
+        public string Author;
+        public long Timestamp;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitTypes.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/GitTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96ca0288a2a343aaa64cd49202405c07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IAIApiService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IAIApiService.cs
@@ -1,0 +1,18 @@
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Gwt.Core.Models
+{
+    public interface IAIApiService
+    {
+        UniTask<string> SuggestBranchNameAsync(string description, ResolvedAISettings settings, CancellationToken ct = default);
+        UniTask<string> GenerateCommitMessageAsync(string diff, ResolvedAISettings settings, CancellationToken ct = default);
+        UniTask<string> GeneratePrDescriptionAsync(string commits, string diff, ResolvedAISettings settings, CancellationToken ct = default);
+        UniTask<string> SummarizeIssueAsync(string issueBody, ResolvedAISettings settings, CancellationToken ct = default);
+        UniTask<string> ReviewCodeAsync(string diff, ResolvedAISettings settings, CancellationToken ct = default);
+        UniTask<string> GenerateTestsAsync(string code, ResolvedAISettings settings, CancellationToken ct = default);
+        UniTask<string> ChatAsync(List<ChatMessage> messages, ResolvedAISettings settings, CancellationToken ct = default);
+        UniTask<AIResponse> SendRequestAsync(string systemPrompt, string userMessage, ResolvedAISettings settings, CancellationToken ct = default);
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IAIApiService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IAIApiService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e3815b2de7b4b89b93cc2fa247ebeff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IConfigService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IConfigService.cs
@@ -1,0 +1,13 @@
+using Cysharp.Threading.Tasks;
+using System.Threading;
+
+namespace Gwt.Core.Models
+{
+    public interface IConfigService
+    {
+        UniTask<Settings> LoadSettingsAsync(string projectRoot, CancellationToken ct = default);
+        UniTask SaveSettingsAsync(string projectRoot, Settings settings, CancellationToken ct = default);
+        UniTask<Settings> GetOrCreateSettingsAsync(string projectRoot, CancellationToken ct = default);
+        string GetGwtDir(string projectRoot);
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IConfigService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IConfigService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9eaf6dedb2d4dc2b199be1bb8abde67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitHubService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitHubService.cs
@@ -1,0 +1,17 @@
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Gwt.Core.Models
+{
+    public interface IGitHubService
+    {
+        UniTask<FetchIssuesResult> ListIssuesAsync(string repoRoot, string state, int limit, CancellationToken ct = default);
+        UniTask<GitHubIssue> GetIssueAsync(string repoRoot, long number, CancellationToken ct = default);
+        UniTask<GitHubIssue> CreateIssueAsync(string repoRoot, string title, string body, List<string> labels, CancellationToken ct = default);
+        UniTask<List<PullRequest>> ListPullRequestsAsync(string repoRoot, string state, CancellationToken ct = default);
+        UniTask<PrStatusInfo> GetPrStatusAsync(string repoRoot, long number, CancellationToken ct = default);
+        UniTask<PullRequest> CreatePullRequestAsync(string repoRoot, string title, string body, string head, string baseBranch, CancellationToken ct = default);
+        UniTask<bool> CheckAuthAsync(string repoRoot, CancellationToken ct = default);
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitHubService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitHubService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f202bc8f89d449df9e23ee8989531a45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitService.cs
@@ -1,0 +1,22 @@
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Gwt.Core.Models
+{
+    public interface IGitService
+    {
+        UniTask<List<Worktree>> ListWorktreesAsync(string repoRoot, CancellationToken ct = default);
+        UniTask<Worktree> CreateWorktreeAsync(string repoRoot, string branch, string path, CancellationToken ct = default);
+        UniTask DeleteWorktreeAsync(string repoRoot, string path, bool force, CancellationToken ct = default);
+        UniTask<List<Branch>> ListBranchesAsync(string repoRoot, CancellationToken ct = default);
+        UniTask<string> GetCurrentBranchAsync(string repoRoot, CancellationToken ct = default);
+        UniTask<GitChangeSummary> GetChangeSummaryAsync(string repoRoot, CancellationToken ct = default);
+        UniTask<List<CommitEntry>> GetCommitsAsync(string repoRoot, string branch, int limit, CancellationToken ct = default);
+        UniTask<ChangeStats> GetChangeStatsAsync(string repoRoot, CancellationToken ct = default);
+        UniTask<BranchMeta> GetBranchMetaAsync(string repoRoot, string branch, CancellationToken ct = default);
+        UniTask<List<WorkingTreeEntry>> GetWorkingTreeStatusAsync(string repoRoot, CancellationToken ct = default);
+        UniTask<List<CleanupCandidate>> GetCleanupCandidatesAsync(string repoRoot, CancellationToken ct = default);
+        UniTask<RepoType> GetRepoTypeAsync(string path, CancellationToken ct = default);
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IGitService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 952ded08e29e4d09bea5bb79be1fd22b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IPtyService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IPtyService.cs
@@ -1,0 +1,16 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Threading;
+
+namespace Gwt.Core.Models
+{
+    public interface IPtyService
+    {
+        UniTask<string> SpawnAsync(string command, string[] args, string workingDir, int rows, int cols, CancellationToken ct = default);
+        UniTask WriteAsync(string paneId, string data, CancellationToken ct = default);
+        UniTask ResizeAsync(string paneId, int rows, int cols, CancellationToken ct = default);
+        UniTask KillAsync(string paneId, CancellationToken ct = default);
+        IObservable<string> GetOutputStream(string paneId);
+        PaneStatus GetStatus(string paneId);
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IPtyService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/IPtyService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b42e9d34ada74f6bbb80049944132da9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/ISessionService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/ISessionService.cs
@@ -1,0 +1,15 @@
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Gwt.Core.Models
+{
+    public interface ISessionService
+    {
+        UniTask<Session> CreateSessionAsync(string worktreePath, string branch, CancellationToken ct = default);
+        UniTask<Session> GetSessionAsync(string sessionId, CancellationToken ct = default);
+        UniTask<List<Session>> ListSessionsAsync(string projectRoot, CancellationToken ct = default);
+        UniTask UpdateSessionAsync(Session session, CancellationToken ct = default);
+        UniTask DeleteSessionAsync(string sessionId, CancellationToken ct = default);
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/ISessionService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/ISessionService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8a16b21812e4e148dec456110a05c15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Session.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Session.cs
@@ -1,0 +1,19 @@
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class Session
+    {
+        public string Id;
+        public string WorktreePath;
+        public string Branch;
+        public string Agent;
+        public string AgentLabel;
+        public string AgentSessionId;
+        public string ToolVersion;
+        public string Model;
+        public string CreatedAt;
+        public string UpdatedAt;
+        public AgentStatusValue Status;
+        public string LastActivityAt;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Session.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Session.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45e54accedf241568ac7b6360111e7ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Settings.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Settings.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class Settings
+    {
+        public List<string> ProtectedBranches = new() { "main", "master", "develop" };
+        public string DefaultBaseBranch = "main";
+        public string WorktreeRoot = "";
+        public bool Debug;
+        public string LogDir;
+        public int LogRetentionDays = 30;
+        public AgentSettings Agent = new();
+        public DockerSettings Docker = new();
+        public AppearanceSettings Appearance = new();
+        public string AppLanguage = "en";
+        public VoiceInputSettings VoiceInput = new();
+        public TerminalSettings Terminal = new();
+        public ProfilesConfig Profiles = new();
+    }
+
+    [System.Serializable]
+    public class AgentSettings
+    {
+        public string DefaultAgent;
+        public string ClaudePath;
+        public string CodexPath;
+        public string GeminiPath;
+        public bool AutoInstallDeps;
+        public string GitHubProjectId;
+    }
+
+    [System.Serializable]
+    public class DockerSettings
+    {
+        public bool ForceHost;
+    }
+
+    [System.Serializable]
+    public class AppearanceSettings
+    {
+        public int UiFontSize = 14;
+        public int TerminalFontSize = 14;
+    }
+
+    [System.Serializable]
+    public class VoiceInputSettings
+    {
+        public bool Enabled;
+        public string Engine = "whisper";
+        public string Hotkey = "F5";
+        public string PttHotkey = "F6";
+        public string Language = "en";
+        public string Quality = "medium";
+        public string Model = "base";
+    }
+
+    [System.Serializable]
+    public class TerminalSettings
+    {
+        public string DefaultShell;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Settings.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Settings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e5a89cea189433e973bc7c36efa281d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Worktree.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Worktree.cs
@@ -1,0 +1,29 @@
+namespace Gwt.Core.Models
+{
+    [System.Serializable]
+    public class Worktree
+    {
+        public string Path;
+        public string Branch;
+        public string Commit;
+        public WorktreeStatus Status;
+        public bool IsMain;
+        public bool HasChanges;
+        public bool HasUnpushed;
+    }
+
+    [System.Serializable]
+    public class CleanupCandidate
+    {
+        public string Path;
+        public string Branch;
+        public CleanupReason Reason;
+    }
+
+    [System.Serializable]
+    public class WorktreeRef
+    {
+        public string Path;
+        public string Branch;
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Worktree.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Models/Worktree.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ebba276d2264e9daf13cac5e01979a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/ConfigService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/ConfigService.cs
@@ -1,0 +1,70 @@
+using Cysharp.Threading.Tasks;
+using Gwt.Core.Models;
+using System.IO;
+using System.Threading;
+using UnityEngine;
+
+namespace Gwt.Core.Services.Config
+{
+    public class ConfigService : IConfigService
+    {
+        const string SettingsFileName = "settings.json";
+        const string GwtDirName = ".gwt";
+
+        public string GetGwtDir(string projectRoot)
+        {
+            return Path.Combine(projectRoot, GwtDirName);
+        }
+
+        public async UniTask<Settings> LoadSettingsAsync(string projectRoot, CancellationToken ct = default)
+        {
+            var path = GetSettingsPath(projectRoot);
+            if (!File.Exists(path))
+                return null;
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+            var json = await File.ReadAllTextAsync(path, ct);
+            await UniTask.SwitchToMainThread(ct);
+
+            return JsonUtility.FromJson<Settings>(json);
+        }
+
+        public async UniTask SaveSettingsAsync(string projectRoot, Settings settings, CancellationToken ct = default)
+        {
+            var dir = GetGwtDir(projectRoot);
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var path = GetSettingsPath(projectRoot);
+            var tmpPath = path + ".tmp";
+            var json = JsonUtility.ToJson(settings, true);
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+            await File.WriteAllTextAsync(tmpPath, json, ct);
+
+            if (File.Exists(path))
+                File.Delete(path);
+            File.Move(tmpPath, path);
+
+            await UniTask.SwitchToMainThread(ct);
+        }
+
+        public async UniTask<Settings> GetOrCreateSettingsAsync(string projectRoot, CancellationToken ct = default)
+        {
+            var settings = await LoadSettingsAsync(projectRoot, ct);
+            if (settings != null)
+                return settings;
+
+            settings = new Settings();
+            await SaveSettingsAsync(projectRoot, settings, ct);
+            return settings;
+        }
+
+        string GetSettingsPath(string projectRoot)
+        {
+            return Path.Combine(GetGwtDir(projectRoot), SettingsFileName);
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/ConfigService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/ConfigService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a539820676404abebbd726ac09b7a820
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/RecentProjectsService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/RecentProjectsService.cs
@@ -1,0 +1,106 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using UnityEngine;
+
+namespace Gwt.Core.Services.Config
+{
+    [System.Serializable]
+    public class RecentProject
+    {
+        public string Path;
+        public string LastOpenedAt;
+    }
+
+    [System.Serializable]
+    public class RecentProjectsList
+    {
+        public List<RecentProject> Projects = new();
+    }
+
+    public class RecentProjectsService
+    {
+        const string FileName = "recent-projects.json";
+        const string GwtDirName = ".gwt";
+        const int MaxEntries = 20;
+
+        public async UniTask<List<RecentProject>> ListAsync(CancellationToken ct = default)
+        {
+            var data = await LoadAsync(ct);
+            return data.Projects;
+        }
+
+        public async UniTask AddAsync(string projectPath, CancellationToken ct = default)
+        {
+            var data = await LoadAsync(ct);
+
+            data.Projects.RemoveAll(p => p.Path == projectPath);
+            data.Projects.Insert(0, new RecentProject
+            {
+                Path = projectPath,
+                LastOpenedAt = DateTime.UtcNow.ToString("o")
+            });
+
+            if (data.Projects.Count > MaxEntries)
+                data.Projects.RemoveRange(MaxEntries, data.Projects.Count - MaxEntries);
+
+            await SaveAsync(data, ct);
+        }
+
+        public async UniTask RemoveAsync(string projectPath, CancellationToken ct = default)
+        {
+            var data = await LoadAsync(ct);
+            data.Projects.RemoveAll(p => p.Path == projectPath);
+            await SaveAsync(data, ct);
+        }
+
+        async UniTask<RecentProjectsList> LoadAsync(CancellationToken ct)
+        {
+            var path = GetFilePath();
+            if (!File.Exists(path))
+                return new RecentProjectsList();
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+            var json = await File.ReadAllTextAsync(path, ct);
+            await UniTask.SwitchToMainThread(ct);
+
+            var data = JsonUtility.FromJson<RecentProjectsList>(json);
+            return data ?? new RecentProjectsList();
+        }
+
+        async UniTask SaveAsync(RecentProjectsList data, CancellationToken ct)
+        {
+            var dir = GetGwtDir();
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var path = GetFilePath();
+            var tmpPath = path + ".tmp";
+            var json = JsonUtility.ToJson(data, true);
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+            await File.WriteAllTextAsync(tmpPath, json, ct);
+
+            if (File.Exists(path))
+                File.Delete(path);
+            File.Move(tmpPath, path);
+
+            await UniTask.SwitchToMainThread(ct);
+        }
+
+        static string GetGwtDir()
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, GwtDirName);
+        }
+
+        static string GetFilePath()
+        {
+            return Path.Combine(GetGwtDir(), FileName);
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/RecentProjectsService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/RecentProjectsService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc4d1907eb584d539fc9a75d149095b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/SessionService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/SessionService.cs
@@ -1,0 +1,125 @@
+using Cysharp.Threading.Tasks;
+using Gwt.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using UnityEngine;
+
+namespace Gwt.Core.Services.Config
+{
+    public class SessionService : ISessionService
+    {
+        const string SessionsDirName = "sessions";
+        const string GwtDirName = ".gwt";
+
+        public async UniTask<Session> CreateSessionAsync(string worktreePath, string branch, CancellationToken ct = default)
+        {
+            var session = new Session
+            {
+                Id = Guid.NewGuid().ToString(),
+                WorktreePath = worktreePath,
+                Branch = branch,
+                CreatedAt = DateTime.UtcNow.ToString("o"),
+                UpdatedAt = DateTime.UtcNow.ToString("o"),
+                Status = AgentStatusValue.Unknown,
+                LastActivityAt = DateTime.UtcNow.ToString("o")
+            };
+
+            await SaveSessionFileAsync(session, ct);
+            return session;
+        }
+
+        public async UniTask<Session> GetSessionAsync(string sessionId, CancellationToken ct = default)
+        {
+            var path = GetSessionFilePath(sessionId);
+            if (!File.Exists(path))
+                return null;
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+            var json = await File.ReadAllTextAsync(path, ct);
+            await UniTask.SwitchToMainThread(ct);
+
+            return JsonUtility.FromJson<Session>(json);
+        }
+
+        public async UniTask<List<Session>> ListSessionsAsync(string projectRoot, CancellationToken ct = default)
+        {
+            var dir = GetSessionsDir();
+            if (!Directory.Exists(dir))
+                return new List<Session>();
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+
+            var files = Directory.GetFiles(dir, "*.json");
+            var sessions = new List<Session>();
+
+            foreach (var file in files)
+            {
+                ct.ThrowIfCancellationRequested();
+                var json = await File.ReadAllTextAsync(file, ct);
+                await UniTask.SwitchToMainThread(ct);
+                var session = JsonUtility.FromJson<Session>(json);
+                if (session != null)
+                    sessions.Add(session);
+                await UniTask.SwitchToThreadPool();
+            }
+
+            await UniTask.SwitchToMainThread(ct);
+            return sessions;
+        }
+
+        public async UniTask UpdateSessionAsync(Session session, CancellationToken ct = default)
+        {
+            session.UpdatedAt = DateTime.UtcNow.ToString("o");
+            await SaveSessionFileAsync(session, ct);
+        }
+
+        public async UniTask DeleteSessionAsync(string sessionId, CancellationToken ct = default)
+        {
+            var path = GetSessionFilePath(sessionId);
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+
+            if (File.Exists(path))
+                File.Delete(path);
+
+            await UniTask.SwitchToMainThread(ct);
+        }
+
+        async UniTask SaveSessionFileAsync(Session session, CancellationToken ct)
+        {
+            var dir = GetSessionsDir();
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var path = GetSessionFilePath(session.Id);
+            var tmpPath = path + ".tmp";
+            var json = JsonUtility.ToJson(session, true);
+
+            await UniTask.SwitchToThreadPool();
+            ct.ThrowIfCancellationRequested();
+            await File.WriteAllTextAsync(tmpPath, json, ct);
+
+            if (File.Exists(path))
+                File.Delete(path);
+            File.Move(tmpPath, path);
+
+            await UniTask.SwitchToMainThread(ct);
+        }
+
+        static string GetSessionsDir()
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, GwtDirName, SessionsDirName);
+        }
+
+        static string GetSessionFilePath(string sessionId)
+        {
+            return Path.Combine(GetSessionsDir(), sessionId + ".json");
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/SessionService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Config/SessionService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72c606c87824496bba4e71561045c773
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/CoreModelsTests.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/CoreModelsTests.cs
@@ -1,0 +1,395 @@
+using Gwt.Core.Models;
+using Gwt.Core.Services.Config;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Threading;
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+
+namespace Gwt.Tests.Editor
+{
+    [TestFixture]
+    public class CoreModelsTests
+    {
+        [Test]
+        public void Enums_AllValuesExist()
+        {
+            Assert.AreEqual(4, Enum.GetValues(typeof(WorktreeStatus)).Length);
+            Assert.AreEqual(3, Enum.GetValues(typeof(CleanupReason)).Length);
+            Assert.AreEqual(5, Enum.GetValues(typeof(RepoType)).Length);
+            Assert.AreEqual(4, Enum.GetValues(typeof(AgentStatusValue)).Length);
+            Assert.AreEqual(7, Enum.GetValues(typeof(TaskStatus)).Length);
+            Assert.AreEqual(6, Enum.GetValues(typeof(FileChangeKind)).Length);
+            Assert.AreEqual(4, Enum.GetValues(typeof(PrStatus)).Length);
+            Assert.AreEqual(4, Enum.GetValues(typeof(SessionStatus)).Length);
+            Assert.AreEqual(4, Enum.GetValues(typeof(AgentType)).Length);
+            Assert.AreEqual(4, Enum.GetValues(typeof(DivergenceStatus)).Length);
+            Assert.AreEqual(4, Enum.GetValues(typeof(TestStatus)).Length);
+            Assert.AreEqual(2, Enum.GetValues(typeof(WorktreeStrategy)).Length);
+            Assert.AreEqual(7, Enum.GetValues(typeof(ErrorCategory)).Length);
+            Assert.AreEqual(4, Enum.GetValues(typeof(ErrorSeverity)).Length);
+            Assert.AreEqual(6, Enum.GetValues(typeof(AIErrorType)).Length);
+            Assert.AreEqual(3, Enum.GetValues(typeof(ActiveAISettingsSource)).Length);
+            Assert.AreEqual(3, Enum.GetValues(typeof(PaneStatus)).Length);
+        }
+
+        [Test]
+        public void Worktree_SerializationRoundtrip()
+        {
+            var original = new Worktree
+            {
+                Path = "/tmp/wt",
+                Branch = "feature/test",
+                Commit = "abc123",
+                Status = WorktreeStatus.Active,
+                IsMain = false,
+                HasChanges = true,
+                HasUnpushed = false
+            };
+
+            var json = JsonUtility.ToJson(original);
+            var deserialized = JsonUtility.FromJson<Worktree>(json);
+
+            Assert.AreEqual(original.Path, deserialized.Path);
+            Assert.AreEqual(original.Branch, deserialized.Branch);
+            Assert.AreEqual(original.Commit, deserialized.Commit);
+            Assert.AreEqual(original.Status, deserialized.Status);
+            Assert.AreEqual(original.IsMain, deserialized.IsMain);
+            Assert.AreEqual(original.HasChanges, deserialized.HasChanges);
+            Assert.AreEqual(original.HasUnpushed, deserialized.HasUnpushed);
+        }
+
+        [Test]
+        public void Branch_SerializationRoundtrip()
+        {
+            var original = new Branch
+            {
+                Name = "main",
+                IsCurrent = true,
+                HasRemote = true,
+                Upstream = "origin/main",
+                CommitHash = "def456",
+                Ahead = 2,
+                Behind = 1,
+                CommitTimestamp = 1700000000,
+                IsGone = false
+            };
+
+            var json = JsonUtility.ToJson(original);
+            var deserialized = JsonUtility.FromJson<Branch>(json);
+
+            Assert.AreEqual(original.Name, deserialized.Name);
+            Assert.AreEqual(original.IsCurrent, deserialized.IsCurrent);
+            Assert.AreEqual(original.Ahead, deserialized.Ahead);
+            Assert.AreEqual(original.Behind, deserialized.Behind);
+            Assert.AreEqual(original.CommitTimestamp, deserialized.CommitTimestamp);
+        }
+
+        [Test]
+        public void Settings_DefaultValues()
+        {
+            var settings = new Settings();
+
+            Assert.AreEqual("main", settings.DefaultBaseBranch);
+            Assert.AreEqual(30, settings.LogRetentionDays);
+            Assert.AreEqual("en", settings.AppLanguage);
+            Assert.IsNotNull(settings.ProtectedBranches);
+            Assert.AreEqual(3, settings.ProtectedBranches.Count);
+            Assert.IsNotNull(settings.Agent);
+            Assert.IsNotNull(settings.Docker);
+            Assert.IsNotNull(settings.Appearance);
+        }
+
+        [Test]
+        public void Settings_SerializationRoundtrip()
+        {
+            var original = new Settings
+            {
+                DefaultBaseBranch = "develop",
+                Debug = true,
+                LogRetentionDays = 7
+            };
+
+            var json = JsonUtility.ToJson(original);
+            var deserialized = JsonUtility.FromJson<Settings>(json);
+
+            Assert.AreEqual("develop", deserialized.DefaultBaseBranch);
+            Assert.AreEqual(true, deserialized.Debug);
+            Assert.AreEqual(7, deserialized.LogRetentionDays);
+        }
+
+        [Test]
+        public void Session_SerializationRoundtrip()
+        {
+            var original = new Session
+            {
+                Id = "test-id-123",
+                WorktreePath = "/tmp/wt",
+                Branch = "feature/x",
+                Agent = "claude",
+                Status = AgentStatusValue.Running,
+                CreatedAt = "2024-01-01T00:00:00Z",
+                UpdatedAt = "2024-01-01T01:00:00Z"
+            };
+
+            var json = JsonUtility.ToJson(original);
+            var deserialized = JsonUtility.FromJson<Session>(json);
+
+            Assert.AreEqual(original.Id, deserialized.Id);
+            Assert.AreEqual(original.WorktreePath, deserialized.WorktreePath);
+            Assert.AreEqual(original.Branch, deserialized.Branch);
+            Assert.AreEqual(original.Agent, deserialized.Agent);
+            Assert.AreEqual(original.Status, deserialized.Status);
+        }
+
+        [Test]
+        public void CommitEntry_SerializationRoundtrip()
+        {
+            var original = new CommitEntry
+            {
+                Hash = "abc123def456",
+                Message = "feat: add something"
+            };
+
+            var json = JsonUtility.ToJson(original);
+            var deserialized = JsonUtility.FromJson<CommitEntry>(json);
+
+            Assert.AreEqual(original.Hash, deserialized.Hash);
+            Assert.AreEqual(original.Message, deserialized.Message);
+        }
+
+        [Test]
+        public void AISettings_DefaultValues()
+        {
+            var settings = new AISettings();
+
+            Assert.AreEqual("", settings.Endpoint);
+            Assert.AreEqual("", settings.ApiKey);
+            Assert.AreEqual("", settings.Model);
+            Assert.AreEqual("en", settings.Language);
+            Assert.AreEqual(true, settings.SummaryEnabled);
+        }
+
+        [Test]
+        public void VoiceInputSettings_DefaultValues()
+        {
+            var settings = new VoiceInputSettings();
+
+            Assert.AreEqual(false, settings.Enabled);
+            Assert.AreEqual("whisper", settings.Engine);
+            Assert.AreEqual("F5", settings.Hotkey);
+            Assert.AreEqual("F6", settings.PttHotkey);
+            Assert.AreEqual("en", settings.Language);
+            Assert.AreEqual("medium", settings.Quality);
+            Assert.AreEqual("base", settings.Model);
+        }
+
+        [Test]
+        public void AppearanceSettings_DefaultValues()
+        {
+            var settings = new AppearanceSettings();
+
+            Assert.AreEqual(14, settings.UiFontSize);
+            Assert.AreEqual(14, settings.TerminalFontSize);
+        }
+
+        [Test]
+        public void ConfigService_GetGwtDir()
+        {
+            var service = new ConfigService();
+            var dir = service.GetGwtDir("/tmp/project");
+
+            Assert.AreEqual(Path.Combine("/tmp/project", ".gwt"), dir);
+        }
+
+        [UnityTest]
+        public System.Collections.IEnumerator ConfigService_SaveAndLoad() => UniTask.ToCoroutine(async () =>
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), "gwt-test-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(tmpDir);
+                var service = new ConfigService();
+
+                var settings = new Settings
+                {
+                    DefaultBaseBranch = "develop",
+                    Debug = true
+                };
+
+                await service.SaveSettingsAsync(tmpDir, settings);
+                var loaded = await service.LoadSettingsAsync(tmpDir);
+
+                Assert.IsNotNull(loaded);
+                Assert.AreEqual("develop", loaded.DefaultBaseBranch);
+                Assert.AreEqual(true, loaded.Debug);
+            }
+            finally
+            {
+                if (Directory.Exists(tmpDir))
+                    Directory.Delete(tmpDir, true);
+            }
+        });
+
+        [UnityTest]
+        public System.Collections.IEnumerator ConfigService_GetOrCreate_CreatesDefault() => UniTask.ToCoroutine(async () =>
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), "gwt-test-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(tmpDir);
+                var service = new ConfigService();
+
+                var settings = await service.GetOrCreateSettingsAsync(tmpDir);
+
+                Assert.IsNotNull(settings);
+                Assert.AreEqual("main", settings.DefaultBaseBranch);
+
+                // Verify file was created
+                var filePath = Path.Combine(tmpDir, ".gwt", "settings.json");
+                Assert.IsTrue(File.Exists(filePath));
+            }
+            finally
+            {
+                if (Directory.Exists(tmpDir))
+                    Directory.Delete(tmpDir, true);
+            }
+        });
+
+        [UnityTest]
+        public System.Collections.IEnumerator ConfigService_LoadNonExistent_ReturnsNull() => UniTask.ToCoroutine(async () =>
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), "gwt-test-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(tmpDir);
+                var service = new ConfigService();
+
+                var settings = await service.LoadSettingsAsync(tmpDir);
+
+                Assert.IsNull(settings);
+            }
+            finally
+            {
+                if (Directory.Exists(tmpDir))
+                    Directory.Delete(tmpDir, true);
+            }
+        });
+
+        [UnityTest]
+        public System.Collections.IEnumerator SessionService_CrudOperations() => UniTask.ToCoroutine(async () =>
+        {
+            var service = new SessionService();
+
+            // Create
+            var session = await service.CreateSessionAsync("/tmp/wt", "feature/test");
+            Assert.IsNotNull(session);
+            Assert.IsNotNull(session.Id);
+            Assert.AreEqual("/tmp/wt", session.WorktreePath);
+            Assert.AreEqual("feature/test", session.Branch);
+
+            try
+            {
+                // Get
+                var loaded = await service.GetSessionAsync(session.Id);
+                Assert.IsNotNull(loaded);
+                Assert.AreEqual(session.Id, loaded.Id);
+                Assert.AreEqual(session.WorktreePath, loaded.WorktreePath);
+
+                // Update
+                session.Status = AgentStatusValue.Running;
+                await service.UpdateSessionAsync(session);
+                var updated = await service.GetSessionAsync(session.Id);
+                Assert.AreEqual(AgentStatusValue.Running, updated.Status);
+
+                // Delete
+                await service.DeleteSessionAsync(session.Id);
+                var deleted = await service.GetSessionAsync(session.Id);
+                Assert.IsNull(deleted);
+            }
+            finally
+            {
+                // Cleanup in case test fails before delete
+                await service.DeleteSessionAsync(session.Id);
+            }
+        });
+
+        [UnityTest]
+        public System.Collections.IEnumerator SessionService_GetNonExistent_ReturnsNull() => UniTask.ToCoroutine(async () =>
+        {
+            var service = new SessionService();
+            var result = await service.GetSessionAsync("non-existent-id");
+            Assert.IsNull(result);
+        });
+
+        [Test]
+        public void RecentProject_SerializationRoundtrip()
+        {
+            var original = new RecentProjectsList();
+            original.Projects.Add(new RecentProject
+            {
+                Path = "/tmp/project",
+                LastOpenedAt = "2024-01-01T00:00:00Z"
+            });
+
+            var json = JsonUtility.ToJson(original);
+            var deserialized = JsonUtility.FromJson<RecentProjectsList>(json);
+
+            Assert.AreEqual(1, deserialized.Projects.Count);
+            Assert.AreEqual("/tmp/project", deserialized.Projects[0].Path);
+        }
+
+        [Test]
+        public void BranchSummary_DefaultCollections()
+        {
+            var summary = new BranchSummary();
+
+            Assert.IsNotNull(summary.Commits);
+            Assert.AreEqual(0, summary.Commits.Count);
+        }
+
+        [Test]
+        public void GitChangeSummary_DefaultCollections()
+        {
+            var summary = new GitChangeSummary();
+
+            Assert.IsNotNull(summary.Files);
+            Assert.AreEqual(0, summary.Files.Count);
+            Assert.AreEqual(false, summary.HasChanges);
+        }
+
+        [Test]
+        public void PrStatusInfo_DefaultCollections()
+        {
+            var info = new PrStatusInfo();
+
+            Assert.IsNotNull(info.Labels);
+            Assert.IsNotNull(info.Assignees);
+            Assert.IsNotNull(info.LinkedIssues);
+            Assert.IsNotNull(info.CheckSuites);
+            Assert.IsNotNull(info.Reviews);
+            Assert.IsNotNull(info.ReviewComments);
+        }
+
+        [Test]
+        public void ProfilesConfig_DefaultValues()
+        {
+            var config = new ProfilesConfig();
+
+            Assert.AreEqual(1, config.Version);
+            Assert.IsNotNull(config.Profiles);
+            Assert.AreEqual(0, config.Profiles.Count);
+        }
+
+        [Test]
+        public void SessionSummary_DefaultCollections()
+        {
+            var summary = new SessionSummary();
+
+            Assert.IsNotNull(summary.BulletPoints);
+            Assert.AreEqual(0, summary.BulletPoints.Count);
+            Assert.IsNotNull(summary.Metrics);
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/CoreModelsTests.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/CoreModelsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 680b4d49cb874f7a9318cbe0161dfae0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- All C# data models, enums, and DTOs for the gwt Unity 6 project (Enums, Worktree, Branch, GitTypes, GitHubTypes, Settings, AITypes, Session, BranchSummary)
- Service interfaces: IConfigService, ISessionService, IGitService, IGitHubService, IPtyService, IAIApiService
- Config service implementations: ConfigService (JSON settings load/save with atomic writes), SessionService (GUID-based CRUD with JSON persistence), RecentProjectsService (LRU with max 20 entries)
- VContainer installer: GwtCoreConfigInstaller
- EditMode tests: enum value counts, DTO serialization roundtrips, ConfigService load/save/GetOrCreate, SessionService CRUD, default value assertions

## Test plan

- [ ] Verify Unity Editor compiles without errors
- [ ] Run EditMode tests via Unity Test Runner (CoreModelsTests)
- [ ] Verify .meta GUIDs are unique and files are properly imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added core infrastructure for AI-powered features including branch naming suggestions, commit message generation, code review, and chat capabilities.
  * Introduced multi-session management system for tracking project work and agent activity.
  * Added project configuration management with settings persistence.
  * Added GitHub integration framework for issue and pull request operations.
  * Added enhanced git operations support including worktree management and branch metadata tracking.

* **Tests**
  * Added comprehensive unit test suite covering core models, services, and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->