### PR TITLE
chore: pre-commit に svelte-check + pnpm test、pre-push に pnpm build を追加

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,9 @@ set -e
 
 echo "Validating SKILL.md frontmatter..."
 pnpm lint:skills
+
+echo "Running frontend type check (svelte-check)..."
+(cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json --fail-on-warnings false)
+
+echo "Running frontend unit tests..."
+(cd gwt-gui && pnpm test)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,4 +9,7 @@ cargo fmt --all -- --check
 bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md
 pnpm lint:skills
 
-echo "Lint checks passed."
+echo "Running frontend build check..."
+(cd gwt-gui && pnpm run build)
+
+echo "All pre-push checks passed."


### PR DESCRIPTION
## Summary
- pre-commit フックに `svelte-check`（型チェック）と `pnpm test`（フロントエンド単体テスト）を追加
- pre-push フックに `pnpm run build`（フロントエンドビルドチェック）を追加
- CI で検出されるべきフロントエンドエラーをリモート push 前にローカルで確実に検出

## Test plan
- [x] `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors
- [x] `pnpm test` — 1420 tests passed
- [x] 両ファイルの内容を目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)