### PR TITLE
feat: SPEC-1776 Branches/Issues/Logs タブのデータロードを実装

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -240,10 +240,26 @@ pub fn update(model: &mut Model, msg: Message) {
 
         // Screen-specific messages
         Message::BranchesMsg(msg) => {
-            crate::screens::branches::update(&mut model.branches_state, msg);
+            if matches!(msg, crate::screens::branches::BranchesMessage::Refresh) {
+                let branches = crate::screens::branches::load_branches(&model.repo_root);
+                crate::screens::branches::update(
+                    &mut model.branches_state,
+                    crate::screens::branches::BranchesMessage::Loaded(branches),
+                );
+            } else {
+                crate::screens::branches::update(&mut model.branches_state, msg);
+            }
         }
         Message::IssuesMsg(msg) => {
-            crate::screens::issues::update(&mut model.issues_state, msg);
+            if matches!(msg, crate::screens::issues::IssuesMessage::Refresh) {
+                let issues = crate::screens::issues::load_initial_issues(&model.repo_root);
+                crate::screens::issues::update(
+                    &mut model.issues_state,
+                    crate::screens::issues::IssuesMessage::Loaded(issues),
+                );
+            } else {
+                crate::screens::issues::update(&mut model.issues_state, msg);
+            }
         }
         Message::SettingsMsg(msg) => {
             handle_settings_msg(model, msg);
@@ -796,7 +812,17 @@ pub fn run(repo_root: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     // Initialize model
-    let mut model = Model::new(repo_root);
+    let mut model = Model::new(repo_root.clone());
+
+    // Load initial data for management tabs
+    let initial_branches = crate::screens::branches::load_branches(&repo_root);
+    model.branches_state.branches = initial_branches;
+
+    let initial_issues = crate::screens::issues::load_initial_issues(&repo_root);
+    model.issues_state.set_issues(initial_issues);
+
+    let initial_logs = crate::screens::logs::load_log_entries();
+    model.logs_state = crate::screens::LogsState::new().with_entries(initial_logs);
 
     // PTY output channel
     let (pty_tx, pty_rx) = event::pty_output_channel();

--- a/crates/gwt-tui/src/screens/issues.rs
+++ b/crates/gwt-tui/src/screens/issues.rs
@@ -1,5 +1,7 @@
 //! Issues/SPECs screen — list GitHub Issues and local SPECs with search
 
+use std::path::Path;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
@@ -405,6 +407,38 @@ fn render_search_bar(state: &IssuePanelState, buf: &mut Buffer, area: Rect) {
         ),
     ]);
     buf.set_line(area.x, area.y, &line, area.width);
+}
+
+// ---------------------------------------------------------------------------
+// Data loading
+// ---------------------------------------------------------------------------
+
+/// Load issues from local SPEC directories (`specs/SPEC-*/metadata.json`).
+pub fn load_initial_issues(repo_root: &Path) -> Vec<IssueItem> {
+    let specs = gwt_core::git::local_spec::list_local_specs(repo_root).unwrap_or_default();
+
+    let mut items: Vec<IssueItem> = specs
+        .iter()
+        .map(|spec| {
+            let number = spec
+                .id
+                .trim_start_matches("SPEC-")
+                .parse::<u64>()
+                .unwrap_or(0);
+            IssueItem {
+                number,
+                title: spec.title.clone(),
+                is_spec: true,
+                spec_id: Some(spec.id.clone()),
+                state: spec.status.clone(),
+                labels: vec!["spec".to_string()],
+            }
+        })
+        .collect();
+
+    // Sort by number descending (newest first)
+    items.sort_by(|a, b| b.number.cmp(&a.number));
+    items
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- TUI 管理画面の Branches/Issues/Logs タブで起動時にデータをロードするように実装
- Branches: `load_branches()` で gwt-core の `Branch::list()` / `Branch::list_remote()` を使用してローカル・リモートブランチを取得
- Issues: 新規 `load_initial_issues()` で `specs/SPEC-*/metadata.json` をスキャンしてローカル SPEC 一覧を表示
- Logs: `load_log_entries()` で `~/.gwt/logs/` の JSON ログファイルを読み込み
- 各タブの Refresh (r キー) でもデータを再読み込みするように修正

## Test plan
- [x] `cargo build -p gwt-tui` ビルド成功
- [x] `cargo test -p gwt-tui` 全 256 テスト通過
- [x] `cargo clippy -p gwt-tui` 警告なし
- [x] `cargo test -p gwt-core` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Branches and Issues data now load automatically during application startup, providing faster access to management tab information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->