### PR TITLE
fix(branches): animate live session icons only while running

### DIFF
--- a/.codex/hooks/scripts/gwt-forward-hook.mjs
+++ b/.codex/hooks/scripts/gwt-forward-hook.mjs
@@ -16,12 +16,12 @@ const payload = Buffer.concat(chunks).toString();
 function hookStatus(eventName) {
   switch (eventName) {
     case "SessionStart":
+    case "Stop":
+      return "WaitingInput";
     case "UserPromptSubmit":
     case "PreToolUse":
     case "PostToolUse":
       return "Running";
-    case "Stop":
-      return "WaitingInput";
     default:
       return null;
   }

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -224,10 +224,8 @@ pub fn persist_session_status(
 
 fn hook_event_status(event: &str) -> Option<AgentStatus> {
     match event {
-        "SessionStart" | "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => {
-            Some(AgentStatus::Running)
-        }
-        "Stop" => Some(AgentStatus::WaitingInput),
+        "SessionStart" | "Stop" => Some(AgentStatus::WaitingInput),
+        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => Some(AgentStatus::Running),
         _ => None,
     }
 }
@@ -337,16 +335,16 @@ mod tests {
 
     #[test]
     fn hook_runtime_state_maps_running_and_waiting_events() {
-        for event in [
-            "SessionStart",
-            "UserPromptSubmit",
-            "PreToolUse",
-            "PostToolUse",
-        ] {
+        for event in ["UserPromptSubmit", "PreToolUse", "PostToolUse"] {
             let runtime = SessionRuntimeState::from_hook_event(event).expect("running event");
             assert_eq!(runtime.status, AgentStatus::Running, "{event}");
             assert_eq!(runtime.source_event.as_deref(), Some(event));
         }
+
+        let session_start =
+            SessionRuntimeState::from_hook_event("SessionStart").expect("session start event");
+        assert_eq!(session_start.status, AgentStatus::WaitingInput);
+        assert_eq!(session_start.source_event.as_deref(), Some("SessionStart"));
 
         let waiting = SessionRuntimeState::from_hook_event("Stop").expect("waiting event");
         assert_eq!(waiting.status, AgentStatus::WaitingInput);

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3913,7 +3913,13 @@ fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Resul
 
     let main_repo_path =
         gwt_git::worktree::main_worktree_root(repo_path).map_err(|err| err.to_string())?;
-    if let Some(existing_worktree) = existing_worktree_for_branch(&main_repo_path, &branch_name)? {
+    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+    let worktrees = manager.list().map_err(|err| err.to_string())?;
+    if let Some(existing_worktree) = worktrees
+        .iter()
+        .find(|worktree| worktree.branch.as_deref() == Some(branch_name.as_str()))
+        .map(|worktree| worktree.path.clone())
+    {
         config.working_dir = Some(existing_worktree.clone());
         config.env_vars.insert(
             "GWT_PROJECT_ROOT".to_string(),
@@ -3928,7 +3934,6 @@ fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Resul
         .unwrap_or_else(|| DEFAULT_NEW_BRANCH_BASE_BRANCH.to_string());
     let remote_base_ref = origin_remote_ref(&base_branch);
     let remote_branch_ref = origin_remote_ref(&branch_name);
-    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
 
     manager
         .fetch_origin()
@@ -3959,7 +3964,20 @@ fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Resul
             .map_err(|err| format!("failed to refresh origin refs after push: {err}"))?;
     }
 
-    let worktree_path = gwt_git::worktree::sibling_worktree_path(&main_repo_path, &branch_name);
+    let preferred_worktree_path =
+        gwt_git::worktree::sibling_worktree_path(&main_repo_path, &branch_name);
+    let worktree_path = first_available_worktree_path(&preferred_worktree_path, &worktrees)
+        .ok_or_else(|| {
+            format!("failed to resolve available worktree path for branch {branch_name}")
+        })?;
+    if worktree_path != preferred_worktree_path {
+        tracing::warn!(
+            branch = branch_name,
+            preferred = %preferred_worktree_path.display(),
+            selected = %worktree_path.display(),
+            "preferred worktree path is occupied; using suffixed fallback"
+        );
+    }
     if local_branch_exists(&main_repo_path, &branch_name)? {
         manager
             .create(&branch_name, &worktree_path)
@@ -3978,6 +3996,48 @@ fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Resul
     Ok(())
 }
 
+fn first_available_worktree_path(
+    preferred_path: &Path,
+    worktrees: &[gwt_git::WorktreeInfo],
+) -> Option<PathBuf> {
+    if !worktree_path_is_occupied(preferred_path, worktrees) && !preferred_path.exists() {
+        return Some(preferred_path.to_path_buf());
+    }
+
+    for suffix in 2usize.. {
+        let candidate = suffixed_worktree_path(preferred_path, suffix)?;
+        if !worktree_path_is_occupied(&candidate, worktrees) && !candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn suffixed_worktree_path(path: &Path, suffix: usize) -> Option<PathBuf> {
+    let file_name = path.file_name()?.to_str()?;
+    let mut candidate = path.to_path_buf();
+    candidate.set_file_name(format!("{file_name}-{suffix}"));
+    Some(candidate)
+}
+
+fn worktree_path_is_occupied(path: &Path, worktrees: &[gwt_git::WorktreeInfo]) -> bool {
+    worktrees
+        .iter()
+        .any(|worktree| same_worktree_path(&worktree.path, path))
+}
+
+fn same_worktree_path(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
 fn origin_remote_ref(branch_name: &str) -> String {
     if let Some(ref_name) = branch_name.strip_prefix("refs/remotes/") {
         ref_name.to_string()
@@ -3986,22 +4046,6 @@ fn origin_remote_ref(branch_name: &str) -> String {
     } else {
         format!("origin/{branch_name}")
     }
-}
-
-fn existing_worktree_for_branch(
-    repo_path: &Path,
-    branch_name: &str,
-) -> Result<Option<PathBuf>, String> {
-    let manager = gwt_git::WorktreeManager::new(repo_path);
-    manager
-        .list()
-        .map_err(|err| err.to_string())
-        .map(|worktrees| {
-            worktrees
-                .into_iter()
-                .find(|worktree| worktree.branch.as_deref() == Some(branch_name))
-                .map(|worktree| worktree.path)
-        })
 }
 
 fn current_git_branch(repo_path: &Path) -> Result<String, String> {
@@ -12465,6 +12509,76 @@ CUSTOM_ENV = "enabled"
         let persisted = AgentSession::load(&session_entry).expect("load persisted session");
         assert_eq!(persisted.branch, "feature/test");
         assert_eq!(persisted.worktree_path, stale_worktree);
+    }
+
+    #[test]
+    fn materialize_pending_launch_with_occupied_preferred_worktree_path_uses_suffixed_fallback() {
+        let workspace_dir = tempfile::tempdir().expect("temp workspace dir");
+        let repo_path = workspace_dir.path().join("gwt");
+        let remote_path = workspace_dir.path().join("origin.git");
+        let sessions_dir = tempfile::tempdir().expect("temp sessions dir");
+        std::fs::create_dir_all(&repo_path).expect("create repo dir");
+        init_git_repo(&repo_path);
+        init_bare_git_repo(&remote_path);
+        git_add_remote(&repo_path, "origin", &remote_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+
+        git_checkout_branch_or_create(&repo_path, "main");
+        git_push_branch(&repo_path, "main");
+        git_checkout_branch_or_create(&repo_path, "develop");
+        git_push_branch(&repo_path, "develop");
+        git_checkout_branch_or_create(&repo_path, "main");
+
+        let occupied_path = workspace_dir.path().join("develop");
+        let occupied_output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "dependabot/npm_and_yarn/test",
+                occupied_path.to_str().expect("occupied worktree path"),
+                "develop",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree add occupied path");
+        assert!(
+            occupied_output.status.success(),
+            "git worktree add occupied path failed: {}",
+            String::from_utf8_lossy(&occupied_output.stderr)
+        );
+
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            is_new_branch: true,
+            base_branch_name: Some("develop".to_string()),
+            branch_name: "develop".to_string(),
+            worktree_path: Some(repo_path.clone()),
+            ..Default::default()
+        };
+
+        let mut model = Model::new(repo_path);
+        model.pending_launch_config = Some(build_launch_config_from_wizard(&wizard));
+
+        materialize_pending_launch_with(&mut model, sessions_dir.path())
+            .expect("materialize launch with occupied preferred path");
+
+        let expected_worktree = workspace_dir.path().join("develop-2");
+        let expected_worktree =
+            std::fs::canonicalize(&expected_worktree).expect("canonicalize fallback worktree");
+        assert!(
+            expected_worktree.exists(),
+            "launch should create a suffixed fallback path when the canonical branch path is occupied by another worktree"
+        );
+
+        let session_entry = std::fs::read_dir(sessions_dir.path())
+            .expect("read sessions dir")
+            .map(|entry| entry.expect("dir entry").path())
+            .find(|path| path.extension().is_some_and(|ext| ext == "toml"))
+            .expect("session entry");
+        let persisted = AgentSession::load(&session_entry).expect("load persisted session");
+        assert_eq!(persisted.branch, "develop");
+        assert_eq!(persisted.worktree_path, expected_worktree);
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -1684,6 +1684,13 @@ pub fn tick_redraw_required(model: &Model) -> bool {
         return true;
     }
 
+    if model.active_layer == ActiveLayer::Management
+        && model.management_tab == ManagementTab::Branches
+        && model.branches.has_running_live_sessions()
+    {
+        return true;
+    }
+
     model
         .wizard
         .as_ref()
@@ -10870,10 +10877,15 @@ mod tests {
             .chars()
             .filter(|ch| matches!(ch, '◐' | '◓' | '◑' | '◒'))
             .count();
+        let waiting_count = rendered.chars().filter(|ch| *ch == '●').count();
 
         assert_eq!(
-            spinner_count, 2,
-            "one live branch row should keep one spinner per live agent session"
+            spinner_count, 1,
+            "one live branch row should animate only the running agent session"
+        );
+        assert_eq!(
+            waiting_count, 1,
+            "one live branch row should keep the waiting agent visible with a static dot"
         );
         assert!(
             !rendered.contains("run ") && !rendered.contains("wait "),
@@ -10882,7 +10894,7 @@ mod tests {
     }
 
     #[test]
-    fn branch_live_session_rendering_uses_agent_colors_for_each_spinner() {
+    fn branch_live_session_rendering_uses_agent_colors_for_running_and_waiting_indicators() {
         let dir = tempfile::tempdir().expect("temp sessions dir");
         let repo_path = dir.path().join("repo");
         let selected_worktree = repo_path.join("wt-feature-test");
@@ -10946,19 +10958,63 @@ mod tests {
             })
             .expect("draw branches");
 
-        let spinner_colors: Vec<Color> = terminal
+        let indicator_colors: Vec<Color> = terminal
             .backend()
             .buffer()
             .content
             .iter()
-            .filter(|cell| matches!(cell.symbol(), "◐" | "◓" | "◑" | "◒"))
+            .filter(|cell| matches!(cell.symbol(), "◐" | "◓" | "◑" | "◒" | "●"))
             .map(|cell| cell.fg)
             .collect();
 
         assert_eq!(
-            spinner_colors,
+            indicator_colors,
             vec![Color::Cyan, Color::Yellow],
-            "spinner indicators should keep per-agent colors so multiple agents remain distinguishable"
+            "running and waiting indicators should keep per-agent colors so multiple agents remain distinguishable"
+        );
+    }
+
+    #[test]
+    fn tick_redraw_required_keeps_terminal_focus_animating_for_running_branch_indicators() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Management;
+        model.active_focus = FocusPane::Terminal;
+        model.management_tab = ManagementTab::Branches;
+        model.branches.live_session_summaries.insert(
+            "feature/test".to_string(),
+            screens::branches::BranchLiveSessionSummary {
+                indicators: vec![screens::branches::BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::Running,
+                    color: crate::model::AgentColor::Cyan,
+                }],
+            },
+        );
+
+        assert!(
+            tick_redraw_required(&model),
+            "Branches should keep redrawing while a running live-session indicator is visible, even when terminal focus owns input"
+        );
+    }
+
+    #[test]
+    fn tick_redraw_required_keeps_waiting_branch_indicators_static_under_terminal_focus() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Management;
+        model.active_focus = FocusPane::Terminal;
+        model.management_tab = ManagementTab::Branches;
+        model.branches.live_session_summaries.insert(
+            "feature/test".to_string(),
+            screens::branches::BranchLiveSessionSummary {
+                indicators: vec![screens::branches::BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::WaitingInput,
+                    color: crate::model::AgentColor::Yellow,
+                }],
+            },
+        );
+
+        assert!(
+            !tick_redraw_required(&model),
+            "waiting-only live-session indicators should stay static and must not re-enable idle redraws under terminal focus"
         );
     }
 

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, VecDeque};
 #[cfg(test)]
 use std::fs;
+use std::hash::{Hash, Hasher};
 #[cfg(test)]
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -1679,6 +1680,34 @@ fn route_key_to_initialization(model: &mut Model, key: crossterm::event::KeyEven
 ///
 /// This keeps non-terminal surfaces animated while allowing terminal-focused
 /// IME composition to proceed without idle repaints.
+fn visible_branch_live_indicator_rows(
+    model: &Model,
+) -> Vec<crate::screens::branches::VisibleBranchLiveIndicatorRow> {
+    visible_branches_list_area(model)
+        .map(|area| model.branches.visible_live_indicator_rows(area))
+        .unwrap_or_default()
+}
+
+pub fn visible_branch_live_indicator_signature(model: &Model) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for row in visible_branch_live_indicator_rows(model) {
+        row.branch_name.hash(&mut hasher);
+        for indicator in row.indicators {
+            branch_live_indicator_status_tag(indicator.status).hash(&mut hasher);
+            branch_live_indicator_color_tag(indicator.color).hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+pub fn should_render_after_tick_with_visible_branch_signature(
+    visible_branch_signature_before: u64,
+    model: &Model,
+) -> bool {
+    visible_branch_signature_before != visible_branch_live_indicator_signature(model)
+        || tick_redraw_required(model)
+}
+
 pub fn tick_redraw_required(model: &Model) -> bool {
     if model.active_focus != FocusPane::Terminal {
         return true;
@@ -1686,7 +1715,8 @@ pub fn tick_redraw_required(model: &Model) -> bool {
 
     if model.active_layer == ActiveLayer::Management
         && model.management_tab == ManagementTab::Branches
-        && model.branches.has_running_live_sessions()
+        && visible_branches_list_area(model)
+            .is_some_and(|area| model.branches.has_running_live_sessions(area))
     {
         return true;
     }
@@ -1700,6 +1730,47 @@ pub fn tick_redraw_required(model: &Model) -> bool {
             .as_ref()
             .is_some_and(|progress| progress.visible)
         || model.voice.is_active()
+}
+
+fn visible_branches_list_area(model: &Model) -> Option<Rect> {
+    if model.active_layer != ActiveLayer::Management
+        || model.management_tab != ManagementTab::Branches
+    {
+        return None;
+    }
+
+    let management = visible_management_area(model)?;
+    let top = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(management)[0];
+    let list_inner = pane_block(management_tab_title(model, top.width), false).inner(top);
+    Some(
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(list_inner)[1],
+    )
+}
+
+fn branch_live_indicator_status_tag(status: gwt_agent::AgentStatus) -> u8 {
+    match status {
+        gwt_agent::AgentStatus::Unknown => 0,
+        gwt_agent::AgentStatus::Running => 1,
+        gwt_agent::AgentStatus::WaitingInput => 2,
+        gwt_agent::AgentStatus::Stopped => 3,
+    }
+}
+
+fn branch_live_indicator_color_tag(color: crate::model::AgentColor) -> u8 {
+    match color {
+        crate::model::AgentColor::Green => 0,
+        crate::model::AgentColor::Blue => 1,
+        crate::model::AgentColor::Cyan => 2,
+        crate::model::AgentColor::Yellow => 3,
+        crate::model::AgentColor::Magenta => 4,
+        crate::model::AgentColor::Gray => 5,
+    }
 }
 
 fn route_overlay_key(model: &mut Model, key: crossterm::event::KeyEvent) -> bool {
@@ -11024,6 +11095,13 @@ mod tests {
         model.active_layer = ActiveLayer::Management;
         model.active_focus = FocusPane::Terminal;
         model.management_tab = ManagementTab::Branches;
+        model.branches.branches = vec![screens::branches::BranchItem {
+            name: "feature/test".to_string(),
+            is_head: false,
+            is_local: true,
+            category: screens::branches::BranchCategory::Feature,
+            worktree_path: Some(PathBuf::from("/tmp/wt-feature-test")),
+        }];
         model.branches.live_session_summaries.insert(
             "feature/test".to_string(),
             screens::branches::BranchLiveSessionSummary {
@@ -11046,6 +11124,13 @@ mod tests {
         model.active_layer = ActiveLayer::Management;
         model.active_focus = FocusPane::Terminal;
         model.management_tab = ManagementTab::Branches;
+        model.branches.branches = vec![screens::branches::BranchItem {
+            name: "feature/test".to_string(),
+            is_head: false,
+            is_local: true,
+            category: screens::branches::BranchCategory::Feature,
+            worktree_path: Some(PathBuf::from("/tmp/wt-feature-test")),
+        }];
         model.branches.live_session_summaries.insert(
             "feature/test".to_string(),
             screens::branches::BranchLiveSessionSummary {
@@ -11059,6 +11144,115 @@ mod tests {
         assert!(
             !tick_redraw_required(&model),
             "waiting-only live-session indicators should stay static and must not re-enable idle redraws under terminal focus"
+        );
+    }
+
+    #[test]
+    fn tick_redraw_required_ignores_filtered_out_running_branch_indicators() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Management;
+        model.active_focus = FocusPane::Terminal;
+        model.management_tab = ManagementTab::Branches;
+        model.branches.view_mode = screens::branches::ViewMode::All;
+        model.branches.branches = vec![
+            screens::branches::BranchItem {
+                name: "feature/visible".to_string(),
+                is_head: false,
+                is_local: true,
+                category: screens::branches::BranchCategory::Feature,
+                worktree_path: Some(PathBuf::from("/tmp/wt-feature-visible")),
+            },
+            screens::branches::BranchItem {
+                name: "feature/hidden".to_string(),
+                is_head: false,
+                is_local: true,
+                category: screens::branches::BranchCategory::Feature,
+                worktree_path: Some(PathBuf::from("/tmp/wt-feature-hidden")),
+            },
+        ];
+        model.branches.search_query = "visible".to_string();
+        model.branches.live_session_summaries.insert(
+            "feature/hidden".to_string(),
+            screens::branches::BranchLiveSessionSummary {
+                indicators: vec![screens::branches::BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::Running,
+                    color: crate::model::AgentColor::Blue,
+                }],
+            },
+        );
+
+        assert!(
+            !tick_redraw_required(&model),
+            "running indicators on filtered-out rows must not force idle redraws under terminal focus"
+        );
+    }
+
+    #[test]
+    fn tick_redraw_required_ignores_running_branch_indicators_without_visible_width() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Management;
+        model.active_focus = FocusPane::Terminal;
+        model.management_tab = ManagementTab::Branches;
+        model.terminal_size = (24, 8);
+        model.branches.branches = vec![screens::branches::BranchItem {
+            name: "feature/this-branch-name-is-too-wide".to_string(),
+            is_head: true,
+            is_local: true,
+            category: screens::branches::BranchCategory::Feature,
+            worktree_path: Some(PathBuf::from("/tmp/wt-feature-wide")),
+        }];
+        model.branches.live_session_summaries.insert(
+            "feature/this-branch-name-is-too-wide".to_string(),
+            screens::branches::BranchLiveSessionSummary {
+                indicators: vec![screens::branches::BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::Running,
+                    color: crate::model::AgentColor::Cyan,
+                }],
+            },
+        );
+
+        assert!(
+            !tick_redraw_required(&model),
+            "running indicators with no visible summary strip must not re-enable idle redraws"
+        );
+    }
+
+    #[test]
+    fn should_render_after_tick_repaints_visible_branch_indicator_state_changes() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Management;
+        model.active_focus = FocusPane::Terminal;
+        model.management_tab = ManagementTab::Branches;
+        model.branches.branches = vec![screens::branches::BranchItem {
+            name: "feature/test".to_string(),
+            is_head: false,
+            is_local: true,
+            category: screens::branches::BranchCategory::Feature,
+            worktree_path: Some(PathBuf::from("/tmp/wt-feature-test")),
+        }];
+        model.branches.live_session_summaries.insert(
+            "feature/test".to_string(),
+            screens::branches::BranchLiveSessionSummary {
+                indicators: vec![screens::branches::BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::Running,
+                    color: crate::model::AgentColor::Cyan,
+                }],
+            },
+        );
+        let before = visible_branch_live_indicator_signature(&model);
+        model.branches.live_session_summaries.insert(
+            "feature/test".to_string(),
+            screens::branches::BranchLiveSessionSummary {
+                indicators: vec![screens::branches::BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::WaitingInput,
+                    color: crate::model::AgentColor::Cyan,
+                }],
+            },
+        );
+
+        assert!(
+            should_render_after_tick_with_visible_branch_signature(before, &model),
+            "a visible running spinner must repaint once when it transitions to a static waiting dot"
         );
     }
 

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -720,16 +720,16 @@ fn persist_agent_session_stopped(sessions_dir: &Path, session_id: &str) {
     }
 }
 
-fn bootstrap_agent_session_running(sessions_dir: &Path, session_id: &str) {
+fn bootstrap_agent_session_waiting_input(sessions_dir: &Path, session_id: &str) {
     let runtime_path = runtime_state_path(sessions_dir, session_id);
     if runtime_path.exists() {
         return;
     }
 
-    let mut runtime = SessionRuntimeState::new(gwt_agent::AgentStatus::Running);
+    let mut runtime = SessionRuntimeState::new(gwt_agent::AgentStatus::WaitingInput);
     runtime.source_event = Some("LaunchBootstrap".to_string());
     if let Err(err) = runtime.save(&runtime_path) {
-        tracing::warn!(session_id, error = %err, "failed to bootstrap running runtime state");
+        tracing::warn!(session_id, error = %err, "failed to bootstrap waiting runtime state");
     }
 }
 
@@ -3837,7 +3837,7 @@ fn materialize_pending_launch_with(
             ),
         );
     } else {
-        bootstrap_agent_session_running(sessions_dir, &session.id);
+        bootstrap_agent_session_waiting_input(sessions_dir, &session.id);
         // Phase 8: ensure a watcher is running for this Worktree so live
         // SPEC/file edits feed the incremental indexer.
         crate::index_worker::ensure_watcher(&repo_path_for_watcher, &worktree);
@@ -11842,7 +11842,7 @@ CUSTOM_ENV = "enabled"
     }
 
     #[test]
-    fn materialize_pending_launch_with_bootstraps_running_runtime_sidecar_after_spawn() {
+    fn materialize_pending_launch_with_bootstraps_waiting_runtime_sidecar_after_spawn() {
         let dir = tempfile::tempdir().expect("temp sessions dir");
         let worktree = dir.path().join("wt-develop");
         fs::create_dir_all(&worktree).expect("create worktree");
@@ -11877,7 +11877,7 @@ CUSTOM_ENV = "enabled"
             .clone();
         let runtime = SessionRuntimeState::load(&runtime_state_path(dir.path(), &session_id))
             .expect("bootstrap runtime state");
-        assert_eq!(runtime.status, gwt_agent::AgentStatus::Running);
+        assert_eq!(runtime.status, gwt_agent::AgentStatus::WaitingInput);
         assert_eq!(runtime.source_event.as_deref(), Some("LaunchBootstrap"));
     }
 

--- a/crates/gwt-tui/src/cli/hook/runtime_state.rs
+++ b/crates/gwt-tui/src/cli/hook/runtime_state.rs
@@ -29,8 +29,8 @@ pub struct RuntimeState {
 /// [`HookError::InvalidEvent`].
 pub fn status_for_event(event: &str) -> Option<&'static str> {
     match event {
-        "SessionStart" | "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => Some("Running"),
-        "Stop" => Some("WaitingInput"),
+        "SessionStart" | "Stop" => Some("WaitingInput"),
+        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => Some("Running"),
         _ => None,
     }
 }

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -136,9 +136,14 @@ fn dispatch_post_normalized_message(
     };
 
     let was_tick = matches!(msg, Message::Tick);
+    let visible_branch_signature_before =
+        was_tick.then(|| app::visible_branch_live_indicator_signature(model));
     app::update(model, msg);
     if was_tick {
-        *needs_render |= should_render_after_tick(model);
+        *needs_render |= app::should_render_after_tick_with_visible_branch_signature(
+            visible_branch_signature_before.unwrap_or_default(),
+            model,
+        );
     } else {
         *needs_render = true;
     }
@@ -219,6 +224,7 @@ fn pty_redraw_poll_slice(now: Instant, last_draw_at: Instant) -> Duration {
     PTY_REDRAW_FRAME_INTERVAL.saturating_sub(now.saturating_duration_since(last_draw_at))
 }
 
+#[cfg(test)]
 fn should_render_after_tick(model: &Model) -> bool {
     app::tick_redraw_required(model)
 }

--- a/crates/gwt-tui/src/screens/branches.rs
+++ b/crates/gwt-tui/src/screens/branches.rs
@@ -217,6 +217,13 @@ pub struct BranchLiveSessionIndicator {
     pub color: crate::model::AgentColor,
 }
 
+/// Visible live-session indicators for a single rendered branch row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VisibleBranchLiveIndicatorRow {
+    pub(crate) branch_name: String,
+    pub(crate) indicators: Vec<BranchLiveSessionIndicator>,
+}
+
 /// Lifecycle action requested for a Docker container.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DockerLifecycleAction {
@@ -633,12 +640,57 @@ impl BranchesState {
         self.merge_spinner_tick = self.merge_spinner_tick.wrapping_add(1);
     }
 
+    /// Returns the visible live-session indicators for the currently rendered
+    /// branch rows in `area`.
+    pub(crate) fn visible_live_indicator_rows(
+        &self,
+        area: Rect,
+    ) -> Vec<VisibleBranchLiveIndicatorRow> {
+        if area.width == 0 || area.height == 0 {
+            return Vec::new();
+        }
+
+        let filtered = self.filtered_branches();
+        if filtered.is_empty() {
+            return Vec::new();
+        }
+
+        let selected = self.selected.min(filtered.len().saturating_sub(1));
+        let visible_rows = (area.height as usize).min(filtered.len());
+        let first_visible = selected.saturating_add(1).saturating_sub(visible_rows);
+
+        filtered
+            .iter()
+            .enumerate()
+            .skip(first_visible)
+            .take(visible_rows)
+            .filter_map(|(idx, branch)| {
+                let left_width = branch_row_leading_width(self, branch, idx == selected);
+                let available_width =
+                    (area.width as usize).saturating_sub(left_width.saturating_add(1));
+                let indicators = self
+                    .live_session_summaries
+                    .get(&branch.name)
+                    .into_iter()
+                    .flat_map(|summary| visible_branch_live_indicators(summary, available_width))
+                    .collect::<Vec<_>>();
+                if indicators.is_empty() {
+                    None
+                } else {
+                    Some(VisibleBranchLiveIndicatorRow {
+                        branch_name: branch.name.clone(),
+                        indicators,
+                    })
+                }
+            })
+            .collect()
+    }
+
     /// Returns true when at least one visible live-session indicator is in
     /// the animated `Running` state.
-    pub fn has_running_live_sessions(&self) -> bool {
-        self.live_session_summaries.values().any(|summary| {
-            summary
-                .indicators
+    pub fn has_running_live_sessions(&self, area: Rect) -> bool {
+        self.visible_live_indicator_rows(area).iter().any(|row| {
+            row.indicators
                 .iter()
                 .any(|indicator| indicator.status == AgentStatus::Running)
         })
@@ -972,50 +1024,7 @@ fn render_branch_list(state: &BranchesState, frame: &mut Frame, area: Rect) {
         .iter()
         .enumerate()
         .map(|(idx, branch)| {
-            let worktree_icon = if branch.worktree_path.is_some() {
-                theme::icon::WORKTREE_ACTIVE
-            } else {
-                theme::icon::WORKTREE_INACTIVE
-            };
-            let head_indicator = if branch.is_head {
-                theme::icon::HEAD_INDICATOR
-            } else {
-                ""
-            };
-            // Branch Cleanup gutter glyphs (FR-018c/d):
-            //   `●` (cyan)   — selected for cleanup
-            //   `✔` (green)  — cleanable now (merged into main or develop)
-            //   spinner      — merge detection still running
-            //   `·` (gray)   — local feature branch with unmerged commits
-            //   `–` (dim)    — protected / current HEAD / active session
-            //   ` ` (blank)  — remote-tracking branch (never a candidate)
-            let spinner_glyph = state.merge_spinner_glyph();
-            let (gutter_glyph, gutter_color) = if !branch.is_local {
-                (" ", theme::color::TEXT_DISABLED)
-            } else if state.is_cleanup_selected(&branch.name) {
-                ("\u{25CF}", theme::color::ACTIVE)
-            } else if !state.is_cleanable_candidate(&branch.name) {
-                ("\u{2013}", theme::color::TEXT_DISABLED)
-            } else {
-                match state.merge_state(&branch.name) {
-                    MergeState::Computing => (spinner_glyph, theme::color::ACTIVE),
-                    MergeState::Cleanable(_) => ("\u{2714}", theme::color::SUCCESS),
-                    MergeState::NotMerged => ("\u{00B7}", theme::color::TEXT_SECONDARY),
-                }
-            };
-
-            let mut spans = vec![
-                super::selection_prefix(idx == state.selected),
-                Span::styled(gutter_glyph, Style::default().fg(gutter_color)),
-                Span::raw(" "),
-                Span::styled(
-                    &branch.name,
-                    Style::default().fg(theme::color::TEXT_PRIMARY),
-                ),
-                Span::raw(" "),
-                Span::styled(worktree_icon, Style::default().fg(theme::color::FOCUS)),
-                Span::styled(head_indicator, Style::default().fg(theme::color::SUCCESS)),
-            ];
+            let mut spans = branch_row_leading_spans(state, branch, idx == state.selected);
             let left_width = spans_width(&spans);
             let available_summary_width = area.width as usize;
             if let Some(summary_spans) =
@@ -1050,6 +1059,65 @@ fn render_branch_list(state: &BranchesState, frame: &mut Frame, area: Rect) {
     frame.render_stateful_widget(list, area, &mut list_state);
 }
 
+fn branch_row_leading_spans<'a>(
+    state: &BranchesState,
+    branch: &'a BranchItem,
+    is_selected: bool,
+) -> Vec<Span<'a>> {
+    let worktree_icon = if branch.worktree_path.is_some() {
+        theme::icon::WORKTREE_ACTIVE
+    } else {
+        theme::icon::WORKTREE_INACTIVE
+    };
+    let head_indicator = if branch.is_head {
+        theme::icon::HEAD_INDICATOR
+    } else {
+        ""
+    };
+    // Branch Cleanup gutter glyphs (FR-018c/d):
+    //   `●` (cyan)   — selected for cleanup
+    //   `✔` (green)  — cleanable now (merged into main or develop)
+    //   spinner      — merge detection still running
+    //   `·` (gray)   — local feature branch with unmerged commits
+    //   `–` (dim)    — protected / current HEAD / active session
+    //   ` ` (blank)  — remote-tracking branch (never a candidate)
+    let spinner_glyph = state.merge_spinner_glyph();
+    let (gutter_glyph, gutter_color) = if !branch.is_local {
+        (" ", theme::color::TEXT_DISABLED)
+    } else if state.is_cleanup_selected(&branch.name) {
+        ("\u{25CF}", theme::color::ACTIVE)
+    } else if !state.is_cleanable_candidate(&branch.name) {
+        ("\u{2013}", theme::color::TEXT_DISABLED)
+    } else {
+        match state.merge_state(&branch.name) {
+            MergeState::Computing => (spinner_glyph, theme::color::ACTIVE),
+            MergeState::Cleanable(_) => ("\u{2714}", theme::color::SUCCESS),
+            MergeState::NotMerged => ("\u{00B7}", theme::color::TEXT_SECONDARY),
+        }
+    };
+
+    vec![
+        super::selection_prefix(is_selected),
+        Span::styled(gutter_glyph, Style::default().fg(gutter_color)),
+        Span::raw(" "),
+        Span::styled(
+            &branch.name,
+            Style::default().fg(theme::color::TEXT_PRIMARY),
+        ),
+        Span::raw(" "),
+        Span::styled(worktree_icon, Style::default().fg(theme::color::FOCUS)),
+        Span::styled(head_indicator, Style::default().fg(theme::color::SUCCESS)),
+    ]
+}
+
+fn branch_row_leading_width(
+    state: &BranchesState,
+    branch: &BranchItem,
+    is_selected: bool,
+) -> usize {
+    spans_width(&branch_row_leading_spans(state, branch, is_selected))
+}
+
 fn build_branch_live_summary(
     summary: &BranchLiveSessionSummary,
     animation_tick: usize,
@@ -1059,8 +1127,7 @@ fn build_branch_live_summary(
         return None;
     }
 
-    let visible_indicators = summary.indicators.iter().take(available_width);
-    let spans: Vec<Span<'static>> = visible_indicators
+    let spans: Vec<Span<'static>> = visible_branch_live_indicators(summary, available_width)
         .filter_map(|indicator| {
             let glyph = branch_live_indicator_glyph(indicator.status, animation_tick)?;
             Some(Span::styled(
@@ -1075,6 +1142,18 @@ fn build_branch_live_summary(
     } else {
         Some(spans)
     }
+}
+
+fn visible_branch_live_indicators(
+    summary: &BranchLiveSessionSummary,
+    available_width: usize,
+) -> impl Iterator<Item = BranchLiveSessionIndicator> + '_ {
+    summary
+        .indicators
+        .iter()
+        .take(available_width)
+        .filter(|indicator| branch_live_indicator_glyph(indicator.status, 0).is_some())
+        .copied()
 }
 
 fn branch_live_indicator_glyph(status: AgentStatus, animation_tick: usize) -> Option<char> {
@@ -2310,6 +2389,73 @@ mod tests {
         assert!(
             lines.iter().any(|line| line.contains("feature/narrow")),
             "narrow rows should preserve the branch label even if the spinner strip must disappear"
+        );
+    }
+
+    #[test]
+    fn visible_live_indicator_rows_ignore_filtered_out_running_branches() {
+        let mut state = BranchesState::default();
+        state.view_mode = ViewMode::All;
+        state.branches = vec![
+            BranchItem {
+                name: "feature/visible".to_string(),
+                is_head: false,
+                is_local: true,
+                category: BranchCategory::Feature,
+                worktree_path: Some(PathBuf::from("/tmp/wt-feature-visible")),
+            },
+            BranchItem {
+                name: "feature/hidden".to_string(),
+                is_head: false,
+                is_local: true,
+                category: BranchCategory::Feature,
+                worktree_path: Some(PathBuf::from("/tmp/wt-feature-hidden")),
+            },
+        ];
+        state.search_query = "visible".to_string();
+        state.live_session_summaries.insert(
+            "feature/hidden".to_string(),
+            BranchLiveSessionSummary {
+                indicators: vec![BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::Running,
+                    color: crate::model::AgentColor::Blue,
+                }],
+            },
+        );
+
+        let rows = state.visible_live_indicator_rows(Rect::new(0, 0, 80, 4));
+
+        assert!(
+            rows.is_empty(),
+            "filtered-out branches must not keep the tick redraw gate open"
+        );
+    }
+
+    #[test]
+    fn visible_live_indicator_rows_ignore_running_summaries_without_renderable_width() {
+        let mut state = BranchesState::default();
+        state.branches = vec![BranchItem {
+            name: "feature/this-branch-name-is-too-wide".to_string(),
+            is_head: true,
+            is_local: true,
+            category: BranchCategory::Feature,
+            worktree_path: Some(PathBuf::from("/tmp/wt-feature-wide")),
+        }];
+        state.live_session_summaries.insert(
+            "feature/this-branch-name-is-too-wide".to_string(),
+            BranchLiveSessionSummary {
+                indicators: vec![BranchLiveSessionIndicator {
+                    status: gwt_agent::AgentStatus::Running,
+                    color: crate::model::AgentColor::Cyan,
+                }],
+            },
+        );
+
+        let rows = state.visible_live_indicator_rows(Rect::new(0, 0, 24, 1));
+
+        assert!(
+            rows.is_empty(),
+            "rows that cannot render even one live indicator must not count as visible animation"
         );
     }
 

--- a/crates/gwt-tui/src/screens/branches.rs
+++ b/crates/gwt-tui/src/screens/branches.rs
@@ -633,6 +633,17 @@ impl BranchesState {
         self.merge_spinner_tick = self.merge_spinner_tick.wrapping_add(1);
     }
 
+    /// Returns true when at least one visible live-session indicator is in
+    /// the animated `Running` state.
+    pub fn has_running_live_sessions(&self) -> bool {
+        self.live_session_summaries.values().any(|summary| {
+            summary
+                .indicators
+                .iter()
+                .any(|indicator| indicator.status == AgentStatus::Running)
+        })
+    }
+
     /// Current spinner glyph for the `⋯` gutter slot. Cycles through a
     /// short Braille pattern so the gutter visibly animates while merge
     /// detection is running.
@@ -1048,14 +1059,14 @@ fn build_branch_live_summary(
         return None;
     }
 
-    let spinner = running_spinner_frame(animation_tick);
     let visible_indicators = summary.indicators.iter().take(available_width);
     let spans: Vec<Span<'static>> = visible_indicators
-        .map(|indicator| {
-            Span::styled(
-                spinner.to_string(),
+        .filter_map(|indicator| {
+            let glyph = branch_live_indicator_glyph(indicator.status, animation_tick)?;
+            Some(Span::styled(
+                glyph.to_string(),
                 Style::default().fg(branch_live_indicator_color(indicator.color)),
-            )
+            ))
         })
         .collect();
 
@@ -1063,6 +1074,14 @@ fn build_branch_live_summary(
         None
     } else {
         Some(spans)
+    }
+}
+
+fn branch_live_indicator_glyph(status: AgentStatus, animation_tick: usize) -> Option<char> {
+    match status {
+        AgentStatus::Running => Some(running_spinner_frame(animation_tick)),
+        AgentStatus::WaitingInput => Some('●'),
+        AgentStatus::Unknown | AgentStatus::Stopped => None,
     }
 }
 
@@ -2250,9 +2269,12 @@ mod tests {
         let lines = buffer_to_lines(terminal.backend().buffer());
         assert!(
             lines.iter().any(|line| line.contains("feature/wait"))
-                && lines.iter().any(|line| line.contains("◐"))
+                && lines.iter().any(|line| line.contains("●"))
+                && !lines
+                    .iter()
+                    .any(|line| line.contains("◐") || line.contains("◓") || line.contains("◑") || line.contains("◒"))
                 && !lines.iter().any(|line| line.contains(" wait ")),
-            "waiting rows should keep a spinner-only indicator instead of a textual wait label"
+            "waiting rows should stay visible with a static dot indicator instead of an animated spinner or textual wait label"
         );
     }
 

--- a/crates/gwt-tui/tests/hook_runtime_state_test.rs
+++ b/crates/gwt-tui/tests/hook_runtime_state_test.rs
@@ -4,8 +4,8 @@
 //! JSON file at `$GWT_SESSION_RUNTIME_PATH` that the Branches tab polls to
 //! render per-session status badges. This test pins:
 //!
-//! - the event → status mapping (`PreToolUse` → `Running`, `Stop` →
-//!   `WaitingInput`),
+//! - the event → status mapping (`SessionStart`/`Stop` → `WaitingInput`,
+//!   `PreToolUse` → `Running`),
 //! - that writes are crash-safe (no `.tmp-*` residue after success),
 //! - that the active-file is rewritten, not appended, on repeat calls,
 //! - that unknown events surface as `HookError::InvalidEvent`,
@@ -46,6 +46,19 @@ fn write_for_event_stop_maps_to_waiting_input() {
     let state: RuntimeState = serde_json::from_str(&raw).unwrap();
     assert_eq!(state.status, "WaitingInput");
     assert_eq!(state.source_event, "Stop");
+}
+
+#[test]
+fn write_for_event_session_start_maps_to_waiting_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("runtime-state.json");
+
+    runtime_state::write_for_event(&path, "SessionStart").expect("write should succeed");
+
+    let raw = fs::read_to_string(&path).unwrap();
+    let state: RuntimeState = serde_json::from_str(&raw).unwrap();
+    assert_eq!(state.status, "WaitingInput");
+    assert_eq!(state.source_event, "SessionStart");
 }
 
 #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,28 @@
 # Lessons Learned
 
+## 2026-04-10 — fix: terminal-focus redraw gate は raw summary 全体ではなく visible surface と tick 前後差分で判定する
+
+### 事象
+
+Branches の live session indicator で、filter/search で見えていない branch や
+summary strip が表示できない狭い row に `Running` session があるだけで
+terminal focus 中の idle redraw が復活した。
+さらに visible な spinner が `Running -> WaitingInput` に変わる tick で、
+最後の 1 回の repaint が落ちて古い spinner が残り得た。
+
+### 原因
+
+- redraw gate が `live_session_summaries` 全体を見ており、
+  実際に描画中の branch row / summary width / viewport を反映していなかった。
+- tick 後の `needs_render` 判定が post-update state だけを見ていたため、
+  `Running` が消えた tick 自体は redraw 不要と誤判定した。
+
+### 再発防止策
+
+1. redraw suppression / animation gate は backing store 全体ではなく、実際に render される visible surface から計算する。
+2. tick-driven animation が static state や hidden state に切り替わる UI は、post-tick の要否だけでなく pre/post の visible snapshot 差分で final repaint を保証する。
+3. render と gate で幅計算や visibility 判定を二重実装しない。少なくとも同じ helper を通して narrow-row / filtered-row の挙動を揃える。
+
 ## 2026-04-10 — fix: `SessionStart` は「起動した」だけで `Running` とみなさない
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,26 @@
 # Lessons Learned
 
+## 2026-04-10 — fix: `SessionStart` は「起動した」だけで `Running` とみなさない
+
+### 事象
+
+Branches の live session indicator で、agent を起動した直後まだ入力待ちのはずなのに
+spinner が回り続けて見えた。
+
+### 原因
+
+- launch bootstrap が runtime sidecar を `Running` で初期化していた。
+- hook state mapping でも `SessionStart` を `Running` にしており、
+  実行中イベントと待機イベントの境界を誤っていた。
+- そのため、ユーザー入力も tool 実行も始まっていない session でも
+  `WaitingInput` ではなく `Running` として Branches に表示されていた。
+
+### 再発防止策
+
+1. hook event を state に写像するときは、`session started` と `work started` を同一視しない。
+2. launch bootstrap が必要でも、初期状態は「見えてほしい state」にするのであって、「最初に困らない animation state」に寄せない。
+3. live indicator の仕様変更では、launch 直後の bootstrap、hook の `SessionStart`、実行中の `Pre/PostToolUse` を別々に RED テストで固定する。
+
 ## 2026-04-09 — fix: `tracing_appender::rolling::daily` の日付境界は思い込みで local 扱いしない
 
 ### 事象


### PR DESCRIPTION
## Summary
- make Branches live-session indicators animate only for `Running` sessions
- keep `WaitingInput` sessions visible as static dots with per-agent colors
- keep idle redraw suppressed under terminal focus unless the visible Branches strip still has a running indicator

## Changes
- update `Branches` live indicator rendering to choose glyphs by runtime state
- add a Branches helper for detecting visible running indicators
- gate tick redraw on `Management + Branches + visible running indicator` instead of all live-session states
- add focused tests for waiting-dot rendering, mixed running/waiting rows, and redraw gating
- refresh SPEC-1920 US-8 / FR-006q / Phase 67 artifacts to match the new contract

## Testing
- `cargo test -p gwt-core -p gwt-tui`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `cargo build -p gwt-tui`

## Closing Issues
- None

## Related Issues
- Related: #1920

## Checklist
- [x] Tests added or updated for the behavior change
- [x] SPEC artifacts updated to match the implemented behavior
- [x] Branch pushed to GitHub
- [ ] Manual UX verification in a live TUI session
  - Not run in this CLI session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session state initialization to properly display "waiting for input" status instead of incorrectly showing "running"
  * Improved live indicator rendering accuracy and visual feedback in the branches management view
  * Enhanced worktree path resolution with automatic fallback selection when preferred paths are already occupied
  * Refined UI redraw logic for proper state synchronization with live sessions in branches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->