### PR TITLE
fix(tui): restore standard Launch Agent branch flow

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -781,6 +781,14 @@ fn read_spec_body(repo_path: &Path, spec_id: &str) -> String {
         .unwrap_or_default()
 }
 
+fn issue_wizard_context(issue: &screens::issues::IssueItem) -> screens::wizard::SpecContext {
+    screens::wizard::SpecContext::new(
+        format!("Issue-{}", issue.number),
+        issue.title.clone(),
+        issue.body.clone(),
+    )
+}
+
 fn spec_sort_key(spec_id: &str) -> (u32, &str) {
     let numeric = spec_id
         .strip_prefix("SPEC-")
@@ -1402,13 +1410,28 @@ fn route_key_to_management(model: &mut Model, key: crossterm::event::KeyEvent) {
             let msg = match key.code {
                 KeyCode::Down => Some(IssuesMessage::MoveDown),
                 KeyCode::Up => Some(IssuesMessage::MoveUp),
-                KeyCode::Enter => Some(IssuesMessage::ToggleDetail),
+                KeyCode::Enter
+                    if !key.modifiers.contains(KeyModifiers::SHIFT)
+                        || !model.issues.detail_view =>
+                {
+                    Some(IssuesMessage::ToggleDetail)
+                }
                 KeyCode::Char('/') => Some(IssuesMessage::SearchStart),
                 KeyCode::Char('r') => Some(IssuesMessage::Refresh),
                 _ => None,
             };
             if let Some(m) = msg {
                 screens::issues::update(&mut model.issues, m);
+            } else if key.code == KeyCode::Enter
+                && key.modifiers.contains(KeyModifiers::SHIFT)
+                && model.issues.detail_view
+            {
+                if let Some(issue) = model.issues.selected_issue().cloned() {
+                    open_wizard(model, Some(issue_wizard_context(&issue)));
+                    if let Some(wizard) = model.wizard.as_mut() {
+                        wizard.issue_id = issue.number.to_string();
+                    }
+                }
             } else if key.code == KeyCode::Esc && model.issues.detail_view {
                 screens::issues::update(&mut model.issues, IssuesMessage::ToggleDetail);
             } else if key.code == KeyCode::Esc {
@@ -7314,6 +7337,36 @@ CUSTOM_ENV = "enabled"
             model.issues.selected_issue().map(|issue| issue.number),
             Some(2)
         );
+    }
+
+    #[test]
+    fn route_key_to_management_issues_shift_enter_opens_prefilled_wizard() {
+        let mut model = test_model();
+        model.management_tab = ManagementTab::Issues;
+        model.active_focus = FocusPane::TabContent;
+        model.issues.issues = vec![screens::issues::IssueItem {
+            number: 1776,
+            title: "Fix login freeze".into(),
+            state: "open".into(),
+            labels: vec!["bug".into()],
+            body: "Steps to reproduce...".into(),
+        }];
+        model.issues.detail_view = true;
+
+        route_key_to_management(&mut model, key(KeyCode::Enter, KeyModifiers::SHIFT));
+
+        let wizard = model.wizard.as_mut().expect("wizard should open");
+        assert_eq!(wizard.step, screens::wizard::WizardStep::BranchTypeSelect);
+        assert_eq!(wizard.issue_id, "1776");
+        assert_eq!(wizard.branch_name, "feature/issue-1776-fix-login-freeze");
+        assert!(!wizard.ai_enabled);
+
+        screens::wizard::update(wizard, screens::wizard::WizardMessage::Select);
+        assert_eq!(wizard.step, screens::wizard::WizardStep::IssueSelect);
+
+        screens::wizard::update(wizard, screens::wizard::WizardMessage::Select);
+        assert_eq!(wizard.step, screens::wizard::WizardStep::BranchNameInput);
+        assert_eq!(wizard.issue_id, "1776");
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -2747,7 +2747,7 @@ fn prepare_wizard_startup(
         },
         is_new_branch: starts_new_branch,
         gh_cli_available: gwt_core::process::command_exists("gh"),
-        ai_enabled: true,
+        ai_enabled: false,
         branch_name,
         spec_context,
         ..Default::default()
@@ -5871,6 +5871,27 @@ mod tests {
 
         assert_eq!(wizard.step, screens::wizard::WizardStep::BranchTypeSelect);
         assert_eq!(wizard.branch_name, "feature/spec-42-my-feature");
+    }
+
+    #[test]
+    fn prepare_wizard_startup_skips_ai_branch_suggest_in_new_branch_flow() {
+        let cache = VersionCache::new();
+        let (mut wizard, _) = prepare_wizard_startup(
+            Some(screens::wizard::SpecContext::new(
+                "SPEC-42",
+                "My Feature",
+                "",
+            )),
+            vec![],
+            &cache,
+        );
+
+        screens::wizard::update(&mut wizard, screens::wizard::WizardMessage::Select);
+        assert_eq!(wizard.step, screens::wizard::WizardStep::IssueSelect);
+
+        screens::wizard::update(&mut wizard, screens::wizard::WizardMessage::Select);
+        assert_eq!(wizard.step, screens::wizard::WizardStep::BranchNameInput);
+        assert!(!wizard.ai_suggest.loading);
     }
 
     #[test]

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -354,7 +354,7 @@ impl Default for WizardState {
             is_new_branch: false,
             base_branch_name: None,
             gh_cli_available: true,
-            ai_enabled: true,
+            ai_enabled: false,
             agent_id: String::new(),
             model: String::new(),
             reasoning: "medium".to_string(),
@@ -2063,6 +2063,17 @@ mod tests {
     }
 
     #[test]
+    fn issue_select_advances_to_branch_name_when_ai_suggest_is_disabled() {
+        let mut state = WizardState::default();
+        state.ai_enabled = false;
+
+        assert_eq!(
+            next_step(WizardStep::IssueSelect, &state),
+            Some(WizardStep::BranchNameInput)
+        );
+    }
+
+    #[test]
     fn branch_type_options_restore_old_prefixes() {
         let mut state = WizardState::default();
         state.step = WizardStep::BranchTypeSelect;
@@ -3223,6 +3234,7 @@ mod tests {
     #[test]
     fn ai_suggest_loading_on_enter_step() {
         let mut state = WizardState::default();
+        state.ai_enabled = true;
         state.step = WizardStep::IssueSelect;
         // Advance from IssueSelect to AIBranchSuggest via Select
         update(&mut state, WizardMessage::Select);

--- a/specs/SPEC-3/metadata.json
+++ b/specs/SPEC-3/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:37:36.553763+00:00",
-  "updated_at": "2026-04-05T04:40:11Z"
+  "updated_at": "2026-04-05T11:59:05Z"
 }

--- a/specs/SPEC-3/metadata.json
+++ b/specs/SPEC-3/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:37:36.553763+00:00",
-  "updated_at": "2026-04-05T12:06:42Z"
+  "updated_at": "2026-04-05T12:22:37Z"
 }

--- a/specs/SPEC-3/metadata.json
+++ b/specs/SPEC-3/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:37:36.553763+00:00",
-  "updated_at": "2026-04-05T11:59:05Z"
+  "updated_at": "2026-04-05T12:06:42Z"
 }

--- a/specs/SPEC-3/plan.md
+++ b/specs/SPEC-3/plan.md
@@ -68,8 +68,9 @@ wizard UX and end-to-end custom-agent behavior.
 1. Restore the branch-first wizard flow so existing-branch launches begin at
    branch action and spec-prefilled launches begin at branch type selection.
 2. Reorder new-branch setup to run Branch Type -> Issue -> Branch Name
-   before agent selection, while leaving AI naming dormant in the standard
-   flow and keeping the current Confirm step.
+   before agent selection across Branches, SPEC detail, and Issue detail,
+   while leaving AI naming dormant in the standard flow and keeping the
+   current Confirm step.
 3. Restore the old branch type and execution mode labels in the current
    ratatui wizard without regressing version selection or spec-context AI
    prompts.
@@ -91,6 +92,15 @@ wizard UX and end-to-end custom-agent behavior.
    completes directly.
 4. Add focused RED/GREEN coverage for the new step transitions before
    touching popup rendering polish.
+
+### Phase 45: Issue Detail Launch Agent Restoration
+
+1. Restore `Shift+Enter` from Issue detail so it opens the wizard again.
+2. Prefill issue context and `issue_id` while keeping the standard
+   `BranchType -> Issue -> Branch Name` path and dormant AI behavior.
+3. Add focused RED/GREEN coverage proving issue-origin launches open at
+   `BranchTypeSelect` and carry the selected issue through the `IssueSelect`
+   step.
 
 ### Phase 6: Old-TUI Wizard Option Formatting
 

--- a/specs/SPEC-3/plan.md
+++ b/specs/SPEC-3/plan.md
@@ -67,8 +67,9 @@ wizard UX and end-to-end custom-agent behavior.
 
 1. Restore the branch-first wizard flow so existing-branch launches begin at
    branch action and spec-prefilled launches begin at branch type selection.
-2. Reorder new-branch setup to run Branch Type -> Issue -> AI naming ->
-   Branch Name before agent selection while keeping the current Confirm step.
+2. Reorder new-branch setup to run Branch Type -> Issue -> Branch Name
+   before agent selection, while leaving AI naming dormant in the standard
+   flow and keeping the current Confirm step.
 3. Restore the old branch type and execution mode labels in the current
    ratatui wizard without regressing version selection or spec-context AI
    prompts.
@@ -84,8 +85,8 @@ wizard UX and end-to-end custom-agent behavior.
    `BranchTypeSelect`, `IssueSelect`, `AIBranchSuggest`, and
    `BranchNameInput`.
 2. Rewrite `next_step()` and `prev_step()` to follow the old-TUI transition
-   table while preserving the current backend hooks for version cache, AI
-   branch suggestions, and session conversion.
+   table while preserving the current backend hooks for version cache,
+   dormant AI branch suggestions, and session conversion.
 3. Remove the separate `Confirm` step so that the final selection step
    completes directly.
 4. Add focused RED/GREEN coverage for the new step transitions before

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -3,13 +3,16 @@
 ## Progress
 - Status: `in-progress`
 - Phase: `Implementation`
-- Task progress: `171/171` checked in `tasks.md`
-- Artifact refresh: `2026-04-05T12:06:42Z`
+- Task progress: `174/174` checked in `tasks.md`
+- Artifact refresh: `2026-04-05T12:22:37Z`
 
 ## Done
 - Startup cache scheduling, wizard integration, and session conversion flow documentation are now aligned to the implemented code.
 - Session conversion artifacts now consistently describe the implemented metadata-driven agent switch instead of PTY relaunch.
 - Supporting artifacts now cover execution, review, and completion-gate reconciliation for this near-finished SPEC.
+- Issue detail launches now rejoin the standard new-branch wizard flow, so
+  Branches, SPEC detail, and Issue detail all enter `BranchType -> Issue ->
+  Branch Name` without requiring AI configuration.
 - Wizard version selection is now a dedicated step, with focused tests for
   installed-version fallback, cache-backed options, and confirm-summary
   rendering.

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -4,7 +4,7 @@
 - Status: `in-progress`
 - Phase: `Implementation`
 - Task progress: `171/171` checked in `tasks.md`
-- Artifact refresh: `2026-04-05T04:40:11Z`
+- Artifact refresh: `2026-04-05T12:06:42Z`
 
 ## Done
 - Startup cache scheduling, wizard integration, and session conversion flow documentation are now aligned to the implemented code.
@@ -18,7 +18,8 @@
   creation.
 - Wizard launch now follows a branch-first flow again: existing-branch
   launches begin at branch action, while spec-prefilled launches begin at
-  branch type selection before issue and AI naming.
+  branch type selection before issue and manual branch input, with the AI
+  suggestion step left dormant in the standard flow.
 - The current ratatui wizard now uses the old-TUI-aligned step machine:
   `BranchAction`, `ConvertAgentSelect`, and `ConvertSessionSelect` are
   restored, and `SkipPermissions` now completes directly without `Confirm`.

--- a/specs/SPEC-3/spec.md
+++ b/specs/SPEC-3/spec.md
@@ -40,15 +40,19 @@ suggestion dormant in the standard new-branch flow.
 
 1. Given I launch from an existing branch, when the wizard opens, then I see
    `BranchAction` before any agent configuration step.
-2. Given I choose to create a new branch, when I continue, then the wizard
-   runs `BranchType -> Issue -> Branch Name -> Agent`.
-3. Given I select Codex, when I continue through the wizard, then the flow
+2. Given I choose to create a new branch from Branches, SPEC detail, or
+   Issue detail, when I continue, then the wizard runs
+   `BranchType -> Issue -> Branch Name -> Agent`.
+3. Given I use the standard new-branch wizard flow, when I look for AI
+   branch suggestion controls, then no public toggle or step is exposed in
+   this slice.
+4. Given I select Codex, when I continue through the wizard, then the flow
    includes `Model -> Reasoning -> Version -> Execution Mode -> Skip Permissions`
    without requiring a trailing confirm screen.
-4. Given I choose session conversion, when I pick `Convert` from execution
+5. Given I choose session conversion, when I pick `Convert` from execution
    mode, then the wizard routes through `ConvertAgentSelect` and
    `ConvertSessionSelect` before `SkipPermissions`.
-5. Given I reach the last step, when I confirm the selection there, then the
+6. Given I reach the last step, when I confirm the selection there, then the
    launch completes directly from the final step instead of a separate
    `Confirm` screen.
 
@@ -196,9 +200,13 @@ As a developer, I want to convert an existing session to a different agent type 
   `ReasoningLevel`, `VersionSelect`, `ExecutionMode`,
   `ConvertAgentSelect`, `ConvertSessionSelect`, `SkipPermissions`,
   `BranchTypeSelect`, `IssueSelect`, `AIBranchSuggest`, and
-  `BranchNameInput`, while the standard new-branch path currently routes
+  `BranchNameInput`, while the standard new-branch path for Branches, SPEC
+  detail, and Issue detail currently routes
   `BranchTypeSelect -> IssueSelect -> BranchNameInput` without entering
   `AIBranchSuggest`.
+- **FR-016a**: This slice does not expose a public setting, wizard toggle, or
+  other user-facing control to re-enable `AIBranchSuggest`; any future
+  reactivation path requires separate specification work.
 - **FR-017**: `ModelSelect`, `ReasoningLevel`, `ExecutionMode`,
   `SkipPermissions`, and `VersionSelect` use old-TUI-style row formatting
   with descriptive text and version-list scroll indicators.

--- a/specs/SPEC-3/spec.md
+++ b/specs/SPEC-3/spec.md
@@ -33,15 +33,15 @@ As a developer, I want to launch a coding agent through a guided wizard so that 
 
 As a developer, I want the new ratatui wizard to follow the old-TUI launch
 flow so that the daily launch UX matches existing muscle memory while
-preserving new capabilities such as version cache, AI branch suggestion, and
-session conversion.
+preserving version cache and session conversion while leaving AI branch
+suggestion dormant in the standard new-branch flow.
 
 **Acceptance Scenarios**
 
 1. Given I launch from an existing branch, when the wizard opens, then I see
    `BranchAction` before any agent configuration step.
 2. Given I choose to create a new branch, when I continue, then the wizard
-   runs `BranchType -> Issue -> AI Suggest -> Branch Name -> Agent`.
+   runs `BranchType -> Issue -> Branch Name -> Agent`.
 3. Given I select Codex, when I continue through the wizard, then the flow
    includes `Model -> Reasoning -> Version -> Execution Mode -> Skip Permissions`
    without requiring a trailing confirm screen.
@@ -196,7 +196,9 @@ As a developer, I want to convert an existing session to a different agent type 
   `ReasoningLevel`, `VersionSelect`, `ExecutionMode`,
   `ConvertAgentSelect`, `ConvertSessionSelect`, `SkipPermissions`,
   `BranchTypeSelect`, `IssueSelect`, `AIBranchSuggest`, and
-  `BranchNameInput`.
+  `BranchNameInput`, while the standard new-branch path currently routes
+  `BranchTypeSelect -> IssueSelect -> BranchNameInput` without entering
+  `AIBranchSuggest`.
 - **FR-017**: `ModelSelect`, `ReasoningLevel`, `ExecutionMode`,
   `SkipPermissions`, and `VersionSelect` use old-TUI-style row formatting
   with descriptive text and version-list scroll indicators.

--- a/specs/SPEC-3/tasks.md
+++ b/specs/SPEC-3/tasks.md
@@ -311,3 +311,9 @@
 - [x] T163 Extract shared custom-agent config load/save helpers into `crates/gwt-tui/src/custom_agents.rs`, preserving unrelated settings and unknown nested custom-agent tables.
 - [x] T164 Implement Settings > Custom Agents selector/edit/action rows in `crates/gwt-tui/src/screens/settings.rs` and wire them to the shared helper.
 - [x] T165 Verify focused `custom_agents` and `screens::settings` tests, then refresh SPEC-3 artifacts.
+
+## Phase 45: Issue Detail Launch Agent Restoration
+
+- [x] T166 Write RED test: `Shift+Enter` on Issue detail opens the wizard with prefilled issue context and the standard new-branch flow.
+- [x] T167 Restore the Issues detail route in `app.rs` so `Shift+Enter` opens the wizard, seeds issue-derived branch context, and prefills `issue_id`.
+- [x] T168 Verify focused issue-launch tests, broad workspace checks, and refresh SPEC-3 artifacts.

--- a/specs/SPEC-3/tasks.md
+++ b/specs/SPEC-3/tasks.md
@@ -69,15 +69,15 @@
 
 - [x] T033 Write RED test: branch launch create-new path enters BranchTypeSelect instead of jumping directly to agent selection.
 - [x] T034 Write RED test: spec-prefilled wizard startup begins at BranchTypeSelect and preserves the SPEC branch seed.
-- [x] T035 Implement branch-first wizard ordering (Branch Type -> Issue -> AI naming -> Branch Name -> Agent) while keeping current Confirm handoff.
+- [x] T035 Implement branch-first wizard ordering (Branch Type -> Issue -> Branch Name -> Agent) while keeping current Confirm handoff and leaving AI naming dormant in the standard flow.
 - [x] T036 Restore old branch type and execution mode labels in the current wizard UI and update focused wizard tests.
 
 ## Phase 8: Old-TUI Wizard Step Machine Restoration
 
 - [x] T037 [P] Write RED test: existing-branch launches use `BranchAction` as the first actionable step and reach completion without a separate `Confirm` step.
-- [x] T038 [P] Write RED test: new-branch and spec-prefilled launches traverse `BranchType -> Issue -> AI Suggest -> BranchName -> Agent`.
+- [x] T038 [P] Write RED test: new-branch and spec-prefilled launches traverse `BranchType -> Issue -> BranchName -> Agent` in the standard flow.
 - [x] T039 [P] Write RED test: `Convert` execution mode routes through `ConvertAgentSelect` and `ConvertSessionSelect`.
-- [x] T040 Rewrite `WizardStep`, `next_step()`, and `prev_step()` to the old-TUI-aligned step machine while preserving version cache, AI suggestion, and session conversion state.
+- [x] T040 Rewrite `WizardStep`, `next_step()`, and `prev_step()` to the old-TUI-aligned step machine while preserving version cache, dormant AI suggestion support, and session conversion state.
 - [x] T041 Verify focused wizard tests, workspace checks, and refresh SPEC-3 artifacts.
 
 ## Phase 9: Old-TUI Wizard Option Formatting

--- a/specs/SPEC-4/metadata.json
+++ b/specs/SPEC-4/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:37:51.557878+00:00",
-  "updated_at": "2026-04-04T08:10:00Z"
+  "updated_at": "2026-04-05T12:22:37Z"
 }

--- a/specs/SPEC-4/plan.md
+++ b/specs/SPEC-4/plan.md
@@ -45,6 +45,27 @@
 - GraphQL primary (`gh api graphql`) for batched PR + check data
 - REST fallback (`gh api repos/{owner}/{repo}/pulls`) when GraphQL is unavailable
 
+## Phase 3: Issue Detail Launch Agent
+
+**Goal:** Keep Issue detail launches wired to the shared Launch Agent wizard.
+
+### Approach
+
+- Reuse the existing wizard startup path instead of building an issue-only
+  launch flow.
+- Seed issue-derived branch context plus the issue number before the wizard
+  renders.
+
+### Components
+
+1. **Issue detail shortcut** — `Shift+Enter` from Issue detail opens the
+   wizard.
+2. **Issue context prefill** — The selected issue title/body seed the
+   branch context, and the numeric issue id pre-populates `IssueSelect`.
+3. **Shared wizard flow** — Issue-origin launches follow
+   `BranchType -> Issue -> Branch Name` with AI suggestion dormant by
+   default.
+
 ## Dependencies
 
 - `gwt-core::git::pr_status` module (PrStatus struct) — exists

--- a/specs/SPEC-4/progress.md
+++ b/specs/SPEC-4/progress.md
@@ -3,8 +3,8 @@
 ## Progress
 - Status: `in-progress`
 - Phase: `Implementation`
-- Task progress: `40/40` checked in `tasks.md`
-- Artifact refresh: `2026-04-04T08:10:00Z`
+- Task progress: `43/43` checked in `tasks.md`
+- Artifact refresh: `2026-04-05T12:22:37Z`
 
 ## Done
 - The missing planning support files for this SPEC are now present.
@@ -22,6 +22,9 @@
 - `fetch_pr_list()` now uses the gh CLI's GraphQL-backed `pr list --json`
   surface as the primary transport and falls back to the REST pulls endpoint
   when that surface is unavailable, so `FR-008` is now implemented.
+- Issue detail now routes `Shift+Enter` back into the shared Launch Agent
+  wizard with the selected issue number prefilled, matching the standard
+  new-branch flow without AI configuration.
 - The remaining gap is completion-gate review, not unchecked execution tasks.
 
 ## Next

--- a/specs/SPEC-4/spec.md
+++ b/specs/SPEC-4/spec.md
@@ -68,6 +68,9 @@ As a developer, I want to launch an agent session from an Issue detail view so t
 
 - AC-6.1: Shift+Enter on Issue detail opens agent launch wizard
 - AC-6.2: Agent launch pre-fills Issue context
+- AC-6.3: Issue-origin launches enter the standard new-branch wizard flow at
+  `BranchTypeSelect`, keep the issue number prefilled in `IssueSelect`, and
+  do not require AI settings to continue to manual branch input
 
 ## Functional Requirements
 
@@ -81,6 +84,7 @@ As a developer, I want to launch an agent session from an Issue detail view so t
 | FR-006 | PR detail with CI check badges | P1 | Implemented |
 | FR-007 | PR status from gwt-core::git::pr_status (PrStatus struct) | P1 | Implemented |
 | FR-008 | GraphQL primary, REST fallback for GitHub API | P1 | Implemented |
+| FR-009 | Issue detail launch pre-fills issue context and issue number while following the standard new-branch wizard flow | P1 | Implemented |
 
 ## Non-Functional Requirements
 

--- a/specs/SPEC-4/tasks.md
+++ b/specs/SPEC-4/tasks.md
@@ -77,3 +77,12 @@
 - [x] TEST: End-to-end test: Git View shows correct file status for a test repo (FUTURE: requires test repo fixtures)
 - [x] TEST: End-to-end test: PR dashboard shows PRs from a mock gh CLI response (FUTURE: requires test repo fixtures)
 - [x] TEST: Regression test: existing Issue tab functionality unaffected
+
+## Phase 4: Issue Detail Launch Agent
+
+- [x] TEST: Add regression test proving `Shift+Enter` on Issue detail opens
+  the wizard with issue-origin prefill.
+- [x] IMPL: Route Issue detail `Shift+Enter` through the shared wizard
+  startup path and prefill the selected issue number.
+- [x] VERIFY: Confirm Issue-origin launches follow the standard
+  `BranchType -> Issue -> Branch Name` flow without AI configuration.

--- a/specs/SPEC-8/metadata.json
+++ b/specs/SPEC-8/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:38:43.183905+00:00",
-  "updated_at": "2026-04-05T12:06:42Z"
+  "updated_at": "2026-04-05T12:22:37Z"
 }

--- a/specs/SPEC-8/metadata.json
+++ b/specs/SPEC-8/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:38:43.183905+00:00",
-  "updated_at": "2026-04-05T11:59:05Z"
+  "updated_at": "2026-04-05T12:06:42Z"
 }

--- a/specs/SPEC-8/metadata.json
+++ b/specs/SPEC-8/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:38:43.183905+00:00",
-  "updated_at": "2026-04-04T00:00:00Z"
+  "updated_at": "2026-04-05T11:59:05Z"
 }

--- a/specs/SPEC-8/plan.md
+++ b/specs/SPEC-8/plan.md
@@ -53,7 +53,9 @@
 
 ## Phase 3: AI Branch Naming Wizard Integration
 
-**Goal**: Keep `BranchNameSuggester` integrated behind the wizard's dedicated AI suggestion step while the standard Launch Agent flow continues directly to manual branch input.
+**Goal**: Keep `BranchNameSuggester` integrated behind the wizard's dedicated
+AI suggestion step while the standard Launch Agent flow from Branches, SPEC
+detail, and Issue detail continues directly to manual branch input.
 
 ### Key Changes
 

--- a/specs/SPEC-8/plan.md
+++ b/specs/SPEC-8/plan.md
@@ -53,11 +53,11 @@
 
 ## Phase 3: AI Branch Naming Wizard Integration
 
-**Goal**: Integrate `BranchNameSuggester` into the wizard's AgentSelect step to display branch name candidates.
+**Goal**: Keep `BranchNameSuggester` integrated behind the wizard's dedicated AI suggestion step while the standard Launch Agent flow continues directly to manual branch input.
 
 ### Key Changes
 
-1. **gwt-tui**: In the wizard AgentSelect step, after SPEC/Issue context is available, call `BranchNameSuggester::suggest()`.
+1. **gwt-tui**: In the dedicated AI suggestion step, after SPEC/Issue context is available, call `BranchNameSuggester::suggest()`.
    - Display 3-5 suggestions as a selectable list.
    - Add "Manual input" option at the bottom.
    - Show a loading spinner while waiting for suggestions.
@@ -67,7 +67,7 @@
    - Strip or replace invalid characters.
    - Enforce 255-byte maximum length.
 
-3. **gwt-tui**: Timeout handling.
+3. **gwt-tui**: Timeout handling for the dormant AI suggestion step.
    - 10-second timeout on suggestion generation.
    - On timeout, auto-select "Manual input" and show a brief notification.
 
@@ -80,4 +80,4 @@
 
 - **Qwen3-ASR integration complexity**: Start with a mock recorder for TUI development; swap in real backend once model loading is verified.
 - **Platform clipboard differences**: Use conditional compilation (`#[cfg(target_os)]`) with fallback to text-only paste.
-- **AI branch naming latency**: The 10-second timeout with manual fallback ensures the wizard never blocks indefinitely.
+- **AI branch naming latency**: When the AI suggestion step is enabled, the 10-second timeout with manual fallback ensures the wizard never blocks indefinitely.

--- a/specs/SPEC-8/progress.md
+++ b/specs/SPEC-8/progress.md
@@ -4,7 +4,7 @@
 - Status: `in-progress`
 - Phase: `Implementation`
 - Task progress: `49/49` checked in `tasks.md`
-- Artifact refresh: `2026-04-03T13:05:00Z`
+- Artifact refresh: `2026-04-05T12:06:42Z`
 
 ## Done
 - Supporting artifacts now reflect the current split between the incomplete
@@ -19,6 +19,9 @@
 - File paste now also parses `file://` and `file://localhost/` clipboard payloads, improving macOS-style file URL handling when the clipboard exposes file URLs as text.
 - AI branch suggestion parsing now enforces `3..=5` git-safe names before the wizard displays them.
 - The wizard AI suggestion step now keeps an explicit `Manual input` option at the bottom of the list.
+- The standard Launch Agent new-branch flow now skips the AI suggestion step
+  and opens manual branch input directly, so AI settings are no longer
+  required just to type a branch name.
 - The wizard now has a render-content regression test for the AI suggestion list, and the voice hotkey chord has its own keybinding test.
 - The gwt-voice, gwt-clipboard, and gwt-ai suites now provide focused
   verification evidence for the currently implemented slices.

--- a/specs/SPEC-8/progress.md
+++ b/specs/SPEC-8/progress.md
@@ -4,7 +4,7 @@
 - Status: `in-progress`
 - Phase: `Implementation`
 - Task progress: `49/49` checked in `tasks.md`
-- Artifact refresh: `2026-04-05T12:06:42Z`
+- Artifact refresh: `2026-04-05T12:22:37Z`
 
 ## Done
 - Supporting artifacts now reflect the current split between the incomplete
@@ -20,8 +20,8 @@
 - AI branch suggestion parsing now enforces `3..=5` git-safe names before the wizard displays them.
 - The wizard AI suggestion step now keeps an explicit `Manual input` option at the bottom of the list.
 - The standard Launch Agent new-branch flow now skips the AI suggestion step
-  and opens manual branch input directly, so AI settings are no longer
-  required just to type a branch name.
+  from Branches, SPEC detail, and Issue detail and opens manual branch input
+  directly, so AI settings are no longer required just to type a branch name.
 - The wizard now has a render-content regression test for the AI suggestion list, and the voice hotkey chord has its own keybinding test.
 - The gwt-voice, gwt-clipboard, and gwt-ai suites now provide focused
   verification evidence for the currently implemented slices.

--- a/specs/SPEC-8/spec.md
+++ b/specs/SPEC-8/spec.md
@@ -6,11 +6,11 @@ gwt-tui extends terminal input with voice transcription (Qwen3-ASR), file
 paste from clipboard, and AI-assisted branch naming. The voice path now
 routes start/stop/transcribe through a shared TUI runtime seam, but the
 concrete Qwen3-ASR backend remains a stub that returns model-loading errors.
-The AI branch
-naming flow is live in the wizard, including explicit manual-entry fallback in
-the suggestion list and normalization to `3..=5` git-safe names. File paste
-now shell-quotes injected paths and parses `file://` clipboard payloads for
-safer PTY input.
+The AI branch naming flow remains implemented in the codebase, including
+explicit manual-entry fallback in the suggestion list and normalization to
+`3..=5` git-safe names, but the standard Launch Agent wizard currently skips
+that step and opens manual branch input directly. File paste now shell-quotes
+injected paths and parses `file://` clipboard payloads for safer PTY input.
 
 ## User Stories
 
@@ -38,16 +38,16 @@ As a developer, I want to paste file paths from the system clipboard into the te
 3. Given the clipboard contains text (not file references), when I press Ctrl+G,p, then the text is pasted as-is.
 4. Given the clipboard is empty, when I press Ctrl+G,p, then nothing is pasted and no error is shown.
 
-### US-3: Get AI-Suggested Branch Names in Wizard (P2) -- IMPLEMENTED
+### US-3: Get AI-Suggested Branch Names in Wizard (P2) -- PARTIALLY IMPLEMENTED
 
 As a developer, I want AI-suggested branch names when creating a new worktree so that I can quickly pick a well-formatted name.
 
 **Acceptance Scenarios**
 
-1. Given I am in the wizard at the AgentSelect step, when the SPEC title or Issue description is available, then 3-5 AI-generated branch name suggestions are displayed.
-2. Given suggestions are displayed, when I select one, then it is used as the branch name.
-3. Given I prefer a custom name, when I select "Manual input", then I can type a branch name freely.
-4. Given the AI provider is unavailable or times out (10s), when suggestions fail, then manual input is shown as the fallback.
+1. Given I create a new worktree through the standard Launch Agent flow, when I continue past branch type and issue selection, then the wizard opens manual branch input directly without requiring AI settings.
+2. Given the AI suggestion step is explicitly re-enabled, when the SPEC title or Issue description is available, then 3-5 AI-generated branch name suggestions are displayed.
+3. Given suggestions are displayed, when I select one, then it is used as the branch name.
+4. Given I prefer a custom name or the AI provider is unavailable or times out (10s), when I choose manual input, then I can type a branch name freely.
 5. Given a suggestion is selected, when validated, then it conforms to Git branch naming rules (no spaces, no special chars except /-_).
 
 ## Edge Cases
@@ -82,16 +82,16 @@ As a developer, I want AI-suggested branch names when creating a new worktree so
 
 ### AI Branch Naming
 
-- **FR-011**: AI branch name suggestion displayed in wizard AgentSelect step when creating a new worktree.
-- **FR-012**: `BranchNameSuggester` generates 3-5 candidate names from the SPEC title or Issue description.
-- **FR-013**: Fallback to manual text input if AI is unavailable or timeout exceeds 10 seconds.
-- **FR-014**: All generated branch names validated against Git branch naming rules before display.
+- **FR-011**: The standard new-worktree Launch Agent flow skips AI branch suggestion and opens manual branch input without requiring active AI settings.
+- **FR-012**: When the AI suggestion step is explicitly enabled, `BranchNameSuggester` generates 3-5 candidate names from the SPEC title or Issue description.
+- **FR-013**: When the AI suggestion step is enabled, manual text input remains available if AI is unavailable or timeout exceeds 10 seconds.
+- **FR-014**: All generated branch names are validated against Git branch naming rules before display.
 
 ## Non-Functional Requirements
 
 - **NFR-001**: Voice transcription completes within 5 seconds for 10-second audio input.
 - **NFR-002**: File paste operation completes within 100ms from hotkey press to PTY injection.
-- **NFR-003**: AI branch name suggestion completes within 10 seconds; timeout triggers fallback.
+- **NFR-003**: When enabled, AI branch name suggestion completes within 10 seconds; timeout triggers fallback.
 - **NFR-004**: Voice recording introduces no audible latency or glitches.
 - **NFR-005**: All hotkeys use the Ctrl+G chord prefix to avoid conflicts with terminal applications.
 
@@ -101,6 +101,6 @@ As a developer, I want AI-suggested branch names when creating a new worktree so
 - **SC-002**: Status bar recording indicator appears during voice capture and disappears on completion.
 - **SC-003**: File paste correctly extracts and injects file paths from the system clipboard.
 - **SC-004**: Multi-file paste produces one path per line with correct shell escaping.
-- **SC-005**: AI branch naming displays 3-5 suggestions in the wizard and allows selection or manual override.
+- **SC-005**: Standard Launch Agent new-branch flow reaches manual branch entry without AI configuration, and the dormant AI suggestion path still supports selection or manual override when explicitly enabled.
 - **SC-006**: All generated branch names pass Git naming validation.
 - **SC-007**: Timeout and fallback paths work correctly for both voice and AI branch naming.

--- a/specs/SPEC-8/spec.md
+++ b/specs/SPEC-8/spec.md
@@ -44,11 +44,15 @@ As a developer, I want AI-suggested branch names when creating a new worktree so
 
 **Acceptance Scenarios**
 
-1. Given I create a new worktree through the standard Launch Agent flow, when I continue past branch type and issue selection, then the wizard opens manual branch input directly without requiring AI settings.
+1. Given I create a new worktree through the standard Launch Agent flow from
+   Branches, SPEC detail, or Issue detail, when I continue past branch type
+   and issue selection, then the wizard opens manual branch input directly
+   without requiring AI settings.
 2. Given the AI suggestion step is explicitly re-enabled, when the SPEC title or Issue description is available, then 3-5 AI-generated branch name suggestions are displayed.
 3. Given suggestions are displayed, when I select one, then it is used as the branch name.
 4. Given I prefer a custom name or the AI provider is unavailable or times out (10s), when I choose manual input, then I can type a branch name freely.
 5. Given a suggestion is selected, when validated, then it conforms to Git branch naming rules (no spaces, no special chars except /-_).
+6. Given I use the current product surface, when I configure Launch Agent, then no public control is available to re-enable the dormant AI suggestion step.
 
 ## Edge Cases
 
@@ -82,10 +86,14 @@ As a developer, I want AI-suggested branch names when creating a new worktree so
 
 ### AI Branch Naming
 
-- **FR-011**: The standard new-worktree Launch Agent flow skips AI branch suggestion and opens manual branch input without requiring active AI settings.
+- **FR-011**: The standard new-worktree Launch Agent flow from Branches,
+  SPEC detail, and Issue detail skips AI branch suggestion and opens manual
+  branch input without requiring active AI settings.
 - **FR-012**: When the AI suggestion step is explicitly enabled, `BranchNameSuggester` generates 3-5 candidate names from the SPEC title or Issue description.
 - **FR-013**: When the AI suggestion step is enabled, manual text input remains available if AI is unavailable or timeout exceeds 10 seconds.
 - **FR-014**: All generated branch names are validated against Git branch naming rules before display.
+- **FR-015**: The dormant AI suggestion step is implementation-only in this
+  slice; no public UI or settings affordance re-enables it.
 
 ## Non-Functional Requirements
 

--- a/specs/SPEC-8/tasks.md
+++ b/specs/SPEC-8/tasks.md
@@ -56,7 +56,7 @@
 - [x] **T-033**: Implement PTY injection of extracted file paths.
 - [x] **T-034**: Verify T-030, T-031 pass (GREEN).
 
-## Phase 3: AI Branch Naming Wizard Integration (Dormant in Standard Launch Agent Flow)
+## Phase 3: AI Branch Naming Wizard Integration (Dormant in Standard Launch Agent Flow from Branches / SPEC Detail / Issue Detail)
 
 ### 3.1 Branch Name Suggestion Display
 

--- a/specs/SPEC-8/tasks.md
+++ b/specs/SPEC-8/tasks.md
@@ -56,15 +56,15 @@
 - [x] **T-033**: Implement PTY injection of extracted file paths.
 - [x] **T-034**: Verify T-030, T-031 pass (GREEN).
 
-## Phase 3: AI Branch Naming Wizard Integration
+## Phase 3: AI Branch Naming Wizard Integration (Dormant in Standard Launch Agent Flow)
 
 ### 3.1 Branch Name Suggestion Display
 
 - [x] **T-035**: Write test for `BranchNameSuggester::suggest()` returning 3-5 valid names.
 - [x] **T-036**: Write test for all suggestions passing `git check-ref-format` validation.
-- [x] **T-037**: Write test for suggestion list rendering in wizard AgentSelect step.
+- [x] **T-037**: Write test for suggestion list rendering in the wizard AI suggestion step.
 - [x] **T-038**: Write test for "Manual input" option always present at bottom of list.
-- [x] **T-039**: Implement suggestion list UI in wizard AgentSelect step.
+- [x] **T-039**: Implement suggestion list UI in the wizard AI suggestion step.
 - [x] **T-040**: Wire `BranchNameSuggester::suggest()` call with SPEC title / Issue description context.
 - [x] **T-041**: Verify T-035 through T-038 pass (GREEN).
 
@@ -80,4 +80,4 @@
 
 - [x] **T-047**: Manual verification: voice input records, transcribes, and injects text into PTY. (runtime/session wiring is now verified by unit tests in `gwt-tui`, but concrete Qwen3-ASR capture remains pending real backend availability)
 - [x] **T-048**: Manual verification: file paste extracts paths from clipboard and injects into PTY. (obsolete: covered by unit tests on ClipboardFilePaste and PTY injection)
-- [x] **T-049**: Manual verification: wizard displays branch name suggestions and allows selection. (obsolete: covered by unit tests on BranchNameSuggester and wizard rendering)
+- [x] **T-049**: Manual verification: the dedicated wizard AI suggestion step displays branch name suggestions and allows selection. (obsolete: covered by unit tests on BranchNameSuggester and wizard rendering)


### PR DESCRIPTION
## Summary

- Skip the Launch Agent AI branch suggestion step in the standard new-branch flow so manual branch entry works without AI settings.
- Restore Issue Detail `Shift+Enter` to open the shared wizard path with issue-prefilled context so issue-origin launches match Branches and SPEC Detail behavior.
- Align `SPEC-3`, `SPEC-4`, and `SPEC-8` artifacts with the dormant AI suggestion policy so the implemented flow and tracked requirements stay synchronized.

## Changes

- `crates/gwt-tui/src/screens/wizard.rs`: default `ai_enabled` to `false` for the standard new-branch flow and keep AI-specific tests explicit.
- `crates/gwt-tui/src/app.rs`: initialize wizard startup without AI suggestion by default, add issue-context seeding, and route Issue Detail `Shift+Enter` into the prefilled wizard flow.
- `specs/SPEC-3/*`: define the standard Launch Agent flow scope and document the internal-only dormant AI suggestion policy.
- `specs/SPEC-4/*` and `specs/SPEC-8/*`: sync issue-launch and AI-branch-naming plans, tasks, progress, and metadata with the restored flow.

## Testing

- [x] `cargo fmt` — formatting completed successfully.
- [x] `cargo test -p gwt-tui route_key_to_management_issues_shift_enter_opens_prefilled_wizard` — the issue-detail regression test passed.
- [x] `cargo test -p gwt-core -p gwt-tui` — the full Rust test suite passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint completed with no warnings.
- [x] `bunx markdownlint-cli specs/SPEC-3/spec.md specs/SPEC-3/plan.md specs/SPEC-3/tasks.md specs/SPEC-3/progress.md specs/SPEC-4/spec.md specs/SPEC-4/plan.md specs/SPEC-4/tasks.md specs/SPEC-4/progress.md specs/SPEC-8/spec.md specs/SPEC-8/plan.md specs/SPEC-8/tasks.md specs/SPEC-8/progress.md` — markdown lint passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — the latest commit message passed commitlint.

## Closing Issues

None

## Related Issues / Links

- https://github.com/akiojin/gwt/blob/bugfix/ai-branch-suggestion/specs/SPEC-3/spec.md
- https://github.com/akiojin/gwt/blob/bugfix/ai-branch-suggestion/specs/SPEC-4/spec.md
- https://github.com/akiojin/gwt/blob/bugfix/ai-branch-suggestion/specs/SPEC-8/spec.md

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema or data change
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- A regression forced `AIBranchSuggest` on in the standard new-branch wizard path, which made Launch Agent depend on AI configuration and left Issue Detail launch behavior inconsistent with the restored shared flow.

## Risk / Impact

- **Affected areas**: Launch Agent wizard routing from Branches, SPEC Detail, and Issue Detail; issue-management shortcut handling; SPEC-3, SPEC-4, and SPEC-8 artifacts.
- **Rollback plan**: Revert commits `020cf97d`, `00de1a3f`, and `f29734c3` if the restored branch-flow routing needs to be undone.

## Screenshots

| Before | After |
|--------|-------|
| Standard new-branch launch could fail with an AI settings requirement, and Issue Detail `Shift+Enter` did not rejoin the shared wizard path. | Standard new-branch launch opens manual branch input without AI settings, and Issue Detail `Shift+Enter` opens the shared prefilled wizard path. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shift+Enter shortcut in issue detail view to launch the wizard with issue context pre-filled.

* **Changes**
  * Reordered wizard step sequence: branch name input now occurs before agent selection in the standard new-branch workflow.
  * Disabled AI-powered suggestions by default in the wizard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->