### PR TITLE
feat(gui): App.svelte Tauri import migration with browser dev mode guard

### DIFF
--- a/gwt-gui/src/App.svelte
+++ b/gwt-gui/src/App.svelte
@@ -28,6 +28,7 @@
   import QuitConfirmToast from "./lib/components/QuitConfirmToast.svelte";
   import ReportDialog from "./lib/components/ReportDialog.svelte";
   import { formatWindowTitle } from "./lib/windowTitle";
+  import { isBrowserDevMode } from "./lib/tauriMock";
   import {
     buildWindowMenuTabsSignature,
     buildWindowMenuVisibleTabs,
@@ -437,11 +438,16 @@
   }
   async function confirmAndApplyUpdate(latest: string) {
     try {
-      const { confirm } = await import("@tauri-apps/plugin-dialog");
-      const ok = await confirm(
-        `Update available: v${latest}\nRestart to update now?`,
-        { title: "gwt", kind: "info" },
-      );
+      let ok: boolean;
+      if (isBrowserDevMode()) {
+        ok = window.confirm(`Update available: v${latest}\nRestart to update now?`);
+      } else {
+        const { confirm } = await import("@tauri-apps/plugin-dialog");
+        ok = await confirm(
+          `Update available: v${latest}\nRestart to update now?`,
+          { title: "gwt", kind: "info" },
+        );
+      }
       if (!ok) return;
 
       showToast(`Updating to v${latest}...`, 0);
@@ -468,9 +474,11 @@
     toastMessage = null;
     toastAction = null;
     // Bring window to front so the report dialog is visible (#1256)
-    import("@tauri-apps/api/window")
-      .then(({ getCurrentWindow }) => getCurrentWindow().setFocus())
-      .catch(() => {});
+    if (!isBrowserDevMode()) {
+      import("@tauri-apps/api/window")
+        .then(({ getCurrentWindow }) => getCurrentWindow().setFocus())
+        .catch(() => {});
+    }
   }
 
   // Subscribe to toast bus for success/info notifications (gwt-spec issue FR-006)
@@ -1380,11 +1388,13 @@
     // Document title also covers non-tauri contexts (e.g. web preview).
     document.title = title;
 
-    try {
-      const { getCurrentWindow } = await import("@tauri-apps/api/window");
-      await getCurrentWindow().setTitle(title);
-    } catch {
-      // Ignore: title API not available outside Tauri runtime.
+    if (!isBrowserDevMode()) {
+      try {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        await getCurrentWindow().setTitle(title);
+      } catch {
+        // Ignore: title API not available outside Tauri runtime.
+      }
     }
   }
 

--- a/gwt-gui/src/lib/tauriMock.ts
+++ b/gwt-gui/src/lib/tauriMock.ts
@@ -1,0 +1,13 @@
+/**
+ * Browser dev mode detection for Tauri API guards.
+ * When running outside the Tauri runtime (e.g. `vite dev` in a browser),
+ * Tauri APIs are unavailable — callers use this to branch into fallback logic.
+ */
+
+export function isBrowserDevMode(): boolean {
+  if (typeof window === "undefined") return true;
+  return (
+    typeof (window as Window & { __TAURI_INTERNALS__?: unknown })
+      .__TAURI_INTERNALS__ === "undefined"
+  );
+}


### PR DESCRIPTION
## Summary
- App.svelte の直接 `@tauri-apps` インポート 3 箇所を `isBrowserDevMode()` ガードで保護
- `@tauri-apps/plugin-dialog` の `confirm` → ブラウザdevモードでは `window.confirm()` にフォールバック
- `@tauri-apps/api/window` の `getCurrentWindow().setFocus()` → ブラウザdevモードではスキップ
- `@tauri-apps/api/window` の `getCurrentWindow().setTitle()` → ブラウザdevモードではスキップ（`document.title` は常に設定）
- `isBrowserDevMode()` ユーティリティを `$lib/tauriMock.ts` として新設

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `pnpm test` — 1420 tests passed (69 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved browser development mode support, enabling the application to run without Tauri runtime dependencies during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->