### PR TITLE
fix(voice): harden windows python runtime detection

### DIFF
--- a/crates/gwt-tauri/src/commands/voice.rs
+++ b/crates/gwt-tauri/src/commands/voice.rs
@@ -161,23 +161,85 @@ fn find_python_override() -> Result<Option<PathBuf>, String> {
     Ok(None)
 }
 
+fn system_python_candidates() -> &'static [&'static str] {
+    #[cfg(windows)]
+    {
+        &[
+            "python3.13",
+            "python3.12",
+            "python3.11",
+            "python3",
+            "py",
+            "python",
+        ]
+    }
+
+    #[cfg(not(windows))]
+    {
+        &[
+            "python3.13",
+            "python3.12",
+            "python3.11",
+            "python3",
+            "python",
+        ]
+    }
+}
+
+fn is_windows_store_python_alias(path: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        let normalized = path
+            .to_string_lossy()
+            .replace('/', "\\")
+            .to_ascii_lowercase();
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_ascii_lowercase())
+            .unwrap_or_default();
+
+        normalized.contains("\\appdata\\local\\microsoft\\windowsapps\\")
+            && file_name.starts_with("python")
+            && file_name.ends_with(".exe")
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = path;
+        false
+    }
+}
+
+fn can_execute_python(path: &Path) -> bool {
+    match command_os(path)
+        .arg("-c")
+        .arg("import sys; print(sys.version_info[0])")
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim() == "3"
+        }
+        _ => false,
+    }
+}
+
 fn find_system_python_binary() -> Result<PathBuf, String> {
-    for candidate in [
-        "python3.13",
-        "python3.12",
-        "python3.11",
-        "python3",
-        "python",
-    ] {
+    for candidate in system_python_candidates() {
         if let Ok(path) = which::which(candidate) {
-            return Ok(path);
+            if can_execute_python(&path) {
+                return Ok(path);
+            }
+
+            if is_windows_store_python_alias(&path) {
+                continue;
+            }
         }
     }
 
-    Err(
-        "Python runtime not found (checked python3.13/python3.12/python3.11/python3/python)"
-            .to_string(),
-    )
+    Err(format!(
+        "Python runtime not found (checked {})",
+        system_python_candidates().join("/")
+    ))
 }
 
 fn find_managed_python_binary() -> Result<PathBuf, String> {
@@ -800,6 +862,71 @@ mod tests {
         assert_eq!(normalize_language("ja"), "ja");
         assert_eq!(normalize_language("en"), "en");
         assert_eq!(normalize_language("xx"), "auto");
+    }
+
+    #[test]
+    fn system_python_candidates_include_windows_launcher_only_on_windows() {
+        let candidates = system_python_candidates();
+
+        #[cfg(windows)]
+        {
+            let py_index = candidates
+                .iter()
+                .position(|candidate| *candidate == "py")
+                .expect("Windows candidates must include py launcher");
+            let python_index = candidates
+                .iter()
+                .position(|candidate| *candidate == "python")
+                .expect("Windows candidates must include python executable");
+            assert!(
+                py_index < python_index,
+                "py launcher must be tried before bare python to avoid WindowsApps stubs"
+            );
+        }
+
+        #[cfg(not(windows))]
+        {
+            assert!(
+                !candidates.contains(&"py"),
+                "non-Windows candidates must not include py launcher"
+            );
+        }
+    }
+
+    #[test]
+    fn windows_store_python_alias_detection_matches_known_alias_paths() {
+        #[cfg(windows)]
+        {
+            assert!(is_windows_store_python_alias(Path::new(
+                r"C:\Users\example\AppData\Local\Microsoft\WindowsApps\python.exe"
+            )));
+            assert!(is_windows_store_python_alias(Path::new(
+                r"C:\Users\example\AppData\Local\Microsoft\WindowsApps\python3.exe"
+            )));
+            assert!(is_windows_store_python_alias(Path::new(
+                r"C:\Users\example\AppData\Local\Microsoft\WindowsApps\python3.13.exe"
+            )));
+        }
+
+        #[cfg(not(windows))]
+        {
+            assert!(!is_windows_store_python_alias(Path::new(
+                r"C:\Users\example\AppData\Local\Microsoft\WindowsApps\python.exe"
+            )));
+            assert!(!is_windows_store_python_alias(Path::new(
+                r"C:\Users\example\AppData\Local\Microsoft\WindowsApps\python3.exe"
+            )));
+            assert!(!is_windows_store_python_alias(Path::new(
+                r"C:\Users\example\AppData\Local\Microsoft\WindowsApps\python3.13.exe"
+            )));
+        }
+
+        assert!(!is_windows_store_python_alias(Path::new(
+            r"C:\Python313\python.exe"
+        )));
+        assert!(!is_windows_store_python_alias(Path::new(
+            r"C:\Windows\py.exe"
+        )));
     }
 
     #[test]


### PR DESCRIPTION
﻿## Summary

- Harden Windows voice runtime bootstrap so setup can recover when bare `python` resolves to a broken alias and avoid exit code 9009 during runtime setup.
- Add regression tests for Python candidate ordering and WindowsApps alias rejection so voice bootstrap stays aligned with the safer project-index behavior.
- Backfill canonical voice spec #1551 with the desktop runtime compatibility requirements exposed by #1599.

## Changes

- `crates/gwt-tauri/src/commands/voice.rs`: added Windows-safe system Python candidate discovery, executable validation, `py` launcher fallback, and WindowsApps alias rejection.
- `crates/gwt-tauri/src/commands/voice.rs`: added regression tests covering Windows launcher ordering and WindowsApps alias detection.
- `#1551`: updated the canonical voice spec body to capture desktop runtime bootstrap and retry expectations for the current Rust/Tauri implementation.

## Testing

- [x] `cargo test -p gwt-tauri voice` — 11 targeted tests passed, including the new Windows bootstrap regressions.
- [x] `cargo clippy -p gwt-tauri --all-targets -- -D warnings` — completed without warnings.
- [x] `cargo fmt --package gwt-tauri` — completed successfully.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — completed successfully.

## Related Issues / Links

- #1599
- #1551

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — `cargo fmt` and `cargo clippy` passed; `svelte-check` N/A because no frontend files changed.
- [x] Documentation updated (if user-facing change) — N/A: no user-facing documentation change was needed.
- [x] Migration/backfill plan included (if schema/data change) — N/A for schema/data; canonical spec #1551 was backfilled for runtime compatibility.
- [x] CHANGELOG impact considered (breaking change flagged in commit) — patch-level bug fix only; no breaking change.

## Context

- #1599 reported `Voice runtime is not ready: Qwen helper failed (status=exit code: 9009): Python` on Windows when `Setup Voice Runtime` ran from Settings.
- `crates/gwt-tauri/src/commands/project_index.rs` already had safer Windows Python resolution, so this PR aligns voice runtime bootstrap with that existing behavior instead of introducing a new workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced Python runtime detection on Windows with support for the py launcher
  * Improved detection to avoid problematic Windows Store Python installations
  * Added verification that detected Python installations can execute properly
  * Improved error messages when Python runtime cannot be found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->