### PR TITLE
chore(release): v8.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [8.17.1] - 2026-03-19
+
+### Bug Fixes
+
+- **tauri:** Reset legacy macOS WebKit local storage (#1721)
+
 ## [8.17.0] - 2026-03-19
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "8.17.0"
+version = "8.17.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-tauri"
-version = "8.17.0"
+version = "8.17.1"
 dependencies = [
  "chrono",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "8.17.0"
+version = "8.17.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-tauri/src/main.rs
+++ b/crates/gwt-tauri/src/main.rs
@@ -19,7 +19,13 @@ mod tool_helpers;
 
 use std::{io::Read, sync::Arc};
 
+#[cfg(any(test, target_os = "macos"))]
+use std::path::{Path, PathBuf};
+
 use state::AppState;
+
+#[cfg(any(test, target_os = "macos"))]
+const LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL: &str = "webkit-localstorage-reset-issue-1720-v1";
 
 fn main() {
     // Self-update helper mode: do not start GUI, just execute requested update action.
@@ -47,6 +53,9 @@ fn main() {
         profiling: settings.profiling,
     };
     let _profiling_guard = gwt_core::logging::init_logger(&log_config);
+
+    #[cfg(target_os = "macos")]
+    maybe_reset_legacy_webkit_local_storage();
 
     let single_instance_guard = match crate::single_instance::try_acquire_single_instance() {
         Ok(crate::single_instance::AcquireOutcome::Acquired(guard)) => Arc::new(guard),
@@ -77,6 +86,111 @@ fn main() {
     .expect("error while building tauri application");
 
     app.run(crate::app::handle_run_event);
+}
+
+#[cfg(target_os = "macos")]
+fn maybe_reset_legacy_webkit_local_storage() {
+    let Some(home_dir) = dirs::home_dir() else {
+        return;
+    };
+    match reset_legacy_webkit_local_storage(&home_dir) {
+        Ok(removed_targets) if !removed_targets.is_empty() => {
+            tracing::info!(
+                category = "startup_migration",
+                removed_targets = removed_targets.len(),
+                "Reset legacy WebKit LocalStorage to avoid startup crash"
+            );
+        }
+        Ok(_) => {}
+        Err(err) => {
+            tracing::warn!(
+                category = "startup_migration",
+                error = %err,
+                "Failed to reset legacy WebKit LocalStorage"
+            );
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn webkit_local_storage_reset_sentinel(home_dir: &Path) -> PathBuf {
+    home_dir
+        .join(".gwt")
+        .join("runtime")
+        .join(LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn webkit_local_storage_targets(home_dir: &Path) -> Vec<PathBuf> {
+    let website_data_root = home_dir
+        .join("Library")
+        .join("WebKit")
+        .join("com.akiojin.gwt")
+        .join("WebsiteData");
+
+    let mut targets = Vec::new();
+    let top_level_local_storage = website_data_root.join("LocalStorage");
+    if top_level_local_storage.exists() {
+        targets.push(top_level_local_storage);
+    }
+
+    let default_root = website_data_root.join("Default");
+    let Ok(origin_dirs) = std::fs::read_dir(default_root) else {
+        targets.sort();
+        targets.dedup();
+        return targets;
+    };
+
+    for origin_dir in origin_dirs.flatten() {
+        let Ok(origin_children) = std::fs::read_dir(origin_dir.path()) else {
+            continue;
+        };
+        for origin_child in origin_children.flatten() {
+            let local_storage = origin_child.path().join("LocalStorage");
+            if local_storage.exists() {
+                targets.push(local_storage);
+            }
+        }
+    }
+
+    targets.sort();
+    targets.dedup();
+    targets
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn reset_legacy_webkit_local_storage(home_dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let sentinel = webkit_local_storage_reset_sentinel(home_dir);
+    if sentinel.exists() {
+        return Ok(Vec::new());
+    }
+
+    let targets = webkit_local_storage_targets(home_dir);
+    for target in &targets {
+        if target.is_dir() {
+            std::fs::remove_dir_all(target)
+                .map_err(|err| format!("failed to remove {}: {err}", target.display()))?;
+        } else if target.is_file() {
+            std::fs::remove_file(target)
+                .map_err(|err| format!("failed to remove {}: {err}", target.display()))?;
+        }
+    }
+
+    if let Some(parent) = sentinel.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+    }
+    std::fs::write(
+        &sentinel,
+        format!(
+            "migration={}\npackage_version={}\n",
+            LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL,
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .map_err(|err| format!("failed to write {}: {err}", sentinel.display()))?;
+
+    Ok(targets)
 }
 
 fn handle_hook_cli() -> bool {
@@ -251,5 +365,98 @@ fn maybe_run_internal_mode() -> bool {
             eprintln!("Unknown internal mode: {other}");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn webkit_local_storage_targets_collects_top_level_and_nested_dirs() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let top_level = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("LocalStorage");
+        let nested = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin-a")
+            .join("site-a")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&top_level).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let targets = webkit_local_storage_targets(home);
+
+        assert_eq!(targets.len(), 2);
+        assert!(targets.contains(&top_level));
+        assert!(targets.contains(&nested));
+    }
+
+    #[test]
+    fn reset_legacy_webkit_local_storage_removes_targets_and_writes_sentinel() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let top_level = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("LocalStorage");
+        let nested = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin-a")
+            .join("site-a")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&top_level).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(top_level.join("https___tauri.local_0.localstorage"), "").unwrap();
+        std::fs::write(nested.join("localstorage.sqlite3"), "legacy").unwrap();
+
+        let removed_targets = reset_legacy_webkit_local_storage(home).unwrap();
+        let sentinel = webkit_local_storage_reset_sentinel(home);
+
+        assert_eq!(removed_targets.len(), 2);
+        assert!(!top_level.exists());
+        assert!(!nested.exists());
+        assert!(sentinel.exists());
+
+        let sentinel_body = std::fs::read_to_string(sentinel).unwrap();
+        assert!(sentinel_body.contains(LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL));
+    }
+
+    #[test]
+    fn reset_legacy_webkit_local_storage_skips_when_sentinel_exists() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let top_level = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&top_level).unwrap();
+
+        let sentinel = webkit_local_storage_reset_sentinel(home);
+        std::fs::create_dir_all(sentinel.parent().unwrap()).unwrap();
+        std::fs::write(&sentinel, "already-migrated").unwrap();
+
+        let removed_targets = reset_legacy_webkit_local_storage(home).unwrap();
+
+        assert!(removed_targets.is_empty());
+        assert!(top_level.exists());
     }
 }

--- a/crates/gwt-tauri/tauri.conf.json
+++ b/crates/gwt-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "gwt",
-  "version": "8.17.0",
+  "version": "8.17.1",
   "identifier": "com.akiojin.gwt",
   "build": {
     "frontendDist": "../../gwt-gui/dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gwt",
-  "version": "8.17.0",
+  "version": "8.17.1",
   "private": true,
   "description": "Tauri desktop GUI for Git worktree management and coding agent launch",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release that fixes legacy macOS WebKit local storage reset issue.

## Changes

- **Bug Fix**: Reset legacy macOS WebKit local storage (#1721)

## Version

v8.17.1 (patch)

## Closing Issues

Closes #1720

## Related Issues / Links

None