### PR TITLE
docs: SPEC-1651〜1776 に gwt-tui 移行注釈を追加

### DIFF
--- a/specs/SPEC-1651/spec.md
+++ b/specs/SPEC-1651/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC describes backend/gwt-core functionality unaffected by the gwt-tui migration (SPEC-1776). No changes required.
+
 ### 背景
 トースト通知、OS通知、エラーバス、統合通知アーキテクチャを提供する。Assistantの提案はチャットタイムライン内のアクション付きカードとして表示される。Studio時代の #1548（HUD＆UIシステム）の通知関連機能を現行スタックで再定義。
 

--- a/specs/SPEC-1652/spec.md
+++ b/specs/SPEC-1652/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC describes backend/gwt-core functionality unaffected by the gwt-tui migration (SPEC-1776). No changes required.
+
 ### 背景
 Tauriビルド（.dmg/.msi/.AppImage）、CI/CDパイプライン、GitHub Releases、自動更新チェック機能を包含する。release.yml、cargo tauri build、更新チェック機能は実装済み。Studio時代の #1553（ビルド・配布・システム監視）の概念を現行Tauriスタックで再定義。
 

--- a/specs/SPEC-1653/metadata.json
+++ b/specs/SPEC-1653/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "1653",
   "title": "gwt-spec: ターミナルコア",
-  "status": "open",
+  "status": "deprecated",
   "phase": "draft",
   "created_at": "2026-03-17T03:41:06Z",
   "updated_at": "2026-03-23T17:27:07Z"

--- a/specs/SPEC-1653/spec.md
+++ b/specs/SPEC-1653/spec.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATED (SPEC-1776)**: This SPEC describes GUI-only functionality (Tauri/Svelte/xterm.js) that has been superseded by the gwt-tui migration. The gwt-tui equivalent is defined in SPEC-1776.
+
 ### 背景
 xterm.js v6統合、portable-pty管理、ANSI処理、リサイズ、パフォーマンスを包含するターミナルコア機能。TerminalView.svelte、PTYコマンド群、ANSI診断機能は実装済み。TerminalオーバーレイUI (#1612) とは分離し、コアはPTY+レンダリングに集中する。Studio時代の #1540（PTY管理）と #1541（ターミナルエミュレータ）の概念を現行スタックで再定義。
 

--- a/specs/SPEC-1654/spec.md
+++ b/specs/SPEC-1654/spec.md
@@ -1,3 +1,5 @@
+> **🔄 TUI MIGRATION (SPEC-1776)**: This SPEC requires adaptation for the gwt-tui migration. GUI-specific references (gwt-tauri, Svelte, xterm.js) should be read as gwt-tui equivalents. See SPEC-1776 for the migration plan.
+
 # Workspace Shell（Agent Canvas・Branch Browser・マルチウィンドウ実行セッション）
 
 ## Background

--- a/specs/SPEC-1661/spec.md
+++ b/specs/SPEC-1661/spec.md
@@ -1,3 +1,5 @@
+> **📝 HISTORICAL (GUI era)**: This SPEC was written for the gwt-gui (Tauri/Svelte) architecture. The gwt-tui migration (SPEC-1776) supersedes the GUI stack. Retain for historical context.
+
 ### Background
 
 AssistantPanel の textarea で日本語 IME 入力時、変換確定の Enter キーでメッセージが送信されてしまう。

--- a/specs/SPEC-1662/spec.md
+++ b/specs/SPEC-1662/spec.md
@@ -1,3 +1,5 @@
+> **📝 HISTORICAL (GUI era)**: This SPEC was written for the gwt-gui (Tauri/Svelte) architecture. The gwt-tui migration (SPEC-1776) supersedes the GUI stack. Retain for historical context.
+
 ### Background
 
 AssistantPanel のチャット表示で 2 つの UX 崩れがある。1 つ目はメッセージ本文中の改行が保持されず、複数行の内容が 1 行に潰れて表示されること。2 つ目はユーザー入力が `assistant_send_message` 完了まで履歴に反映されず、送信直後に自分の発言が見えないこと。コードや箇条書き、複数段落の応答が読みにくく、送信後のフィードバックも遅れる。加えて、送信済み user message を `ArrowUp` / `ArrowDown` で辿れないため、直前の入力を再利用しにくい。

--- a/specs/SPEC-1671/spec.md
+++ b/specs/SPEC-1671/spec.md
@@ -1,3 +1,5 @@
+> **📝 HISTORICAL (GUI era)**: This SPEC was written for the gwt-gui (Tauri/Svelte) architecture. The gwt-tui migration (SPEC-1776) supersedes the GUI stack. Retain for historical context.
+
 ### Background
 
 Assistant Mode を開いても、Assistant が自律的に何も始めない。現状の `assistant_start` は engine を作って state に格納するだけで、初回分析を実行しない。そのため、ユーザーが最初のメッセージを送るまで Assistant transcript は空のままで、project open 直後の「参謀」として機能しない。

--- a/specs/SPEC-1682/spec.md
+++ b/specs/SPEC-1682/spec.md
@@ -1,3 +1,5 @@
+> **📝 HISTORICAL (GUI era)**: This SPEC was written for the gwt-gui (Tauri/Svelte) architecture. The gwt-tui migration (SPEC-1776) supersedes the GUI stack. Retain for historical context.
+
 ### Background
 
 Assistant startup analysis は動くが、現在の UI は `Analyzing project...` としか出さず、何をしているかが分からない。また、project を開くたびに同じ初回解析を毎回 LLM でやり直しており、起動体験と API コストの両方が無駄になる。さらに、analysis 結果が markdown で返っても transcript 側で plain text 表示されるため、見出しや箇条書きが崩れる。さらに startup path は user request 前の自動処理なので、write-capable tool を使わせず read-only に限定する必要がある。

--- a/specs/SPEC-1692/metadata.json
+++ b/specs/SPEC-1692/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "1692",
   "title": "gwt-spec: エージェント起動ダイアログ（起動設定・ブランチ作成・起動パイプライン・Docker 統合）",
-  "status": "open",
+  "status": "deprecated",
   "phase": "draft",
   "created_at": "2026-03-18T10:45:36Z",
   "updated_at": "2026-03-23T17:27:03Z"

--- a/specs/SPEC-1692/spec.md
+++ b/specs/SPEC-1692/spec.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATED (SPEC-1776)**: This SPEC describes GUI-only functionality (Tauri/Svelte/xterm.js) that has been superseded by the gwt-tui migration. The gwt-tui equivalent is defined in SPEC-1776.
+
 ### Background
 
 Launch Agent ダイアログは gwt の主要機能であり、Worktree 選択時のエージェント起動設定 UI として完全に実装済みである。

--- a/specs/SPEC-1705/metadata.json
+++ b/specs/SPEC-1705/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "1705",
   "title": "gwt-spec: パフォーマンスプロファイリング基盤（tracing + Chrome Trace 出力）",
-  "status": "open",
+  "status": "deprecated",
   "phase": "in",
   "created_at": "2026-03-19T01:30:51Z",
   "updated_at": "2026-03-23T17:27:02Z"

--- a/specs/SPEC-1705/spec.md
+++ b/specs/SPEC-1705/spec.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATED (SPEC-1776)**: This SPEC describes GUI-only functionality (Tauri/Svelte/xterm.js) that has been superseded by the gwt-tui migration. The gwt-tui equivalent is defined in SPEC-1776.
+
 <!-- GWT_SPEC_ARTIFACT:doc:spec.md -->
 doc:spec.md
 

--- a/specs/SPEC-1714/spec.md
+++ b/specs/SPEC-1714/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC describes backend/gwt-core functionality unaffected by the gwt-tui migration (SPEC-1776). No changes required.
+
 ## 背景
 
 Worktree 一覧や tab 表示名は Issue タイトルを必要とするが、現状は `gh issue view` の都度取得と branch 名パースに強く依存しており、rate limit・通信失敗・linkage の曖昧さに弱い。現在の Chroma `issues` index は `gwt-spec` 限定の semantic search 用であり、一般 Issue の exact cache としては使えない。

--- a/specs/SPEC-1758/metadata.json
+++ b/specs/SPEC-1758/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "1758",
   "title": "gwt-spec: 統合ログ基盤（機能・障害ログの90%カバレッジ）",
-  "status": "open",
+  "status": "deprecated",
   "phase": "implementation",
   "created_at": "2026-03-22T12:58:36Z",
   "updated_at": "2026-03-23T17:26:59Z"

--- a/specs/SPEC-1758/spec.md
+++ b/specs/SPEC-1758/spec.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATED (SPEC-1776)**: This SPEC describes GUI-only functionality (Tauri/Svelte/xterm.js) that has been superseded by the gwt-tui migration. The gwt-tui equivalent is defined in SPEC-1776.
+
 <!-- GWT_SPEC_ARTIFACT:doc:spec.md -->
 doc:spec.md
 

--- a/specs/SPEC-1766/metadata.json
+++ b/specs/SPEC-1766/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "1766",
   "title": "gwt-spec: Agent Canvas コードエディタタイル",
-  "status": "open",
+  "status": "deprecated",
   "phase": "plan",
   "created_at": "2026-03-23T12:22:49Z",
   "updated_at": "2026-03-23T12:33:56Z"

--- a/specs/SPEC-1766/spec.md
+++ b/specs/SPEC-1766/spec.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATED (SPEC-1776)**: This SPEC describes GUI-only functionality (Tauri/Svelte/xterm.js) that has been superseded by the gwt-tui migration. The gwt-tui equivalent is defined in SPEC-1776.
+
 <!-- GWT_SPEC_ARTIFACT:doc:spec.md -->
 doc:spec.md
 

--- a/specs/SPEC-1767/metadata.json
+++ b/specs/SPEC-1767/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "1767",
   "title": "gwt-spec: Agent Canvas メモタイル",
-  "status": "open",
+  "status": "deprecated",
   "phase": "plan",
   "created_at": "2026-03-23T12:23:11Z",
   "updated_at": "2026-03-23T12:55:32Z"

--- a/specs/SPEC-1767/spec.md
+++ b/specs/SPEC-1767/spec.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATED (SPEC-1776)**: This SPEC describes GUI-only functionality (Tauri/Svelte/xterm.js) that has been superseded by the gwt-tui migration. The gwt-tui equivalent is defined in SPEC-1776.
+
 # Agent Canvas メモタイル — spec.md
 
 ## Overview

--- a/specs/SPEC-1768/spec.md
+++ b/specs/SPEC-1768/spec.md
@@ -1,3 +1,5 @@
+> **🔄 TUI MIGRATION (SPEC-1776)**: This SPEC requires adaptation for the gwt-tui migration. GUI-specific references (gwt-tauri, Svelte, xterm.js) should be read as gwt-tui equivalents. See SPEC-1776 for the migration plan.
+
 <!-- GWT_SPEC_ARTIFACT:doc:spec.md -->
 
 # spec.md — Agent Canvas タイルシステム共通仕様

--- a/specs/SPEC-1769/spec.md
+++ b/specs/SPEC-1769/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC describes backend/gwt-core functionality unaffected by the gwt-tui migration (SPEC-1776). No changes required.
+
 # spec.md — Agent Canvas 画像ビューアタイル
 
 ## Background

--- a/specs/SPEC-1770/plan.md
+++ b/specs/SPEC-1770/plan.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC describes backend/gwt-core functionality unaffected by the gwt-tui migration (SPEC-1776). No changes required.
+
 # plan.md — Agent Canvas インタラクション詳細 (#1770)
 
 ## Overview

--- a/specs/SPEC-1775/spec.md
+++ b/specs/SPEC-1775/spec.md
@@ -1,3 +1,5 @@
+> **ℹ️ TUI MIGRATION NOTE**: This SPEC describes backend/gwt-core functionality unaffected by the gwt-tui migration (SPEC-1776). No changes required.
+
 # Feature Specification: gwt-pr-check 統合ステータスレポート
 
 ## Background


### PR DESCRIPTION
## Summary

- 6 GUI-only SPECs (1653, 1692, 1705, 1758, 1766, 1767) に DEPRECATED 注釈を追加し、metadata.json の status を deprecated に更新
- 2 TUI adaptation SPECs (1654, 1768) に TUI MIGRATION 注釈を追加
- 6 backend SPECs (1651, 1652, 1714, 1769, 1770, 1775) に TUI MIGRATION NOTE（影響なし）注釈を追加
- 4 historical SPECs (1661, 1662, 1671, 1682) に HISTORICAL (GUI era) 注釈を追加
- SPEC-1656 は GUI 参照なしのためスキップ、SPEC-1776 は対象外のためスキップ

## Test plan

- [ ] 各 SPEC ファイルの先頭に適切な注釈が挿入されていること
- [ ] deprecated SPEC の metadata.json の status が "deprecated" であること
- [ ] SPEC-1656, SPEC-1776 が変更されていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)