### PR TITLE
fix(launch): derive worktree path from main repo root

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -111,6 +111,40 @@ impl WorktreeManager {
     }
 }
 
+/// Resolve the main worktree root for a repository or linked worktree path.
+pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| GwtError::Git(format!("rev-parse --git-common-dir: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(GwtError::Git(format!(
+            "rev-parse --git-common-dir: {stderr}"
+        )));
+    }
+
+    let common_dir = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+    if common_dir.as_os_str().is_empty() {
+        return Err(GwtError::Git(
+            "rev-parse --git-common-dir returned an empty path".to_string(),
+        ));
+    }
+
+    if common_dir.file_name().and_then(|name| name.to_str()) == Some(".git") {
+        return common_dir.parent().map(Path::to_path_buf).ok_or_else(|| {
+            GwtError::Git(format!(
+                "git common dir has no parent repository: {}",
+                common_dir.display()
+            ))
+        });
+    }
+
+    Ok(repo_path.to_path_buf())
+}
+
 /// Derive a sibling worktree path from the repo root and branch name.
 pub fn sibling_worktree_path(repo_path: &Path, branch: &str) -> PathBuf {
     let repo_name = repo_path
@@ -334,6 +368,38 @@ prunable gitdir file points to non-existent location
         let repo_path = Path::new("/tmp/my-repo");
         let worktree = sibling_worktree_path(repo_path, "feature/banner");
         assert_eq!(worktree, PathBuf::from("/tmp/my-repo-feature-banner"));
+    }
+
+    #[test]
+    fn main_worktree_root_returns_primary_repo_for_linked_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("gwt");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+
+        let linked_worktree = tmp.path().join("develop");
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "develop",
+                linked_worktree.to_str().unwrap(),
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree add -b");
+        assert!(
+            output.status.success(),
+            "git worktree add -b failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert_eq!(
+            main_worktree_root(&linked_worktree).unwrap(),
+            std::fs::canonicalize(&repo_path).unwrap()
+        );
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -2736,9 +2736,11 @@ fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Resul
         return Ok(());
     }
 
-    let worktree_path = gwt_git::worktree::sibling_worktree_path(repo_path, &branch_name);
-    let manager = gwt_git::WorktreeManager::new(repo_path);
-    if local_branch_exists(repo_path, &branch_name)? {
+    let main_repo_path =
+        gwt_git::worktree::main_worktree_root(repo_path).map_err(|err| err.to_string())?;
+    let worktree_path = gwt_git::worktree::sibling_worktree_path(&main_repo_path, &branch_name);
+    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+    if local_branch_exists(&main_repo_path, &branch_name)? {
         manager
             .create(&branch_name, &worktree_path)
             .map_err(|err| err.to_string())?;
@@ -7412,6 +7414,8 @@ CUSTOM_ENV = "enabled"
             .expect("repo dir parent")
             .join(format!("{repo_name}-feature-materialized-launch"));
         assert!(expected_worktree.exists(), "new worktree should exist");
+        let expected_worktree =
+            std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
 
         let branch_output = std::process::Command::new("git")
             .args(["branch", "--show-current"])
@@ -7473,6 +7477,8 @@ CUSTOM_ENV = "enabled"
             .expect("repo dir parent")
             .join(format!("{repo_name}-feature-launch-from-selected"));
         assert!(expected_worktree.exists(), "new worktree should exist");
+        let expected_worktree =
+            std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
 
         let branch_output = std::process::Command::new("git")
             .args(["branch", "--show-current"])
@@ -7497,6 +7503,85 @@ CUSTOM_ENV = "enabled"
             .path();
         let persisted = AgentSession::load(&session_entry).expect("load persisted session");
         assert_eq!(persisted.branch, "feature/launch-from-selected");
+        assert_eq!(persisted.worktree_path, expected_worktree);
+    }
+
+    #[test]
+    fn materialize_pending_launch_with_linked_worktree_uses_main_repo_sibling_layout() {
+        let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
+        let repo_path = workspace_dir.path().join("gwt");
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        std::fs::create_dir_all(&repo_path).expect("create repo dir");
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+
+        let develop_worktree = workspace_dir.path().join("develop");
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "develop",
+                develop_worktree.to_str().expect("develop worktree path"),
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree add -b");
+        assert!(
+            output.status.success(),
+            "git worktree add -b failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            base_branch_name: Some("develop".to_string()),
+            branch_name: "feature/test".to_string(),
+            worktree_path: Some(develop_worktree.clone()),
+            ..Default::default()
+        };
+
+        let mut model = Model::new(develop_worktree.clone());
+        model.pending_launch_config = Some(build_launch_config_from_wizard(&wizard));
+
+        materialize_pending_launch_with(&mut model, sessions_dir.path())
+            .expect("materialize launch");
+
+        let expected_worktree = workspace_dir.path().join("gwt-feature-test");
+        let expected_worktree =
+            std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
+        assert!(
+            expected_worktree.exists(),
+            "new sibling worktree should exist"
+        );
+        assert!(
+            !workspace_dir.path().join("develop-feature-test").exists(),
+            "linked worktree name must not be used as sibling-layout repo prefix"
+        );
+
+        let branch_output = std::process::Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&expected_worktree)
+            .output()
+            .expect("read worktree branch");
+        assert!(
+            branch_output.status.success(),
+            "git branch --show-current failed: {}",
+            String::from_utf8_lossy(&branch_output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&branch_output.stdout).trim(),
+            "feature/test"
+        );
+
+        let session_entry = std::fs::read_dir(sessions_dir.path())
+            .expect("read sessions dir")
+            .next()
+            .expect("session entry")
+            .expect("dir entry")
+            .path();
+        let persisted = AgentSession::load(&session_entry).expect("load persisted session");
         assert_eq!(persisted.worktree_path, expected_worktree);
     }
 

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -4,7 +4,7 @@
 - Status: `in-progress`
 - Phase: `Implementation`
 - Task progress: `185/185` checked in `tasks.md`
-- Artifact refresh: `2026-04-07T00:20:00Z`
+- Artifact refresh: `2026-04-07T01:10:00Z`
 
 ## Done
 - Startup cache scheduling, wizard integration, and session conversion flow documentation are now aligned to the implemented code.
@@ -151,6 +151,9 @@
   existing worktree into `LaunchConfig`, so launch-time materialization now
   still creates the requested sibling worktree instead of silently reusing
   `develop`.
+- Launches started from a linked worktree such as `develop` now resolve the
+  main repository root before deriving the sibling layout, so new branches no
+  longer materialize under `develop-*` paths like `develop-feature-test`.
 - The actual launched worktree path is now persisted into session metadata
   and exported through `GWT_PROJECT_ROOT`, so Quick Start / resume operate on
   the materialized launch target instead of a repo-root alias.
@@ -162,8 +165,10 @@
 - Focused verification for the worktree-materialization slice now includes
   `cargo test -p gwt-git sibling_worktree_path_uses_repo_name_and_slugged_branch -- --nocapture`,
   `cargo test -p gwt-git create_from_base_creates_new_branch_worktree -- --nocapture`,
+  `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`,
   `cargo test -p gwt-tui base_branch -- --nocapture`, and
   `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`,
+  `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`,
   plus `cargo test -p gwt-tui from_selected_branch -- --nocapture`.
 
 ## Next

--- a/specs/SPEC-3/quickstart.md
+++ b/specs/SPEC-3/quickstart.md
@@ -108,7 +108,7 @@
 41. From Branches, choose `Create new from selected`, finish the wizard, and
     verify Launch Agent creates a sibling worktree for the requested branch
     before the PTY starts, even when the selected base branch already has its
-    own worktree.
+    own linked worktree such as `develop`.
 42. Repeat the new-branch launch from SPEC or Issue context and verify the
     created worktree uses the new branch while the session metadata records
     that actual launched path.
@@ -135,6 +135,8 @@
 - `cargo test -p gwt-tui materialize_pending_launch_with -- --nocapture`
 - `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`
 - `cargo test -p gwt-tui from_selected_branch -- --nocapture`
+- `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`
+- `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`
 - `cargo test -p gwt-tui session_conversion`
 
 ## Expected Result

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2,6 +2,25 @@
 
 ## 2026-04-06 — fix: startup 時の agent detection は main thread で同期実行しない
 
+## 2026-04-07 — fix: sibling worktree path は linked worktree 名ではなく main repo 名を基準にする
+
+### 事象
+
+Launch Agent の新規ブランチ導線で、`develop` linked worktree 上から `feature/test` を起動すると
+worktree path が `.../develop-feature-test` になり、SPEC-10 の sibling layout と一致しなかった。
+
+### 原因
+
+- `resolve_launch_worktree()` が `model.repo_path` をそのまま `sibling_worktree_path()` に渡していた。
+- app を linked worktree (`.../develop`) から起動している場合、`repo_path.file_name()` が main repo 名ではなく
+  linked worktree 名の `develop` になるため、path prefix が誤っていた。
+
+### 再発防止策
+
+1. sibling layout を導出する前に、`git rev-parse --git-common-dir` 等で main worktree root を解決する。
+2. worktree path のテストは main repo 直下だけでなく、linked worktree を起点にした Launch Agent 経路でも固定する。
+3. `git worktree` 系の path 期待値は macOS の `/var` → `/private/var` 正規化を考慮して canonical path で比較する。
+
 ### 事象
 
 `load_initial_data_prefetches_branch_detail_async` が GitHub Actions で約 5 秒ブロックし、

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -22,6 +22,23 @@ sandbox 環境では home 配下への書き込みが拒否され、期待した
 
 ## 2026-04-06 — fix: startup 時の agent detection は main thread で同期実行しない
 
+### 事象
+
+`load_initial_data_prefetches_branch_detail_async` が GitHub Actions で約 5 秒ブロックし、
+branch detail preload 自体は非同期でも startup 全体が重く見えていた。
+
+### 原因
+
+- `schedule_startup_version_cache_refresh()` が `AgentDetector::detect_all()` を呼び、
+  `gh copilot --version` などの version probe を main thread 上で同期実行していた。
+- branch detail preload の非同期性とは無関係な agent detection が、同じ startup path に混ざっていた。
+
+### 再発防止策
+
+1. startup で補助的な cache refresh や probe を走らせる場合は、dispatch から background thread に逃がして UI/initial load を塞がない。
+2. 非同期 preload の test は、対象 worker だけでなく同じ code path 上の別 I/O が同期で混ざっていないか確認する。
+3. global in-flight flag を使う scheduler test は並列実行で干渉するため、test 側で lock を入れて検証を直列化する。
+
 ## 2026-04-07 — fix: sibling worktree path は linked worktree 名ではなく main repo 名を基準にする
 
 ### 事象
@@ -40,23 +57,6 @@ worktree path が `.../develop-feature-test` になり、SPEC-10 の sibling lay
 1. sibling layout を導出する前に、`git rev-parse --git-common-dir` 等で main worktree root を解決する。
 2. worktree path のテストは main repo 直下だけでなく、linked worktree を起点にした Launch Agent 経路でも固定する。
 3. `git worktree` 系の path 期待値は macOS の `/var` → `/private/var` 正規化を考慮して canonical path で比較する。
-
-### 事象
-
-`load_initial_data_prefetches_branch_detail_async` が GitHub Actions で約 5 秒ブロックし、
-branch detail preload 自体は非同期でも startup 全体が重く見えていた。
-
-### 原因
-
-- `schedule_startup_version_cache_refresh()` が `AgentDetector::detect_all()` を呼び、
-  `gh copilot --version` などの version probe を main thread 上で同期実行していた。
-- branch detail preload の非同期性とは無関係な agent detection が、同じ startup path に混ざっていた。
-
-### 再発防止策
-
-1. startup で補助的な cache refresh や probe を走らせる場合は、dispatch から background thread に逃がして UI/initial load を塞がない。
-2. 非同期 preload の test は、対象 worker だけでなく同じ code path 上の別 I/O が同期で混ざっていないか確認する。
-3. global in-flight flag を使う scheduler test は並列実行で干渉するため、test 側で lock を入れて検証を直列化する。
 
 ## 2026-04-06 — fix: process-wide fake docker env は並列 app テストの観測値を汚す
 


### PR DESCRIPTION
## Summary
- resolve Launch Agent sibling worktree paths from the main repository root even when gwt is running inside a linked worktree such as `develop`
- add regression coverage for linked worktree launches so `feature/test` no longer materializes under `develop-feature-test`
- refresh SPEC-3 reviewer evidence and local lessons for the linked-worktree case

## Testing
- cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture
- cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture
- cargo test -p gwt-core -p gwt-agent -p gwt-git -p gwt-tui
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo build -p gwt-tui
- bunx markdownlint-cli2 specs/SPEC-3/progress.md specs/SPEC-3/quickstart.md
- git diff --check