### PR TITLE
fix(launch): handle bare workspace common-dir path derivation

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -142,7 +142,7 @@ pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
         });
     }
 
-    Ok(repo_path.to_path_buf())
+    Ok(common_dir)
 }
 
 /// Derive a sibling worktree path from the repo root and branch name.
@@ -150,6 +150,7 @@ pub fn sibling_worktree_path(repo_path: &Path, branch: &str) -> PathBuf {
     let repo_name = repo_path
         .file_name()
         .and_then(|name| name.to_str())
+        .map(|name| name.strip_suffix(".git").unwrap_or(name))
         .filter(|name| !name.is_empty())
         .unwrap_or("repo");
     let suffix = slug_branch_for_path(branch);
@@ -265,6 +266,39 @@ mod tests {
             .output()
             .expect("git config user.name");
         assert!(name.status.success(), "git config user.name failed");
+    }
+
+    fn init_bare_git_repo(path: &Path) {
+        let output = std::process::Command::new("git")
+            .args(["init", "--bare", path.to_str().unwrap()])
+            .output()
+            .expect("git init --bare");
+        assert!(output.status.success(), "git init --bare failed");
+    }
+
+    fn git_clone_repo(src: &Path, dst: &Path) {
+        let output = std::process::Command::new("git")
+            .args(["clone", src.to_str().unwrap(), dst.to_str().unwrap()])
+            .output()
+            .expect("git clone");
+        assert!(
+            output.status.success(),
+            "git clone failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_push_branch(path: &Path, branch: &str) {
+        let output = std::process::Command::new("git")
+            .args(["push", "-u", "origin", branch])
+            .current_dir(path)
+            .output()
+            .expect("git push -u origin");
+        assert!(
+            output.status.success(),
+            "git push -u origin failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     fn git_commit_allow_empty(path: &Path, message: &str) {
@@ -399,6 +433,56 @@ prunable gitdir file points to non-existent location
         assert_eq!(
             main_worktree_root(&linked_worktree).unwrap(),
             std::fs::canonicalize(&repo_path).unwrap()
+        );
+    }
+
+    #[test]
+    fn main_worktree_root_uses_bare_common_dir_for_linked_workspace_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare_repo_path = tmp.path().join("gwt.git");
+        init_bare_git_repo(&bare_repo_path);
+
+        let bootstrap_path = tmp.path().join("bootstrap");
+        git_clone_repo(&bare_repo_path, &bootstrap_path);
+        let email = std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&bootstrap_path)
+            .output()
+            .expect("git config user.email");
+        assert!(email.status.success(), "git config user.email failed");
+        let name = std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&bootstrap_path)
+            .output()
+            .expect("git config user.name");
+        assert!(name.status.success(), "git config user.name failed");
+        git_checkout_new_branch(&bootstrap_path, "develop");
+        git_commit_allow_empty(&bootstrap_path, "initial commit");
+        git_push_branch(&bootstrap_path, "develop");
+
+        let linked_worktree = tmp.path().join("develop");
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                linked_worktree.to_str().unwrap(),
+                "develop",
+            ])
+            .current_dir(&bare_repo_path)
+            .output()
+            .expect("git worktree add");
+        assert!(
+            output.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let layout_root = main_worktree_root(&linked_worktree).unwrap();
+        assert_eq!(layout_root, std::fs::canonicalize(&bare_repo_path).unwrap());
+        let expected_parent = std::fs::canonicalize(tmp.path()).unwrap();
+        assert_eq!(
+            sibling_worktree_path(&layout_root, "feature/banner"),
+            expected_parent.join("gwt-feature-banner")
         );
     }
 

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -6075,6 +6075,44 @@ mod tests {
         assert!(name.status.success(), "git config user.name failed");
     }
 
+    fn init_bare_git_repo(path: &std::path::Path) {
+        let path_str = path.to_string_lossy().to_string();
+        let init = std::process::Command::new("git")
+            .args(["init", "--bare", &path_str])
+            .output()
+            .expect("init bare git repo");
+        assert!(init.status.success(), "git init --bare failed: {:?}", init);
+    }
+
+    fn git_clone_repo(src: &std::path::Path, dst: &std::path::Path) {
+        let output = std::process::Command::new("git")
+            .args([
+                "clone",
+                src.to_str().expect("clone src"),
+                dst.to_str().expect("clone dst"),
+            ])
+            .output()
+            .expect("clone git repo");
+        assert!(
+            output.status.success(),
+            "git clone failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_push_branch(path: &std::path::Path, name: &str) {
+        let output = std::process::Command::new("git")
+            .args(["push", "-u", "origin", name])
+            .current_dir(path)
+            .output()
+            .expect("push git branch");
+        assert!(
+            output.status.success(),
+            "git push -u origin failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     fn git_commit_allow_empty(path: &std::path::Path, message: &str) {
         let output = std::process::Command::new("git")
             .args(["commit", "--allow-empty", "-m", message])
@@ -7836,6 +7874,85 @@ CUSTOM_ENV = "enabled"
         assert_eq!(
             String::from_utf8_lossy(&branch_output.stdout).trim(),
             "feature/test"
+        );
+
+        let session_entry = std::fs::read_dir(sessions_dir.path())
+            .expect("read sessions dir")
+            .next()
+            .expect("session entry")
+            .expect("dir entry")
+            .path();
+        let persisted = AgentSession::load(&session_entry).expect("load persisted session");
+        assert_eq!(persisted.worktree_path, expected_worktree);
+    }
+
+    #[test]
+    fn materialize_pending_launch_with_bare_workspace_linked_worktree_uses_repo_name_layout() {
+        let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
+        let bare_repo_path = workspace_dir.path().join("gwt.git");
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        init_bare_git_repo(&bare_repo_path);
+
+        let bootstrap_path = workspace_dir.path().join("bootstrap");
+        git_clone_repo(&bare_repo_path, &bootstrap_path);
+        let email = std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&bootstrap_path)
+            .output()
+            .expect("set git email");
+        assert!(email.status.success(), "git config user.email failed");
+        let name = std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&bootstrap_path)
+            .output()
+            .expect("set git name");
+        assert!(name.status.success(), "git config user.name failed");
+        git_checkout_new_branch(&bootstrap_path, "develop");
+        git_commit_allow_empty(&bootstrap_path, "initial commit");
+        git_push_branch(&bootstrap_path, "develop");
+
+        let develop_worktree = workspace_dir.path().join("develop");
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                develop_worktree.to_str().expect("develop worktree path"),
+                "develop",
+            ])
+            .current_dir(&bare_repo_path)
+            .output()
+            .expect("git worktree add");
+        assert!(
+            output.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            base_branch_name: Some("develop".to_string()),
+            branch_name: "feature/test".to_string(),
+            worktree_path: Some(develop_worktree.clone()),
+            ..Default::default()
+        };
+
+        let mut model = Model::new(develop_worktree);
+        model.pending_launch_config = Some(build_launch_config_from_wizard(&wizard));
+
+        materialize_pending_launch_with(&mut model, sessions_dir.path())
+            .expect("materialize launch");
+
+        let expected_worktree = workspace_dir.path().join("gwt-feature-test");
+        let expected_worktree =
+            std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
+        assert!(
+            expected_worktree.exists(),
+            "new sibling worktree should exist for bare workspace layout"
+        );
+        assert!(
+            !workspace_dir.path().join("develop-feature-test").exists(),
+            "bare workspace linked worktree name must not be used as repo prefix"
         );
 
         let session_entry = std::fs::read_dir(sessions_dir.path())

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -154,6 +154,11 @@
 - Launches started from a linked worktree such as `develop` now resolve the
   main repository root before deriving the sibling layout, so new branches no
   longer materialize under `develop-*` paths like `develop-feature-test`.
+- Launches started from a legacy bare workspace layout (`gwt.git` +
+  `develop/`) now use the bare common-dir as the Git control path while
+  stripping the `.git` suffix from the repo name for sibling path derivation,
+  so new branches no longer materialize under `develop-*` paths like
+  `develop-feature-test2`.
 - If a branch was already materialized into a stale worktree path from an
   earlier launch bug, Launch Agent now reuses that existing branch worktree
   instead of failing a second `git worktree add`.
@@ -169,9 +174,11 @@
   `cargo test -p gwt-git sibling_worktree_path_uses_repo_name_and_slugged_branch -- --nocapture`,
   `cargo test -p gwt-git create_from_base_creates_new_branch_worktree -- --nocapture`,
   `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`,
+  `cargo test -p gwt-git bare_common_dir -- --nocapture`,
   `cargo test -p gwt-tui base_branch -- --nocapture`, and
   `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`,
   `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`,
+  `cargo test -p gwt-tui bare_workspace_linked_worktree_uses_repo_name_layout -- --nocapture`,
   `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`,
   plus `cargo test -p gwt-tui from_selected_branch -- --nocapture`.
 

--- a/specs/SPEC-3/quickstart.md
+++ b/specs/SPEC-3/quickstart.md
@@ -115,6 +115,9 @@
 43. If a stale worktree for the same branch already exists from a previous
     failed launch attempt, retry Launch Agent and verify it reuses that
     existing branch worktree instead of failing to start.
+44. Repeat the new-branch launch from a legacy bare workspace layout
+    (`gwt.git` + `develop/`) and verify sibling paths use the bare repo name
+    (`gwt-*`) instead of the linked worktree name (`develop-*`).
 
 ## Repeatable Evidence
 - `cargo test -p gwt-agent detect -- --nocapture`
@@ -139,7 +142,9 @@
 - `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`
 - `cargo test -p gwt-tui from_selected_branch -- --nocapture`
 - `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`
+- `cargo test -p gwt-git bare_common_dir -- --nocapture`
 - `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`
+- `cargo test -p gwt-tui bare_workspace_linked_worktree_uses_repo_name_layout -- --nocapture`
 - `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`
 - `cargo test -p gwt-tui session_conversion`
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -78,6 +78,27 @@ agent PTY が起動しなかった。
 2. linked worktree path 修正の回帰テストだけで終わらせず、「旧 path が残っている再 launch」まで RED/GREEN で固定する。
 3. launch failure の切り分けでは `~/.gwt/sessions/*.toml` の増加有無と `git worktree list` を合わせて確認する。
 
+## 2026-04-07 — fix: bare workspace の `gwt.git` を linked worktree 名で代用しない
+
+### 事象
+
+`/Users/.../gwt/gwt.git` を common-dir に持つ legacy bare workspace で Launch Agent から
+`feature/test2` を作成すると、worktree path が `gwt-feature-test2` ではなく
+`develop-feature-test2` になっていた。
+
+### 原因
+
+- `main_worktree_root()` は `--git-common-dir` が `.git` で終わる normal clone しか想定しておらず、
+  bare common-dir の `gwt.git` を見たときに linked worktree 自身 (`develop/`) を返していた。
+- さらに sibling path 生成側も repo 名の `.git` suffix を落としていなかったため、
+  bare repo path をそのまま渡しても期待どおりの `gwt-*` 名にならない設計だった。
+
+### 再発防止策
+
+1. linked worktree から layout root を引く helper は、normal clone の `.git` と bare repo の `*.git` を分けて扱う。
+2. bare workspace を使う実運用が残っている間は、tempdir 上の `gwt.git + develop/` fixture を app 層の RED テストに含める。
+3. `git-common-dir` を使う path 変換では、`repo name` と `git control dir` を同一視しない。
+
 ## 2026-04-06 — fix: process-wide fake docker env は並列 app テストの観測値を汚す
 
 ### 事象


### PR DESCRIPTION
## Summary
- fix Launch Agent path derivation when the current repo is a linked worktree backed by a bare common-dir such as `gwt.git`
- keep the Git control path pointed at the bare repo while deriving sibling worktree names from the repo name without the `.git` suffix
- add regression coverage and SPEC evidence for the legacy bare workspace layout

## Changes
- update `main_worktree_root()` to return the actual bare common-dir instead of falling back to the linked worktree path
- update `sibling_worktree_path()` to strip a trailing `.git` suffix from the repo name before composing sibling worktree directories
- add RED/GREEN tests in `gwt-git` and `gwt-tui` covering `gwt.git + develop/` workspace layouts, plus SPEC-3 and lessons updates

## Testing
- `cargo test -p gwt-git main_worktree_root -- --nocapture`
- `cargo test -p gwt-tui materialize_pending_launch_with -- --nocapture`
- `cargo test -p gwt-core -p gwt-agent -p gwt-git -p gwt-tui`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `cargo build -p gwt-tui`
- `bunx markdownlint-cli2 tasks/lessons.md specs/SPEC-3/progress.md specs/SPEC-3/quickstart.md`
- `bunx commitlint --from HEAD~2 --to HEAD`
- `git diff --check`

## Closing Issues
None

## Related Issues
- SPEC-3

## Checklist
- [x] bare workspace (`gwt.git + develop/`) launch path is covered by regression tests
- [x] linked worktree and stale-worktree launch regressions still pass
- [x] local test / clippy / fmt / build / markdownlint / commitlint checks were re-run after merging `origin/develop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed worktree path derivation for repositories using legacy bare common-directory layouts, ensuring new branch worktrees are created with correct naming patterns instead of inheriting incorrect names from linked worktrees.
  * Added comprehensive test coverage for bare workspace scenarios to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->