### PR TITLE
fix(launch): restore codex quick start resume flow

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -356,6 +356,22 @@ impl AgentLaunchBuilder {
             "1".to_string(),
         );
 
+        match self.session_mode {
+            SessionMode::Continue => {
+                args.push("resume".to_string());
+                args.push("--last".to_string());
+            }
+            SessionMode::Resume => {
+                args.push("resume".to_string());
+                if let Some(ref id) = self.resume_session_id {
+                    args.push(id.clone());
+                } else {
+                    args.push("--last".to_string());
+                }
+            }
+            SessionMode::Normal => {}
+        }
+
         if let Some(ref model) = self.model {
             args.push(format!("--model={}", model));
         }
@@ -549,6 +565,43 @@ mod tests {
 
         assert!(config.args.contains(&"--yolo".to_string()));
         assert!(config.skip_permissions);
+    }
+
+    #[test]
+    fn build_codex_resume_with_id_uses_resume_subcommand() {
+        let config = AgentLaunchBuilder::new(AgentId::Codex)
+            .session_mode(SessionMode::Resume)
+            .resume_session_id("sess-123")
+            .build();
+
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "resume" && pair[1] == "sess-123"));
+    }
+
+    #[test]
+    fn build_codex_resume_without_id_uses_last_session() {
+        let config = AgentLaunchBuilder::new(AgentId::Codex)
+            .session_mode(SessionMode::Resume)
+            .build();
+
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "resume" && pair[1] == "--last"));
+    }
+
+    #[test]
+    fn build_codex_continue_uses_last_session() {
+        let config = AgentLaunchBuilder::new(AgentId::Codex)
+            .session_mode(SessionMode::Continue)
+            .build();
+
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "resume" && pair[1] == "--last"));
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -7542,6 +7542,23 @@ CUSTOM_ENV = "enabled"
     }
 
     #[test]
+    fn build_launch_config_from_wizard_codex_quick_start_resume_uses_resume_subcommand() {
+        let wizard = screens::wizard::WizardState {
+            agent_id: "codex".to_string(),
+            model: "gpt-5.4".to_string(),
+            branch_name: "feature/spec-42".to_string(),
+            mode: "resume".to_string(),
+            resume_session_id: Some("sess-123".to_string()),
+            ..Default::default()
+        };
+
+        let config = build_launch_config_from_wizard(&wizard);
+
+        assert!(config.args.contains(&"resume".to_string()));
+        assert!(config.args.contains(&"sess-123".to_string()));
+    }
+
+    #[test]
     fn build_launch_config_from_wizard_falls_back_to_continue_without_resume_session_id() {
         let wizard = screens::wizard::WizardState {
             agent_id: "claude".to_string(),

--- a/specs/SPEC-3/spec.md
+++ b/specs/SPEC-3/spec.md
@@ -382,6 +382,8 @@ Model list snapshot: **2026-04-06**.
 
 | Flag | Description |
 |------|-------------|
+| `resume [SESSION_ID]` | Resume a specific Codex interactive session by session/thread ID |
+| `resume --last` | Continue the most recent Codex interactive session |
 | `--model <model>` | Default: `gpt-5.4`; available: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini` |
 | `-c model_reasoning_effort=<level>` | Reasoning level: low/medium/high |
 | `-c service_tier=fast` | Fast mode (Codex-only speed tier). Independent from skip-permission settings |


### PR DESCRIPTION
## Summary

- Fix Codex Quick Start so selecting `Resume` actually launches Codex in resume mode instead of a normal new session.
- Map Codex session modes to Codex CLI semantics (`resume <SESSION_ID>` / `resume --last`) so Resume and Continue behavior is explicit and deterministic.
- Add regression tests and update SPEC-3 CLI docs to keep implementation and contract aligned.

## Changes

- `crates/gwt-agent/src/launch.rs`: Added Codex `SessionMode` mapping in launch arg builder (`Continue` -> `resume --last`, `Resume` -> `resume <id>` or `resume --last`).
- `crates/gwt-agent/src/launch.rs`: Added tests for Codex resume/continue arg generation.
- `crates/gwt-tui/src/app.rs`: Added Quick Start regression test ensuring Codex resume selection emits resume-subcommand args.
- `specs/SPEC-3/spec.md`: Documented Codex resume commands (`resume [SESSION_ID]`, `resume --last`) in Agent CLI Flags.

## Testing

- [x] `cargo test -p gwt-agent build_codex_` — all Codex launch-arg tests pass, including new resume/continue cases.
- [x] `cargo test -p gwt-tui build_launch_config_from_wizard_` — wizard launch-config tests pass, including new Codex Quick Start resume regression.
- [x] `cargo fmt -- --check` — formatting check passes.
- [x] `cargo clippy -p gwt-agent -p gwt-tui --all-targets --all-features -- -D warnings` — lint passes with no warnings.
- [x] `bunx markdownlint-cli2 specs/SPEC-3/spec.md` — markdown lint passes.

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (N/A: no schema/data change)
- [x] CHANGELOG impact considered (patch-level `fix:` change, no breaking change)

## Context

- Quick Start UI already set `mode=resume` and carried `resume_session_id`, but Codex launch arg generation ignored session mode entirely.
- As a result, selecting `Resume` for Codex did not restore prior sessions, even though Claude path worked.
