### PR TITLE
fix(launch): materialize new-branch worktrees before launch

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -85,6 +85,7 @@ pub struct LaunchConfig {
     pub env_vars: HashMap<String, String>,
     pub working_dir: Option<PathBuf>,
     pub branch: Option<String>,
+    pub base_branch: Option<String>,
     pub display_name: String,
     pub color: AgentColor,
     pub model: Option<String>,
@@ -113,6 +114,7 @@ pub struct AgentLaunchBuilder {
     agent_id: AgentId,
     working_dir: Option<PathBuf>,
     branch: Option<String>,
+    base_branch: Option<String>,
     model: Option<String>,
     version: Option<String>,
     fast_mode: bool,
@@ -131,6 +133,7 @@ impl AgentLaunchBuilder {
             agent_id,
             working_dir: None,
             branch: None,
+            base_branch: None,
             model: None,
             version: None,
             fast_mode: false,
@@ -151,6 +154,11 @@ impl AgentLaunchBuilder {
 
     pub fn branch(mut self, branch: impl Into<String>) -> Self {
         self.branch = Some(branch.into());
+        self
+    }
+
+    pub fn base_branch(mut self, branch: impl Into<String>) -> Self {
+        self.base_branch = Some(branch.into());
         self
     }
 
@@ -276,6 +284,7 @@ impl AgentLaunchBuilder {
             env_vars,
             working_dir: self.working_dir,
             branch: self.branch,
+            base_branch: self.base_branch,
             display_name,
             color,
             model,
@@ -433,6 +442,7 @@ mod tests {
         let builder = AgentLaunchBuilder::new(AgentId::ClaudeCode);
         assert_eq!(builder.agent_id, AgentId::ClaudeCode);
         assert!(builder.working_dir.is_none());
+        assert!(builder.base_branch.is_none());
         assert!(!builder.fast_mode);
         assert_eq!(builder.session_mode, SessionMode::Normal);
     }
@@ -458,6 +468,17 @@ mod tests {
             config.env_vars.get("GWT_PROJECT_ROOT"),
             Some(&"/tmp/project".to_string())
         );
+    }
+
+    #[test]
+    fn build_carries_base_branch() {
+        let config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .branch("feature/demo")
+            .base_branch("develop")
+            .build();
+
+        assert_eq!(config.branch.as_deref(), Some("feature/demo"));
+        assert_eq!(config.base_branch.as_deref(), Some("develop"));
     }
 
     #[test]

--- a/crates/gwt-git/src/lib.rs
+++ b/crates/gwt-git/src/lib.rs
@@ -22,4 +22,4 @@ pub use repository::{
     clone_repo, detect_repo_type, initialize_workspace, install_develop_protection, RepoType,
     Repository,
 };
-pub use worktree::{WorktreeInfo, WorktreeManager};
+pub use worktree::{sibling_worktree_path, WorktreeInfo, WorktreeManager};

--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -64,6 +64,36 @@ impl WorktreeManager {
         Ok(())
     }
 
+    /// Create a new worktree at `path`, creating `new_branch` from `base_branch`.
+    pub fn create_from_base(&self, base_branch: &str, new_branch: &str, path: &Path) -> Result<()> {
+        if path.exists() {
+            return Err(GwtError::Git(format!(
+                "worktree path already exists: {}",
+                path.display()
+            )));
+        }
+
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                new_branch,
+                path.to_str().unwrap_or(""),
+                base_branch,
+            ])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| GwtError::Git(format!("worktree add -b: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(GwtError::Git(stderr));
+        }
+
+        Ok(())
+    }
+
     /// Remove the worktree at `path`.
     pub fn remove(&self, path: &Path) -> Result<()> {
         let output = std::process::Command::new("git")
@@ -79,6 +109,50 @@ impl WorktreeManager {
 
         Ok(())
     }
+}
+
+/// Derive a sibling worktree path from the repo root and branch name.
+pub fn sibling_worktree_path(repo_path: &Path, branch: &str) -> PathBuf {
+    let repo_name = repo_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("repo");
+    let suffix = slug_branch_for_path(branch);
+    let dir_name = if suffix.is_empty() {
+        repo_name.to_string()
+    } else {
+        format!("{repo_name}-{suffix}")
+    };
+
+    repo_path.parent().unwrap_or(repo_path).join(dir_name)
+}
+
+fn slug_branch_for_path(branch: &str) -> String {
+    let mut out = String::with_capacity(branch.len());
+    let mut prev_dash = false;
+
+    for ch in branch.trim().chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            ch.to_ascii_lowercase()
+        } else if matches!(ch, '-' | '_') {
+            ch
+        } else {
+            '-'
+        };
+
+        if mapped == '-' {
+            if !prev_dash {
+                out.push(mapped);
+            }
+            prev_dash = true;
+        } else {
+            out.push(mapped);
+            prev_dash = false;
+        }
+    }
+
+    out.trim_matches('-').to_string()
 }
 
 /// Parse `git worktree list --porcelain` output into `WorktreeInfo` entries.
@@ -136,6 +210,54 @@ fn matches_annotation(line: &str, key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn init_git_repo(path: &Path) {
+        let output = std::process::Command::new("git")
+            .args(["init", path.to_str().unwrap()])
+            .output()
+            .expect("git init");
+        assert!(output.status.success(), "git init failed");
+
+        let email = std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .output()
+            .expect("git config user.email");
+        assert!(email.status.success(), "git config user.email failed");
+
+        let name = std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path)
+            .output()
+            .expect("git config user.name");
+        assert!(name.status.success(), "git config user.name failed");
+    }
+
+    fn git_commit_allow_empty(path: &Path, message: &str) {
+        let output = std::process::Command::new("git")
+            .args(["commit", "--allow-empty", "-m", message])
+            .current_dir(path)
+            .output()
+            .expect("git commit");
+        assert!(
+            output.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_checkout_new_branch(path: &Path, branch: &str) {
+        let output = std::process::Command::new("git")
+            .args(["checkout", "-b", branch])
+            .current_dir(path)
+            .output()
+            .expect("git checkout -b");
+        assert!(
+            output.status.success(),
+            "git checkout -b failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn parse_porcelain_single_entry() {
@@ -205,6 +327,40 @@ prunable gitdir file points to non-existent location
         let entries = parse_porcelain_output(output);
         assert_eq!(entries.len(), 1);
         assert!(entries[0].branch.is_none());
+    }
+
+    #[test]
+    fn sibling_worktree_path_uses_repo_name_and_slugged_branch() {
+        let repo_path = Path::new("/tmp/my-repo");
+        let worktree = sibling_worktree_path(repo_path, "feature/banner");
+        assert_eq!(worktree, PathBuf::from("/tmp/my-repo-feature-banner"));
+    }
+
+    #[test]
+    fn create_from_base_creates_new_branch_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_git_repo(tmp.path());
+        git_commit_allow_empty(tmp.path(), "initial commit");
+        git_checkout_new_branch(tmp.path(), "develop");
+
+        let manager = WorktreeManager::new(tmp.path());
+        let worktree_path = sibling_worktree_path(tmp.path(), "feature/materialized");
+
+        manager
+            .create_from_base("develop", "feature/materialized", &worktree_path)
+            .unwrap();
+
+        assert!(worktree_path.exists());
+        let branch_output = std::process::Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&worktree_path)
+            .output()
+            .expect("git branch --show-current");
+        assert!(branch_output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&branch_output.stdout).trim(),
+            "feature/materialized"
+        );
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -47,6 +47,7 @@ static STARTUP_VERSION_CACHE_REFRESH_DISPATCH_IN_FLIGHT: AtomicBool = AtomicBool
 /// Cap branch-detail preload event application per tick so one refresh burst
 /// cannot monopolize the UI thread.
 const BRANCH_DETAIL_EVENTS_PER_TICK_BUDGET: usize = 8;
+const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
 
 // ---------------------------------------------------------------------------
 // PTY lifecycle helpers
@@ -2382,6 +2383,9 @@ fn build_launch_config_from_wizard_with_custom_agents(
     if !wizard.branch_name.is_empty() {
         builder = builder.branch(&wizard.branch_name);
     }
+    if let Some(base_branch) = wizard_launch_base_branch(wizard) {
+        builder = builder.base_branch(base_branch);
+    }
 
     if is_explicit_model_selection(&wizard.model) {
         builder = builder.model(&wizard.model);
@@ -2470,6 +2474,7 @@ fn build_custom_launch_config_from_wizard(
         env_vars,
         working_dir: wizard.worktree_path.clone(),
         branch: (!wizard.branch_name.is_empty()).then(|| wizard.branch_name.clone()),
+        base_branch: wizard_launch_base_branch(wizard),
         display_name: custom_agent.display_name.clone(),
         model: None,
         tool_version: None,
@@ -2483,6 +2488,19 @@ fn build_custom_launch_config_from_wizard(
 
 fn is_explicit_model_selection(model: &str) -> bool {
     !model.is_empty() && !model.starts_with("Default")
+}
+
+fn wizard_launch_base_branch(wizard: &screens::wizard::WizardState) -> Option<String> {
+    if wizard.worktree_path.is_some() || !wizard.is_new_branch {
+        None
+    } else {
+        Some(
+            wizard
+                .base_branch_name
+                .clone()
+                .unwrap_or_else(|| DEFAULT_NEW_BRANCH_BASE_BRANCH.to_string()),
+        )
+    }
 }
 
 fn materialize_pending_launch(model: &mut Model) {
@@ -2503,9 +2521,11 @@ fn materialize_pending_launch_with(
     model: &mut Model,
     sessions_dir: &std::path::Path,
 ) -> Result<(), String> {
-    let Some(config) = model.pending_launch_config.take() else {
+    let Some(mut config) = model.pending_launch_config.take() else {
         return Ok(());
     };
+
+    resolve_launch_worktree(&model.repo_path, &mut config)?;
 
     let worktree = config
         .working_dir
@@ -2591,6 +2611,88 @@ fn materialize_pending_launch_with(
     );
 
     Ok(())
+}
+
+fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Result<(), String> {
+    let Some(branch_name) = config.branch.clone() else {
+        return Ok(());
+    };
+    if config.working_dir.is_some() {
+        return Ok(());
+    }
+
+    let current_branch = match current_git_branch(repo_path) {
+        Ok(branch) => branch,
+        Err(_) if config.base_branch.is_none() => return Ok(()),
+        Err(_) => config
+            .base_branch
+            .clone()
+            .unwrap_or_else(|| DEFAULT_NEW_BRANCH_BASE_BRANCH.to_string()),
+    };
+    if current_branch == branch_name {
+        config.working_dir = Some(repo_path.to_path_buf());
+        config.env_vars.insert(
+            "GWT_PROJECT_ROOT".to_string(),
+            repo_path.display().to_string(),
+        );
+        return Ok(());
+    }
+
+    let worktree_path = gwt_git::worktree::sibling_worktree_path(repo_path, &branch_name);
+    let manager = gwt_git::WorktreeManager::new(repo_path);
+    if local_branch_exists(repo_path, &branch_name)? {
+        manager
+            .create(&branch_name, &worktree_path)
+            .map_err(|err| err.to_string())?;
+    } else {
+        let base_branch = config.base_branch.clone().unwrap_or(current_branch);
+        manager
+            .create_from_base(&base_branch, &branch_name, &worktree_path)
+            .map_err(|err| err.to_string())?;
+    }
+
+    config.working_dir = Some(worktree_path.clone());
+    config.env_vars.insert(
+        "GWT_PROJECT_ROOT".to_string(),
+        worktree_path.display().to_string(),
+    );
+    Ok(())
+}
+
+fn current_git_branch(repo_path: &Path) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|err| format!("git branch --show-current: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git branch --show-current: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        Err("git branch --show-current returned an empty branch name".to_string())
+    } else {
+        Ok(branch)
+    }
+}
+
+fn local_branch_exists(repo_path: &Path, branch_name: &str) -> Result<bool, String> {
+    let output = Command::new("git")
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch_name}"),
+        ])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|err| format!("git show-ref --verify refs/heads/{branch_name}: {err}"))?;
+
+    Ok(output.status.success())
 }
 
 fn configure_existing_branch_wizard_with_sessions(
@@ -5630,6 +5732,19 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
     }
+
+    fn git_checkout_new_branch(path: &std::path::Path, name: &str) {
+        let output = std::process::Command::new("git")
+            .args(["checkout", "-b", name])
+            .current_dir(path)
+            .output()
+            .expect("checkout new git branch");
+        assert!(
+            output.status.success(),
+            "git checkout -b failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
     #[test]
     fn update_quit_sets_flag() {
         let mut model = test_model();
@@ -6919,6 +7034,41 @@ CUSTOM_ENV = "enabled"
     }
 
     #[test]
+    fn build_launch_config_from_wizard_carries_selected_base_branch_for_new_branch_flow() {
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            base_branch_name: Some("feature/source".to_string()),
+            branch_name: "feature/child".to_string(),
+            ..Default::default()
+        };
+
+        let config = build_launch_config_from_wizard(&wizard);
+
+        assert_eq!(config.branch.as_deref(), Some("feature/child"));
+        assert_eq!(config.base_branch.as_deref(), Some("feature/source"));
+    }
+
+    #[test]
+    fn build_launch_config_from_wizard_defaults_spec_prefill_base_branch_to_develop() {
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            branch_name: "feature/spec-42-my-feature".to_string(),
+            spec_context: Some(screens::wizard::SpecContext::new(
+                "SPEC-42",
+                "My Feature",
+                "",
+            )),
+            ..Default::default()
+        };
+
+        let config = build_launch_config_from_wizard(&wizard);
+
+        assert_eq!(config.base_branch.as_deref(), Some("develop"));
+    }
+
+    #[test]
     fn build_launch_config_from_wizard_keeps_selected_version() {
         let wizard = screens::wizard::WizardState {
             agent_id: "claude".to_string(),
@@ -7096,6 +7246,75 @@ CUSTOM_ENV = "enabled"
     }
 
     #[test]
+    fn materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path() {
+        let repo_dir = tempfile::tempdir().expect("temp repo dir");
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        init_git_repo(repo_dir.path());
+        git_commit_allow_empty(repo_dir.path(), "initial commit");
+        git_checkout_new_branch(repo_dir.path(), "develop");
+
+        let mut model = Model::new(repo_dir.path().to_path_buf());
+        model.pending_launch_config = Some(LaunchConfig {
+            agent_id: AgentId::Custom("my-agent".to_string()),
+            command: "/bin/echo".to_string(),
+            args: vec!["agent-test".to_string()],
+            env_vars: HashMap::new(),
+            working_dir: None,
+            branch: Some("feature/materialized-launch".to_string()),
+            base_branch: None,
+            display_name: "My Agent".to_string(),
+            color: AgentId::Custom("my-agent".to_string()).default_color(),
+            model: None,
+            tool_version: None,
+            reasoning_level: None,
+            session_mode: SessionMode::Normal,
+            resume_session_id: None,
+            skip_permissions: false,
+            codex_fast_mode: false,
+        });
+
+        materialize_pending_launch_with(&mut model, sessions_dir.path())
+            .expect("materialize launch");
+
+        let repo_name = repo_dir
+            .path()
+            .file_name()
+            .expect("repo dir name")
+            .to_string_lossy();
+        let expected_worktree = repo_dir
+            .path()
+            .parent()
+            .expect("repo dir parent")
+            .join(format!("{repo_name}-feature-materialized-launch"));
+        assert!(expected_worktree.exists(), "new worktree should exist");
+
+        let branch_output = std::process::Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&expected_worktree)
+            .output()
+            .expect("read worktree branch");
+        assert!(
+            branch_output.status.success(),
+            "git branch --show-current failed: {}",
+            String::from_utf8_lossy(&branch_output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&branch_output.stdout).trim(),
+            "feature/materialized-launch"
+        );
+
+        let session_entry = fs::read_dir(sessions_dir.path())
+            .expect("read sessions dir")
+            .next()
+            .expect("session entry")
+            .expect("dir entry")
+            .path();
+        let persisted = AgentSession::load(&session_entry).expect("load persisted session");
+        assert_eq!(persisted.branch, "feature/materialized-launch");
+        assert_eq!(persisted.worktree_path, expected_worktree);
+    }
+
+    #[test]
     fn materialize_pending_launch_with_spawn_failure_mentions_command() {
         let dir = tempfile::tempdir().expect("temp sessions dir");
         let mut model = test_model();
@@ -7107,6 +7326,7 @@ CUSTOM_ENV = "enabled"
             env_vars: HashMap::new(),
             working_dir: None,
             branch: Some("feature/custom-agent".to_string()),
+            base_branch: None,
             display_name: "My Agent".to_string(),
             color: AgentId::Custom("my-agent".to_string()).default_color(),
             model: None,

--- a/specs/SPEC-3/checklists/acceptance.md
+++ b/specs/SPEC-3/checklists/acceptance.md
@@ -1,7 +1,7 @@
 # Acceptance Checklist: SPEC-3 - Agent Management
 
 - [x] The local artifact set now includes supporting planning and execution files.
-- [x] `181/181` task progress is reflected in `progress.md` and related notes.
+- [x] `185/185` task progress is reflected in `progress.md` and related notes.
 - [x] The artifact set now consistently describes the implemented session metadata swap instead of a full PTY relaunch.
 - [x] `analysis.md` now matches the repaired session-conversion semantics.
 - [x] The artifact set now consistently describes dedicated version selection
@@ -15,6 +15,8 @@
   chrome and AgentSelect visuals.
 - [x] The artifact set now consistently describes the CLI-synced Codex model
   snapshot and its default-selection launch behavior.
+- [x] The artifact set now consistently describes new-branch launch
+  materialization and actual worktree-path persistence.
 - [ ] All acceptance scenarios in `spec.md` are satisfied end to end on the current branch.
 - [ ] The reviewer flow in `quickstart.md` has been completed without open gaps.
 - [x] Every task in `tasks.md` is checked and backed by evidence.

--- a/specs/SPEC-3/checklists/tdd.md
+++ b/specs/SPEC-3/checklists/tdd.md
@@ -11,6 +11,8 @@
 - [x] The latest implementation slice has spec-focused verification evidence attached to it.
 - [x] The Codex model snapshot sync slice was driven by failing wizard tests
   before the Launch Agent model list was updated.
+- [x] The new-branch worktree materialization slice was driven by a failing
+  pending-launch test before launch-time worktree creation was implemented.
 - [x] The reviewer flow in `quickstart.md` has been captured as repeatable
   completion evidence, including launch-config and launch-materialization
   commands.

--- a/specs/SPEC-3/metadata.json
+++ b/specs/SPEC-3/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:37:36.553763+00:00",
-  "updated_at": "2026-04-06T11:05:03Z"
+  "updated_at": "2026-04-06T11:59:47Z"
 }

--- a/specs/SPEC-3/plan.md
+++ b/specs/SPEC-3/plan.md
@@ -5,8 +5,9 @@
 Implement the version cache feature and complete the session conversion UI.
 Agent detection, launch wizard, Quick Start, config-backed custom-agent
 runtime integration, and Settings-backed custom-agent CRUD are implemented
-and tested. The remaining work is reviewer confirmation of the restored
-wizard UX and end-to-end custom-agent behavior.
+and tested. The latest reopened slice makes new-branch launches materialize
+the requested branch/worktree before PTY spawn so Launch Agent no longer
+falls back to the repository root checkout.
 
 ## Technical Context
 
@@ -111,6 +112,18 @@ wizard UX and end-to-end custom-agent behavior.
    omitted when the user keeps the default label selected.
 3. Add focused RED/GREEN coverage for the Codex model list values and rendered
    old-TUI label/description rows before broad workspace verification.
+
+### Phase 47: New-Branch Launch Worktree Materialization
+
+1. Extend launch configuration so the wizard can carry a selected base branch
+   for new-branch launches, while SPEC/Issue-prefilled launches default to
+   `develop`.
+2. Materialize a sibling git worktree before PTY spawn whenever Launch Agent
+   targets a new branch without an existing worktree.
+3. Persist the actual launched worktree path into session metadata and
+   `GWT_PROJECT_ROOT` so Quick Start / resume operate on the correct target.
+4. Add focused RED/GREEN coverage for base-branch propagation and new-branch
+   worktree creation before broad workspace verification.
 
 ### Phase 6: Old-TUI Wizard Option Formatting
 

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -3,8 +3,8 @@
 ## Progress
 - Status: `in-progress`
 - Phase: `Implementation`
-- Task progress: `181/181` checked in `tasks.md`
-- Artifact refresh: `2026-04-06T11:05:03Z`
+- Task progress: `185/185` checked in `tasks.md`
+- Artifact refresh: `2026-04-06T11:59:47Z`
 
 ## Done
 - Startup cache scheduling, wizard integration, and session conversion flow documentation are now aligned to the implemented code.
@@ -141,11 +141,25 @@
 - Launch Agent's Codex model list now matches the current Codex CLI snapshot,
   including `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`, while
   keeping `Default (Auto)` on the no-`--model` path.
+- New-branch launches now materialize a sibling git worktree before PTY
+  spawn, so Launch Agent no longer falls back to the repository root
+  checkout when creating a new branch.
+- Branch-origin launches now preserve the selected base branch for
+  worktree creation, while SPEC/Issue-prefilled launches default that base
+  branch to `develop`.
+- The actual launched worktree path is now persisted into session metadata
+  and exported through `GWT_PROJECT_ROOT`, so Quick Start / resume operate on
+  the materialized launch target instead of a repo-root alias.
 - Verification for the Codex model sync slice now includes `cargo test -p
   gwt-tui`, `cargo test -p gwt-core -p gwt-tui`,
   `cargo clippy --all-targets --all-features -- -D warnings`,
   `cargo build -p gwt-tui`, and `bunx markdownlint-cli2` on the refreshed
   SPEC-3 artifacts.
+- Focused verification for the worktree-materialization slice now includes
+  `cargo test -p gwt-git sibling_worktree_path_uses_repo_name_and_slugged_branch -- --nocapture`,
+  `cargo test -p gwt-git create_from_base_creates_new_branch_worktree -- --nocapture`,
+  `cargo test -p gwt-tui base_branch -- --nocapture`, and
+  `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`.
 
 ## Next
 - Run the manual reviewer flow in `quickstart.md` and close the remaining

--- a/specs/SPEC-3/quickstart.md
+++ b/specs/SPEC-3/quickstart.md
@@ -105,6 +105,12 @@
 40. Verify a single-entry Quick Start with no persisted model now promotes
    only the agent label into the popup title (`Quick Start — Codex`) instead
    of inventing a `default` model placeholder.
+41. From Branches, choose `Create new from selected`, finish the wizard, and
+    verify Launch Agent creates a sibling worktree for the requested branch
+    before the PTY starts.
+42. Repeat the new-branch launch from SPEC or Issue context and verify the
+    created worktree uses the new branch while the session metadata records
+    that actual launched path.
 
 ## Repeatable Evidence
 - `cargo test -p gwt-agent detect -- --nocapture`
@@ -118,6 +124,7 @@
 - `cargo test -p gwt-tui quick_start -- --nocapture`
 - `cargo test -p gwt-tui prepare_wizard_startup_starts_spec_prefill_at_branch_type_select -- --nocapture`
 - `cargo test -p gwt-tui build_launch_config_from_wizard -- --nocapture`
+- `cargo test -p gwt-tui base_branch -- --nocapture`
 - `cargo test -p gwt-tui load_custom_agents_from_path_parses_spec_schema -- --nocapture`
 - `cargo test -p gwt-tui save_stored_custom_agents_to_path_preserves_models_and_other_settings -- --nocapture`
 - `cargo test -p gwt-tui build_wizard_agent_options_with_custom_agents_appends_settings_agents -- --nocapture`
@@ -125,6 +132,7 @@
 - `cargo test -p gwt-tui custom_agents_category_loads_persisted_agent_fields -- --nocapture`
 - `cargo test -p gwt-tui custom_agents_add_edit_delete_persist_immediately -- --nocapture`
 - `cargo test -p gwt-tui materialize_pending_launch_with -- --nocapture`
+- `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`
 - `cargo test -p gwt-tui session_conversion`
 
 ## Expected Result
@@ -204,5 +212,8 @@
 - Multi-entry Quick Start now indents the plain `Start new` rows beneath the
   paired `Resume` rows so the old-TUI primary/secondary action hierarchy is
   visible again without adding standalone headers back.
+- New-branch launches now materialize a sibling worktree before PTY spawn, so
+  Launch Agent no longer drops back to the repository root checkout for the
+  new-branch flow.
 - Any missing behavior is logged against acceptance or reviewer gaps rather than unchecked implementation tasks.
 - No step should be treated as complete unless the code path is actually reachable today.

--- a/specs/SPEC-3/spec.md
+++ b/specs/SPEC-3/spec.md
@@ -26,8 +26,18 @@ As a developer, I want to launch a coding agent through a guided wizard so that 
    step, then the launch completes directly without a trailing confirm
    screen.
 4. Given I confirm the wizard, when the agent launches, then a new persisted
-   session is created with the configured parameters.
-5. Given I cancel at any wizard step, when I press Escape, then no session is created and I return to the previous view.
+   session is created with the configured parameters and the actual launched
+   worktree path.
+5. Given I create a new branch from the Branches flow, when launch
+   materialization runs, then gwt creates a sibling worktree for that new
+   branch before spawning the agent PTY.
+6. Given the new-branch flow starts from a selected branch, when launch
+   materialization runs, then that selected branch is used as the base branch
+   instead of always falling back to the repo root checkout.
+7. Given the new-branch flow starts from SPEC or Issue context without a
+   selected base branch, when launch materialization runs, then `develop` is
+   used as the default base branch.
+8. Given I cancel at any wizard step, when I press Escape, then no session is created and I return to the previous view.
 
 ### US-7: Restore Old-TUI Wizard Step Machine (P0) -- IMPLEMENTED
 
@@ -284,6 +294,16 @@ As a developer, I want to convert an existing session to a different agent type 
   `CodexFastMode` only controls Codex service-tier behavior.
 - **FR-041**: When `CodexFastMode=On`, Codex launch args include
   `-c service_tier=fast`; when Off, that key is omitted.
+- **FR-042**: New-branch launches materialize the requested branch into a
+  sibling git worktree before PTY spawn, rather than running the agent from
+  the repository root.
+- **FR-043**: When the new-branch flow starts from Branches,
+  `BranchAction -> Create new from selected` preserves the selected branch as
+  the base branch for worktree creation; when no selected base branch exists,
+  Launch Agent defaults that base branch to `develop`.
+- **FR-044**: After launch materialization, `GWT_PROJECT_ROOT` and persisted
+  session metadata use the actual launched worktree path, and any
+  materialization error aborts launch before PTY spawn.
 
 ## Non-Functional Requirements
 
@@ -326,7 +346,7 @@ As a developer, I want to convert an existing session to a different agent type 
 
 | Variable | Value | Purpose |
 |----------|-------|---------|
-| `GWT_PROJECT_ROOT` | repo root path | Repository root for agent context |
+| `GWT_PROJECT_ROOT` | active worktree or repo root path | Launch target for agent context |
 | `TERM` | `xterm-256color` | Terminal type |
 | `COLORTERM` | `truecolor` | Color support |
 | Profile env vars | (from profile) | User-defined environment overrides |
@@ -453,3 +473,6 @@ default = { id = "default", label = "Default", arg = "" }
 - **SC-007**: Session conversion preserves repository context, updates agent identity safely, and handles errors gracefully.
 - **SC-008**: Version selection remains separated from model selection and the
   launch summary shows the effective version that will be used.
+- **SC-009**: New-branch launches from Branches, SPEC detail, and Issue
+  detail start inside a materialized sibling worktree instead of falling back
+  to the repository root checkout.

--- a/specs/SPEC-3/tasks.md
+++ b/specs/SPEC-3/tasks.md
@@ -330,3 +330,10 @@
 - [x] T169 Write RED test: Codex model options and old-TUI model-step rendering match the current Codex CLI snapshot.
 - [x] T170 Update `wizard.rs` so the Launch Agent Codex model list and descriptions match the current CLI snapshot while keeping `Default (Auto)` as the non-explicit override.
 - [x] T171 Verify focused wizard tests, broad workspace checks, and refresh SPEC-3 artifacts.
+
+## Phase 47: New-Branch Launch Worktree Materialization
+
+- [x] T172 Write RED test: materializing a pending new-branch launch creates a sibling worktree and persists the actual launched path.
+- [x] T173 Extend launch configuration so new-branch wizard flows preserve the selected base branch, with `develop` as the SPEC/Issue fallback.
+- [x] T174 Implement launch-time worktree materialization and actual-path persistence before PTY spawn.
+- [x] T175 Verify focused worktree/materialization tests, broad workspace checks, and refresh SPEC-3 artifacts.


### PR DESCRIPTION
## Summary

- Materialize pending new-branch launches into sibling worktrees before PTY spawn so Launch Agent sessions no longer start from the repository root on `develop`.
- Carry the wizard's selected base branch into `LaunchConfig` so branch launches fork from the intended parent and SPEC or Issue flows default to `develop`.\n- Update SPEC-3 artifacts and regression coverage to lock the new launch-worktree behavior in place.\n\n## Changes\n\n- `crates/gwt-tui/src/app.rs`: resolve pending launch worktrees before session persistence and PTY spawn, derive default base branches, and add regression tests.\n- `crates/gwt-git/src/worktree.rs`: add sibling worktree path generation and base-branch-aware worktree creation helpers with unit coverage.\n- `crates/gwt-git/src/lib.rs`: re-export the sibling worktree helper for the TUI launch flow.\n- `crates/gwt-agent/src/launch.rs`: extend `LaunchConfig` and builder plumbing with `base_branch`.\n- `specs/SPEC-3/*`: update the spec, plan, tasks, progress, quickstart, and checklists for the new launch behavior.\n\n## Testing\n\n- [x] `cargo test -p gwt-core -p gwt-agent -p gwt-git -p gwt-tui` — all tests pass after merging `origin/develop`.\n- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings.\n- [x] `cargo fmt -- --check` — formatting check passes; the existing nightly-option warnings are unchanged.\n- [x] `cargo build -p gwt-tui` — build succeeds.\n- [x] `bunx markdownlint-cli2 specs/SPEC-3/spec.md specs/SPEC-3/plan.md specs/SPEC-3/tasks.md specs/SPEC-3/quickstart.md specs/SPEC-3/progress.md specs/SPEC-3/checklists/tdd.md specs/SPEC-3/checklists/acceptance.md` — markdown lint passes.\n- [x] `git diff --check` — no whitespace errors.\n- [x] `bunx commitlint --from HEAD~2 --to HEAD` — commit messages pass.\n\n## Closing Issues\n\n- None\n\n## Related Issues / Links\n\n- None\n\n## Checklist\n\n- [x] Tests added/updated\n- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)\n- [x] Documentation updated (if user-facing change)\n- [ ] Migration/backfill plan included (if schema/data change) — No schema or data migration is involved.\n- [x] CHANGELOG impact considered (breaking change flagged in commit)\n\n## Context\n\n- Launch Agent carried a new `branch_name` through the wizard but did not materialize a branch worktree before spawn, so sessions fell back to the repository root and effectively launched on `develop`.\n\n## Risk / Impact\n\n- **Affected areas**: Launch Agent new-branch startup, git worktree creation, session metadata persistence, and `GWT_PROJECT_ROOT`.\n- **Rollback plan**: Revert the launch-worktree materialization change if new-branch startup regresses.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New-branch launches now automatically create dedicated git worktrees before opening terminal sessions, eliminating fallback to repository root.
  * Base branch selection is preserved across launch workflows and defaults to `develop` when launching from issue/spec context.
  * Session metadata now persists the actual worktree path for accurate resumption.

* **Documentation**
  * Updated specifications and acceptance criteria for new-branch worktree materialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->