### PR TITLE
fix(launch): ignore selected worktree for new-branch runs

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -2470,8 +2470,10 @@ fn build_launch_config_from_wizard_with_custom_agents(
 
     let mut builder = AgentLaunchBuilder::new(agent_id);
 
-    if let Some(ref wt) = wizard.worktree_path {
-        builder = builder.working_dir(wt);
+    if !wizard.is_new_branch {
+        if let Some(ref wt) = wizard.worktree_path {
+            builder = builder.working_dir(wt);
+        }
     }
 
     if !wizard.branch_name.is_empty() {
@@ -2566,7 +2568,9 @@ fn build_custom_launch_config_from_wizard(
         command,
         args,
         env_vars,
-        working_dir: wizard.worktree_path.clone(),
+        working_dir: (!wizard.is_new_branch)
+            .then(|| wizard.worktree_path.clone())
+            .flatten(),
         branch: (!wizard.branch_name.is_empty()).then(|| wizard.branch_name.clone()),
         base_branch: wizard_launch_base_branch(wizard),
         display_name: custom_agent.display_name.clone(),
@@ -2585,7 +2589,7 @@ fn is_explicit_model_selection(model: &str) -> bool {
 }
 
 fn wizard_launch_base_branch(wizard: &screens::wizard::WizardState) -> Option<String> {
-    if wizard.worktree_path.is_some() || !wizard.is_new_branch {
+    if !wizard.is_new_branch {
         None
     } else {
         Some(
@@ -7153,6 +7157,24 @@ CUSTOM_ENV = "enabled"
     }
 
     #[test]
+    fn build_launch_config_from_wizard_new_branch_ignores_selected_branch_worktree() {
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            base_branch_name: Some("develop".to_string()),
+            branch_name: "feature/child".to_string(),
+            worktree_path: Some(PathBuf::from("/tmp/wt-develop")),
+            ..Default::default()
+        };
+
+        let config = build_launch_config_from_wizard(&wizard);
+
+        assert_eq!(config.branch.as_deref(), Some("feature/child"));
+        assert_eq!(config.base_branch.as_deref(), Some("develop"));
+        assert!(config.working_dir.is_none());
+    }
+
+    #[test]
     fn build_launch_config_from_wizard_defaults_spec_prefill_base_branch_to_develop() {
         let wizard = screens::wizard::WizardState {
             agent_id: "claude".to_string(),
@@ -7414,6 +7436,67 @@ CUSTOM_ENV = "enabled"
             .path();
         let persisted = AgentSession::load(&session_entry).expect("load persisted session");
         assert_eq!(persisted.branch, "feature/materialized-launch");
+        assert_eq!(persisted.worktree_path, expected_worktree);
+    }
+
+    #[test]
+    fn materialize_pending_launch_with_new_branch_from_selected_branch_creates_new_worktree() {
+        let repo_dir = tempfile::tempdir().expect("temp repo dir");
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        init_git_repo(repo_dir.path());
+        git_commit_allow_empty(repo_dir.path(), "initial commit");
+        git_checkout_new_branch(repo_dir.path(), "develop");
+
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            base_branch_name: Some("develop".to_string()),
+            branch_name: "feature/launch-from-selected".to_string(),
+            worktree_path: Some(repo_dir.path().to_path_buf()),
+            ..Default::default()
+        };
+
+        let mut model = Model::new(repo_dir.path().to_path_buf());
+        model.pending_launch_config = Some(build_launch_config_from_wizard(&wizard));
+
+        materialize_pending_launch_with(&mut model, sessions_dir.path())
+            .expect("materialize launch");
+
+        let repo_name = repo_dir
+            .path()
+            .file_name()
+            .expect("repo dir name")
+            .to_string_lossy();
+        let expected_worktree = repo_dir
+            .path()
+            .parent()
+            .expect("repo dir parent")
+            .join(format!("{repo_name}-feature-launch-from-selected"));
+        assert!(expected_worktree.exists(), "new worktree should exist");
+
+        let branch_output = std::process::Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&expected_worktree)
+            .output()
+            .expect("read worktree branch");
+        assert!(
+            branch_output.status.success(),
+            "git branch --show-current failed: {}",
+            String::from_utf8_lossy(&branch_output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&branch_output.stdout).trim(),
+            "feature/launch-from-selected"
+        );
+
+        let session_entry = fs::read_dir(sessions_dir.path())
+            .expect("read sessions dir")
+            .next()
+            .expect("session entry")
+            .expect("dir entry")
+            .path();
+        let persisted = AgentSession::load(&session_entry).expect("load persisted session");
+        assert_eq!(persisted.branch, "feature/launch-from-selected");
         assert_eq!(persisted.worktree_path, expected_worktree);
     }
 

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -4,7 +4,7 @@
 - Status: `in-progress`
 - Phase: `Implementation`
 - Task progress: `185/185` checked in `tasks.md`
-- Artifact refresh: `2026-04-06T11:59:47Z`
+- Artifact refresh: `2026-04-07T00:20:00Z`
 
 ## Done
 - Startup cache scheduling, wizard integration, and session conversion flow documentation are now aligned to the implemented code.
@@ -147,6 +147,10 @@
 - Branch-origin launches now preserve the selected base branch for
   worktree creation, while SPEC/Issue-prefilled launches default that base
   branch to `develop`.
+- Selected-branch new-branch launches no longer leak the selected branch's
+  existing worktree into `LaunchConfig`, so launch-time materialization now
+  still creates the requested sibling worktree instead of silently reusing
+  `develop`.
 - The actual launched worktree path is now persisted into session metadata
   and exported through `GWT_PROJECT_ROOT`, so Quick Start / resume operate on
   the materialized launch target instead of a repo-root alias.
@@ -159,7 +163,8 @@
   `cargo test -p gwt-git sibling_worktree_path_uses_repo_name_and_slugged_branch -- --nocapture`,
   `cargo test -p gwt-git create_from_base_creates_new_branch_worktree -- --nocapture`,
   `cargo test -p gwt-tui base_branch -- --nocapture`, and
-  `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`.
+  `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`,
+  plus `cargo test -p gwt-tui from_selected_branch -- --nocapture`.
 
 ## Next
 - Run the manual reviewer flow in `quickstart.md` and close the remaining

--- a/specs/SPEC-3/quickstart.md
+++ b/specs/SPEC-3/quickstart.md
@@ -107,7 +107,8 @@
    of inventing a `default` model placeholder.
 41. From Branches, choose `Create new from selected`, finish the wizard, and
     verify Launch Agent creates a sibling worktree for the requested branch
-    before the PTY starts.
+    before the PTY starts, even when the selected base branch already has its
+    own worktree.
 42. Repeat the new-branch launch from SPEC or Issue context and verify the
     created worktree uses the new branch while the session metadata records
     that actual launched path.
@@ -133,6 +134,7 @@
 - `cargo test -p gwt-tui custom_agents_add_edit_delete_persist_immediately -- --nocapture`
 - `cargo test -p gwt-tui materialize_pending_launch_with -- --nocapture`
 - `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`
+- `cargo test -p gwt-tui from_selected_branch -- --nocapture`
 - `cargo test -p gwt-tui session_conversion`
 
 ## Expected Result


### PR DESCRIPTION
## Summary

- Prevent Launch Agent from reusing the selected branch's existing worktree when the wizard switches to `Create new from selected`, so new-branch runs no longer fall back to `develop`.
- Keep the selected base branch on the new-branch path even when the wizard still carries the original branch worktree in memory, so launch-time materialization still creates the requested sibling worktree.
- Refresh SPEC-3 reviewer evidence with the new selected-branch regression coverage.

## Changes

- `crates/gwt-tui/src/app.rs`: only forward `worktree_path` into `LaunchConfig` for existing-branch runs, keep `base_branch` available for new-branch runs, and add regression tests for the selected-branch path.
- `specs/SPEC-3/progress.md`: document the follow-up fix for the selected-worktree leak.
- `specs/SPEC-3/quickstart.md`: add reviewer guidance and repeatable evidence for the selected-branch regression case.

## Testing

- [x] `cargo test -p gwt-core -p gwt-agent -p gwt-git -p gwt-tui` — full Rust suite passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings.
- [x] `cargo fmt -- --check` — formatting check passes; the existing nightly-option warnings are unchanged.
- [x] `cargo build -p gwt-tui` — build succeeds.
- [x] `bunx markdownlint-cli2 specs/SPEC-3/progress.md specs/SPEC-3/quickstart.md` — markdown lint passes.
- [x] `git diff --check` — no whitespace errors.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — fix commit passes commitlint before the sync merge.

## Closing Issues

- None

## Related Issues / Links

- https://github.com/akiojin/gwt/pull/1897

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — No schema or data migration is involved.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- PR #1897 fixed launch-time worktree materialization, but a follow-up regression remained in the wizard path: existing-branch launches kept `wizard.worktree_path` populated after switching to `Create new from selected`, which caused `LaunchConfig.working_dir` and `base_branch` normalization to skip the new-branch materialization path.

## Risk / Impact

- **Affected areas**: Launch Agent wizard state normalization for branch-origin launches and follow-up reviewer documentation in SPEC-3.
- **Rollback plan**: Revert this PR to restore the pre-follow-up behavior if launch selection regresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed new-branch wizard to correctly create a new sibling worktree when the selected branch already has an existing worktree, instead of reusing it.

* **Tests**
  * Added and updated tests to verify correct worktree materialization behavior for new-branch launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->