### PR TITLE
fix(gui): flush xterm write buffer before refreshing on window reactivation

### DIFF
--- a/gwt-gui/src/lib/terminal/TerminalView.svelte
+++ b/gwt-gui/src/lib/terminal/TerminalView.svelte
@@ -72,6 +72,29 @@
       void fitAndNotifyCurrent();
     });
   }
+
+  /**
+   * Flush xterm's internal write buffer before running fit + refresh.
+   *
+   * When the window is inactive, the browser throttles requestAnimationFrame,
+   * so xterm accumulates unprocessed writes. A plain scheduleFitAndNotify()
+   * may refresh before the buffer is drained, causing corrupted output.
+   * Writing an empty string pushes a no-op to the end of xterm's write queue;
+   * its callback fires only after every preceding write has been processed.
+   *
+   * The callback runs inside xterm's rAF-based processing loop, so layout is
+   * already up-to-date and we can run fit + refresh synchronously without an
+   * extra requestAnimationFrame round-trip.
+   */
+  function scheduleFitAfterBufferFlush() {
+    if (!active) return;
+    if (!terminal) return;
+    terminal.write("", () => {
+      if (!active) return;
+      void fitAndNotifyCurrent();
+    });
+  }
+
   function isTerminalFocused(rootEl: HTMLElement): boolean {
     const el = document.activeElement;
     return !!el && rootEl.contains(el);
@@ -177,16 +200,18 @@
     const currentSerial = activationSerial + 1;
     activationSerial = currentSerial;
 
-    const rafId = requestAnimationFrame(() => {
+    // Flush xterm's write buffer before the first fit + refresh on
+    // tab activation. While the tab was inactive, writes may have
+    // accumulated without being fully processed (e.g. window was
+    // also inactive and rAF was throttled).
+    term.write("", () => {
+      if (!active) return;
+      if (activationSerial !== currentSerial) return;
       void fitAndNotifyCurrent({
         emitReady: true,
         expectedActivationSerial: currentSerial,
       });
     });
-
-    return () => {
-      cancelAnimationFrame(rafId);
-    };
   });
 
   function getInitialTerminalFontSize(): number {
@@ -413,19 +438,39 @@
     const handleWindowFocus = () => {
       if (hasFocusedModalOutsideTerminal(rootEl)) return;
       focusTerminalIfNeeded(rootEl, true);
-      scheduleFitAndNotify();
+      scheduleFitAfterBufferFlush();
     };
     const handleVisibilityChange = () => {
       if (document.hidden) return;
       if (hasFocusedModalOutsideTerminal(rootEl)) return;
       focusTerminalIfNeeded(rootEl);
-      scheduleFitAndNotify();
+      scheduleFitAfterBufferFlush();
     };
 
     rootEl.addEventListener("pointerdown", handleRootPointerDown, { capture: true });
     rootEl.addEventListener("wheel", handleWheel, { passive: false, capture: true });
     window.addEventListener("focus", handleWindowFocus);
     document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // Tauri's native window focus event is more reliable than the DOM
+    // `window.focus` event on Windows—taskbar clicks and some Alt-Tab
+    // transitions may not propagate to the WebView.
+    let unlistenTauriFocus: (() => void) | null = null;
+    (async () => {
+      try {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        unlistenTauriFocus = await getCurrentWindow().listen(
+          "tauri://focus",
+          () => {
+            if (hasFocusedModalOutsideTerminal(rootEl)) return;
+            focusTerminalIfNeeded(rootEl, true);
+            scheduleFitAfterBufferFlush();
+          },
+        );
+      } catch {
+        // Not running inside Tauri runtime (tests / dev server).
+      }
+    })();
 
     term.attachCustomKeyEventHandler((event: KeyboardEvent) => {
       if (event.type !== "keydown") return true;
@@ -643,6 +688,7 @@
       window.removeEventListener("gwt-terminal-edit-action", handleTerminalEditAction);
       window.removeEventListener("gwt-terminal-font-size", handleFontSizeChange);
       window.removeEventListener("gwt-terminal-font-family", handleFontFamilyChange);
+      unlistenTauriFocus?.();
       removeFontListener?.();
       delete (rootEl as CaptureTerminalContainer).__gwtTerminal;
       observer.disconnect();

--- a/gwt-gui/src/lib/terminal/TerminalView.test.ts
+++ b/gwt-gui/src/lib/terminal/TerminalView.test.ts
@@ -86,7 +86,9 @@ vi.mock("@xterm/xterm", () => ({
     onData = vi.fn();
     onBinary = vi.fn();
     getSelection = vi.fn(() => "");
-    write = vi.fn();
+    write = vi.fn((_data: any, callback?: () => void) => {
+      if (callback) setTimeout(callback, 0);
+    });
     refresh = vi.fn();
     dispose = vi.fn();
     scrollLines = vi.fn((amount: number) => {
@@ -537,20 +539,30 @@ describe("TerminalView", () => {
     });
 
     await Promise.resolve();
-    expect(term.write).not.toHaveBeenCalled();
+    // The only write at this point should be the activation buffer flush
+    // (empty string with callback). No real terminal data should have been
+    // written because terminal_ready has not resolved yet.
+    const dataWrites = term.write.mock.calls.filter(
+      (c: any[]) => c[0] !== "",
+    );
+    expect(dataWrites).toHaveLength(0);
 
     // Resolve terminal_ready with initial data first, then flush buffered output.
     resolveReady!(Array.from(new TextEncoder().encode("history\n")));
 
     await waitFor(() => {
-      expect(term.write).toHaveBeenCalledTimes(2);
+      const dw = term.write.mock.calls.filter((c: any[]) => c[0] !== "");
+      expect(dw).toHaveLength(2);
     });
 
-    const readyChunk = term.write.mock.calls[0][0];
+    const dataCalls = term.write.mock.calls.filter(
+      (c: any[]) => c[0] !== "",
+    );
+    const readyChunk = dataCalls[0][0];
     expect(readyChunk).toBeInstanceOf(Uint8Array);
     expect(new TextDecoder().decode(readyChunk)).toBe("history\n");
 
-    const liveChunk = term.write.mock.calls[1][0];
+    const liveChunk = dataCalls[1][0];
     expect(liveChunk).toBeInstanceOf(Uint8Array);
     expect(new TextDecoder().decode(liveChunk)).toBe("LIVE\n");
 
@@ -562,9 +574,13 @@ describe("TerminalView", () => {
       },
     });
     await waitFor(() => {
-      expect(term.write).toHaveBeenCalledTimes(3);
+      const dw = term.write.mock.calls.filter((c: any[]) => c[0] !== "");
+      expect(dw).toHaveLength(3);
     });
-    const afterChunk = term.write.mock.calls[2][0];
+    const allDataCalls = term.write.mock.calls.filter(
+      (c: any[]) => c[0] !== "",
+    );
+    const afterChunk = allDataCalls[2][0];
     expect(afterChunk).toBeInstanceOf(Uint8Array);
     expect(new TextDecoder().decode(afterChunk)).toBe("AFTER\n");
   });
@@ -749,6 +765,78 @@ describe("TerminalView", () => {
       expect(fit).toHaveBeenCalled();
       expect(term.refresh).toHaveBeenCalled();
     });
+  });
+
+  it("flushes xterm write buffer before refreshing on window focus", async () => {
+    await renderTerminalView({
+      paneId: "pane-focus-flush",
+      active: true,
+    });
+
+    await waitFor(() => {
+      expect(terminalInstances.length).toBeGreaterThan(0);
+      expect(fitAddonInstances.length).toBeGreaterThan(0);
+    });
+
+    const term = terminalInstances[0];
+    const fit = fitAddonInstances[0].fit;
+    fit.mockClear();
+    term.refresh.mockClear();
+    term.write.mockClear();
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => {
+      // write('', callback) must be called to flush pending buffer
+      expect(term.write).toHaveBeenCalledWith("", expect.any(Function));
+      expect(fit).toHaveBeenCalled();
+      expect(term.refresh).toHaveBeenCalled();
+    });
+
+    // Verify write flush happened before fit
+    const writeCallIndex = term.write.mock.invocationCallOrder[0];
+    const fitCallIndex = fit.mock.invocationCallOrder[0];
+    expect(writeCallIndex).toBeLessThan(fitCallIndex);
+  });
+
+  it("flushes xterm write buffer before refreshing on visibility restore", async () => {
+    await renderTerminalView({
+      paneId: "pane-visibility-flush",
+      active: true,
+    });
+
+    await waitFor(() => {
+      expect(terminalInstances.length).toBeGreaterThan(0);
+      expect(fitAddonInstances.length).toBeGreaterThan(0);
+    });
+
+    const term = terminalInstances[0];
+    const fit = fitAddonInstances[0].fit;
+    fit.mockClear();
+    term.refresh.mockClear();
+    term.write.mockClear();
+
+    const hiddenDescriptor = Object.getOwnPropertyDescriptor(document, "hidden");
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      await waitFor(() => {
+        expect(term.write).toHaveBeenCalledWith("", expect.any(Function));
+        expect(fit).toHaveBeenCalled();
+        expect(term.refresh).toHaveBeenCalled();
+      });
+    } finally {
+      if (hiddenDescriptor) {
+        Object.defineProperty(document, "hidden", hiddenDescriptor);
+      } else {
+        Reflect.deleteProperty(document, "hidden");
+      }
+    }
   });
 
   it("does not steal focus from an active modal on visibility restore", async () => {


### PR DESCRIPTION
## Summary

- Flush xterm's internal write buffer before running fit + refresh on window reactivation to prevent cursor position drift caused by partially processed writes
- Add Tauri native window focus listener (`tauri://focus`) for reliable focus detection on Windows where DOM `window.focus` may not fire for all activation paths
- Apply buffer flush to all reactivation paths: window focus, visibility change, and tab activation

## Changes

- `gwt-gui/src/lib/terminal/TerminalView.svelte`: Add `scheduleFitAfterBufferFlush()` using `terminal.write('', callback)` to drain xterm's write buffer before fit + refresh; replace `scheduleFitAndNotify()` in `handleWindowFocus` and `handleVisibilityChange`; change `$effect` activation path to use buffer flush instead of `requestAnimationFrame`; add `tauri://focus` native window event listener with cleanup
- `gwt-gui/src/lib/terminal/TerminalView.test.ts`: Update Terminal mock `write` to invoke callback asynchronously matching production behavior; add tests for buffer flush on window focus and visibility restore; adjust `terminal_ready` buffering test to account for activation flush writes

## Testing

- [x] `pnpm test src/lib/terminal/TerminalView.test.ts` — 56 tests passed
- [x] `pnpm exec svelte-check --tsconfig ./tsconfig.json` — 0 errors, 1 pre-existing warning (MergeDialog.svelte)

## Related Issues / Links

- Closes #1457

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — N/A: internal terminal rendering fix
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema change
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — N/A: patch-level bug fix

## Context

- Issue #1457 reported terminal display collapse on Windows when interacting with agents. Three prior PRs (#1468, #1523, #1585) addressed viewport resize observation, ConPTY options, scrollbar gutter, and focus-return refresh, but cursor position drift persisted when the window was inactive while terminal output progressed.
- Root cause: the browser throttles `requestAnimationFrame` for inactive windows, causing xterm.js to accumulate unprocessed writes. On reactivation, fit + refresh ran before the buffer was fully drained, producing garbled output.
- Additionally, Tauri on Windows does not always propagate native window focus as a DOM `focus` event (e.g., taskbar clicks), meaning the refresh path could be skipped entirely.

## Risk / Impact

- **Affected areas**: Terminal rendering on all platforms (the buffer flush is a no-op when no writes are pending)
- **Rollback plan**: Revert this commit; the previous behavior (immediate rAF-based refresh) is restored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal display synchronization to ensure output renders correctly when the buffer contains pending content.
  * Enhanced terminal refresh behavior when the application window regains focus.

* **Tests**
  * Updated test suite to validate terminal buffer synchronization and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->