### PR TITLE
feat(unity): add Core Git service (#1543)

### DIFF
--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitInstaller.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitInstaller.cs
@@ -1,0 +1,14 @@
+using Gwt.Shared;
+using VContainer;
+
+namespace Gwt.Core.Installers
+{
+    public class GwtCoreGitInstaller : IGwtInstaller
+    {
+        public void Install(IContainerBuilder builder)
+        {
+            builder.Register<Services.Git.GitCommandRunner>(Lifetime.Singleton);
+            builder.Register<Services.Git.GitService>(Lifetime.Singleton).As<Services.Git.IGitService>();
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitInstaller.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Installers/GwtCoreGitInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01fcf41d12d841bf8916c7b7dbd6db7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitCommandRunner.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitCommandRunner.cs
@@ -1,0 +1,66 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace Gwt.Core.Services.Git
+{
+    public class GitCommandRunner
+    {
+        public async UniTask<(string stdout, string stderr, int exitCode)> RunAsync(
+            string args, string workingDir, CancellationToken ct = default, int timeoutMs = 30000)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = args,
+                WorkingDirectory = workingDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
+            };
+
+            using var process = new Process { StartInfo = psi };
+            var stdoutBuilder = new StringBuilder();
+            var stderrBuilder = new StringBuilder();
+
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) stdoutBuilder.AppendLine(e.Data);
+            };
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) stderrBuilder.AppendLine(e.Data);
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            using var timeoutCts = new CancellationTokenSource(timeoutMs);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+            try
+            {
+                while (!process.HasExited)
+                {
+                    linkedCts.Token.ThrowIfCancellationRequested();
+                    await UniTask.Delay(50, cancellationToken: linkedCts.Token);
+                }
+
+                process.WaitForExit();
+            }
+            catch (OperationCanceledException)
+            {
+                try { if (!process.HasExited) process.Kill(); } catch { }
+                throw;
+            }
+
+            return (stdoutBuilder.ToString(), stderrBuilder.ToString(), process.ExitCode);
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitCommandRunner.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitCommandRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1406f1a2ebaf49379c34a380cc291e8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitService.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitService.cs
@@ -1,0 +1,489 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Gwt.Core.Models;
+
+namespace Gwt.Core.Services.Git
+{
+    public interface IGitService
+    {
+        UniTask<List<Worktree>> ListWorktreesAsync(string repoPath, CancellationToken ct = default);
+        UniTask<string> CreateWorktreeAsync(string repoPath, string worktreePath, string branch, CancellationToken ct = default);
+        UniTask DeleteWorktreeAsync(string repoPath, string worktreePath, bool force = false, CancellationToken ct = default);
+        UniTask<List<BranchInfo>> ListBranchesAsync(string repoPath, CancellationToken ct = default);
+        UniTask<string> GetCurrentBranchAsync(string repoPath, CancellationToken ct = default);
+        UniTask<ChangeSummary> GetChangeSummaryAsync(string repoPath, CancellationToken ct = default);
+        UniTask<List<CommitEntry>> GetCommitsAsync(string repoPath, string branch = null, int limit = 10, CancellationToken ct = default);
+        UniTask<ChangeStats> GetChangeStatsAsync(string repoPath, CancellationToken ct = default);
+        UniTask<BranchMeta> GetBranchMetaAsync(string repoPath, string branch = null, CancellationToken ct = default);
+        UniTask<List<FileStatusEntry>> GetWorkingTreeStatusAsync(string repoPath, CancellationToken ct = default);
+        UniTask<List<CleanupCandidate>> GetCleanupCandidatesAsync(string repoPath, CancellationToken ct = default);
+        UniTask<RepoType> GetRepoTypeAsync(string path, CancellationToken ct = default);
+        UniTask<string> GetDiffAsync(string repoPath, bool cached = false, string file = null, CancellationToken ct = default);
+        UniTask<List<StashEntry>> GetStashListAsync(string repoPath, CancellationToken ct = default);
+        UniTask<List<string>> GetBaseBranchCandidatesAsync(string repoPath, CancellationToken ct = default);
+        UniTask<List<string>> GetTagsAsync(string repoPath, CancellationToken ct = default);
+    }
+
+    [Serializable]
+    public class BranchInfo
+    {
+        public string Name;
+        public string Commit;
+        public string Upstream;
+        public string TrackingStatus;
+        public bool IsRemote;
+    }
+
+    [Serializable]
+    public class CommitEntry
+    {
+        public string Hash;
+        public string Message;
+    }
+
+    [Serializable]
+    public class ChangeStats
+    {
+        public int FilesChanged;
+        public int Insertions;
+        public int Deletions;
+        public bool HasUncommitted;
+        public bool HasUnpushed;
+    }
+
+    [Serializable]
+    public class BranchMeta
+    {
+        public string Upstream;
+        public int Ahead;
+        public int Behind;
+        public string BaseBranch;
+    }
+
+    [Serializable]
+    public class ChangeSummary
+    {
+        public int StagedFiles;
+        public int UnstagedFiles;
+        public List<FileStatusEntry> Files = new();
+    }
+
+    [Serializable]
+    public class FileStatusEntry
+    {
+        public char IndexStatus;
+        public char WorktreeStatus;
+        public string FilePath;
+    }
+
+    [Serializable]
+    public class StashEntry
+    {
+        public int Index;
+        public string Message;
+    }
+
+    public class GitService : IGitService
+    {
+        private readonly GitCommandRunner _runner;
+
+        public GitService(GitCommandRunner runner)
+        {
+            _runner = runner;
+        }
+
+        public async UniTask<List<Worktree>> ListWorktreesAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (stdout, _, _) = await _runner.RunAsync("worktree list --porcelain", repoPath, ct);
+            return ParseWorktreeList(stdout);
+        }
+
+        public async UniTask<string> CreateWorktreeAsync(string repoPath, string worktreePath, string branch, CancellationToken ct = default)
+        {
+            var (stdout, stderr, exitCode) = await _runner.RunAsync(
+                $"worktree add \"{worktreePath}\" -b \"{branch}\"", repoPath, ct);
+            if (exitCode != 0)
+                throw new InvalidOperationException($"Failed to create worktree: {stderr.Trim()}");
+            return stdout.Trim();
+        }
+
+        public async UniTask DeleteWorktreeAsync(string repoPath, string worktreePath, bool force = false, CancellationToken ct = default)
+        {
+            var forceFlag = force ? " --force" : "";
+            var (_, stderr, exitCode) = await _runner.RunAsync(
+                $"worktree remove \"{worktreePath}\"{forceFlag}", repoPath, ct);
+            if (exitCode != 0)
+                throw new InvalidOperationException($"Failed to delete worktree: {stderr.Trim()}");
+        }
+
+        public async UniTask<List<BranchInfo>> ListBranchesAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (stdout, _, _) = await _runner.RunAsync(
+                "branch -a --format=%(refname:short)|%(objectname:short)|%(upstream:short)|%(upstream:track)", repoPath, ct);
+            return ParseBranchList(stdout);
+        }
+
+        public async UniTask<string> GetCurrentBranchAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (stdout, _, exitCode) = await _runner.RunAsync("rev-parse --abbrev-ref HEAD", repoPath, ct);
+            if (exitCode != 0) return null;
+            var name = stdout.Trim();
+            return name == "HEAD" ? null : name;
+        }
+
+        public async UniTask<ChangeSummary> GetChangeSummaryAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (stdout, _, _) = await _runner.RunAsync("status --porcelain", repoPath, ct);
+            return ParseChangeSummary(stdout);
+        }
+
+        public async UniTask<List<CommitEntry>> GetCommitsAsync(string repoPath, string branch = null, int limit = 10, CancellationToken ct = default)
+        {
+            var branchArg = string.IsNullOrEmpty(branch) ? "" : $" {branch}";
+            var (stdout, _, _) = await _runner.RunAsync($"log --format=%H|%s -n {limit}{branchArg}", repoPath, ct);
+            return ParseCommitLog(stdout);
+        }
+
+        public async UniTask<ChangeStats> GetChangeStatsAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (shortstat, _, _) = await _runner.RunAsync("diff --shortstat", repoPath, ct);
+            var stats = ParseShortStat(shortstat);
+
+            var (statusOut, _, _) = await _runner.RunAsync("status --porcelain", repoPath, ct);
+            stats.HasUncommitted = !string.IsNullOrWhiteSpace(statusOut);
+
+            var (aheadOut, _, exitCode) = await _runner.RunAsync("rev-list @{u}..HEAD --count", repoPath, ct);
+            if (exitCode == 0 && int.TryParse(aheadOut.Trim(), out var ahead))
+                stats.HasUnpushed = ahead > 0;
+
+            return stats;
+        }
+
+        public async UniTask<BranchMeta> GetBranchMetaAsync(string repoPath, string branch = null, CancellationToken ct = default)
+        {
+            var meta = new BranchMeta();
+
+            var branchName = branch;
+            if (string.IsNullOrEmpty(branchName))
+                branchName = await GetCurrentBranchAsync(repoPath, ct);
+            if (string.IsNullOrEmpty(branchName))
+                return meta;
+
+            var (upstreamOut, _, upstreamExit) = await _runner.RunAsync(
+                $"config --get branch.{branchName}.remote", repoPath, ct);
+            if (upstreamExit == 0)
+            {
+                var remote = upstreamOut.Trim();
+                var (mergeOut, _, mergeExit) = await _runner.RunAsync(
+                    $"config --get branch.{branchName}.merge", repoPath, ct);
+                if (mergeExit == 0)
+                {
+                    var mergeBranch = mergeOut.Trim().Replace("refs/heads/", "");
+                    meta.Upstream = $"{remote}/{mergeBranch}";
+                }
+            }
+
+            var (aheadOut, _, aheadExit) = await _runner.RunAsync(
+                $"rev-list @{{u}}..HEAD --count", repoPath, ct);
+            if (aheadExit == 0 && int.TryParse(aheadOut.Trim(), out var ahead))
+                meta.Ahead = ahead;
+
+            var (behindOut, _, behindExit) = await _runner.RunAsync(
+                $"rev-list HEAD..@{{u}} --count", repoPath, ct);
+            if (behindExit == 0 && int.TryParse(behindOut.Trim(), out var behind))
+                meta.Behind = behind;
+
+            return meta;
+        }
+
+        public async UniTask<List<FileStatusEntry>> GetWorkingTreeStatusAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (stdout, _, _) = await _runner.RunAsync("status --porcelain", repoPath, ct);
+            return ParseStatusPorcelain(stdout);
+        }
+
+        public async UniTask<List<CleanupCandidate>> GetCleanupCandidatesAsync(string repoPath, CancellationToken ct = default)
+        {
+            var worktrees = await ListWorktreesAsync(repoPath, ct);
+            var candidates = new List<CleanupCandidate>();
+            foreach (var wt in worktrees)
+            {
+                if (wt.Status == WorktreeStatus.Prunable || wt.Status == WorktreeStatus.Missing)
+                {
+                    candidates.Add(new CleanupCandidate
+                    {
+                        Path = wt.Path,
+                        Branch = wt.Branch,
+                        Reason = wt.Status == WorktreeStatus.Missing
+                            ? CleanupReason.PathMissing
+                            : CleanupReason.Orphaned
+                    });
+                }
+            }
+            return candidates;
+        }
+
+        public async UniTask<RepoType> GetRepoTypeAsync(string path, CancellationToken ct = default)
+        {
+            var (_, _, revParseExit) = await _runner.RunAsync("rev-parse --git-dir", path, ct);
+            if (revParseExit != 0)
+            {
+                if (!System.IO.Directory.Exists(path))
+                    return RepoType.NonRepo;
+                var entries = System.IO.Directory.GetFileSystemEntries(path);
+                return entries.Length == 0 ? RepoType.Empty : RepoType.NonRepo;
+            }
+
+            var (bareOut, _, bareExit) = await _runner.RunAsync("rev-parse --is-bare-repository", path, ct);
+            if (bareExit == 0 && bareOut.Trim() == "true")
+                return RepoType.Bare;
+
+            var gitPath = System.IO.Path.Combine(path, ".git");
+            if (System.IO.File.Exists(gitPath))
+                return RepoType.Worktree;
+
+            return RepoType.Normal;
+        }
+
+        public async UniTask<string> GetDiffAsync(string repoPath, bool cached = false, string file = null, CancellationToken ct = default)
+        {
+            var args = "diff";
+            if (cached) args += " --cached";
+            if (!string.IsNullOrEmpty(file)) args += $" -- \"{file}\"";
+            var (stdout, _, _) = await _runner.RunAsync(args, repoPath, ct);
+            return stdout;
+        }
+
+        public async UniTask<List<StashEntry>> GetStashListAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (stdout, _, _) = await _runner.RunAsync("stash list", repoPath, ct);
+            return ParseStashList(stdout);
+        }
+
+        public async UniTask<List<string>> GetBaseBranchCandidatesAsync(string repoPath, CancellationToken ct = default)
+        {
+            var candidates = new List<string>();
+            var defaultBranches = new[] { "main", "master", "develop" };
+            foreach (var branch in defaultBranches)
+            {
+                var (_, _, exitCode) = await _runner.RunAsync($"rev-parse --verify {branch}", repoPath, ct);
+                if (exitCode == 0)
+                    candidates.Add(branch);
+            }
+            return candidates;
+        }
+
+        public async UniTask<List<string>> GetTagsAsync(string repoPath, CancellationToken ct = default)
+        {
+            var (stdout, _, _) = await _runner.RunAsync("tag --sort=-v:refname", repoPath, ct);
+            return ParseLines(stdout);
+        }
+
+        // --- Parsing helpers (internal for testability) ---
+
+        internal static List<Worktree> ParseWorktreeList(string output)
+        {
+            var worktrees = new List<Worktree>();
+            if (string.IsNullOrWhiteSpace(output)) return worktrees;
+
+            Worktree current = null;
+            foreach (var rawLine in output.Split('\n'))
+            {
+                var line = rawLine.Trim();
+                if (line.StartsWith("worktree "))
+                {
+                    current = new Worktree();
+                    current.Path = line.Substring("worktree ".Length);
+                    worktrees.Add(current);
+                }
+                else if (current != null && line.StartsWith("HEAD "))
+                {
+                    current.Commit = line.Substring("HEAD ".Length);
+                }
+                else if (current != null && line.StartsWith("branch "))
+                {
+                    var refName = line.Substring("branch ".Length);
+                    current.Branch = refName.StartsWith("refs/heads/")
+                        ? refName.Substring("refs/heads/".Length)
+                        : refName;
+                }
+                else if (current != null && line == "prunable")
+                {
+                    current.Status = WorktreeStatus.Prunable;
+                }
+                else if (current != null && line == "locked")
+                {
+                    current.Status = WorktreeStatus.Locked;
+                }
+                else if (current != null && line == "bare")
+                {
+                    current.IsMain = true;
+                }
+            }
+
+            // Mark the first worktree as main if not already set
+            if (worktrees.Count > 0 && !worktrees.Any(w => w.IsMain))
+                worktrees[0].IsMain = true;
+
+            return worktrees;
+        }
+
+        internal static List<BranchInfo> ParseBranchList(string output)
+        {
+            var branches = new List<BranchInfo>();
+            if (string.IsNullOrWhiteSpace(output)) return branches;
+
+            foreach (var rawLine in output.Split('\n'))
+            {
+                var line = rawLine.Trim();
+                if (string.IsNullOrEmpty(line)) continue;
+
+                var parts = line.Split('|');
+                var branch = new BranchInfo
+                {
+                    Name = parts.Length > 0 ? parts[0] : "",
+                    Commit = parts.Length > 1 ? parts[1] : "",
+                    Upstream = parts.Length > 2 ? parts[2] : "",
+                    TrackingStatus = parts.Length > 3 ? parts[3] : ""
+                };
+                branch.IsRemote = branch.Name.StartsWith("origin/")
+                    || branch.Name.Contains("/");
+                branches.Add(branch);
+            }
+            return branches;
+        }
+
+        internal static List<CommitEntry> ParseCommitLog(string output)
+        {
+            var commits = new List<CommitEntry>();
+            if (string.IsNullOrWhiteSpace(output)) return commits;
+
+            foreach (var rawLine in output.Split('\n'))
+            {
+                var line = rawLine.Trim();
+                if (string.IsNullOrEmpty(line)) continue;
+
+                var sepIndex = line.IndexOf('|');
+                if (sepIndex > 0)
+                {
+                    commits.Add(new CommitEntry
+                    {
+                        Hash = line.Substring(0, sepIndex),
+                        Message = line.Substring(sepIndex + 1)
+                    });
+                }
+                else
+                {
+                    commits.Add(new CommitEntry { Hash = line, Message = "" });
+                }
+            }
+            return commits;
+        }
+
+        internal static ChangeStats ParseShortStat(string output)
+        {
+            var stats = new ChangeStats();
+            if (string.IsNullOrWhiteSpace(output)) return stats;
+
+            var line = output.Trim();
+            stats.FilesChanged = ExtractNumber(line, "file");
+            stats.Insertions = ExtractNumber(line, "insertion");
+            stats.Deletions = ExtractNumber(line, "deletion");
+            return stats;
+        }
+
+        internal static ChangeSummary ParseChangeSummary(string output)
+        {
+            var summary = new ChangeSummary();
+            if (string.IsNullOrWhiteSpace(output)) return summary;
+
+            foreach (var rawLine in output.Split('\n'))
+            {
+                if (rawLine.Length < 3) continue;
+                var entry = new FileStatusEntry
+                {
+                    IndexStatus = rawLine[0],
+                    WorktreeStatus = rawLine[1],
+                    FilePath = rawLine.Substring(3)
+                };
+                summary.Files.Add(entry);
+
+                if (entry.IndexStatus != ' ' && entry.IndexStatus != '?')
+                    summary.StagedFiles++;
+                if (entry.WorktreeStatus != ' ' && entry.WorktreeStatus != '?')
+                    summary.UnstagedFiles++;
+                if (entry.IndexStatus == '?' && entry.WorktreeStatus == '?')
+                    summary.UnstagedFiles++;
+            }
+            return summary;
+        }
+
+        internal static List<FileStatusEntry> ParseStatusPorcelain(string output)
+        {
+            var entries = new List<FileStatusEntry>();
+            if (string.IsNullOrWhiteSpace(output)) return entries;
+
+            foreach (var rawLine in output.Split('\n'))
+            {
+                if (rawLine.Length < 3) continue;
+                entries.Add(new FileStatusEntry
+                {
+                    IndexStatus = rawLine[0],
+                    WorktreeStatus = rawLine[1],
+                    FilePath = rawLine.Substring(3)
+                });
+            }
+            return entries;
+        }
+
+        internal static List<StashEntry> ParseStashList(string output)
+        {
+            var stashes = new List<StashEntry>();
+            if (string.IsNullOrWhiteSpace(output)) return stashes;
+
+            var index = 0;
+            foreach (var rawLine in output.Split('\n'))
+            {
+                var line = rawLine.Trim();
+                if (string.IsNullOrEmpty(line)) continue;
+
+                // Format: stash@{0}: WIP on branch: message
+                var colonIndex = line.IndexOf(':');
+                var message = colonIndex >= 0 ? line.Substring(colonIndex + 1).Trim() : line;
+                stashes.Add(new StashEntry { Index = index++, Message = message });
+            }
+            return stashes;
+        }
+
+        private static List<string> ParseLines(string output)
+        {
+            var lines = new List<string>();
+            if (string.IsNullOrWhiteSpace(output)) return lines;
+
+            foreach (var rawLine in output.Split('\n'))
+            {
+                var line = rawLine.Trim();
+                if (!string.IsNullOrEmpty(line))
+                    lines.Add(line);
+            }
+            return lines;
+        }
+
+        private static int ExtractNumber(string line, string keyword)
+        {
+            var parts = line.Split(',');
+            foreach (var part in parts)
+            {
+                var trimmed = part.Trim();
+                if (!trimmed.Contains(keyword)) continue;
+                var words = trimmed.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (words.Length > 0 && int.TryParse(words[0], out var num))
+                    return num;
+            }
+            return 0;
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitService.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Core/Services/Git/GitService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 621eb123fce648198d6fcda30f1cc6a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitServiceTests.cs
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitServiceTests.cs
@@ -1,0 +1,350 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using Gwt.Core.Models;
+using Gwt.Core.Services.Git;
+
+namespace Gwt.Tests.Editor
+{
+    [TestFixture]
+    public class GitServiceTests
+    {
+        // --- Worktree list parsing ---
+
+        [Test]
+        public void ParseWorktreeList_BasicOutput_ParsesCorrectly()
+        {
+            var output =
+                "worktree /path/to/main\n" +
+                "HEAD abc1234567890abcdef1234567890abcdef123456\n" +
+                "branch refs/heads/main\n" +
+                "\n" +
+                "worktree /path/to/feature\n" +
+                "HEAD def4567890abcdef1234567890abcdef12345678\n" +
+                "branch refs/heads/feature/test\n" +
+                "\n";
+
+            var result = GitService.ParseWorktreeList(output);
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.AreEqual("/path/to/main", result[0].Path);
+            Assert.AreEqual("abc1234567890abcdef1234567890abcdef123456", result[0].Commit);
+            Assert.AreEqual("main", result[0].Branch);
+            Assert.IsTrue(result[0].IsMain);
+
+            Assert.AreEqual("/path/to/feature", result[1].Path);
+            Assert.AreEqual("def4567890abcdef1234567890abcdef12345678", result[1].Commit);
+            Assert.AreEqual("feature/test", result[1].Branch);
+            Assert.IsFalse(result[1].IsMain);
+        }
+
+        [Test]
+        public void ParseWorktreeList_PrunableWorktree_SetsStatus()
+        {
+            var output =
+                "worktree /path/to/main\n" +
+                "HEAD abc123\n" +
+                "branch refs/heads/main\n" +
+                "\n" +
+                "worktree /path/to/prunable\n" +
+                "HEAD def456\n" +
+                "branch refs/heads/old-branch\n" +
+                "prunable\n" +
+                "\n";
+
+            var result = GitService.ParseWorktreeList(output);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(WorktreeStatus.Prunable, result[1].Status);
+        }
+
+        [Test]
+        public void ParseWorktreeList_LockedWorktree_SetsStatus()
+        {
+            var output =
+                "worktree /path/to/main\n" +
+                "HEAD abc123\n" +
+                "branch refs/heads/main\n" +
+                "\n" +
+                "worktree /path/to/locked\n" +
+                "HEAD def456\n" +
+                "branch refs/heads/locked-branch\n" +
+                "locked\n" +
+                "\n";
+
+            var result = GitService.ParseWorktreeList(output);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(WorktreeStatus.Locked, result[1].Status);
+        }
+
+        [Test]
+        public void ParseWorktreeList_BareRepo_SetsIsMain()
+        {
+            var output =
+                "worktree /path/to/repo.git\n" +
+                "HEAD abc123\n" +
+                "bare\n" +
+                "\n" +
+                "worktree /path/to/feature\n" +
+                "HEAD def456\n" +
+                "branch refs/heads/feature\n" +
+                "\n";
+
+            var result = GitService.ParseWorktreeList(output);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result[0].IsMain);
+        }
+
+        [Test]
+        public void ParseWorktreeList_EmptyOutput_ReturnsEmpty()
+        {
+            Assert.AreEqual(0, GitService.ParseWorktreeList("").Count);
+            Assert.AreEqual(0, GitService.ParseWorktreeList(null).Count);
+            Assert.AreEqual(0, GitService.ParseWorktreeList("  ").Count);
+        }
+
+        // --- Branch list parsing ---
+
+        [Test]
+        public void ParseBranchList_StandardOutput_ParsesCorrectly()
+        {
+            var output =
+                "main|abc1234|origin/main|[ahead 1]\n" +
+                "feature/test|def5678|origin/feature/test|\n" +
+                "origin/main|abc1234||\n";
+
+            var result = GitService.ParseBranchList(output);
+
+            Assert.AreEqual(3, result.Count);
+
+            Assert.AreEqual("main", result[0].Name);
+            Assert.AreEqual("abc1234", result[0].Commit);
+            Assert.AreEqual("origin/main", result[0].Upstream);
+            Assert.AreEqual("[ahead 1]", result[0].TrackingStatus);
+
+            Assert.AreEqual("feature/test", result[1].Name);
+            Assert.AreEqual("def5678", result[1].Commit);
+            Assert.AreEqual("origin/feature/test", result[1].Upstream);
+            Assert.AreEqual("", result[1].TrackingStatus);
+
+            Assert.AreEqual("origin/main", result[2].Name);
+            Assert.IsTrue(result[2].IsRemote);
+        }
+
+        [Test]
+        public void ParseBranchList_EmptyOutput_ReturnsEmpty()
+        {
+            Assert.AreEqual(0, GitService.ParseBranchList("").Count);
+            Assert.AreEqual(0, GitService.ParseBranchList(null).Count);
+        }
+
+        // --- Commit log parsing ---
+
+        [Test]
+        public void ParseCommitLog_StandardOutput_ParsesCorrectly()
+        {
+            var output =
+                "abc1234567890abcdef1234567890abcdef123456|feat: add new feature\n" +
+                "def4567890abcdef1234567890abcdef12345678|fix: resolve bug\n" +
+                "789012345abcdef1234567890abcdef1234567890|chore: update deps\n";
+
+            var result = GitService.ParseCommitLog(output);
+
+            Assert.AreEqual(3, result.Count);
+            Assert.AreEqual("abc1234567890abcdef1234567890abcdef123456", result[0].Hash);
+            Assert.AreEqual("feat: add new feature", result[0].Message);
+            Assert.AreEqual("def4567890abcdef1234567890abcdef12345678", result[1].Hash);
+            Assert.AreEqual("fix: resolve bug", result[1].Message);
+        }
+
+        [Test]
+        public void ParseCommitLog_HashOnly_ReturnsEmptyMessage()
+        {
+            var output = "abc1234567890abcdef\n";
+
+            var result = GitService.ParseCommitLog(output);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("abc1234567890abcdef", result[0].Hash);
+            Assert.AreEqual("", result[0].Message);
+        }
+
+        [Test]
+        public void ParseCommitLog_MessageWithPipe_PreservesFullMessage()
+        {
+            var output = "abc123|feat: add foo | bar support\n";
+
+            var result = GitService.ParseCommitLog(output);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("abc123", result[0].Hash);
+            Assert.AreEqual("feat: add foo | bar support", result[0].Message);
+        }
+
+        [Test]
+        public void ParseCommitLog_EmptyOutput_ReturnsEmpty()
+        {
+            Assert.AreEqual(0, GitService.ParseCommitLog("").Count);
+            Assert.AreEqual(0, GitService.ParseCommitLog(null).Count);
+        }
+
+        // --- Diff stat parsing ---
+
+        [Test]
+        public void ParseShortStat_FullOutput_ParsesAllFields()
+        {
+            var output = " 5 files changed, 120 insertions(+), 45 deletions(-)";
+
+            var result = GitService.ParseShortStat(output);
+
+            Assert.AreEqual(5, result.FilesChanged);
+            Assert.AreEqual(120, result.Insertions);
+            Assert.AreEqual(45, result.Deletions);
+        }
+
+        [Test]
+        public void ParseShortStat_InsertionsOnly_ParsesCorrectly()
+        {
+            var output = " 1 file changed, 10 insertions(+)";
+
+            var result = GitService.ParseShortStat(output);
+
+            Assert.AreEqual(1, result.FilesChanged);
+            Assert.AreEqual(10, result.Insertions);
+            Assert.AreEqual(0, result.Deletions);
+        }
+
+        [Test]
+        public void ParseShortStat_DeletionsOnly_ParsesCorrectly()
+        {
+            var output = " 3 files changed, 5 deletions(-)";
+
+            var result = GitService.ParseShortStat(output);
+
+            Assert.AreEqual(3, result.FilesChanged);
+            Assert.AreEqual(0, result.Insertions);
+            Assert.AreEqual(5, result.Deletions);
+        }
+
+        [Test]
+        public void ParseShortStat_EmptyOutput_ReturnsZeros()
+        {
+            var result = GitService.ParseShortStat("");
+
+            Assert.AreEqual(0, result.FilesChanged);
+            Assert.AreEqual(0, result.Insertions);
+            Assert.AreEqual(0, result.Deletions);
+        }
+
+        // --- Status parsing ---
+
+        [Test]
+        public void ParseStatusPorcelain_StandardOutput_ParsesCorrectly()
+        {
+            var output =
+                "M  src/main.rs\n" +
+                " M README.md\n" +
+                "?? new-file.txt\n" +
+                "A  added.cs\n";
+
+            var result = GitService.ParseStatusPorcelain(output);
+
+            Assert.AreEqual(4, result.Count);
+            Assert.AreEqual('M', result[0].IndexStatus);
+            Assert.AreEqual(' ', result[0].WorktreeStatus);
+            Assert.AreEqual("src/main.rs", result[0].FilePath);
+
+            Assert.AreEqual(' ', result[1].IndexStatus);
+            Assert.AreEqual('M', result[1].WorktreeStatus);
+            Assert.AreEqual("README.md", result[1].FilePath);
+
+            Assert.AreEqual('?', result[2].IndexStatus);
+            Assert.AreEqual('?', result[2].WorktreeStatus);
+            Assert.AreEqual("new-file.txt", result[2].FilePath);
+
+            Assert.AreEqual('A', result[3].IndexStatus);
+            Assert.AreEqual(' ', result[3].WorktreeStatus);
+            Assert.AreEqual("added.cs", result[3].FilePath);
+        }
+
+        [Test]
+        public void ParseStatusPorcelain_EmptyOutput_ReturnsEmpty()
+        {
+            Assert.AreEqual(0, GitService.ParseStatusPorcelain("").Count);
+            Assert.AreEqual(0, GitService.ParseStatusPorcelain(null).Count);
+        }
+
+        // --- Change summary parsing ---
+
+        [Test]
+        public void ParseChangeSummary_MixedStatus_CountsCorrectly()
+        {
+            var output =
+                "M  staged.cs\n" +
+                " M unstaged.cs\n" +
+                "MM both.cs\n" +
+                "?? untracked.txt\n";
+
+            var result = GitService.ParseChangeSummary(output);
+
+            Assert.AreEqual(4, result.Files.Count);
+            Assert.AreEqual(2, result.StagedFiles);   // M_ and MM
+            Assert.AreEqual(3, result.UnstagedFiles);  // _M, MM, and ??
+        }
+
+        [Test]
+        public void ParseChangeSummary_EmptyOutput_ReturnsZeros()
+        {
+            var result = GitService.ParseChangeSummary("");
+
+            Assert.AreEqual(0, result.Files.Count);
+            Assert.AreEqual(0, result.StagedFiles);
+            Assert.AreEqual(0, result.UnstagedFiles);
+        }
+
+        // --- Stash list parsing ---
+
+        [Test]
+        public void ParseStashList_StandardOutput_ParsesCorrectly()
+        {
+            var output =
+                "stash@{0}: WIP on main: abc123 some work\n" +
+                "stash@{1}: On feature: def456 other work\n";
+
+            var result = GitService.ParseStashList(output);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(0, result[0].Index);
+            Assert.AreEqual("WIP on main: abc123 some work", result[0].Message);
+            Assert.AreEqual(1, result[1].Index);
+            Assert.AreEqual("On feature: def456 other work", result[1].Message);
+        }
+
+        [Test]
+        public void ParseStashList_EmptyOutput_ReturnsEmpty()
+        {
+            Assert.AreEqual(0, GitService.ParseStashList("").Count);
+            Assert.AreEqual(0, GitService.ParseStashList(null).Count);
+        }
+
+        // --- Repo type detection (via parsing logic) ---
+
+        [Test]
+        public void ParseWorktreeList_DetectsMainWorktree()
+        {
+            var output =
+                "worktree /repo\n" +
+                "HEAD abc123\n" +
+                "branch refs/heads/main\n" +
+                "\n";
+
+            var result = GitService.ParseWorktreeList(output);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result[0].IsMain);
+        }
+    }
+}

--- a/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitServiceTests.cs.meta
+++ b/gwt/gwt/Assets/Scripts/Gwt/Tests/Editor/GitServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 105250d74e5742ef95832ccfd7eedf7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add `GitCommandRunner` for async git CLI execution with timeout/cancellation support via UniTask
- Add `GitService` implementing `IGitService` with 16 git operations (worktree, branch, commit, diff, status, stash, tags, repo type detection)
- Add `GwtCoreGitInstaller` for VContainer DI registration
- Add comprehensive NUnit tests for all parsing logic (worktree list, branch list, commit log, shortstat, status porcelain, stash list, change summary)

## Files
- `Core/Services/Git/GitCommandRunner.cs` — Process-based async git command execution
- `Core/Services/Git/GitService.cs` — Full git service with IGitService interface and parsing helpers
- `Core/Installers/GwtCoreGitInstaller.cs` — VContainer installer
- `Tests/Editor/GitServiceTests.cs` — Unit tests for parsing logic

## Test plan
- [ ] Verify Unity project compiles with new files
- [ ] Run editor tests: `GitServiceTests` (worktree, branch, commit, diff, status, stash parsing)
- [ ] Verify VContainer registration resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)