### PR TITLE
feat(wizard): add Claude effort and refresh reasoning UI

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -395,6 +395,12 @@ impl AgentLaunchBuilder {
             args.push("--model".to_string());
             args.push(model.clone());
         }
+
+        if let Some(ref level) = self.reasoning_level {
+            if level != "auto" {
+                env_vars.insert("CLAUDE_CODE_EFFORT_LEVEL".to_string(), level.clone());
+            }
+        }
     }
 
     fn build_codex_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
@@ -594,6 +600,31 @@ mod tests {
         assert!(config
             .args
             .contains(&"claude-sonnet-4-20250514".to_string()));
+    }
+
+    #[test]
+    fn build_claude_with_auto_reasoning_does_not_export_effort_env() {
+        let config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .reasoning_level("auto")
+            .build();
+
+        assert_eq!(config.reasoning_level.as_deref(), Some("auto"));
+        assert!(!config.env_vars.contains_key("CLAUDE_CODE_EFFORT_LEVEL"));
+        assert!(!config.args.contains(&"--effort".to_string()));
+    }
+
+    #[test]
+    fn build_claude_with_reasoning_level_exports_effort_env() {
+        let config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .reasoning_level("high")
+            .build();
+
+        assert_eq!(config.reasoning_level.as_deref(), Some("high"));
+        assert_eq!(
+            config.env_vars.get("CLAUDE_CODE_EFFORT_LEVEL"),
+            Some(&"high".to_string())
+        );
+        assert!(!config.args.contains(&"--effort".to_string()));
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3600,8 +3600,8 @@ fn build_launch_config_from_wizard_with_custom_agents(
         builder = builder.version(&wizard.version);
     }
 
-    if !wizard.reasoning.is_empty() && wizard.reasoning != "medium" {
-        builder = builder.reasoning_level(&wizard.reasoning);
+    if let Some(reasoning_level) = wizard_reasoning_level_for_launch(wizard) {
+        builder = builder.reasoning_level(reasoning_level);
     }
 
     if wizard.agent_id == "codex" && wizard.codex_fast_mode {
@@ -3622,11 +3622,7 @@ fn build_launch_config_from_wizard_with_custom_agents(
         builder = builder.resume_session_id(resume_session_id);
     }
 
-    let mut config = builder.build();
-    if wizard.agent_id == "codex" && !wizard.reasoning.is_empty() {
-        config.reasoning_level = Some(wizard.reasoning.clone());
-    }
-    config
+    builder.build()
 }
 
 fn build_custom_launch_config_from_wizard(
@@ -3695,6 +3691,22 @@ fn build_custom_launch_config_from_wizard(
 
 fn is_explicit_model_selection(model: &str) -> bool {
     !model.is_empty() && !model.starts_with("Default")
+}
+
+fn wizard_reasoning_level_for_launch(wizard: &screens::wizard::WizardState) -> Option<&str> {
+    match wizard.agent_id.as_str() {
+        "codex" if !wizard.reasoning.is_empty() => Some(wizard.reasoning.as_str()),
+        "claude"
+            if !wizard.reasoning.is_empty()
+                && matches!(
+                    wizard.model.as_str(),
+                    "Default (Opus 4.6)" | "opus" | "sonnet"
+                ) =>
+        {
+            Some(wizard.reasoning.as_str())
+        }
+        _ => None,
+    }
 }
 
 fn wizard_launch_base_branch(wizard: &screens::wizard::WizardState) -> Option<String> {
@@ -11354,6 +11366,39 @@ CUSTOM_ENV = "enabled"
         assert!(!config
             .args
             .contains(&"--dangerously-skip-permissions".to_string()));
+    }
+
+    #[test]
+    fn build_launch_config_from_wizard_claude_effort_auto_persists_without_env() {
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            model: "opus".to_string(),
+            reasoning: "auto".to_string(),
+            ..Default::default()
+        };
+
+        let config = build_launch_config_from_wizard(&wizard);
+
+        assert_eq!(config.reasoning_level.as_deref(), Some("auto"));
+        assert!(!config.env_vars.contains_key("CLAUDE_CODE_EFFORT_LEVEL"));
+    }
+
+    #[test]
+    fn build_launch_config_from_wizard_claude_effort_high_exports_env() {
+        let wizard = screens::wizard::WizardState {
+            agent_id: "claude".to_string(),
+            model: "opus".to_string(),
+            reasoning: "high".to_string(),
+            ..Default::default()
+        };
+
+        let config = build_launch_config_from_wizard(&wizard);
+
+        assert_eq!(config.reasoning_level.as_deref(), Some("high"));
+        assert_eq!(
+            config.env_vars.get("CLAUDE_CODE_EFFORT_LEVEL"),
+            Some(&"high".to_string())
+        );
     }
 
     // SPEC-6 Phase 5: `append_agent_launch_log_with` and its redaction

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -54,6 +54,20 @@ impl WizardStep {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudeModelFamily {
+    Opus,
+    Sonnet,
+    Haiku,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReasoningStepKind {
+    None,
+    Codex,
+    ClaudeEffort { max_available: bool },
+}
+
 /// Determine the next step based on current step and wizard context.
 ///
 /// Restores the old branch-first flow:
@@ -84,7 +98,7 @@ fn next_step(current: WizardStep, state: &WizardState) -> Option<WizardStep> {
             }
         }
         WizardStep::ModelSelect => {
-            if state.agent_is_codex() {
+            if state.agent_uses_reasoning_step() {
                 Some(WizardStep::ReasoningLevel)
             } else if state.agent_has_npm_package() {
                 Some(WizardStep::VersionSelect)
@@ -159,7 +173,7 @@ fn prev_step(current: WizardStep, state: &WizardState) -> Option<WizardStep> {
         WizardStep::ModelSelect => Some(WizardStep::AgentSelect),
         WizardStep::ReasoningLevel => Some(WizardStep::ModelSelect),
         WizardStep::VersionSelect => {
-            if state.agent_is_codex() {
+            if state.agent_uses_reasoning_step() {
                 Some(WizardStep::ReasoningLevel)
             } else if state.agent_has_models() {
                 Some(WizardStep::ModelSelect)
@@ -170,7 +184,7 @@ fn prev_step(current: WizardStep, state: &WizardState) -> Option<WizardStep> {
         WizardStep::ExecutionMode => {
             if state.agent_has_npm_package() {
                 Some(WizardStep::VersionSelect)
-            } else if state.agent_is_codex() {
+            } else if state.agent_uses_reasoning_step() {
                 Some(WizardStep::ReasoningLevel)
             } else if state.agent_has_models() {
                 Some(WizardStep::ModelSelect)
@@ -371,7 +385,7 @@ impl Default for WizardState {
             ai_enabled: false,
             agent_id: String::new(),
             model: String::new(),
-            reasoning: "medium".to_string(),
+            reasoning: String::new(),
             version: String::new(),
             version_options: Vec::new(),
             mode: "normal".to_string(),
@@ -452,6 +466,8 @@ impl WizardState {
         }
         if let Some(reasoning) = entry.reasoning {
             self.reasoning = reasoning;
+        } else if entry.agent_id == "claude" {
+            self.reasoning = "auto".to_string();
         }
         if let Some(version) = entry.version {
             self.version = version;
@@ -461,6 +477,7 @@ impl WizardState {
         if !self.agent_is_codex() {
             self.codex_fast_mode = false;
         }
+        self.sync_reasoning_state();
 
         match action {
             QuickStartAction::ResumeWithPrevious => {
@@ -586,6 +603,72 @@ impl WizardState {
         if !self.agent_is_codex() {
             self.codex_fast_mode = false;
         }
+        self.sync_reasoning_state();
+    }
+
+    fn reasoning_step_kind(&self) -> ReasoningStepKind {
+        if self.agent_is_codex() {
+            return ReasoningStepKind::Codex;
+        }
+
+        if self.effective_agent_id() != "claude" {
+            return ReasoningStepKind::None;
+        }
+
+        match claude_model_family(&self.model) {
+            Some(ClaudeModelFamily::Opus) => ReasoningStepKind::ClaudeEffort {
+                max_available: true,
+            },
+            Some(ClaudeModelFamily::Sonnet) => ReasoningStepKind::ClaudeEffort {
+                max_available: false,
+            },
+            _ => ReasoningStepKind::None,
+        }
+    }
+
+    pub fn agent_uses_reasoning_step(&self) -> bool {
+        !matches!(self.reasoning_step_kind(), ReasoningStepKind::None)
+    }
+
+    fn current_reasoning_options(&self) -> &'static [ReasoningDisplayOption] {
+        match self.reasoning_step_kind() {
+            ReasoningStepKind::Codex => &CODEX_REASONING_DISPLAY_OPTIONS,
+            ReasoningStepKind::ClaudeEffort {
+                max_available: true,
+            } => &CLAUDE_OPUS_EFFORT_DISPLAY_OPTIONS,
+            ReasoningStepKind::ClaudeEffort {
+                max_available: false,
+            } => &CLAUDE_SONNET_EFFORT_DISPLAY_OPTIONS,
+            ReasoningStepKind::None => &[],
+        }
+    }
+
+    fn current_reasoning_value(&self) -> Option<&str> {
+        let value = self.reasoning.as_str();
+        if value.is_empty() {
+            return None;
+        }
+        self.current_reasoning_options()
+            .iter()
+            .find(|option| option.stored_value == value)
+            .map(|option| option.stored_value)
+    }
+
+    fn sync_reasoning_state(&mut self) {
+        if self.current_reasoning_value().is_none() {
+            self.reasoning.clear();
+        }
+    }
+
+    fn reasoning_title(&self) -> String {
+        let model = reasoning_title_model(self);
+        match self.reasoning_step_kind() {
+            ReasoningStepKind::Codex => format!("Select Reasoning Level for {model}"),
+            ReasoningStepKind::ClaudeEffort { .. } => {
+                format!("Select Effort Level for {model}")
+            }
+            ReasoningStepKind::None => WizardStep::ReasoningLevel.title().to_string(),
+        }
     }
 
     /// Number of selectable options for the current step.
@@ -595,7 +678,7 @@ impl WizardState {
             WizardStep::BranchAction => 2, // existing branch / create new branch
             WizardStep::AgentSelect => self.detected_agents.len().max(1),
             WizardStep::ModelSelect => self.current_model_options().len(),
-            WizardStep::ReasoningLevel => 4, // low, medium, high, xhigh
+            WizardStep::ReasoningLevel => self.current_reasoning_options().len(),
             WizardStep::VersionSelect => self.version_options.len().max(1),
             WizardStep::ExecutionMode => 4, // normal, continue, resume, convert
             WizardStep::ConvertAgentSelect => self.convert_source_agents.len().max(1),
@@ -621,7 +704,11 @@ impl WizardState {
     pub fn current_static_options(&self) -> Vec<&'static str> {
         match self.step {
             WizardStep::BranchAction => vec!["Use selected branch", "Create new from selected"],
-            WizardStep::ReasoningLevel => vec!["Low", "Medium", "High", "XHigh"],
+            WizardStep::ReasoningLevel => self
+                .current_reasoning_options()
+                .iter()
+                .map(|option| option.label)
+                .collect(),
             WizardStep::ExecutionMode => vec!["Normal", "Continue", "Resume", "Convert"],
             WizardStep::BranchTypeSelect => vec!["feature/", "bugfix/", "hotfix/", "release/"],
             WizardStep::SkipPermissions => vec!["Yes", "No"],
@@ -906,6 +993,7 @@ pub fn update(state: &mut WizardState, msg: WizardMessage) {
 
 fn step_default_selection(step: WizardStep, state: &WizardState) -> usize {
     match step {
+        WizardStep::ReasoningLevel => reasoning_default_selection(state),
         WizardStep::SkipPermissions => usize::from(!state.skip_perms),
         WizardStep::CodexFastMode => usize::from(!state.codex_fast_mode),
         _ => 0,
@@ -963,8 +1051,8 @@ fn apply_selection(state: &mut WizardState) {
             state.sync_selected_agent_options();
         }
         WizardStep::ReasoningLevel => {
-            if let Some(opt) = options.get(state.selected) {
-                state.reasoning = opt.to_lowercase();
+            if let Some(opt) = state.current_reasoning_options().get(state.selected) {
+                state.reasoning = opt.stored_value.to_string();
             }
         }
         WizardStep::VersionSelect => {
@@ -1122,7 +1210,7 @@ const CLAUDE_MODEL_DISPLAY_OPTIONS: [ModelDisplayOption; 4] = [
         description: "Most capable for complex work",
     },
     ModelDisplayOption {
-        label: "Sonnet 4.5",
+        label: "Sonnet 4.6",
         description: "Best for everyday tasks",
     },
     ModelDisplayOption {
@@ -1197,11 +1285,79 @@ const GEMINI_MODEL_DISPLAY_OPTIONS: [ModelDisplayOption; 6] = [
     },
 ];
 
-const REASONING_DISPLAY_OPTIONS: [(&str, &str); 4] = [
-    ("Low", "Faster, less thorough"),
-    ("Medium", "Balanced"),
-    ("High", "Slower, more thorough"),
-    ("XHigh", "Extended high reasoning"),
+#[derive(Clone, Copy)]
+struct ReasoningDisplayOption {
+    label: &'static str,
+    stored_value: &'static str,
+    description: &'static str,
+    is_default: bool,
+}
+
+const CLAUDE_OPUS_EFFORT_DISPLAY_OPTIONS: [ReasoningDisplayOption; 5] = [
+    ReasoningDisplayOption {
+        label: "Auto",
+        stored_value: "auto",
+        description: "Let the model decide how deeply to think",
+        is_default: false,
+    },
+    ReasoningDisplayOption {
+        label: "Low",
+        stored_value: "low",
+        description: "Fast, cheap responses for simple renames, greps, and quick questions",
+        is_default: false,
+    },
+    ReasoningDisplayOption {
+        label: "Medium",
+        stored_value: "medium",
+        description: "Balanced reasoning for everyday agentic coding and tool-heavy work",
+        is_default: true,
+    },
+    ReasoningDisplayOption {
+        label: "High",
+        stored_value: "high",
+        description: "Deeper reasoning for complex problems",
+        is_default: false,
+    },
+    ReasoningDisplayOption {
+        label: "Max",
+        stored_value: "max",
+        description: "Deepest reasoning with no token-spending constraint",
+        is_default: false,
+    },
+];
+
+const CLAUDE_SONNET_EFFORT_DISPLAY_OPTIONS: [ReasoningDisplayOption; 4] = [
+    CLAUDE_OPUS_EFFORT_DISPLAY_OPTIONS[0],
+    CLAUDE_OPUS_EFFORT_DISPLAY_OPTIONS[1],
+    CLAUDE_OPUS_EFFORT_DISPLAY_OPTIONS[2],
+    CLAUDE_OPUS_EFFORT_DISPLAY_OPTIONS[3],
+];
+
+const CODEX_REASONING_DISPLAY_OPTIONS: [ReasoningDisplayOption; 4] = [
+    ReasoningDisplayOption {
+        label: "Low",
+        stored_value: "low",
+        description: "Fast responses with lighter reasoning",
+        is_default: false,
+    },
+    ReasoningDisplayOption {
+        label: "Medium",
+        stored_value: "medium",
+        description: "Balances speed and reasoning depth for everyday tasks",
+        is_default: true,
+    },
+    ReasoningDisplayOption {
+        label: "High",
+        stored_value: "high",
+        description: "Greater reasoning depth for complex problems",
+        is_default: false,
+    },
+    ReasoningDisplayOption {
+        label: "Extra high",
+        stored_value: "xhigh",
+        description: "Extra high reasoning depth for complex problems",
+        is_default: false,
+    },
 ];
 
 const EXECUTION_MODE_DISPLAY_OPTIONS: [(&str, &str); 4] = [
@@ -1228,6 +1384,56 @@ fn model_display_options(agent_id: &str) -> &'static [ModelDisplayOption] {
         "gemini" => &GEMINI_MODEL_DISPLAY_OPTIONS,
         _ => &[],
     }
+}
+
+fn claude_model_family(model: &str) -> Option<ClaudeModelFamily> {
+    match model {
+        "Default (Opus 4.6)" | "opus" => Some(ClaudeModelFamily::Opus),
+        "sonnet" => Some(ClaudeModelFamily::Sonnet),
+        "haiku" => Some(ClaudeModelFamily::Haiku),
+        _ => None,
+    }
+}
+
+fn reasoning_title_model(state: &WizardState) -> &str {
+    match claude_model_family(&state.model) {
+        Some(ClaudeModelFamily::Opus) => "opus",
+        Some(ClaudeModelFamily::Sonnet) => "sonnet",
+        Some(ClaudeModelFamily::Haiku) => "haiku",
+        None if state.model.is_empty() => "model",
+        None => state.model.as_str(),
+    }
+}
+
+fn reasoning_label(option: &ReasoningDisplayOption, is_current: bool) -> String {
+    let mut label = option.label.to_string();
+    if option.is_default {
+        label.push_str(" (default)");
+    }
+    if is_current {
+        label.push_str(" (current)");
+    }
+    label
+}
+
+fn reasoning_default_selection(state: &WizardState) -> usize {
+    if let Some(value) = state.current_reasoning_value() {
+        return state
+            .current_reasoning_options()
+            .iter()
+            .position(|option| option.stored_value == value)
+            .unwrap_or(0);
+    }
+
+    state
+        .current_reasoning_options()
+        .iter()
+        .position(|option| match state.reasoning_step_kind() {
+            ReasoningStepKind::Codex => option.stored_value == "medium",
+            ReasoningStepKind::ClaudeEffort { .. } => option.stored_value == "low",
+            ReasoningStepKind::None => false,
+        })
+        .unwrap_or(0)
 }
 
 fn truncate_with_ellipsis(text: &str, max_width: usize) -> String {
@@ -1360,12 +1566,30 @@ fn render_model_step(state: &WizardState, frame: &mut Frame, area: Rect) {
 
 fn render_reasoning_level_step(state: &WizardState, frame: &mut Frame, area: Rect) {
     let available_width = area.width as usize;
-    let items = REASONING_DISPLAY_OPTIONS
+    let label_width = state
+        .current_reasoning_options()
         .iter()
         .enumerate()
-        .map(|(idx, (label, description))| {
+        .map(|(idx, option)| {
+            reasoning_label(option, idx == state.selected)
+                .chars()
+                .count()
+        })
+        .max()
+        .unwrap_or(10);
+    let items = state
+        .current_reasoning_options()
+        .iter()
+        .enumerate()
+        .map(|(idx, option)| {
             let marker = if idx == state.selected { "> " } else { "  " };
-            let text = format_fixed_width_line(marker, label, description, 10, available_width);
+            let text = format_fixed_width_line(
+                marker,
+                &reasoning_label(option, idx == state.selected),
+                option.description,
+                label_width,
+                available_width,
+            );
             ListItem::new(text).style(wizard_row_style(idx == state.selected))
         })
         .collect();
@@ -1564,8 +1788,17 @@ fn wizard_popup_width(state: &WizardState, max_width: u16) -> u16 {
             }
         }
         WizardStep::ReasoningLevel => {
-            for &(label, desc) in &REASONING_DISPLAY_OPTIONS {
-                max_line = max_line.max(2 + 10.max(label.len()) + 1 + desc.len());
+            let label_width = state
+                .current_reasoning_options()
+                .iter()
+                .enumerate()
+                .map(|(idx, option)| reasoning_label(option, idx == state.selected).len())
+                .max()
+                .unwrap_or(10);
+            for (idx, option) in state.current_reasoning_options().iter().enumerate() {
+                let label = reasoning_label(option, idx == state.selected);
+                max_line =
+                    max_line.max(2 + label_width.max(label.len()) + 1 + option.description.len());
             }
         }
         WizardStep::SkipPermissions => {
@@ -1616,6 +1849,8 @@ fn popup_title(state: &WizardState) -> String {
             state.step.title(),
             quick_start_title_summary(&state.quick_start_entries[0])
         )
+    } else if state.step == WizardStep::ReasoningLevel {
+        state.reasoning_title()
     } else {
         state.step.title().to_string()
     }
@@ -2152,21 +2387,38 @@ mod tests {
     }
 
     #[test]
-    fn step_transitions_claude_skips_reasoning() {
+    fn step_transitions_claude_opus_includes_reasoning() {
         let mut state = WizardState::default();
         state.agent_id = "claude".to_string();
-        // Claude: AgentSelect → ModelSelect → VersionSelect → ExecutionMode
+        state.model = "opus".to_string();
+        // Claude Opus: AgentSelect → ModelSelect → ReasoningLevel → VersionSelect → ExecutionMode
         assert_eq!(
             next_step(WizardStep::AgentSelect, &state),
             Some(WizardStep::ModelSelect)
         );
         assert_eq!(
             next_step(WizardStep::ModelSelect, &state),
+            Some(WizardStep::ReasoningLevel)
+        );
+        assert_eq!(
+            next_step(WizardStep::ReasoningLevel, &state),
             Some(WizardStep::VersionSelect)
         );
         assert_eq!(
             next_step(WizardStep::VersionSelect, &state),
             Some(WizardStep::ExecutionMode)
+        );
+    }
+
+    #[test]
+    fn step_transitions_claude_haiku_skips_reasoning() {
+        let mut state = WizardState::default();
+        state.agent_id = "claude".to_string();
+        state.model = "haiku".to_string();
+
+        assert_eq!(
+            next_step(WizardStep::ModelSelect, &state),
+            Some(WizardStep::VersionSelect)
         );
     }
 
@@ -2487,6 +2739,7 @@ mod tests {
         state.agent_id = "claude".to_string();
         state.detected_agents = sample_agents();
         state.step = WizardStep::ModelSelect;
+        state.selected = 3;
 
         update(&mut state, WizardMessage::Select);
 
@@ -2499,6 +2752,22 @@ mod tests {
                 "1.0.53".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn selecting_claude_haiku_clears_staged_effort() {
+        let mut state = WizardState::default();
+        state.agent_id = "claude".to_string();
+        state.detected_agents = sample_agents();
+        state.step = WizardStep::ModelSelect;
+        state.reasoning = "high".to_string();
+        state.selected = 3;
+
+        update(&mut state, WizardMessage::Select);
+
+        assert_eq!(state.model, "haiku");
+        assert!(state.reasoning.is_empty());
+        assert_eq!(state.step, WizardStep::VersionSelect);
     }
 
     #[test]
@@ -2605,6 +2874,22 @@ mod tests {
         assert_eq!(state.resume_session_id.as_deref(), Some("sess-12345678"));
         assert!(state.skip_perms);
         assert!(state.codex_fast_mode);
+    }
+
+    #[test]
+    fn select_on_quick_start_without_reasoning_treats_legacy_claude_entry_as_auto() {
+        let mut state = WizardState::default();
+        state.step = WizardStep::QuickStart;
+        state.has_quick_start = true;
+        state.quick_start_entries = sample_quick_start_entries();
+        state.detected_agents = sample_agents();
+        state.selected = 2;
+
+        update(&mut state, WizardMessage::Select);
+
+        assert_eq!(state.agent_id, "claude");
+        assert_eq!(state.model, "sonnet");
+        assert_eq!(state.reasoning, "auto");
     }
 
     #[test]
@@ -3269,7 +3554,7 @@ mod tests {
         assert!(text.contains("Select Model"));
         assert!(text.contains("Default (recommended) - Opus 4.6 - Most capable for complex work"));
         assert!(text.contains("> Opus 4.6 - Most capable for complex work"));
-        assert!(text.contains("  Sonnet 4.5 - Best for everyday tasks"));
+        assert!(text.contains("  Sonnet 4.6 - Best for everyday tasks"));
         assert!(text.contains("  Haiku 4.5 - Fastest for quick answers"));
         assert!(text.contains("[Enter] Select  [Esc] Back  [Up/Down] Navigate"));
     }
@@ -3382,19 +3667,53 @@ mod tests {
     }
 
     #[test]
-    fn render_reasoning_step_shows_fixed_width_old_tui_layout() {
+    fn render_codex_reasoning_step_shows_model_title_and_refreshed_labels() {
         let mut state = WizardState::default();
         state.step = WizardStep::ReasoningLevel;
         state.agent_id = "codex".to_string();
+        state.model = "gpt-5.4".to_string();
         state.selected = 2;
 
         let text = render_text(&state, 90, 24);
 
-        assert!(text.contains("Reasoning Level"));
-        assert!(text.contains("  Low        Faster, less thorough"));
-        assert!(text.contains("  Medium     Balanced"));
-        assert!(text.contains("> High       Slower, more thorough"));
-        assert!(text.contains("  XHigh      Extended high reasoning"));
+        assert!(text.contains("Select Reasoning Level for gpt-5.4"));
+        assert!(text.contains("Low"));
+        assert!(text.contains("Fast responses with lighter reasoning"));
+        assert!(text.contains("Medium (default)"));
+        assert!(text.contains("> High"));
+        assert!(text.contains("Extra high"));
+    }
+
+    #[test]
+    fn render_claude_effort_step_uses_effort_title_and_opus_rows() {
+        let mut state = WizardState::default();
+        state.step = WizardStep::ReasoningLevel;
+        state.agent_id = "claude".to_string();
+        state.model = "opus".to_string();
+        state.selected = 1;
+
+        let text = render_text(&state, 120, 24);
+
+        assert!(text.contains("Select Effort Level for opus"));
+        assert!(text.contains("Auto"));
+        assert!(text.contains("> Low"));
+        assert!(text.contains("Medium (default)"));
+        assert!(text.contains("High"));
+        assert!(text.contains("Max"));
+    }
+
+    #[test]
+    fn render_claude_effort_step_hides_max_for_sonnet() {
+        let mut state = WizardState::default();
+        state.step = WizardStep::ReasoningLevel;
+        state.agent_id = "claude".to_string();
+        state.model = "sonnet".to_string();
+        state.selected = 1;
+
+        let text = render_text(&state, 120, 24);
+
+        assert!(text.contains("Select Effort Level for sonnet"));
+        assert!(!text.contains("Max"));
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,31 @@
 # Lessons Learned
 
+## 2026-04-10 — spec: 旧 GitHub-backed SPEC を更新する前に `gwt issue spec --section` / `repair` の健全性を先に確認する
+
+### 事象
+
+SPEC 更新作業で `#1930` を `gwt issue spec 1930 --section spec` と
+`gwt issue spec repair 1930` で扱おうとしたところ、どちらも
+`body parse error: malformed marker: nested BEGIN for 'spec' inside 'tasks'`
+で失敗した。
+
+### 原因
+
+- 旧 GitHub-backed SPEC の artifact 配置が current parser の前提とずれており、
+  section 読み取り前提の CLI 経路自体が壊れていた。
+- 「既に GitHub Issue 化されている SPEC なら `gwt issue spec` で必ず
+  section 単位に読める」と思い込んで更新フローを組み立てた。
+
+### 再発防止策
+
+1. 旧 SPEC の更新前に `gwt issue spec <n> --section spec` と
+   `gwt issue spec repair <n>` の smoke check を先に実行し、section parser
+   が生きていることを確認する。
+2. parser が壊れている legacy SPEC は、無理に section CLI に載せず、
+   raw issue body / comment を直接更新する暫定経路へ切り替える。
+3. 暫定経路を使った場合は、後続で artifact format 自体を repair する
+   follow-up を SPEC / tasks に明記し、同じ壊れ方を放置しない。
+
 ## 2026-04-09 — fix: `tracing_appender::rolling::daily` の日付境界は思い込みで local 扱いしない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Add Claude Code effort selection to the launch wizard so `opus` and `sonnet` launches can persist `CLAUDE_CODE_EFFORT_LEVEL` without using `--effort`.
- Refresh the Codex `ReasoningLevel` step to match the current CLI labels and annotations while preserving launch-side token mapping.
- Sync the GitHub-backed SPEC for #1921 and record the legacy SPEC parser lesson discovered during implementation.

## Changes

- `crates/gwt-tui/src/screens/wizard.rs`: make `ReasoningLevel` agent-aware, add Claude effort rows and Codex refreshed labels, normalize Claude model gating to `opus` / `sonnet`, and restore legacy Claude Quick Start entries as `Auto`.
- `crates/gwt-tui/src/app.rs`: pass reasoning selections to launch only for supported agents/models and add focused launch-config coverage for Claude effort persistence.
- `crates/gwt-agent/src/launch.rs`: export `CLAUDE_CODE_EFFORT_LEVEL` for non-`auto` Claude launches and keep Codex reasoning mapped through `model_reasoning_effort`.
- `tasks/lessons.md`: record the lesson about smoke-checking legacy GitHub-backed SPEC section parsing before editing.

## Testing

- [x] `cargo test -p gwt-agent -p gwt-tui` — pass
- [x] `cargo build -p gwt-tui` — pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — pass
- [x] `cargo fmt -- --check` — pass
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — pass

## Closing Issues

- None

## Related Issues / Links

- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — README was not updated in this PR; the behavior change is captured in the GitHub-backed SPEC for #1921.
- [x] Migration/backfill plan included (if schema/data change) — no schema/data migration is required; legacy Claude Quick Start entries fall back to `Auto` in code.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- #1921 still had `US-10` / `US-11` marked `NOT IMPLEMENTED` even though this branch was intended to land the Claude effort flow and Codex reasoning UI refresh.
- The implementation keeps Claude capability detection alias-based (`opus` / `sonnet`) instead of introducing full model IDs into persistence, and it treats legacy Claude `reasoning_level=None` as `Auto` for backward compatibility.

## Risk / Impact

- **Affected areas**: Launch Agent wizard flow, Quick Start restoration, Claude PTY environment injection, Codex reasoning label rendering.
- **Rollback plan**: Revert this PR to restore the previous Codex-only reasoning step behavior and remove Claude effort env injection.

## Notes

- The branch also records a lessons entry from the SPEC sync work so future updates to legacy GitHub-backed SPECs start with a section-read smoke check.
