### PR TITLE
feat: add gwt-docker crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gwt-docker"
+version = "8.17.2"
+dependencies = [
+ "gwt-core",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "gwt-tauri"
 version = "8.17.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/gwt-core",
+    "crates/gwt-docker",
     "crates/gwt-tauri",
 ]
 default-members = [

--- a/crates/gwt-docker/Cargo.toml
+++ b/crates/gwt-docker/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gwt-docker"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Docker detection, container management, and DevContainer support for gwt"
+publish = false
+
+[dependencies]
+gwt-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/gwt-docker/src/compose.rs
+++ b/crates/gwt-docker/src/compose.rs
@@ -1,0 +1,200 @@
+//! Docker Compose file parsing.
+//!
+//! Extracts service definitions from docker-compose.yml / compose.yml files.
+
+use std::path::Path;
+
+use gwt_core::{GwtError, Result};
+use serde_yaml::Value;
+use tracing::debug;
+
+/// A service defined in a Docker Compose file.
+#[derive(Debug, Clone)]
+pub struct ComposeService {
+    /// Service name.
+    pub name: String,
+    /// Image name (if specified).
+    pub image: Option<String>,
+    /// Published ports (raw strings, e.g. "8080:80").
+    pub ports: Vec<String>,
+    /// Services this service depends on.
+    pub depends_on: Vec<String>,
+}
+
+/// Parse a Docker Compose file and return its service definitions.
+pub fn parse_compose_file(path: &Path) -> Result<Vec<ComposeService>> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| GwtError::Docker(format!("failed to read compose file: {e}")))?;
+    parse_compose_content(&content)
+}
+
+fn parse_compose_content(content: &str) -> Result<Vec<ComposeService>> {
+    let root: Value = serde_yaml::from_str(content)
+        .map_err(|e| GwtError::Docker(format!("failed to parse compose YAML: {e}")))?;
+
+    let services = root
+        .get("services")
+        .and_then(|v| v.as_mapping())
+        .ok_or_else(|| GwtError::Docker("no 'services' key in compose file".to_string()))?;
+
+    let mut result = Vec::new();
+
+    for (key, value) in services {
+        let name = key.as_str().unwrap_or_default().to_string();
+
+        let image = value
+            .get("image")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let ports = value
+            .get("ports")
+            .and_then(|v| v.as_sequence())
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let depends_on = extract_depends_on(value);
+
+        result.push(ComposeService {
+            name,
+            image,
+            ports,
+            depends_on,
+        });
+    }
+
+    debug!(
+        category = "docker",
+        count = result.len(),
+        "parsed compose services"
+    );
+    Ok(result)
+}
+
+/// Extract depends_on which can be either a list of strings or a mapping.
+fn extract_depends_on(service: &Value) -> Vec<String> {
+    match service.get("depends_on") {
+        Some(Value::Sequence(seq)) => seq
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+        Some(Value::Mapping(map)) => map
+            .keys()
+            .filter_map(|k| k.as_str().map(|s| s.to_string()))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn parse_simple_compose() {
+        let yaml = r#"
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "8080:80"
+  db:
+    image: postgres:15
+    ports:
+      - "5432:5432"
+"#;
+        let services = parse_compose_content(yaml).unwrap();
+        assert_eq!(services.len(), 2);
+
+        let web = services.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(web.image.as_deref(), Some("nginx:latest"));
+        assert_eq!(web.ports, vec!["8080:80"]);
+
+        let db = services.iter().find(|s| s.name == "db").unwrap();
+        assert_eq!(db.image.as_deref(), Some("postgres:15"));
+    }
+
+    #[test]
+    fn parse_depends_on_list() {
+        let yaml = r#"
+services:
+  web:
+    image: node:18
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:15
+  redis:
+    image: redis:7
+"#;
+        let services = parse_compose_content(yaml).unwrap();
+        let web = services.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(web.depends_on, vec!["db", "redis"]);
+    }
+
+    #[test]
+    fn parse_depends_on_mapping() {
+        let yaml = r#"
+services:
+  web:
+    image: node:18
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: postgres:15
+"#;
+        let services = parse_compose_content(yaml).unwrap();
+        let web = services.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(web.depends_on, vec!["db"]);
+    }
+
+    #[test]
+    fn parse_service_without_image() {
+        let yaml = r#"
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+"#;
+        let services = parse_compose_content(yaml).unwrap();
+        assert_eq!(services.len(), 1);
+        assert!(services[0].image.is_none());
+    }
+
+    #[test]
+    fn parse_compose_file_from_disk() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("docker-compose.yml");
+        std::fs::write(
+            &path,
+            "services:\n  app:\n    image: alpine:3.18\n",
+        )
+        .unwrap();
+        let services = parse_compose_file(&path).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "app");
+    }
+
+    #[test]
+    fn missing_services_key_returns_error() {
+        let yaml = "version: '3'\n";
+        let result = parse_compose_content(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_services_returns_empty_vec() {
+        let yaml = "services: {}\n";
+        let services = parse_compose_content(yaml).unwrap();
+        assert!(services.is_empty());
+    }
+}

--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -1,0 +1,213 @@
+//! Container information and lifecycle management.
+//!
+//! Provides data structures for representing Docker containers and functions
+//! to list, start, stop, and restart them via the Docker CLI.
+
+use gwt_core::{GwtError, Result};
+use tracing::debug;
+
+/// Status of a Docker container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerStatus {
+    Created,
+    Running,
+    Paused,
+    Stopped,
+    Exited,
+}
+
+impl ContainerStatus {
+    /// Parse a status string from `docker ps --format`.
+    pub fn from_docker_state(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "created" => Self::Created,
+            "running" => Self::Running,
+            "paused" => Self::Paused,
+            "exited" => Self::Exited,
+            _ => Self::Stopped,
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        matches!(self, Self::Running)
+    }
+}
+
+/// Information about a Docker container.
+#[derive(Debug, Clone)]
+pub struct ContainerInfo {
+    /// Short container ID.
+    pub id: String,
+    /// Container name.
+    pub name: String,
+    /// Current status.
+    pub status: ContainerStatus,
+    /// Image name.
+    pub image: String,
+    /// Published ports (e.g. "0.0.0.0:8080->80/tcp").
+    pub ports: String,
+}
+
+/// List all containers (including stopped ones).
+pub fn list_containers() -> Result<Vec<ContainerInfo>> {
+    let output = gwt_core::process::command("docker")
+        .args([
+            "ps",
+            "-a",
+            "--format",
+            "{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Image}}\t{{.Ports}}",
+        ])
+        .output()
+        .map_err(|e| GwtError::Docker(format!("failed to run docker ps: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GwtError::Docker(format!("docker ps failed: {stderr}")));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let containers: Vec<ContainerInfo> = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.splitn(5, '\t').collect();
+            if parts.len() < 4 {
+                return None;
+            }
+            Some(ContainerInfo {
+                id: parts[0].to_string(),
+                name: parts[1].to_string(),
+                status: ContainerStatus::from_docker_state(parts[2]),
+                image: parts[3].to_string(),
+                ports: parts.get(4).unwrap_or(&"").to_string(),
+            })
+        })
+        .collect();
+
+    debug!(
+        category = "docker",
+        count = containers.len(),
+        "listed containers"
+    );
+    Ok(containers)
+}
+
+/// Run a docker lifecycle command (`start`, `stop`, `restart`) on a container.
+fn lifecycle(action: &str, id: &str) -> Result<()> {
+    let output = gwt_core::process::command("docker")
+        .args([action, id])
+        .output()
+        .map_err(|e| GwtError::Docker(format!("failed to {action} container: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GwtError::Docker(format!(
+            "docker {action} failed: {stderr}"
+        )));
+    }
+    debug!(category = "docker", id = id, action = action, "container lifecycle");
+    Ok(())
+}
+
+/// Start a container by ID or name.
+pub fn start(id: &str) -> Result<()> {
+    lifecycle("start", id)
+}
+
+/// Stop a container by ID or name.
+pub fn stop(id: &str) -> Result<()> {
+    lifecycle("stop", id)
+}
+
+/// Restart a container by ID or name.
+pub fn restart(id: &str) -> Result<()> {
+    lifecycle("restart", id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn container_status_from_docker_state() {
+        assert_eq!(
+            ContainerStatus::from_docker_state("created"),
+            ContainerStatus::Created
+        );
+        assert_eq!(
+            ContainerStatus::from_docker_state("running"),
+            ContainerStatus::Running
+        );
+        assert_eq!(
+            ContainerStatus::from_docker_state("Running"),
+            ContainerStatus::Running
+        );
+        assert_eq!(
+            ContainerStatus::from_docker_state("paused"),
+            ContainerStatus::Paused
+        );
+        assert_eq!(
+            ContainerStatus::from_docker_state("exited"),
+            ContainerStatus::Exited
+        );
+        assert_eq!(
+            ContainerStatus::from_docker_state("unknown"),
+            ContainerStatus::Stopped
+        );
+    }
+
+    #[test]
+    fn container_status_is_running() {
+        assert!(ContainerStatus::Running.is_running());
+        assert!(!ContainerStatus::Created.is_running());
+        assert!(!ContainerStatus::Paused.is_running());
+        assert!(!ContainerStatus::Stopped.is_running());
+        assert!(!ContainerStatus::Exited.is_running());
+    }
+
+    #[test]
+    fn container_info_fields() {
+        let info = ContainerInfo {
+            id: "abc123".to_string(),
+            name: "my-app".to_string(),
+            status: ContainerStatus::Running,
+            image: "node:18".to_string(),
+            ports: "0.0.0.0:3000->3000/tcp".to_string(),
+        };
+        assert_eq!(info.id, "abc123");
+        assert_eq!(info.name, "my-app");
+        assert!(info.status.is_running());
+        assert_eq!(info.image, "node:18");
+        assert_eq!(info.ports, "0.0.0.0:3000->3000/tcp");
+    }
+
+    #[test]
+    fn parse_docker_ps_line() {
+        let line = "abc123\tmy-app\trunning\tnode:18\t0.0.0.0:3000->3000/tcp";
+        let parts: Vec<&str> = line.splitn(5, '\t').collect();
+        assert_eq!(parts.len(), 5);
+        let info = ContainerInfo {
+            id: parts[0].to_string(),
+            name: parts[1].to_string(),
+            status: ContainerStatus::from_docker_state(parts[2]),
+            image: parts[3].to_string(),
+            ports: parts[4].to_string(),
+        };
+        assert_eq!(info.id, "abc123");
+        assert!(info.status.is_running());
+    }
+
+    #[test]
+    fn parse_docker_ps_line_no_ports() {
+        let line = "def456\tstopped-app\texited\talpine:3.18\t";
+        let parts: Vec<&str> = line.splitn(5, '\t').collect();
+        let info = ContainerInfo {
+            id: parts[0].to_string(),
+            name: parts[1].to_string(),
+            status: ContainerStatus::from_docker_state(parts[2]),
+            image: parts[3].to_string(),
+            ports: parts.get(4).unwrap_or(&"").to_string(),
+        };
+        assert_eq!(info.status, ContainerStatus::Exited);
+        assert!(info.ports.is_empty());
+    }
+}

--- a/crates/gwt-docker/src/detect.rs
+++ b/crates/gwt-docker/src/detect.rs
@@ -1,0 +1,210 @@
+//! Docker environment detection.
+//!
+//! Checks for Docker CLI availability, daemon status, and discovers
+//! Docker-related files (Dockerfile, docker-compose.yml, .devcontainer/).
+
+use std::path::{Path, PathBuf};
+
+use tracing::debug;
+
+/// Detected Docker files in a directory.
+#[derive(Debug, Clone, Default)]
+pub struct DockerFiles {
+    /// Path to Dockerfile, if found.
+    pub dockerfile: Option<PathBuf>,
+    /// Path to docker-compose.yml (or compose.yml variant), if found.
+    pub compose_file: Option<PathBuf>,
+    /// Path to .devcontainer/ directory, if found.
+    pub devcontainer_dir: Option<PathBuf>,
+}
+
+impl DockerFiles {
+    /// Returns true if any Docker files were detected.
+    pub fn any_found(&self) -> bool {
+        self.dockerfile.is_some()
+            || self.compose_file.is_some()
+            || self.devcontainer_dir.is_some()
+    }
+}
+
+/// Run a docker sub-command and return whether it succeeded.
+fn docker_probe(args: &[&str], label: &str) -> bool {
+    let result = gwt_core::process::command("docker").args(args).output();
+    match result {
+        Ok(output) => {
+            let ok = output.status.success();
+            debug!(category = "docker", ok = ok, label = label, "probe");
+            ok
+        }
+        Err(e) => {
+            debug!(category = "docker", error = %e, label = label, "probe failed");
+            false
+        }
+    }
+}
+
+/// Check if the `docker` command is available in PATH.
+pub fn docker_available() -> bool {
+    docker_probe(&["--version"], "docker CLI")
+}
+
+/// Check if `docker compose` (v2) is available.
+pub fn compose_available() -> bool {
+    docker_probe(&["compose", "version"], "docker compose")
+}
+
+/// Check if the Docker daemon is running.
+pub fn daemon_running() -> bool {
+    docker_probe(&["info"], "daemon")
+}
+
+/// Detect Docker-related files in a directory.
+///
+/// Scans for Dockerfile, docker-compose.yml / compose.yml variants,
+/// and .devcontainer/ directory.
+pub fn detect_docker_files(dir: &Path) -> DockerFiles {
+    let mut files = DockerFiles::default();
+
+    // Compose files (check common variants)
+    let compose_names = [
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "compose.yml",
+        "compose.yaml",
+    ];
+    for name in compose_names {
+        let p = dir.join(name);
+        if p.is_file() {
+            debug!(category = "docker", file = %name, "found compose file");
+            files.compose_file = Some(p);
+            break;
+        }
+    }
+
+    // Dockerfile
+    let dockerfile = dir.join("Dockerfile");
+    if dockerfile.is_file() {
+        debug!(category = "docker", "found Dockerfile");
+        files.dockerfile = Some(dockerfile);
+    }
+
+    // .devcontainer/
+    let devcontainer = dir.join(".devcontainer");
+    if devcontainer.is_dir() {
+        debug!(category = "docker", "found .devcontainer/");
+        files.devcontainer_dir = Some(devcontainer);
+    }
+
+    files
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn detect_empty_dir_finds_nothing() {
+        let tmp = TempDir::new().unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(!files.any_found());
+        assert!(files.dockerfile.is_none());
+        assert!(files.compose_file.is_none());
+        assert!(files.devcontainer_dir.is_none());
+    }
+
+    #[test]
+    fn detect_dockerfile() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("Dockerfile"), "FROM ubuntu:22.04").unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(files.any_found());
+        assert!(files.dockerfile.is_some());
+        assert!(files.compose_file.is_none());
+    }
+
+    #[test]
+    fn detect_docker_compose_yml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("docker-compose.yml"), "version: '3'").unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(files.any_found());
+        assert!(files.compose_file.is_some());
+        assert!(
+            files
+                .compose_file
+                .as_ref()
+                .unwrap()
+                .ends_with("docker-compose.yml")
+        );
+    }
+
+    #[test]
+    fn detect_compose_yml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("compose.yml"), "version: '3'").unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(files.compose_file.is_some());
+    }
+
+    #[test]
+    fn detect_devcontainer_dir() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".devcontainer")).unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(files.any_found());
+        assert!(files.devcontainer_dir.is_some());
+    }
+
+    #[test]
+    fn detect_all_docker_files() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("Dockerfile"), "FROM node:18").unwrap();
+        std::fs::write(tmp.path().join("docker-compose.yml"), "version: '3'").unwrap();
+        std::fs::create_dir(tmp.path().join(".devcontainer")).unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(files.dockerfile.is_some());
+        assert!(files.compose_file.is_some());
+        assert!(files.devcontainer_dir.is_some());
+    }
+
+    #[test]
+    fn docker_compose_yml_takes_priority_over_compose_yml() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("docker-compose.yml"), "version: '3'").unwrap();
+        std::fs::write(tmp.path().join("compose.yml"), "version: '3'").unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(
+            files
+                .compose_file
+                .as_ref()
+                .unwrap()
+                .ends_with("docker-compose.yml")
+        );
+    }
+
+    #[test]
+    fn directory_named_dockerfile_is_ignored() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("Dockerfile")).unwrap();
+        let files = detect_docker_files(tmp.path());
+        assert!(files.dockerfile.is_none());
+    }
+
+    // Smoke tests — just verify the functions return without panic.
+    #[test]
+    fn docker_available_returns_bool() {
+        let _ = docker_available();
+    }
+
+    #[test]
+    fn compose_available_returns_bool() {
+        let _ = compose_available();
+    }
+
+    #[test]
+    fn daemon_running_returns_bool() {
+        let _ = daemon_running();
+    }
+}

--- a/crates/gwt-docker/src/devcontainer.rs
+++ b/crates/gwt-docker/src/devcontainer.rs
@@ -1,0 +1,295 @@
+//! DevContainer configuration parsing.
+//!
+//! Parses `.devcontainer/devcontainer.json` files, supporting JSON with
+//! comments (JSONC) as used by VS Code DevContainers.
+
+use std::path::Path;
+
+use gwt_core::{GwtError, Result};
+use serde::Deserialize;
+use tracing::debug;
+
+/// Parsed devcontainer.json configuration.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DevContainerConfig {
+    /// Container name.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Docker image to use.
+    #[serde(default)]
+    pub image: Option<String>,
+    /// Build configuration.
+    #[serde(default)]
+    pub build: Option<BuildConfig>,
+    /// Ports to forward from container to host.
+    #[serde(default)]
+    pub forward_ports: Option<Vec<u16>>,
+    /// Post-create command.
+    #[serde(default)]
+    pub post_create_command: Option<StringOrArray>,
+    /// Reference to a docker-compose file.
+    #[serde(default)]
+    pub docker_compose_file: Option<StringOrArray>,
+    /// Service to use from docker-compose.
+    #[serde(default)]
+    pub service: Option<String>,
+    /// Working directory inside the container.
+    #[serde(default)]
+    pub workspace_folder: Option<String>,
+}
+
+/// Build configuration inside devcontainer.json.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildConfig {
+    /// Dockerfile path (relative to .devcontainer).
+    #[serde(default)]
+    pub dockerfile: Option<String>,
+    /// Build context path.
+    #[serde(default)]
+    pub context: Option<String>,
+}
+
+/// A string or array of strings (common in devcontainer.json).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum StringOrArray {
+    String(String),
+    Array(Vec<String>),
+}
+
+impl StringOrArray {
+    pub fn to_vec(&self) -> Vec<String> {
+        match self {
+            Self::String(s) => vec![s.clone()],
+            Self::Array(v) => v.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for StringOrArray {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String(s) => write!(f, "{s}"),
+            Self::Array(v) => write!(f, "{}", v.join(" ")),
+        }
+    }
+}
+
+impl DevContainerConfig {
+    /// Load and parse a devcontainer.json file.
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| GwtError::Docker(format!("failed to read devcontainer.json: {e}")))?;
+        let cleaned = strip_json_comments(&content);
+        let config: Self = serde_json::from_str(&cleaned)
+            .map_err(|e| GwtError::Docker(format!("failed to parse devcontainer.json: {e}")))?;
+        debug!(
+            category = "docker",
+            name = ?config.name,
+            "loaded devcontainer.json"
+        );
+        Ok(config)
+    }
+
+    /// Get forwarded ports, defaulting to empty.
+    pub fn get_forward_ports(&self) -> Vec<u16> {
+        self.forward_ports.clone().unwrap_or_default()
+    }
+
+    /// Whether this config references a docker-compose file.
+    pub fn uses_compose(&self) -> bool {
+        self.docker_compose_file.is_some()
+    }
+}
+
+/// Strip single-line (`//`) and multi-line (`/* */`) comments from JSONC.
+fn strip_json_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    let mut in_string = false;
+    let mut escape = false;
+
+    while let Some(c) = chars.next() {
+        if escape {
+            out.push(c);
+            escape = false;
+            continue;
+        }
+        if c == '\\' && in_string {
+            out.push(c);
+            escape = true;
+            continue;
+        }
+        if c == '"' {
+            in_string = !in_string;
+            out.push(c);
+            continue;
+        }
+        if in_string {
+            out.push(c);
+            continue;
+        }
+        if c == '/' {
+            match chars.peek() {
+                Some(&'/') => {
+                    chars.next();
+                    // Skip until newline.
+                    for ch in chars.by_ref() {
+                        if ch == '\n' {
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                Some(&'*') => {
+                    chars.next();
+                    // Skip until `*/`.
+                    while let Some(ch) = chars.next() {
+                        if ch == '*' && chars.peek() == Some(&'/') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        out.push(c);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn load_basic_devcontainer() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("devcontainer.json");
+        std::fs::write(
+            &path,
+            r#"{ "name": "Test", "image": "ubuntu:22.04" }"#,
+        )
+        .unwrap();
+        let cfg = DevContainerConfig::load(&path).unwrap();
+        assert_eq!(cfg.name.as_deref(), Some("Test"));
+        assert_eq!(cfg.image.as_deref(), Some("ubuntu:22.04"));
+    }
+
+    #[test]
+    fn load_with_forward_ports() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("devcontainer.json");
+        std::fs::write(
+            &path,
+            r#"{ "image": "node:18", "forwardPorts": [3000, 8080] }"#,
+        )
+        .unwrap();
+        let cfg = DevContainerConfig::load(&path).unwrap();
+        assert_eq!(cfg.get_forward_ports(), vec![3000, 8080]);
+    }
+
+    #[test]
+    fn load_with_build_config() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("devcontainer.json");
+        std::fs::write(
+            &path,
+            r#"{ "build": { "dockerfile": "Dockerfile", "context": ".." } }"#,
+        )
+        .unwrap();
+        let cfg = DevContainerConfig::load(&path).unwrap();
+        let build = cfg.build.unwrap();
+        assert_eq!(build.dockerfile.as_deref(), Some("Dockerfile"));
+        assert_eq!(build.context.as_deref(), Some(".."));
+    }
+
+    #[test]
+    fn load_with_compose_reference() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("devcontainer.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "dockerComposeFile": "docker-compose.yml",
+                "service": "app",
+                "workspaceFolder": "/workspace"
+            }"#,
+        )
+        .unwrap();
+        let cfg = DevContainerConfig::load(&path).unwrap();
+        assert!(cfg.uses_compose());
+        assert_eq!(cfg.service.as_deref(), Some("app"));
+    }
+
+    #[test]
+    fn load_with_post_create_command_string() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("devcontainer.json");
+        std::fs::write(
+            &path,
+            r#"{ "postCreateCommand": "npm install" }"#,
+        )
+        .unwrap();
+        let cfg = DevContainerConfig::load(&path).unwrap();
+        let cmd = cfg.post_create_command.unwrap();
+        assert_eq!(cmd.to_vec(), vec!["npm install"]);
+    }
+
+    #[test]
+    fn load_with_post_create_command_array() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("devcontainer.json");
+        std::fs::write(
+            &path,
+            r#"{ "postCreateCommand": ["npm", "install"] }"#,
+        )
+        .unwrap();
+        let cfg = DevContainerConfig::load(&path).unwrap();
+        let cmd = cfg.post_create_command.unwrap();
+        assert_eq!(cmd.to_vec(), vec!["npm", "install"]);
+    }
+
+    #[test]
+    fn strip_single_line_comments() {
+        let input = "{\n// comment\n\"key\": \"value\"\n}";
+        let out = strip_json_comments(input);
+        assert!(!out.contains("comment"));
+        assert!(out.contains("\"key\""));
+    }
+
+    #[test]
+    fn strip_multi_line_comments() {
+        let input = "{\n/* multi\nline */\n\"key\": \"value\"\n}";
+        let out = strip_json_comments(input);
+        assert!(!out.contains("multi"));
+        assert!(out.contains("\"key\""));
+    }
+
+    #[test]
+    fn preserve_urls_in_strings() {
+        let input = r#"{"url": "http://example.com/path"}"#;
+        let out = strip_json_comments(input);
+        assert!(out.contains("http://example.com/path"));
+    }
+
+    #[test]
+    fn string_or_array_display() {
+        let s = StringOrArray::String("hello".into());
+        assert_eq!(s.to_string(), "hello");
+        let a = StringOrArray::Array(vec!["a".into(), "b".into()]);
+        assert_eq!(a.to_string(), "a b");
+    }
+
+    #[test]
+    fn default_forward_ports_is_empty() {
+        let cfg = DevContainerConfig::default();
+        assert!(cfg.get_forward_ports().is_empty());
+    }
+}

--- a/crates/gwt-docker/src/lib.rs
+++ b/crates/gwt-docker/src/lib.rs
@@ -1,0 +1,18 @@
+//! gwt-docker: Docker detection, container management, and DevContainer support.
+//!
+//! Provides utilities for detecting Docker environments, managing containers,
+//! parsing DevContainer and Docker Compose configurations, and allocating ports.
+
+pub mod compose;
+pub mod container;
+pub mod detect;
+pub mod devcontainer;
+pub mod port;
+
+pub use compose::{parse_compose_file, ComposeService};
+pub use container::{list_containers, restart, start, stop, ContainerInfo, ContainerStatus};
+pub use detect::{
+    compose_available, daemon_running, detect_docker_files, docker_available, DockerFiles,
+};
+pub use devcontainer::DevContainerConfig;
+pub use port::{check_port_available, PortAllocator, PortMapping};

--- a/crates/gwt-docker/src/port.rs
+++ b/crates/gwt-docker/src/port.rs
@@ -1,0 +1,144 @@
+//! Port management utilities.
+//!
+//! Provides port availability checks and an allocator for finding free host
+//! ports when running Docker containers.
+
+use std::net::TcpListener;
+
+use tracing::debug;
+
+/// A mapping between a host port and a container port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortMapping {
+    /// Port on the host machine.
+    pub host_port: u16,
+    /// Port inside the container.
+    pub container_port: u16,
+    /// Protocol (e.g. "tcp", "udp").
+    pub protocol: String,
+}
+
+impl PortMapping {
+    pub fn tcp(host: u16, container: u16) -> Self {
+        Self {
+            host_port: host,
+            container_port: container,
+            protocol: "tcp".to_string(),
+        }
+    }
+}
+
+/// Check whether a port is available for binding on localhost.
+pub fn check_port_available(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+/// Allocator that finds available host ports in a configurable range.
+#[derive(Debug, Clone)]
+pub struct PortAllocator {
+    range_start: u16,
+    range_end: u16,
+}
+
+impl Default for PortAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const DEFAULT_RANGE_START: u16 = 10000;
+const DEFAULT_RANGE_END: u16 = 65535;
+const MAX_SEARCH_ATTEMPTS: u16 = 100;
+
+impl PortAllocator {
+    /// Create an allocator with the default range (10000-65535).
+    pub fn new() -> Self {
+        Self {
+            range_start: DEFAULT_RANGE_START,
+            range_end: DEFAULT_RANGE_END,
+        }
+    }
+
+    /// Create an allocator with a custom range.
+    pub fn with_range(start: u16, end: u16) -> Self {
+        Self {
+            range_start: start,
+            range_end: end,
+        }
+    }
+
+    /// Find an available port starting from `base_port`.
+    ///
+    /// Searches incrementally within the configured range, up to
+    /// `MAX_SEARCH_ATTEMPTS` tries.
+    pub fn find_available(&self, base_port: u16) -> Option<u16> {
+        let start = base_port.max(self.range_start);
+        for offset in 0..MAX_SEARCH_ATTEMPTS {
+            let port = start.saturating_add(offset);
+            if port > self.range_end {
+                break;
+            }
+            if check_port_available(port) {
+                debug!(category = "docker", port = port, "found available port");
+                return Some(port);
+            }
+        }
+        debug!(
+            category = "docker",
+            base_port = base_port,
+            "no available port found"
+        );
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn port_mapping_tcp() {
+        let pm = PortMapping::tcp(8080, 80);
+        assert_eq!(pm.host_port, 8080);
+        assert_eq!(pm.container_port, 80);
+        assert_eq!(pm.protocol, "tcp");
+    }
+
+    #[test]
+    fn check_port_available_ephemeral() {
+        // Port 0 asks the OS for any available port — should succeed.
+        assert!(check_port_available(0));
+    }
+
+    #[test]
+    fn check_port_in_use() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(!check_port_available(port));
+        drop(listener);
+    }
+
+    #[test]
+    fn find_available_in_default_range() {
+        let alloc = PortAllocator::new();
+        let port = alloc.find_available(10000);
+        assert!(port.is_some());
+        assert!(port.unwrap() >= 10000);
+    }
+
+    #[test]
+    fn find_available_in_custom_range() {
+        let alloc = PortAllocator::with_range(30000, 30100);
+        let port = alloc.find_available(30000);
+        assert!(port.is_some());
+        let p = port.unwrap();
+        assert!((30000..=30100).contains(&p));
+    }
+
+    #[test]
+    fn default_allocator() {
+        let alloc = PortAllocator::default();
+        assert_eq!(alloc.range_start, DEFAULT_RANGE_START);
+        assert_eq!(alloc.range_end, DEFAULT_RANGE_END);
+    }
+}


### PR DESCRIPTION
## Summary
- New `crates/gwt-docker/` crate with 5 modules: detect, container, devcontainer, port, compose
- Docker CLI detection (`docker_available`, `compose_available`, `daemon_running`) and file discovery (`DockerFiles`)
- Container lifecycle management (`list_containers`, `start`, `stop`, `restart`) with `ContainerInfo`/`ContainerStatus`
- DevContainer JSON parsing with JSONC comment stripping
- Docker Compose file parsing (`ComposeService` with `depends_on` support for both list and mapping forms)
- Port availability checking and `PortAllocator` for finding free host ports

## Test plan
- [x] `cargo test -p gwt-docker` — 40 tests pass
- [x] `cargo clippy -p gwt-docker --all-targets -- -D warnings` — clean
- [x] `commitlint` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)