### PR TITLE
fix(launch): reuse existing branch worktree on relaunch

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -2738,6 +2738,14 @@ fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Resul
 
     let main_repo_path =
         gwt_git::worktree::main_worktree_root(repo_path).map_err(|err| err.to_string())?;
+    if let Some(existing_worktree) = existing_worktree_for_branch(&main_repo_path, &branch_name)? {
+        config.working_dir = Some(existing_worktree.clone());
+        config.env_vars.insert(
+            "GWT_PROJECT_ROOT".to_string(),
+            existing_worktree.display().to_string(),
+        );
+        return Ok(());
+    }
     let worktree_path = gwt_git::worktree::sibling_worktree_path(&main_repo_path, &branch_name);
     let manager = gwt_git::WorktreeManager::new(&main_repo_path);
     if local_branch_exists(&main_repo_path, &branch_name)? {
@@ -2757,6 +2765,22 @@ fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Resul
         worktree_path.display().to_string(),
     );
     Ok(())
+}
+
+fn existing_worktree_for_branch(
+    repo_path: &Path,
+    branch_name: &str,
+) -> Result<Option<PathBuf>, String> {
+    let manager = gwt_git::WorktreeManager::new(repo_path);
+    manager
+        .list()
+        .map_err(|err| err.to_string())
+        .map(|worktrees| {
+            worktrees
+                .into_iter()
+                .find(|worktree| worktree.branch.as_deref() == Some(branch_name))
+                .map(|worktree| worktree.path)
+        })
 }
 
 fn current_git_branch(repo_path: &Path) -> Result<String, String> {
@@ -7822,6 +7846,85 @@ CUSTOM_ENV = "enabled"
             .path();
         let persisted = AgentSession::load(&session_entry).expect("load persisted session");
         assert_eq!(persisted.worktree_path, expected_worktree);
+    }
+
+    #[test]
+    fn materialize_pending_launch_with_existing_branch_worktree_reuses_previous_path() {
+        let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
+        let repo_path = workspace_dir.path().join("gwt");
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        std::fs::create_dir_all(&repo_path).expect("create repo dir");
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+
+        let develop_worktree = workspace_dir.path().join("develop");
+        let develop_output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "develop",
+                develop_worktree.to_str().expect("develop worktree path"),
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree add -b develop");
+        assert!(
+            develop_output.status.success(),
+            "git worktree add -b develop failed: {}",
+            String::from_utf8_lossy(&develop_output.stderr)
+        );
+
+        let stale_worktree = workspace_dir.path().join("develop-feature-test");
+        let stale_output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "feature/test",
+                stale_worktree.to_str().expect("stale worktree path"),
+                "develop",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree add -b feature/test");
+        assert!(
+            stale_output.status.success(),
+            "git worktree add -b feature/test failed: {}",
+            String::from_utf8_lossy(&stale_output.stderr)
+        );
+        let stale_worktree =
+            std::fs::canonicalize(&stale_worktree).expect("canonicalize stale worktree");
+
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            base_branch_name: Some("develop".to_string()),
+            branch_name: "feature/test".to_string(),
+            worktree_path: Some(develop_worktree.clone()),
+            ..Default::default()
+        };
+
+        let mut model = Model::new(develop_worktree);
+        model.pending_launch_config = Some(build_launch_config_from_wizard(&wizard));
+
+        materialize_pending_launch_with(&mut model, sessions_dir.path())
+            .expect("materialize launch");
+
+        assert!(
+            !workspace_dir.path().join("gwt-feature-test").exists(),
+            "launch should reuse the existing branch worktree instead of trying to create a new sibling path"
+        );
+
+        let session_entry = std::fs::read_dir(sessions_dir.path())
+            .expect("read sessions dir")
+            .next()
+            .expect("session entry")
+            .expect("dir entry")
+            .path();
+        let persisted = AgentSession::load(&session_entry).expect("load persisted session");
+        assert_eq!(persisted.branch, "feature/test");
+        assert_eq!(persisted.worktree_path, stale_worktree);
     }
 
     #[test]

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -4,7 +4,7 @@
 - Status: `in-progress`
 - Phase: `Implementation`
 - Task progress: `185/185` checked in `tasks.md`
-- Artifact refresh: `2026-04-07T01:10:00Z`
+- Artifact refresh: `2026-04-07T01:45:00Z`
 
 ## Done
 - Startup cache scheduling, wizard integration, and session conversion flow documentation are now aligned to the implemented code.
@@ -154,6 +154,9 @@
 - Launches started from a linked worktree such as `develop` now resolve the
   main repository root before deriving the sibling layout, so new branches no
   longer materialize under `develop-*` paths like `develop-feature-test`.
+- If a branch was already materialized into a stale worktree path from an
+  earlier launch bug, Launch Agent now reuses that existing branch worktree
+  instead of failing a second `git worktree add`.
 - The actual launched worktree path is now persisted into session metadata
   and exported through `GWT_PROJECT_ROOT`, so Quick Start / resume operate on
   the materialized launch target instead of a repo-root alias.
@@ -169,6 +172,7 @@
   `cargo test -p gwt-tui base_branch -- --nocapture`, and
   `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`,
   `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`,
+  `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`,
   plus `cargo test -p gwt-tui from_selected_branch -- --nocapture`.
 
 ## Next

--- a/specs/SPEC-3/quickstart.md
+++ b/specs/SPEC-3/quickstart.md
@@ -112,6 +112,9 @@
 42. Repeat the new-branch launch from SPEC or Issue context and verify the
     created worktree uses the new branch while the session metadata records
     that actual launched path.
+43. If a stale worktree for the same branch already exists from a previous
+    failed launch attempt, retry Launch Agent and verify it reuses that
+    existing branch worktree instead of failing to start.
 
 ## Repeatable Evidence
 - `cargo test -p gwt-agent detect -- --nocapture`
@@ -137,6 +140,7 @@
 - `cargo test -p gwt-tui from_selected_branch -- --nocapture`
 - `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`
 - `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`
+- `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`
 - `cargo test -p gwt-tui session_conversion`
 
 ## Expected Result

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -58,6 +58,26 @@ worktree path が `.../develop-feature-test` になり、SPEC-10 の sibling lay
 2. worktree path のテストは main repo 直下だけでなく、linked worktree を起点にした Launch Agent 経路でも固定する。
 3. `git worktree` 系の path 期待値は macOS の `/var` → `/private/var` 正規化を考慮して canonical path で比較する。
 
+## 2026-04-07 — fix: 誤った旧 worktree が残る branch は再作成ではなく再利用する
+
+### 事象
+
+`develop-feature-test` のような誤った旧 worktree が残った状態で同じ branch を Launch Agent すると、
+session TOML は保存されるが `git worktree add` が「その branch は別 worktree で checkout 済み」で失敗し、
+agent PTY が起動しなかった。
+
+### 原因
+
+- path 生成の不具合を直した後も、`resolve_launch_worktree()` は branch の既存 worktree を見ずに
+  新しい sibling path を作ろうとしていた。
+- `feature/test` はすでに旧 path で checkout 済みのため、Git が二重 checkout を拒否していた。
+
+### 再発防止策
+
+1. new-branch launch でも、対象 branch が既存 worktree で checkout 済みなら `git worktree add` せずその path を再利用する。
+2. linked worktree path 修正の回帰テストだけで終わらせず、「旧 path が残っている再 launch」まで RED/GREEN で固定する。
+3. launch failure の切り分けでは `~/.gwt/sessions/*.toml` の増加有無と `git worktree list` を合わせて確認する。
+
 ## 2026-04-06 — fix: process-wide fake docker env は並列 app テストの観測値を汚す
 
 ### 事象


### PR DESCRIPTION
## Summary
- prevent Launch Agent relaunch from failing when the target branch is already checked out in an older worktree path
- reuse the existing branch worktree instead of attempting a second `git worktree add`
- document the stale-worktree recovery path in SPEC-3 artifacts and lessons learned

## Changes
- add `existing_worktree_for_branch()` in `gwt-tui` launch-time materialization and short-circuit to the existing path when the branch is already present in `git worktree list`
- add a regression test covering a stale `develop-feature-test` worktree left by the earlier path bug
- update `specs/SPEC-3/progress.md`, `specs/SPEC-3/quickstart.md`, and `tasks/lessons.md` with the new failure mode and evidence

## Testing
- `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`
- `cargo test -p gwt-core -p gwt-agent -p gwt-git -p gwt-tui`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `cargo build -p gwt-tui`
- `bunx markdownlint-cli2 tasks/lessons.md specs/SPEC-3/progress.md specs/SPEC-3/quickstart.md`
- `bunx commitlint --from HEAD~2 --to HEAD`
- `git diff --check`

## Closing Issues
None

## Related Issues
- SPEC-3

## Checklist
- [x] develop を merge 済み
- [x] Launch Agent の stale worktree 再利用を回帰テストで固定
- [x] ローカルの test / clippy / fmt / build / markdownlint / commitlint を実行


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Launch Agent now reuses existing branch worktrees instead of attempting to create duplicates, preventing launch failures when a worktree from a prior attempt remains.

* **Tests**
  * Added test coverage for branch worktree reuse scenarios.

* **Documentation**
  * Updated specification and progress tracking to reflect improved worktree materialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->