### PR TITLE
feat: SPEC-1776 詳細ビュー・セッション保存・終了確認・Versions タブを実装

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -158,14 +158,13 @@ pub fn update(model: &mut Model, msg: Message) {
         }
         Message::KeyInput(key) => {
             // Error overlay: Enter/Esc dismisses the error
-            if !model.error_queue.is_empty() || !model.error_queue_v2.is_empty() {
-                if key.code == crossterm::event::KeyCode::Enter
-                    || key.code == crossterm::event::KeyCode::Esc
-                {
-                    model.dismiss_error();
-                    model.error_queue_v2.dismiss_current();
-                    return;
-                }
+            if (!model.error_queue.is_empty() || !model.error_queue_v2.is_empty())
+                && (key.code == crossterm::event::KeyCode::Enter
+                    || key.code == crossterm::event::KeyCode::Esc)
+            {
+                model.dismiss_error();
+                model.error_queue_v2.dismiss_current();
+                return;
             }
 
             // Management layer: Tab key cycles management tabs
@@ -183,7 +182,8 @@ pub fn update(model: &mut Model, msg: Message) {
                         ManagementTab::Issues => ManagementTab::Specs,
                         ManagementTab::Specs => ManagementTab::Settings,
                         ManagementTab::Settings => ManagementTab::Logs,
-                        ManagementTab::Logs => ManagementTab::Branches,
+                        ManagementTab::Logs => ManagementTab::Versions,
+                        ManagementTab::Versions => ManagementTab::Branches,
                     };
                     return;
                 }
@@ -217,15 +217,39 @@ pub fn update(model: &mut Model, msg: Message) {
                                 .map(Message::BranchesMsg)
                         }
                         ManagementTab::Issues => {
-                            crate::screens::issues::handle_key(&model.issues_state, &key)
-                                .map(Message::IssuesMsg)
+                            let msg = crate::screens::issues::handle_key(&model.issues_state, &key);
+                            // Intercept OpenDetail to load content
+                            if let Some(crate::screens::issues::IssuesMessage::OpenDetail) = &msg {
+                                if let Some(issue) = model.issues_state.selected_issue() {
+                                    if issue.is_spec {
+                                        let spec_id = issue.spec_id.as_deref().unwrap_or("");
+                                        let spec_path = model.repo_root.join("specs").join(spec_id).join("spec.md");
+                                        model.issues_state.detail_content = std::fs::read_to_string(&spec_path)
+                                            .unwrap_or_else(|_| format!("(Could not read {})", spec_path.display()));
+                                    } else {
+                                        model.issues_state.detail_content = format!(
+                                            "(GitHub Issue detail - run `gh issue view {}` for details)",
+                                            issue.number
+                                        );
+                                    }
+                                }
+                            }
+                            msg.map(Message::IssuesMsg)
                         }
                         ManagementTab::Specs => {
                             crate::screens::specs::handle_key(&model.specs_state, &key)
                                 .map(|m| {
+                                    // Intercept OpenDetail to load spec.md content
+                                    if matches!(m, crate::screens::specs::SpecsMessage::OpenDetail) {
+                                        let visible = model.specs_state.visible_specs();
+                                        if let Some(spec) = visible.get(model.specs_state.selected) {
+                                            let spec_path = model.repo_root.join("specs").join(&spec.id).join("spec.md");
+                                            model.specs_state.detail_content = std::fs::read_to_string(&spec_path)
+                                                .unwrap_or_else(|_| format!("(Could not read {})", spec_path.display()));
+                                        }
+                                    }
                                     crate::screens::specs::update(&mut model.specs_state, m);
-                                    // Return None — update already applied inline
-                                    Message::Tick // dummy, won't cause issues
+                                    Message::Tick // dummy
                                 })
                         }
                         ManagementTab::Settings => {
@@ -235,6 +259,20 @@ pub fn update(model: &mut Model, msg: Message) {
                         ManagementTab::Logs => {
                             crate::screens::logs::handle_key(&model.logs_state, &key)
                                 .map(Message::LogsMsg)
+                        }
+                        ManagementTab::Versions => {
+                            crate::screens::versions::handle_key(&model.versions_state, &key)
+                                .map(|m| {
+                                    // Intercept OpenDetail to load tag detail
+                                    if matches!(m, crate::screens::versions::VersionsMessage::OpenDetail) {
+                                        if let Some(tag) = model.versions_state.tags.get(model.versions_state.selected) {
+                                            model.versions_state.detail_content =
+                                                crate::screens::versions::load_tag_detail(&model.repo_root, &tag.name);
+                                        }
+                                    }
+                                    crate::screens::versions::update(&mut model.versions_state, m);
+                                    Message::Tick // dummy
+                                })
                         }
                     };
                     // Recursively apply sub-message if any
@@ -337,6 +375,9 @@ pub fn update(model: &mut Model, msg: Message) {
         Message::IssuesMsg(msg) => {
             crate::screens::issues::update(&mut model.issues_state, msg);
         }
+        Message::VersionsMsg(_) => {
+            // Versions messages are handled inline via the key handler
+        }
         Message::SettingsMsg(msg) => {
             handle_settings_msg(model, msg);
         }
@@ -406,6 +447,9 @@ pub fn view(model: &Model, frame: &mut Frame) {
             }
             ManagementTab::Logs => {
                 crate::screens::logs::render(&model.logs_state, buf, layout[2]);
+            }
+            ManagementTab::Versions => {
+                crate::screens::versions::render(&model.versions_state, buf, layout[2]);
             }
         },
     }
@@ -876,7 +920,6 @@ fn spawn_agent_session(
     wiz_config: &crate::screens::wizard::WizardLaunchConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use gwt_core::agent::launch::AgentLaunchBuilder;
-    use gwt_core::terminal::AgentColor;
 
     let agent_id = &wiz_config.agent_id;
     let working_dir = model.repo_root.clone();
@@ -1113,6 +1156,7 @@ pub fn run(repo_root: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     model.logs_state.entries = crate::screens::logs::load_log_entries();
     model.issues_state.issues = crate::screens::issues::load_specs(&repo_root);
     model.specs_state.specs = crate::screens::specs::load_specs(&repo_root);
+    model.versions_state.tags = crate::screens::versions::load_tags(&repo_root);
 
     // PTY output channel
     let (pty_tx, pty_rx) = event::pty_output_channel();
@@ -1134,6 +1178,26 @@ pub fn run(repo_root: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
                 // Only handle key Press events (ignore Release/Repeat/IME)
                 if key.kind != crossterm::event::KeyEventKind::Press {
                     None
+                }
+                // When confirm dialog is open, intercept all keys
+                else if model.confirm.is_some() {
+                    match key.code {
+                        crossterm::event::KeyCode::Enter => {
+                            if model.confirm.as_ref().is_some_and(|c| c.selected_confirm) {
+                                Some(Message::ConfirmAccepted)
+                            } else {
+                                Some(Message::ConfirmCancelled)
+                            }
+                        }
+                        crossterm::event::KeyCode::Esc => Some(Message::ConfirmCancelled),
+                        crossterm::event::KeyCode::Left | crossterm::event::KeyCode::Right => {
+                            if let Some(ref mut c) = model.confirm {
+                                c.toggle_selection();
+                            }
+                            None
+                        }
+                        _ => None,
+                    }
                 }
                 // When wizard is open, intercept all keys
                 else if model.wizard.is_some() {
@@ -1404,6 +1468,66 @@ mod tests {
             "Loading...",
             Some("step 1"),
         ));
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| view(&model, f)).unwrap();
+    }
+
+    // -- Quit confirmation tests ------------------------------------------------
+
+    #[test]
+    fn quit_with_running_agents_shows_confirm() {
+        let mut m = test_model();
+        m.add_session(SessionTab {
+            pane_id: "p1".into(),
+            name: "Agent #1".into(),
+            tab_type: SessionTabType::Agent,
+            color: AgentColor::Blue,
+            status: SessionStatus::Running,
+            branch: Some("feature/test".into()),
+            spec_id: None,
+        });
+        update(&mut m, Message::Quit);
+        assert!(!m.should_quit, "Should not quit immediately with running agents");
+        assert!(m.confirm.is_some(), "Confirm dialog should appear");
+        assert_eq!(m.overlay_mode, OverlayMode::Confirm);
+    }
+
+    #[test]
+    fn quit_without_agents_exits_immediately() {
+        let mut m = test_model();
+        // Only shell sessions — no agents
+        m.add_session(test_session("shell-1"));
+        update(&mut m, Message::Quit);
+        assert!(m.should_quit, "Should quit immediately with no running agents");
+    }
+
+    #[test]
+    fn confirm_accepted_quits() {
+        let mut m = test_model();
+        m.confirm = Some(crate::screens::confirm::ConfirmState::exit_with_running_agents(1));
+        m.overlay_mode = OverlayMode::Confirm;
+        update(&mut m, Message::ConfirmAccepted);
+        assert!(m.should_quit);
+        assert!(m.confirm.is_none());
+    }
+
+    #[test]
+    fn confirm_cancelled_does_not_quit() {
+        let mut m = test_model();
+        m.confirm = Some(crate::screens::confirm::ConfirmState::exit_with_running_agents(1));
+        m.overlay_mode = OverlayMode::Confirm;
+        update(&mut m, Message::ConfirmCancelled);
+        assert!(!m.should_quit);
+        assert!(m.confirm.is_none());
+    }
+
+    // -- Versions tab view test -------------------------------------------------
+
+    #[test]
+    fn view_versions_tab_renders() {
+        let mut model = test_model();
+        model.management_tab = ManagementTab::Versions;
         let backend = ratatui::backend::TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| view(&model, f)).unwrap();

--- a/crates/gwt-tui/src/message.rs
+++ b/crates/gwt-tui/src/message.rs
@@ -4,6 +4,7 @@ use crossterm::event::{KeyEvent, MouseEvent};
 
 use crate::model::{ErrorEntry, ManagementTab};
 use crate::screens::{BranchesMessage, IssuesMessage, LogsMessage, SettingsMessage};
+use crate::screens::versions::VersionsMessage;
 
 /// All messages that can flow through the Elm Architecture update loop.
 #[derive(Debug)]
@@ -89,6 +90,7 @@ pub enum Message {
     IssuesMsg(IssuesMessage),
     SettingsMsg(SettingsMessage),
     LogsMsg(LogsMessage),
+    VersionsMsg(VersionsMessage),
 }
 
 #[cfg(test)]
@@ -143,6 +145,7 @@ mod tests {
             Message::IssuesMsg(IssuesMessage::Refresh),
             Message::SettingsMsg(SettingsMessage::Refresh),
             Message::LogsMsg(LogsMessage::Refresh),
+            Message::VersionsMsg(VersionsMessage::SelectNext),
         ];
         assert!(msgs.len() > 10);
     }

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -16,6 +16,7 @@ use crate::screens::error::ErrorQueue;
 use crate::screens::issues::IssuePanelState;
 use crate::screens::migration_dialog::MigrationDialogState;
 use crate::screens::speckit_wizard::SpecKitState;
+use crate::screens::versions::VersionsState;
 use crate::screens::{LogsState, SettingsState};
 use crate::widgets::progress_modal::ProgressState;
 
@@ -38,15 +39,17 @@ pub enum ManagementTab {
     Specs,
     Settings,
     Logs,
+    Versions,
 }
 
 impl ManagementTab {
-    pub const ALL: [ManagementTab; 5] = [
+    pub const ALL: [ManagementTab; 6] = [
         ManagementTab::Branches,
         ManagementTab::Issues,
         ManagementTab::Specs,
         ManagementTab::Settings,
         ManagementTab::Logs,
+        ManagementTab::Versions,
     ];
 
     pub fn index(self) -> usize {
@@ -56,6 +59,7 @@ impl ManagementTab {
             ManagementTab::Specs => 2,
             ManagementTab::Settings => 3,
             ManagementTab::Logs => 4,
+            ManagementTab::Versions => 5,
         }
     }
 
@@ -66,6 +70,7 @@ impl ManagementTab {
             ManagementTab::Specs => "SPECs",
             ManagementTab::Settings => "Settings",
             ManagementTab::Logs => "Logs",
+            ManagementTab::Versions => "Versions",
         }
     }
 }
@@ -160,6 +165,7 @@ pub struct Model {
     pub specs_state: SpecsState,
     pub settings_state: SettingsState,
     pub logs_state: LogsState,
+    pub versions_state: VersionsState,
 
     // PTY management
     pub pane_manager: PaneManager,
@@ -203,6 +209,7 @@ impl Model {
             specs_state: SpecsState::new(),
             settings_state: SettingsState::new(),
             logs_state: LogsState::new(),
+            versions_state: VersionsState::new(),
             pane_manager: PaneManager::new(),
             vt_parsers: HashMap::new(),
             pty_tx: None,
@@ -478,7 +485,7 @@ mod tests {
     fn management_tab_metadata() {
         assert_eq!(ManagementTab::Branches.index(), 0);
         assert_eq!(ManagementTab::Logs.label(), "Logs");
-        assert_eq!(ManagementTab::ALL.len(), 5);
+        assert_eq!(ManagementTab::ALL.len(), 6);
     }
 
     #[test]

--- a/crates/gwt-tui/src/screens/issues.rs
+++ b/crates/gwt-tui/src/screens/issues.rs
@@ -62,6 +62,9 @@ pub struct IssuePanelState {
     pub search_query: String,
     pub search_mode: bool,
     pub loading: bool,
+    pub detail_mode: bool,
+    pub detail_content: String,
+    pub detail_scroll: usize,
 }
 
 impl IssuePanelState {
@@ -150,6 +153,10 @@ pub enum IssuesMessage {
     SearchClear,
     Enter,
     Loaded(Vec<IssueItem>),
+    OpenDetail,
+    CloseDetail,
+    ScrollDetailUp,
+    ScrollDetailDown,
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +165,14 @@ pub enum IssuesMessage {
 
 /// Handle a key event for the issues screen.
 pub fn handle_key(state: &IssuePanelState, key: &KeyEvent) -> Option<IssuesMessage> {
+    if state.detail_mode {
+        return match key.code {
+            KeyCode::Esc => Some(IssuesMessage::CloseDetail),
+            KeyCode::Up | KeyCode::Char('k') => Some(IssuesMessage::ScrollDetailUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(IssuesMessage::ScrollDetailDown),
+            _ => None,
+        };
+    }
     if state.search_mode {
         return handle_search_key(key);
     }
@@ -167,7 +182,7 @@ pub fn handle_key(state: &IssuePanelState, key: &KeyEvent) -> Option<IssuesMessa
         KeyCode::Char('k') | KeyCode::Up => Some(IssuesMessage::SelectPrev),
         KeyCode::Char('/') => Some(IssuesMessage::ToggleSearch),
         KeyCode::Char('r') => Some(IssuesMessage::Refresh),
-        KeyCode::Enter => Some(IssuesMessage::Enter),
+        KeyCode::Enter => Some(IssuesMessage::OpenDetail),
         _ => None,
     }
 }
@@ -212,7 +227,25 @@ pub fn update(state: &mut IssuePanelState, msg: IssuesMessage) {
             state.set_issues(issues);
         }
         IssuesMessage::Enter => {
-            // Handled at app level.
+            // Handled at app level (intercepted for OpenDetail).
+        }
+        IssuesMessage::OpenDetail => {
+            if state.selected_issue().is_some() {
+                state.detail_mode = true;
+                state.detail_scroll = 0;
+                // detail_content is populated by app.rs intercept
+            }
+        }
+        IssuesMessage::CloseDetail => {
+            state.detail_mode = false;
+            state.detail_content.clear();
+            state.detail_scroll = 0;
+        }
+        IssuesMessage::ScrollDetailUp => {
+            state.detail_scroll = state.detail_scroll.saturating_sub(1);
+        }
+        IssuesMessage::ScrollDetailDown => {
+            state.detail_scroll = state.detail_scroll.saturating_add(1);
         }
     }
 }
@@ -224,6 +257,11 @@ pub fn update(state: &mut IssuePanelState, msg: IssuesMessage) {
 /// Render the issues screen.
 pub fn render(state: &IssuePanelState, buf: &mut Buffer, area: Rect) {
     if area.height < 3 || area.width < 10 {
+        return;
+    }
+
+    if state.detail_mode {
+        render_detail(state, buf, area);
         return;
     }
 
@@ -405,6 +443,36 @@ fn render_search_bar(state: &IssuePanelState, buf: &mut Buffer, area: Rect) {
         ),
     ]);
     buf.set_line(area.x, area.y, &line, area.width);
+}
+
+/// Render detail view for a selected issue.
+fn render_detail(state: &IssuePanelState, buf: &mut Buffer, area: Rect) {
+    let issue = state.selected_issue();
+    let title = issue.map(|i| i.title.as_str()).unwrap_or("?");
+    let number = issue.map(|i| i.number).unwrap_or(0);
+
+    let layout = Layout::vertical([
+        Constraint::Length(1), // Header
+        Constraint::Min(1),   // Content
+    ])
+    .split(area);
+
+    // Header
+    let header = format!(" #{number} {title}  [Esc] Back");
+    let header_span = Span::styled(header, Style::default().fg(Color::Cyan).bold());
+    buf.set_span(layout[0].x, layout[0].y, &header_span, layout[0].width);
+
+    // Content
+    let lines: Vec<&str> = state.detail_content.lines().collect();
+    let content_area = layout[1];
+    let max_rows = content_area.height as usize;
+    let scroll = state.detail_scroll.min(lines.len().saturating_sub(1));
+
+    for (i, line) in lines.iter().skip(scroll).take(max_rows).enumerate() {
+        let y = content_area.y + i as u16;
+        let span = Span::styled(*line, Style::default().fg(Color::White));
+        buf.set_span(content_area.x, y, &span, content_area.width);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -747,6 +815,70 @@ mod tests {
     fn render_small_area_does_not_panic() {
         let state = IssuePanelState::new();
         let backend = TestBackend::new(5, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                render(&state, f.buffer_mut(), area);
+            })
+            .unwrap();
+    }
+
+    // -- Detail mode tests --
+
+    #[test]
+    fn detail_open_close() {
+        let mut state = IssuePanelState::new();
+        state.issues = vec![make_issue(1, "Test", "open")];
+        update(&mut state, IssuesMessage::OpenDetail);
+        assert!(state.detail_mode);
+        assert_eq!(state.detail_scroll, 0);
+        state.detail_content = "detail text".to_string();
+        update(&mut state, IssuesMessage::CloseDetail);
+        assert!(!state.detail_mode);
+        assert!(state.detail_content.is_empty());
+    }
+
+    #[test]
+    fn detail_scroll() {
+        let mut state = IssuePanelState::new();
+        state.detail_mode = true;
+        update(&mut state, IssuesMessage::ScrollDetailDown);
+        assert_eq!(state.detail_scroll, 1);
+        update(&mut state, IssuesMessage::ScrollDetailUp);
+        assert_eq!(state.detail_scroll, 0);
+        update(&mut state, IssuesMessage::ScrollDetailUp);
+        assert_eq!(state.detail_scroll, 0);
+    }
+
+    #[test]
+    fn handle_key_detail_mode() {
+        let mut state = IssuePanelState::new();
+        state.detail_mode = true;
+        let key_esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        assert!(matches!(
+            handle_key(&state, &key_esc),
+            Some(IssuesMessage::CloseDetail)
+        ));
+        let key_up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
+        assert!(matches!(
+            handle_key(&state, &key_up),
+            Some(IssuesMessage::ScrollDetailUp)
+        ));
+        let key_down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
+        assert!(matches!(
+            handle_key(&state, &key_down),
+            Some(IssuesMessage::ScrollDetailDown)
+        ));
+    }
+
+    #[test]
+    fn render_detail_mode() {
+        let mut state = IssuePanelState::new();
+        state.issues = vec![make_issue(1, "Bug Fix", "open")];
+        state.detail_mode = true;
+        state.detail_content = "Detail line 1\nDetail line 2".to_string();
+        let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {

--- a/crates/gwt-tui/src/screens/mod.rs
+++ b/crates/gwt-tui/src/screens/mod.rs
@@ -11,6 +11,7 @@ pub mod migration_dialog;
 pub mod settings;
 pub mod specs;
 pub mod speckit_wizard;
+pub mod versions;
 pub mod wizard;
 
 pub use branches::{

--- a/crates/gwt-tui/src/screens/specs.rs
+++ b/crates/gwt-tui/src/screens/specs.rs
@@ -2,7 +2,6 @@
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
-use ratatui::widgets::Paragraph;
 
 #[derive(Debug, Clone)]
 pub struct SpecItem {
@@ -12,27 +11,24 @@ pub struct SpecItem {
     pub phase: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SpecsState {
     pub specs: Vec<SpecItem>,
     pub selected: usize,
     pub search_query: String,
     pub search_mode: bool,
     pub offset: usize,
+    pub detail_mode: bool,
+    pub detail_content: String,
+    pub detail_scroll: usize,
 }
 
 impl SpecsState {
     pub fn new() -> Self {
-        Self {
-            specs: Vec::new(),
-            selected: 0,
-            search_query: String::new(),
-            search_mode: false,
-            offset: 0,
-        }
+        Self::default()
     }
 
-    fn visible_specs(&self) -> Vec<&SpecItem> {
+    pub fn visible_specs(&self) -> Vec<&SpecItem> {
         if self.search_query.is_empty() {
             self.specs.iter().collect()
         } else {
@@ -55,9 +51,21 @@ pub enum SpecsMessage {
     ToggleSearch,
     SearchChar(char),
     SearchBackspace,
+    OpenDetail,
+    CloseDetail,
+    ScrollDetailUp,
+    ScrollDetailDown,
 }
 
 pub fn handle_key(state: &SpecsState, key: &KeyEvent) -> Option<SpecsMessage> {
+    if state.detail_mode {
+        return match key.code {
+            KeyCode::Esc => Some(SpecsMessage::CloseDetail),
+            KeyCode::Up | KeyCode::Char('k') => Some(SpecsMessage::ScrollDetailUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(SpecsMessage::ScrollDetailDown),
+            _ => None,
+        };
+    }
     if state.search_mode {
         match key.code {
             KeyCode::Esc | KeyCode::Enter => Some(SpecsMessage::ToggleSearch),
@@ -70,6 +78,7 @@ pub fn handle_key(state: &SpecsState, key: &KeyEvent) -> Option<SpecsMessage> {
             KeyCode::Up | KeyCode::Char('k') => Some(SpecsMessage::SelectPrev),
             KeyCode::Down | KeyCode::Char('j') => Some(SpecsMessage::SelectNext),
             KeyCode::Char('/') => Some(SpecsMessage::ToggleSearch),
+            KeyCode::Enter => Some(SpecsMessage::OpenDetail),
             _ => None,
         }
     }
@@ -101,11 +110,34 @@ pub fn update(state: &mut SpecsState, msg: SpecsMessage) {
             state.search_query.pop();
             state.selected = 0;
         }
+        SpecsMessage::OpenDetail => {
+            if !state.visible_specs().is_empty() {
+                state.detail_mode = true;
+                state.detail_scroll = 0;
+                // detail_content is populated by app.rs intercept
+            }
+        }
+        SpecsMessage::CloseDetail => {
+            state.detail_mode = false;
+            state.detail_content.clear();
+            state.detail_scroll = 0;
+        }
+        SpecsMessage::ScrollDetailUp => {
+            state.detail_scroll = state.detail_scroll.saturating_sub(1);
+        }
+        SpecsMessage::ScrollDetailDown => {
+            state.detail_scroll = state.detail_scroll.saturating_add(1);
+        }
     }
 }
 
 pub fn render(state: &SpecsState, buf: &mut Buffer, area: Rect) {
     if area.height < 3 {
+        return;
+    }
+
+    if state.detail_mode {
+        render_detail(state, buf, area);
         return;
     }
 
@@ -165,6 +197,41 @@ pub fn render(state: &SpecsState, buf: &mut Buffer, area: Rect) {
         let search_line = format!(" Search: {}_", state.search_query);
         let span = Span::styled(search_line, Style::default().fg(Color::Yellow));
         buf.set_span(layout[2].x, layout[2].y, &span, layout[2].width);
+    }
+}
+
+fn render_detail(state: &SpecsState, buf: &mut Buffer, area: Rect) {
+    let visible = state.visible_specs();
+    let spec_id = visible
+        .get(state.selected)
+        .map(|s| s.id.as_str())
+        .unwrap_or("?");
+    let spec_title = visible
+        .get(state.selected)
+        .map(|s| s.title.as_str())
+        .unwrap_or("");
+
+    let layout = Layout::vertical([
+        Constraint::Length(1), // Header
+        Constraint::Min(1),   // Content
+    ])
+    .split(area);
+
+    // Header
+    let header = format!(" {spec_id} - {spec_title}  [Esc] Back");
+    let header_span = Span::styled(header, Style::default().fg(Color::Cyan).bold());
+    buf.set_span(layout[0].x, layout[0].y, &header_span, layout[0].width);
+
+    // Content: wrap spec.md text
+    let lines: Vec<&str> = state.detail_content.lines().collect();
+    let content_area = layout[1];
+    let max_rows = content_area.height as usize;
+    let scroll = state.detail_scroll.min(lines.len().saturating_sub(1));
+
+    for (i, line) in lines.iter().skip(scroll).take(max_rows).enumerate() {
+        let y = content_area.y + i as u16;
+        let span = Span::styled(*line, Style::default().fg(Color::White));
+        buf.set_span(content_area.x, y, &span, content_area.width);
     }
 }
 
@@ -556,5 +623,90 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let items = load_specs(dir.path());
         assert!(items.is_empty());
+    }
+
+    // -- detail_mode tests --
+
+    #[test]
+    fn detail_open_sets_flag() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        update(&mut s, SpecsMessage::OpenDetail);
+        assert!(s.detail_mode);
+        assert_eq!(s.detail_scroll, 0);
+    }
+
+    #[test]
+    fn detail_close_clears_state() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.detail_mode = true;
+        s.detail_content = "some content".into();
+        s.detail_scroll = 5;
+        update(&mut s, SpecsMessage::CloseDetail);
+        assert!(!s.detail_mode);
+        assert!(s.detail_content.is_empty());
+        assert_eq!(s.detail_scroll, 0);
+    }
+
+    #[test]
+    fn detail_scroll_up_down() {
+        let mut s = SpecsState::new();
+        s.detail_mode = true;
+        update(&mut s, SpecsMessage::ScrollDetailDown);
+        assert_eq!(s.detail_scroll, 1);
+        update(&mut s, SpecsMessage::ScrollDetailDown);
+        assert_eq!(s.detail_scroll, 2);
+        update(&mut s, SpecsMessage::ScrollDetailUp);
+        assert_eq!(s.detail_scroll, 1);
+        update(&mut s, SpecsMessage::ScrollDetailUp);
+        assert_eq!(s.detail_scroll, 0);
+        // Saturates at zero
+        update(&mut s, SpecsMessage::ScrollDetailUp);
+        assert_eq!(s.detail_scroll, 0);
+    }
+
+    #[test]
+    fn handle_key_detail_mode_esc_closes() {
+        let mut s = SpecsState::new();
+        s.detail_mode = true;
+        assert!(matches!(
+            handle_key(&s, &key(KeyCode::Esc)),
+            Some(SpecsMessage::CloseDetail)
+        ));
+    }
+
+    #[test]
+    fn handle_key_detail_mode_scroll() {
+        let mut s = SpecsState::new();
+        s.detail_mode = true;
+        assert!(matches!(
+            handle_key(&s, &key(KeyCode::Up)),
+            Some(SpecsMessage::ScrollDetailUp)
+        ));
+        assert!(matches!(
+            handle_key(&s, &key(KeyCode::Down)),
+            Some(SpecsMessage::ScrollDetailDown)
+        ));
+    }
+
+    #[test]
+    fn handle_key_enter_opens_detail() {
+        let s = SpecsState::new();
+        assert!(matches!(
+            handle_key(&s, &key(KeyCode::Enter)),
+            Some(SpecsMessage::OpenDetail)
+        ));
+    }
+
+    #[test]
+    fn render_detail_mode_no_panic() {
+        let mut s = SpecsState::new();
+        s.specs = sample_specs();
+        s.detail_mode = true;
+        s.detail_content = "# SPEC-1\n\nTest content\nLine 2".to_string();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
     }
 }

--- a/crates/gwt-tui/src/screens/versions.rs
+++ b/crates/gwt-tui/src/screens/versions.rs
@@ -1,0 +1,355 @@
+//! Versions tab — list git tags (releases)
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::prelude::*;
+use ratatui::widgets::Paragraph;
+
+/// A single version/tag entry.
+#[derive(Debug, Clone)]
+pub struct VersionTag {
+    pub name: String,
+    pub date: String,
+    pub message: String,
+}
+
+/// State for the Versions screen.
+#[derive(Debug, Default)]
+pub struct VersionsState {
+    pub tags: Vec<VersionTag>,
+    pub selected: usize,
+    pub scroll: usize,
+    pub detail_mode: bool,
+    pub detail_content: String,
+    pub detail_scroll: usize,
+}
+
+impl VersionsState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Messages for the Versions screen.
+#[derive(Debug)]
+pub enum VersionsMessage {
+    SelectPrev,
+    SelectNext,
+    OpenDetail,
+    CloseDetail,
+    ScrollDetailUp,
+    ScrollDetailDown,
+}
+
+/// Handle key input for the Versions screen.
+pub fn handle_key(state: &VersionsState, key: &KeyEvent) -> Option<VersionsMessage> {
+    if state.detail_mode {
+        match key.code {
+            KeyCode::Esc => Some(VersionsMessage::CloseDetail),
+            KeyCode::Up | KeyCode::Char('k') => Some(VersionsMessage::ScrollDetailUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(VersionsMessage::ScrollDetailDown),
+            _ => None,
+        }
+    } else {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => Some(VersionsMessage::SelectPrev),
+            KeyCode::Down | KeyCode::Char('j') => Some(VersionsMessage::SelectNext),
+            KeyCode::Enter => Some(VersionsMessage::OpenDetail),
+            _ => None,
+        }
+    }
+}
+
+/// Apply a VersionsMessage to state.
+pub fn update(state: &mut VersionsState, msg: VersionsMessage) {
+    match msg {
+        VersionsMessage::SelectPrev => {
+            state.selected = state.selected.saturating_sub(1);
+        }
+        VersionsMessage::SelectNext => {
+            let max = state.tags.len().saturating_sub(1);
+            if state.selected < max {
+                state.selected += 1;
+            }
+        }
+        VersionsMessage::OpenDetail => {
+            if !state.tags.is_empty() {
+                state.detail_mode = true;
+                state.detail_scroll = 0;
+                // detail_content is populated externally (app.rs)
+            }
+        }
+        VersionsMessage::CloseDetail => {
+            state.detail_mode = false;
+            state.detail_content.clear();
+            state.detail_scroll = 0;
+        }
+        VersionsMessage::ScrollDetailUp => {
+            state.detail_scroll = state.detail_scroll.saturating_sub(1);
+        }
+        VersionsMessage::ScrollDetailDown => {
+            state.detail_scroll = state.detail_scroll.saturating_add(1);
+        }
+    }
+}
+
+/// Render the Versions screen.
+pub fn render(state: &VersionsState, buf: &mut Buffer, area: Rect) {
+    if area.height < 3 {
+        return;
+    }
+
+    if state.detail_mode {
+        render_detail(state, buf, area);
+        return;
+    }
+
+    let layout = Layout::vertical([
+        Constraint::Length(1), // Header
+        Constraint::Min(1),   // List
+    ])
+    .split(area);
+
+    // Header
+    let count = state.tags.len();
+    let header = format!(" Versions ({count})");
+    let header_span = Span::styled(header, Style::default().fg(Color::Cyan).bold());
+    buf.set_span(layout[0].x, layout[0].y, &header_span, layout[0].width);
+
+    // List
+    if state.tags.is_empty() {
+        let msg = Paragraph::new("No tags found")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::DarkGray));
+        let y = layout[1].y + layout[1].height / 2;
+        let text_area = Rect::new(layout[1].x, y, layout[1].width, 1);
+        ratatui::widgets::Widget::render(msg, text_area, buf);
+        return;
+    }
+
+    let list_area = layout[1];
+    let max_rows = list_area.height as usize;
+
+    let offset = if state.selected >= max_rows {
+        state.selected - max_rows + 1
+    } else {
+        0
+    };
+
+    for (i, tag) in state.tags.iter().skip(offset).take(max_rows).enumerate() {
+        let y = list_area.y + i as u16;
+        let is_selected = (i + offset) == state.selected;
+
+        let marker = if is_selected { ">" } else { " " };
+        let line = format!(
+            " {marker} {:<20} {:<12} {}",
+            tag.name, tag.date, tag.message
+        );
+
+        let style = if is_selected {
+            Style::default().fg(Color::Black).bg(Color::Cyan)
+        } else {
+            Style::default()
+        };
+
+        let span = Span::styled(line, style);
+        buf.set_span(list_area.x, y, &span, list_area.width);
+    }
+}
+
+fn render_detail(state: &VersionsState, buf: &mut Buffer, area: Rect) {
+    let tag_name = state
+        .tags
+        .get(state.selected)
+        .map(|t| t.name.as_str())
+        .unwrap_or("?");
+
+    let layout = Layout::vertical([
+        Constraint::Length(1), // Header
+        Constraint::Min(1),   // Content
+    ])
+    .split(area);
+
+    // Header
+    let header = format!(" {tag_name}  [Esc] Back");
+    let header_span = Span::styled(header, Style::default().fg(Color::Cyan).bold());
+    buf.set_span(layout[0].x, layout[0].y, &header_span, layout[0].width);
+
+    // Content
+    let lines: Vec<&str> = state.detail_content.lines().collect();
+    let content_area = layout[1];
+    let max_rows = content_area.height as usize;
+    let scroll = state.detail_scroll.min(lines.len().saturating_sub(1));
+
+    for (i, line) in lines.iter().skip(scroll).take(max_rows).enumerate() {
+        let y = content_area.y + i as u16;
+        let span = Span::styled(*line, Style::default().fg(Color::White));
+        buf.set_span(content_area.x, y, &span, content_area.width);
+    }
+}
+
+/// Load version tags from git.
+pub fn load_tags(repo_root: &std::path::Path) -> Vec<VersionTag> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["tag", "-l", "--sort=-creatordate", "--format=%(refname:short)|%(creatordate:short)|%(subject)"])
+        .output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|line| {
+            let parts: Vec<&str> = line.splitn(3, '|').collect();
+            VersionTag {
+                name: parts.first().copied().unwrap_or("").to_string(),
+                date: parts.get(1).copied().unwrap_or("").to_string(),
+                message: parts.get(2).copied().unwrap_or("").to_string(),
+            }
+        })
+        .collect()
+}
+
+/// Load tag detail via git show.
+pub fn load_tag_detail(repo_root: &std::path::Path, tag_name: &str) -> String {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["show", "--stat", tag_name])
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+        _ => format!("(Failed to load details for tag '{tag_name}')"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn sample_tags() -> Vec<VersionTag> {
+        vec![
+            VersionTag {
+                name: "v1.0.0".into(),
+                date: "2024-01-01".into(),
+                message: "Initial release".into(),
+            },
+            VersionTag {
+                name: "v1.1.0".into(),
+                date: "2024-02-01".into(),
+                message: "Feature update".into(),
+            },
+            VersionTag {
+                name: "v2.0.0".into(),
+                date: "2024-03-01".into(),
+                message: "Major release".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn new_state_is_empty() {
+        let s = VersionsState::new();
+        assert!(s.tags.is_empty());
+        assert_eq!(s.selected, 0);
+        assert!(!s.detail_mode);
+    }
+
+    #[test]
+    fn select_prev_next() {
+        let mut s = VersionsState::new();
+        s.tags = sample_tags();
+        update(&mut s, VersionsMessage::SelectNext);
+        assert_eq!(s.selected, 1);
+        update(&mut s, VersionsMessage::SelectPrev);
+        assert_eq!(s.selected, 0);
+        // Saturate at zero
+        update(&mut s, VersionsMessage::SelectPrev);
+        assert_eq!(s.selected, 0);
+        // Saturate at max
+        s.selected = 2;
+        update(&mut s, VersionsMessage::SelectNext);
+        assert_eq!(s.selected, 2);
+    }
+
+    #[test]
+    fn open_close_detail() {
+        let mut s = VersionsState::new();
+        s.tags = sample_tags();
+        update(&mut s, VersionsMessage::OpenDetail);
+        assert!(s.detail_mode);
+        update(&mut s, VersionsMessage::CloseDetail);
+        assert!(!s.detail_mode);
+    }
+
+    #[test]
+    fn detail_scroll() {
+        let mut s = VersionsState::new();
+        s.tags = sample_tags();
+        s.detail_mode = true;
+        s.detail_content = "line1\nline2\nline3".to_string();
+        update(&mut s, VersionsMessage::ScrollDetailDown);
+        assert_eq!(s.detail_scroll, 1);
+        update(&mut s, VersionsMessage::ScrollDetailUp);
+        assert_eq!(s.detail_scroll, 0);
+        update(&mut s, VersionsMessage::ScrollDetailUp);
+        assert_eq!(s.detail_scroll, 0);
+    }
+
+    #[test]
+    fn handle_key_list_mode() {
+        let s = VersionsState::new();
+        assert!(matches!(handle_key(&s, &key(KeyCode::Up)), Some(VersionsMessage::SelectPrev)));
+        assert!(matches!(handle_key(&s, &key(KeyCode::Down)), Some(VersionsMessage::SelectNext)));
+        assert!(matches!(handle_key(&s, &key(KeyCode::Enter)), Some(VersionsMessage::OpenDetail)));
+        assert!(handle_key(&s, &key(KeyCode::Char('z'))).is_none());
+    }
+
+    #[test]
+    fn handle_key_detail_mode() {
+        let mut s = VersionsState::new();
+        s.detail_mode = true;
+        assert!(matches!(handle_key(&s, &key(KeyCode::Esc)), Some(VersionsMessage::CloseDetail)));
+        assert!(matches!(handle_key(&s, &key(KeyCode::Up)), Some(VersionsMessage::ScrollDetailUp)));
+        assert!(matches!(handle_key(&s, &key(KeyCode::Down)), Some(VersionsMessage::ScrollDetailDown)));
+    }
+
+    #[test]
+    fn render_empty_no_panic() {
+        let s = VersionsState::new();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
+    }
+
+    #[test]
+    fn render_with_tags_no_panic() {
+        let mut s = VersionsState::new();
+        s.tags = sample_tags();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
+    }
+
+    #[test]
+    fn render_detail_mode_no_panic() {
+        let mut s = VersionsState::new();
+        s.tags = sample_tags();
+        s.detail_mode = true;
+        s.detail_content = "tag v1.0.0\nDate: 2024-01-01\n\nInitial release".to_string();
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&s, &mut buf, area);
+    }
+}

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -932,14 +932,7 @@ impl WizardState {
         let mut options = Vec::new();
 
         // Detect installed version
-        let cmd_name = match agent_id {
-            "claude" => "claude",
-            "codex" => "codex",
-            "gemini" => "gemini",
-            "opencode" => "opencode",
-            "copilot" => "copilot",
-            _ => agent_id,
-        };
+        let cmd_name = agent_id;
         if let Ok(output) = std::process::Command::new(cmd_name)
             .arg("--version")
             .output()

--- a/crates/gwt-tui/src/widgets/status_bar.rs
+++ b/crates/gwt-tui/src/widgets/status_bar.rs
@@ -2,7 +2,16 @@
 
 use ratatui::prelude::*;
 
-use crate::model::{ActiveLayer, ManagementTab, Model};
+use crate::model::{ActiveLayer, Model, SessionStatus, SessionTabType};
+
+/// Count running agent sessions.
+fn running_session_count(model: &Model) -> usize {
+    model
+        .session_tabs
+        .iter()
+        .filter(|t| t.tab_type == SessionTabType::Agent && matches!(t.status, SessionStatus::Running))
+        .count()
+}
 
 /// Render the status bar.
 pub fn render(model: &Model, buf: &mut Buffer, area: Rect) {
@@ -30,7 +39,12 @@ pub fn render(model: &Model, buf: &mut Buffer, area: Rect) {
         }
         ActiveLayer::Management => {
             let tab_name = model.management_tab.label();
-            format!(" {tab_name}")
+            let running = running_session_count(model);
+            if running > 0 {
+                format!(" {tab_name} | {running} running")
+            } else {
+                format!(" {tab_name}")
+            }
         }
     };
 
@@ -53,8 +67,7 @@ pub fn render(model: &Model, buf: &mut Buffer, area: Rect) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::Model;
-    use ratatui::prelude::*;
+    use crate::model::{ManagementTab, Model};
     use std::path::PathBuf;
 
     fn test_model() -> Model {
@@ -139,6 +152,54 @@ mod tests {
         let text = buf_row_text(&buf, 0, 120);
         assert!(text.contains("Agent #1"), "Expected tab name in: {text:?}");
         assert!(text.contains("feature/test"), "Expected branch in: {text:?}");
+    }
+
+    #[test]
+    fn render_management_with_running_agents() {
+        let mut model = test_model();
+        use crate::model::{SessionTab, SessionTabType, SessionStatus};
+        use gwt_core::terminal::AgentColor;
+        model.session_tabs.push(SessionTab {
+            pane_id: "p1".into(),
+            name: "Agent #1".into(),
+            tab_type: SessionTabType::Agent,
+            color: AgentColor::Blue,
+            status: SessionStatus::Running,
+            branch: Some("feature/test".into()),
+            spec_id: None,
+        });
+        model.session_tabs.push(SessionTab {
+            pane_id: "p2".into(),
+            name: "Agent #2".into(),
+            tab_type: SessionTabType::Agent,
+            color: AgentColor::Green,
+            status: SessionStatus::Running,
+            branch: None,
+            spec_id: None,
+        });
+        // Stay in management layer
+        model.active_layer = ActiveLayer::Management;
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut buf, area);
+        let text = buf_row_text(&buf, 0, 120);
+        assert!(
+            text.contains("2 running"),
+            "Expected '2 running' in: {text:?}"
+        );
+    }
+
+    #[test]
+    fn render_management_no_running_agents() {
+        let model = test_model();
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut buf, area);
+        let text = buf_row_text(&buf, 0, 120);
+        assert!(
+            !text.contains("running"),
+            "Expected no 'running' in: {text:?}"
+        );
     }
 
     #[test]

--- a/specs/SPEC-1776/spec.md
+++ b/specs/SPEC-1776/spec.md
@@ -24,10 +24,10 @@ Reference code: `crates/gwt-cli/` at commit `becf0aab` (38,415 lines)
 W1 | claude | feat/x | running | SPEC-42
 ```
 
-**管理画面** (Ctrl+G, Ctrl+G でトグル): Branches / Issues / SPECs / Settings / Logs の5タブ。ブランチ一覧がデフォルト表示。
+**管理画面** (Ctrl+G, Ctrl+G でトグル): Branches / Issues / SPECs / Settings / Logs / Versions の6タブ。ブランチ一覧がデフォルト表示。
 
 ```
-[Branches] [Issues] [SPECs] [Settings] [Logs]
+[Branches] [Issues] [SPECs] [Settings] [Logs] [Versions]
 ─────────────────────────────────────────────
   main              -   ○  #42 open
 * feat/x   Claude   *   ●  #38 merged
@@ -116,10 +116,16 @@ As a developer, I want to paste files from clipboard to the agent via a dedicate
 13. Branches タブでブランチの Quick Start → 前回設定でワンクリック起動
 14. 同じブランチで複数エージェントを起動可能
 15. Docker compose 検出 → サービス選択 → コンテナ内でエージェント起動
-16. 管理画面内で Tab キーで Branches/Issues/SPECs/Settings/Logs を切替
+16. 管理画面内で Tab キーで Branches/Issues/SPECs/Settings/Logs/Versions を切替
 17. マウスクリックでブランチ選択、スクロールでリスト操作
 18. エラー発生 → 重大エラーはモーダル、軽微はステータスバーに表示
 19. エージェント起動中 → 6段階プログレスモーダル + キャンセルボタン
+20. SPECs タブで Enter → spec.md の詳細ビューが表示、Esc で戻る
+21. Issues タブで Enter → SPEC の場合は spec.md、それ以外は gh コマンド案内を表示
+22. Ctrl+C ダブルタップ → 実行中エージェントがある場合は確認ダイアログ表示
+23. 確認ダイアログで Enter(確定)/Esc(キャンセル)/Left-Right(選択切替)
+24. Versions タブで git タグ一覧を表示、Enter でタグ詳細
+25. 管理画面のステータスバーに実行中セッション数を表示
 
 ## Edge Cases
 
@@ -138,7 +144,7 @@ As a developer, I want to paste files from clipboard to the agent via a dedicate
 ### Core UI
 
 - FR-001: gwt-tui crate using ratatui + crossterm, Elm Architecture (Model/View/Update)
-- FR-002: 2-layer tab structure: メイン画面 (Agent/Shell tabs) + 管理画面 (Branches/Issues/SPECs/Settings/Logs tabs)
+- FR-002: 2-layer tab structure: メイン画面 (Agent/Shell tabs) + 管理画面 (Branches/Issues/SPECs/Settings/Logs/Versions tabs)
 - FR-003: Ctrl+G,Ctrl+G トグルで メイン ↔ 管理画面 切替
 - FR-004: Ctrl+G prefix key system (2s timeout) for all management operations
 - FR-005: VT100 emulator buffer to ratatui Cell conversion (renderer)
@@ -207,6 +213,11 @@ As a developer, I want to paste files from clipboard to the agent via a dedicate
 - FR-075: File paste from clipboard (dedicated shortcut, OS-native API)
 - FR-076: Mouse support (click selection, scroll, double-click)
 - FR-077: Error handling: ErrorQueue + modal (critical) + status bar (minor)
+- FR-078: Versions tab — git tag list with detail view (git show)
+- FR-079: Session history saving (ToolSessionEntry) on agent/shell spawn
+- FR-083: Quit confirmation dialog when running agents exist (Ctrl+C×2)
+- FR-081: SPECs/Issues detail view — Enter to view spec.md or issue details, Esc to return
+- FR-082: Status bar shows running agent session count in management layer
 
 ### npm Distribution
 


### PR DESCRIPTION
## Summary

- SPECs/Issues タブに Enter で詳細ビュー（spec.md 表示）、Esc で戻る機能を追加
- Versions タブ（6番目の管理タブ）を新規追加。git tag 一覧と詳細表示
- Ctrl+C ダブルタップ時に実行中エージェントがあれば確認ダイアログを表示
- 確認ダイアログのキー処理（Enter/Esc/Left/Right）をイベントループに追加
- ステータスバーに実行中セッション数を表示（管理画面レイヤー）
- セッション履歴保存は既に spawn_agent_session/spawn_shell_session に実装済みを確認
- SPEC-1776 spec.md に FR-078〜FR-083 と受け入れシナリオ 20〜25 を追記

## Test plan

- [x] 既存 301 テスト全通過 + 27 新規テスト = 328 テスト通過
- [x] `cargo build -p gwt-tui` 成功
- [x] `cargo clippy -p gwt-tui -- -D warnings -A dead_code` 成功
- [x] `cargo test -p gwt-core -p gwt-tui` 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Versions tab to the management panel displaying git tags with detail views
  * Added detail view mode for Issues and Specs tabs—press Enter to open details, Esc to close, arrow keys to scroll
  * Added quit confirmation dialog when agents are running
  * Added running agent session count display in the status bar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->