### PR TITLE
feat(tui): show branch names in agent tabs

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -445,7 +445,7 @@ mod tests {
 
         assert_eq!(config.command, "claude");
         assert_eq!(config.display_name, "Claude Code");
-        assert_eq!(config.color, AgentColor::Green);
+        assert_eq!(config.color, AgentColor::Yellow);
         assert_eq!(
             config.env_vars.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"),
             Some(&"1".to_string())

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -54,11 +54,11 @@ impl AgentId {
     /// Default UI color for this agent.
     pub fn default_color(&self) -> AgentColor {
         match self {
-            Self::ClaudeCode => AgentColor::Green,
-            Self::Codex => AgentColor::Blue,
-            Self::Gemini => AgentColor::Cyan,
-            Self::OpenCode => AgentColor::Yellow,
-            Self::Copilot => AgentColor::Magenta,
+            Self::ClaudeCode => AgentColor::Yellow,
+            Self::Codex => AgentColor::Cyan,
+            Self::Gemini => AgentColor::Magenta,
+            Self::OpenCode => AgentColor::Green,
+            Self::Copilot => AgentColor::Blue,
             Self::Custom(_) => AgentColor::Gray,
         }
     }
@@ -156,8 +156,9 @@ mod tests {
 
     #[test]
     fn agent_id_default_color() {
-        assert_eq!(AgentId::ClaudeCode.default_color(), AgentColor::Green);
-        assert_eq!(AgentId::Codex.default_color(), AgentColor::Blue);
+        assert_eq!(AgentId::ClaudeCode.default_color(), AgentColor::Yellow);
+        assert_eq!(AgentId::Codex.default_color(), AgentColor::Cyan);
+        assert_eq!(AgentId::Gemini.default_color(), AgentColor::Magenta);
         assert_eq!(
             AgentId::Custom("x".into()).default_color(),
             AgentColor::Gray
@@ -169,7 +170,7 @@ mod tests {
         let info = AgentInfo::from_id(AgentId::ClaudeCode);
         assert_eq!(info.display_name, "Claude Code");
         assert_eq!(info.command, "claude");
-        assert_eq!(info.color, AgentColor::Green);
+        assert_eq!(info.color, AgentColor::Yellow);
         assert_eq!(info.package_name, Some("@anthropic-ai/claude-code".into()));
     }
 

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3976,56 +3976,94 @@ fn render_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
 
 /// Build session tab title line (same pattern as management tabs in Block title).
 fn build_session_title(model: &Model, width: u16) -> Line<'static> {
-    if should_compact_session_title(model, width) {
-        if let Some(active) = model.active_session_tab() {
+    build_session_title_with(model, width, &gwt_sessions_dir())
+}
+
+fn build_session_title_with(model: &Model, width: u16, sessions_dir: &Path) -> Line<'static> {
+    let entries: Vec<(String, Style, &'static str)> = model
+        .sessions
+        .iter()
+        .enumerate()
+        .map(|(i, session)| {
+            (
+                session_title_label(session, sessions_dir),
+                session_title_style(session, i == model.active_session),
+                session.tab_type.icon(),
+            )
+        })
+        .collect();
+
+    if should_compact_session_title(width, &entries) {
+        if let Some((label, style, icon)) = entries.get(model.active_session) {
             let position = model.active_session.saturating_add(1);
             let total = model.sessions.len();
-            let label = format!(
-                " {position}/{total} {} {} ",
-                active.tab_type.icon(),
-                active.name
-            );
-            return Line::from(vec![Span::styled(
-                label,
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            )]);
+            let title = format!(" {position}/{total} {icon} {label} ");
+            return Line::from(vec![Span::styled(title, *style)]);
         }
     }
 
     let mut spans: Vec<Span<'static>> = Vec::new();
-    for (i, s) in model.sessions.iter().enumerate() {
+    for (i, (label, style, icon)) in entries.into_iter().enumerate() {
         if i > 0 {
-            spans.push(Span::raw("│"));
+            spans.push(Span::styled("│", Style::default().fg(Color::DarkGray)));
         }
-        let label = format!(" {} {} ", s.tab_type.icon(), s.name);
-        if i == model.active_session {
-            spans.push(Span::styled(
-                label,
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ));
-        } else {
-            spans.push(Span::styled(label, Style::default().fg(Color::Gray)));
-        }
+        spans.push(Span::styled(format!(" {icon} {label} "), style));
     }
     Line::from(spans)
 }
 
-fn should_compact_session_title(model: &Model, width: u16) -> bool {
+fn session_title_label(session: &crate::model::SessionTab, sessions_dir: &Path) -> String {
+    match &session.tab_type {
+        SessionTabType::Agent { .. } => load_persisted_branch_label(&session.id, sessions_dir)
+            .unwrap_or_else(|| session.name.clone()),
+        SessionTabType::Shell => session.name.clone(),
+    }
+}
+
+fn load_persisted_branch_label(session_id: &str, sessions_dir: &Path) -> Option<String> {
+    let path = sessions_dir.join(format!("{session_id}.toml"));
+    let persisted = AgentSession::load(&path).ok()?;
+    let branch = persisted.branch.trim();
+    if branch.is_empty() {
+        None
+    } else {
+        Some(persisted.branch)
+    }
+}
+
+fn session_title_style(session: &crate::model::SessionTab, is_active: bool) -> Style {
+    match &session.tab_type {
+        SessionTabType::Shell => {
+            if is_active {
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            } else {
+                Style::default().fg(Color::Gray)
+            }
+        }
+        SessionTabType::Agent { color, .. } => {
+            let style = Style::default().fg(agent_color_to_ratatui(*color));
+            if is_active {
+                style.add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            } else {
+                style.add_modifier(Modifier::DIM)
+            }
+        }
+    }
+}
+
+fn should_compact_session_title(width: u16, entries: &[(String, Style, &'static str)]) -> bool {
     let available_title_width = width.saturating_sub(2) as usize;
     if available_title_width == 0 {
         return false;
     }
 
-    let full_strip_width: usize = model
-        .sessions
+    let full_strip_width: usize = entries
         .iter()
         .enumerate()
-        .map(|(i, session)| {
-            let label_width = format!(" {} {} ", session.tab_type.icon(), session.name).len();
+        .map(|(i, (label, _, icon))| {
+            let label_width = format!(" {icon} {label} ").len();
             if i == 0 {
                 label_width
             } else {
@@ -4373,7 +4411,7 @@ mod tests {
     use gwt_notification::{Notification, Severity};
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
-    use ratatui::style::Color;
+    use ratatui::style::{Color, Modifier};
     use ratatui::text::Line;
     use ratatui::widgets::Widget;
     use ratatui::{buffer::Buffer, Terminal};
@@ -4478,6 +4516,47 @@ mod tests {
             .draw(|frame| view(model, frame))
             .expect("draw model");
         terminal.backend().buffer().clone()
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>()
+    }
+
+    fn persist_agent_tab(
+        sessions_dir: &Path,
+        branch: &str,
+        agent_id: AgentId,
+        color: crate::model::AgentColor,
+    ) -> (crate::model::SessionTab, PathBuf) {
+        fs::create_dir_all(sessions_dir).expect("create sessions dir");
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let session_id = format!("test-session-{}-{unique}", agent_id.command());
+
+        let mut session = AgentSession::new("/tmp/test-worktree", branch, agent_id.clone());
+        session.id = session_id.clone();
+        session.display_name = agent_id.display_name().to_string();
+        session.save(sessions_dir).expect("persist session");
+
+        (
+            crate::model::SessionTab {
+                id: session_id.clone(),
+                name: agent_id.display_name().to_string(),
+                tab_type: SessionTabType::Agent {
+                    agent_id: agent_id.command().to_string(),
+                    color,
+                },
+                vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
+            },
+            sessions_dir.join(format!("{session_id}.toml")),
+        )
     }
 
     fn append_session_line(model: &mut Model, session_id: &str, line: &str) {
@@ -5420,6 +5499,166 @@ mod tests {
             !first_line.contains("2/4"),
             "extra-wide panes should keep the full strip rather than the compact index/count chrome"
         );
+    }
+
+    #[test]
+    fn build_session_title_agent_tabs_prefer_persisted_branch_names_in_full_strip() {
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        let (claude, claude_path) = persist_agent_tab(
+            sessions_dir.path(),
+            "feature/claude-branch",
+            AgentId::ClaudeCode,
+            crate::model::AgentColor::Yellow,
+        );
+        let (codex, codex_path) = persist_agent_tab(
+            sessions_dir.path(),
+            "feature/codex-branch",
+            AgentId::Codex,
+            crate::model::AgentColor::Cyan,
+        );
+
+        let mut model = test_model();
+        model.sessions = vec![claude, codex];
+        model.active_session = 0;
+
+        let title = build_session_title_with(&model, 220, sessions_dir.path());
+        let text = line_text(&title);
+
+        assert!(text.contains("feature/claude-branch"));
+        assert!(text.contains("feature/codex-branch"));
+        assert!(!text.contains("Claude Code"));
+        assert!(!text.contains("Codex"));
+
+        let _ = fs::remove_file(claude_path);
+        let _ = fs::remove_file(codex_path);
+    }
+
+    #[test]
+    fn build_session_title_compact_agent_tabs_show_active_branch_name_and_count() {
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        let mut cleanup = Vec::new();
+        let mut sessions = Vec::new();
+
+        for (branch, agent_id, color) in [
+            (
+                "feature/branch-one",
+                AgentId::ClaudeCode,
+                crate::model::AgentColor::Yellow,
+            ),
+            (
+                "feature/branch-two",
+                AgentId::Codex,
+                crate::model::AgentColor::Cyan,
+            ),
+            (
+                "feature/branch-three",
+                AgentId::Gemini,
+                crate::model::AgentColor::Magenta,
+            ),
+            (
+                "feature/branch-four",
+                AgentId::ClaudeCode,
+                crate::model::AgentColor::Yellow,
+            ),
+            (
+                "feature/branch-five",
+                AgentId::Codex,
+                crate::model::AgentColor::Cyan,
+            ),
+            (
+                "feature/branch-six",
+                AgentId::Gemini,
+                crate::model::AgentColor::Magenta,
+            ),
+            (
+                "feature/branch-seven",
+                AgentId::ClaudeCode,
+                crate::model::AgentColor::Yellow,
+            ),
+            (
+                "feature/branch-eight",
+                AgentId::Codex,
+                crate::model::AgentColor::Cyan,
+            ),
+        ] {
+            let (session, path) = persist_agent_tab(sessions_dir.path(), branch, agent_id, color);
+            sessions.push(session);
+            cleanup.push(path);
+        }
+
+        let mut model = test_model();
+        model.sessions = sessions;
+        model.active_session = 5;
+
+        let title = build_session_title_with(&model, 40, sessions_dir.path());
+        let text = line_text(&title);
+
+        assert!(text.contains("6/8"));
+        assert!(text.contains("feature/branch-six"));
+        assert!(!text.contains("Gemini CLI"));
+
+        for path in cleanup {
+            let _ = fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn build_session_title_agent_tabs_keep_identity_colors_and_use_modifiers_for_active_state() {
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        let (claude, claude_path) = persist_agent_tab(
+            sessions_dir.path(),
+            "feature/claude-active",
+            AgentId::ClaudeCode,
+            crate::model::AgentColor::Yellow,
+        );
+        let (codex, codex_path) = persist_agent_tab(
+            sessions_dir.path(),
+            "feature/codex-idle",
+            AgentId::Codex,
+            crate::model::AgentColor::Cyan,
+        );
+        let (gemini, gemini_path) = persist_agent_tab(
+            sessions_dir.path(),
+            "feature/gemini-idle",
+            AgentId::Gemini,
+            crate::model::AgentColor::Magenta,
+        );
+
+        let mut model = test_model();
+        model.sessions = vec![claude, codex, gemini];
+        model.active_session = 0;
+
+        let title = build_session_title_with(&model, 220, sessions_dir.path());
+        let claude_span = title
+            .spans
+            .iter()
+            .find(|span| span.content.contains("feature/claude-active"))
+            .expect("claude span");
+        let codex_span = title
+            .spans
+            .iter()
+            .find(|span| span.content.contains("feature/codex-idle"))
+            .expect("codex span");
+        let gemini_span = title
+            .spans
+            .iter()
+            .find(|span| span.content.contains("feature/gemini-idle"))
+            .expect("gemini span");
+
+        assert_eq!(claude_span.style.fg, Some(Color::Yellow));
+        assert!(claude_span.style.add_modifier.contains(Modifier::BOLD));
+        assert!(claude_span
+            .style
+            .add_modifier
+            .contains(Modifier::UNDERLINED));
+        assert_eq!(codex_span.style.fg, Some(Color::Cyan));
+        assert!(codex_span.style.add_modifier.contains(Modifier::DIM));
+        assert_eq!(gemini_span.style.fg, Some(Color::Magenta));
+        assert!(gemini_span.style.add_modifier.contains(Modifier::DIM));
+
+        let _ = fs::remove_file(claude_path);
+        let _ = fs::remove_file(codex_path);
+        let _ = fs::remove_file(gemini_path);
     }
 
     #[test]
@@ -7146,7 +7385,7 @@ CUSTOM_ENV = "enabled"
             session_tab.tab_type,
             SessionTabType::Agent {
                 agent_id: "claude".to_string(),
-                color: crate::model::AgentColor::Green,
+                color: crate::model::AgentColor::Yellow,
             }
         );
 
@@ -7442,7 +7681,7 @@ CUSTOM_ENV = "enabled"
             converted.tab_type,
             SessionTabType::Agent {
                 agent_id: "codex".to_string(),
-                color: crate::model::AgentColor::Blue,
+                color: crate::model::AgentColor::Cyan,
             }
         );
         assert_eq!(converted.vt.rows(), 30);

--- a/specs/SPEC-2/metadata.json
+++ b/specs/SPEC-2/metadata.json
@@ -4,5 +4,5 @@
   "status": "done",
   "phase": "Done",
   "created_at": "2026-04-02T09:37:31.960909+00:00",
-  "updated_at": "2026-04-06T09:33:36Z"
+  "updated_at": "2026-04-06T12:14:05Z"
 }

--- a/specs/SPEC-2/plan.md
+++ b/specs/SPEC-2/plan.md
@@ -684,6 +684,21 @@ Close the remaining workspace-shell usability gap where session PTYs rightfully 
 - Re-run focused keybind/workspace-shell verification after the implementation turns green.
 - Refresh SPEC-2 artifacts and progress evidence with the prefixed focus-escape contract.
 
+### Phase 50: Make Agent Session Titles Branch-First And Color-Stable (5 tasks)
+Make the right-side agent tabs identify workstreams by branch name instead of by agent name, while
+keeping agent identity visible through fixed colors that do not collapse when Claude Code is active.
+
+50.1: Session-title contract (2 tasks)
+- Agent session titles prefer persisted branch names over agent display names in both full-width and compact title chrome, while shell tabs keep their existing session-name labels.
+- Claude Code, Codex, and Gemini titles keep fixed Yellow/Cyan/Magenta identity colors, and active-state emphasis uses modifiers instead of a shared active-only foreground color.
+
+50.2: Focused coverage (2 tasks)
+- Add RED coverage for full-width and compact agent titles showing persisted branch names with `n/N` context preserved in compact mode.
+- Add RED coverage for identity-color stability plus modifier-based active emphasis, and refresh launch/conversion expectations to the new agent color contract.
+
+50.3: Verification (1 task)
+- Re-run focused session-title / launch-color tests, broad workspace verification, and refresh SPEC-2 artifacts and progress tracking.
+
 ## Dependencies
 
 - SPEC-3 (Agent Management): Agent detection for agent launch action

--- a/specs/SPEC-2/progress.md
+++ b/specs/SPEC-2/progress.md
@@ -3,8 +3,8 @@
 ## Progress
 - Status: `done`
 - Phase: `Done`
-- Task progress: `288/288` checked in `tasks.md`
-- Artifact refresh: `2026-04-06T09:33:36Z`
+- Task progress: `320/320` checked in `tasks.md`
+- Artifact refresh: `2026-04-06T12:14:05Z`
 
 ## Done
 - Supporting artifacts were refreshed so they no longer describe the older shell shape.
@@ -62,6 +62,8 @@
 - `Ctrl+G,g` pane toggles now resize live PTYs and vt100 parsers immediately to the new visible session geometry, keeping placeholder chrome and actual terminal width aligned.
 - Exited PTY-backed sessions now remove their tabs automatically, clamp the active session safely, and notify with the auto-close result instead of leaving dead tabs behind.
 - Session PTYs now also expose an explicit prefixed focus-escape path: `Ctrl+G,Tab` and `Ctrl+G,Shift+Tab` cycle focus without stealing the raw plain-`Tab` key from Shell or Agent processes.
+- Agent session titles now identify the workstream by persisted branch name instead of the tool label, so the right-side tab strip reads as branch-first workspace context.
+- Claude Code, Codex, and Gemini now keep fixed Yellow/Cyan/Magenta identity colors in session-title chrome, while active emphasis is carried by styling modifiers instead of a shared yellow active color.
 
 ## Next
 - Run the reviewer walkthrough in `quickstart.md` and close the remaining manual acceptance evidence.

--- a/specs/SPEC-2/spec.md
+++ b/specs/SPEC-2/spec.md
@@ -93,9 +93,11 @@ As a developer, I want all navigation keybindings to use a consistent Ctrl+G pre
 
 ## Functional Requirements
 
-- **FR-001**: Tab mode shows single active session with session tabs in the Block title (active session yellow/bold, inactive gray, separated by │).
+- **FR-001**: Tab mode shows single active session with session tabs in the Block title, separated by `│`. Shell tabs keep their session name, while agent tabs show the persisted branch name instead of the agent display name whenever branch metadata is available.
 - **FR-001a**: When the session pane is too narrow to fit the full session tab strip in the pane title, the title collapses to the active session only so the current workstream stays legible; extra-wide panes restore the full strip.
 - **FR-001b**: That compact session title still preserves multi-session context by showing the active session position as `n/N`, so standard-width workspaces do not lose track of how many sessions remain open when the strip collapses.
+- **FR-001c**: Agent tab identity is color-coded instead of name-coded: Claude Code uses Yellow, Codex uses Cyan, and Gemini uses Magenta across session-title chrome.
+- **FR-001d**: Active session emphasis is expressed through title styling modifiers instead of a shared active-only foreground color, so agent identity colors remain stable even when the active tab is Claude Code.
 - **FR-002**: Split mode shows an equal grid of all sessions (e.g., 2x2 for 4 sessions, 2x3 for 5-6).
 - **FR-002a**: Split/grid mode pane titles preserve session identity by showing each pane's stable `n:` shortcut position plus the session-type icon alongside the session name, so the old-TUI numeric muscle memory still applies when multiple panes are visible.
 - **FR-003**: Toggle between tab and split with Ctrl+G,z.
@@ -188,7 +190,7 @@ Ctrl+G, Tab →  Tab Content (list) → Terminal → ...
 - Unfocused pane: **white** border (`Color::Gray`)
 - Reverse focus cycling accepts both `BackTab` and `Shift+Tab` key encodings
 - Management tabs are rendered in the Block title of the management panel (Left/Right switches tabs within TabContent focus)
-- Session tabs are rendered in the Block title of the terminal content area (active session highlighted yellow/bold, inactive gray)
+- Session tabs are rendered in the Block title of the terminal content area. Shell tabs keep their session name, agent tabs prefer the persisted branch name, and agent colors stay fixed (`Claude Code = Yellow`, `Codex = Cyan`, `Gemini = Magenta`) while active-state emphasis comes from styling modifiers rather than a shared active foreground color.
 - Ctrl+G,g toggles management panel visibility (same as before)
 - Overlays (Wizard, Confirm, Error) capture all input when visible
 

--- a/specs/SPEC-2/tasks.md
+++ b/specs/SPEC-2/tasks.md
@@ -491,3 +491,11 @@ banner in favor of pane-title chrome.
 - [x] T313 [P] Write RED test: applying the forward focus-cycle message from `ActiveLayer::Main` reveals management and lands on the next logical pane instead of forwarding `Tab` into the PTY.
 - [x] T314 Update the keybind registry and app update path so prefixed focus-cycle commands work consistently from Shell and Agent panes.
 - [x] T315 Refresh `SPEC-2` artifacts and focused verification evidence for the prefixed focus-escape contract.
+
+## Phase 50: Make Agent Session Titles Branch-First And Color-Stable
+
+- [x] T316 [P] Write RED test: full-width agent session titles prefer persisted branch names over agent display names.
+- [x] T317 [P] Write RED test: compact agent session titles keep `n/N` context while showing the active persisted branch name.
+- [x] T318 [P] Write RED test: agent identity colors stay fixed while active-state emphasis comes from modifiers instead of a shared active-yellow foreground.
+- [x] T319 Update `app.rs` and `gwt-agent` color defaults so agent session titles render branch-first and keep Claude/Codex/Gemini as Yellow/Cyan/Magenta.
+- [x] T320 Refresh `SPEC-2` artifacts, launch/conversion expectations, and verification evidence for the branch-first agent-title contract.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,25 @@
 # Lessons Learned
 
+## 2026-04-06 — feat: session-title tests must not depend on the real home sessions dir
+
+### 事象
+
+agent tab title を branch-first にする RED テストを最初に `gwt_sessions_dir()` 直書きで組んだところ、
+sandbox 環境では home 配下への書き込みが拒否され、期待した振る舞いの失敗ではなく `PermissionDenied`
+でテストが落ちた。
+
+### 原因
+
+- session title の branch 解決が `~/.gwt/sessions` 前提だったため、テストも同じ実ディレクトリを書き換えようとした。
+- render/title 系のテストで「本当に検証したいのは label/style 契約」であるにもかかわらず、
+  ファイル配置の実環境依存を切り離していなかった。
+
+### 再発防止策
+
+1. `~/.gwt/*` のような home 配下の永続ディレクトリに依存する表示ロジックは、テストから注入できる `Path` 引数つき helper を先に用意する。
+2. render/title 系の RED テストでは、まず tempdir で再現できる最小 helper を叩き、環境権限エラーを期待失敗に混ぜない。
+3. sandbox で書き込めるか不明な path を使うテスト helper は作らず、`tempfile` で閉じた fixture に寄せる。
+
 ## 2026-04-06 — fix: startup 時の agent detection は main thread で同期実行しない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Show agent session tabs by persisted branch name instead of provider name so the right-side pane is easier to scan by workstream.
- Keep Claude Code, Codex, and Gemini identifiable through stable Yellow/Cyan/Magenta title colors while moving active emphasis to modifiers that do not conflict with Claude's yellow.
- Refresh SPEC-2 and regression coverage so the branch-first title contract and color mapping stay locked.

## Changes

- `crates/gwt-tui/src/app.rs`: resolve agent tab labels from persisted session metadata, keep compact `n/N` chrome branch-first, and separate active-state styling from identity color.
- `crates/gwt-agent/src/types.rs` / `crates/gwt-agent/src/launch.rs`: update default agent color mapping and test expectations to Claude=Yellow, Codex=Cyan, Gemini=Magenta.
- `specs/SPEC-2/*` / `tasks/lessons.md`: document the new session-title contract, add Phase 50 tracking, and record the tempdir-based testing lesson for session metadata.

## Testing

- [x] `cargo test -p gwt-tui build_session_title_agent_tabs -- --nocapture` — agent title rows resolve persisted branch names and keep modifier-based active emphasis.
- [x] `cargo test -p gwt-tui build_session_title_compact_agent_tabs_show_active_branch_name_and_count -- --nocapture` — compact title keeps `n/N` context while showing the active branch name.
- [x] `cargo test -p gwt-agent agent_id_default_color -- --nocapture` — default agent color mapping matches the new Claude/Codex/Gemini contract.
- [x] `cargo test -p gwt-agent build_claude_normal -- --nocapture` — launch config uses the updated Claude color.
- [x] `cargo test -p gwt-tui materialize_pending_launch_with_creates_agent_session_and_persists_metadata -- --nocapture` — newly launched sessions still persist metadata correctly.
- [x] `cargo test -p gwt-tui apply_pending_session_conversion_with_updates_active_session_and_preserves_repo_path -- --nocapture` — session conversion keeps the new agent color mapping.
- [x] `cargo test -p gwt-tui handle_confirm_message_with_accept_applies_pending_session_conversion_and_logs_info -- --nocapture` — confirm flow preserves the updated color contract.
- [x] `cargo test -p gwt-core -p gwt-tui` — full targeted workspace tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes cleanly.
- [x] `cargo fmt -- --check` — formatting is clean.
- [x] `cargo build -p gwt-tui` — the TUI crate builds successfully.

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — N/A, no schema or persisted data shape changed.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- The previous session-title chrome made the right-side agent tabs read as provider labels (`Codex`, `Claude Code`) instead of the actual workstream branch, which made multiple concurrent agent tabs hard to distinguish at a glance.
- Switching Claude Code to Yellow would have collided with the old shared active-tab Yellow highlight, so the active-state contract had to be separated from identity color instead of just remapping one color constant.

## Screenshots

- Not included. This is a one-line TUI title change covered by focused render tests and full snapshot verification.

## Notes

- The worktree remains locally dirty in `.claude/skills/gwt-search/SKILL.md` and `.claude/skills/gwt-spec-build/SKILL.md`; those pre-existing changes are not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent session tabs now display persisted branch names instead of agent display names, providing better workspace context.

* **UI/Visual Updates**
  * Agent identity colors are now fixed and stable (Claude Code: Yellow, Codex: Cyan, Gemini: Magenta).
  * Active session state is now indicated via styling modifiers (bold, underline) rather than color changes, preserving consistent agent identity colors.

* **Documentation**
  * Updated specifications and implementation plans to reflect branch-first session tab behavior and fixed agent color identity mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->