### PR TITLE
docs: SPEC-1355〜1404 に gwt-tui 移行注釈を追加

### DIFF
--- a/specs/SPEC-1355/spec.md
+++ b/specs/SPEC-1355/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Cmd+Q 二重確認によるアプリ終了
 
 **仕様ID**: `SPEC-d3a1f5b2`

--- a/specs/SPEC-1356/spec.md
+++ b/specs/SPEC-1356/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Session Summary + PR Status Preview（GUI）
 
 **仕様ID**: `SPEC-d6949f99`

--- a/specs/SPEC-1357/spec.md
+++ b/specs/SPEC-1357/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: Cleanup「Select All Safe」が機能しない
 
 **仕様ID**: `SPEC-d7f2a1b3`

--- a/specs/SPEC-1358/spec.md
+++ b/specs/SPEC-1358/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: URLクリック時の外部ブラウザ起動統一
 
 **仕様ID**: `SPEC-d95a7e0c`

--- a/specs/SPEC-1359/spec.md
+++ b/specs/SPEC-1359/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: PRタブへのWorkflow統合とブランチ状態表示
 
 **仕様ID**: `SPEC-de3290fc`

--- a/specs/SPEC-1360/spec.md
+++ b/specs/SPEC-1360/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: macOS リリースの署名/公証を必須化して Gatekeeper エラーを防止
 
 **仕様ID**: `SPEC-e0e11640`

--- a/specs/SPEC-1361/spec.md
+++ b/specs/SPEC-1361/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Branch Already Exists → Use Existing Branch 確認
 
 **仕様ID**: `SPEC-e1004use`

--- a/specs/SPEC-1363/spec.md
+++ b/specs/SPEC-1363/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: ウィンドウ・タブ切り替えショートカット
 
 **仕様ID**: `SPEC-e7b3a1d2`

--- a/specs/SPEC-1364/spec.md
+++ b/specs/SPEC-1364/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: プロジェクトを開いたときに前回のエージェントタブを復元する
 
 **仕様ID**: `SPEC-f466bc68`

--- a/specs/SPEC-1367/spec.md
+++ b/specs/SPEC-1367/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Worktree詳細ビューでMergeableクリックによるマージ実行
 
 **仕様ID**: `SPEC-merge-pr`

--- a/specs/SPEC-1368/spec.md
+++ b/specs/SPEC-1368/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: PR Dashboard
 
 **仕様ID**: `SPEC-prlist`

--- a/specs/SPEC-1370/spec.md
+++ b/specs/SPEC-1370/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: ボイス入力設定フィールドが操作不能
 
 **仕様ID**: `SPEC-voicefix`

--- a/specs/SPEC-1371/spec.md
+++ b/specs/SPEC-1371/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: プロジェクトモード（Project Mode）
 
 **仕様ID**: `SPEC-ba3f610c`

--- a/specs/SPEC-1395/spec.md
+++ b/specs/SPEC-1395/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### 背景
 
 gwt は複数プロジェクトを同時に開ける設計だが、以下の3箇所でプロジェクト間の分離が不完全:


### PR DESCRIPTION
## Summary

- gwt-tauri/GUI 関連の参照を含む 14 件の SPEC ファイル（SPEC-1355〜1395）に TUI 移行注釈を追加
- 対象: SPEC-1355, 1356, 1357, 1358, 1359, 1360, 1361, 1363, 1364, 1367, 1368, 1370, 1371, 1395
- スキップ: SPEC-1362, 1369, 1398（GUI 参照なし）、SPEC-1365, 1366, 1404（ファイル不在）

## Test plan

- [x] 注釈が spec.md の先頭に正しく挿入されていること
- [x] 注釈以外の内容が変更されていないこと
- [x] GUI 参照のない SPEC はスキップされていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added historical context notes to specification documents indicating legacy GUI references from prior technology era. Clarifies that current implementation uses TUI instead. Specification content remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->