### PR TITLE
feat(tui): add gwt-tui crate with Elm Architecture foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,10 +362,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -540,6 +561,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +724,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +822,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +860,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +890,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.116",
 ]
@@ -884,7 +978,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1040,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1849,7 +1943,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix",
+ "rustix 1.1.3",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -1989,7 +2083,7 @@ dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
- "rustix",
+ "rustix 1.1.3",
  "thiserror 2.0.18",
 ]
 
@@ -2451,6 +2545,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gwt-tui"
+version = "8.17.2"
+dependencies = [
+ "crossterm",
+ "gwt-core",
+ "ratatui",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "vt100",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2590,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2836,6 +2946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +2990,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2968,7 +3100,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3194,6 +3326,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -3218,6 +3356,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3504,7 +3651,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3764,7 +3911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3824,6 +3971,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -4424,6 +4577,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4656,6 +4830,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -4663,8 +4850,8 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5139,6 +5326,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5278,6 +5476,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "subtle"
@@ -5751,8 +5971,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6339,6 +6559,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6394,6 +6637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6441,6 +6690,39 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vt100"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+dependencies = [
+ "itoa",
+ "log",
+ "unicode-width 0.1.14",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -6760,7 +7042,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7454,7 +7736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/gwt-core",
     "crates/gwt-tauri",
+    "crates/gwt-tui",
 ]
 default-members = [
     "crates/gwt-tauri",

--- a/crates/gwt-tui/Cargo.toml
+++ b/crates/gwt-tui/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "gwt-tui"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Terminal UI for Git Worktree Manager"
+publish = false
+
+[[bin]]
+name = "gwt-tui"
+path = "src/main.rs"
+
+[dependencies]
+gwt-core = { workspace = true }
+ratatui = "0.29"
+crossterm = "0.28"
+tokio = { workspace = true }
+vt100 = "0.15"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -1,0 +1,446 @@
+//! App — Update and View functions for the Elm Architecture.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::Line,
+    widgets::{Block, Borders, Paragraph, Tabs},
+    Frame,
+};
+
+use crate::{
+    message::Message,
+    model::{ActiveLayer, ManagementTab, Model, SessionLayout, SessionTabType},
+    screens,
+};
+
+/// Process a message and update the model (Elm: update).
+pub fn update(model: &mut Model, msg: Message) {
+    match msg {
+        Message::Quit => {
+            model.quit = true;
+        }
+        Message::ToggleLayer => {
+            model.active_layer = match model.active_layer {
+                ActiveLayer::Main => {
+                    model.management_visible = true;
+                    ActiveLayer::Management
+                }
+                ActiveLayer::Management => {
+                    model.management_visible = false;
+                    ActiveLayer::Main
+                }
+            };
+        }
+        Message::SwitchManagementTab(tab) => {
+            model.management_tab = tab;
+            model.active_layer = ActiveLayer::Management;
+            model.management_visible = true;
+        }
+        Message::NextSession => {
+            if !model.sessions.is_empty() {
+                model.active_session = (model.active_session + 1) % model.sessions.len();
+            }
+        }
+        Message::PrevSession => {
+            if !model.sessions.is_empty() {
+                model.active_session = if model.active_session == 0 {
+                    model.sessions.len() - 1
+                } else {
+                    model.active_session - 1
+                };
+            }
+        }
+        Message::SwitchSession(idx) => {
+            if idx < model.sessions.len() {
+                model.active_session = idx;
+            }
+        }
+        Message::ToggleSessionLayout => {
+            model.session_layout = match model.session_layout {
+                SessionLayout::Tab => SessionLayout::Grid,
+                SessionLayout::Grid => SessionLayout::Tab,
+            };
+        }
+        Message::NewShell => {
+            let idx = model.sessions.len();
+            let session = crate::model::SessionTab {
+                id: format!("shell-{idx}"),
+                name: format!("Shell {}", idx + 1),
+                tab_type: SessionTabType::Shell,
+                vt: crate::model::VtState::new(24, 80),
+            };
+            model.sessions.push(session);
+            model.active_session = idx;
+        }
+        Message::CloseSession => {
+            if model.sessions.len() > 1 {
+                model.sessions.remove(model.active_session);
+                if model.active_session >= model.sessions.len() {
+                    model.active_session = model.sessions.len() - 1;
+                }
+            }
+        }
+        Message::Resize(w, h) => {
+            model.terminal_size = (w, h);
+        }
+        Message::PtyOutput(_pane_id, _data) => {
+            // Phase 2: feed data into vt100 parser for the matching pane
+        }
+        Message::PushError(err) => {
+            model.error_queue.push(err);
+        }
+        Message::DismissError => {
+            if !model.error_queue.is_empty() {
+                model.error_queue.remove(0);
+            }
+        }
+        Message::KeyInput(_) | Message::MouseInput(_) | Message::Tick => {
+            // Phase 2: forward to active pane / tick logic
+        }
+    }
+}
+
+/// Render the full UI (Elm: view).
+pub fn view(model: &Model, frame: &mut Frame) {
+    let size = frame.area();
+
+    if model.management_visible {
+        // Split: left = management panel, right = sessions
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+            .split(size);
+
+        render_management_panel(model, frame, chunks[0]);
+        render_sessions_area(model, frame, chunks[1]);
+    } else {
+        render_sessions_area(model, frame, size);
+    }
+
+    // Error overlay on top
+    if let Some(err) = model.error_queue.first() {
+        render_error_overlay(err, frame, size);
+    }
+}
+
+/// Render the management panel (left side).
+fn render_management_panel(model: &Model, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(area);
+
+    // Tab bar
+    let titles: Vec<Line> = ManagementTab::ALL
+        .iter()
+        .map(|t| Line::from(t.label()))
+        .collect();
+
+    let active_idx = ManagementTab::ALL
+        .iter()
+        .position(|t| *t == model.management_tab)
+        .unwrap_or(0);
+
+    let tabs = Tabs::new(titles)
+        .block(Block::default().borders(Borders::ALL).title("Management"))
+        .select(active_idx)
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_widget(tabs, chunks[0]);
+
+    // Tab content
+    render_management_tab_content(model, frame, chunks[1]);
+}
+
+/// Render the content of the active management tab.
+fn render_management_tab_content(model: &Model, frame: &mut Frame, area: Rect) {
+    match model.management_tab {
+        ManagementTab::Branches => screens::branches::render(frame, area),
+        ManagementTab::Specs => screens::specs::render(frame, area),
+        ManagementTab::Issues => screens::issues::render(frame, area),
+        ManagementTab::Profiles => screens::profiles::render(frame, area),
+        ManagementTab::GitView => screens::git_view::render(frame, area),
+        ManagementTab::Versions => screens::versions::render(frame, area),
+        ManagementTab::Settings => screens::settings::render(frame, area),
+        ManagementTab::Logs => screens::logs::render(frame, area),
+    }
+}
+
+/// Render the sessions area (right side, or full screen).
+fn render_sessions_area(model: &Model, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // Tab bar
+            Constraint::Min(0),    // Terminal content
+            Constraint::Length(1), // Status bar
+        ])
+        .split(area);
+
+    // Session tab bar — delegate to widget
+    crate::widgets::tab_bar::render(model, frame, chunks[0]);
+
+    // Session content
+    render_session_content(model, frame, chunks[1]);
+
+    // Status bar — delegate to widget
+    crate::widgets::status_bar::render(model, frame, chunks[2]);
+}
+
+/// Render session content (Tab mode = single, Grid mode = tiled).
+fn render_session_content(model: &Model, frame: &mut Frame, area: Rect) {
+    match model.session_layout {
+        SessionLayout::Tab => {
+            if let Some(session) = model.active_session_tab() {
+                render_single_session(session, frame, area);
+            }
+        }
+        SessionLayout::Grid => {
+            render_grid_sessions(model, frame, area);
+        }
+    }
+}
+
+/// Render a single session pane.
+fn render_single_session(session: &crate::model::SessionTab, frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(session.name.as_str());
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Phase 2: render vt100 screen buffer here
+    let placeholder = Paragraph::new(format!(
+        "Session: {} ({}x{})",
+        session.name,
+        session.vt.cols(),
+        session.vt.rows()
+    ))
+    .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(placeholder, inner);
+}
+
+/// Render sessions in a grid layout.
+fn render_grid_sessions(model: &Model, frame: &mut Frame, area: Rect) {
+    let count = model.sessions.len();
+    if count == 0 {
+        return;
+    }
+
+    let cols = (count as f64).sqrt().ceil() as usize;
+    let rows = count.div_ceil(cols);
+
+    let row_constraints: Vec<Constraint> = (0..rows)
+        .map(|_| Constraint::Ratio(1, rows as u32))
+        .collect();
+
+    let row_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(row_constraints)
+        .split(area);
+
+    for (row_idx, row_area) in row_chunks.iter().enumerate() {
+        let start = row_idx * cols;
+        let end = (start + cols).min(count);
+        let n = end - start;
+
+        let col_constraints: Vec<Constraint> =
+            (0..n).map(|_| Constraint::Ratio(1, n as u32)).collect();
+
+        let col_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(col_constraints)
+            .split(*row_area);
+
+        for (col_idx, col_area) in col_chunks.iter().enumerate() {
+            let session_idx = start + col_idx;
+            if let Some(session) = model.sessions.get(session_idx) {
+                let is_active = session_idx == model.active_session;
+                let border_style = if is_active {
+                    Style::default().fg(Color::Yellow)
+                } else {
+                    Style::default().fg(Color::DarkGray)
+                };
+                let block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(border_style)
+                    .title(session.name.as_str());
+                frame.render_widget(block, *col_area);
+            }
+        }
+    }
+}
+
+/// Render an error overlay.
+fn render_error_overlay(err: &str, frame: &mut Frame, area: Rect) {
+    let width = (area.width / 2).max(40).min(area.width);
+    let height = 5_u16.min(area.height);
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let overlay_area = Rect::new(x, y, width, height);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Red))
+        .title("Error");
+
+    let text = Paragraph::new(err.to_string())
+        .block(block)
+        .style(Style::default().fg(Color::Red));
+
+    frame.render_widget(text, overlay_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_model() -> Model {
+        Model::new(PathBuf::from("/tmp/test"))
+    }
+
+    #[test]
+    fn update_quit_sets_flag() {
+        let mut model = test_model();
+        update(&mut model, Message::Quit);
+        assert!(model.quit);
+    }
+
+    #[test]
+    fn update_toggle_layer() {
+        let mut model = test_model();
+        assert_eq!(model.active_layer, ActiveLayer::Main);
+        assert!(!model.management_visible);
+
+        update(&mut model, Message::ToggleLayer);
+        assert_eq!(model.active_layer, ActiveLayer::Management);
+        assert!(model.management_visible);
+
+        update(&mut model, Message::ToggleLayer);
+        assert_eq!(model.active_layer, ActiveLayer::Main);
+        assert!(!model.management_visible);
+    }
+
+    #[test]
+    fn update_switch_management_tab() {
+        let mut model = test_model();
+        update(
+            &mut model,
+            Message::SwitchManagementTab(ManagementTab::Settings),
+        );
+        assert_eq!(model.management_tab, ManagementTab::Settings);
+        assert_eq!(model.active_layer, ActiveLayer::Management);
+        assert!(model.management_visible);
+    }
+
+    #[test]
+    fn update_next_prev_session() {
+        let mut model = test_model();
+        // Add a second session
+        update(&mut model, Message::NewShell);
+        assert_eq!(model.active_session, 1);
+
+        update(&mut model, Message::PrevSession);
+        assert_eq!(model.active_session, 0);
+
+        update(&mut model, Message::PrevSession);
+        // Wraps to last
+        assert_eq!(model.active_session, 1);
+
+        update(&mut model, Message::NextSession);
+        assert_eq!(model.active_session, 0);
+    }
+
+    #[test]
+    fn update_switch_session_by_index() {
+        let mut model = test_model();
+        update(&mut model, Message::NewShell);
+        update(&mut model, Message::NewShell);
+
+        update(&mut model, Message::SwitchSession(0));
+        assert_eq!(model.active_session, 0);
+
+        update(&mut model, Message::SwitchSession(2));
+        assert_eq!(model.active_session, 2);
+
+        // Out of range — no change
+        update(&mut model, Message::SwitchSession(99));
+        assert_eq!(model.active_session, 2);
+    }
+
+    #[test]
+    fn update_toggle_session_layout() {
+        let mut model = test_model();
+        assert_eq!(model.session_layout, SessionLayout::Tab);
+
+        update(&mut model, Message::ToggleSessionLayout);
+        assert_eq!(model.session_layout, SessionLayout::Grid);
+
+        update(&mut model, Message::ToggleSessionLayout);
+        assert_eq!(model.session_layout, SessionLayout::Tab);
+    }
+
+    #[test]
+    fn update_new_shell_adds_session() {
+        let mut model = test_model();
+        assert_eq!(model.session_count(), 1);
+
+        update(&mut model, Message::NewShell);
+        assert_eq!(model.session_count(), 2);
+        assert_eq!(model.active_session, 1);
+        assert_eq!(model.sessions[1].name, "Shell 2");
+    }
+
+    #[test]
+    fn update_close_session_removes_active() {
+        let mut model = test_model();
+        update(&mut model, Message::NewShell);
+        update(&mut model, Message::NewShell);
+        assert_eq!(model.session_count(), 3);
+        assert_eq!(model.active_session, 2);
+
+        update(&mut model, Message::CloseSession);
+        assert_eq!(model.session_count(), 2);
+        assert_eq!(model.active_session, 1);
+    }
+
+    #[test]
+    fn update_close_session_wont_remove_last() {
+        let mut model = test_model();
+        assert_eq!(model.session_count(), 1);
+
+        update(&mut model, Message::CloseSession);
+        assert_eq!(model.session_count(), 1);
+    }
+
+    #[test]
+    fn update_resize() {
+        let mut model = test_model();
+        update(&mut model, Message::Resize(120, 40));
+        assert_eq!(model.terminal_size, (120, 40));
+    }
+
+    #[test]
+    fn update_error_queue() {
+        let mut model = test_model();
+        update(&mut model, Message::PushError("e1".into()));
+        update(&mut model, Message::PushError("e2".into()));
+        assert_eq!(model.error_queue.len(), 2);
+
+        update(&mut model, Message::DismissError);
+        assert_eq!(model.error_queue.len(), 1);
+        assert_eq!(model.error_queue[0], "e2");
+    }
+
+    #[test]
+    fn update_dismiss_empty_error_queue_is_noop() {
+        let mut model = test_model();
+        update(&mut model, Message::DismissError);
+        assert!(model.error_queue.is_empty());
+    }
+}

--- a/crates/gwt-tui/src/event.rs
+++ b/crates/gwt-tui/src/event.rs
@@ -1,0 +1,61 @@
+//! Event loop — polls crossterm events, PTY output, and tick timer.
+
+use std::time::{Duration, Instant};
+
+use crossterm::event::{self, Event, KeyEvent};
+
+use crate::message::Message;
+
+/// Tick interval for the event loop.
+const TICK_RATE: Duration = Duration::from_millis(100);
+
+/// Poll for the next message. Returns `None` on timeout with no events.
+pub fn poll_event(deadline: Instant) -> Option<Message> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return Some(Message::Tick);
+    }
+
+    if event::poll(remaining).unwrap_or(false) {
+        match event::read() {
+            Ok(Event::Key(key)) => Some(Message::KeyInput(key)),
+            Ok(Event::Mouse(mouse)) => Some(Message::MouseInput(mouse)),
+            Ok(Event::Resize(w, h)) => Some(Message::Resize(w, h)),
+            _ => None,
+        }
+    } else {
+        Some(Message::Tick)
+    }
+}
+
+/// Calculate the next tick deadline.
+pub fn next_tick_deadline() -> Instant {
+    Instant::now() + TICK_RATE
+}
+
+/// Convert a raw key event into a high-level Message via the keybind system,
+/// or return it as-is for PTY forwarding.
+pub fn classify_key(key: KeyEvent) -> Message {
+    // Phase 2: integrate with keybind registry for Ctrl+G prefix
+    Message::KeyInput(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_tick_deadline_is_in_the_future() {
+        let now = Instant::now();
+        let deadline = next_tick_deadline();
+        assert!(deadline > now);
+        assert!(deadline - now <= TICK_RATE + Duration::from_millis(5));
+    }
+
+    #[test]
+    fn poll_event_returns_tick_on_expired_deadline() {
+        let past = Instant::now() - Duration::from_secs(1);
+        let msg = poll_event(past);
+        assert!(matches!(msg, Some(Message::Tick)));
+    }
+}

--- a/crates/gwt-tui/src/input/keybind.rs
+++ b/crates/gwt-tui/src/input/keybind.rs
@@ -1,0 +1,270 @@
+//! Keybind registry — Ctrl+G prefix system with auto-collected help.
+
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::message::Message;
+use crate::model::ManagementTab;
+
+/// Timeout for the Ctrl+G prefix sequence.
+const PREFIX_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// State machine for the Ctrl+G prefix system.
+#[derive(Debug, Clone, Default)]
+pub enum PrefixState {
+    /// Waiting for Ctrl+G.
+    #[default]
+    Idle,
+    /// Ctrl+G pressed, waiting for the second key.
+    Active { since: Instant },
+}
+
+impl PrefixState {
+    /// Check if the prefix has timed out.
+    pub fn is_expired(&self) -> bool {
+        match self {
+            Self::Idle => false,
+            Self::Active { since } => since.elapsed() > PREFIX_TIMEOUT,
+        }
+    }
+}
+
+/// A registered keybinding.
+#[derive(Debug, Clone)]
+pub struct Keybinding {
+    /// Display string for the key combo (e.g. "Ctrl+G, g").
+    pub keys: String,
+    /// Description of what this binding does.
+    pub description: String,
+}
+
+/// Registry of all keybindings, also drives the prefix state machine.
+#[derive(Debug)]
+pub struct KeybindRegistry {
+    pub prefix_state: PrefixState,
+    bindings: Vec<Keybinding>,
+}
+
+impl Default for KeybindRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KeybindRegistry {
+    pub fn new() -> Self {
+        let bindings = vec![
+            Keybinding {
+                keys: "Ctrl+G, g".into(),
+                description: "Toggle management panel".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, ]".into(),
+                description: "Next session".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, [".into(),
+                description: "Previous session".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, 1-9".into(),
+                description: "Switch to session N".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, z".into(),
+                description: "Toggle Tab/Grid layout".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, c".into(),
+                description: "New shell session".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, x".into(),
+                description: "Close active session".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, q".into(),
+                description: "Quit".into(),
+            },
+            Keybinding {
+                keys: "Ctrl+G, ?".into(),
+                description: "Show help".into(),
+            },
+        ];
+
+        Self {
+            prefix_state: PrefixState::Idle,
+            bindings,
+        }
+    }
+
+    /// Get all bindings for help display.
+    pub fn all_bindings(&self) -> &[Keybinding] {
+        &self.bindings
+    }
+
+    /// Process a key event through the prefix state machine.
+    /// Returns `Some(Message)` if the key was consumed, `None` if it should be forwarded.
+    pub fn process_key(&mut self, key: KeyEvent) -> Option<Message> {
+        // Check for timeout
+        if self.prefix_state.is_expired() {
+            self.prefix_state = PrefixState::Idle;
+        }
+
+        match &self.prefix_state {
+            PrefixState::Idle => {
+                // Check for Ctrl+G
+                if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('g') {
+                    self.prefix_state = PrefixState::Active {
+                        since: Instant::now(),
+                    };
+                    return Some(Message::Tick); // Consumed, no action yet
+                }
+                None // Not a prefix key, forward to PTY
+            }
+            PrefixState::Active { .. } => {
+                self.prefix_state = PrefixState::Idle;
+                match key.code {
+                    KeyCode::Char('g') => Some(Message::ToggleLayer),
+                    KeyCode::Char(']') => Some(Message::NextSession),
+                    KeyCode::Char('[') => Some(Message::PrevSession),
+                    KeyCode::Char('z') => Some(Message::ToggleSessionLayout),
+                    KeyCode::Char('c') => Some(Message::NewShell),
+                    KeyCode::Char('x') => Some(Message::CloseSession),
+                    KeyCode::Char('q') => Some(Message::Quit),
+                    KeyCode::Char(n) if n.is_ascii_digit() && n != '0' => {
+                        let idx = (n as usize) - ('1' as usize);
+                        Some(Message::SwitchSession(idx))
+                    }
+                    KeyCode::Char('b') => {
+                        Some(Message::SwitchManagementTab(ManagementTab::Branches))
+                    }
+                    KeyCode::Char('s') => Some(Message::SwitchManagementTab(ManagementTab::Specs)),
+                    KeyCode::Char('i') => Some(Message::SwitchManagementTab(ManagementTab::Issues)),
+                    KeyCode::Esc => Some(Message::Tick), // Cancel prefix
+                    _ => None,                           // Unknown, discard
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: mods,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
+        }
+    }
+
+    #[test]
+    fn idle_ctrl_g_activates_prefix() {
+        let mut reg = KeybindRegistry::new();
+        let result = reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        assert!(result.is_some());
+        assert!(matches!(reg.prefix_state, PrefixState::Active { .. }));
+    }
+
+    #[test]
+    fn prefix_g_toggles_layer() {
+        let mut reg = KeybindRegistry::new();
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert!(matches!(result, Some(Message::ToggleLayer)));
+        assert!(matches!(reg.prefix_state, PrefixState::Idle));
+    }
+
+    #[test]
+    fn prefix_q_quits() {
+        let mut reg = KeybindRegistry::new();
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(matches!(result, Some(Message::Quit)));
+    }
+
+    #[test]
+    fn prefix_bracket_navigates_sessions() {
+        let mut reg = KeybindRegistry::new();
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char(']'), KeyModifiers::NONE));
+        assert!(matches!(result, Some(Message::NextSession)));
+
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char('['), KeyModifiers::NONE));
+        assert!(matches!(result, Some(Message::PrevSession)));
+    }
+
+    #[test]
+    fn prefix_number_switches_session() {
+        let mut reg = KeybindRegistry::new();
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char('3'), KeyModifiers::NONE));
+        assert!(matches!(result, Some(Message::SwitchSession(2))));
+    }
+
+    #[test]
+    fn prefix_z_toggles_layout() {
+        let mut reg = KeybindRegistry::new();
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char('z'), KeyModifiers::NONE));
+        assert!(matches!(result, Some(Message::ToggleSessionLayout)));
+    }
+
+    #[test]
+    fn prefix_esc_cancels() {
+        let mut reg = KeybindRegistry::new();
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(result.is_some()); // Tick — consumed but no action
+        assert!(matches!(reg.prefix_state, PrefixState::Idle));
+    }
+
+    #[test]
+    fn non_prefix_key_returns_none() {
+        let mut reg = KeybindRegistry::new();
+        let result = reg.process_key(key(KeyCode::Char('a'), KeyModifiers::NONE));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn all_bindings_not_empty() {
+        let reg = KeybindRegistry::new();
+        assert!(!reg.all_bindings().is_empty());
+    }
+
+    #[test]
+    fn expired_prefix_resets_to_idle() {
+        let mut reg = KeybindRegistry::new();
+        reg.prefix_state = PrefixState::Active {
+            since: Instant::now() - Duration::from_secs(3),
+        };
+        let result = reg.process_key(key(KeyCode::Char('g'), KeyModifiers::NONE));
+        // Should treat as idle — 'g' without ctrl is not a prefix trigger
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn prefix_management_shortcuts() {
+        let mut reg = KeybindRegistry::new();
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char('b'), KeyModifiers::NONE));
+        assert!(matches!(
+            result,
+            Some(Message::SwitchManagementTab(ManagementTab::Branches))
+        ));
+
+        reg.process_key(key(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        let result = reg.process_key(key(KeyCode::Char('i'), KeyModifiers::NONE));
+        assert!(matches!(
+            result,
+            Some(Message::SwitchManagementTab(ManagementTab::Issues))
+        ));
+    }
+}

--- a/crates/gwt-tui/src/input/mod.rs
+++ b/crates/gwt-tui/src/input/mod.rs
@@ -1,0 +1,4 @@
+//! Input handling — keybindings and voice input.
+
+pub mod keybind;
+pub mod voice;

--- a/crates/gwt-tui/src/input/voice.rs
+++ b/crates/gwt-tui/src/input/voice.rs
@@ -1,0 +1,48 @@
+//! Voice input state tracking (minimal stub for Phase 1).
+
+/// Voice input state.
+#[derive(Debug, Clone, Default)]
+pub struct VoiceState {
+    /// Whether voice input is currently active.
+    pub active: bool,
+    /// Transcription buffer.
+    pub buffer: String,
+}
+
+impl VoiceState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Toggle voice input on/off.
+    pub fn toggle(&mut self) {
+        self.active = !self.active;
+        if !self.active {
+            self.buffer.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn voice_state_default_is_inactive() {
+        let state = VoiceState::new();
+        assert!(!state.active);
+        assert!(state.buffer.is_empty());
+    }
+
+    #[test]
+    fn voice_toggle_activates_and_deactivates() {
+        let mut state = VoiceState::new();
+        state.toggle();
+        assert!(state.active);
+
+        state.buffer = "hello".into();
+        state.toggle();
+        assert!(!state.active);
+        assert!(state.buffer.is_empty());
+    }
+}

--- a/crates/gwt-tui/src/lib.rs
+++ b/crates/gwt-tui/src/lib.rs
@@ -1,0 +1,14 @@
+//! gwt-tui: Terminal UI for Git Worktree Manager
+//!
+//! Elm Architecture: Model -> Message -> Update -> View
+//! Built with ratatui + crossterm.
+
+pub mod app;
+pub mod event;
+pub mod input;
+pub mod message;
+pub mod model;
+pub mod notification_router;
+pub mod renderer;
+pub mod screens;
+pub mod widgets;

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -1,0 +1,84 @@
+//! gwt-tui entry point.
+//!
+//! Initializes the terminal, creates the Model, and runs the event loop.
+
+use std::{io, path::PathBuf};
+
+use crossterm::{
+    event::{DisableMouseCapture, EnableMouseCapture},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{backend::CrosstermBackend, Terminal};
+
+use gwt_tui::{app, event, input::keybind::KeybindRegistry, message::Message, model::Model};
+
+fn main() -> io::Result<()> {
+    // Parse CLI args: optional repo path
+    let repo_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+
+    // Initialize terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Run the app
+    let result = run_app(&mut terminal, repo_path);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+    )?;
+    terminal.show_cursor()?;
+
+    if let Err(e) = result {
+        eprintln!("Error: {e}");
+    }
+
+    Ok(())
+}
+
+fn run_app(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    repo_path: PathBuf,
+) -> io::Result<()> {
+    let mut model = Model::new(repo_path);
+    let mut keybinds = KeybindRegistry::new();
+
+    loop {
+        // View: render
+        terminal.draw(|frame| {
+            app::view(&model, frame);
+        })?;
+
+        // Check quit
+        if model.quit {
+            break;
+        }
+
+        // Event: poll
+        let deadline = event::next_tick_deadline();
+        if let Some(msg) = event::poll_event(deadline) {
+            // Route key events through keybind registry
+            let msg = match msg {
+                Message::KeyInput(key) => {
+                    keybinds.process_key(key).unwrap_or(Message::KeyInput(key))
+                }
+                other => other,
+            };
+
+            // Update: process message
+            app::update(&mut model, msg);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/gwt-tui/src/message.rs
+++ b/crates/gwt-tui/src/message.rs
@@ -1,0 +1,65 @@
+//! Message type — all actions in the Elm Architecture.
+
+use crossterm::event::{KeyEvent, MouseEvent};
+
+use crate::model::ManagementTab;
+
+/// Every possible action in the TUI.
+#[derive(Debug, Clone)]
+pub enum Message {
+    /// Quit the application.
+    Quit,
+    /// Toggle between Main (sessions) and Management layers.
+    ToggleLayer,
+    /// Switch to a specific management tab.
+    SwitchManagementTab(ManagementTab),
+    /// Activate the next session tab.
+    NextSession,
+    /// Activate the previous session tab.
+    PrevSession,
+    /// Switch to session by index (0-based).
+    SwitchSession(usize),
+    /// Toggle session layout between Tab and Grid.
+    ToggleSessionLayout,
+    /// Create a new shell session.
+    NewShell,
+    /// Close the active session.
+    CloseSession,
+    /// Raw key input forwarded to the active pane.
+    KeyInput(KeyEvent),
+    /// Mouse input.
+    MouseInput(MouseEvent),
+    /// Terminal resize.
+    Resize(u16, u16),
+    /// PTY output arrived for a pane.
+    PtyOutput(String, Vec<u8>),
+    /// Periodic tick (100ms).
+    Tick,
+    /// Push an error message onto the queue.
+    PushError(String),
+    /// Dismiss the top error.
+    DismissError,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_variants_are_constructible() {
+        let _ = Message::Quit;
+        let _ = Message::ToggleLayer;
+        let _ = Message::SwitchManagementTab(ManagementTab::Branches);
+        let _ = Message::NextSession;
+        let _ = Message::PrevSession;
+        let _ = Message::SwitchSession(0);
+        let _ = Message::ToggleSessionLayout;
+        let _ = Message::NewShell;
+        let _ = Message::CloseSession;
+        let _ = Message::Tick;
+        let _ = Message::PushError("err".into());
+        let _ = Message::DismissError;
+        let _ = Message::Resize(80, 24);
+        let _ = Message::PtyOutput("id".into(), vec![0x41]);
+    }
+}

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -1,0 +1,208 @@
+//! Model — central application state for the Elm Architecture.
+
+use std::path::PathBuf;
+
+/// Which UI layer is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActiveLayer {
+    /// Session panes (shell / agent terminals).
+    Main,
+    /// Management panel (branches, specs, issues, etc.).
+    Management,
+}
+
+/// Session layout mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionLayout {
+    /// One session visible at a time.
+    Tab,
+    /// All sessions in an equal grid.
+    Grid,
+}
+
+/// Management panel tabs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagementTab {
+    Branches,
+    Specs,
+    Issues,
+    Profiles,
+    GitView,
+    Versions,
+    Settings,
+    Logs,
+}
+
+impl ManagementTab {
+    /// All tabs in display order.
+    pub const ALL: [ManagementTab; 8] = [
+        ManagementTab::Branches,
+        ManagementTab::Specs,
+        ManagementTab::Issues,
+        ManagementTab::Profiles,
+        ManagementTab::GitView,
+        ManagementTab::Versions,
+        ManagementTab::Settings,
+        ManagementTab::Logs,
+    ];
+
+    /// Human-readable label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Branches => "Branches",
+            Self::Specs => "Specs",
+            Self::Issues => "Issues",
+            Self::Profiles => "Profiles",
+            Self::GitView => "Git View",
+            Self::Versions => "Versions",
+            Self::Settings => "Settings",
+            Self::Logs => "Logs",
+        }
+    }
+}
+
+/// Type of a session tab.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionTabType {
+    Shell,
+    Agent { agent_id: String, color: AgentColor },
+}
+
+/// Re-export AgentColor from gwt-core to avoid duplication.
+pub use gwt_core::terminal::AgentColor;
+
+/// A single session tab (shell or agent).
+#[derive(Debug, Clone)]
+pub struct SessionTab {
+    pub id: String,
+    pub name: String,
+    pub tab_type: SessionTabType,
+    pub vt: VtState,
+}
+
+/// Minimal vt100 screen state wrapper.
+#[derive(Debug, Clone)]
+pub struct VtState {
+    rows: u16,
+    cols: u16,
+}
+
+impl VtState {
+    pub fn new(rows: u16, cols: u16) -> Self {
+        Self { rows, cols }
+    }
+
+    pub fn rows(&self) -> u16 {
+        self.rows
+    }
+
+    pub fn cols(&self) -> u16 {
+        self.cols
+    }
+}
+
+/// Central application state.
+#[derive(Debug)]
+pub struct Model {
+    /// Which layer has focus.
+    pub active_layer: ActiveLayer,
+    /// All open session tabs.
+    pub sessions: Vec<SessionTab>,
+    /// Index of the active session.
+    pub active_session: usize,
+    /// Session layout mode.
+    pub session_layout: SessionLayout,
+    /// Active management tab.
+    pub management_tab: ManagementTab,
+    /// Whether the management panel is visible.
+    pub management_visible: bool,
+    /// Error queue (shown as overlays).
+    pub error_queue: Vec<String>,
+    /// Whether the app should quit.
+    pub quit: bool,
+    /// Repository path.
+    pub repo_path: PathBuf,
+    /// Terminal size.
+    pub terminal_size: (u16, u16),
+}
+
+impl Model {
+    /// Create a new Model with sensible defaults.
+    pub fn new(repo_path: PathBuf) -> Self {
+        let default_session = SessionTab {
+            id: "shell-0".to_string(),
+            name: "Shell".to_string(),
+            tab_type: SessionTabType::Shell,
+            vt: VtState::new(24, 80),
+        };
+
+        Self {
+            active_layer: ActiveLayer::Main,
+            sessions: vec![default_session],
+            active_session: 0,
+            session_layout: SessionLayout::Tab,
+            management_tab: ManagementTab::Branches,
+            management_visible: false,
+            error_queue: Vec::new(),
+            quit: false,
+            repo_path,
+            terminal_size: (80, 24),
+        }
+    }
+
+    /// Number of sessions.
+    pub fn session_count(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Get the active session, if any.
+    pub fn active_session_tab(&self) -> Option<&SessionTab> {
+        self.sessions.get(self.active_session)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn model_new_defaults() {
+        let model = Model::new(PathBuf::from("/tmp/repo"));
+        assert_eq!(model.active_layer, ActiveLayer::Main);
+        assert_eq!(model.session_count(), 1);
+        assert_eq!(model.active_session, 0);
+        assert_eq!(model.session_layout, SessionLayout::Tab);
+        assert_eq!(model.management_tab, ManagementTab::Branches);
+        assert!(!model.management_visible);
+        assert!(model.error_queue.is_empty());
+        assert!(!model.quit);
+    }
+
+    #[test]
+    fn active_session_tab_returns_first() {
+        let model = Model::new(PathBuf::from("/tmp/repo"));
+        let tab = model.active_session_tab().unwrap();
+        assert_eq!(tab.name, "Shell");
+        assert_eq!(tab.tab_type, SessionTabType::Shell);
+    }
+
+    #[test]
+    fn management_tab_labels() {
+        assert_eq!(ManagementTab::Branches.label(), "Branches");
+        assert_eq!(ManagementTab::Settings.label(), "Settings");
+        assert_eq!(ManagementTab::Logs.label(), "Logs");
+    }
+
+    #[test]
+    fn management_tab_all_has_eight_entries() {
+        assert_eq!(ManagementTab::ALL.len(), 8);
+    }
+
+    #[test]
+    fn vt_state_dimensions() {
+        let vt = VtState::new(40, 120);
+        assert_eq!(vt.rows(), 40);
+        assert_eq!(vt.cols(), 120);
+    }
+}

--- a/crates/gwt-tui/src/notification_router.rs
+++ b/crates/gwt-tui/src/notification_router.rs
@@ -1,0 +1,83 @@
+//! Notification router — routes notifications by severity.
+
+use crate::message::Message;
+
+/// Notification severity levels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Debug: log only, no UI.
+    Debug,
+    /// Info: status bar for 5 seconds.
+    Info,
+    /// Warning: status bar, persisted until dismissed.
+    Warn,
+    /// Error: modal overlay.
+    Error,
+}
+
+/// A notification to be routed.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub severity: Severity,
+    pub message: String,
+}
+
+/// Route a notification to the appropriate UI message.
+///
+/// Returns `Some(Message)` for notifications that need UI action,
+/// `None` for debug-level (log-only).
+pub fn route(notification: &Notification) -> Option<Message> {
+    match notification.severity {
+        Severity::Debug => {
+            tracing::debug!("{}", notification.message);
+            None
+        }
+        Severity::Info => {
+            tracing::info!("{}", notification.message);
+            // Phase 2: status bar notification with 5s timeout
+            None
+        }
+        Severity::Warn => {
+            tracing::warn!("{}", notification.message);
+            // Phase 2: persistent status bar notification
+            None
+        }
+        Severity::Error => {
+            tracing::error!("{}", notification.message);
+            Some(Message::PushError(notification.message.clone()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_returns_none() {
+        let n = Notification {
+            severity: Severity::Debug,
+            message: "debug msg".into(),
+        };
+        assert!(route(&n).is_none());
+    }
+
+    #[test]
+    fn info_returns_none_for_now() {
+        let n = Notification {
+            severity: Severity::Info,
+            message: "info msg".into(),
+        };
+        assert!(route(&n).is_none());
+    }
+
+    #[test]
+    fn error_returns_push_error() {
+        let n = Notification {
+            severity: Severity::Error,
+            message: "boom".into(),
+        };
+        let msg = route(&n);
+        assert!(matches!(msg, Some(Message::PushError(ref s)) if s == "boom"));
+    }
+}

--- a/crates/gwt-tui/src/renderer.rs
+++ b/crates/gwt-tui/src/renderer.rs
@@ -1,0 +1,114 @@
+//! Renderer — converts vt100 screen cells to ratatui Buffer.
+
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+
+/// Map a vt100 color to a ratatui color.
+pub fn map_vt_color(color: vt100::Color) -> Color {
+    match color {
+        vt100::Color::Default => Color::Reset,
+        vt100::Color::Idx(i) => Color::Indexed(i),
+        vt100::Color::Rgb(r, g, b) => Color::Rgb(r, g, b),
+    }
+}
+
+/// Map vt100 cell attributes to ratatui Modifier.
+pub fn map_vt_attrs(bold: bool, italic: bool, underline: bool, inverse: bool) -> Modifier {
+    let mut mods = Modifier::empty();
+    if bold {
+        mods |= Modifier::BOLD;
+    }
+    if italic {
+        mods |= Modifier::ITALIC;
+    }
+    if underline {
+        mods |= Modifier::UNDERLINED;
+    }
+    if inverse {
+        mods |= Modifier::REVERSED;
+    }
+    mods
+}
+
+/// Render a vt100 screen into a ratatui Buffer at the given area.
+pub fn render_vt_screen(screen: &vt100::Screen, buf: &mut Buffer, area: Rect) {
+    let rows = area.height.min(screen.size().0);
+    let cols = area.width.min(screen.size().1);
+
+    for row in 0..rows {
+        for col in 0..cols {
+            let cell = screen.cell(row, col);
+            if let Some(cell) = cell {
+                let x = area.x + col;
+                let y = area.y + row;
+
+                if x < buf.area().right() && y < buf.area().bottom() {
+                    let buf_cell = &mut buf[(x, y)];
+                    buf_cell.set_char(cell.contents().chars().next().unwrap_or(' '));
+                    buf_cell.set_style(Style {
+                        fg: Some(map_vt_color(cell.fgcolor())),
+                        bg: Some(map_vt_color(cell.bgcolor())),
+                        underline_color: None,
+                        add_modifier: map_vt_attrs(
+                            cell.bold(),
+                            cell.italic(),
+                            cell.underline(),
+                            cell.inverse(),
+                        ),
+                        sub_modifier: Modifier::empty(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_vt_color_default() {
+        assert_eq!(map_vt_color(vt100::Color::Default), Color::Reset);
+    }
+
+    #[test]
+    fn map_vt_color_indexed() {
+        assert_eq!(map_vt_color(vt100::Color::Idx(42)), Color::Indexed(42));
+    }
+
+    #[test]
+    fn map_vt_color_rgb() {
+        assert_eq!(
+            map_vt_color(vt100::Color::Rgb(10, 20, 30)),
+            Color::Rgb(10, 20, 30)
+        );
+    }
+
+    #[test]
+    fn map_vt_attrs_none() {
+        assert_eq!(map_vt_attrs(false, false, false, false), Modifier::empty());
+    }
+
+    #[test]
+    fn map_vt_attrs_all() {
+        let m = map_vt_attrs(true, true, true, true);
+        assert!(m.contains(Modifier::BOLD));
+        assert!(m.contains(Modifier::ITALIC));
+        assert!(m.contains(Modifier::UNDERLINED));
+        assert!(m.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn render_vt_screen_basic() {
+        let parser = vt100::Parser::new(2, 3, 0);
+        let screen = parser.screen();
+        let area = Rect::new(0, 0, 3, 2);
+        let mut buf = Buffer::empty(area);
+        render_vt_screen(screen, &mut buf, area);
+        // Should not panic — cells are blank
+    }
+}

--- a/crates/gwt-tui/src/screens/branches.rs
+++ b/crates/gwt-tui/src/screens/branches.rs
@@ -1,0 +1,25 @@
+//! Branches management screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the branches screen.
+#[derive(Debug, Default)]
+pub struct BranchesState;
+
+/// Messages specific to the branches screen.
+#[derive(Debug, Clone)]
+pub enum BranchesMessage {}
+
+/// Render the branches screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Branches");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/confirm.rs
+++ b/crates/gwt-tui/src/screens/confirm.rs
@@ -1,0 +1,25 @@
+//! Confirmation dialog overlay (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the confirmation dialog.
+#[derive(Debug, Default)]
+pub struct ConfirmState;
+
+/// Messages specific to the confirmation dialog.
+#[derive(Debug, Clone)]
+pub enum ConfirmMessage {}
+
+/// Render the confirmation dialog.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Confirm");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/error.rs
+++ b/crates/gwt-tui/src/screens/error.rs
@@ -1,0 +1,28 @@
+//! Error overlay screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the error overlay.
+#[derive(Debug, Default)]
+pub struct ErrorState;
+
+/// Messages specific to the error overlay.
+#[derive(Debug, Clone)]
+pub enum ErrorMessage {}
+
+/// Render the error overlay.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Red))
+        .title("Error");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::Red));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/git_view.rs
+++ b/crates/gwt-tui/src/screens/git_view.rs
@@ -1,0 +1,25 @@
+//! Git View screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the git view screen.
+#[derive(Debug, Default)]
+pub struct GitViewState;
+
+/// Messages specific to the git view screen.
+#[derive(Debug, Clone)]
+pub enum GitViewMessage {}
+
+/// Render the git view screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Git View");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/issues.rs
+++ b/crates/gwt-tui/src/screens/issues.rs
@@ -1,0 +1,25 @@
+//! Issues management screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the issues screen.
+#[derive(Debug, Default)]
+pub struct IssuesState;
+
+/// Messages specific to the issues screen.
+#[derive(Debug, Clone)]
+pub enum IssuesMessage {}
+
+/// Render the issues screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Issues");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/logs.rs
+++ b/crates/gwt-tui/src/screens/logs.rs
@@ -1,0 +1,25 @@
+//! Logs viewer screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the logs screen.
+#[derive(Debug, Default)]
+pub struct LogsState;
+
+/// Messages specific to the logs screen.
+#[derive(Debug, Clone)]
+pub enum LogsMessage {}
+
+/// Render the logs screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Logs");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/mod.rs
+++ b/crates/gwt-tui/src/screens/mod.rs
@@ -1,0 +1,14 @@
+//! Screen modules — one per management tab, plus overlays.
+
+pub mod branches;
+pub mod confirm;
+pub mod error;
+pub mod git_view;
+pub mod issues;
+pub mod logs;
+pub mod pr_dashboard;
+pub mod profiles;
+pub mod settings;
+pub mod specs;
+pub mod versions;
+pub mod wizard;

--- a/crates/gwt-tui/src/screens/pr_dashboard.rs
+++ b/crates/gwt-tui/src/screens/pr_dashboard.rs
@@ -1,0 +1,25 @@
+//! PR Dashboard screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the PR dashboard screen.
+#[derive(Debug, Default)]
+pub struct PrDashboardState;
+
+/// Messages specific to the PR dashboard screen.
+#[derive(Debug, Clone)]
+pub enum PrDashboardMessage {}
+
+/// Render the PR dashboard screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("PR Dashboard");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/profiles.rs
+++ b/crates/gwt-tui/src/screens/profiles.rs
@@ -1,0 +1,25 @@
+//! Profiles management screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the profiles screen.
+#[derive(Debug, Default)]
+pub struct ProfilesState;
+
+/// Messages specific to the profiles screen.
+#[derive(Debug, Clone)]
+pub enum ProfilesMessage {}
+
+/// Render the profiles screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Profiles");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/settings.rs
+++ b/crates/gwt-tui/src/screens/settings.rs
@@ -1,0 +1,25 @@
+//! Settings management screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the settings screen.
+#[derive(Debug, Default)]
+pub struct SettingsState;
+
+/// Messages specific to the settings screen.
+#[derive(Debug, Clone)]
+pub enum SettingsMessage {}
+
+/// Render the settings screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Settings");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/specs.rs
+++ b/crates/gwt-tui/src/screens/specs.rs
@@ -1,0 +1,25 @@
+//! Specs management screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the specs screen.
+#[derive(Debug, Default)]
+pub struct SpecsState;
+
+/// Messages specific to the specs screen.
+#[derive(Debug, Clone)]
+pub enum SpecsMessage {}
+
+/// Render the specs screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Specs");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/versions.rs
+++ b/crates/gwt-tui/src/screens/versions.rs
@@ -1,0 +1,25 @@
+//! Versions screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the versions screen.
+#[derive(Debug, Default)]
+pub struct VersionsState;
+
+/// Messages specific to the versions screen.
+#[derive(Debug, Clone)]
+pub enum VersionsMessage {}
+
+/// Render the versions screen.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Versions");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -1,0 +1,25 @@
+//! Wizard overlay screen (stub).
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// State for the wizard overlay.
+#[derive(Debug, Default)]
+pub struct WizardState;
+
+/// Messages specific to the wizard overlay.
+#[derive(Debug, Clone)]
+pub enum WizardMessage {}
+
+/// Render the wizard overlay.
+pub fn render(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title("Wizard");
+    let text = Paragraph::new("Not yet implemented")
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(text, area);
+}

--- a/crates/gwt-tui/src/widgets/markdown.rs
+++ b/crates/gwt-tui/src/widgets/markdown.rs
@@ -1,0 +1,93 @@
+//! Markdown rendering widget for Issue/SPEC detail views.
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
+};
+
+/// Render markdown text with basic formatting.
+///
+/// Supports: headings (#), bold (**), code blocks (```), inline code (`).
+/// This is intentionally simple — full markdown parsing is out of scope.
+pub fn render(title: &str, content: &str, frame: &mut Frame, area: Rect) {
+    let lines: Vec<Line> = content.lines().map(style_line).collect();
+
+    let block = Block::default().borders(Borders::ALL).title(title);
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(paragraph, area);
+}
+
+fn style_line(line: &str) -> Line<'static> {
+    if line.starts_with("### ") {
+        Line::from(Span::styled(
+            line.to_string(),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ))
+    } else if line.starts_with("## ") {
+        Line::from(Span::styled(
+            line.to_string(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ))
+    } else if line.starts_with("# ") {
+        Line::from(Span::styled(
+            line.to_string(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ))
+    } else if line.starts_with("```") {
+        Line::from(Span::styled(
+            line.to_string(),
+            Style::default().fg(Color::DarkGray),
+        ))
+    } else if line.starts_with("- ") || line.starts_with("* ") {
+        Line::from(Span::styled(
+            format!("  \u{2022} {}", &line[2..]),
+            Style::default().fg(Color::White),
+        ))
+    } else {
+        Line::from(line.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn style_line_heading_levels() {
+        let h1 = style_line("# Title");
+        assert_eq!(h1.spans.len(), 1);
+
+        let h2 = style_line("## Sub");
+        assert_eq!(h2.spans.len(), 1);
+
+        let h3 = style_line("### Detail");
+        assert_eq!(h3.spans.len(), 1);
+    }
+
+    #[test]
+    fn style_line_bullet() {
+        let bullet = style_line("- item");
+        let text: String = bullet.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains('\u{2022}'));
+    }
+
+    #[test]
+    fn style_line_plain() {
+        let plain = style_line("Just text");
+        let text: String = plain.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "Just text");
+    }
+}

--- a/crates/gwt-tui/src/widgets/mod.rs
+++ b/crates/gwt-tui/src/widgets/mod.rs
@@ -1,0 +1,6 @@
+//! Reusable widgets for the TUI.
+
+pub mod markdown;
+pub mod status_bar;
+pub mod tab_bar;
+pub mod terminal_view;

--- a/crates/gwt-tui/src/widgets/status_bar.rs
+++ b/crates/gwt-tui/src/widgets/status_bar.rs
@@ -1,0 +1,50 @@
+//! Status bar widget — footer with session info, branch, and help hint.
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::model::{ActiveLayer, Model, SessionLayout};
+
+/// Render the status bar.
+pub fn render(model: &Model, frame: &mut Frame, area: Rect) {
+    let session_name = model
+        .active_session_tab()
+        .map(|s| s.name.as_str())
+        .unwrap_or("No session");
+
+    let layout_icon = match model.session_layout {
+        SessionLayout::Tab => "\u{25A3}",
+        SessionLayout::Grid => "\u{25A6}",
+    };
+
+    let layer = match model.active_layer {
+        ActiveLayer::Main => "Main",
+        ActiveLayer::Management => "Mgmt",
+    };
+
+    let status = Line::from(vec![
+        Span::styled(
+            format!(" {layout_icon} {session_name} "),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled(
+            format!(" [{layer}] "),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" {} ", model.repo_path.display()),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(" Ctrl+G,? Help ", Style::default().fg(Color::DarkGray)),
+    ]);
+
+    let bar = Paragraph::new(status).style(Style::default().bg(Color::DarkGray));
+    frame.render_widget(bar, area);
+}

--- a/crates/gwt-tui/src/widgets/tab_bar.rs
+++ b/crates/gwt-tui/src/widgets/tab_bar.rs
@@ -1,0 +1,44 @@
+//! Session tab bar widget.
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Tabs,
+    Frame,
+};
+
+use crate::model::{Model, SessionTabType};
+
+/// Render the session tab bar.
+pub fn render(model: &Model, frame: &mut Frame, area: Rect) {
+    let titles: Vec<Line> = model
+        .sessions
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let icon = match &s.tab_type {
+                SessionTabType::Shell => "\u{25B6}",
+                SessionTabType::Agent { .. } => "\u{2B50}",
+            };
+            let style = if i == model.active_session {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            Line::from(Span::styled(format!(" {icon} {} ", s.name), style))
+        })
+        .collect();
+
+    let tabs = Tabs::new(titles)
+        .select(model.active_session)
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    frame.render_widget(tabs, area);
+}

--- a/crates/gwt-tui/src/widgets/terminal_view.rs
+++ b/crates/gwt-tui/src/widgets/terminal_view.rs
@@ -1,0 +1,36 @@
+//! Terminal view widget — renders a vt100 screen buffer.
+
+use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
+
+use crate::renderer;
+
+/// Widget that renders a vt100 screen into a ratatui area.
+pub struct TerminalView<'a> {
+    screen: &'a vt100::Screen,
+}
+
+impl<'a> TerminalView<'a> {
+    pub fn new(screen: &'a vt100::Screen) -> Self {
+        Self { screen }
+    }
+}
+
+impl Widget for TerminalView<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        renderer::render_vt_screen(self.screen, buf, area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_view_renders_without_panic() {
+        let parser = vt100::Parser::new(4, 10, 0);
+        let view = TerminalView::new(parser.screen());
+        let area = Rect::new(0, 0, 10, 4);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+    }
+}


### PR DESCRIPTION
## Summary

- Add new `gwt-tui` crate implementing full Elm Architecture (Model/Message/Update/View) with ratatui + crossterm
- Implement Ctrl+G prefix keybinding system with 2-second timeout and auto-collected help registry
- Include vt100-to-ratatui renderer, management panel with 8 tab stubs, session Tab/Grid layout modes, notification router, and 46 unit tests

## Test plan

- [x] `cargo test -p gwt-tui` -- 46 tests pass
- [x] `cargo build -p gwt-tui` -- builds successfully
- [x] `cargo clippy -p gwt-tui --all-targets -- -D warnings` -- zero warnings
- [x] `cargo fmt -p gwt-tui --check` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a terminal user interface (TUI) application with multi-session management and tab/grid layout switching.
  * Implemented session creation, navigation, and closure with shell and agent tab types.
  * Added a management panel with dedicated sections for branches, specs, issues, profiles, git view, versions, settings, and logs.
  * Introduced Ctrl+G keybinding system for command access and application controls.
  * Integrated voice input state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->