### PR TITLE
feat(gui): add split tab group layout

### DIFF
--- a/gwt-gui/e2e/tab-layout.spec.ts
+++ b/gwt-gui/e2e/tab-layout.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installTauriMock } from "./support/tauri-mock";
+import {
+  defaultRecentProject,
+  emitTauriEvent,
+  openRecentProject,
+  waitForMenuActionListener,
+} from "./support/helpers";
+
+async function openSettingsTab(page: Page) {
+  await waitForMenuActionListener(page);
+  await emitTauriEvent(page, "menu-action", { action: "open-settings" });
+  await expect(page.locator('[data-tab-id="settings"]')).toBeVisible();
+}
+
+async function createDataTransfer(page: Page) {
+  return page.evaluateHandle(() => new DataTransfer());
+}
+
+test.beforeEach(async ({ page }) => {
+  await installTauriMock(page, {
+    commandResponses: {
+      get_recent_projects: [defaultRecentProject],
+    },
+  });
+  await page.goto("/");
+  await openRecentProject(page);
+  await openSettingsTab(page);
+});
+
+test("explicit split action creates a second group and drag merge collapses back", async ({
+  page,
+}) => {
+  const settingsTab = page.locator('[data-tab-id="settings"]').first();
+  await settingsTab.locator(".tab-actions-toggle").click();
+  await settingsTab
+    .locator(".tab-actions-menu")
+    .getByRole("button", { name: "Split Right" })
+    .click();
+
+  await expect(page.locator(".group-pane")).toHaveCount(2);
+
+  const dataTransfer = await createDataTransfer(page);
+  const sourceTab = page.locator(".group-pane").nth(1).locator('[data-tab-id="settings"]');
+  const targetTabBar = page.locator(".group-pane").nth(0).locator(".tab-bar");
+
+  await sourceTab.dispatchEvent("dragstart", { dataTransfer });
+  await targetTabBar.dispatchEvent("dragover", { dataTransfer });
+  await targetTabBar.dispatchEvent("drop", { dataTransfer });
+
+  await expect(page.locator(".group-pane")).toHaveCount(1);
+  await expect(page.locator(".group-pane").first().locator('[data-tab-id="settings"]')).toBeVisible();
+});
+
+test("dragging a tab onto a split target creates a new group", async ({ page }) => {
+  const settingsTab = page.locator('[data-tab-id="settings"]').first();
+  const splitTarget = page.locator(".group-pane").first().locator(".split-target-right");
+  const dataTransfer = await createDataTransfer(page);
+
+  await settingsTab.dispatchEvent("dragstart", { dataTransfer });
+  await splitTarget.dispatchEvent("dragover", { dataTransfer });
+  await splitTarget.dispatchEvent("drop", { dataTransfer });
+  await settingsTab.dispatchEvent("dragend", { dataTransfer });
+
+  await expect(page.locator(".group-pane")).toHaveCount(2);
+});
+
+test("group-local tabs use a compact fixed width", async ({ page }) => {
+  const assistantTab = page.locator('[data-tab-id="assistant"]').first();
+  const settingsTab = page.locator('[data-tab-id="settings"]').first();
+
+  const assistantWidth = await assistantTab.evaluate((element) =>
+    element.getBoundingClientRect().width,
+  );
+  const settingsWidth = await settingsTab.evaluate((element) =>
+    element.getBoundingClientRect().width,
+  );
+
+  expect(assistantWidth).toBeGreaterThanOrEqual(175);
+  expect(assistantWidth).toBeLessThanOrEqual(185);
+  expect(settingsWidth).toBeGreaterThanOrEqual(175);
+  expect(settingsWidth).toBeLessThanOrEqual(185);
+});

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -42,15 +42,30 @@
     buildRestoredProjectTabs,
     shouldRetryAgentTabRestore,
     type StoredProjectTab,
+    type StoredTabGroup,
+    type StoredTabLayoutNode,
     type StoredTerminalTab,
   } from "./lib/agentTabsPersistence";
-  import {
-    defaultAppTabs,
-    reorderTabsByDrop,
-    shouldAllowRestoredActiveTab,
-    type TabDropPosition,
-  } from "./lib/appTabs";
+  import { defaultAppTabs, shouldAllowRestoredActiveTab } from "./lib/appTabs";
   import { getNextTabId, getPreviousTabId } from "./lib/tabNavigation";
+  import {
+    addTabToActiveGroup,
+    canSplitTab,
+    createInitialTabLayout,
+    flattenTabIdsByLayout,
+    getGroupForTab,
+    moveTabToGroup,
+    removeTabFromLayout,
+    reorderTabsInGroup,
+    resizeSplitNode,
+    setActiveGroup,
+    setActiveTabInGroup,
+    splitTabToGroupEdge,
+    type TabDropPosition,
+    type TabGroupState,
+    type TabLayoutNode,
+    type TabSplitDirection,
+  } from "./lib/tabLayout";
   import {
     runStartupUpdateCheck,
     STARTUP_UPDATE_INITIAL_DELAY_MS,
@@ -260,6 +275,10 @@
   let migrationSourceRoot: string = $state("");
 
   let tabs: Tab[] = $state(defaultAppTabs());
+  const initialTabLayout = createInitialTabLayout(defaultAppTabs(), "assistant");
+  let layoutGroups: Record<string, TabGroupState> = $state(initialTabLayout.groups);
+  let layoutRoot: TabLayoutNode = $state(initialTabLayout.root);
+  let activeGroupId: string = $state(initialTabLayout.activeGroupId);
   let activeTabId: string = $state("assistant");
   let lastWindowMenuTabsSignature: string | null = null;
   let lastWindowMenuActiveTabId: string | null = null;
@@ -327,6 +346,61 @@
   let osEnvDebugLoading = $state(false);
   let osEnvDebugError = $state<string | null>(null);
   type AvailableUpdateState = Extract<UpdateState, { state: "available" }>;
+
+  function readTabLayoutState() {
+    return {
+      groups: layoutGroups,
+      root: layoutRoot,
+      activeGroupId,
+    };
+  }
+
+  function applyTabLayoutState(next: {
+    groups: Record<string, TabGroupState>;
+    root: TabLayoutNode;
+    activeGroupId: string;
+  }) {
+    layoutGroups = next.groups;
+    layoutRoot = next.root;
+    activeGroupId = next.activeGroupId;
+    const nextActiveTabId =
+      next.groups[next.activeGroupId]?.activeTabId ??
+      tabs.find((tab) => tab.id === activeTabId)?.id ??
+      tabs[0]?.id ??
+      "";
+    activeTabId = nextActiveTabId;
+  }
+
+  function activeGroupTabIds(): string[] {
+    return layoutGroups[activeGroupId]?.tabIds ?? [];
+  }
+
+  function buildStoredLayoutGroups(): StoredTabGroup[] {
+    return Object.values(layoutGroups).map((group) => ({
+      id: group.id,
+      tabIds: [...group.tabIds],
+      activeTabId: group.activeTabId,
+    }));
+  }
+
+  function buildStoredLayoutRoot(node: TabLayoutNode): StoredTabLayoutNode {
+    if (node.type === "group") {
+      return {
+        type: "group",
+        groupId: node.groupId,
+      };
+    }
+    return {
+      type: "split",
+      id: node.id,
+      axis: node.axis,
+      sizes: node.sizes,
+      children: [
+        buildStoredLayoutRoot(node.children[0]),
+        buildStoredLayoutRoot(node.children[1]),
+      ],
+    };
+  }
 
   function showToast(
     message: string,
@@ -1879,18 +1953,68 @@
     removeTabLocal(tabId);
   }
 
-  function handleTabSelect(tabId: string) {
+  function handleTabSelect(groupId: string, tabId: string) {
+    activeGroupId = groupId;
     activeTabId = tabId;
   }
 
   function handleTabReorder(
+    groupId: string,
     dragTabId: string,
     overTabId: string,
     position: TabDropPosition,
   ) {
-    const nextTabs = reorderTabsByDrop(tabs, dragTabId, overTabId, position);
-    if (nextTabs === tabs) return;
-    tabs = nextTabs;
+    const next = reorderTabsInGroup(
+      readTabLayoutState(),
+      groupId,
+      dragTabId,
+      overTabId,
+      position,
+    );
+    applyTabLayoutState(next);
+  }
+
+  function handleTabMoveToGroup(
+    dragTabId: string,
+    targetGroupId: string,
+    overTabId: string | null = null,
+    position: TabDropPosition = "after",
+  ) {
+    const next = moveTabToGroup(
+      readTabLayoutState(),
+      dragTabId,
+      targetGroupId,
+      overTabId,
+      position,
+    );
+    applyTabLayoutState(next);
+  }
+
+  function handleTabSplitToGroupEdge(
+    dragTabId: string,
+    targetGroupId: string,
+    direction: TabSplitDirection,
+  ) {
+    if (!canSplitTab(readTabLayoutState(), dragTabId)) return;
+    const next = splitTabToGroupEdge(
+      readTabLayoutState(),
+      dragTabId,
+      targetGroupId,
+      direction,
+    );
+    applyTabLayoutState(next);
+  }
+
+  function handleGroupFocus(groupId: string) {
+    const next = setActiveGroup(readTabLayoutState(), groupId);
+    applyTabLayoutState(next);
+  }
+
+  function handleSplitResize(splitId: string, primaryFraction: number) {
+    const next = resizeSplitNode(readTabLayoutState(), splitId, primaryFraction);
+    layoutGroups = next.groups;
+    layoutRoot = next.root;
+    activeGroupId = next.activeGroupId;
   }
 
   function openSettingsTab() {
@@ -2487,17 +2611,71 @@
         break;
       }
       case "previous-tab": {
-        const prevId = getPreviousTabId(tabs, activeTabId);
+        const groupTabs = activeGroupTabIds()
+          .map((tabId) => tabs.find((tab) => tab.id === tabId))
+          .filter((tab): tab is Tab => Boolean(tab));
+        const prevId = getPreviousTabId(groupTabs, activeTabId);
         if (prevId) activeTabId = prevId;
         break;
       }
       case "next-tab": {
-        const nextId = getNextTabId(tabs, activeTabId);
+        const groupTabs = activeGroupTabIds()
+          .map((tabId) => tabs.find((tab) => tab.id === tabId))
+          .filter((tab): tab is Tab => Boolean(tab));
+        const nextId = getNextTabId(groupTabs, activeTabId);
         if (nextId) activeTabId = nextId;
         break;
       }
     }
   }
+
+  $effect(() => {
+    void tabs;
+    void activeTabId;
+    void activeGroupId;
+    void layoutGroups;
+    void layoutRoot;
+
+    const knownTabIds = new Set(tabs.map((tab) => tab.id));
+    let next = readTabLayoutState();
+
+    for (const group of Object.values(next.groups)) {
+      for (const tabId of [...group.tabIds]) {
+        if (!knownTabIds.has(tabId)) {
+          next = removeTabFromLayout(next, tabId);
+        }
+      }
+    }
+
+    for (const tab of tabs) {
+      if (!getGroupForTab(next, tab.id)) {
+        next = addTabToActiveGroup(next, tab.id);
+      }
+    }
+
+    if (activeTabId && knownTabIds.has(activeTabId)) {
+      const owningGroup = getGroupForTab(next, activeTabId);
+      if (owningGroup) {
+        next = setActiveGroup(next, owningGroup.id);
+        next = setActiveTabInGroup(next, owningGroup.id, activeTabId);
+      }
+    }
+
+    if (
+      next.groups !== layoutGroups ||
+      next.root !== layoutRoot ||
+      next.activeGroupId !== activeGroupId
+    ) {
+      layoutGroups = next.groups;
+      layoutRoot = next.root;
+      activeGroupId = next.activeGroupId;
+      const nextActiveTab =
+        next.groups[next.activeGroupId]?.activeTabId ?? tabs[0]?.id ?? "";
+      if (nextActiveTab && nextActiveTab !== activeTabId) {
+        activeTabId = nextActiveTab;
+      }
+    }
+  });
 
   $effect(() => {
     void tabs;
@@ -2616,6 +2794,20 @@
     tabs = mergedTabs;
     await refreshAgentTabLabelsForProject(targetProjectPath);
 
+    const restoredGroups: Record<string, TabGroupState> = Object.fromEntries(
+      restored.groups.map((group) => [
+        group.id,
+        {
+          id: group.id,
+          tabIds: [...group.tabIds],
+          activeTabId: group.activeTabId,
+        },
+      ]),
+    );
+    layoutGroups = restoredGroups;
+    layoutRoot = restored.root as TabLayoutNode;
+    activeGroupId = restored.activeGroupId ?? restored.groups[0]?.id ?? activeGroupId;
+
     const allowOverrideActive = shouldAllowRestoredActiveTab(activeTabId);
     if (allowOverrideActive) {
       if (
@@ -2658,12 +2850,21 @@
     void tabs;
     void activeTabId;
     void agentTabsHydratedProjectPath;
+    void layoutGroups;
+    void layoutRoot;
+    void activeGroupId;
 
     if (!projectPath) return;
     if (agentTabsHydratedProjectPath !== projectPath) return;
 
+    const orderedTabIds = flattenTabIdsByLayout(readTabLayoutState());
+    const orderedTabs = orderedTabIds
+      .map((tabId) => tabs.find((tab) => tab.id === tabId))
+      .filter((tab): tab is Tab => Boolean(tab));
+    const fallbackOrderedTabs = orderedTabs.length > 0 ? orderedTabs : tabs;
+
     const storedTabs: StoredProjectTab[] = [];
-    for (const tab of tabs) {
+    for (const tab of fallbackOrderedTabs) {
       if (tab.type === "agent") {
         if (typeof tab.paneId !== "string" || tab.paneId.length === 0) continue;
         storedTabs.push({
@@ -2689,7 +2890,10 @@
         tab.type === "assistant" ||
         tab.type === "settings" ||
         tab.type === "versionHistory" ||
-        tab.type === "issues"
+        tab.type === "issues" ||
+        tab.type === "prs" ||
+        tab.type === "projectIndex" ||
+        tab.type === "issueSpec"
       ) {
         const staticType = tab.type === "assistant" ? "assistant" : tab.type;
         const staticId = tab.id === "assistant" ? "assistant" : tab.id;
@@ -2698,6 +2902,9 @@
           type: staticType,
           id: staticId,
           label: staticLabel,
+          ...(tab.type === "issueSpec" && tab.issueNumber
+            ? { issueNumber: tab.issueNumber }
+            : {}),
         });
       }
     }
@@ -2714,6 +2921,9 @@
     persistStoredProjectTabs(projectPath, {
       tabs: storedTabs,
       activeTabId: storedActiveTabId,
+      activeGroupId,
+      groups: buildStoredLayoutGroups(),
+      root: buildStoredLayoutRoot(layoutRoot),
     });
   });
 
@@ -2957,14 +3167,19 @@
       {/if}
       <MainArea
         {tabs}
-        {activeTabId}
-        {selectedBranch}
+        groups={layoutGroups}
+        layoutRoot={layoutRoot}
+        {activeGroupId}
         projectPath={projectPath as string}
         onLaunchAgent={requestAgentLaunch}
         onQuickLaunch={handleAgentLaunch}
         onTabSelect={handleTabSelect}
         onTabClose={handleTabClose}
         onTabReorder={handleTabReorder}
+        onTabMoveToGroup={handleTabMoveToGroup}
+        onTabSplitToGroupEdge={handleTabSplitToGroupEdge}
+        onSplitResize={handleSplitResize}
+        onGroupFocus={handleGroupFocus}
         onWorkOnIssue={handleWorkOnIssueFromTab}
         onSwitchToWorktree={handleSwitchToWorktreeFromTab}
         onIssueCountChange={handleIssueCountChange}

--- a/gwt-gui/src/lib/agentTabsPersistence.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.ts
@@ -1,5 +1,7 @@
 import type { Tab, TerminalInfo } from "./types";
 import { inferAgentId } from "./agentUtils";
+import type { TabGroupState, TabLayoutNode } from "./tabLayout";
+import { createInitialTabLayout, flattenTabIdsByLayout } from "./tabLayout";
 
 /**
  * localStorage key used to persist tab state (per project path).
@@ -26,9 +28,17 @@ export type StoredTerminalTab = {
 };
 
 export type StoredStaticTab = {
-  type: "assistant" | "settings" | "versionHistory" | "issues";
+  type:
+    | "assistant"
+    | "settings"
+    | "versionHistory"
+    | "issues"
+    | "prs"
+    | "projectIndex"
+    | "issueSpec";
   id: string;
   label: string;
+  issueNumber?: number;
 };
 
 export type StoredProjectTab =
@@ -42,6 +52,9 @@ export type StoredProjectTab =
 export type StoredProjectTabs = {
   tabs: StoredProjectTab[];
   activeTabId: string | null;
+  activeGroupId?: string | null;
+  groups?: StoredTabGroup[];
+  root?: StoredTabLayoutNode | null;
 };
 
 /**
@@ -50,6 +63,9 @@ export type StoredProjectTabs = {
 export type BuildRestoredProjectTabsResult = {
   tabs: Tab[];
   activeTabId: string | null;
+  activeGroupId: string | null;
+  groups: StoredTabGroup[];
+  root: StoredTabLayoutNode;
   terminalTabsToRespawn: StoredTerminalTab[];
   activeTerminalPaneIdToRespawn: string | null;
 };
@@ -79,9 +95,28 @@ export function shouldRetryAgentTabRestore(
 }
 
 type StoredProjectTabsRoot = {
-  version: 2;
+  version: 2 | 3;
   byProjectPath: Record<string, StoredProjectTabs>;
 };
+
+export type StoredTabGroup = {
+  id: string;
+  tabIds: string[];
+  activeTabId: string | null;
+};
+
+export type StoredTabLayoutNode =
+  | {
+      type: "group";
+      groupId: string;
+    }
+  | {
+      type: "split";
+      id: string;
+      axis: "horizontal" | "vertical";
+      sizes: [number, number];
+      children: [StoredTabLayoutNode, StoredTabLayoutNode];
+    };
 
 type LegacyStoredAgentTab = {
   paneId: string;
@@ -165,7 +200,10 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
     type === "assistant" ||
     type === "settings" ||
     type === "versionHistory" ||
-    type === "issues"
+    type === "issues" ||
+    type === "prs" ||
+    type === "projectIndex" ||
+    type === "issueSpec"
   ) {
     const canonicalType = type === "assistant" ? "assistant" : type;
     const fallbackId =
@@ -175,7 +213,13 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
           ? "settings"
           : canonicalType === "issues"
             ? "issues"
-            : "versionHistory";
+            : canonicalType === "prs"
+              ? "prs"
+              : canonicalType === "projectIndex"
+                ? "projectIndex"
+                : canonicalType === "issueSpec"
+                  ? "issueSpec"
+                  : "versionHistory";
     const fallbackLabel =
       canonicalType === "assistant"
         ? "Assistant"
@@ -183,7 +227,13 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
           ? "Settings"
           : canonicalType === "issues"
             ? "Issues"
-            : "Version History";
+            : canonicalType === "prs"
+              ? "Pull Requests"
+              : canonicalType === "projectIndex"
+                ? "Project Index"
+                : canonicalType === "issueSpec"
+                  ? "Issue"
+                  : "Version History";
     const idRaw = normalizeString(obj.id);
     const id =
       canonicalType === "assistant"
@@ -194,7 +244,16 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
       canonicalType === "assistant" && (type === "assistant" || !labelRaw)
         ? "Assistant"
         : labelRaw || fallbackLabel;
-    return { type: canonicalType, id, label };
+    const issueNumber =
+      canonicalType === "issueSpec" && Number.isFinite(Number(obj.issueNumber))
+        ? Number(obj.issueNumber)
+        : undefined;
+    return {
+      type: canonicalType,
+      id,
+      label,
+      ...(issueNumber && issueNumber > 0 ? { issueNumber } : {}),
+    };
   }
 
   return null;
@@ -223,7 +282,104 @@ function sanitizeProjectTabsEntry(rawEntry: unknown): StoredProjectTabs | null {
   }
 
   const activeTabId = normalizeString(entry.activeTabId) || null;
-  return { tabs, activeTabId };
+  const groups = sanitizeStoredGroups(entry.groups, tabs.map(resolveStoredTabId));
+  const root = sanitizeStoredRoot(entry.root, groups.map((group) => group.id));
+  const activeGroupId = normalizeString(entry.activeGroupId) || null;
+
+  return {
+    tabs,
+    activeTabId,
+    ...(groups.length > 0 ? { groups } : {}),
+    ...(root ? { root } : {}),
+    ...(activeGroupId ? { activeGroupId } : {}),
+  };
+}
+
+function resolveStoredTabId(tab: StoredProjectTab): string {
+  if (tab.type === "agent") return `agent-${tab.paneId}`;
+  if (tab.type === "terminal") return `terminal-${tab.paneId}`;
+  return tab.id;
+}
+
+function sanitizeStoredGroups(
+  rawGroups: unknown,
+  knownTabIds: string[],
+): StoredTabGroup[] {
+  if (!Array.isArray(rawGroups) || knownTabIds.length === 0) {
+    return [];
+  }
+
+  const known = new Set(knownTabIds);
+  const groups: StoredTabGroup[] = [];
+  const seenGroups = new Set<string>();
+
+  for (const rawGroup of rawGroups) {
+    if (!rawGroup || typeof rawGroup !== "object") continue;
+    const obj = rawGroup as Record<string, unknown>;
+    const id = normalizeString(obj.id);
+    if (!id || seenGroups.has(id)) continue;
+    const tabIds = Array.isArray(obj.tabIds)
+      ? obj.tabIds
+          .map((value) => normalizeString(value))
+          .filter((value) => value && known.has(value))
+      : [];
+    if (tabIds.length === 0) continue;
+    const activeTabIdRaw = normalizeString(obj.activeTabId);
+    groups.push({
+      id,
+      tabIds,
+      activeTabId: activeTabIdRaw && tabIds.includes(activeTabIdRaw) ? activeTabIdRaw : (tabIds[0] ?? null),
+    });
+    seenGroups.add(id);
+  }
+
+  return groups;
+}
+
+function sanitizeStoredRoot(
+  rawRoot: unknown,
+  knownGroupIds: string[],
+): StoredTabLayoutNode | null {
+  if (!rawRoot || typeof rawRoot !== "object" || knownGroupIds.length === 0) {
+    return null;
+  }
+  const known = new Set(knownGroupIds);
+
+  function visit(rawNode: unknown): StoredTabLayoutNode | null {
+    if (!rawNode || typeof rawNode !== "object") return null;
+    const obj = rawNode as Record<string, unknown>;
+    const type = normalizeString(obj.type);
+    if (type === "group") {
+      const groupId = normalizeString(obj.groupId);
+      return groupId && known.has(groupId) ? { type: "group", groupId } : null;
+    }
+    if (type !== "split") return null;
+    const id = normalizeString(obj.id);
+    const axis =
+      normalizeString(obj.axis) === "vertical" ? "vertical" : "horizontal";
+    const childrenRaw = Array.isArray(obj.children) ? obj.children : [];
+    if (childrenRaw.length !== 2) return null;
+    const first = visit(childrenRaw[0]);
+    const second = visit(childrenRaw[1]);
+    if (!first && !second) return null;
+    if (!first) return second;
+    if (!second) return first;
+    const sizesRaw = Array.isArray(obj.sizes) ? obj.sizes : [];
+    const firstSize = Number(sizesRaw[0]);
+    const primary =
+      Number.isFinite(firstSize) && firstSize > 0 && firstSize < 1
+        ? firstSize
+        : 0.5;
+    return {
+      type: "split",
+      id: id || `split-restored-${knownGroupIds.length}`,
+      axis,
+      sizes: [primary, 1 - primary],
+      children: [first, second],
+    };
+  }
+
+  return visit(rawRoot);
 }
 
 function sanitizeLegacyProjectTabsEntry(
@@ -257,7 +413,7 @@ function sanitizeLegacyProjectTabsEntry(
   return { tabs, activePaneId };
 }
 
-function loadStoredProjectTabsV2(
+function loadStoredProjectTabsCurrent(
   projectPath: string,
   store: Storage,
 ): StoredProjectTabs | null {
@@ -269,7 +425,7 @@ function loadStoredProjectTabsV2(
     if (!parsed || typeof parsed !== "object") return null;
     const root = parsed as Partial<StoredProjectTabsRoot>;
 
-    if (root.version !== 2) return null;
+    if (root.version !== 2 && root.version !== 3) return null;
     if (!root.byProjectPath || typeof root.byProjectPath !== "object")
       return null;
 
@@ -351,7 +507,7 @@ export function loadStoredProjectTabs(
   if (!key) return null;
 
   return (
-    loadStoredProjectTabsV2(key, store) ??
+    loadStoredProjectTabsCurrent(key, store) ??
     loadStoredProjectTabsLegacy(key, store)
   );
 }
@@ -374,18 +530,18 @@ export function persistStoredProjectTabs(
 
   try {
     const raw = store.getItem(PROJECT_TABS_STORAGE_KEY);
-    let root: StoredProjectTabsRoot = { version: 2, byProjectPath: {} };
+    let root: StoredProjectTabsRoot = { version: 3, byProjectPath: {} };
 
     if (raw) {
       const parsed: unknown = JSON.parse(raw);
       if (parsed && typeof parsed === "object") {
         const existing = parsed as Partial<StoredProjectTabsRoot>;
         if (
-          existing.version === 2 &&
+          (existing.version === 2 || existing.version === 3) &&
           existing.byProjectPath &&
           typeof existing.byProjectPath === "object"
         ) {
-          root = { version: 2, byProjectPath: existing.byProjectPath };
+          root = { version: existing.version, byProjectPath: existing.byProjectPath };
         }
       }
     }
@@ -492,11 +648,90 @@ export function buildRestoredProjectTabs(
       ? activeTerminalPaneId
       : null;
 
+  const restoredLayout = buildRestoredLayoutState(
+    stored,
+    restoredTabs,
+    activeTabId,
+  );
+
   return {
     tabs: restoredTabs,
     activeTabId,
+    activeGroupId: restoredLayout.activeGroupId,
+    groups: Object.values(restoredLayout.groups),
+    root: restoredLayout.root as StoredTabLayoutNode,
     terminalTabsToRespawn,
     activeTerminalPaneIdToRespawn,
+  };
+}
+
+function buildRestoredLayoutState(
+  stored: StoredProjectTabs,
+  restoredTabs: Tab[],
+  restoredActiveTabId: string | null,
+): { groups: Record<string, TabGroupState>; root: TabLayoutNode; activeGroupId: string } {
+  if (restoredTabs.length === 0) {
+    return createInitialTabLayout([], null);
+  }
+
+  const restoredTabIds = restoredTabs.map((tab) => tab.id);
+  const knownTabs = new Set(restoredTabIds);
+  const storedGroups = Array.isArray(stored.groups) ? stored.groups : [];
+  const nextGroups: Record<string, TabGroupState> = {};
+
+  for (const group of storedGroups) {
+    const tabIds = group.tabIds.filter((tabId) => knownTabs.has(tabId));
+    if (tabIds.length === 0) continue;
+    nextGroups[group.id] = {
+      id: group.id,
+      tabIds,
+      activeTabId:
+        group.activeTabId && tabIds.includes(group.activeTabId)
+          ? group.activeTabId
+          : (tabIds[0] ?? null),
+    };
+  }
+
+  let root =
+    stored.root && Object.keys(nextGroups).length > 0
+      ? sanitizeStoredRoot(stored.root, Object.keys(nextGroups))
+      : null;
+
+  if (!root || Object.keys(nextGroups).length === 0) {
+    return createInitialTabLayout(restoredTabs, restoredActiveTabId);
+  }
+
+  const assigned = new Set<string>();
+  for (const group of Object.values(nextGroups)) {
+    for (const tabId of group.tabIds) {
+      assigned.add(tabId);
+    }
+  }
+
+  const missingTabIds = restoredTabIds.filter((tabId) => !assigned.has(tabId));
+  if (missingTabIds.length > 0) {
+    const firstGroupId = Object.keys(nextGroups)[0];
+    if (firstGroupId) {
+      const target = nextGroups[firstGroupId];
+      target.tabIds = [...target.tabIds, ...missingTabIds];
+      if (!target.activeTabId) {
+        target.activeTabId = target.tabIds[0] ?? null;
+      }
+    }
+  }
+
+  const activeGroupIdRaw =
+    normalizeString(stored.activeGroupId) ||
+    Object.values(nextGroups).find(
+      (group) => group.activeTabId && group.activeTabId === restoredActiveTabId,
+    )?.id ||
+    Object.keys(nextGroups)[0] ||
+    "";
+
+  return {
+    groups: nextGroups,
+    root,
+    activeGroupId: activeGroupIdRaw,
   };
 }
 

--- a/gwt-gui/src/lib/components/MainArea.svelte
+++ b/gwt-gui/src/lib/components/MainArea.svelte
@@ -1,41 +1,34 @@
 <script lang="ts">
   import type { GitHubIssueInfo, LaunchAgentRequest, Tab } from "../types";
-  import type { TabDropPosition } from "../appTabs";
-  import TerminalView from "../terminal/TerminalView.svelte";
-  import IssueListPanel from "./IssueListPanel.svelte";
-  import IssueSpecPanel from "./IssueSpecPanel.svelte";
-  import PrListPanel from "./PrListPanel.svelte";
-  import SettingsPanel from "./SettingsPanel.svelte";
-  import VersionHistoryPanel from "./VersionHistoryPanel.svelte";
-  import ProjectIndexPanel from "./ProjectIndexPanel.svelte";
-  import AssistantPanel from "./AssistantPanel.svelte";
+  import type {
+    TabDropPosition,
+    TabGroupState,
+    TabLayoutDropTarget,
+    TabLayoutNode,
+    TabSplitDirection,
+  } from "../tabLayout";
+  import { createInitialTabLayout } from "../tabLayout";
+  import TabLayoutNodeView from "./TabLayoutNode.svelte";
 
-  function isAgentTabWithPaneId(tab: Tab): tab is Tab & { paneId: string } {
-    return (
-      tab.type === "agent" &&
-      typeof tab.paneId === "string" &&
-      tab.paneId.length > 0
-    );
-  }
-
-  function isTerminalTabWithPaneId(tab: Tab): tab is Tab & { paneId: string } {
-    return (
-      tab.type === "terminal" &&
-      typeof tab.paneId === "string" &&
-      tab.paneId.length > 0
-    );
-  }
+  const TAB_ID_MIME = "application/x-gwt-tab-id";
 
   let {
     tabs,
-    activeTabId,
-    selectedBranch: _selectedBranch,
+    groups = undefined,
+    layoutRoot = undefined,
+    activeGroupId = undefined,
+    activeTabId = undefined,
+    selectedBranch: _selectedBranch = undefined,
     projectPath,
-    onLaunchAgent: _onLaunchAgent,
-    onQuickLaunch: _onQuickLaunch,
+    onLaunchAgent,
+    onQuickLaunch,
     onTabSelect,
     onTabClose,
     onTabReorder,
+    onTabMoveToGroup = () => {},
+    onTabSplitToGroupEdge = () => {},
+    onSplitResize = () => {},
+    onGroupFocus = () => {},
     onWorkOnIssue,
     onSwitchToWorktree,
     onIssueCountChange,
@@ -49,18 +42,39 @@
     voiceInputError = null,
   }: {
     tabs: Tab[];
-    activeTabId: string;
+    groups?: Record<string, TabGroupState> | undefined;
+    layoutRoot?: TabLayoutNode | undefined;
+    activeGroupId?: string | undefined;
+    activeTabId?: string | undefined;
     selectedBranch?: unknown;
     projectPath: string;
     onLaunchAgent?: () => void;
     onQuickLaunch?: (request: LaunchAgentRequest) => Promise<void>;
-    onTabSelect: (tabId: string) => void;
+    onTabSelect:
+      | ((groupId: string, tabId: string) => void)
+      | ((tabId: string) => void);
     onTabClose: (tabId: string) => void;
-    onTabReorder: (
+    onTabReorder:
+      | ((
+          groupId: string,
+          dragTabId: string,
+          overTabId: string,
+          position: TabDropPosition,
+        ) => void)
+      | ((dragTabId: string, overTabId: string, position: TabDropPosition) => void);
+    onTabMoveToGroup?: (
       dragTabId: string,
-      overTabId: string,
-      position: TabDropPosition,
+      targetGroupId: string,
+      overTabId?: string | null,
+      position?: TabDropPosition,
     ) => void;
+    onTabSplitToGroupEdge?: (
+      dragTabId: string,
+      targetGroupId: string,
+      direction: TabSplitDirection,
+    ) => void;
+    onSplitResize?: (splitId: string, primaryFraction: number) => void;
+    onGroupFocus?: (groupId: string) => void;
     onWorkOnIssue?: (issue: GitHubIssueInfo) => void;
     onSwitchToWorktree?: (branchName: string) => void;
     onIssueCountChange?: (count: number) => void;
@@ -74,689 +88,250 @@
     voiceInputError?: string | null;
   } = $props();
 
-  let activeTab = $derived(tabs.find((t) => t.id === activeTabId));
-  let agentTabs = $derived(tabs.filter(isAgentTabWithPaneId));
-  let terminalTabs = $derived(tabs.filter(isTerminalTabWithPaneId));
-  let nonTerminalTabs = $derived(
-    tabs.filter((tab) => tab.type !== "agent" && tab.type !== "terminal"),
+  let fallbackLayout = $derived(
+    createInitialTabLayout(tabs, activeTabId ?? tabs[0]?.id ?? null),
   );
-  let mountedPanelTabIds: Set<string> = $state(new Set());
-  let mountedNonTerminalTabs = $derived(
-    nonTerminalTabs.filter((tab) => mountedPanelTabIds.has(tab.id)),
+  let resolvedGroups = $derived(groups ?? fallbackLayout.groups);
+  let resolvedLayoutRoot = $derived(layoutRoot ?? fallbackLayout.root);
+  let resolvedActiveGroupId = $derived(
+    activeGroupId ?? fallbackLayout.activeGroupId,
   );
-  let activeTerminalTabId = $derived(
-    (activeTab?.type === "agent" || activeTab?.type === "terminal") &&
-      typeof activeTab.paneId === "string" &&
-      activeTab.paneId.length > 0
-      ? activeTab.id
-      : null,
-  );
-  let hasActiveNonTerminalTab = $derived(
-    nonTerminalTabs.some((tab) => tab.id === activeTabId),
-  );
-  let terminalTabIdByPaneId = $derived(
-    (() => {
-      const map = new Map<string, string>();
-      for (const tab of agentTabs) map.set(tab.paneId, tab.id);
-      for (const tab of terminalTabs) map.set(tab.paneId, tab.id);
-      return map;
-    })(),
-  );
-  let showTerminalLayer = $derived(
-    activeTerminalTabId !== null,
-  );
-  let showDetachedTerminalPlaceholder = $derived(
-    (activeTab?.type === "agent" || activeTab?.type === "terminal") &&
-      activeTerminalTabId === null,
-  );
-  let isPinnedTab = (tabType?: Tab["type"]) => tabType === "assistant";
-  let draggingTabId: string | null = $state(null);
-  let terminalPendingTabId: string | null = $state(null);
-  let visibleTerminalTabId: string | null = $state(null);
-  let terminalViewRefs = new Map<string, { focusTerminal: () => void }>();
-  let terminalReadyTabIds: Set<string> = $state(new Set());
-  let terminalActivationFallbackTimer: ReturnType<typeof setTimeout> | null =
-    null;
-  let pointerDrag:
-    | {
-        tabId: string;
-        pointerId: number;
-        startX: number;
-        startY: number;
-      }
-    | null = null;
+  let draggedTabId: string | null = $state(null);
+  let dropTarget: TabLayoutDropTarget | null = $state(null);
   let lastReorderSignature = "";
-  const TERMINAL_ACTIVATION_FALLBACK_MS = 120;
-
-  function areSetsEqual(a: Set<string>, b: Set<string>): boolean {
-    if (a.size !== b.size) return false;
-    for (const item of a) {
-      if (!b.has(item)) return false;
-    }
-    return true;
-  }
-
-  function clearTerminalActivationFallbackTimer() {
-    if (terminalActivationFallbackTimer === null) return;
-    clearTimeout(terminalActivationFallbackTimer);
-    terminalActivationFallbackTimer = null;
-  }
-
-  function handleTerminalReady(paneId: string) {
-    const tabId = terminalTabIdByPaneId.get(paneId);
-    if (!tabId) return;
-    if (!terminalReadyTabIds.has(tabId)) {
-      terminalReadyTabIds = new Set(terminalReadyTabIds).add(tabId);
-    }
-    if (!terminalPendingTabId || tabId !== terminalPendingTabId) return;
-    clearTerminalActivationFallbackTimer();
-    visibleTerminalTabId = tabId;
-  }
-
-  function isTerminalTabVisible(tabId: string): boolean {
-    if (tabId !== activeTerminalTabId) return false;
-    if (terminalReadyTabIds.has(tabId)) return true;
-    return tabId === visibleTerminalTabId;
-  }
+  let tabsById = $derived(
+    Object.fromEntries(tabs.map((tab) => [tab.id, tab])),
+  );
 
   function readDraggedTabId(event: DragEvent): string {
-    if (draggingTabId) return draggingTabId;
-
-    const appData =
-      event.dataTransfer?.getData("application/x-gwt-tab-id") ?? "";
+    if (draggedTabId) return draggedTabId;
+    const appData = event.dataTransfer?.getData(TAB_ID_MIME) ?? "";
     if (appData.trim()) return appData.trim();
     const textData = event.dataTransfer?.getData("text/plain") ?? "";
     return textData.trim();
   }
 
-  function resetDragState() {
-    removeGlobalPointerListeners();
-    draggingTabId = null;
-    pointerDrag = null;
+  function clearDragState() {
+    draggedTabId = null;
+    dropTarget = null;
     lastReorderSignature = "";
   }
 
-  function removeGlobalPointerListeners() {
-    if (typeof window === "undefined") return;
-    window.removeEventListener("pointermove", handleGlobalPointerMove);
-    window.removeEventListener("pointerup", handleGlobalPointerUp);
-    window.removeEventListener("pointercancel", handleGlobalPointerCancel);
-  }
-
-  function addGlobalPointerListeners() {
-    if (typeof window === "undefined") return;
-    removeGlobalPointerListeners();
-    window.addEventListener("pointermove", handleGlobalPointerMove);
-    window.addEventListener("pointerup", handleGlobalPointerUp);
-    window.addEventListener("pointercancel", handleGlobalPointerCancel);
-  }
-
-  function handleTabDragStart(event: DragEvent, tabId: string) {
-    draggingTabId = tabId;
-    lastReorderSignature = "";
+  function handleTabDragStart(tabId: string, event: DragEvent) {
+    draggedTabId = tabId;
     if (!event.dataTransfer) return;
     event.dataTransfer.effectAllowed = "move";
-    event.dataTransfer.setData("application/x-gwt-tab-id", tabId);
+    event.dataTransfer.setData(TAB_ID_MIME, tabId);
     event.dataTransfer.setData("text/plain", tabId);
   }
 
-  function handleTabDragOver(event: DragEvent, overTabId: string) {
-    const dragTabId = readDraggedTabId(event);
-    if (!dragTabId || dragTabId === overTabId) return;
+  function handleTabDragEnd() {
+    clearDragState();
+  }
 
+  function handleTabSplitAction(
+    tabId: string,
+    groupId: string,
+    direction: TabSplitDirection,
+  ) {
+    onTabSplitToGroupEdge(tabId, groupId, direction);
+  }
+
+  function handleTabSelectForward(groupId: string, tabId: string) {
+    if (onTabSelect.length >= 2) {
+      (onTabSelect as (groupId: string, tabId: string) => void)(groupId, tabId);
+    } else {
+      (onTabSelect as (tabId: string) => void)(tabId);
+    }
+  }
+
+  function handleTabDragOver(
+    groupId: string,
+    tabId: string,
+    position: TabDropPosition,
+    event: DragEvent,
+  ) {
+    const dragTabId = readDraggedTabId(event);
+    if (!dragTabId || dragTabId === tabId) return;
     event.preventDefault();
     if (event.dataTransfer) {
       event.dataTransfer.dropEffect = "move";
     }
-
-    const target = event.currentTarget;
-    if (!(target instanceof HTMLElement)) return;
-
-    const rect = target.getBoundingClientRect();
-    const position: TabDropPosition =
-      event.clientX <= rect.left + rect.width / 2 ? "before" : "after";
-
-    const signature = `${dragTabId}:${overTabId}:${position}`;
-    if (signature === lastReorderSignature) return;
-    lastReorderSignature = signature;
-    onTabReorder(dragTabId, overTabId, position);
-  }
-
-  function handleTabDrop(event: DragEvent) {
-    event.preventDefault();
-    lastReorderSignature = "";
-  }
-
-  function handleTabDragEnd() {
-    resetDragState();
-  }
-
-  function isTabCloseControl(target: EventTarget | null): boolean {
-    return target instanceof Element && target.closest(".tab-close") !== null;
-  }
-
-  function handleTabPointerDown(event: PointerEvent, tabId: string) {
-    if (event.button !== 0) return;
-    if (isTabCloseControl(event.target)) return;
-
-    draggingTabId = tabId;
-    pointerDrag = {
+    const sourceGroup = Object.values(resolvedGroups).find((group) =>
+      group.tabIds.includes(dragTabId),
+    );
+    if (sourceGroup?.id === groupId) {
+      const signature = `${dragTabId}:${tabId}:${position}`;
+      if (signature !== lastReorderSignature) {
+        lastReorderSignature = signature;
+        if (onTabReorder.length >= 4) {
+          (onTabReorder as (
+            groupId: string,
+            dragTabId: string,
+            overTabId: string,
+            position: TabDropPosition,
+          ) => void)(groupId, dragTabId, tabId, position);
+        } else {
+          (onTabReorder as (
+            dragTabId: string,
+            overTabId: string,
+            position: TabDropPosition,
+          ) => void)(dragTabId, tabId, position);
+        }
+      }
+    }
+    dropTarget = {
+      kind: "tab",
+      groupId,
       tabId,
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
+      position,
     };
-    lastReorderSignature = "";
-    addGlobalPointerListeners();
   }
 
-  function handleGlobalPointerMove(event: PointerEvent) {
-    if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return;
-    // Ignore micro jitter so simple clicks do not trigger reordering.
-    if (
-      Math.abs(event.clientX - pointerDrag.startX) < 3 &&
-      Math.abs(event.clientY - pointerDrag.startY) < 3
-    ) {
+  function handleTabDrop(
+    groupId: string,
+    tabId: string,
+    position: TabDropPosition,
+    event: DragEvent,
+  ) {
+    const dragTabId = readDraggedTabId(event);
+    if (!dragTabId || dragTabId === tabId) {
+      clearDragState();
       return;
     }
-
-    const fromPoint =
-      typeof document !== "undefined" &&
-      typeof document.elementFromPoint === "function"
-        ? document
-            .elementFromPoint(event.clientX, event.clientY)
-            ?.closest<HTMLElement>(".tab[data-tab-id]")
-        : null;
-    const fromTarget =
-      event.target instanceof Element
-        ? event.target.closest<HTMLElement>(".tab[data-tab-id]")
-        : null;
-    const overTab = fromPoint ?? fromTarget ?? null;
-    if (!overTab) return;
-
-    const overTabId = overTab.dataset.tabId ?? "";
-    if (!overTabId || overTabId === pointerDrag.tabId) return;
-
-    const rect = overTab.getBoundingClientRect();
-    const position: TabDropPosition =
-      event.clientX <= rect.left + rect.width / 2 ? "before" : "after";
-    const signature = `${pointerDrag.tabId}:${overTabId}:${position}`;
-    if (signature === lastReorderSignature) return;
-
-    lastReorderSignature = signature;
-    onTabReorder(pointerDrag.tabId, overTabId, position);
+    event.preventDefault();
+    const currentGroups = resolvedGroups;
+    const sourceGroup = Object.values(currentGroups).find((group) =>
+      group.tabIds.includes(dragTabId),
+    );
+    if (sourceGroup?.id === groupId) {
+      if (onTabReorder.length >= 4) {
+        (onTabReorder as (
+          groupId: string,
+          dragTabId: string,
+          overTabId: string,
+          position: TabDropPosition,
+        ) => void)(groupId, dragTabId, tabId, position);
+      } else {
+        (onTabReorder as (
+          dragTabId: string,
+          overTabId: string,
+          position: TabDropPosition,
+        ) => void)(dragTabId, tabId, position);
+      }
+    } else {
+      onTabMoveToGroup(dragTabId, groupId, tabId, position);
+    }
+    clearDragState();
   }
 
-  function handleGlobalPointerUp(event: PointerEvent) {
-    if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return;
-    resetDragState();
-  }
-
-  function handleGlobalPointerCancel(event: PointerEvent) {
-    if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return;
-    resetDragState();
-  }
-
-  $effect(() => {
-    void nonTerminalTabs;
-    void activeTabId;
-
-    const validIds = new Set(nonTerminalTabs.map((tab) => tab.id));
-    const next = new Set<string>();
-    for (const tabId of mountedPanelTabIds) {
-      if (validIds.has(tabId)) {
-        next.add(tabId);
-      }
+  function handleGroupDragOver(groupId: string, event: DragEvent) {
+    const dragTabId = readDraggedTabId(event);
+    if (!dragTabId) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "move";
     }
-    if (validIds.has(activeTabId)) {
-      next.add(activeTabId);
-    }
-
-    if (!areSetsEqual(next, mountedPanelTabIds)) {
-      mountedPanelTabIds = next;
-    }
-  });
-
-  $effect(() => {
-    void activeTerminalTabId;
-
-    clearTerminalActivationFallbackTimer();
-    terminalPendingTabId = activeTerminalTabId;
-
-    if (!activeTerminalTabId) {
-      visibleTerminalTabId = null;
-      return;
-    }
-
-    if (terminalReadyTabIds.has(activeTerminalTabId)) {
-      visibleTerminalTabId = activeTerminalTabId;
-      return;
-    }
-
-    visibleTerminalTabId = null;
-
-    if (typeof window === "undefined") {
-      visibleTerminalTabId = activeTerminalTabId;
-      return;
-    }
-
-    const pendingId = activeTerminalTabId;
-    const timeoutId = window.setTimeout(() => {
-      if (
-        activeTerminalTabId === pendingId &&
-        terminalPendingTabId === pendingId
-      ) {
-        terminalReadyTabIds = new Set(terminalReadyTabIds).add(pendingId);
-        visibleTerminalTabId = pendingId;
-      }
-      if (terminalActivationFallbackTimer === timeoutId) {
-        terminalActivationFallbackTimer = null;
-      }
-    }, TERMINAL_ACTIVATION_FALLBACK_MS);
-    terminalActivationFallbackTimer = timeoutId;
-
-    return () => {
-      if (terminalActivationFallbackTimer === timeoutId) {
-        clearTimeout(timeoutId);
-        terminalActivationFallbackTimer = null;
-      }
+    dropTarget = {
+      kind: "group",
+      groupId,
     };
-  });
+  }
 
-  $effect(() => {
-    void agentTabs;
-    void terminalTabs;
-
-    const validTerminalTabIds = new Set([
-      ...agentTabs.map((tab) => tab.id),
-      ...terminalTabs.map((tab) => tab.id),
-    ]);
-
-    const next = new Set<string>();
-    for (const tabId of terminalReadyTabIds) {
-      if (validTerminalTabIds.has(tabId)) {
-        next.add(tabId);
-      }
+  function handleGroupDrop(groupId: string, event: DragEvent) {
+    const dragTabId = readDraggedTabId(event);
+    if (!dragTabId) {
+      clearDragState();
+      return;
     }
+    event.preventDefault();
+    onTabMoveToGroup(dragTabId, groupId, null, "after");
+    clearDragState();
+  }
 
-    if (!areSetsEqual(next, terminalReadyTabIds)) {
-      terminalReadyTabIds = next;
+  function handleSplitDragOver(
+    groupId: string,
+    direction: TabSplitDirection,
+    event: DragEvent,
+  ) {
+    const dragTabId = readDraggedTabId(event);
+    if (!dragTabId) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "move";
     }
-  });
-
-  $effect(() => {
-    return () => {
-      clearTerminalActivationFallbackTimer();
-      removeGlobalPointerListeners();
+    dropTarget = {
+      kind: "split",
+      groupId,
+      direction,
     };
-  });
+  }
+
+  function handleSplitDrop(
+    groupId: string,
+    direction: TabSplitDirection,
+    event: DragEvent,
+  ) {
+    const dragTabId = readDraggedTabId(event);
+    if (!dragTabId) {
+      clearDragState();
+      return;
+    }
+    event.preventDefault();
+    onTabSplitToGroupEdge(dragTabId, groupId, direction);
+    clearDragState();
+  }
 </script>
 
-<main class="main-area">
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="tab-bar">
-    {#each tabs as tab}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="tab"
-        data-tab-id={tab.id}
-        class:active={activeTabId === tab.id}
-        class:dragging={draggingTabId === tab.id}
-        draggable="false"
-        onclick={() => onTabSelect(tab.id)}
-        title={tab.type === "terminal" ? tab.cwd || "" : ""}
-        onpointerdown={(e) => handleTabPointerDown(e, tab.id)}
-        ondragstart={(e) => handleTabDragStart(e, tab.id)}
-        ondragover={(e) => handleTabDragOver(e, tab.id)}
-        ondrop={handleTabDrop}
-        ondragend={handleTabDragEnd}
-      >
-        {#if tab.type === "agent"}
-          <span
-            class="tab-dot"
-            class:claude={tab.agentId === "claude"}
-            class:codex={tab.agentId === "codex"}
-            class:gemini={tab.agentId === "gemini"}
-            class:opencode={tab.agentId === "opencode"}
-          ></span>
-        {:else if tab.type === "terminal"}
-          <span class="tab-dot terminal"></span>
-        {/if}
-        {#if tab.type === "agent"}
-          <span class="tab-label tab-label-scroll" aria-label={tab.label}>
-            <span class="tab-label-track">
-              <span>{tab.label}</span>
-              <span aria-hidden="true">{tab.label}</span>
-            </span>
-          </span>
-        {:else}
-          <span class="tab-label">{tab.label}</span>
-        {/if}
-        {#if !isPinnedTab(tab.type)}
-          <button
-            class="tab-close"
-            type="button"
-            onpointerdown={(e) => e.stopPropagation()}
-            onclick={(e) => {
-              e.stopPropagation();
-              onTabClose(tab.id);
-            }}
-          >
-            x
-          </button>
-        {/if}
-      </div>
-    {/each}
-  </div>
-
-  <div class="tab-content">
-    <div class="panel-layer" class:hidden={showTerminalLayer}>
-      {#if nonTerminalTabs.length === 0}
-        {#if showDetachedTerminalPlaceholder}
-          <div class="placeholder">
-            <h2>Agent starting...</h2>
-            <p>Waiting for the backend terminal pane to attach.</p>
-          </div>
-        {:else}
-          <div class="placeholder">
-            <h2>Select a tab</h2>
-          </div>
-        {/if}
-      {:else}
-        {#each mountedNonTerminalTabs as tab (tab.id)}
-          <div class="panel-wrapper" class:active={activeTabId === tab.id}>
-            {#if tab.type === "settings"}
-              <SettingsPanel onClose={() => onTabClose(tab.id)} />
-            {:else if tab.type === "versionHistory"}
-              <VersionHistoryPanel {projectPath} />
-            {:else if tab.type === "issueSpec"}
-              <IssueSpecPanel
-                projectPath={projectPath}
-                issueNumber={tab.issueNumber ?? 0}
-              />
-            {:else if tab.type === "issues"}
-              <IssueListPanel
-                {projectPath}
-                onWorkOnIssue={onWorkOnIssue ?? (() => {})}
-                onSwitchToWorktree={onSwitchToWorktree ?? (() => {})}
-                {onIssueCountChange}
-              />
-            {:else if tab.type === "prs"}
-              <PrListPanel
-                {projectPath}
-                isActive={activeTabId === tab.id}
-                onSwitchToWorktree={onSwitchToWorktree ?? (() => {})}
-              />
-            {:else if tab.type === "projectIndex"}
-              <ProjectIndexPanel {projectPath} />
-            {:else if tab.type === "assistant"}
-              <AssistantPanel
-                isActive={activeTabId === tab.id}
-                {projectPath}
-                onOpenSettings={onOpenSettings ?? (() => {})}
-              />
-            {:else}
-              <div class="placeholder">
-                <h2>Select a tab</h2>
-              </div>
-            {/if}
-          </div>
-        {/each}
-        {#if !hasActiveNonTerminalTab}
-          {#if showDetachedTerminalPlaceholder}
-            <div class="placeholder panel-fallback">
-              <h2>Agent starting...</h2>
-              <p>Waiting for the backend terminal pane to attach.</p>
-            </div>
-          {:else}
-            <div class="placeholder panel-fallback">
-              <h2>Select a tab</h2>
-            </div>
-          {/if}
-        {/if}
-      {/if}
-    </div>
-
-    <div class="terminal-layer" class:hidden={!showTerminalLayer}>
-      {#each agentTabs as tab (tab.id)}
-        <div class="terminal-wrapper" class:active={isTerminalTabVisible(tab.id)}>
-          <TerminalView
-            paneId={tab.paneId}
-            active={activeTabId === tab.id}
-            agentId={tab.agentId ?? null}
-            {voiceInputEnabled}
-            {voiceInputListening}
-            {voiceInputPreparing}
-            {voiceInputSupported}
-            {voiceInputAvailable}
-            {voiceInputAvailabilityReason}
-            {voiceInputError}
-            onReady={handleTerminalReady}
-          />
-        </div>
-      {/each}
-      {#each terminalTabs as tab (tab.id)}
-        <div class="terminal-wrapper" class:active={isTerminalTabVisible(tab.id)}>
-          <TerminalView
-            paneId={tab.paneId}
-            active={activeTabId === tab.id}
-            agentId={null}
-            {voiceInputEnabled}
-            {voiceInputListening}
-            {voiceInputPreparing}
-            {voiceInputSupported}
-            {voiceInputAvailable}
-            {voiceInputAvailabilityReason}
-            {voiceInputError}
-            onReady={handleTerminalReady}
-          />
-        </div>
-      {/each}
-    </div>
-  </div>
+<main class="main-area" class:drag-active={draggedTabId !== null}>
+  <TabLayoutNodeView
+    node={resolvedLayoutRoot}
+    groups={resolvedGroups}
+    {tabsById}
+    activeGroupId={resolvedActiveGroupId}
+    {projectPath}
+    {draggedTabId}
+    {dropTarget}
+    {onGroupFocus}
+    {onLaunchAgent}
+    {onQuickLaunch}
+    {onWorkOnIssue}
+    {onSwitchToWorktree}
+    {onIssueCountChange}
+    {onOpenSettings}
+    {voiceInputEnabled}
+    {voiceInputListening}
+    {voiceInputPreparing}
+    {voiceInputSupported}
+    {voiceInputAvailable}
+    {voiceInputAvailabilityReason}
+    {voiceInputError}
+    onTabSelect={handleTabSelectForward}
+    onTabClose={onTabClose}
+    onTabSplitAction={handleTabSplitAction}
+    onTabDragStart={handleTabDragStart}
+    onTabDragEnd={handleTabDragEnd}
+    onTabDragOver={handleTabDragOver}
+    onTabDrop={handleTabDrop}
+    onGroupDragOver={handleGroupDragOver}
+    onGroupDrop={handleGroupDrop}
+    onSplitDragOver={handleSplitDragOver}
+    onSplitDrop={handleSplitDrop}
+    onSplitResize={onSplitResize}
+  />
 </main>
 
 <style>
   .main-area {
     flex: 1;
     display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    background-color: var(--bg-primary);
-  }
-
-  .tab-bar {
-    display: flex;
-    height: var(--tab-height);
-    background-color: var(--bg-secondary);
-    border-bottom: 1px solid var(--border-color);
-    overflow-x: auto;
-    scrollbar-width: none;
-  }
-
-  .tab-bar::-webkit-scrollbar {
-    display: none;
-  }
-
-  .tab {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 0 16px;
-    background: none;
-    border: none;
-    border-right: 1px solid var(--border-color);
-    color: var(--text-secondary);
-    font-size: var(--ui-font-md);
-    cursor: pointer;
-    white-space: nowrap;
-    font-family: inherit;
-  }
-
-  .tab:hover {
-    color: var(--text-primary);
-    background-color: var(--bg-hover);
-  }
-
-  .tab.dragging {
-    opacity: 0.6;
-  }
-
-  .tab.active {
-    color: var(--text-primary);
-    background-color: var(--bg-primary);
-    border-bottom: 2px solid var(--accent);
-  }
-
-  .tab-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background-color: var(--green);
-    flex-shrink: 0;
-  }
-
-  .tab-dot.claude {
-    background-color: var(--yellow);
-  }
-
-  .tab-dot.codex {
-    background-color: var(--cyan);
-  }
-
-  .tab-dot.gemini {
-    background-color: var(--magenta);
-  }
-
-  .tab-dot.opencode {
-    background-color: var(--green);
-  }
-
-  .tab-dot.terminal {
-    background-color: var(--text-muted);
-  }
-
-  .tab-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .tab-label-scroll {
-    display: inline-flex;
     min-width: 0;
-    white-space: nowrap;
-  }
-
-  .tab-label-track {
-    display: inline-flex;
-    gap: 24px;
-    min-width: max-content;
-    animation: tab-label-marquee 12s linear infinite;
-  }
-
-  @keyframes tab-label-marquee {
-    from {
-      transform: translateX(0);
-    }
-
-    to {
-      transform: translateX(calc(-50% - 12px));
-    }
-  }
-
-  .tab-close {
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: var(--ui-font-sm);
-    font-family: monospace;
-    cursor: pointer;
-    padding: 0 2px;
-    line-height: 1;
-    flex-shrink: 0;
-  }
-
-  .tab-close:hover {
-    color: var(--red);
-  }
-
-  .tab-content {
-    flex: 1;
-    position: relative;
+    min-height: 0;
     overflow: hidden;
+    background: var(--bg-primary);
   }
 
-  .panel-layer {
-    position: absolute;
-    inset: 0;
-    overflow: hidden;
-    padding: 0;
-    z-index: 2;
-  }
-
-  .panel-wrapper {
-    position: absolute;
-    inset: 0;
-    overflow: auto;
-    padding: 24px;
-    visibility: hidden;
-    pointer-events: none;
-  }
-
-  .panel-wrapper.active {
-    visibility: visible;
-    pointer-events: auto;
-  }
-
-  .terminal-layer {
-    position: absolute;
-    inset: 0;
-    overflow: hidden;
-    z-index: 1;
-  }
-
-  .panel-layer.hidden,
-  .terminal-layer.hidden {
-    visibility: hidden;
-    pointer-events: none;
-  }
-
-  .terminal-wrapper {
-    position: absolute;
-    inset: 0;
-    visibility: hidden;
-    pointer-events: none;
-  }
-
-  .terminal-wrapper.active {
-    visibility: visible;
-    pointer-events: auto;
-  }
-
-  .placeholder {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    color: var(--text-muted);
-  }
-
-  .panel-fallback {
-    position: absolute;
-    inset: 24px;
-  }
-
-  .placeholder h2 {
-    font-size: var(--ui-font-2xl);
-    font-weight: 500;
-    color: var(--text-secondary);
-  }
-
-  .placeholder p {
-    margin-top: 10px;
-    font-size: var(--ui-font-sm);
-    color: var(--text-muted);
+  .main-area.drag-active {
+    user-select: none;
   }
 </style>

--- a/gwt-gui/src/lib/components/MainArea.test.ts
+++ b/gwt-gui/src/lib/components/MainArea.test.ts
@@ -1,39 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  cleanup,
-  createEvent,
-  fireEvent,
-  render,
-  waitFor,
-} from "@testing-library/svelte";
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
 import MainArea from "./MainArea.svelte";
 import type { Tab } from "../types";
-
-async function renderMainArea(props: {
-  tabs: Tab[];
-  activeTabId: string;
-  onTabSelect?: (tabId: string) => void;
-  onTabClose?: (tabId: string) => void;
-  onTabReorder?: (
-    dragTabId: string,
-    overTabId: string,
-    position: "before" | "after",
-  ) => void;
-}) {
-  return render(MainArea, {
-    props: {
-      projectPath: "/tmp/project",
-      selectedBranch: null,
-      onLaunchAgent: vi.fn(),
-      onQuickLaunch: vi.fn(),
-      onTabSelect: props.onTabSelect ?? vi.fn(),
-      onTabClose: props.onTabClose ?? vi.fn(),
-      onTabReorder: props.onTabReorder ?? vi.fn(),
-      activeTabId: props.activeTabId,
-      tabs: props.tabs,
-    },
-  });
-}
+import {
+  createInitialTabLayout,
+  splitTabToGroupEdge,
+  type TabLayoutState,
+} from "../tabLayout";
 
 function createDataTransferMock(): DataTransfer {
   const data = new Map<string, string>();
@@ -58,49 +31,67 @@ function createDataTransferMock(): DataTransfer {
   } as DataTransfer;
 }
 
-function setupTerminalMocks(): () => void {
-  const originalMatchMedia = window.matchMedia;
-  const originalResizeObserver = (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
-  Object.defineProperty(window, "matchMedia", {
-    configurable: true,
-    value: vi.fn(() => ({
-      matches: false,
-      media: "",
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
+function renderMainArea({
+  tabs,
+  layout,
+  onTabSelect = vi.fn(),
+  onTabClose = vi.fn(),
+  onTabReorder = vi.fn(),
+  onTabMoveToGroup = vi.fn(),
+  onTabSplitToGroupEdge = vi.fn(),
+  onSplitResize = vi.fn(),
+  onGroupFocus = vi.fn(),
+}: {
+  tabs: Tab[];
+  layout?: TabLayoutState;
+  onTabSelect?: (groupId: string, tabId: string) => void;
+  onTabClose?: (tabId: string) => void;
+  onTabReorder?: (
+    groupId: string,
+    dragTabId: string,
+    overTabId: string,
+    position: "before" | "after",
+  ) => void;
+  onTabMoveToGroup?: (
+    dragTabId: string,
+    targetGroupId: string,
+    overTabId?: string | null,
+    position?: "before" | "after",
+  ) => void;
+  onTabSplitToGroupEdge?: (
+    dragTabId: string,
+    targetGroupId: string,
+    direction: "left" | "right" | "up" | "down",
+  ) => void;
+  onSplitResize?: (splitId: string, primaryFraction: number) => void;
+  onGroupFocus?: (groupId: string) => void;
+}) {
+  const resolvedLayout =
+    layout ?? createInitialTabLayout(tabs, tabs[0]?.id ?? null);
+  return render(MainArea, {
+    props: {
+      tabs,
+      groups: resolvedLayout.groups,
+      layoutRoot: resolvedLayout.root,
+      activeGroupId: resolvedLayout.activeGroupId,
+      activeTabId:
+        resolvedLayout.groups[resolvedLayout.activeGroupId]?.activeTabId ?? undefined,
+      projectPath: "/tmp/project",
+      onLaunchAgent: vi.fn(),
+      onQuickLaunch: vi.fn(),
+      onTabSelect,
+      onTabClose,
+      onTabReorder,
+      onTabMoveToGroup,
+      onTabSplitToGroupEdge,
+      onSplitResize,
+      onGroupFocus,
+    },
   });
-  class ResizeObserverMock {
-    observe = vi.fn();
-    unobserve = vi.fn();
-    disconnect = vi.fn();
-  }
-  Object.defineProperty(globalThis, "ResizeObserver", {
-    configurable: true,
-    value: ResizeObserverMock,
-  });
-  return () => {
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      value: originalMatchMedia,
-    });
-    if (originalResizeObserver) {
-      Object.defineProperty(globalThis, "ResizeObserver", {
-        configurable: true,
-        value: originalResizeObserver,
-      });
-    } else {
-      delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
-    }
-  };
 }
 
 function getTabByLabel(container: HTMLElement, label: string): HTMLElement {
-  const tab = Array.from(container.querySelectorAll<HTMLElement>(".tab-bar .tab")).find(
+  const tab = Array.from(container.querySelectorAll<HTMLElement>(".tab")).find(
     (el) => {
       const tabLabel = el.querySelector(".tab-label");
       const effectiveLabel =
@@ -120,155 +111,115 @@ describe("MainArea", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders without Session Summary tab", async () => {
+  it("renders a single group by default", () => {
     const tabs: Tab[] = [
       { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "settings", label: "Settings", type: "settings" },
     ];
-    const rendered = await renderMainArea({ tabs, activeTabId: "assistant" });
+    const rendered = renderMainArea({ tabs });
 
-    expect(rendered.queryByText("Session Summary")).toBeNull();
-    const tabLabels = Array.from(
-      rendered.container.querySelectorAll(".tab-bar .tab-label"),
-    ).map((el) => el.textContent?.trim());
-    expect(tabLabels).toEqual(["Assistant"]);
+    expect(rendered.container.querySelectorAll(".group-pane")).toHaveLength(1);
+    expect(rendered.container.querySelectorAll(".tab")).toHaveLength(2);
   });
 
-  it("keeps Assistant pinned (no close button)", async () => {
+  it("renders split groups from the layout tree", () => {
     const tabs: Tab[] = [
       { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "settings", label: "Settings", type: "settings" },
+      { id: "issues", label: "Issues", type: "issues" },
     ];
-    const rendered = await renderMainArea({ tabs, activeTabId: "assistant" });
+    const base = createInitialTabLayout(tabs, "assistant");
+    const split = splitTabToGroupEdge(base, "issues", base.activeGroupId, "right");
+    const rendered = renderMainArea({ tabs, layout: split });
 
-    const assistantTab = rendered.container.querySelector(".tab-bar .tab");
-    expect(assistantTab).toBeTruthy();
-    expect(assistantTab?.querySelector(".tab-close")).toBeNull();
+    expect(rendered.container.querySelectorAll(".group-pane")).toHaveLength(2);
+    expect(rendered.container.querySelector(".split-node")).toBeTruthy();
   });
 
-  it("renders agent tab labels with always-scrolling markup only for agent tabs", async () => {
+  it("keeps Assistant pinned and emits close for non-pinned tabs", async () => {
+    const onTabClose = vi.fn();
+    const tabs: Tab[] = [
+      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "settings", label: "Settings", type: "settings" },
+    ];
+    const rendered = renderMainArea({ tabs, onTabClose });
+
+    expect(getTabByLabel(rendered.container, "Assistant").querySelector(".tab-close")).toBeNull();
+    const closeButton = getTabByLabel(rendered.container, "Settings").querySelector(
+      ".tab-close",
+    ) as HTMLButtonElement;
+    await fireEvent.click(closeButton);
+    expect(onTabClose).toHaveBeenCalledWith("settings");
+  });
+
+  it("renders agent tabs with scrolling label markup and agent-specific dots", () => {
     const tabs: Tab[] = [
       { id: "assistant", label: "Assistant", type: "assistant" },
       {
         id: "agent-1",
-        label: "#1644 Worktree管理",
+        label: "Long Agent Label",
         type: "agent",
         paneId: "pane-1",
-        branchName: "feature/issue-1644",
+        agentId: "codex",
       },
-      { id: "settings", label: "Settings", type: "settings" },
     ];
-    const restoreTerminalMocks = setupTerminalMocks();
-    try {
-      const rendered = await renderMainArea({ tabs, activeTabId: "assistant" });
-      const agentTab = rendered.container.querySelector('[data-tab-id="agent-1"]');
-      const staticTab = rendered.container.querySelector('[data-tab-id="settings"]');
-      expect(agentTab?.querySelector(".tab-label-scroll .tab-label-track")).toBeTruthy();
-      expect(staticTab?.querySelector(".tab-label-scroll")).toBeNull();
-    } finally {
-      restoreTerminalMocks();
-    }
+    const rendered = renderMainArea({ tabs });
+    const agentTab = rendered.container.querySelector('[data-tab-id="agent-1"]');
+    expect(agentTab?.querySelector(".tab-label-scroll .tab-label-track")).toBeTruthy();
+    expect(agentTab?.querySelector(".tab-dot.codex")).toBeTruthy();
   });
 
-  it("shows close button for non-pinned tabs and emits close callback", async () => {
-    const onTabClose = vi.fn();
+  it("shows waiting placeholder when the active agent tab has no paneId", () => {
+    const tabs: Tab[] = [
+      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agent-1", label: "Agent", type: "agent" },
+    ];
+    const layout = createInitialTabLayout(tabs, "agent-1");
+    const rendered = renderMainArea({ tabs, layout });
+
+    expect(rendered.container.textContent).toContain("Agent starting...");
+  });
+
+  it("emits tab select with group id", async () => {
+    const onTabSelect = vi.fn();
     const tabs: Tab[] = [
       { id: "assistant", label: "Assistant", type: "assistant" },
       { id: "settings", label: "Settings", type: "settings" },
     ];
-    const rendered = await renderMainArea({
+    const rendered = renderMainArea({
       tabs,
-      activeTabId: "assistant",
-      onTabClose,
+      onTabSelect: ((groupId: string, tabId: string) =>
+        onTabSelect(groupId, tabId)) as (groupId: string, tabId: string) => void,
     });
 
-    const settingsTab = getTabByLabel(rendered.container, "Settings");
-    expect(settingsTab).toBeTruthy();
-    const closeButton = settingsTab?.querySelector(".tab-close");
-    expect(closeButton).toBeTruthy();
-
-    await fireEvent.click(closeButton as HTMLButtonElement);
-    expect(onTabClose).toHaveBeenCalledTimes(1);
-    expect(onTabClose).toHaveBeenCalledWith("settings");
+    await fireEvent.click(getTabByLabel(rendered.container, "Settings"));
+    expect(onTabSelect).toHaveBeenCalledWith(expect.any(String), "settings");
   });
 
-  it("closes tab via X without starting pointer reorder", async () => {
-    const onTabClose = vi.fn();
+  it("emits reorder during dragover inside the same group", async () => {
     const onTabReorder = vi.fn();
     const tabs: Tab[] = [
       { id: "assistant", label: "Assistant", type: "assistant" },
       { id: "settings", label: "Settings", type: "settings" },
-      {
-        id: "versionHistory",
-        label: "Version History",
-        type: "versionHistory",
-      },
+      { id: "issues", label: "Issues", type: "issues" },
     ];
-    const rendered = await renderMainArea({
+    const rendered = renderMainArea({
       tabs,
-      activeTabId: "assistant",
-      onTabClose,
-      onTabReorder,
-    });
-
-    const tabBar = rendered.container.querySelector(".tab-bar") as HTMLElement;
-    const settingsTab = getTabByLabel(rendered.container, "Settings");
-    const targetTab = getTabByLabel(rendered.container, "Version History");
-    const closeButton = settingsTab.querySelector(".tab-close");
-    expect(closeButton).toBeTruthy();
-
-    const originalElementFromPoint = document.elementFromPoint;
-    Object.defineProperty(document, "elementFromPoint", {
-      configurable: true,
-      value: vi.fn(() => targetTab),
-    });
-
-    try {
-      await fireEvent.pointerDown(closeButton as HTMLButtonElement, {
-        button: 0,
-        pointerId: 7,
-        clientX: 120,
-      });
-      await fireEvent.pointerMove(tabBar, {
-        pointerId: 7,
-        clientX: 290,
-        clientY: 10,
-      });
-      await fireEvent.pointerUp(tabBar, {
-        pointerId: 7,
-        clientX: 290,
-        clientY: 10,
-      });
-      await fireEvent.click(closeButton as HTMLButtonElement);
-    } finally {
-      Object.defineProperty(document, "elementFromPoint", {
-        configurable: true,
-        value: originalElementFromPoint,
-      });
-    }
-
-    expect(onTabReorder).not.toHaveBeenCalled();
-    expect(onTabClose).toHaveBeenCalledTimes(1);
-    expect(onTabClose).toHaveBeenCalledWith("settings");
-  });
-
-  it("emits onTabReorder during dragover with before/after positions", async () => {
-    const onTabReorder = vi.fn();
-    const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "settings", label: "Settings", type: "settings" },
-      {
-        id: "versionHistory",
-        label: "Version History",
-        type: "versionHistory",
-      },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabReorder,
+      onTabReorder: ((
+        groupId: string,
+        dragTabId: string,
+        overTabId: string,
+        position: "before" | "after",
+      ) => onTabReorder(groupId, dragTabId, overTabId, position)) as (
+        groupId: string,
+        dragTabId: string,
+        overTabId: string,
+        position: "before" | "after",
+      ) => void,
     });
 
     const dragTab = getTabByLabel(rendered.container, "Settings");
-    const targetTab = getTabByLabel(rendered.container, "Version History");
+    const targetTab = getTabByLabel(rendered.container, "Issues");
     const dataTransfer = createDataTransferMock();
     vi.spyOn(targetTab, "getBoundingClientRect").mockReturnValue({
       x: 100,
@@ -283,901 +234,101 @@ describe("MainArea", () => {
     });
 
     await fireEvent.dragStart(dragTab, { dataTransfer });
-    const overBefore = createEvent.dragOver(targetTab, { dataTransfer });
-    Object.defineProperty(overBefore, "clientX", {
-      configurable: true,
-      value: 110,
-    });
-    await fireEvent(targetTab, overBefore);
+    const overEvent = new Event("dragover", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(overEvent, "dataTransfer", { value: dataTransfer });
+    Object.defineProperty(overEvent, "clientX", { value: 110 });
+    await fireEvent(targetTab, overEvent);
 
-    const overBeforeDuplicate = createEvent.dragOver(targetTab, {
-      dataTransfer,
-    });
-    Object.defineProperty(overBeforeDuplicate, "clientX", {
-      configurable: true,
-      value: 110,
-    });
-    await fireEvent(targetTab, overBeforeDuplicate);
-
-    const overAfter = createEvent.dragOver(targetTab, { dataTransfer });
-    Object.defineProperty(overAfter, "clientX", {
-      configurable: true,
-      value: 290,
-    });
-    await fireEvent(targetTab, overAfter);
-    await fireEvent.drop(targetTab, { dataTransfer });
-    await fireEvent.dragEnd(dragTab, { dataTransfer });
-
-    expect(onTabReorder).toHaveBeenCalledTimes(2);
-    expect(onTabReorder).toHaveBeenNthCalledWith(
-      1,
+    expect(onTabReorder).toHaveBeenCalledWith(
+      expect.any(String),
       "settings",
-      "versionHistory",
+      "issues",
       "before",
     );
-    expect(onTabReorder).toHaveBeenNthCalledWith(
-      2,
+  });
+
+  it("emits move-to-group when dropping onto another group tab bar", async () => {
+    const onTabMoveToGroup = vi.fn();
+    const tabs: Tab[] = [
+      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "settings", label: "Settings", type: "settings" },
+      { id: "issues", label: "Issues", type: "issues" },
+    ];
+    const base = createInitialTabLayout(tabs, "assistant");
+    const split = splitTabToGroupEdge(base, "issues", base.activeGroupId, "right");
+    const rendered = renderMainArea({ tabs, layout: split, onTabMoveToGroup });
+
+    const dragTab = getTabByLabel(rendered.container, "Settings");
+    const targetBar = rendered.container.querySelectorAll(".tab-bar")[1] as HTMLElement;
+    const dataTransfer = createDataTransferMock();
+
+    await fireEvent.dragStart(dragTab, { dataTransfer });
+    const overEvent = new Event("dragover", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(overEvent, "dataTransfer", { value: dataTransfer });
+    await fireEvent(targetBar, overEvent);
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(dropEvent, "dataTransfer", { value: dataTransfer });
+    await fireEvent(targetBar, dropEvent);
+
+    expect(onTabMoveToGroup).toHaveBeenCalledWith(
       "settings",
-      "versionHistory",
+      expect.any(String),
+      null,
       "after",
     );
   });
 
-  it("does not emit onTabReorder when dragging over the same tab", async () => {
-    const onTabReorder = vi.fn();
+  it("emits split-to-edge when dropping on a split target", async () => {
+    const onTabSplitToGroupEdge = vi.fn();
     const tabs: Tab[] = [
       { id: "assistant", label: "Assistant", type: "assistant" },
       { id: "settings", label: "Settings", type: "settings" },
+      { id: "issues", label: "Issues", type: "issues" },
     ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabReorder,
-    });
+    const rendered = renderMainArea({ tabs, onTabSplitToGroupEdge });
 
-    const tab = getTabByLabel(rendered.container, "Settings");
+    const dragTab = getTabByLabel(rendered.container, "Settings");
+    const splitTarget = rendered.container.querySelector(
+      ".split-target-right",
+    ) as HTMLElement;
     const dataTransfer = createDataTransferMock();
-    vi.spyOn(tab, "getBoundingClientRect").mockReturnValue({
-      x: 100,
-      y: 0,
-      width: 200,
-      height: 36,
-      top: 0,
-      right: 300,
-      bottom: 36,
-      left: 100,
-      toJSON: () => ({}),
-    });
 
-    await fireEvent.dragStart(tab, { dataTransfer });
-    await fireEvent.dragOver(tab, { dataTransfer, clientX: 120 });
+    await fireEvent.dragStart(dragTab, { dataTransfer });
+    const overEvent = new Event("dragover", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(overEvent, "dataTransfer", { value: dataTransfer });
+    await fireEvent(splitTarget, overEvent);
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(dropEvent, "dataTransfer", { value: dataTransfer });
+    await fireEvent(splitTarget, dropEvent);
 
-    expect(onTabReorder).not.toHaveBeenCalled();
+    expect(onTabSplitToGroupEdge).toHaveBeenCalledWith(
+      "settings",
+      expect.any(String),
+      "right",
+    );
   });
 
-  it("emits onTabReorder via pointer drag fallback", async () => {
-    const onTabReorder = vi.fn();
-    const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "settings", label: "Settings", type: "settings" },
-      {
-        id: "versionHistory",
-        label: "Version History",
-        type: "versionHistory",
-      },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabReorder,
-    });
-
-    const tabBar = rendered.container.querySelector(".tab-bar") as HTMLElement;
-    const dragTab = getTabByLabel(rendered.container, "Settings");
-    const targetTab = getTabByLabel(rendered.container, "Version History");
-    const originalElementFromPoint = document.elementFromPoint;
-    Object.defineProperty(document, "elementFromPoint", {
-      configurable: true,
-      value: vi.fn(() => targetTab),
-    });
-
-    try {
-      vi.spyOn(targetTab, "getBoundingClientRect").mockReturnValue({
-        x: 100,
-        y: 0,
-        width: 200,
-        height: 36,
-        top: 0,
-        right: 300,
-        bottom: 36,
-        left: 100,
-        toJSON: () => ({}),
-      });
-
-      await fireEvent.pointerDown(dragTab, {
-        button: 0,
-        pointerId: 1,
-        clientX: 120,
-      });
-      await fireEvent.pointerMove(tabBar, {
-        pointerId: 1,
-        clientX: 290,
-        clientY: 10,
-      });
-      await fireEvent.pointerUp(tabBar, {
-        pointerId: 1,
-        clientX: 290,
-        clientY: 10,
-      });
-
-      expect(onTabReorder).toHaveBeenCalledTimes(1);
-      expect(onTabReorder).toHaveBeenCalledWith(
-        "settings",
-        "versionHistory",
-        "after",
-      );
-    } finally {
-      Object.defineProperty(document, "elementFromPoint", {
-        configurable: true,
-        value: originalElementFromPoint,
-      });
-    }
-  });
-
-  it("emits onTabReorder when pointermove is dispatched on window", async () => {
-    const onTabReorder = vi.fn();
-    const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "settings", label: "Settings", type: "settings" },
-      {
-        id: "versionHistory",
-        label: "Version History",
-        type: "versionHistory",
-      },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabReorder,
-    });
-
-    const dragTab = getTabByLabel(rendered.container, "Settings");
-    const targetTab = getTabByLabel(rendered.container, "Version History");
-    const originalElementFromPoint = document.elementFromPoint;
-    Object.defineProperty(document, "elementFromPoint", {
-      configurable: true,
-      value: vi.fn(() => targetTab),
-    });
-
-    try {
-      vi.spyOn(targetTab, "getBoundingClientRect").mockReturnValue({
-        x: 100,
-        y: 0,
-        width: 200,
-        height: 36,
-        top: 0,
-        right: 300,
-        bottom: 36,
-        left: 100,
-        toJSON: () => ({}),
-      });
-
-      await fireEvent.pointerDown(dragTab, {
-        button: 0,
-        pointerId: 1,
-        clientX: 120,
-      });
-      await fireEvent.pointerMove(window, {
-        pointerId: 1,
-        clientX: 290,
-        clientY: 10,
-      });
-      await fireEvent.pointerUp(window, {
-        pointerId: 1,
-        clientX: 290,
-        clientY: 10,
-      });
-
-      expect(onTabReorder).toHaveBeenCalledTimes(1);
-      expect(onTabReorder).toHaveBeenCalledWith(
-        "settings",
-        "versionHistory",
-        "after",
-      );
-    } finally {
-      Object.defineProperty(document, "elementFromPoint", {
-        configurable: true,
-        value: originalElementFromPoint,
-      });
-    }
-  });
-
-  it("selects tabs on click and shows placeholder for unknown tab type", async () => {
-    const onTabSelect = vi.fn();
-    const tabs: Tab[] = [
-      { id: "unknown", label: "Unknown", type: "unknown" as Tab["type"] },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "unknown",
-      onTabSelect,
-    });
-
-    const tab = rendered.getByText("Unknown").closest(".tab");
-    expect(tab).toBeTruthy();
-    await fireEvent.click(tab as HTMLElement);
-    expect(onTabSelect).toHaveBeenCalledWith("unknown");
-    expect(rendered.getByText("Select a tab")).toBeTruthy();
-  });
-
-  it("shows waiting placeholder when active agent tab has no paneId", async () => {
-    const tabs: Tab[] = [
-      { id: "agent-missing-pane", label: "feature-terminal", type: "agent" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "agent-missing-pane",
-    });
-
-    expect(rendered.getByText("Agent starting...")).toBeTruthy();
-    expect(rendered.getByText("Waiting for the backend terminal pane to attach.")).toBeTruthy();
-    expect(rendered.container.querySelectorAll(".terminal-wrapper").length).toBe(0);
-  });
-
-  it("renders agent/terminal tab dots and terminal wrappers", async () => {
-    const restoreMocks = setupTerminalMocks();
-
-    const tabs: Tab[] = [
-      {
-        id: "agent-1",
-        label: "Agent",
-        type: "agent",
-        paneId: "pane-agent",
-        agentId: "codex",
-      },
-      {
-        id: "term-1",
-        label: "Terminal",
-        type: "terminal",
-        cwd: "/tmp/project",
-        paneId: "pane-term",
-      },
-    ];
-
-    try {
-      const rendered = await renderMainArea({
-        tabs,
-        activeTabId: "agent-1",
-      });
-
-      expect(rendered.container.querySelector(".tab-dot.codex")).toBeTruthy();
-      expect(rendered.container.querySelector(".tab-dot.terminal")).toBeTruthy();
-      expect(rendered.container.querySelectorAll(".terminal-wrapper").length).toBe(2);
-      await waitFor(() => {
-        expect(
-          rendered.container.querySelectorAll(".terminal-wrapper.active").length,
-        ).toBe(1);
-      });
-    } finally {
-      restoreMocks();
-    }
-  });
-
-  it("keeps terminal hidden until the next tab reports ready", async () => {
-    const restoreMocks = setupTerminalMocks();
-
-    const tabs: Tab[] = [
-      {
-        id: "agent-1",
-        label: "Agent",
-        type: "agent",
-        paneId: "pane-agent",
-        agentId: "codex",
-      },
-      {
-        id: "term-1",
-        label: "Terminal",
-        type: "terminal",
-        cwd: "/tmp/project",
-        paneId: "pane-term",
-      },
-    ];
-
-    try {
-      const rendered = await renderMainArea({
-        tabs,
-        activeTabId: "agent-1",
-      });
-
-      await waitFor(() => {
-        expect(
-          rendered.container.querySelectorAll(".terminal-wrapper.active").length,
-        ).toBe(1);
-      });
-
-      await rendered.rerender({
-        projectPath: "/tmp/project",
-        selectedBranch: null,
-        onLaunchAgent: vi.fn(),
-        onQuickLaunch: vi.fn(),
-        onTabSelect: vi.fn(),
-        onTabClose: vi.fn(),
-        onTabReorder: vi.fn(),
-        activeTabId: "term-1",
-        tabs,
-      });
-
-      expect(rendered.container.querySelectorAll(".terminal-wrapper.active").length).toBe(0);
-
-      await waitFor(() => {
-        expect(
-          rendered.container.querySelectorAll(".terminal-wrapper.active").length,
-        ).toBe(1);
-      });
-    } finally {
-      restoreMocks();
-    }
-  });
-
-  it("shows previously-ready terminal tab immediately when switching back", async () => {
-    const restoreMocks = setupTerminalMocks();
-
-    const tabs: Tab[] = [
-      {
-        id: "agent-1",
-        label: "Agent",
-        type: "agent",
-        paneId: "pane-agent",
-        agentId: "codex",
-      },
-      {
-        id: "term-1",
-        label: "Terminal",
-        type: "terminal",
-        cwd: "/tmp/project",
-        paneId: "pane-term",
-      },
-    ];
-
-    try {
-      const rendered = await renderMainArea({
-        tabs,
-        activeTabId: "agent-1",
-      });
-
-      await waitFor(() => {
-        expect(
-          rendered.container.querySelectorAll(".terminal-wrapper.active").length,
-        ).toBe(1);
-      });
-
-      await rendered.rerender({
-        projectPath: "/tmp/project",
-        selectedBranch: null,
-        onLaunchAgent: vi.fn(),
-        onQuickLaunch: vi.fn(),
-        onTabSelect: vi.fn(),
-        onTabClose: vi.fn(),
-        onTabReorder: vi.fn(),
-        activeTabId: "term-1",
-        tabs,
-      });
-
-      await waitFor(() => {
-        expect(
-          rendered.container.querySelectorAll(".terminal-wrapper.active").length,
-        ).toBe(1);
-      });
-
-      await rendered.rerender({
-        projectPath: "/tmp/project",
-        selectedBranch: null,
-        onLaunchAgent: vi.fn(),
-        onQuickLaunch: vi.fn(),
-        onTabSelect: vi.fn(),
-        onTabClose: vi.fn(),
-        onTabReorder: vi.fn(),
-        activeTabId: "agent-1",
-        tabs,
-      });
-
-      expect(rendered.container.querySelectorAll(".terminal-wrapper.active").length).toBe(1);
-    } finally {
-      restoreMocks();
-    }
-  });
-
-  it("no visibility gap when switching between ready terminal tabs", async () => {
-    const restoreMocks = setupTerminalMocks();
-
-    const tabs: Tab[] = [
-      {
-        id: "agent-1",
-        label: "Agent",
-        type: "agent",
-        paneId: "pane-agent",
-        agentId: "codex",
-      },
-      {
-        id: "term-1",
-        label: "Terminal",
-        type: "terminal",
-        cwd: "/tmp/project",
-        paneId: "pane-term",
-      },
-    ];
-
-    const baseRerenderProps = {
-      projectPath: "/tmp/project",
-      selectedBranch: null,
-      onLaunchAgent: vi.fn(),
-      onQuickLaunch: vi.fn(),
-      onTabSelect: vi.fn(),
-      onTabClose: vi.fn(),
-      onTabReorder: vi.fn(),
-    };
-
-    try {
-      const rendered = await renderMainArea({
-        tabs,
-        activeTabId: "agent-1",
-      });
-
-      // Step 1: agent-1 becomes ready
-      await waitFor(() => {
-        expect(
-          rendered.container.querySelectorAll(".terminal-wrapper.active").length,
-        ).toBe(1);
-      });
-
-      // Step 2: switch to term-1, wait for it to become ready
-      await rendered.rerender({ ...baseRerenderProps, activeTabId: "term-1", tabs });
-
-      await waitFor(() => {
-        expect(
-          rendered.container.querySelectorAll(".terminal-wrapper.active").length,
-        ).toBe(1);
-      });
-
-      // Step 3: switch back to agent-1 — must be immediate (no waitFor)
-      await rendered.rerender({ ...baseRerenderProps, activeTabId: "agent-1", tabs });
-
-      expect(rendered.container.querySelectorAll(".terminal-wrapper.active").length).toBe(1);
-
-      // Step 4: switch back to term-1 — must ALSO be immediate (no waitFor)
-      await rendered.rerender({ ...baseRerenderProps, activeTabId: "term-1", tabs });
-
-      expect(rendered.container.querySelectorAll(".terminal-wrapper.active").length).toBe(1);
-    } finally {
-      restoreMocks();
-    }
-  });
-
-  it("supports text/plain drag fallback and ignores dragStart without dataTransfer", async () => {
-    const onTabReorder = vi.fn();
-    const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "settings", label: "Settings", type: "settings" },
-      { id: "versionHistory", label: "Version History", type: "versionHistory" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabReorder,
-    });
-
-    const dragTab = getTabByLabel(rendered.container, "Settings");
-    const targetTab = getTabByLabel(rendered.container, "Version History");
-    vi.spyOn(targetTab, "getBoundingClientRect").mockReturnValue({
-      x: 100,
-      y: 0,
-      width: 200,
-      height: 36,
-      top: 0,
-      right: 300,
-      bottom: 36,
-      left: 100,
-      toJSON: () => ({}),
-    });
-
-    await fireEvent.dragStart(dragTab);
-
-    const dataTransfer = createDataTransferMock();
-    dataTransfer.setData("text/plain", "settings");
-    const over = createEvent.dragOver(targetTab, { dataTransfer });
-    Object.defineProperty(over, "clientX", {
-      configurable: true,
-      value: 290,
-    });
-    await fireEvent(targetTab, over);
-
-    expect(onTabReorder).toHaveBeenCalledWith("settings", "versionHistory", "after");
-  });
-
-  it("shows settings and versionHistory panel content", async () => {
-    const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "settings", label: "Settings", type: "settings" },
-      { id: "versionHistory", label: "Version History", type: "versionHistory" },
-    ];
-    const rendered = await renderMainArea({ tabs, activeTabId: "settings" });
-
-    // Settings tab should be active
-    const settingsTab = getTabByLabel(rendered.container, "Settings");
-    expect(settingsTab.classList.contains("active")).toBe(true);
-  });
-
-  it("shows empty placeholder when no non-terminal tabs", async () => {
-    const tabs: Tab[] = [];
-    const rendered = await renderMainArea({ tabs, activeTabId: "" });
-
-    expect(rendered.getByText("Select a tab")).toBeTruthy();
-  });
-
-  it("handles tab select callback on tab click", async () => {
-    const onTabSelect = vi.fn();
+  it("offers an explicit split action from the tab menu", async () => {
+    const onTabSplitToGroupEdge = vi.fn();
     const tabs: Tab[] = [
       { id: "assistant", label: "Assistant", type: "assistant" },
       { id: "settings", label: "Settings", type: "settings" },
     ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabSelect,
-    });
+    const rendered = renderMainArea({ tabs, onTabSplitToGroupEdge });
 
     const settingsTab = getTabByLabel(rendered.container, "Settings");
-    await fireEvent.click(settingsTab);
-    expect(onTabSelect).toHaveBeenCalledWith("settings");
-  });
+    const menuToggle = settingsTab.querySelector(".tab-actions-toggle") as HTMLElement;
+    await fireEvent.click(menuToggle);
+    const splitRight = Array.from(
+      settingsTab.querySelectorAll<HTMLButtonElement>(".tab-actions-menu button"),
+    ).find((button) => button.textContent?.trim() === "Split Right");
+    expect(splitRight).toBeTruthy();
+    await fireEvent.click(splitRight!);
 
-  it("ignores pointer drag when button is not left-click", async () => {
-    const onTabReorder = vi.fn();
-    const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "settings", label: "Settings", type: "settings" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabReorder,
-    });
-
-    const settingsTab = getTabByLabel(rendered.container, "Settings");
-    // Right-click should not start drag
-    await fireEvent.pointerDown(settingsTab, {
-      button: 2,
-      pointerId: 1,
-      clientX: 120,
-    });
-
-    expect(onTabReorder).not.toHaveBeenCalled();
-  });
-
-  it("renders issues tab panel", async () => {
-    const onWorkOnIssue = vi.fn();
-    const onSwitchToWorktree = vi.fn();
-    const onIssueCountChange = vi.fn();
-    const tabs: Tab[] = [
-      { id: "issues-1", label: "Issues", type: "issues" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "issues-1",
-    });
-    // The tab should be rendered
-    const tabEl = getTabByLabel(rendered.container, "Issues");
-    expect(tabEl).toBeTruthy();
-    // Should have a panel-wrapper active for the issues tab
-    const panels = rendered.container.querySelectorAll(".panel-wrapper.active");
-    expect(panels.length).toBe(1);
-  });
-
-  it("renders prs tab panel", async () => {
-    const tabs: Tab[] = [
-      { id: "prs-1", label: "Pull Requests", type: "prs" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "prs-1",
-    });
-    const tabEl = getTabByLabel(rendered.container, "Pull Requests");
-    expect(tabEl).toBeTruthy();
-    const panels = rendered.container.querySelectorAll(".panel-wrapper.active");
-    expect(panels.length).toBe(1);
-  });
-
-  it("renders issueSpec tab panel", async () => {
-    const tabs: Tab[] = [
-      { id: "issueSpec-1", label: "Issue Spec", type: "issueSpec", issueNumber: 42 },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "issueSpec-1",
-    });
-    const tabEl = getTabByLabel(rendered.container, "Issue Spec");
-    expect(tabEl).toBeTruthy();
-    const panels = rendered.container.querySelectorAll(".panel-wrapper.active");
-    expect(panels.length).toBe(1);
-  });
-
-  it("shows panel-fallback placeholder when active tab is agent without paneId and non-terminal tabs exist", async () => {
-    const tabs: Tab[] = [
-      { id: "settings", label: "Settings", type: "settings" },
-      { id: "agent-no-pane", label: "Agent", type: "agent" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "agent-no-pane",
-    });
-
-    await new Promise((r) => setTimeout(r, 0));
-
-    // Should show detached terminal placeholder within panel-fallback
-    const fallbacks = rendered.container.querySelectorAll(".placeholder.panel-fallback");
-    expect(fallbacks.length).toBeGreaterThan(0);
-    expect(rendered.getByText("Agent starting...")).toBeTruthy();
-  });
-
-  it("shows select-a-tab panel-fallback when non-terminal tabs exist but active tab is not among them", async () => {
-    const tabs: Tab[] = [
-      { id: "settings", label: "Settings", type: "settings" },
-    ];
-    // activeTabId doesn't match any tab
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "nonexistent",
-    });
-
-    await new Promise((r) => setTimeout(r, 0));
-
-    const fallbacks = rendered.container.querySelectorAll(".placeholder.panel-fallback");
-    expect(fallbacks.length).toBeGreaterThan(0);
-  });
-
-  it("renders different agent dot classes (claude, gemini, opencode)", async () => {
-    const restoreMocks = setupTerminalMocks();
-
-    const tabs: Tab[] = [
-      {
-        id: "agent-claude",
-        label: "Claude",
-        type: "agent",
-        paneId: "pane-claude",
-        agentId: "claude",
-      },
-      {
-        id: "agent-gemini",
-        label: "Gemini",
-        type: "agent",
-        paneId: "pane-gemini",
-        agentId: "gemini",
-      },
-      {
-        id: "agent-opencode",
-        label: "OpenCode",
-        type: "agent",
-        paneId: "pane-opencode",
-        agentId: "opencode",
-      },
-    ];
-
-    try {
-      const rendered = await renderMainArea({
-        tabs,
-        activeTabId: "agent-claude",
-      });
-
-      expect(rendered.container.querySelector(".tab-dot.claude")).toBeTruthy();
-      expect(rendered.container.querySelector(".tab-dot.gemini")).toBeTruthy();
-      expect(rendered.container.querySelector(".tab-dot.opencode")).toBeTruthy();
-    } finally {
-      restoreMocks();
-    }
-  });
-
-  it("shows terminal tab title with cwd", async () => {
-    const restoreMocks = setupTerminalMocks();
-
-    const tabs: Tab[] = [
-      {
-        id: "term-1",
-        label: "Terminal",
-        type: "terminal",
-        cwd: "/some/path",
-        paneId: "pane-term",
-      },
-    ];
-
-    try {
-      const rendered = await renderMainArea({
-        tabs,
-        activeTabId: "term-1",
-      });
-
-      const termTab = getTabByLabel(rendered.container, "Terminal");
-      expect(termTab.getAttribute("title")).toBe("/some/path");
-    } finally {
-      restoreMocks();
-    }
-  });
-
-  it("shows empty title for terminal tab without cwd", async () => {
-    const restoreMocks = setupTerminalMocks();
-
-    const tabs: Tab[] = [
-      {
-        id: "term-1",
-        label: "Terminal",
-        type: "terminal",
-        paneId: "pane-term",
-      },
-    ];
-
-    try {
-      const rendered = await renderMainArea({
-        tabs,
-        activeTabId: "term-1",
-      });
-
-      const termTab = getTabByLabel(rendered.container, "Terminal");
-      expect(termTab.getAttribute("title")).toBe("");
-    } finally {
-      restoreMocks();
-    }
-  });
-
-  it("shows empty title for non-terminal tabs", async () => {
-    const tabs: Tab[] = [
-      { id: "settings", label: "Settings", type: "settings" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "settings",
-    });
-    const tab = getTabByLabel(rendered.container, "Settings");
-    expect(tab.getAttribute("title")).toBe("");
-  });
-
-  it("renders issueSpec tab with default issueNumber when not provided", async () => {
-    const tabs: Tab[] = [
-      { id: "issueSpec-2", label: "Issue Spec", type: "issueSpec" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "issueSpec-2",
-    });
-    const panels = rendered.container.querySelectorAll(".panel-wrapper.active");
-    expect(panels.length).toBe(1);
-  });
-
-  it("resets pointer drag state on pointercancel", async () => {
-    const onTabReorder = vi.fn();
-    const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "settings", label: "Settings", type: "settings" },
-      { id: "versionHistory", label: "Version History", type: "versionHistory" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "assistant",
-      onTabReorder,
-    });
-
-    const dragTab = getTabByLabel(rendered.container, "Settings");
-    const targetTab = getTabByLabel(rendered.container, "Version History");
-    const originalElementFromPoint = document.elementFromPoint;
-    Object.defineProperty(document, "elementFromPoint", {
-      configurable: true,
-      value: vi.fn(() => targetTab),
-    });
-
-    try {
-      vi.spyOn(targetTab, "getBoundingClientRect").mockReturnValue({
-        x: 100,
-        y: 0,
-        width: 200,
-        height: 36,
-        top: 0,
-        right: 300,
-        bottom: 36,
-        left: 100,
-        toJSON: () => ({}),
-      });
-
-      await fireEvent.pointerDown(dragTab, {
-        button: 0,
-        pointerId: 9,
-        clientX: 120,
-      });
-      await fireEvent.pointerCancel(window, {
-        pointerId: 9,
-      });
-      await fireEvent.pointerMove(window, {
-        pointerId: 9,
-        clientX: 290,
-        clientY: 10,
-      });
-
-      expect(onTabReorder).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(document, "elementFromPoint", {
-        configurable: true,
-        value: originalElementFromPoint,
-      });
-    }
-  });
-
-  it("renders versionHistory tab panel when it is the active tab", async () => {
-    // Exercises the {:else if tab.type === "versionHistory"} branch (line 443)
-    const tabs: Tab[] = [
-      { id: "versionHistory-1", label: "Version History", type: "versionHistory" },
-    ];
-    const rendered = await renderMainArea({
-      tabs,
-      activeTabId: "versionHistory-1",
-    });
-
-    await new Promise((r) => setTimeout(r, 0));
-
-    const tabEl = getTabByLabel(rendered.container, "Version History");
-    expect(tabEl).toBeTruthy();
-    // versionHistory panel-wrapper should be active
-    const panels = rendered.container.querySelectorAll(".panel-wrapper.active");
-    expect(panels.length).toBe(1);
-  });
-
-  it("passes onWorkOnIssue callback (non-null) to IssueListPanel instead of fallback", async () => {
-    // Covers the "left side of ??" for onWorkOnIssue ?? (() => {}) (lines 455-456)
-    const onWorkOnIssue = vi.fn();
-    const onSwitchToWorktree = vi.fn();
-
-    const { default: MainArea } = await import("./MainArea.svelte");
-    const rendered = render(MainArea, {
-      props: {
-        projectPath: "/tmp/project",
-        selectedBranch: null,
-        onLaunchAgent: vi.fn(),
-        onQuickLaunch: vi.fn(),
-        onTabSelect: vi.fn(),
-        onTabClose: vi.fn(),
-        onTabReorder: vi.fn(),
-        activeTabId: "issues-1",
-        tabs: [{ id: "issues-1", label: "Issues", type: "issues" }] as Tab[],
-        onWorkOnIssue,
-        onSwitchToWorktree,
-      },
-    });
-
-    await new Promise((r) => setTimeout(r, 0));
-
-    const panels = rendered.container.querySelectorAll(".panel-wrapper.active");
-    expect(panels.length).toBe(1);
-  });
-
-  it("passes onSwitchToWorktree callback (non-null) to PrListPanel instead of fallback", async () => {
-    // Covers the "left side of ??" for onSwitchToWorktree ?? (() => {}) (line 463)
-    const onSwitchToWorktree = vi.fn();
-
-    const { default: MainArea } = await import("./MainArea.svelte");
-    const rendered = render(MainArea, {
-      props: {
-        projectPath: "/tmp/project",
-        selectedBranch: null,
-        onLaunchAgent: vi.fn(),
-        onQuickLaunch: vi.fn(),
-        onTabSelect: vi.fn(),
-        onTabClose: vi.fn(),
-        onTabReorder: vi.fn(),
-        activeTabId: "prs-1",
-        tabs: [{ id: "prs-1", label: "Pull Requests", type: "prs" }] as Tab[],
-        onSwitchToWorktree,
-      },
-    });
-
-    await new Promise((r) => setTimeout(r, 0));
-
-    const panels = rendered.container.querySelectorAll(".panel-wrapper.active");
-    expect(panels.length).toBe(1);
+    expect(onTabSplitToGroupEdge).toHaveBeenCalledWith(
+      "settings",
+      expect.any(String),
+      "right",
+    );
   });
 });

--- a/gwt-gui/src/lib/components/TabGroupPane.svelte
+++ b/gwt-gui/src/lib/components/TabGroupPane.svelte
@@ -1,0 +1,691 @@
+<script lang="ts">
+  import type { GitHubIssueInfo, LaunchAgentRequest, Tab } from "../types";
+  import type {
+    TabDropPosition,
+    TabGroupState,
+    TabLayoutDropTarget,
+    TabSplitDirection,
+  } from "../tabLayout";
+  import TerminalView from "../terminal/TerminalView.svelte";
+  import IssueListPanel from "./IssueListPanel.svelte";
+  import IssueSpecPanel from "./IssueSpecPanel.svelte";
+  import PrListPanel from "./PrListPanel.svelte";
+  import SettingsPanel from "./SettingsPanel.svelte";
+  import VersionHistoryPanel from "./VersionHistoryPanel.svelte";
+  import ProjectIndexPanel from "./ProjectIndexPanel.svelte";
+  import AssistantPanel from "./AssistantPanel.svelte";
+
+  function isAgentOrTerminal(tab: Tab | null | undefined): boolean {
+    return tab?.type === "agent" || tab?.type === "terminal";
+  }
+
+  let {
+    group,
+    tabsById,
+    activeGroupId,
+    projectPath,
+    draggedTabId = null,
+    dropTarget = null,
+    onGroupFocus,
+    onTabSelect,
+    onTabClose,
+    onTabSplitAction,
+    onTabDragStart,
+    onTabDragEnd,
+    onTabDragOver,
+    onTabDrop,
+    onGroupDragOver,
+    onGroupDrop,
+    onSplitDragOver,
+    onSplitDrop,
+    onLaunchAgent: _onLaunchAgent,
+    onQuickLaunch: _onQuickLaunch,
+    onWorkOnIssue,
+    onSwitchToWorktree,
+    onIssueCountChange,
+    onOpenSettings,
+    voiceInputEnabled = false,
+    voiceInputListening = false,
+    voiceInputPreparing = false,
+    voiceInputSupported = true,
+    voiceInputAvailable = false,
+    voiceInputAvailabilityReason = null,
+    voiceInputError = null,
+  }: {
+    group: TabGroupState;
+    tabsById: Record<string, Tab>;
+    activeGroupId: string;
+    projectPath: string;
+    draggedTabId?: string | null;
+    dropTarget?: TabLayoutDropTarget | null;
+    onGroupFocus: (groupId: string) => void;
+    onTabSelect: (groupId: string, tabId: string) => void;
+    onTabClose: (tabId: string) => void;
+    onTabSplitAction: (
+      tabId: string,
+      groupId: string,
+      direction: TabSplitDirection,
+    ) => void;
+    onTabDragStart: (tabId: string, event: DragEvent) => void;
+    onTabDragEnd: () => void;
+    onTabDragOver: (
+      groupId: string,
+      tabId: string,
+      position: TabDropPosition,
+      event: DragEvent,
+    ) => void;
+    onTabDrop: (
+      groupId: string,
+      tabId: string,
+      position: TabDropPosition,
+      event: DragEvent,
+    ) => void;
+    onGroupDragOver: (groupId: string, event: DragEvent) => void;
+    onGroupDrop: (groupId: string, event: DragEvent) => void;
+    onSplitDragOver: (
+      groupId: string,
+      direction: TabSplitDirection,
+      event: DragEvent,
+    ) => void;
+    onSplitDrop: (
+      groupId: string,
+      direction: TabSplitDirection,
+      event: DragEvent,
+    ) => void;
+    onLaunchAgent?: () => void;
+    onQuickLaunch?: (request: LaunchAgentRequest) => Promise<void>;
+    onWorkOnIssue?: (issue: GitHubIssueInfo) => void;
+    onSwitchToWorktree?: (branchName: string) => void;
+    onIssueCountChange?: (count: number) => void;
+    onOpenSettings?: () => void;
+    voiceInputEnabled?: boolean;
+    voiceInputListening?: boolean;
+    voiceInputPreparing?: boolean;
+    voiceInputSupported?: boolean;
+    voiceInputAvailable?: boolean;
+    voiceInputAvailabilityReason?: string | null;
+    voiceInputError?: string | null;
+  } = $props();
+
+  let groupTabs = $derived(
+    group.tabIds.map((tabId) => tabsById[tabId]).filter(Boolean),
+  );
+  let activeTab = $derived(
+    group.activeTabId ? tabsById[group.activeTabId] : null,
+  );
+  let isActiveGroup = $derived(activeGroupId === group.id);
+  let showDetachedTerminalPlaceholder = $derived(
+    isAgentOrTerminal(activeTab) &&
+      (!activeTab?.paneId || activeTab.paneId.length === 0),
+  );
+
+  function isPinnedTab(tab: Tab | null | undefined) {
+    return tab?.type === "assistant";
+  }
+
+  function canSplitCurrentGroup(): boolean {
+    return group.tabIds.length > 1;
+  }
+
+  function handleSplitAction(
+    menuEl: HTMLDetailsElement,
+    tabId: string,
+    direction: TabSplitDirection,
+  ) {
+    if (!canSplitCurrentGroup()) return;
+    onTabSplitAction(tabId, group.id, direction);
+    menuEl.open = false;
+  }
+
+  function isTabDropTarget(
+    tabId: string,
+    position: TabDropPosition,
+  ): boolean {
+    return (
+      dropTarget?.kind === "tab" &&
+      dropTarget.groupId === group.id &&
+      dropTarget.tabId === tabId &&
+      dropTarget.position === position
+    );
+  }
+
+  function isGroupDropTarget(): boolean {
+    return dropTarget?.kind === "group" && dropTarget.groupId === group.id;
+  }
+
+  function isSplitTarget(direction: TabSplitDirection): boolean {
+    return (
+      dropTarget?.kind === "split" &&
+      dropTarget.groupId === group.id &&
+      dropTarget.direction === direction
+    );
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+  class="group-pane"
+  role="group"
+  class:active-group={isActiveGroup}
+  onmousedown={() => onGroupFocus(group.id)}
+>
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="tab-bar"
+    role="tablist"
+    tabindex="-1"
+    class:drop-target={isGroupDropTarget()}
+    ondragover={(event) => onGroupDragOver(group.id, event)}
+    ondrop={(event) => onGroupDrop(group.id, event)}
+  >
+    {#each groupTabs as tab (tab.id)}
+      <div
+        class="tab"
+        role="tab"
+        tabindex="0"
+        aria-selected={group.activeTabId === tab.id}
+        data-tab-id={tab.id}
+        class:active={group.activeTabId === tab.id}
+        class:dragging={draggedTabId === tab.id}
+        class:drop-before={isTabDropTarget(tab.id, "before")}
+        class:drop-after={isTabDropTarget(tab.id, "after")}
+        draggable="true"
+        title={tab.type === "terminal" ? tab.cwd || "" : ""}
+        onclick={() => onTabSelect(group.id, tab.id)}
+        onkeydown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onTabSelect(group.id, tab.id);
+          }
+        }}
+        ondragstart={(event) => onTabDragStart(tab.id, event)}
+        ondragend={onTabDragEnd}
+        ondragover={(event) => {
+          const target = event.currentTarget;
+          if (!(target instanceof HTMLElement)) return;
+          const rect = target.getBoundingClientRect();
+          const position: TabDropPosition =
+            event.clientX <= rect.left + rect.width / 2 ? "before" : "after";
+          onTabDragOver(group.id, tab.id, position, event);
+        }}
+        ondrop={(event) => {
+          const target = event.currentTarget;
+          if (!(target instanceof HTMLElement)) return;
+          const rect = target.getBoundingClientRect();
+          const position: TabDropPosition =
+            event.clientX <= rect.left + rect.width / 2 ? "before" : "after";
+          onTabDrop(group.id, tab.id, position, event);
+        }}
+      >
+        {#if tab.type === "agent"}
+          <span
+            class="tab-dot"
+            class:claude={tab.agentId === "claude"}
+            class:codex={tab.agentId === "codex"}
+            class:gemini={tab.agentId === "gemini"}
+            class:opencode={tab.agentId === "opencode"}
+          ></span>
+        {:else if tab.type === "terminal"}
+          <span class="tab-dot terminal"></span>
+        {/if}
+        {#if tab.type === "agent"}
+          <span class="tab-label tab-label-scroll" aria-label={tab.label}>
+            <span class="tab-label-track">
+              <span>{tab.label}</span>
+              <span aria-hidden="true">{tab.label}</span>
+            </span>
+          </span>
+        {:else}
+          <span class="tab-label">{tab.label}</span>
+        {/if}
+        <details class="tab-actions">
+          <summary
+            class="tab-actions-toggle"
+            onpointerdown={(event) => event.stopPropagation()}
+          >
+            ⋯
+          </summary>
+          <div class="tab-actions-menu">
+            <button
+              type="button"
+              disabled={!canSplitCurrentGroup()}
+              onclick={(event) => {
+                event.stopPropagation();
+                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "left");
+              }}
+            >
+              Split Left
+            </button>
+            <button
+              type="button"
+              disabled={!canSplitCurrentGroup()}
+              onclick={(event) => {
+                event.stopPropagation();
+                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "right");
+              }}
+            >
+              Split Right
+            </button>
+            <button
+              type="button"
+              disabled={!canSplitCurrentGroup()}
+              onclick={(event) => {
+                event.stopPropagation();
+                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "up");
+              }}
+            >
+              Split Up
+            </button>
+            <button
+              type="button"
+              disabled={!canSplitCurrentGroup()}
+              onclick={(event) => {
+                event.stopPropagation();
+                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "down");
+              }}
+            >
+              Split Down
+            </button>
+          </div>
+        </details>
+        {#if !isPinnedTab(tab)}
+          <button
+            class="tab-close"
+            type="button"
+            onpointerdown={(event) => event.stopPropagation()}
+            onclick={(event) => {
+              event.stopPropagation();
+              onTabClose(tab.id);
+            }}
+          >
+            x
+          </button>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <div class="group-content">
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="split-target split-target-top"
+      role="presentation"
+      class:active={isSplitTarget("up")}
+      ondragover={(event) => onSplitDragOver(group.id, "up", event)}
+      ondrop={(event) => onSplitDrop(group.id, "up", event)}
+    ></div>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="split-target split-target-right"
+      role="presentation"
+      class:active={isSplitTarget("right")}
+      ondragover={(event) => onSplitDragOver(group.id, "right", event)}
+      ondrop={(event) => onSplitDrop(group.id, "right", event)}
+    ></div>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="split-target split-target-bottom"
+      role="presentation"
+      class:active={isSplitTarget("down")}
+      ondragover={(event) => onSplitDragOver(group.id, "down", event)}
+      ondrop={(event) => onSplitDrop(group.id, "down", event)}
+    ></div>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="split-target split-target-left"
+      role="presentation"
+      class:active={isSplitTarget("left")}
+      ondragover={(event) => onSplitDragOver(group.id, "left", event)}
+      ondrop={(event) => onSplitDrop(group.id, "left", event)}
+    ></div>
+
+    {#if groupTabs.length === 0}
+      <div class="placeholder">
+        <h2>Select a tab</h2>
+      </div>
+    {:else if showDetachedTerminalPlaceholder}
+      <div class="placeholder panel-fallback">
+        <h2>Agent starting...</h2>
+        <p>Waiting for the backend terminal pane to attach.</p>
+      </div>
+    {:else}
+      {#each groupTabs as tab (tab.id)}
+        {#if !isAgentOrTerminal(tab)}
+          <div class="panel-wrapper" class:active={group.activeTabId === tab.id}>
+            {#if tab.type === "settings"}
+              <SettingsPanel onClose={() => onTabClose(tab.id)} />
+            {:else if tab.type === "versionHistory"}
+              <VersionHistoryPanel {projectPath} />
+            {:else if tab.type === "issueSpec"}
+              <IssueSpecPanel
+                projectPath={projectPath}
+                issueNumber={tab.issueNumber ?? 0}
+              />
+            {:else if tab.type === "issues"}
+              <IssueListPanel
+                {projectPath}
+                onWorkOnIssue={onWorkOnIssue ?? (() => {})}
+                onSwitchToWorktree={onSwitchToWorktree ?? (() => {})}
+                {onIssueCountChange}
+              />
+            {:else if tab.type === "prs"}
+              <PrListPanel
+                {projectPath}
+                isActive={group.activeTabId === tab.id}
+                onSwitchToWorktree={onSwitchToWorktree ?? (() => {})}
+              />
+            {:else if tab.type === "projectIndex"}
+              <ProjectIndexPanel {projectPath} />
+            {:else if tab.type === "assistant"}
+              <AssistantPanel
+                isActive={group.activeTabId === tab.id}
+                {projectPath}
+                onOpenSettings={onOpenSettings ?? (() => {})}
+              />
+            {:else}
+              <div class="placeholder">
+                <h2>Select a tab</h2>
+              </div>
+            {/if}
+          </div>
+        {:else if group.activeTabId === tab.id && tab.paneId}
+          <div class="terminal-wrapper" class:active={group.activeTabId === tab.id}>
+            <TerminalView
+              paneId={tab.paneId ?? ""}
+              active={group.activeTabId === tab.id}
+              agentId={tab.type === "agent" ? tab.agentId ?? null : null}
+              {voiceInputEnabled}
+              {voiceInputListening}
+              {voiceInputPreparing}
+              {voiceInputSupported}
+              {voiceInputAvailable}
+              {voiceInputAvailabilityReason}
+              {voiceInputError}
+            />
+          </div>
+        {/if}
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .group-pane {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+  }
+
+  .group-pane.active-group {
+    border-color: var(--accent);
+  }
+
+  .tab-bar {
+    display: flex;
+    min-height: var(--tab-height);
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    overflow-x: auto;
+    user-select: none;
+  }
+
+  .tab-bar.drop-target {
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg-secondary));
+  }
+
+  .tab {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    box-sizing: border-box;
+    flex: 0 0 180px;
+    min-width: 180px;
+    max-width: 180px;
+    padding: 0 14px;
+    border-right: 1px solid var(--border-color);
+    cursor: pointer;
+    white-space: nowrap;
+    user-select: none;
+    background: transparent;
+    color: var(--text-secondary);
+  }
+
+  .tab.active {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border-bottom: 2px solid var(--accent);
+  }
+
+  .tab.dragging {
+    opacity: 0.45;
+  }
+
+  .tab.drop-before::before,
+  .tab.drop-after::after {
+    content: "";
+    position: absolute;
+    top: 4px;
+    bottom: 4px;
+    width: 3px;
+    background: var(--accent);
+    border-radius: 999px;
+  }
+
+  .tab.drop-before::before {
+    left: 0;
+  }
+
+  .tab.drop-after::after {
+    right: 0;
+  }
+
+  .tab-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--green);
+  }
+
+  .tab-dot.claude {
+    background: var(--yellow);
+  }
+
+  .tab-dot.codex {
+    background: var(--cyan);
+  }
+
+  .tab-dot.gemini {
+    background: var(--magenta);
+  }
+
+  .tab-dot.opencode {
+    background: var(--green);
+  }
+
+  .tab-dot.terminal {
+    background: var(--text-muted);
+  }
+
+  .tab-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .tab-label-scroll {
+    display: inline-flex;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .tab-label-track {
+    display: inline-flex;
+    gap: 24px;
+    min-width: max-content;
+    animation: tab-label-marquee 12s linear infinite;
+  }
+
+  @keyframes tab-label-marquee {
+    from {
+      transform: translateX(0);
+    }
+
+    to {
+      transform: translateX(calc(-50% - 12px));
+    }
+  }
+
+  .tab-close {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: var(--ui-font-sm);
+    font-family: monospace;
+    cursor: pointer;
+    padding: 0 2px;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  .tab-actions {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .tab-actions-toggle {
+    list-style: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: var(--ui-font-sm);
+  }
+
+  .tab-actions-toggle::-webkit-details-marker {
+    display: none;
+  }
+
+  .tab-actions-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    min-width: 132px;
+    padding: 6px;
+    gap: 4px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    z-index: 20;
+  }
+
+  .tab-actions-menu button {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    padding: 6px 8px;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .tab-actions-menu button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .tab-close:hover {
+    color: var(--red);
+  }
+
+  .group-content {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .panel-wrapper,
+  .terminal-wrapper {
+    position: absolute;
+    inset: 0;
+    visibility: hidden;
+    pointer-events: none;
+    overflow: auto;
+    background: var(--bg-primary);
+  }
+
+  .panel-wrapper {
+    padding: 24px;
+  }
+
+  .panel-wrapper.active,
+  .terminal-wrapper.active {
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .split-target {
+    position: absolute;
+    z-index: 5;
+    opacity: 0;
+    pointer-events: auto;
+  }
+
+  .split-target.active {
+    opacity: 1;
+    background: color-mix(in srgb, var(--accent) 20%, transparent);
+    outline: 2px solid var(--accent);
+  }
+
+  .split-target-top,
+  .split-target-bottom {
+    left: 18%;
+    right: 18%;
+    height: 22%;
+  }
+
+  .split-target-top {
+    top: 0;
+  }
+
+  .split-target-bottom {
+    bottom: 0;
+  }
+
+  .split-target-left,
+  .split-target-right {
+    top: 18%;
+    bottom: 18%;
+    width: 22%;
+  }
+
+  .split-target-left {
+    left: 0;
+  }
+
+  .split-target-right {
+    right: 0;
+  }
+
+  .placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--text-muted);
+  }
+
+  .panel-fallback {
+    position: absolute;
+    inset: 24px;
+  }
+</style>

--- a/gwt-gui/src/lib/components/TabLayoutNode.svelte
+++ b/gwt-gui/src/lib/components/TabLayoutNode.svelte
@@ -1,0 +1,296 @@
+<script lang="ts">
+  import type { GitHubIssueInfo, LaunchAgentRequest, Tab } from "../types";
+  import type {
+    TabDropPosition,
+    TabGroupState,
+    TabLayoutDropTarget,
+    TabLayoutNode,
+    TabSplitDirection,
+  } from "../tabLayout";
+  import TabGroupPane from "./TabGroupPane.svelte";
+  import SelfTabLayoutNode from "./TabLayoutNode.svelte";
+
+  let {
+    node,
+    groups,
+    tabsById,
+    activeGroupId,
+    projectPath,
+    draggedTabId = null,
+    dropTarget = null,
+    onGroupFocus,
+    onTabSelect,
+    onTabClose,
+    onTabSplitAction,
+    onTabDragStart,
+    onTabDragEnd,
+    onTabDragOver,
+    onTabDrop,
+    onGroupDragOver,
+    onGroupDrop,
+    onSplitDragOver,
+    onSplitDrop,
+    onSplitResize,
+    onLaunchAgent,
+    onQuickLaunch,
+    onWorkOnIssue,
+    onSwitchToWorktree,
+    onIssueCountChange,
+    onOpenSettings,
+    voiceInputEnabled = false,
+    voiceInputListening = false,
+    voiceInputPreparing = false,
+    voiceInputSupported = true,
+    voiceInputAvailable = false,
+    voiceInputAvailabilityReason = null,
+    voiceInputError = null,
+  }: {
+    node: TabLayoutNode;
+    groups: Record<string, TabGroupState>;
+    tabsById: Record<string, Tab>;
+    activeGroupId: string;
+    projectPath: string;
+    draggedTabId?: string | null;
+    dropTarget?: TabLayoutDropTarget | null;
+    onGroupFocus: (groupId: string) => void;
+    onTabSelect: (groupId: string, tabId: string) => void;
+    onTabClose: (tabId: string) => void;
+    onTabSplitAction: (
+      tabId: string,
+      groupId: string,
+      direction: TabSplitDirection,
+    ) => void;
+    onTabDragStart: (tabId: string, event: DragEvent) => void;
+    onTabDragEnd: () => void;
+    onTabDragOver: (
+      groupId: string,
+      tabId: string,
+      position: TabDropPosition,
+      event: DragEvent,
+    ) => void;
+    onTabDrop: (
+      groupId: string,
+      tabId: string,
+      position: TabDropPosition,
+      event: DragEvent,
+    ) => void;
+    onGroupDragOver: (groupId: string, event: DragEvent) => void;
+    onGroupDrop: (groupId: string, event: DragEvent) => void;
+    onSplitDragOver: (
+      groupId: string,
+      direction: TabSplitDirection,
+      event: DragEvent,
+    ) => void;
+    onSplitDrop: (
+      groupId: string,
+      direction: TabSplitDirection,
+      event: DragEvent,
+    ) => void;
+    onSplitResize: (splitId: string, primaryFraction: number) => void;
+    onLaunchAgent?: () => void;
+    onQuickLaunch?: (request: LaunchAgentRequest) => Promise<void>;
+    onWorkOnIssue?: (issue: GitHubIssueInfo) => void;
+    onSwitchToWorktree?: (branchName: string) => void;
+    onIssueCountChange?: (count: number) => void;
+    onOpenSettings?: () => void;
+    voiceInputEnabled?: boolean;
+    voiceInputListening?: boolean;
+    voiceInputPreparing?: boolean;
+    voiceInputSupported?: boolean;
+    voiceInputAvailable?: boolean;
+    voiceInputAvailabilityReason?: string | null;
+    voiceInputError?: string | null;
+  } = $props();
+
+  let resizeContainer: HTMLDivElement | null = $state(null);
+
+  function startResize(event: PointerEvent, splitId: string) {
+    const container = resizeContainer;
+    if (!container) return;
+    const axis = node.type === "split" ? node.axis : "horizontal";
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const rect = container.getBoundingClientRect();
+      if (axis === "horizontal") {
+        const primary = (moveEvent.clientX - rect.left) / rect.width;
+        onSplitResize(splitId, primary);
+      } else {
+        const primary = (moveEvent.clientY - rect.top) / rect.height;
+        onSplitResize(splitId, primary);
+      }
+    };
+
+    const handlePointerUp = () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+    handlePointerMove(event);
+  }
+</script>
+
+{#if node.type === "group"}
+  {#if groups[node.groupId]}
+    <TabGroupPane
+      group={groups[node.groupId]}
+      {tabsById}
+      {activeGroupId}
+      {projectPath}
+      {draggedTabId}
+      {dropTarget}
+      {onGroupFocus}
+      {onTabSelect}
+      {onTabClose}
+      {onTabSplitAction}
+      {onTabDragStart}
+      {onTabDragEnd}
+      {onTabDragOver}
+      {onTabDrop}
+      {onGroupDragOver}
+      {onGroupDrop}
+      {onSplitDragOver}
+      {onSplitDrop}
+      {onLaunchAgent}
+      {onQuickLaunch}
+      {onWorkOnIssue}
+      {onSwitchToWorktree}
+      {onIssueCountChange}
+      {onOpenSettings}
+      {voiceInputEnabled}
+      {voiceInputListening}
+      {voiceInputPreparing}
+      {voiceInputSupported}
+      {voiceInputAvailable}
+      {voiceInputAvailabilityReason}
+      {voiceInputError}
+    />
+  {/if}
+{:else}
+  <div
+    bind:this={resizeContainer}
+    class="split-node"
+    class:vertical={node.axis === "vertical"}
+  >
+    <div class="split-child" style={`flex-basis: ${node.sizes[0] * 100}%`}>
+      <SelfTabLayoutNode
+        node={node.children[0]}
+        {groups}
+        {tabsById}
+        {activeGroupId}
+        {projectPath}
+        {draggedTabId}
+        {dropTarget}
+        {onGroupFocus}
+        {onTabSelect}
+        {onTabClose}
+        {onTabSplitAction}
+        {onTabDragStart}
+        {onTabDragEnd}
+        {onTabDragOver}
+        {onTabDrop}
+        {onGroupDragOver}
+        {onGroupDrop}
+        {onSplitDragOver}
+        {onSplitDrop}
+        {onSplitResize}
+        {onLaunchAgent}
+        {onQuickLaunch}
+        {onWorkOnIssue}
+        {onSwitchToWorktree}
+        {onIssueCountChange}
+        {onOpenSettings}
+        {voiceInputEnabled}
+        {voiceInputListening}
+        {voiceInputPreparing}
+        {voiceInputSupported}
+        {voiceInputAvailable}
+        {voiceInputAvailabilityReason}
+        {voiceInputError}
+      />
+    </div>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="split-divider"
+      class:vertical={node.axis === "vertical"}
+      onpointerdown={(event) => startResize(event, node.id)}
+    ></div>
+    <div class="split-child" style={`flex-basis: ${node.sizes[1] * 100}%`}>
+      <SelfTabLayoutNode
+        node={node.children[1]}
+        {groups}
+        {tabsById}
+        {activeGroupId}
+        {projectPath}
+        {draggedTabId}
+        {dropTarget}
+        {onGroupFocus}
+        {onTabSelect}
+        {onTabClose}
+        {onTabSplitAction}
+        {onTabDragStart}
+        {onTabDragEnd}
+        {onTabDragOver}
+        {onTabDrop}
+        {onGroupDragOver}
+        {onGroupDrop}
+        {onSplitDragOver}
+        {onSplitDrop}
+        {onSplitResize}
+        {onLaunchAgent}
+        {onQuickLaunch}
+        {onWorkOnIssue}
+        {onSwitchToWorktree}
+        {onIssueCountChange}
+        {onOpenSettings}
+        {voiceInputEnabled}
+        {voiceInputListening}
+        {voiceInputPreparing}
+        {voiceInputSupported}
+        {voiceInputAvailable}
+        {voiceInputAvailabilityReason}
+        {voiceInputError}
+      />
+    </div>
+  </div>
+{/if}
+
+<style>
+  .split-node {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .split-node.vertical {
+    flex-direction: column;
+  }
+
+  .split-child {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .split-divider {
+    flex: 0 0 6px;
+    background: var(--bg-secondary);
+    cursor: col-resize;
+    border-left: 1px solid var(--border-color);
+    border-right: 1px solid var(--border-color);
+  }
+
+  .split-divider.vertical {
+    cursor: row-resize;
+    border-left: none;
+    border-right: none;
+    border-top: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+  }
+</style>

--- a/gwt-gui/src/lib/tabLayout.test.ts
+++ b/gwt-gui/src/lib/tabLayout.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  addTabToActiveGroup,
+  canSplitTab,
+  createInitialTabLayout,
+  flattenTabIdsByLayout,
+  moveTabToGroup,
+  removeTabFromLayout,
+  reorderTabsInGroup,
+  setActiveGroup,
+  splitTabToGroupEdge,
+} from "./tabLayout";
+
+describe("tabLayout", () => {
+  it("creates a single-group layout from flat tabs", () => {
+    const layout = createInitialTabLayout(
+      [{ id: "assistant" }, { id: "agent-1" }, { id: "terminal-1" }],
+      "agent-1",
+    );
+
+    const group = layout.groups[layout.activeGroupId];
+    expect(group?.tabIds).toEqual(["assistant", "agent-1", "terminal-1"]);
+    expect(group?.activeTabId).toBe("agent-1");
+  });
+
+  it("adds new tabs to the active group", () => {
+    const layout = createInitialTabLayout([{ id: "assistant" }], "assistant");
+    const next = addTabToActiveGroup(layout, "settings");
+
+    expect(next.groups[next.activeGroupId]?.tabIds).toEqual([
+      "assistant",
+      "settings",
+    ]);
+    expect(next.groups[next.activeGroupId]?.activeTabId).toBe("settings");
+  });
+
+  it("reorders tabs within a group", () => {
+    const layout = createInitialTabLayout(
+      [{ id: "assistant" }, { id: "settings" }, { id: "issues" }],
+      "assistant",
+    );
+    const next = reorderTabsInGroup(
+      layout,
+      layout.activeGroupId,
+      "issues",
+      "assistant",
+      "before",
+    );
+
+    expect(next.groups[next.activeGroupId]?.tabIds).toEqual([
+      "issues",
+      "assistant",
+      "settings",
+    ]);
+  });
+
+  it("prevents split when the source group only has one tab", () => {
+    const layout = createInitialTabLayout([{ id: "assistant" }], "assistant");
+    expect(canSplitTab(layout, "assistant")).toBe(false);
+    expect(
+      splitTabToGroupEdge(layout, "assistant", layout.activeGroupId, "right"),
+    ).toEqual(layout);
+  });
+
+  it("splits a tab into a new adjacent group", () => {
+    const layout = createInitialTabLayout(
+      [{ id: "assistant" }, { id: "agent-1" }],
+      "assistant",
+    );
+    const next = splitTabToGroupEdge(
+      layout,
+      "agent-1",
+      layout.activeGroupId,
+      "right",
+    );
+
+    expect(Object.values(next.groups)).toHaveLength(2);
+    expect(flattenTabIdsByLayout(next)).toEqual(["assistant", "agent-1"]);
+    expect(next.activeGroupId).not.toBe(layout.activeGroupId);
+    expect(next.groups[next.activeGroupId]?.tabIds).toEqual(["agent-1"]);
+    expect(next.root.type).toBe("split");
+  });
+
+  it("moves a tab into another group and collapses an emptied source group", () => {
+    const layout = createInitialTabLayout(
+      [{ id: "assistant" }, { id: "agent-1" }, { id: "terminal-1" }],
+      "assistant",
+    );
+    const split = splitTabToGroupEdge(
+      layout,
+      "terminal-1",
+      layout.activeGroupId,
+      "right",
+    );
+    const sourceGroupId = split.groups[split.activeGroupId]?.tabIds.includes("terminal-1")
+      ? Object.keys(split.groups).find((id) => id !== split.activeGroupId) ?? ""
+      : split.activeGroupId;
+    const targetGroupId = split.activeGroupId;
+
+    const moved = moveTabToGroup(
+      split,
+      "assistant",
+      targetGroupId,
+      "terminal-1",
+      "before",
+    );
+    const collapsed = removeTabFromLayout(moved, "agent-1");
+
+    expect(flattenTabIdsByLayout(collapsed)).toEqual(["assistant", "terminal-1"]);
+    expect(Object.values(collapsed.groups)).toHaveLength(1);
+    expect(collapsed.root.type).toBe("group");
+    expect(collapsed.groups[collapsed.activeGroupId]?.tabIds).toEqual([
+      "assistant",
+      "terminal-1",
+    ]);
+    expect(collapsed.activeGroupId).not.toBe(sourceGroupId);
+  });
+
+  it("can retarget the active group explicitly", () => {
+    const layout = createInitialTabLayout(
+      [{ id: "assistant" }, { id: "agent-1" }],
+      "assistant",
+    );
+    const split = splitTabToGroupEdge(
+      layout,
+      "agent-1",
+      layout.activeGroupId,
+      "right",
+    );
+    const otherGroupId =
+      Object.keys(split.groups).find((id) => id !== split.activeGroupId) ?? "";
+    const next = setActiveGroup(split, otherGroupId);
+
+    expect(next.activeGroupId).toBe(otherGroupId);
+  });
+});

--- a/gwt-gui/src/lib/tabLayout.ts
+++ b/gwt-gui/src/lib/tabLayout.ts
@@ -1,0 +1,446 @@
+import type { Tab } from "./types";
+
+export type TabDropPosition = "before" | "after";
+export type TabSplitDirection = "left" | "right" | "up" | "down";
+export type TabSplitAxis = "horizontal" | "vertical";
+
+export interface TabGroupState {
+  id: string;
+  tabIds: string[];
+  activeTabId: string | null;
+}
+
+export type TabLayoutNode =
+  | {
+      type: "group";
+      groupId: string;
+    }
+  | {
+      type: "split";
+      id: string;
+      axis: TabSplitAxis;
+      sizes: [number, number];
+      children: [TabLayoutNode, TabLayoutNode];
+    };
+
+export interface TabLayoutState {
+  groups: Record<string, TabGroupState>;
+  root: TabLayoutNode;
+  activeGroupId: string;
+}
+
+export type TabLayoutDropTarget =
+  | {
+      kind: "tab";
+      groupId: string;
+      tabId: string;
+      position: TabDropPosition;
+    }
+  | {
+      kind: "group";
+      groupId: string;
+    }
+  | {
+      kind: "split";
+      groupId: string;
+      direction: TabSplitDirection;
+    };
+
+let syntheticIdCounter = 0;
+
+function createSyntheticId(prefix: "group" | "split"): string {
+  syntheticIdCounter += 1;
+  return `${prefix}-${syntheticIdCounter}`;
+}
+
+function cloneGroups(
+  groups: Record<string, TabGroupState>,
+): Record<string, TabGroupState> {
+  const next: Record<string, TabGroupState> = {};
+  for (const [id, group] of Object.entries(groups)) {
+    next[id] = {
+      id: group.id,
+      tabIds: [...group.tabIds],
+      activeTabId: group.activeTabId,
+    };
+  }
+  return next;
+}
+
+function axisForDirection(direction: TabSplitDirection): TabSplitAxis {
+  return direction === "left" || direction === "right"
+    ? "horizontal"
+    : "vertical";
+}
+
+function splitChildrenForDirection(
+  direction: TabSplitDirection,
+  groupNode: TabLayoutNode,
+  newGroupNode: TabLayoutNode,
+): [TabLayoutNode, TabLayoutNode] {
+  if (direction === "left" || direction === "up") {
+    return [newGroupNode, groupNode];
+  }
+  return [groupNode, newGroupNode];
+}
+
+function replaceGroupNode(
+  node: TabLayoutNode,
+  groupId: string,
+  replacement: TabLayoutNode,
+): TabLayoutNode {
+  if (node.type === "group") {
+    return node.groupId === groupId ? replacement : node;
+  }
+
+  const [left, right] = node.children;
+  const nextLeft = replaceGroupNode(left, groupId, replacement);
+  const nextRight = replaceGroupNode(right, groupId, replacement);
+  if (nextLeft === left && nextRight === right) {
+    return node;
+  }
+  return {
+    ...node,
+    children: [nextLeft, nextRight],
+  };
+}
+
+function removeGroupNode(node: TabLayoutNode, groupId: string): TabLayoutNode | null {
+  if (node.type === "group") {
+    return node.groupId === groupId ? null : node;
+  }
+
+  const [left, right] = node.children;
+  const nextLeft = removeGroupNode(left, groupId);
+  const nextRight = removeGroupNode(right, groupId);
+
+  if (!nextLeft && !nextRight) return null;
+  if (!nextLeft) return nextRight;
+  if (!nextRight) return nextLeft;
+  if (nextLeft === left && nextRight === right) return node;
+  return {
+    ...node,
+    children: [nextLeft, nextRight],
+  };
+}
+
+function collectGroupIds(node: TabLayoutNode): string[] {
+  if (node.type === "group") return [node.groupId];
+  return [...collectGroupIds(node.children[0]), ...collectGroupIds(node.children[1])];
+}
+
+function pickFallbackActiveTab(
+  tabIds: string[],
+  removedTabId: string,
+): string | null {
+  if (tabIds.length === 0) return null;
+  const removedIndex = tabIds.indexOf(removedTabId);
+  if (removedIndex >= 0) {
+    return tabIds[Math.min(removedIndex, tabIds.length - 1)] ?? null;
+  }
+  return tabIds[0] ?? null;
+}
+
+function sanitizeActiveGroupId(
+  root: TabLayoutNode,
+  activeGroupId: string | null,
+): string {
+  const groupIds = collectGroupIds(root);
+  if (activeGroupId && groupIds.includes(activeGroupId)) {
+    return activeGroupId;
+  }
+  return groupIds[0] ?? "group-unknown";
+}
+
+export function createInitialTabLayout(
+  tabs: Pick<Tab, "id">[],
+  activeTabId: string | null,
+): TabLayoutState {
+  const groupId = createSyntheticId("group");
+  const tabIds = tabs.map((tab) => tab.id);
+  return {
+    groups: {
+      [groupId]: {
+        id: groupId,
+        tabIds,
+        activeTabId: activeTabId && tabIds.includes(activeTabId) ? activeTabId : (tabIds[0] ?? null),
+      },
+    },
+    root: {
+      type: "group",
+      groupId,
+    },
+    activeGroupId: groupId,
+  };
+}
+
+export function getGroupForTab(
+  layout: TabLayoutState,
+  tabId: string,
+): TabGroupState | null {
+  return (
+    Object.values(layout.groups).find((group) => group.tabIds.includes(tabId)) ??
+    null
+  );
+}
+
+export function canSplitTab(
+  layout: TabLayoutState,
+  tabId: string,
+): boolean {
+  const group = getGroupForTab(layout, tabId);
+  return (group?.tabIds.length ?? 0) > 1;
+}
+
+export function setActiveGroup(
+  layout: TabLayoutState,
+  groupId: string,
+): TabLayoutState {
+  if (!layout.groups[groupId] || layout.activeGroupId === groupId) {
+    return layout;
+  }
+  return {
+    ...layout,
+    activeGroupId: groupId,
+  };
+}
+
+export function setActiveTabInGroup(
+  layout: TabLayoutState,
+  groupId: string,
+  tabId: string,
+): TabLayoutState {
+  const group = layout.groups[groupId];
+  if (!group || !group.tabIds.includes(tabId) || group.activeTabId === tabId) {
+    return layout;
+  }
+  return {
+    ...layout,
+    activeGroupId: groupId,
+    groups: {
+      ...layout.groups,
+      [groupId]: {
+        ...group,
+        activeTabId: tabId,
+      },
+    },
+  };
+}
+
+export function addTabToActiveGroup(
+  layout: TabLayoutState,
+  tabId: string,
+): TabLayoutState {
+  const group = layout.groups[layout.activeGroupId];
+  if (!group || group.tabIds.includes(tabId)) return layout;
+  return {
+    ...layout,
+    groups: {
+      ...layout.groups,
+      [group.id]: {
+        ...group,
+        tabIds: [...group.tabIds, tabId],
+        activeTabId: tabId,
+      },
+    },
+  };
+}
+
+export function reorderTabsInGroup(
+  layout: TabLayoutState,
+  groupId: string,
+  dragTabId: string,
+  overTabId: string,
+  position: TabDropPosition,
+): TabLayoutState {
+  const group = layout.groups[groupId];
+  if (!group) return layout;
+
+  const dragIndex = group.tabIds.indexOf(dragTabId);
+  const overIndex = group.tabIds.indexOf(overTabId);
+  if (dragIndex < 0 || overIndex < 0 || dragIndex === overIndex) {
+    return layout;
+  }
+
+  const nextTabIds = [...group.tabIds];
+  const [dragged] = nextTabIds.splice(dragIndex, 1);
+  if (!dragged) return layout;
+  const targetIndex = nextTabIds.indexOf(overTabId);
+  if (targetIndex < 0) return layout;
+  const insertIndex = position === "before" ? targetIndex : targetIndex + 1;
+  nextTabIds.splice(insertIndex, 0, dragged);
+
+  return {
+    ...layout,
+    groups: {
+      ...layout.groups,
+      [groupId]: {
+        ...group,
+        tabIds: nextTabIds,
+      },
+    },
+  };
+}
+
+function removeTabFromGroupState(
+  layout: TabLayoutState,
+  groupId: string,
+  tabId: string,
+): TabLayoutState {
+  const group = layout.groups[groupId];
+  if (!group || !group.tabIds.includes(tabId)) return layout;
+
+  const nextGroups = cloneGroups(layout.groups);
+  const nextGroup = nextGroups[groupId];
+  if (!nextGroup) return layout;
+  nextGroup.tabIds = nextGroup.tabIds.filter((candidate) => candidate !== tabId);
+  if (nextGroup.activeTabId === tabId) {
+    nextGroup.activeTabId = pickFallbackActiveTab(nextGroup.tabIds, tabId);
+  }
+
+  let nextRoot = layout.root;
+  if (nextGroup.tabIds.length === 0) {
+    delete nextGroups[groupId];
+    const removed = removeGroupNode(layout.root, groupId);
+    if (!removed) {
+      return layout;
+    }
+    nextRoot = removed;
+  }
+
+  return {
+    groups: nextGroups,
+    root: nextRoot,
+    activeGroupId: sanitizeActiveGroupId(nextRoot, layout.activeGroupId),
+  };
+}
+
+export function removeTabFromLayout(
+  layout: TabLayoutState,
+  tabId: string,
+): TabLayoutState {
+  const group = getGroupForTab(layout, tabId);
+  if (!group) return layout;
+  return removeTabFromGroupState(layout, group.id, tabId);
+}
+
+export function moveTabToGroup(
+  layout: TabLayoutState,
+  tabId: string,
+  targetGroupId: string,
+  overTabId?: string | null,
+  position: TabDropPosition = "after",
+): TabLayoutState {
+  const sourceGroup = getGroupForTab(layout, tabId);
+  const targetGroup = layout.groups[targetGroupId];
+  if (!sourceGroup || !targetGroup) return layout;
+
+  if (sourceGroup.id === targetGroupId) {
+    if (!overTabId) return layout;
+    return reorderTabsInGroup(layout, targetGroupId, tabId, overTabId, position);
+  }
+
+  const withoutSource = removeTabFromGroupState(layout, sourceGroup.id, tabId);
+  const nextGroups = cloneGroups(withoutSource.groups);
+  const nextTarget = nextGroups[targetGroupId];
+  if (!nextTarget || nextTarget.tabIds.includes(tabId)) {
+    return withoutSource;
+  }
+
+  const insertIndex =
+    overTabId && nextTarget.tabIds.includes(overTabId)
+      ? nextTarget.tabIds.indexOf(overTabId) + (position === "after" ? 1 : 0)
+      : nextTarget.tabIds.length;
+
+  nextTarget.tabIds.splice(insertIndex, 0, tabId);
+  nextTarget.activeTabId = tabId;
+
+  return {
+    ...withoutSource,
+    groups: nextGroups,
+    activeGroupId: targetGroupId,
+  };
+}
+
+export function splitTabToGroupEdge(
+  layout: TabLayoutState,
+  tabId: string,
+  targetGroupId: string,
+  direction: TabSplitDirection,
+): TabLayoutState {
+  const sourceGroup = getGroupForTab(layout, tabId);
+  const targetGroup = layout.groups[targetGroupId];
+  if (!sourceGroup || !targetGroup) return layout;
+  if (sourceGroup.id === targetGroupId && sourceGroup.tabIds.length <= 1) {
+    return layout;
+  }
+
+  const withoutSource = removeTabFromGroupState(layout, sourceGroup.id, tabId);
+  const nextGroups = cloneGroups(withoutSource.groups);
+  const newGroupId = createSyntheticId("group");
+  nextGroups[newGroupId] = {
+    id: newGroupId,
+    tabIds: [tabId],
+    activeTabId: tabId,
+  };
+
+  const targetNode: TabLayoutNode = { type: "group", groupId: targetGroupId };
+  const newGroupNode: TabLayoutNode = { type: "group", groupId: newGroupId };
+  const replacement: TabLayoutNode = {
+    type: "split",
+    id: createSyntheticId("split"),
+    axis: axisForDirection(direction),
+    sizes: [0.5, 0.5],
+    children: splitChildrenForDirection(direction, targetNode, newGroupNode),
+  };
+
+  const nextRoot = replaceGroupNode(withoutSource.root, targetGroupId, replacement);
+  return {
+    groups: nextGroups,
+    root: nextRoot,
+    activeGroupId: newGroupId,
+  };
+}
+
+export function resizeSplitNode(
+  layout: TabLayoutState,
+  splitId: string,
+  primaryFraction: number,
+): TabLayoutState {
+  const clamped = Math.max(0.1, Math.min(0.9, primaryFraction));
+
+  function visit(node: TabLayoutNode): TabLayoutNode {
+    if (node.type === "group") return node;
+    const [left, right] = node.children;
+    const nextLeft = visit(left);
+    const nextRight = visit(right);
+    if (node.id !== splitId && nextLeft === left && nextRight === right) {
+      return node;
+    }
+    return {
+      ...node,
+      sizes: node.id === splitId ? [clamped, 1 - clamped] : node.sizes,
+      children: [nextLeft, nextRight],
+    };
+  }
+
+  const nextRoot = visit(layout.root);
+  if (nextRoot === layout.root) return layout;
+  return {
+    ...layout,
+    root: nextRoot,
+  };
+}
+
+export function flattenTabIdsByLayout(
+  layout: TabLayoutState,
+): string[] {
+  const orderedGroupIds = collectGroupIds(layout.root);
+  const out: string[] = [];
+  for (const groupId of orderedGroupIds) {
+    const group = layout.groups[groupId];
+    if (!group) continue;
+    out.push(...group.tabIds);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- Add split editor-group style tab layout in the GUI so Assistant, Settings, Issues, and terminal-backed tabs can be arranged side by side within one window.
- Replace the single active-tab model with group-aware layout persistence so split and merge state restores correctly after reopening a project.
- Improve tab interaction clarity by adding drag targets, split overlays, merge behavior, and compact fixed-width tabs for denser layouts.

## Changes

- `gwt-gui/src/App.svelte`: track group-aware tab layout state, route tab open/navigation/menu sync through the active group, and persist layout metadata per project.
- `gwt-gui/src/lib/tabLayout.ts`: add the pure layout reducer for split, merge, collapse, move, reorder, and resize behavior.
- `gwt-gui/src/lib/components/MainArea.svelte`, `gwt-gui/src/lib/components/TabLayoutNode.svelte`, `gwt-gui/src/lib/components/TabGroupPane.svelte`: replace the single tab strip with recursive editor groups, drag/drop split and merge targets, explicit split actions, and compact fixed-width tabs.
- `gwt-gui/src/lib/agentTabsPersistence.ts`: extend project tab persistence with backward-compatible layout metadata restore.
- `gwt-gui/src/lib/components/MainArea.test.ts`, `gwt-gui/src/lib/tabLayout.test.ts`, `gwt-gui/e2e/tab-layout.spec.ts`: cover the new layout reducer, component behavior, and Chromium browser split/merge flows.

## Testing

- [x] `pnpm --dir gwt-gui test src/lib/tabLayout.test.ts src/lib/components/MainArea.test.ts src/lib/agentTabsPersistence.test.ts src/lib/windowMenuSync.test.ts` - passed
- [x] `pnpm --dir gwt-gui check` - passed
- [x] `pnpm --dir gwt-gui exec playwright test e2e/tab-layout.spec.ts --project=chromium` - passed

## Closing Issues

- Closes #1687

## Related Issues / Links

- #1654
- https://github.com/akiojin/gwt/issues/1687

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) - `svelte-check` passed; Rust formatting/lint not needed for this GUI-only change
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) - N/A: localStorage tab state remains backward compatible and migrates lazily on read/write
- [ ] CHANGELOG impact considered (breaking change flagged in commit) - N/A: non-breaking feature work on a feature branch

## Context

- The previous GUI model only supported a single tab strip and one active tab per window, which blocked common workflows like keeping Assistant visible while inspecting another tab.
- The old drag interaction also lacked clear drop affordances and visually resembled text selection, making tab movement hard to trust.
- This change establishes the canonical tab layout implementation tracked by #1687 and keeps the multi-window relationship documented in #1654.

## Risk / Impact

- **Affected areas**: tab rendering, tab persistence, window menu tab sync, and browser drag interactions in `gwt-gui`
- **Rollback plan**: revert this PR to restore the previous single-tab-strip behavior

## Screenshots

Interactive UI change; no static screenshots are attached in this CLI workflow, and the split/merge flows are covered by `e2e/tab-layout.spec.ts`.

## Notes

- This PR supersedes https://github.com/akiojin/gwt/pull/1710 because the original protected branch could not be updated from this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-pane tab layout with split functionality — organize tabs across side-by-side or stacked panes
  * Drag-and-drop tabs between panes and reorder within groups
  * Resizable split pane dividers for custom layout sizing
  * Tab layout persistence across sessions
  * Support for additional tab types: Pull Requests, Project Index, and Issue Spec

* **Tests**
  * Added comprehensive end-to-end test coverage for tab splitting, dragging, and layout behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->