### PR TITLE
chore(release): v8.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [8.17.2] - 2026-03-20
+
+### Bug Fixes
+
+- **tauri:** Harden macOS startup migration (#1723)
+
 ## [8.17.1] - 2026-03-19
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ## [8.17.2] - 2026-03-20
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "8.17.1"
+version = "8.17.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-tauri"
-version = "8.17.1"
+version = "8.17.2"
 dependencies = [
  "chrono",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "8.17.1"
+version = "8.17.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-tauri/src/main.rs
+++ b/crates/gwt-tauri/src/main.rs
@@ -54,9 +54,6 @@ fn main() {
     };
     let _profiling_guard = gwt_core::logging::init_logger(&log_config);
 
-    #[cfg(target_os = "macos")]
-    maybe_reset_legacy_webkit_local_storage();
-
     let single_instance_guard = match crate::single_instance::try_acquire_single_instance() {
         Ok(crate::single_instance::AcquireOutcome::Acquired(guard)) => Arc::new(guard),
         Ok(crate::single_instance::AcquireOutcome::AlreadyRunning(running)) => {
@@ -74,6 +71,9 @@ fn main() {
             return;
         }
     };
+
+    #[cfg(target_os = "macos")]
+    maybe_reset_legacy_webkit_local_storage();
 
     let app_state = AppState::new();
 
@@ -142,13 +142,24 @@ fn webkit_local_storage_targets(home_dir: &Path) -> Vec<PathBuf> {
     };
 
     for origin_dir in origin_dirs.flatten() {
+        let direct_local_storage = origin_dir.path().join("LocalStorage");
+        if direct_local_storage.exists() {
+            targets.push(direct_local_storage);
+        }
         let Ok(origin_children) = std::fs::read_dir(origin_dir.path()) else {
             continue;
         };
         for origin_child in origin_children.flatten() {
-            let local_storage = origin_child.path().join("LocalStorage");
-            if local_storage.exists() {
-                targets.push(local_storage);
+            let origin_child_path = origin_child.path();
+            if origin_child_path.file_name().and_then(|name| name.to_str()) == Some("LocalStorage")
+            {
+                targets.push(origin_child_path);
+                continue;
+            }
+
+            let nested_local_storage = origin_child_path.join("LocalStorage");
+            if nested_local_storage.exists() {
+                targets.push(nested_local_storage);
             }
         }
     }
@@ -400,6 +411,26 @@ mod tests {
         assert_eq!(targets.len(), 2);
         assert!(targets.contains(&top_level));
         assert!(targets.contains(&nested));
+    }
+
+    #[test]
+    fn webkit_local_storage_targets_collects_direct_origin_local_storage() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let direct_origin_local_storage = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin-a")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&direct_origin_local_storage).unwrap();
+
+        let targets = webkit_local_storage_targets(home);
+
+        assert_eq!(targets.len(), 1);
+        assert!(targets.contains(&direct_origin_local_storage));
     }
 
     #[test]

--- a/crates/gwt-tauri/tauri.conf.json
+++ b/crates/gwt-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "gwt",
-  "version": "8.17.1",
+  "version": "8.17.2",
   "identifier": "com.akiojin.gwt",
   "build": {
     "frontendDist": "../../gwt-gui/dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gwt",
-  "version": "8.17.1",
+  "version": "8.17.2",
   "private": true,
   "description": "Tauri desktop GUI for Git worktree management and coding agent launch",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release fixing macOS startup migration reliability.

## Changes

- **fix(tauri):** Harden macOS startup migration (#1723)

## Version

`v8.17.2` (patch)

## Closing Issues

Closes #1720

## Related Issues / Links

#1721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened macOS startup migration to improve app startup stability.
  * Improved local storage detection to ensure more reliable initialization on macOS.

* **Chores**
  * Version bump to 8.17.2 and added corresponding release notes entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->