### PR TITLE
fix(tui): PTYスポーン・入出力・カーソル・リサイズを復元する

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -216,12 +216,16 @@ pub fn update(model: &mut Model, msg: Message) {
         }
         Message::Resize(w, h) => {
             model.terminal_size = (w, h);
-            // Propagate resize to all PTY processes and VtState parsers.
-            for pty in model.pty_handles.values() {
-                let _ = pty.resize(w, h);
-            }
-            for session in &mut model.sessions {
-                session.vt.resize(h, w);
+            // Propagate resize to all PTY processes and VtState parsers
+            // using the actual session pane content area, not the full
+            // terminal size.
+            if let Some(content) = active_session_content_area(model) {
+                for pty in model.pty_handles.values() {
+                    let _ = pty.resize(content.width, content.height);
+                }
+                for session in &mut model.sessions {
+                    session.vt.resize(content.height, content.width);
+                }
             }
         }
         Message::PtyOutput(pane_id, data) => {
@@ -1574,8 +1578,10 @@ fn check_branch_pending_actions(model: &mut Model) {
         model.branches.pending_launch_agent = false;
         if let Some(branch) = model.branches.selected_branch() {
             let branch_name = branch.name.clone();
+            let worktree_path = branch.worktree_path.clone();
             open_wizard(model, None);
             if let Some(ref mut wizard) = model.wizard {
+                wizard.worktree_path = worktree_path;
                 configure_existing_branch_wizard_with_sessions(
                     wizard,
                     &model.repo_path,
@@ -1588,17 +1594,39 @@ fn check_branch_pending_actions(model: &mut Model) {
     if model.branches.pending_open_shell {
         model.branches.pending_open_shell = false;
         if let Some(branch) = model.branches.selected_branch() {
-            if branch.worktree_path.is_some() {
+            if let Some(ref wt_path) = branch.worktree_path {
                 let idx = model.sessions.len();
+                let (cols, rows) = model.terminal_size;
                 let session = crate::model::SessionTab {
                     id: format!("shell-{idx}"),
                     name: format!("Shell: {}", branch.name),
                     tab_type: crate::model::SessionTabType::Shell,
-                    vt: crate::model::VtState::new(24, 80),
+                    vt: crate::model::VtState::new(rows, cols),
                 };
+                let session_id = session.id.clone();
                 model.sessions.push(session);
                 model.active_session = idx;
                 model.active_focus = FocusPane::Terminal;
+
+                let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+                let config = gwt_terminal::pty::SpawnConfig {
+                    command: shell,
+                    args: vec![],
+                    cols,
+                    rows,
+                    env: HashMap::new(),
+                    cwd: Some(wt_path.clone()),
+                };
+                if let Err(e) = spawn_pty_for_session(model, &session_id, config) {
+                    apply_notification(
+                        model,
+                        Notification::new(
+                            Severity::Error,
+                            "pty",
+                            format!("Branch shell spawn failed: {e}"),
+                        ),
+                    );
+                }
             }
         }
     }
@@ -2249,6 +2277,10 @@ fn build_launch_config_from_wizard_with_custom_agents(
 
     let mut builder = AgentLaunchBuilder::new(agent_id);
 
+    if let Some(ref wt) = wizard.worktree_path {
+        builder = builder.working_dir(wt);
+    }
+
     if !wizard.branch_name.is_empty() {
         builder = builder.branch(&wizard.branch_name);
     }
@@ -2331,7 +2363,7 @@ fn build_custom_launch_config_from_wizard(
         command,
         args,
         env_vars,
-        working_dir: None,
+        working_dir: wizard.worktree_path.clone(),
         branch: (!wizard.branch_name.is_empty()).then(|| wizard.branch_name.clone()),
         display_name: custom_agent.display_name.clone(),
         model: None,
@@ -2369,8 +2401,12 @@ fn materialize_pending_launch_with(
         return Ok(());
     };
 
+    let worktree = config
+        .working_dir
+        .clone()
+        .unwrap_or_else(|| model.repo_path.clone());
     let mut session = AgentSession::new(
-        model.repo_path.clone(),
+        worktree,
         config.branch.clone().unwrap_or_default(),
         config.agent_id.clone(),
     );
@@ -2950,8 +2986,34 @@ fn key_event_to_bytes(key: crossterm::event::KeyEvent) -> Option<Vec<u8>> {
         KeyCode::Down => Some(b"\x1b[B".to_vec()),
         KeyCode::Right => Some(b"\x1b[C".to_vec()),
         KeyCode::Left => Some(b"\x1b[D".to_vec()),
+        KeyCode::Home => Some(b"\x1b[H".to_vec()),
+        KeyCode::End => Some(b"\x1b[F".to_vec()),
+        KeyCode::Delete => Some(b"\x1b[3~".to_vec()),
+        KeyCode::Insert => Some(b"\x1b[2~".to_vec()),
+        KeyCode::PageUp => Some(b"\x1b[5~".to_vec()),
+        KeyCode::PageDown => Some(b"\x1b[6~".to_vec()),
+        KeyCode::F(n) => f_key_to_bytes(n),
         _ => None,
     }
+}
+
+fn f_key_to_bytes(n: u8) -> Option<Vec<u8>> {
+    let code = match n {
+        1 => "11",
+        2 => "12",
+        3 => "13",
+        4 => "14",
+        5 => "15",
+        6 => "17",
+        7 => "18",
+        8 => "19",
+        9 => "20",
+        10 => "21",
+        11 => "23",
+        12 => "24",
+        _ => return None,
+    };
+    Some(format!("\x1b[{code}~").into_bytes())
 }
 
 fn control_char_bytes(ch: char) -> Option<Vec<u8>> {

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3221,7 +3221,12 @@ fn open_url(url: &str) -> Result<(), String> {
         })
 }
 
-fn render_session_surface(session: &crate::model::SessionTab, frame: &mut Frame, area: Rect) {
+fn render_session_surface(
+    session: &crate::model::SessionTab,
+    frame: &mut Frame,
+    area: Rect,
+    show_cursor: bool,
+) {
     if session.vt.screen().contents().trim().is_empty() {
         let placeholder = Paragraph::new(format!(
             "Session: {} ({}x{})",
@@ -3236,6 +3241,16 @@ fn render_session_surface(session: &crate::model::SessionTab, frame: &mut Frame,
             crate::widgets::terminal_view::TerminalView::new(session.vt.screen()),
             area,
         );
+    }
+
+    // Show the vt100 cursor when this session has terminal focus.
+    if show_cursor && !session.vt.screen().hide_cursor() {
+        let (cursor_row, cursor_col) = session.vt.screen().cursor_position();
+        let x = area.x + cursor_col;
+        let y = area.y + cursor_row;
+        if x < area.right() && y < area.bottom() {
+            frame.set_cursor_position((x, y));
+        }
     }
 }
 
@@ -3406,7 +3421,7 @@ fn render_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
                 let block = pane_block(title, terminal_focused);
                 let inner = block.inner(area);
                 frame.render_widget(block, area);
-                render_session_surface(session, frame, inner);
+                render_session_surface(session, frame, inner, terminal_focused);
             }
         }
         SessionLayout::Grid => {

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -95,6 +95,15 @@ pub fn spawn_pty_for_session(
     Ok(())
 }
 
+/// Compute the session pane content size `(cols, rows)` for PTY/VtState
+/// initialization.  Falls back to `model.terminal_size` when the layout
+/// geometry is not yet available (e.g. during early startup).
+pub fn session_content_size(model: &Model) -> (u16, u16) {
+    active_session_content_area(model)
+        .map(|r| (r.width, r.height))
+        .unwrap_or(model.terminal_size)
+}
+
 /// Drain buffered PTY input and write it to the corresponding PTY handles.
 fn drain_pending_pty_inputs(model: &mut Model) {
     while let Some(input) = model.pending_pty_inputs.pop_front() {
@@ -175,16 +184,23 @@ pub fn update(model: &mut Model, msg: Message) {
         }
         Message::NewShell => {
             let idx = model.sessions.len();
-            let (cols, rows) = model.terminal_size;
             let session = crate::model::SessionTab {
                 id: format!("shell-{idx}"),
                 name: format!("Shell {}", idx + 1),
                 tab_type: SessionTabType::Shell,
-                vt: crate::model::VtState::new(rows, cols),
+                vt: crate::model::VtState::new(24, 80),
             };
             let session_id = session.id.clone();
             model.sessions.push(session);
             model.active_session = idx;
+
+            // Use actual pane content area for PTY size.
+            let (cols, rows) = session_content_size(model);
+
+            // Resize VtState to match.
+            if let Some(s) = model.sessions.last_mut() {
+                s.vt.resize(rows, cols);
+            }
 
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
             let config = gwt_terminal::pty::SpawnConfig {
@@ -1596,17 +1612,21 @@ fn check_branch_pending_actions(model: &mut Model) {
         if let Some(branch) = model.branches.selected_branch() {
             if let Some(ref wt_path) = branch.worktree_path {
                 let idx = model.sessions.len();
-                let (cols, rows) = model.terminal_size;
                 let session = crate::model::SessionTab {
                     id: format!("shell-{idx}"),
                     name: format!("Shell: {}", branch.name),
                     tab_type: crate::model::SessionTabType::Shell,
-                    vt: crate::model::VtState::new(rows, cols),
+                    vt: crate::model::VtState::new(24, 80),
                 };
                 let session_id = session.id.clone();
                 model.sessions.push(session);
                 model.active_session = idx;
                 model.active_focus = FocusPane::Terminal;
+
+                let (cols, rows) = session_content_size(model);
+                if let Some(s) = model.sessions.last_mut() {
+                    s.vt.resize(rows, cols);
+                }
 
                 let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
                 let config = gwt_terminal::pty::SpawnConfig {
@@ -2421,7 +2441,6 @@ fn materialize_pending_launch_with(
     session.display_name = config.display_name.clone();
     session.save(sessions_dir).map_err(|err| err.to_string())?;
 
-    let (cols, rows) = model.terminal_size;
     let tab = crate::model::SessionTab {
         id: session.id.clone(),
         name: config.display_name.clone(),
@@ -2429,12 +2448,18 @@ fn materialize_pending_launch_with(
             agent_id: config.agent_id.command().to_string(),
             color: tui_agent_color(config.color),
         },
-        vt: crate::model::VtState::new(rows, cols),
+        vt: crate::model::VtState::new(24, 80),
     };
     let tab_id = tab.id.clone();
     model.sessions.push(tab);
     model.active_session = model.sessions.len().saturating_sub(1);
     model.active_layer = ActiveLayer::Main;
+
+    // Use actual pane content area for PTY size.
+    let (cols, rows) = session_content_size(model);
+    if let Some(s) = model.sessions.last_mut() {
+        s.vt.resize(rows, cols);
+    }
 
     // Spawn PTY process for the agent session.
     let pty_config = gwt_terminal::pty::SpawnConfig {

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -1595,12 +1595,15 @@ fn check_branch_pending_actions(model: &mut Model) {
         if let Some(branch) = model.branches.selected_branch() {
             let branch_name = branch.name.clone();
             let worktree_path = branch.worktree_path.clone();
+            let quick_start_root = worktree_path
+                .clone()
+                .unwrap_or_else(|| model.repo_path.clone());
             open_wizard(model, None);
             if let Some(ref mut wizard) = model.wizard {
                 wizard.worktree_path = worktree_path;
                 configure_existing_branch_wizard_with_sessions(
                     wizard,
-                    &model.repo_path,
+                    &quick_start_root,
                     &gwt_sessions_dir(),
                     &branch_name,
                 );
@@ -3023,22 +3026,23 @@ fn key_event_to_bytes(key: crossterm::event::KeyEvent) -> Option<Vec<u8>> {
 }
 
 fn f_key_to_bytes(n: u8) -> Option<Vec<u8>> {
-    let code = match n {
-        1 => "11",
-        2 => "12",
-        3 => "13",
-        4 => "14",
-        5 => "15",
-        6 => "17",
-        7 => "18",
-        8 => "19",
-        9 => "20",
-        10 => "21",
-        11 => "23",
-        12 => "24",
-        _ => return None,
-    };
-    Some(format!("\x1b[{code}~").into_bytes())
+    match n {
+        // F1-F4: SS3 sequences (xterm PC-style default)
+        1 => Some(b"\x1bOP".to_vec()),
+        2 => Some(b"\x1bOQ".to_vec()),
+        3 => Some(b"\x1bOR".to_vec()),
+        4 => Some(b"\x1bOS".to_vec()),
+        // F5-F12: CSI sequences
+        5 => Some(b"\x1b[15~".to_vec()),
+        6 => Some(b"\x1b[17~".to_vec()),
+        7 => Some(b"\x1b[18~".to_vec()),
+        8 => Some(b"\x1b[19~".to_vec()),
+        9 => Some(b"\x1b[20~".to_vec()),
+        10 => Some(b"\x1b[21~".to_vec()),
+        11 => Some(b"\x1b[23~".to_vec()),
+        12 => Some(b"\x1b[24~".to_vec()),
+        _ => None,
+    }
 }
 
 fn control_char_bytes(ch: char) -> Option<Vec<u8>> {

--- a/crates/gwt-tui/src/input/keybind.rs
+++ b/crates/gwt-tui/src/input/keybind.rs
@@ -179,22 +179,38 @@ impl KeybindRegistry {
 
     /// Process a key event through the prefix state machine.
     /// Returns `Some(Message)` if the key was consumed, `None` if it should be forwarded.
+    ///
+    /// When `terminal_focused` is true, Ctrl+C double-tap quit is disabled so
+    /// that every Ctrl+C reaches the PTY as SIGINT.  Use `Ctrl+G, q` to quit.
     pub fn process_key(&mut self, key: KeyEvent) -> Option<Message> {
+        self.process_key_with_focus(key, false)
+    }
+
+    /// Process a key event, optionally suppressing double-tap Ctrl+C quit
+    /// when a terminal session has focus.
+    pub fn process_key_with_focus(
+        &mut self,
+        key: KeyEvent,
+        terminal_focused: bool,
+    ) -> Option<Message> {
         // Check for timeout
         if self.prefix_state.is_expired() {
             self.prefix_state = PrefixState::Idle;
         }
 
-        // Ctrl+C double-tap quit (works in any state)
+        // Ctrl+C double-tap quit — disabled when terminal has focus so that
+        // every Ctrl+C reaches the PTY as SIGINT.
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
-            if let Some(last) = self.last_ctrl_c {
-                if last.elapsed() < DOUBLE_TAP_WINDOW {
-                    self.last_ctrl_c = None;
-                    return Some(Message::Quit);
+            if !terminal_focused {
+                if let Some(last) = self.last_ctrl_c {
+                    if last.elapsed() < DOUBLE_TAP_WINDOW {
+                        self.last_ctrl_c = None;
+                        return Some(Message::Quit);
+                    }
                 }
+                self.last_ctrl_c = Some(Instant::now());
             }
-            self.last_ctrl_c = Some(Instant::now());
-            return None; // Single Ctrl+C: forward to PTY
+            return None; // Forward to PTY (or non-terminal handler)
         }
         // Any non-Ctrl+C key resets the double-tap tracker
         self.last_ctrl_c = None;

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -144,7 +144,11 @@ fn run_app(
             // (skip keybind processing when in Initialization layer)
             let msg = match msg {
                 Message::KeyInput(key) if model.active_layer != ActiveLayer::Initialization => {
-                    keybinds.process_key(key).unwrap_or(Message::KeyInput(key))
+                    let terminal_focused =
+                        model.active_focus == gwt_tui::model::FocusPane::Terminal;
+                    keybinds
+                        .process_key_with_focus(key, terminal_focused)
+                        .unwrap_or(Message::KeyInput(key))
                 }
                 other => other,
             };

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -103,7 +103,11 @@ fn run_app(
     // Spawn PTY for the default shell-0 session.
     if model.active_layer != ActiveLayer::Initialization {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-        let (cols, rows) = model.terminal_size();
+        let (cols, rows) = app::session_content_size(&model);
+        // Resize default VtState to match actual pane area.
+        if let Some(s) = model.active_session_tab_mut() {
+            s.vt.resize(rows, cols);
+        }
         let config = gwt_terminal::pty::SpawnConfig {
             command: shell,
             args: vec![],

--- a/crates/gwt-tui/src/renderer.rs
+++ b/crates/gwt-tui/src/renderer.rs
@@ -45,6 +45,11 @@ pub fn detect_urls(text: &str) -> Vec<(usize, usize)> {
     let mut i = 0;
 
     while i < len {
+        // Skip to the next valid UTF-8 char boundary.
+        if !text.is_char_boundary(i) {
+            i += 1;
+            continue;
+        }
         // Look for "http://" or "https://"
         let remaining = &text[i..];
         let scheme_len = if remaining.starts_with("https://") {
@@ -52,7 +57,7 @@ pub fn detect_urls(text: &str) -> Vec<(usize, usize)> {
         } else if remaining.starts_with("http://") {
             7
         } else {
-            i += 1;
+            i += remaining.chars().next().map_or(1, |c| c.len_utf8());
             continue;
         };
 
@@ -388,6 +393,15 @@ mod tests {
     #[test]
     fn detect_urls_empty_string() {
         assert!(detect_urls("").is_empty());
+    }
+
+    #[test]
+    fn detect_urls_with_emoji_prefix() {
+        // Emoji like 🔍 is 4 bytes — must not panic on byte-boundary checks.
+        let text = "  🔍  Resolving https://example.com done";
+        let urls = detect_urls(text);
+        assert_eq!(urls.len(), 1);
+        assert_eq!(&text[urls[0].0..urls[0].1], "https://example.com");
     }
 
     #[test]

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -339,6 +339,8 @@ pub struct WizardState {
     pub cancelled: bool,
     /// Optional SPEC context for prefilling.
     pub spec_context: Option<SpecContext>,
+    /// Worktree path for the selected branch (None = use repo root).
+    pub worktree_path: Option<std::path::PathBuf>,
 }
 
 impl Default for WizardState {
@@ -369,6 +371,7 @@ impl Default for WizardState {
             completed: false,
             cancelled: false,
             spec_context: None,
+            worktree_path: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Elm Architecture リファクタリング（Phase 2）で削除されたPTYスポーン処理を復元し、ターミナルセッション（シェル・エージェント）が実際に動作するようにする
- PTY 入出力、カーソル表示、リサイズ、キー転送、作業ディレクトリ解決など、ターミナル機能の基盤を完成させる

## Context

- Phase 2 Elm Architecture リファクタリングで PTY スポーンコードが削除され、セッションタブは作成されるが実際のプロセスが起動しない状態だった
- `portable_pty` の `take_writer()` が一度しか呼べない制約により入力転送が失敗していた
- URL 検出が絵文字（🔍等）を含むマルチバイト文字で panic していた
- PTY 初期サイズがターミナル全体サイズで、実際のペイン領域より大きかった

## Changes

- `crates/gwt-terminal/src/pty.rs`: `PtyHandle` に writer キャッシュ追加（`take_writer()` 一度制約の回避）
- `crates/gwt-tui/src/app.rs`: PTY スポーンヘルパー（`spawn_pty_for_session`, `spawn_pty_reader`）、入力フラッシュ（`drain_pending_pty_inputs`）、終了検知（`check_pty_exits`）、拡張キー（Home/End/Delete/PgUp/PgDn/F1-F12）、カーソル表示、作業ディレクトリ解決、ブランチシェル PTY スポーン、PTY 初期サイズ修正
- `crates/gwt-tui/src/model.rs`: `pty_handles`, `pty_output_tx/rx` フィールド追加、手動 Debug impl、アクセサメソッド
- `crates/gwt-tui/src/main.rs`: イベントループで PTY 出力ドレイン、デフォルト shell-0 スポーン、シャットダウン時 PTY kill、panic hook
- `crates/gwt-tui/src/input/keybind.rs`: ターミナルフォーカス時に Ctrl+C ダブルタップ終了を無効化
- `crates/gwt-tui/src/renderer.rs`: URL 検出のマルチバイト文字 panic 修正
- `crates/gwt-tui/src/screens/wizard.rs`: `WizardState` に `worktree_path` 追加

## Testing

- [x] `cargo build -p gwt-tui` — ビルド成功
- [x] `cargo test -p gwt-tui --lib` — 717 テスト全通過
- [x] `cargo test -p gwt-terminal --lib` — 40 テスト全通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 警告なし
- [x] 手動: gwt-tui 起動 → エージェント起動 → 入力受付 → カーソル表示確認

## Closing Issues

None

## Related Issues / Links

- #1776

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated — N/A: 内部実装変更のみ、ユーザー向け変更なし
- [ ] Migration/backfill plan included — N/A: スキーマ変更なし
- [ ] CHANGELOG impact considered — N/A: パッチレベル修正

## Risk / Impact

- **Affected areas**: gwt-tui ターミナルセッション全体（PTY スポーン・入出力・レンダリング）
- **Rollback plan**: このPRをリバートすればPTYなしの状態に戻る（ターミナルは動作しないが管理パネルは影響なし）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended terminal key encoding to support Home, End, Delete, Insert, PageUp, PageDown, and F1–F12 keys.
  * Added cursor visibility in terminal based on focus state.
  * Shell sessions now spawn with the correct working directory from the selected branch.

* **Bug Fixes**
  * Fixed URL detection crash with emoji prefixes due to UTF-8 byte-boundary handling.
  * Improved terminal session sizing to respect pane content area.
  * Fixed Ctrl+C double-tap quit behavior when terminal has focus.
  * Added error notifications for PTY spawn failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->