### PR TITLE
refactor(gui): AppRoot に新ランタイムモジュールを統合

### DIFF
--- a/gwt-gui/src/AppRoot.svelte
+++ b/gwt-gui/src/AppRoot.svelte
@@ -19,6 +19,58 @@
     UpdateState,
     VoiceInputSettings,
   } from "./lib/types";
+  import {
+    createToastState,
+    showToast as showToastRuntime,
+    showAvailableUpdateToast as showAvailableUpdateToastRuntime,
+    dismissToast as dismissToastRuntime,
+    setupToastSubscriptions,
+    type ToastState,
+    type ToastAction as ToastActionRT,
+    type ShowToastCallbacks,
+  } from "./lib/appToastRuntime";
+  import {
+    createVoiceInputState,
+    applyVoiceInputSettings as applyVoiceInputSettingsRT,
+    resetVoiceInputTransientState,
+    syncControllerState,
+    setupVoiceController,
+    type VoiceInputState,
+  } from "./lib/appVoiceInputRuntime";
+  import {
+    createModalState,
+    showReportDialogRuntime,
+    openAboutDialogRuntime,
+    openCleanupModalRuntime,
+    type ModalState,
+  } from "./lib/appModalStateRuntime";
+  import {
+    createAppearanceState,
+    applyAppearanceSettingsRuntime,
+    checkOsEnvCaptureOnStartupRuntime,
+    clampFontSizeRuntime as clampFontSizeAppearance,
+    normalizeAppLanguageRuntime as normalizeAppLanguageAppearance,
+    normalizeUiFontFamilyRuntime,
+    normalizeTerminalFontFamilyRuntime,
+    normalizeVoiceInputSettingsRuntime as normalizeVoiceInputSettingsAppearance,
+    applyUiFontSizeRuntime,
+    applyUiFontFamilyRuntime,
+    applyTerminalFontSizeRuntime,
+    applyTerminalFontFamilyRuntime,
+    DEFAULT_UI_FONT_FAMILY as DEFAULT_UI_FONT_FAMILY_APPEARANCE,
+    DEFAULT_TERMINAL_FONT_FAMILY as DEFAULT_TERMINAL_FONT_FAMILY_APPEARANCE,
+    DEFAULT_VOICE_INPUT_SETTINGS as DEFAULT_VOICE_INPUT_SETTINGS_APPEARANCE,
+    type AppearanceState,
+  } from "./lib/appAppearanceRuntime";
+  import {
+    createLaunchState,
+    bufferLaunchProgressEventRuntime,
+    bufferLaunchFinishedEventRuntime,
+    LAUNCH_STEP_IDS as LAUNCH_STEP_IDS_RT,
+    LAUNCH_EVENT_BUFFER_LIMIT as LAUNCH_EVENT_BUFFER_LIMIT_RT,
+    type LaunchState,
+    type LaunchStepId as LaunchStepIdRT,
+  } from "./lib/appLaunchStateRuntime";
   import MainArea from "./lib/components/MainArea.svelte";
   import StatusBar from "./lib/components/StatusBar.svelte";
   import AboutDialog from "./lib/components/AboutDialog.svelte";
@@ -32,7 +84,7 @@
   import TerminalDiagnosticsDialog from "./lib/components/TerminalDiagnosticsDialog.svelte";
   import CapturedEnvironmentDialog from "./lib/components/CapturedEnvironmentDialog.svelte";
   import AppErrorDialog from "./lib/components/AppErrorDialog.svelte";
-  import ToastBanner, { type ToastAction } from "./lib/components/ToastBanner.svelte";
+  import ToastBanner from "./lib/components/ToastBanner.svelte";
   import { formatWindowTitle } from "./lib/windowTitle";
   import {
     buildWindowMenuTabsSignature,
@@ -56,10 +108,8 @@
     shouldAllowRestoredActiveTab,
   } from "./lib/appTabs";
   import { getNextTabId, getPreviousTabId } from "./lib/tabNavigation";
-  import {
-    VoiceInputController,
-    type VoiceControllerState,
-  } from "./lib/voice/voiceInputController";
+  import type { VoiceControllerState } from "./lib/voice/voiceInputController";
+  import { VoiceInputController } from "./lib/voice/voiceInputController";
   import { createSystemMonitor } from "./lib/systemMonitor.svelte";
   import {
     deduplicateByProjectPath,
@@ -150,9 +200,6 @@
     fallbackMenuEditActionRuntime,
     getActiveTerminalPaneIdRuntime,
     isTauriRuntimeAvailableRuntime,
-    normalizeAppLanguageRuntime,
-    normalizeFontFamilyRuntime,
-    normalizeVoiceInputSettingsRuntime,
     shouldHandleExternalLinkClickRuntime,
     toErrorMessageRuntime,
   } from "./lib/appUiRuntime";
@@ -208,17 +255,9 @@
 
   const ISSUE_CACHE_WARMUP_DELAY_MS = 2_000;
 
-  const DEFAULT_VOICE_INPUT_SETTINGS: VoiceInputSettings = {
-    enabled: false,
-    engine: "qwen3-asr",
-    language: "auto",
-    quality: "balanced",
-    model: "Qwen/Qwen3-ASR-1.7B",
-  };
-  const DEFAULT_UI_FONT_FAMILY =
-    'system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, sans-serif';
-  const DEFAULT_TERMINAL_FONT_FAMILY =
-    '"JetBrains Mono", "Fira Code", "SF Mono", Menlo, Consolas, monospace';
+  const DEFAULT_VOICE_INPUT_SETTINGS = DEFAULT_VOICE_INPUT_SETTINGS_APPEARANCE;
+  const DEFAULT_UI_FONT_FAMILY = DEFAULT_UI_FONT_FAMILY_APPEARANCE;
+  const DEFAULT_TERMINAL_FONT_FAMILY = DEFAULT_TERMINAL_FONT_FAMILY_APPEARANCE;
   const DOCS_EDITOR_AUTO_CLOSE_POLL_MS = 1200;
   const DEFAULT_BRANCH_BROWSER_STATE: BranchBrowserPanelState = {
     filter: "Local",
@@ -249,12 +288,7 @@
   let projectPath: string | null = $state(null);
   let showAgentLaunch: boolean = $state(false);
   let prefillIssue: GitHubIssueInfo | null = $state(null);
-  let showCleanupModal: boolean = $state(false);
-  let cleanupPreselectedBranch: string | null = $state(null);
-  let showAbout: boolean = $state(false);
-  let aboutInitialTab: "general" | "system" | "statistics" = $state("general");
-  let showTerminalDiagnostics: boolean = $state(false);
-  let appError: string | null = $state(null);
+  const modal: ModalState = $state(createModalState());
   let worktreeInventoryRefreshKey: number = $state(0);
   let issueCacheWarmupTimer: ReturnType<typeof setTimeout> | null = null;
   let issueCacheWarmupProjectPath: string | null = null;
@@ -264,37 +298,10 @@
   let selectedBranch: BranchInfo | null = $state(null);
   let currentBranch: string = $state("");
 
-  let launchProgressOpen: boolean = $state(false);
-  let launchJobId: string = $state("");
-  let pendingLaunchRequest: LaunchAgentRequest | null = $state(null);
-  let docsEditorAutoClosePaneIds: string[] = $state([]);
-
-  type LaunchStepId =
-    | "fetch"
-    | "validate"
-    | "paths"
-    | "conflicts"
-    | "create"
-    | "skills"
-    | "deps";
-  let launchStep: LaunchStepId = $state("fetch");
-  let launchDetail: string = $state("");
-  let launchStatus: "running" | "ok" | "error" | "cancelled" =
-    $state("running");
-  let launchError: string | null = $state(null);
-  const LAUNCH_STEP_IDS: LaunchStepId[] = [
-    "fetch",
-    "validate",
-    "paths",
-    "conflicts",
-    "create",
-    "skills",
-    "deps",
-  ];
-  const LAUNCH_EVENT_BUFFER_LIMIT = 64;
-  let launchJobStartPending = false;
-  let bufferedLaunchProgressEvents: LaunchProgressPayload[] = [];
-  let bufferedLaunchFinishedEvents: LaunchFinishedPayload[] = [];
+  const launch: LaunchState = $state(createLaunchState());
+  type LaunchStepId = LaunchStepIdRT;
+  const LAUNCH_STEP_IDS = LAUNCH_STEP_IDS_RT;
+  const LAUNCH_EVENT_BUFFER_LIMIT = LAUNCH_EVENT_BUFFER_LIMIT_RT;
 
   let migrationOpen: boolean = $state(false);
   let migrationSourceRoot: string = $state("");
@@ -343,24 +350,12 @@
   let branchBrowserState = $state<BranchBrowserPanelState>(
     DEFAULT_BRANCH_BROWSER_STATE,
   );
-  let terminalDiagnosticsLoading: boolean = $state(false);
-  let terminalDiagnostics: TerminalAnsiProbe | null = $state(null);
-  let terminalDiagnosticsError: string | null = $state(null);
-
-  let osEnvReady = $state(false);
+  const appearance: AppearanceState = $state(createAppearanceState());
   let startupOsEnvCaptureChecked = false;
   let startupOsEnvCaptureResolved = $state(false);
   let startupDiagnostics: StartupDiagnostics | null = $state(null);
-  let voiceInputSettings: VoiceInputSettings = $state(
-    DEFAULT_VOICE_INPUT_SETTINGS,
-  );
+  const voice: VoiceInputState = $state(createVoiceInputState());
   let appLanguage: SettingsData["app_language"] = $state("auto");
-  let voiceInputListening = $state(false);
-  let voiceInputPreparing = $state(false);
-  let voiceInputSupported = $state(true);
-  let voiceInputAvailable = $state(false);
-  let voiceInputAvailabilityReason: string | null = $state(null);
-  let voiceInputError: string | null = $state(null);
   let voiceController: VoiceInputController | null = null;
   let branchBrowserConfig = $derived<BranchBrowserPanelConfig | undefined>(
     projectPath
@@ -398,49 +393,28 @@
 
   const systemMonitor = createSystemMonitor();
 
+  const toast: ToastState = $state(createToastState());
   let toastMessage = $state<string | null>(null);
-  let toastTimeout: ReturnType<typeof setTimeout> | null = null;
-  let toastAction = $state<ToastAction>(null);
-  let lastUpdateToastVersion = $state<string | null>(null);
-
-  let showOsEnvDebug = $state(false);
-  let osEnvDebugData = $state<CapturedEnvInfo | null>(null);
-  let osEnvDebugLoading = $state(false);
-  let osEnvDebugError = $state<string | null>(null);
+  let toastAction = $state<ToastActionRT>(null);
   type AvailableUpdateState = Extract<UpdateState, { state: "available" }>;
+
+  const toastCallbacks: ShowToastCallbacks = {
+    setState: (message, action) => {
+      toastMessage = message;
+      toastAction = action;
+    },
+  };
 
   function showToast(
     message: string,
     durationMs = 8000,
-    action: ToastAction = null,
+    action: ToastActionRT = null,
   ) {
-    toastMessage = message;
-    toastAction = action;
-    if (toastTimeout) clearTimeout(toastTimeout);
-    toastTimeout = null;
-    if (durationMs > 0) {
-      toastTimeout = setTimeout(() => {
-        toastMessage = null;
-        toastAction = null;
-      }, durationMs);
-    }
+    showToastRuntime(toast, message, durationMs, action, toastCallbacks);
   }
 
   function showAvailableUpdateToast(s: AvailableUpdateState, force = false) {
-    if (!force && lastUpdateToastVersion === s.latest) return;
-    lastUpdateToastVersion = s.latest;
-
-    if (s.asset_url) {
-      showToast(`Update available: v${s.latest} (click update)`, 0, {
-        kind: "apply-update",
-        latest: s.latest,
-      });
-    } else {
-      showToast(
-        `Update available: v${s.latest}. Manual download required.`,
-        15000,
-      );
-    }
+    showAvailableUpdateToastRuntime(toast, s, force, toastCallbacks);
   }
   async function confirmAndApplyUpdate(latest: string) {
     try {
@@ -460,36 +434,25 @@
     }
   }
 
-  let reportDialogOpen = $state(false);
-  let reportDialogMode = $state<"bug" | "feature">("bug");
-  let reportDialogPrefillError = $state<StructuredError | undefined>(undefined);
-
   function showReportDialog(
     mode: "bug" | "feature",
     prefillError?: StructuredError,
   ) {
-    reportDialogMode = mode;
-    reportDialogPrefillError = prefillError;
-    reportDialogOpen = true;
+    showReportDialogRuntime(modal, mode, prefillError);
     // Close the toast
-    toastMessage = null;
-    toastAction = null;
+    dismissToastRuntime(toast, toastCallbacks);
     // Bring window to front so the report dialog is visible (#1256)
     import("@tauri-apps/api/window")
       .then(({ getCurrentWindow }) => getCurrentWindow().setFocus())
       .catch(() => {});
   }
 
-  // Subscribe to toast bus for success/info notifications (gwt-spec issue FR-006)
-  const unsubToastBus = toastBus.subscribe((event) => {
-    showToast(event.message, event.durationMs ?? 5000);
-  });
-
-  // Subscribe to error bus for report-worthy errors
-  const unsubErrorBus = errorBus.subscribe((error) => {
-    if (error.severity === "error" || error.severity === "critical") {
-      showToast(`Error: ${error.message}`, 0, { kind: "report-error", error });
-    }
+  // Subscribe to toast bus and error bus for notifications
+  const unsubToastSubscriptions = setupToastSubscriptions({
+    toastBus,
+    errorBus,
+    state: toast,
+    cb: toastCallbacks,
   });
 
   async function handleToastClick() {
@@ -504,36 +467,30 @@
   }
 
   function clearBufferedLaunchEvents() {
-    launchJobStartPending = false;
-    bufferedLaunchProgressEvents = [];
-    bufferedLaunchFinishedEvents = [];
+    launch.jobStartPending = false;
+    launch.bufferedProgressEvents = [];
+    launch.bufferedFinishedEvents = [];
   }
 
   function bufferLaunchProgressEvent(payload: LaunchProgressPayload) {
-    if (bufferedLaunchProgressEvents.length >= LAUNCH_EVENT_BUFFER_LIMIT) {
-      bufferedLaunchProgressEvents.shift();
-    }
-    bufferedLaunchProgressEvents.push(payload);
+    bufferLaunchProgressEventRuntime(launch, payload);
   }
 
   function bufferLaunchFinishedEvent(payload: LaunchFinishedPayload) {
-    if (bufferedLaunchFinishedEvents.length >= LAUNCH_EVENT_BUFFER_LIMIT) {
-      bufferedLaunchFinishedEvents.shift();
-    }
-    bufferedLaunchFinishedEvents.push(payload);
+    bufferLaunchFinishedEventRuntime(launch, payload);
   }
 
   function applyLaunchProgressPayload(payload: LaunchProgressPayload) {
     applyLaunchProgressRuntime({
       payload,
-      launchStatus,
+      launchStatus: launch.status,
       launchStepIds: LAUNCH_STEP_IDS,
-      currentLaunchStep: launchStep,
+      currentLaunchStep: launch.step,
       setLaunchStep: (step) => {
-        launchStep = step;
+        launch.step = step;
       },
       setLaunchDetail: (detail) => {
-        launchDetail = detail;
+        launch.detail = detail;
       },
     });
   }
@@ -541,16 +498,16 @@
   function applyLaunchFinishedPayload(payload: LaunchFinishedPayload) {
     applyLaunchFinishedRuntime({
       payload,
-      pendingLaunchRequest,
+      pendingLaunchRequest: launch.pendingRequest,
       parseE1004BranchName,
       setPendingLaunchRequest: (request) => {
-        pendingLaunchRequest = request;
+        launch.pendingRequest = request;
       },
       setLaunchStatus: (status) => {
-        launchStatus = status;
+        launch.status = status;
       },
       setLaunchError: (error) => {
-        launchError = error;
+        launch.error = error;
       },
       onCancelled: () => {
         handleLaunchModalClose();
@@ -563,13 +520,13 @@
 
   function flushBufferedLaunchEventsForActiveJob() {
     flushBufferedLaunchEventsRuntime({
-      launchJobId,
-      bufferedLaunchProgressEvents,
-      bufferedLaunchFinishedEvents,
+      launchJobId: launch.jobId,
+      bufferedLaunchProgressEvents: launch.bufferedProgressEvents,
+      bufferedLaunchFinishedEvents: launch.bufferedFinishedEvents,
       clearBufferedLaunchEvents,
       applyLaunchProgressPayload,
       applyLaunchFinishedPayload,
-      getLaunchJobId: () => launchJobId,
+      getLaunchJobId: () => launch.jobId,
     });
   }
 
@@ -591,9 +548,9 @@
   // Poll OS env readiness at startup; stop once ready.
   $effect(() => {
     return setupOsEnvReadyPollingEffect({
-      getOsEnvReady: () => osEnvReady,
+      getOsEnvReady: () => appearance.osEnvReady,
       setOsEnvReady: (value) => {
-        osEnvReady = value;
+        appearance.osEnvReady = value;
       },
     });
   });
@@ -607,7 +564,7 @@
   $effect(() => {
     return setupStartupUpdateCheckEffect({
       startupDiagnostics,
-      lastUpdateToastVersion,
+      lastUpdateToastVersion: toast.lastUpdateVersion,
       showAvailableUpdateToast,
     });
   });
@@ -715,8 +672,8 @@
   // LaunchProgressModal is a pure display component; all event handling lives here.
   $effect(() => {
     return setupLaunchProgressListenerEffect({
-      getLaunchJobId: () => launchJobId,
-      getLaunchJobStartPending: () => launchJobStartPending,
+      getLaunchJobId: () => launch.jobId,
+      getLaunchJobStartPending: () => launch.jobStartPending,
       applyLaunchProgressPayload,
       bufferLaunchProgressEvent,
       debugLaunchEvent,
@@ -729,8 +686,8 @@
   // Handle progress modal state on launch completion.
   $effect(() => {
     return setupLaunchFinishedListenerEffect({
-      getLaunchJobId: () => launchJobId,
-      getLaunchJobStartPending: () => launchJobStartPending,
+      getLaunchJobId: () => launch.jobId,
+      getLaunchJobStartPending: () => launch.jobStartPending,
       applyLaunchFinishedPayload,
       bufferLaunchFinishedEvent,
       debugLaunchEvent,
@@ -746,14 +703,14 @@
   // event would be.
   $effect(() => {
     return setupLaunchPollEffect({
-      launchProgressOpen,
-      launchJobId,
-      launchStatus,
+      launchProgressOpen: launch.progressOpen,
+      launchJobId: launch.jobId,
+      launchStatus: launch.status,
       pollIntervalMs: 1500,
       applyLaunchFinishedPayload,
       setUnexpectedLaunchError: () => {
-        launchStatus = "error";
-        launchError = "Launch job ended unexpectedly. Please retry.";
+        launch.status = "error";
+        launch.error = "Launch job ended unexpectedly. Please retry.";
       },
     });
   });
@@ -761,7 +718,7 @@
   // Close docs editor tabs automatically after vi exits.
   $effect(() => {
     return setupDocsEditorAutoCloseEffect({
-      paneIds: docsEditorAutoClosePaneIds,
+      paneIds: launch.docsEditorAutoClosePaneIds,
       pollIntervalMs: DOCS_EDITOR_AUTO_CLOSE_POLL_MS,
       isTerminalProcessEnded,
       removeDocsEditorAutoClosePane,
@@ -800,60 +757,45 @@
   function normalizeVoiceInputSettings(
     value: Partial<VoiceInputSettings> | null | undefined,
   ): VoiceInputSettings {
-    return normalizeVoiceInputSettingsRuntime(value, DEFAULT_VOICE_INPUT_SETTINGS);
+    return normalizeVoiceInputSettingsAppearance(value);
   }
 
   function normalizeAppLanguage(
     value: string | null | undefined,
   ): SettingsData["app_language"] {
-    return normalizeAppLanguageRuntime(value);
+    return normalizeAppLanguageAppearance(value);
   }
 
   function normalizeUiFontFamily(value: string | null | undefined): string {
-    return normalizeFontFamilyRuntime(value, DEFAULT_UI_FONT_FAMILY);
+    return normalizeUiFontFamilyRuntime(value);
   }
 
   function normalizeTerminalFontFamily(
     value: string | null | undefined,
   ): string {
-    return normalizeFontFamilyRuntime(value, DEFAULT_TERMINAL_FONT_FAMILY);
+    return normalizeTerminalFontFamilyRuntime(value);
   }
 
   function applyUiFontSize(size: number) {
-    document.documentElement.style.setProperty("--ui-font-base", `${size}px`);
+    applyUiFontSizeRuntime(size);
   }
 
   function applyUiFontFamily(family: string | null | undefined) {
-    document.documentElement.style.setProperty(
-      "--ui-font-family",
-      normalizeUiFontFamily(family),
-    );
+    applyUiFontFamilyRuntime(family);
   }
 
   function applyTerminalFontSize(size: number) {
-    (window as any).__gwtTerminalFontSize = size;
-    window.dispatchEvent(
-      new CustomEvent("gwt-terminal-font-size", { detail: size }),
-    );
+    applyTerminalFontSizeRuntime(size);
   }
 
   function applyTerminalFontFamily(family: string | null | undefined) {
-    const normalized = normalizeTerminalFontFamily(family);
-    document.documentElement.style.setProperty(
-      "--terminal-font-family",
-      normalized,
-    );
-    (window as any).__gwtTerminalFontFamily = normalized;
-    window.dispatchEvent(
-      new CustomEvent("gwt-terminal-font-family", { detail: normalized }),
-    );
+    applyTerminalFontFamilyRuntime(family);
   }
 
   function applyVoiceInputSettings(
     value: Partial<VoiceInputSettings> | null | undefined,
   ) {
-    voiceInputSettings = normalizeVoiceInputSettings(value);
-    voiceController?.updateSettings();
+    applyVoiceInputSettingsRT(voice, value, { controller: voiceController });
   }
 
   function applyAppLanguage(value: string | null | undefined) {
@@ -861,21 +803,17 @@
   }
 
   async function checkOsEnvCaptureOnStartup() {
-    // OS env capture is now automatic (login_shell on Unix, process_env on Windows).
-    // No prompt needed - just mark as resolved and check readiness.
-    if (!isTauriRuntimeAvailable()) {
-      startupOsEnvCaptureResolved = true;
-      return;
-    }
-
-    try {
-      const { invoke } = await import("$lib/tauriInvoke");
-      osEnvReady = await invoke<boolean>("is_os_env_ready");
-      startupOsEnvCaptureResolved = true;
-    } catch (err) {
-      startupOsEnvCaptureResolved = true;
-      console.error("Failed to check os env capture status:", err);
-    }
+    await checkOsEnvCaptureOnStartupRuntime({
+      state: appearance,
+      isTauriAvailable: isTauriRuntimeAvailable,
+      invokeIsOsEnvReady: async () => {
+        const { invoke } = await import("$lib/tauriInvoke");
+        return invoke<boolean>("is_os_env_ready");
+      },
+      onResolved: () => {
+        startupOsEnvCaptureResolved = true;
+      },
+    });
   }
 
   async function rebuildAllBranchSessionSummaries(
@@ -906,7 +844,7 @@
   }
 
   function readVoiceInputSettingsForController(): VoiceInputSettings {
-    return voiceInputSettings;
+    return voice.settings;
   }
 
   function readVoiceFallbackTerminalPaneId(): string | null {
@@ -915,25 +853,19 @@
 
   async function applyAppearanceSettings() {
     try {
-      const { invoke } = await import("$lib/tauriInvoke");
-      const settings =
-        await invoke<
-          Pick<
-            SettingsData,
-            | "ui_font_size"
-            | "terminal_font_size"
-            | "ui_font_family"
-            | "terminal_font_family"
-            | "app_language"
-            | "voice_input"
-          >
-        >("get_settings");
-      applyUiFontSize(clampFontSize(settings.ui_font_size ?? 13));
-      applyTerminalFontSize(clampFontSize(settings.terminal_font_size ?? 13));
-      applyUiFontFamily(settings.ui_font_family);
-      applyTerminalFontFamily(settings.terminal_font_family);
-      applyAppLanguage(settings.app_language);
-      applyVoiceInputSettings(settings.voice_input);
+      await applyAppearanceSettingsRuntime({
+        state: appearance,
+        onLanguageChange: (lang) => {
+          appLanguage = lang;
+        },
+        onVoiceInputChange: (settings) => {
+          applyVoiceInputSettings(settings);
+        },
+        invokeGetSettings: async () => {
+          const { invoke } = await import("$lib/tauriInvoke");
+          return invoke<SettingsData>("get_settings");
+        },
+      });
     } catch {
       // Ignore: settings API not available outside Tauri runtime.
     }
@@ -972,7 +904,7 @@
         migrationOpen = value;
       },
       setAppError: (message) => {
-        appError = message;
+        modal.appError = message;
       },
     });
   }
@@ -1204,8 +1136,7 @@
   }
 
   function handleCleanupRequest(preSelectedBranch?: string) {
-    cleanupPreselectedBranch = preSelectedBranch ?? null;
-    showCleanupModal = true;
+    openCleanupModalRuntime(modal, preSelectedBranch);
   }
 
   async function handleOpenCiLog(runId: number) {
@@ -1453,15 +1384,15 @@
   function addDocsEditorAutoClosePane(paneId: string) {
     const normalized = paneId.trim();
     if (!normalized) return;
-    if (docsEditorAutoClosePaneIds.includes(normalized)) return;
-    docsEditorAutoClosePaneIds = [...docsEditorAutoClosePaneIds, normalized];
+    if (launch.docsEditorAutoClosePaneIds.includes(normalized)) return;
+    launch.docsEditorAutoClosePaneIds = [...launch.docsEditorAutoClosePaneIds, normalized];
   }
 
   function removeDocsEditorAutoClosePane(paneId: string) {
     const normalized = paneId.trim();
     if (!normalized) return;
-    if (!docsEditorAutoClosePaneIds.includes(normalized)) return;
-    docsEditorAutoClosePaneIds = docsEditorAutoClosePaneIds.filter(
+    if (!launch.docsEditorAutoClosePaneIds.includes(normalized)) return;
+    launch.docsEditorAutoClosePaneIds = launch.docsEditorAutoClosePaneIds.filter(
       (id) => id !== normalized,
     );
   }
@@ -1533,22 +1464,22 @@
 
   async function handleAgentLaunch(request: LaunchAgentRequest) {
     // Reset progress state before starting the job.
-    launchStep = "fetch";
-    launchDetail = "";
-    launchStatus = "running";
-    launchError = null;
-    launchJobStartPending = true;
-    bufferedLaunchProgressEvents = [];
-    bufferedLaunchFinishedEvents = [];
+    launch.step = "fetch";
+    launch.detail = "";
+    launch.status = "running";
+    launch.error = null;
+    launch.jobStartPending = true;
+    launch.bufferedProgressEvents = [];
+    launch.bufferedFinishedEvents = [];
 
     try {
       const { invoke } = await import("$lib/tauriInvoke");
       const jobId = await invoke<string>("start_launch_job", { request });
 
-      pendingLaunchRequest = request;
-      launchJobId = jobId;
-      launchJobStartPending = false;
-      launchProgressOpen = true;
+      launch.pendingRequest = request;
+      launch.jobId = jobId;
+      launch.jobStartPending = false;
+      launch.progressOpen = true;
       flushBufferedLaunchEventsForActiveJob();
     } catch (err) {
       clearBufferedLaunchEvents();
@@ -1557,18 +1488,18 @@
   }
 
   async function handleLaunchCancel() {
-    if (!launchJobId) {
+    if (!launch.jobId) {
       handleLaunchModalClose();
       return;
     }
     try {
       const { invoke } = await import("$lib/tauriInvoke");
-      await invoke("cancel_launch_job", { jobId: launchJobId });
+      await invoke("cancel_launch_job", { jobId: launch.jobId });
       handleLaunchModalClose();
     } catch (err) {
       console.error("Failed to cancel launch job:", err);
-      launchStatus = "error";
-      launchError =
+      launch.status = "error";
+      launch.error =
         "Failed to send cancel request. Close this dialog and retry.";
     }
   }
@@ -1577,38 +1508,38 @@
     closeLaunchModalRuntime({
       clearBufferedLaunchEvents,
       setLaunchProgressOpen: (open) => {
-        launchProgressOpen = open;
+        launch.progressOpen = open;
       },
       setLaunchJobId: (jobId) => {
-        launchJobId = jobId;
+        launch.jobId = jobId;
       },
       setPendingLaunchRequest: (request) => {
-        pendingLaunchRequest = request;
+        launch.pendingRequest = request;
       },
       setLaunchStatus: (status) => {
-        launchStatus = status;
+        launch.status = status;
       },
       setLaunchStep: (step) => {
-        launchStep = step;
+        launch.step = step;
       },
       setLaunchDetail: (detail) => {
-        launchDetail = detail;
+        launch.detail = detail;
       },
       setLaunchError: (error) => {
-        launchError = error;
+        launch.error = error;
       },
     });
   }
 
   function handleUseExistingBranch() {
-    const retryRequest = buildUseExistingBranchRetryRequest(pendingLaunchRequest);
+    const retryRequest = buildUseExistingBranchRetryRequest(launch.pendingRequest);
     if (!retryRequest) return;
     handleLaunchModalClose();
     void handleAgentLaunch(retryRequest);
   }
 
   function handleLaunchSuccess(paneId: string) {
-    const req = pendingLaunchRequest;
+    const req = launch.pendingRequest;
     const requestedBranch = req?.branch?.trim() ?? "";
     const label = req ? worktreeTabLabel(requestedBranch) : "Worktree";
     const requestedAgentId = inferAgentId(req?.agentId);
@@ -2032,7 +1963,7 @@
             migrationOpen = value;
           },
           setAppError: (message) => {
-            appError = message;
+            modal.appError = message;
           },
           toErrorMessage,
         }),
@@ -2046,7 +1977,7 @@
             migrationOpen = value;
           },
           setAppError: (message) => {
-            appError = message;
+            modal.appError = message;
           },
           toErrorMessage,
         }),
@@ -2081,8 +2012,7 @@
       },
       cleanupWorktrees: () => {
         if (projectPath) {
-          cleanupPreselectedBranch = null;
-          showCleanupModal = true;
+          openCleanupModalRuntime(modal);
         }
       },
       openSettings: () => {
@@ -2107,8 +2037,7 @@
           toErrorMessage,
         }),
       openAbout: () => {
-        aboutInitialTab = "general";
-        showAbout = true;
+        openAboutDialogRuntime(modal);
       },
       reportIssue: () => {
         showReportDialog("bug");
@@ -2136,16 +2065,16 @@
       debugOsEnv: () => {
         void openOsEnvDebug({
           setShowOsEnvDebug: (value) => {
-            showOsEnvDebug = value;
+            modal.osEnvDebug.open = value;
           },
           setOsEnvDebugLoading: (value) => {
-            osEnvDebugLoading = value;
+            modal.osEnvDebug.loading = value;
           },
           setOsEnvDebugError: (value) => {
-            osEnvDebugError = value;
+            modal.osEnvDebug.error = value;
           },
           setOsEnvDebugData: (value) => {
-            osEnvDebugData = value;
+            modal.osEnvDebug.data = value;
           },
         });
       },
@@ -2155,19 +2084,19 @@
             getSelectedCanvasSessionTab()?.paneId ??
             (tabs.find((t) => t.id === activeTabId)?.paneId ?? null),
           setAppError: (message) => {
-            appError = message;
+            modal.appError = message;
           },
           setShowTerminalDiagnostics: (value) => {
-            showTerminalDiagnostics = value;
+            modal.terminalDiagnostics.open = value;
           },
           setTerminalDiagnosticsLoading: (value) => {
-            terminalDiagnosticsLoading = value;
+            modal.terminalDiagnostics.loading = value;
           },
           setTerminalDiagnosticsError: (value) => {
-            terminalDiagnosticsError = value;
+            modal.terminalDiagnostics.error = value;
           },
           setTerminalDiagnostics: (value) => {
-            terminalDiagnostics = value;
+            modal.terminalDiagnostics.data = value;
           },
           toErrorMessage,
         }),
@@ -2361,7 +2290,7 @@
       isTauriRuntimeAvailable,
       handleMenuAction,
       setAppError: (message) => {
-        appError = message;
+        modal.appError = message;
       },
       toErrorMessage,
     });
@@ -2376,43 +2305,21 @@
   });
 
   $effect(() => {
-    const controller = new VoiceInputController({
+    const result = setupVoiceController({
       getSettings: readVoiceInputSettingsForController,
       getFallbackTerminalPaneId: readVoiceFallbackTerminalPaneId,
-      onStateChange: (state: VoiceControllerState) => {
-        voiceInputListening = state.listening;
-        voiceInputPreparing = state.preparing;
-        voiceInputSupported = state.supported;
-        voiceInputAvailable = state.available;
-        voiceInputAvailabilityReason = state.availabilityReason;
-        voiceInputError = state.error;
+      onStateChange: (cs: VoiceControllerState) => {
+        syncControllerState(voice, cs);
       },
     });
-    voiceController = controller;
-    controller.updateSettings();
-
-    const handleVoicePttStart = () => {
-      controller.pressPushToTalk();
-    };
-    const handleVoicePttStop = () => {
-      controller.releasePushToTalk();
-    };
-    window.addEventListener("gwt-voice-ptt-start", handleVoicePttStart);
-    window.addEventListener("gwt-voice-ptt-stop", handleVoicePttStop);
+    voiceController = result.controller;
 
     return () => {
-      window.removeEventListener("gwt-voice-ptt-start", handleVoicePttStart);
-      window.removeEventListener("gwt-voice-ptt-stop", handleVoicePttStop);
-      controller.dispose();
-      if (voiceController === controller) {
+      result.cleanup();
+      if (voiceController === result.controller) {
         voiceController = null;
       }
-      voiceInputListening = false;
-      voiceInputPreparing = false;
-      voiceInputError = null;
-      voiceInputSupported = true;
-      voiceInputAvailable = false;
-      voiceInputAvailabilityReason = null;
+      resetVoiceInputTransientState(voice);
     };
   });
 
@@ -2421,16 +2328,16 @@
       const detail = (event as CustomEvent<SettingsUpdatedPayload>).detail;
       if (!detail) return;
       if (typeof detail.uiFontSize === "number") {
-        applyUiFontSize(clampFontSize(detail.uiFontSize));
+        applyUiFontSizeRuntime(clampFontSizeAppearance(detail.uiFontSize));
       }
       if (typeof detail.terminalFontSize === "number") {
-        applyTerminalFontSize(clampFontSize(detail.terminalFontSize));
+        applyTerminalFontSizeRuntime(clampFontSizeAppearance(detail.terminalFontSize));
       }
       if (typeof detail.uiFontFamily === "string") {
-        applyUiFontFamily(detail.uiFontFamily);
+        applyUiFontFamilyRuntime(detail.uiFontFamily);
       }
       if (typeof detail.terminalFontFamily === "string") {
-        applyTerminalFontFamily(detail.terminalFontFamily);
+        applyTerminalFontFamilyRuntime(detail.terminalFontFamily);
       }
       if (typeof detail.appLanguage === "string") {
         const nextLanguage = normalizeAppLanguage(detail.appLanguage);
@@ -2476,11 +2383,11 @@
       getActiveTabId: () => activeTabId,
       getProjectPath: () => projectPath,
       getToastMessage: () => toastMessage,
-      isReportDialogOpen: () => reportDialogOpen,
+      isReportDialogOpen: () => modal.reportDialog.open,
       resetCurrentWindowLabelCache: () => {
         currentWindowLabel = null;
       },
-      getDocsEditorAutoClosePaneIds: () => docsEditorAutoClosePaneIds,
+      getDocsEditorAutoClosePaneIds: () => launch.docsEditorAutoClosePaneIds,
       forceActiveTabId: (tabId) => {
         activeTabId = tabId;
       },
@@ -2541,16 +2448,16 @@
       openCiLog: handleOpenCiLog,
       branchDisplayNameChanged: handleBranchDisplayNameChanged,
       dismissAppError: () => {
-        appError = null;
+        modal.appError = null;
       },
       dismissOsEnvDebug: () => {
-        showOsEnvDebug = false;
+        modal.osEnvDebug.open = false;
       },
       dismissTerminalDiagnostics: () => {
-        showTerminalDiagnostics = false;
+        modal.terminalDiagnostics.open = false;
       },
       dismissAbout: () => {
-        showAbout = false;
+        modal.about.open = false;
       },
       clearToast: () => {
         toastMessage = null;
@@ -2670,13 +2577,13 @@
         onSwitchToWorktree={handleSwitchToWorktreeFromTab}
         onIssueCountChange={handleIssueCountChange}
         onOpenSettings={openSettingsTab}
-        voiceInputEnabled={voiceInputSettings.enabled}
-        {voiceInputListening}
-        {voiceInputPreparing}
-        {voiceInputSupported}
-        {voiceInputAvailable}
-        {voiceInputAvailabilityReason}
-        {voiceInputError}
+        voiceInputEnabled={voice.settings.enabled}
+        voiceInputListening={voice.listening}
+        voiceInputPreparing={voice.preparing}
+        voiceInputSupported={voice.supported}
+        voiceInputAvailable={voice.available}
+        voiceInputAvailabilityReason={voice.availabilityReason}
+        voiceInputError={voice.error}
         canvasWorktrees={canvasWorktrees}
         selectedCanvasWorktreeBranch={selectedCanvasWorktreeBranch}
         onCanvasWorktreeSelect={(branchName) => {
@@ -2689,14 +2596,14 @@
       {projectPath}
       {currentBranch}
       {terminalCount}
-      {osEnvReady}
-      voiceInputEnabled={voiceInputSettings.enabled}
-      {voiceInputListening}
-      {voiceInputPreparing}
-      {voiceInputSupported}
-      {voiceInputAvailable}
-      {voiceInputAvailabilityReason}
-      {voiceInputError}
+      osEnvReady={appearance.osEnvReady}
+      voiceInputEnabled={voice.settings.enabled}
+      voiceInputListening={voice.listening}
+      voiceInputPreparing={voice.preparing}
+      voiceInputSupported={voice.supported}
+      voiceInputAvailable={voice.available}
+      voiceInputAvailabilityReason={voice.availabilityReason}
+      voiceInputError={voice.error}
     />
   </div>
 {/if}
@@ -2705,7 +2612,7 @@
   <AgentLaunchForm
     projectPath={projectPath as string}
     selectedBranch={selectedBranch?.name ?? currentBranch}
-    {osEnvReady}
+    osEnvReady={appearance.osEnvReady}
     {prefillIssue}
     onLaunch={handleAgentLaunch}
     onClose={() => {
@@ -2718,30 +2625,30 @@
 <QuitConfirmToast />
 
 <CleanupModal
-  open={showCleanupModal}
-  preselectedBranch={cleanupPreselectedBranch}
+  open={modal.cleanup.open}
+  preselectedBranch={modal.cleanup.preselectedBranch}
   refreshKey={worktreeInventoryRefreshKey}
   projectPath={projectPath ?? ""}
   {agentTabBranches}
-  onClose={() => (showCleanupModal = false)}
+  onClose={() => (modal.cleanup.open = false)}
 />
 
 <AboutDialog
-  open={showAbout}
-  initialTab={aboutInitialTab}
+  open={modal.about.open}
+  initialTab={modal.about.initialTab}
   cpuUsage={systemMonitor.cpuUsage}
   memUsed={systemMonitor.memUsed}
   memTotal={systemMonitor.memTotal}
   gpuInfos={systemMonitor.gpuInfos}
-  onclose={() => (showAbout = false)}
+  onclose={() => (modal.about.open = false)}
 />
 
 <TerminalDiagnosticsDialog
-  open={showTerminalDiagnostics}
-  loading={terminalDiagnosticsLoading}
-  error={terminalDiagnosticsError}
-  diagnostics={terminalDiagnostics}
-  onclose={() => (showTerminalDiagnostics = false)}
+  open={modal.terminalDiagnostics.open}
+  loading={modal.terminalDiagnostics.loading}
+  error={modal.terminalDiagnostics.error}
+  diagnostics={modal.terminalDiagnostics.data}
+  onclose={() => (modal.terminalDiagnostics.open = false)}
 />
 
 <MigrationModal
@@ -2754,7 +2661,7 @@
     try {
       await openProjectAndApplyCurrentWindow(p);
     } catch (err) {
-      appError = `Failed to open migrated project: ${toErrorMessage(err)}`;
+      modal.appError = `Failed to open migrated project: ${toErrorMessage(err)}`;
     }
   }}
   onDismiss={() => {
@@ -2764,26 +2671,26 @@
 />
 
 <LaunchProgressModal
-  open={launchProgressOpen}
-  step={launchStep}
-  detail={launchDetail}
-  status={launchStatus}
-  error={launchError}
+  open={launch.progressOpen}
+  step={launch.step}
+  detail={launch.detail}
+  status={launch.status}
+  error={launch.error}
   onCancel={handleLaunchCancel}
   onClose={handleLaunchModalClose}
   onUseExisting={handleUseExistingBranch}
 />
 <CapturedEnvironmentDialog
-  open={showOsEnvDebug}
-  loading={osEnvDebugLoading}
-  error={osEnvDebugError}
-  data={osEnvDebugData}
-  onclose={() => (showOsEnvDebug = false)}
+  open={modal.osEnvDebug.open}
+  loading={modal.osEnvDebug.loading}
+  error={modal.osEnvDebug.error}
+  data={modal.osEnvDebug.data}
+  onclose={() => (modal.osEnvDebug.open = false)}
 />
 
 <AppErrorDialog
-  message={appError}
-  onclose={() => (appError = null)}
+  message={modal.appError}
+  onclose={() => (modal.appError = null)}
 />
 
 {#if copyFlashActive}
@@ -2802,18 +2709,18 @@
 />
 
 <ReportDialog
-  open={reportDialogOpen}
-  mode={reportDialogMode}
-  prefillError={reportDialogPrefillError}
+  open={modal.reportDialog.open}
+  mode={modal.reportDialog.mode}
+  prefillError={modal.reportDialog.prefillError}
   projectPath={projectPath ?? ""}
   screenCaptureBranch={currentBranch}
   screenCaptureActiveTab={tabs.find((t) => t.id === activeTabId)?.label ??
     activeTabId}
   onclose={() => {
-    reportDialogOpen = false;
+    modal.reportDialog.open = false;
   }}
   onsuccess={(result: { url: string; number: number }) => {
-    reportDialogOpen = false;
+    modal.reportDialog.open = false;
     showToast(`Issue #${result.number} created successfully.`, 8000);
   }}
 />

--- a/gwt-gui/src/lib/appAppearanceRuntime.ts
+++ b/gwt-gui/src/lib/appAppearanceRuntime.ts
@@ -1,0 +1,198 @@
+/**
+ * Appearance / settings state management extracted from App.svelte.
+ *
+ * Pure-function utilities (clampFontSize, normalization helpers) live here so
+ * they can be unit-tested without a Svelte runtime.  The orchestration
+ * functions (`applyAppearanceSettingsRuntime`, `applyFontSettingsRuntime`,
+ * `checkOsEnvCaptureOnStartupRuntime`) wrap them into higher-level operations
+ * that App.svelte delegates to.
+ */
+
+import type { SettingsData, VoiceInputSettings } from "./types";
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+export const DEFAULT_UI_FONT_FAMILY =
+  'system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, sans-serif';
+
+export const DEFAULT_TERMINAL_FONT_FAMILY =
+  '"JetBrains Mono", "Fira Code", "SF Mono", Menlo, Consolas, monospace';
+
+export const DEFAULT_VOICE_INPUT_SETTINGS: VoiceInputSettings = {
+  enabled: false,
+  engine: "qwen3-asr",
+  language: "auto",
+  quality: "balanced",
+  model: "Qwen/Qwen3-ASR-1.7B",
+};
+
+const FONT_SIZE_MIN = 8;
+const FONT_SIZE_MAX = 24;
+
+// ── Appearance state ─────────────────────────────────────────────────────
+
+export interface AppearanceState {
+  appLanguage: SettingsData["app_language"];
+  osEnvReady: boolean;
+}
+
+export function createAppearanceState(): AppearanceState {
+  return {
+    appLanguage: "auto",
+    osEnvReady: false,
+  };
+}
+
+// ── Pure normalisation / clamping ────────────────────────────────────────
+
+export function clampFontSizeRuntime(size: number): number {
+  return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, Math.round(size)));
+}
+
+export function normalizeAppLanguageRuntime(
+  value: string | null | undefined,
+): SettingsData["app_language"] {
+  const language = (value ?? "").trim().toLowerCase();
+  if (language === "ja" || language === "en" || language === "auto") {
+    return language as SettingsData["app_language"];
+  }
+  return "auto";
+}
+
+export function normalizeUiFontFamilyRuntime(
+  value: string | null | undefined,
+): string {
+  const family = (value ?? "").trim();
+  return family.length > 0 ? family : DEFAULT_UI_FONT_FAMILY;
+}
+
+export function normalizeTerminalFontFamilyRuntime(
+  value: string | null | undefined,
+): string {
+  const family = (value ?? "").trim();
+  return family.length > 0 ? family : DEFAULT_TERMINAL_FONT_FAMILY;
+}
+
+export function normalizeVoiceInputSettingsRuntime(
+  value: Partial<VoiceInputSettings> | null | undefined,
+): VoiceInputSettings {
+  const engine = (value?.engine ?? "").trim().toLowerCase();
+  const language = (value?.language ?? "").trim().toLowerCase();
+  const quality = (value?.quality ?? "").trim().toLowerCase();
+  const model = (value?.model ?? "").trim();
+  const normalizedQuality =
+    quality === "fast" || quality === "balanced" || quality === "accurate"
+      ? (quality as VoiceInputSettings["quality"])
+      : DEFAULT_VOICE_INPUT_SETTINGS.quality;
+  const defaultModel =
+    normalizedQuality === "fast"
+      ? "Qwen/Qwen3-ASR-0.6B"
+      : "Qwen/Qwen3-ASR-1.7B";
+
+  return {
+    enabled: !!value?.enabled,
+    engine:
+      engine === "qwen3-asr" || engine === "qwen" || engine === "whisper"
+        ? "qwen3-asr"
+        : DEFAULT_VOICE_INPUT_SETTINGS.engine,
+    language:
+      language === "ja" || language === "en" || language === "auto"
+        ? (language as VoiceInputSettings["language"])
+        : DEFAULT_VOICE_INPUT_SETTINGS.language,
+    quality: normalizedQuality,
+    model: model.length > 0 ? model : defaultModel,
+  };
+}
+
+// ── DOM side-effect helpers ──────────────────────────────────────────────
+
+export function applyUiFontSizeRuntime(size: number): void {
+  document.documentElement.style.setProperty("--ui-font-base", `${size}px`);
+}
+
+export function applyUiFontFamilyRuntime(
+  family: string | null | undefined,
+): void {
+  document.documentElement.style.setProperty(
+    "--ui-font-family",
+    normalizeUiFontFamilyRuntime(family),
+  );
+}
+
+export function applyTerminalFontSizeRuntime(size: number): void {
+  (window as any).__gwtTerminalFontSize = size;
+  window.dispatchEvent(
+    new CustomEvent("gwt-terminal-font-size", { detail: size }),
+  );
+}
+
+export function applyTerminalFontFamilyRuntime(
+  family: string | null | undefined,
+): void {
+  const normalized = normalizeTerminalFontFamilyRuntime(family);
+  document.documentElement.style.setProperty(
+    "--terminal-font-family",
+    normalized,
+  );
+  (window as any).__gwtTerminalFontFamily = normalized;
+  window.dispatchEvent(
+    new CustomEvent("gwt-terminal-font-family", { detail: normalized }),
+  );
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────
+
+/**
+ * Apply font-related settings to the DOM (synchronous, no Tauri call).
+ */
+export function applyFontSettingsRuntime(settings: SettingsData): void {
+  applyUiFontSizeRuntime(clampFontSizeRuntime(settings.ui_font_size ?? 13));
+  applyTerminalFontSizeRuntime(
+    clampFontSizeRuntime(settings.terminal_font_size ?? 13),
+  );
+  applyUiFontFamilyRuntime(settings.ui_font_family);
+  applyTerminalFontFamilyRuntime(settings.terminal_font_family);
+}
+
+/**
+ * Load settings from the Tauri backend and apply all appearance values.
+ *
+ * The caller must supply callbacks for state that lives in App.svelte's
+ * reactive scope (language, voice-input settings).
+ */
+export async function applyAppearanceSettingsRuntime(args: {
+  state: AppearanceState;
+  onLanguageChange: (lang: SettingsData["app_language"]) => void;
+  onVoiceInputChange: (settings: VoiceInputSettings) => void;
+  invokeGetSettings: () => Promise<SettingsData>;
+}): Promise<void> {
+  const settings = await args.invokeGetSettings();
+  applyFontSettingsRuntime(settings);
+  const lang = normalizeAppLanguageRuntime(settings.app_language);
+  args.state.appLanguage = lang;
+  args.onLanguageChange(lang);
+  args.onVoiceInputChange(normalizeVoiceInputSettingsRuntime(settings.voice_input));
+}
+
+/**
+ * Check OS environment capture readiness on startup.
+ */
+export async function checkOsEnvCaptureOnStartupRuntime(args: {
+  state: AppearanceState;
+  isTauriAvailable: () => boolean;
+  invokeIsOsEnvReady: () => Promise<boolean>;
+  onResolved: () => void;
+}): Promise<void> {
+  if (!args.isTauriAvailable()) {
+    args.onResolved();
+    return;
+  }
+
+  try {
+    args.state.osEnvReady = await args.invokeIsOsEnvReady();
+    args.onResolved();
+  } catch (err) {
+    args.onResolved();
+    console.error("Failed to check os env capture status:", err);
+  }
+}

--- a/gwt-gui/src/lib/appLaunchStateRuntime.ts
+++ b/gwt-gui/src/lib/appLaunchStateRuntime.ts
@@ -1,0 +1,90 @@
+import type {
+  LaunchAgentRequest,
+  LaunchProgressPayload,
+  LaunchFinishedPayload,
+} from "./types";
+
+export type LaunchStepId =
+  | "fetch"
+  | "validate"
+  | "paths"
+  | "conflicts"
+  | "create"
+  | "skills"
+  | "deps";
+
+export const LAUNCH_STEP_IDS: LaunchStepId[] = [
+  "fetch",
+  "validate",
+  "paths",
+  "conflicts",
+  "create",
+  "skills",
+  "deps",
+];
+
+export const LAUNCH_EVENT_BUFFER_LIMIT = 64;
+
+export interface LaunchState {
+  progressOpen: boolean;
+  jobId: string;
+  step: LaunchStepId;
+  detail: string;
+  status: "running" | "ok" | "error" | "cancelled";
+  error: string | null;
+  pendingRequest: LaunchAgentRequest | null;
+  jobStartPending: boolean;
+  bufferedProgressEvents: LaunchProgressPayload[];
+  bufferedFinishedEvents: LaunchFinishedPayload[];
+  docsEditorAutoClosePaneIds: string[];
+}
+
+export function createLaunchState(): LaunchState {
+  return {
+    progressOpen: false,
+    jobId: "",
+    step: "fetch",
+    detail: "",
+    status: "running",
+    error: null,
+    pendingRequest: null,
+    jobStartPending: false,
+    bufferedProgressEvents: [],
+    bufferedFinishedEvents: [],
+    docsEditorAutoClosePaneIds: [],
+  };
+}
+
+export function bufferLaunchProgressEventRuntime(
+  state: LaunchState,
+  payload: LaunchProgressPayload,
+): void {
+  if (state.bufferedProgressEvents.length >= LAUNCH_EVENT_BUFFER_LIMIT) {
+    state.bufferedProgressEvents.shift();
+  }
+  state.bufferedProgressEvents.push(payload);
+}
+
+export function bufferLaunchFinishedEventRuntime(
+  state: LaunchState,
+  payload: LaunchFinishedPayload,
+): void {
+  if (state.bufferedFinishedEvents.length >= LAUNCH_EVENT_BUFFER_LIMIT) {
+    state.bufferedFinishedEvents.shift();
+  }
+  state.bufferedFinishedEvents.push(payload);
+}
+
+export function resetLaunchStateRuntime(state: LaunchState): void {
+  state.progressOpen = false;
+  state.jobId = "";
+  state.step = "fetch";
+  state.detail = "";
+  state.status = "running";
+  state.error = null;
+  state.pendingRequest = null;
+  state.jobStartPending = false;
+  state.bufferedProgressEvents = [];
+  state.bufferedFinishedEvents = [];
+  state.docsEditorAutoClosePaneIds = [];
+}

--- a/gwt-gui/src/lib/appModalStateRuntime.ts
+++ b/gwt-gui/src/lib/appModalStateRuntime.ts
@@ -1,0 +1,67 @@
+import type { StructuredError } from "./errorBus";
+import type { TerminalAnsiProbe, CapturedEnvInfo } from "./types";
+
+export interface ModalState {
+  about: { open: boolean; initialTab: "general" | "system" | "statistics" };
+  cleanup: { open: boolean; preselectedBranch: string | null };
+  reportDialog: {
+    open: boolean;
+    mode: "bug" | "feature";
+    prefillError?: StructuredError;
+  };
+  terminalDiagnostics: {
+    open: boolean;
+    loading: boolean;
+    data: TerminalAnsiProbe | null;
+    error: string | null;
+  };
+  osEnvDebug: {
+    open: boolean;
+    data: CapturedEnvInfo | null;
+    loading: boolean;
+    error: string | null;
+  };
+  appError: string | null;
+}
+
+export function createModalState(): ModalState {
+  return {
+    about: { open: false, initialTab: "general" },
+    cleanup: { open: false, preselectedBranch: null },
+    reportDialog: { open: false, mode: "bug", prefillError: undefined },
+    terminalDiagnostics: {
+      open: false,
+      loading: false,
+      data: null,
+      error: null,
+    },
+    osEnvDebug: { open: false, data: null, loading: false, error: null },
+    appError: null,
+  };
+}
+
+export function showReportDialogRuntime(
+  state: ModalState,
+  mode: "bug" | "feature",
+  prefillError?: StructuredError,
+): void {
+  state.reportDialog.mode = mode;
+  state.reportDialog.prefillError = prefillError;
+  state.reportDialog.open = true;
+}
+
+export function openAboutDialogRuntime(
+  state: ModalState,
+  tab?: "general" | "system" | "statistics",
+): void {
+  state.about.initialTab = tab ?? "general";
+  state.about.open = true;
+}
+
+export function openCleanupModalRuntime(
+  state: ModalState,
+  branch?: string | null,
+): void {
+  state.cleanup.preselectedBranch = branch ?? null;
+  state.cleanup.open = true;
+}

--- a/gwt-gui/src/lib/appToastRuntime.ts
+++ b/gwt-gui/src/lib/appToastRuntime.ts
@@ -1,0 +1,141 @@
+/**
+ * Toast / notification state management extracted from App.svelte.
+ *
+ * Pure functions that operate on an explicit {@link ToastState} object.
+ * The module has no side-effects; callers own state mutation and scheduling.
+ */
+
+import type { StructuredError } from "./errorBus";
+import type { UpdateState } from "./types";
+
+export type ToastAction =
+  | { kind: "apply-update"; latest: string }
+  | { kind: "report-error"; error: StructuredError }
+  | null;
+
+/** Subset of UpdateState narrowed to `"available"`. */
+export type AvailableUpdateState = Extract<UpdateState, { state: "available" }>;
+
+export interface ToastState {
+  message: string | null;
+  action: ToastAction;
+  timeout: ReturnType<typeof setTimeout> | null;
+  lastUpdateVersion: string | null;
+}
+
+export function createToastState(): ToastState {
+  return {
+    message: null,
+    action: null,
+    timeout: null,
+    lastUpdateVersion: null,
+  };
+}
+
+export interface ShowToastCallbacks {
+  setState: (message: string | null, action: ToastAction) => void;
+}
+
+/**
+ * Show a toast notification.
+ *
+ * @param durationMs Auto-dismiss delay in ms. 0 = sticky (no auto-dismiss).
+ */
+export function showToast(
+  state: ToastState,
+  message: string,
+  durationMs: number,
+  action: ToastAction,
+  cb: ShowToastCallbacks,
+): void {
+  cb.setState(message, action);
+  state.message = message;
+  state.action = action;
+
+  if (state.timeout) clearTimeout(state.timeout);
+  state.timeout = null;
+
+  if (durationMs > 0) {
+    state.timeout = setTimeout(() => {
+      cb.setState(null, null);
+      state.message = null;
+      state.action = null;
+    }, durationMs);
+  }
+}
+
+/**
+ * Show an "update available" toast, de-duplicated by version string.
+ *
+ * @returns `true` if a toast was shown; `false` if suppressed.
+ */
+export function showAvailableUpdateToast(
+  state: ToastState,
+  update: AvailableUpdateState,
+  force: boolean,
+  cb: ShowToastCallbacks,
+): boolean {
+  if (!force && state.lastUpdateVersion === update.latest) return false;
+  state.lastUpdateVersion = update.latest;
+
+  if (update.asset_url) {
+    showToast(
+      state,
+      `Update available: v${update.latest} (click update)`,
+      0,
+      { kind: "apply-update", latest: update.latest },
+      cb,
+    );
+  } else {
+    showToast(
+      state,
+      `Update available: v${update.latest}. Manual download required.`,
+      15_000,
+      null,
+      cb,
+    );
+  }
+  return true;
+}
+
+/**
+ * Dismiss the current toast (clear message + action).
+ */
+export function dismissToast(state: ToastState, cb: ShowToastCallbacks): void {
+  if (state.timeout) clearTimeout(state.timeout);
+  state.timeout = null;
+  state.message = null;
+  state.action = null;
+  cb.setState(null, null);
+}
+
+export interface ToastSubscriptionDeps {
+  toastBus: { subscribe: (handler: (event: { message: string; durationMs?: number }) => void) => () => void };
+  errorBus: { subscribe: (handler: (error: StructuredError) => void) => () => void };
+  state: ToastState;
+  cb: ShowToastCallbacks;
+}
+
+/**
+ * Wire up toastBus and errorBus subscriptions.
+ *
+ * @returns A cleanup function that unsubscribes both listeners.
+ */
+export function setupToastSubscriptions(deps: ToastSubscriptionDeps): () => void {
+  const { toastBus, errorBus, state, cb } = deps;
+
+  const unsubToast = toastBus.subscribe((event) => {
+    showToast(state, event.message, event.durationMs ?? 5000, null, cb);
+  });
+
+  const unsubError = errorBus.subscribe((error) => {
+    if (error.severity === "error" || error.severity === "critical") {
+      showToast(state, `Error: ${error.message}`, 0, { kind: "report-error", error }, cb);
+    }
+  });
+
+  return () => {
+    unsubToast();
+    unsubError();
+  };
+}

--- a/gwt-gui/src/lib/appVoiceInputRuntime.ts
+++ b/gwt-gui/src/lib/appVoiceInputRuntime.ts
@@ -1,0 +1,105 @@
+import type { VoiceInputSettings } from "./types";
+import {
+  VoiceInputController,
+  type VoiceControllerState,
+} from "./voice/voiceInputController";
+import {
+  DEFAULT_VOICE_INPUT,
+  normalizeVoiceInputSettings,
+} from "./components/settingsPanelHelpers";
+
+export { DEFAULT_VOICE_INPUT, normalizeVoiceInputSettings };
+
+export interface VoiceInputState {
+  settings: VoiceInputSettings;
+  listening: boolean;
+  preparing: boolean;
+  supported: boolean;
+  available: boolean;
+  availabilityReason: string | null;
+  error: string | null;
+}
+
+export interface ApplyVoiceInputSettingsDeps {
+  controller: VoiceInputController | null;
+}
+
+export function applyVoiceInputSettings(
+  state: VoiceInputState,
+  value: Partial<VoiceInputSettings> | null | undefined,
+  deps: ApplyVoiceInputSettingsDeps,
+): void {
+  state.settings = normalizeVoiceInputSettings(value);
+  deps.controller?.updateSettings();
+}
+
+export function createVoiceInputState(
+  defaults: VoiceInputSettings = DEFAULT_VOICE_INPUT,
+): VoiceInputState {
+  return {
+    settings: { ...defaults },
+    listening: false,
+    preparing: false,
+    supported: true,
+    available: false,
+    availabilityReason: null,
+    error: null,
+  };
+}
+
+export function resetVoiceInputTransientState(state: VoiceInputState): void {
+  state.listening = false;
+  state.preparing = false;
+  state.error = null;
+  state.supported = true;
+  state.available = false;
+  state.availabilityReason = null;
+}
+
+export function syncControllerState(
+  state: VoiceInputState,
+  cs: VoiceControllerState,
+): void {
+  state.listening = cs.listening;
+  state.preparing = cs.preparing;
+  state.supported = cs.supported;
+  state.available = cs.available;
+  state.availabilityReason = cs.availabilityReason;
+  state.error = cs.error;
+}
+
+export interface SetupVoiceControllerDeps {
+  getSettings: () => VoiceInputSettings;
+  getFallbackTerminalPaneId: () => string | null;
+  onStateChange: (cs: VoiceControllerState) => void;
+}
+
+export interface SetupVoiceControllerResult {
+  controller: VoiceInputController;
+  cleanup: () => void;
+}
+
+export function setupVoiceController(
+  deps: SetupVoiceControllerDeps,
+): SetupVoiceControllerResult {
+  const controller = new VoiceInputController({
+    getSettings: deps.getSettings,
+    getFallbackTerminalPaneId: deps.getFallbackTerminalPaneId,
+    onStateChange: deps.onStateChange,
+  });
+  controller.updateSettings();
+
+  const handlePttStart = () => controller.pressPushToTalk();
+  const handlePttStop = () => controller.releasePushToTalk();
+
+  window.addEventListener("gwt-voice-ptt-start", handlePttStart);
+  window.addEventListener("gwt-voice-ptt-stop", handlePttStop);
+
+  const cleanup = () => {
+    window.removeEventListener("gwt-voice-ptt-start", handlePttStart);
+    window.removeEventListener("gwt-voice-ptt-stop", handlePttStop);
+    controller.dispose();
+  };
+
+  return { controller, cleanup };
+}


### PR DESCRIPTION
## Summary

- AppRoot.svelte のインライン状態宣言とハンドラを5つの抽出済みランタイムモジュールのAPIに置き換え
- 統合対象: `appToastRuntime`, `appVoiceInputRuntime`, `appModalStateRuntime`, `appAppearanceRuntime`, `appLaunchStateRuntime`
- 動作変更なしの純粋リファクタリング（テスト結果はベースラインと同一）

## Changes

- **Toast**: `toastMessage`/`toastTimeout`/`toastAction`/`lastUpdateToastVersion` → `createToastState()` + `showToastRuntime`/`dismissToastRuntime`/`setupToastSubscriptions`
- **Voice Input**: 6つの個別 `$state` 変数 → `createVoiceInputState()` + `setupVoiceController`/`syncControllerState`/`resetVoiceInputTransientState`
- **Modal State**: `showAbout`/`showCleanupModal`/`reportDialogOpen` 等 → `createModalState()` + `showReportDialogRuntime`/`openAboutDialogRuntime`/`openCleanupModalRuntime`
- **Appearance**: `DEFAULT_*` 定数 + `applyUiFontSize` 等のDOM操作関数 → `appAppearanceRuntime` のエクスポートに委譲
- **Launch State**: `launchProgressOpen`/`launchJobId` 等 → `createLaunchState()` + `bufferLaunchProgressEventRuntime`/`bufferLaunchFinishedEventRuntime`

## Test plan

- [x] `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors
- [x] `pnpm test` — 65 passed, 8 failed (same as baseline)
- [ ] Manual smoke test via `cargo tauri dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)