### PR TITLE
docs: SPEC-1407〜1521 に gwt-tui 移行注釈を追加

### DIFF
--- a/specs/SPEC-1408/spec.md
+++ b/specs/SPEC-1408/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### 背景
 
 Issue一覧パネル (`IssueListPanel.svelte`) の無限スクロールで「Loading more」状態でUIが固まる。

--- a/specs/SPEC-1410/spec.md
+++ b/specs/SPEC-1410/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### 背景
 
 Windows 環境で gwt のターミナルタブ間（agent-1 → term-1 など）を切り替えると、1フレームの背景フラッシュが発生する。ネイティブメニュー領域までターミナル表示が被るように見える。

--- a/specs/SPEC-1429/spec.md
+++ b/specs/SPEC-1429/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: 音声入力が動作しない（ランタイムセットアップ・リトライ・Python互換性）
 
 **作成日**: 2026-03-03

--- a/specs/SPEC-1433/spec.md
+++ b/specs/SPEC-1433/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### 背景
 
 v8.3.1 で導入した API Key の peek/copy UI について、以下の表示回帰が報告された。

--- a/specs/SPEC-1438/spec.md
+++ b/specs/SPEC-1438/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### Overview
 
 gwt はエージェント起動時に、起動対象の project/worktree 配下へ gwt 管理の skill/command/hook assets を埋め込む。グローバルな `~/.claude` / `~/.codex` / `~/.gemini` への起動時登録・終了時解除は行わない。

--- a/specs/SPEC-1453/spec.md
+++ b/specs/SPEC-1453/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### 背景
 Issue検索フィルターでIssue番号を入力しても一致せず、既存Issueの絞り込み効率が下がっている。
 

--- a/specs/SPEC-1463/spec.md
+++ b/specs/SPEC-1463/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### 背景
 
 Settings > Profiles で `ai.api_key` を保存しても、macOS 環境で Codex が `Not authenticated` 扱いになる。

--- a/specs/SPEC-1489/metadata.json
+++ b/specs/SPEC-1489/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "1489",
   "title": "gwt-spec: AI エージェントモデル管理",
-  "status": "open",
+  "status": "deprecated",
   "phase": "draft",
   "created_at": "2026-03-06T00:39:32Z",
   "updated_at": "2026-03-23T17:27:20Z"

--- a/specs/SPEC-1489/spec.md
+++ b/specs/SPEC-1489/spec.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATED (SPEC-1776)**: This SPEC describes GUI-only functionality (Tauri/Svelte/xterm.js) that has been superseded by the gwt-tui migration. The gwt-tui equivalent is defined in SPEC-1776.
+
 ### 背景
 
 gwt は Launch Agent UI 上で、エージェントごとのモデル候補を明示的に管理している。現在の主な管理箇所は `gwt-gui/src/lib/components/AgentLaunchForm.svelte` であり、Codex / Claude Code / Gemini / Copilot のモデル候補がここで定義されている。

--- a/specs/SPEC-1505/spec.md
+++ b/specs/SPEC-1505/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 # バグ修正仕様: PR 作成前の branch preflight を Codex / Claude Code / GWT で必須化
 
 **作成日**: 2026-03-06

--- a/specs/SPEC-1521/spec.md
+++ b/specs/SPEC-1521/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC was completed during the gwt-tauri era. The gwt-tauri frontend has been replaced by gwt-tui (SPEC-1776). GUI-specific references are historical.
+
 ### Background
 Settings > Profiles の API Key 入力で、手入力した値は一時的に使えても Save 後に reopen すると失われる。また、貼り付けた値は UI state に反映されず、Peek/Copy ボタン表示、Refresh、Save に使えない。関連 bug report: #1480。
 


### PR DESCRIPTION
## Summary
- GUI/Tauri/Svelte 参照を含む 9 件の SPEC に TUI MIGRATION NOTE を追加（SPEC-1408, 1410, 1429, 1433, 1438, 1453, 1463, 1505, 1521）
- SPEC-1489 を DEPRECATED に変更（spec.md + metadata.json の status を deprecated に更新）
- GUI 参照のない 10 件の SPEC はスキップ（SPEC-1407, 1411, 1427, 1428, 1439, 1464, 1475, 1487, 1488, 1520）

## Test plan
- [ ] 注釈付き spec.md の先頭行に blockquote が正しく挿入されていること
- [ ] SPEC-1489 の metadata.json の status が `deprecated` であること
- [ ] GUI 参照のない SPEC が変更されていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)