### PR TITLE
feat(gui): add workspace shell agent canvas and branch browser

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,6 +29,18 @@ curl -fsSL https://raw.githubusercontent.com/akiojin/gwt/main/installers/macos/i
 pnpm run installer:macos
 ```
 
+GitHub Release を待たずにローカルビルドを `/Applications/gwt.app` へ直接入れて素早く検証:
+
+```bash
+pnpm run install:local:macos
+```
+
+すでにビルド済みの `.app` を再ビルドせず入れ直す:
+
+```bash
+pnpm run install:local:macos:skip-build
+```
+
 ### Windows
 
 GitHub Releases から `.msi` をダウンロードして実行します。

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Build installers locally (one command):
 pnpm run installer:macos
 ```
 
+Fast local app install for iterative testing (without waiting for a GitHub Release):
+
+```bash
+pnpm run install:local:macos
+```
+
+Reinstall the already-built local `.app` bundle without rebuilding:
+
+```bash
+pnpm run install:local:macos:skip-build
+```
+
+This installs the local build directly to `/Applications/gwt.app`.
+
 ### Windows
 
 Download `.msi` from GitHub Releases and run the installer.

--- a/crates/gwt-tauri/src/app.rs
+++ b/crates/gwt-tauri/src/app.rs
@@ -16,9 +16,22 @@ use tokio::io::AsyncReadExt;
 use tracing::{info, warn};
 
 use crate::state::AppState;
+#[cfg(not(test))]
+use crate::commands::system::{startup_diagnostics_from_env, StartupDiagnostics};
 
 fn should_prevent_window_close(is_quitting: bool) -> bool {
     !is_quitting
+}
+
+#[cfg(not(test))]
+fn log_startup_checkpoint(diagnostics: &StartupDiagnostics, checkpoint: &'static str) {
+    if diagnostics.startup_trace {
+        info!(
+            category = "startup_diag",
+            checkpoint = checkpoint,
+            "Startup checkpoint"
+        );
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -297,90 +310,112 @@ pub fn build_app(
         .setup(move |_app| {
             #[cfg(not(test))]
             {
+                let startup_diagnostics = startup_diagnostics_from_env();
+                log_startup_checkpoint(&startup_diagnostics, "setup.begin");
+
                 if let Some(guard) = single_instance_guard.as_ref() {
                     spawn_single_instance_focus_listener(_app.handle().clone(), guard.clone());
                 }
 
                 // Native menubar (gwt-spec issue)
+                log_startup_checkpoint(&startup_diagnostics, "menu.begin");
                 if let Err(e) = crate::menu::rebuild_menu(_app.handle()) {
                     warn!(category = "menu", error = %e, "Failed to build initial menu");
                 } else {
                     info!(category = "menu", "Initial native menu built");
                 }
+                log_startup_checkpoint(&startup_diagnostics, "menu.ready");
 
                 // System tray (gwt-spec issue FR-310〜FR-313)
-                let tray_menu = tauri::menu::Menu::new(_app)?;
-                let show_item =
-                    tauri::menu::MenuItem::with_id(_app, "tray-show", "Show", true, None::<&str>)?;
-                let quit_item =
-                    tauri::menu::MenuItem::with_id(_app, "tray-quit", "Quit", true, None::<&str>)?;
-                tray_menu.append_items(&[&show_item, &quit_item])?;
+                if startup_diagnostics.disable_tray {
+                    info!(
+                        category = "startup_diag",
+                        checkpoint = "tray.skipped",
+                        "Startup tray creation disabled by diagnostics"
+                    );
+                } else {
+                    log_startup_checkpoint(&startup_diagnostics, "tray.begin");
+                    let tray_menu = tauri::menu::Menu::new(_app)?;
+                    let show_item = tauri::menu::MenuItem::with_id(
+                        _app,
+                        "tray-show",
+                        "Show",
+                        true,
+                        None::<&str>,
+                    )?;
+                    let quit_item = tauri::menu::MenuItem::with_id(
+                        _app,
+                        "tray-quit",
+                        "Quit",
+                        true,
+                        None::<&str>,
+                    )?;
+                    tray_menu.append_items(&[&show_item, &quit_item])?;
 
-                // NOTE: Requires `tauri` features `tray-icon` + `image-png`.
-                // macOS: use a template icon so the system can tint it appropriately.
-                // Others: use a high-contrast 2-tone icon for light/dark tray backgrounds.
-                #[cfg(target_os = "macos")]
-                let tray_icon_bytes = include_bytes!("../icons/trayTemplate.png");
-                #[cfg(not(target_os = "macos"))]
-                let tray_icon_bytes = include_bytes!("../icons/tray.png");
-                let icon = tauri::image::Image::from_bytes(tray_icon_bytes)?;
+                    #[cfg(target_os = "macos")]
+                    let tray_icon_bytes = include_bytes!("../icons/trayTemplate.png");
+                    #[cfg(not(target_os = "macos"))]
+                    let tray_icon_bytes = include_bytes!("../icons/tray.png");
+                    let icon = tauri::image::Image::from_bytes(tray_icon_bytes)?;
 
-                let _tray = tauri::tray::TrayIconBuilder::with_id("gwt-tray")
-                    .icon(icon)
-                    .tooltip("gwt")
-                    .menu(&tray_menu)
-                    .on_menu_event(|app, event| match event.id().as_ref() {
-                        "tray-show" => {
-                            show_best_window(app);
-                        }
-                        "tray-quit" => {
-                            let state = app.state::<AppState>();
-                            if !has_running_agents(&state) {
-                                cleanup_pty_processes(&state);
-                                state.request_quit();
-                                app.exit(0);
-                                return;
+                    let _tray = tauri::tray::TrayIconBuilder::with_id("gwt-tray")
+                        .icon(icon)
+                        .tooltip("gwt")
+                        .menu(&tray_menu)
+                        .on_menu_event(|app, event| match event.id().as_ref() {
+                            "tray-show" => {
+                                show_best_window(app);
                             }
+                            "tray-quit" => {
+                                let state = app.state::<AppState>();
+                                if !has_running_agents(&state) {
+                                    cleanup_pty_processes(&state);
+                                    state.request_quit();
+                                    app.exit(0);
+                                    return;
+                                }
 
-                            if !try_begin_exit_confirm(&state) {
-                                return;
+                                if !try_begin_exit_confirm(&state) {
+                                    return;
+                                }
+
+                                let app_handle = app.clone();
+                                app.dialog()
+                                    .message("Agents are still running. Quit gwt anyway?")
+                                    .kind(MessageDialogKind::Warning)
+                                    .buttons(MessageDialogButtons::OkCancelCustom(
+                                        "Quit".to_string(),
+                                        "Cancel".to_string(),
+                                    ))
+                                    .show(move |ok| {
+                                        let state = app_handle.state::<AppState>();
+                                        end_exit_confirm(&state);
+                                        if ok {
+                                            cleanup_pty_processes(&state);
+                                            state.request_quit();
+                                            app_handle.exit(0);
+                                        }
+                                    });
                             }
+                            _ => {}
+                        })
+                        .on_tray_icon_event(|tray, event| {
+                            use tauri::tray::{MouseButton, MouseButtonState, TrayIconEvent};
+                            if let TrayIconEvent::Click {
+                                button: MouseButton::Left,
+                                button_state: MouseButtonState::Up,
+                                ..
+                            } = event
+                            {
+                                show_best_window(tray.app_handle());
+                            }
+                        })
+                        .build(_app)?;
 
-                            let app_handle = app.clone();
-                            app.dialog()
-                                .message("Agents are still running. Quit gwt anyway?")
-                                .kind(MessageDialogKind::Warning)
-                                .buttons(MessageDialogButtons::OkCancelCustom(
-                                    "Quit".to_string(),
-                                    "Cancel".to_string(),
-                                ))
-                                .show(move |ok| {
-                                    let state = app_handle.state::<AppState>();
-                                    end_exit_confirm(&state);
-                                    if ok {
-                                        cleanup_pty_processes(&state);
-                                        state.request_quit();
-                                        app_handle.exit(0);
-                                    }
-                                });
-                        }
-                        _ => {}
-                    })
-                    .on_tray_icon_event(|tray, event| {
-                        use tauri::tray::{MouseButton, MouseButtonState, TrayIconEvent};
-                        if let TrayIconEvent::Click {
-                            button: MouseButton::Left,
-                            button_state: MouseButtonState::Up,
-                            ..
-                        } = event
-                        {
-                            show_best_window(tray.app_handle());
-                        }
-                    })
-                    .build(_app)?;
-
-                #[cfg(target_os = "macos")]
-                _tray.set_icon_as_template(true)?;
+                    #[cfg(target_os = "macos")]
+                    _tray.set_icon_as_template(true)?;
+                    log_startup_checkpoint(&startup_diagnostics, "tray.ready");
+                }
 
                 // Startup shell environment behavior.
                 // On Unix, capture from login shell to get PATH extensions (nvm, pyenv, etc.).
@@ -388,12 +423,24 @@ pub fn build_app(
                 {
                     #[cfg(unix)]
                     {
-                        info!(
-                            category = "os_env",
-                            mode = "login_shell",
-                            "Capturing environment from login shell"
-                        );
-                        spawn_login_shell_env_capture(_app.handle().clone());
+                        if startup_diagnostics.disable_login_shell_capture {
+                            let state = _app.state::<AppState>();
+                            state.set_os_env_process_env_snapshot();
+                            info!(
+                                category = "startup_diag",
+                                checkpoint = "os_env.skipped",
+                                mode = "process_env",
+                                "Startup login shell capture disabled by diagnostics"
+                            );
+                        } else {
+                            log_startup_checkpoint(&startup_diagnostics, "os_env.begin");
+                            info!(
+                                category = "os_env",
+                                mode = "login_shell",
+                                "Capturing environment from login shell"
+                            );
+                            spawn_login_shell_env_capture(_app.handle().clone());
+                        }
                     }
                     #[cfg(not(unix))]
                     {
@@ -410,7 +457,14 @@ pub fn build_app(
                 // Project-scoped registration is executed when an agent is launched.
 
                 // Background task: frontend heartbeat watchdog (freeze detection)
-                {
+                if startup_diagnostics.disable_heartbeat_watchdog {
+                    info!(
+                        category = "startup_diag",
+                        checkpoint = "heartbeat_watchdog.skipped",
+                        "Startup heartbeat watchdog disabled by diagnostics"
+                    );
+                } else {
+                    log_startup_checkpoint(&startup_diagnostics, "heartbeat_watchdog.begin");
                     let watchdog_handle = _app.handle().clone();
                     tokio::spawn(async move {
                         let mut interval = tokio::time::interval(Duration::from_secs(2));
@@ -433,6 +487,7 @@ pub fn build_app(
                             }
                         }
                     });
+                    log_startup_checkpoint(&startup_diagnostics, "heartbeat_watchdog.ready");
                 }
 
                 // Background task: check gh CLI authentication (gwt-spec issue T009)
@@ -453,7 +508,14 @@ pub fn build_app(
                 }
 
                 // Background task: watch session files for agent status changes (gwt-spec issue FR-820)
-                {
+                if startup_diagnostics.disable_session_watcher {
+                    info!(
+                        category = "startup_diag",
+                        checkpoint = "session_watcher.skipped",
+                        "Startup session watcher disabled by diagnostics"
+                    );
+                } else {
+                    log_startup_checkpoint(&startup_diagnostics, "session_watcher.begin");
                     let watcher_handle = _app.handle().clone();
                     if let Err(e) = crate::session_watcher::start_session_watcher(watcher_handle) {
                         warn!(
@@ -462,10 +524,18 @@ pub fn build_app(
                             "Failed to start session watcher (agent status updates will use polling fallback)"
                         );
                     }
+                    log_startup_checkpoint(&startup_diagnostics, "session_watcher.ready");
                 }
 
                 // Background task: check app update (best-effort, TTL cached).
-                {
+                if startup_diagnostics.disable_startup_update_check {
+                    info!(
+                        category = "startup_diag",
+                        checkpoint = "startup_update_check.skipped",
+                        "Startup update check disabled by diagnostics"
+                    );
+                } else {
+                    log_startup_checkpoint(&startup_diagnostics, "startup_update_check.begin");
                     let mgr = _app.state::<AppState>().update_manager.clone();
                     let app_handle_clone = _app.handle().clone();
                     tauri::async_runtime::spawn_blocking(move || {
@@ -482,7 +552,9 @@ pub fn build_app(
                         }
                         let _ = app_handle_clone.emit("app-update-state", &state);
                     });
+                    log_startup_checkpoint(&startup_diagnostics, "startup_update_check.ready");
                 }
+                log_startup_checkpoint(&startup_diagnostics, "setup.ready");
             }
 
             Ok(())
@@ -802,6 +874,7 @@ pub fn build_app(
             crate::commands::pullrequest::mark_pr_ready,
             crate::commands::system::get_system_info,
             crate::commands::system::get_stats,
+            crate::commands::system::get_startup_diagnostics,
             crate::commands::system::heartbeat,
             crate::commands::system::report_frontend_metrics,
             crate::commands::project_index::ensure_index_runtime,

--- a/crates/gwt-tauri/src/app.rs
+++ b/crates/gwt-tauri/src/app.rs
@@ -733,6 +733,7 @@ pub fn build_app(
             crate::commands::branches::list_branches,
             crate::commands::branches::list_worktree_branches,
             crate::commands::branches::list_remote_branches,
+            crate::commands::branches::materialize_worktree_ref,
             crate::commands::branches::get_current_branch,
             crate::commands::project::open_project,
             crate::commands::project::probe_path,

--- a/crates/gwt-tauri/src/app.rs
+++ b/crates/gwt-tauri/src/app.rs
@@ -733,6 +733,7 @@ pub fn build_app(
             crate::commands::branches::list_branches,
             crate::commands::branches::list_worktree_branches,
             crate::commands::branches::list_remote_branches,
+            crate::commands::branches::list_branch_inventory,
             crate::commands::branches::materialize_worktree_ref,
             crate::commands::branches::get_current_branch,
             crate::commands::project::open_project,

--- a/crates/gwt-tauri/src/app.rs
+++ b/crates/gwt-tauri/src/app.rs
@@ -15,9 +15,9 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tokio::io::AsyncReadExt;
 use tracing::{info, warn};
 
-use crate::state::AppState;
 #[cfg(not(test))]
 use crate::commands::system::{startup_diagnostics_from_env, StartupDiagnostics};
+use crate::state::AppState;
 
 fn should_prevent_window_close(is_quitting: bool) -> bool {
     !is_quitting
@@ -464,30 +464,12 @@ pub fn build_app(
                         "Startup heartbeat watchdog disabled by diagnostics"
                     );
                 } else {
-                    log_startup_checkpoint(&startup_diagnostics, "heartbeat_watchdog.begin");
-                    let watchdog_handle = _app.handle().clone();
-                    tokio::spawn(async move {
-                        let mut interval = tokio::time::interval(Duration::from_secs(2));
-                        loop {
-                            interval.tick().await;
-                            let state = watchdog_handle.state::<AppState>();
-                            let elapsed = {
-                                let slot = state.last_heartbeat.lock().ok();
-                                slot.and_then(|guard| guard.map(|ts| ts.elapsed()))
-                            };
-                            if let Some(elapsed) = elapsed {
-                                if elapsed > Duration::from_secs(3) {
-                                    warn!(
-                                        category = "freeze_detection",
-                                        elapsed_ms = elapsed.as_millis(),
-                                        "Frontend heartbeat stale – possible UI freeze"
-                                    );
-                                    let _ = watchdog_handle.emit("freeze-detected", elapsed.as_millis() as u64);
-                                }
-                            }
-                        }
-                    });
-                    log_startup_checkpoint(&startup_diagnostics, "heartbeat_watchdog.ready");
+                    log_startup_checkpoint(&startup_diagnostics, "heartbeat_watchdog.deferred");
+                    info!(
+                        category = "startup_diag",
+                        checkpoint = "heartbeat_watchdog.deferred",
+                        "Frontend heartbeat watchdog will arm after the first heartbeat"
+                    );
                 }
 
                 // Background task: check gh CLI authentication (gwt-spec issue T009)

--- a/crates/gwt-tauri/src/commands/branches.rs
+++ b/crates/gwt-tauri/src/commands/branches.rs
@@ -51,6 +51,29 @@ pub struct MaterializeWorktreeResult {
     pub created: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BranchInventoryResolutionAction {
+    FocusExisting,
+    CreateWorktree,
+    ResolveAmbiguity,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BranchInventoryEntry {
+    pub id: String,
+    pub canonical_name: String,
+    pub primary_branch: BranchInfo,
+    pub local_branch: Option<BranchInfo>,
+    pub remote_branch: Option<BranchInfo>,
+    pub has_local: bool,
+    pub has_remote: bool,
+    pub worktree: Option<crate::commands::cleanup::WorktreeInfo>,
+    pub worktree_count: usize,
+    pub resolution_action: BranchInventoryResolutionAction,
+}
+
 impl From<Branch> for BranchInfo {
     fn from(b: Branch) -> Self {
         let divergence_status = b.divergence_status().to_string();
@@ -223,6 +246,78 @@ fn strip_known_remote_prefix<'a>(branch: &'a str, remotes: &[Remote]) -> &'a str
     branch
 }
 
+fn branch_inventory_key(branch: &str, remotes: &[Remote]) -> String {
+    strip_known_remote_prefix(branch, remotes)
+        .trim()
+        .to_string()
+}
+
+fn build_branch_inventory_entries(
+    local: Vec<BranchInfo>,
+    remote: Vec<BranchInfo>,
+    worktrees: Vec<crate::commands::cleanup::WorktreeInfo>,
+    remotes: &[Remote],
+) -> Vec<BranchInventoryEntry> {
+    let mut local_by_key = HashMap::new();
+    let mut remote_by_key = HashMap::new();
+    let mut keys = HashSet::new();
+
+    for info in local {
+        let key = branch_inventory_key(&info.name, remotes);
+        keys.insert(key.clone());
+        local_by_key.insert(key, info);
+    }
+
+    for info in remote {
+        let key = branch_inventory_key(&info.name, remotes);
+        keys.insert(key.clone());
+        remote_by_key.insert(key, info);
+    }
+
+    let mut worktrees_by_key: HashMap<String, Vec<crate::commands::cleanup::WorktreeInfo>> =
+        HashMap::new();
+    for worktree in worktrees {
+        let key = branch_inventory_key(&worktree.branch, remotes);
+        worktrees_by_key.entry(key).or_default().push(worktree);
+    }
+
+    let mut sorted_keys = keys.into_iter().collect::<Vec<_>>();
+    sorted_keys.sort();
+
+    sorted_keys
+        .into_iter()
+        .filter_map(|key| {
+            let local_branch = local_by_key.remove(&key);
+            let remote_branch = remote_by_key.remove(&key);
+            let primary_branch = local_branch.clone().or_else(|| remote_branch.clone())?;
+            let matching_worktrees = worktrees_by_key.remove(&key).unwrap_or_default();
+            let worktree_count = matching_worktrees.len();
+            let worktree = if worktree_count == 1 {
+                matching_worktrees.into_iter().next()
+            } else {
+                None
+            };
+            let resolution_action = match worktree_count {
+                0 => BranchInventoryResolutionAction::CreateWorktree,
+                1 => BranchInventoryResolutionAction::FocusExisting,
+                _ => BranchInventoryResolutionAction::ResolveAmbiguity,
+            };
+            Some(BranchInventoryEntry {
+                id: key.clone(),
+                canonical_name: key,
+                primary_branch,
+                has_local: local_branch.is_some(),
+                has_remote: remote_branch.is_some(),
+                local_branch,
+                remote_branch,
+                worktree,
+                worktree_count,
+                resolution_action,
+            })
+        })
+        .collect()
+}
+
 fn materialize_worktree_ref_impl(
     project_path: &str,
     branch_ref: &str,
@@ -236,9 +331,7 @@ fn materialize_worktree_ref_impl(
 
     let mut existing = crate::commands::cleanup::list_worktrees_impl(project_path, state)?
         .into_iter()
-        .filter(|info| {
-            info.branch == normalized_branch || info.branch == branch_ref
-        })
+        .filter(|info| info.branch == normalized_branch || info.branch == branch_ref)
         .collect::<Vec<_>>();
 
     if existing.len() > 1 {
@@ -716,6 +809,26 @@ fn list_remote_branches_impl(
     Ok(infos)
 }
 
+fn list_branch_inventory_impl(
+    project_path: &str,
+    state: &AppState,
+) -> Result<Vec<BranchInventoryEntry>, StructuredError> {
+    let project_root = Path::new(project_path);
+    let repo_path = resolve_repo_path_for_project_root(project_root)
+        .map_err(|e| StructuredError::internal(&e, "list_branch_inventory"))?;
+    let remotes = Remote::list(&repo_path).unwrap_or_default();
+    let local = list_worktree_branches_impl(project_path, state)?;
+    let remote = list_remote_branches_impl(project_path, state)?;
+    let worktrees = crate::commands::cleanup::list_worktrees_impl(project_path, state)
+        .map_err(|e| StructuredError::internal(&e, "list_branch_inventory"))?;
+    Ok(build_branch_inventory_entries(
+        local.infos,
+        remote,
+        worktrees,
+        &remotes,
+    ))
+}
+
 /// List all local branches in a repository
 #[instrument(skip_all, fields(command = "list_branches", project_path))]
 #[tauri::command]
@@ -755,6 +868,17 @@ pub fn list_branches(
             );
         }
         Ok(infos)
+    })
+}
+
+#[instrument(skip_all, fields(command = "list_branch_inventory", project_path))]
+#[tauri::command]
+pub fn list_branch_inventory(
+    project_path: String,
+    state: State<AppState>,
+) -> Result<Vec<BranchInventoryEntry>, StructuredError> {
+    with_panic_guard("listing branch inventory", "list_branch_inventory", || {
+        list_branch_inventory_impl(&project_path, &state)
     })
 }
 
@@ -819,7 +943,10 @@ pub async fn list_remote_branches(
     })?
 }
 
-#[instrument(skip_all, fields(command = "materialize_worktree_ref", project_path, branch_ref))]
+#[instrument(
+    skip_all,
+    fields(command = "materialize_worktree_ref", project_path, branch_ref)
+)]
 #[tauri::command]
 pub async fn materialize_worktree_ref(
     project_path: String,
@@ -894,6 +1021,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::commands::cleanup::{SafetyLevel, WorktreeInfo};
     use crate::state::{AppState, IssueListCacheEntry};
 
     fn init_git_repo(path: &Path) {
@@ -1052,6 +1180,100 @@ mod tests {
         assert!(!second.created);
         assert_eq!(second.worktree.branch, branch);
         assert_eq!(second.worktree.path, first.worktree.path);
+    }
+
+    fn make_branch_info(name: &str) -> BranchInfo {
+        BranchInfo {
+            name: name.to_string(),
+            display_name: None,
+            commit: "abc1234".to_string(),
+            is_current: false,
+            is_agent_running: false,
+            agent_status: "unknown".to_string(),
+            has_remote: false,
+            upstream: None,
+            ahead: 0,
+            behind: 0,
+            divergence_status: "UpToDate".to_string(),
+            commit_timestamp: Some(1_700_000_000_000),
+            is_gone: false,
+            last_tool_usage: None,
+        }
+    }
+
+    fn make_worktree_info(path: &str, branch: &str) -> WorktreeInfo {
+        WorktreeInfo {
+            path: path.to_string(),
+            branch: branch.to_string(),
+            commit: "abc1234".to_string(),
+            status: "active".to_string(),
+            is_main: false,
+            has_changes: false,
+            has_unpushed: false,
+            is_current: false,
+            is_protected: false,
+            is_agent_running: false,
+            agent_status: "unknown".to_string(),
+            ahead: 0,
+            behind: 0,
+            is_gone: false,
+            last_tool_usage: None,
+            safety_level: SafetyLevel::Safe,
+        }
+    }
+
+    #[test]
+    fn test_build_branch_inventory_entries_merges_local_and_remote_refs() {
+        let entries = build_branch_inventory_entries(
+            vec![make_branch_info("feature/inventory")],
+            vec![make_branch_info("origin/feature/inventory")],
+            vec![make_worktree_info(
+                "/tmp/wt-feature-inventory",
+                "feature/inventory",
+            )],
+            &[Remote::new("origin", "https://example.com/repo.git")],
+        );
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.canonical_name, "feature/inventory");
+        assert!(entry.has_local);
+        assert!(entry.has_remote);
+        assert_eq!(entry.primary_branch.name, "feature/inventory");
+        assert_eq!(
+            entry.resolution_action,
+            BranchInventoryResolutionAction::FocusExisting
+        );
+        assert_eq!(entry.worktree_count, 1);
+        assert_eq!(
+            entry
+                .worktree
+                .as_ref()
+                .map(|worktree| worktree.branch.as_str()),
+            Some("feature/inventory")
+        );
+    }
+
+    #[test]
+    fn test_build_branch_inventory_entries_marks_ambiguous_worktrees() {
+        let entries = build_branch_inventory_entries(
+            vec![make_branch_info("feature/ambiguous")],
+            Vec::new(),
+            vec![
+                make_worktree_info("/tmp/wt-a", "feature/ambiguous"),
+                make_worktree_info("/tmp/wt-b", "feature/ambiguous"),
+            ],
+            &[Remote::new("origin", "https://example.com/repo.git")],
+        );
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.worktree_count, 2);
+        assert!(entry.worktree.is_none());
+        assert_eq!(
+            entry.resolution_action,
+            BranchInventoryResolutionAction::ResolveAmbiguity
+        );
     }
 
     // --- display_name tests ---

--- a/crates/gwt-tauri/src/commands/branches.rs
+++ b/crates/gwt-tauri/src/commands/branches.rs
@@ -44,6 +44,13 @@ pub struct BranchInfo {
     pub last_tool_usage: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterializeWorktreeResult {
+    pub worktree: crate::commands::cleanup::WorktreeInfo,
+    pub created: bool,
+}
+
 impl From<Branch> for BranchInfo {
     fn from(b: Branch) -> Self {
         let divergence_status = b.divergence_status().to_string();
@@ -214,6 +221,58 @@ fn strip_known_remote_prefix<'a>(branch: &'a str, remotes: &[Remote]) -> &'a str
         return rest;
     }
     branch
+}
+
+fn materialize_worktree_ref_impl(
+    project_path: &str,
+    branch_ref: &str,
+    state: &AppState,
+) -> Result<MaterializeWorktreeResult, String> {
+    let project_root = Path::new(project_path);
+    let repo_path = resolve_repo_path_for_project_root(project_root)?;
+    let manager = WorktreeManager::new(&repo_path).map_err(|e| e.to_string())?;
+    let remotes = Remote::list(&repo_path).unwrap_or_default();
+    let normalized_branch = strip_known_remote_prefix(branch_ref, &remotes).to_string();
+
+    let mut existing = crate::commands::cleanup::list_worktrees_impl(project_path, state)?
+        .into_iter()
+        .filter(|info| {
+            info.branch == normalized_branch || info.branch == branch_ref
+        })
+        .collect::<Vec<_>>();
+
+    if existing.len() > 1 {
+        return Err(format!(
+            "Multiple worktrees already exist for branch '{}'; resolve the ambiguity before focusing.",
+            normalized_branch
+        ));
+    }
+
+    if let Some(worktree) = existing.pop() {
+        return Ok(MaterializeWorktreeResult {
+            worktree,
+            created: false,
+        });
+    }
+
+    let created = manager
+        .create_for_branch(branch_ref)
+        .map_err(|e| e.to_string())?;
+
+    let worktree = crate::commands::cleanup::list_worktrees_impl(project_path, state)?
+        .into_iter()
+        .find(|info| info.path == created.path.to_string_lossy())
+        .ok_or_else(|| {
+            format!(
+                "Worktree was created for '{}' but could not be resolved in the refreshed listing.",
+                branch_ref
+            )
+        })?;
+
+    Ok(MaterializeWorktreeResult {
+        worktree,
+        created: true,
+    })
 }
 
 fn build_last_tool_usage_map(repo_path: &Path) -> HashMap<String, String> {
@@ -760,6 +819,33 @@ pub async fn list_remote_branches(
     })?
 }
 
+#[instrument(skip_all, fields(command = "materialize_worktree_ref", project_path, branch_ref))]
+#[tauri::command]
+pub async fn materialize_worktree_ref(
+    project_path: String,
+    branch_ref: String,
+    app_handle: AppHandle,
+) -> Result<MaterializeWorktreeResult, StructuredError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        with_panic_guard(
+            "materializing worktree ref",
+            "materialize_worktree_ref",
+            || {
+                let state = app_handle.state::<AppState>();
+                materialize_worktree_ref_impl(&project_path, &branch_ref, &state)
+                    .map_err(|e| StructuredError::internal(&e, "materialize_worktree_ref"))
+            },
+        )
+    })
+    .await
+    .map_err(|e| {
+        StructuredError::internal(
+            &format!("Unexpected error while materializing worktree ref: {e}"),
+            "materialize_worktree_ref",
+        )
+    })?
+}
+
 /// Get the current branch
 #[instrument(skip_all, fields(command = "get_current_branch", project_path))]
 #[tauri::command]
@@ -939,6 +1025,33 @@ mod tests {
 
         let out = list_remote_branches_impl(&project_path, &state).expect("listing should work");
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_materialize_worktree_ref_impl_reuses_existing_worktree() {
+        let repo = TempDir::new().expect("temp dir");
+        init_git_repo(repo.path());
+        let branch = "feature/browser-open";
+        let create_branch = command("git")
+            .args(["branch", branch])
+            .current_dir(repo.path())
+            .output()
+            .expect("git branch should run");
+        assert!(create_branch.status.success(), "git branch failed");
+
+        let project_path = repo.path().to_string_lossy().to_string();
+        let state = AppState::new();
+
+        let first =
+            materialize_worktree_ref_impl(&project_path, branch, &state).expect("first create");
+        assert!(first.created);
+        assert_eq!(first.worktree.branch, branch);
+
+        let second =
+            materialize_worktree_ref_impl(&project_path, branch, &state).expect("reuse existing");
+        assert!(!second.created);
+        assert_eq!(second.worktree.branch, branch);
+        assert_eq!(second.worktree.path, first.worktree.path);
     }
 
     // --- display_name tests ---

--- a/crates/gwt-tauri/src/commands/cleanup.rs
+++ b/crates/gwt-tauri/src/commands/cleanup.rs
@@ -251,7 +251,10 @@ fn running_agent_branches(state: &AppState) -> HashSet<String> {
     branches
 }
 
-fn list_worktrees_impl(project_path: &str, state: &AppState) -> Result<Vec<WorktreeInfo>, String> {
+pub(crate) fn list_worktrees_impl(
+    project_path: &str,
+    state: &AppState,
+) -> Result<Vec<WorktreeInfo>, String> {
     let project_root = Path::new(project_path);
     let repo_path = resolve_repo_path_for_project_root(project_root)?;
     let last_tool = build_last_tool_usage_map(&repo_path);

--- a/crates/gwt-tauri/src/commands/system.rs
+++ b/crates/gwt-tauri/src/commands/system.rs
@@ -1,13 +1,16 @@
 //! Tauri commands for system info and statistics.
 
-use std::time::{Duration, Instant};
+use std::{
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
 
 use gwt_core::{
     config::stats::Stats,
     system_info::{GpuDynamicInfo, GpuStaticInfo},
 };
 use serde::Serialize;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tracing::{instrument, warn};
 
 use crate::state::AppState;
@@ -272,9 +275,47 @@ pub fn get_startup_diagnostics() -> StartupDiagnostics {
 
 #[instrument(skip_all, fields(command = "heartbeat"))]
 #[tauri::command]
-pub fn heartbeat(state: tauri::State<'_, AppState>) {
+pub fn heartbeat(state: tauri::State<'_, AppState>, app_handle: AppHandle) {
     if let Ok(mut slot) = state.last_heartbeat.lock() {
         *slot = Some(Instant::now());
+    }
+
+    if startup_diagnostics_from_env().disable_heartbeat_watchdog {
+        return;
+    }
+
+    if state
+        .heartbeat_watchdog_started
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        tauri::async_runtime::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(2));
+            loop {
+                interval.tick().await;
+                let state = app_handle.state::<AppState>();
+                let elapsed = {
+                    let slot = state.last_heartbeat.lock().ok();
+                    slot.and_then(|guard| guard.map(|ts| ts.elapsed()))
+                };
+                if let Some(elapsed) = elapsed {
+                    if elapsed > Duration::from_secs(3) {
+                        warn!(
+                            category = "freeze_detection",
+                            elapsed_ms = elapsed.as_millis(),
+                            "Frontend heartbeat stale – possible UI freeze"
+                        );
+                        let _ = app_handle.emit("freeze-detected", elapsed.as_millis() as u64);
+                    }
+                }
+            }
+        });
+
+        tracing::info!(
+            category = "startup_diag",
+            checkpoint = "heartbeat_watchdog.ready",
+            "Frontend heartbeat watchdog armed after first heartbeat"
+        );
     }
 }
 

--- a/crates/gwt-tauri/src/commands/system.rs
+++ b/crates/gwt-tauri/src/commands/system.rs
@@ -14,6 +14,56 @@ use crate::state::AppState;
 
 const GET_SYSTEM_INFO_WARN_THRESHOLD: Duration = Duration::from_millis(300);
 
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupDiagnostics {
+    pub startup_trace: bool,
+    pub disable_tray: bool,
+    pub disable_login_shell_capture: bool,
+    pub disable_heartbeat_watchdog: bool,
+    pub disable_session_watcher: bool,
+    pub disable_startup_update_check: bool,
+    pub disable_profiling: bool,
+    pub disable_tab_restore: bool,
+    pub disable_window_session_restore: bool,
+}
+
+fn parse_env_flag(value: Option<std::ffi::OsString>) -> bool {
+    value
+        .and_then(|value| value.into_string().ok())
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+pub fn startup_diagnostics_from_env() -> StartupDiagnostics {
+    StartupDiagnostics {
+        startup_trace: parse_env_flag(std::env::var_os("GWT_DIAG_STARTUP_TRACE")),
+        disable_tray: parse_env_flag(std::env::var_os("GWT_DIAG_DISABLE_TRAY")),
+        disable_login_shell_capture: parse_env_flag(std::env::var_os(
+            "GWT_DIAG_DISABLE_LOGIN_SHELL_CAPTURE",
+        )),
+        disable_heartbeat_watchdog: parse_env_flag(std::env::var_os(
+            "GWT_DIAG_DISABLE_HEARTBEAT_WATCHDOG",
+        )),
+        disable_session_watcher: parse_env_flag(std::env::var_os(
+            "GWT_DIAG_DISABLE_SESSION_WATCHER",
+        )),
+        disable_startup_update_check: parse_env_flag(std::env::var_os(
+            "GWT_DIAG_DISABLE_STARTUP_UPDATE_CHECK",
+        )),
+        disable_profiling: parse_env_flag(std::env::var_os("GWT_DIAG_DISABLE_PROFILING")),
+        disable_tab_restore: parse_env_flag(std::env::var_os("GWT_DIAG_DISABLE_TAB_RESTORE")),
+        disable_window_session_restore: parse_env_flag(std::env::var_os(
+            "GWT_DIAG_DISABLE_WINDOW_SESSION_RESTORE",
+        )),
+    }
+}
+
 // --- T030: SystemInfoResponse / GpuInfo ---
 
 #[derive(Debug, Clone, Serialize)]
@@ -212,6 +262,12 @@ pub fn get_stats() -> StatsResponse {
     }
 }
 
+#[instrument(skip_all, fields(command = "get_startup_diagnostics"))]
+#[tauri::command]
+pub fn get_startup_diagnostics() -> StartupDiagnostics {
+    startup_diagnostics_from_env()
+}
+
 // --- Freeze detection: heartbeat + frontend metrics ---
 
 #[instrument(skip_all, fields(command = "heartbeat"))]
@@ -352,5 +408,20 @@ mod tests {
 
         assert_eq!(gpus.len(), 1);
         assert_eq!(gpus[0].name, "NVIDIA GPU");
+    }
+
+    #[test]
+    fn parse_env_flag_accepts_truthy_values() {
+        for value in ["1", "true", "TRUE", "yes", "on"] {
+            assert!(parse_env_flag(Some(std::ffi::OsString::from(value))));
+        }
+    }
+
+    #[test]
+    fn parse_env_flag_rejects_falsey_values() {
+        assert!(!parse_env_flag(None));
+        for value in ["0", "false", "FALSE", "no", "off", ""] {
+            assert!(!parse_env_flag(Some(std::ffi::OsString::from(value))));
+        }
     }
 }

--- a/crates/gwt-tauri/src/main.rs
+++ b/crates/gwt-tauri/src/main.rs
@@ -54,9 +54,6 @@ fn main() {
     };
     let _profiling_guard = gwt_core::logging::init_logger(&log_config);
 
-    #[cfg(target_os = "macos")]
-    maybe_reset_legacy_webkit_local_storage();
-
     let single_instance_guard = match crate::single_instance::try_acquire_single_instance() {
         Ok(crate::single_instance::AcquireOutcome::Acquired(guard)) => Arc::new(guard),
         Ok(crate::single_instance::AcquireOutcome::AlreadyRunning(running)) => {
@@ -74,6 +71,9 @@ fn main() {
             return;
         }
     };
+
+    #[cfg(target_os = "macos")]
+    maybe_reset_legacy_webkit_local_storage();
 
     let app_state = AppState::new();
 
@@ -142,13 +142,25 @@ fn webkit_local_storage_targets(home_dir: &Path) -> Vec<PathBuf> {
     };
 
     for origin_dir in origin_dirs.flatten() {
+        let direct_local_storage = origin_dir.path().join("LocalStorage");
+        if direct_local_storage.exists() {
+            targets.push(direct_local_storage);
+        }
+
         let Ok(origin_children) = std::fs::read_dir(origin_dir.path()) else {
             continue;
         };
         for origin_child in origin_children.flatten() {
-            let local_storage = origin_child.path().join("LocalStorage");
-            if local_storage.exists() {
-                targets.push(local_storage);
+            let origin_child_path = origin_child.path();
+            if origin_child_path.file_name().and_then(|name| name.to_str()) == Some("LocalStorage")
+            {
+                targets.push(origin_child_path);
+                continue;
+            }
+
+            let nested_local_storage = origin_child_path.join("LocalStorage");
+            if nested_local_storage.exists() {
+                targets.push(nested_local_storage);
             }
         }
     }
@@ -400,6 +412,26 @@ mod tests {
         assert_eq!(targets.len(), 2);
         assert!(targets.contains(&top_level));
         assert!(targets.contains(&nested));
+    }
+
+    #[test]
+    fn webkit_local_storage_targets_collects_direct_origin_local_storage() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let direct_origin_local_storage = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin-a")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&direct_origin_local_storage).unwrap();
+
+        let targets = webkit_local_storage_targets(home);
+
+        assert_eq!(targets.len(), 1);
+        assert!(targets.contains(&direct_origin_local_storage));
     }
 
     #[test]

--- a/crates/gwt-tauri/src/main.rs
+++ b/crates/gwt-tauri/src/main.rs
@@ -17,14 +17,14 @@ mod single_instance;
 mod state;
 mod tool_helpers;
 
-use std::{
-    io::Read,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{io::Read, sync::Arc};
+
+#[cfg(any(test, target_os = "macos"))]
+use std::path::{Path, PathBuf};
 
 use state::AppState;
 
+#[cfg(any(test, target_os = "macos"))]
 const LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL: &str = "webkit-localstorage-reset-issue-1720-v1";
 
 fn main() {

--- a/crates/gwt-tauri/src/main.rs
+++ b/crates/gwt-tauri/src/main.rs
@@ -17,9 +17,15 @@ mod single_instance;
 mod state;
 mod tool_helpers;
 
-use std::{io::Read, sync::Arc};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use state::AppState;
+
+const LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL: &str = "webkit-localstorage-reset-issue-1720-v1";
 
 fn main() {
     // Self-update helper mode: do not start GUI, just execute requested update action.
@@ -47,6 +53,9 @@ fn main() {
         profiling: settings.profiling,
     };
     let _profiling_guard = gwt_core::logging::init_logger(&log_config);
+
+    #[cfg(target_os = "macos")]
+    maybe_reset_legacy_webkit_local_storage();
 
     let single_instance_guard = match crate::single_instance::try_acquire_single_instance() {
         Ok(crate::single_instance::AcquireOutcome::Acquired(guard)) => Arc::new(guard),
@@ -77,6 +86,111 @@ fn main() {
     .expect("error while building tauri application");
 
     app.run(crate::app::handle_run_event);
+}
+
+#[cfg(target_os = "macos")]
+fn maybe_reset_legacy_webkit_local_storage() {
+    let Some(home_dir) = dirs::home_dir() else {
+        return;
+    };
+    match reset_legacy_webkit_local_storage(&home_dir) {
+        Ok(removed_targets) if !removed_targets.is_empty() => {
+            tracing::info!(
+                category = "startup_migration",
+                removed_targets = removed_targets.len(),
+                "Reset legacy WebKit LocalStorage to avoid startup crash"
+            );
+        }
+        Ok(_) => {}
+        Err(err) => {
+            tracing::warn!(
+                category = "startup_migration",
+                error = %err,
+                "Failed to reset legacy WebKit LocalStorage"
+            );
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn webkit_local_storage_reset_sentinel(home_dir: &Path) -> PathBuf {
+    home_dir
+        .join(".gwt")
+        .join("runtime")
+        .join(LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn webkit_local_storage_targets(home_dir: &Path) -> Vec<PathBuf> {
+    let website_data_root = home_dir
+        .join("Library")
+        .join("WebKit")
+        .join("com.akiojin.gwt")
+        .join("WebsiteData");
+
+    let mut targets = Vec::new();
+    let top_level_local_storage = website_data_root.join("LocalStorage");
+    if top_level_local_storage.exists() {
+        targets.push(top_level_local_storage);
+    }
+
+    let default_root = website_data_root.join("Default");
+    let Ok(origin_dirs) = std::fs::read_dir(default_root) else {
+        targets.sort();
+        targets.dedup();
+        return targets;
+    };
+
+    for origin_dir in origin_dirs.flatten() {
+        let Ok(origin_children) = std::fs::read_dir(origin_dir.path()) else {
+            continue;
+        };
+        for origin_child in origin_children.flatten() {
+            let local_storage = origin_child.path().join("LocalStorage");
+            if local_storage.exists() {
+                targets.push(local_storage);
+            }
+        }
+    }
+
+    targets.sort();
+    targets.dedup();
+    targets
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn reset_legacy_webkit_local_storage(home_dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let sentinel = webkit_local_storage_reset_sentinel(home_dir);
+    if sentinel.exists() {
+        return Ok(Vec::new());
+    }
+
+    let targets = webkit_local_storage_targets(home_dir);
+    for target in &targets {
+        if target.is_dir() {
+            std::fs::remove_dir_all(target)
+                .map_err(|err| format!("failed to remove {}: {err}", target.display()))?;
+        } else if target.is_file() {
+            std::fs::remove_file(target)
+                .map_err(|err| format!("failed to remove {}: {err}", target.display()))?;
+        }
+    }
+
+    if let Some(parent) = sentinel.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+    }
+    std::fs::write(
+        &sentinel,
+        format!(
+            "migration={}\npackage_version={}\n",
+            LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL,
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .map_err(|err| format!("failed to write {}: {err}", sentinel.display()))?;
+
+    Ok(targets)
 }
 
 fn handle_hook_cli() -> bool {
@@ -251,5 +365,98 @@ fn maybe_run_internal_mode() -> bool {
             eprintln!("Unknown internal mode: {other}");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn webkit_local_storage_targets_collects_top_level_and_nested_dirs() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let top_level = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("LocalStorage");
+        let nested = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin-a")
+            .join("site-a")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&top_level).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let targets = webkit_local_storage_targets(home);
+
+        assert_eq!(targets.len(), 2);
+        assert!(targets.contains(&top_level));
+        assert!(targets.contains(&nested));
+    }
+
+    #[test]
+    fn reset_legacy_webkit_local_storage_removes_targets_and_writes_sentinel() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let top_level = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("LocalStorage");
+        let nested = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin-a")
+            .join("site-a")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&top_level).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(top_level.join("https___tauri.local_0.localstorage"), "").unwrap();
+        std::fs::write(nested.join("localstorage.sqlite3"), "legacy").unwrap();
+
+        let removed_targets = reset_legacy_webkit_local_storage(home).unwrap();
+        let sentinel = webkit_local_storage_reset_sentinel(home);
+
+        assert_eq!(removed_targets.len(), 2);
+        assert!(!top_level.exists());
+        assert!(!nested.exists());
+        assert!(sentinel.exists());
+
+        let sentinel_body = std::fs::read_to_string(sentinel).unwrap();
+        assert!(sentinel_body.contains(LEGACY_WEBKIT_LOCAL_STORAGE_RESET_SENTINEL));
+    }
+
+    #[test]
+    fn reset_legacy_webkit_local_storage_skips_when_sentinel_exists() {
+        let temp = tempdir().unwrap();
+        let home = temp.path();
+        let top_level = home
+            .join("Library")
+            .join("WebKit")
+            .join("com.akiojin.gwt")
+            .join("WebsiteData")
+            .join("LocalStorage");
+        std::fs::create_dir_all(&top_level).unwrap();
+
+        let sentinel = webkit_local_storage_reset_sentinel(home);
+        std::fs::create_dir_all(sentinel.parent().unwrap()).unwrap();
+        std::fs::write(&sentinel, "already-migrated").unwrap();
+
+        let removed_targets = reset_legacy_webkit_local_storage(home).unwrap();
+
+        assert!(removed_targets.is_empty());
+        assert!(top_level.exists());
     }
 }

--- a/crates/gwt-tauri/src/state.rs
+++ b/crates/gwt-tauri/src/state.rs
@@ -205,6 +205,8 @@ pub struct AppState {
         Mutex<HashMap<String, crate::assistant_monitor::AssistantMonitorHandle>>,
     /// Last heartbeat timestamp from the frontend (freeze detection).
     pub last_heartbeat: Mutex<Option<Instant>>,
+    /// Whether the frontend watchdog task has already been armed.
+    pub heartbeat_watchdog_started: AtomicBool,
 }
 
 impl AppState {
@@ -253,6 +255,7 @@ impl AppState {
             assistant_runtime: Mutex::new(HashMap::new()),
             assistant_monitor_handle: Mutex::new(HashMap::new()),
             last_heartbeat: Mutex::new(None),
+            heartbeat_watchdog_started: AtomicBool::new(false),
         }
     }
 

--- a/gwt-gui/e2e/agent-canvas-browser.spec.ts
+++ b/gwt-gui/e2e/agent-canvas-browser.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "@playwright/test";
+import { installTauriMock } from "./support/tauri-mock";
+import {
+  branchDevelop,
+  branchFeature,
+  branchMain,
+  defaultRecentProject,
+  openRecentProject,
+  setMockCommandResponses,
+} from "./support/helpers";
+
+const existingWorktree = {
+  path: "/tmp/gwt-playwright/.gwt/worktrees/feature-workflow-demo",
+  branch: branchFeature.name,
+  commit: branchFeature.commit,
+  status: "active",
+  is_main: false,
+  has_changes: false,
+  has_unpushed: false,
+  is_current: false,
+  is_protected: false,
+  is_agent_running: false,
+  agent_status: "unknown",
+  ahead: 1,
+  behind: 0,
+  is_gone: false,
+  last_tool_usage: null,
+  safety_level: "warning",
+};
+
+test.beforeEach(async ({ page }) => {
+  await installTauriMock(page, {
+    commandResponses: {
+      get_recent_projects: [defaultRecentProject],
+    },
+  });
+});
+
+test("Branch Browser can focus an existing worktree and create a remote one into Agent Canvas", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.evaluate(() => {
+    window.localStorage.setItem(
+      "gwt.projectTabs.v2",
+      JSON.stringify({
+        version: 2,
+        byProjectPath: {
+          "/tmp/gwt-playwright": {
+            tabs: [
+              { type: "agentCanvas", id: "agentCanvas", label: "Agent Canvas" },
+              { type: "branchBrowser", id: "branchBrowser", label: "Branch Browser" },
+            ],
+            activeTabId: "branchBrowser",
+          },
+        },
+      }),
+    );
+  });
+  await setMockCommandResponses(page, {
+    list_branch_inventory: [
+      {
+        id: branchMain.name,
+        canonical_name: branchMain.name,
+        primary_branch: branchMain,
+        local_branch: branchMain,
+        remote_branch: null,
+        has_local: true,
+        has_remote: false,
+        worktree: null,
+        worktree_count: 0,
+        resolution_action: "createWorktree",
+      },
+      {
+        id: branchDevelop.name,
+        canonical_name: branchDevelop.name,
+        primary_branch: branchDevelop,
+        local_branch: branchDevelop,
+        remote_branch: null,
+        has_local: true,
+        has_remote: false,
+        worktree: null,
+        worktree_count: 0,
+        resolution_action: "createWorktree",
+      },
+      {
+        id: branchFeature.name,
+        canonical_name: branchFeature.name,
+        primary_branch: branchFeature,
+        local_branch: branchFeature,
+        remote_branch: null,
+        has_local: true,
+        has_remote: false,
+        worktree: existingWorktree,
+        worktree_count: 1,
+        resolution_action: "focusExisting",
+      },
+      {
+        id: "feature/new-browser-flow",
+        canonical_name: "feature/new-browser-flow",
+        primary_branch: {
+          ...branchFeature,
+          name: "origin/feature/new-browser-flow",
+          commit: "remote123",
+        },
+        local_branch: null,
+        remote_branch: {
+          ...branchFeature,
+          name: "origin/feature/new-browser-flow",
+          commit: "remote123",
+        },
+        has_local: false,
+        has_remote: true,
+        worktree: null,
+        worktree_count: 0,
+        resolution_action: "createWorktree",
+      },
+    ],
+    list_worktree_branches: [branchMain, branchDevelop, branchFeature],
+    list_remote_branches: [
+      { ...branchFeature, name: "origin/feature/new-browser-flow", commit: "remote123" },
+    ],
+    list_worktrees: [existingWorktree],
+  });
+  await openRecentProject(page);
+  const visibleBrowser = page.locator('[data-testid="branch-browser-panel"]:visible');
+  await expect(visibleBrowser).toBeVisible();
+  await expect(page.locator(".branch-row", { hasText: branchFeature.name })).toBeVisible();
+
+  await page.locator(".branch-row", { hasText: branchFeature.name }).click();
+  await page.getByRole("button", { name: "Focus Worktree" }).click();
+
+  await expect(
+    page.locator('[data-testid^="agent-canvas-worktree-card-"]', {
+      hasText: branchFeature.name,
+    }),
+  ).toBeVisible();
+
+  await page.getByRole("tab", { name: "Branch Browser" }).click();
+  await expect(page.locator('[data-testid="branch-browser-panel"]:visible')).toBeVisible();
+  await page.getByRole("button", { name: "Remote" }).click();
+  await expect(page.locator(".branch-row", { hasText: "origin/feature/new-browser-flow" })).toBeVisible();
+  await page.locator(".branch-row", { hasText: "origin/feature/new-browser-flow" }).click();
+  await page.getByRole("button", { name: "Create Worktree" }).click();
+
+  await expect(
+    page.locator('[data-testid^="agent-canvas-worktree-card-"]', {
+      hasText: "feature/new-browser-flow",
+    }),
+  ).toBeVisible();
+});

--- a/gwt-gui/e2e/support/tauri-mock.ts
+++ b/gwt-gui/e2e/support/tauri-mock.ts
@@ -83,6 +83,15 @@ export async function installTauriMock(
       let nextSpawnShellError = false;
       let lastSpawnedPaneId: string | null = null;
       let restoreLeaderAcquired = false;
+      let mockLocalBranches = Array.isArray(commandResponses.list_worktree_branches)
+        ? structuredClone(commandResponses.list_worktree_branches)
+        : [];
+      let mockRemoteBranches = Array.isArray(commandResponses.list_remote_branches)
+        ? structuredClone(commandResponses.list_remote_branches)
+        : [];
+      let mockWorktrees = Array.isArray(commandResponses.list_worktrees)
+        ? structuredClone(commandResponses.list_worktrees)
+        : [];
 
       let projectModeState: ProjectModeState = {
         messages: [],
@@ -137,6 +146,114 @@ export async function installTauriMock(
               ? "running"
               : `error: ${pane.errorMessage ?? "PTY stream error: mock failure"}`,
         }));
+      }
+
+      function branchInventoryKey(nameLike: unknown): string {
+        const name =
+          typeof nameLike === "string" && nameLike.trim()
+            ? nameLike.trim()
+            : "";
+        return name.startsWith("origin/") ? name.slice("origin/".length) : name;
+      }
+
+      function listBranchInventory() {
+        const entries = new Map<
+          string,
+          {
+            id: string;
+            canonical_name: string;
+            primary_branch: unknown;
+            local_branch: unknown | null;
+            remote_branch: unknown | null;
+            has_local: boolean;
+            has_remote: boolean;
+            worktree: unknown | null;
+            worktree_count: number;
+            resolution_action: "focusExisting" | "createWorktree" | "resolveAmbiguity";
+          }
+        >();
+
+        for (const branch of mockLocalBranches) {
+          const key = branchInventoryKey(branch?.name);
+          if (!key) continue;
+          entries.set(key, {
+            id: key,
+            canonical_name: key,
+            primary_branch: branch,
+            local_branch: branch,
+            remote_branch: null,
+            has_local: true,
+            has_remote: false,
+            worktree: null,
+            worktree_count: 0,
+            resolution_action: "createWorktree",
+          });
+        }
+
+        for (const branch of mockRemoteBranches) {
+          const key = branchInventoryKey(branch?.name);
+          if (!key) continue;
+          const existing = entries.get(key);
+          entries.set(key, {
+            id: key,
+            canonical_name: key,
+            primary_branch: existing?.primary_branch ?? branch,
+            local_branch: existing?.local_branch ?? null,
+            remote_branch: branch,
+            has_local: existing?.has_local ?? false,
+            has_remote: true,
+            worktree: existing?.worktree ?? null,
+            worktree_count: existing?.worktree_count ?? 0,
+            resolution_action: existing?.resolution_action ?? "createWorktree",
+          });
+        }
+
+        for (const worktree of mockWorktrees) {
+          const key = branchInventoryKey(worktree?.branch);
+          if (!key) continue;
+          const existing = entries.get(key);
+          const worktreeCount = (existing?.worktree_count ?? 0) + 1;
+          entries.set(key, {
+            id: key,
+            canonical_name: key,
+            primary_branch:
+              existing?.primary_branch ??
+              mockLocalBranches.find((branch) => branchInventoryKey(branch?.name) === key) ??
+              mockRemoteBranches.find((branch) => branchInventoryKey(branch?.name) === key) ??
+              {
+                name: key,
+                commit: worktree?.commit ?? "mock-created",
+                is_current: false,
+                is_agent_running: false,
+                agent_status: "unknown",
+                ahead: 0,
+                behind: 0,
+                divergence_status: "UpToDate",
+                commit_timestamp: null,
+                last_tool_usage: null,
+              },
+            local_branch:
+              existing?.local_branch ??
+              mockLocalBranches.find((branch) => branchInventoryKey(branch?.name) === key) ??
+              null,
+            remote_branch:
+              existing?.remote_branch ??
+              mockRemoteBranches.find((branch) => branchInventoryKey(branch?.name) === key) ??
+              null,
+            has_local:
+              existing?.has_local ??
+              mockLocalBranches.some((branch) => branchInventoryKey(branch?.name) === key),
+            has_remote:
+              existing?.has_remote ??
+              mockRemoteBranches.some((branch) => branchInventoryKey(branch?.name) === key),
+            worktree: worktreeCount === 1 ? worktree : null,
+            worktree_count: worktreeCount,
+            resolution_action:
+              worktreeCount > 1 ? "resolveAmbiguity" : "focusExisting",
+          });
+        }
+
+        return Array.from(entries.values());
       }
 
       function spawnShell(workingDirLike: unknown): string {
@@ -250,6 +367,30 @@ export async function installTauriMock(
             __GWT_MOCK_COMMAND_RESPONSES__?: Record<string, unknown>;
           }
         ).__GWT_MOCK_COMMAND_RESPONSES__;
+        if (runtimeCommandResponses) {
+          if (Array.isArray(runtimeCommandResponses.list_worktree_branches)) {
+            mockLocalBranches = structuredClone(
+              runtimeCommandResponses.list_worktree_branches,
+            );
+          }
+          if (Array.isArray(runtimeCommandResponses.list_remote_branches)) {
+            mockRemoteBranches = structuredClone(
+              runtimeCommandResponses.list_remote_branches,
+            );
+          }
+          if (Array.isArray(runtimeCommandResponses.list_worktrees)) {
+            mockWorktrees = structuredClone(runtimeCommandResponses.list_worktrees);
+          }
+        }
+        if (cmd === "list_worktree_branches") {
+          return mockLocalBranches;
+        }
+        if (cmd === "list_remote_branches") {
+          return mockRemoteBranches;
+        }
+        if (cmd === "list_worktrees") {
+          return mockWorktrees;
+        }
         if (
           runtimeCommandResponses &&
           Object.prototype.hasOwnProperty.call(runtimeCommandResponses, cmd)
@@ -347,9 +488,77 @@ export async function installTauriMock(
           case "close_project":
             return null;
           case "list_worktree_branches":
+            return mockLocalBranches;
+          case "list_branch_inventory":
+            return listBranchInventory();
           case "list_remote_branches":
+            return mockRemoteBranches;
+          case "list_branch_inventory": {
+            const byKey = new Map<string, Record<string, unknown>>();
+            const keyFor = (name: string) => name.replace(/^origin\//, "");
+
+            for (const branch of mockLocalBranches) {
+              const key = keyFor(String(branch?.name ?? ""));
+              if (!key) continue;
+              byKey.set(key, {
+                id: key,
+                canonical_name: key,
+                primary_branch: branch,
+                local_branch: branch,
+                remote_branch: null,
+                has_local: true,
+                has_remote: false,
+                worktree: null,
+                worktree_count: 0,
+                resolution_action: "createWorktree",
+              });
+            }
+
+            for (const branch of mockRemoteBranches) {
+              const key = keyFor(String(branch?.name ?? ""));
+              if (!key) continue;
+              const existing = byKey.get(key);
+              if (existing) {
+                existing.has_remote = true;
+                existing.remote_branch = branch;
+              } else {
+                byKey.set(key, {
+                  id: key,
+                  canonical_name: key,
+                  primary_branch: branch,
+                  local_branch: null,
+                  remote_branch: branch,
+                  has_local: false,
+                  has_remote: true,
+                  worktree: null,
+                  worktree_count: 0,
+                  resolution_action: "createWorktree",
+                });
+              }
+            }
+
+            for (const worktree of mockWorktrees) {
+              const key = keyFor(String(worktree?.branch ?? ""));
+              if (!key) continue;
+              const entry = byKey.get(key);
+              if (entry) {
+                const count =
+                  typeof entry.worktree_count === "number" ? entry.worktree_count : 0;
+                entry.worktree_count = count + 1;
+                if (count === 0) {
+                  entry.worktree = worktree;
+                  entry.resolution_action = "focusExisting";
+                } else {
+                  entry.worktree = null;
+                  entry.resolution_action = "resolveAmbiguity";
+                }
+              }
+            }
+
+            return Array.from(byKey.values());
+          }
           case "list_worktrees":
-            return [];
+            return mockWorktrees;
           case "list_terminals":
             return listTerminals();
           case "get_current_branch":
@@ -363,6 +572,65 @@ export async function installTauriMock(
               divergence_status: "UpToDate",
               last_tool_usage: null,
             };
+          case "materialize_worktree_ref": {
+            const branchRef =
+              typeof args.branchRef === "string" ? args.branchRef.trim() : "";
+            const normalizedBranch = branchRef.replace(/^origin\//, "");
+            const existing = mockWorktrees.find(
+              (worktree) => worktree?.branch === normalizedBranch,
+            );
+            if (existing) {
+              return { worktree: existing, created: false };
+            }
+
+            const created = {
+              path: `${projectPath}/.gwt/worktrees/${normalizedBranch.replace(/[^a-zA-Z0-9_-]+/g, "-")}`,
+              branch: normalizedBranch,
+              commit: "mock-created",
+              status: "active",
+              is_main: false,
+              has_changes: false,
+              has_unpushed: false,
+              is_current: false,
+              is_protected: false,
+              is_agent_running: false,
+              agent_status: "unknown",
+              ahead: 0,
+              behind: 0,
+              is_gone: false,
+              last_tool_usage: null,
+              safety_level: "safe",
+            };
+
+            mockWorktrees = [...mockWorktrees, created];
+            if (
+              !mockLocalBranches.some(
+                (branch) => branch?.name?.trim?.() === normalizedBranch,
+              )
+            ) {
+              mockLocalBranches = [
+                ...mockLocalBranches,
+                {
+                  name: normalizedBranch,
+                  commit: "mock-created",
+                  is_current: false,
+                  is_agent_running: false,
+                  ahead: 0,
+                  behind: 0,
+                  divergence_status: "UpToDate",
+                  last_tool_usage: null,
+                },
+              ];
+            }
+            if (runtimeCommandResponses) {
+              runtimeCommandResponses.list_worktrees = structuredClone(mockWorktrees);
+              runtimeCommandResponses.list_worktree_branches = structuredClone(
+                mockLocalBranches,
+              );
+            }
+
+            return { worktree: created, created: true };
+          }
           case "sync_window_agent_tabs":
             return null;
           case "start_launch_job":

--- a/gwt-gui/e2e/windows-shell-selection.spec.ts
+++ b/gwt-gui/e2e/windows-shell-selection.spec.ts
@@ -129,17 +129,19 @@ async function openProjectAndSelectBranch(
   ).toBeVisible();
   await dismissSkillRegistrationScopeDialogIfPresent(page);
   await page.locator("button.recent-item").first().click();
-  await expect(
-    page.getByPlaceholder("Type a task and press Enter..."),
-  ).toBeVisible();
+  await expect(page.locator('[data-tab-id="branchBrowser"]')).toBeVisible();
+  await page.locator('[data-tab-id="branchBrowser"]').click();
 
-  const branchButton = page
-    .locator(".branch-item")
+  const visibleBrowser = page.locator('[data-testid="branch-browser-panel"]:visible');
+  await expect(visibleBrowser).toBeVisible();
+
+  const branchButton = visibleBrowser
+    .locator(".branch-row")
     .filter({ hasText: branchFeature.name });
   await expect(branchButton).toBeVisible();
   await branchButton.click();
 
-  await expect(page.locator(".branch-detail h2")).toContainText(
+  await expect(page.getByTestId("branch-browser-detail")).toContainText(
     branchFeature.name,
   );
 }
@@ -205,6 +207,18 @@ async function openSettingsFromMenu(page: Page) {
   await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 }
 
+async function emitMenuAction(page: Page, action: string) {
+  await waitForMenuActionListener(page);
+  await page.evaluate((menuAction) => {
+    const globalWindow = window as unknown as {
+      __GWT_MOCK_EMIT_EVENT__?: (event: string, payload: unknown) => void;
+    };
+    globalWindow.__GWT_MOCK_EMIT_EVENT__?.("menu-action", {
+      action: menuAction,
+    });
+  }, action);
+}
+
 test.beforeEach(async ({ page }) => {
   await installTauriMock(page, {
     commandResponses: {
@@ -224,7 +238,7 @@ test("launches with selected Windows shell from Launch Agent form", async ({
     get_available_shells: availableShells,
   });
 
-  await page.getByRole("button", { name: "Launch Agent..." }).click();
+  await emitMenuAction(page, "launch-agent");
   await expect(
     page.getByRole("dialog", { name: "Launch Agent" }),
   ).toBeVisible();
@@ -275,7 +289,7 @@ test("disables shell selection in Docker mode and does not send terminalShell", 
     },
   });
 
-  await page.getByRole("button", { name: "Launch Agent..." }).click();
+  await emitMenuAction(page, "launch-agent");
   await expect(
     page.getByRole("dialog", { name: "Launch Agent" }),
   ).toBeVisible();
@@ -450,7 +464,7 @@ test("opens a terminal from WorktreeSummaryPanel New Terminal button", async ({
     list_worktrees: [],
   });
 
-  await page.getByTitle("New Terminal").click();
+  await emitMenuAction(page, "new-terminal");
   await waitForInvokeCommand(page, "spawn_shell");
 
   const spawnArgs = await page.evaluate(() => {

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -335,6 +335,7 @@
       return branch;
     })(),
   );
+  let selectedCanvasSessionTabId: string | null = $state(null);
   let terminalDiagnosticsLoading: boolean = $state(false);
   let terminalDiagnostics: TerminalAnsiProbe | null = $state(null);
   let terminalDiagnosticsError: string | null = $state(null);
@@ -1528,6 +1529,26 @@
     activeTabId = "branchBrowser";
   }
 
+  function getSelectedCanvasSessionTab(): Tab | null {
+    if (!selectedCanvasSessionTabId) return null;
+    return (
+      tabs.find(
+        (tab) =>
+          tab.id === selectedCanvasSessionTabId &&
+          (tab.type === "agent" || tab.type === "terminal"),
+      ) ?? null
+    );
+  }
+
+  function handleCanvasSessionSelect(tabId: string) {
+    const sessionTab = tabs.find(
+      (tab) => tab.id === tabId && (tab.type === "agent" || tab.type === "terminal"),
+    );
+    if (!sessionTab) return;
+    selectedCanvasSessionTabId = tabId;
+    openAgentCanvasTab();
+  }
+
   function handleSidebarModeChange(next: SidebarMode) {
     if (sidebarMode === next) return;
     sidebarMode = next;
@@ -1560,6 +1581,7 @@
         cwd: workingDir || undefined,
       };
       tabs = [...tabs, newTab];
+      selectedCanvasSessionTabId = newTab.id;
       openAgentCanvasTab();
 
       // Resolve and read logs via backend so bare-repo project roots still work.
@@ -1776,6 +1798,7 @@
         cwd: workingDir,
       };
       tabs = [...tabs, tab];
+      selectedCanvasSessionTabId = tab.id;
       openAgentCanvasTab();
 
       const command = `${buildDocsEditorCommand(platform, shellId)}\n`;
@@ -1982,6 +2005,7 @@
     }
 
     tabs = [...tabs, newTab];
+    selectedCanvasSessionTabId = newTab.id;
     openAgentCanvasTab();
     if (projectPath) {
       agentTabsHydratedProjectPath = null;
@@ -2041,6 +2065,11 @@
 
     const nextTabs = tabs.filter((t) => t.id !== tabId);
     tabs = nextTabs;
+    if (selectedCanvasSessionTabId === tabId) {
+      const fallbackSession =
+        nextTabs.find((t) => t.type === "agent" || t.type === "terminal") ?? null;
+      selectedCanvasSessionTabId = fallbackSession?.id ?? null;
+    }
 
     if (activeTabId !== tabId) return;
     const fallback =
@@ -2068,6 +2097,14 @@
   function handleTabSelect(groupId: string, tabId: string) {
     activeGroupId = groupId;
     activeTabId = tabId;
+    if (tabId === "agentCanvas" || tabId === "branchBrowser") {
+      return;
+    }
+    const selected = tabs.find((tab) => tab.id === tabId);
+    if (selected?.type === "agent" || selected?.type === "terminal") {
+      selectedCanvasSessionTabId = tabId;
+      activeTabId = "agentCanvas";
+    }
   }
 
   function handleTabReorder(
@@ -2264,11 +2301,17 @@
   }
 
   function getActiveTerminalPaneId(): string | null {
-    const active = tabs.find((t) => t.id === activeTabId);
-    if (!active || (active.type !== "agent" && active.type !== "terminal")) {
-      return null;
+    const active = tabs.find((t) => t.id === activeTabId) ?? null;
+    if (active?.type === "agent" || active?.type === "terminal") {
+      return active.paneId && active.paneId.length > 0 ? active.paneId : null;
     }
-    return active.paneId && active.paneId.length > 0 ? active.paneId : null;
+    if (active?.type === "agentCanvas") {
+      const selected = getSelectedCanvasSessionTab();
+      if (selected?.paneId) {
+        return selected.paneId;
+      }
+    }
+    return null;
   }
 
   function getActiveEditableElement(
@@ -2351,13 +2394,16 @@
 
   async function handleScreenCopy() {
     const activeTab = tabs.find((t) => t.id === activeTabId);
+    const selectedCanvasSession =
+      activeTab?.type === "agentCanvas" ? getSelectedCanvasSessionTab() : null;
+    const effectiveActiveTab = selectedCanvasSession ?? activeTab ?? null;
     const text = collectScreenText({
       branch: currentBranch,
-      activeTab: activeTab?.label ?? activeTabId,
-      activeTabType: activeTab?.type,
+      activeTab: effectiveActiveTab?.label ?? activeTabId,
+      activeTabType: effectiveActiveTab?.type,
       activePaneId:
-        activeTab?.type === "agent" || activeTab?.type === "terminal"
-          ? activeTab.paneId
+        effectiveActiveTab?.type === "agent" || effectiveActiveTab?.type === "terminal"
+          ? effectiveActiveTab.paneId
           : undefined,
     });
     try {
@@ -2453,7 +2499,8 @@
             t.id === tabId && (t.type === "agent" || t.type === "terminal"),
         )
       ) {
-        activeTabId = tabId;
+        selectedCanvasSessionTabId = tabId;
+        activeTabId = "agentCanvas";
       }
       return;
     }
@@ -2562,6 +2609,7 @@
           void updateWindowSession(null);
           tabs = defaultAppTabs();
           activeTabId = "agentCanvas";
+          selectedCanvasSessionTabId = null;
           selectedBranch = null;
           currentBranch = "";
         }
@@ -2686,6 +2734,7 @@
             cwd: workingDir || undefined,
           };
           tabs = [...tabs, newTab];
+          selectedCanvasSessionTabId = newTab.id;
           openAgentCanvasTab();
         } catch (err) {
           console.error("Failed to spawn shell:", err);
@@ -3271,6 +3320,8 @@
         projectPath={projectPath as string}
         {branchBrowserConfig}
         {currentBranch}
+        {selectedCanvasSessionTabId}
+        onCanvasSessionSelect={handleCanvasSessionSelect}
         onLaunchAgent={requestAgentLaunch}
         onQuickLaunch={handleAgentLaunch}
         onTabSelect={handleTabSelect}

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -133,6 +133,30 @@
     issueUrl?: string | null;
   }
 
+  interface StartupDiagnostics {
+    startupTrace: boolean;
+    disableTray: boolean;
+    disableLoginShellCapture: boolean;
+    disableHeartbeatWatchdog: boolean;
+    disableSessionWatcher: boolean;
+    disableStartupUpdateCheck: boolean;
+    disableProfiling: boolean;
+    disableTabRestore: boolean;
+    disableWindowSessionRestore: boolean;
+  }
+
+  const DEFAULT_STARTUP_DIAGNOSTICS: StartupDiagnostics = {
+    startupTrace: false,
+    disableTray: false,
+    disableLoginShellCapture: false,
+    disableHeartbeatWatchdog: false,
+    disableSessionWatcher: false,
+    disableStartupUpdateCheck: false,
+    disableProfiling: false,
+    disableTabRestore: false,
+    disableWindowSessionRestore: false,
+  };
+
   const SIDEBAR_WIDTH_STORAGE_KEY = "gwt.sidebar.width";
   const SIDEBAR_MODE_STORAGE_KEY = "gwt.sidebar.mode";
   const DEFAULT_SIDEBAR_WIDTH_PX = 260;
@@ -318,6 +342,7 @@
   let osEnvReady = $state(false);
   let startupOsEnvCaptureChecked = false;
   let startupOsEnvCaptureResolved = $state(false);
+  let startupDiagnostics: StartupDiagnostics | null = $state(null);
   let voiceInputSettings: VoiceInputSettings = $state(
     DEFAULT_VOICE_INPUT_SETTINGS,
   );
@@ -569,8 +594,36 @@
     clearBufferedLaunchEvents();
   }
 
+  $effect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!isTauriRuntimeAvailable()) {
+        startupDiagnostics = DEFAULT_STARTUP_DIAGNOSTICS;
+        return;
+      }
+      try {
+        const { invoke } = await import("$lib/tauriInvoke");
+        const diagnostics = await invoke<StartupDiagnostics>(
+          "get_startup_diagnostics",
+        );
+        if (!cancelled) {
+          startupDiagnostics = diagnostics;
+        }
+      } catch {
+        if (!cancelled) {
+          startupDiagnostics = DEFAULT_STARTUP_DIAGNOSTICS;
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  });
+
   // Initialize profiling subsystem at startup.
   $effect(() => {
+    if (startupDiagnostics === null) return;
+    if (startupDiagnostics.disableProfiling) return;
     let cancelled = false;
     (async () => {
       try {
@@ -640,6 +693,8 @@
 
   // Best-effort: request update state once on startup.
   $effect(() => {
+    if (startupDiagnostics === null) return;
+    if (startupDiagnostics.disableStartupUpdateCheck) return;
     if (lastUpdateToastVersion !== null) return;
     const controller = new AbortController();
     void runStartupUpdateCheck({
@@ -662,6 +717,8 @@
 
   // Listen for app update state notifications from backend startup checks.
   $effect(() => {
+    if (startupDiagnostics === null) return;
+    if (startupDiagnostics.disableStartupUpdateCheck) return;
     let unlisten: null | (() => void) = null;
     let cancelled = false;
     (async () => {
@@ -725,6 +782,8 @@
   });
 
   $effect(() => {
+    if (startupDiagnostics === null) return;
+    if (startupDiagnostics.disableWindowSessionRestore) return;
     if (windowSessionRestoreStarted) return;
     windowSessionRestoreStarted = true;
     const releaseDelayMs = 3000;
@@ -2727,6 +2786,16 @@
     token: number,
     attempt = 0,
   ) {
+    if (startupDiagnostics?.disableTabRestore) {
+      if (
+        projectPath === targetProjectPath &&
+        agentTabsRestoreToken === token
+      ) {
+        agentTabsHydratedProjectPath = targetProjectPath;
+      }
+      return;
+    }
+
     const stored = loadStoredProjectTabs(targetProjectPath);
 
     // Even if no stored state exists, mark hydrated so persistence can proceed.

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -55,6 +55,7 @@
     flattenTabIdsByLayout,
     getGroupForTab,
     moveTabToGroup,
+    normalizeTabLayoutState,
     removeTabFromLayout,
     reorderTabsInGroup,
     resizeSplitNode,
@@ -373,11 +374,11 @@
   type AvailableUpdateState = Extract<UpdateState, { state: "available" }>;
 
   function readTabLayoutState() {
-    return {
+    return normalizeTabLayoutState({
       groups: layoutGroups,
       root: layoutRoot,
       activeGroupId,
-    };
+    }, activeTabId);
   }
 
   function applyTabLayoutState(next: {
@@ -385,11 +386,12 @@
     root: TabLayoutNode;
     activeGroupId: string;
   }) {
-    layoutGroups = next.groups;
-    layoutRoot = next.root;
-    activeGroupId = next.activeGroupId;
+    const normalized = normalizeTabLayoutState(next, activeTabId);
+    layoutGroups = normalized.groups;
+    layoutRoot = normalized.root;
+    activeGroupId = normalized.activeGroupId;
     const nextActiveTabId =
-      next.groups[next.activeGroupId]?.activeTabId ??
+      normalized.groups[normalized.activeGroupId]?.activeTabId ??
       tabs.find((tab) => tab.id === activeTabId)?.id ??
       tabs[0]?.id ??
       "";
@@ -2071,9 +2073,7 @@
 
   function handleSplitResize(splitId: string, primaryFraction: number) {
     const next = resizeSplitNode(readTabLayoutState(), splitId, primaryFraction);
-    layoutGroups = next.groups;
-    layoutRoot = next.root;
-    activeGroupId = next.activeGroupId;
+    applyTabLayoutState(next);
   }
 
   function openSettingsTab() {
@@ -2725,11 +2725,14 @@
       next.root !== layoutRoot ||
       next.activeGroupId !== activeGroupId
     ) {
-      layoutGroups = next.groups;
-      layoutRoot = next.root;
-      activeGroupId = next.activeGroupId;
+      const normalized = normalizeTabLayoutState(next, activeTabId);
+      layoutGroups = normalized.groups;
+      layoutRoot = normalized.root;
+      activeGroupId = normalized.activeGroupId;
       const nextActiveTab =
-        next.groups[next.activeGroupId]?.activeTabId ?? tabs[0]?.id ?? "";
+        normalized.groups[normalized.activeGroupId]?.activeTabId ??
+        tabs[0]?.id ??
+        "";
       if (nextActiveTab && nextActiveTab !== activeTabId) {
         activeTabId = nextActiveTab;
       }
@@ -2873,9 +2876,12 @@
         },
       ]),
     );
-    layoutGroups = restoredGroups;
-    layoutRoot = restored.root as TabLayoutNode;
-    activeGroupId = restored.activeGroupId ?? restored.groups[0]?.id ?? activeGroupId;
+    applyTabLayoutState({
+      groups: restoredGroups,
+      root: restored.root as TabLayoutNode,
+      activeGroupId:
+        restored.activeGroupId ?? restored.groups[0]?.id ?? activeGroupId,
+    });
 
     const allowOverrideActive = shouldAllowRestoredActiveTab(activeTabId);
     if (allowOverrideActive) {

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -319,6 +319,7 @@
   let selectedCanvasSessionTabId: string | null = $state(null);
   let canvasWorktrees: WorktreeInfo[] = $state([]);
   let selectedCanvasWorktreeBranch: string | null = $state(null);
+  let selectedCanvasWorktreePath: string | null = $state(null);
   let terminalDiagnosticsLoading: boolean = $state(false);
   let terminalDiagnostics: TerminalAnsiProbe | null = $state(null);
   let terminalDiagnosticsError: string | null = $state(null);
@@ -1417,6 +1418,17 @@
     }
   }
 
+  function resolveCanvasWorktreePath(branchName?: string | null): string | null {
+    const normalizedBranch = (branchName ?? "").trim();
+    if (!normalizedBranch) {
+      return selectedCanvasWorktreePath;
+    }
+    return (
+      canvasWorktrees.find((worktree) => worktree.branch === normalizedBranch)?.path ??
+      selectedCanvasWorktreePath
+    );
+  }
+
   async function focusOrCreateWorktreeFromBranch(branch: BranchInfo) {
     if (!projectPath) return;
     handleBranchSelect(branch);
@@ -1432,6 +1444,7 @@
       );
       await refreshCanvasWorktrees(projectPath);
       selectedCanvasWorktreeBranch = result.worktree.branch;
+      selectedCanvasWorktreePath = result.worktree.path;
       openAgentCanvasTab();
       showToast(
         result.created
@@ -1530,9 +1543,9 @@
     );
     if (!sessionTab) return;
     selectedCanvasSessionTabId = tabId;
-    if (sessionTab.branchName) {
-      selectedCanvasWorktreeBranch = sessionTab.branchName;
-    }
+    selectedCanvasWorktreeBranch = sessionTab.branchName ?? selectedCanvasWorktreeBranch;
+    selectedCanvasWorktreePath =
+      sessionTab.worktreePath ?? resolveCanvasWorktreePath(sessionTab.branchName);
     openAgentCanvasTab();
   }
 
@@ -1567,6 +1580,7 @@
         ...(selectedCanvasWorktreeBranch
           ? { branchName: selectedCanvasWorktreeBranch }
           : {}),
+        ...(workingDir ? { worktreePath: workingDir } : {}),
         cwd: workingDir || undefined,
       };
       tabs = [...tabs, newTab];
@@ -1608,6 +1622,9 @@
         if (!selectedCanvasWorktreeBranch) {
           selectedCanvasWorktreeBranch = branch.name;
         }
+        if (!selectedCanvasWorktreePath) {
+          selectedCanvasWorktreePath = resolveCanvasWorktreePath(branch.name);
+        }
       }
     } catch (err) {
       console.error("Failed to fetch current branch:", err);
@@ -1625,17 +1642,19 @@
       if (targetProjectPath !== projectPath) return;
       canvasWorktrees = worktrees;
       if (!selectedCanvasWorktreeBranch) {
-        selectedCanvasWorktreeBranch =
-          worktrees.find((worktree) => worktree.is_current)?.branch ??
-          worktrees[0]?.branch ??
-          null;
+        const selectedWorktree =
+          worktrees.find((worktree) => worktree.is_current) ?? worktrees[0] ?? null;
+        selectedCanvasWorktreeBranch = selectedWorktree?.branch ?? null;
+        selectedCanvasWorktreePath = selectedWorktree?.path ?? null;
       } else if (
         !worktrees.some((worktree) => worktree.branch === selectedCanvasWorktreeBranch)
       ) {
-        selectedCanvasWorktreeBranch =
-          worktrees.find((worktree) => worktree.is_current)?.branch ??
-          worktrees[0]?.branch ??
-          null;
+        const selectedWorktree =
+          worktrees.find((worktree) => worktree.is_current) ?? worktrees[0] ?? null;
+        selectedCanvasWorktreeBranch = selectedWorktree?.branch ?? null;
+        selectedCanvasWorktreePath = selectedWorktree?.path ?? null;
+      } else {
+        selectedCanvasWorktreePath = resolveCanvasWorktreePath(selectedCanvasWorktreeBranch);
       }
     } catch (err) {
       console.error("Failed to refresh canvas worktrees:", err);
@@ -1710,28 +1729,11 @@
 
   async function resolveNewTerminalWorkingDir(): Promise<string | null> {
     if (!projectPath) return null;
-
-    const branchName = selectedBranch?.name?.trim() || "";
-    if (!branchName) return projectPath;
-
-    try {
-      const { invoke } = await import("$lib/tauriInvoke");
-      const worktrees = await invoke<WorktreeInfo[]>("list_worktrees", {
-        projectPath,
-      });
-      const normalizedBranchName = normalizeBranchName(branchName);
-      const selectedWorktree = worktrees.find((worktree) => {
-        const worktreeBranch = (worktree.branch ?? "").trim();
-        if (!worktreeBranch) return false;
-        return normalizeBranchName(worktreeBranch) === normalizedBranchName;
-      });
-      const selectedPath = selectedWorktree?.path?.trim() || "";
-      if (selectedPath) return selectedPath;
-    } catch (err) {
-      console.error("Failed to resolve selected worktree path:", err);
-    }
-
-    return projectPath;
+    return (
+      selectedCanvasWorktreePath ||
+      resolveCanvasWorktreePath(selectedCanvasWorktreeBranch) ||
+      projectPath
+    );
   }
 
   async function handleNewTerminal() {
@@ -1749,6 +1751,7 @@
         ...(selectedCanvasWorktreeBranch
           ? { branchName: selectedCanvasWorktreeBranch }
           : {}),
+        ...(workingDir ? { worktreePath: workingDir } : {}),
         cwd: workingDir || undefined,
       };
       tabs = [...tabs, newTab];
@@ -1821,6 +1824,7 @@
         ...(selectedCanvasWorktreeBranch
           ? { branchName: selectedCanvasWorktreeBranch }
           : {}),
+        ...(workingDir ? { worktreePath: workingDir } : {}),
         cwd: workingDir,
       };
       tabs = [...tabs, tab];
@@ -1871,6 +1875,8 @@
             label: terminalTabLabel(workingDir, storedTab.label || "Terminal"),
             type: "terminal",
             paneId,
+            ...(storedTab.branchName ? { branchName: storedTab.branchName } : {}),
+            ...(storedTab.worktreePath ? { worktreePath: storedTab.worktreePath } : {}),
             cwd: workingDir,
           });
         } catch (err) {
@@ -2024,6 +2030,9 @@
       type: "agent",
       paneId,
       ...(requestedBranch ? { branchName: requestedBranch } : {}),
+      ...(resolveCanvasWorktreePath(requestedBranch)
+        ? { worktreePath: resolveCanvasWorktreePath(requestedBranch) ?? undefined }
+        : {}),
     };
 
     if (requestedAgentId) {
@@ -2051,6 +2060,10 @@
           const resolvedBranch = terminal.branch_name?.trim() ?? "";
           if (resolvedBranch) {
             updates.branchName = resolvedBranch;
+            const resolvedWorktreePath = resolveCanvasWorktreePath(resolvedBranch);
+            if (resolvedWorktreePath) {
+              updates.worktreePath = resolvedWorktreePath;
+            }
             if (needsBranchResolution) {
               updates.label = worktreeTabLabel(resolvedBranch);
             }
@@ -2095,6 +2108,10 @@
       const fallbackSession =
         nextTabs.find((t) => t.type === "agent" || t.type === "terminal") ?? null;
       selectedCanvasSessionTabId = fallbackSession?.id ?? null;
+      selectedCanvasWorktreeBranch = fallbackSession?.branchName ?? selectedCanvasWorktreeBranch;
+      selectedCanvasWorktreePath =
+        fallbackSession?.worktreePath ??
+        resolveCanvasWorktreePath(fallbackSession?.branchName);
     }
 
     if (activeTabId !== tabId) return;
@@ -2129,6 +2146,9 @@
     const selected = tabs.find((tab) => tab.id === tabId);
     if (selected?.type === "agent" || selected?.type === "terminal") {
       selectedCanvasSessionTabId = tabId;
+      selectedCanvasWorktreeBranch = selected.branchName ?? selectedCanvasWorktreeBranch;
+      selectedCanvasWorktreePath =
+        selected.worktreePath ?? resolveCanvasWorktreePath(selected.branchName);
       activeTabId = "agentCanvas";
     }
   }
@@ -2243,6 +2263,8 @@
     const agentTab = findAgentTabByBranchName(tabs, branchName);
     if (agentTab) {
       selectedCanvasSessionTabId = agentTab.id;
+      selectedCanvasWorktreeBranch = branchName;
+      selectedCanvasWorktreePath = resolveCanvasWorktreePath(branchName);
       openAgentCanvasTab();
       return;
     }
@@ -2600,6 +2622,7 @@
           activeTabId = "agentCanvas";
           selectedCanvasSessionTabId = null;
           selectedCanvasWorktreeBranch = null;
+          selectedCanvasWorktreePath = null;
           canvasWorktrees = [];
           selectedBranch = null;
           currentBranch = "";
@@ -2723,6 +2746,10 @@
             label,
             type: "terminal",
             paneId,
+            ...(selectedCanvasWorktreeBranch
+              ? { branchName: selectedCanvasWorktreeBranch }
+              : {}),
+            ...(workingDir ? { worktreePath: workingDir } : {}),
             cwd: workingDir || undefined,
           };
           tabs = [...tabs, newTab];
@@ -2836,7 +2863,8 @@
       return;
     }
 
-    const stored = loadStoredProjectTabs(targetProjectPath);
+    const windowLabel = await resolveCurrentWindowLabel();
+    const stored = loadStoredProjectTabs(targetProjectPath, undefined, windowLabel);
 
     // Even if no stored state exists, mark hydrated so persistence can proceed.
     if (!stored) {
@@ -2905,6 +2933,16 @@
 
     const allowOverrideActive = shouldAllowRestoredActiveTab(activeTabId);
     selectedCanvasSessionTabId = restored.activeCanvasSessionTabId;
+    const restoredCanvasSession =
+      restored.activeCanvasSessionTabId
+        ? mergedTabs.find((tab) => tab.id === restored.activeCanvasSessionTabId)
+        : null;
+    if (restoredCanvasSession?.branchName) {
+      selectedCanvasWorktreeBranch = restoredCanvasSession.branchName;
+      selectedCanvasWorktreePath =
+        restoredCanvasSession.worktreePath ??
+        resolveCanvasWorktreePath(restoredCanvasSession.branchName);
+    }
     if (allowOverrideActive) {
       if (
         restored.activeTabId &&
@@ -2969,6 +3007,7 @@
           paneId: tab.paneId,
           label: tab.label,
           ...(tab.branchName ? { branchName: tab.branchName } : {}),
+          ...(tab.worktreePath ? { worktreePath: tab.worktreePath } : {}),
           ...(tab.agentId ? { agentId: tab.agentId } : {}),
         });
         continue;
@@ -2980,6 +3019,8 @@
           paneId: tab.paneId,
           label: tab.label,
           ...(tab.cwd ? { cwd: tab.cwd } : {}),
+          ...(tab.branchName ? { branchName: tab.branchName } : {}),
+          ...(tab.worktreePath ? { worktreePath: tab.worktreePath } : {}),
         });
         continue;
       }
@@ -3017,7 +3058,7 @@
       tabs: storedTabs,
       activeTabId: storedActiveTabId,
       activeCanvasSessionTabId: selectedCanvasSessionTabId,
-    });
+    }, undefined, currentWindowLabel);
   });
 
   // Native menubar integration (Tauri emits "menu-action" to the focused window).
@@ -3171,16 +3212,6 @@
         e.preventDefault();
         void handleMenuAction("cleanup-worktrees");
       }
-      if (
-        e.ctrlKey &&
-        e.code === "Backquote" &&
-        !e.shiftKey &&
-        !e.altKey &&
-        !e.metaKey
-      ) {
-        e.preventDefault();
-        void handleMenuAction("new-terminal");
-      }
       // Cmd+O / Ctrl+O → Open Project
       if (
         e.key === "o" &&
@@ -3234,6 +3265,7 @@
     <div class="app-body">
       <MainArea
         {tabs}
+        {activeTabId}
         projectPath={projectPath as string}
         {branchBrowserConfig}
         {currentBranch}
@@ -3260,6 +3292,7 @@
         selectedCanvasWorktreeBranch={selectedCanvasWorktreeBranch}
         onCanvasWorktreeSelect={(branchName) => {
           selectedCanvasWorktreeBranch = branchName;
+          selectedCanvasWorktreePath = resolveCanvasWorktreePath(branchName);
         }}
       />
     </div>

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -2828,7 +2828,8 @@
     void layoutGroups;
     void layoutRoot;
 
-    const knownTabIds = new Set(tabs.map((tab) => tab.id));
+    const shellTabs = tabs.filter((tab) => isShellTab(tab));
+    const knownTabIds = new Set(shellTabs.map((tab) => tab.id));
     let next = readTabLayoutState();
 
     for (const group of Object.values(next.groups)) {
@@ -2839,7 +2840,7 @@
       }
     }
 
-    for (const tab of tabs) {
+    for (const tab of shellTabs) {
       if (!getGroupForTab(next, tab.id)) {
         next = addTabToActiveGroup(next, tab.id);
       }
@@ -3017,18 +3018,22 @@
     });
 
     const allowOverrideActive = shouldAllowRestoredActiveTab(activeTabId);
+    selectedCanvasSessionTabId = restored.activeCanvasSessionTabId;
     if (allowOverrideActive) {
       if (
         restored.activeTabId &&
         mergedTabs.some((tab) => tab.id === restored.activeTabId)
       ) {
         activeTabId = restored.activeTabId;
+      } else if (restored.activeCanvasSessionTabId) {
+        activeTabId = "agentCanvas";
       } else if (restored.activeTerminalPaneIdToRespawn) {
         const paneId = respawnedTerminalResult.paneIdMap.get(
           restored.activeTerminalPaneIdToRespawn,
         );
         if (paneId) {
-          activeTabId = `terminal-${paneId}`;
+          selectedCanvasSessionTabId = `terminal-${paneId}`;
+          activeTabId = "agentCanvas";
         }
       }
     } else if (!mergedTabs.some((tab) => tab.id === activeTabId)) {
@@ -3065,11 +3070,15 @@
     if (!projectPath) return;
     if (agentTabsHydratedProjectPath !== projectPath) return;
 
-    const orderedTabIds = flattenTabIdsByLayout(readTabLayoutState());
-    const orderedTabs = orderedTabIds
+    const orderedShellTabIds = flattenTabIdsByLayout(readTabLayoutState());
+    const orderedShellTabs = orderedShellTabIds
       .map((tabId) => tabs.find((tab) => tab.id === tabId))
       .filter((tab): tab is Tab => Boolean(tab));
-    const fallbackOrderedTabs = orderedTabs.length > 0 ? orderedTabs : tabs;
+    const seenShellIds = new Set(orderedShellTabs.map((tab) => tab.id));
+    const fallbackOrderedTabs =
+      orderedShellTabs.length > 0
+        ? [...orderedShellTabs, ...tabs.filter((tab) => !seenShellIds.has(tab.id))]
+        : tabs;
 
     const storedTabs: StoredProjectTab[] = [];
     for (const tab of fallbackOrderedTabs) {
@@ -3122,11 +3131,12 @@
       return tab.id === activeTabId;
     })
       ? activeTabId
-      : null;
+      : fallbackOrderedTabs.find((tab) => isShellTab(tab))?.id ?? "agentCanvas";
 
     persistStoredProjectTabs(projectPath, {
       tabs: storedTabs,
       activeTabId: storedActiveTabId,
+      activeCanvasSessionTabId: selectedCanvasSessionTabId,
       activeGroupId,
       groups: buildStoredLayoutGroups(),
       root: buildStoredLayoutRoot(layoutRoot),

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type {
     BranchBrowserPanelConfig,
+    MaterializeWorktreeResult,
     Tab,
     BranchInfo,
     GitHubIssueInfo,
@@ -42,35 +43,15 @@
     buildRestoredProjectTabs,
     shouldRetryAgentTabRestore,
     type StoredProjectTab,
-    type StoredTabGroup,
-    type StoredTabLayoutNode,
     type StoredTerminalTab,
   } from "./lib/agentTabsPersistence";
   import {
     defaultAppTabs,
+    type TabDropPosition,
     reorderTabsByDrop,
     shouldAllowRestoredActiveTab,
   } from "./lib/appTabs";
   import { getNextTabId, getPreviousTabId } from "./lib/tabNavigation";
-  import {
-    addTabToActiveGroup,
-    canSplitTab,
-    createInitialTabLayout,
-    flattenTabIdsByLayout,
-    getGroupForTab,
-    moveTabToGroup,
-    normalizeTabLayoutState,
-    removeTabFromLayout,
-    reorderTabsInGroup,
-    resizeSplitNode,
-    setActiveGroup,
-    setActiveTabInGroup,
-    splitTabToGroupEdge,
-    type TabDropPosition,
-    type TabGroupState,
-    type TabLayoutNode,
-    type TabSplitDirection,
-  } from "./lib/tabLayout";
   import {
     runStartupUpdateCheck,
     STARTUP_UPDATE_INITIAL_DELAY_MS,
@@ -304,10 +285,6 @@
   let migrationSourceRoot: string = $state("");
 
   let tabs: Tab[] = $state(defaultAppTabs());
-  const initialTabLayout = createInitialTabLayout(defaultAppTabs(), "agentCanvas");
-  let layoutGroups: Record<string, TabGroupState> = $state(initialTabLayout.groups);
-  let layoutRoot: TabLayoutNode = $state(initialTabLayout.root);
-  let activeGroupId: string = $state(initialTabLayout.activeGroupId);
   let activeTabId: string = $state("agentCanvas");
   let lastWindowMenuTabsSignature: string | null = null;
   let lastWindowMenuActiveTabId: string | null = null;
@@ -340,6 +317,8 @@
     })(),
   );
   let selectedCanvasSessionTabId: string | null = $state(null);
+  let canvasWorktrees: WorktreeInfo[] = $state([]);
+  let selectedCanvasWorktreeBranch: string | null = $state(null);
   let terminalDiagnosticsLoading: boolean = $state(false);
   let terminalDiagnostics: TerminalAnsiProbe | null = $state(null);
   let terminalDiagnosticsError: string | null = $state(null);
@@ -404,62 +383,6 @@
   let osEnvDebugLoading = $state(false);
   let osEnvDebugError = $state<string | null>(null);
   type AvailableUpdateState = Extract<UpdateState, { state: "available" }>;
-
-  function readTabLayoutState() {
-    return normalizeTabLayoutState({
-      groups: layoutGroups,
-      root: layoutRoot,
-      activeGroupId,
-    }, activeTabId);
-  }
-
-  function applyTabLayoutState(next: {
-    groups: Record<string, TabGroupState>;
-    root: TabLayoutNode;
-    activeGroupId: string;
-  }) {
-    const normalized = normalizeTabLayoutState(next, activeTabId);
-    layoutGroups = normalized.groups;
-    layoutRoot = normalized.root;
-    activeGroupId = normalized.activeGroupId;
-    const nextActiveTabId =
-      normalized.groups[normalized.activeGroupId]?.activeTabId ??
-      tabs.find((tab) => tab.id === activeTabId)?.id ??
-      tabs[0]?.id ??
-      "";
-    activeTabId = nextActiveTabId;
-  }
-
-  function activeGroupTabIds(): string[] {
-    return layoutGroups[activeGroupId]?.tabIds ?? [];
-  }
-
-  function buildStoredLayoutGroups(): StoredTabGroup[] {
-    return Object.values(layoutGroups).map((group) => ({
-      id: group.id,
-      tabIds: [...group.tabIds],
-      activeTabId: group.activeTabId,
-    }));
-  }
-
-  function buildStoredLayoutRoot(node: TabLayoutNode): StoredTabLayoutNode {
-    if (node.type === "group") {
-      return {
-        type: "group",
-        groupId: node.groupId,
-      };
-    }
-    return {
-      type: "split",
-      id: node.id,
-      axis: node.axis,
-      sizes: node.sizes,
-      children: [
-        buildStoredLayoutRoot(node.children[0]),
-        buildStoredLayoutRoot(node.children[1]),
-      ],
-    };
-  }
 
   function showToast(
     message: string,
@@ -894,12 +817,13 @@
             const p = (event as { payload?: unknown }).payload;
             if (p && typeof p === "object" && "project_path" in p) {
               const raw = (p as { project_path?: unknown }).project_path;
-              if (typeof raw === "string" && raw && raw !== projectPath) return;
-            }
+            if (typeof raw === "string" && raw && raw !== projectPath) return;
+          }
 
-            sidebarRefreshKey++;
-          },
-        );
+          sidebarRefreshKey++;
+          void refreshCanvasWorktrees(projectPath);
+        },
+      );
 
         if (cancelled) {
           unlistenFn();
@@ -1450,6 +1374,7 @@
   function handleOpenedProjectPath(path: string) {
     projectPath = path;
     fetchCurrentBranch();
+    void refreshCanvasWorktrees(path);
     void updateWindowSession(path);
   }
 
@@ -1489,6 +1414,33 @@
     selectedBranch = branch;
     if (branch.is_current) {
       currentBranch = branch.name;
+    }
+  }
+
+  async function focusOrCreateWorktreeFromBranch(branch: BranchInfo) {
+    if (!projectPath) return;
+    handleBranchSelect(branch);
+
+    try {
+      const { invoke } = await import("$lib/tauriInvoke");
+      const result = await invoke<MaterializeWorktreeResult>(
+        "materialize_worktree_ref",
+        {
+          projectPath,
+          branchRef: branch.name,
+        },
+      );
+      await refreshCanvasWorktrees(projectPath);
+      selectedCanvasWorktreeBranch = result.worktree.branch;
+      openAgentCanvasTab();
+      showToast(
+        result.created
+          ? `Worktree created: ${result.worktree.branch}`
+          : `Worktree focused: ${result.worktree.branch}`,
+        5000,
+      );
+    } catch (err) {
+      showToast(`Failed to open worktree: ${toErrorMessage(err)}`, 8000);
     }
   }
 
@@ -1578,6 +1530,9 @@
     );
     if (!sessionTab) return;
     selectedCanvasSessionTabId = tabId;
+    if (sessionTab.branchName) {
+      selectedCanvasWorktreeBranch = sessionTab.branchName;
+    }
     openAgentCanvasTab();
   }
 
@@ -1588,8 +1543,7 @@
   }
 
   function handleBranchActivate(branch: BranchInfo) {
-    handleBranchSelect(branch);
-    requestAgentLaunch();
+    void focusOrCreateWorktreeFromBranch(branch);
   }
 
   function handleCleanupRequest(preSelectedBranch?: string) {
@@ -1610,6 +1564,9 @@
         label,
         type: "terminal",
         paneId,
+        ...(selectedCanvasWorktreeBranch
+          ? { branchName: selectedCanvasWorktreeBranch }
+          : {}),
         cwd: workingDir || undefined,
       };
       tabs = [...tabs, newTab];
@@ -1648,10 +1605,40 @@
       });
       if (branch) {
         currentBranch = branch.name;
+        if (!selectedCanvasWorktreeBranch) {
+          selectedCanvasWorktreeBranch = branch.name;
+        }
       }
     } catch (err) {
       console.error("Failed to fetch current branch:", err);
       currentBranch = "";
+    }
+  }
+
+  async function refreshCanvasWorktrees(targetProjectPath = projectPath) {
+    if (!targetProjectPath) return;
+    try {
+      const { invoke } = await import("$lib/tauriInvoke");
+      const worktrees = await invoke<WorktreeInfo[]>("list_worktrees", {
+        projectPath: targetProjectPath,
+      });
+      if (targetProjectPath !== projectPath) return;
+      canvasWorktrees = worktrees;
+      if (!selectedCanvasWorktreeBranch) {
+        selectedCanvasWorktreeBranch =
+          worktrees.find((worktree) => worktree.is_current)?.branch ??
+          worktrees[0]?.branch ??
+          null;
+      } else if (
+        !worktrees.some((worktree) => worktree.branch === selectedCanvasWorktreeBranch)
+      ) {
+        selectedCanvasWorktreeBranch =
+          worktrees.find((worktree) => worktree.is_current)?.branch ??
+          worktrees[0]?.branch ??
+          null;
+      }
+    } catch (err) {
+      console.error("Failed to refresh canvas worktrees:", err);
     }
   }
 
@@ -1759,9 +1746,13 @@
         label,
         type: "terminal",
         paneId,
+        ...(selectedCanvasWorktreeBranch
+          ? { branchName: selectedCanvasWorktreeBranch }
+          : {}),
         cwd: workingDir || undefined,
       };
       tabs = [...tabs, newTab];
+      selectedCanvasSessionTabId = newTab.id;
       openAgentCanvasTab();
     } catch (err) {
       console.error("Failed to spawn new terminal:", err);
@@ -1827,6 +1818,9 @@
         label: "Docs Edit",
         type: "terminal",
         paneId,
+        ...(selectedCanvasWorktreeBranch
+          ? { branchName: selectedCanvasWorktreeBranch }
+          : {}),
         cwd: workingDir,
       };
       tabs = [...tabs, tab];
@@ -2127,7 +2121,7 @@
   }
 
   function handleTabSelect(groupId: string, tabId: string) {
-    activeGroupId = groupId;
+    void groupId;
     activeTabId = tabId;
     if (tabId === "agentCanvas" || tabId === "branchBrowser") {
       return;
@@ -2149,47 +2143,6 @@
     if (nextTabs !== tabs) {
       tabs = nextTabs;
     }
-  }
-
-  function handleTabMoveToGroup(
-    dragTabId: string,
-    targetGroupId: string,
-    overTabId: string | null = null,
-    position: TabDropPosition = "after",
-  ) {
-    const next = moveTabToGroup(
-      readTabLayoutState(),
-      dragTabId,
-      targetGroupId,
-      overTabId,
-      position,
-    );
-    applyTabLayoutState(next);
-  }
-
-  function handleTabSplitToGroupEdge(
-    dragTabId: string,
-    targetGroupId: string,
-    direction: TabSplitDirection,
-  ) {
-    if (!canSplitTab(readTabLayoutState(), dragTabId)) return;
-    const next = splitTabToGroupEdge(
-      readTabLayoutState(),
-      dragTabId,
-      targetGroupId,
-      direction,
-    );
-    applyTabLayoutState(next);
-  }
-
-  function handleGroupFocus(groupId: string) {
-    const next = setActiveGroup(readTabLayoutState(), groupId);
-    applyTabLayoutState(next);
-  }
-
-  function handleSplitResize(splitId: string, primaryFraction: number) {
-    const next = resizeSplitNode(readTabLayoutState(), splitId, primaryFraction);
-    applyTabLayoutState(next);
   }
 
   function openSettingsTab() {
@@ -2646,6 +2599,8 @@
           tabs = defaultAppTabs();
           activeTabId = "agentCanvas";
           selectedCanvasSessionTabId = null;
+          selectedCanvasWorktreeBranch = null;
+          canvasWorktrees = [];
           selectedBranch = null;
           currentBranch = "";
         }
@@ -2823,58 +2778,6 @@
 
   $effect(() => {
     void tabs;
-    void activeTabId;
-    void activeGroupId;
-    void layoutGroups;
-    void layoutRoot;
-
-    const shellTabs = tabs.filter((tab) => isShellTab(tab));
-    const knownTabIds = new Set(shellTabs.map((tab) => tab.id));
-    let next = readTabLayoutState();
-
-    for (const group of Object.values(next.groups)) {
-      for (const tabId of [...group.tabIds]) {
-        if (!knownTabIds.has(tabId)) {
-          next = removeTabFromLayout(next, tabId);
-        }
-      }
-    }
-
-    for (const tab of shellTabs) {
-      if (!getGroupForTab(next, tab.id)) {
-        next = addTabToActiveGroup(next, tab.id);
-      }
-    }
-
-    if (activeTabId && knownTabIds.has(activeTabId)) {
-      const owningGroup = getGroupForTab(next, activeTabId);
-      if (owningGroup) {
-        next = setActiveGroup(next, owningGroup.id);
-        next = setActiveTabInGroup(next, owningGroup.id, activeTabId);
-      }
-    }
-
-    if (
-      next.groups !== layoutGroups ||
-      next.root !== layoutRoot ||
-      next.activeGroupId !== activeGroupId
-    ) {
-      const normalized = normalizeTabLayoutState(next, activeTabId);
-      layoutGroups = normalized.groups;
-      layoutRoot = normalized.root;
-      activeGroupId = normalized.activeGroupId;
-      const nextActiveTab =
-        normalized.groups[normalized.activeGroupId]?.activeTabId ??
-        tabs[0]?.id ??
-        "";
-      if (nextActiveTab && nextActiveTab !== activeTabId) {
-        activeTabId = nextActiveTab;
-      }
-    }
-  });
-
-  $effect(() => {
-    void tabs;
     void syncWindowAgentTabsSnapshot();
   });
 
@@ -3000,21 +2903,6 @@
     tabs = mergedTabs;
     await refreshAgentTabLabelsForProject(targetProjectPath);
 
-    const restoredGroups: Record<string, TabGroupState> = Object.fromEntries(
-      restored.groups.map((group) => [
-        group.id,
-        {
-          id: group.id,
-          tabIds: [...group.tabIds],
-          activeTabId: group.activeTabId,
-        },
-      ]),
-    );
-    layoutGroups = restoredGroups;
-    layoutRoot = restored.root as TabLayoutNode;
-    activeGroupId =
-      restored.activeGroupId ?? restored.groups[0]?.id ?? activeGroupId;
-
     const allowOverrideActive = shouldAllowRestoredActiveTab(activeTabId);
     selectedCanvasSessionTabId = restored.activeCanvasSessionTabId;
     if (allowOverrideActive) {
@@ -3061,17 +2949,11 @@
     void tabs;
     void activeTabId;
     void agentTabsHydratedProjectPath;
-    void layoutGroups;
-    void layoutRoot;
-    void activeGroupId;
 
     if (!projectPath) return;
     if (agentTabsHydratedProjectPath !== projectPath) return;
 
-    const orderedShellTabIds = flattenTabIdsByLayout(readTabLayoutState());
-    const orderedShellTabs = orderedShellTabIds
-      .map((tabId) => tabs.find((tab) => tab.id === tabId))
-      .filter((tab): tab is Tab => Boolean(tab));
+    const orderedShellTabs = getShellTabs();
     const seenShellIds = new Set(orderedShellTabs.map((tab) => tab.id));
     const fallbackOrderedTabs =
       orderedShellTabs.length > 0
@@ -3374,6 +3256,11 @@
         {voiceInputAvailable}
         {voiceInputAvailabilityReason}
         {voiceInputError}
+        canvasWorktrees={canvasWorktrees}
+        selectedCanvasWorktreeBranch={selectedCanvasWorktreeBranch}
+        onCanvasWorktreeSelect={(branchName) => {
+          selectedCanvasWorktreeBranch = branchName;
+        }}
       />
     </div>
     <StatusBar

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type {
+    BranchBrowserPanelConfig,
     Tab,
     BranchInfo,
     GitHubIssueInfo,
@@ -16,7 +17,6 @@
     UpdateState,
     VoiceInputSettings,
   } from "./lib/types";
-  import Sidebar from "./lib/components/Sidebar.svelte";
   import MainArea from "./lib/components/MainArea.svelte";
   import StatusBar from "./lib/components/StatusBar.svelte";
   import AboutDialog from "./lib/components/AboutDialog.svelte";
@@ -300,11 +300,11 @@
   let migrationSourceRoot: string = $state("");
 
   let tabs: Tab[] = $state(defaultAppTabs());
-  const initialTabLayout = createInitialTabLayout(defaultAppTabs(), "assistant");
+  const initialTabLayout = createInitialTabLayout(defaultAppTabs(), "agentCanvas");
   let layoutGroups: Record<string, TabGroupState> = $state(initialTabLayout.groups);
   let layoutRoot: TabLayoutNode = $state(initialTabLayout.root);
   let activeGroupId: string = $state(initialTabLayout.activeGroupId);
-  let activeTabId: string = $state("assistant");
+  let activeTabId: string = $state("agentCanvas");
   let lastWindowMenuTabsSignature: string | null = null;
   let lastWindowMenuActiveTabId: string | null = null;
   let agentPasteHintDismissed = loadAgentPasteHintDismissed();
@@ -335,7 +335,6 @@
       return branch;
     })(),
   );
-
   let terminalDiagnosticsLoading: boolean = $state(false);
   let terminalDiagnostics: TerminalAnsiProbe | null = $state(null);
   let terminalDiagnosticsError: string | null = $state(null);
@@ -355,6 +354,34 @@
   let voiceInputAvailabilityReason: string | null = $state(null);
   let voiceInputError: string | null = $state(null);
   let voiceController: VoiceInputController | null = null;
+  let branchBrowserConfig = $derived<BranchBrowserPanelConfig | undefined>(
+    projectPath
+      ? {
+          projectPath,
+          refreshKey: sidebarRefreshKey,
+          widthPx: sidebarWidthPx,
+          minWidthPx: MIN_SIDEBAR_WIDTH_PX,
+          maxWidthPx: MAX_SIDEBAR_WIDTH_PX,
+          mode: sidebarMode,
+          selectedBranch,
+          currentBranch,
+          agentTabBranches,
+          activeAgentTabBranch,
+          appLanguage,
+          onModeChange: handleSidebarModeChange,
+          onResize: handleSidebarResize,
+          onBranchSelect: handleBranchSelect,
+          onBranchActivate: handleBranchActivate,
+          onCleanupRequest: handleCleanupRequest,
+          onLaunchAgent: requestAgentLaunch,
+          onQuickLaunch: handleAgentLaunch,
+          onNewTerminal: handleNewTerminal,
+          onOpenDocsEditor: handleOpenDocsEditor,
+          onOpenCiLog: handleOpenCiLog,
+          onDisplayNameChanged: handleBranchDisplayNameChanged,
+        }
+      : undefined,
+  );
 
   const systemMonitor = createSystemMonitor();
 
@@ -1471,18 +1498,34 @@
     persistSidebarWidth(next);
   }
 
-  function ensureAssistantTab() {
-    const existing = tabs.find(
-      (t) => t.type === "assistant" || t.id === "assistant",
-    );
-    if (existing) return;
-
-    const tab: Tab = {
-      id: "assistant",
-      label: "Assistant",
-      type: "assistant",
-    };
+  function ensureWorkspaceTab(tab: Tab) {
+    if (tabs.some((candidate) => candidate.id === tab.id || candidate.type === tab.type)) {
+      return;
+    }
     tabs = [...tabs, tab];
+  }
+
+  function ensurePrimaryShellTabs() {
+    ensureWorkspaceTab({
+      id: "agentCanvas",
+      label: "Agent Canvas",
+      type: "agentCanvas",
+    });
+    ensureWorkspaceTab({
+      id: "branchBrowser",
+      label: "Branch Browser",
+      type: "branchBrowser",
+    });
+  }
+
+  function openAgentCanvasTab() {
+    ensurePrimaryShellTabs();
+    activeTabId = "agentCanvas";
+  }
+
+  function openBranchBrowserTab() {
+    ensurePrimaryShellTabs();
+    activeTabId = "branchBrowser";
   }
 
   function handleSidebarModeChange(next: SidebarMode) {
@@ -1517,7 +1560,7 @@
         cwd: workingDir || undefined,
       };
       tabs = [...tabs, newTab];
-      activeTabId = newTab.id;
+      openAgentCanvasTab();
 
       // Resolve and read logs via backend so bare-repo project roots still work.
       const logOutput = await invoke<string>("fetch_ci_log", {
@@ -1665,7 +1708,7 @@
         cwd: workingDir || undefined,
       };
       tabs = [...tabs, newTab];
-      activeTabId = newTab.id;
+      openAgentCanvasTab();
     } catch (err) {
       console.error("Failed to spawn new terminal:", err);
     }
@@ -1733,7 +1776,7 @@
         cwd: workingDir,
       };
       tabs = [...tabs, tab];
-      activeTabId = tab.id;
+      openAgentCanvasTab();
 
       const command = `${buildDocsEditorCommand(platform, shellId)}\n`;
       const data = Array.from(new TextEncoder().encode(command));
@@ -1807,9 +1850,9 @@
     if (tab.type === "assistant" || tab.id === "assistant") {
       return {
         ...tab,
-        id: "assistant",
-        label: "Assistant",
-        type: "assistant",
+        id: "agentCanvas",
+        label: "Agent Canvas",
+        type: "agentCanvas",
       };
     }
     return tab;
@@ -1827,11 +1870,19 @@
       merged.push(normalized);
     }
 
-    if (!merged.some((tab) => tab.id === "assistant")) {
+    if (!merged.some((tab) => tab.id === "agentCanvas")) {
       merged.unshift({
-        id: "assistant",
-        label: "Assistant",
-        type: "assistant",
+        id: "agentCanvas",
+        label: "Agent Canvas",
+        type: "agentCanvas",
+      });
+    }
+
+    if (!merged.some((tab) => tab.id === "branchBrowser")) {
+      merged.splice(1, 0, {
+        id: "branchBrowser",
+        label: "Branch Browser",
+        type: "branchBrowser",
       });
     }
 
@@ -1931,7 +1982,7 @@
     }
 
     tabs = [...tabs, newTab];
-    activeTabId = newTab.id;
+    openAgentCanvasTab();
     if (projectPath) {
       agentTabsHydratedProjectPath = null;
       triggerRestoreProjectAgentTabs(projectPath);
@@ -2510,13 +2561,13 @@
           projectPath = null;
           void updateWindowSession(null);
           tabs = defaultAppTabs();
-          activeTabId = "assistant";
+          activeTabId = "agentCanvas";
           selectedBranch = null;
           currentBranch = "";
         }
         break;
       case "toggle-sidebar":
-        sidebarVisible = !sidebarVisible;
+        openBranchBrowserTab();
         break;
       case "launch-agent":
         if (projectPath) {
@@ -2635,7 +2686,7 @@
             cwd: workingDir || undefined,
           };
           tabs = [...tabs, newTab];
-          activeTabId = newTab.id;
+          openAgentCanvasTab();
         } catch (err) {
           console.error("Failed to spawn shell:", err);
         }
@@ -2899,7 +2950,7 @@
         }
       }
     } else if (!mergedTabs.some((tab) => tab.id === activeTabId)) {
-      activeTabId = mergedTabs[0]?.id ?? "assistant";
+      activeTabId = mergedTabs[0]?.id ?? "agentCanvas";
     }
 
     agentTabsHydratedProjectPath = targetProjectPath;
@@ -2962,7 +3013,8 @@
         continue;
       }
       if (
-        tab.type === "assistant" ||
+        tab.type === "agentCanvas" ||
+        tab.type === "branchBrowser" ||
         tab.type === "settings" ||
         tab.type === "versionHistory" ||
         tab.type === "issues" ||
@@ -2970,13 +3022,10 @@
         tab.type === "projectIndex" ||
         tab.type === "issueSpec"
       ) {
-        const staticType = tab.type === "assistant" ? "assistant" : tab.type;
-        const staticId = tab.id === "assistant" ? "assistant" : tab.id;
-        const staticLabel = tab.type === "assistant" ? "Assistant" : tab.label;
         storedTabs.push({
-          type: staticType,
-          id: staticId,
-          label: staticLabel,
+          type: tab.type,
+          id: tab.id,
+          label: tab.label,
           ...(tab.type === "issueSpec" && tab.issueNumber
             ? { issueNumber: tab.issueNumber }
             : {}),
@@ -3214,38 +3263,14 @@
 {:else}
   <div class="app-layout">
     <div class="app-body">
-      {#if sidebarVisible}
-        <Sidebar
-          {projectPath}
-          refreshKey={sidebarRefreshKey}
-          widthPx={sidebarWidthPx}
-          minWidthPx={MIN_SIDEBAR_WIDTH_PX}
-          maxWidthPx={MAX_SIDEBAR_WIDTH_PX}
-          mode={sidebarMode}
-          onModeChange={handleSidebarModeChange}
-          {selectedBranch}
-          {currentBranch}
-          {agentTabBranches}
-          {activeAgentTabBranch}
-          {appLanguage}
-          onResize={handleSidebarResize}
-          onBranchSelect={handleBranchSelect}
-          onBranchActivate={handleBranchActivate}
-          onCleanupRequest={handleCleanupRequest}
-          onLaunchAgent={requestAgentLaunch}
-          onQuickLaunch={handleAgentLaunch}
-          onNewTerminal={handleNewTerminal}
-          onOpenDocsEditor={handleOpenDocsEditor}
-          onOpenCiLog={handleOpenCiLog}
-          onDisplayNameChanged={handleBranchDisplayNameChanged}
-        />
-      {/if}
       <MainArea
         {tabs}
         groups={layoutGroups}
         layoutRoot={layoutRoot}
         {activeGroupId}
         projectPath={projectPath as string}
+        {branchBrowserConfig}
+        {currentBranch}
         onLaunchAgent={requestAgentLaunch}
         onQuickLaunch={handleAgentLaunch}
         onTabSelect={handleTabSelect}

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -46,7 +46,11 @@
     type StoredTabLayoutNode,
     type StoredTerminalTab,
   } from "./lib/agentTabsPersistence";
-  import { defaultAppTabs, shouldAllowRestoredActiveTab } from "./lib/appTabs";
+  import {
+    defaultAppTabs,
+    reorderTabsByDrop,
+    shouldAllowRestoredActiveTab,
+  } from "./lib/appTabs";
   import { getNextTabId, getPreviousTabId } from "./lib/tabNavigation";
   import {
     addTabToActiveGroup,
@@ -2136,19 +2140,15 @@
   }
 
   function handleTabReorder(
-    groupId: string,
+    _groupId: string,
     dragTabId: string,
     overTabId: string,
     position: TabDropPosition,
   ) {
-    const next = reorderTabsInGroup(
-      readTabLayoutState(),
-      groupId,
-      dragTabId,
-      overTabId,
-      position,
-    );
-    applyTabLayoutState(next);
+    const nextTabs = reorderTabsByDrop(tabs, dragTabId, overTabId, position);
+    if (nextTabs !== tabs) {
+      tabs = nextTabs;
+    }
   }
 
   function handleTabMoveToGroup(
@@ -3010,12 +3010,10 @@
         },
       ]),
     );
-    applyTabLayoutState({
-      groups: restoredGroups,
-      root: restored.root as TabLayoutNode,
-      activeGroupId:
-        restored.activeGroupId ?? restored.groups[0]?.id ?? activeGroupId,
-    });
+    layoutGroups = restoredGroups;
+    layoutRoot = restored.root as TabLayoutNode;
+    activeGroupId =
+      restored.activeGroupId ?? restored.groups[0]?.id ?? activeGroupId;
 
     const allowOverrideActive = shouldAllowRestoredActiveTab(activeTabId);
     selectedCanvasSessionTabId = restored.activeCanvasSessionTabId;
@@ -3137,9 +3135,6 @@
       tabs: storedTabs,
       activeTabId: storedActiveTabId,
       activeCanvasSessionTabId: selectedCanvasSessionTabId,
-      activeGroupId,
-      groups: buildStoredLayoutGroups(),
-      root: buildStoredLayoutRoot(layoutRoot),
     });
   });
 
@@ -3357,23 +3352,17 @@
     <div class="app-body">
       <MainArea
         {tabs}
-        groups={layoutGroups}
-        layoutRoot={layoutRoot}
-        {activeGroupId}
         projectPath={projectPath as string}
         {branchBrowserConfig}
         {currentBranch}
         {selectedCanvasSessionTabId}
+        disableSplit={true}
         onCanvasSessionSelect={handleCanvasSessionSelect}
         onLaunchAgent={requestAgentLaunch}
         onQuickLaunch={handleAgentLaunch}
         onTabSelect={handleTabSelect}
         onTabClose={handleTabClose}
         onTabReorder={handleTabReorder}
-        onTabMoveToGroup={handleTabMoveToGroup}
-        onTabSplitToGroupEdge={handleTabSplitToGroupEdge}
-        onSplitResize={handleSplitResize}
-        onGroupFocus={handleGroupFocus}
         onWorkOnIssue={handleWorkOnIssueFromTab}
         onSwitchToWorktree={handleSwitchToWorktreeFromTab}
         onIssueCountChange={handleIssueCountChange}

--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -1540,6 +1540,34 @@
     );
   }
 
+  function isShellTab(tab: Tab): boolean {
+    return (
+      tab.type === "agentCanvas" ||
+      tab.type === "branchBrowser" ||
+      tab.type === "settings" ||
+      tab.type === "versionHistory" ||
+      tab.type === "issues" ||
+      tab.type === "prs" ||
+      tab.type === "projectIndex" ||
+      tab.type === "issueSpec"
+    );
+  }
+
+  function getShellTabs(): Tab[] {
+    return tabs.filter((tab) => isShellTab(tab));
+  }
+
+  function getEffectiveWindowMenuActiveTabId(): string | null {
+    const active = tabs.find((t) => t.id === activeTabId) ?? null;
+    if (active?.type === "agent" || active?.type === "terminal") {
+      return active.id;
+    }
+    if (active?.type === "agentCanvas") {
+      return getSelectedCanvasSessionTab()?.id ?? null;
+    }
+    return null;
+  }
+
   function handleCanvasSessionSelect(tabId: string) {
     const sessionTab = tabs.find(
       (tab) => tab.id === tabId && (tab.type === "agent" || tab.type === "terminal"),
@@ -2261,10 +2289,12 @@
     // Find the matching agent tab and switch to it
     const agentTab = findAgentTabByBranchName(tabs, branchName);
     if (agentTab) {
-      activeTabId = agentTab.id;
+      selectedCanvasSessionTabId = agentTab.id;
+      openAgentCanvasTab();
       return;
     }
-    // If no tab exists, select the branch in the sidebar
+    // If no session exists yet, move the user to Branch Browser and refresh its source view.
+    openBranchBrowserTab();
     sidebarRefreshKey++;
   }
 
@@ -2448,10 +2478,11 @@
       if (tabsSignature === lastWindowMenuTabsSignature) {
         return;
       }
-      const activeVisibleTabId = resolveActiveWindowMenuTabId(
-        visibleTabs,
-        activeTabId,
-      );
+      const requestedActiveTabId = getEffectiveWindowMenuActiveTabId();
+      const activeVisibleTabId =
+        requestedActiveTabId === null
+          ? null
+          : resolveActiveWindowMenuTabId(visibleTabs, requestedActiveTabId);
       await invoke("sync_window_agent_tabs", {
         request: {
           tabs: visibleTabs,
@@ -2460,7 +2491,11 @@
       });
       lastWindowMenuTabsSignature = tabsSignature;
       if (
-        shouldKeepSnapshotActiveTabCache(activeVisibleTabId, tabs, activeTabId)
+        shouldKeepSnapshotActiveTabCache(
+          activeVisibleTabId,
+          tabs,
+          requestedActiveTabId ?? activeTabId,
+        )
       ) {
         lastWindowMenuActiveTabId = activeVisibleTabId;
       }
@@ -2473,10 +2508,11 @@
     try {
       const { invoke } = await import("$lib/tauriInvoke");
       const visibleTabs = buildWindowMenuVisibleTabs(tabs);
-      const activeVisibleTabId = resolveActiveWindowMenuTabId(
-        visibleTabs,
-        activeTabId,
-      );
+      const requestedActiveTabId = getEffectiveWindowMenuActiveTabId();
+      const activeVisibleTabId =
+        requestedActiveTabId === null
+          ? null
+          : resolveActiveWindowMenuTabId(visibleTabs, requestedActiveTabId);
       if (activeVisibleTabId === lastWindowMenuActiveTabId) {
         return;
       }
@@ -2689,7 +2725,8 @@
             (t) => t.type === "agent" || t.type === "terminal",
           );
           if (firstAgent) {
-            activeTabId = firstAgent.id;
+            selectedCanvasSessionTabId = firstAgent.id;
+            openAgentCanvasTab();
           }
         }
         break;
@@ -2742,7 +2779,9 @@
         break;
       }
       case "terminal-diagnostics": {
-        const active = tabs.find((t) => t.id === activeTabId) ?? null;
+        const active =
+          getSelectedCanvasSessionTab() ??
+          (tabs.find((t) => t.id === activeTabId) ?? null);
         const paneId = active?.paneId ?? "";
         if (!paneId) {
           appError = "No active terminal tab.";
@@ -2770,18 +2809,12 @@
         break;
       }
       case "previous-tab": {
-        const groupTabs = activeGroupTabIds()
-          .map((tabId) => tabs.find((tab) => tab.id === tabId))
-          .filter((tab): tab is Tab => Boolean(tab));
-        const prevId = getPreviousTabId(groupTabs, activeTabId);
+        const prevId = getPreviousTabId(getShellTabs(), activeTabId);
         if (prevId) activeTabId = prevId;
         break;
       }
       case "next-tab": {
-        const groupTabs = activeGroupTabIds()
-          .map((tabId) => tabs.find((tab) => tab.id === tabId))
-          .filter((tab): tab is Tab => Boolean(tab));
-        const nextId = getNextTabId(groupTabs, activeTabId);
+        const nextId = getNextTabId(getShellTabs(), activeTabId);
         if (nextId) activeTabId = nextId;
         break;
       }

--- a/gwt-gui/src/lib/agentCanvas.test.ts
+++ b/gwt-gui/src/lib/agentCanvas.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentCanvasGraph,
+  buildAgentCanvasState,
+  createDefaultAgentCanvasViewport,
+} from "./agentCanvas";
+import type { Tab, WorktreeInfo } from "./types";
+
+const mainWorktree: WorktreeInfo = {
+  path: "/tmp/project",
+  branch: "main",
+  commit: "main123",
+  status: "active",
+  is_main: true,
+  has_changes: false,
+  has_unpushed: false,
+  is_current: true,
+  is_protected: true,
+  is_agent_running: false,
+  agent_status: "unknown",
+  ahead: 0,
+  behind: 0,
+  is_gone: false,
+  last_tool_usage: null,
+  safety_level: "safe",
+};
+
+const featureWorktree: WorktreeInfo = {
+  ...mainWorktree,
+  path: "/tmp/project/.gwt/worktrees/feature-demo",
+  branch: "feature/demo",
+  is_main: false,
+  is_current: false,
+  is_protected: false,
+  safety_level: "warning",
+};
+
+describe("agentCanvas", () => {
+  it("binds sessions to worktree identity by path before branch label", () => {
+    const tabs: Tab[] = [
+      {
+        id: "agent-pane-1",
+        label: "#1654 Demo",
+        type: "agent",
+        paneId: "pane-1",
+        branchName: "renamed-display-branch",
+        worktreePath: featureWorktree.path,
+      },
+    ];
+
+    const graph = buildAgentCanvasGraph("/tmp/project", "main", tabs, [
+      mainWorktree,
+      featureWorktree,
+    ]);
+
+    expect(graph.sessionCards[0].worktreeCardId).toBe(`worktree:${featureWorktree.path}`);
+    expect(graph.edges).toEqual([
+      {
+        id: `worktree:${featureWorktree.path}->session:agent-pane-1`,
+        sourceCardId: `worktree:${featureWorktree.path}`,
+        targetCardId: "session:agent-pane-1",
+      },
+    ]);
+  });
+
+  it("falls back to the current worktree when a session has no explicit branch", () => {
+    const tabs: Tab[] = [
+      {
+        id: "terminal-pane-1",
+        label: "Terminal",
+        type: "terminal",
+        paneId: "pane-1",
+      },
+    ];
+
+    const graph = buildAgentCanvasGraph("/tmp/project", "main", tabs, [mainWorktree]);
+
+    expect(graph.sessionCards[0].worktreeCardId).toBe(`worktree:${mainWorktree.path}`);
+  });
+
+  it("builds a default viewport-backed canvas state", () => {
+    const state = buildAgentCanvasState(
+      "/tmp/project",
+      "main",
+      [],
+      [mainWorktree],
+      createDefaultAgentCanvasViewport(),
+    );
+
+    expect(state.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
+    expect(state.cards.map((card) => card.id)).toContain("assistant");
+    expect(state.cards.map((card) => card.id)).toContain(`worktree:${mainWorktree.path}`);
+  });
+});

--- a/gwt-gui/src/lib/agentCanvas.ts
+++ b/gwt-gui/src/lib/agentCanvas.ts
@@ -1,0 +1,149 @@
+import type { Tab, WorktreeInfo } from "./types";
+
+export type AgentCanvasCardType = "assistant" | "worktree" | "agent" | "terminal";
+export type AgentCanvasViewport = {
+  x: number;
+  y: number;
+  zoom: number;
+};
+
+export type AgentCanvasWorktreeCard = {
+  id: string;
+  type: "worktree";
+  worktree: WorktreeInfo;
+};
+
+export type AgentCanvasSessionCard = {
+  id: string;
+  type: "agent" | "terminal";
+  tab: Tab;
+  worktreeCardId: string | null;
+};
+
+export type AgentCanvasEdge = {
+  id: string;
+  sourceCardId: string;
+  targetCardId: string;
+};
+
+export type AgentCanvasCard =
+  | AgentCanvasWorktreeCard
+  | AgentCanvasSessionCard
+  | {
+      id: "assistant";
+      type: "assistant";
+    };
+
+export type AgentCanvasGraph = {
+  worktrees: WorktreeInfo[];
+  worktreeCards: AgentCanvasWorktreeCard[];
+  sessionCards: AgentCanvasSessionCard[];
+  edges: AgentCanvasEdge[];
+};
+
+export type AgentCanvasState = {
+  viewport: AgentCanvasViewport;
+  cards: AgentCanvasCard[];
+  edges: AgentCanvasEdge[];
+  graph: AgentCanvasGraph;
+};
+
+export function createDefaultAgentCanvasViewport(): AgentCanvasViewport {
+  return {
+    x: 0,
+    y: 0,
+    zoom: 1,
+  };
+}
+
+function fallbackWorktree(projectPath: string, currentBranch: string): WorktreeInfo {
+  return {
+    path: projectPath,
+    branch: currentBranch || "Project Root",
+    commit: "",
+    status: "active",
+    is_main: false,
+    has_changes: false,
+    has_unpushed: false,
+    is_current: true,
+    is_protected: false,
+    is_agent_running: false,
+    agent_status: "unknown",
+    ahead: 0,
+    behind: 0,
+    is_gone: false,
+    last_tool_usage: null,
+    safety_level: "safe",
+  };
+}
+
+export function buildAgentCanvasGraph(
+  projectPath: string,
+  currentBranch: string,
+  tabs: Tab[],
+  worktrees: WorktreeInfo[],
+): AgentCanvasGraph {
+  const normalizedWorktrees = worktrees.length > 0 ? worktrees : [fallbackWorktree(projectPath, currentBranch)];
+  const worktreeCards = normalizedWorktrees.map((worktree) => ({
+    id: `worktree:${worktree.path}`,
+    type: "worktree" as const,
+    worktree,
+  }));
+  const worktreeByPath = new Map(normalizedWorktrees.map((worktree) => [worktree.path, worktree]));
+  const worktreeByBranch = new Map(
+    normalizedWorktrees.map((worktree) => [(worktree.branch ?? "").trim(), worktree]),
+  );
+  const currentWorktree = normalizedWorktrees.find((worktree) => worktree.is_current) ?? normalizedWorktrees[0] ?? null;
+
+  const sessionTabs = tabs.filter(
+    (tab): tab is Tab & { type: "agent" | "terminal" } =>
+      tab.type === "agent" || tab.type === "terminal",
+  );
+  const sessionCards = sessionTabs.map((tab) => {
+    const matchedWorktree =
+      (tab.worktreePath ? worktreeByPath.get(tab.worktreePath) : null) ??
+      (tab.branchName ? worktreeByBranch.get(tab.branchName.trim()) : null) ??
+      (!tab.branchName && currentWorktree ? currentWorktree : null);
+    return {
+      id: `session:${tab.id}`,
+      type: tab.type,
+      tab,
+      worktreeCardId: matchedWorktree ? `worktree:${matchedWorktree.path}` : null,
+    } satisfies AgentCanvasSessionCard;
+  });
+
+  const edges = sessionCards
+    .filter((card) => card.worktreeCardId !== null)
+    .map((card) => ({
+      id: `${card.worktreeCardId!}->${card.id}`,
+      sourceCardId: card.worktreeCardId!,
+      targetCardId: card.id,
+    }));
+
+  return {
+    worktrees: normalizedWorktrees,
+    worktreeCards,
+    sessionCards,
+    edges,
+  };
+}
+
+export function buildAgentCanvasState(
+  projectPath: string,
+  currentBranch: string,
+  tabs: Tab[],
+  worktrees: WorktreeInfo[],
+  viewport: AgentCanvasViewport = createDefaultAgentCanvasViewport(),
+): AgentCanvasState {
+  const graph = buildAgentCanvasGraph(projectPath, currentBranch, tabs, worktrees);
+  return {
+    viewport,
+    cards: [
+      { id: "assistant", type: "assistant" },
+      ...graph.worktreeCards,
+      ...graph.sessionCards,
+    ],
+    edges: graph.edges,
+    graph,
+  };
+}

--- a/gwt-gui/src/lib/agentTabsPersistence.test.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.test.ts
@@ -270,7 +270,7 @@ describe("agentTabsPersistence", () => {
     const loaded = loadStoredProjectTabs("/repo", store);
     expect(loaded).toEqual({
       tabs: [
-        { type: "assistant", id: "assistant", label: "Assistant" },
+        { type: "agentCanvas", id: "agentCanvas", label: "Agent Canvas" },
         { type: "terminal", paneId: "t1", label: "term", cwd: "/tmp" },
         { type: "agent", paneId: "new", label: "new-agent" },
       ],
@@ -777,7 +777,7 @@ describe("agentTabsPersistence", () => {
     );
     const loaded = loadStoredProjectTabs("/repo", store);
     expect(loaded!.tabs).toEqual([
-      { type: "assistant", id: "assistant", label: "Assistant" },
+      { type: "agentCanvas", id: "agentCanvas", label: "Agent Canvas" },
       { type: "issues", id: "issues", label: "Issues" },
     ]);
   });

--- a/gwt-gui/src/lib/agentTabsPersistence.test.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.test.ts
@@ -138,6 +138,42 @@ describe("agentTabsPersistence", () => {
     });
   });
 
+  it("loadStoredProjectTabs preserves worktreePath for canvas session tabs", () => {
+    store.setItem(
+      PROJECT_TABS_STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        byProjectPath: {
+          "/repo": {
+            tabs: [
+              {
+                type: "terminal",
+                paneId: "t1",
+                label: "Shell",
+                branchName: "feature/demo",
+                worktreePath: "/repo/.gwt/worktrees/feature-demo",
+              },
+            ],
+            activeTabId: "terminal-t1",
+          },
+        },
+      }),
+    );
+
+    expect(loadStoredProjectTabs("/repo", store)).toEqual({
+      tabs: [
+        {
+          type: "terminal",
+          paneId: "t1",
+          label: "Shell",
+          branchName: "feature/demo",
+          worktreePath: "/repo/.gwt/worktrees/feature-demo",
+        },
+      ],
+      activeTabId: "terminal-t1",
+    });
+  });
+
   it("loadStoredProjectTabs falls back to legacy v1 state with terminal support", () => {
     store.setItem(
       PROJECT_AGENT_TABS_STORAGE_KEY,
@@ -241,6 +277,36 @@ describe("agentTabsPersistence", () => {
           activeTabId: "terminal-t1",
         },
       },
+    });
+  });
+
+  it("persistStoredProjectTabs isolates state per window label when provided", () => {
+    persistStoredProjectTabs(
+      "/repo",
+      {
+        tabs: [{ type: "agentCanvas", id: "agentCanvas", label: "Agent Canvas" }],
+        activeTabId: "agentCanvas",
+      },
+      store,
+      "main",
+    );
+    persistStoredProjectTabs(
+      "/repo",
+      {
+        tabs: [{ type: "branchBrowser", id: "branchBrowser", label: "Branch Browser" }],
+        activeTabId: "branchBrowser",
+      },
+      store,
+      "project-2",
+    );
+
+    expect(loadStoredProjectTabs("/repo", store, "main")).toEqual({
+      tabs: [{ type: "agentCanvas", id: "agentCanvas", label: "Agent Canvas" }],
+      activeTabId: "agentCanvas",
+    });
+    expect(loadStoredProjectTabs("/repo", store, "project-2")).toEqual({
+      tabs: [{ type: "branchBrowser", id: "branchBrowser", label: "Branch Browser" }],
+      activeTabId: "branchBrowser",
     });
   });
 

--- a/gwt-gui/src/lib/agentTabsPersistence.test.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.test.ts
@@ -454,6 +454,56 @@ describe("agentTabsPersistence", () => {
     expect(restored.activeTerminalPaneIdToRespawn).toBe("t-old");
   });
 
+  it("buildRestoredProjectTabs collapses corrupted split roots back to one visible group", () => {
+    const restored = buildRestoredProjectTabs(
+      {
+        tabs: [
+          { type: "assistant", id: "assistant", label: "Assistant" },
+          { type: "settings", id: "settings", label: "Settings" },
+          { type: "issues", id: "issues", label: "Issues" },
+        ],
+        activeTabId: "issues",
+        activeGroupId: "group-a",
+        groups: [
+          {
+            id: "group-a",
+            tabIds: ["assistant", "settings"],
+            activeTabId: "assistant",
+          },
+          {
+            id: "group-b",
+            tabIds: ["issues"],
+            activeTabId: "issues",
+          },
+        ],
+        root: {
+          type: "split",
+          id: "split-corrupt",
+          axis: "horizontal",
+          sizes: [0.5, 0.5],
+          children: [
+            { type: "group", groupId: "group-a" },
+            { type: "group", groupId: "missing-group" },
+          ],
+        },
+      },
+      [],
+    );
+
+    expect(restored.groups).toEqual([
+      {
+        id: "group-a",
+        tabIds: ["assistant", "settings", "issues"],
+        activeTabId: "issues",
+      },
+    ]);
+    expect(restored.root).toEqual({
+      type: "group",
+      groupId: "group-a",
+    });
+    expect(restored.activeGroupId).toBe("group-a");
+  });
+
   it("shouldRetryAgentTabRestore handles transient empty matches", () => {
     expect(shouldRetryAgentTabRestore(2, 0, 0)).toBe(true);
     expect(shouldRetryAgentTabRestore(2, 1, 0)).toBe(false);

--- a/gwt-gui/src/lib/agentTabsPersistence.test.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.test.ts
@@ -327,7 +327,8 @@ describe("agentTabsPersistence", () => {
     );
 
     expect(restored.tabs).toEqual([
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
       { id: "settings", label: "Settings", type: "settings" },
       {
         id: "agent-p1",
@@ -361,12 +362,13 @@ describe("agentTabsPersistence", () => {
       [makeTerminal("p1"), makeTerminal("p2")],
     );
 
-    expect(restored.tabs.length).toBe(4);
+    expect(restored.tabs.length).toBe(5);
     expect(restored.activeTabId).toBe("settings");
     expect(restored.terminalTabsToRespawn).toEqual([]);
     expect(restored.activeTerminalPaneIdToRespawn).toBeNull();
     expect(restored.tabs).toEqual([
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
       {
         id: "settings",
         label: "Settings",
@@ -401,7 +403,8 @@ describe("agentTabsPersistence", () => {
     );
 
     expect(restored.tabs).toEqual([
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
       {
         id: "agent-p1",
         label: "one",
@@ -432,7 +435,8 @@ describe("agentTabsPersistence", () => {
     );
 
     expect(restored.tabs).toEqual([
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
       {
         id: "agent-a-live",
         label: "feature-a",
@@ -493,7 +497,7 @@ describe("agentTabsPersistence", () => {
     expect(restored.groups).toEqual([
       {
         id: "group-a",
-        tabIds: ["assistant", "settings", "issues"],
+        tabIds: ["settings", "agentCanvas", "branchBrowser", "issues"],
         activeTabId: "issues",
       },
     ]);
@@ -851,7 +855,7 @@ describe("agentTabsPersistence", () => {
       },
       [],
     );
-    expect(restored.activeTabId).toBe("assistant");
+    expect(restored.activeTabId).toBe("agentCanvas");
   });
 
   it("buildRestoredProjectTabs deduplicates tabs by key", () => {

--- a/gwt-gui/src/lib/agentTabsPersistence.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.ts
@@ -21,6 +21,7 @@ export type StoredAgentTab = {
   paneId: string;
   label: string;
   branchName?: string;
+  worktreePath?: string;
   agentId?: Tab["agentId"];
 };
 
@@ -30,6 +31,7 @@ export type StoredTerminalTab = {
   label: string;
   cwd?: string;
   branchName?: string;
+  worktreePath?: string;
 };
 
 export type StoredStaticTab = {
@@ -172,6 +174,15 @@ function normalizeAgentId(value: unknown): Tab["agentId"] | undefined {
   return undefined;
 }
 
+function buildProjectStorageKey(
+  projectPath: string,
+  windowLabel?: string | null,
+): string {
+  const path = projectPath.trim();
+  const label = normalizeString(windowLabel);
+  return label ? `${path}::window=${label}` : path;
+}
+
 function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
   if (!raw || typeof raw !== "object") return null;
   const obj = raw as Record<string, unknown>;
@@ -182,12 +193,14 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
     if (!paneId) return null;
     const label = typeof obj.label === "string" ? obj.label : "";
     const branchName = normalizeString(obj.branchName);
+    const worktreePath = normalizeString(obj.worktreePath);
     const agentId = normalizeAgentId(obj.agentId);
     return {
       type: "agent",
       paneId,
       label,
       ...(branchName ? { branchName } : {}),
+      ...(worktreePath ? { worktreePath } : {}),
       ...(agentId ? { agentId } : {}),
     };
   }
@@ -198,12 +211,14 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
     const label = typeof obj.label === "string" ? obj.label : "";
     const cwd = typeof obj.cwd === "string" ? obj.cwd : undefined;
     const branchName = normalizeString(obj.branchName);
+    const worktreePath = normalizeString(obj.worktreePath);
     return {
       type: "terminal",
       paneId,
       label,
       ...(cwd ? { cwd } : {}),
       ...(branchName ? { branchName } : {}),
+      ...(worktreePath ? { worktreePath } : {}),
     };
   }
 
@@ -535,16 +550,19 @@ function loadStoredProjectTabsLegacy(
 export function loadStoredProjectTabs(
   projectPath: string,
   storage?: Storage | null,
+  windowLabel?: string | null,
 ): StoredProjectTabs | null {
   const store = getStorageSafe(storage);
   if (!store) return null;
 
-  const key = projectPath.trim();
-  if (!key) return null;
+  const baseKey = projectPath.trim();
+  if (!baseKey) return null;
+  const scopedKey = buildProjectStorageKey(baseKey, windowLabel);
 
   return (
-    loadStoredProjectTabsCurrent(key, store) ??
-    loadStoredProjectTabsLegacy(key, store)
+    loadStoredProjectTabsCurrent(scopedKey, store) ??
+    loadStoredProjectTabsCurrent(baseKey, store) ??
+    loadStoredProjectTabsLegacy(baseKey, store)
   );
 }
 
@@ -557,11 +575,12 @@ export function persistStoredProjectTabs(
   projectPath: string,
   state: StoredProjectTabs,
   storage?: Storage | null,
+  windowLabel?: string | null,
 ) {
   const store = getStorageSafe(storage);
   if (!store) return;
 
-  const key = projectPath.trim();
+  const key = buildProjectStorageKey(projectPath, windowLabel);
   if (!key) return;
 
   try {
@@ -620,11 +639,13 @@ export function buildRestoredProjectTabs(
         normalizeString(tab.branchName) ||
         normalizeString(terminal?.branch_name) ||
         normalizeString(tab.label);
+      const worktreePath = normalizeString(tab.worktreePath);
       const agentId = inferAgentId(terminal?.agent_name) ?? tab.agentId;
       restoredTabs.push({
         id: `agent-${tab.paneId}`,
         label: tab.label,
         ...(branchName ? { branchName } : {}),
+        ...(worktreePath ? { worktreePath } : {}),
         type: "agent",
         paneId: tab.paneId,
         ...(agentId ? { agentId } : {}),
@@ -645,6 +666,7 @@ export function buildRestoredProjectTabs(
           paneId: tab.paneId,
           ...(tab.cwd ? { cwd: tab.cwd } : {}),
           ...(tab.branchName ? { branchName: tab.branchName } : {}),
+          ...(tab.worktreePath ? { worktreePath: tab.worktreePath } : {}),
         });
       } else {
         terminalTabsToRespawn.push(tab);
@@ -808,8 +830,9 @@ function buildRestoredLayoutState(
 export function loadStoredProjectAgentTabs(
   projectPath: string,
   storage?: Storage | null,
+  windowLabel?: string | null,
 ): StoredProjectAgentTabs | null {
-  const stored = loadStoredProjectTabs(projectPath, storage);
+  const stored = loadStoredProjectTabs(projectPath, storage, windowLabel);
   if (!stored) return null;
 
   const tabs = stored.tabs
@@ -832,6 +855,7 @@ export function persistStoredProjectAgentTabs(
   projectPath: string,
   state: StoredProjectAgentTabs,
   storage?: Storage | null,
+  windowLabel?: string | null,
 ) {
   const agentTabs: StoredProjectTab[] = state.tabs
     .map((tab) => {
@@ -846,7 +870,7 @@ export function persistStoredProjectAgentTabs(
     })
     .filter((tab): tab is StoredAgentTab => tab !== null);
 
-  const existing = loadStoredProjectTabs(projectPath, storage);
+  const existing = loadStoredProjectTabs(projectPath, storage, windowLabel);
   const preservedTabs = (existing?.tabs ?? []).filter((tab) => tab.type !== "agent");
 
   const activePaneId = normalizeString(state.activePaneId ?? "");
@@ -867,6 +891,7 @@ export function persistStoredProjectAgentTabs(
         : {}),
     },
     storage,
+    windowLabel,
   );
 }
 

--- a/gwt-gui/src/lib/agentTabsPersistence.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.ts
@@ -29,6 +29,7 @@ export type StoredTerminalTab = {
   paneId: string;
   label: string;
   cwd?: string;
+  branchName?: string;
 };
 
 export type StoredStaticTab = {
@@ -196,11 +197,13 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
     if (!paneId) return null;
     const label = typeof obj.label === "string" ? obj.label : "";
     const cwd = typeof obj.cwd === "string" ? obj.cwd : undefined;
+    const branchName = normalizeString(obj.branchName);
     return {
       type: "terminal",
       paneId,
       label,
       ...(cwd ? { cwd } : {}),
+      ...(branchName ? { branchName } : {}),
     };
   }
 
@@ -641,6 +644,7 @@ export function buildRestoredProjectTabs(
           type: "terminal",
           paneId: tab.paneId,
           ...(tab.cwd ? { cwd: tab.cwd } : {}),
+          ...(tab.branchName ? { branchName: tab.branchName } : {}),
         });
       } else {
         terminalTabsToRespawn.push(tab);

--- a/gwt-gui/src/lib/agentTabsPersistence.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.ts
@@ -1,7 +1,11 @@
 import type { Tab, TerminalInfo } from "./types";
 import { inferAgentId } from "./agentUtils";
 import type { TabGroupState, TabLayoutNode } from "./tabLayout";
-import { createInitialTabLayout, flattenTabIdsByLayout } from "./tabLayout";
+import {
+  createInitialTabLayout,
+  flattenTabIdsByLayout,
+  normalizeTabLayoutState,
+} from "./tabLayout";
 
 /**
  * localStorage key used to persist tab state (per project path).
@@ -728,11 +732,14 @@ function buildRestoredLayoutState(
     Object.keys(nextGroups)[0] ||
     "";
 
-  return {
-    groups: nextGroups,
-    root,
-    activeGroupId: activeGroupIdRaw,
-  };
+  return normalizeTabLayoutState(
+    {
+      groups: nextGroups,
+      root,
+      activeGroupId: activeGroupIdRaw,
+    },
+    restoredActiveTabId,
+  );
 }
 
 export function loadStoredProjectAgentTabs(

--- a/gwt-gui/src/lib/agentTabsPersistence.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.ts
@@ -34,6 +34,8 @@ export type StoredTerminalTab = {
 export type StoredStaticTab = {
   type:
     | "assistant"
+    | "agentCanvas"
+    | "branchBrowser"
     | "settings"
     | "versionHistory"
     | "issues"
@@ -202,6 +204,8 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
 
   if (
     type === "assistant" ||
+    type === "agentCanvas" ||
+    type === "branchBrowser" ||
     type === "settings" ||
     type === "versionHistory" ||
     type === "issues" ||
@@ -209,10 +213,13 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
     type === "projectIndex" ||
     type === "issueSpec"
   ) {
-    const canonicalType = type === "assistant" ? "assistant" : type;
+    const canonicalType =
+      type === "assistant" ? "agentCanvas" : type;
     const fallbackId =
-      canonicalType === "assistant"
-        ? "assistant"
+      canonicalType === "agentCanvas"
+        ? "agentCanvas"
+        : canonicalType === "branchBrowser"
+          ? "branchBrowser"
         : canonicalType === "settings"
           ? "settings"
           : canonicalType === "issues"
@@ -225,8 +232,10 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
                   ? "issueSpec"
                   : "versionHistory";
     const fallbackLabel =
-      canonicalType === "assistant"
-        ? "Assistant"
+      canonicalType === "agentCanvas"
+        ? "Agent Canvas"
+        : canonicalType === "branchBrowser"
+          ? "Branch Browser"
         : canonicalType === "settings"
           ? "Settings"
           : canonicalType === "issues"
@@ -240,13 +249,13 @@ function parseStoredProjectTab(raw: unknown): StoredProjectTab | null {
                   : "Version History";
     const idRaw = normalizeString(obj.id);
     const id =
-      canonicalType === "assistant"
-        ? "assistant"
+      canonicalType === "agentCanvas"
+        ? "agentCanvas"
         : idRaw || fallbackId;
     const labelRaw = typeof obj.label === "string" ? obj.label.trim() : "";
     const label =
-      canonicalType === "assistant" && (type === "assistant" || !labelRaw)
-        ? "Assistant"
+      canonicalType === "agentCanvas" && (type === "assistant" || !labelRaw)
+        ? "Agent Canvas"
         : labelRaw || fallbackLabel;
     const issueNumber =
       canonicalType === "issueSpec" && Number.isFinite(Number(obj.issueNumber))

--- a/gwt-gui/src/lib/agentTabsPersistence.ts
+++ b/gwt-gui/src/lib/agentTabsPersistence.ts
@@ -58,6 +58,7 @@ export type StoredProjectTab =
 export type StoredProjectTabs = {
   tabs: StoredProjectTab[];
   activeTabId: string | null;
+  activeCanvasSessionTabId?: string | null;
   activeGroupId?: string | null;
   groups?: StoredTabGroup[];
   root?: StoredTabLayoutNode | null;
@@ -69,6 +70,7 @@ export type StoredProjectTabs = {
 export type BuildRestoredProjectTabsResult = {
   tabs: Tab[];
   activeTabId: string | null;
+  activeCanvasSessionTabId: string | null;
   activeGroupId: string | null;
   groups: StoredTabGroup[];
   root: StoredTabLayoutNode;
@@ -278,6 +280,21 @@ function tabStorageKey(tab: StoredProjectTab): string {
   return `id:${tab.id}`;
 }
 
+function isShellTabType(
+  type: StoredStaticTab["type"] | Tab["type"],
+): boolean {
+  return (
+    type === "agentCanvas" ||
+    type === "branchBrowser" ||
+    type === "settings" ||
+    type === "versionHistory" ||
+    type === "issues" ||
+    type === "prs" ||
+    type === "projectIndex" ||
+    type === "issueSpec"
+  );
+}
+
 function sanitizeProjectTabsEntry(rawEntry: unknown): StoredProjectTabs | null {
   if (!rawEntry || typeof rawEntry !== "object") return null;
   const entry = rawEntry as Record<string, unknown>;
@@ -295,6 +312,8 @@ function sanitizeProjectTabsEntry(rawEntry: unknown): StoredProjectTabs | null {
   }
 
   const activeTabId = normalizeString(entry.activeTabId) || null;
+  const activeCanvasSessionTabId =
+    normalizeString(entry.activeCanvasSessionTabId) || null;
   const groups = sanitizeStoredGroups(entry.groups, tabs.map(resolveStoredTabId));
   const root = sanitizeStoredRoot(entry.root, groups.map((group) => group.id));
   const activeGroupId = normalizeString(entry.activeGroupId) || null;
@@ -302,6 +321,7 @@ function sanitizeProjectTabsEntry(rawEntry: unknown): StoredProjectTabs | null {
   return {
     tabs,
     activeTabId,
+    ...(activeCanvasSessionTabId ? { activeCanvasSessionTabId } : {}),
     ...(groups.length > 0 ? { groups } : {}),
     ...(root ? { root } : {}),
     ...(activeGroupId ? { activeGroupId } : {}),
@@ -631,24 +651,53 @@ export function buildRestoredProjectTabs(
     const key = `id:${tab.id}`;
     if (seen.has(key)) continue;
     seen.add(key);
+    if (tab.type === "assistant") {
+      restoredTabs.push({
+        id: "agentCanvas",
+        label: "Agent Canvas",
+        type: "agentCanvas",
+      });
+      continue;
+    }
     restoredTabs.push({ id: tab.id, label: tab.label, type: tab.type });
   }
 
-  if (!restoredTabs.some((tab) => tab.id === "assistant")) {
+  if (!restoredTabs.some((tab) => tab.id === "agentCanvas")) {
     restoredTabs.unshift({
-      id: "assistant",
-      label: "Assistant",
-      type: "assistant",
+      id: "agentCanvas",
+      label: "Agent Canvas",
+      type: "agentCanvas",
+    });
+  }
+  if (!restoredTabs.some((tab) => tab.id === "branchBrowser")) {
+    restoredTabs.splice(1, 0, {
+      id: "branchBrowser",
+      label: "Branch Browser",
+      type: "branchBrowser",
     });
   }
 
   const restoredIds = new Set(restoredTabs.map((tab) => tab.id));
   const normalizedActiveTabId =
-    stored.activeTabId === "assistant" ? "assistant" : stored.activeTabId;
+    stored.activeTabId === "assistant" ? "agentCanvas" : stored.activeTabId;
+  const normalizedActiveCanvasSessionTabId =
+    normalizeString(stored.activeCanvasSessionTabId) ||
+    (normalizedActiveTabId &&
+    (normalizedActiveTabId.startsWith("agent-") ||
+      normalizedActiveTabId.startsWith("terminal-"))
+      ? normalizedActiveTabId
+      : null);
+  const activeCanvasSessionTabId =
+    normalizedActiveCanvasSessionTabId &&
+    restoredIds.has(normalizedActiveCanvasSessionTabId)
+      ? normalizedActiveCanvasSessionTabId
+      : null;
   const activeTabId =
     normalizedActiveTabId && restoredIds.has(normalizedActiveTabId)
       ? normalizedActiveTabId
-      : null;
+      : activeCanvasSessionTabId
+        ? "agentCanvas"
+        : null;
 
   const activeTerminalPaneId =
     stored.activeTabId && stored.activeTabId.startsWith("terminal-")
@@ -663,13 +712,14 @@ export function buildRestoredProjectTabs(
 
   const restoredLayout = buildRestoredLayoutState(
     stored,
-    restoredTabs,
+    restoredTabs.filter((tab) => isShellTabType(tab.type)),
     activeTabId,
   );
 
   return {
     tabs: restoredTabs,
     activeTabId,
+    activeCanvasSessionTabId,
     activeGroupId: restoredLayout.activeGroupId,
     groups: Object.values(restoredLayout.groups),
     root: restoredLayout.root as StoredTabLayoutNode,
@@ -808,6 +858,9 @@ export function persistStoredProjectAgentTabs(
     {
       tabs: [...preservedTabs, ...agentTabs],
       activeTabId,
+      ...(existing?.activeCanvasSessionTabId
+        ? { activeCanvasSessionTabId: existing.activeCanvasSessionTabId }
+        : {}),
     },
     storage,
   );

--- a/gwt-gui/src/lib/appTabs.test.ts
+++ b/gwt-gui/src/lib/appTabs.test.ts
@@ -7,27 +7,29 @@ import {
 import type { Tab } from "./types";
 
 describe("appTabs", () => {
-  it("uses Assistant as the only default tab", () => {
+  it("uses Agent Canvas and Branch Browser as the default top-level tabs", () => {
     expect(defaultAppTabs()).toEqual([
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
     ]);
   });
 
-  it("does not allow restoring active tab from removed summary tab", () => {
+  it("allows restoring shell-owned default tabs only", () => {
     expect(shouldAllowRestoredActiveTab("summary")).toBe(false);
-    expect(shouldAllowRestoredActiveTab("assistant")).toBe(true);
+    expect(shouldAllowRestoredActiveTab("agentCanvas")).toBe(true);
+    expect(shouldAllowRestoredActiveTab("branchBrowser")).toBe(true);
     expect(shouldAllowRestoredActiveTab("legacyMode")).toBe(false);
   });
 
   it("moves dragged tab before target tab", () => {
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
       { id: "versionHistory", label: "Version History", type: "versionHistory" },
     ];
 
     expect(reorderTabsByDrop(tabs, "versionHistory", "settings", "before")).toEqual([
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "versionHistory", label: "Version History", type: "versionHistory" },
       { id: "settings", label: "Settings", type: "settings" },
     ]);
@@ -35,21 +37,21 @@ describe("appTabs", () => {
 
   it("moves dragged tab after target tab", () => {
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
       { id: "versionHistory", label: "Version History", type: "versionHistory" },
     ];
 
-    expect(reorderTabsByDrop(tabs, "assistant", "versionHistory", "after")).toEqual([
+    expect(reorderTabsByDrop(tabs, "agentCanvas", "versionHistory", "after")).toEqual([
       { id: "settings", label: "Settings", type: "settings" },
       { id: "versionHistory", label: "Version History", type: "versionHistory" },
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
     ]);
   });
 
   it("returns the original array when no reorder is needed", () => {
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
       { id: "versionHistory", label: "Version History", type: "versionHistory" },
     ];
@@ -61,7 +63,7 @@ describe("appTabs", () => {
 
   it("returns original array when overTabId not found", () => {
     const tabs: Tab[] = [
-      { id: "a", label: "A", type: "assistant" },
+      { id: "a", label: "A", type: "agentCanvas" },
       { id: "b", label: "B", type: "settings" },
     ];
     expect(reorderTabsByDrop(tabs, "a", "missing", "before")).toBe(tabs);
@@ -69,7 +71,7 @@ describe("appTabs", () => {
 
   it("returns original array when dragTabId not found", () => {
     const tabs: Tab[] = [
-      { id: "a", label: "A", type: "assistant" },
+      { id: "a", label: "A", type: "agentCanvas" },
       { id: "b", label: "B", type: "settings" },
     ];
     expect(reorderTabsByDrop(tabs, "missing", "b", "before")).toBe(tabs);

--- a/gwt-gui/src/lib/appTabs.ts
+++ b/gwt-gui/src/lib/appTabs.ts
@@ -1,7 +1,8 @@
 import type { Tab } from "./types";
 
 const DEFAULT_APP_TABS: Tab[] = [
-  { id: "assistant", label: "Assistant", type: "assistant" },
+  { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+  { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
 ];
 export type TabDropPosition = "before" | "after";
 
@@ -10,7 +11,7 @@ export function defaultAppTabs(): Tab[] {
 }
 
 export function shouldAllowRestoredActiveTab(activeTabId: string): boolean {
-  return activeTabId === "assistant";
+  return activeTabId === "agentCanvas" || activeTabId === "branchBrowser";
 }
 
 export function reorderTabsByDrop(

--- a/gwt-gui/src/lib/branchInventory.test.ts
+++ b/gwt-gui/src/lib/branchInventory.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { branchInventoryKey } from "./branchInventory";
+
+describe("branchInventory", () => {
+  it("normalizes remote refs to canonical keys", () => {
+    expect(branchInventoryKey("origin/feature/demo")).toBe("feature/demo");
+  });
+
+  it("keeps local refs unchanged", () => {
+    expect(branchInventoryKey("feature/demo")).toBe("feature/demo");
+  });
+});

--- a/gwt-gui/src/lib/branchInventory.ts
+++ b/gwt-gui/src/lib/branchInventory.ts
@@ -1,0 +1,105 @@
+import type { BranchInfo, BranchInventoryEntry, BranchInventoryResolutionAction, WorktreeInfo } from "./types";
+import type { SidebarFilterType } from "./components/sidebarHelpers";
+import { stripRemotePrefix } from "./components/sidebarHelpers";
+
+export function branchInventoryKey(name: string): string {
+  const trimmed = name.trim();
+  return trimmed.startsWith("origin/") ? stripRemotePrefix(trimmed) : trimmed;
+}
+
+function buildInventoryEntry(
+  key: string,
+  localBranch: BranchInfo | null,
+  remoteBranch: BranchInfo | null,
+  worktrees: WorktreeInfo[],
+): BranchInventoryEntry {
+  const worktree = worktrees[0] ?? null;
+  const worktreeCount = worktrees.length;
+  let resolutionAction: BranchInventoryResolutionAction = "createWorktree";
+  if (worktreeCount > 1) {
+    resolutionAction = "resolveAmbiguity";
+  } else if (worktree) {
+    resolutionAction = "focusExisting";
+  }
+
+  return {
+    id: key,
+    canonical_name: key,
+    primary_branch: localBranch ?? remoteBranch ?? {
+      name: key,
+      commit: "",
+      is_current: false,
+      is_agent_running: false,
+      agent_status: "unknown",
+      ahead: 0,
+      behind: 0,
+      divergence_status: "UpToDate",
+      commit_timestamp: null,
+      last_tool_usage: null,
+    },
+    local_branch: localBranch,
+    remote_branch: remoteBranch,
+    has_local: Boolean(localBranch),
+    has_remote: Boolean(remoteBranch),
+    worktree,
+    worktree_count: worktreeCount,
+    resolution_action: resolutionAction,
+  };
+}
+
+export function buildBranchInventoryEntries(
+  local: BranchInfo[],
+  remote: BranchInfo[],
+  worktrees: WorktreeInfo[],
+  filter: SidebarFilterType,
+): BranchInventoryEntry[] {
+  const localByKey = new Map(local.map((branch) => [branchInventoryKey(branch.name), branch]));
+  const remoteByKey = new Map(remote.map((branch) => [branchInventoryKey(branch.name), branch]));
+  const worktreesByKey = new Map<string, WorktreeInfo[]>();
+  for (const worktree of worktrees) {
+    const key = branchInventoryKey(worktree.branch ?? "");
+    if (!key) continue;
+    const existing = worktreesByKey.get(key) ?? [];
+    worktreesByKey.set(key, [...existing, worktree]);
+  }
+
+  if (filter === "Local") {
+    return local.map((branch) =>
+      buildInventoryEntry(
+        branchInventoryKey(branch.name),
+        branch,
+        remoteByKey.get(branchInventoryKey(branch.name)) ?? null,
+        worktreesByKey.get(branchInventoryKey(branch.name)) ?? [],
+      ),
+    );
+  }
+
+  if (filter === "Remote") {
+    return remote.map((branch) =>
+      buildInventoryEntry(
+        branchInventoryKey(branch.name),
+        localByKey.get(branchInventoryKey(branch.name)) ?? null,
+        branch,
+        worktreesByKey.get(branchInventoryKey(branch.name)) ?? [],
+      ),
+    );
+  }
+
+  const keys = new Set([
+    ...local.map((branch) => branchInventoryKey(branch.name)),
+    ...remote.map((branch) => branchInventoryKey(branch.name)),
+  ]);
+
+  return Array.from(keys).map((key) =>
+    buildInventoryEntry(
+      key,
+      localByKey.get(key) ?? null,
+      remoteByKey.get(key) ?? null,
+      worktreesByKey.get(key) ?? [],
+    ),
+  );
+}
+
+export function resolveBranchInventoryAction(entry: BranchInventoryEntry): BranchInventoryResolutionAction {
+  return entry.resolution_action;
+}

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
@@ -36,6 +36,7 @@
   let sessionCards = $derived(
     tabs.filter((tab) => tab.type === "agent" || tab.type === "terminal"),
   );
+  let worktreeDetailsOpen = $state(false);
 </script>
 
 <div class="agent-canvas">
@@ -48,7 +49,12 @@
   </div>
 
   <div class="canvas-grid">
-    <section class="canvas-card worktree-card" data-testid="agent-canvas-worktree-card">
+    <button
+      type="button"
+      class="canvas-card worktree-card"
+      data-testid="agent-canvas-worktree-card"
+      onclick={() => (worktreeDetailsOpen = true)}
+    >
       <div class="card-header">
         <span class="card-kind">Worktree</span>
         <span class="card-title">{currentBranch || "Project Root"}</span>
@@ -56,7 +62,7 @@
       <p class="card-copy">
         Worktree cards will become the parent nodes for agent and terminal sessions.
       </p>
-    </section>
+    </button>
 
     <section class="canvas-card assistant-card" data-testid="agent-canvas-assistant-card">
       <div class="card-header">
@@ -110,6 +116,53 @@
       </button>
     {/each}
   </div>
+
+  {#if worktreeDetailsOpen}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="worktree-overlay"
+      data-testid="agent-canvas-worktree-overlay"
+      onclick={() => (worktreeDetailsOpen = false)}
+    >
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="worktree-dialog"
+        data-testid="agent-canvas-worktree-dialog"
+        role="dialog"
+        aria-modal="true"
+        tabindex="0"
+        onclick={(event) => event.stopPropagation()}
+      >
+        <div class="card-header">
+          <span class="card-kind">Worktree</span>
+          <span class="card-title">{currentBranch || "Project Root"}</span>
+        </div>
+        <div class="dialog-body">
+          <div class="detail-row">
+            <span class="detail-label">Project</span>
+            <span class="detail-value">{projectPath}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Branch</span>
+            <span class="detail-value">{currentBranch || "Project Root"}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Sessions</span>
+            <span class="detail-value">{sessionCards.length}</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="dialog-close"
+          onclick={() => (worktreeDetailsOpen = false)}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -170,6 +223,10 @@
 
   .worktree-card {
     grid-column: 1;
+    cursor: pointer;
+    padding: 0;
+    text-align: left;
+    font: inherit;
   }
 
   .assistant-card {
@@ -259,6 +316,57 @@
     margin: 0;
     padding: 14px;
     color: var(--text-secondary);
+  }
+
+  .worktree-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.46);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+
+  .worktree-dialog {
+    width: min(560px, calc(100vw - 32px));
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+    background: color-mix(in srgb, var(--bg-secondary) 85%, var(--bg-primary));
+    box-shadow: 0 22px 44px rgba(0, 0, 0, 0.24);
+  }
+
+  .dialog-body {
+    display: grid;
+    gap: 12px;
+    padding: 16px;
+  }
+
+  .detail-row {
+    display: grid;
+    gap: 4px;
+  }
+
+  .detail-label {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .detail-value {
+    word-break: break-all;
+  }
+
+  .dialog-close {
+    margin: 0 16px 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 8px 14px;
+    background: transparent;
+    color: var(--text-primary);
+    cursor: pointer;
   }
 
   .session-placeholder {

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Tab } from "../types";
+  import type { Tab, WorktreeInfo } from "../types";
   import AssistantPanel from "./AssistantPanel.svelte";
   import TerminalView from "../terminal/TerminalView.svelte";
 
@@ -7,6 +7,9 @@
     projectPath,
     currentBranch = "",
     tabs,
+    worktrees = [],
+    selectedWorktreeBranch = null,
+    onWorktreeSelect = () => {},
     selectedSessionTabId = null,
     onSessionSelect = () => {},
     onOpenSettings,
@@ -21,6 +24,9 @@
     projectPath: string;
     currentBranch?: string;
     tabs: Tab[];
+    worktrees?: WorktreeInfo[];
+    selectedWorktreeBranch?: string | null;
+    onWorktreeSelect?: (branchName: string) => void;
     selectedSessionTabId?: string | null;
     onSessionSelect?: (tabId: string) => void;
     onOpenSettings?: () => void;
@@ -37,6 +43,53 @@
     tabs.filter((tab) => tab.type === "agent" || tab.type === "terminal"),
   );
   let worktreeDetailsOpen = $state(false);
+  let popupWorktreeBranch = $state<string | null>(null);
+  let canvasWorktrees = $derived(
+    worktrees.length > 0
+      ? worktrees
+      : [
+          {
+            path: projectPath,
+            branch: currentBranch || "Project Root",
+            commit: "",
+            status: "active",
+            is_main: false,
+            has_changes: false,
+            has_unpushed: false,
+            is_current: true,
+            is_protected: false,
+            is_agent_running: false,
+            agent_status: "unknown",
+            ahead: 0,
+            behind: 0,
+            is_gone: false,
+            last_tool_usage: null,
+            safety_level: "safe",
+          } satisfies WorktreeInfo,
+        ],
+  );
+  let popupWorktree = $derived(
+    popupWorktreeBranch
+      ? canvasWorktrees.find((worktree) => worktree.branch === popupWorktreeBranch) ?? null
+      : null,
+  );
+
+  function sessionBelongsToWorktree(tab: Tab, worktree: WorktreeInfo): boolean {
+    const worktreeBranch = (worktree.branch ?? "").trim();
+    const tabBranch = (tab.branchName ?? "").trim();
+    if (worktreeBranch && tabBranch) {
+      return worktreeBranch === tabBranch;
+    }
+    if (worktree.is_current && !tabBranch) {
+      return true;
+    }
+    return false;
+  }
+
+  function worktreeCardTestId(worktree: WorktreeInfo): string {
+    const raw = worktree.branch ?? "project-root";
+    return `agent-canvas-worktree-card-${raw.replace(/[^a-zA-Z0-9_-]+/g, "-")}`;
+  }
 </script>
 
 <div class="agent-canvas">
@@ -45,25 +98,10 @@
       <h2>Agent Canvas</h2>
       <p>Canvas cards replace the old assistant and session tabs.</p>
     </div>
-    <div class="toolbar-chip">Cards: {sessionCards.length + 2}</div>
+    <div class="toolbar-chip">Cards: {sessionCards.length + canvasWorktrees.length + 1}</div>
   </div>
 
   <div class="canvas-grid">
-    <button
-      type="button"
-      class="canvas-card worktree-card"
-      data-testid="agent-canvas-worktree-card"
-      onclick={() => (worktreeDetailsOpen = true)}
-    >
-      <div class="card-header">
-        <span class="card-kind">Worktree</span>
-        <span class="card-title">{currentBranch || "Project Root"}</span>
-      </div>
-      <p class="card-copy">
-        Worktree cards will become the parent nodes for agent and terminal sessions.
-      </p>
-    </button>
-
     <section class="canvas-card assistant-card" data-testid="agent-canvas-assistant-card">
       <div class="card-header">
         <span class="card-kind">Assistant</span>
@@ -78,42 +116,66 @@
       </div>
     </section>
 
-    {#each sessionCards as tab (tab.id)}
+    {#each canvasWorktrees as worktree ((worktree.branch ?? worktree.path))}
       <button
-        class="canvas-card session-card"
-        class:agent-session={tab.type === "agent"}
-        class:terminal-session={tab.type === "terminal"}
-        class:selected={selectedSessionTabId === tab.id}
-        data-testid={`agent-canvas-session-${tab.id}`}
         type="button"
-        onclick={() => onSessionSelect(tab.id)}
+        class="canvas-card worktree-card"
+        class:selected={selectedWorktreeBranch === worktree.branch}
+        data-testid={worktreeCardTestId(worktree)}
+        onclick={() => {
+          if (worktree.branch) {
+            onWorktreeSelect(worktree.branch);
+            popupWorktreeBranch = worktree.branch;
+          }
+          worktreeDetailsOpen = true;
+        }}
       >
-        <span class="session-edge" aria-hidden="true"></span>
         <div class="card-header">
-          <span class="card-kind">{tab.type === "agent" ? "Agent" : "Terminal"}</span>
-          <span class="card-title">{tab.label}</span>
+          <span class="card-kind">Worktree</span>
+          <span class="card-title">{worktree.branch || "Project Root"}</span>
         </div>
-        <div class="card-body">
-          {#if tab.paneId}
-            <TerminalView
-              paneId={tab.paneId}
-              active={true}
-              agentId={tab.type === "agent" ? tab.agentId ?? null : null}
-              {voiceInputEnabled}
-              {voiceInputListening}
-              {voiceInputPreparing}
-              {voiceInputSupported}
-              {voiceInputAvailable}
-              {voiceInputAvailabilityReason}
-              {voiceInputError}
-            />
-          {:else}
-            <div class="session-placeholder">
-              {tab.type === "agent" ? "Agent starting..." : "Terminal starting..."}
-            </div>
-          {/if}
-        </div>
+        <p class="card-copy">
+          {worktree.path}
+        </p>
       </button>
+
+      {#each sessionCards.filter((tab) => sessionBelongsToWorktree(tab, worktree)) as tab (tab.id)}
+        <button
+          class="canvas-card session-card"
+          class:agent-session={tab.type === "agent"}
+          class:terminal-session={tab.type === "terminal"}
+          class:selected={selectedSessionTabId === tab.id}
+          data-testid={`agent-canvas-session-${tab.id}`}
+          type="button"
+          onclick={() => onSessionSelect(tab.id)}
+        >
+          <span class="session-edge" aria-hidden="true"></span>
+          <div class="card-header">
+            <span class="card-kind">{tab.type === "agent" ? "Agent" : "Terminal"}</span>
+            <span class="card-title">{tab.label}</span>
+          </div>
+          <div class="card-body">
+            {#if tab.paneId}
+              <TerminalView
+                paneId={tab.paneId}
+                active={true}
+                agentId={tab.type === "agent" ? tab.agentId ?? null : null}
+                {voiceInputEnabled}
+                {voiceInputListening}
+                {voiceInputPreparing}
+                {voiceInputSupported}
+                {voiceInputAvailable}
+                {voiceInputAvailabilityReason}
+                {voiceInputError}
+              />
+            {:else}
+              <div class="session-placeholder">
+                {tab.type === "agent" ? "Agent starting..." : "Terminal starting..."}
+              </div>
+            {/if}
+          </div>
+        </button>
+      {/each}
     {/each}
   </div>
 
@@ -137,7 +199,7 @@
       >
         <div class="card-header">
           <span class="card-kind">Worktree</span>
-          <span class="card-title">{currentBranch || "Project Root"}</span>
+          <span class="card-title">{popupWorktree?.branch || currentBranch || "Project Root"}</span>
         </div>
         <div class="dialog-body">
           <div class="detail-row">
@@ -146,11 +208,15 @@
           </div>
           <div class="detail-row">
             <span class="detail-label">Branch</span>
-            <span class="detail-value">{currentBranch || "Project Root"}</span>
+            <span class="detail-value">{popupWorktree?.branch || currentBranch || "Project Root"}</span>
           </div>
           <div class="detail-row">
             <span class="detail-label">Sessions</span>
-            <span class="detail-value">{sessionCards.length}</span>
+            <span class="detail-value">{sessionCards.filter((tab) => popupWorktree ? sessionBelongsToWorktree(tab, popupWorktree) : true).length}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Worktree Path</span>
+            <span class="detail-value">{popupWorktree?.path || projectPath}</span>
           </div>
         </div>
         <button

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
@@ -7,6 +7,8 @@
     projectPath,
     currentBranch = "",
     tabs,
+    selectedSessionTabId = null,
+    onSessionSelect = () => {},
     onOpenSettings,
     voiceInputEnabled = false,
     voiceInputListening = false,
@@ -19,6 +21,8 @@
     projectPath: string;
     currentBranch?: string;
     tabs: Tab[];
+    selectedSessionTabId?: string | null;
+    onSessionSelect?: (tabId: string) => void;
     onOpenSettings?: () => void;
     voiceInputEnabled?: boolean;
     voiceInputListening?: boolean;
@@ -69,11 +73,14 @@
     </section>
 
     {#each sessionCards as tab (tab.id)}
-      <section
+      <button
         class="canvas-card session-card"
         class:agent-session={tab.type === "agent"}
         class:terminal-session={tab.type === "terminal"}
+        class:selected={selectedSessionTabId === tab.id}
         data-testid={`agent-canvas-session-${tab.id}`}
+        type="button"
+        onclick={() => onSessionSelect(tab.id)}
       >
         <span class="session-edge" aria-hidden="true"></span>
         <div class="card-header">
@@ -100,7 +107,7 @@
             </div>
           {/if}
         </div>
-      </section>
+      </button>
     {/each}
   </div>
 </div>
@@ -173,6 +180,17 @@
   .session-card {
     grid-column: 2;
     min-height: 280px;
+    cursor: pointer;
+    padding: 0;
+    text-align: left;
+    font: inherit;
+  }
+
+  .session-card.selected {
+    border-color: color-mix(in srgb, var(--accent) 58%, var(--border-color));
+    box-shadow:
+      0 14px 28px rgba(0, 0, 0, 0.16),
+      0 0 0 1px color-mix(in srgb, var(--accent) 36%, transparent);
   }
 
   .session-edge {

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Tab, WorktreeInfo } from "../types";
+  import { buildAgentCanvasGraph } from "../agentCanvas";
   import AssistantPanel from "./AssistantPanel.svelte";
   import TerminalView from "../terminal/TerminalView.svelte";
 
@@ -39,52 +40,16 @@
     voiceInputError?: string | null;
   } = $props();
 
-  let sessionCards = $derived(
-    tabs.filter((tab) => tab.type === "agent" || tab.type === "terminal"),
-  );
+  let graph = $derived(buildAgentCanvasGraph(projectPath, currentBranch, tabs, worktrees));
+  let sessionCards = $derived(graph.sessionCards.map((card) => card.tab));
   let worktreeDetailsOpen = $state(false);
   let popupWorktreeBranch = $state<string | null>(null);
-  let canvasWorktrees = $derived(
-    worktrees.length > 0
-      ? worktrees
-      : [
-          {
-            path: projectPath,
-            branch: currentBranch || "Project Root",
-            commit: "",
-            status: "active",
-            is_main: false,
-            has_changes: false,
-            has_unpushed: false,
-            is_current: true,
-            is_protected: false,
-            is_agent_running: false,
-            agent_status: "unknown",
-            ahead: 0,
-            behind: 0,
-            is_gone: false,
-            last_tool_usage: null,
-            safety_level: "safe",
-          } satisfies WorktreeInfo,
-        ],
-  );
+  let canvasWorktrees = $derived(graph.worktrees);
   let popupWorktree = $derived(
     popupWorktreeBranch
       ? canvasWorktrees.find((worktree) => worktree.branch === popupWorktreeBranch) ?? null
       : null,
   );
-
-  function sessionBelongsToWorktree(tab: Tab, worktree: WorktreeInfo): boolean {
-    const worktreeBranch = (worktree.branch ?? "").trim();
-    const tabBranch = (tab.branchName ?? "").trim();
-    if (worktreeBranch && tabBranch) {
-      return worktreeBranch === tabBranch;
-    }
-    if (worktree.is_current && !tabBranch) {
-      return true;
-    }
-    return false;
-  }
 
   function worktreeCardTestId(worktree: WorktreeInfo): string {
     const raw = worktree.branch ?? "project-root";
@@ -139,27 +104,31 @@
         </p>
       </button>
 
-      {#each sessionCards.filter((tab) => sessionBelongsToWorktree(tab, worktree)) as tab (tab.id)}
+      {#each graph.sessionCards.filter((card) => card.worktreeCardId === `worktree:${worktree.path}`) as card (card.id)}
         <button
           class="canvas-card session-card"
-          class:agent-session={tab.type === "agent"}
-          class:terminal-session={tab.type === "terminal"}
-          class:selected={selectedSessionTabId === tab.id}
-          data-testid={`agent-canvas-session-${tab.id}`}
+          class:agent-session={card.tab.type === "agent"}
+          class:terminal-session={card.tab.type === "terminal"}
+          class:selected={selectedSessionTabId === card.tab.id}
+          data-testid={`agent-canvas-session-${card.tab.id}`}
           type="button"
-          onclick={() => onSessionSelect(tab.id)}
+          onclick={() => onSessionSelect(card.tab.id)}
         >
-          <span class="session-edge" aria-hidden="true"></span>
+          <span
+            class="session-edge"
+            aria-hidden="true"
+            data-testid={`agent-canvas-edge-${card.id.replace(/[^a-zA-Z0-9_-]+/g, "-")}`}
+          ></span>
           <div class="card-header">
-            <span class="card-kind">{tab.type === "agent" ? "Agent" : "Terminal"}</span>
-            <span class="card-title">{tab.label}</span>
+            <span class="card-kind">{card.tab.type === "agent" ? "Agent" : "Terminal"}</span>
+            <span class="card-title">{card.tab.label}</span>
           </div>
           <div class="card-body">
-            {#if tab.paneId}
+            {#if card.tab.paneId}
               <TerminalView
-                paneId={tab.paneId}
+                paneId={card.tab.paneId}
                 active={true}
-                agentId={tab.type === "agent" ? tab.agentId ?? null : null}
+                agentId={card.tab.type === "agent" ? card.tab.agentId ?? null : null}
                 {voiceInputEnabled}
                 {voiceInputListening}
                 {voiceInputPreparing}
@@ -170,7 +139,7 @@
               />
             {:else}
               <div class="session-placeholder">
-                {tab.type === "agent" ? "Agent starting..." : "Terminal starting..."}
+                {card.tab.type === "agent" ? "Agent starting..." : "Terminal starting..."}
               </div>
             {/if}
           </div>
@@ -212,7 +181,7 @@
           </div>
           <div class="detail-row">
             <span class="detail-label">Sessions</span>
-            <span class="detail-value">{sessionCards.filter((tab) => popupWorktree ? sessionBelongsToWorktree(tab, popupWorktree) : true).length}</span>
+            <span class="detail-value">{graph.sessionCards.filter((card) => popupWorktree ? card.worktreeCardId === `worktree:${popupWorktree.path}` : true).length}</span>
           </div>
           <div class="detail-row">
             <span class="detail-label">Worktree Path</span>

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+  import type { Tab } from "../types";
+  import AssistantPanel from "./AssistantPanel.svelte";
+  import TerminalView from "../terminal/TerminalView.svelte";
+
+  let {
+    projectPath,
+    currentBranch = "",
+    tabs,
+    onOpenSettings,
+    voiceInputEnabled = false,
+    voiceInputListening = false,
+    voiceInputPreparing = false,
+    voiceInputSupported = true,
+    voiceInputAvailable = false,
+    voiceInputAvailabilityReason = null,
+    voiceInputError = null,
+  }: {
+    projectPath: string;
+    currentBranch?: string;
+    tabs: Tab[];
+    onOpenSettings?: () => void;
+    voiceInputEnabled?: boolean;
+    voiceInputListening?: boolean;
+    voiceInputPreparing?: boolean;
+    voiceInputSupported?: boolean;
+    voiceInputAvailable?: boolean;
+    voiceInputAvailabilityReason?: string | null;
+    voiceInputError?: string | null;
+  } = $props();
+
+  let sessionCards = $derived(
+    tabs.filter((tab) => tab.type === "agent" || tab.type === "terminal"),
+  );
+</script>
+
+<div class="agent-canvas">
+  <div class="canvas-toolbar">
+    <div>
+      <h2>Agent Canvas</h2>
+      <p>Canvas cards replace the old assistant and session tabs.</p>
+    </div>
+    <div class="toolbar-chip">Cards: {sessionCards.length + 2}</div>
+  </div>
+
+  <div class="canvas-grid">
+    <section class="canvas-card worktree-card" data-testid="agent-canvas-worktree-card">
+      <div class="card-header">
+        <span class="card-kind">Worktree</span>
+        <span class="card-title">{currentBranch || "Project Root"}</span>
+      </div>
+      <p class="card-copy">
+        Worktree cards will become the parent nodes for agent and terminal sessions.
+      </p>
+    </section>
+
+    <section class="canvas-card assistant-card" data-testid="agent-canvas-assistant-card">
+      <div class="card-header">
+        <span class="card-kind">Assistant</span>
+        <span class="card-title">Assistant</span>
+      </div>
+      <div class="card-body assistant-body">
+        <AssistantPanel
+          isActive={true}
+          {projectPath}
+          onOpenSettings={onOpenSettings ?? (() => {})}
+        />
+      </div>
+    </section>
+
+    {#each sessionCards as tab (tab.id)}
+      <section
+        class="canvas-card session-card"
+        class:agent-session={tab.type === "agent"}
+        class:terminal-session={tab.type === "terminal"}
+        data-testid={`agent-canvas-session-${tab.id}`}
+      >
+        <span class="session-edge" aria-hidden="true"></span>
+        <div class="card-header">
+          <span class="card-kind">{tab.type === "agent" ? "Agent" : "Terminal"}</span>
+          <span class="card-title">{tab.label}</span>
+        </div>
+        <div class="card-body">
+          {#if tab.paneId}
+            <TerminalView
+              paneId={tab.paneId}
+              active={true}
+              agentId={tab.type === "agent" ? tab.agentId ?? null : null}
+              {voiceInputEnabled}
+              {voiceInputListening}
+              {voiceInputPreparing}
+              {voiceInputSupported}
+              {voiceInputAvailable}
+              {voiceInputAvailabilityReason}
+              {voiceInputError}
+            />
+          {:else}
+            <div class="session-placeholder">
+              {tab.type === "agent" ? "Agent starting..." : "Terminal starting..."}
+            </div>
+          {/if}
+        </div>
+      </section>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .agent-canvas {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px 18px 18px;
+    background:
+      radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 10%, transparent), transparent 28%),
+      linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 88%, transparent), var(--bg-primary));
+    overflow: auto;
+  }
+
+  .canvas-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .canvas-toolbar h2 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .canvas-toolbar p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+  }
+
+  .toolbar-chip {
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 6px 10px;
+    color: var(--text-secondary);
+    background: color-mix(in srgb, var(--bg-secondary) 75%, transparent);
+  }
+
+  .canvas-grid {
+    display: grid;
+    grid-template-columns: minmax(240px, 300px) minmax(340px, 1fr);
+    gap: 18px 22px;
+    align-items: start;
+  }
+
+  .canvas-card {
+    position: relative;
+    min-width: 0;
+    min-height: 180px;
+    border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+    background: color-mix(in srgb, var(--bg-secondary) 80%, var(--bg-primary));
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.16);
+    border-radius: 16px;
+    overflow: hidden;
+  }
+
+  .worktree-card {
+    grid-column: 1;
+  }
+
+  .assistant-card {
+    grid-column: 2;
+    min-height: 420px;
+  }
+
+  .session-card {
+    grid-column: 2;
+    min-height: 280px;
+  }
+
+  .session-edge {
+    position: absolute;
+    left: -22px;
+    top: 50%;
+    width: 22px;
+    height: 2px;
+    background: color-mix(in srgb, var(--accent) 58%, var(--border-color));
+  }
+
+  .session-edge::before {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: -9px;
+    width: 10px;
+    height: 20px;
+    border-left: 2px solid color-mix(in srgb, var(--accent) 58%, var(--border-color));
+    border-top: 2px solid color-mix(in srgb, var(--accent) 58%, var(--border-color));
+    border-bottom: 2px solid color-mix(in srgb, var(--accent) 58%, var(--border-color));
+    border-radius: 10px 0 0 10px;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+    background: color-mix(in srgb, var(--bg-primary) 65%, transparent);
+  }
+
+  .card-kind {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 76px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .card-title {
+    font-weight: 600;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .card-body {
+    min-height: 0;
+    height: calc(100% - 49px);
+  }
+
+  .assistant-body {
+    height: calc(100% - 49px);
+  }
+
+  .card-copy {
+    margin: 0;
+    padding: 14px;
+    color: var(--text-secondary);
+  }
+
+  .session-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 1100px) {
+    .canvas-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .worktree-card,
+    .assistant-card,
+    .session-card {
+      grid-column: 1;
+    }
+
+    .session-edge {
+      display: none;
+    }
+  }
+</style>

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.test.ts
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import AgentCanvasPanel from "./AgentCanvasPanel.svelte";
+import type { Tab } from "../types";
+
+describe("AgentCanvasPanel", () => {
+  it("opens worktree details from the worktree card", async () => {
+    const tabs: Tab[] = [
+      { id: "agent-1", label: "Agent One", type: "agent" },
+      { id: "terminal-1", label: "Shell", type: "terminal" },
+    ];
+
+    const rendered = render(AgentCanvasPanel, {
+      props: {
+        projectPath: "/tmp/project",
+        currentBranch: "feature/canvas",
+        tabs,
+      },
+    });
+
+    expect(rendered.queryByTestId("agent-canvas-worktree-dialog")).toBeNull();
+    await fireEvent.click(rendered.getByTestId("agent-canvas-worktree-card"));
+
+    const dialog = rendered.getByTestId("agent-canvas-worktree-dialog");
+    expect(dialog.textContent).toContain("/tmp/project");
+    expect(dialog.textContent).toContain("feature/canvas");
+    expect(dialog.textContent).toContain("2");
+  });
+});

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.test.ts
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.test.ts
@@ -1,13 +1,45 @@
 import { describe, expect, it } from "vitest";
 import { fireEvent, render } from "@testing-library/svelte";
 import AgentCanvasPanel from "./AgentCanvasPanel.svelte";
-import type { Tab } from "../types";
+import type { Tab, WorktreeInfo } from "../types";
 
 describe("AgentCanvasPanel", () => {
   it("opens worktree details from the worktree card", async () => {
     const tabs: Tab[] = [
-      { id: "agent-1", label: "Agent One", type: "agent" },
-      { id: "terminal-1", label: "Shell", type: "terminal" },
+      {
+        id: "agent-1",
+        label: "Agent One",
+        type: "agent",
+        branchName: "feature/canvas",
+        worktreePath: "/tmp/project/.gwt/worktrees/feature-canvas",
+      },
+      {
+        id: "terminal-1",
+        label: "Shell",
+        type: "terminal",
+        branchName: "feature/canvas",
+        worktreePath: "/tmp/project/.gwt/worktrees/feature-canvas",
+      },
+    ];
+    const worktrees: WorktreeInfo[] = [
+      {
+        path: "/tmp/project/.gwt/worktrees/feature-canvas",
+        branch: "feature/canvas",
+        commit: "abc123",
+        status: "active",
+        is_main: false,
+        has_changes: false,
+        has_unpushed: false,
+        is_current: true,
+        is_protected: false,
+        is_agent_running: false,
+        agent_status: "unknown",
+        ahead: 0,
+        behind: 0,
+        is_gone: false,
+        last_tool_usage: null,
+        safety_level: "safe",
+      },
     ];
 
     const rendered = render(AgentCanvasPanel, {
@@ -15,6 +47,7 @@ describe("AgentCanvasPanel", () => {
         projectPath: "/tmp/project",
         currentBranch: "feature/canvas",
         tabs,
+        worktrees,
       },
     });
 
@@ -29,5 +62,6 @@ describe("AgentCanvasPanel", () => {
     expect(dialog.textContent).toContain("/tmp/project");
     expect(dialog.textContent).toContain("feature/canvas");
     expect(dialog.textContent).toContain("2");
+    expect(rendered.getByTestId("agent-canvas-edge-session-agent-1")).toBeTruthy();
   });
 });

--- a/gwt-gui/src/lib/components/AgentCanvasPanel.test.ts
+++ b/gwt-gui/src/lib/components/AgentCanvasPanel.test.ts
@@ -19,7 +19,11 @@ describe("AgentCanvasPanel", () => {
     });
 
     expect(rendered.queryByTestId("agent-canvas-worktree-dialog")).toBeNull();
-    await fireEvent.click(rendered.getByTestId("agent-canvas-worktree-card"));
+    const worktreeCard = rendered.container.querySelector(
+      '[data-testid^="agent-canvas-worktree-card-"]',
+    ) as HTMLElement;
+    expect(worktreeCard).toBeTruthy();
+    await fireEvent.click(worktreeCard);
 
     const dialog = rendered.getByTestId("agent-canvas-worktree-dialog");
     expect(dialog.textContent).toContain("/tmp/project");

--- a/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
+++ b/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { BranchBrowserPanelConfig } from "../types";
+  import Sidebar from "./Sidebar.svelte";
+
+  let { config }: { config: BranchBrowserPanelConfig } = $props();
+</script>
+
+<div class="branch-browser-panel">
+  <Sidebar
+    projectPath={config.projectPath}
+    refreshKey={config.refreshKey}
+    widthPx={config.widthPx}
+    minWidthPx={config.minWidthPx}
+    maxWidthPx={config.maxWidthPx}
+    mode={config.mode}
+    onModeChange={config.onModeChange}
+    selectedBranch={config.selectedBranch}
+    currentBranch={config.currentBranch}
+    agentTabBranches={config.agentTabBranches}
+    activeAgentTabBranch={config.activeAgentTabBranch}
+    appLanguage={config.appLanguage}
+    onResize={config.onResize}
+    onBranchSelect={config.onBranchSelect}
+    onBranchActivate={config.onBranchActivate}
+    onCleanupRequest={config.onCleanupRequest}
+    onLaunchAgent={config.onLaunchAgent}
+    onQuickLaunch={config.onQuickLaunch}
+    onNewTerminal={config.onNewTerminal}
+    onOpenDocsEditor={config.onOpenDocsEditor}
+    onOpenCiLog={config.onOpenCiLog}
+    onDisplayNameChanged={config.onDisplayNameChanged}
+    embedded={true}
+  />
+</div>
+
+<style>
+  .branch-browser-panel {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+</style>

--- a/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
+++ b/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { invoke } from "$lib/tauriInvoke";
-  import type { BranchBrowserPanelConfig, BranchInfo, WorktreeInfo } from "../types";
+  import type { BranchBrowserPanelConfig, BranchInventoryEntry } from "../types";
+  import { branchInventoryKey } from "../branchInventory";
   import {
-    buildWorktreeMap,
     divergenceClass,
     divergenceIndicator,
-    getSafetyLevel,
-    getSafetyTitle,
-    stripRemotePrefix,
+    safetyTitleForLevel,
     sortBranches,
     type SidebarFilterType,
   } from "./sidebarHelpers";
@@ -19,116 +17,52 @@
   let searchQuery = $state("");
   let loading = $state(true);
   let errorMessage: string | null = $state(null);
-  let branches: BranchInfo[] = $state([]);
-  let remoteBranchNames = $state(new Set<string>());
-  let worktreeMap = $state(new Map<string, WorktreeInfo>());
+  let remotePrimaryNames = $state(new Set<string>());
   let requestToken = 0;
 
   const filters: SidebarFilterType[] = ["Local", "Remote", "All"];
 
-  type BranchBrowserEntry = {
-    key: string;
-    branch: BranchInfo;
-    hasLocal: boolean;
-    hasRemote: boolean;
-    worktree: WorktreeInfo | null;
-  };
+  let branchEntries = $state<BranchInventoryEntry[]>([]);
 
-  function branchKey(name: string): string {
-    return name.trim().startsWith("origin/") ? stripRemotePrefix(name) : name.trim();
-  }
-
-  function buildEntries(
-    local: BranchInfo[],
-    remote: BranchInfo[],
-    worktrees: WorktreeInfo[],
+  function matchesFilter(
+    entry: BranchInventoryEntry,
     filter: SidebarFilterType,
-  ): BranchBrowserEntry[] {
-    const worktreeByBranch = buildWorktreeMap(worktrees);
-
-    if (filter === "Local") {
-      return local.map((branch) => ({
-        key: branchKey(branch.name),
-        branch,
-        hasLocal: true,
-        hasRemote: false,
-        worktree: worktreeByBranch.get(branchKey(branch.name)) ?? null,
-      }));
-    }
-
-    if (filter === "Remote") {
-      return remote.map((branch) => ({
-        key: branchKey(branch.name),
-        branch,
-        hasLocal: false,
-        hasRemote: true,
-        worktree: worktreeByBranch.get(branchKey(branch.name)) ?? null,
-      }));
-    }
-
-    const merged = new Map<string, BranchBrowserEntry>();
-    for (const branch of local) {
-      const key = branchKey(branch.name);
-      merged.set(key, {
-        key,
-        branch,
-        hasLocal: true,
-        hasRemote: false,
-        worktree: worktreeByBranch.get(key) ?? null,
-      });
-    }
-    for (const branch of remote) {
-      const key = branchKey(branch.name);
-      const existing = merged.get(key);
-      if (existing) {
-        merged.set(key, {
-          ...existing,
-          hasRemote: true,
-        });
-      } else {
-        merged.set(key, {
-          key,
-          branch,
-          hasLocal: false,
-          hasRemote: true,
-          worktree: worktreeByBranch.get(key) ?? null,
-        });
-      }
-    }
-    return Array.from(merged.values());
+  ): boolean {
+    if (filter === "Local") return entry.has_local;
+    if (filter === "Remote") return entry.has_remote;
+    return true;
   }
 
-  let branchEntries = $state<BranchBrowserEntry[]>([]);
-
-  let filteredBranches = $derived.by(() => {
+  let filteredEntries = $derived.by(() => {
     const q = searchQuery.trim().toLowerCase();
-    return sortBranches(
-      branchEntries
-        .map((entry) => entry.branch)
-        .filter((branch) => {
-        if (!q) return true;
-        const haystack = `${branch.display_name ?? ""} ${branch.name}`.toLowerCase();
-        return haystack.includes(q);
-      }),
+    const matchingEntries = branchEntries.filter((entry) => {
+      if (!matchesFilter(entry, activeFilter)) return false;
+      if (!q) return true;
+      const branch = entry.primary_branch;
+      const haystack =
+        `${branch.display_name ?? ""} ${branch.name} ${entry.canonical_name}`.toLowerCase();
+      return haystack.includes(q);
+    });
+    const sortedBranches = sortBranches(
+      matchingEntries.map((entry) => entry.primary_branch),
       activeFilter,
-      remoteBranchNames,
+      remotePrimaryNames,
       "name",
     );
-  });
-
-  let selectedWorktree = $derived.by(() => {
-    const selectedBranchName = config.selectedBranch?.name?.trim() ?? "";
-    if (!selectedBranchName) return null;
-    return (
-      worktreeMap.get(selectedBranchName) ??
-      worktreeMap.get(selectedBranchName.replace(/^origin\//, "")) ??
-      null
+    const orderedNames = new Map(
+      sortedBranches.map((branch, index) => [branch.name, index]),
+    );
+    return [...matchingEntries].sort(
+      (a, b) =>
+        (orderedNames.get(a.primary_branch.name) ?? Number.MAX_SAFE_INTEGER) -
+        (orderedNames.get(b.primary_branch.name) ?? Number.MAX_SAFE_INTEGER),
     );
   });
+
   let selectedEntry = $derived.by(() => {
     const selectedBranchName = config.selectedBranch?.name?.trim() ?? "";
-    const key = branchKey(selectedBranchName);
-    return branchEntries.find((entry) => entry.key === key) ?? null;
+    const key = branchInventoryKey(selectedBranchName);
+    return branchEntries.find((entry) => entry.canonical_name === key) ?? null;
   });
 
   async function fetchBranches(path: string) {
@@ -137,28 +71,36 @@
     errorMessage = null;
 
     try {
-      const [local, remote, worktrees] = await Promise.all([
-        invoke<BranchInfo[]>("list_worktree_branches", { projectPath: path }),
-        invoke<BranchInfo[]>("list_remote_branches", { projectPath: path }),
-        invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
-      ]);
+      const entries = await invoke<BranchInventoryEntry[]>("list_branch_inventory", {
+        projectPath: path,
+      });
       if (token !== requestToken) return;
-      branches = activeFilter === "Local" ? local : activeFilter === "Remote" ? remote : local;
-      remoteBranchNames = new Set(remote.map((branch) => branchKey(branch.name)));
-      worktreeMap = buildWorktreeMap(worktrees);
-      branchEntries = buildEntries(local, remote, worktrees, activeFilter);
+      branchEntries = entries;
+      remotePrimaryNames = new Set(
+        entries
+          .filter((entry) => !entry.has_local && entry.has_remote)
+          .map((entry) => entry.primary_branch.name),
+      );
     } catch (error) {
       if (token !== requestToken) return;
-      errorMessage =
-        error instanceof Error ? error.message : String(error);
-      branches = [];
+      errorMessage = error instanceof Error ? error.message : String(error);
       branchEntries = [];
-      remoteBranchNames = new Set();
-      worktreeMap = new Map();
+      remotePrimaryNames = new Set();
     } finally {
       if (token === requestToken) {
         loading = false;
       }
+    }
+  }
+
+  function actionLabel(entry: BranchInventoryEntry): string {
+    switch (entry.resolution_action) {
+      case "focusExisting":
+        return "Focus Worktree";
+      case "resolveAmbiguity":
+        return "Resolve Ambiguity";
+      default:
+        return "Create Worktree";
     }
   }
 
@@ -170,10 +112,8 @@
   $effect(() => {
     const path = config.projectPath;
     const refreshKey = config.refreshKey;
-    const filter = activeFilter;
     void refreshKey;
     if (!path) return;
-    void filter;
     void fetchBranches(path);
   });
 </script>
@@ -220,36 +160,40 @@
         <div class="state-msg">Loading branches...</div>
       {:else if errorMessage}
         <div class="state-msg error">{errorMessage}</div>
-      {:else if filteredBranches.length === 0}
+      {:else if filteredEntries.length === 0}
         <div class="state-msg">No branches found.</div>
       {:else}
         <div class="branch-list">
-          {#each filteredBranches as branch}
+          {#each filteredEntries as entry (entry.id)}
             <button
               type="button"
               class="branch-row"
-              class:selected={selectedEntry?.key === branchKey(branch.name)}
-              onclick={() => config.onBranchSelect(branch)}
-              ondblclick={() => config.onBranchActivate?.(branch)}
+              class:selected={selectedEntry?.id === entry.id}
+              onclick={() => config.onBranchSelect(entry.primary_branch)}
+              ondblclick={() =>
+                entry.resolution_action !== "resolveAmbiguity" &&
+                config.onBranchActivate?.(entry.primary_branch)}
             >
               <div class="branch-primary">
-                <span class="branch-name">{branch.display_name ?? branch.name}</span>
-                {#if branch.display_name && branch.display_name !== branch.name}
-                  <span class="branch-sub">{branch.name}</span>
+                <span class="branch-name">{entry.primary_branch.display_name ?? entry.primary_branch.name}</span>
+                {#if entry.primary_branch.display_name && entry.primary_branch.display_name !== entry.primary_branch.name}
+                  <span class="branch-sub">{entry.primary_branch.name}</span>
                 {/if}
               </div>
               <div class="branch-meta">
-                {#if getSafetyLevel(branch, worktreeMap)}
+                {#if entry.worktree?.safety_level}
                   <span
-                    class={`safety-pill ${getSafetyLevel(branch, worktreeMap)}`}
-                    title={getSafetyTitle(branch, worktreeMap)}
+                    class={`safety-pill ${entry.worktree.safety_level}`}
+                    title={safetyTitleForLevel(entry.worktree.safety_level)}
                   >
-                    {getSafetyLevel(branch, worktreeMap)}
+                    {entry.worktree.safety_level}
                   </span>
                 {/if}
-                {#if divergenceIndicator(branch)}
-                  <span class={`divergence-pill ${divergenceClass(branch.divergence_status)}`}>
-                    {divergenceIndicator(branch)}
+                {#if divergenceIndicator(entry.primary_branch)}
+                  <span
+                    class={`divergence-pill ${divergenceClass(entry.primary_branch.divergence_status)}`}
+                  >
+                    {divergenceIndicator(entry.primary_branch)}
                   </span>
                 {/if}
               </div>
@@ -277,19 +221,31 @@
             </div>
             <div class="detail-row">
               <span class="detail-label">Worktree</span>
-              <span class="detail-value mono">{selectedWorktree?.path ?? "Not materialized"}</span>
+              <span class="detail-value mono">{selectedEntry?.worktree?.path ?? "Not materialized"}</span>
             </div>
             <div class="detail-row">
               <span class="detail-label">Coverage</span>
               <span class="detail-value">
-                {#if selectedEntry?.hasLocal && selectedEntry?.hasRemote}
+                {#if selectedEntry?.has_local && selectedEntry?.has_remote}
                   Local + Remote
-                {:else if selectedEntry?.hasLocal}
+                {:else if selectedEntry?.has_local}
                   Local
-                {:else if selectedEntry?.hasRemote}
+                {:else if selectedEntry?.has_remote}
                   Remote
                 {:else}
                   Unknown
+                {/if}
+              </span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">Resolution</span>
+              <span class="detail-value">
+                {#if selectedEntry?.resolution_action === "focusExisting"}
+                  Existing worktree
+                {:else if selectedEntry?.resolution_action === "resolveAmbiguity"}
+                  Multiple worktrees
+                {:else}
+                  Create new worktree
                 {/if}
               </span>
             </div>
@@ -298,9 +254,13 @@
             <button
               type="button"
               class="cleanup-btn"
-              onclick={() => config.onBranchActivate?.(config.selectedBranch!)}
+              disabled={selectedEntry?.resolution_action === "resolveAmbiguity"}
+              onclick={() => {
+                if (selectedEntry?.resolution_action === "resolveAmbiguity") return;
+                config.onBranchActivate?.(config.selectedBranch!);
+              }}
             >
-              {selectedWorktree ? "Focus Worktree" : "Create Worktree"}
+              {selectedEntry ? actionLabel(selectedEntry) : "Create Worktree"}
             </button>
           </div>
         </div>
@@ -361,6 +321,11 @@
     padding: 7px 12px;
     cursor: pointer;
     font: inherit;
+  }
+
+  .cleanup-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 
   .filter-btn.active {

--- a/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
+++ b/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
@@ -1,36 +1,230 @@
 <script lang="ts">
-  import type { BranchBrowserPanelConfig } from "../types";
-  import Sidebar from "./Sidebar.svelte";
+  import { onMount } from "svelte";
+  import { invoke } from "$lib/tauriInvoke";
+  import type { BranchBrowserPanelConfig, BranchInfo, WorktreeInfo } from "../types";
+  import {
+    buildWorktreeMap,
+    divergenceClass,
+    divergenceIndicator,
+    getSafetyLevel,
+    getSafetyTitle,
+    sortBranches,
+    type SidebarFilterType,
+  } from "./sidebarHelpers";
 
   let { config }: { config: BranchBrowserPanelConfig } = $props();
+
+  let activeFilter: SidebarFilterType = $state("Local");
+  let searchQuery = $state("");
+  let loading = $state(true);
+  let errorMessage: string | null = $state(null);
+  let branches: BranchInfo[] = $state([]);
+  let remoteBranchNames = $state(new Set<string>());
+  let worktreeMap = $state(new Map<string, WorktreeInfo>());
+  let requestToken = 0;
+
+  const filters: SidebarFilterType[] = ["Local", "Remote", "All"];
+
+  let filteredBranches = $derived.by(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return sortBranches(
+      branches.filter((branch) => {
+        if (!q) return true;
+        const haystack = `${branch.display_name ?? ""} ${branch.name}`.toLowerCase();
+        return haystack.includes(q);
+      }),
+      activeFilter,
+      remoteBranchNames,
+      "name",
+    );
+  });
+
+  let selectedWorktree = $derived.by(() => {
+    const selectedBranchName = config.selectedBranch?.name?.trim() ?? "";
+    return selectedBranchName ? worktreeMap.get(selectedBranchName) ?? null : null;
+  });
+
+  async function fetchBranches(path: string) {
+    const token = ++requestToken;
+    loading = true;
+    errorMessage = null;
+
+    try {
+      if (activeFilter === "Local") {
+        const [local, worktrees] = await Promise.all([
+          invoke<BranchInfo[]>("list_worktree_branches", { projectPath: path }),
+          invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
+        ]);
+        if (token !== requestToken) return;
+        branches = local;
+        remoteBranchNames = new Set();
+        worktreeMap = buildWorktreeMap(worktrees);
+      } else if (activeFilter === "Remote") {
+        const [remote, worktrees] = await Promise.all([
+          invoke<BranchInfo[]>("list_remote_branches", { projectPath: path }),
+          invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
+        ]);
+        if (token !== requestToken) return;
+        branches = remote;
+        remoteBranchNames = new Set(remote.map((branch) => branch.name.trim()));
+        worktreeMap = buildWorktreeMap(worktrees);
+      } else {
+        const [local, remote, worktrees] = await Promise.all([
+          invoke<BranchInfo[]>("list_worktree_branches", { projectPath: path }),
+          invoke<BranchInfo[]>("list_remote_branches", { projectPath: path }),
+          invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
+        ]);
+        if (token !== requestToken) return;
+        const merged = new Map<string, BranchInfo>();
+        for (const branch of local) {
+          merged.set(branch.name, branch);
+        }
+        for (const branch of remote) {
+          if (merged.has(branch.name)) continue;
+          merged.set(branch.name, branch);
+        }
+        branches = Array.from(merged.values());
+        remoteBranchNames = new Set(remote.map((branch) => branch.name.trim()));
+        worktreeMap = buildWorktreeMap(worktrees);
+      }
+    } catch (error) {
+      if (token !== requestToken) return;
+      errorMessage =
+        error instanceof Error ? error.message : String(error);
+      branches = [];
+      remoteBranchNames = new Set();
+      worktreeMap = new Map();
+    } finally {
+      if (token === requestToken) {
+        loading = false;
+      }
+    }
+  }
+
+  onMount(() => {
+    if (!config.projectPath) return;
+    void fetchBranches(config.projectPath);
+  });
+
+  $effect(() => {
+    const path = config.projectPath;
+    const refreshKey = config.refreshKey;
+    const filter = activeFilter;
+    void refreshKey;
+    if (!path) return;
+    void filter;
+    void fetchBranches(path);
+  });
 </script>
 
-<div class="branch-browser-panel">
-  <Sidebar
-    projectPath={config.projectPath}
-    refreshKey={config.refreshKey}
-    widthPx={config.widthPx}
-    minWidthPx={config.minWidthPx}
-    maxWidthPx={config.maxWidthPx}
-    mode={config.mode}
-    onModeChange={config.onModeChange}
-    selectedBranch={config.selectedBranch}
-    currentBranch={config.currentBranch}
-    agentTabBranches={config.agentTabBranches}
-    activeAgentTabBranch={config.activeAgentTabBranch}
-    appLanguage={config.appLanguage}
-    onResize={config.onResize}
-    onBranchSelect={config.onBranchSelect}
-    onBranchActivate={config.onBranchActivate}
-    onCleanupRequest={config.onCleanupRequest}
-    onLaunchAgent={config.onLaunchAgent}
-    onQuickLaunch={config.onQuickLaunch}
-    onNewTerminal={config.onNewTerminal}
-    onOpenDocsEditor={config.onOpenDocsEditor}
-    onOpenCiLog={config.onOpenCiLog}
-    onDisplayNameChanged={config.onDisplayNameChanged}
-    embedded={true}
-  />
+<div class="branch-browser-panel" data-testid="branch-browser-panel">
+  <div class="browser-header">
+    <div>
+      <h2>Branch Browser</h2>
+      <p>Browse `Local`, `Remote`, and `All` refs without reopening the old sidebar.</p>
+    </div>
+    <button
+      type="button"
+      class="cleanup-btn"
+      onclick={() => config.onCleanupRequest?.()}
+    >
+      Cleanup
+    </button>
+  </div>
+
+  <div class="browser-toolbar">
+    <div class="filter-row">
+      {#each filters as filter}
+        <button
+          type="button"
+          class="filter-btn"
+          class:active={activeFilter === filter}
+          onclick={() => (activeFilter = filter)}
+        >
+          {filter}
+        </button>
+      {/each}
+    </div>
+    <input
+      type="text"
+      class="search-input"
+      placeholder="Filter branches..."
+      bind:value={searchQuery}
+    />
+  </div>
+
+  <div class="browser-body">
+    <section class="branch-list-panel">
+      {#if loading}
+        <div class="state-msg">Loading branches...</div>
+      {:else if errorMessage}
+        <div class="state-msg error">{errorMessage}</div>
+      {:else if filteredBranches.length === 0}
+        <div class="state-msg">No branches found.</div>
+      {:else}
+        <div class="branch-list">
+          {#each filteredBranches as branch}
+            <button
+              type="button"
+              class="branch-row"
+              class:selected={config.selectedBranch?.name === branch.name}
+              onclick={() => config.onBranchSelect(branch)}
+              ondblclick={() => config.onBranchActivate?.(branch)}
+            >
+              <div class="branch-primary">
+                <span class="branch-name">{branch.display_name ?? branch.name}</span>
+                {#if branch.display_name && branch.display_name !== branch.name}
+                  <span class="branch-sub">{branch.name}</span>
+                {/if}
+              </div>
+              <div class="branch-meta">
+                {#if getSafetyLevel(branch, worktreeMap)}
+                  <span
+                    class={`safety-pill ${getSafetyLevel(branch, worktreeMap)}`}
+                    title={getSafetyTitle(branch, worktreeMap)}
+                  >
+                    {getSafetyLevel(branch, worktreeMap)}
+                  </span>
+                {/if}
+                {#if divergenceIndicator(branch)}
+                  <span class={`divergence-pill ${divergenceClass(branch.divergence_status)}`}>
+                    {divergenceIndicator(branch)}
+                  </span>
+                {/if}
+              </div>
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </section>
+
+    <section class="detail-panel" data-testid="branch-browser-detail">
+      {#if config.selectedBranch}
+        <div class="detail-card">
+          <div class="detail-header">
+            <span class="detail-kind">Selected</span>
+            <span class="detail-title">{config.selectedBranch.display_name ?? config.selectedBranch.name}</span>
+          </div>
+          <div class="detail-grid">
+            <div class="detail-row">
+              <span class="detail-label">Branch</span>
+              <span class="detail-value mono">{config.selectedBranch.name}</span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">Commit</span>
+              <span class="detail-value mono">{config.selectedBranch.commit}</span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-label">Worktree</span>
+              <span class="detail-value mono">{selectedWorktree?.path ?? "Not materialized"}</span>
+            </div>
+          </div>
+        </div>
+      {:else}
+        <div class="state-msg">Select a branch or worktree to inspect it.</div>
+      {/if}
+    </section>
+  </div>
 </div>
 
 <style>
@@ -39,6 +233,238 @@
     height: 100%;
     min-width: 0;
     min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 18px 18px;
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--bg-secondary) 88%, transparent), var(--bg-primary)),
+      radial-gradient(circle at top right, color-mix(in srgb, var(--cyan) 12%, transparent), transparent 32%);
     overflow: hidden;
+  }
+
+  .browser-header,
+  .browser-toolbar,
+  .filter-row,
+  .branch-meta,
+  .detail-header {
+    display: flex;
+    align-items: center;
+  }
+
+  .browser-header,
+  .browser-toolbar {
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .browser-header h2 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .browser-header p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+  }
+
+  .cleanup-btn,
+  .filter-btn {
+    border: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--bg-secondary) 80%, transparent);
+    color: var(--text-primary);
+    border-radius: 999px;
+    padding: 7px 12px;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .filter-btn.active {
+    border-color: color-mix(in srgb, var(--accent) 58%, var(--border-color));
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+  }
+
+  .filter-row {
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .search-input {
+    min-width: 240px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border-radius: 10px;
+    padding: 8px 10px;
+    font: inherit;
+  }
+
+  .browser-body {
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: minmax(280px, 420px) minmax(280px, 1fr);
+    gap: 16px;
+  }
+
+  .branch-list-panel,
+  .detail-card,
+  .detail-panel {
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .branch-list-panel,
+  .detail-card,
+  .detail-panel {
+    border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+    background: color-mix(in srgb, var(--bg-secondary) 82%, var(--bg-primary));
+    border-radius: 16px;
+    overflow: hidden;
+  }
+
+  .branch-list {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    max-height: 100%;
+    overflow: auto;
+  }
+
+  .branch-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+    width: 100%;
+    padding: 12px 14px;
+    border: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .branch-row.selected {
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+  }
+
+  .branch-primary {
+    min-width: 0;
+    display: grid;
+    gap: 4px;
+  }
+
+  .branch-name,
+  .branch-sub,
+  .detail-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .branch-sub {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+
+  .branch-meta {
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .safety-pill,
+  .divergence-pill,
+  .detail-kind {
+    border-radius: 999px;
+    padding: 4px 8px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .detail-kind {
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+  }
+
+  .safety-pill.safe {
+    background: color-mix(in srgb, var(--green) 16%, transparent);
+  }
+
+  .safety-pill.warning {
+    background: color-mix(in srgb, var(--yellow) 16%, transparent);
+  }
+
+  .safety-pill.danger,
+  .safety-pill.disabled {
+    background: color-mix(in srgb, var(--red) 16%, transparent);
+  }
+
+  .detail-panel {
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+  }
+
+  .detail-card {
+    width: 100%;
+  }
+
+  .detail-header {
+    gap: 10px;
+    padding: 12px 14px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-color) 68%, transparent);
+  }
+
+  .detail-title {
+    font-weight: 600;
+  }
+
+  .detail-grid {
+    display: grid;
+    gap: 12px;
+    padding: 16px;
+  }
+
+  .detail-row {
+    display: grid;
+    gap: 4px;
+  }
+
+  .detail-label {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .mono {
+    font-family: monospace;
+  }
+
+  .state-msg {
+    padding: 16px;
+    color: var(--text-muted);
+  }
+
+  .state-msg.error {
+    color: var(--red);
+  }
+
+  @media (max-width: 980px) {
+    .browser-toolbar,
+    .browser-header {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .search-input {
+      min-width: 0;
+      width: 100%;
+    }
+
+    .browser-body {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 </style>

--- a/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
+++ b/gwt-gui/src/lib/components/BranchBrowserPanel.svelte
@@ -8,6 +8,7 @@
     divergenceIndicator,
     getSafetyLevel,
     getSafetyTitle,
+    stripRemotePrefix,
     sortBranches,
     type SidebarFilterType,
   } from "./sidebarHelpers";
@@ -25,10 +26,86 @@
 
   const filters: SidebarFilterType[] = ["Local", "Remote", "All"];
 
+  type BranchBrowserEntry = {
+    key: string;
+    branch: BranchInfo;
+    hasLocal: boolean;
+    hasRemote: boolean;
+    worktree: WorktreeInfo | null;
+  };
+
+  function branchKey(name: string): string {
+    return name.trim().startsWith("origin/") ? stripRemotePrefix(name) : name.trim();
+  }
+
+  function buildEntries(
+    local: BranchInfo[],
+    remote: BranchInfo[],
+    worktrees: WorktreeInfo[],
+    filter: SidebarFilterType,
+  ): BranchBrowserEntry[] {
+    const worktreeByBranch = buildWorktreeMap(worktrees);
+
+    if (filter === "Local") {
+      return local.map((branch) => ({
+        key: branchKey(branch.name),
+        branch,
+        hasLocal: true,
+        hasRemote: false,
+        worktree: worktreeByBranch.get(branchKey(branch.name)) ?? null,
+      }));
+    }
+
+    if (filter === "Remote") {
+      return remote.map((branch) => ({
+        key: branchKey(branch.name),
+        branch,
+        hasLocal: false,
+        hasRemote: true,
+        worktree: worktreeByBranch.get(branchKey(branch.name)) ?? null,
+      }));
+    }
+
+    const merged = new Map<string, BranchBrowserEntry>();
+    for (const branch of local) {
+      const key = branchKey(branch.name);
+      merged.set(key, {
+        key,
+        branch,
+        hasLocal: true,
+        hasRemote: false,
+        worktree: worktreeByBranch.get(key) ?? null,
+      });
+    }
+    for (const branch of remote) {
+      const key = branchKey(branch.name);
+      const existing = merged.get(key);
+      if (existing) {
+        merged.set(key, {
+          ...existing,
+          hasRemote: true,
+        });
+      } else {
+        merged.set(key, {
+          key,
+          branch,
+          hasLocal: false,
+          hasRemote: true,
+          worktree: worktreeByBranch.get(key) ?? null,
+        });
+      }
+    }
+    return Array.from(merged.values());
+  }
+
+  let branchEntries = $state<BranchBrowserEntry[]>([]);
+
   let filteredBranches = $derived.by(() => {
     const q = searchQuery.trim().toLowerCase();
     return sortBranches(
-      branches.filter((branch) => {
+      branchEntries
+        .map((entry) => entry.branch)
+        .filter((branch) => {
         if (!q) return true;
         const haystack = `${branch.display_name ?? ""} ${branch.name}`.toLowerCase();
         return haystack.includes(q);
@@ -41,7 +118,17 @@
 
   let selectedWorktree = $derived.by(() => {
     const selectedBranchName = config.selectedBranch?.name?.trim() ?? "";
-    return selectedBranchName ? worktreeMap.get(selectedBranchName) ?? null : null;
+    if (!selectedBranchName) return null;
+    return (
+      worktreeMap.get(selectedBranchName) ??
+      worktreeMap.get(selectedBranchName.replace(/^origin\//, "")) ??
+      null
+    );
+  });
+  let selectedEntry = $derived.by(() => {
+    const selectedBranchName = config.selectedBranch?.name?.trim() ?? "";
+    const key = branchKey(selectedBranchName);
+    return branchEntries.find((entry) => entry.key === key) ?? null;
   });
 
   async function fetchBranches(path: string) {
@@ -50,48 +137,22 @@
     errorMessage = null;
 
     try {
-      if (activeFilter === "Local") {
-        const [local, worktrees] = await Promise.all([
-          invoke<BranchInfo[]>("list_worktree_branches", { projectPath: path }),
-          invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
-        ]);
-        if (token !== requestToken) return;
-        branches = local;
-        remoteBranchNames = new Set();
-        worktreeMap = buildWorktreeMap(worktrees);
-      } else if (activeFilter === "Remote") {
-        const [remote, worktrees] = await Promise.all([
-          invoke<BranchInfo[]>("list_remote_branches", { projectPath: path }),
-          invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
-        ]);
-        if (token !== requestToken) return;
-        branches = remote;
-        remoteBranchNames = new Set(remote.map((branch) => branch.name.trim()));
-        worktreeMap = buildWorktreeMap(worktrees);
-      } else {
-        const [local, remote, worktrees] = await Promise.all([
-          invoke<BranchInfo[]>("list_worktree_branches", { projectPath: path }),
-          invoke<BranchInfo[]>("list_remote_branches", { projectPath: path }),
-          invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
-        ]);
-        if (token !== requestToken) return;
-        const merged = new Map<string, BranchInfo>();
-        for (const branch of local) {
-          merged.set(branch.name, branch);
-        }
-        for (const branch of remote) {
-          if (merged.has(branch.name)) continue;
-          merged.set(branch.name, branch);
-        }
-        branches = Array.from(merged.values());
-        remoteBranchNames = new Set(remote.map((branch) => branch.name.trim()));
-        worktreeMap = buildWorktreeMap(worktrees);
-      }
+      const [local, remote, worktrees] = await Promise.all([
+        invoke<BranchInfo[]>("list_worktree_branches", { projectPath: path }),
+        invoke<BranchInfo[]>("list_remote_branches", { projectPath: path }),
+        invoke<WorktreeInfo[]>("list_worktrees", { projectPath: path }),
+      ]);
+      if (token !== requestToken) return;
+      branches = activeFilter === "Local" ? local : activeFilter === "Remote" ? remote : local;
+      remoteBranchNames = new Set(remote.map((branch) => branchKey(branch.name)));
+      worktreeMap = buildWorktreeMap(worktrees);
+      branchEntries = buildEntries(local, remote, worktrees, activeFilter);
     } catch (error) {
       if (token !== requestToken) return;
       errorMessage =
         error instanceof Error ? error.message : String(error);
       branches = [];
+      branchEntries = [];
       remoteBranchNames = new Set();
       worktreeMap = new Map();
     } finally {
@@ -167,7 +228,7 @@
             <button
               type="button"
               class="branch-row"
-              class:selected={config.selectedBranch?.name === branch.name}
+              class:selected={selectedEntry?.key === branchKey(branch.name)}
               onclick={() => config.onBranchSelect(branch)}
               ondblclick={() => config.onBranchActivate?.(branch)}
             >
@@ -218,6 +279,29 @@
               <span class="detail-label">Worktree</span>
               <span class="detail-value mono">{selectedWorktree?.path ?? "Not materialized"}</span>
             </div>
+            <div class="detail-row">
+              <span class="detail-label">Coverage</span>
+              <span class="detail-value">
+                {#if selectedEntry?.hasLocal && selectedEntry?.hasRemote}
+                  Local + Remote
+                {:else if selectedEntry?.hasLocal}
+                  Local
+                {:else if selectedEntry?.hasRemote}
+                  Remote
+                {:else}
+                  Unknown
+                {/if}
+              </span>
+            </div>
+          </div>
+          <div class="detail-actions">
+            <button
+              type="button"
+              class="cleanup-btn"
+              onclick={() => config.onBranchActivate?.(config.selectedBranch!)}
+            >
+              {selectedWorktree ? "Focus Worktree" : "Create Worktree"}
+            </button>
           </div>
         </div>
       {:else}
@@ -424,6 +508,10 @@
     display: grid;
     gap: 12px;
     padding: 16px;
+  }
+
+  .detail-actions {
+    padding: 0 16px 16px;
   }
 
   .detail-row {

--- a/gwt-gui/src/lib/components/BranchBrowserPanel.test.ts
+++ b/gwt-gui/src/lib/components/BranchBrowserPanel.test.ts
@@ -1,0 +1,141 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import BranchBrowserPanel from "./BranchBrowserPanel.svelte";
+import type { BranchBrowserPanelConfig, BranchInfo, WorktreeInfo } from "../types";
+
+const invokeMock = vi.fn();
+
+vi.mock("$lib/tauriInvoke", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+const localBranch: BranchInfo = {
+  name: "feature/local",
+  display_name: "Local feature",
+  commit: "abc1234",
+  is_current: false,
+  is_agent_running: false,
+  agent_status: "unknown",
+  ahead: 1,
+  behind: 0,
+  divergence_status: "Ahead",
+  commit_timestamp: 1_700_000_000_000,
+  last_tool_usage: "codex@latest",
+};
+
+const remoteBranch: BranchInfo = {
+  name: "origin/feature/remote",
+  commit: "def5678",
+  is_current: false,
+  is_agent_running: false,
+  agent_status: "unknown",
+  ahead: 0,
+  behind: 0,
+  divergence_status: "UpToDate",
+  commit_timestamp: 1_700_000_000_500,
+  last_tool_usage: null,
+};
+
+const worktree: WorktreeInfo = {
+  path: "/tmp/project/.gwt/worktrees/feature-local",
+  branch: "feature/local",
+  commit: "abc1234",
+  status: "active",
+  is_main: false,
+  has_changes: false,
+  has_unpushed: true,
+  is_current: false,
+  is_protected: false,
+  is_agent_running: false,
+  agent_status: "unknown",
+  ahead: 1,
+  behind: 0,
+  is_gone: false,
+  last_tool_usage: "codex@latest",
+  safety_level: "warning",
+};
+
+function createConfig(overrides: Partial<BranchBrowserPanelConfig> = {}): BranchBrowserPanelConfig {
+  return {
+    projectPath: "/tmp/project",
+    refreshKey: 0,
+    widthPx: 260,
+    minWidthPx: 220,
+    maxWidthPx: 520,
+    mode: "branch",
+    currentBranch: "feature/local",
+    agentTabBranches: [],
+    activeAgentTabBranch: null,
+    appLanguage: "en",
+    onBranchSelect: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("BranchBrowserPanel", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "list_worktree_branches") return Promise.resolve([localBranch]);
+      if (command === "list_remote_branches") return Promise.resolve([remoteBranch]);
+      if (command === "list_worktrees") return Promise.resolve([worktree]);
+      return Promise.resolve([]);
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loads Local branches by default and renders branch details", async () => {
+    const onBranchSelect = vi.fn();
+    const rendered = render(BranchBrowserPanel, {
+      props: {
+        config: createConfig({
+          selectedBranch: localBranch,
+          onBranchSelect,
+        }),
+      },
+    });
+
+    await waitFor(() => expect(rendered.getByText("Local feature")).toBeTruthy());
+    expect(invokeMock).toHaveBeenCalledWith("list_worktree_branches", {
+      projectPath: "/tmp/project",
+    });
+    expect(rendered.getByTestId("branch-browser-detail").textContent).toContain(
+      "/tmp/project/.gwt/worktrees/feature-local",
+    );
+  });
+
+  it("switches to Remote mode and renders remote refs", async () => {
+    const rendered = render(BranchBrowserPanel, {
+      props: {
+        config: createConfig(),
+      },
+    });
+
+    await waitFor(() => expect(rendered.getByText("Local feature")).toBeTruthy());
+    await fireEvent.click(rendered.getByText("Remote"));
+
+    await waitFor(() =>
+      expect(rendered.getByText("origin/feature/remote")).toBeTruthy(),
+    );
+    expect(invokeMock).toHaveBeenCalledWith("list_remote_branches", {
+      projectPath: "/tmp/project",
+    });
+  });
+
+  it("forwards branch selection to the host shell", async () => {
+    const onBranchSelect = vi.fn();
+    const rendered = render(BranchBrowserPanel, {
+      props: {
+        config: createConfig({ onBranchSelect }),
+      },
+    });
+
+    await waitFor(() => expect(rendered.getByText("Local feature")).toBeTruthy());
+    await fireEvent.click(rendered.getByText("Local feature"));
+
+    expect(onBranchSelect).toHaveBeenCalledWith(localBranch);
+  });
+});

--- a/gwt-gui/src/lib/components/BranchBrowserPanel.test.ts
+++ b/gwt-gui/src/lib/components/BranchBrowserPanel.test.ts
@@ -125,6 +125,35 @@ describe("BranchBrowserPanel", () => {
     });
   });
 
+  it("merges local and remote refs into one canonical entry in All mode", async () => {
+    const matchingRemote: BranchInfo = {
+      ...remoteBranch,
+      name: "origin/feature/local",
+    };
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "list_worktree_branches") return Promise.resolve([localBranch]);
+      if (command === "list_remote_branches") return Promise.resolve([matchingRemote]);
+      if (command === "list_worktrees") return Promise.resolve([worktree]);
+      return Promise.resolve([]);
+    });
+
+    const rendered = render(BranchBrowserPanel, {
+      props: {
+        config: createConfig({
+          selectedBranch: localBranch,
+        }),
+      },
+    });
+
+    await waitFor(() => expect(rendered.getByText("Local feature")).toBeTruthy());
+    await fireEvent.click(rendered.getByText("All"));
+
+    await waitFor(() =>
+      expect(rendered.getByText("Local + Remote")).toBeTruthy(),
+    );
+    expect(rendered.container.querySelectorAll(".branch-row")).toHaveLength(1);
+  });
+
   it("forwards branch selection to the host shell", async () => {
     const onBranchSelect = vi.fn();
     const rendered = render(BranchBrowserPanel, {
@@ -137,5 +166,45 @@ describe("BranchBrowserPanel", () => {
     await fireEvent.click(rendered.getByText("Local feature"));
 
     expect(onBranchSelect).toHaveBeenCalledWith(localBranch);
+  });
+
+  it("forwards open/focus worktree action for the selected branch", async () => {
+    const onBranchActivate = vi.fn();
+    const rendered = render(BranchBrowserPanel, {
+      props: {
+        config: createConfig({
+          selectedBranch: localBranch,
+          onBranchActivate,
+        }),
+      },
+    });
+
+    await waitFor(() =>
+      expect(rendered.getByRole("button", { name: "Focus Worktree" })).toBeTruthy(),
+    );
+    await fireEvent.click(rendered.getByRole("button", { name: "Focus Worktree" }));
+
+    expect(onBranchActivate).toHaveBeenCalledWith(localBranch);
+  });
+
+  it("shows create worktree when the selected branch has no materialized worktree", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "list_worktree_branches") return Promise.resolve([]);
+      if (command === "list_remote_branches") return Promise.resolve([remoteBranch]);
+      if (command === "list_worktrees") return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+
+    const rendered = render(BranchBrowserPanel, {
+      props: {
+        config: createConfig({
+          selectedBranch: remoteBranch,
+        }),
+      },
+    });
+
+    await waitFor(() =>
+      expect(rendered.getByRole("button", { name: "Create Worktree" })).toBeTruthy(),
+    );
   });
 });

--- a/gwt-gui/src/lib/components/BranchBrowserPanel.test.ts
+++ b/gwt-gui/src/lib/components/BranchBrowserPanel.test.ts
@@ -1,7 +1,12 @@
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import BranchBrowserPanel from "./BranchBrowserPanel.svelte";
-import type { BranchBrowserPanelConfig, BranchInfo, WorktreeInfo } from "../types";
+import type {
+  BranchBrowserPanelConfig,
+  BranchInfo,
+  BranchInventoryEntry,
+  WorktreeInfo,
+} from "../types";
 
 const invokeMock = vi.fn();
 
@@ -55,6 +60,32 @@ const worktree: WorktreeInfo = {
   safety_level: "warning",
 };
 
+const localEntry: BranchInventoryEntry = {
+  id: "feature/local",
+  canonical_name: "feature/local",
+  primary_branch: localBranch,
+  local_branch: localBranch,
+  remote_branch: null,
+  has_local: true,
+  has_remote: false,
+  worktree,
+  worktree_count: 1,
+  resolution_action: "focusExisting",
+};
+
+const remoteEntry: BranchInventoryEntry = {
+  id: "feature/remote",
+  canonical_name: "feature/remote",
+  primary_branch: remoteBranch,
+  local_branch: null,
+  remote_branch: remoteBranch,
+  has_local: false,
+  has_remote: true,
+  worktree: null,
+  worktree_count: 0,
+  resolution_action: "createWorktree",
+};
+
 function createConfig(overrides: Partial<BranchBrowserPanelConfig> = {}): BranchBrowserPanelConfig {
   return {
     projectPath: "/tmp/project",
@@ -76,9 +107,9 @@ describe("BranchBrowserPanel", () => {
   beforeEach(() => {
     invokeMock.mockReset();
     invokeMock.mockImplementation((command: string) => {
-      if (command === "list_worktree_branches") return Promise.resolve([localBranch]);
-      if (command === "list_remote_branches") return Promise.resolve([remoteBranch]);
-      if (command === "list_worktrees") return Promise.resolve([worktree]);
+      if (command === "list_branch_inventory") {
+        return Promise.resolve([localEntry, remoteEntry]);
+      }
       return Promise.resolve([]);
     });
   });
@@ -99,7 +130,7 @@ describe("BranchBrowserPanel", () => {
     });
 
     await waitFor(() => expect(rendered.getByText("Local feature")).toBeTruthy());
-    expect(invokeMock).toHaveBeenCalledWith("list_worktree_branches", {
+    expect(invokeMock).toHaveBeenCalledWith("list_branch_inventory", {
       projectPath: "/tmp/project",
     });
     expect(rendered.getByTestId("branch-browser-detail").textContent).toContain(
@@ -120,20 +151,19 @@ describe("BranchBrowserPanel", () => {
     await waitFor(() =>
       expect(rendered.getByText("origin/feature/remote")).toBeTruthy(),
     );
-    expect(invokeMock).toHaveBeenCalledWith("list_remote_branches", {
-      projectPath: "/tmp/project",
-    });
   });
 
   it("merges local and remote refs into one canonical entry in All mode", async () => {
-    const matchingRemote: BranchInfo = {
-      ...remoteBranch,
-      name: "origin/feature/local",
+    const mergedEntry: BranchInventoryEntry = {
+      ...localEntry,
+      has_remote: true,
+      remote_branch: {
+        ...remoteBranch,
+        name: "origin/feature/local",
+      },
     };
     invokeMock.mockImplementation((command: string) => {
-      if (command === "list_worktree_branches") return Promise.resolve([localBranch]);
-      if (command === "list_remote_branches") return Promise.resolve([matchingRemote]);
-      if (command === "list_worktrees") return Promise.resolve([worktree]);
+      if (command === "list_branch_inventory") return Promise.resolve([mergedEntry]);
       return Promise.resolve([]);
     });
 
@@ -189,9 +219,7 @@ describe("BranchBrowserPanel", () => {
 
   it("shows create worktree when the selected branch has no materialized worktree", async () => {
     invokeMock.mockImplementation((command: string) => {
-      if (command === "list_worktree_branches") return Promise.resolve([]);
-      if (command === "list_remote_branches") return Promise.resolve([remoteBranch]);
-      if (command === "list_worktrees") return Promise.resolve([]);
+      if (command === "list_branch_inventory") return Promise.resolve([remoteEntry]);
       return Promise.resolve([]);
     });
 
@@ -206,5 +234,37 @@ describe("BranchBrowserPanel", () => {
     await waitFor(() =>
       expect(rendered.getByRole("button", { name: "Create Worktree" })).toBeTruthy(),
     );
+  });
+
+  it("disables activation when multiple worktrees map to one ref", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "list_branch_inventory") {
+        return Promise.resolve([
+          {
+            ...localEntry,
+            worktree: null,
+            worktree_count: 2,
+            resolution_action: "resolveAmbiguity" as const,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const onBranchActivate = vi.fn();
+    const rendered = render(BranchBrowserPanel, {
+      props: {
+        config: createConfig({
+          selectedBranch: localBranch,
+          onBranchActivate,
+        }),
+      },
+    });
+
+    const button = await waitFor(() =>
+      rendered.getByRole("button", { name: "Resolve Ambiguity" }),
+    );
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(onBranchActivate).not.toHaveBeenCalled();
   });
 });

--- a/gwt-gui/src/lib/components/MainArea.svelte
+++ b/gwt-gui/src/lib/components/MainArea.svelte
@@ -27,6 +27,8 @@
     projectPath,
     branchBrowserConfig = undefined,
     currentBranch = "",
+    selectedCanvasSessionTabId = null,
+    onCanvasSessionSelect = () => {},
     onLaunchAgent,
     onQuickLaunch,
     onTabSelect,
@@ -57,6 +59,8 @@
     projectPath: string;
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
+    selectedCanvasSessionTabId?: string | null;
+    onCanvasSessionSelect?: (tabId: string) => void;
     onLaunchAgent?: () => void;
     onQuickLaunch?: (request: LaunchAgentRequest) => Promise<void>;
     onTabSelect:
@@ -301,6 +305,8 @@
     {projectPath}
     {branchBrowserConfig}
     {currentBranch}
+    {selectedCanvasSessionTabId}
+    {onCanvasSessionSelect}
     {draggedTabId}
     {dropTarget}
     {onGroupFocus}

--- a/gwt-gui/src/lib/components/MainArea.svelte
+++ b/gwt-gui/src/lib/components/MainArea.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import type { GitHubIssueInfo, LaunchAgentRequest, Tab } from "../types";
+  import type {
+    BranchBrowserPanelConfig,
+    GitHubIssueInfo,
+    LaunchAgentRequest,
+    Tab,
+  } from "../types";
   import type {
     TabDropPosition,
     TabGroupState,
@@ -20,6 +25,8 @@
     activeTabId = undefined,
     selectedBranch: _selectedBranch = undefined,
     projectPath,
+    branchBrowserConfig = undefined,
+    currentBranch = "",
     onLaunchAgent,
     onQuickLaunch,
     onTabSelect,
@@ -48,6 +55,8 @@
     activeTabId?: string | undefined;
     selectedBranch?: unknown;
     projectPath: string;
+    branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
+    currentBranch?: string;
     onLaunchAgent?: () => void;
     onQuickLaunch?: (request: LaunchAgentRequest) => Promise<void>;
     onTabSelect:
@@ -290,6 +299,8 @@
     {tabsById}
     activeGroupId={resolvedActiveGroupId}
     {projectPath}
+    {branchBrowserConfig}
+    {currentBranch}
     {draggedTabId}
     {dropTarget}
     {onGroupFocus}

--- a/gwt-gui/src/lib/components/MainArea.svelte
+++ b/gwt-gui/src/lib/components/MainArea.svelte
@@ -4,6 +4,7 @@
     GitHubIssueInfo,
     LaunchAgentRequest,
     Tab,
+    WorktreeInfo,
   } from "../types";
   import type {
     TabDropPosition,
@@ -28,6 +29,9 @@
     branchBrowserConfig = undefined,
     currentBranch = "",
     selectedCanvasSessionTabId = null,
+    canvasWorktrees = [],
+    selectedCanvasWorktreeBranch = null,
+    onCanvasWorktreeSelect = () => {},
     disableSplit = false,
     onCanvasSessionSelect = () => {},
     onLaunchAgent,
@@ -61,6 +65,9 @@
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
     selectedCanvasSessionTabId?: string | null;
+    canvasWorktrees?: WorktreeInfo[];
+    selectedCanvasWorktreeBranch?: string | null;
+    onCanvasWorktreeSelect?: (branchName: string) => void;
     disableSplit?: boolean;
     onCanvasSessionSelect?: (tabId: string) => void;
     onLaunchAgent?: () => void;
@@ -308,6 +315,9 @@
     {branchBrowserConfig}
     {currentBranch}
     {selectedCanvasSessionTabId}
+    {canvasWorktrees}
+    {selectedCanvasWorktreeBranch}
+    {onCanvasWorktreeSelect}
     {disableSplit}
     {onCanvasSessionSelect}
     {draggedTabId}

--- a/gwt-gui/src/lib/components/MainArea.svelte
+++ b/gwt-gui/src/lib/components/MainArea.svelte
@@ -28,6 +28,7 @@
     branchBrowserConfig = undefined,
     currentBranch = "",
     selectedCanvasSessionTabId = null,
+    disableSplit = false,
     onCanvasSessionSelect = () => {},
     onLaunchAgent,
     onQuickLaunch,
@@ -60,6 +61,7 @@
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
     selectedCanvasSessionTabId?: string | null;
+    disableSplit?: boolean;
     onCanvasSessionSelect?: (tabId: string) => void;
     onLaunchAgent?: () => void;
     onQuickLaunch?: (request: LaunchAgentRequest) => Promise<void>;
@@ -306,6 +308,7 @@
     {branchBrowserConfig}
     {currentBranch}
     {selectedCanvasSessionTabId}
+    {disableSplit}
     {onCanvasSessionSelect}
     {draggedTabId}
     {dropTarget}

--- a/gwt-gui/src/lib/components/MainArea.test.ts
+++ b/gwt-gui/src/lib/components/MainArea.test.ts
@@ -123,6 +123,44 @@ describe("MainArea", () => {
     expect(rendered.container.querySelectorAll(".tab")).toHaveLength(3);
   });
 
+  it("honors the explicit activeTabId when fallback layout is used", () => {
+    const tabs: Tab[] = [
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
+    ];
+
+    const rendered = render(MainArea, {
+      props: {
+        tabs,
+        activeTabId: "branchBrowser",
+        projectPath: "/tmp/project",
+        onLaunchAgent: vi.fn(),
+        onQuickLaunch: vi.fn(),
+        onTabSelect: vi.fn(),
+        onTabClose: vi.fn(),
+        onTabReorder: vi.fn(),
+        branchBrowserConfig: {
+          projectPath: "/tmp/project",
+          refreshKey: 0,
+          widthPx: 260,
+          minWidthPx: 220,
+          maxWidthPx: 520,
+          mode: "branch",
+          currentBranch: "main",
+          agentTabBranches: [],
+          activeAgentTabBranch: null,
+          appLanguage: "en",
+          onBranchSelect: vi.fn(),
+        },
+      },
+    });
+
+    expect(
+      rendered.container.querySelector('[data-tab-id="branchBrowser"]')?.classList.contains("active"),
+    ).toBe(true);
+    expect(rendered.container.querySelector('[data-testid="branch-browser-panel"]')).toBeTruthy();
+  });
+
   it("keeps agent and terminal sessions off the top-level tab bar when Agent Canvas is present", () => {
     const tabs: Tab[] = [
       { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },

--- a/gwt-gui/src/lib/components/MainArea.test.ts
+++ b/gwt-gui/src/lib/components/MainArea.test.ts
@@ -197,7 +197,9 @@ describe("MainArea", () => {
     const rendered = renderMainArea({ tabs, layout });
 
     expect(rendered.container.querySelector('[data-testid="agent-canvas-assistant-card"]')).toBeTruthy();
-    expect(rendered.container.querySelector('[data-testid="agent-canvas-worktree-card"]')).toBeTruthy();
+    expect(
+      rendered.container.querySelector('[data-testid^="agent-canvas-worktree-card-"]'),
+    ).toBeTruthy();
   });
 
   it("emits tab select with group id", async () => {

--- a/gwt-gui/src/lib/components/MainArea.test.ts
+++ b/gwt-gui/src/lib/components/MainArea.test.ts
@@ -113,22 +113,42 @@ describe("MainArea", () => {
 
   it("renders a single group by default", () => {
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
       { id: "settings", label: "Settings", type: "settings" },
     ];
     const rendered = renderMainArea({ tabs });
 
     expect(rendered.container.querySelectorAll(".group-pane")).toHaveLength(1);
+    expect(rendered.container.querySelectorAll(".tab")).toHaveLength(3);
+  });
+
+  it("keeps agent and terminal sessions off the top-level tab bar when Agent Canvas is present", () => {
+    const tabs: Tab[] = [
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
+      {
+        id: "agent-1",
+        label: "Worktree Agent",
+        type: "agent",
+        agentId: "codex",
+      },
+      { id: "terminal-1", label: "Shell", type: "terminal" },
+    ];
+    const rendered = renderMainArea({ tabs });
+
     expect(rendered.container.querySelectorAll(".tab")).toHaveLength(2);
+    expect(rendered.container.textContent).toContain("Agent Canvas");
+    expect(rendered.container.querySelector('[data-tab-id="agent-1"]')).toBeNull();
   });
 
   it("renders split groups from the layout tree", () => {
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
       { id: "issues", label: "Issues", type: "issues" },
     ];
-    const base = createInitialTabLayout(tabs, "assistant");
+    const base = createInitialTabLayout(tabs, "agentCanvas");
     const split = splitTabToGroupEdge(base, "issues", base.activeGroupId, "right");
     const rendered = renderMainArea({ tabs, layout: split });
 
@@ -139,12 +159,14 @@ describe("MainArea", () => {
   it("keeps Assistant pinned and emits close for non-pinned tabs", async () => {
     const onTabClose = vi.fn();
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
+      { id: "branchBrowser", label: "Branch Browser", type: "branchBrowser" },
       { id: "settings", label: "Settings", type: "settings" },
     ];
     const rendered = renderMainArea({ tabs, onTabClose });
 
-    expect(getTabByLabel(rendered.container, "Assistant").querySelector(".tab-close")).toBeNull();
+    expect(getTabByLabel(rendered.container, "Agent Canvas").querySelector(".tab-close")).toBeNull();
+    expect(getTabByLabel(rendered.container, "Branch Browser").querySelector(".tab-close")).toBeNull();
     const closeButton = getTabByLabel(rendered.container, "Settings").querySelector(
       ".tab-close",
     ) as HTMLButtonElement;
@@ -152,38 +174,36 @@ describe("MainArea", () => {
     expect(onTabClose).toHaveBeenCalledWith("settings");
   });
 
-  it("renders agent tabs with scrolling label markup and agent-specific dots", () => {
+  it("renders agent sessions inside Agent Canvas instead of the top-level tab bar", () => {
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       {
         id: "agent-1",
         label: "Long Agent Label",
         type: "agent",
-        paneId: "pane-1",
         agentId: "codex",
       },
     ];
     const rendered = renderMainArea({ tabs });
-    const agentTab = rendered.container.querySelector('[data-tab-id="agent-1"]');
-    expect(agentTab?.querySelector(".tab-label-scroll .tab-label-track")).toBeTruthy();
-    expect(agentTab?.querySelector(".tab-dot.codex")).toBeTruthy();
+    expect(rendered.container.querySelector('[data-tab-id="agent-1"]')).toBeNull();
+    expect(rendered.container.querySelector('[data-testid="agent-canvas-session-agent-1"]')).toBeTruthy();
   });
 
-  it("shows waiting placeholder when the active agent tab has no paneId", () => {
+  it("shows a worktree card and assistant card inside Agent Canvas", () => {
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
-      { id: "agent-1", label: "Agent", type: "agent" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
     ];
-    const layout = createInitialTabLayout(tabs, "agent-1");
+    const layout = createInitialTabLayout(tabs, "agentCanvas");
     const rendered = renderMainArea({ tabs, layout });
 
-    expect(rendered.container.textContent).toContain("Agent starting...");
+    expect(rendered.container.querySelector('[data-testid="agent-canvas-assistant-card"]')).toBeTruthy();
+    expect(rendered.container.querySelector('[data-testid="agent-canvas-worktree-card"]')).toBeTruthy();
   });
 
   it("emits tab select with group id", async () => {
     const onTabSelect = vi.fn();
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
     ];
     const rendered = renderMainArea({
@@ -199,7 +219,7 @@ describe("MainArea", () => {
   it("emits reorder during dragover inside the same group", async () => {
     const onTabReorder = vi.fn();
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
       { id: "issues", label: "Issues", type: "issues" },
     ];
@@ -250,11 +270,11 @@ describe("MainArea", () => {
   it("emits move-to-group when dropping onto another group tab bar", async () => {
     const onTabMoveToGroup = vi.fn();
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
       { id: "issues", label: "Issues", type: "issues" },
     ];
-    const base = createInitialTabLayout(tabs, "assistant");
+    const base = createInitialTabLayout(tabs, "agentCanvas");
     const split = splitTabToGroupEdge(base, "issues", base.activeGroupId, "right");
     const rendered = renderMainArea({ tabs, layout: split, onTabMoveToGroup });
 
@@ -281,7 +301,7 @@ describe("MainArea", () => {
   it("emits split-to-edge when dropping on a split target", async () => {
     const onTabSplitToGroupEdge = vi.fn();
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
       { id: "issues", label: "Issues", type: "issues" },
     ];
@@ -311,7 +331,7 @@ describe("MainArea", () => {
   it("offers an explicit split action from the tab menu", async () => {
     const onTabSplitToGroupEdge = vi.fn();
     const tabs: Tab[] = [
-      { id: "assistant", label: "Assistant", type: "assistant" },
+      { id: "agentCanvas", label: "Agent Canvas", type: "agentCanvas" },
       { id: "settings", label: "Settings", type: "settings" },
     ];
     const rendered = renderMainArea({ tabs, onTabSplitToGroupEdge });

--- a/gwt-gui/src/lib/components/Sidebar.svelte
+++ b/gwt-gui/src/lib/components/Sidebar.svelte
@@ -61,6 +61,7 @@
     onResize,
     onOpenCiLog,
     onDisplayNameChanged,
+    embedded = false,
     widthPx = 260,
     minWidthPx = 220,
     maxWidthPx = 520,
@@ -86,6 +87,7 @@
     onResize?: (nextWidthPx: number) => void;
     onOpenCiLog?: (runId: number) => void;
     onDisplayNameChanged?: () => void;
+    embedded?: boolean;
     widthPx?: number;
     minWidthPx?: number;
     maxWidthPx?: number;
@@ -1505,6 +1507,7 @@
 
 <aside
   class="sidebar"
+  class:embedded={embedded}
   style="width: {clampedWidthPx}px; min-width: {clampedWidthPx}px;"
 >
   <div class="mode-toggle">
@@ -1722,13 +1725,15 @@
       </div>
     </div>
   {/if}
-  <button
-    type="button"
-    class="resize-handle"
-    aria-label="Resize sidebar"
-    onpointerdown={handleResizePointerDown}
-    onkeydown={handleResizeKeydown}
-  ></button>
+  {#if !embedded}
+    <button
+      type="button"
+      class="resize-handle"
+      aria-label="Resize sidebar"
+      onpointerdown={handleResizePointerDown}
+      onkeydown={handleResizeKeydown}
+    ></button>
+  {/if}
 </aside>
 
 <!-- Context menu (fixed position, outside sidebar overflow) -->
@@ -1778,6 +1783,12 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+  }
+
+  .sidebar.embedded {
+    width: 100% !important;
+    min-width: 0 !important;
+    border-right: none;
   }
 
   .resize-handle {

--- a/gwt-gui/src/lib/components/TabGroupPane.svelte
+++ b/gwt-gui/src/lib/components/TabGroupPane.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import type { GitHubIssueInfo, LaunchAgentRequest, Tab } from "../types";
+  import type {
+    BranchBrowserPanelConfig,
+    GitHubIssueInfo,
+    LaunchAgentRequest,
+    Tab,
+  } from "../types";
   import type {
     TabDropPosition,
     TabGroupState,
@@ -14,6 +19,8 @@
   import VersionHistoryPanel from "./VersionHistoryPanel.svelte";
   import ProjectIndexPanel from "./ProjectIndexPanel.svelte";
   import AssistantPanel from "./AssistantPanel.svelte";
+  import AgentCanvasPanel from "./AgentCanvasPanel.svelte";
+  import BranchBrowserPanel from "./BranchBrowserPanel.svelte";
 
   function isAgentOrTerminal(tab: Tab | null | undefined): boolean {
     return tab?.type === "agent" || tab?.type === "terminal";
@@ -24,6 +31,8 @@
     tabsById,
     activeGroupId,
     projectPath,
+    branchBrowserConfig = undefined,
+    currentBranch = "",
     draggedTabId = null,
     dropTarget = null,
     onGroupFocus,
@@ -56,6 +65,8 @@
     tabsById: Record<string, Tab>;
     activeGroupId: string;
     projectPath: string;
+    branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
+    currentBranch?: string;
     draggedTabId?: string | null;
     dropTarget?: TabLayoutDropTarget | null;
     onGroupFocus: (groupId: string) => void;
@@ -110,6 +121,19 @@
   let groupTabs = $derived(
     group.tabIds.map((tabId) => tabsById[tabId]).filter(Boolean),
   );
+  let visibleGroupTabs = $derived(
+    groupTabs.filter(
+      (tab) =>
+        tab.type !== "assistant" &&
+        tab.type !== "agent" &&
+        tab.type !== "terminal",
+    ),
+  );
+  let canvasSessionTabs = $derived(
+    Object.values(tabsById).filter(
+      (tab) => tab.type === "agent" || tab.type === "terminal",
+    ),
+  );
   let activeTab = $derived(
     group.activeTabId ? tabsById[group.activeTabId] : null,
   );
@@ -120,7 +144,7 @@
   );
 
   function isPinnedTab(tab: Tab | null | undefined) {
-    return tab?.type === "assistant";
+    return tab?.type === "agentCanvas" || tab?.type === "branchBrowser";
   }
 
   function canSplitCurrentGroup(): boolean {
@@ -178,7 +202,7 @@
     ondragover={(event) => onGroupDragOver(group.id, event)}
     ondrop={(event) => onGroupDrop(group.id, event)}
   >
-    {#each groupTabs as tab (tab.id)}
+    {#each visibleGroupTabs as tab (tab.id)}
       <div
         class="tab"
         role="tab"
@@ -339,7 +363,7 @@
       ondrop={(event) => onSplitDrop(group.id, "left", event)}
     ></div>
 
-    {#if groupTabs.length === 0}
+    {#if visibleGroupTabs.length === 0}
       <div class="placeholder">
         <h2>Select a tab</h2>
       </div>
@@ -376,6 +400,22 @@
               />
             {:else if tab.type === "projectIndex"}
               <ProjectIndexPanel {projectPath} />
+            {:else if tab.type === "agentCanvas"}
+              <AgentCanvasPanel
+                {projectPath}
+                {currentBranch}
+                tabs={canvasSessionTabs}
+                onOpenSettings={onOpenSettings ?? (() => {})}
+                {voiceInputEnabled}
+                {voiceInputListening}
+                {voiceInputPreparing}
+                {voiceInputSupported}
+                {voiceInputAvailable}
+                {voiceInputAvailabilityReason}
+                {voiceInputError}
+              />
+            {:else if tab.type === "branchBrowser" && branchBrowserConfig}
+              <BranchBrowserPanel config={branchBrowserConfig} />
             {:else if tab.type === "assistant"}
               <AssistantPanel
                 isActive={group.activeTabId === tab.id}

--- a/gwt-gui/src/lib/components/TabGroupPane.svelte
+++ b/gwt-gui/src/lib/components/TabGroupPane.svelte
@@ -418,11 +418,11 @@
     min-height: 0;
     overflow: hidden;
     background: var(--bg-primary);
-    border: 1px solid var(--border-color);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border-color) 72%, transparent);
   }
 
   .group-pane.active-group {
-    border-color: var(--accent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 36%, var(--border-color));
   }
 
   .tab-bar {
@@ -610,6 +610,7 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
+    background: var(--bg-primary);
   }
 
   .panel-wrapper,
@@ -623,7 +624,7 @@
   }
 
   .panel-wrapper {
-    padding: 24px;
+    padding: 0;
   }
 
   .panel-wrapper.active,

--- a/gwt-gui/src/lib/components/TabGroupPane.svelte
+++ b/gwt-gui/src/lib/components/TabGroupPane.svelte
@@ -4,6 +4,7 @@
     GitHubIssueInfo,
     LaunchAgentRequest,
     Tab,
+    WorktreeInfo,
   } from "../types";
   import type {
     TabDropPosition,
@@ -34,6 +35,9 @@
     branchBrowserConfig = undefined,
     currentBranch = "",
     selectedCanvasSessionTabId = null,
+    canvasWorktrees = [],
+    selectedCanvasWorktreeBranch = null,
+    onCanvasWorktreeSelect = () => {},
     disableSplit = false,
     onCanvasSessionSelect = () => {},
     draggedTabId = null,
@@ -71,6 +75,9 @@
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
     selectedCanvasSessionTabId?: string | null;
+    canvasWorktrees?: WorktreeInfo[];
+    selectedCanvasWorktreeBranch?: string | null;
+    onCanvasWorktreeSelect?: (branchName: string) => void;
     disableSplit?: boolean;
     onCanvasSessionSelect?: (tabId: string) => void;
     draggedTabId?: string | null;
@@ -415,6 +422,9 @@
                 {projectPath}
                 {currentBranch}
                 tabs={canvasSessionTabs}
+                worktrees={canvasWorktrees}
+                selectedWorktreeBranch={selectedCanvasWorktreeBranch}
+                onWorktreeSelect={onCanvasWorktreeSelect}
                 selectedSessionTabId={selectedCanvasSessionTabId}
                 onSessionSelect={onCanvasSessionSelect}
                 onOpenSettings={onOpenSettings ?? (() => {})}

--- a/gwt-gui/src/lib/components/TabGroupPane.svelte
+++ b/gwt-gui/src/lib/components/TabGroupPane.svelte
@@ -33,6 +33,8 @@
     projectPath,
     branchBrowserConfig = undefined,
     currentBranch = "",
+    selectedCanvasSessionTabId = null,
+    onCanvasSessionSelect = () => {},
     draggedTabId = null,
     dropTarget = null,
     onGroupFocus,
@@ -67,6 +69,8 @@
     projectPath: string;
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
+    selectedCanvasSessionTabId?: string | null;
+    onCanvasSessionSelect?: (tabId: string) => void;
     draggedTabId?: string | null;
     dropTarget?: TabLayoutDropTarget | null;
     onGroupFocus: (groupId: string) => void;
@@ -405,6 +409,8 @@
                 {projectPath}
                 {currentBranch}
                 tabs={canvasSessionTabs}
+                selectedSessionTabId={selectedCanvasSessionTabId}
+                onSessionSelect={onCanvasSessionSelect}
                 onOpenSettings={onOpenSettings ?? (() => {})}
                 {voiceInputEnabled}
                 {voiceInputListening}

--- a/gwt-gui/src/lib/components/TabGroupPane.svelte
+++ b/gwt-gui/src/lib/components/TabGroupPane.svelte
@@ -34,6 +34,7 @@
     branchBrowserConfig = undefined,
     currentBranch = "",
     selectedCanvasSessionTabId = null,
+    disableSplit = false,
     onCanvasSessionSelect = () => {},
     draggedTabId = null,
     dropTarget = null,
@@ -70,6 +71,7 @@
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
     selectedCanvasSessionTabId?: string | null;
+    disableSplit?: boolean;
     onCanvasSessionSelect?: (tabId: string) => void;
     draggedTabId?: string | null;
     dropTarget?: TabLayoutDropTarget | null;
@@ -152,7 +154,7 @@
   }
 
   function canSplitCurrentGroup(): boolean {
-    return group.tabIds.length > 1;
+    return !disableSplit && group.tabIds.length > 1;
   }
 
   function handleSplitAction(
@@ -266,56 +268,58 @@
         {:else}
           <span class="tab-label">{tab.label}</span>
         {/if}
-        <details class="tab-actions">
-          <summary
-            class="tab-actions-toggle"
-            onpointerdown={(event) => event.stopPropagation()}
-          >
-            ⋯
-          </summary>
-          <div class="tab-actions-menu">
-            <button
-              type="button"
-              disabled={!canSplitCurrentGroup()}
-              onclick={(event) => {
-                event.stopPropagation();
-                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "left");
-              }}
+        {#if !disableSplit}
+          <details class="tab-actions">
+            <summary
+              class="tab-actions-toggle"
+              onpointerdown={(event) => event.stopPropagation()}
             >
-              Split Left
-            </button>
-            <button
-              type="button"
-              disabled={!canSplitCurrentGroup()}
-              onclick={(event) => {
-                event.stopPropagation();
-                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "right");
-              }}
-            >
-              Split Right
-            </button>
-            <button
-              type="button"
-              disabled={!canSplitCurrentGroup()}
-              onclick={(event) => {
-                event.stopPropagation();
-                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "up");
-              }}
-            >
-              Split Up
-            </button>
-            <button
-              type="button"
-              disabled={!canSplitCurrentGroup()}
-              onclick={(event) => {
-                event.stopPropagation();
-                handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "down");
-              }}
-            >
-              Split Down
-            </button>
-          </div>
-        </details>
+              ⋯
+            </summary>
+            <div class="tab-actions-menu">
+              <button
+                type="button"
+                disabled={!canSplitCurrentGroup()}
+                onclick={(event) => {
+                  event.stopPropagation();
+                  handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "left");
+                }}
+              >
+                Split Left
+              </button>
+              <button
+                type="button"
+                disabled={!canSplitCurrentGroup()}
+                onclick={(event) => {
+                  event.stopPropagation();
+                  handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "right");
+                }}
+              >
+                Split Right
+              </button>
+              <button
+                type="button"
+                disabled={!canSplitCurrentGroup()}
+                onclick={(event) => {
+                  event.stopPropagation();
+                  handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "up");
+                }}
+              >
+                Split Up
+              </button>
+              <button
+                type="button"
+                disabled={!canSplitCurrentGroup()}
+                onclick={(event) => {
+                  event.stopPropagation();
+                  handleSplitAction(event.currentTarget.closest("details") as HTMLDetailsElement, tab.id, "down");
+                }}
+              >
+                Split Down
+              </button>
+            </div>
+          </details>
+        {/if}
         {#if !isPinnedTab(tab)}
           <button
             class="tab-close"
@@ -334,38 +338,40 @@
   </div>
 
   <div class="group-content" class:drag-active={draggedTabId !== null}>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="split-target split-target-top"
-      role="presentation"
-      class:active={isSplitTarget("up")}
-      ondragover={(event) => onSplitDragOver(group.id, "up", event)}
-      ondrop={(event) => onSplitDrop(group.id, "up", event)}
-    ></div>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="split-target split-target-right"
-      role="presentation"
-      class:active={isSplitTarget("right")}
-      ondragover={(event) => onSplitDragOver(group.id, "right", event)}
-      ondrop={(event) => onSplitDrop(group.id, "right", event)}
-    ></div>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="split-target split-target-bottom"
-      role="presentation"
-      class:active={isSplitTarget("down")}
-      ondragover={(event) => onSplitDragOver(group.id, "down", event)}
-      ondrop={(event) => onSplitDrop(group.id, "down", event)}
-    ></div>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="split-target split-target-left"
-      role="presentation"
-      class:active={isSplitTarget("left")}
-      ondragover={(event) => onSplitDragOver(group.id, "left", event)}
-      ondrop={(event) => onSplitDrop(group.id, "left", event)}
-    ></div>
+    {#if !disableSplit}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="split-target split-target-top"
+        role="presentation"
+        class:active={isSplitTarget("up")}
+        ondragover={(event) => onSplitDragOver(group.id, "up", event)}
+        ondrop={(event) => onSplitDrop(group.id, "up", event)}
+      ></div>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="split-target split-target-right"
+        role="presentation"
+        class:active={isSplitTarget("right")}
+        ondragover={(event) => onSplitDragOver(group.id, "right", event)}
+        ondrop={(event) => onSplitDrop(group.id, "right", event)}
+      ></div>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="split-target split-target-bottom"
+        role="presentation"
+        class:active={isSplitTarget("down")}
+        ondragover={(event) => onSplitDragOver(group.id, "down", event)}
+        ondrop={(event) => onSplitDrop(group.id, "down", event)}
+      ></div>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="split-target split-target-left"
+        role="presentation"
+        class:active={isSplitTarget("left")}
+        ondragover={(event) => onSplitDragOver(group.id, "left", event)}
+        ondrop={(event) => onSplitDrop(group.id, "left", event)}
+      ></div>
+    {/if}
 
     {#if visibleGroupTabs.length === 0}
       <div class="placeholder">

--- a/gwt-gui/src/lib/components/TabGroupPane.svelte
+++ b/gwt-gui/src/lib/components/TabGroupPane.svelte
@@ -226,7 +226,7 @@
         class:dragging={draggedTabId === tab.id}
         class:drop-before={isTabDropTarget(tab.id, "before")}
         class:drop-after={isTabDropTarget(tab.id, "after")}
-        draggable="true"
+        draggable={!disableSplit}
         title={tab.type === "terminal" ? tab.cwd || "" : ""}
         onclick={() => onTabSelect(group.id, tab.id)}
         onkeydown={(event) => {

--- a/gwt-gui/src/lib/components/TabLayoutNode.svelte
+++ b/gwt-gui/src/lib/components/TabLayoutNode.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import type { GitHubIssueInfo, LaunchAgentRequest, Tab } from "../types";
+  import type {
+    BranchBrowserPanelConfig,
+    GitHubIssueInfo,
+    LaunchAgentRequest,
+    Tab,
+  } from "../types";
   import type {
     TabDropPosition,
     TabGroupState,
@@ -16,6 +21,8 @@
     tabsById,
     activeGroupId,
     projectPath,
+    branchBrowserConfig = undefined,
+    currentBranch = "",
     draggedTabId = null,
     dropTarget = null,
     onGroupFocus,
@@ -50,6 +57,8 @@
     tabsById: Record<string, Tab>;
     activeGroupId: string;
     projectPath: string;
+    branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
+    currentBranch?: string;
     draggedTabId?: string | null;
     dropTarget?: TabLayoutDropTarget | null;
     onGroupFocus: (groupId: string) => void;
@@ -140,6 +149,8 @@
       {tabsById}
       {activeGroupId}
       {projectPath}
+      {branchBrowserConfig}
+      {currentBranch}
       {draggedTabId}
       {dropTarget}
       {onGroupFocus}
@@ -182,6 +193,8 @@
         {tabsById}
         {activeGroupId}
         {projectPath}
+        {branchBrowserConfig}
+        {currentBranch}
         {draggedTabId}
         {dropTarget}
         {onGroupFocus}
@@ -225,6 +238,8 @@
         {tabsById}
         {activeGroupId}
         {projectPath}
+        {branchBrowserConfig}
+        {currentBranch}
         {draggedTabId}
         {dropTarget}
         {onGroupFocus}

--- a/gwt-gui/src/lib/components/TabLayoutNode.svelte
+++ b/gwt-gui/src/lib/components/TabLayoutNode.svelte
@@ -279,18 +279,19 @@
   }
 
   .split-divider {
-    flex: 0 0 6px;
-    background: var(--bg-secondary);
+    flex: 0 0 4px;
+    background: color-mix(in srgb, var(--bg-secondary) 45%, transparent);
     cursor: col-resize;
-    border-left: 1px solid var(--border-color);
-    border-right: 1px solid var(--border-color);
+    border-left: 1px solid color-mix(in srgb, var(--border-color) 75%, transparent);
+  }
+
+  .split-divider:hover {
+    background: color-mix(in srgb, var(--accent) 18%, var(--bg-secondary));
   }
 
   .split-divider.vertical {
     cursor: row-resize;
     border-left: none;
-    border-right: none;
-    border-top: 1px solid var(--border-color);
-    border-bottom: 1px solid var(--border-color);
+    border-top: 1px solid color-mix(in srgb, var(--border-color) 75%, transparent);
   }
 </style>

--- a/gwt-gui/src/lib/components/TabLayoutNode.svelte
+++ b/gwt-gui/src/lib/components/TabLayoutNode.svelte
@@ -23,6 +23,8 @@
     projectPath,
     branchBrowserConfig = undefined,
     currentBranch = "",
+    selectedCanvasSessionTabId = null,
+    onCanvasSessionSelect = () => {},
     draggedTabId = null,
     dropTarget = null,
     onGroupFocus,
@@ -59,6 +61,8 @@
     projectPath: string;
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
+    selectedCanvasSessionTabId?: string | null;
+    onCanvasSessionSelect?: (tabId: string) => void;
     draggedTabId?: string | null;
     dropTarget?: TabLayoutDropTarget | null;
     onGroupFocus: (groupId: string) => void;
@@ -151,6 +155,8 @@
       {projectPath}
       {branchBrowserConfig}
       {currentBranch}
+      {selectedCanvasSessionTabId}
+      {onCanvasSessionSelect}
       {draggedTabId}
       {dropTarget}
       {onGroupFocus}
@@ -195,6 +201,8 @@
         {projectPath}
         {branchBrowserConfig}
         {currentBranch}
+        {selectedCanvasSessionTabId}
+        {onCanvasSessionSelect}
         {draggedTabId}
         {dropTarget}
         {onGroupFocus}
@@ -240,6 +248,8 @@
         {projectPath}
         {branchBrowserConfig}
         {currentBranch}
+        {selectedCanvasSessionTabId}
+        {onCanvasSessionSelect}
         {draggedTabId}
         {dropTarget}
         {onGroupFocus}

--- a/gwt-gui/src/lib/components/TabLayoutNode.svelte
+++ b/gwt-gui/src/lib/components/TabLayoutNode.svelte
@@ -24,6 +24,7 @@
     branchBrowserConfig = undefined,
     currentBranch = "",
     selectedCanvasSessionTabId = null,
+    disableSplit = false,
     onCanvasSessionSelect = () => {},
     draggedTabId = null,
     dropTarget = null,
@@ -62,6 +63,7 @@
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
     selectedCanvasSessionTabId?: string | null;
+    disableSplit?: boolean;
     onCanvasSessionSelect?: (tabId: string) => void;
     draggedTabId?: string | null;
     dropTarget?: TabLayoutDropTarget | null;
@@ -156,6 +158,7 @@
       {branchBrowserConfig}
       {currentBranch}
       {selectedCanvasSessionTabId}
+      {disableSplit}
       {onCanvasSessionSelect}
       {draggedTabId}
       {dropTarget}
@@ -202,6 +205,7 @@
         {branchBrowserConfig}
         {currentBranch}
         {selectedCanvasSessionTabId}
+        {disableSplit}
         {onCanvasSessionSelect}
         {draggedTabId}
         {dropTarget}
@@ -249,6 +253,7 @@
         {branchBrowserConfig}
         {currentBranch}
         {selectedCanvasSessionTabId}
+        {disableSplit}
         {onCanvasSessionSelect}
         {draggedTabId}
         {dropTarget}

--- a/gwt-gui/src/lib/components/TabLayoutNode.svelte
+++ b/gwt-gui/src/lib/components/TabLayoutNode.svelte
@@ -4,6 +4,7 @@
     GitHubIssueInfo,
     LaunchAgentRequest,
     Tab,
+    WorktreeInfo,
   } from "../types";
   import type {
     TabDropPosition,
@@ -24,6 +25,9 @@
     branchBrowserConfig = undefined,
     currentBranch = "",
     selectedCanvasSessionTabId = null,
+    canvasWorktrees = [],
+    selectedCanvasWorktreeBranch = null,
+    onCanvasWorktreeSelect = () => {},
     disableSplit = false,
     onCanvasSessionSelect = () => {},
     draggedTabId = null,
@@ -63,6 +67,9 @@
     branchBrowserConfig?: BranchBrowserPanelConfig | undefined;
     currentBranch?: string;
     selectedCanvasSessionTabId?: string | null;
+    canvasWorktrees?: WorktreeInfo[];
+    selectedCanvasWorktreeBranch?: string | null;
+    onCanvasWorktreeSelect?: (branchName: string) => void;
     disableSplit?: boolean;
     onCanvasSessionSelect?: (tabId: string) => void;
     draggedTabId?: string | null;
@@ -158,6 +165,9 @@
       {branchBrowserConfig}
       {currentBranch}
       {selectedCanvasSessionTabId}
+      {canvasWorktrees}
+      {selectedCanvasWorktreeBranch}
+      {onCanvasWorktreeSelect}
       {disableSplit}
       {onCanvasSessionSelect}
       {draggedTabId}
@@ -205,6 +215,9 @@
         {branchBrowserConfig}
         {currentBranch}
         {selectedCanvasSessionTabId}
+        {canvasWorktrees}
+        {selectedCanvasWorktreeBranch}
+        {onCanvasWorktreeSelect}
         {disableSplit}
         {onCanvasSessionSelect}
         {draggedTabId}
@@ -253,6 +266,9 @@
         {branchBrowserConfig}
         {currentBranch}
         {selectedCanvasSessionTabId}
+        {canvasWorktrees}
+        {selectedCanvasWorktreeBranch}
+        {onCanvasWorktreeSelect}
         {disableSplit}
         {onCanvasSessionSelect}
         {draggedTabId}

--- a/gwt-gui/src/lib/screenCapture.test.ts
+++ b/gwt-gui/src/lib/screenCapture.test.ts
@@ -65,6 +65,21 @@ describe("collectScreenText", () => {
     expect(result).toContain("main\ndevelop\nfeature/x");
   });
 
+  it("labels the browser surface as Branch Browser when that shell tab is active", () => {
+    container.appendChild(createEl("aside", "sidebar", "Local\nRemote\nAll"));
+    container.appendChild(createEl("main", "main-area", ""));
+    container.appendChild(createEl("footer", "statusbar", ""));
+
+    const result = collectScreenText({
+      branch: "main",
+      activeTab: "Branch Browser",
+      activeTabType: "branchBrowser",
+    });
+
+    expect(result).toContain("--- Branch Browser ---");
+    expect(result).not.toContain("--- Sidebar ---");
+  });
+
   it("includes main area visible text", () => {
     container.appendChild(createEl("aside", "sidebar", ""));
     container.appendChild(createEl("main", "main-area", "$ cargo test\nok"));

--- a/gwt-gui/src/lib/screenCapture.test.ts
+++ b/gwt-gui/src/lib/screenCapture.test.ts
@@ -80,6 +80,23 @@ describe("collectScreenText", () => {
     expect(result).not.toContain("--- Sidebar ---");
   });
 
+  it("captures standalone branch browser surfaces without relying on .sidebar", () => {
+    container.appendChild(
+      createEl("section", "branch-browser-panel", "Local\nRemote\nAll\nfeature/x"),
+    );
+    container.appendChild(createEl("main", "main-area", "browser content"));
+    container.appendChild(createEl("footer", "statusbar", ""));
+
+    const result = collectScreenText({
+      branch: "feature/x",
+      activeTab: "Branch Browser",
+      activeTabType: "branchBrowser",
+    });
+
+    expect(result).toContain("--- Branch Browser ---");
+    expect(result).toContain("Local\nRemote\nAll\nfeature/x");
+  });
+
   it("includes main area visible text", () => {
     container.appendChild(createEl("aside", "sidebar", ""));
     container.appendChild(createEl("main", "main-area", "$ cargo test\nok"));

--- a/gwt-gui/src/lib/screenCapture.ts
+++ b/gwt-gui/src/lib/screenCapture.ts
@@ -128,12 +128,16 @@ export function collectScreenText(ctx: ScreenCaptureContext): string {
     lines.push(modalText);
   }
 
-  // Sidebar
+  // Branch Browser / legacy Sidebar surface
   const sidebar = document.querySelector(".sidebar");
   if (sidebar) {
     const sidebarText = getVisibleText(sidebar);
     lines.push("");
-    lines.push("--- Sidebar ---");
+    lines.push(
+      ctx.activeTabType === "branchBrowser"
+        ? "--- Branch Browser ---"
+        : "--- Sidebar ---",
+    );
     lines.push(sidebarText || "(empty)");
   }
 

--- a/gwt-gui/src/lib/screenCapture.ts
+++ b/gwt-gui/src/lib/screenCapture.ts
@@ -129,9 +129,11 @@ export function collectScreenText(ctx: ScreenCaptureContext): string {
   }
 
   // Branch Browser / legacy Sidebar surface
-  const sidebar = document.querySelector(".sidebar");
-  if (sidebar) {
-    const sidebarText = getVisibleText(sidebar);
+  const browserSurface =
+    document.querySelector(".branch-browser-panel") ??
+    document.querySelector(".sidebar");
+  if (browserSurface) {
+    const sidebarText = getVisibleText(browserSurface);
     lines.push("");
     lines.push(
       ctx.activeTabType === "branchBrowser"

--- a/gwt-gui/src/lib/tabLayout.test.ts
+++ b/gwt-gui/src/lib/tabLayout.test.ts
@@ -5,6 +5,7 @@ import {
   createInitialTabLayout,
   flattenTabIdsByLayout,
   moveTabToGroup,
+  normalizeTabLayoutState,
   removeTabFromLayout,
   reorderTabsInGroup,
   setActiveGroup,
@@ -132,5 +133,47 @@ describe("tabLayout", () => {
     const next = setActiveGroup(split, otherGroupId);
 
     expect(next.activeGroupId).toBe(otherGroupId);
+  });
+
+  it("collapses a dangling split tree back to one full group", () => {
+    const layout = createInitialTabLayout(
+      [{ id: "assistant" }, { id: "settings" }, { id: "issues" }],
+      "assistant",
+    );
+    const split = splitTabToGroupEdge(
+      layout,
+      "issues",
+      layout.activeGroupId,
+      "right",
+    );
+    const survivingGroupId =
+      Object.keys(split.groups).find((id) => id !== split.activeGroupId) ??
+      split.activeGroupId;
+
+    const normalized = normalizeTabLayoutState({
+      ...split,
+      root: {
+        type: "split",
+        id: "split-corrupt",
+        axis: "horizontal",
+        sizes: [0.5, 0.5],
+        children: [
+          { type: "group", groupId: survivingGroupId },
+          { type: "group", groupId: "missing-group" },
+        ],
+      },
+    });
+
+    expect(normalized.root).toEqual({
+      type: "group",
+      groupId: survivingGroupId,
+    });
+    expect(Object.keys(normalized.groups)).toEqual([survivingGroupId]);
+    expect(normalized.groups[survivingGroupId]?.tabIds).toEqual([
+      "assistant",
+      "settings",
+      "issues",
+    ]);
+    expect(normalized.activeGroupId).toBe(survivingGroupId);
   });
 });

--- a/gwt-gui/src/lib/tabLayout.ts
+++ b/gwt-gui/src/lib/tabLayout.ts
@@ -152,6 +152,87 @@ function sanitizeActiveGroupId(
   return groupIds[0] ?? "group-unknown";
 }
 
+function sanitizeRuntimeRoot(
+  node: TabLayoutNode,
+  knownGroupIds: Set<string>,
+): TabLayoutNode | null {
+  if (node.type === "group") {
+    return knownGroupIds.has(node.groupId) ? node : null;
+  }
+
+  const first = sanitizeRuntimeRoot(node.children[0], knownGroupIds);
+  const second = sanitizeRuntimeRoot(node.children[1], knownGroupIds);
+
+  if (!first && !second) return null;
+  if (!first) return second;
+  if (!second) return first;
+
+  const [primary, secondary] = node.sizes;
+  const normalizedPrimary =
+    Number.isFinite(primary) && primary > 0 && primary < 1 ? primary : 0.5;
+
+  return {
+    ...node,
+    sizes: [normalizedPrimary, 1 - normalizedPrimary],
+    children: [first, second],
+  };
+}
+
+function dedupeTabIds(tabIds: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const tabId of tabIds) {
+    if (!tabId || seen.has(tabId)) continue;
+    seen.add(tabId);
+    out.push(tabId);
+  }
+  return out;
+}
+
+function collapseToSingleGroup(
+  groups: Record<string, TabGroupState>,
+  preferredGroupId: string | null,
+  preferredActiveTabId: string | null,
+  orderedTabIds: string[],
+): TabLayoutState {
+  const groupIds = Object.keys(groups);
+  if (groupIds.length === 0) {
+    return createInitialTabLayout([], null);
+  }
+
+  const targetGroupId =
+    (preferredGroupId && groups[preferredGroupId] && preferredGroupId) ||
+    groupIds[0] ||
+    "group-unknown";
+  const targetGroup = groups[targetGroupId];
+  const fallbackOrder = dedupeTabIds(
+    orderedTabIds.length > 0
+      ? orderedTabIds
+      : groupIds.flatMap((groupId) => groups[groupId]?.tabIds ?? []),
+  );
+  const activeTabId =
+    preferredActiveTabId && fallbackOrder.includes(preferredActiveTabId)
+      ? preferredActiveTabId
+      : targetGroup?.activeTabId && fallbackOrder.includes(targetGroup.activeTabId)
+        ? targetGroup.activeTabId
+        : (fallbackOrder[0] ?? null);
+
+  return {
+    groups: {
+      [targetGroupId]: {
+        id: targetGroupId,
+        tabIds: fallbackOrder,
+        activeTabId,
+      },
+    },
+    root: {
+      type: "group",
+      groupId: targetGroupId,
+    },
+    activeGroupId: targetGroupId,
+  };
+}
+
 export function createInitialTabLayout(
   tabs: Pick<Tab, "id">[],
   activeTabId: string | null,
@@ -171,6 +252,85 @@ export function createInitialTabLayout(
       groupId,
     },
     activeGroupId: groupId,
+  };
+}
+
+export function normalizeTabLayoutState(
+  layout: TabLayoutState,
+  preferredActiveTabIdOverride: string | null = null,
+): TabLayoutState {
+  const normalizedGroups: Record<string, TabGroupState> = {};
+
+  for (const [groupId, group] of Object.entries(layout.groups)) {
+    const tabIds = dedupeTabIds(group.tabIds);
+    if (tabIds.length === 0) continue;
+    normalizedGroups[groupId] = {
+      id: group.id,
+      tabIds,
+      activeTabId:
+        group.activeTabId && tabIds.includes(group.activeTabId)
+          ? group.activeTabId
+          : (tabIds[0] ?? null),
+    };
+  }
+
+  const groupIds = Object.keys(normalizedGroups);
+  if (groupIds.length === 0) {
+    return createInitialTabLayout([], null);
+  }
+
+  const knownGroupIds = new Set(groupIds);
+  const sanitizedRoot = sanitizeRuntimeRoot(layout.root, knownGroupIds);
+  const preferredActiveTabId =
+    preferredActiveTabIdOverride ??
+    normalizedGroups[layout.activeGroupId]?.activeTabId ??
+    normalizedGroups[groupIds[0]]?.activeTabId ??
+    null;
+
+  if (!sanitizedRoot) {
+    return collapseToSingleGroup(
+      normalizedGroups,
+      layout.activeGroupId,
+      preferredActiveTabId,
+      groupIds.flatMap((groupId) => normalizedGroups[groupId]?.tabIds ?? []),
+    );
+  }
+
+  const renderedGroupIds = collectGroupIds(sanitizedRoot);
+  const rootOrderedTabIds = dedupeTabIds(
+    renderedGroupIds.flatMap((groupId) => normalizedGroups[groupId]?.tabIds ?? []),
+  );
+
+  if (renderedGroupIds.length !== groupIds.length) {
+    return collapseToSingleGroup(
+      normalizedGroups,
+      renderedGroupIds[0] ?? layout.activeGroupId,
+      preferredActiveTabId,
+      [
+        ...rootOrderedTabIds,
+        ...groupIds.flatMap((groupId) => normalizedGroups[groupId]?.tabIds ?? []),
+      ],
+    );
+  }
+
+  if (renderedGroupIds.length === 1) {
+    const groupId = renderedGroupIds[0] ?? groupIds[0] ?? "group-unknown";
+    return {
+      groups: {
+        [groupId]: normalizedGroups[groupId],
+      },
+      root: {
+        type: "group",
+        groupId,
+      },
+      activeGroupId: groupId,
+    };
+  }
+
+  return {
+    groups: normalizedGroups,
+    root: sanitizedRoot,
+    activeGroupId: sanitizeActiveGroupId(sanitizedRoot, layout.activeGroupId),
   };
 }
 

--- a/gwt-gui/src/lib/terminal/TerminalView.test.ts
+++ b/gwt-gui/src/lib/terminal/TerminalView.test.ts
@@ -1790,6 +1790,28 @@ describe("TerminalView", () => {
     expect(result).toBe(false);
   });
 
+  it("passes Ctrl+Backquote through for native window cycling", async () => {
+    await renderTerminalView({ paneId: "pane-window-cycle", active: true });
+
+    await waitFor(() => {
+      expect(customKeyEventHandler).not.toBeNull();
+    });
+
+    const handler = customKeyEventHandler!;
+    const event = new KeyboardEvent("keydown", {
+      code: "Backquote",
+      key: "`",
+      ctrlKey: true,
+      bubbles: true,
+    });
+    const preventDefaultMock = vi.spyOn(event, "preventDefault");
+
+    const result = handler(event);
+
+    expect(result).toBe(true);
+    expect(preventDefaultMock).not.toHaveBeenCalled();
+  });
+
   it("passes non-keydown events through", async () => {
     await renderTerminalView({ paneId: "pane-keyup", active: true });
 

--- a/gwt-gui/src/lib/types.ts
+++ b/gwt-gui/src/lib/types.ts
@@ -208,7 +208,9 @@ export interface Tab {
   agentId?: AgentId;
   type:
     | "summary"
+    | "agentCanvas"
     | "agent"
+    | "branchBrowser"
     | "settings"
     | "versionHistory"
     | "terminal"
@@ -220,6 +222,31 @@ export interface Tab {
   paneId?: string;
   cwd?: string;
   issueNumber?: number;
+}
+
+export interface BranchBrowserPanelConfig {
+  projectPath: string;
+  refreshKey: number;
+  widthPx: number;
+  minWidthPx: number;
+  maxWidthPx: number;
+  mode: "branch";
+  selectedBranch?: BranchInfo | null;
+  currentBranch: string;
+  agentTabBranches: string[];
+  activeAgentTabBranch?: string | null;
+  appLanguage: SettingsData["app_language"];
+  onModeChange?: (next: "branch") => void;
+  onResize?: (nextWidthPx: number) => void;
+  onBranchSelect: (branch: BranchInfo) => void;
+  onBranchActivate?: (branch: BranchInfo) => void;
+  onCleanupRequest?: (preSelectedBranch?: string) => void;
+  onLaunchAgent?: () => void;
+  onQuickLaunch?: (request: LaunchAgentRequest) => Promise<void>;
+  onNewTerminal?: () => void;
+  onOpenDocsEditor?: (worktreePath: string) => Promise<void> | void;
+  onOpenCiLog?: (runId: number) => void;
+  onDisplayNameChanged?: () => void;
 }
 
 export interface ToolSessionEntry {

--- a/gwt-gui/src/lib/types.ts
+++ b/gwt-gui/src/lib/types.ts
@@ -30,6 +30,11 @@ export interface BranchInfo {
   last_tool_usage?: string | null;
 }
 
+export interface MaterializeWorktreeResult {
+  worktree: WorktreeInfo;
+  created: boolean;
+}
+
 export interface ProjectInfo {
   path: string;
   repo_name: string;

--- a/gwt-gui/src/lib/types.ts
+++ b/gwt-gui/src/lib/types.ts
@@ -30,6 +30,24 @@ export interface BranchInfo {
   last_tool_usage?: string | null;
 }
 
+export type BranchInventoryResolutionAction =
+  | "focusExisting"
+  | "createWorktree"
+  | "resolveAmbiguity";
+
+export interface BranchInventoryEntry {
+  id: string;
+  canonical_name: string;
+  primary_branch: BranchInfo;
+  local_branch?: BranchInfo | null;
+  remote_branch?: BranchInfo | null;
+  has_local: boolean;
+  has_remote: boolean;
+  worktree?: WorktreeInfo | null;
+  worktree_count: number;
+  resolution_action: BranchInventoryResolutionAction;
+}
+
 export interface MaterializeWorktreeResult {
   worktree: WorktreeInfo;
   created: boolean;
@@ -210,6 +228,7 @@ export interface Tab {
   id: string;
   label: string;
   branchName?: string;
+  worktreePath?: string;
   agentId?: AgentId;
   type:
     | "summary"

--- a/installers/macos/install-local.sh
+++ b/installers/macos/install-local.sh
@@ -61,8 +61,13 @@ if [[ -z "$APP_PATH" ]]; then
   if [[ -z "$SKIP_BUILD" ]]; then
     need_cmd cargo
 
-    info "Building app bundle..."
-    (cd "$REPO_ROOT" && cargo tauri build)
+    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
+    export CMAKE_OSX_DEPLOYMENT_TARGET="${CMAKE_OSX_DEPLOYMENT_TARGET:-${MACOSX_DEPLOYMENT_TARGET}}"
+
+    info "Building app bundle only (skip dmg for local install)..."
+    info "MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
+    info "CMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}"
+    (cd "$REPO_ROOT" && cargo tauri build --bundles app -- --bin gwt-tauri)
   fi
 fi
 

--- a/installers/macos/install.sh
+++ b/installers/macos/install.sh
@@ -34,6 +34,19 @@ need_cmd() {
 copy_app_with_privilege() {
   local app_path="$1"
   local dest="/Applications/${APP_NAME}.app"
+  local dest_parent="/Applications"
+
+  if [[ ! -e "$dest" && -w "$dest_parent" ]]; then
+    info "Copying ${APP_NAME}.app to /Applications..."
+    /usr/bin/ditto "$app_path" "$dest"
+    return
+  fi
+
+  if [[ -d "$dest" && -w "$dest" ]]; then
+    info "Copying ${APP_NAME}.app to /Applications..."
+    /usr/bin/ditto "$app_path" "$dest"
+    return
+  fi
 
   # Remove existing installation
   if [[ -d "$dest" ]]; then

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "dev": "cargo tauri dev",
     "build": "cargo tauri build",
+    "install:local:macos": "bash installers/macos/install-local.sh",
+    "install:local:macos:skip-build": "bash installers/macos/install-local.sh --skip-build",
     "test": "cargo test -p gwt-core -p gwt-tauri --all-features",
     "test:frontend": "cd gwt-gui && pnpm test",
     "test:e2e": "cd gwt-gui && pnpm test:e2e",


### PR DESCRIPTION
## Summary

- Add the Workspace Shell flow so Agent Canvas and Branch Browser can open, focus, and launch worktrees from the main GUI.
- Persist canvas session selection, tab layout, and shell preferences so reopened projects restore the same working context.
- Cover the new workflow with backend, GUI, and Chromium E2E tests while updating install and README guidance for local usage.

## Changes

- `gwt-gui/src/App.svelte`, `gwt-gui/src/lib/components/AgentCanvasPanel.svelte`, `gwt-gui/src/lib/components/BranchBrowserPanel.svelte`: add Agent Canvas and Branch Browser interactions, tab routing, and worktree launch/open flows.
- `gwt-gui/src/lib/agentCanvas.ts`, `gwt-gui/src/lib/branchInventory.ts`, `gwt-gui/src/lib/agentTabsPersistence.ts`, `gwt-gui/src/lib/types.ts`: model canvas sessions, branch inventory, and persisted project/session state.
- `crates/gwt-tauri/src/commands/branches.rs`, `crates/gwt-tauri/src/commands/system.rs`, `crates/gwt-tauri/src/app.rs`, `crates/gwt-tauri/src/state.rs`: expose branch inventory and system metadata, wire startup/runtime state, and support the new shell workflow from Tauri.
- `gwt-gui/src/lib/components/MainArea.svelte`, `gwt-gui/src/lib/components/TabGroupPane.svelte`, `gwt-gui/src/lib/components/TabLayoutNode.svelte`, `gwt-gui/src/lib/tabLayout.ts`: keep the split-tab layout compatible with the new canvas-driven navigation.
- `README.md`, `README.ja.md`, `installers/macos/install.sh`, `installers/macos/install-local.sh`: document the workflow and improve local install support around the new GUI feature set.

## Testing

- [x] `cargo test -p gwt-tauri --all-features 'commands::branches::tests::'` — passed
- [x] `cargo test -p gwt-tauri --all-features 'commands::system::tests::'` — passed
- [x] `cargo test -p gwt-tauri --all-features 'app::tests::'` — passed
- [x] `cargo test -p gwt-tauri --all-features 'state::tests::'` — passed
- [x] `pnpm --dir gwt-gui test src/lib/agentCanvas.test.ts src/lib/agentTabsPersistence.test.ts src/lib/branchInventory.test.ts src/lib/components/AgentCanvasPanel.test.ts src/lib/components/BranchBrowserPanel.test.ts src/lib/components/MainArea.test.ts src/lib/tabLayout.test.ts src/lib/terminal/TerminalView.test.ts src/lib/screenCapture.test.ts` — passed
- [x] `pnpm --dir gwt-gui check` — passed
- [x] `pnpm --dir gwt-gui exec playwright test e2e/agent-canvas-browser.spec.ts e2e/windows-shell-selection.spec.ts --project=chromium` — passed

## Closing Issues

- Closes #1654

## Related Issues / Links

- #1687
- #1714
- https://github.com/akiojin/gwt/issues/1654

## Checklist

- [x] Tests added/updated
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — Partial: `svelte-check` passed; `cargo clippy` and `cargo fmt` were not run in this PR workflow
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — N/A: persisted project/tab state stays local and remains backward compatible on restore
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — N/A: non-breaking feature work on a feature branch

## Context

- Issue #1654 defines the Workspace Shell feature set that combines Agent Canvas, Branch Browser, multi-window session handling, and shell launch behavior.
- The branch also carries follow-up integration work for the split-tab layout so the new canvas workflow can coexist with the existing main-area layout.
- The previous PR on this branch was closed without merge, so this PR reintroduces the current branch state for review with the updated feature scope.

## Risk / Impact

- **Affected areas**: Tauri branch/system commands, project/session persistence, main GUI navigation, split-tab layout, and shell launch settings
- **Rollback plan**: revert the feature branch commits introduced after `origin/develop` and restore the previous single-surface workflow for worktree and session handling

## Screenshots

Interactive UI change; no static screenshots are attached in this CLI workflow, and the new behavior is covered by the Chromium Playwright scenarios above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Branch Browser panel for browsing and managing git branches with integrated worktree operations.
  * Added Agent Canvas visualization for managing agent sessions and worktree interactions.
  * Added local macOS installation commands (`pnpm run install:local:macos`) for faster iterative development without waiting for releases.
  * Added startup diagnostics environment variables for troubleshooting.

* **Documentation**
  * Updated macOS installation instructions with local build options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->