### PR TITLE
fix(search): split project file search into code and docs collections

### DIFF
--- a/.claude/skills/gwt-project-index/SKILL.md
+++ b/.claude/skills/gwt-project-index/SKILL.md
@@ -5,7 +5,7 @@ description: Compatibility-oriented reference for the project file index. Prefer
 
 # Project Structure Index
 
-gwt maintains a vector search index of all project files using ChromaDB embeddings.
+gwt maintains a vector search index of project implementation files plus a separate docs collection using ChromaDB embeddings.
 
 ## File search command
 
@@ -46,6 +46,8 @@ JSON object with ranked results:
 ## Notes
 
 - File index is auto-generated when the project is opened in gwt
+- `search-files` targets the implementation-file collection; embedded skill assets, SPEC trees, local task logs, and snapshots are excluded from that collection
+- Project docs are indexed separately and can be searched with `search-files-docs`
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance
 - Canonical standalone file-search skill: `gwt-project-search`

--- a/.claude/skills/gwt-project-search/SKILL.md
+++ b/.claude/skills/gwt-project-search/SKILL.md
@@ -5,7 +5,7 @@ description: "Semantic search over project source files using vector embeddings.
 
 # Project Search
 
-gwt maintains a vector search index of project source files using ChromaDB embeddings.
+gwt maintains a vector search index of project implementation files using ChromaDB embeddings.
 The index is automatically updated when source files change (via file system watcher).
 
 ## File search command
@@ -47,6 +47,8 @@ JSON object with ranked results:
 ## Notes
 
 - Project file index is automatically maintained by the file system watcher (changes trigger re-indexing)
+- `search-files` is implementation-focused and excludes embedded skill assets, local/archived SPEC trees, local task logs, and snapshot files
+- Project docs are indexed separately and can be searched with `search-files-docs`
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance
 - Canonical standalone skill name: `gwt-project-search`

--- a/.claude/skills/gwt-search/SKILL.md
+++ b/.claude/skills/gwt-search/SKILL.md
@@ -11,7 +11,7 @@ gwt maintains ChromaDB vector search indexes for three scopes:
 |-------|---------|-------------------|
 | SPECs | Local SPEC files (`specs/SPEC-{N}/`) | Automatic (file system watcher) |
 | Issues | GitHub Issues (all states) | Manual (`index-issues` action or GUI button) |
-| Files | Project source files | Automatic (file system watcher) |
+| Files | Project implementation files (code/config; excludes embedded skill assets, SPEC trees, and snapshots) | Automatic (file system watcher) |
 
 ## Quick reference
 
@@ -19,7 +19,7 @@ gwt maintains ChromaDB vector search indexes for three scopes:
 gwt-search "query"              # search all three scopes
 gwt-search --specs "query"      # SPECs only
 gwt-search --issues "query"     # GitHub Issues only
-gwt-search --files "query"      # project source files only
+gwt-search --files "query"      # implementation files only
 ```
 
 ## Filter options
@@ -29,7 +29,7 @@ gwt-search --files "query"      # project source files only
 | (none) | All three | Run all three searches | Default behavior |
 | `--specs` | SPECs only | `search-specs` | Local `specs/SPEC-{N}/` directories |
 | `--issues` | Issues only | `search-issues` | GitHub Issues via ChromaDB index |
-| `--files` | Files only | `search-files` | Project source files |
+| `--files` | Files only | `search-files` | Implementation files only |
 
 ## Search commands
 
@@ -73,6 +73,18 @@ $PYTHON $RUNNER \
   --n-results 10
 ```
 
+`search-files` is implementation-focused: it excludes embedded skill assets (`.claude/`, `.codex/`), local/archived SPEC trees, local task logs, and snapshot files so code search is not dominated by docs noise.
+
+### Search project docs (advanced runner action)
+
+```bash
+$PYTHON $RUNNER \
+  --action search-files-docs \
+  --db-path "$DB_PATH" \
+  --query "your search query" \
+  --n-results 10
+```
+
 ### Search all scopes (default)
 
 Run all three search commands above and merge results by scope.
@@ -105,6 +117,8 @@ $PYTHON $RUNNER \
   --project-root "$GWT_PROJECT_ROOT" \
   --db-path "$DB_PATH"
 ```
+
+`index-files` rebuilds both the implementation-file collection and the separate docs collection.
 
 ## Output formats
 
@@ -145,8 +159,9 @@ $PYTHON $RUNNER \
 
 This skill is a **mandatory preflight step** before:
 
-- `gwt-spec-design`
-- `gwt-issue`
+- `gwt-spec-design` (spec brainstorm, register, clarify, ops)
+- `gwt-spec-register` / `gwt-spec-ops`
+- `gwt-issue-register` / `gwt-issue-resolve`
 
 Run at least 2-3 semantic queries derived from the request before creating any new SPEC or Issue.
 

--- a/.codex/skills/gwt-project-index/SKILL.md
+++ b/.codex/skills/gwt-project-index/SKILL.md
@@ -5,7 +5,7 @@ description: Compatibility-oriented reference for the project file index. Prefer
 
 # Project Structure Index
 
-gwt maintains a vector search index of all project files using ChromaDB embeddings.
+gwt maintains a vector search index of project implementation files plus a separate docs collection using ChromaDB embeddings.
 
 ## File search command
 
@@ -46,6 +46,8 @@ JSON object with ranked results:
 ## Notes
 
 - File index is auto-generated when the project is opened in gwt
+- `search-files` targets the implementation-file collection; embedded skill assets, SPEC trees, local task logs, and snapshots are excluded from that collection
+- Project docs are indexed separately and can be searched with `search-files-docs`
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance
 - Canonical standalone file-search skill: `gwt-project-search`

--- a/.codex/skills/gwt-project-search/SKILL.md
+++ b/.codex/skills/gwt-project-search/SKILL.md
@@ -5,7 +5,7 @@ description: "Semantic search over project source files using vector embeddings.
 
 # Project Search
 
-gwt maintains a vector search index of project source files using ChromaDB embeddings.
+gwt maintains a vector search index of project implementation files using ChromaDB embeddings.
 The index is automatically updated when source files change (via file system watcher).
 
 ## File search command
@@ -47,6 +47,8 @@ JSON object with ranked results:
 ## Notes
 
 - Project file index is automatically maintained by the file system watcher (changes trigger re-indexing)
+- `search-files` is implementation-focused and excludes embedded skill assets, local/archived SPEC trees, local task logs, and snapshot files
+- Project docs are indexed separately and can be searched with `search-files-docs`
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance
 - Canonical standalone skill name: `gwt-project-search`

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -67,6 +67,33 @@ BINARY_EXTENSIONS = {
 }
 
 MAX_FILE_SIZE = 1_048_576  # 1 MiB
+CODE_COLLECTION = "files_code"
+DOC_COLLECTION = "files_docs"
+LEGACY_FILE_COLLECTION = "files"
+
+SKIP_FILE_EXTENSIONS = {
+    ".snap",
+}
+
+SKIP_ROOT_DIRECTORIES = {
+    ".claude",
+    ".codex",
+    "specs",
+    "specs-archive",
+    "tasks",
+}
+
+DOC_FILE_EXTENSIONS = {
+    ".md",
+    ".mdx",
+    ".rst",
+    ".adoc",
+    ".txt",
+}
+
+DOC_ROOT_DIRECTORIES = {
+    "docs",
+}
 
 
 def load_gitignore_patterns(project_root: Path) -> List[str]:
@@ -120,6 +147,30 @@ def should_ignore(rel_path: str, compiled_patterns: List[re.Pattern]) -> bool:
 def is_binary_file(path: Path) -> bool:
     """Check if a file is likely binary."""
     return path.suffix.lower() in BINARY_EXTENSIONS
+
+
+def classify_file_bucket(rel_path: str) -> str:
+    """Classify a collected file into code/docs buckets or skip it entirely."""
+    rel = Path(rel_path)
+    parts = rel.parts
+    suffix = rel.suffix.lower()
+
+    if suffix in SKIP_FILE_EXTENSIONS:
+        return "skip"
+
+    if parts and parts[0] in SKIP_ROOT_DIRECTORIES:
+        return "skip"
+
+    if rel.name.lower().startswith("readme"):
+        return "docs"
+
+    if suffix in DOC_FILE_EXTENSIONS:
+        return "docs"
+
+    if parts and parts[0] in DOC_ROOT_DIRECTORIES:
+        return "docs"
+
+    return "code"
 
 
 def collect_files(project_root: Path) -> List[Path]:
@@ -296,62 +347,119 @@ def action_index(project_root: str, db_path: str) -> dict:
     start = time.monotonic()
 
     client = chromadb.PersistentClient(path=str(db))
-    collection = client.get_or_create_collection(
-        name="files",
+    code_collection = client.get_or_create_collection(
+        name=CODE_COLLECTION,
+        metadata={"hnsw:space": "cosine"},
+    )
+    doc_collection = client.get_or_create_collection(
+        name=DOC_COLLECTION,
         metadata={"hnsw:space": "cosine"},
     )
 
     files = collect_files(root)
-    current_ids = {str(f.relative_to(root)) for f in files}
+    current_code_ids = set()
+    current_doc_ids = set()
 
     batch_size = 100
-    total_indexed = 0
+    total_code_indexed = 0
+    total_doc_indexed = 0
 
     if files:
         for i in range(0, len(files), batch_size):
             batch = files[i : i + batch_size]
-            ids = []
-            documents = []
-            metadatas = []
+            code_ids = []
+            code_documents = []
+            code_metadatas = []
+            doc_ids = []
+            doc_documents = []
+            doc_metadatas = []
 
             for fpath in batch:
                 rel = str(fpath.relative_to(root))
+                bucket = classify_file_bucket(rel)
+                if bucket == "skip":
+                    continue
                 desc = extract_description(fpath)
                 try:
                     size = fpath.stat().st_size
                 except OSError:
                     size = 0
 
-                ids.append(rel)
-                documents.append(f"{rel}: {desc}")
-                metadatas.append({
+                payload = {
                     "path": rel,
                     "description": desc,
                     "file_type": fpath.suffix.lstrip(".") or "unknown",
                     "size": size,
-                })
+                    "bucket": bucket,
+                }
 
-            collection.upsert(ids=ids, documents=documents, metadatas=metadatas)
-            total_indexed += len(batch)
+                if bucket == "docs":
+                    current_doc_ids.add(rel)
+                    doc_ids.append(rel)
+                    doc_documents.append(f"{rel}: {desc}")
+                    doc_metadatas.append(payload)
+                else:
+                    current_code_ids.add(rel)
+                    code_ids.append(rel)
+                    code_documents.append(f"{rel}: {desc}")
+                    code_metadatas.append(payload)
+
+            if code_ids:
+                code_collection.upsert(
+                    ids=code_ids,
+                    documents=code_documents,
+                    metadatas=code_metadatas,
+                )
+                total_code_indexed += len(code_ids)
+
+            if doc_ids:
+                doc_collection.upsert(
+                    ids=doc_ids,
+                    documents=doc_documents,
+                    metadatas=doc_metadatas,
+                )
+                total_doc_indexed += len(doc_ids)
 
     try:
-        existing = collection.get()
-        stale = [eid for eid in existing["ids"] if eid not in current_ids]
-        if stale:
-            collection.delete(ids=stale)
+        existing_code = code_collection.get()
+        stale_code = [eid for eid in existing_code["ids"] if eid not in current_code_ids]
+        if stale_code:
+            code_collection.delete(ids=stale_code)
+
+        existing_docs = doc_collection.get()
+        stale_docs = [eid for eid in existing_docs["ids"] if eid not in current_doc_ids]
+        if stale_docs:
+            doc_collection.delete(ids=stale_docs)
     except Exception as exc:
         print(f"Warning: stale entry cleanup failed: {exc}", file=sys.stderr)
+
+    try:
+        client.delete_collection(LEGACY_FILE_COLLECTION)
+    except Exception:
+        pass
 
     elapsed = int((time.monotonic() - start) * 1000)
     return {
         "ok": True,
-        "filesIndexed": total_indexed,
+        "filesIndexed": total_code_indexed + total_doc_indexed,
+        "codeFilesIndexed": total_code_indexed,
+        "docFilesIndexed": total_doc_indexed,
         "durationMs": elapsed,
     }
 
 
-def action_search(db_path: str, query: str, n_results: int = 10) -> dict:
-    """Search the project index."""
+def _load_file_collection(client, name: str):
+    """Load a file collection, falling back to the legacy collection for code search."""
+    try:
+        return client.get_collection(name)
+    except Exception:
+        if name == CODE_COLLECTION:
+            return client.get_collection(LEGACY_FILE_COLLECTION)
+        raise
+
+
+def _search_file_collection(db_path: str, query: str, n_results: int, collection_name: str, missing_message: str) -> dict:
+    """Search one of the file-oriented collections."""
     import chromadb  # type: ignore
 
     db = Path(db_path).resolve()
@@ -360,9 +468,9 @@ def action_search(db_path: str, query: str, n_results: int = 10) -> dict:
 
     client = chromadb.PersistentClient(path=str(db))
     try:
-        collection = client.get_collection("files")
+        collection = _load_file_collection(client, collection_name)
     except Exception:
-        return {"ok": False, "error": "Collection 'files' not found. Run index-files first."}
+        return {"ok": False, "error": missing_message}
 
     count = collection.count()
     if count == 0:
@@ -388,6 +496,28 @@ def action_search(db_path: str, query: str, n_results: int = 10) -> dict:
         items = fallback_substring_search(collection, query, actual_n)
 
     return {"ok": True, "results": items}
+
+
+def action_search(db_path: str, query: str, n_results: int = 10) -> dict:
+    """Search implementation-focused project files."""
+    return _search_file_collection(
+        db_path,
+        query,
+        n_results,
+        CODE_COLLECTION,
+        "Collection 'files_code' not found. Run index-files first.",
+    )
+
+
+def action_search_docs(db_path: str, query: str, n_results: int = 10) -> dict:
+    """Search project docs kept separate from implementation files."""
+    return _search_file_collection(
+        db_path,
+        query,
+        n_results,
+        DOC_COLLECTION,
+        "Collection 'files_docs' not found. Run index-files first.",
+    )
 
 
 def fallback_substring_search(collection, query: str, n_results: int) -> List[dict]:
@@ -680,18 +810,33 @@ def action_status(db_path: str) -> dict:
         return {"ok": True, "indexed": False, "totalFiles": 0}
 
     client = chromadb.PersistentClient(path=str(db))
+    total_code = 0
+    total_docs = 0
+    indexed = False
+
     try:
-        collection = client.get_collection("files")
-        total = collection.count()
+        total_code = _load_file_collection(client, CODE_COLLECTION).count()
+        indexed = indexed or total_code > 0
     except Exception:
-        return {"ok": True, "indexed": False, "totalFiles": 0}
+        total_code = 0
+
+    try:
+        total_docs = client.get_collection(DOC_COLLECTION).count()
+        indexed = indexed or total_docs > 0
+    except Exception:
+        total_docs = 0
+
+    if not indexed:
+        return {"ok": True, "indexed": False, "totalFiles": 0, "totalCodeFiles": 0, "totalDocFiles": 0}
 
     db_size = sum(f.stat().st_size for f in db.rglob("*") if f.is_file())
 
     return {
         "ok": True,
         "indexed": True,
-        "totalFiles": total,
+        "totalFiles": total_code + total_docs,
+        "totalCodeFiles": total_code,
+        "totalDocFiles": total_docs,
         "dbSizeBytes": db_size,
     }
 
@@ -705,6 +850,7 @@ def parse_args() -> argparse.Namespace:
             "probe",
             "index-files",
             "search-files",
+            "search-files-docs",
             "index",
             "search",
             "status",
@@ -752,6 +898,16 @@ def main() -> int:
                 emit({"ok": False, "error": "--query is required for search-files"})
                 return 2
             emit(action_search(args.db_path, args.query, args.n_results))
+            return 0
+
+        if action == "search-files-docs":
+            if not args.db_path:
+                emit({"ok": False, "error": "--db-path is required for search-files-docs"})
+                return 2
+            if not args.query:
+                emit({"ok": False, "error": "--query is required for search-files-docs"})
+                return 2
+            emit(action_search_docs(args.db_path, args.query, args.n_results))
             return 0
 
         if action == "status":

--- a/crates/gwt-core/runtime/test_chroma_index_runner.py
+++ b/crates/gwt-core/runtime/test_chroma_index_runner.py
@@ -1,0 +1,77 @@
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import chroma_index_runner as runner
+
+
+class ChromaIndexRunnerTests(unittest.TestCase):
+    def test_classify_file_bucket_separates_code_docs_and_skip(self):
+        self.assertEqual(runner.classify_file_bucket('crates/gwt-core/src/runtime.rs'), 'code')
+        self.assertEqual(runner.classify_file_bucket('README.md'), 'docs')
+        self.assertEqual(runner.classify_file_bucket('docs/search.md'), 'docs')
+        self.assertEqual(runner.classify_file_bucket('.claude/skills/gwt-search/SKILL.md'), 'skip')
+        self.assertEqual(runner.classify_file_bucket('.codex/skills/gwt-search/SKILL.md'), 'skip')
+        self.assertEqual(runner.classify_file_bucket('specs/SPEC-9/spec.md'), 'skip')
+        self.assertEqual(runner.classify_file_bucket('specs-archive/SPEC-9/spec.md'), 'skip')
+        self.assertEqual(runner.classify_file_bucket('crates/gwt-tui/tests/snapshots/view.snap'), 'skip')
+
+    def test_index_files_writes_code_and_docs_collections_without_embedded_assets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / 'project'
+            db = Path(tmp) / 'db'
+            (root / 'src').mkdir(parents=True)
+            (root / 'docs').mkdir(parents=True)
+            (root / '.claude' / 'skills' / 'foo').mkdir(parents=True)
+            (root / 'specs' / 'SPEC-1').mkdir(parents=True)
+            (root / 'crates' / 'gwt-tui' / 'tests' / 'snapshots').mkdir(parents=True)
+
+            (root / 'src' / 'runtime.rs').write_text('//! Runtime bootstrap manager\nfn main() {}\n')
+            (root / 'README.md').write_text('# Runtime Overview\n')
+            (root / 'docs' / 'search.md').write_text('# Search Guide\n')
+            (root / '.claude' / 'skills' / 'foo' / 'SKILL.md').write_text('# Ignored\n')
+            (root / 'specs' / 'SPEC-1' / 'spec.md').write_text('# Ignored Spec\n')
+            (root / 'crates' / 'gwt-tui' / 'tests' / 'snapshots' / 'view.snap').write_text('ignored snapshot\n')
+
+            result = runner.action_index(str(root), str(db))
+            self.assertTrue(result['ok'])
+            self.assertEqual(result['codeFilesIndexed'], 1)
+            self.assertEqual(result['docFilesIndexed'], 2)
+            self.assertEqual(result['filesIndexed'], 3)
+
+            import chromadb
+
+            client = chromadb.PersistentClient(path=str(db))
+            code = client.get_collection(runner.CODE_COLLECTION)
+            docs = client.get_collection(runner.DOC_COLLECTION)
+            self.assertEqual(code.count(), 1)
+            self.assertEqual(docs.count(), 2)
+            self.assertEqual(code.get()['ids'], ['src/runtime.rs'])
+            self.assertCountEqual(docs.get()['ids'], ['README.md', 'docs/search.md'])
+
+    def test_search_files_returns_code_only_and_search_files_docs_returns_docs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / 'project'
+            db = Path(tmp) / 'db'
+            (root / 'src').mkdir(parents=True)
+            (root / 'docs').mkdir(parents=True)
+
+            (root / 'src' / 'runtime.rs').write_text('//! Runtime bootstrap manager\nfn main() {}\n')
+            (root / 'docs' / 'runtime.md').write_text('# Runtime bootstrap guide\n')
+
+            runner.action_index(str(root), str(db))
+
+            code_result = runner.action_search(str(db), 'runtime bootstrap', 5)
+            self.assertTrue(code_result['ok'])
+            self.assertEqual(code_result['results'][0]['path'], 'src/runtime.rs')
+            self.assertNotIn('docs/runtime.md', [item['path'] for item in code_result['results']])
+
+            docs_result = runner.action_search_docs(str(db), 'runtime bootstrap', 5)
+            self.assertTrue(docs_result['ok'])
+            self.assertEqual(docs_result['results'][0]['path'], 'docs/runtime.md')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/specs/SPEC-9/metadata.json
+++ b/specs/SPEC-9/metadata.json
@@ -4,5 +4,5 @@
   "status": "in-progress",
   "phase": "Implementation",
   "created_at": "2026-04-02T09:38:44.299823+00:00",
-  "updated_at": "2026-04-07T06:55:43Z"
+  "updated_at": "2026-04-07T07:45:00Z"
 }

--- a/specs/SPEC-9/plan.md
+++ b/specs/SPEC-9/plan.md
@@ -188,6 +188,7 @@ The following capabilities from SPEC-1786 are already implemented:
 4. Update `gwt-search` family skills so `index-issues` examples include `--project-root`.
 5. Validate bootstrap Python candidates before venv creation, keep working Store/launcher entrypoints, and translate only true no-candidate cases into install guidance.
 6. Restore `gwt-project-search` as the canonical standalone semantic project-search skill / command while keeping `search-files` / `index-files` as the internal runner action names.
+7. Split file indexing into code/docs collections so `search-files` stays implementation-focused while noisy skill/spec/snapshot artifacts are excluded from the code collection.
 
 ### Dependencies
 

--- a/specs/SPEC-9/progress.md
+++ b/specs/SPEC-9/progress.md
@@ -4,8 +4,8 @@
 
 - Status: `in-progress`
 - Phase: `Implementation`
-- Task progress: Phase 1: 21/21, Phase 2: 13/13, Phase 2b: 41/41, Phase 2c: 11/11, Phase 3: 31/31, Phase 4: 11/11, Phase 5: 14/20, Phase 6: 7/7
-- Artifact refresh: `2026-04-07T06:55:43Z`
+- Task progress: Phase 1: 21/21, Phase 2: 13/13, Phase 2b: 41/41, Phase 2c: 11/11, Phase 3: 31/31, Phase 4: 11/11, Phase 5: 14/20, Phase 6: 11/11
+- Artifact refresh: `2026-04-07T07:45:00Z`
 
 ## Done
 
@@ -24,6 +24,8 @@
 - Search runtime bootstrap now validates Python candidates before venv creation and surfaces install guidance when Python 3.9+ is unavailable.
 - Phase 6 keeps the runtime contract on `search-files` / `index-files`, but the standalone user-facing skill / slash-command surface is restored to `gwt-project-search` because the workflow semantically finds related implementation areas inside the project.
 - Bundled Claude/Codex skills now distribute canonical `gwt-project-search` assets, while `gwt-file-search` assets are intentionally absent so public naming stays aligned with project-search semantics.
+- Phase 6 follow-up now targets file-index quality itself: implementation search must ignore embedded skill/spec/snapshot noise and split docs into a separate collection so `search-files` behaves like code discovery instead of generic markdown retrieval.
+- The repo-tracked runner now writes separate code/docs collections, exposes `search-files-docs` for project docs, and keeps `search-files` focused on implementation files after excluding `.claude/`, `.codex/`, `specs/`, `specs-archive/`, `tasks/`, and `*.snap`.
 
 ## Next
 

--- a/specs/SPEC-9/spec.md
+++ b/specs/SPEC-9/spec.md
@@ -267,6 +267,8 @@ As a developer using `gwt-search`, I want the shared search runtime to repair it
 8. Given the managed search runtime cannot be bootstrapped because no suitable Python candidate exists at all, when gwt surfaces the warning, then the message includes install guidance.
 9. Given a user invokes standalone semantic search over project implementation files, when gwt exposes the standalone skill and slash command surface, then `gwt-project-search` is the canonical name.
 10. Given the bundled assets are distributed to a worktree, when standalone project search assets are materialized, then no `gwt-file-search` skill or slash-command asset is written.
+11. Given `search-files` is used for implementation discovery, when file indexing runs, then embedded skill assets, local SPEC directories, archived SPEC directories, local task logs, and snapshot files are excluded from the implementation-file collection.
+12. Given project documentation is indexed separately from implementation files, when `index-files` completes, then `search-files` searches the code-focused collection by default and `search-files-docs` can search the docs-focused collection explicitly.
 
 ## Functional Requirements (Phase 4: Skill Consolidation)
 
@@ -294,6 +296,8 @@ As a developer using `gwt-search`, I want the shared search runtime to repair it
 - **FR-045**: Startup and clone-completion notifications use the same stable project-index runtime classification rather than brittle human-text matching.
 - **FR-046**: `gwt-project-search` is the canonical standalone skill and slash-command name for semantic search over project implementation files, while internal runner actions remain `search-files` / `index-files`.
 - **FR-047**: Search-related skill documentation that points users to standalone project-file search references `gwt-project-search` as the primary entrypoint, and `gwt-file-search` is not distributed as a public asset.
+- **FR-048**: `index-files` splits indexed project files into separate code and docs collections. `search-files` targets the code-focused collection by default, while `search-files-docs` targets project docs explicitly.
+- **FR-049**: The code-focused file collection excludes embedded skill assets (`.claude/`, `.codex/`), local SPEC directories (`specs/`), archived SPEC directories (`specs-archive/`), local task logs (`tasks/`), and snapshot files (`*.snap`) so implementation search is not dominated by generated or planning artifacts.
 
 ## Success Criteria
 
@@ -327,3 +331,5 @@ As a developer using `gwt-search`, I want the shared search runtime to repair it
 - **SC-026**: When no suitable bootstrap Python is available, gwt surfaces install guidance that references Python 3.9+ and the expected Windows `python` / `py -3` commands.
 - **SC-027**: Distributed skill assets include `gwt-project-search` for both Claude and Codex, and `/gwt:gwt-project-search` is available as the canonical slash command.
 - **SC-028**: Distributed worktrees do not contain `gwt-file-search` skill or slash-command assets, preventing public naming drift away from the project-search workflow.
+- **SC-029**: Reindexing a repository with `.claude/`, `.codex/`, `specs/`, `specs-archive/`, `tasks/`, and snapshot files present leaves those artifacts out of the implementation-file collection while still indexing implementation code.
+- **SC-030**: After `index-files`, a query executed through `search-files` returns implementation files without README/spec/skill asset noise, and `search-files-docs` can still retrieve project documentation separately.

--- a/specs/SPEC-9/tasks.md
+++ b/specs/SPEC-9/tasks.md
@@ -258,3 +258,7 @@
 - [x] **T-135**: Add RED tests that require `gwt-project-search` as the canonical distributed project-search asset and reject `gwt-file-search` assets.
 - [x] **T-136**: Restore canonical `gwt-project-search` skill / slash-command assets across bundled docs while keeping `search-files` / `index-files` as internal runner actions.
 - [x] **T-137**: Update SPEC-9 artifacts and search-family references so standalone semantic project search points to `gwt-project-search` as the canonical public name.
+- [x] **T-138**: Add RED tests for file-bucket classification so embedded skill assets, SPEC directories, archived SPEC directories, task logs, and snapshots are excluded from implementation search.
+- [x] **T-139**: Split `index-files` into code/docs collections and add `search-files-docs` while keeping `search-files` implementation-focused.
+- [x] **T-140**: Update `gwt-search`, `gwt-project-search`, and `gwt-project-index` docs to describe implementation-focused `search-files` behavior and the separate docs collection.
+- [x] **T-141**: Refresh SPEC-9 artifacts and rerun Python + Cargo verification for the new code/docs file-index contract.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,23 @@
 # Lessons Learned
 
+## 2026-04-07 — fix: semantic file search は collection 設計でノイズを消す
+
+### 事象
+
+`gwt-search --files` が skill docs、SPEC、archive、snapshot まで同じ collection に入れていたため、
+implementation code を探したい query でも markdown 系 artifacts が先に出やすかった。
+
+### 原因
+
+- 「files」を 1 collection で持ち、planning/docs artifacts と implementation files を分離していなかった。
+- embedded skills や local SPECs は別 search surface を持っているのに、file search 側でも再度 index してしまっていた。
+
+### 再発防止策
+
+1. semantic search の品質問題を query tuning だけで片付けず、collection 境界が user intent に合っているか先に確認する。
+2. 別の検索 surface を持つ artifacts（embedded skills, SPECs, archive, task logs, snapshots）は implementation-file collection に入れない。
+3. implementation search と docs search を両立したい場合は 1 collection に混ぜず、collection を分けて default surface を意図的に選ぶ。
+
 ## 2026-04-07 — fix: public skill 名は internal action 名ではなくユーザー責務に合わせる
 
 ### 事象


### PR DESCRIPTION
## Summary

- split the project file index into separate `files_code` and `files_docs` collections so `search-files` returns implementation files instead of skill/spec noise.
- keep documentation searchable via the new `search-files-docs` action while excluding embedded skills, specs, tasks, and snapshots from the code-focused collection.
- add runner tests and refresh SPEC-9 and search skill documentation so the code/docs indexing contract stays explicit.

## Changes

- `crates/gwt-core/runtime/chroma_index_runner.py`: classify project files into code/docs/skip buckets, index into separate collections, add `search-files-docs`, and extend `status` output.
- `crates/gwt-core/runtime/test_chroma_index_runner.py`: add coverage for bucket classification, split indexing, and code-vs-doc search behavior.
- `.claude/skills/*` and `.codex/skills/*`: update project search and index guidance to match the code/docs collection split.
- `specs/SPEC-9/*` and `tasks/lessons.md`: record the new file-index contract, acceptance coverage, and the lesson about removing semantic-search noise at the collection boundary.

## Testing

- [x] `~/.gwt/runtime/chroma-venv/bin/python3 -m unittest crates/gwt-core/runtime/test_chroma_index_runner.py` — passes
- [x] `cargo fmt` — passes
- [x] `cargo fmt -- --check` — passes
- [x] `cargo test -p gwt-core -p gwt-git -p gwt-skills -p gwt-tui` — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes
- [x] `cargo build -p gwt-tui` — passes
- [x] `npx --yes markdownlint-cli2 .claude/skills/gwt-search/SKILL.md .claude/skills/gwt-project-search/SKILL.md .claude/skills/gwt-project-index/SKILL.md .codex/skills/gwt-project-search/SKILL.md .codex/skills/gwt-project-index/SKILL.md specs/SPEC-9/spec.md specs/SPEC-9/plan.md specs/SPEC-9/tasks.md specs/SPEC-9/progress.md tasks/lessons.md` — passes

## Closing Issues

- None

## Related Issues / Links

- #1452
- #1524

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change) — N/A: no schema or persisted data migration
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- semantic file search was returning `.claude`, `.codex`, and SPEC artifacts ahead of implementation files because the index used one mixed collection for all project assets.
- this PR moves the noise filtering into the indexing boundary so standalone `gwt-project-search` stays implementation-oriented without losing documentation lookup entirely.

## Notes

- `search-files` remains the public code-oriented file search path.
- `search-files-docs` is available for explicit documentation-focused lookups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `search-files-docs` command to search project documentation through a dedicated collection.

* **Improvements**
  * Restructured file indexing to split code and documentation searches. The `search-files` action now focuses exclusively on implementation files while excluding embedded skill assets, specification directories, task logs, and snapshot files for cleaner, more relevant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->