### PR TITLE
fix(tui): keep AI branch suggestion disabled in wizard startup

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -2959,7 +2959,7 @@ fn prepare_wizard_startup(
         },
         is_new_branch: starts_new_branch,
         gh_cli_available: gwt_core::process::command_exists("gh"),
-        ai_enabled: true,
+        ai_enabled: false,
         branch_name,
         spec_context,
         ..Default::default()
@@ -6781,6 +6781,23 @@ mod tests {
 
         assert_eq!(wizard.step, screens::wizard::WizardStep::BranchTypeSelect);
         assert_eq!(wizard.branch_name, "feature/spec-42-my-feature");
+    }
+
+    #[test]
+    fn prepare_wizard_startup_disables_ai_branch_suggestions_by_default() {
+        let cache = VersionCache::new();
+
+        let (wizard, _) = prepare_wizard_startup(
+            Some(screens::wizard::SpecContext::new(
+                "SPEC-99",
+                "AI-disabled flow",
+                "",
+            )),
+            vec![],
+            &cache,
+        );
+
+        assert!(!wizard.ai_enabled);
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -18,6 +18,23 @@
 2. 「1 Tick で全件 drain しない」ことを固定する RED テストを追加し、回帰で即検知できるようにする。
 3. `Branches` 系のレスポンス不具合では、I/O の非同期化だけでなく「メインスレッド適用量」の上限有無まで確認する。
 
+## 2026-04-06 — fix: Launch Agent の AI branch suggestion が復活しないことをテストで固定する
+
+### 事象
+
+`origin/develop` をマージした直後、`prepare_wizard_startup()` が `ai_enabled = true` を再導入してしまい、
+Branch Name 入力後に AI suggestion step が復活してブランチ作成が阻害された。
+
+### 原因
+
+- `prepare_wizard_startup()` が `WizardState::default()` の `ai_enabled = false` を上書きしていた。
+- 標準 new-branch フローで AI を無効にする前提が、テストで固定されていなかった。
+
+### 再発防止策
+
+1. `prepare_wizard_startup()` が `ai_enabled = false` を保持することを RED テストで固定する。
+2. `origin/develop` のマージ後は、Launch Agent の新規ブランチ導線で AI step が出ないことを最小テストで検証する。
+
 ## 2026-04-04 — fix: Docker 系 broad verification は Cargo を並列実行しない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Keep the Launch Agent wizard startup from re-enabling AI branch suggestions so new-branch flows do not surface the AI step after manual input.
- Add a regression test that locks `prepare_wizard_startup()` to `ai_enabled = false` for standard new-branch launches.
- Record the regression lesson to prevent future merges from reintroducing the AI suggestion step.

## Changes

- `crates/gwt-tui/src/app.rs`: force `prepare_wizard_startup()` to keep `ai_enabled = false` and add a focused regression test.
- `tasks/lessons.md`: log the regression cause and prevention steps.

## Testing

- [x] `cargo test -p gwt-tui prepare_wizard_startup_disables_ai_branch_suggestions_by_default` — passes.

## Closing Issues

None

## Related Issues / Links

None

## Checklist

- [x] Tests added/updated
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — Not run in this fix.
- [ ] Documentation updated (if user-facing change) — N/A: no user-facing docs updated.
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema or data change.
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — Not applicable for this regression fix.

## Context

- A merge from `origin/develop` reintroduced `ai_enabled = true` inside `prepare_wizard_startup()`, so the AI branch suggestion step appeared again after branch name input and blocked creation. This change re-locks the default to `false` and adds a regression test to keep the behavior stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI branch suggestion feature now defaults to disabled in the wizard.

* **Tests**
  * Added regression test to ensure AI branch suggestion remains disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->