### PR TITLE
test: agent_pane/specs/status_bar/terminal_view のテストを追加

### DIFF
--- a/crates/gwt-tui/src/screens/agent_pane.rs
+++ b/crates/gwt-tui/src/screens/agent_pane.rs
@@ -27,3 +27,81 @@ pub fn render(buf: &mut Buffer, area: Rect, parser: Option<&vt100::Parser>) -> O
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::prelude::*;
+
+    #[test]
+    fn render_none_shows_starting_placeholder() {
+        let area = Rect::new(0, 0, 40, 10);
+        let mut buf = Buffer::empty(area);
+        let result = render(&mut buf, area, None);
+        assert!(result.is_none());
+        // "Starting..." should appear somewhere in the buffer
+        let text: String = (0..area.width)
+            .map(|x| buf.cell((x, area.y)).map_or(' ', |c| {
+                c.symbol().chars().next().unwrap_or(' ')
+            }))
+            .collect();
+        // The paragraph is center-aligned, so it may have padding
+        assert!(
+            text.contains("Starting..."),
+            "Expected 'Starting...' in buffer, got: {:?}",
+            text.trim()
+        );
+    }
+
+    #[test]
+    fn render_with_parser_no_cursor() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        parser.process(b"Hello, world!");
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        let result = render(&mut buf, area, Some(&parser));
+        // Cursor is visible by default in vt100, so we get Some
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn render_with_parser_hidden_cursor() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        // ESC[?25l hides cursor
+        parser.process(b"\x1b[?25lHidden cursor");
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        let result = render(&mut buf, area, Some(&parser));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn render_with_parser_cursor_position() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        // Move cursor to row 2, col 5 (1-based in ANSI)
+        parser.process(b"\x1b[3;6HX");
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        let result = render(&mut buf, area, Some(&parser));
+        if let Some((x, y)) = result {
+            // Cursor is after the 'X' we wrote at (row=2, col=6) in 0-based
+            assert!(x < area.right());
+            assert!(y < area.bottom());
+        }
+    }
+
+    #[test]
+    fn render_with_parser_text_appears_in_buffer() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        parser.process(b"TestOutput");
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&mut buf, area, Some(&parser));
+        let row: String = (0..10)
+            .map(|x| buf.cell((x, 0)).map_or(' ', |c| {
+                c.symbol().chars().next().unwrap_or(' ')
+            }))
+            .collect();
+        assert_eq!(row, "TestOutput");
+    }
+}

--- a/crates/gwt-tui/src/screens/specs.rs
+++ b/crates/gwt-tui/src/screens/specs.rs
@@ -212,3 +212,349 @@ pub fn load_specs(repo_root: &std::path::Path) -> Vec<SpecItem> {
     items.sort_by(|a, b| a.id.cmp(&b.id));
     items
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::prelude::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn sample_specs() -> Vec<SpecItem> {
+        vec![
+            SpecItem {
+                id: "SPEC-1".into(),
+                title: "Alpha feature".into(),
+                status: "open".into(),
+                phase: "planning".into(),
+            },
+            SpecItem {
+                id: "SPEC-2".into(),
+                title: "Beta bugfix".into(),
+                status: "closed".into(),
+                phase: "done".into(),
+            },
+            SpecItem {
+                id: "SPEC-3".into(),
+                title: "Gamma refactor".into(),
+                status: "open".into(),
+                phase: "implementation".into(),
+            },
+        ]
+    }
+
+    // -- SpecsState::new() --
+
+    #[test]
+    fn new_state_is_empty() {
+        let s = SpecsState::new();
+        assert!(s.specs.is_empty());
+        assert_eq!(s.selected, 0);
+        assert!(s.search_query.is_empty());
+        assert!(!s.search_mode);
+        assert_eq!(s.offset, 0);
+    }
+
+    // -- visible_specs() --
+
+    #[test]
+    fn visible_specs_returns_all_when_query_empty() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        assert_eq!(s.visible_specs().len(), 3);
+    }
+
+    #[test]
+    fn visible_specs_filters_by_id() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.search_query = "SPEC-2".into();
+        let v = s.visible_specs();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].id, "SPEC-2");
+    }
+
+    #[test]
+    fn visible_specs_filters_by_title_case_insensitive() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.search_query = "alpha".into();
+        let v = s.visible_specs();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].title, "Alpha feature");
+    }
+
+    #[test]
+    fn visible_specs_filters_by_status() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.search_query = "closed".into();
+        let v = s.visible_specs();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].id, "SPEC-2");
+    }
+
+    #[test]
+    fn visible_specs_returns_empty_on_no_match() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.search_query = "nonexistent".into();
+        assert!(s.visible_specs().is_empty());
+    }
+
+    // -- handle_key() normal mode --
+
+    #[test]
+    fn handle_key_up_returns_select_prev() {
+        let s = SpecsState::new();
+        assert!(matches!(handle_key(&s, &key(KeyCode::Up)), Some(SpecsMessage::SelectPrev)));
+    }
+
+    #[test]
+    fn handle_key_k_returns_select_prev() {
+        let s = SpecsState::new();
+        assert!(matches!(handle_key(&s, &key(KeyCode::Char('k'))), Some(SpecsMessage::SelectPrev)));
+    }
+
+    #[test]
+    fn handle_key_down_returns_select_next() {
+        let s = SpecsState::new();
+        assert!(matches!(handle_key(&s, &key(KeyCode::Down)), Some(SpecsMessage::SelectNext)));
+    }
+
+    #[test]
+    fn handle_key_j_returns_select_next() {
+        let s = SpecsState::new();
+        assert!(matches!(handle_key(&s, &key(KeyCode::Char('j'))), Some(SpecsMessage::SelectNext)));
+    }
+
+    #[test]
+    fn handle_key_slash_returns_toggle_search() {
+        let s = SpecsState::new();
+        assert!(matches!(handle_key(&s, &key(KeyCode::Char('/'))), Some(SpecsMessage::ToggleSearch)));
+    }
+
+    #[test]
+    fn handle_key_unknown_returns_none() {
+        let s = SpecsState::new();
+        assert!(handle_key(&s, &key(KeyCode::Char('z'))).is_none());
+    }
+
+    // -- handle_key() search mode --
+
+    #[test]
+    fn handle_key_search_char() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        assert!(matches!(handle_key(&s, &key(KeyCode::Char('a'))), Some(SpecsMessage::SearchChar('a'))));
+    }
+
+    #[test]
+    fn handle_key_search_backspace() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        assert!(matches!(handle_key(&s, &key(KeyCode::Backspace)), Some(SpecsMessage::SearchBackspace)));
+    }
+
+    #[test]
+    fn handle_key_search_esc_toggles() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        assert!(matches!(handle_key(&s, &key(KeyCode::Esc)), Some(SpecsMessage::ToggleSearch)));
+    }
+
+    #[test]
+    fn handle_key_search_enter_toggles() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        assert!(matches!(handle_key(&s, &key(KeyCode::Enter)), Some(SpecsMessage::ToggleSearch)));
+    }
+
+    // -- update() --
+
+    #[test]
+    fn update_select_prev_saturates_at_zero() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.selected = 0;
+        update(&mut s, SpecsMessage::SelectPrev);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn update_select_prev_decrements() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.selected = 2;
+        update(&mut s, SpecsMessage::SelectPrev);
+        assert_eq!(s.selected, 1);
+    }
+
+    #[test]
+    fn update_select_next_increments() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.selected = 0;
+        update(&mut s, SpecsMessage::SelectNext);
+        assert_eq!(s.selected, 1);
+    }
+
+    #[test]
+    fn update_select_next_stops_at_max() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.selected = 2;
+        update(&mut s, SpecsMessage::SelectNext);
+        assert_eq!(s.selected, 2);
+    }
+
+    #[test]
+    fn update_toggle_search_enters_search_mode() {
+        let mut s = SpecsState::new();
+        assert!(!s.search_mode);
+        update(&mut s, SpecsMessage::ToggleSearch);
+        assert!(s.search_mode);
+    }
+
+    #[test]
+    fn update_toggle_search_exits_and_clears_query() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        s.search_query = "test".into();
+        s.selected = 1;
+        update(&mut s, SpecsMessage::ToggleSearch);
+        assert!(!s.search_mode);
+        assert!(s.search_query.is_empty());
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn update_search_char_appends_and_resets_selection() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        s.selected = 2;
+        update(&mut s, SpecsMessage::SearchChar('a'));
+        assert_eq!(s.search_query, "a");
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn update_search_backspace_removes_last_char() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        s.search_query = "abc".into();
+        update(&mut s, SpecsMessage::SearchBackspace);
+        assert_eq!(s.search_query, "ab");
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn update_search_backspace_on_empty_is_safe() {
+        let mut s = SpecsState::new();
+        s.search_mode = true;
+        update(&mut s, SpecsMessage::SearchBackspace);
+        assert!(s.search_query.is_empty());
+    }
+
+    // -- render() --
+
+    #[test]
+    fn render_smoke_no_specs() {
+        let s = SpecsState::new();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
+        // No panic
+    }
+
+    #[test]
+    fn render_smoke_with_specs() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
+        // No panic
+    }
+
+    #[test]
+    fn render_smoke_search_mode() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.search_mode = true;
+        s.search_query = "alpha".into();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
+        // No panic
+    }
+
+    #[test]
+    fn render_small_area_returns_early() {
+        let s = SpecsState::new();
+        let area = Rect::new(0, 0, 80, 2);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
+        // No panic, early return for height < 3
+    }
+
+    // -- load_specs() --
+
+    #[test]
+    fn load_specs_from_tempdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let specs_dir = dir.path().join("specs");
+        std::fs::create_dir(&specs_dir).unwrap();
+
+        let spec1 = specs_dir.join("SPEC-100");
+        std::fs::create_dir(&spec1).unwrap();
+        std::fs::write(
+            spec1.join("metadata.json"),
+            r#"{"id":"SPEC-100","title":"Test spec","status":"open","phase":"planning"}"#,
+        )
+        .unwrap();
+
+        let spec2 = specs_dir.join("SPEC-200");
+        std::fs::create_dir(&spec2).unwrap();
+        std::fs::write(
+            spec2.join("metadata.json"),
+            r#"{"id":"SPEC-200","title":"Another spec","status":"closed","phase":"done"}"#,
+        )
+        .unwrap();
+
+        let items = load_specs(dir.path());
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "SPEC-100");
+        assert_eq!(items[1].id, "SPEC-200");
+        assert_eq!(items[0].status, "open");
+        assert_eq!(items[1].status, "closed");
+    }
+
+    #[test]
+    fn load_specs_ignores_non_spec_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let specs_dir = dir.path().join("specs");
+        std::fs::create_dir(&specs_dir).unwrap();
+
+        // Non-SPEC directory
+        let other = specs_dir.join("not-a-spec");
+        std::fs::create_dir(&other).unwrap();
+
+        // SPEC dir without metadata.json
+        let no_meta = specs_dir.join("SPEC-999");
+        std::fs::create_dir(&no_meta).unwrap();
+
+        let items = load_specs(dir.path());
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn load_specs_missing_specs_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let items = load_specs(dir.path());
+        assert!(items.is_empty());
+    }
+}

--- a/crates/gwt-tui/src/widgets/status_bar.rs
+++ b/crates/gwt-tui/src/widgets/status_bar.rs
@@ -49,3 +49,113 @@ pub fn render(model: &Model, buf: &mut Buffer, area: Rect) {
     let right_x = area.x + left_width;
     buf.set_span(right_x, area.y, &right_span, right_width);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Model;
+    use ratatui::prelude::*;
+    use std::path::PathBuf;
+
+    fn test_model() -> Model {
+        Model::new(PathBuf::from("/tmp/test-repo"))
+    }
+
+    fn buf_row_text(buf: &Buffer, y: u16, width: u16) -> String {
+        (0..width)
+            .map(|x| {
+                buf.cell((x, y))
+                    .map_or(' ', |c| c.symbol().chars().next().unwrap_or(' '))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn render_management_layer_smoke() {
+        let model = test_model();
+        assert_eq!(model.active_layer, ActiveLayer::Management);
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut buf, area);
+        let text = buf_row_text(&buf, 0, 120);
+        // Management tab label should appear
+        assert!(text.contains("Branches"), "Expected 'Branches' in: {text:?}");
+        // Hint text should appear
+        assert!(text.contains("Tab: Switch"), "Expected hint text in: {text:?}");
+    }
+
+    #[test]
+    fn render_main_layer_no_sessions_smoke() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Main;
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut buf, area);
+        let text = buf_row_text(&buf, 0, 120);
+        assert!(
+            text.contains("Ctrl+G,c: Shell"),
+            "Expected session creation hint in: {text:?}"
+        );
+    }
+
+    #[test]
+    fn render_main_layer_with_session_no_branch() {
+        let mut model = test_model();
+        use crate::model::{SessionTab, SessionTabType, SessionStatus};
+        use gwt_core::terminal::AgentColor;
+        model.add_session(SessionTab {
+            pane_id: "p1".into(),
+            name: "Shell #1".into(),
+            tab_type: SessionTabType::Shell,
+            color: AgentColor::Green,
+            status: SessionStatus::Running,
+            branch: None,
+            spec_id: None,
+        });
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut buf, area);
+        let text = buf_row_text(&buf, 0, 120);
+        assert!(text.contains("Shell #1"), "Expected tab name in: {text:?}");
+    }
+
+    #[test]
+    fn render_main_layer_with_session_and_branch() {
+        let mut model = test_model();
+        use crate::model::{SessionTab, SessionTabType, SessionStatus};
+        use gwt_core::terminal::AgentColor;
+        model.add_session(SessionTab {
+            pane_id: "p2".into(),
+            name: "Agent #1".into(),
+            tab_type: SessionTabType::Agent,
+            color: AgentColor::Blue,
+            status: SessionStatus::Running,
+            branch: Some("feature/test".into()),
+            spec_id: None,
+        });
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut buf, area);
+        let text = buf_row_text(&buf, 0, 120);
+        assert!(text.contains("Agent #1"), "Expected tab name in: {text:?}");
+        assert!(text.contains("feature/test"), "Expected branch in: {text:?}");
+    }
+
+    #[test]
+    fn render_all_management_tabs_no_panic() {
+        let mut model = test_model();
+        let area = Rect::new(0, 0, 120, 1);
+        for tab in ManagementTab::ALL {
+            model.management_tab = tab;
+            model.active_layer = ActiveLayer::Management;
+            let mut buf = Buffer::empty(area);
+            render(&model, &mut buf, area);
+            let text = buf_row_text(&buf, 0, 120);
+            assert!(
+                text.contains(tab.label()),
+                "Expected '{}' in: {text:?}",
+                tab.label()
+            );
+        }
+    }
+}

--- a/crates/gwt-tui/src/widgets/terminal_view.rs
+++ b/crates/gwt-tui/src/widgets/terminal_view.rs
@@ -8,3 +8,34 @@ use ratatui::prelude::*;
 pub fn render(_buf: &mut Buffer, _area: Rect, _parser: Option<&vt100::Parser>) {
     // Phase 2: delegate to renderer module for VT100 cell conversion
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::prelude::*;
+
+    #[test]
+    fn render_none_smoke() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&mut buf, area, None);
+        // No-op, no panic
+    }
+
+    #[test]
+    fn render_with_parser_smoke() {
+        let parser = vt100::Parser::new(24, 80, 0);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&mut buf, area, Some(&parser));
+        // No-op (Phase 2 stub), no panic
+    }
+
+    #[test]
+    fn render_zero_area_smoke() {
+        let area = Rect::new(0, 0, 0, 0);
+        let mut buf = Buffer::empty(area);
+        render(&mut buf, area, None);
+        // No panic with zero-sized area
+    }
+}


### PR DESCRIPTION
## Summary
- `specs.rs`: 32 tests covering `SpecsState::new()`, `visible_specs()` filtering, `handle_key()` key mappings (normal + search mode), `update()` message handling with boundary checks, `render()` smoke tests, and `load_specs()` with tempdir
- `agent_pane.rs`: 5 tests covering render with `None` (placeholder), render with `vt100::Parser` (visible/hidden cursor, cursor position, text output)
- `status_bar.rs`: 5 tests covering Management layer, Main layer (no sessions / with session / with branch), all management tabs
- `terminal_view.rs`: 3 smoke tests for the Phase 2 stub (None, parser, zero area)

Total: 45 new tests (target was 20+). All 301 gwt-tui tests pass.

## Test plan
- [x] `cargo test -p gwt-tui` — 301 tests pass
- [x] `cargo clippy -p gwt-tui` — no new warnings (pre-existing warnings unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across multiple components with comprehensive unit tests for rendering logic, state management, and user interactions. Added smoke tests to verify core functionality operates without errors across various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->