### PR TITLE
fix(skills): require gwt-issue-register for new work routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,8 @@
 
 Skills are located in `.claude/skills/<name>/SKILL.md`.
 Commands can be invoked as `/gwt:<command-name>`.
+Routing rule: if the user is registering new work and no GitHub Issue number or URL exists yet, use `gwt-issue-register` before any manual `gh issue create` or SPEC command.
+Never bypass `gwt-issue-register` for duplicate search or ISSUE vs SPEC selection.
 
 ### Issue & SPEC Management
 

--- a/crates/gwt-core/src/config/skill_registration.rs
+++ b/crates/gwt-core/src/config/skill_registration.rs
@@ -71,7 +71,11 @@ pub fn generate_managed_skills_block() -> String {
     block.push('\n');
     block.push_str("## Available Skills & Commands (gwt)\n\n");
     block.push_str("Skills are located in `.claude/skills/<name>/SKILL.md`.\n");
-    block.push_str("Commands can be invoked as `/gwt:<command-name>`.\n\n");
+    block.push_str("Commands can be invoked as `/gwt:<command-name>`.\n");
+    block.push_str("Routing rule: if the user is registering new work and no GitHub Issue number or URL exists yet, use `gwt-issue-register` before any manual `gh issue create` or SPEC command.\n");
+    block.push_str(
+        "Never bypass `gwt-issue-register` for duplicate search or ISSUE vs SPEC selection.\n\n",
+    );
 
     block.push_str("### Issue & SPEC Management\n\n");
     block.push_str("| Skill | Command | Description |\n");
@@ -2369,6 +2373,7 @@ OPENAI_API_KEY = "legacy-key"
         assert!(issue_register_skill.contains("gwt-issue-search"));
         assert!(issue_register_skill.contains("gwt-spec-register"));
         assert!(issue_register_skill.contains("gwt-issue-resolve"));
+        assert!(issue_register_skill.contains("Do not call `gh issue create` manually"));
 
         let project_index_skill = std::fs::read_to_string(
             temp.path()
@@ -2501,6 +2506,7 @@ OPENAI_API_KEY = "legacy-key"
         assert!(issue_register_command.contains("gwt-spec-register"));
         assert!(issue_register_command.contains("gwt-spec-ops"));
         assert!(issue_register_command.contains("POST /repos/<owner>/<repo>/issues"));
+        assert!(issue_register_command.contains("instead of creating a GitHub Issue directly"));
 
         let issue_resolve_command = std::fs::read_to_string(
             temp.path()
@@ -2978,6 +2984,9 @@ another-pattern
                 "managed block should NOT contain command ref for no-command skill: {command_ref}"
             );
         }
+
+        assert!(block.contains("no GitHub Issue number or URL exists yet"));
+        assert!(block.contains("Never bypass `gwt-issue-register`"));
     }
 
     #[test]

--- a/plugins/gwt/commands/gwt-issue-register.md
+++ b/plugins/gwt/commands/gwt-issue-register.md
@@ -11,6 +11,8 @@ allowed-tools: Read, Glob, Grep, Bash
 
 Use this command as the main entrypoint for new work registration.
 
+Hard routing rule: when the user asks to issue-file or register new work without an existing GitHub Issue number or URL, invoke this command instead of creating a GitHub Issue directly with `gh issue create`.
+
 ## Usage
 
 ```text
@@ -32,13 +34,13 @@ Use this command as the main entrypoint for new work registration.
 <example>
 Context: User wants to register a new bug report
 user: "この不具合を Issue 化して"
-assistant: "gwt-issue-register で既存 Issue / SPEC の重複を確認し、重複がなければ通常 Issue か新規 SPEC かを判断して登録します。"
+assistant: "新規登録なので、まず gwt-issue-register で既存 Issue / SPEC の重複を確認し、直接 `gh issue create` はせずに通常 Issue か新規 SPEC かを判断して登録します。"
 </example>
 
 <example>
 Context: User wants to formalize a new feature request
 user: "この要望を起票して"
-assistant: "gwt-issue-register で既存の Issue / SPEC を検索し、既存の行き先がなければ通常 Issue か新規 SPEC かを決めて登録します。"
+assistant: "新規の起票要求なので、gwt-issue-register で既存の Issue / SPEC を検索し、既存の行き先がなければ通常 Issue か新規 SPEC かを決めます。"
 </example>
 
 ## Examples

--- a/plugins/gwt/skills/gwt-issue-register/SKILL.md
+++ b/plugins/gwt/skills/gwt-issue-register/SKILL.md
@@ -10,6 +10,11 @@ feature request, enhancement idea, documentation task, or rough note.
 
 `gwt-issue-register` is the main entrypoint for new work registration.
 
+Hard routing rule:
+
+- If the user is asking to create, file, register, or draft new work and does not already have a GitHub Issue number or URL, start with this skill.
+- Do not call `gh issue create` manually and do not jump to `gwt-spec-register` before this skill completes duplicate search and ISSUE vs SPEC selection.
+
 - If the user already has an Issue number or URL, use `gwt-issue-resolve`.
 - If the target `gwt-spec` issue is already known, use `gwt-spec-ops`.
 - If this skill determines that a new SPEC is required, create it through


### PR DESCRIPTION
## Summary

- Add explicit routing rules that force new work registration through `gwt-issue-register` before any manual `gh issue create` path.
- Strengthen the `gwt-issue-register` skill and command guidance so duplicate search and ISSUE-vs-SPEC selection cannot be skipped by prompt phrasing alone.
- Add regression assertions in `gwt-core` so regenerated managed skill assets keep the stronger routing guardrails.

## Changes

- `crates/gwt-core/src/config/skill_registration.rs`: add the new-work routing rule to the generated managed skills block and assert the generated block/asset content in tests.
- `plugins/gwt/skills/gwt-issue-register/SKILL.md`: document a hard routing rule that forbids manual `gh issue create` or early `gwt-spec-register` jumps.
- `plugins/gwt/commands/gwt-issue-register.md`: make the command entrypoint mandatory for new issue-filing requests and strengthen the trigger examples.
- `CLAUDE.md`: sync the checked-in managed skills block with the new routing rule text.

## Testing

- [x] `cargo fmt --all` — formatting completed successfully
- [x] `cargo test -p gwt-core project_index_and_spec_ops_assets_encode_issue_search_first_guidance --lib` — generated skill assets include the new guardrail text
- [x] `cargo test -p gwt-core generate_managed_skills_block_contains_all_skills --lib` — managed skills block contains the new routing rule

## Closing Issues

- Closes #1712

## Related Issues / Links

- #1711

## Checklist

- [x] Tests added/updated
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — Partial: ran `cargo fmt --all`; `cargo clippy` and `svelte-check` were not run for this non-runtime skill/documentation change
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change) — N/A: no schema or stored data change
- [x] CHANGELOG impact considered (breaking change flagged in commit) — No breaking change

## Context

- Issue #1712 was filed because a real registration flow bypassed `gwt-issue-register` and went directly to plain issue creation.
- The fix targets both the generated `CLAUDE.md` guidance and the skill/command source assets so future project-local regeneration preserves the stronger routing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated workflow documentation with explicit routing rules for registering new work items
- Clarified that the issue registration process must run before direct issue creation commands
- Added guidance requiring duplicate checking and type selection to complete before advancing to next registration steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->