### PR TITLE
fix(tui): revert skip permissions to legacy flags

### DIFF
--- a/crates/gwt-agent/src/custom.rs
+++ b/crates/gwt-agent/src/custom.rs
@@ -40,6 +40,8 @@ pub struct CustomCodingAgent {
     #[serde(default)]
     pub mode_args: Option<ModeArgs>,
     #[serde(default)]
+    pub skip_permissions_args: Vec<String>,
+    #[serde(default)]
     pub env: HashMap<String, String>,
 }
 
@@ -83,6 +85,7 @@ mod tests {
                 continue_mode: vec!["--continue".to_string()],
                 resume: vec!["--resume".to_string()],
             }),
+            skip_permissions_args: vec!["--yolo".to_string()],
             env: HashMap::from([("KEY".to_string(), "VALUE".to_string())]),
         }
     }
@@ -156,6 +159,7 @@ mod tests {
         let parsed: CustomCodingAgent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.id, agent.id);
         assert_eq!(parsed.agent_type, agent.agent_type);
+        assert_eq!(parsed.skip_permissions_args, agent.skip_permissions_args);
     }
 
     #[test]

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -116,6 +116,7 @@ pub struct AgentLaunchBuilder {
     model: Option<String>,
     version: Option<String>,
     fast_mode: bool,
+    skip_permissions: bool,
     reasoning_level: Option<String>,
     session_mode: SessionMode,
     resume_session_id: Option<String>,
@@ -133,6 +134,7 @@ impl AgentLaunchBuilder {
             model: None,
             version: None,
             fast_mode: false,
+            skip_permissions: false,
             reasoning_level: None,
             session_mode: SessionMode::Normal,
             resume_session_id: None,
@@ -165,6 +167,11 @@ impl AgentLaunchBuilder {
 
     pub fn fast_mode(mut self, enabled: bool) -> Self {
         self.fast_mode = enabled;
+        self
+    }
+
+    pub fn skip_permissions(mut self, enabled: bool) -> Self {
+        self.skip_permissions = enabled;
         self
     }
 
@@ -255,10 +262,11 @@ impl AgentLaunchBuilder {
         let reasoning_level = self.reasoning_level.clone();
         let session_mode = self.session_mode;
         let resume_session_id = self.resume_session_id.clone();
-        let skip_permissions = matches!(
-            self.permission_mode,
-            Some(PermissionMode::Auto | PermissionMode::BypassPermissions)
-        );
+        let skip_permissions = self.skip_permissions
+            || matches!(
+                self.permission_mode,
+                Some(PermissionMode::Auto | PermissionMode::BypassPermissions)
+            );
         let codex_fast_mode = matches!(self.agent_id, AgentId::Codex) && self.fast_mode;
 
         LaunchConfig {
@@ -311,6 +319,10 @@ impl AgentLaunchBuilder {
             );
         }
 
+        if self.skip_permissions {
+            args.push("--dangerously-skip-permissions".to_string());
+        }
+
         // Session mode
         match self.session_mode {
             SessionMode::Continue => args.push("--continue".to_string()),
@@ -360,6 +372,10 @@ impl AgentLaunchBuilder {
             args.push("service_tier=fast".to_string());
         }
 
+        if self.skip_permissions {
+            args.push("--yolo".to_string());
+        }
+
         // Web search args
         if let Some(ref ver) = parsed_version {
             if *ver >= semver::Version::new(0, 90, 0) {
@@ -389,6 +405,10 @@ impl AgentLaunchBuilder {
             args.push("--model".to_string());
             args.push(model.clone());
         }
+
+        if self.skip_permissions {
+            args.push("--yolo".to_string());
+        }
     }
 
     fn build_opencode_args(&self, _args: &mut Vec<String>) {
@@ -398,6 +418,9 @@ impl AgentLaunchBuilder {
     fn build_copilot_args(&self, args: &mut Vec<String>) {
         // gh copilot is invoked as `gh copilot`
         args.insert(0, "copilot".to_string());
+        if self.skip_permissions {
+            args.push("--yolo".to_string());
+        }
     }
 }
 
@@ -470,6 +493,18 @@ mod tests {
     }
 
     #[test]
+    fn build_claude_skip_permissions_adds_dangerous_flag() {
+        let config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .skip_permissions(true)
+            .build();
+
+        assert!(config
+            .args
+            .contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(config.skip_permissions);
+    }
+
+    #[test]
     fn build_codex_fast_mode() {
         let config = AgentLaunchBuilder::new(AgentId::Codex)
             .fast_mode(true)
@@ -483,6 +518,36 @@ mod tests {
         assert!(!config.args.contains(&"--full-auto".to_string()));
         assert!(config.codex_fast_mode);
         assert!(!config.skip_permissions);
+    }
+
+    #[test]
+    fn build_codex_skip_permissions_adds_yolo() {
+        let config = AgentLaunchBuilder::new(AgentId::Codex)
+            .skip_permissions(true)
+            .build();
+
+        assert!(config.args.contains(&"--yolo".to_string()));
+        assert!(config.skip_permissions);
+    }
+
+    #[test]
+    fn build_gemini_skip_permissions_adds_yolo() {
+        let config = AgentLaunchBuilder::new(AgentId::Gemini)
+            .skip_permissions(true)
+            .build();
+
+        assert!(config.args.contains(&"--yolo".to_string()));
+        assert!(config.skip_permissions);
+    }
+
+    #[test]
+    fn build_copilot_skip_permissions_adds_yolo() {
+        let config = AgentLaunchBuilder::new(AgentId::Copilot)
+            .skip_permissions(true)
+            .build();
+
+        assert!(config.args.contains(&"--yolo".to_string()));
+        assert!(config.skip_permissions);
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -2529,7 +2529,7 @@ fn build_launch_config_from_wizard_with_custom_agents(
     }
 
     if wizard.skip_perms {
-        builder = builder.permission_mode(gwt_agent::launch::PermissionMode::Auto);
+        builder = builder.skip_permissions(true);
     }
     let session_mode = match wizard.mode.as_str() {
         "continue" => SessionMode::Continue,
@@ -2567,6 +2567,9 @@ fn build_custom_launch_config_from_wizard(
             SessionMode::Continue => args.extend(mode_args.continue_mode.clone()),
             SessionMode::Resume => args.extend(mode_args.resume.clone()),
         }
+    }
+    if wizard.skip_perms {
+        args.extend(custom_agent.skip_permissions_args.clone());
     }
 
     let command = match custom_agent.agent_type {
@@ -4544,6 +4547,7 @@ mod tests {
                 continue_mode: vec!["--continue".to_string()],
                 resume: vec!["--resume".to_string()],
             }),
+            skip_permissions_args: vec!["--yolo".to_string()],
             env: HashMap::from([("CUSTOM_ENV".to_string(), "enabled".to_string())]),
         }
     }
@@ -7211,7 +7215,24 @@ CUSTOM_ENV = "enabled"
 
         assert!(config.skip_permissions);
         assert!(!config.codex_fast_mode);
+        assert!(config.args.contains(&"--yolo".to_string()));
         assert!(!config.args.contains(&"service_tier=fast".to_string()));
+    }
+
+    #[test]
+    fn build_launch_config_from_wizard_claude_skip_permissions_uses_dangerous_flag() {
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            skip_perms: true,
+            ..Default::default()
+        };
+
+        let config = build_launch_config_from_wizard(&wizard);
+
+        assert!(config.skip_permissions);
+        assert!(config
+            .args
+            .contains(&"--dangerously-skip-permissions".to_string()));
     }
 
     #[test]

--- a/crates/gwt-tui/src/custom_agents.rs
+++ b/crates/gwt-tui/src/custom_agents.rs
@@ -44,6 +44,13 @@ struct CustomAgentToml {
     default_args: Vec<String>,
     #[serde(
         default,
+        rename = "skipPermissionsArgs",
+        alias = "skip_permissions_args",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    skip_permissions_args: Vec<String>,
+    #[serde(
+        default,
         rename = "modeArgs",
         alias = "mode_args",
         skip_serializing_if = "Option::is_none"
@@ -65,6 +72,7 @@ impl CustomAgentToml {
             agent_type: self.agent_type,
             command: self.command,
             default_args: self.default_args,
+            skip_permissions_args: self.skip_permissions_args,
             mode_args: self.mode_args,
             env: self.env,
         };
@@ -81,6 +89,7 @@ impl From<&CustomCodingAgent> for CustomAgentToml {
             agent_type: agent.agent_type,
             command: agent.command.clone(),
             default_args: agent.default_args.clone(),
+            skip_permissions_args: agent.skip_permissions_args.clone(),
             mode_args: agent.mode_args.clone(),
             env: agent.env.clone(),
         }
@@ -216,6 +225,8 @@ fn normalized_custom_agent_table(entry: &StoredCustomAgent) -> Result<Table, Str
         "command",
         "defaultArgs",
         "default_args",
+        "skipPermissionsArgs",
+        "skip_permissions_args",
         "modeArgs",
         "mode_args",
         "env",
@@ -307,6 +318,7 @@ displayName = "My Agent"
 agentType = "command"
 command = "my-agent-cli"
 defaultArgs = ["--flag"]
+skipPermissionsArgs = ["--yolo"]
 
 [tools.customCodingAgents.my-agent.modeArgs]
 normal = ["--normal"]
@@ -328,6 +340,7 @@ CUSTOM_ENV = "enabled"
         assert_eq!(agent.agent_type, CustomAgentType::Command);
         assert_eq!(agent.command, "my-agent-cli");
         assert_eq!(agent.default_args, vec!["--flag"]);
+        assert_eq!(agent.skip_permissions_args, vec!["--yolo"]);
         assert_eq!(
             agent
                 .mode_args

--- a/crates/gwt-tui/src/screens/settings.rs
+++ b/crates/gwt-tui/src/screens/settings.rs
@@ -480,6 +480,7 @@ fn default_custom_agent(existing: &[StoredCustomAgent]) -> StoredCustomAgent {
         command: id,
         default_args: Vec::new(),
         mode_args: None,
+        skip_permissions_args: Vec::new(),
         env: std::collections::HashMap::new(),
     })
 }

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -3,8 +3,8 @@
 ## Progress
 - Status: `in-progress`
 - Phase: `Implementation`
-- Task progress: `174/174` checked in `tasks.md`
-- Artifact refresh: `2026-04-05T12:22:37Z`
+- Task progress: `178/178` checked in `tasks.md`
+- Artifact refresh: `2026-04-06T09:16:20Z`
 
 ## Done
 - Startup cache scheduling, wizard integration, and session conversion flow documentation are now aligned to the implemented code.
@@ -37,6 +37,9 @@
   (`reasoning_level`, `skip_permissions`, resume session ID) so future
   launches can replay the previous configuration instead of showing a static
   placeholder.
+- SkipPermissions now restores legacy flags per agent (Claude:
+  `--dangerously-skip-permissions`; Codex/Gemini/Copilot: `--yolo`) and custom
+  agents can supply `skipPermissionsArgs` for opt-in behavior.
 - Recent verification exists for SPEC-3 slices: `cargo fmt --all`, `cargo test -p gwt-tui`, `cargo test -p gwt-core -p gwt-tui`, `cargo clippy -p gwt-tui --all-targets --all-features -- -D warnings`, `cargo clippy --all-targets --all-features -- -D warnings`, `bunx markdownlint-cli specs/SPEC-3/tasks.md`, and `bunx commitlint --from HEAD~1 --to HEAD`.
 - Repeatable reviewer evidence is now captured in `quickstart.md` with detect,
   version-cache, wizard, launch-materialization, and session-conversion test

--- a/specs/SPEC-3/spec.md
+++ b/specs/SPEC-3/spec.md
@@ -338,8 +338,8 @@ As a developer, I want to convert an existing session to a different agent type 
 | Flag | Description |
 |------|-------------|
 | `--print` | Non-interactive mode (SDK mode) |
-| `--permission-mode auto` | Auto mode — execute without prompts (recommended over --dangerously-skip-permissions) |
-| `--permission-mode bypassPermissions` | Bypass all permission checks (legacy: `--dangerously-skip-permissions`) |
+| `--dangerously-skip-permissions` | Skip permission prompts (legacy behavior) |
+| `--permission-mode bypassPermissions` | Bypass all permission checks (alternate permission-mode form) |
 | `--enable-auto-mode` | Unlock auto mode in Shift+Tab cycle |
 | `--model <model>` | Model selection (alias: `sonnet`, `opus`, or full name) |
 | `--allowedTools <tools>` | Tools that execute without prompting (pattern matching supported) |
@@ -365,7 +365,7 @@ Model list snapshot: **2026-04-05**.
 | `-c model_reasoning_effort=<level>` | Reasoning level: low/medium/high |
 | `-c service_tier=fast` | Fast mode (Codex-only speed tier). Independent from skip-permission settings |
 | `--full-auto` | Approval/sandbox automation convenience alias (not a Fast mode toggle) |
-| `--dangerously-bypass-approvals-and-sandbox` | Skip permissions (v0.80.0+) |
+| `--yolo` | Skip permissions (Codex legacy flag) |
 | `--enable web_search` | Enable web search (v0.90.0+) |
 | `--enable collaboration_modes` | Enable collaboration (v0.91.0+) |
 | `-c shell_environment_policy=inherit` | Shell policy |
@@ -375,6 +375,13 @@ Model list snapshot: **2026-04-05**.
 | Flag | Description |
 |------|-------------|
 | `--non-interactive` | Non-interactive mode |
+| `--yolo` | Skip permissions (Gemini legacy flag) |
+
+#### GitHub Copilot
+
+| Flag | Description |
+|------|-------------|
+| `--yolo` | Skip permissions (Copilot legacy flag) |
 
 ### Session File Schema (`~/.gwt/sessions/{base64_path}.toml`)
 
@@ -409,6 +416,7 @@ displayName = "My Agent"
 agentType = "command"  # command | path | bunx
 command = "my-agent-cli"
 defaultArgs = ["--flag"]
+skipPermissionsArgs = ["--yolo"]
 
 [tools.customCodingAgents.my-agent.modeArgs]
 normal = []

--- a/specs/SPEC-3/tasks.md
+++ b/specs/SPEC-3/tasks.md
@@ -9,6 +9,13 @@
 - [x] T-A05 Write test: Claude Code build with PermissionMode::Auto emits --permission-mode auto
 - [x] T-A06 Update SPEC-3 spec.md with complete env var table and CLI flags
 
+## Phase 0b: SkipPermissions Legacy Flags
+
+- [x] T-A07 Write RED tests: SkipPermissions adds legacy flags per agent (Claude: --dangerously-skip-permissions, Codex/Gemini/Copilot: --yolo).
+- [x] T-A08 Write RED tests: Custom Agent schema accepts skipPermissionsArgs and applies them on launch.
+- [x] T-A09 Update launch builder + wizard to use legacy SkipPermissions flags and custom args.
+- [x] T-A10 Update SPEC-3 spec.md with legacy flags and custom agent schema field.
+
 ## Phase 1: Version Cache -- Core
 
 - [x] T001 [P] Write RED test: cache file round-trip (write versions, read back, verify content matches).


### PR DESCRIPTION
## Summary

- Revert SkipPermissions to legacy CLI flags because Claude Code auto-mode is unreliable and we need stable behavior.
- Apply per-agent skip flags (Claude: `--dangerously-skip-permissions`, Codex/Gemini/Copilot: `--yolo`) and allow custom agents to define their own skip args.

## Changes

- `crates/gwt-agent/src/launch.rs`: add `skip_permissions` builder flag and emit legacy skip flags per agent.
- `crates/gwt-agent/src/custom.rs`: add `skip_permissions_args` to custom agent schema and tests.
- `crates/gwt-tui/src/app.rs`: wire SkipPermissions to builder flag and apply custom skip args on launch.
- `crates/gwt-tui/src/custom_agents.rs`: load/save `skipPermissionsArgs` in config TOML.
- `crates/gwt-tui/src/screens/settings.rs`: initialize custom agents with empty skip args.
- `specs/SPEC-3/spec.md`: update CLI flag docs and custom agent schema.
- `specs/SPEC-3/tasks.md`: record completed SkipPermissions legacy tasks.
- `specs/SPEC-3/progress.md`: refresh progress notes and verification evidence.

## Testing

- [x] `cargo test -p gwt-agent` — pass
- [x] `cargo test -p gwt-tui` — pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — pass
- [x] `cargo fmt --all` — warnings only (nightly-only options), no diffs

## Closing Issues

- Closes #1890

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — Not needed (additive config field)
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — Not a breaking change

## Context

- Claude Code auto-mode (`--permission-mode auto`) was introduced as a replacement for skip-permissions but is not functioning reliably; this reverts to stable legacy flags and aligns other agents.

## Risk / Impact

- **Affected areas**: Agent launch flags for SkipPermissions; custom agent config schema.
- **Rollback plan**: Revert this PR to restore auto-mode behavior.
