### PR TITLE
feat: add gwt-voice, gwt-clipboard, gwt-skills utility crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gwt-clipboard"
+version = "8.17.2"
+dependencies = [
+ "gwt-core",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gwt-core"
 version = "8.17.2"
 dependencies = [
@@ -2416,6 +2425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gwt-skills"
+version = "8.17.2"
+dependencies = [
+ "gwt-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gwt-tauri"
 version = "8.17.2"
 dependencies = [
@@ -2448,6 +2468,15 @@ dependencies = [
  "uuid",
  "which",
  "whisper-rs",
+]
+
+[[package]]
+name = "gwt-voice"
+version = "8.17.2"
+dependencies = [
+ "gwt-core",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ resolver = "2"
 members = [
     "crates/gwt-core",
     "crates/gwt-tauri",
+    "crates/gwt-voice",
+    "crates/gwt-clipboard",
+    "crates/gwt-skills",
 ]
 default-members = [
     "crates/gwt-tauri",

--- a/crates/gwt-clipboard/Cargo.toml
+++ b/crates/gwt-clipboard/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gwt-clipboard"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Clipboard abstraction for file paste and text operations"
+publish = false
+
+[dependencies]
+gwt-core.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/gwt-clipboard/src/file_paste.rs
+++ b/crates/gwt-clipboard/src/file_paste.rs
@@ -1,0 +1,113 @@
+//! Extract file paths from the system clipboard.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Clipboard-based file path extraction.
+pub struct ClipboardFilePaste;
+
+impl ClipboardFilePaste {
+    /// Extract file paths from the system clipboard.
+    ///
+    /// Returns absolute paths parsed from the clipboard content (newline-separated).
+    /// Uses platform-specific tools: `pbpaste` on macOS, `xclip`/`wl-paste` on Linux.
+    pub fn extract_file_paths() -> Result<Vec<PathBuf>, ClipboardError> {
+        let text = read_clipboard()?;
+        let paths: Vec<PathBuf> = text
+            .lines()
+            .map(|line| line.trim())
+            .filter(|line| !line.is_empty())
+            .map(PathBuf::from)
+            .filter(|p| p.is_absolute())
+            .collect();
+        Ok(paths)
+    }
+}
+
+// ── Shared clipboard helpers (crate-internal) ──
+
+/// Read text from the system clipboard using platform-specific tools.
+pub(crate) fn read_clipboard() -> Result<String, ClipboardError> {
+    if cfg!(target_os = "macos") {
+        run_command("pbpaste", &[])
+    } else if cfg!(target_os = "linux") {
+        // Try wl-paste first (Wayland), fall back to xclip (X11)
+        run_command("wl-paste", &[])
+            .or_else(|_| run_command("xclip", &["-selection", "clipboard", "-o"]))
+    } else {
+        Err(ClipboardError::UnsupportedPlatform)
+    }
+}
+
+/// Write text to the system clipboard using platform-specific tools.
+pub(crate) fn write_clipboard(text: &str) -> Result<(), ClipboardError> {
+    if cfg!(target_os = "macos") {
+        pipe_to_command("pbcopy", &[], text)
+    } else if cfg!(target_os = "linux") {
+        pipe_to_command("wl-copy", &[], text)
+            .or_else(|_| pipe_to_command("xclip", &["-selection", "clipboard"], text))
+    } else {
+        Err(ClipboardError::UnsupportedPlatform)
+    }
+}
+
+/// Run a command and capture its stdout as a String.
+pub(crate) fn run_command(cmd: &str, args: &[&str]) -> Result<String, ClipboardError> {
+    let output = Command::new(cmd)
+        .args(args)
+        .output()
+        .map_err(|e| ClipboardError::CommandFailed(format!("{cmd}: {e}")))?;
+
+    if !output.status.success() {
+        return Err(ClipboardError::CommandFailed(format!(
+            "{cmd} exited with {}",
+            output.status
+        )));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| ClipboardError::InvalidUtf8(e.to_string()))
+}
+
+/// Pipe text into a command's stdin.
+fn pipe_to_command(cmd: &str, args: &[&str], text: &str) -> Result<(), ClipboardError> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = Command::new(cmd)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|e| ClipboardError::CommandFailed(format!("{cmd}: {e}")))?;
+
+    if let Some(ref mut stdin) = child.stdin {
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| ClipboardError::CommandFailed(format!("{cmd} stdin: {e}")))?;
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| ClipboardError::CommandFailed(format!("{cmd} wait: {e}")))?;
+
+    if !status.success() {
+        return Err(ClipboardError::CommandFailed(format!(
+            "{cmd} exited with {status}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Errors produced by clipboard operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ClipboardError {
+    #[error("Clipboard command failed: {0}")]
+    CommandFailed(String),
+
+    #[error("Clipboard content is not valid UTF-8: {0}")]
+    InvalidUtf8(String),
+
+    #[error("Unsupported platform for clipboard access")]
+    UnsupportedPlatform,
+}

--- a/crates/gwt-clipboard/src/lib.rs
+++ b/crates/gwt-clipboard/src/lib.rs
@@ -1,0 +1,52 @@
+//! gwt-clipboard: Clipboard abstraction for file paste and text operations.
+
+pub mod file_paste;
+pub mod text;
+
+pub use file_paste::{ClipboardError, ClipboardFilePaste};
+pub use text::ClipboardText;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn extract_file_paths_filters_non_absolute() {
+        // ClipboardFilePaste::extract_file_paths relies on system clipboard,
+        // so we test the filtering logic via a unit helper.
+        let input = "/usr/bin/git\nrelative/path\n/tmp/file.txt\n\n";
+        let paths: Vec<PathBuf> = input
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .map(PathBuf::from)
+            .filter(|p| p.is_absolute())
+            .collect();
+
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], PathBuf::from("/usr/bin/git"));
+        assert_eq!(paths[1], PathBuf::from("/tmp/file.txt"));
+    }
+
+    #[test]
+    fn clipboard_error_display() {
+        let err = ClipboardError::UnsupportedPlatform;
+        assert_eq!(
+            err.to_string(),
+            "Unsupported platform for clipboard access"
+        );
+    }
+
+    #[test]
+    fn clipboard_error_command_failed_display() {
+        let err = ClipboardError::CommandFailed("pbpaste: not found".to_string());
+        assert!(err.to_string().contains("pbpaste"));
+    }
+
+    #[test]
+    fn clipboard_error_invalid_utf8_display() {
+        let err = ClipboardError::InvalidUtf8("bad bytes".to_string());
+        assert!(err.to_string().contains("UTF-8"));
+    }
+}

--- a/crates/gwt-clipboard/src/text.rs
+++ b/crates/gwt-clipboard/src/text.rs
@@ -1,0 +1,18 @@
+//! Plain-text clipboard read/write.
+
+use crate::file_paste::{read_clipboard, write_clipboard, ClipboardError};
+
+/// Plain-text clipboard operations.
+pub struct ClipboardText;
+
+impl ClipboardText {
+    /// Read plain text from the system clipboard.
+    pub fn get_text() -> Result<String, ClipboardError> {
+        read_clipboard()
+    }
+
+    /// Write plain text to the system clipboard.
+    pub fn set_text(text: &str) -> Result<(), ClipboardError> {
+        write_clipboard(text)
+    }
+}

--- a/crates/gwt-skills/Cargo.toml
+++ b/crates/gwt-skills/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "gwt-skills"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Skill registry and hooks management for gwt"
+publish = false
+
+[dependencies]
+gwt-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/gwt-skills/src/hooks.rs
+++ b/crates/gwt-skills/src/hooks.rs
@@ -1,0 +1,51 @@
+//! Hooks management — merge managed and user hooks while preserving ownership.
+
+use serde::{Deserialize, Serialize};
+
+/// Marker prefix that identifies gwt-managed hooks.
+const GWT_MANAGED_MARKER: &str = "# gwt-managed";
+
+/// A single hook definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Hook {
+    /// Event that triggers this hook (e.g. "pre-commit", "post-merge").
+    pub event: String,
+    /// Shell command to execute.
+    pub command: String,
+    /// Optional comment marker used to identify the hook's owner.
+    pub comment_marker: Option<String>,
+}
+
+/// Configuration holding both managed and user hooks.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HooksConfig {
+    /// Hooks managed by gwt (auto-generated, may be overwritten).
+    pub managed_hooks: Vec<Hook>,
+    /// Hooks added by the user (preserved across updates).
+    pub user_hooks: Vec<Hook>,
+}
+
+/// Check whether a hook is gwt-managed based on its comment marker.
+pub fn is_gwt_managed(hook: &Hook) -> bool {
+    hook.comment_marker
+        .as_deref()
+        .is_some_and(|m| m.starts_with(GWT_MANAGED_MARKER))
+}
+
+/// Merge managed and user hooks into a single list.
+///
+/// Managed hooks come first, followed by user hooks. User hooks for the
+/// same event are never overwritten.
+pub fn merge_hooks(managed: &[Hook], user: &[Hook]) -> Vec<Hook> {
+    let mut merged: Vec<Hook> = managed.to_vec();
+    for uh in user {
+        // Only add user hooks that don't duplicate a managed hook for the same event+command.
+        let dominated = merged
+            .iter()
+            .any(|mh| mh.event == uh.event && mh.command == uh.command);
+        if !dominated {
+            merged.push(uh.clone());
+        }
+    }
+    merged
+}

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -1,0 +1,174 @@
+//! gwt-skills: Skill registry and hooks management for gwt.
+
+pub mod hooks;
+pub mod registry;
+
+pub use hooks::{Hook, HooksConfig, is_gwt_managed, merge_hooks};
+pub use registry::{EmbeddedSkill, RegistryError, SkillRegistry};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ── SkillRegistry tests ──
+
+    #[test]
+    fn register_and_list_skills() {
+        let mut reg = SkillRegistry::new();
+        assert!(reg.list().is_empty());
+
+        reg.register(make_skill("alpha"));
+        reg.register(make_skill("beta"));
+        assert_eq!(reg.list().len(), 2);
+    }
+
+    #[test]
+    fn register_replaces_duplicate_name() {
+        let mut reg = SkillRegistry::new();
+        reg.register(make_skill("alpha"));
+        reg.register(EmbeddedSkill {
+            name: "alpha".to_string(),
+            description: "updated".to_string(),
+            script_path: PathBuf::from("new.sh"),
+            enabled: false,
+        });
+        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.list()[0].description, "updated");
+    }
+
+    #[test]
+    fn unregister_removes_skill() {
+        let mut reg = SkillRegistry::new();
+        reg.register(make_skill("alpha"));
+        assert!(reg.unregister("alpha"));
+        assert!(reg.list().is_empty());
+    }
+
+    #[test]
+    fn unregister_nonexistent_returns_false() {
+        let mut reg = SkillRegistry::new();
+        assert!(!reg.unregister("ghost"));
+    }
+
+    #[test]
+    fn load_from_dir_reads_skill_json_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("my-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("skill.json"),
+            serde_json::to_string(&make_skill("loaded")).unwrap(),
+        )
+        .unwrap();
+
+        let mut reg = SkillRegistry::new();
+        let count = reg.load_from_dir(dir.path()).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(reg.list()[0].name, "loaded");
+    }
+
+    #[test]
+    fn load_from_dir_skips_dirs_without_skill_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("empty-skill");
+        std::fs::create_dir(&sub).unwrap();
+
+        let mut reg = SkillRegistry::new();
+        let count = reg.load_from_dir(dir.path()).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn load_from_dir_error_on_missing_dir() {
+        let mut reg = SkillRegistry::new();
+        let result = reg.load_from_dir(&PathBuf::from("/nonexistent/path"));
+        assert!(result.is_err());
+    }
+
+    // ── Hooks tests ──
+
+    #[test]
+    fn is_gwt_managed_with_marker() {
+        let hook = Hook {
+            event: "pre-commit".into(),
+            command: "echo hi".into(),
+            comment_marker: Some("# gwt-managed: lint".into()),
+        };
+        assert!(is_gwt_managed(&hook));
+    }
+
+    #[test]
+    fn is_gwt_managed_without_marker() {
+        let hook = Hook {
+            event: "pre-commit".into(),
+            command: "echo hi".into(),
+            comment_marker: None,
+        };
+        assert!(!is_gwt_managed(&hook));
+    }
+
+    #[test]
+    fn is_gwt_managed_with_user_marker() {
+        let hook = Hook {
+            event: "pre-commit".into(),
+            command: "echo hi".into(),
+            comment_marker: Some("# user-custom".into()),
+        };
+        assert!(!is_gwt_managed(&hook));
+    }
+
+    #[test]
+    fn merge_hooks_combines_both() {
+        let managed = vec![make_hook("pre-commit", "lint", true)];
+        let user = vec![make_hook("post-merge", "notify", false)];
+        let merged = merge_hooks(&managed, &user);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn merge_hooks_deduplicates_same_event_and_command() {
+        let managed = vec![make_hook("pre-commit", "lint", true)];
+        let user = vec![make_hook("pre-commit", "lint", false)];
+        let merged = merge_hooks(&managed, &user);
+        assert_eq!(merged.len(), 1);
+    }
+
+    #[test]
+    fn merge_hooks_keeps_different_commands_same_event() {
+        let managed = vec![make_hook("pre-commit", "lint", true)];
+        let user = vec![make_hook("pre-commit", "test", false)];
+        let merged = merge_hooks(&managed, &user);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn hooks_config_default_is_empty() {
+        let cfg = HooksConfig::default();
+        assert!(cfg.managed_hooks.is_empty());
+        assert!(cfg.user_hooks.is_empty());
+    }
+
+    // ── helpers ──
+
+    fn make_skill(name: &str) -> EmbeddedSkill {
+        EmbeddedSkill {
+            name: name.to_string(),
+            description: format!("{name} skill"),
+            script_path: PathBuf::from(format!("{name}.sh")),
+            enabled: true,
+        }
+    }
+
+    fn make_hook(event: &str, command: &str, managed: bool) -> Hook {
+        Hook {
+            event: event.to_string(),
+            command: command.to_string(),
+            comment_marker: if managed {
+                Some(format!("# gwt-managed: {command}"))
+            } else {
+                None
+            },
+        }
+    }
+}

--- a/crates/gwt-skills/src/registry.rs
+++ b/crates/gwt-skills/src/registry.rs
@@ -1,0 +1,80 @@
+//! Skill registry for embedded skill management.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// A single embedded skill definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EmbeddedSkill {
+    /// Human-readable skill name.
+    pub name: String,
+    /// Short description of what this skill does.
+    pub description: String,
+    /// Path to the skill script (relative to the skill directory).
+    pub script_path: PathBuf,
+    /// Whether this skill is currently enabled.
+    pub enabled: bool,
+}
+
+/// Registry that holds and manages embedded skills.
+#[derive(Debug, Default)]
+pub struct SkillRegistry {
+    skills: Vec<EmbeddedSkill>,
+}
+
+impl SkillRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a skill. Replaces any existing skill with the same name.
+    pub fn register(&mut self, skill: EmbeddedSkill) {
+        self.unregister(&skill.name);
+        self.skills.push(skill);
+    }
+
+    /// Remove a skill by name. Returns `true` if a skill was removed.
+    pub fn unregister(&mut self, name: &str) -> bool {
+        let before = self.skills.len();
+        self.skills.retain(|s| s.name != name);
+        self.skills.len() < before
+    }
+
+    /// List all registered skills.
+    pub fn list(&self) -> &[EmbeddedSkill] {
+        &self.skills
+    }
+
+    /// Scan a directory for skill definitions (JSON files named `skill.json`).
+    pub fn load_from_dir(&mut self, dir: &Path) -> Result<usize, RegistryError> {
+        let entries = std::fs::read_dir(dir)
+            .map_err(|e| RegistryError::Io(format!("{}: {e}", dir.display())))?;
+
+        let mut count = 0;
+        for entry in entries {
+            let entry =
+                entry.map_err(|e| RegistryError::Io(format!("{}: {e}", dir.display())))?;
+            let skill_file = entry.path().join("skill.json");
+            if skill_file.is_file() {
+                let content = std::fs::read_to_string(&skill_file)
+                    .map_err(|e| RegistryError::Io(format!("{}: {e}", skill_file.display())))?;
+                let skill: EmbeddedSkill = serde_json::from_str(&content)
+                    .map_err(|e| RegistryError::Parse(format!("{}: {e}", skill_file.display())))?;
+                self.register(skill);
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+}
+
+/// Errors from skill registry operations.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    #[error("IO error: {0}")]
+    Io(String),
+
+    #[error("Parse error: {0}")]
+    Parse(String),
+}

--- a/crates/gwt-voice/Cargo.toml
+++ b/crates/gwt-voice/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gwt-voice"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Voice input backend abstraction for gwt"
+publish = false
+
+[dependencies]
+gwt-core.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/gwt-voice/src/backend.rs
+++ b/crates/gwt-voice/src/backend.rs
@@ -1,0 +1,35 @@
+//! Voice backend trait definition.
+
+/// Trait for voice input backends (recording + transcription).
+pub trait VoiceBackend {
+    /// Start recording audio from the microphone.
+    fn start_recording(&mut self) -> Result<(), VoiceError>;
+
+    /// Stop recording and return the captured audio data.
+    fn stop_recording(&mut self) -> Result<Vec<u8>, VoiceError>;
+
+    /// Transcribe raw audio data into text.
+    fn transcribe(&self, audio: &[u8]) -> Result<String, VoiceError>;
+
+    /// Check whether this backend is available on the current system.
+    fn is_available(&self) -> bool;
+}
+
+/// Errors produced by voice operations.
+#[derive(Debug, thiserror::Error)]
+pub enum VoiceError {
+    #[error("Voice backend not available")]
+    NotAvailable,
+
+    #[error("Not currently recording")]
+    NotRecording,
+
+    #[error("Already recording")]
+    AlreadyRecording,
+
+    #[error("Transcription failed: {0}")]
+    TranscriptionFailed(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/gwt-voice/src/config.rs
+++ b/crates/gwt-voice/src/config.rs
@@ -1,0 +1,26 @@
+//! Voice state management.
+
+/// Current state of the voice subsystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VoiceState {
+    /// No voice activity.
+    Idle,
+    /// Microphone is actively recording.
+    Recording,
+    /// Audio is being transcribed to text.
+    Transcribing,
+    /// An error occurred.
+    Error(String),
+}
+
+impl VoiceState {
+    /// Returns `true` when the voice subsystem is idle.
+    pub fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+
+    /// Returns `true` when recording is in progress.
+    pub fn is_recording(&self) -> bool {
+        matches!(self, Self::Recording)
+    }
+}

--- a/crates/gwt-voice/src/lib.rs
+++ b/crates/gwt-voice/src/lib.rs
@@ -1,0 +1,73 @@
+//! gwt-voice: Voice input backend abstraction for gwt.
+
+pub mod backend;
+pub mod config;
+pub mod noop;
+
+pub use backend::{VoiceBackend, VoiceError};
+pub use config::VoiceState;
+pub use noop::NoOpVoiceBackend;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_backend_is_not_available() {
+        let backend = NoOpVoiceBackend::new();
+        assert!(!backend.is_available());
+    }
+
+    #[test]
+    fn noop_start_recording_returns_error() {
+        let mut backend = NoOpVoiceBackend::new();
+        let result = backend.start_recording();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VoiceError::NotAvailable
+        ));
+    }
+
+    #[test]
+    fn noop_stop_recording_returns_error() {
+        let mut backend = NoOpVoiceBackend::new();
+        let result = backend.stop_recording();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn noop_transcribe_returns_error() {
+        let backend = NoOpVoiceBackend::new();
+        let result = backend.transcribe(&[0u8; 10]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn voice_state_idle_by_default() {
+        let state = VoiceState::Idle;
+        assert!(state.is_idle());
+        assert!(!state.is_recording());
+    }
+
+    #[test]
+    fn voice_state_recording() {
+        let state = VoiceState::Recording;
+        assert!(state.is_recording());
+        assert!(!state.is_idle());
+    }
+
+    #[test]
+    fn voice_state_error_holds_message() {
+        let state = VoiceState::Error("mic failed".to_string());
+        assert!(!state.is_idle());
+        assert!(!state.is_recording());
+        assert_eq!(state, VoiceState::Error("mic failed".to_string()));
+    }
+
+    #[test]
+    fn noop_default_trait() {
+        let backend: NoOpVoiceBackend = Default::default();
+        assert!(!backend.is_available());
+    }
+}

--- a/crates/gwt-voice/src/noop.rs
+++ b/crates/gwt-voice/src/noop.rs
@@ -1,0 +1,36 @@
+//! No-op voice backend for environments without audio support.
+
+use crate::backend::{VoiceBackend, VoiceError};
+
+/// A voice backend that does nothing — all operations return errors or empty values.
+pub struct NoOpVoiceBackend;
+
+impl NoOpVoiceBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NoOpVoiceBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VoiceBackend for NoOpVoiceBackend {
+    fn start_recording(&mut self) -> Result<(), VoiceError> {
+        Err(VoiceError::NotAvailable)
+    }
+
+    fn stop_recording(&mut self) -> Result<Vec<u8>, VoiceError> {
+        Err(VoiceError::NotAvailable)
+    }
+
+    fn transcribe(&self, _audio: &[u8]) -> Result<String, VoiceError> {
+        Err(VoiceError::NotAvailable)
+    }
+
+    fn is_available(&self) -> bool {
+        false
+    }
+}


### PR DESCRIPTION
## Summary

- Add **gwt-voice** crate: `VoiceBackend` trait, `NoOpVoiceBackend` implementation, `VoiceState` enum (Idle/Recording/Transcribing/Error)
- Add **gwt-clipboard** crate: `ClipboardFilePaste` for extracting file paths from system clipboard, `ClipboardText` for read/write with platform backends (macOS pbpaste/pbcopy, Linux wl-paste/xclip)
- Add **gwt-skills** crate: `SkillRegistry` with register/unregister/load_from_dir, `HooksConfig` with managed/user hook merging

All 3 crates are added to workspace members and independently compilable/testable (26 unit tests total).

## Test plan

- [x] `cargo test -p gwt-voice -p gwt-clipboard -p gwt-skills` — 26 tests pass
- [x] `cargo clippy -p gwt-voice -p gwt-clipboard -p gwt-skills --all-targets -- -D warnings` — clean
- [x] Code review (simplify pass): deduplicated clipboard command helpers, changed `SkillRegistry::list()` to return `&[EmbeddedSkill]` slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)