### PR TITLE
fix(renderer): order wide trailing clears before redraw

### DIFF
--- a/crates/gwt-tui/src/renderer.rs
+++ b/crates/gwt-tui/src/renderer.rs
@@ -360,6 +360,7 @@ fn normalize_selection(selection: TerminalSelection) -> (TerminalCell, TerminalC
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::buffer::Cell;
 
     #[test]
     fn map_vt_color_default() {
@@ -707,6 +708,28 @@ mod tests {
                 .iter()
                 .any(|(x, y, cell)| (*x, *y, cell.symbol()) == (2, 0, " ")),
             "wide CJK glyph redraw should explicitly clear the trailing cell so full-screen updates do not leave stale text behind",
+        );
+    }
+
+    #[test]
+    fn render_vt_screen_orders_trailing_clear_before_wide_glyph_redraw() {
+        let area = Rect::new(0, 0, 3, 1);
+        let mut previous = Buffer::empty(area);
+        previous.set_string(0, 0, "abc", Style::default());
+
+        let mut parser = vt100::Parser::new(1, 3, 0);
+        parser.process("aあ".as_bytes());
+        let mut next = previous.clone();
+        render_vt_screen(parser.screen(), &mut next, area);
+
+        let updates = previous.diff(&next);
+        assert_eq!(
+            updates,
+            [
+                (2, 0, &Cell::new(" ")),
+                (1, 0, &Cell::new("あ")),
+            ],
+            "wide glyph redraws should clear the trailing cell before redrawing the visible glyph so terminal backends do not leave a visual gap",
         );
     }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,27 @@
 # Lessons Learned
 
+## 2026-04-10 — fix: wide glyph の trailing clear は「出すか」だけでなく「順序」まで固定する
+
+### 事象
+
+wide glyph redraw で stale trailing text を防ぐために trailing clear を追加したが、
+crossterm backend では `wide glyph -> trailing blank` の順で `Print` され、
+一時的な余分な空白が表示された。マウス選択で glyph が再描画されると見た目だけ
+正常化した。
+
+### 原因
+
+- `ratatui-core::Buffer::diff` が wide glyph の visible cell を先に、trailing clear を
+  後に emit していた。
+- `ratatui-crossterm` backend は diff をそのまま cursor move + `Print` に変換するため、
+  blank 後描きがそのまま視覚アーティファクトになった。
+
+### 再発防止策
+
+1. wide glyph の redraw 回帰では「trailing clear があること」だけでなく、「clear が visible glyph より前に出ること」を diff レベルでテストに固定する。
+2. backend 依存の表示不具合では buffer equality だけで完了扱いせず、diff の update 順と backend の print 順まで追う。
+3. 「選択や hover で正常化する」症状は redraw 順序不正のシグナルとして扱い、overlay 側の見た目修正で済ませない。
+
 ## 2026-04-10 — fix: wide glyph の見切れは renderer だけでなく backend diff の trailing clear まで確認する
 
 ### 事象

--- a/vendor/ratatui-core/src/buffer/buffer.rs
+++ b/vendor/ratatui-core/src/buffer/buffer.rs
@@ -499,14 +499,12 @@ impl Buffer {
         let mut to_skip: usize = 0;
         for (i, (current, previous)) in next_buffer.iter().zip(previous_buffer.iter()).enumerate() {
             if !current.skip && (current != previous || invalidated > 0) && to_skip == 0 {
-                let (x, y) = self.pos_of(i);
-                updates.push((x, y, &next_buffer[i]));
-
                 // If the current cell is multi-width, ensure the trailing cells are explicitly
                 // cleared when they previously contained non-blank content. Some terminals do not
                 // reliably clear the trailing cell(s) when printing a wide grapheme, which can
-                // result in visual artifacts (e.g., leftover characters). Emitting an explicit
-                // update for the trailing cells avoids this.
+                // result in visual artifacts (e.g., leftover characters). Emit those clears
+                // before reprinting the visible glyph so backends that translate the diff stream
+                // directly into cursor moves + prints do not leave a blank trailing cell behind.
                 let symbol = current.symbol();
                 let cell_width = symbol.width();
                 // Some terminals also leave stale text behind for standard wide glyphs
@@ -523,7 +521,7 @@ impl Buffer {
                         let next_trailing = &next_buffer[j];
                         if !next_trailing.skip && prev_trailing != next_trailing {
                             let (tx, ty) = self.pos_of(j);
-                            // Push an explicit update for the trailing cell.
+                            // Push an explicit update for the trailing cell first.
                             // This is expected to be a blank cell, but we use the actual
                             // content from the next buffer to handle cases where
                             // the user has explicitly set something else.
@@ -531,6 +529,9 @@ impl Buffer {
                         }
                     }
                 }
+
+                let (x, y) = self.pos_of(i);
+                updates.push((x, y, &next_buffer[i]));
             }
 
             to_skip = current.symbol().width().saturating_sub(1);
@@ -1364,6 +1365,24 @@ mod tests {
         assert!(
             diff.iter()
                 .any(|(x, y, c)| *x == 1 && *y == 0 && c.symbol() == " ")
+        );
+    }
+
+    #[test]
+    fn diff_orders_trailing_clear_before_wide_grapheme_redraw() {
+        let prev = Buffer::with_lines(["ab"]);
+
+        let mut next = Buffer::with_lines(["  "]);
+        next.set_string(0, 0, "界", Style::new());
+
+        let diff = prev.diff(&next);
+        assert_eq!(
+            diff,
+            [
+                (1, 0, &Cell::new(" ")),
+                (0, 0, &Cell::new("界")),
+            ],
+            "trailing clear must be emitted before the visible wide glyph so crossterm backends do not overdraw a blank after printing the glyph",
         );
     }
 }


### PR DESCRIPTION
## Summary

- Reorder wide-glyph trailing clears so terminal backends clear stale trailing cells before redrawing the visible glyph, which prevents transient blank gaps in Codex agent panes.
- Add redraw-order regression coverage through the shared renderer path so selection-triggered redraws are no longer needed to visually normalize wide-character rows.

## Changes

- `vendor/ratatui-core/src/buffer/buffer.rs`: emit trailing-cell clear updates before the visible multi-width glyph update in `Buffer::diff`, and add a diff-order regression test.
- `crates/gwt-tui/src/renderer.rs`: add an integration-style renderer regression test that asserts the wide-glyph redraw order through `previous.diff(&next)`.
- `tasks/lessons.md`: record the trailing-clear ordering lesson so future wide-glyph fixes verify diff/update order, not only buffer contents.

## Testing

- [x] `cargo test -p gwt-tui render_vt_screen_ -- --nocapture` — renderer wide-glyph regression tests pass.
- [x] `cargo test -p gwt-core -p gwt-tui` — full Rust test suites pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes.
- [x] `cargo fmt -- --check` — formatting check passes.
- [x] `cargo build -p gwt-tui` — workspace target builds successfully.

## Closing Issues

- None

## Related Issues / Links

- #1919
- https://github.com/akiojin/gwt/pull/1956

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — Not needed; this is a renderer/backend diff regression with no README or CLI contract change.
- [ ] Migration/backfill plan included (if schema/data change) — Not needed; no schema or persisted data changed.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- A prior follow-up to #1956 fixed stale trailing text for wide glyph redraws, but the diff stream still emitted `visible glyph -> trailing blank`. `ratatui-crossterm` prints updates in-order, so that sequence could leave a transient blank gap that disappeared only after a later redraw such as mouse selection.

## Risk / Impact

- **Affected areas**: terminal renderer redraw ordering for multi-width glyphs in `ratatui-core` consumers.
- **Rollback plan**: Revert `fix: ワイド文字 trailing clear の描画順を修正する` if downstream terminal regressions appear.

## Notes

- `cargo test -p gwt-core -p gwt-tui` flaked once on pre-existing timing-sensitive tests, but the same full suite passed on immediate standalone re-run and the three flaky tests also passed individually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a visual rendering issue where wide characters (such as CJK glyphs) would display transient extra whitespace during redraw operations. Updates now occur in the correct order to eliminate visual artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->