### PR TITLE
fix(tui): re-focus terminal on session-pane mouse scroll

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3340,8 +3340,19 @@ where
         return Ok(true);
     }
 
-    if model.active_focus != FocusPane::Terminal || !mouse_hits_active_session(model, mouse) {
+    if !mouse_hits_active_session(model, mouse) {
         return Ok(false);
+    }
+
+    if matches!(
+        mouse.kind,
+        MouseEventKind::ScrollUp
+            | MouseEventKind::ScrollDown
+            | MouseEventKind::Down(MouseButton::Left)
+            | MouseEventKind::Drag(MouseButton::Left)
+            | MouseEventKind::Up(MouseButton::Left)
+    ) {
+        model.active_focus = FocusPane::Terminal;
     }
 
     match mouse.kind {
@@ -4753,6 +4764,43 @@ mod tests {
     }
 
     #[test]
+    fn mouse_scroll_up_over_session_focuses_terminal_and_scrolls() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Management;
+        model.active_focus = FocusPane::TabContent;
+        update(&mut model, Message::Resize(18, 8));
+        for i in 0..12 {
+            append_session_line(&mut model, "shell-0", &format!("line-{i}"));
+        }
+
+        let area = active_session_content_area(&model).expect("active session area");
+        update(
+            &mut model,
+            Message::MouseInput(MouseEvent {
+                kind: MouseEventKind::ScrollUp,
+                column: area.x,
+                row: area.y,
+                modifiers: KeyModifiers::NONE,
+            }),
+        );
+
+        assert_eq!(
+            model.active_focus,
+            FocusPane::Terminal,
+            "session mouse scroll should move focus to the terminal pane"
+        );
+        assert!(
+            model
+                .active_session_tab()
+                .expect("active session")
+                .vt
+                .scrollback()
+                > 0,
+            "session mouse scroll should move the viewport away from live follow mode"
+        );
+    }
+
+    #[test]
     fn render_model_text_terminal_overflow_draws_scrollbar_only_when_needed() {
         let mut overflow_model = test_model();
         overflow_model.active_layer = ActiveLayer::Main;
@@ -5569,9 +5617,10 @@ mod tests {
     }
 
     #[test]
-    fn click_without_ctrl_does_not_invoke_opener() {
+    fn click_without_ctrl_does_not_invoke_opener_and_focuses_terminal() {
         let mut model = test_model();
         model.active_layer = ActiveLayer::Main;
+        model.active_focus = FocusPane::TabContent;
         let expected_url = "https://example.com";
         update(
             &mut model,
@@ -5606,8 +5655,9 @@ mod tests {
         )
         .expect("mouse handler succeeds");
 
-        assert!(!opened_result);
+        assert!(opened_result);
         assert!(!opened);
+        assert_eq!(model.active_focus, FocusPane::Terminal);
     }
 
     fn init_git_repo(path: &std::path::Path) {

--- a/specs/SPEC-1/metadata.json
+++ b/specs/SPEC-1/metadata.json
@@ -4,5 +4,5 @@
   "status": "done",
   "phase": "Done",
   "created_at": "2026-04-02T09:37:28.319624+00:00",
-  "updated_at": "2026-04-06T05:14:42Z"
+  "updated_at": "2026-04-06T08:39:47Z"
 }

--- a/specs/SPEC-1/progress.md
+++ b/specs/SPEC-1/progress.md
@@ -3,8 +3,8 @@
 ## Progress
 - Status: `done`
 - Phase: `Done`
-- Task progress: `25/25` checked in `tasks.md`
-- Artifact refresh: `2026-04-06T05:14:42Z`
+- Task progress: `26/26` checked in `tasks.md`
+- Artifact refresh: `2026-04-06T08:39:47Z`
 
 ## Done
 - Supporting artifacts now exist for planning, execution tracking, and review.
@@ -14,6 +14,7 @@
 - Wrapped URLs are now detected across soft-wrapped terminal rows and remain underlined/clickable across every visible segment.
 - Terminal sessions now keep viewport-local scrollback state, expose overflow-only scrollbar chrome, and restore the cursor against the text area even when the gutter is present.
 - Mouse-wheel scrolling now freezes live follow against vt100 scrollback, and drag selection copies from the visible scrollback viewport through `contents_between()`.
+- Session-pane mouse interactions now re-focus the terminal before scrollback routing, so wheel scrolling works from the default management-focus state instead of dropping the first event.
 - Acceptance and TDD checklists now reflect that the implementation tasks are complete and backed by focused verification evidence.
 
 ## Next

--- a/specs/SPEC-1/tasks.md
+++ b/specs/SPEC-1/tasks.md
@@ -36,3 +36,4 @@
 - [x] T023 Implement drag-selection extraction/highlighting and clipboard copy in `app.rs` / `renderer.rs`.
 - [x] T024 Render the overflow-only terminal scrollbar in the session surface and keep cursor placement correct when the gutter is present.
 - [x] T025 Refresh SPEC-1 artifacts and rerun focused terminal interaction verification.
+- [x] T026 Fix regression: session-pane mouse wheel now re-focuses the terminal before applying scrollback.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,24 @@
 # Lessons Learned
 
+## 2026-04-06 — fix: session pane mouse interaction は keyboard focus 前提で捨てない
+
+### 事象
+
+terminal pane の scrollback 実装自体は存在していたが、管理ビューの初期状態から session 上でホイールしても
+スクロールせず、最初のマウス操作が無視されていた。
+
+### 原因
+
+- `handle_mouse_input_with_tools()` が `active_focus == FocusPane::Terminal` を満たさない限り
+  session 領域上の `ScrollUp` / `ScrollDown` / click / drag をまとめて `Ok(false)` で捨てていた。
+- モデルの初期 focus は `TabContent` のため、session 上の最初のマウス操作だけでは terminal focus に遷移できなかった。
+
+### 再発防止策
+
+1. session pane の mouse UX を追加・変更するときは、「keyboard focus が terminal でない状態」からの 1 発目の操作を RED テストで固定する。
+2. session 領域上の wheel / click / drag は、必要なら先に terminal focus へ遷移させてから個別処理へ流す。
+3. opener 呼び出しの有無だけを見るテストと、イベントが session interaction として handled されるかを見るテストを分けて評価する。
+
 ## 2026-04-06 — fix: Branch detail preload は Tick ごとに処理上限を設ける
 
 ### 事象


### PR DESCRIPTION
## Summary

- re-focus the terminal pane when mouse wheel and click interactions land on the session surface so the first scroll event is no longer dropped from the default management-focus state
- add a regression test for session-surface wheel scrolling from non-terminal focus and align mouse-click expectations with the new focus routing
- refresh `SPEC-1` execution artifacts and lessons so the regression and its prevention remain traceable

## Changes

- `crates/gwt-tui/src/app.rs`: route session-surface wheel/click/drag events through terminal focus before applying scrollback or selection handling
- `crates/gwt-tui/src/app.rs`: add a RED/GREEN regression test for wheel scrolling over the session pane from management focus and update the plain-click mouse test to assert focus transfer instead of URL opening
- `specs/SPEC-1/*`: record the regression fix in tasks/progress/metadata for the terminal interaction owner
- `tasks/lessons.md`: capture the root cause and guardrails for session-pane mouse interaction regressions

## Testing

- [x] `cargo test -p gwt-tui mouse_scroll_up_over_session_focuses_terminal_and_scrolls -- --nocapture` — passes
- [x] `cargo test -p gwt-tui mouse_scroll_up -- --nocapture` — passes
- [x] `cargo test -p gwt-tui selection_copy_uses_scrollback_viewport_coordinates -- --nocapture` — passes
- [x] `cargo test -p gwt-tui ctrl_click_on_url_invokes_opener_with_full_url -- --nocapture` — passes
- [x] `cargo fmt --all --check` — passes
- [x] `cargo test -p gwt-core -p gwt-tui` — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes
- [x] `cargo build -p gwt-tui` — passes
- [x] `bunx markdownlint-cli2 specs/SPEC-1/progress.md specs/SPEC-1/tasks.md tasks/lessons.md` — passes
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passes

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (SPEC / lessons artifacts refreshed for this behavior change)
- [ ] Migration/backfill plan included (not needed; no schema/data change)
- [x] CHANGELOG impact considered (non-breaking `fix:` change only)

## Context

- The merged `feature/terminal` PR already shipped terminal scrollback support, but the session pane still required keyboard focus to be on `Terminal` before any mouse event would be honored.
- The default management layout starts with `TabContent` focus, so the first wheel event over the visible session pane was dropped even though scrollback logic itself worked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session pane mouse wheel scrolling now works from the default focus state. Previously, the first scroll event was ignored. Mouse interactions over the session pane automatically refocus the terminal before processing.

* **Tests**
  * Extended test coverage to verify scrollback behavior and focus switching when interacting with the session pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->