### PR TITLE
fix: resolve Version History error for legacy profiles config

### DIFF
--- a/crates/gwt-core/src/config/profile.rs
+++ b/crates/gwt-core/src/config/profile.rs
@@ -461,6 +461,43 @@ model = "gpt-5"
     }
 
     #[test]
+    fn load_accepts_legacy_nested_profiles_table() {
+        let _lock = crate::config::HOME_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let _env = crate::config::TestEnvGuard::new(temp.path());
+
+        let config_path = Settings::global_config_path().unwrap();
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &config_path,
+            r#"
+[profiles]
+version = 1
+active = "default"
+
+[profiles.profiles.default]
+name = "default"
+disabled_env = []
+description = ""
+
+[profiles.profiles.default.ai]
+endpoint = "https://api.example.com/v1"
+api_key = "sk-legacy"
+model = "gpt-5"
+"#,
+        )
+        .unwrap();
+
+        let loaded = ProfilesConfig::load().unwrap();
+        assert_eq!(loaded.active.as_deref(), Some("default"));
+        assert!(loaded.profiles.contains_key("default"));
+        assert!(!loaded.profiles.contains_key("profiles"));
+        let default = loaded.profiles.get("default").unwrap();
+        assert_eq!(default.name, "default");
+        assert_eq!(default.ai.as_ref().unwrap().api_key, "sk-legacy");
+    }
+
+    #[test]
     fn test_ai_settings_resolved_defaults() {
         // AISettings::default() uses #[derive(Default)], so all fields are empty
         // The serde default functions (default_endpoint, default_model) are only used during deserialization

--- a/crates/gwt-core/src/config/settings.rs
+++ b/crates/gwt-core/src/config/settings.rs
@@ -67,6 +67,8 @@ struct ProfilesSectionToml {
     active: Option<String>,
     #[serde(flatten)]
     profiles: std::collections::HashMap<String, Profile>,
+    #[serde(default, rename = "profiles", skip_serializing)]
+    legacy_profiles: std::collections::HashMap<String, Profile>,
 }
 
 impl From<ProfilesConfig> for ProfilesSectionToml {
@@ -75,16 +77,21 @@ impl From<ProfilesConfig> for ProfilesSectionToml {
             version: value.version,
             active: value.active,
             profiles: value.profiles,
+            legacy_profiles: std::collections::HashMap::new(),
         }
     }
 }
 
 impl From<ProfilesSectionToml> for ProfilesConfig {
     fn from(value: ProfilesSectionToml) -> Self {
+        let mut profiles = value.profiles;
+        for (name, profile) in value.legacy_profiles {
+            profiles.entry(name).or_insert(profile);
+        }
         Self {
             version: value.version,
             active: value.active,
-            profiles: value.profiles,
+            profiles,
         }
     }
 }


### PR DESCRIPTION
## Summary
- load legacy `[profiles.profiles.<name>]` tables from `~/.gwt/config.toml`
- keep the canonical save format as `[profiles.<name>]`
- add a regression test for the legacy config shape that triggered Version History failures

## Background
Issue #1655 was caused by older config files using a nested profiles table. The current loader treated `profiles` as a reserved profile key and Version History failed while reading AI settings.

## Testing
- `cargo test -p gwt-core config::profile::tests::load_accepts_legacy_nested_profiles_table -- --nocapture`
- `cargo test -p gwt-core config::profile::tests::test_profiles_config_roundtrip_config_toml -- --nocapture`
- `cargo test -p gwt-core config::profile::tests -- --nocapture`
- `cargo test -p gwt-core config::settings::tests::test_local_save_strips_global_only_profiles_and_load_uses_global_profiles -- --nocapture`
- `cargo fmt --all`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Links
- Closes #1655
- Spec #1656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading legacy profile configurations, enabling compatibility with older config file formats. The system now automatically merges legacy profile data into newer configurations without overriding existing settings.

* **Tests**
  * Added unit tests to verify proper loading of legacy nested profile structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->