### PR TITLE
feat: add gwt-config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gwt-config"
+version = "8.17.2"
+dependencies = [
+ "dirs",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml 1.0.6+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "gwt-core"
 version = "8.17.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/gwt-config",
     "crates/gwt-core",
     "crates/gwt-tauri",
 ]
@@ -17,6 +18,7 @@ authors = ["akiojin"]
 
 [workspace.dependencies]
 # Internal crates
+gwt-config = { path = "crates/gwt-config" }
 gwt-core = { path = "crates/gwt-core" }
 
 # Error handling

--- a/crates/gwt-config/Cargo.toml
+++ b/crates/gwt-config/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gwt-config"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Configuration management for Git Worktree Manager"
+publish = false
+
+[dependencies]
+serde.workspace = true
+toml.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+dirs.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/gwt-config/src/agent_config.rs
+++ b/crates/gwt-config/src/agent_config.rs
@@ -1,0 +1,48 @@
+//! Agent-related configuration.
+
+use std::{collections::HashMap, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Agent runtime configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AgentConfig {
+    /// Default agent identifier (e.g. "claude", "codex", "gemini").
+    pub default_agent: Option<String>,
+    /// Named agent executable paths.
+    pub agent_paths: HashMap<String, PathBuf>,
+    /// Auto-install agent dependencies before launch.
+    pub auto_install_deps: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_has_no_agent() {
+        let c = AgentConfig::default();
+        assert!(c.default_agent.is_none());
+        assert!(c.agent_paths.is_empty());
+        assert!(!c.auto_install_deps);
+    }
+
+    #[test]
+    fn roundtrip_toml() {
+        let mut paths = HashMap::new();
+        paths.insert("claude".to_string(), PathBuf::from("/usr/bin/claude"));
+        paths.insert("codex".to_string(), PathBuf::from("/usr/bin/codex"));
+
+        let c = AgentConfig {
+            default_agent: Some("claude".to_string()),
+            agent_paths: paths,
+            auto_install_deps: true,
+        };
+        let toml_str = toml::to_string_pretty(&c).unwrap();
+        let loaded: AgentConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(loaded.default_agent, c.default_agent);
+        assert_eq!(loaded.agent_paths.len(), 2);
+        assert!(loaded.auto_install_deps);
+    }
+}

--- a/crates/gwt-config/src/ai_settings.rs
+++ b/crates/gwt-config/src/ai_settings.rs
@@ -1,0 +1,149 @@
+//! AI provider settings.
+
+use serde::{Deserialize, Serialize};
+
+fn default_endpoint() -> String {
+    "https://api.openai.com/v1".to_string()
+}
+
+fn default_language() -> Option<String> {
+    Some("en".to_string())
+}
+
+fn default_summary_enabled() -> bool {
+    true
+}
+
+/// AI provider configuration for OpenAI-compatible APIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AISettings {
+    /// API endpoint URL.
+    #[serde(default = "default_endpoint")]
+    pub endpoint: String,
+    /// API key (optional for local LLMs).
+    #[serde(default)]
+    pub api_key: Option<String>,
+    /// Model name.
+    #[serde(default)]
+    pub model: String,
+    /// Output language ("en" | "ja" | "auto").
+    #[serde(default = "default_language")]
+    pub language: Option<String>,
+    /// Enable session summary generation.
+    #[serde(default = "default_summary_enabled")]
+    pub summary_enabled: bool,
+}
+
+impl Default for AISettings {
+    fn default() -> Self {
+        Self {
+            endpoint: default_endpoint(),
+            api_key: None,
+            model: String::new(),
+            language: default_language(),
+            summary_enabled: default_summary_enabled(),
+        }
+    }
+}
+
+impl AISettings {
+    /// Check if the settings are valid for use (endpoint and model required).
+    pub fn is_enabled(&self) -> bool {
+        !self.endpoint.trim().is_empty() && !self.model.trim().is_empty()
+    }
+
+    /// Normalize language to a known value ("en", "ja", "auto").
+    pub fn normalized_language(&self) -> String {
+        match self
+            .language
+            .as_deref()
+            .unwrap_or("en")
+            .trim()
+            .to_lowercase()
+            .as_str()
+        {
+            "ja" => "ja".to_string(),
+            "auto" => "auto".to_string(),
+            _ => "en".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_has_endpoint_but_no_model() {
+        let s = AISettings::default();
+        assert!(!s.endpoint.is_empty());
+        assert!(s.model.is_empty());
+        assert!(!s.is_enabled());
+    }
+
+    #[test]
+    fn enabled_when_endpoint_and_model_set() {
+        let s = AISettings {
+            endpoint: "http://localhost:11434/v1".to_string(),
+            model: "llama3".to_string(),
+            ..Default::default()
+        };
+        assert!(s.is_enabled());
+    }
+
+    #[test]
+    fn disabled_when_model_empty() {
+        let s = AISettings {
+            endpoint: "http://localhost:11434/v1".to_string(),
+            model: "  ".to_string(),
+            ..Default::default()
+        };
+        assert!(!s.is_enabled());
+    }
+
+    #[test]
+    fn language_normalizes_known_values() {
+        let s = AISettings {
+            language: Some("JA".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(s.normalized_language(), "ja");
+
+        let s = AISettings {
+            language: Some(" auto ".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(s.normalized_language(), "auto");
+
+        let s = AISettings {
+            language: Some("fr".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(s.normalized_language(), "en");
+
+        let s = AISettings {
+            language: None,
+            ..Default::default()
+        };
+        assert_eq!(s.normalized_language(), "en");
+    }
+
+    #[test]
+    fn roundtrip_toml() {
+        let s = AISettings {
+            endpoint: "https://api.example.com/v1".to_string(),
+            api_key: Some("sk-test".to_string()),
+            model: "gpt-4".to_string(),
+            language: Some("ja".to_string()),
+            summary_enabled: false,
+        };
+        let toml_str = toml::to_string_pretty(&s).unwrap();
+        let loaded: AISettings = toml::from_str(&toml_str).unwrap();
+        assert_eq!(loaded.endpoint, s.endpoint);
+        assert_eq!(loaded.api_key, s.api_key);
+        assert_eq!(loaded.model, s.model);
+        assert_eq!(loaded.language, s.language);
+        assert_eq!(loaded.summary_enabled, s.summary_enabled);
+    }
+}

--- a/crates/gwt-config/src/atomic.rs
+++ b/crates/gwt-config/src/atomic.rs
@@ -1,0 +1,39 @@
+//! Atomic file write utilities.
+
+use std::path::Path;
+
+use tracing::warn;
+
+use crate::error::{ConfigError, Result};
+
+/// Write content to a file atomically via temp file + rename.
+pub fn write_atomic(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = path.with_extension("tmp");
+
+    std::fs::write(&temp_path, content).map_err(|e| ConfigError::WriteError {
+        reason: format!("failed to write temp file: {e}"),
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = std::fs::set_permissions(&temp_path, perms) {
+            warn!(
+                path = %temp_path.display(),
+                error = %e,
+                "Failed to set temp file permissions"
+            );
+        }
+    }
+
+    std::fs::rename(&temp_path, path).map_err(|e| ConfigError::WriteError {
+        reason: format!("failed to rename temp file: {e}"),
+    })?;
+
+    Ok(())
+}

--- a/crates/gwt-config/src/error.rs
+++ b/crates/gwt-config/src/error.rs
@@ -1,0 +1,30 @@
+//! Error types for gwt-config.
+
+use thiserror::Error;
+
+/// Result alias for gwt-config operations.
+pub type Result<T> = std::result::Result<T, ConfigError>;
+
+/// Errors that can occur during configuration operations.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Failed to parse a configuration file.
+    #[error("config parse error: {reason}")]
+    ParseError { reason: String },
+
+    /// Failed to write a configuration file.
+    #[error("config write error: {reason}")]
+    WriteError { reason: String },
+
+    /// The global config path could not be determined.
+    #[error("could not determine global config path")]
+    NoConfigPath,
+
+    /// An I/O error occurred.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Validation failed.
+    #[error("validation error: {reason}")]
+    ValidationError { reason: String },
+}

--- a/crates/gwt-config/src/lib.rs
+++ b/crates/gwt-config/src/lib.rs
@@ -1,0 +1,19 @@
+//! Configuration management for Git Worktree Manager.
+//!
+//! Provides typed configuration structs backed by TOML files with
+//! atomic writes and sensible defaults.
+
+pub mod agent_config;
+pub mod ai_settings;
+mod atomic;
+pub mod error;
+pub mod profile;
+pub mod settings;
+pub mod voice_config;
+
+pub use agent_config::AgentConfig;
+pub use ai_settings::AISettings;
+pub use error::{ConfigError, Result};
+pub use profile::{Profile, ProfilesConfig};
+pub use settings::Settings;
+pub use voice_config::VoiceConfig;

--- a/crates/gwt-config/src/profile.rs
+++ b/crates/gwt-config/src/profile.rs
@@ -1,0 +1,202 @@
+//! Profile management for environment variables.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::ai_settings::AISettings;
+
+/// An environment profile with optional AI settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Profile {
+    /// Profile name.
+    #[serde(default)]
+    pub name: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Environment variables to set when this profile is active.
+    #[serde(default)]
+    pub env_vars: HashMap<String, String>,
+    /// OS environment variables to suppress when this profile is active.
+    #[serde(default)]
+    pub disabled_env: Vec<String>,
+    /// AI provider settings (optional).
+    #[serde(default)]
+    pub ai_settings: Option<AISettings>,
+}
+
+impl Profile {
+    /// Create a new profile with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Builder: add an environment variable.
+    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env_vars.insert(key.into(), value.into());
+        self
+    }
+
+    /// Builder: set AI settings.
+    pub fn with_ai(mut self, ai: AISettings) -> Self {
+        self.ai_settings = Some(ai);
+        self
+    }
+}
+
+/// Container for all profiles and the active selection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfilesConfig {
+    /// All known profiles keyed by name.
+    #[serde(default)]
+    pub profiles: Vec<Profile>,
+    /// Currently active profile name.
+    #[serde(default)]
+    pub active: Option<String>,
+}
+
+impl Default for ProfilesConfig {
+    fn default() -> Self {
+        Self {
+            profiles: vec![Profile::new("default")],
+            active: Some("default".to_string()),
+        }
+    }
+}
+
+impl ProfilesConfig {
+    /// Get a reference to the active profile.
+    pub fn active_profile(&self) -> Option<&Profile> {
+        self.active
+            .as_ref()
+            .and_then(|name| self.profiles.iter().find(|p| p.name == *name))
+    }
+
+    /// Get a mutable reference to the active profile.
+    pub fn active_profile_mut(&mut self) -> Option<&mut Profile> {
+        let name = self.active.clone();
+        name.and_then(move |n| self.profiles.iter_mut().find(|p| p.name == n))
+    }
+
+    /// Find a profile by name.
+    pub fn get(&self, name: &str) -> Option<&Profile> {
+        self.profiles.iter().find(|p| p.name == name)
+    }
+
+    /// Add a profile. Returns an error string if a profile with the same name exists.
+    pub fn add(&mut self, profile: Profile) -> Result<(), String> {
+        if self.profiles.iter().any(|p| p.name == profile.name) {
+            return Err(format!("profile '{}' already exists", profile.name));
+        }
+        self.profiles.push(profile);
+        Ok(())
+    }
+
+    /// Remove a profile by name. Returns the removed profile if found.
+    pub fn remove(&mut self, name: &str) -> Option<Profile> {
+        if let Some(idx) = self.profiles.iter().position(|p| p.name == name) {
+            let removed = self.profiles.remove(idx);
+            if self.active.as_deref() == Some(name) {
+                self.active = None;
+            }
+            Some(removed)
+        } else {
+            None
+        }
+    }
+
+    /// Switch the active profile. Returns an error string if the profile is not found.
+    pub fn switch(&mut self, name: &str) -> Result<(), String> {
+        if !self.profiles.iter().any(|p| p.name == name) {
+            return Err(format!("profile '{}' not found", name));
+        }
+        self.active = Some(name.to_string());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_profile_has_name() {
+        let p = Profile::new("dev");
+        assert_eq!(p.name, "dev");
+        assert!(p.env_vars.is_empty());
+        assert!(p.ai_settings.is_none());
+    }
+
+    #[test]
+    fn builder_methods() {
+        let p = Profile::new("dev")
+            .with_env("FOO", "bar")
+            .with_ai(AISettings::default());
+        assert_eq!(p.env_vars.get("FOO"), Some(&"bar".to_string()));
+        assert!(p.ai_settings.is_some());
+    }
+
+    #[test]
+    fn default_profiles_config_has_default_profile() {
+        let c = ProfilesConfig::default();
+        assert_eq!(c.active.as_deref(), Some("default"));
+        assert!(c.active_profile().is_some());
+    }
+
+    #[test]
+    fn add_and_get_profile() {
+        let mut c = ProfilesConfig::default();
+        c.add(Profile::new("dev")).unwrap();
+        assert!(c.get("dev").is_some());
+    }
+
+    #[test]
+    fn add_duplicate_fails() {
+        let mut c = ProfilesConfig::default();
+        assert!(c.add(Profile::new("default")).is_err());
+    }
+
+    #[test]
+    fn remove_profile() {
+        let mut c = ProfilesConfig::default();
+        c.add(Profile::new("dev")).unwrap();
+        c.switch("dev").unwrap();
+        let removed = c.remove("dev");
+        assert!(removed.is_some());
+        assert_eq!(c.active, None);
+        assert!(c.get("dev").is_none());
+    }
+
+    #[test]
+    fn switch_to_nonexistent_fails() {
+        let mut c = ProfilesConfig::default();
+        assert!(c.switch("nonexistent").is_err());
+    }
+
+    #[test]
+    fn switch_active_profile() {
+        let mut c = ProfilesConfig::default();
+        c.add(Profile::new("dev")).unwrap();
+        c.switch("dev").unwrap();
+        assert_eq!(c.active_profile().unwrap().name, "dev");
+    }
+
+    #[test]
+    fn roundtrip_toml() {
+        let mut c = ProfilesConfig::default();
+        let p = Profile::new("dev").with_env("KEY", "val");
+        c.add(p).unwrap();
+        let toml_str = toml::to_string_pretty(&c).unwrap();
+        let loaded: ProfilesConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(loaded.profiles.len(), 2);
+        assert!(loaded.get("dev").is_some());
+        assert_eq!(
+            loaded.get("dev").unwrap().env_vars.get("KEY"),
+            Some(&"val".to_string())
+        );
+    }
+}

--- a/crates/gwt-config/src/settings.rs
+++ b/crates/gwt-config/src/settings.rs
@@ -1,0 +1,203 @@
+//! Top-level application settings backed by `~/.gwt/config.toml`.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info};
+
+use crate::{
+    agent_config::AgentConfig,
+    atomic::write_atomic,
+    error::{ConfigError, Result},
+    profile::ProfilesConfig,
+    voice_config::VoiceConfig,
+};
+
+static UPDATE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Top-level application settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Settings {
+    /// Branches that cannot be deleted.
+    pub protected_branches: Vec<String>,
+    /// Default base branch for new worktrees.
+    pub default_base_branch: String,
+    /// Worktree root directory override.
+    pub worktree_root: Option<PathBuf>,
+    /// Enable debug logging.
+    pub debug: bool,
+    /// Enable performance profiling.
+    pub profiling: bool,
+    /// Profile management.
+    pub profiles: ProfilesConfig,
+    /// Voice input configuration.
+    pub voice: VoiceConfig,
+    /// Agent configuration.
+    pub agent: AgentConfig,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            protected_branches: vec![
+                "main".to_string(),
+                "master".to_string(),
+                "develop".to_string(),
+            ],
+            default_base_branch: "main".to_string(),
+            worktree_root: None,
+            debug: false,
+            profiling: false,
+            profiles: ProfilesConfig::default(),
+            voice: VoiceConfig::default(),
+            agent: AgentConfig::default(),
+        }
+    }
+}
+
+impl Settings {
+    /// Return the global config file path: `~/.gwt/config.toml`.
+    pub fn global_config_path() -> Option<PathBuf> {
+        dirs::home_dir().map(|home| home.join(".gwt").join("config.toml"))
+    }
+
+    /// Load settings from `~/.gwt/config.toml`, falling back to defaults.
+    pub fn load() -> Result<Self> {
+        let path = match Self::global_config_path() {
+            Some(p) if p.exists() => p,
+            _ => {
+                debug!("No global config found, using defaults");
+                return Ok(Self::default());
+            }
+        };
+
+        Self::load_from_path(&path)
+    }
+
+    /// Load settings from an explicit path.
+    pub fn load_from_path(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            error!(path = %path.display(), error = %e, "Failed to read config");
+            ConfigError::ParseError {
+                reason: e.to_string(),
+            }
+        })?;
+
+        toml::from_str(&content).map_err(|e| {
+            error!(path = %path.display(), error = %e, "Failed to parse config");
+            ConfigError::ParseError {
+                reason: e.to_string(),
+            }
+        })
+    }
+
+    /// Save settings to the given path using atomic write.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let content = toml::to_string_pretty(self).map_err(|e| ConfigError::WriteError {
+            reason: format!("failed to serialize settings: {e}"),
+        })?;
+
+        write_atomic(path, &content)?;
+
+        info!(path = %path.display(), "Settings saved");
+        Ok(())
+    }
+
+    /// Save settings to the global config path.
+    pub fn save_global(&self) -> Result<()> {
+        let path = Self::global_config_path().ok_or(ConfigError::NoConfigPath)?;
+        self.save(&path)
+    }
+
+    /// Load, mutate, and save the global config atomically.
+    pub fn update_global<F>(mutate: F) -> Result<()>
+    where
+        F: FnOnce(&mut Self) -> Result<()>,
+    {
+        let _guard = UPDATE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let mut settings = Self::load()?;
+        mutate(&mut settings)?;
+        settings.save_global()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_settings_are_sane() {
+        let s = Settings::default();
+        assert_eq!(s.default_base_branch, "main");
+        assert!(s.protected_branches.contains(&"main".to_string()));
+        assert!(!s.debug);
+        assert!(!s.profiling);
+    }
+
+    #[test]
+    fn roundtrip_toml() {
+        let s = Settings {
+            debug: true,
+            worktree_root: Some(PathBuf::from("/tmp/wt")),
+            ..Default::default()
+        };
+        let toml_str = toml::to_string_pretty(&s).unwrap();
+        let loaded: Settings = toml::from_str(&toml_str).unwrap();
+        assert!(loaded.debug);
+        assert_eq!(loaded.worktree_root, Some(PathBuf::from("/tmp/wt")));
+    }
+
+    #[test]
+    fn save_and_load_from_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let s = Settings {
+            debug: true,
+            default_base_branch: "develop".to_string(),
+            ..Default::default()
+        };
+        s.save(&path).unwrap();
+
+        let loaded = Settings::load_from_path(&path).unwrap();
+        assert!(loaded.debug);
+        assert_eq!(loaded.default_base_branch, "develop");
+    }
+
+    #[test]
+    fn load_from_missing_file_returns_error() {
+        let result = Settings::load_from_path(Path::new("/nonexistent/config.toml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub").join("dir").join("config.toml");
+
+        let s = Settings::default();
+        s.save(&path).unwrap();
+
+        assert!(path.exists());
+        let loaded = Settings::load_from_path(&path).unwrap();
+        assert_eq!(loaded.default_base_branch, "main");
+    }
+
+    #[test]
+    fn partial_toml_fills_defaults() {
+        let toml_str = r#"
+debug = true
+"#;
+        let loaded: Settings = toml::from_str(toml_str).unwrap();
+        assert!(loaded.debug);
+        assert_eq!(loaded.default_base_branch, "main");
+        assert!(loaded.protected_branches.contains(&"main".to_string()));
+    }
+}

--- a/crates/gwt-config/src/voice_config.rs
+++ b/crates/gwt-config/src/voice_config.rs
@@ -1,0 +1,116 @@
+//! Voice input configuration.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ConfigError, Result};
+
+fn default_hotkey() -> String {
+    "Ctrl+G,v".to_string()
+}
+
+/// Voice input configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct VoiceConfig {
+    /// Path to the local ASR model (e.g. Qwen3-ASR).
+    pub model_path: Option<PathBuf>,
+    /// Hotkey to toggle voice input.
+    #[serde(default = "default_hotkey")]
+    pub hotkey: String,
+    /// Audio input device name (None = system default).
+    pub input_device: Option<String>,
+    /// Recognition language (None = auto-detect).
+    pub language: Option<String>,
+    /// Whether voice input is enabled.
+    pub enabled: bool,
+}
+
+impl Default for VoiceConfig {
+    fn default() -> Self {
+        Self {
+            model_path: None,
+            hotkey: default_hotkey(),
+            input_device: None,
+            language: None,
+            enabled: false,
+        }
+    }
+}
+
+impl VoiceConfig {
+    /// Validate the configuration.
+    ///
+    /// Checks that `model_path`, if set, points to an existing path.
+    pub fn validate(&self) -> Result<()> {
+        if let Some(ref path) = self.model_path {
+            if !path.exists() {
+                return Err(ConfigError::ValidationError {
+                    reason: format!("voice model path does not exist: {}", path.display()),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_disabled() {
+        let v = VoiceConfig::default();
+        assert!(!v.enabled);
+        assert_eq!(v.hotkey, "Ctrl+G,v");
+        assert!(v.model_path.is_none());
+    }
+
+    #[test]
+    fn validate_ok_when_no_model_path() {
+        let v = VoiceConfig::default();
+        assert!(v.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_fails_when_model_path_missing() {
+        let v = VoiceConfig {
+            model_path: Some(PathBuf::from("/nonexistent/model")),
+            ..Default::default()
+        };
+        let err = v.validate().unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn validate_ok_when_model_path_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let model = dir.path().join("model.bin");
+        std::fs::write(&model, b"fake").unwrap();
+
+        let v = VoiceConfig {
+            model_path: Some(model),
+            ..Default::default()
+        };
+        assert!(v.validate().is_ok());
+    }
+
+    #[test]
+    fn roundtrip_toml() {
+        let v = VoiceConfig {
+            model_path: Some(PathBuf::from("/tmp/model")),
+            hotkey: "Ctrl+M".to_string(),
+            input_device: Some("mic0".to_string()),
+            language: Some("ja".to_string()),
+            enabled: true,
+        };
+        let toml_str = toml::to_string_pretty(&v).unwrap();
+        let loaded: VoiceConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(loaded.model_path, v.model_path);
+        assert_eq!(loaded.hotkey, v.hotkey);
+        assert_eq!(loaded.input_device, v.input_device);
+        assert_eq!(loaded.language, v.language);
+        assert!(loaded.enabled);
+    }
+}


### PR DESCRIPTION
## Summary
- Create `crates/gwt-config/` with typed configuration structs: `Settings`, `ProfilesConfig`, `Profile`, `AISettings`, `VoiceConfig`, `AgentConfig`
- TOML-backed load/save with atomic writes (temp file + rename)
- 27 unit tests covering roundtrip serialization, validation, CRUD operations, and edge cases

## Test plan
- [x] `cargo test -p gwt-config` -- 27 tests pass
- [x] `cargo clippy -p gwt-config --all-targets -- -D warnings` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration management system supporting agent, AI/OpenAI, voice input, and environment profiles
  * Settings persisted in ~/.gwt/config.toml with atomic write safeguards for data integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->