### PR TITLE
feat: add gwt-notification crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gwt-notification"
+version = "8.17.2"
+dependencies = [
+ "chrono",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "gwt-tauri"
 version = "8.17.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/gwt-core",
+    "crates/gwt-notification",
     "crates/gwt-tauri",
 ]
 default-members = [
@@ -18,6 +19,7 @@ authors = ["akiojin"]
 [workspace.dependencies]
 # Internal crates
 gwt-core = { path = "crates/gwt-core" }
+gwt-notification = { path = "crates/gwt-notification" }
 
 # Error handling
 thiserror = "2"

--- a/crates/gwt-notification/Cargo.toml
+++ b/crates/gwt-notification/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gwt-notification"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Notification bus and structured logging for gwt"
+publish = false
+
+[dependencies]
+tokio.workspace = true
+chrono.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/gwt-notification/src/bus.rs
+++ b/crates/gwt-notification/src/bus.rs
@@ -1,0 +1,106 @@
+use tokio::sync::mpsc;
+
+use crate::Notification;
+
+/// Bounded channel capacity for the notification bus.
+const CHANNEL_CAPACITY: usize = 1000;
+
+/// Sender half of the notification bus.
+#[derive(Clone)]
+pub struct NotificationBus {
+    tx: mpsc::Sender<Notification>,
+}
+
+/// Receiver half of the notification bus.
+pub struct NotificationReceiver {
+    rx: mpsc::Receiver<Notification>,
+}
+
+impl NotificationBus {
+    /// Create a new bus pair (sender, receiver).
+    pub fn new() -> (Self, NotificationReceiver) {
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        (Self { tx }, NotificationReceiver { rx })
+    }
+
+    /// Send a notification (non-blocking best-effort).
+    /// Returns `true` if sent, `false` if the channel is full or closed.
+    pub fn send(&self, notification: Notification) -> bool {
+        self.tx.try_send(notification).is_ok()
+    }
+}
+
+impl NotificationReceiver {
+    /// Try to receive a notification without blocking.
+    pub fn try_recv(&mut self) -> Option<Notification> {
+        self.rx.try_recv().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Severity;
+
+    #[test]
+    fn send_and_receive() {
+        let (bus, mut rx) = NotificationBus::new();
+        let n = Notification::new(Severity::Info, "test", "hello");
+        assert!(bus.send(n));
+        let received = rx.try_recv();
+        assert!(received.is_some());
+        assert_eq!(received.unwrap().message, "hello");
+    }
+
+    #[test]
+    fn try_recv_empty_returns_none() {
+        let (_bus, mut rx) = NotificationBus::new();
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn send_multiple() {
+        let (bus, mut rx) = NotificationBus::new();
+        for i in 0..5 {
+            bus.send(Notification::new(Severity::Debug, "test", format!("msg-{i}")));
+        }
+        let mut count = 0;
+        while rx.try_recv().is_some() {
+            count += 1;
+        }
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn bus_is_cloneable() {
+        let (bus, mut rx) = NotificationBus::new();
+        let bus2 = bus.clone();
+        bus.send(Notification::new(Severity::Info, "a", "from-original"));
+        bus2.send(Notification::new(Severity::Info, "b", "from-clone"));
+        assert!(rx.try_recv().is_some());
+        assert!(rx.try_recv().is_some());
+    }
+
+    #[test]
+    fn dropped_sender_closes_channel() {
+        let (bus, mut rx) = NotificationBus::new();
+        bus.send(Notification::new(Severity::Info, "test", "last"));
+        drop(bus);
+        // Can still drain buffered messages
+        assert!(rx.try_recv().is_some());
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn channel_bounded_at_capacity() {
+        let (bus, _rx) = NotificationBus::new();
+        let mut sent = 0;
+        for _ in 0..1100 {
+            if bus.send(Notification::new(Severity::Debug, "test", "fill")) {
+                sent += 1;
+            }
+        }
+        // Should cap at 1000
+        assert_eq!(sent, 1000);
+    }
+}

--- a/crates/gwt-notification/src/lib.rs
+++ b/crates/gwt-notification/src/lib.rs
@@ -1,0 +1,14 @@
+//! gwt-notification: Notification bus and structured logging for gwt
+//!
+//! Provides a bounded async notification channel and a ring-buffered
+//! structured log with severity-based filtering (SPEC-6).
+
+mod bus;
+mod log;
+mod notification;
+mod severity;
+
+pub use bus::{NotificationBus, NotificationReceiver};
+pub use log::StructuredLog;
+pub use notification::Notification;
+pub use severity::Severity;

--- a/crates/gwt-notification/src/log.rs
+++ b/crates/gwt-notification/src/log.rs
@@ -1,0 +1,151 @@
+use crate::{Notification, Severity};
+
+/// Maximum entries in the ring buffer.
+const MAX_ENTRIES: usize = 10_000;
+
+/// Ring-buffered structured log of notifications.
+pub struct StructuredLog {
+    entries: Vec<Notification>,
+    /// Write position in the ring buffer.
+    head: usize,
+    /// Total entries written (may exceed MAX_ENTRIES).
+    len: usize,
+}
+
+impl StructuredLog {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::with_capacity(256),
+            head: 0,
+            len: 0,
+        }
+    }
+
+    /// Push a notification into the ring buffer.
+    pub fn push(&mut self, notification: Notification) {
+        if self.entries.len() < MAX_ENTRIES {
+            self.entries.push(notification);
+        } else {
+            self.entries[self.head] = notification;
+        }
+        self.head = (self.head + 1) % MAX_ENTRIES;
+        self.len += 1;
+    }
+
+    /// Return entries in insertion order.
+    pub fn entries(&self) -> Vec<&Notification> {
+        let actual_len = self.entries.len();
+        if actual_len < MAX_ENTRIES || self.len <= MAX_ENTRIES {
+            // Not yet wrapped
+            self.entries.iter().collect()
+        } else {
+            // Wrapped: oldest is at head, read head..end then 0..head
+            let mut result = Vec::with_capacity(actual_len);
+            result.extend(self.entries[self.head..].iter());
+            result.extend(self.entries[..self.head].iter());
+            result
+        }
+    }
+
+    /// Filter entries with severity >= the given threshold.
+    pub fn filter(&self, min_severity: Severity) -> Vec<&Notification> {
+        self.entries()
+            .into_iter()
+            .filter(|n| n.severity >= min_severity)
+            .collect()
+    }
+
+    /// Clear all entries.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.head = 0;
+        self.len = 0;
+    }
+
+    /// Number of entries currently stored.
+    pub fn count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+impl Default for StructuredLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make(severity: Severity, msg: &str) -> Notification {
+        Notification::new(severity, "test", msg)
+    }
+
+    #[test]
+    fn push_and_entries() {
+        let mut log = StructuredLog::new();
+        log.push(make(Severity::Info, "a"));
+        log.push(make(Severity::Warn, "b"));
+        let entries = log.entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].message, "a");
+        assert_eq!(entries[1].message, "b");
+    }
+
+    #[test]
+    fn filter_by_severity() {
+        let mut log = StructuredLog::new();
+        log.push(make(Severity::Debug, "d"));
+        log.push(make(Severity::Info, "i"));
+        log.push(make(Severity::Warn, "w"));
+        log.push(make(Severity::Error, "e"));
+
+        let warn_plus = log.filter(Severity::Warn);
+        assert_eq!(warn_plus.len(), 2);
+        assert_eq!(warn_plus[0].message, "w");
+        assert_eq!(warn_plus[1].message, "e");
+    }
+
+    #[test]
+    fn filter_debug_returns_all() {
+        let mut log = StructuredLog::new();
+        log.push(make(Severity::Debug, "d"));
+        log.push(make(Severity::Error, "e"));
+        assert_eq!(log.filter(Severity::Debug).len(), 2);
+    }
+
+    #[test]
+    fn clear_empties_log() {
+        let mut log = StructuredLog::new();
+        log.push(make(Severity::Info, "x"));
+        log.push(make(Severity::Info, "y"));
+        assert_eq!(log.count(), 2);
+        log.clear();
+        assert_eq!(log.count(), 0);
+        assert!(log.entries().is_empty());
+    }
+
+    #[test]
+    fn ring_buffer_wraps_at_max() {
+        let mut log = StructuredLog::new();
+        for i in 0..10_500 {
+            log.push(make(Severity::Debug, &format!("msg-{i}")));
+        }
+        // Should cap at MAX_ENTRIES
+        assert_eq!(log.count(), MAX_ENTRIES);
+
+        let entries = log.entries();
+        // Oldest surviving entry should be msg-500 (10500 - 10000)
+        assert_eq!(entries[0].message, "msg-500");
+        // Newest should be msg-10499
+        assert_eq!(entries[MAX_ENTRIES - 1].message, "msg-10499");
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let log = StructuredLog::default();
+        assert_eq!(log.count(), 0);
+        assert!(log.entries().is_empty());
+    }
+}

--- a/crates/gwt-notification/src/notification.rs
+++ b/crates/gwt-notification/src/notification.rs
@@ -1,0 +1,75 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::Severity;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// A single notification entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Notification {
+    pub id: u64,
+    pub severity: Severity,
+    pub source: String,
+    pub message: String,
+    pub detail: Option<String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl Notification {
+    /// Create a new notification with auto-assigned id and current timestamp.
+    pub fn new(severity: Severity, source: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            severity,
+            source: source.into(),
+            message: message.into(),
+            detail: None,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Attach optional detail text.
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_assigns_unique_ids() {
+        let a = Notification::new(Severity::Info, "test", "msg-a");
+        let b = Notification::new(Severity::Info, "test", "msg-b");
+        assert_ne!(a.id, b.id);
+        assert!(b.id > a.id);
+    }
+
+    #[test]
+    fn new_sets_fields() {
+        let n = Notification::new(Severity::Warn, "git", "conflict detected");
+        assert_eq!(n.severity, Severity::Warn);
+        assert_eq!(n.source, "git");
+        assert_eq!(n.message, "conflict detected");
+        assert!(n.detail.is_none());
+    }
+
+    #[test]
+    fn with_detail_sets_detail() {
+        let n = Notification::new(Severity::Error, "pty", "crash")
+            .with_detail("segfault at 0x0");
+        assert_eq!(n.detail.as_deref(), Some("segfault at 0x0"));
+    }
+
+    #[test]
+    fn timestamp_is_recent() {
+        let before = Utc::now();
+        let n = Notification::new(Severity::Debug, "test", "ts check");
+        let after = Utc::now();
+        assert!(n.timestamp >= before && n.timestamp <= after);
+    }
+}

--- a/crates/gwt-notification/src/severity.rs
+++ b/crates/gwt-notification/src/severity.rs
@@ -1,0 +1,95 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Severity level for notifications.
+///
+/// Routing rules (SPEC-6):
+/// - Debug  -> log only
+/// - Info   -> status bar (5s)
+/// - Warn   -> status bar (persist)
+/// - Error  -> modal dialog
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Severity {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl Severity {
+    fn ordinal(self) -> u8 {
+        match self {
+            Self::Debug => 0,
+            Self::Info => 1,
+            Self::Warn => 2,
+            Self::Error => 3,
+        }
+    }
+}
+
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Debug => write!(f, "DEBUG"),
+            Self::Info => write!(f, "INFO"),
+            Self::Warn => write!(f, "WARN"),
+            Self::Error => write!(f, "ERROR"),
+        }
+    }
+}
+
+impl PartialOrd for Severity {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Severity {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.ordinal().cmp(&other.ordinal())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordering_debug_less_than_info() {
+        assert!(Severity::Debug < Severity::Info);
+    }
+
+    #[test]
+    fn ordering_info_less_than_warn() {
+        assert!(Severity::Info < Severity::Warn);
+    }
+
+    #[test]
+    fn ordering_warn_less_than_error() {
+        assert!(Severity::Warn < Severity::Error);
+    }
+
+    #[test]
+    fn ordering_full_chain() {
+        let mut levels = vec![Severity::Error, Severity::Debug, Severity::Warn, Severity::Info];
+        levels.sort();
+        assert_eq!(
+            levels,
+            vec![Severity::Debug, Severity::Info, Severity::Warn, Severity::Error]
+        );
+    }
+
+    #[test]
+    fn display_variants() {
+        assert_eq!(Severity::Debug.to_string(), "DEBUG");
+        assert_eq!(Severity::Info.to_string(), "INFO");
+        assert_eq!(Severity::Warn.to_string(), "WARN");
+        assert_eq!(Severity::Error.to_string(), "ERROR");
+    }
+
+    #[test]
+    fn equality() {
+        assert_eq!(Severity::Info, Severity::Info);
+        assert_ne!(Severity::Debug, Severity::Error);
+    }
+}


### PR DESCRIPTION
## Summary

- New `crates/gwt-notification/` crate implementing SPEC-6 notification foundation
- `Severity` enum (Debug/Info/Warn/Error) with `Ord` for routing rules
- `Notification` struct with auto-id, timestamps, and builder pattern
- `NotificationBus` / `NotificationReceiver` via tokio mpsc (1000 capacity, non-blocking send)
- `StructuredLog` ring buffer (10k max) with severity-based filtering

## Test plan

- [x] 22 unit tests covering all modules (severity ordering, notification creation, bus send/recv/capacity, ring buffer wrap/filter/clear)
- [x] `cargo test -p gwt-notification` -- all pass
- [x] `cargo clippy -p gwt-notification --all-targets -- -D warnings` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)