### PR TITLE
feat(logging): 通常ログ基盤の統合設計と機能・障害対応ログ90%カバレッジ

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -182,13 +182,8 @@ scripts/voice-eval.sh
 
 ### ログとプロファイリング
 
-gwt は 2 種類の出力を分離して管理します。
-
-- **通常ログ** (`gwt.jsonl.*`) — JSON Lines 形式の運用ログ。Issue report に使用。`~/.gwt/logs/<workspace>/` に保存
-- **プロファイリング** (`profile.json`) — Chrome Trace 形式の性能分析用。**Settings > Profiling** で有効化
-
-Report Dialog の **Application Logs** は通常ログのみを収集し、プロファイリング出力は含みません。
-詳細は [#1758](https://github.com/akiojin/gwt/issues/1758) を参照してください。
+通常ログは `~/.gwt/logs/` 配下に JSON Lines 形式で保存されます。パフォーマンスプロファイリングは **Settings > Profiling** で有効化できます。
+ログ仕様の詳細は [#1758](https://github.com/akiojin/gwt/issues/1758) を参照してください。
 
 ## ライセンス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -180,6 +180,16 @@ scripts/voice-eval.sh
 - `GWT_AGENT_AUTO_INSTALL_DEPS` (`true` / `false`)
 - `GWT_DOCKER_FORCE_HOST` (`true` / `false`)
 
+### ログとプロファイリング
+
+gwt は 2 種類の出力を分離して管理します。
+
+- **通常ログ** (`gwt.jsonl.*`) — JSON Lines 形式の運用ログ。Issue report に使用。`~/.gwt/logs/<workspace>/` に保存
+- **プロファイリング** (`profile.json`) — Chrome Trace 形式の性能分析用。**Settings > Profiling** で有効化
+
+Report Dialog の **Application Logs** は通常ログのみを収集し、プロファイリング出力は含みません。
+詳細は [#1758](https://github.com/akiojin/gwt/issues/1758) を参照してください。
+
 ## ライセンス
 
 MIT

--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Voice input uses Qwen3-ASR via a local Python runtime.
 - `GWT_AGENT_AUTO_INSTALL_DEPS` (`true` / `false`)
 - `GWT_DOCKER_FORCE_HOST` (`true` / `false`)
 
+### Logging and profiling
+
+gwt writes two separate output streams:
+
+- **Normal logs** (`gwt.jsonl.*`) — JSON Lines for operational tracking and issue reports. Stored under `~/.gwt/logs/<workspace>/`.
+- **Profiling** (`profile.json`) — Chrome Trace format for performance analysis. Enable in **Settings > Profiling**.
+
+The Report Dialog's **Application Logs** section collects normal logs only; profiling output is never included.
+For details see [#1758](https://github.com/akiojin/gwt/issues/1758).
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -188,13 +188,8 @@ Voice input uses Qwen3-ASR via a local Python runtime.
 
 ### Logging and profiling
 
-gwt writes two separate output streams:
-
-- **Normal logs** (`gwt.jsonl.*`) — JSON Lines for operational tracking and issue reports. Stored under `~/.gwt/logs/<workspace>/`.
-- **Profiling** (`profile.json`) — Chrome Trace format for performance analysis. Enable in **Settings > Profiling**.
-
-The Report Dialog's **Application Logs** section collects normal logs only; profiling output is never included.
-For details see [#1758](https://github.com/akiojin/gwt/issues/1758).
+Normal logs are stored as JSON Lines under `~/.gwt/logs/`. Performance profiling can be enabled in **Settings > Profiling**.
+See [#1758](https://github.com/akiojin/gwt/issues/1758) for the logging specification.
 
 ## License
 

--- a/crates/gwt-core/src/config/settings.rs
+++ b/crates/gwt-core/src/config/settings.rs
@@ -469,6 +469,12 @@ impl Settings {
 
     fn load_from_path(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path).map_err(|e| {
+            crate::logging::log_incident(
+                "config",
+                "load",
+                Some("CONFIG_LOAD_FAILED"),
+                &format!("path={}: {}", path.display(), e),
+            );
             error!(
                 category = "config",
                 path = %path.display(),
@@ -483,6 +489,12 @@ impl Settings {
         toml::from_str::<ConfigToml>(&content)
             .map(Into::into)
             .map_err(|e| {
+                crate::logging::log_incident(
+                    "config",
+                    "load",
+                    Some("CONFIG_PARSE_FAILED"),
+                    &format!("path={}: {}", path.display(), e),
+                );
                 error!(
                     category = "config",
                     path = %path.display(),
@@ -689,6 +701,12 @@ impl Settings {
             toml::to_string_pretty(&LocalConfigToml::from(persisted))
         }
         .map_err(|e| {
+            crate::logging::log_incident(
+                "config",
+                "save",
+                Some("CONFIG_SERIALIZE_FAILED"),
+                &format!("path={}: {}", path.display(), e),
+            );
             error!(
                 category = "config",
                 path = %path.display(),

--- a/crates/gwt-core/src/docker/manager.rs
+++ b/crates/gwt-core/src/docker/manager.rs
@@ -19,7 +19,10 @@ use super::{
     detector::DockerFileType,
     port::PortAllocator,
 };
-use crate::{GwtError, Result};
+use crate::{
+    logging::{log_flow_failure, log_flow_start, log_flow_success},
+    GwtError, Result,
+};
 
 fn extract_port_envs_from_compose(content: &str) -> Vec<(String, u16)> {
     extract_port_envs_from_compose_filtered(content, None)
@@ -742,7 +745,13 @@ impl DockerManager {
     /// Runs `docker compose up -d` in the worktree directory.
     #[instrument(skip(self))]
     pub fn start(&self) -> Result<ContainerInfo> {
-        self.start_internal()
+        log_flow_start("docker", "start_container");
+        let result = self.start_internal();
+        match &result {
+            Ok(_) => log_flow_success("docker", "start_container"),
+            Err(e) => log_flow_failure("docker", "start_container", &e.to_string()),
+        }
+        result
     }
 
     /// Start the Docker container with automatic retry on transient failures
@@ -769,12 +778,24 @@ impl DockerManager {
             .env("COMPOSE_PROJECT_NAME", &self.container_name)
             .envs(&env_vars);
 
-        let output = command
-            .output()
-            .map_err(|e| GwtError::Docker(format!("Failed to run docker compose: {}", e)))?;
+        let output = command.output().map_err(|e| {
+            crate::logging::log_incident(
+                "docker",
+                "start",
+                Some("DOCKER_COMPOSE_UP_SPAWN_FAILED"),
+                &e.to_string(),
+            );
+            GwtError::Docker(format!("Failed to run docker compose: {}", e))
+        })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            crate::logging::log_incident(
+                "docker",
+                "start",
+                Some("DOCKER_COMPOSE_UP_FAILED"),
+                &stderr,
+            );
             warn!(
                 category = "docker",
                 container = %self.container_name,
@@ -814,6 +835,7 @@ impl DockerManager {
     /// Runs `docker compose down` in the worktree directory.
     #[instrument(skip(self))]
     pub fn stop(&self) -> Result<()> {
+        log_flow_start("docker", "stop_container");
         info!(
             category = "docker",
             container = %self.container_name,
@@ -827,16 +849,31 @@ impl DockerManager {
             .env("COMPOSE_PROJECT_NAME", &self.container_name)
             .envs(&env_vars)
             .output()
-            .map_err(|e| GwtError::Docker(format!("Failed to run docker compose down: {}", e)))?;
+            .map_err(|e| {
+                crate::logging::log_incident(
+                    "docker",
+                    "stop",
+                    Some("DOCKER_COMPOSE_DOWN_SPAWN_FAILED"),
+                    &e.to_string(),
+                );
+                GwtError::Docker(format!("Failed to run docker compose down: {}", e))
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            crate::logging::log_incident(
+                "docker",
+                "stop",
+                Some("DOCKER_COMPOSE_DOWN_FAILED"),
+                &stderr,
+            );
             warn!(
                 category = "docker",
                 container = %self.container_name,
                 error = %stderr,
                 "Docker compose down failed"
             );
+            log_flow_failure("docker", "stop_container", &stderr);
             return Err(GwtError::Docker(format!(
                 "Docker compose down failed: {}",
                 stderr
@@ -849,6 +886,7 @@ impl DockerManager {
             "Docker compose down succeeded"
         );
 
+        log_flow_success("docker", "stop_container");
         Ok(())
     }
 
@@ -1182,10 +1220,19 @@ impl DockerManager {
             .env("COMPOSE_PROJECT_NAME", &self.container_name)
             .envs(&env_vars)
             .output()
-            .map_err(|e| GwtError::Docker(format!("Failed to run docker compose build: {}", e)))?;
+            .map_err(|e| {
+                crate::logging::log_incident(
+                    "docker",
+                    "rebuild",
+                    Some("DOCKER_BUILD_SPAWN_FAILED"),
+                    &e.to_string(),
+                );
+                GwtError::Docker(format!("Failed to run docker compose build: {}", e))
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            crate::logging::log_incident("docker", "rebuild", Some("DOCKER_BUILD_FAILED"), &stderr);
             warn!(
                 category = "docker",
                 container = %self.container_name,
@@ -1252,11 +1299,28 @@ impl DockerManager {
             .env("COMPOSE_PROJECT_NAME", &self.container_name)
             .envs(&env_vars);
 
-        let status = cmd
-            .status()
-            .map_err(|e| GwtError::Docker(format!("Failed to run docker compose exec: {}", e)))?;
+        let status = cmd.status().map_err(|e| {
+            crate::logging::log_incident(
+                "docker",
+                "run_in_service",
+                Some("DOCKER_EXEC_SPAWN_FAILED"),
+                &e.to_string(),
+            );
+            GwtError::Docker(format!("Failed to run docker compose exec: {}", e))
+        })?;
 
         if !status.success() {
+            let detail = format!(
+                "Command '{}' failed with exit code {:?}",
+                command,
+                status.code()
+            );
+            crate::logging::log_incident(
+                "docker",
+                "run_in_service",
+                Some("DOCKER_EXEC_FAILED"),
+                &detail,
+            );
             warn!(
                 category = "docker",
                 service = %service,
@@ -1264,11 +1328,7 @@ impl DockerManager {
                 exit_code = ?status.code(),
                 "Command in container failed"
             );
-            return Err(GwtError::Docker(format!(
-                "Command '{}' failed with exit code {:?}",
-                command,
-                status.code()
-            )));
+            return Err(GwtError::Docker(detail));
         }
 
         debug!(

--- a/crates/gwt-core/src/git/branch.rs
+++ b/crates/gwt-core/src/git/branch.rs
@@ -11,7 +11,10 @@ use std::{
 
 use tracing::{debug, error, info, warn};
 
-use crate::error::{GwtError, Result};
+use crate::{
+    error::{GwtError, Result},
+    logging::{log_flow_failure, log_flow_start, log_flow_success},
+};
 
 const LS_REMOTE_TIMEOUT: Duration = Duration::from_secs(5);
 const GH_MERGE_BASE_BAD_KEY: &str = "branch..gh-merge-base";
@@ -735,6 +738,7 @@ impl Branch {
 
     /// Create a new branch from a base
     pub fn create(repo_path: &Path, name: &str, base: &str) -> Result<Branch> {
+        log_flow_start("git", "create_branch");
         debug!(category = "git", branch = name, base, "Creating branch");
 
         let output = crate::process::command("git")
@@ -755,6 +759,7 @@ impl Branch {
                 error = err_msg.as_str(),
                 "Failed to create branch"
             );
+            log_flow_failure("git", "create_branch", &err_msg);
             return Err(GwtError::BranchCreateFailed {
                 name: name.to_string(),
                 details: err_msg,
@@ -784,6 +789,7 @@ impl Branch {
             "Branch created"
         );
 
+        log_flow_success("git", "create_branch");
         Ok(Branch::new(name, commit))
     }
 
@@ -848,6 +854,7 @@ impl Branch {
 
     /// Delete a branch
     pub fn delete(repo_path: &Path, name: &str, force: bool) -> Result<()> {
+        log_flow_start("git", "delete_branch");
         debug!(category = "git", branch = name, force, "Deleting branch");
 
         let flag = if force { "-D" } else { "-d" };
@@ -861,6 +868,7 @@ impl Branch {
                 force,
                 "Branch deleted"
             );
+            log_flow_success("git", "delete_branch");
             Ok(())
         } else {
             let err_msg = String::from_utf8_lossy(&output.stderr).to_string();
@@ -883,6 +891,7 @@ impl Branch {
                         fallback = true,
                         "Branch deleted via automatic force fallback"
                     );
+                    log_flow_success("git", "delete_branch");
                     return Ok(());
                 }
 
@@ -898,6 +907,7 @@ impl Branch {
                     error = combined_err.as_str(),
                     "Failed to delete branch after fallback"
                 );
+                log_flow_failure("git", "delete_branch", &combined_err);
                 return Err(GwtError::BranchDeleteFailed {
                     name: name.to_string(),
                     details: combined_err,
@@ -911,6 +921,7 @@ impl Branch {
                 error = err_msg.as_str(),
                 "Failed to delete branch"
             );
+            log_flow_failure("git", "delete_branch", &err_msg);
             Err(GwtError::BranchDeleteFailed {
                 name: name.to_string(),
                 details: err_msg,

--- a/crates/gwt-core/src/git/repository.rs
+++ b/crates/gwt-core/src/git/repository.rs
@@ -341,6 +341,12 @@ impl Repository {
             }
         }
 
+        crate::logging::log_incident(
+            "git",
+            "discover",
+            Some("GIT_REPO_NOT_FOUND"),
+            &format!("Repository not found: {}", path.display()),
+        );
         Err(GwtError::RepositoryNotFound {
             path: path.to_path_buf(),
         })
@@ -412,6 +418,12 @@ impl Repository {
                 gix_repo: None,
             })
         } else {
+            crate::logging::log_incident(
+                "git",
+                "open",
+                Some("GIT_REPO_NOT_FOUND"),
+                &format!("Repository not found at: {}", path.display()),
+            );
             Err(GwtError::RepositoryNotFound {
                 path: path.to_path_buf(),
             })
@@ -649,17 +661,32 @@ impl Repository {
             .args(["pull", "--ff-only"])
             .current_dir(&self.root)
             .output()
-            .map_err(|e| GwtError::GitOperationFailed {
-                operation: "pull".to_string(),
-                details: e.to_string(),
+            .map_err(|e| {
+                crate::logging::log_incident(
+                    "git",
+                    "pull_fast_forward",
+                    Some("GIT_PULL_SPAWN_FAILED"),
+                    &e.to_string(),
+                );
+                GwtError::GitOperationFailed {
+                    operation: "pull".to_string(),
+                    details: e.to_string(),
+                }
             })?;
 
         if output.status.success() {
             Ok(())
         } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            crate::logging::log_incident(
+                "git",
+                "pull_fast_forward",
+                Some("GIT_PULL_FAILED"),
+                &stderr,
+            );
             Err(GwtError::GitOperationFailed {
                 operation: "pull --ff-only".to_string(),
-                details: String::from_utf8_lossy(&output.stderr).to_string(),
+                details: stderr,
             })
         }
     }
@@ -671,17 +698,27 @@ impl Repository {
             .args(["fetch", "--all", "--prune"])
             .current_dir(&self.root)
             .output()
-            .map_err(|e| GwtError::GitOperationFailed {
-                operation: "fetch".to_string(),
-                details: e.to_string(),
+            .map_err(|e| {
+                crate::logging::log_incident(
+                    "git",
+                    "fetch_all",
+                    Some("GIT_FETCH_SPAWN_FAILED"),
+                    &e.to_string(),
+                );
+                GwtError::GitOperationFailed {
+                    operation: "fetch".to_string(),
+                    details: e.to_string(),
+                }
             })?;
 
         if output.status.success() {
             Ok(())
         } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            crate::logging::log_incident("git", "fetch_all", Some("GIT_FETCH_FAILED"), &stderr);
             Err(GwtError::GitOperationFailed {
                 operation: "fetch --all".to_string(),
-                details: String::from_utf8_lossy(&output.stderr).to_string(),
+                details: stderr,
             })
         }
     }
@@ -885,6 +922,12 @@ impl Repository {
             return Ok(());
         }
 
+        crate::logging::log_incident(
+            "git",
+            "remove_worktree",
+            Some("GIT_WORKTREE_REMOVE_FAILED"),
+            &err_msg,
+        );
         error!(
             category = "git",
             operation = "worktree_remove",

--- a/crates/gwt-core/src/logging/logger.rs
+++ b/crates/gwt-core/src/logging/logger.rs
@@ -247,14 +247,24 @@ pub fn log_flow_failure(category: &str, event: &str, error_detail: &str) {
 
 /// Log an incident with full context for first-response triage.
 pub fn log_incident(category: &str, event: &str, error_code: Option<&str>, error_detail: &str) {
-    tracing::error!(
-        category = category,
-        event = event,
-        result = "failure",
-        workspace = "default",
-        error_code = error_code.unwrap_or(""),
-        error_detail = error_detail,
-    );
+    if let Some(code) = error_code {
+        tracing::error!(
+            category = category,
+            event = event,
+            result = "failure",
+            workspace = "default",
+            error_code = code,
+            error_detail = error_detail,
+        );
+    } else {
+        tracing::error!(
+            category = category,
+            event = event,
+            result = "failure",
+            workspace = "default",
+            error_detail = error_detail,
+        );
+    }
 }
 
 /// Initialize a lightweight tracing subscriber for tests.

--- a/crates/gwt-core/src/logging/logger.rs
+++ b/crates/gwt-core/src/logging/logger.rs
@@ -214,6 +214,49 @@ pub fn log_error_message(code: &str, category: &str, message: &str, details: Opt
     );
 }
 
+/// Log the start of a feature flow with required structured fields.
+pub fn log_flow_start(category: &str, event: &str) {
+    tracing::info!(
+        category = category,
+        event = event,
+        result = "start",
+        workspace = "default",
+    );
+}
+
+/// Log successful completion of a feature flow.
+pub fn log_flow_success(category: &str, event: &str) {
+    tracing::info!(
+        category = category,
+        event = event,
+        result = "success",
+        workspace = "default",
+    );
+}
+
+/// Log a feature flow failure with error detail for triage.
+pub fn log_flow_failure(category: &str, event: &str, error_detail: &str) {
+    tracing::warn!(
+        category = category,
+        event = event,
+        result = "failure",
+        workspace = "default",
+        error_detail = error_detail,
+    );
+}
+
+/// Log an incident with full context for first-response triage.
+pub fn log_incident(category: &str, event: &str, error_code: Option<&str>, error_detail: &str) {
+    tracing::error!(
+        category = category,
+        event = event,
+        result = "failure",
+        workspace = "default",
+        error_code = error_code.unwrap_or(""),
+        error_detail = error_detail,
+    );
+}
+
 /// Initialize a lightweight tracing subscriber for tests.
 ///
 /// Uses `try_init()` so it silently succeeds even when another test in the

--- a/crates/gwt-core/src/logging/mod.rs
+++ b/crates/gwt-core/src/logging/mod.rs
@@ -10,7 +10,10 @@ use std::path::Path;
 use chrono::{Duration, Utc};
 #[cfg(test)]
 pub use logger::init_test_tracing;
-pub use logger::{init_logger, log_error_message, log_gwt_error, LogConfig, ProfilingGuard};
+pub use logger::{
+    init_logger, log_error_message, log_flow_failure, log_flow_start, log_flow_success,
+    log_gwt_error, log_incident, LogConfig, ProfilingGuard,
+};
 pub use reader::{LogEntry, LogReader};
 
 use crate::error::Result;
@@ -97,6 +100,37 @@ mod tests {
         assert_eq!(entry.message(), "test message");
         assert_eq!(entry.category(), Some("worktree"));
         assert_eq!(entry.target, "gwt");
+    }
+
+    #[test]
+    fn test_flow_log_entry_has_all_required_fields() {
+        let json = r#"{"timestamp":"2026-03-22T00:00:00Z","level":"INFO","fields":{"message":"flow_start","category":"project","event":"open_project","result":"start","workspace":"default"},"target":"gwt"}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.category(), Some("project"));
+        assert_eq!(entry.event(), Some("open_project"));
+        assert_eq!(entry.result(), Some("start"));
+        assert_eq!(entry.workspace(), Some("default"));
+    }
+
+    #[test]
+    fn test_flow_failure_entry_includes_error_fields() {
+        let json = r#"{"timestamp":"2026-03-22T00:00:00Z","level":"WARN","fields":{"message":"flow_failure","category":"git","event":"push","result":"failure","workspace":"default","error_code":"GIT_PUSH_REJECTED","error_detail":"remote rejected"},"target":"gwt"}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.result(), Some("failure"));
+        assert_eq!(entry.error_code(), Some("GIT_PUSH_REJECTED"));
+        assert_eq!(entry.error_detail(), Some("remote rejected"));
+    }
+
+    #[test]
+    fn test_flow_result_variants_all_parse() {
+        for result_value in ["start", "success", "failure", "progress"] {
+            let json = format!(
+                r#"{{"timestamp":"2026-03-22T00:00:00Z","level":"INFO","fields":{{"message":"test","category":"project","event":"open","result":"{}","workspace":"default"}},"target":"gwt"}}"#,
+                result_value
+            );
+            let entry: LogEntry = serde_json::from_str(&json).unwrap();
+            assert_eq!(entry.result(), Some(result_value));
+        }
     }
 
     #[test]

--- a/crates/gwt-core/src/logging/reader.rs
+++ b/crates/gwt-core/src/logging/reader.rs
@@ -16,9 +16,24 @@ pub struct LogFields {
     /// Log message
     #[serde(default)]
     pub message: String,
-    /// Category field
+    /// Subsystem category (e.g. "project", "git", "docker")
     #[serde(default)]
     pub category: Option<String>,
+    /// Operation or state transition name
+    #[serde(default)]
+    pub event: Option<String>,
+    /// Flow result: "start", "success", "failure", "progress"
+    #[serde(default)]
+    pub result: Option<String>,
+    /// Workspace name
+    #[serde(default)]
+    pub workspace: Option<String>,
+    /// Typed error code
+    #[serde(default)]
+    pub error_code: Option<String>,
+    /// Triage detail for failures
+    #[serde(default)]
+    pub error_detail: Option<String>,
     /// Additional fields
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
@@ -51,6 +66,31 @@ impl LogEntry {
     /// Get the category if present
     pub fn category(&self) -> Option<&str> {
         self.fields.category.as_deref()
+    }
+
+    /// Get the event name if present
+    pub fn event(&self) -> Option<&str> {
+        self.fields.event.as_deref()
+    }
+
+    /// Get the flow result if present
+    pub fn result(&self) -> Option<&str> {
+        self.fields.result.as_deref()
+    }
+
+    /// Get the workspace if present
+    pub fn workspace(&self) -> Option<&str> {
+        self.fields.workspace.as_deref()
+    }
+
+    /// Get the error code if present
+    pub fn error_code(&self) -> Option<&str> {
+        self.fields.error_code.as_deref()
+    }
+
+    /// Get the error detail if present
+    pub fn error_detail(&self) -> Option<&str> {
+        self.fields.error_detail.as_deref()
     }
 }
 

--- a/crates/gwt-core/src/migration/executor.rs
+++ b/crates/gwt-core/src/migration/executor.rs
@@ -13,6 +13,7 @@ use super::{
     backup::create_backup, config::MigrationConfig, error::MigrationError, state::MigrationState,
     validator::validate_migration,
 };
+use crate::logging::{log_flow_start, log_flow_success};
 
 /// Information about a worktree being migrated
 #[derive(Debug, Clone)]
@@ -49,6 +50,7 @@ pub fn execute_migration(
     config: &MigrationConfig,
     progress: Option<MigrationProgress>,
 ) -> Result<(), MigrationError> {
+    log_flow_start("migration", "execute_migration");
     let report_progress = |state: MigrationState| {
         if let Some(ref cb) = progress {
             cb(state);
@@ -61,11 +63,21 @@ pub fn execute_migration(
     let validation = validate_migration(config)?;
     info!("Phase 1 complete: Validation passed");
     if !validation.passed {
-        return Err(validation.errors.into_iter().next().unwrap_or(
-            MigrationError::ValidationFailed {
-                reason: "Unknown validation error".to_string(),
-            },
-        ));
+        let err =
+            validation
+                .errors
+                .into_iter()
+                .next()
+                .unwrap_or(MigrationError::ValidationFailed {
+                    reason: "Unknown validation error".to_string(),
+                });
+        crate::logging::log_incident(
+            "migration",
+            "execute_migration",
+            Some("MIGRATION_VALIDATION_FAILED"),
+            &err.to_string(),
+        );
+        return Err(err);
     }
 
     // Phase 2: Backup
@@ -194,6 +206,7 @@ pub fn execute_migration(
 
     report_progress(MigrationState::Completed);
     info!("Migration completed successfully");
+    log_flow_success("migration", "execute_migration");
     Ok(())
 }
 
@@ -673,12 +686,26 @@ fn create_bare_repository(config: &MigrationConfig) -> Result<(), MigrationError
             .args(["clone", "--bare", "--", &url])
             .arg(&bare_path)
             .output()
-            .map_err(|e| MigrationError::BareRepoCreationFailed {
-                reason: format!("Failed to clone bare: {}", e),
+            .map_err(|e| {
+                crate::logging::log_incident(
+                    "migration",
+                    "create_bare_repository",
+                    Some("MIGRATION_BARE_CLONE_SPAWN_FAILED"),
+                    &e.to_string(),
+                );
+                MigrationError::BareRepoCreationFailed {
+                    reason: format!("Failed to clone bare: {}", e),
+                }
             })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            crate::logging::log_incident(
+                "migration",
+                "create_bare_repository",
+                Some("MIGRATION_BARE_CLONE_FAILED"),
+                &stderr,
+            );
             return Err(MigrationError::BareRepoCreationFailed {
                 reason: format!("git clone --bare failed: {}", stderr),
             });
@@ -936,13 +963,27 @@ fn migrate_dirty_worktree(
         .arg(&wt_info.branch)
         .current_dir(&bare_path)
         .output()
-        .map_err(|e| MigrationError::WorktreeMigrationFailed {
-            branch: wt_info.branch.clone(),
-            reason: format!("Failed to add worktree: {}", e),
+        .map_err(|e| {
+            crate::logging::log_incident(
+                "migration",
+                "migrate_dirty_worktree",
+                Some("MIGRATION_WORKTREE_ADD_SPAWN_FAILED"),
+                &format!("branch={}: {}", wt_info.branch, e),
+            );
+            MigrationError::WorktreeMigrationFailed {
+                branch: wt_info.branch.clone(),
+                reason: format!("Failed to add worktree: {}", e),
+            }
         })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        crate::logging::log_incident(
+            "migration",
+            "migrate_dirty_worktree",
+            Some("MIGRATION_WORKTREE_ADD_FAILED"),
+            &format!("branch={}: {}", wt_info.branch, stderr),
+        );
         return Err(MigrationError::WorktreeMigrationFailed {
             branch: wt_info.branch.clone(),
             reason: format!("git worktree add failed: {}", stderr),
@@ -1003,13 +1044,27 @@ fn migrate_clean_worktree(
         .arg(&wt_info.branch)
         .current_dir(&bare_path)
         .output()
-        .map_err(|e| MigrationError::WorktreeMigrationFailed {
-            branch: wt_info.branch.clone(),
-            reason: format!("Failed to add worktree: {}", e),
+        .map_err(|e| {
+            crate::logging::log_incident(
+                "migration",
+                "migrate_clean_worktree",
+                Some("MIGRATION_WORKTREE_ADD_SPAWN_FAILED"),
+                &format!("branch={}: {}", wt_info.branch, e),
+            );
+            MigrationError::WorktreeMigrationFailed {
+                branch: wt_info.branch.clone(),
+                reason: format!("Failed to add worktree: {}", e),
+            }
         })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        crate::logging::log_incident(
+            "migration",
+            "migrate_clean_worktree",
+            Some("MIGRATION_WORKTREE_ADD_FAILED"),
+            &format!("branch={}: {}", wt_info.branch, stderr),
+        );
         return Err(MigrationError::WorktreeMigrationFailed {
             branch: wt_info.branch.clone(),
             reason: format!("git worktree add failed: {}", stderr),

--- a/crates/gwt-core/src/worktree/manager.rs
+++ b/crates/gwt-core/src/worktree/manager.rs
@@ -8,6 +8,7 @@ use super::{CleanupCandidate, Worktree, WorktreeLocation, WorktreePath, Worktree
 use crate::{
     error::{GwtError, Result},
     git::{get_main_repo_root, is_bare_repository, Branch, Remote, Repository},
+    logging::{log_flow_start, log_flow_success},
 };
 
 /// Protected branch names that cannot be deleted
@@ -65,6 +66,7 @@ impl WorktreeManager {
     /// List all worktrees
     #[instrument(skip(self))]
     pub fn list(&self) -> Result<Vec<Worktree>> {
+        log_flow_start("worktree", "list_worktrees");
         let git_worktrees = self.repo.list_worktrees()?;
         let mut worktrees = Vec::with_capacity(git_worktrees.len());
 
@@ -91,6 +93,7 @@ impl WorktreeManager {
             worktrees.push(wt);
         }
 
+        log_flow_success("worktree", "list_worktrees");
         Ok(worktrees)
     }
 
@@ -344,6 +347,7 @@ impl WorktreeManager {
     /// Create a new worktree for an existing branch
     #[instrument(skip(self))]
     pub fn create_for_branch(&self, branch_name: &str) -> Result<Worktree> {
+        log_flow_start("worktree", "create_for_branch");
         debug!(
             category = "worktree",
             branch = branch_name,
@@ -649,6 +653,7 @@ impl WorktreeManager {
             path = %worktree.path.display(),
             "Worktree created for existing branch"
         );
+        log_flow_success("worktree", "create_for_branch");
         Ok(worktree)
     }
 
@@ -659,6 +664,7 @@ impl WorktreeManager {
         branch_name: &str,
         base_branch: Option<&str>,
     ) -> Result<Worktree> {
+        log_flow_start("worktree", "create_new_branch");
         debug!(
             category = "worktree",
             branch = branch_name,
@@ -680,6 +686,12 @@ impl WorktreeManager {
 
         // Check if branch already exists
         if Branch::exists(&self.repo_root, branch_name)? {
+            crate::logging::log_incident(
+                "worktree",
+                "create_new_branch",
+                Some("WORKTREE_BRANCH_ALREADY_EXISTS"),
+                &format!("Branch already exists: {}", branch_name),
+            );
             error!(
                 category = "worktree",
                 branch = branch_name,
@@ -816,13 +828,26 @@ impl WorktreeManager {
                 .args(["reset", "--hard", base])
                 .current_dir(&path)
                 .output()
-                .map_err(|e| GwtError::WorktreeCreateFailed {
-                    reason: e.to_string(),
+                .map_err(|e| {
+                    crate::logging::log_incident(
+                        "worktree",
+                        "create_new_branch",
+                        Some("WORKTREE_RESET_FAILED"),
+                        &e.to_string(),
+                    );
+                    GwtError::WorktreeCreateFailed {
+                        reason: e.to_string(),
+                    }
                 })?;
             if !reset_output.status.success() {
-                return Err(GwtError::WorktreeCreateFailed {
-                    reason: String::from_utf8_lossy(&reset_output.stderr).to_string(),
-                });
+                let stderr = String::from_utf8_lossy(&reset_output.stderr).to_string();
+                crate::logging::log_incident(
+                    "worktree",
+                    "create_new_branch",
+                    Some("WORKTREE_RESET_FAILED"),
+                    &stderr,
+                );
+                return Err(GwtError::WorktreeCreateFailed { reason: stderr });
             }
             drop(wt_repo);
         }
@@ -865,12 +890,14 @@ impl WorktreeManager {
             path = %worktree.path.display(),
             "Worktree created with new branch"
         );
+        log_flow_success("worktree", "create_new_branch");
         Ok(worktree)
     }
 
     /// Remove a worktree by path
     #[instrument(skip(self))]
     pub fn remove(&self, path: &Path, force: bool) -> Result<()> {
+        log_flow_start("worktree", "remove_worktree");
         debug!(
             category = "worktree",
             path = %path.display(),
@@ -890,6 +917,12 @@ impl WorktreeManager {
         // Check for protected branch
         if let Some(ref branch) = wt.branch {
             if Self::is_protected(branch) && !force {
+                crate::logging::log_incident(
+                    "worktree",
+                    "remove",
+                    Some("WORKTREE_PROTECTED_BRANCH"),
+                    &format!("Attempted to remove protected branch worktree: {}", branch),
+                );
                 warn!(
                     category = "worktree",
                     branch = branch.as_str(),
@@ -903,6 +936,12 @@ impl WorktreeManager {
 
         // Check for uncommitted changes
         if wt.has_changes && !force {
+            crate::logging::log_incident(
+                "worktree",
+                "remove",
+                Some("WORKTREE_UNCOMMITTED_CHANGES"),
+                &format!("Worktree has uncommitted changes: {}", path.display()),
+            );
             warn!(
                 category = "worktree",
                 path = %path.display(),
@@ -923,6 +962,7 @@ impl WorktreeManager {
             "Worktree removed"
         );
 
+        log_flow_success("worktree", "remove_worktree");
         Ok(())
     }
 

--- a/crates/gwt-tauri/src/commands/assistant.rs
+++ b/crates/gwt-tauri/src/commands/assistant.rs
@@ -3,6 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
+use gwt_core::logging::{log_flow_failure, log_flow_start, log_flow_success};
 use gwt_core::{
     git::{self, get_spec_issue_detail, graphql, Branch, PrCache, WorkflowRunInfo},
     process::command as process_command,
@@ -197,15 +198,29 @@ pub async fn assistant_send_message(
     input: String,
     delivery_mode: Option<AssistantDeliveryMode>,
 ) -> Result<AssistantStateResponse, String> {
+    log_flow_start("assistant", "assistant_send_message");
     let window_label = window.label().to_string();
     let input = input.trim().to_string();
     if input.is_empty() {
+        tracing::warn!(
+            category = "assistant",
+            event = "assistant_send_message",
+            result = "failure",
+            error_code = "ASSISTANT_EMPTY_MESSAGE",
+            "Empty message rejected",
+        );
         return Err("Message cannot be empty".to_string());
     }
     let delivery_mode = delivery_mode.unwrap_or(AssistantDeliveryMode::Interrupt);
-    let project_path = state
-        .project_for_window(&window_label)
-        .ok_or_else(|| "No project opened. Open a project first.".to_string())?;
+    let project_path = state.project_for_window(&window_label).ok_or_else(|| {
+        gwt_core::logging::log_incident(
+            "assistant",
+            "assistant_send_message",
+            Some("ASSISTANT_NO_PROJECT"),
+            "No project opened",
+        );
+        "No project opened. Open a project first.".to_string()
+    })?;
 
     let runtime_before = state.assistant_runtime_snapshot(&window_label);
     if runtime_before.active_kind.is_some() && delivery_mode == AssistantDeliveryMode::Queue {
@@ -222,6 +237,7 @@ pub async fn assistant_send_message(
         let context = current_assistant_context(&state, &window_label);
         let runtime = state.assistant_runtime_snapshot(&window_label);
         let startup_status_message = current_startup_status_message(&state, &window_label);
+        log_flow_success("assistant", "assistant_send_message");
         return Ok(build_assistant_state_response(
             &engine,
             Some(window_label),
@@ -249,6 +265,7 @@ pub async fn assistant_send_message(
 
     let context = current_assistant_context(&state, &window_label);
     let runtime = state.assistant_runtime_snapshot(&window_label);
+    log_flow_success("assistant", "assistant_send_message");
     Ok(build_pending_user_send_state_response(
         &base_engine,
         &window_label,
@@ -264,10 +281,18 @@ pub async fn assistant_start(
     window: tauri::Window,
     state: tauri::State<'_, AppState>,
 ) -> Result<AssistantStateResponse, String> {
+    log_flow_start("assistant", "assistant_start");
     let window_label = window.label().to_string();
-    let project_path = state
-        .project_for_window(&window_label)
-        .ok_or_else(|| "No project opened. Open a project first.".to_string())?;
+    let project_path = state.project_for_window(&window_label).ok_or_else(|| {
+        gwt_core::logging::log_incident(
+            "assistant",
+            "assistant_start",
+            Some("ASSISTANT_NO_PROJECT"),
+            "No project opened",
+        );
+        log_flow_failure("assistant", "assistant_start", "No project opened");
+        "No project opened. Open a project first.".to_string()
+    })?;
 
     state.clear_assistant_session_for_window(&window_label);
     let session_generation = state.begin_assistant_session_for_window(&window_label);
@@ -323,6 +348,12 @@ pub async fn assistant_start(
         {
             Ok(fingerprint) => fingerprint,
             Err(err) => {
+                gwt_core::logging::log_incident(
+                    "assistant",
+                    "assistant_start",
+                    Some("ASSISTANT_REPO_INSPECTION_FAILED"),
+                    &err,
+                );
                 engine.apply_startup_failure_message(format!(
                     "Assistant started, but repository inspection failed: {err}"
                 ));
@@ -348,6 +379,12 @@ pub async fn assistant_start(
                 context
             }
             Err(err) => {
+                gwt_core::logging::log_incident(
+                    "assistant",
+                    "assistant_start",
+                    Some("ASSISTANT_CONTEXT_RESOLVE_FAILED"),
+                    &err,
+                );
                 let context = AssistantContext {
                     current_status: Some("blocked".to_string()),
                     blockers: vec![format!(
@@ -466,6 +503,12 @@ pub async fn assistant_start(
                 return;
             }
             Err(err) => {
+                gwt_core::logging::log_incident(
+                    "assistant",
+                    "assistant_start",
+                    Some("ASSISTANT_INITIAL_ANALYSIS_FAILED"),
+                    &err.to_string(),
+                );
                 engine.apply_startup_failure_message(format!(
                     "Assistant started, but the initial analysis failed: {err}"
                 ));
@@ -482,6 +525,7 @@ pub async fn assistant_start(
         );
     });
 
+    log_flow_success("assistant", "assistant_start");
     Ok(build_startup_inflight_state_response(
         window_label,
         "Inspecting repository state...".to_string(),
@@ -494,9 +538,11 @@ pub async fn assistant_stop(
     window: tauri::Window,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    log_flow_start("assistant", "assistant_stop");
     let window_label = window.label().to_string();
     state.clear_assistant_session_for_window(&window_label);
 
+    log_flow_success("assistant", "assistant_stop");
     Ok(())
 }
 
@@ -883,6 +929,12 @@ fn spawn_assistant_user_run(
             Ok(Some(_)) => {}
             Ok(None) => return,
             Err(err) => {
+                gwt_core::logging::log_incident(
+                    "assistant",
+                    "assistant_send_message",
+                    Some("ASSISTANT_REQUEST_FAILED"),
+                    &err.to_string(),
+                );
                 engine.push_visible_assistant_message(format!("Assistant request failed: {err}"));
             }
         }

--- a/crates/gwt-tauri/src/commands/issue.rs
+++ b/crates/gwt-tauri/src/commands/issue.rs
@@ -9,6 +9,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use gwt_core::logging::{log_flow_failure, log_flow_start, log_flow_success};
 use gwt_core::{
     ai::{classify_issue_prefix as core_classify_issue_prefix, format_error_for_display, AIClient},
     config::ProfilesConfig,
@@ -398,9 +399,12 @@ fn fetch_github_issues_impl(
     force_refresh: Option<bool>,
     app_state: &AppState,
 ) -> Result<FetchIssuesResponse, StructuredError> {
+    log_flow_start("issue", "fetch_github_issues");
     let project_root = Path::new(&project_path);
-    let repo_path = resolve_repo_path_for_project_root(project_root)
-        .map_err(|e| StructuredError::internal(&e, "fetch_github_issues"))?;
+    let repo_path = resolve_repo_path_for_project_root(project_root).map_err(|e| {
+        log_flow_failure("issue", "fetch_github_issues", &e);
+        StructuredError::internal(&e, "fetch_github_issues")
+    })?;
     let state = state.unwrap_or_else(|| "open".to_string());
     let category = parse_issue_category(category);
     let include_body = include_body.unwrap_or(false);
@@ -459,9 +463,13 @@ fn fetch_github_issues_impl(
                     now_millis(),
                 );
             }
+            log_flow_success("issue", "fetch_github_issues");
             Ok(response)
         }
-        Err(err) => Err(err),
+        Err(err) => {
+            log_flow_failure("issue", "fetch_github_issues", &err.message);
+            Err(err)
+        }
     };
 
     if cache_enabled && fetch_owner {

--- a/crates/gwt-tauri/src/commands/issue.rs
+++ b/crates/gwt-tauri/src/commands/issue.rs
@@ -420,6 +420,7 @@ fn fetch_github_issues_impl(
     } else if cache_enabled {
         if let Some(hit) = try_get_issue_cache(app_state, &repo_path, &repo_key, &cache_key, now_ms)
         {
+            log_flow_success("issue", "fetch_github_issues");
             return Ok(hit);
         }
     }
@@ -432,6 +433,7 @@ fn fetch_github_issues_impl(
             if let Some(hit) =
                 try_get_issue_cache(app_state, &repo_path, &repo_key, &cache_key, now_millis())
             {
+                log_flow_success("issue", "fetch_github_issues");
                 return Ok(hit);
             }
         }

--- a/crates/gwt-tauri/src/commands/project.rs
+++ b/crates/gwt-tauri/src/commands/project.rs
@@ -18,6 +18,8 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tracing::{instrument, warn};
 use uuid::Uuid;
 
+use gwt_core::logging::{log_flow_failure, log_flow_start, log_flow_success};
+
 use crate::state::AppState;
 
 /// Serializable project info for the frontend
@@ -247,9 +249,21 @@ pub fn open_project(
     path: String,
     state: State<AppState>,
 ) -> Result<OpenProjectResult, StructuredError> {
+    log_flow_start("project", "open_project");
     let p = Path::new(&path);
 
     if !p.exists() {
+        gwt_core::logging::log_incident(
+            "project",
+            "open_project",
+            Some("PROJECT_PATH_NOT_FOUND"),
+            &format!("Path does not exist: {}", path),
+        );
+        log_flow_failure(
+            "project",
+            "open_project",
+            &format!("Path does not exist: {}", path),
+        );
         return Err(StructuredError::internal(
             &format!("Path does not exist: {}", path),
             "open_project",
@@ -257,9 +271,24 @@ pub fn open_project(
     }
 
     let project_root = resolve_project_root(p);
-    let repo_path = resolve_repo_path_for_project_root(&project_root)
-        .map_err(|e| StructuredError::internal(&e, "open_project"))?;
+    let repo_path = resolve_repo_path_for_project_root(&project_root).map_err(|e| {
+        gwt_core::logging::log_incident(
+            "project",
+            "open_project",
+            Some("PROJECT_REPO_RESOLVE_FAILED"),
+            &e,
+        );
+        log_flow_failure("project", "open_project", &e);
+        StructuredError::internal(&e, "open_project")
+    })?;
     if git::is_git_repo(&repo_path) && !git::is_bare_repository(&repo_path) {
+        gwt_core::logging::log_incident(
+            "project",
+            "open_project",
+            Some("PROJECT_MIGRATION_REQUIRED"),
+            "Normal repositories are not supported. Migration to bare gwt project required.",
+        );
+        log_flow_failure("project", "open_project", "Migration required");
         return Err(StructuredError::internal("Migration required: normal repositories are not supported. Please migrate to a bare gwt project.", "open_project"));
     }
     let project_root_str = project_root.to_string_lossy().to_string();
@@ -368,6 +397,7 @@ pub fn open_project(
                     });
                 }
 
+                log_flow_success("project", "open_project");
                 return Ok(OpenProjectResult {
                     info,
                     action: OpenProjectAction::Opened,
@@ -383,6 +413,7 @@ pub fn open_project(
                     let _ = existing_window.show();
                     let _ = existing_window.set_focus();
                     let _ = crate::menu::rebuild_menu(window.app_handle());
+                    log_flow_success("project", "open_project");
                     return Ok(OpenProjectResult {
                         info,
                         action: OpenProjectAction::FocusedExisting,
@@ -396,6 +427,13 @@ pub fn open_project(
         }
     }
 
+    gwt_core::logging::log_incident(
+        "project",
+        "open_project",
+        Some("PROJECT_STALE_WINDOW_STATE"),
+        "Failed to open project due to stale duplicate window state",
+    );
+    log_flow_failure("project", "open_project", "Stale duplicate window state");
     Err(StructuredError::internal(
         "Failed to open project due to stale duplicate window state. Please retry.",
         "open_project",
@@ -429,8 +467,10 @@ pub fn get_project_info(window: tauri::Window, state: State<AppState>) -> Option
 #[instrument(skip_all, fields(command = "close_project", window_label = window.label()))]
 #[tauri::command]
 pub fn close_project(window: tauri::Window, state: State<AppState>) -> Result<(), StructuredError> {
+    log_flow_start("project", "close_project");
     state.clear_project_for_window(window.label());
     let _ = crate::menu::rebuild_menu(window.app_handle());
+    log_flow_success("project", "close_project");
     Ok(())
 }
 
@@ -546,7 +586,15 @@ pub fn create_project(
     state: State<AppState>,
     app_handle: AppHandle,
 ) -> Result<OpenProjectResult, StructuredError> {
+    log_flow_start("project", "create_project");
     if !is_valid_github_repo_url(&request.repo_url) {
+        gwt_core::logging::log_incident(
+            "project",
+            "create_project",
+            Some("PROJECT_INVALID_REPO_URL"),
+            &format!("Invalid repository URL: {}", request.repo_url),
+        );
+        log_flow_failure("project", "create_project", "Invalid repository URL");
         return Err(StructuredError::internal(
             "Invalid repository URL",
             "create_project",
@@ -555,6 +603,17 @@ pub fn create_project(
 
     let parent = std::path::PathBuf::from(&request.parent_dir);
     if !parent.exists() {
+        gwt_core::logging::log_incident(
+            "project",
+            "create_project",
+            Some("PROJECT_PARENT_DIR_NOT_FOUND"),
+            &format!("Parent directory does not exist: {}", request.parent_dir),
+        );
+        log_flow_failure(
+            "project",
+            "create_project",
+            "Parent directory does not exist",
+        );
         return Err(StructuredError::internal(
             &format!("Parent directory does not exist: {}", request.parent_dir),
             "create_project",
@@ -590,6 +649,12 @@ pub fn create_project(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| {
+            gwt_core::logging::log_incident(
+                "project",
+                "create_project",
+                Some("PROJECT_GIT_CLONE_SPAWN_FAILED"),
+                &e.to_string(),
+            );
             StructuredError::internal(
                 &format!("Failed to execute git clone: {}", e),
                 "create_project",
@@ -639,6 +704,12 @@ pub fn create_project(
     flush_line(&mut line_buf);
 
     let status = child.wait().map_err(|e| {
+        gwt_core::logging::log_incident(
+            "project",
+            "create_project",
+            Some("PROJECT_GIT_CLONE_WAIT_FAILED"),
+            &e.to_string(),
+        );
         StructuredError::internal(
             &format!("Failed to wait for git clone: {}", e),
             "create_project",
@@ -663,11 +734,25 @@ pub fn create_project(
             .join("\n");
 
         if tail.trim().is_empty() {
+            gwt_core::logging::log_incident(
+                "project",
+                "create_project",
+                Some("PROJECT_GIT_CLONE_FAILED"),
+                "git clone failed with no stderr output",
+            );
+            log_flow_failure("project", "create_project", "git clone failed");
             return Err(StructuredError::internal(
                 "git clone failed",
                 "create_project",
             ));
         }
+        gwt_core::logging::log_incident(
+            "project",
+            "create_project",
+            Some("PROJECT_GIT_CLONE_FAILED"),
+            tail.trim(),
+        );
+        log_flow_failure("project", "create_project", tail.trim());
         return Err(StructuredError::internal(
             &format!("git clone failed: {}", tail.trim()),
             "create_project",
@@ -675,6 +760,7 @@ pub fn create_project(
     }
 
     // Open the project root (FR-304)
+    // Note: open_project has its own flow logging
     open_project(window, request.parent_dir, state)
 }
 
@@ -724,8 +810,16 @@ pub fn start_migration_job(
     state: State<AppState>,
     app_handle: AppHandle,
 ) -> Result<String, StructuredError> {
+    log_flow_start("migration", "start_migration_job");
     let selected = Path::new(&path);
     if !selected.exists() {
+        gwt_core::logging::log_incident(
+            "migration",
+            "start_migration_job",
+            Some("MIGRATION_PATH_NOT_FOUND"),
+            &format!("Path does not exist: {}", path),
+        );
+        log_flow_failure("migration", "start_migration_job", "Path does not exist");
         return Err(StructuredError::internal(
             &format!("Path does not exist: {}", path),
             "start_migration_job",
@@ -734,12 +828,30 @@ pub fn start_migration_job(
 
     let source_root = git::get_main_repo_root(selected);
     if !git::is_git_repo(&source_root) {
+        gwt_core::logging::log_incident(
+            "migration",
+            "start_migration_job",
+            Some("MIGRATION_NOT_GIT_REPO"),
+            "Not a git repository",
+        );
+        log_flow_failure("migration", "start_migration_job", "Not a git repository");
         return Err(StructuredError::internal(
             "Not a git repository",
             "start_migration_job",
         ));
     }
     if git::is_bare_repository(&source_root) {
+        gwt_core::logging::log_incident(
+            "migration",
+            "start_migration_job",
+            Some("MIGRATION_ALREADY_BARE"),
+            "Repository is already bare",
+        );
+        log_flow_failure(
+            "migration",
+            "start_migration_job",
+            "Repository is already bare",
+        );
         return Err(StructuredError::internal(
             "Repository is already bare",
             "start_migration_job",
@@ -806,6 +918,7 @@ pub fn start_migration_job(
         let _ = app.emit("migration-finished", &finished);
     });
 
+    log_flow_success("migration", "start_migration_job");
     Ok(job_id)
 }
 

--- a/crates/gwt-tauri/src/commands/project.rs
+++ b/crates/gwt-tauri/src/commands/project.rs
@@ -641,7 +641,7 @@ pub fn create_project(
             "project",
             "create_project",
             Some("PROJECT_INVALID_REPO_URL"),
-            &format!("Invalid repository URL: {}", request.repo_url),
+            "invalid repo URL format",
         );
         log_flow_failure("project", "create_project", "Invalid repository URL");
         return Err(StructuredError::internal(
@@ -672,6 +672,17 @@ pub fn create_project(
     let repo_name = git::extract_repo_name(&request.repo_url);
     let target = parent.join(&repo_name);
     if target.exists() {
+        gwt_core::logging::log_incident(
+            "project",
+            "create_project",
+            Some("PROJECT_TARGET_DIR_EXISTS"),
+            &format!("Target directory already exists: {}", target.display()),
+        );
+        log_flow_failure(
+            "project",
+            "create_project",
+            "Target directory already exists",
+        );
         return Err(StructuredError::internal(
             &format!("Target directory already exists: {}", target.display()),
             "create_project",
@@ -809,7 +820,8 @@ pub fn create_project(
     }
 
     // Open the project root (FR-304)
-    // Note: open_project has its own flow logging
+    // Note: open_project has its own flow logging for the open_project flow
+    log_flow_success("project", "create_project");
     open_project(window, request.parent_dir, state)
 }
 

--- a/crates/gwt-tauri/src/commands/report.rs
+++ b/crates/gwt-tauri/src/commands/report.rs
@@ -105,10 +105,15 @@ fn is_log_file_candidate(path: &Path) -> bool {
     name.ends_with(".jsonl") || name.contains(".jsonl.")
 }
 
-/// Read the last `max_lines` lines from the most recent log file.
+/// Read the last `max_lines` lines from the most recent **normal** log file.
+///
+/// Only `gwt.jsonl*` files are collected; profiling output (`profile.json`)
+/// is excluded by `is_log_file_candidate`.
 #[instrument(skip_all, fields(command = "read_recent_logs"))]
 #[tauri::command]
 pub fn read_recent_logs(max_lines: Option<u32>) -> Result<String, StructuredError> {
+    gwt_core::logging::log_flow_start("report", "read_recent_logs");
+
     let max = max_lines.unwrap_or(100) as usize;
     let mut candidates: Vec<PathBuf> = Vec::new();
 
@@ -117,14 +122,24 @@ pub fn read_recent_logs(max_lines: Option<u32>) -> Result<String, StructuredErro
     }
 
     let Some(latest_log_path) = select_most_recent_log(candidates) else {
+        gwt_core::logging::log_flow_success("report", "read_recent_logs");
         return Ok("(No log files found)".to_string());
     };
 
-    let content = fs::read_to_string(&latest_log_path)
-        .map_err(|e| StructuredError::internal(&e.to_string(), "read_recent_logs"))?;
+    // TODO(#1758): error_detail and extra fields in JSONL entries may contain
+    // absolute file paths (e.g. /Users/<name>/...) that reveal the local
+    // username. Frontend privacyMask covers API keys/tokens/passwords but does
+    // not yet redact home-directory paths. Consider adding a home-path
+    // masking pattern on the frontend or sanitising here before returning.
+    let content = fs::read_to_string(&latest_log_path).map_err(|e| {
+        gwt_core::logging::log_flow_failure("report", "read_recent_logs", &e.to_string());
+        StructuredError::internal(&e.to_string(), "read_recent_logs")
+    })?;
 
     let lines: Vec<&str> = content.lines().collect();
     let start = lines.len().saturating_sub(max);
+
+    gwt_core::logging::log_flow_success("report", "read_recent_logs");
     Ok(lines[start..].join("\n"))
 }
 
@@ -443,6 +458,25 @@ mod tests {
     #[test]
     fn log_file_candidate_rejects_non_jsonl() {
         assert!(!is_log_file_candidate(Path::new("gwt.log")));
+    }
+
+    #[test]
+    fn log_file_candidate_rejects_profile_json() {
+        assert!(!is_log_file_candidate(Path::new("profile.json")));
+    }
+
+    #[test]
+    fn collect_log_candidates_excludes_profile_json() {
+        let temp = tempdir().unwrap();
+        let ws = temp.path().join("default");
+        fs::create_dir_all(&ws).unwrap();
+        fs::write(ws.join("gwt.jsonl.2026-03-22"), "log line\n").unwrap();
+        fs::write(ws.join("profile.json"), "trace data\n").unwrap();
+
+        let candidates = collect_log_candidates(temp.path());
+
+        assert_eq!(candidates.len(), 1, "profile.json must not be collected");
+        assert!(candidates[0].to_string_lossy().contains("gwt.jsonl"));
     }
 
     #[test]

--- a/crates/gwt-tauri/src/commands/settings.rs
+++ b/crates/gwt-tauri/src/commands/settings.rs
@@ -5,6 +5,7 @@ use std::{
     path::PathBuf,
 };
 
+use gwt_core::logging::{log_flow_failure, log_flow_start, log_flow_success};
 use gwt_core::{
     config::{Settings, SkillRegistrationPreferences},
     GwtError, StructuredError,
@@ -307,28 +308,55 @@ fn normalize_voice_input(value: &VoiceInputSettingsData) -> Result<NormalizedVoi
 #[instrument(skip_all, fields(command = "get_settings"))]
 #[tauri::command]
 pub fn get_settings() -> Result<SettingsData, StructuredError> {
-    with_panic_guard("loading settings", "get_settings", || {
-        let settings = Settings::load_global()
-            .map_err(|e| StructuredError::from_gwt_error(&e, "get_settings"))?;
+    log_flow_start("config", "get_settings");
+    let result = with_panic_guard("loading settings", "get_settings", || {
+        let settings = Settings::load_global().map_err(|e| {
+            gwt_core::logging::log_incident(
+                "config",
+                "get_settings",
+                Some("CONFIG_LOAD_FAILED"),
+                &e.to_string(),
+            );
+            StructuredError::from_gwt_error(&e, "get_settings")
+        })?;
         Ok(SettingsData::from(&settings))
-    })
+    });
+    match &result {
+        Ok(_) => log_flow_success("config", "get_settings"),
+        Err(e) => log_flow_failure("config", "get_settings", &e.message),
+    }
+    result
 }
 
 /// Save settings
 #[instrument(skip_all, fields(command = "save_settings"))]
 #[tauri::command]
 pub fn save_settings(settings: SettingsData) -> Result<(), StructuredError> {
-    with_panic_guard("saving settings", "save_settings", || {
+    log_flow_start("config", "save_settings");
+    let result = with_panic_guard("saving settings", "save_settings", || {
         Settings::update_global(|core_settings| {
             settings
                 .apply_to_settings(core_settings)
                 .map_err(|e| GwtError::ConfigWriteError { reason: e })?;
             Ok(())
         })
-        .map_err(|e| StructuredError::from_gwt_error(&e, "save_settings"))?;
+        .map_err(|e| {
+            gwt_core::logging::log_incident(
+                "config",
+                "save_settings",
+                Some("CONFIG_SAVE_FAILED"),
+                &e.to_string(),
+            );
+            StructuredError::from_gwt_error(&e, "save_settings")
+        })?;
 
         Ok(())
-    })
+    });
+    match &result {
+        Ok(_) => log_flow_success("config", "save_settings"),
+        Err(e) => log_flow_failure("config", "save_settings", &e.message),
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/gwt-tauri/src/commands/system.rs
+++ b/crates/gwt-tauri/src/commands/system.rs
@@ -195,11 +195,19 @@ pub async fn get_system_info(app_handle: AppHandle) -> SystemInfoResponse {
         get_system_info_impl(&state)
     })
     .await
-    .unwrap_or_else(|_| SystemInfoResponse {
-        cpu_usage_percent: 0.0,
-        memory_used_bytes: 0,
-        memory_total_bytes: 0,
-        gpus: Vec::new(),
+    .unwrap_or_else(|e| {
+        gwt_core::logging::log_incident(
+            "system",
+            "get_system_info",
+            Some("SYSTEM_INFO_TASK_FAILED"),
+            &e.to_string(),
+        );
+        SystemInfoResponse {
+            cpu_usage_percent: 0.0,
+            memory_used_bytes: 0,
+            memory_total_bytes: 0,
+            gpus: Vec::new(),
+        }
     });
     let elapsed = started.elapsed();
     if elapsed > GET_SYSTEM_INFO_WARN_THRESHOLD {

--- a/crates/gwt-tauri/src/commands/terminal.rs
+++ b/crates/gwt-tauri/src/commands/terminal.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use chrono::Utc;
+use gwt_core::logging::{log_flow_failure, log_flow_start, log_flow_success};
 use gwt_core::{
     ai::SessionParser,
     config::{stats::Stats, AgentConfig, ClaudeAgentProvider, ProfilesConfig, Settings},
@@ -2231,8 +2232,16 @@ pub fn launch_terminal(
     state: State<AppState>,
     app_handle: AppHandle,
 ) -> Result<String, StructuredError> {
+    log_flow_start("terminal", "launch_terminal");
     let project_root = {
         let Some(p) = state.project_for_window(window.label()) else {
+            gwt_core::logging::log_incident(
+                "terminal",
+                "launch_terminal",
+                Some("TERMINAL_NO_PROJECT"),
+                "No project opened",
+            );
+            log_flow_failure("terminal", "launch_terminal", "No project opened");
             return Err(StructuredError::internal(
                 "No project opened",
                 "launch_terminal",
@@ -2241,10 +2250,26 @@ pub fn launch_terminal(
         PathBuf::from(p)
     };
 
-    let repo_path = resolve_repo_path_for_project_root(&project_root)
-        .map_err(|e| StructuredError::internal(&e, "launch_terminal"))?;
-    let (working_dir, _created) = resolve_worktree_path(&repo_path, &branch)
-        .map_err(|e| StructuredError::internal(&e, "launch_terminal"))?;
+    let repo_path = resolve_repo_path_for_project_root(&project_root).map_err(|e| {
+        gwt_core::logging::log_incident(
+            "terminal",
+            "launch_terminal",
+            Some("TERMINAL_REPO_RESOLVE_FAILED"),
+            &e,
+        );
+        log_flow_failure("terminal", "launch_terminal", &e);
+        StructuredError::internal(&e, "launch_terminal")
+    })?;
+    let (working_dir, _created) = resolve_worktree_path(&repo_path, &branch).map_err(|e| {
+        gwt_core::logging::log_incident(
+            "terminal",
+            "launch_terminal",
+            Some("TERMINAL_WORKTREE_RESOLVE_FAILED"),
+            &e,
+        );
+        log_flow_failure("terminal", "launch_terminal", &e);
+        StructuredError::internal(&e, "launch_terminal")
+    })?;
 
     let config = BuiltinLaunchConfig {
         command: agent_name.clone(),
@@ -2259,8 +2284,20 @@ pub fn launch_terminal(
         windows_force_utf8: cfg!(target_os = "windows"),
     };
 
-    launch_with_config(&repo_path, config, None, &state, app_handle)
-        .map_err(|e| StructuredError::internal(&e, "launch_terminal"))
+    let result = launch_with_config(&repo_path, config, None, &state, app_handle).map_err(|e| {
+        gwt_core::logging::log_incident(
+            "terminal",
+            "launch_terminal",
+            Some("TERMINAL_LAUNCH_FAILED"),
+            &e,
+        );
+        log_flow_failure("terminal", "launch_terminal", &e);
+        StructuredError::internal(&e, "launch_terminal")
+    });
+    if result.is_ok() {
+        log_flow_success("terminal", "launch_terminal");
+    }
+    result
 }
 
 fn non_empty_env_var(key: &str) -> Option<String> {
@@ -5165,8 +5202,16 @@ pub fn launch_agent(
     state: State<AppState>,
     app_handle: AppHandle,
 ) -> Result<String, StructuredError> {
+    log_flow_start("terminal", "launch_agent");
     let project_root = {
         let Some(p) = state.project_for_window(window.label()) else {
+            gwt_core::logging::log_incident(
+                "terminal",
+                "launch_agent",
+                Some("TERMINAL_NO_PROJECT"),
+                "No project opened",
+            );
+            log_flow_failure("terminal", "launch_agent", "No project opened");
             return Err(StructuredError::internal(
                 "No project opened",
                 "launch_agent",
@@ -5174,8 +5219,22 @@ pub fn launch_agent(
         };
         PathBuf::from(p)
     };
-    launch_agent_for_project_root(project_root, request, &state, app_handle, None, None)
-        .map_err(|e| StructuredError::internal(&e, "launch_agent"))
+    let result =
+        launch_agent_for_project_root(project_root, request, &state, app_handle, None, None)
+            .map_err(|e| {
+                gwt_core::logging::log_incident(
+                    "terminal",
+                    "launch_agent",
+                    Some("TERMINAL_AGENT_LAUNCH_FAILED"),
+                    &e,
+                );
+                log_flow_failure("terminal", "launch_agent", &e);
+                StructuredError::internal(&e, "launch_agent")
+            });
+    if result.is_ok() {
+        log_flow_success("terminal", "launch_agent");
+    }
+    result
 }
 
 /// Start an async launch job with progress events (gwt-spec issue US15).
@@ -5189,6 +5248,12 @@ pub fn start_launch_job(
 ) -> Result<String, StructuredError> {
     let project_root = {
         let Some(p) = state.project_for_window(window.label()) else {
+            gwt_core::logging::log_incident(
+                "terminal",
+                "start_launch_job",
+                Some("TERMINAL_NO_PROJECT"),
+                "No project opened",
+            );
             return Err(StructuredError::internal(
                 "No project opened",
                 "start_launch_job",
@@ -5970,7 +6035,9 @@ pub fn close_terminal(
     state: State<AppState>,
     app_handle: AppHandle,
 ) -> Result<(), StructuredError> {
+    log_flow_start("terminal", "close_terminal");
     let mut manager = state.pane_manager.lock().map_err(|e| {
+        log_flow_failure("terminal", "close_terminal", &format!("Lock error: {}", e));
         StructuredError::internal(
             &format!("Failed to lock pane manager: {}", e),
             "close_terminal",
@@ -5982,6 +6049,11 @@ pub fn close_terminal(
         .iter()
         .position(|p| p.pane_id() == pane_id)
         .ok_or_else(|| {
+            log_flow_failure(
+                "terminal",
+                "close_terminal",
+                &format!("Pane not found: {}", pane_id),
+            );
             StructuredError::internal(&format!("Pane not found: {}", pane_id), "close_terminal")
         })?;
 
@@ -5992,6 +6064,7 @@ pub fn close_terminal(
             pane_id: pane_id.clone(),
         },
     );
+    log_flow_success("terminal", "close_terminal");
     Ok(())
 }
 

--- a/crates/gwt-tauri/src/main.rs
+++ b/crates/gwt-tauri/src/main.rs
@@ -54,6 +54,8 @@ fn main() {
     };
     let _profiling_guard = gwt_core::logging::init_logger(&log_config);
 
+    gwt_core::logging::log_flow_start("startup", "app_init");
+
     let single_instance_guard = match crate::single_instance::try_acquire_single_instance() {
         Ok(crate::single_instance::AcquireOutcome::Acquired(guard)) => Arc::new(guard),
         Ok(crate::single_instance::AcquireOutcome::AlreadyRunning(running)) => {
@@ -84,6 +86,8 @@ fn main() {
     )
     .build(tauri::generate_context!())
     .expect("error while building tauri application");
+
+    gwt_core::logging::log_flow_success("startup", "app_init");
 
     app.run(crate::app::handle_run_event);
 }

--- a/gwt-gui/src/lib/components/ReportDialog.svelte
+++ b/gwt-gui/src/lib/components/ReportDialog.svelte
@@ -195,6 +195,10 @@
     }
   });
 
+  // Application Logs: collects only normal logs (gwt.jsonl*) via the backend
+  // read_recent_logs command. Profiling output (profile.json) is excluded at
+  // the backend candidate-selection level. Privacy masking is applied by
+  // collectRecentLogs before the text reaches this component.
   $effect(() => {
     if (open && includeLogs && !logsText && !logsUnavailable) {
       collectRecentLogs().then((text) => {

--- a/gwt-gui/src/lib/diagnostics.ts
+++ b/gwt-gui/src/lib/diagnostics.ts
@@ -1,3 +1,11 @@
+/**
+ * Diagnostics collection for Issue Reports.
+ *
+ * Log collection delegates to the Tauri `read_recent_logs` command which only
+ * returns normal logs (gwt.jsonl*). Profiling output (profile.json) is excluded
+ * at the backend candidate-selection level. Privacy masking is applied on the
+ * returned text before it is surfaced in the report.
+ */
 import { invoke } from "$lib/tauriInvoke";
 import { maskSensitiveData } from "$lib/privacyMask";
 
@@ -21,6 +29,14 @@ export async function collectSystemInfo(): Promise<string> {
   }
 }
 
+/**
+ * Collect recent normal logs (gwt.jsonl*) via the backend command.
+ *
+ * Profiling output (profile.json) is never included — filtering is enforced
+ * by `is_log_file_candidate` on the Rust side. The returned text is run
+ * through `maskSensitiveData` to redact API keys, tokens, and passwords
+ * before inclusion in a report.
+ */
 export async function collectRecentLogs(maxLines = 50): Promise<string> {
   try {
     const logs = await invoke<string>("read_recent_logs", { maxLines });


### PR DESCRIPTION
## Summary

- Add a unified normal-log foundation (`log_flow_start/success/failure`, `log_incident`) separated from Chrome Trace profiling, covering 100% of major feature flows and incident scenarios
- Extend `LogEntry` with structured fields (`event`, `result`, `workspace`, `error_code`, `error_detail`) for cross-subsystem log analysis
- Verify the Report Dialog's Application Logs pipeline excludes `profile.json` and document the logging/profiling separation in README

## Changes

- `crates/gwt-core/src/logging/logger.rs`: Add `log_flow_start`, `log_flow_success`, `log_flow_failure`, `log_incident` helper functions
- `crates/gwt-core/src/logging/reader.rs`: Add `event`, `result`, `workspace`, `error_code`, `error_detail` fields to `LogFields`; add accessor methods to `LogEntry`
- `crates/gwt-core/src/logging/mod.rs`: Re-export new helpers; add 3 structured-field unit tests
- `crates/gwt-core/src/config/settings.rs`: Add incident logging for config load/save/parse failures
- `crates/gwt-core/src/docker/manager.rs`: Add feature-flow + incident logging to start/stop/rebuild/exec
- `crates/gwt-core/src/git/branch.rs`: Add feature-flow logging to `Branch::create`/`delete`
- `crates/gwt-core/src/git/repository.rs`: Add incident logging to discover/pull/fetch/remove_worktree failures
- `crates/gwt-core/src/migration/executor.rs`: Add feature-flow + incident logging to migration execution
- `crates/gwt-core/src/worktree/manager.rs`: Add feature-flow + incident logging to list/create/remove
- `crates/gwt-tauri/src/main.rs`: Add startup flow logging
- `crates/gwt-tauri/src/commands/project.rs`: Add flow + incident logging to open/close/create/migration
- `crates/gwt-tauri/src/commands/settings.rs`: Add flow + incident logging to get/save_settings
- `crates/gwt-tauri/src/commands/assistant.rs`: Add flow + incident logging to start/stop/send
- `crates/gwt-tauri/src/commands/terminal.rs`: Add flow + incident logging to launch/close terminal/agent
- `crates/gwt-tauri/src/commands/issue.rs`: Add flow logging to fetch_github_issues
- `crates/gwt-tauri/src/commands/report.rs`: Add flow logging + profile.json exclusion tests + privacy TODO
- `crates/gwt-tauri/src/commands/system.rs`: Add incident logging for system_info join errors
- `gwt-gui/src/lib/diagnostics.ts`: Add JSDoc for normal-log-only constraint
- `gwt-gui/src/lib/components/ReportDialog.svelte`: Add code comment for profiling exclusion
- `README.md`, `README.ja.md`: Add Logging and profiling section

## Testing

- [x] `cargo test` — 558 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — clean
- [x] `cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `cd gwt-gui && pnpm test` — 1448 passed (73 test files)
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — clean

## Closing Issues

- Closes #1758

## Related Issues / Links

- #1705 (profiling SPEC — separate responsibility)
- #1448 (Application Logs fix — related prior work)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included — N/A: no schema/data change
- [ ] CHANGELOG impact considered — `feat:` commit → minor version bump

## Context

gwt had JSON Lines normal logs and Chrome Trace profiling coexisting without a unified contract for coverage or structured fields. This PR introduces a formal logging foundation that:
1. Defines required structured fields (`category`, `event`, `result`, `workspace`) and conditional fields (`error_code`, `error_detail`)
2. Provides helper functions for consistent start/success/failure/incident patterns
3. Achieves 100% coverage across 24 feature flows and 27 incident scenarios (target was 90%)
4. Verifies the Report Dialog pipeline excludes profiling output

## Notes

- `TODO(#1758)` in `report.rs`: `error_detail` may contain home-directory paths. Frontend `privacyMask.ts` covers API keys/tokens but not local paths. Low severity, deferred.
- Coverage matrix posted as `checklist:coverage-matrix.md` artifact on issue #1758.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Added “Logging and profiling” docs: runtime logs saved as JSON Lines under ~/.gwt/logs/, profiling can be enabled via Settings > Profiling, and application reports collect only normal logs (gwt.jsonl*), excluding profile.json.

* **Improvements**
  - Enhanced structured flow and incident logging across the app for better error visibility and troubleshooting.
  - Report log retrieval applies privacy masking before inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->