### PR TITLE
docs: SPEC-1235〜1313 に gwt-tui 移行注釈を追加

### DIFF
--- a/specs/SPEC-1256/spec.md
+++ b/specs/SPEC-1256/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### User Scenario
 
 1. ユーザーが gwt アプリを使用中にエラーが発生する

--- a/specs/SPEC-1288/spec.md
+++ b/specs/SPEC-1288/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: From Issue でブランチ名に prefix が二重表示される
 
 **仕様ID**: `SPEC-1288`

--- a/specs/SPEC-1298/spec.md
+++ b/specs/SPEC-1298/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: 全画面テキストコピー (Cmd+Shift+C)
 
 **仕様ID**: `SPEC-0e6abbb7`

--- a/specs/SPEC-1299/spec.md
+++ b/specs/SPEC-1299/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Sidebar Filter Cache for Local/Remote/All
 
 **仕様ID**: `SPEC-0f8e9c12`

--- a/specs/SPEC-1301/spec.md
+++ b/specs/SPEC-1301/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Windows 移行プロジェクトの Docker 起動でポート競合を回避する
 
 **仕様ID**: `SPEC-1161b0a1`

--- a/specs/SPEC-1303/spec.md
+++ b/specs/SPEC-1303/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Version History の最新タグ表示を安定化
 
 **仕様ID**: `SPEC-1242`  

--- a/specs/SPEC-1304/spec.md
+++ b/specs/SPEC-1304/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### 背景
 
 - 2026-03-02 に Issue #1265 で Windows Launch Agent の再発が報告された。

--- a/specs/SPEC-1305/spec.md
+++ b/specs/SPEC-1305/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Project Version History（タグ単位のAI要約 + 簡易CHANGELOG）
 
 **仕様ID**: `SPEC-133bf64f`

--- a/specs/SPEC-1307/spec.md
+++ b/specs/SPEC-1307/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: Windows Docker Launch で `service "dev" is not running` を防止する
 
 **仕様ID**: `SPEC-17e47ece`

--- a/specs/SPEC-1308/spec.md
+++ b/specs/SPEC-1308/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: Claude Code Hooks 経由の gwt-tauri hook 実行で GUI を起動しない
 
 **仕様ID**: `SPEC-1b98b6d7`

--- a/specs/SPEC-1309/spec.md
+++ b/specs/SPEC-1309/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: Window復元時の無限生成防止
 
 **仕様ID**: `SPEC-1f9d2a6c`  

--- a/specs/SPEC-1310/spec.md
+++ b/specs/SPEC-1310/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正: ターミナル行数増加時のトラックパッドスクロール不能
 
 **仕様ID**: `SPEC-25251fb9`

--- a/specs/SPEC-1312/spec.md
+++ b/specs/SPEC-1312/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: v7.11.0 起動不能（Issue #1219）
 
 **仕様ID**: `SPEC-434cef4e`

--- a/specs/SPEC-1313/spec.md
+++ b/specs/SPEC-1313/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # 機能仕様: gwt GUI マルチウィンドウ + Native Windowメニュー
 
 **仕様ID**: `SPEC-4470704f`


### PR DESCRIPTION
## Summary

- GUI/Tauri 関連の SPEC 14 件（SPEC-1256, 1288, 1298, 1299, 1301, 1303, 1304, 1305, 1307, 1308, 1309, 1310, 1312, 1313）の spec.md 先頭に TUI 移行注釈を追加
- GUI/Tauri を参照しない SPEC（1235, 1297, 1300, 1302）はスキップ
- spec.md が存在しない SPEC（1306, 1311）はスキップ

## Test plan

- [x] 注釈が各 spec.md の先頭に正しく挿入されている
- [x] 注釈以外の内容は一切変更なし
- [x] metadata.json は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)