### PR TITLE
feat(gui): refresh codex model selector list

### DIFF
--- a/gwt-gui/src/lib/components/AgentLaunchForm.svelte
+++ b/gwt-gui/src/lib/components/AgentLaunchForm.svelte
@@ -245,12 +245,13 @@
   let modelOptions: SelectOption[] = $derived(
     selectedAgent === "codex"
       ? [
-          { value: "gpt-5.3-codex", label: "gpt-5.3-codex" },
           { value: "gpt-5.4", label: "gpt-5.4" },
+          { value: "gpt-5.4-mini", label: "gpt-5.4-mini" },
+          { value: "gpt-5.3-codex", label: "gpt-5.3-codex" },
           { value: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },
           { value: "gpt-5.2-codex", label: "gpt-5.2-codex" },
-          { value: "gpt-5.1-codex-max", label: "gpt-5.1-codex-max" },
           { value: "gpt-5.2", label: "gpt-5.2" },
+          { value: "gpt-5.1-codex-max", label: "gpt-5.1-codex-max" },
           { value: "gpt-5.1-codex-mini", label: "gpt-5.1-codex-mini" },
         ]
       : selectedAgent === "claude"

--- a/gwt-gui/src/lib/components/AgentLaunchForm.test.ts
+++ b/gwt-gui/src/lib/components/AgentLaunchForm.test.ts
@@ -202,7 +202,7 @@ describe("AgentLaunchForm", () => {
     expect(binaryFallbackNotice).toBeTruthy();
   });
 
-  it("displays codex model options including gpt-5.4", async () => {
+  it("displays codex model options including gpt-5.4-mini", async () => {
     invokeMock.mockImplementation(async (cmd: string) => {
       if (cmd === "detect_agents") {
         return [
@@ -239,12 +239,13 @@ describe("AgentLaunchForm", () => {
     const options = Array.from(modelSelect.options).map((option) => option.value);
     expect(options).toEqual([
       "",
-      "gpt-5.3-codex",
       "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex",
       "gpt-5.3-codex-spark",
       "gpt-5.2-codex",
-      "gpt-5.1-codex-max",
       "gpt-5.2",
+      "gpt-5.1-codex-max",
       "gpt-5.1-codex-mini",
     ]);
   });


### PR DESCRIPTION
## Summary

- Refresh the Codex model selector to include `gpt-5.4-mini` and match the current supported order so the UI stays aligned with the Codex CLI.
- Update SPEC #1489 from a Codex-only spec to a multi-agent model-management parent spec so future Claude Code and Gemini model updates land in one place.

## Changes

- `gwt-gui/src/lib/components/AgentLaunchForm.svelte`: add `gpt-5.4-mini` and reorder the Codex model options to match the current supported list.
- `gwt-gui/src/lib/components/AgentLaunchForm.test.ts`: update the Codex model option expectation to lock the new order in automated coverage.

## Testing

- `pnpm test src/lib/components/AgentLaunchForm.test.ts src/lib/agentLaunchDefaults.test.ts` - Passed (`2` files, `50` tests).
- `cargo test -p gwt-core agent::codex::tests:: -- --test-threads=1` - Passed (`19` tests).
- `cargo test -p gwt-tauri build_agent_args_codex -- --test-threads=1` - Passed (`8` tests).
- `pnpm exec svelte-check --tsconfig ./tsconfig.json` - Passed with `0` errors and `3` pre-existing warnings in unrelated files.

## Closing Issues

None

## Related Issues / Links

- #1489

## Checklist

- [x] Tests added/updated
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — Partial: `svelte-check` passed; `cargo fmt` / `cargo clippy` were not rerun because this PR only changes Svelte UI/test files and targeted Rust regressions were already green.
- [ ] Documentation updated (if user-facing change) — N/A: no README or docs files changed; the living spec was updated directly in GitHub Issue #1489.
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema or data change.
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — N/A: non-breaking model catalog refresh.

## Context

- SPEC #1489 is intentionally kept open as the living parent spec, so this PR carries the code/test changes while the issue body now tracks multi-agent model management for Codex, Claude Code, and Gemini.

## Screenshots

| Before | After |
|--------|-------|
| Not captured — dropdown option list change only | Not captured — covered by automated UI test updates |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gpt-5.4-mini as a new model option in Agent Launch Form's codex model selection.

* **Updates**
  * Reordered the sequence of available codex model options for improved organization.
  * Updated test cases to reflect the new model arrangement and ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->