### PR TITLE
feat(unity): add Core Terminal engine (#1541)

### DIFF
--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitHubInstaller.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitHubInstaller.cs
@@ -1,0 +1,16 @@
+using Gwt.Core.Models;
+using Gwt.Shared;
+using VContainer;
+
+namespace Gwt.Core.Installers
+{
+    public class GwtCoreGitHubInstaller : IGwtInstaller
+    {
+        public void Install(IContainerBuilder builder)
+        {
+            builder.Register<Services.GitHub.GhCommandRunner>(Lifetime.Singleton);
+            builder.Register<Services.GitHub.GitHubService>(Lifetime.Singleton)
+                .As<IGitHubService>();
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitHubInstaller.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitHubInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3d4e5f6a7b849c0d1e2f3a4b5c6d7e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreTerminalInstaller.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreTerminalInstaller.cs
@@ -1,0 +1,14 @@
+using Gwt.Shared;
+using VContainer;
+
+namespace Gwt.Core.Installers
+{
+    public class GwtCoreTerminalInstaller : IGwtInstaller
+    {
+        public void Install(IContainerBuilder builder)
+        {
+            // TerminalEmulator is created per-terminal instance, not as a singleton.
+            // Consumers create TerminalEmulator directly with desired rows/cols.
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreTerminalInstaller.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreTerminalInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96093eadfbf94c2f968dfddaa523a680
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GhCommandRunner.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GhCommandRunner.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace Gwt.Core.Services.GitHub
+{
+    public class GhCommandRunner
+    {
+        public async UniTask<(string stdout, string stderr, int exitCode)> RunAsync(
+            string args, string workingDir, CancellationToken ct = default, int timeoutMs = 30000)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = args,
+                WorkingDirectory = workingDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
+            };
+
+            using var process = new Process { StartInfo = psi };
+            var stdoutBuf = new StringBuilder();
+            var stderrBuf = new StringBuilder();
+
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) stdoutBuf.AppendLine(e.Data);
+            };
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) stderrBuf.AppendLine(e.Data);
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            using var timeoutCts = new CancellationTokenSource(timeoutMs);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+            try
+            {
+                await UniTask.RunOnThreadPool(() =>
+                {
+                    while (!process.HasExited)
+                    {
+                        linked.Token.ThrowIfCancellationRequested();
+                        process.WaitForExit(200);
+                    }
+                }, cancellationToken: linked.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { if (!process.HasExited) process.Kill(); } catch { }
+                throw;
+            }
+
+            process.WaitForExit();
+            return (stdoutBuf.ToString().TrimEnd(), stderrBuf.ToString().TrimEnd(), process.ExitCode);
+        }
+
+        public async UniTask<string> RunJsonAsync(
+            string args, string workingDir, CancellationToken ct = default)
+        {
+            var (stdout, stderr, exitCode) = await RunAsync(args, workingDir, ct);
+
+            if (exitCode != 0)
+            {
+                throw new GhCliException(
+                    $"gh command failed (exit {exitCode}): {stderr}",
+                    exitCode, stderr);
+            }
+
+            return stdout;
+        }
+    }
+
+    public class GhCliException : Exception
+    {
+        public int ExitCode { get; }
+        public string Stderr { get; }
+
+        public GhCliException(string message, int exitCode, string stderr)
+            : base(message)
+        {
+            ExitCode = exitCode;
+            Stderr = stderr;
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GhCommandRunner.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GhCommandRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f647a8b9c0d1e2f3a4b5c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GitHubService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GitHubService.cs
@@ -1,0 +1,466 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using Gwt.Core.Models;
+
+namespace Gwt.Core.Services.GitHub
+{
+    public class GitHubService : IGitHubService
+    {
+        private readonly GhCommandRunner _runner;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        public GitHubService(GhCommandRunner runner)
+        {
+            _runner = runner;
+        }
+
+        // ── Auth ──────────────────────────────────────────────
+
+        public async UniTask<bool> CheckAuthAsync(string repoRoot, CancellationToken ct = default)
+        {
+            var (_, _, exitCode) = await _runner.RunAsync("auth status", repoRoot, ct);
+            return exitCode == 0;
+        }
+
+        // ── Issues ────────────────────────────────────────────
+
+        private const string IssueJsonFields =
+            "number,title,updatedAt,labels,body,state,url,assignees,comments,milestone";
+
+        public async UniTask<FetchIssuesResult> ListIssuesAsync(
+            string repoRoot, string state, int limit, CancellationToken ct = default)
+        {
+            var json = await _runner.RunJsonAsync(
+                $"issue list --json {IssueJsonFields} --limit {limit} --state {state}",
+                repoRoot, ct);
+            var raw = JsonSerializer.Deserialize<List<GhIssueDto>>(json, JsonOptions)
+                      ?? new List<GhIssueDto>();
+
+            var result = new FetchIssuesResult();
+            foreach (var dto in raw)
+                result.Issues.Add(ToModel(dto));
+            result.HasNextPage = raw.Count >= limit;
+            return result;
+        }
+
+        public async UniTask<GitHubIssue> GetIssueAsync(
+            string repoRoot, long number, CancellationToken ct = default)
+        {
+            var json = await _runner.RunJsonAsync(
+                $"issue view {number} --json {IssueJsonFields}",
+                repoRoot, ct);
+            var dto = JsonSerializer.Deserialize<GhIssueDto>(json, JsonOptions);
+            return ToModel(dto);
+        }
+
+        public async UniTask<GitHubIssue> CreateIssueAsync(
+            string repoRoot, string title, string body,
+            List<string> labels, CancellationToken ct = default)
+        {
+            var args = $"issue create --title {Escape(title)} --body {Escape(body)}";
+            if (labels != null)
+            {
+                foreach (var label in labels)
+                    args += $" --label {Escape(label)}";
+            }
+
+            // gh issue create prints the URL; re-fetch most recent to return full model
+            await _runner.RunAsync(args, repoRoot, ct);
+            var json = await _runner.RunJsonAsync(
+                $"issue list --json {IssueJsonFields} --limit 1 --state open",
+                repoRoot, ct);
+            var list = JsonSerializer.Deserialize<List<GhIssueDto>>(json, JsonOptions);
+            return list?.Count > 0 ? ToModel(list[0]) : null;
+        }
+
+        public async UniTask EditIssueAsync(
+            string repoRoot, int number, string title = null, string body = null,
+            string[] addLabels = null, string[] removeLabels = null,
+            CancellationToken ct = default)
+        {
+            var args = $"issue edit {number}";
+            if (title != null) args += $" --title {Escape(title)}";
+            if (body != null) args += $" --body {Escape(body)}";
+            if (addLabels != null)
+                foreach (var l in addLabels) args += $" --add-label {Escape(l)}";
+            if (removeLabels != null)
+                foreach (var l in removeLabels) args += $" --remove-label {Escape(l)}";
+
+            await _runner.RunJsonAsync(args, repoRoot, ct);
+        }
+
+        public async UniTask CloseIssueAsync(
+            string repoRoot, int number, CancellationToken ct = default)
+        {
+            await _runner.RunAsync($"issue close {number}", repoRoot, ct);
+        }
+
+        public async UniTask AddIssueCommentAsync(
+            string repoRoot, int number, string body, CancellationToken ct = default)
+        {
+            await _runner.RunAsync(
+                $"issue comment {number} --body {Escape(body)}", repoRoot, ct);
+        }
+
+        // ── Pull Requests ─────────────────────────────────────
+
+        private const string PrListFields =
+            "number,title,state,headRefName,baseRefName,isDraft,author,labels,createdAt,updatedAt,url,body";
+
+        private const string PrViewFields =
+            "number,title,state,url,mergeable,mergeStateStatus,author,baseRefName,headRefName," +
+            "labels,assignees,milestone,statusCheckRollup,reviews,reviewRequests," +
+            "changedFiles,additions,deletions";
+
+        public async UniTask<List<PullRequest>> ListPullRequestsAsync(
+            string repoRoot, string state, CancellationToken ct = default)
+        {
+            var json = await _runner.RunJsonAsync(
+                $"pr list --json {PrListFields} --limit 30 --state {state}",
+                repoRoot, ct);
+            var dtos = JsonSerializer.Deserialize<List<GhPrDto>>(json, JsonOptions)
+                       ?? new List<GhPrDto>();
+
+            var result = new List<PullRequest>();
+            foreach (var dto in dtos)
+                result.Add(ToPrModel(dto));
+            return result;
+        }
+
+        public async UniTask<PrStatusInfo> GetPrStatusAsync(
+            string repoRoot, long number, CancellationToken ct = default)
+        {
+            var json = await _runner.RunJsonAsync(
+                $"pr view {number} --json {PrViewFields}",
+                repoRoot, ct);
+            var dto = JsonSerializer.Deserialize<GhPrStatusDto>(json, JsonOptions);
+            return ToPrStatusModel(dto);
+        }
+
+        public async UniTask<PullRequest> CreatePullRequestAsync(
+            string repoRoot, string title, string body, string head, string baseBranch,
+            CancellationToken ct = default)
+        {
+            await _runner.RunAsync(
+                $"pr create --title {Escape(title)} --body {Escape(body)} --head {Escape(head)} --base {Escape(baseBranch)}",
+                repoRoot, ct);
+
+            // Re-fetch to return the created PR
+            var json = await _runner.RunJsonAsync(
+                $"pr list --json {PrListFields} --limit 1 --state open --head {Escape(head)}",
+                repoRoot, ct);
+            var list = JsonSerializer.Deserialize<List<GhPrDto>>(json, JsonOptions);
+            return list?.Count > 0 ? ToPrModel(list[0]) : null;
+        }
+
+        public async UniTask MergePullRequestAsync(
+            string repoRoot, int number, GhMergeMethod method = GhMergeMethod.Merge,
+            CancellationToken ct = default)
+        {
+            var flag = method switch
+            {
+                GhMergeMethod.Squash => "--squash",
+                GhMergeMethod.Rebase => "--rebase",
+                _ => "--merge"
+            };
+            await _runner.RunAsync($"pr merge {number} {flag}", repoRoot, ct);
+        }
+
+        // ── CI Checks ─────────────────────────────────────────
+
+        public async UniTask<List<WorkflowRunInfo>> GetCIStatusAsync(
+            string repoRoot, int prNumber, CancellationToken ct = default)
+        {
+            var json = await _runner.RunJsonAsync(
+                $"pr checks {prNumber} --json name,status,conclusion",
+                repoRoot, ct);
+            var dtos = JsonSerializer.Deserialize<List<GhCheckDto>>(json, JsonOptions)
+                       ?? new List<GhCheckDto>();
+
+            var result = new List<WorkflowRunInfo>();
+            foreach (var dto in dtos)
+            {
+                result.Add(new WorkflowRunInfo
+                {
+                    WorkflowName = dto.Name,
+                    Status = dto.Status,
+                    Conclusion = dto.Conclusion
+                });
+            }
+            return result;
+        }
+
+        // ── Mapping helpers ───────────────────────────────────
+
+        private static GitHubIssue ToModel(GhIssueDto dto)
+        {
+            if (dto == null) return null;
+            var issue = new GitHubIssue
+            {
+                Number = dto.Number,
+                Title = dto.Title,
+                UpdatedAt = dto.UpdatedAt,
+                Body = dto.Body,
+                State = dto.State,
+                HtmlUrl = dto.Url,
+                CommentsCount = dto.Comments
+            };
+
+            if (dto.Labels != null)
+                foreach (var l in dto.Labels)
+                    issue.Labels.Add(new GitHubLabel { Name = l.Name, Color = l.Color });
+
+            if (dto.Assignees != null)
+                foreach (var a in dto.Assignees)
+                    issue.Assignees.Add(new GitHubAssignee { Login = a.Login });
+
+            if (dto.Milestone != null)
+                issue.Milestone = new GitHubMilestone
+                {
+                    Title = dto.Milestone.Title,
+                    Number = dto.Milestone.Number
+                };
+
+            return issue;
+        }
+
+        private static PullRequest ToPrModel(GhPrDto dto)
+        {
+            if (dto == null) return null;
+            return new PullRequest
+            {
+                Number = dto.Number,
+                Title = dto.Title,
+                State = dto.State,
+                HeadBranch = dto.HeadRefName,
+                BaseBranch = dto.BaseRefName,
+                Url = dto.Url,
+                UpdatedAt = dto.UpdatedAt
+            };
+        }
+
+        private static PrStatusInfo ToPrStatusModel(GhPrStatusDto dto)
+        {
+            if (dto == null) return null;
+            var info = new PrStatusInfo
+            {
+                Number = dto.Number,
+                Title = dto.Title,
+                State = dto.State,
+                Url = dto.Url,
+                Mergeable = dto.Mergeable,
+                Author = dto.Author?.Login,
+                BaseBranch = dto.BaseRefName,
+                HeadBranch = dto.HeadRefName,
+                Milestone = dto.Milestone?.Title,
+                ChangedFilesCount = dto.ChangedFiles,
+                Additions = dto.Additions,
+                Deletions = dto.Deletions
+            };
+
+            if (dto.Labels != null)
+                foreach (var l in dto.Labels) info.Labels.Add(l.Name);
+
+            if (dto.Assignees != null)
+                foreach (var a in dto.Assignees) info.Assignees.Add(a.Login);
+
+            if (dto.StatusCheckRollup != null)
+                foreach (var c in dto.StatusCheckRollup)
+                    info.CheckSuites.Add(new WorkflowRunInfo
+                    {
+                        WorkflowName = c.Name,
+                        Status = c.Status,
+                        Conclusion = c.Conclusion
+                    });
+
+            if (dto.Reviews != null)
+                foreach (var r in dto.Reviews)
+                    info.Reviews.Add(new ReviewInfo
+                    {
+                        Reviewer = r.Author?.Login,
+                        State = r.State
+                    });
+
+            return info;
+        }
+
+        private static string Escape(string value)
+        {
+            if (value == null) return "\"\"";
+            return "'" + value.Replace("'", "'\\''") + "'";
+        }
+    }
+
+    // ── Merge method enum ─────────────────────────────────────
+
+    public enum GhMergeMethod { Merge, Squash, Rebase }
+
+    // ── Internal DTOs for JSON deserialization from gh CLI ─────
+
+    internal class GhLabelDto
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("color")]
+        public string Color { get; set; }
+    }
+
+    internal class GhUserDto
+    {
+        [JsonPropertyName("login")]
+        public string Login { get; set; }
+    }
+
+    internal class GhMilestoneDto
+    {
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("number")]
+        public int Number { get; set; }
+    }
+
+    internal class GhIssueDto
+    {
+        [JsonPropertyName("number")]
+        public int Number { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("updatedAt")]
+        public string UpdatedAt { get; set; }
+
+        [JsonPropertyName("labels")]
+        public List<GhLabelDto> Labels { get; set; }
+
+        [JsonPropertyName("body")]
+        public string Body { get; set; }
+
+        [JsonPropertyName("state")]
+        public string State { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("assignees")]
+        public List<GhUserDto> Assignees { get; set; }
+
+        [JsonPropertyName("comments")]
+        public int Comments { get; set; }
+
+        [JsonPropertyName("milestone")]
+        public GhMilestoneDto Milestone { get; set; }
+    }
+
+    internal class GhPrDto
+    {
+        [JsonPropertyName("number")]
+        public int Number { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("state")]
+        public string State { get; set; }
+
+        [JsonPropertyName("headRefName")]
+        public string HeadRefName { get; set; }
+
+        [JsonPropertyName("baseRefName")]
+        public string BaseRefName { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("updatedAt")]
+        public string UpdatedAt { get; set; }
+    }
+
+    internal class GhCheckDto
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("conclusion")]
+        public string Conclusion { get; set; }
+    }
+
+    internal class GhReviewDto
+    {
+        [JsonPropertyName("author")]
+        public GhUserDto Author { get; set; }
+
+        [JsonPropertyName("state")]
+        public string State { get; set; }
+    }
+
+    internal class GhPrStatusDto
+    {
+        [JsonPropertyName("number")]
+        public int Number { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("state")]
+        public string State { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("mergeable")]
+        public string Mergeable { get; set; }
+
+        [JsonPropertyName("mergeStateStatus")]
+        public string MergeStateStatus { get; set; }
+
+        [JsonPropertyName("author")]
+        public GhUserDto Author { get; set; }
+
+        [JsonPropertyName("baseRefName")]
+        public string BaseRefName { get; set; }
+
+        [JsonPropertyName("headRefName")]
+        public string HeadRefName { get; set; }
+
+        [JsonPropertyName("labels")]
+        public List<GhLabelDto> Labels { get; set; }
+
+        [JsonPropertyName("assignees")]
+        public List<GhUserDto> Assignees { get; set; }
+
+        [JsonPropertyName("milestone")]
+        public GhMilestoneDto Milestone { get; set; }
+
+        [JsonPropertyName("statusCheckRollup")]
+        public List<GhCheckDto> StatusCheckRollup { get; set; }
+
+        [JsonPropertyName("reviews")]
+        public List<GhReviewDto> Reviews { get; set; }
+
+        [JsonPropertyName("reviewRequests")]
+        public List<GhUserDto> ReviewRequests { get; set; }
+
+        [JsonPropertyName("changedFiles")]
+        public int ChangedFiles { get; set; }
+
+        [JsonPropertyName("additions")]
+        public int Additions { get; set; }
+
+        [JsonPropertyName("deletions")]
+        public int Deletions { get; set; }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GitHubService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/GitHub/GitHubService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2c3d4e5f6a748b9c0d1e2f3a4b5c6d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/AnsiParser.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/AnsiParser.cs
@@ -1,0 +1,554 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Gwt.Core.Services.Terminal
+{
+    public class AnsiParser
+    {
+        private readonly TerminalBuffer _buffer;
+        private ParserState _state = ParserState.Ground;
+        private readonly StringBuilder _paramBuffer = new();
+        private readonly StringBuilder _oscBuffer = new();
+
+        private bool _alternateScreen;
+        private TerminalCell[][] _savedMainScreen;
+        private int _savedMainRows;
+        private int _savedMainCols;
+
+        private int _savedCursorRow;
+        private int _savedCursorCol;
+
+        public event Action<string> TitleChanged;
+        public event Action<string> UrlDetected;
+
+        public AnsiParser(TerminalBuffer buffer)
+        {
+            _buffer = buffer;
+        }
+
+        public void Process(string data)
+        {
+            foreach (char c in data)
+                ProcessChar(c);
+        }
+
+        private void ProcessChar(char c)
+        {
+            switch (_state)
+            {
+                case ParserState.Ground:
+                    ProcessGround(c);
+                    break;
+                case ParserState.Escape:
+                    ProcessEscape(c);
+                    break;
+                case ParserState.CsiEntry:
+                    ProcessCsiEntry(c);
+                    break;
+                case ParserState.CsiParam:
+                    ProcessCsiParam(c);
+                    break;
+                case ParserState.OscString:
+                    ProcessOsc(c);
+                    break;
+            }
+        }
+
+        private void ProcessGround(char c)
+        {
+            switch (c)
+            {
+                case '\x1b': // ESC
+                    _state = ParserState.Escape;
+                    break;
+                case '\n':
+                    _buffer.Linefeed();
+                    break;
+                case '\r':
+                    _buffer.CarriageReturn();
+                    break;
+                case '\t':
+                    // Tab: advance to next 8-column boundary
+                    int nextTab = (((_buffer.CursorCol / 8) + 1) * 8);
+                    _buffer.CursorCol = Math.Min(nextTab, _buffer.Cols - 1);
+                    break;
+                case '\b':
+                    if (_buffer.CursorCol > 0)
+                        _buffer.CursorCol--;
+                    break;
+                case '\a': // Bell — ignore
+                    break;
+                default:
+                    if (c >= ' ') // Printable
+                        _buffer.WriteChar(c);
+                    break;
+            }
+        }
+
+        private void ProcessEscape(char c)
+        {
+            switch (c)
+            {
+                case '[':
+                    _state = ParserState.CsiEntry;
+                    _paramBuffer.Clear();
+                    break;
+                case ']':
+                    _state = ParserState.OscString;
+                    _oscBuffer.Clear();
+                    break;
+                case '7': // Save cursor (DECSC)
+                    _savedCursorRow = _buffer.CursorRow;
+                    _savedCursorCol = _buffer.CursorCol;
+                    _state = ParserState.Ground;
+                    break;
+                case '8': // Restore cursor (DECRC)
+                    _buffer.CursorRow = _savedCursorRow;
+                    _buffer.CursorCol = _savedCursorCol;
+                    _state = ParserState.Ground;
+                    break;
+                case 'D': // Index — move cursor down, scroll if at bottom
+                    _buffer.Linefeed();
+                    _state = ParserState.Ground;
+                    break;
+                case 'M': // Reverse index — move cursor up, scroll down if at top
+                    if (_buffer.CursorRow == 0)
+                        _buffer.ScrollDown();
+                    else
+                        _buffer.CursorRow--;
+                    _state = ParserState.Ground;
+                    break;
+                case 'c': // Full reset (RIS)
+                    _buffer.ClearScreen();
+                    _buffer.CursorRow = 0;
+                    _buffer.CursorCol = 0;
+                    _buffer.ResetAttributes();
+                    _state = ParserState.Ground;
+                    break;
+                default:
+                    // Unknown escape — return to ground
+                    _state = ParserState.Ground;
+                    break;
+            }
+        }
+
+        private void ProcessCsiEntry(char c)
+        {
+            if (c == '?')
+            {
+                _paramBuffer.Append(c);
+                _state = ParserState.CsiParam;
+            }
+            else if (char.IsDigit(c) || c == ';')
+            {
+                _paramBuffer.Append(c);
+                _state = ParserState.CsiParam;
+            }
+            else
+            {
+                // Immediate final character with no params
+                HandleCsi(c);
+                _state = ParserState.Ground;
+            }
+        }
+
+        private void ProcessCsiParam(char c)
+        {
+            if (char.IsDigit(c) || c == ';')
+            {
+                _paramBuffer.Append(c);
+            }
+            else
+            {
+                HandleCsi(c);
+                _state = ParserState.Ground;
+            }
+        }
+
+        private void ProcessOsc(char c)
+        {
+            if (c == '\a') // BEL terminates OSC
+            {
+                HandleOsc(_oscBuffer.ToString());
+                _state = ParserState.Ground;
+            }
+            else if (c == '\x1b')
+            {
+                // ESC \ (ST) — we'll just terminate on ESC for simplicity
+                HandleOsc(_oscBuffer.ToString());
+                _state = ParserState.Ground;
+            }
+            else
+            {
+                _oscBuffer.Append(c);
+            }
+        }
+
+        private void HandleCsi(char final)
+        {
+            string paramStr = _paramBuffer.ToString();
+            bool privateMode = paramStr.StartsWith("?");
+            if (privateMode)
+                paramStr = paramStr.Substring(1);
+
+            int[] parameters = ParseParameters(paramStr);
+
+            if (privateMode)
+            {
+                HandlePrivateMode(final, parameters);
+                return;
+            }
+
+            switch (final)
+            {
+                case 'A': // CUU — Cursor Up
+                    _buffer.CursorRow = Math.Max(0, _buffer.CursorRow - Math.Max(1, Param(parameters, 0, 1)));
+                    break;
+                case 'B': // CUD — Cursor Down
+                    _buffer.CursorRow = Math.Min(_buffer.Rows - 1,
+                        _buffer.CursorRow + Math.Max(1, Param(parameters, 0, 1)));
+                    break;
+                case 'C': // CUF — Cursor Forward
+                    _buffer.CursorCol = Math.Min(_buffer.Cols - 1,
+                        _buffer.CursorCol + Math.Max(1, Param(parameters, 0, 1)));
+                    break;
+                case 'D': // CUB — Cursor Back
+                    _buffer.CursorCol = Math.Max(0, _buffer.CursorCol - Math.Max(1, Param(parameters, 0, 1)));
+                    break;
+                case 'H': // CUP — Cursor Position
+                case 'f':
+                    _buffer.CursorRow = Math.Min(_buffer.Rows - 1, Math.Max(0, Param(parameters, 0, 1) - 1));
+                    _buffer.CursorCol = Math.Min(_buffer.Cols - 1, Math.Max(0, Param(parameters, 1, 1) - 1));
+                    break;
+                case 'J': // ED — Erase in Display
+                    HandleEraseDisplay(Param(parameters, 0, 0));
+                    break;
+                case 'K': // EL — Erase in Line
+                    HandleEraseLine(Param(parameters, 0, 0));
+                    break;
+                case 'S': // SU — Scroll Up
+                {
+                    int lines = Math.Max(1, Param(parameters, 0, 1));
+                    for (int i = 0; i < lines; i++)
+                        _buffer.ScrollUp();
+                    break;
+                }
+                case 'T': // SD — Scroll Down
+                {
+                    int lines = Math.Max(1, Param(parameters, 0, 1));
+                    for (int i = 0; i < lines; i++)
+                        _buffer.ScrollDown();
+                    break;
+                }
+                case 'm': // SGR — Select Graphic Rendition
+                    HandleSgr(parameters);
+                    break;
+                case 's': // Save cursor position
+                    _savedCursorRow = _buffer.CursorRow;
+                    _savedCursorCol = _buffer.CursorCol;
+                    break;
+                case 'u': // Restore cursor position
+                    _buffer.CursorRow = _savedCursorRow;
+                    _buffer.CursorCol = _savedCursorCol;
+                    break;
+                case 'G': // CHA — Cursor Character Absolute
+                    _buffer.CursorCol = Math.Min(_buffer.Cols - 1, Math.Max(0, Param(parameters, 0, 1) - 1));
+                    break;
+                case 'd': // VPA — Line Position Absolute
+                    _buffer.CursorRow = Math.Min(_buffer.Rows - 1, Math.Max(0, Param(parameters, 0, 1) - 1));
+                    break;
+                case 'X': // ECH — Erase Character
+                {
+                    int count = Math.Max(1, Param(parameters, 0, 1));
+                    for (int i = 0; i < count && _buffer.CursorCol + i < _buffer.Cols; i++)
+                    {
+                        _buffer.SetCell(_buffer.CursorRow, _buffer.CursorCol + i, TerminalCell.Empty);
+                    }
+                    break;
+                }
+                case 'L': // IL — Insert Lines
+                {
+                    int count = Math.Max(1, Param(parameters, 0, 1));
+                    for (int i = 0; i < count; i++)
+                    {
+                        // Shift lines down from cursor, insert blank at cursor row
+                        for (int r = _buffer.Rows - 1; r > _buffer.CursorRow; r--)
+                        {
+                            for (int c = 0; c < _buffer.Cols; c++)
+                                _buffer.SetCell(r, c, _buffer.GetCell(r - 1, c));
+                        }
+                        _buffer.ClearLine(_buffer.CursorRow);
+                    }
+                    break;
+                }
+                case 'M': // DL — Delete Lines
+                {
+                    int count = Math.Max(1, Param(parameters, 0, 1));
+                    for (int i = 0; i < count; i++)
+                    {
+                        // Shift lines up from cursor+1, clear bottom
+                        for (int r = _buffer.CursorRow; r < _buffer.Rows - 1; r++)
+                        {
+                            for (int c = 0; c < _buffer.Cols; c++)
+                                _buffer.SetCell(r, c, _buffer.GetCell(r + 1, c));
+                        }
+                        _buffer.ClearLine(_buffer.Rows - 1);
+                    }
+                    break;
+                }
+            }
+        }
+
+        private void HandlePrivateMode(char final, int[] parameters)
+        {
+            if (parameters.Length == 0) return;
+
+            int mode = parameters[0];
+            switch (final)
+            {
+                case 'h': // DECSET
+                    if (mode == 1049) // Alternate screen buffer
+                    {
+                        if (!_alternateScreen)
+                        {
+                            _alternateScreen = true;
+                            // Save main screen
+                            _savedMainRows = _buffer.Rows;
+                            _savedMainCols = _buffer.Cols;
+                            _savedMainScreen = new TerminalCell[_buffer.Rows][];
+                            for (int r = 0; r < _buffer.Rows; r++)
+                            {
+                                _savedMainScreen[r] = new TerminalCell[_buffer.Cols];
+                                for (int c = 0; c < _buffer.Cols; c++)
+                                    _savedMainScreen[r][c] = _buffer.GetCell(r, c);
+                            }
+                            _savedCursorRow = _buffer.CursorRow;
+                            _savedCursorCol = _buffer.CursorCol;
+                            _buffer.ClearScreen();
+                            _buffer.CursorRow = 0;
+                            _buffer.CursorCol = 0;
+                        }
+                    }
+                    break;
+                case 'l': // DECRST
+                    if (mode == 1049) // Restore main screen
+                    {
+                        if (_alternateScreen)
+                        {
+                            _alternateScreen = false;
+                            if (_savedMainScreen != null)
+                            {
+                                int restoreRows = Math.Min(_savedMainRows, _buffer.Rows);
+                                int restoreCols = Math.Min(_savedMainCols, _buffer.Cols);
+                                _buffer.ClearScreen();
+                                for (int r = 0; r < restoreRows; r++)
+                                {
+                                    for (int c = 0; c < restoreCols; c++)
+                                        _buffer.SetCell(r, c, _savedMainScreen[r][c]);
+                                }
+                                _buffer.CursorRow = Math.Min(_savedCursorRow, _buffer.Rows - 1);
+                                _buffer.CursorCol = Math.Min(_savedCursorCol, _buffer.Cols - 1);
+                                _savedMainScreen = null;
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+        private void HandleEraseDisplay(int mode)
+        {
+            switch (mode)
+            {
+                case 0: // Erase from cursor to end of screen
+                    _buffer.ClearToEndOfScreen();
+                    break;
+                case 1: // Erase from start to cursor
+                    _buffer.ClearFromStartOfScreen();
+                    break;
+                case 2: // Erase entire screen
+                case 3: // Erase entire screen + scrollback (treat same as 2)
+                    _buffer.ClearScreen();
+                    break;
+            }
+        }
+
+        private void HandleEraseLine(int mode)
+        {
+            switch (mode)
+            {
+                case 0: // Erase from cursor to end of line
+                    _buffer.ClearToEndOfLine();
+                    break;
+                case 1: // Erase from start to cursor
+                    _buffer.ClearFromStartOfLine();
+                    break;
+                case 2: // Erase entire line
+                    _buffer.ClearLine(_buffer.CursorRow);
+                    break;
+            }
+        }
+
+        private void HandleSgr(int[] parameters)
+        {
+            if (parameters.Length == 0)
+            {
+                _buffer.ResetAttributes();
+                return;
+            }
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                int p = parameters[i];
+
+                switch (p)
+                {
+                    case 0: // Reset
+                        _buffer.ResetAttributes();
+                        break;
+                    case 1: // Bold
+                        _buffer.Bold = true;
+                        break;
+                    case 3: // Italic
+                        _buffer.Italic = true;
+                        break;
+                    case 4: // Underline
+                        _buffer.Underline = true;
+                        break;
+                    case 7: // Inverse
+                        _buffer.Inverse = true;
+                        break;
+                    case 22: // Normal intensity (not bold)
+                        _buffer.Bold = false;
+                        break;
+                    case 23: // Not italic
+                        _buffer.Italic = false;
+                        break;
+                    case 24: // Not underline
+                        _buffer.Underline = false;
+                        break;
+                    case 27: // Not inverse
+                        _buffer.Inverse = false;
+                        break;
+                    case >= 30 and <= 37: // Standard foreground colors
+                        _buffer.CurrentFg = (byte)(p - 30);
+                        break;
+                    case 38: // Extended foreground color
+                        i = HandleExtendedColor(parameters, i, isForeground: true);
+                        break;
+                    case 39: // Default foreground
+                        _buffer.CurrentFg = 7;
+                        break;
+                    case >= 40 and <= 47: // Standard background colors
+                        _buffer.CurrentBg = (byte)(p - 40);
+                        break;
+                    case 48: // Extended background color
+                        i = HandleExtendedColor(parameters, i, isForeground: false);
+                        break;
+                    case 49: // Default background
+                        _buffer.CurrentBg = 0;
+                        break;
+                    case >= 90 and <= 97: // Bright foreground colors
+                        _buffer.CurrentFg = (byte)(p - 90 + 8);
+                        break;
+                    case >= 100 and <= 107: // Bright background colors
+                        _buffer.CurrentBg = (byte)(p - 100 + 8);
+                        break;
+                }
+            }
+        }
+
+        private int HandleExtendedColor(int[] parameters, int index, bool isForeground)
+        {
+            if (index + 1 >= parameters.Length)
+                return index;
+
+            int colorMode = parameters[index + 1];
+            if (colorMode == 5 && index + 2 < parameters.Length)
+            {
+                // 256 color: ESC[38;5;Nm or ESC[48;5;Nm
+                byte colorIndex = (byte)Math.Min(255, Math.Max(0, parameters[index + 2]));
+                if (isForeground)
+                    _buffer.CurrentFg = colorIndex;
+                else
+                    _buffer.CurrentBg = colorIndex;
+                return index + 2;
+            }
+
+            if (colorMode == 2 && index + 4 < parameters.Length)
+            {
+                // 24-bit color: ESC[38;2;R;G;Bm — map to nearest 256-color
+                // For simplicity, store as 0 (we don't support true color mapping yet)
+                return index + 4;
+            }
+
+            return index + 1;
+        }
+
+        private void HandleOsc(string data)
+        {
+            int semicolonIndex = data.IndexOf(';');
+            if (semicolonIndex < 0) return;
+
+            string codeStr = data.Substring(0, semicolonIndex);
+            string payload = data.Substring(semicolonIndex + 1);
+
+            if (int.TryParse(codeStr, out int code))
+            {
+                switch (code)
+                {
+                    case 0: // Set icon name and window title
+                    case 2: // Set window title
+                        TitleChanged?.Invoke(payload);
+                        break;
+                    case 8: // Hyperlink
+                        // Format: 8;params;uri
+                        int uriSep = payload.IndexOf(';');
+                        if (uriSep >= 0)
+                        {
+                            string uri = payload.Substring(uriSep + 1);
+                            if (!string.IsNullOrEmpty(uri))
+                                UrlDetected?.Invoke(uri);
+                        }
+                        break;
+                }
+            }
+        }
+
+        private static int[] ParseParameters(string paramStr)
+        {
+            if (string.IsNullOrEmpty(paramStr))
+                return Array.Empty<int>();
+
+            string[] parts = paramStr.Split(';');
+            var result = new List<int>();
+
+            foreach (string part in parts)
+            {
+                if (int.TryParse(part, out int val))
+                    result.Add(val);
+                else
+                    result.Add(0);
+            }
+
+            return result.ToArray();
+        }
+
+        private static int Param(int[] parameters, int index, int defaultValue)
+        {
+            if (index < parameters.Length)
+                return parameters[index] == 0 ? defaultValue : parameters[index];
+            return defaultValue;
+        }
+
+        private enum ParserState
+        {
+            Ground,
+            Escape,
+            CsiEntry,
+            CsiParam,
+            OscString
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/AnsiParser.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/AnsiParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d630d74beb90416587933c8fe6ad8efe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/CatppuccinTheme.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/CatppuccinTheme.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+namespace Gwt.Core.Services.Terminal
+{
+    public static class CatppuccinTheme
+    {
+        // Catppuccin Mocha 16-color palette
+        public static readonly Color[] Colors = new Color[16]
+        {
+            new(0.18f, 0.19f, 0.25f, 1f),  // 0  Black (Surface0)
+            new(0.95f, 0.55f, 0.66f, 1f),  // 1  Red
+            new(0.65f, 0.89f, 0.63f, 1f),  // 2  Green
+            new(0.98f, 0.90f, 0.60f, 1f),  // 3  Yellow
+            new(0.54f, 0.71f, 0.98f, 1f),  // 4  Blue
+            new(0.80f, 0.62f, 0.95f, 1f),  // 5  Magenta
+            new(0.58f, 0.89f, 0.87f, 1f),  // 6  Cyan
+            new(0.80f, 0.83f, 0.90f, 1f),  // 7  White (Subtext1)
+            new(0.27f, 0.28f, 0.35f, 1f),  // 8  Bright Black (Surface1)
+            new(0.95f, 0.55f, 0.66f, 1f),  // 9  Bright Red
+            new(0.65f, 0.89f, 0.63f, 1f),  // 10 Bright Green
+            new(0.98f, 0.90f, 0.60f, 1f),  // 11 Bright Yellow
+            new(0.54f, 0.71f, 0.98f, 1f),  // 12 Bright Blue
+            new(0.80f, 0.62f, 0.95f, 1f),  // 13 Bright Magenta
+            new(0.58f, 0.89f, 0.87f, 1f),  // 14 Bright Cyan
+            new(0.81f, 0.85f, 0.92f, 1f),  // 15 Bright White (Text)
+        };
+
+        public static Color Background => new(0.12f, 0.12f, 0.18f, 1f);  // Base
+        public static Color Foreground => Colors[15];
+        public static Color CursorColor => new(0.95f, 0.76f, 0.66f, 1f); // Rosewater
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/CatppuccinTheme.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/CatppuccinTheme.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6211341243647f9bf0b4ca8e1358ce4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalBuffer.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalBuffer.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Gwt.Core.Services.Terminal
+{
+    public struct TerminalCell
+    {
+        public char Character;
+        public byte ForegroundColor;
+        public byte BackgroundColor;
+        public bool Bold;
+        public bool Italic;
+        public bool Underline;
+        public bool Inverse;
+
+        public static TerminalCell Empty => new()
+        {
+            Character = ' ',
+            ForegroundColor = 7,
+            BackgroundColor = 0
+        };
+    }
+
+    public class TerminalBuffer
+    {
+        public int Rows { get; private set; }
+        public int Cols { get; private set; }
+        public int CursorRow { get; set; }
+        public int CursorCol { get; set; }
+        public int ScrollbackLines => _scrollback.Count;
+
+        private TerminalCell[][] _screen;
+        private readonly List<TerminalCell[]> _scrollback = new();
+        private const int MaxScrollback = 10000;
+
+        public byte CurrentFg = 7;
+        public byte CurrentBg = 0;
+        public bool Bold, Italic, Underline, Inverse;
+
+        public TerminalBuffer(int rows, int cols)
+        {
+            Rows = rows;
+            Cols = cols;
+            _screen = CreateScreen(rows, cols);
+        }
+
+        public void Resize(int newRows, int newCols)
+        {
+            var newScreen = CreateScreen(newRows, newCols);
+            int copyRows = System.Math.Min(Rows, newRows);
+            int copyCols = System.Math.Min(Cols, newCols);
+
+            for (int r = 0; r < copyRows; r++)
+            {
+                for (int c = 0; c < copyCols; c++)
+                {
+                    newScreen[r][c] = _screen[r][c];
+                }
+            }
+
+            _screen = newScreen;
+            Rows = newRows;
+            Cols = newCols;
+            CursorRow = System.Math.Min(CursorRow, newRows - 1);
+            CursorCol = System.Math.Min(CursorCol, newCols - 1);
+        }
+
+        public TerminalCell GetCell(int row, int col) => _screen[row][col];
+
+        public TerminalCell[] GetScrollbackLine(int index) => _scrollback[index];
+
+        public void SetCell(int row, int col, TerminalCell cell)
+        {
+            _screen[row][col] = cell;
+        }
+
+        public void WriteChar(char c)
+        {
+            if (CursorCol >= Cols)
+            {
+                CursorCol = 0;
+                CursorRow++;
+                if (CursorRow >= Rows)
+                {
+                    ScrollUp();
+                    CursorRow = Rows - 1;
+                }
+            }
+
+            _screen[CursorRow][CursorCol] = new TerminalCell
+            {
+                Character = c,
+                ForegroundColor = Inverse ? CurrentBg : CurrentFg,
+                BackgroundColor = Inverse ? CurrentFg : CurrentBg,
+                Bold = Bold,
+                Italic = Italic,
+                Underline = Underline,
+                Inverse = Inverse
+            };
+            CursorCol++;
+        }
+
+        public void Linefeed()
+        {
+            CursorRow++;
+            if (CursorRow >= Rows)
+            {
+                ScrollUp();
+                CursorRow = Rows - 1;
+            }
+        }
+
+        public void CarriageReturn()
+        {
+            CursorCol = 0;
+        }
+
+        public void ScrollUp()
+        {
+            // Move top line to scrollback
+            _scrollback.Add(_screen[0]);
+            if (_scrollback.Count > MaxScrollback)
+                _scrollback.RemoveAt(0);
+
+            // Shift screen up
+            for (int r = 0; r < Rows - 1; r++)
+            {
+                _screen[r] = _screen[r + 1];
+            }
+
+            // Clear bottom line
+            _screen[Rows - 1] = CreateEmptyLine(Cols);
+        }
+
+        public void ScrollDown()
+        {
+            // Shift screen down, clear top line
+            for (int r = Rows - 1; r > 0; r--)
+            {
+                _screen[r] = _screen[r - 1];
+            }
+
+            _screen[0] = CreateEmptyLine(Cols);
+        }
+
+        public void ClearScreen()
+        {
+            for (int r = 0; r < Rows; r++)
+            {
+                _screen[r] = CreateEmptyLine(Cols);
+            }
+        }
+
+        public void ClearLine(int row)
+        {
+            _screen[row] = CreateEmptyLine(Cols);
+        }
+
+        public void ClearToEndOfLine()
+        {
+            for (int c = CursorCol; c < Cols; c++)
+            {
+                _screen[CursorRow][c] = TerminalCell.Empty;
+            }
+        }
+
+        public void ClearToEndOfScreen()
+        {
+            ClearToEndOfLine();
+            for (int r = CursorRow + 1; r < Rows; r++)
+            {
+                _screen[r] = CreateEmptyLine(Cols);
+            }
+        }
+
+        public void ClearFromStartOfLine()
+        {
+            for (int c = 0; c <= CursorCol && c < Cols; c++)
+            {
+                _screen[CursorRow][c] = TerminalCell.Empty;
+            }
+        }
+
+        public void ClearFromStartOfScreen()
+        {
+            for (int r = 0; r < CursorRow; r++)
+            {
+                _screen[r] = CreateEmptyLine(Cols);
+            }
+
+            ClearFromStartOfLine();
+        }
+
+        public string GetTextContent(int startRow, int startCol, int endRow, int endCol)
+        {
+            var sb = new StringBuilder();
+
+            for (int r = startRow; r <= endRow && r < Rows; r++)
+            {
+                int cStart = (r == startRow) ? startCol : 0;
+                int cEnd = (r == endRow) ? endCol : Cols - 1;
+                cStart = System.Math.Max(0, cStart);
+                cEnd = System.Math.Min(Cols - 1, cEnd);
+
+                for (int c = cStart; c <= cEnd; c++)
+                {
+                    sb.Append(_screen[r][c].Character);
+                }
+
+                if (r < endRow)
+                    sb.AppendLine();
+            }
+
+            return sb.ToString();
+        }
+
+        public void ResetAttributes()
+        {
+            CurrentFg = 7;
+            CurrentBg = 0;
+            Bold = false;
+            Italic = false;
+            Underline = false;
+            Inverse = false;
+        }
+
+        private static TerminalCell[][] CreateScreen(int rows, int cols)
+        {
+            var screen = new TerminalCell[rows][];
+            for (int r = 0; r < rows; r++)
+            {
+                screen[r] = CreateEmptyLine(cols);
+            }
+
+            return screen;
+        }
+
+        private static TerminalCell[] CreateEmptyLine(int cols)
+        {
+            var line = new TerminalCell[cols];
+            for (int c = 0; c < cols; c++)
+            {
+                line[c] = TerminalCell.Empty;
+            }
+
+            return line;
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalBuffer.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalBuffer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce9c7a8a7ad94c0eb631334a717f034f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalEmulator.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalEmulator.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Gwt.Core.Services.Terminal
+{
+    public class TerminalEmulator : IDisposable
+    {
+        public TerminalBuffer Buffer { get; }
+        public AnsiParser Parser { get; }
+        public int Rows => Buffer.Rows;
+        public int Cols => Buffer.Cols;
+
+        public event Action<string> TitleChanged;
+        public event Action BufferChanged;
+
+        public TerminalEmulator(int rows = 24, int cols = 80)
+        {
+            Buffer = new TerminalBuffer(rows, cols);
+            Parser = new AnsiParser(Buffer);
+            Parser.TitleChanged += t => TitleChanged?.Invoke(t);
+        }
+
+        public void Write(string data)
+        {
+            Parser.Process(data);
+            BufferChanged?.Invoke();
+        }
+
+        public void Resize(int rows, int cols)
+        {
+            Buffer.Resize(rows, cols);
+        }
+
+        public string GetSelectedText(int startRow, int startCol, int endRow, int endCol)
+        {
+            return Buffer.GetTextContent(startRow, startCol, endRow, endCol);
+        }
+
+        public void Dispose()
+        {
+            TitleChanged = null;
+            BufferChanged = null;
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalEmulator.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Terminal/TerminalEmulator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a22157e5c034bb0a51e50348b4bd432
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitHubServiceTests.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitHubServiceTests.cs
@@ -1,0 +1,391 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Gwt.Core.Services.GitHub;
+using NUnit.Framework;
+
+namespace Gwt.Tests.Editor
+{
+    [TestFixture]
+    public class GitHubServiceTests
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        // ── Issue list JSON parsing ───────────────────────────
+
+        private const string IssueListJson = @"[
+            {
+                ""number"": 1,
+                ""title"": ""Bug fix"",
+                ""updatedAt"": ""2024-01-01T00:00:00Z"",
+                ""labels"": [{""name"": ""bug"", ""color"": ""d73a4a""}],
+                ""body"": ""Description"",
+                ""state"": ""OPEN"",
+                ""url"": ""https://github.com/owner/repo/issues/1"",
+                ""assignees"": [{""login"": ""user""}],
+                ""comments"": 5,
+                ""milestone"": {""title"": ""v1.0"", ""number"": 1}
+            },
+            {
+                ""number"": 2,
+                ""title"": ""Feature request"",
+                ""updatedAt"": ""2024-02-15T12:30:00Z"",
+                ""labels"": [{""name"": ""enhancement"", ""color"": ""a2eeef""}],
+                ""body"": ""Add new feature"",
+                ""state"": ""OPEN"",
+                ""url"": ""https://github.com/owner/repo/issues/2"",
+                ""assignees"": [],
+                ""comments"": 0,
+                ""milestone"": null
+            }
+        ]";
+
+        [Test]
+        public void ParseIssueList_DeserializesAllFields()
+        {
+            var issues = JsonSerializer.Deserialize<List<IssueDto>>(IssueListJson, JsonOptions);
+
+            Assert.IsNotNull(issues);
+            Assert.AreEqual(2, issues.Count);
+
+            var first = issues[0];
+            Assert.AreEqual(1, first.Number);
+            Assert.AreEqual("Bug fix", first.Title);
+            Assert.AreEqual("OPEN", first.State);
+            Assert.AreEqual("Description", first.Body);
+            Assert.AreEqual(5, first.Comments);
+            Assert.AreEqual("https://github.com/owner/repo/issues/1", first.Url);
+            Assert.AreEqual("2024-01-01T00:00:00Z", first.UpdatedAt);
+
+            Assert.AreEqual(1, first.Labels.Count);
+            Assert.AreEqual("bug", first.Labels[0].Name);
+            Assert.AreEqual("d73a4a", first.Labels[0].Color);
+
+            Assert.AreEqual(1, first.Assignees.Count);
+            Assert.AreEqual("user", first.Assignees[0].Login);
+
+            Assert.IsNotNull(first.Milestone);
+            Assert.AreEqual("v1.0", first.Milestone.Title);
+            Assert.AreEqual(1, first.Milestone.Number);
+
+            var second = issues[1];
+            Assert.AreEqual(2, second.Number);
+            Assert.IsNull(second.Milestone);
+            Assert.AreEqual(0, second.Assignees.Count);
+        }
+
+        // ── PR status JSON parsing ────────────────────────────
+
+        private const string PrStatusJson = @"{
+            ""number"": 42,
+            ""title"": ""Add feature"",
+            ""state"": ""OPEN"",
+            ""url"": ""https://github.com/owner/repo/pull/42"",
+            ""mergeable"": ""MERGEABLE"",
+            ""mergeStateStatus"": ""CLEAN"",
+            ""author"": {""login"": ""user""},
+            ""baseRefName"": ""main"",
+            ""headRefName"": ""feature"",
+            ""labels"": [{""name"": ""enhancement""}],
+            ""assignees"": [],
+            ""milestone"": null,
+            ""statusCheckRollup"": [
+                {""name"": ""CI"", ""status"": ""COMPLETED"", ""conclusion"": ""SUCCESS""}
+            ],
+            ""reviews"": [
+                {""author"": {""login"": ""reviewer""}, ""state"": ""APPROVED""}
+            ],
+            ""reviewRequests"": [],
+            ""changedFiles"": 5,
+            ""additions"": 100,
+            ""deletions"": 50
+        }";
+
+        [Test]
+        public void ParsePrStatus_DeserializesAllFields()
+        {
+            var pr = JsonSerializer.Deserialize<PrStatusDto>(PrStatusJson, JsonOptions);
+
+            Assert.IsNotNull(pr);
+            Assert.AreEqual(42, pr.Number);
+            Assert.AreEqual("Add feature", pr.Title);
+            Assert.AreEqual("OPEN", pr.State);
+            Assert.AreEqual("MERGEABLE", pr.Mergeable);
+            Assert.AreEqual("CLEAN", pr.MergeStateStatus);
+            Assert.AreEqual("user", pr.Author.Login);
+            Assert.AreEqual("main", pr.BaseRefName);
+            Assert.AreEqual("feature", pr.HeadRefName);
+
+            Assert.AreEqual(1, pr.Labels.Count);
+            Assert.AreEqual("enhancement", pr.Labels[0].Name);
+
+            Assert.AreEqual(0, pr.Assignees.Count);
+            Assert.IsNull(pr.Milestone);
+
+            Assert.AreEqual(1, pr.StatusCheckRollup.Count);
+            Assert.AreEqual("CI", pr.StatusCheckRollup[0].Name);
+            Assert.AreEqual("COMPLETED", pr.StatusCheckRollup[0].Status);
+            Assert.AreEqual("SUCCESS", pr.StatusCheckRollup[0].Conclusion);
+
+            Assert.AreEqual(1, pr.Reviews.Count);
+            Assert.AreEqual("reviewer", pr.Reviews[0].Author.Login);
+            Assert.AreEqual("APPROVED", pr.Reviews[0].State);
+
+            Assert.AreEqual(5, pr.ChangedFiles);
+            Assert.AreEqual(100, pr.Additions);
+            Assert.AreEqual(50, pr.Deletions);
+        }
+
+        // ── CI checks JSON parsing ────────────────────────────
+
+        private const string CiChecksJson = @"[
+            {""name"": ""build"", ""status"": ""COMPLETED"", ""conclusion"": ""SUCCESS""},
+            {""name"": ""lint"", ""status"": ""COMPLETED"", ""conclusion"": ""SUCCESS""},
+            {""name"": ""test"", ""status"": ""IN_PROGRESS"", ""conclusion"": """"}
+        ]";
+
+        [Test]
+        public void ParseCIChecks_DeserializesAllEntries()
+        {
+            var checks = JsonSerializer.Deserialize<List<CheckDto>>(CiChecksJson, JsonOptions);
+
+            Assert.IsNotNull(checks);
+            Assert.AreEqual(3, checks.Count);
+
+            Assert.AreEqual("build", checks[0].Name);
+            Assert.AreEqual("COMPLETED", checks[0].Status);
+            Assert.AreEqual("SUCCESS", checks[0].Conclusion);
+
+            Assert.AreEqual("test", checks[2].Name);
+            Assert.AreEqual("IN_PROGRESS", checks[2].Status);
+            Assert.AreEqual("", checks[2].Conclusion);
+        }
+
+        // ── Auth / error handling ─────────────────────────────
+
+        [Test]
+        public void GhCliException_ContainsExitCodeAndStderr()
+        {
+            var ex = new GhCliException("gh failed", 1, "auth required");
+
+            Assert.AreEqual(1, ex.ExitCode);
+            Assert.AreEqual("auth required", ex.Stderr);
+            Assert.AreEqual("gh failed", ex.Message);
+        }
+
+        // ── Edge cases ────────────────────────────────────────
+
+        [Test]
+        public void ParseEmptyIssueList_ReturnsEmptyList()
+        {
+            var issues = JsonSerializer.Deserialize<List<IssueDto>>("[]", JsonOptions);
+
+            Assert.IsNotNull(issues);
+            Assert.AreEqual(0, issues.Count);
+        }
+
+        [Test]
+        public void ParsePrStatus_NullOptionalFields_HandledGracefully()
+        {
+            const string json = @"{
+                ""number"": 10,
+                ""title"": ""Minimal PR"",
+                ""state"": ""OPEN"",
+                ""url"": ""https://github.com/owner/repo/pull/10"",
+                ""mergeable"": ""UNKNOWN"",
+                ""mergeStateStatus"": ""BLOCKED"",
+                ""author"": {""login"": ""dev""},
+                ""baseRefName"": ""main"",
+                ""headRefName"": ""fix"",
+                ""labels"": [],
+                ""assignees"": [],
+                ""milestone"": null,
+                ""statusCheckRollup"": [],
+                ""reviews"": [],
+                ""reviewRequests"": [],
+                ""changedFiles"": 1,
+                ""additions"": 2,
+                ""deletions"": 0
+            }";
+
+            var pr = JsonSerializer.Deserialize<PrStatusDto>(json, JsonOptions);
+
+            Assert.IsNotNull(pr);
+            Assert.AreEqual(10, pr.Number);
+            Assert.IsNull(pr.Milestone);
+            Assert.AreEqual(0, pr.Labels.Count);
+            Assert.AreEqual(0, pr.StatusCheckRollup.Count);
+            Assert.AreEqual(0, pr.Reviews.Count);
+            Assert.AreEqual("UNKNOWN", pr.Mergeable);
+        }
+
+        [Test]
+        public void ParseIssue_WithEmptyOptionalFields_UsesDefaults()
+        {
+            const string json = @"{
+                ""number"": 99,
+                ""title"": ""Minimal issue"",
+                ""state"": ""CLOSED"",
+                ""url"": ""https://github.com/owner/repo/issues/99"",
+                ""body"": """",
+                ""updatedAt"": ""2024-06-01T00:00:00Z"",
+                ""labels"": [],
+                ""assignees"": [],
+                ""comments"": 0,
+                ""milestone"": null
+            }";
+
+            var issue = JsonSerializer.Deserialize<IssueDto>(json, JsonOptions);
+
+            Assert.IsNotNull(issue);
+            Assert.AreEqual(99, issue.Number);
+            Assert.AreEqual("CLOSED", issue.State);
+            Assert.AreEqual("", issue.Body);
+            Assert.IsNull(issue.Milestone);
+            Assert.AreEqual(0, issue.Labels.Count);
+        }
+
+        // ── Test DTOs mirroring gh CLI JSON structure ─────────
+        // These mirror the internal DTOs in GitHubService to test JSON
+        // parsing independently from the service layer.
+
+        private class LabelDto
+        {
+            [JsonPropertyName("name")]
+            public string Name { get; set; }
+
+            [JsonPropertyName("color")]
+            public string Color { get; set; }
+        }
+
+        private class UserDto
+        {
+            [JsonPropertyName("login")]
+            public string Login { get; set; }
+        }
+
+        private class MilestoneDto
+        {
+            [JsonPropertyName("title")]
+            public string Title { get; set; }
+
+            [JsonPropertyName("number")]
+            public int Number { get; set; }
+        }
+
+        private class IssueDto
+        {
+            [JsonPropertyName("number")]
+            public int Number { get; set; }
+
+            [JsonPropertyName("title")]
+            public string Title { get; set; }
+
+            [JsonPropertyName("updatedAt")]
+            public string UpdatedAt { get; set; }
+
+            [JsonPropertyName("labels")]
+            public List<LabelDto> Labels { get; set; } = new();
+
+            [JsonPropertyName("body")]
+            public string Body { get; set; }
+
+            [JsonPropertyName("state")]
+            public string State { get; set; }
+
+            [JsonPropertyName("url")]
+            public string Url { get; set; }
+
+            [JsonPropertyName("assignees")]
+            public List<UserDto> Assignees { get; set; } = new();
+
+            [JsonPropertyName("comments")]
+            public int Comments { get; set; }
+
+            [JsonPropertyName("milestone")]
+            public MilestoneDto Milestone { get; set; }
+        }
+
+        private class CheckDto
+        {
+            [JsonPropertyName("name")]
+            public string Name { get; set; }
+
+            [JsonPropertyName("status")]
+            public string Status { get; set; }
+
+            [JsonPropertyName("conclusion")]
+            public string Conclusion { get; set; }
+        }
+
+        private class ReviewDto
+        {
+            [JsonPropertyName("author")]
+            public UserDto Author { get; set; }
+
+            [JsonPropertyName("state")]
+            public string State { get; set; }
+        }
+
+        private class PrStatusDto
+        {
+            [JsonPropertyName("number")]
+            public int Number { get; set; }
+
+            [JsonPropertyName("title")]
+            public string Title { get; set; }
+
+            [JsonPropertyName("state")]
+            public string State { get; set; }
+
+            [JsonPropertyName("url")]
+            public string Url { get; set; }
+
+            [JsonPropertyName("mergeable")]
+            public string Mergeable { get; set; }
+
+            [JsonPropertyName("mergeStateStatus")]
+            public string MergeStateStatus { get; set; }
+
+            [JsonPropertyName("author")]
+            public UserDto Author { get; set; }
+
+            [JsonPropertyName("baseRefName")]
+            public string BaseRefName { get; set; }
+
+            [JsonPropertyName("headRefName")]
+            public string HeadRefName { get; set; }
+
+            [JsonPropertyName("labels")]
+            public List<LabelDto> Labels { get; set; } = new();
+
+            [JsonPropertyName("assignees")]
+            public List<UserDto> Assignees { get; set; } = new();
+
+            [JsonPropertyName("milestone")]
+            public MilestoneDto Milestone { get; set; }
+
+            [JsonPropertyName("statusCheckRollup")]
+            public List<CheckDto> StatusCheckRollup { get; set; } = new();
+
+            [JsonPropertyName("reviews")]
+            public List<ReviewDto> Reviews { get; set; } = new();
+
+            [JsonPropertyName("reviewRequests")]
+            public List<UserDto> ReviewRequests { get; set; } = new();
+
+            [JsonPropertyName("changedFiles")]
+            public int ChangedFiles { get; set; }
+
+            [JsonPropertyName("additions")]
+            public int Additions { get; set; }
+
+            [JsonPropertyName("deletions")]
+            public int Deletions { get; set; }
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitHubServiceTests.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitHubServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4e5f6a7b8c940d1e2f3a4b5c6d7e8f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/TerminalTests.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/TerminalTests.cs
@@ -1,0 +1,427 @@
+using NUnit.Framework;
+using Gwt.Core.Services.Terminal;
+
+namespace Gwt.Tests.Editor
+{
+    [TestFixture]
+    public class TerminalBufferTests
+    {
+        [Test]
+        public void PlainText_FillsBuffer()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("Hello");
+
+            Assert.AreEqual('H', emu.Buffer.GetCell(0, 0).Character);
+            Assert.AreEqual('e', emu.Buffer.GetCell(0, 1).Character);
+            Assert.AreEqual('l', emu.Buffer.GetCell(0, 2).Character);
+            Assert.AreEqual('l', emu.Buffer.GetCell(0, 3).Character);
+            Assert.AreEqual('o', emu.Buffer.GetCell(0, 4).Character);
+            Assert.AreEqual(0, emu.Buffer.CursorRow);
+            Assert.AreEqual(5, emu.Buffer.CursorCol);
+        }
+
+        [Test]
+        public void CursorMovement_CUP_MovesToPosition()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            // ESC[5;10H — move cursor to row 5, col 10 (1-based)
+            emu.Write("\x1b[5;10H");
+
+            Assert.AreEqual(4, emu.Buffer.CursorRow); // 0-based
+            Assert.AreEqual(9, emu.Buffer.CursorCol); // 0-based
+        }
+
+        [Test]
+        public void SGR_SetRedForeground()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[31mA");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual('A', cell.Character);
+            Assert.AreEqual(1, cell.ForegroundColor); // Red = ANSI color 1
+        }
+
+        [Test]
+        public void SGR_Reset_RestoresDefaults()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[31;1m");  // Red + Bold
+            emu.Write("\x1b[0m");     // Reset
+            emu.Write("A");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual('A', cell.Character);
+            Assert.AreEqual(7, cell.ForegroundColor); // Default white
+            Assert.AreEqual(0, cell.BackgroundColor); // Default black
+            Assert.IsFalse(cell.Bold);
+        }
+
+        [Test]
+        public void LineWrapping_AtColumnBoundary()
+        {
+            var emu = new TerminalEmulator(24, 5);
+            emu.Write("ABCDE");  // Fills row 0 exactly
+            emu.Write("F");      // Should wrap to row 1
+
+            Assert.AreEqual('E', emu.Buffer.GetCell(0, 4).Character);
+            Assert.AreEqual('F', emu.Buffer.GetCell(1, 0).Character);
+            Assert.AreEqual(1, emu.Buffer.CursorRow);
+            Assert.AreEqual(1, emu.Buffer.CursorCol);
+        }
+
+        [Test]
+        public void ScrollUp_WhenWritingPastLastRow()
+        {
+            var emu = new TerminalEmulator(3, 5);
+            emu.Write("Line1\n");
+            emu.Write("Line2\n");
+            emu.Write("Line3\n");
+            // Line1 should have scrolled into scrollback
+            // Screen should now have Line2, Line3, empty
+
+            Assert.AreEqual(1, emu.Buffer.ScrollbackLines);
+            // Line2 is now at row 0
+            Assert.AreEqual('L', emu.Buffer.GetCell(0, 0).Character);
+        }
+
+        [Test]
+        public void ScrollbackBuffer_AccumulatesLines()
+        {
+            var emu = new TerminalEmulator(2, 10);
+            emu.Write("AAA\n");
+            emu.Write("BBB\n");
+            emu.Write("CCC\n");
+
+            Assert.IsTrue(emu.Buffer.ScrollbackLines >= 2);
+        }
+
+        [Test]
+        public void ClearScreen_ErasesAllCells()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("Hello World");
+            emu.Write("\x1b[2J"); // Clear screen
+
+            Assert.AreEqual(' ', emu.Buffer.GetCell(0, 0).Character);
+            Assert.AreEqual(' ', emu.Buffer.GetCell(0, 5).Character);
+        }
+
+        [Test]
+        public void ClearToEndOfLine()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("Hello World");
+            emu.Write("\x1b[1;6H"); // Move to row 1, col 6 (after "Hello")
+            emu.Write("\x1b[K");    // Clear to end of line
+
+            Assert.AreEqual('H', emu.Buffer.GetCell(0, 0).Character);
+            Assert.AreEqual('o', emu.Buffer.GetCell(0, 4).Character);
+            Assert.AreEqual(' ', emu.Buffer.GetCell(0, 5).Character); // Cleared
+            Assert.AreEqual(' ', emu.Buffer.GetCell(0, 6).Character); // Cleared
+        }
+
+        [Test]
+        public void AlternateScreenBuffer_Toggle()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("Main");
+
+            // Switch to alternate screen
+            emu.Write("\x1b[?1049h");
+            Assert.AreEqual(' ', emu.Buffer.GetCell(0, 0).Character); // Alternate is clear
+            Assert.AreEqual(0, emu.Buffer.CursorRow);
+
+            emu.Write("Alt");
+
+            // Switch back to main screen
+            emu.Write("\x1b[?1049l");
+            Assert.AreEqual('M', emu.Buffer.GetCell(0, 0).Character); // Main restored
+            Assert.AreEqual('a', emu.Buffer.GetCell(0, 1).Character);
+        }
+
+        [Test]
+        public void Color256_Support()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            // ESC[38;5;196m — set foreground to color 196
+            emu.Write("\x1b[38;5;196mA");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual('A', cell.Character);
+            Assert.AreEqual(196, cell.ForegroundColor);
+        }
+
+        [Test]
+        public void BufferResize_PreservesContent()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("Hello");
+
+            emu.Resize(30, 120);
+
+            Assert.AreEqual(30, emu.Rows);
+            Assert.AreEqual(120, emu.Cols);
+            Assert.AreEqual('H', emu.Buffer.GetCell(0, 0).Character);
+            Assert.AreEqual('o', emu.Buffer.GetCell(0, 4).Character);
+        }
+
+        [Test]
+        public void BufferResize_ShrinkPreservesVisibleContent()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("AB");
+
+            emu.Resize(10, 40);
+
+            Assert.AreEqual(10, emu.Rows);
+            Assert.AreEqual(40, emu.Cols);
+            Assert.AreEqual('A', emu.Buffer.GetCell(0, 0).Character);
+            Assert.AreEqual('B', emu.Buffer.GetCell(0, 1).Character);
+        }
+
+        [Test]
+        public void CatppuccinTheme_ColorsAreValid()
+        {
+            Assert.AreEqual(16, CatppuccinTheme.Colors.Length);
+
+            foreach (var color in CatppuccinTheme.Colors)
+            {
+                Assert.GreaterOrEqual(color.r, 0f);
+                Assert.LessOrEqual(color.r, 1f);
+                Assert.GreaterOrEqual(color.g, 0f);
+                Assert.LessOrEqual(color.g, 1f);
+                Assert.GreaterOrEqual(color.b, 0f);
+                Assert.LessOrEqual(color.b, 1f);
+                Assert.AreEqual(1f, color.a);
+            }
+
+            // Background and foreground should be valid
+            Assert.AreEqual(1f, CatppuccinTheme.Background.a);
+            Assert.AreEqual(1f, CatppuccinTheme.Foreground.a);
+            Assert.AreEqual(1f, CatppuccinTheme.CursorColor.a);
+        }
+
+        [Test]
+        public void CursorMovement_CUU_MovesUp()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[5;5H");  // Row 5, Col 5
+            emu.Write("\x1b[2A");    // Move up 2
+
+            Assert.AreEqual(2, emu.Buffer.CursorRow); // 4 - 2 = 2
+        }
+
+        [Test]
+        public void CursorMovement_CUD_MovesDown()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[5;5H");
+            emu.Write("\x1b[3B");    // Move down 3
+
+            Assert.AreEqual(7, emu.Buffer.CursorRow); // 4 + 3 = 7
+        }
+
+        [Test]
+        public void CursorMovement_CUF_MovesForward()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[1;1H");
+            emu.Write("\x1b[10C");   // Move forward 10
+
+            Assert.AreEqual(10, emu.Buffer.CursorCol); // 0 + 10 = 10
+        }
+
+        [Test]
+        public void CursorMovement_CUB_MovesBack()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[1;20H");
+            emu.Write("\x1b[5D");    // Move back 5
+
+            Assert.AreEqual(14, emu.Buffer.CursorCol); // 19 - 5 = 14
+        }
+
+        [Test]
+        public void SGR_BoldAttribute()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[1mB");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual('B', cell.Character);
+            Assert.IsTrue(cell.Bold);
+        }
+
+        [Test]
+        public void SGR_ItalicAttribute()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[3mI");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual('I', cell.Character);
+            Assert.IsTrue(cell.Italic);
+        }
+
+        [Test]
+        public void SGR_UnderlineAttribute()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[4mU");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual('U', cell.Character);
+            Assert.IsTrue(cell.Underline);
+        }
+
+        [Test]
+        public void SGR_InverseAttribute()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[7mR");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual('R', cell.Character);
+            Assert.IsTrue(cell.Inverse);
+            // Inverse swaps fg/bg during write
+            Assert.AreEqual(0, cell.ForegroundColor); // Was bg (0)
+            Assert.AreEqual(7, cell.BackgroundColor); // Was fg (7)
+        }
+
+        [Test]
+        public void SGR_BrightColors()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[91mA"); // Bright red foreground
+            emu.Write("\x1b[102mB"); // Bright green background
+
+            var cellA = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual(9, cellA.ForegroundColor); // Bright red = 8 + 1
+
+            var cellB = emu.Buffer.GetCell(0, 1);
+            Assert.AreEqual(10, cellB.BackgroundColor); // Bright green = 8 + 2
+        }
+
+        [Test]
+        public void SGR_BackgroundColor()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[44mA"); // Blue background
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual(4, cell.BackgroundColor);
+        }
+
+        [Test]
+        public void NewlineAndCarriageReturn()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("AB\r\nCD");
+
+            Assert.AreEqual('A', emu.Buffer.GetCell(0, 0).Character);
+            Assert.AreEqual('B', emu.Buffer.GetCell(0, 1).Character);
+            Assert.AreEqual('C', emu.Buffer.GetCell(1, 0).Character);
+            Assert.AreEqual('D', emu.Buffer.GetCell(1, 1).Character);
+        }
+
+        [Test]
+        public void OSC_WindowTitle()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            string receivedTitle = null;
+            emu.TitleChanged += t => receivedTitle = t;
+
+            emu.Write("\x1b]0;My Terminal\a");
+
+            Assert.AreEqual("My Terminal", receivedTitle);
+        }
+
+        [Test]
+        public void GetTextContent_ExtractsText()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("Hello World");
+
+            string text = emu.GetSelectedText(0, 0, 0, 4);
+            Assert.AreEqual("Hello", text);
+        }
+
+        [Test]
+        public void ScrollDown_ShiftsScreenDown()
+        {
+            var emu = new TerminalEmulator(3, 10);
+            emu.Write("AAA\nBBB\nCCC");
+
+            emu.Write("\x1b[T"); // Scroll down 1
+
+            // Top line should be empty after scroll down
+            Assert.AreEqual(' ', emu.Buffer.GetCell(0, 0).Character);
+            // AAA should now be at row 1
+            Assert.AreEqual('A', emu.Buffer.GetCell(1, 0).Character);
+        }
+
+        [Test]
+        public void CursorSaveRestore()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[5;10H"); // Move to 5,10
+            emu.Write("\x1b[s");     // Save
+            emu.Write("\x1b[1;1H");  // Move to 1,1
+            emu.Write("\x1b[u");     // Restore
+
+            Assert.AreEqual(4, emu.Buffer.CursorRow);
+            Assert.AreEqual(9, emu.Buffer.CursorCol);
+        }
+
+        [Test]
+        public void Color256_BackgroundSupport()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[48;5;42mA");
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.AreEqual(42, cell.BackgroundColor);
+        }
+
+        [Test]
+        public void EraseLine_EntireLine()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("Hello World");
+            emu.Write("\x1b[1;6H");  // Position in middle
+            emu.Write("\x1b[2K");    // Erase entire line
+
+            for (int c = 0; c < 80; c++)
+            {
+                Assert.AreEqual(' ', emu.Buffer.GetCell(0, c).Character);
+            }
+        }
+
+        [Test]
+        public void MultipleSGR_InOneSequence()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            emu.Write("\x1b[1;3;31mA"); // Bold + Italic + Red
+
+            var cell = emu.Buffer.GetCell(0, 0);
+            Assert.IsTrue(cell.Bold);
+            Assert.IsTrue(cell.Italic);
+            Assert.AreEqual(1, cell.ForegroundColor);
+        }
+
+        [Test]
+        public void BufferChanged_EventFires()
+        {
+            var emu = new TerminalEmulator(24, 80);
+            int fireCount = 0;
+            emu.BufferChanged += () => fireCount++;
+
+            emu.Write("A");
+            emu.Write("B");
+
+            Assert.AreEqual(2, fireCount);
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/TerminalTests.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/TerminalTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30dcb57f5ba34ef9885780c0eb92234f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Implement lightweight ANSI terminal emulator engine for Unity (TerminalBuffer + AnsiParser + TerminalEmulator)
- Support CSI sequences (cursor movement, erase, scroll, SGR colors/attributes, alternate screen buffer)
- Include Catppuccin Mocha 16-color theme palette and VContainer installer stub
- Add 30 NUnit editor tests covering all ANSI parser features

## Files

- `Core/Services/Terminal/TerminalBuffer.cs` — Character grid buffer with scrollback
- `Core/Services/Terminal/AnsiParser.cs` — ANSI escape sequence state machine parser
- `Core/Services/Terminal/CatppuccinTheme.cs` — Catppuccin Mocha color palette
- `Core/Services/Terminal/TerminalEmulator.cs` — High-level terminal API
- `Core/Installers/GwtCoreTerminalInstaller.cs` — VContainer installer
- `Tests/Editor/TerminalTests.cs` — 30 NUnit tests

## Test plan

- [ ] Verify all 30 NUnit tests pass in Unity Test Runner
- [ ] Confirm ANSI sequence parsing: cursor movement, SGR colors, erase, scroll
- [ ] Verify alternate screen buffer toggle (ESC[?1049h/l)
- [ ] Confirm 256-color support and Catppuccin theme validity
- [ ] Verify buffer resize preserves content

🤖 Generated with [Claude Code](https://claude.com/claude-code)