### PR TITLE
fix(tui): ウィザード枠構造修正・エージェント起動ステータス表示追加

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -19,7 +19,7 @@ use gwt_notification::{Notification, Severity};
 use gwt_skills::{distribute_to_worktree, generate_settings_local, update_git_exclude};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Style,
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
     Frame,
@@ -190,6 +190,7 @@ pub fn update(model: &mut Model, msg: Message) {
                 name: format!("Shell {}", idx + 1),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             };
             let session_id = session.id.clone();
             model.sessions.push(session);
@@ -1644,6 +1645,7 @@ fn check_branch_pending_actions(model: &mut Model) {
                     name: format!("Shell: {}", branch.name),
                     tab_type: crate::model::SessionTabType::Shell,
                     vt: crate::model::VtState::new(24, 80),
+                    created_at: std::time::Instant::now(),
                 };
                 let session_id = session.id.clone();
                 model.sessions.push(session);
@@ -2476,6 +2478,7 @@ fn materialize_pending_launch_with(
             color: tui_agent_color(config.color),
         },
         vt: crate::model::VtState::new(24, 80),
+        created_at: std::time::Instant::now(),
     };
     let tab_id = tab.id.clone();
     model.sessions.push(tab);
@@ -3006,6 +3009,18 @@ fn tui_agent_color(color: gwt_agent::AgentColor) -> crate::model::AgentColor {
     }
 }
 
+/// Map `AgentColor` to a ratatui `Color` for rendering.
+fn agent_color_to_ratatui(color: crate::model::AgentColor) -> Color {
+    match color {
+        crate::model::AgentColor::Green => Color::Green,
+        crate::model::AgentColor::Blue => Color::Blue,
+        crate::model::AgentColor::Cyan => Color::Cyan,
+        crate::model::AgentColor::Yellow => Color::Yellow,
+        crate::model::AgentColor::Magenta => Color::Magenta,
+        crate::model::AgentColor::Gray => Color::Gray,
+    }
+}
+
 fn clipboard_payload_to_bytes(paths: &[PathBuf], fallback_text: &str) -> Option<Vec<u8>> {
     if !paths.is_empty() {
         let payload = paths
@@ -3282,14 +3297,61 @@ fn render_session_surface(
     show_cursor: bool,
 ) {
     if session.vt.screen().contents().trim().is_empty() {
-        let placeholder = Paragraph::new(format!(
-            "Session: {} ({}x{})",
-            session.name,
-            session.vt.cols(),
-            session.vt.rows()
-        ))
-        .style(Style::default().fg(theme::color::TEXT_DISABLED));
-        frame.render_widget(placeholder, area);
+        match &session.tab_type {
+            crate::model::SessionTabType::Agent { agent_id, color } => {
+                // Braille spinner driven by elapsed time (~5 fps via 100ms tick)
+                const SPINNER: [char; 6] =
+                    ['\u{280B}', '\u{2819}', '\u{2838}', '\u{2834}', '\u{2826}', '\u{2807}'];
+                let elapsed = session.created_at.elapsed().as_millis() as usize;
+                let ch = SPINNER[(elapsed / 200) % SPINNER.len()];
+                let agent_fg = agent_color_to_ratatui(*color);
+
+                // Center the startup display vertically
+                let top_pad = area.height.saturating_sub(5) / 2;
+                let mut lines: Vec<Line<'_>> = Vec::new();
+                for _ in 0..top_pad {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("{} ", theme::icon::SESSION_AGENT),
+                        Style::default().fg(agent_fg),
+                    ),
+                    Span::styled(
+                        session.name.clone(),
+                        Style::default()
+                            .fg(agent_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ]));
+                lines.push(Line::from(""));
+                lines.push(Line::from(vec![
+                    Span::styled(format!("{ch} "), Style::default().fg(agent_fg)),
+                    Span::styled(
+                        format!("Starting {agent_id}..."),
+                        Style::default().fg(theme::color::TEXT_SECONDARY),
+                    ),
+                ]));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    "Waiting for agent output",
+                    Style::default().fg(theme::color::TEXT_DISABLED),
+                )));
+                let paragraph =
+                    Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+                frame.render_widget(paragraph, area);
+            }
+            _ => {
+                let placeholder = Paragraph::new(format!(
+                    "Session: {} ({}x{})",
+                    session.name,
+                    session.vt.cols(),
+                    session.vt.rows()
+                ))
+                .style(Style::default().fg(theme::color::TEXT_DISABLED));
+                frame.render_widget(placeholder, area);
+            }
+        }
     } else {
         frame.render_widget(
             crate::widgets::terminal_view::TerminalView::new(session.vt.screen()),
@@ -3995,6 +4057,7 @@ mod tests {
                 color,
             },
             vt: crate::model::VtState::new(30, 100),
+            created_at: std::time::Instant::now(),
         }
     }
 
@@ -4184,6 +4247,7 @@ mod tests {
             name: "Shell: feature/status-bar".to_string(),
             tab_type: SessionTabType::Shell,
             vt: crate::model::VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         };
 
         let rendered = render_model_text(&model, 220, 24);
@@ -4458,6 +4522,7 @@ mod tests {
             name: name.to_string(),
             tab_type: SessionTabType::Shell,
             vt: crate::model::VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         }
     }
 
@@ -4607,6 +4672,7 @@ mod tests {
             name: "Shell: feature/compact-footer".to_string(),
             tab_type: SessionTabType::Shell,
             vt: crate::model::VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         };
 
         let rendered = render_model_text(&model, 80, 24);
@@ -6067,6 +6133,7 @@ mod tests {
                     color: crate::model::AgentColor::Blue,
                 },
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
             crate::model::SessionTab {
                 id: stale_branch.id.clone(),
@@ -6076,6 +6143,7 @@ mod tests {
                     color: crate::model::AgentColor::Green,
                 },
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
             crate::model::SessionTab {
                 id: stale_worktree.id.clone(),
@@ -6085,12 +6153,14 @@ mod tests {
                     color: crate::model::AgentColor::Cyan,
                 },
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
             crate::model::SessionTab {
                 id: "shell-branch".to_string(),
                 name: "Shell: feature/test".to_string(),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
         ];
         model.active_session = 0;
@@ -7556,12 +7626,14 @@ CUSTOM_ENV = "enabled"
                 name: "Shell: feature/test".to_string(),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
             crate::model::SessionTab {
                 id: "shell-1".to_string(),
                 name: "Shell: feature/test".to_string(),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
         ];
 
@@ -7591,12 +7663,14 @@ CUSTOM_ENV = "enabled"
                 name: "Shell: feature/test".to_string(),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
             crate::model::SessionTab {
                 id: "shell-1".to_string(),
                 name: "Shell: feature/test".to_string(),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
         ];
         model.branches.detail_session_selected = 1;
@@ -7626,12 +7700,14 @@ CUSTOM_ENV = "enabled"
                 name: "Shell: feature/test".to_string(),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
             crate::model::SessionTab {
                 id: "shell-1".to_string(),
                 name: "Shell: feature/test".to_string(),
                 tab_type: SessionTabType::Shell,
                 vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
             },
         ];
         model.branches.detail_session_selected = 99;

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3300,8 +3300,9 @@ fn render_session_surface(
         match &session.tab_type {
             crate::model::SessionTabType::Agent { agent_id, color } => {
                 // Braille spinner driven by elapsed time (~5 fps via 100ms tick)
-                const SPINNER: [char; 6] =
-                    ['\u{280B}', '\u{2819}', '\u{2838}', '\u{2834}', '\u{2826}', '\u{2807}'];
+                const SPINNER: [char; 6] = [
+                    '\u{280B}', '\u{2819}', '\u{2838}', '\u{2834}', '\u{2826}', '\u{2807}',
+                ];
                 let elapsed = session.created_at.elapsed().as_millis() as usize;
                 let ch = SPINNER[(elapsed / 200) % SPINNER.len()];
                 let agent_fg = agent_color_to_ratatui(*color);
@@ -3319,9 +3320,7 @@ fn render_session_surface(
                     ),
                     Span::styled(
                         session.name.clone(),
-                        Style::default()
-                            .fg(agent_fg)
-                            .add_modifier(Modifier::BOLD),
+                        Style::default().fg(agent_fg).add_modifier(Modifier::BOLD),
                     ),
                 ]));
                 lines.push(Line::from(""));
@@ -3337,8 +3336,7 @@ fn render_session_surface(
                     "Waiting for agent output",
                     Style::default().fg(theme::color::TEXT_DISABLED),
                 )));
-                let paragraph =
-                    Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+                let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
                 frame.render_widget(paragraph, area);
             }
             _ => {

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -242,6 +242,8 @@ pub struct SessionTab {
     pub name: String,
     pub tab_type: SessionTabType,
     pub vt: VtState,
+    /// When this session was created (used for startup spinner animation).
+    pub created_at: std::time::Instant,
 }
 
 /// Buffered PTY input waiting to be written to the active session.
@@ -435,6 +437,7 @@ impl Model {
             name: "Shell".to_string(),
             tab_type: SessionTabType::Shell,
             vt: VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         };
         let (notification_bus, notification_receiver) = NotificationBus::new();
         let (pty_output_tx, pty_output_rx) = std::sync::mpsc::channel();
@@ -889,12 +892,14 @@ mod tests {
             name: "Shell 2".to_string(),
             tab_type: SessionTabType::Shell,
             vt: VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         });
         model.sessions.push(SessionTab {
             id: "shell-2".to_string(),
             name: "Shell 3".to_string(),
             tab_type: SessionTabType::Shell,
             vt: VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         });
         model.save_session_state(&path).unwrap();
 

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -1736,9 +1736,7 @@ pub fn render(state: &WizardState, frame: &mut Frame, area: Rect) {
         1,
     );
     let hint = match state.step {
-        WizardStep::BranchNameInput | WizardStep::IssueSelect => {
-            "[Enter] Confirm  [Esc] Back"
-        }
+        WizardStep::BranchNameInput | WizardStep::IssueSelect => "[Enter] Confirm  [Esc] Back",
         WizardStep::AIBranchSuggest if state.ai_suggest.loading => "[Esc] Cancel",
         WizardStep::AIBranchSuggest if state.ai_suggest.error.is_some() => {
             "[Enter] Manual input  [Esc] Retry"

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -1,8 +1,8 @@
 //! Wizard overlay screen — branch-first agent launch wizard.
 
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
@@ -1472,6 +1472,74 @@ fn quick_start_start_new_marker(is_selected: bool, single_entry: bool) -> &'stat
     }
 }
 
+/// Compute popup width based on actual content (title + options + hints).
+///
+/// Mirrors old-TUI `wizard_popup_width`: measure the widest content line,
+/// add border + padding, then clamp to [min_width, max_width].
+fn wizard_popup_width(state: &WizardState, max_width: u16) -> u16 {
+    let min_width = 40u16.min(max_width);
+
+    let mut max_line = 0usize;
+
+    // Title + [ESC] badge
+    let title_len = popup_title(state).len() + " [ESC] ".len() + 4;
+    max_line = max_line.max(title_len);
+
+    // Measure rendered content width per step type.
+    // Fixed-width steps use `format_fixed_width_line` with a column width;
+    // version and model steps use label-description pairs.
+    match state.step {
+        WizardStep::ExecutionMode => {
+            for &(label, desc) in &EXECUTION_MODE_DISPLAY_OPTIONS {
+                // marker(2) + max(label_width, label.len)(12) + space(1) + description
+                max_line = max_line.max(2 + 12.max(label.len()) + 1 + desc.len());
+            }
+        }
+        WizardStep::ReasoningLevel => {
+            for &(label, desc) in &REASONING_DISPLAY_OPTIONS {
+                max_line = max_line.max(2 + 10.max(label.len()) + 1 + desc.len());
+            }
+        }
+        WizardStep::SkipPermissions => {
+            for &(label, desc) in &SKIP_PERMISSION_DISPLAY_OPTIONS {
+                max_line = max_line.max(2 + 6.max(label.len()) + 1 + desc.len());
+            }
+        }
+        WizardStep::ModelSelect => {
+            for opt in model_display_options(&state.agent_id) {
+                // marker(4) + label + " - " + description
+                max_line = max_line.max(4 + opt.label.len() + 3 + opt.description.len());
+            }
+        }
+        WizardStep::VersionSelect => {
+            for opt in &state.version_options {
+                // marker(2) + label + " - " + description (description from render)
+                // Version render uses format_label_description_line which adds description
+                max_line = max_line.max(2 + opt.label.len() + 30);
+            }
+        }
+        _ => {
+            for opt in state.current_options() {
+                max_line = max_line.max(opt.len() + 4);
+            }
+        }
+    }
+
+    // Hint line width
+    let hint_len = match state.step {
+        WizardStep::SkipPermissions => " Up/Down: select | Enter: launch | Esc: back".len(),
+        WizardStep::AIBranchSuggest => {
+            " Up/Down: select | Enter: accept | e: edit | Esc: manual input".len()
+        }
+        _ => " Up/Down: select | Enter: next | Esc: back".len(),
+    };
+    max_line = max_line.max(hint_len);
+
+    // borders(2) + H_PAD on each side (2*2=4)
+    let desired = (max_line as u16).saturating_add(2 + 4);
+    desired.max(min_width).min(max_width)
+}
+
 fn popup_title(state: &WizardState) -> String {
     if state.step == WizardStep::QuickStart && state.quick_start_entries.len() == 1 {
         format!(
@@ -1620,54 +1688,69 @@ fn render_agent_select_step(state: &WizardState, frame: &mut Frame, area: Rect) 
 
 /// Render the wizard overlay.
 pub fn render(state: &WizardState, frame: &mut Frame, area: Rect) {
-    // Centered modal — 60% width, 70% height
-    let width = (area.width * 60 / 100).max(40);
-    let height = (area.height * 70 / 100).max(12);
-    let overlay = super::centered_rect(width, height, area);
+    // Dark overlay background — dims the content behind the modal
+    let overlay_bg = Block::default().style(Style::default().bg(Color::Rgb(20, 20, 30)));
+    frame.render_widget(overlay_bg, area);
 
-    // Clear the area behind the overlay
-    frame.render_widget(Clear, overlay);
+    // Content-aware width, 60% height (matches old-TUI sizing)
+    let max_width = area.width.saturating_sub(2).max(1);
+    let width = wizard_popup_width(state, max_width);
+    let height = (area.height * 60 / 100).max(15);
+    let popup = super::centered_rect(width, height, area);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3), // Popup chrome
-            Constraint::Min(0),    // Content
-            Constraint::Length(1), // Hints
-        ])
-        .split(overlay);
+    frame.render_widget(Clear, popup);
 
-    // Popup chrome
-    let title_block = Block::default()
+    // Single outer border wrapping the entire modal
+    let block = Block::default()
         .borders(Borders::ALL)
-        .border_type(theme::border::modal())
         .border_style(Style::default().fg(theme::color::FOCUS))
-        .title_top(Line::from(popup_title(state)).style(theme::style::header()))
+        .title_top(
+            Line::from(format!(" {} ", popup_title(state))).style(
+                Style::default()
+                    .fg(theme::color::FOCUS)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        )
         .title_top(Line::from(" [ESC] ").right_aligned());
-    frame.render_widget(title_block, chunks[0]);
+
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    // Horizontal padding + vertical margins inside the border
+    const H_PAD: u16 = 2;
+    let content_area = Rect::new(
+        inner.x + H_PAD,
+        inner.y + 1,
+        inner.width.saturating_sub(H_PAD * 2),
+        inner.height.saturating_sub(4), // top margin(1) + bottom gap(2) + footer(1)
+    );
 
     // Content — either a list of options or a text input
-    render_step_content(state, frame, chunks[1]);
+    render_step_content(state, frame, content_area);
 
-    // Hints
+    // Footer — centered keybind hints at the bottom with margin
+    let footer_area = Rect::new(
+        inner.x,
+        inner.y + inner.height.saturating_sub(2),
+        inner.width,
+        1,
+    );
     let hint = match state.step {
         WizardStep::BranchNameInput | WizardStep::IssueSelect => {
-            " Type to input | Enter: next | Esc: back"
+            "[Enter] Confirm  [Esc] Back"
         }
-        WizardStep::AIBranchSuggest if state.ai_suggest.loading => {
-            " Loading AI suggestions... | Esc: skip to manual input"
-        }
+        WizardStep::AIBranchSuggest if state.ai_suggest.loading => "[Esc] Cancel",
         WizardStep::AIBranchSuggest if state.ai_suggest.error.is_some() => {
-            " Enter/Esc: manual input"
+            "[Enter] Manual input  [Esc] Retry"
         }
-        WizardStep::AIBranchSuggest => {
-            " Up/Down: select | Enter: accept | e: edit | Esc: manual input"
-        }
-        WizardStep::SkipPermissions => " Up/Down: select | Enter: launch | Esc: back",
-        _ => " Up/Down: select | Enter: next | Esc: back",
+        WizardStep::AIBranchSuggest => "[Enter] Select  [Esc] Back  [Up/Down] Navigate",
+        WizardStep::SkipPermissions => "[Enter] Launch  [Esc] Back  [Up/Down] Navigate",
+        _ => "[Enter] Select  [Esc] Back  [Up/Down] Navigate",
     };
-    let hints = Paragraph::new(hint).style(theme::style::muted_text());
-    frame.render_widget(hints, chunks[2]);
+    let footer = Paragraph::new(hint)
+        .style(theme::style::muted_text())
+        .alignment(Alignment::Center);
+    frame.render_widget(footer, footer_area);
 }
 
 /// Render the content area for the current wizard step.
@@ -2507,7 +2590,7 @@ mod tests {
             "input value should render on a row below the prompt"
         );
         assert!(
-            text.matches('╔').count() == 1,
+            text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1,
             "branch input should reuse the popup chrome instead of adding a second boxed title inside the content area"
         );
     }
@@ -2530,7 +2613,7 @@ mod tests {
             "input value should render on a row below the prompt"
         );
         assert!(
-            text.matches('╔').count() == 1,
+            text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1,
             "issue input should use the same inline prompt style instead of adding another boxed title"
         );
     }
@@ -2997,7 +3080,7 @@ mod tests {
         let text = render_text(&state, 90, 24);
 
         assert!(text.contains("Use selected branch"));
-        assert!(text.matches('╔').count() == 1);
+        assert!(text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1);
     }
 
     #[test]
@@ -3029,7 +3112,7 @@ mod tests {
         assert!(text.contains("> Opus 4.6 - Most capable for complex work"));
         assert!(text.contains("  Sonnet 4.5 - Best for everyday tasks"));
         assert!(text.contains("  Haiku 4.5 - Fastest for quick answers"));
-        assert!(text.contains("Up/Down: select | Enter: next | Esc: back"));
+        assert!(text.contains("[Enter] Select  [Esc] Back  [Up/Down] Navigate"));
     }
 
     #[test]
@@ -3042,7 +3125,7 @@ mod tests {
         let text = render_text(&state, 160, 24);
 
         assert!(text.contains("Default (recommended) - Opus 4.6"));
-        assert!(text.matches('╔').count() == 1);
+        assert!(text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1);
     }
 
     #[test]
@@ -3104,7 +3187,7 @@ mod tests {
         assert!(text.contains("Skip Permissions"));
         assert!(text.contains("  Yes    Skip permission prompts"));
         assert!(text.contains("> No     Show permission prompts"));
-        assert!(text.contains("Up/Down: select | Enter: launch | Esc: back"));
+        assert!(text.contains("[Enter] Launch  [Esc] Back  [Up/Down] Navigate"));
     }
 
     #[test]
@@ -3182,7 +3265,7 @@ mod tests {
         let text = render_text(&state, 90, 24);
 
         assert!(text.contains("Installed (v1.0.0) - Use installed version"));
-        assert!(text.matches('╔').count() == 1);
+        assert!(text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1);
     }
 
     #[test]
@@ -3374,7 +3457,7 @@ mod tests {
         assert!(text.contains("feature/oauth-flow"));
         assert!(text.contains("Manual input"));
         assert!(
-            text.matches('╔').count() == 1,
+            text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1,
             "AI suggestions should reuse the popup chrome instead of adding inner boxes"
         );
     }
@@ -3478,7 +3561,7 @@ mod tests {
             loading_y > context_y,
             "loading text should render below the context line"
         );
-        assert!(text.matches('╔').count() == 1);
+        assert!(text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1);
     }
 
     #[test]
@@ -3528,7 +3611,7 @@ mod tests {
             error_y > context_y,
             "error copy should render below the context line"
         );
-        assert!(text.matches('╔').count() == 1);
+        assert!(text.chars().filter(|c| "╭╔┌┏".contains(*c)).count() == 1);
     }
 
     #[test]

--- a/crates/gwt-tui/src/widgets/status_bar.rs
+++ b/crates/gwt-tui/src/widgets/status_bar.rs
@@ -326,6 +326,7 @@ mod tests {
             name: "Shell: feature/status-bar".to_string(),
             tab_type: SessionTabType::Shell,
             vt: VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         };
 
         let backend = TestBackend::new(140, 3);
@@ -357,6 +358,7 @@ mod tests {
                 color: AgentColor::Blue,
             },
             vt: VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         };
         model.branches.branches = vec![BranchItem {
             name: "feature/agent-context".to_string(),

--- a/crates/gwt-tui/src/widgets/tab_bar.rs
+++ b/crates/gwt-tui/src/widgets/tab_bar.rs
@@ -67,6 +67,7 @@ mod tests {
                 color: AgentColor::Green,
             },
             vt: VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
         });
         let backend = TestBackend::new(80, 3);
         let mut terminal = Terminal::new(backend).unwrap();


### PR DESCRIPTION
## Summary

- ウィザードモーダルの枠構造を旧TUI (v6.30.3) 同等に修正し、暗いオーバーレイ背景・パディング・フッター中央揃えを復元
- コンテンツ幅ベースの動的ポップアップサイズ計算を実装
- エージェント起動時にBrailleスピナー付きステータス表示を追加（エージェント固有の色・中央配置）

## Changes

### ウィザード枠修正 (`wizard.rs`)
- タイトルだけ囲んでいた壊れた構造を、全体を1つの `Block` で囲む正しい構造に修正
- 暗いオーバーレイ背景 (`bg(Rgb(20,20,30))`) でモーダルを浮き出し
- 水平パディング (`H_PAD=2`) と垂直マージンでコンテンツの余白を確保
- フッターを中央揃え (`Alignment::Center`) で配置
- `wizard_popup_width()` でコンテンツ幅・固定幅ステップ・ヒント行幅を計算し動的サイズ決定

### エージェント起動ステータス (`app.rs`, `model.rs`)
- `SessionTab` に `created_at: Instant` フィールドを追加
- Agent セッションでVT100出力が空の場合、エージェント固有色でスピナー + `Starting {agent}...` を中央表示
- `agent_color_to_ratatui()` でモデル色からratatui色への変換

## Testing

- `cargo test -p gwt-tui` — 725テスト全通過
- `cargo clippy -p gwt-tui --all-targets --all-features -- -D warnings` — 警告なし
- 手動確認: ウィザード表示・エージェント起動ステータスの目視確認

## Closing Issues

None

## Related Issues

None

## Checklist

- [x] ビルド成功
- [x] テスト全通過
- [x] clippy 警告なし
- [x] 旧TUI (v6.30.3) のウィザード構造と同等の品質

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent sessions now display an animated loading spinner during startup, providing real-time visual feedback to users instead of showing an empty initialization screen.

* **Improvements**
  * Redesigned wizard modal layout with dynamic content-aware width calculation, improved footer navigation hints for each step, and enhanced border styling for better visual hierarchy and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->