### PR TITLE
fix(launch): mirror branch hierarchy in worktree paths

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -146,48 +146,22 @@ pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
 }
 
 /// Derive a sibling worktree path from the repo root and branch name.
+///
+/// The layout root stays at the same directory level as the repository or
+/// bare common-dir, while the branch name itself becomes the relative
+/// directory hierarchy (for example `feature/aaa` -> `../feature/aaa`).
 pub fn sibling_worktree_path(repo_path: &Path, branch: &str) -> PathBuf {
-    let repo_name = repo_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| name.strip_suffix(".git").unwrap_or(name))
-        .filter(|name| !name.is_empty())
-        .unwrap_or("repo");
-    let suffix = slug_branch_for_path(branch);
-    let dir_name = if suffix.is_empty() {
-        repo_name.to_string()
-    } else {
-        format!("{repo_name}-{suffix}")
-    };
+    let layout_root = repo_path.parent().unwrap_or(repo_path);
+    let mut path = layout_root.to_path_buf();
 
-    repo_path.parent().unwrap_or(repo_path).join(dir_name)
-}
-
-fn slug_branch_for_path(branch: &str) -> String {
-    let mut out = String::with_capacity(branch.len());
-    let mut prev_dash = false;
-
-    for ch in branch.trim().chars() {
-        let mapped = if ch.is_ascii_alphanumeric() {
-            ch.to_ascii_lowercase()
-        } else if matches!(ch, '-' | '_') {
-            ch
-        } else {
-            '-'
-        };
-
-        if mapped == '-' {
-            if !prev_dash {
-                out.push(mapped);
-            }
-            prev_dash = true;
-        } else {
-            out.push(mapped);
-            prev_dash = false;
+    for segment in branch.trim_matches('/').split('/') {
+        if segment.is_empty() {
+            continue;
         }
+        path.push(segment);
     }
 
-    out.trim_matches('-').to_string()
+    path
 }
 
 /// Parse `git worktree list --porcelain` output into `WorktreeInfo` entries.
@@ -398,10 +372,10 @@ prunable gitdir file points to non-existent location
     }
 
     #[test]
-    fn sibling_worktree_path_uses_repo_name_and_slugged_branch() {
+    fn sibling_worktree_path_preserves_branch_hierarchy() {
         let repo_path = Path::new("/tmp/my-repo");
         let worktree = sibling_worktree_path(repo_path, "feature/banner");
-        assert_eq!(worktree, PathBuf::from("/tmp/my-repo-feature-banner"));
+        assert_eq!(worktree, PathBuf::from("/tmp/feature/banner"));
     }
 
     #[test]
@@ -482,19 +456,21 @@ prunable gitdir file points to non-existent location
         let expected_parent = std::fs::canonicalize(tmp.path()).unwrap();
         assert_eq!(
             sibling_worktree_path(&layout_root, "feature/banner"),
-            expected_parent.join("gwt-feature-banner")
+            expected_parent.join("feature").join("banner")
         );
     }
 
     #[test]
     fn create_from_base_creates_new_branch_worktree() {
         let tmp = tempfile::tempdir().unwrap();
-        init_git_repo(tmp.path());
-        git_commit_allow_empty(tmp.path(), "initial commit");
-        git_checkout_new_branch(tmp.path(), "develop");
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+        git_checkout_new_branch(&repo_path, "develop");
 
-        let manager = WorktreeManager::new(tmp.path());
-        let worktree_path = sibling_worktree_path(tmp.path(), "feature/materialized");
+        let manager = WorktreeManager::new(&repo_path);
+        let worktree_path = sibling_worktree_path(&repo_path, "feature/materialized");
 
         manager
             .create_from_base("develop", "feature/materialized", &worktree_path)

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -6139,7 +6139,16 @@ mod tests {
         );
     }
 
-    fn git_checkout_new_branch(path: &std::path::Path, name: &str) {
+    fn git_checkout_branch_or_create(path: &std::path::Path, name: &str) {
+        let checkout = std::process::Command::new("git")
+            .args(["checkout", name])
+            .current_dir(path)
+            .output()
+            .expect("checkout git branch");
+        if checkout.status.success() {
+            return;
+        }
+
         let output = std::process::Command::new("git")
             .args(["checkout", "-b", name])
             .current_dir(path)
@@ -6147,7 +6156,8 @@ mod tests {
             .expect("checkout new git branch");
         assert!(
             output.status.success(),
-            "git checkout -b failed: {}",
+            "git checkout/create failed: checkout stderr: {}; checkout -b stderr: {}",
+            String::from_utf8_lossy(&checkout.stderr),
             String::from_utf8_lossy(&output.stderr)
         );
     }
@@ -7681,7 +7691,7 @@ CUSTOM_ENV = "enabled"
         std::fs::create_dir_all(&repo_path).expect("create repo dir");
         init_git_repo(&repo_path);
         git_commit_allow_empty(&repo_path, "initial commit");
-        git_checkout_new_branch(&repo_path, "develop");
+        git_checkout_branch_or_create(&repo_path, "develop");
 
         let mut model = Model::new(repo_path.clone());
         model.pending_launch_config = Some(LaunchConfig {
@@ -7690,7 +7700,7 @@ CUSTOM_ENV = "enabled"
             args: vec!["agent-test".to_string()],
             env_vars: HashMap::new(),
             working_dir: None,
-            branch: Some("feature/materialized-launch".to_string()),
+            branch: Some("feature/alpha/beta".to_string()),
             base_branch: None,
             display_name: "My Agent".to_string(),
             color: AgentId::Custom("my-agent".to_string()).default_color(),
@@ -7709,7 +7719,8 @@ CUSTOM_ENV = "enabled"
         let expected_worktree = workspace_dir
             .path()
             .join("feature")
-            .join("materialized-launch");
+            .join("alpha")
+            .join("beta");
         assert!(expected_worktree.exists(), "new worktree should exist");
         let expected_worktree =
             std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
@@ -7726,7 +7737,7 @@ CUSTOM_ENV = "enabled"
         );
         assert_eq!(
             String::from_utf8_lossy(&branch_output.stdout).trim(),
-            "feature/materialized-launch"
+            "feature/alpha/beta"
         );
 
         let session_entry = fs::read_dir(sessions_dir.path())
@@ -7736,7 +7747,7 @@ CUSTOM_ENV = "enabled"
             .expect("dir entry")
             .path();
         let persisted = AgentSession::load(&session_entry).expect("load persisted session");
-        assert_eq!(persisted.branch, "feature/materialized-launch");
+        assert_eq!(persisted.branch, "feature/alpha/beta");
         assert_eq!(persisted.worktree_path, expected_worktree);
     }
 
@@ -7748,7 +7759,7 @@ CUSTOM_ENV = "enabled"
         std::fs::create_dir_all(&repo_path).expect("create repo dir");
         init_git_repo(&repo_path);
         git_commit_allow_empty(&repo_path, "initial commit");
-        git_checkout_new_branch(&repo_path, "develop");
+        git_checkout_branch_or_create(&repo_path, "develop");
 
         let wizard = screens::wizard::WizardState {
             agent_id: "claude".to_string(),
@@ -7900,7 +7911,7 @@ CUSTOM_ENV = "enabled"
             .output()
             .expect("set git name");
         assert!(name.status.success(), "git config user.name failed");
-        git_checkout_new_branch(&bootstrap_path, "develop");
+        git_checkout_branch_or_create(&bootstrap_path, "develop");
         git_commit_allow_empty(&bootstrap_path, "initial commit");
         git_push_branch(&bootstrap_path, "develop");
 

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -7675,13 +7675,15 @@ CUSTOM_ENV = "enabled"
 
     #[test]
     fn materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path() {
-        let repo_dir = tempfile::tempdir().expect("temp repo dir");
+        let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
+        let repo_path = workspace_dir.path().join("gwt");
         let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
-        init_git_repo(repo_dir.path());
-        git_commit_allow_empty(repo_dir.path(), "initial commit");
-        git_checkout_new_branch(repo_dir.path(), "develop");
+        std::fs::create_dir_all(&repo_path).expect("create repo dir");
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+        git_checkout_new_branch(&repo_path, "develop");
 
-        let mut model = Model::new(repo_dir.path().to_path_buf());
+        let mut model = Model::new(repo_path.clone());
         model.pending_launch_config = Some(LaunchConfig {
             agent_id: AgentId::Custom("my-agent".to_string()),
             command: "/bin/echo".to_string(),
@@ -7704,16 +7706,10 @@ CUSTOM_ENV = "enabled"
         materialize_pending_launch_with(&mut model, sessions_dir.path())
             .expect("materialize launch");
 
-        let repo_name = repo_dir
+        let expected_worktree = workspace_dir
             .path()
-            .file_name()
-            .expect("repo dir name")
-            .to_string_lossy();
-        let expected_worktree = repo_dir
-            .path()
-            .parent()
-            .expect("repo dir parent")
-            .join(format!("{repo_name}-feature-materialized-launch"));
+            .join("feature")
+            .join("materialized-launch");
         assert!(expected_worktree.exists(), "new worktree should exist");
         let expected_worktree =
             std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
@@ -7746,37 +7742,33 @@ CUSTOM_ENV = "enabled"
 
     #[test]
     fn materialize_pending_launch_with_new_branch_from_selected_branch_creates_new_worktree() {
-        let repo_dir = tempfile::tempdir().expect("temp repo dir");
+        let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
+        let repo_path = workspace_dir.path().join("gwt");
         let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
-        init_git_repo(repo_dir.path());
-        git_commit_allow_empty(repo_dir.path(), "initial commit");
-        git_checkout_new_branch(repo_dir.path(), "develop");
+        std::fs::create_dir_all(&repo_path).expect("create repo dir");
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+        git_checkout_new_branch(&repo_path, "develop");
 
         let wizard = screens::wizard::WizardState {
             agent_id: "claude".to_string(),
             is_new_branch: true,
             base_branch_name: Some("develop".to_string()),
             branch_name: "feature/launch-from-selected".to_string(),
-            worktree_path: Some(repo_dir.path().to_path_buf()),
+            worktree_path: Some(repo_path.clone()),
             ..Default::default()
         };
 
-        let mut model = Model::new(repo_dir.path().to_path_buf());
+        let mut model = Model::new(repo_path);
         model.pending_launch_config = Some(build_launch_config_from_wizard(&wizard));
 
         materialize_pending_launch_with(&mut model, sessions_dir.path())
             .expect("materialize launch");
 
-        let repo_name = repo_dir
+        let expected_worktree = workspace_dir
             .path()
-            .file_name()
-            .expect("repo dir name")
-            .to_string_lossy();
-        let expected_worktree = repo_dir
-            .path()
-            .parent()
-            .expect("repo dir parent")
-            .join(format!("{repo_name}-feature-launch-from-selected"));
+            .join("feature")
+            .join("launch-from-selected");
         assert!(expected_worktree.exists(), "new worktree should exist");
         let expected_worktree =
             std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
@@ -7808,7 +7800,7 @@ CUSTOM_ENV = "enabled"
     }
 
     #[test]
-    fn materialize_pending_launch_with_linked_worktree_uses_main_repo_sibling_layout() {
+    fn materialize_pending_launch_with_linked_worktree_uses_main_repo_branch_layout() {
         let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
         let repo_path = workspace_dir.path().join("gwt");
         let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
@@ -7849,7 +7841,7 @@ CUSTOM_ENV = "enabled"
         materialize_pending_launch_with(&mut model, sessions_dir.path())
             .expect("materialize launch");
 
-        let expected_worktree = workspace_dir.path().join("gwt-feature-test");
+        let expected_worktree = workspace_dir.path().join("feature").join("test");
         let expected_worktree =
             std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
         assert!(
@@ -7887,7 +7879,8 @@ CUSTOM_ENV = "enabled"
     }
 
     #[test]
-    fn materialize_pending_launch_with_bare_workspace_linked_worktree_uses_repo_name_layout() {
+    fn materialize_pending_launch_with_bare_workspace_linked_worktree_uses_branch_hierarchy_layout()
+    {
         let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
         let bare_repo_path = workspace_dir.path().join("gwt.git");
         let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
@@ -7943,7 +7936,7 @@ CUSTOM_ENV = "enabled"
         materialize_pending_launch_with(&mut model, sessions_dir.path())
             .expect("materialize launch");
 
-        let expected_worktree = workspace_dir.path().join("gwt-feature-test");
+        let expected_worktree = workspace_dir.path().join("feature").join("test");
         let expected_worktree =
             std::fs::canonicalize(&expected_worktree).expect("canonicalize expected worktree");
         assert!(
@@ -8029,7 +8022,7 @@ CUSTOM_ENV = "enabled"
             .expect("materialize launch");
 
         assert!(
-            !workspace_dir.path().join("gwt-feature-test").exists(),
+            !workspace_dir.path().join("feature").join("test").exists(),
             "launch should reuse the existing branch worktree instead of trying to create a new sibling path"
         );
 

--- a/specs/SPEC-10/spec.md
+++ b/specs/SPEC-10/spec.md
@@ -118,13 +118,16 @@ git clone --depth=1 <url> .
 
 ### Worktree Location
 
-Worktrees are created at the same directory level as the repository (sibling layout):
+Worktrees are created at the same directory level as the repository, using the
+branch name itself as the relative directory hierarchy:
 ```
 /home/user/projects/
-├── my-repo/           ← main clone (develop checked out)
-├── my-repo-feature-1/ ← git worktree for feature/feature-1
-├── my-repo-feature-2/ ← git worktree for feature/feature-2
-└── my-repo-bugfix-1/  ← git worktree for bugfix/bugfix-1
+├── my-repo/            ← main clone (develop checked out)
+├── feature/
+│   ├── feature-1/      ← git worktree for feature/feature-1
+│   └── feature-2/      ← git worktree for feature/feature-2
+└── bugfix/
+    └── bugfix-1/       ← git worktree for bugfix/bugfix-1
 ```
 
 ### Full Initialization (on first launch in repo)

--- a/specs/SPEC-3/progress.md
+++ b/specs/SPEC-3/progress.md
@@ -156,9 +156,12 @@
   longer materialize under `develop-*` paths like `develop-feature-test`.
 - Launches started from a legacy bare workspace layout (`gwt.git` +
   `develop/`) now use the bare common-dir as the Git control path while
-  stripping the `.git` suffix from the repo name for sibling path derivation,
-  so new branches no longer materialize under `develop-*` paths like
-  `develop-feature-test2`.
+  deriving sibling paths from the branch hierarchy itself, so new branches no
+  longer materialize under `develop-*` paths like `develop-feature-test2`.
+- New-branch launches now mirror the requested branch hierarchy in the
+  sibling path itself (`feature/aaa` -> `../feature/aaa`) instead of
+  flattening that branch name into repo-name-prefixed directories such as
+  `gwt-feature-aaa`.
 - If a branch was already materialized into a stale worktree path from an
   earlier launch bug, Launch Agent now reuses that existing branch worktree
   instead of failing a second `git worktree add`.
@@ -171,14 +174,14 @@
   `cargo build -p gwt-tui`, and `bunx markdownlint-cli2` on the refreshed
   SPEC-3 artifacts.
 - Focused verification for the worktree-materialization slice now includes
-  `cargo test -p gwt-git sibling_worktree_path_uses_repo_name_and_slugged_branch -- --nocapture`,
+  `cargo test -p gwt-git sibling_worktree_path_preserves_branch_hierarchy -- --nocapture`,
   `cargo test -p gwt-git create_from_base_creates_new_branch_worktree -- --nocapture`,
   `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`,
   `cargo test -p gwt-git bare_common_dir -- --nocapture`,
   `cargo test -p gwt-tui base_branch -- --nocapture`, and
   `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`,
-  `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`,
-  `cargo test -p gwt-tui bare_workspace_linked_worktree_uses_repo_name_layout -- --nocapture`,
+  `cargo test -p gwt-tui linked_worktree_uses_main_repo_branch_layout -- --nocapture`,
+  `cargo test -p gwt-tui bare_workspace_linked_worktree_uses_branch_hierarchy_layout -- --nocapture`,
   `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`,
   plus `cargo test -p gwt-tui from_selected_branch -- --nocapture`.
 

--- a/specs/SPEC-3/quickstart.md
+++ b/specs/SPEC-3/quickstart.md
@@ -106,9 +106,10 @@
    only the agent label into the popup title (`Quick Start — Codex`) instead
    of inventing a `default` model placeholder.
 41. From Branches, choose `Create new from selected`, finish the wizard, and
-    verify Launch Agent creates a sibling worktree for the requested branch
-    before the PTY starts, even when the selected base branch already has its
-    own linked worktree such as `develop`.
+    verify Launch Agent creates a sibling worktree whose path mirrors the
+    requested branch (`feature/aaa` -> `../feature/aaa`) before the PTY
+    starts, even when the selected base branch already has its own linked
+    worktree such as `develop`.
 42. Repeat the new-branch launch from SPEC or Issue context and verify the
     created worktree uses the new branch while the session metadata records
     that actual launched path.
@@ -116,8 +117,9 @@
     failed launch attempt, retry Launch Agent and verify it reuses that
     existing branch worktree instead of failing to start.
 44. Repeat the new-branch launch from a legacy bare workspace layout
-    (`gwt.git` + `develop/`) and verify sibling paths use the bare repo name
-    (`gwt-*`) instead of the linked worktree name (`develop-*`).
+    (`gwt.git` + `develop/`) and verify sibling paths still mirror the branch
+    hierarchy (`feature/test`), never the linked worktree name
+    (`develop-feature-test`) or bare repo-name prefixes (`gwt-feature-test`).
 
 ## Repeatable Evidence
 - `cargo test -p gwt-agent detect -- --nocapture`
@@ -141,10 +143,11 @@
 - `cargo test -p gwt-tui materialize_pending_launch_with -- --nocapture`
 - `cargo test -p gwt-tui materialize_pending_launch_with_new_branch_creates_worktree_and_persists_actual_path -- --nocapture`
 - `cargo test -p gwt-tui from_selected_branch -- --nocapture`
+- `cargo test -p gwt-git sibling_worktree_path_preserves_branch_hierarchy -- --nocapture`
 - `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`
 - `cargo test -p gwt-git bare_common_dir -- --nocapture`
-- `cargo test -p gwt-tui linked_worktree_uses_main_repo_sibling_layout -- --nocapture`
-- `cargo test -p gwt-tui bare_workspace_linked_worktree_uses_repo_name_layout -- --nocapture`
+- `cargo test -p gwt-tui linked_worktree_uses_main_repo_branch_layout -- --nocapture`
+- `cargo test -p gwt-tui bare_workspace_linked_worktree_uses_branch_hierarchy_layout -- --nocapture`
 - `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`
 - `cargo test -p gwt-tui session_conversion`
 

--- a/specs/SPEC-3/quickstart.md
+++ b/specs/SPEC-3/quickstart.md
@@ -145,9 +145,9 @@
 - `cargo test -p gwt-tui from_selected_branch -- --nocapture`
 - `cargo test -p gwt-git sibling_worktree_path_preserves_branch_hierarchy -- --nocapture`
 - `cargo test -p gwt-git main_worktree_root_returns_primary_repo_for_linked_worktree -- --nocapture`
-- `cargo test -p gwt-git bare_common_dir -- --nocapture`
-- `cargo test -p gwt-tui linked_worktree_uses_main_repo_branch_layout -- --nocapture`
-- `cargo test -p gwt-tui bare_workspace_linked_worktree_uses_branch_hierarchy_layout -- --nocapture`
+- `cargo test -p gwt-git main_worktree_root_uses_bare_common_dir_for_linked_workspace_layout -- --nocapture`
+- `cargo test -p gwt-tui materialize_pending_launch_with_linked_worktree_uses_main_repo_branch_layout -- --nocapture`
+- `cargo test -p gwt-tui materialize_pending_launch_with_bare_workspace_linked_worktree_uses_branch_hierarchy_layout -- --nocapture`
 - `cargo test -p gwt-tui existing_branch_worktree_reuses_previous_path -- --nocapture`
 - `cargo test -p gwt-tui session_conversion`
 

--- a/specs/SPEC-3/spec.md
+++ b/specs/SPEC-3/spec.md
@@ -29,8 +29,9 @@ As a developer, I want to launch a coding agent through a guided wizard so that 
    session is created with the configured parameters and the actual launched
    worktree path.
 5. Given I create a new branch from the Branches flow, when launch
-   materialization runs, then gwt creates a sibling worktree for that new
-   branch before spawning the agent PTY.
+   materialization runs, then gwt creates a sibling worktree whose path
+   mirrors that branch hierarchy (for example `feature/aaa` ->
+   `../feature/aaa`) before spawning the agent PTY.
 6. Given the new-branch flow starts from a selected branch, when launch
    materialization runs, then that selected branch is used as the base branch
    instead of always falling back to the repo root checkout.
@@ -474,5 +475,5 @@ default = { id = "default", label = "Default", arg = "" }
 - **SC-008**: Version selection remains separated from model selection and the
   launch summary shows the effective version that will be used.
 - **SC-009**: New-branch launches from Branches, SPEC detail, and Issue
-  detail start inside a materialized sibling worktree instead of falling back
-  to the repository root checkout.
+  detail start inside a materialized sibling worktree whose path mirrors the
+  branch hierarchy instead of falling back to the repository root checkout.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -99,6 +99,27 @@ agent PTY が起動しなかった。
 2. bare workspace を使う実運用が残っている間は、tempdir 上の `gwt.git + develop/` fixture を app 層の RED テストに含める。
 3. `git-common-dir` を使う path 変換では、`repo name` と `git control dir` を同一視しない。
 
+## 2026-04-07 — fix: Launch Agent の worktree path は repo 名 flatten ではなく branch 階層を使う
+
+### 事象
+
+Launch Agent で `feature/aaa` を新規作成すると、worktree path が
+`.../gwt-feature-aaa` になり、既存 workspace の `feature/...` layout と
+一致していなかった。
+
+### 原因
+
+- `sibling_worktree_path()` が branch 名全体を slug 化し、repo 名 prefix
+  (`gwt-`) を付けた単一ディレクトリへ flatten していた。
+- linked worktree 名の誤用は修正済みでも、layout 契約そのものが既存
+  workspace とずれたままだった。
+
+### 再発防止策
+
+1. Launch Agent の worktree path は repo 名由来の prefix ではなく、branch 名の `/` をそのままディレクトリ階層に反映する。
+2. worktree path の RED テストは `feature/aaa -> ../feature/aaa` を明示的に固定し、`gwt-*` の flatten path を期待値に残さない。
+3. SPEC-10 の workspace layout 例と SPEC-3 の Launch Agent acceptance を同じ path 契約で更新し、実装と文書を分離させない。
+
 ## 2026-04-06 — fix: process-wide fake docker env は並列 app テストの観測値を汚す
 
 ### 事象


### PR DESCRIPTION
## Summary
- mirror new-branch launch worktree paths to the branch hierarchy itself so feature/aaa materializes under feature/aaa
- keep the worktree layout rooted at the main repo or bare common-dir while updating launch regression tests to use workspace-scoped fixtures
- refresh SPEC-3, SPEC-10, and lessons evidence for the new Launch Agent path contract

## Testing
- cargo test -p gwt-core -p gwt-agent -p gwt-git -p gwt-tui
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo build -p gwt-tui
- bunx markdownlint-cli2 tasks/lessons.md specs/SPEC-3/spec.md specs/SPEC-3/progress.md specs/SPEC-3/quickstart.md specs/SPEC-10/spec.md
- git diff --check
- bunx commitlint --from HEAD~1 --to HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured worktree path generation. Git worktrees now organize under hierarchical branch names (e.g., `feature/my-branch` → `../feature/my-branch`) rather than flattened naming schemes with repository prefixes.

* **Documentation**
  * Updated worktree layout specifications, acceptance criteria, test documentation, and maintenance notes to align with the branch-hierarchy-preserving directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->