### PR TITLE
fix(issues): scope issue and spec cache by repository

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -124,7 +124,7 @@ idle な 100 ms tick では TUI を再描画しないため、バックグラウ
   TUI は Worktree ごとにファイルシステム watcher を常駐させ、Issue 索引は起動時に
   15 分 TTL で非同期リフレッシュします。初回検索時に `intfloat/multilingual-e5-base`
   埋め込みモデル (約 440MB) を `~/.cache/huggingface/` にダウンロードします。
-  SPEC は `gwt-spec` ラベル付き GitHub Issue として格納され、`~/.gwt/cache/issues/` に
+  SPEC は `gwt-spec` ラベル付き GitHub Issue として格納され、`~/.gwt/cache/issues/<repo-hash>/` に
   キャッシュされます。読み取りは `gwt issue spec <n>`、書き込みは
   `gwt issue spec <n> --edit <section> -f <file>` を使用してください。
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ shell output are not delayed until the next keypress.
   (15-minute TTL) at startup. The first search after a fresh install downloads the
   `intfloat/multilingual-e5-base` embedding model (~440 MB) into `~/.cache/huggingface/`.
   SPECs live as GitHub Issues labeled `gwt-spec` and are cached locally at
-  `~/.gwt/cache/issues/`; use `gwt issue spec <n>` to read and `gwt issue spec <n> --edit <section> -f <file>` to write.
+  `~/.gwt/cache/issues/<repo-hash>/`; use `gwt issue spec <n>` to read and `gwt issue spec <n> --edit <section> -f <file>` to write.
 
 ### GitHub Token (PAT) requirements
 

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -1657,6 +1657,50 @@ def _parse_iso(value: str) -> Optional[datetime.datetime]:
         return None
 
 
+def _issue_cache_root(repo_hash: str) -> Path:
+    return Path.home() / ".gwt" / "cache" / "issues" / repo_hash
+
+
+def _load_cached_issue_documents(repo_hash: str) -> List[Dict[str, Any]]:
+    root = _issue_cache_root(repo_hash)
+    if not root.is_dir():
+        return []
+
+    issues: List[Dict[str, Any]] = []
+    for entry in sorted(root.iterdir(), key=lambda item: item.name):
+        if not entry.is_dir():
+            continue
+        try:
+            number = int(entry.name)
+        except ValueError:
+            continue
+        meta_path = entry / "meta.json"
+        body_path = entry / "body.md"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError, ValueError):
+            continue
+        try:
+            body = body_path.read_text() if body_path.is_file() else ""
+        except OSError:
+            body = ""
+        labels = meta.get("labels", [])
+        if isinstance(labels, str):
+            labels = [labels]
+        issues.append(
+            {
+                "number": number,
+                "title": meta.get("title", ""),
+                "body": body[:2000],
+                "state": meta.get("state", ""),
+                "labels": [label for label in labels if isinstance(label, str)],
+            }
+        )
+    return issues
+
+
 def action_index_issues_v2(
     repo_hash: str,
     project_root: str,
@@ -1699,32 +1743,7 @@ def action_index_issues_v2(
     )
 
     with acquire_lock(db_path, exclusive=True):
-        try:
-            result = subprocess.run(
-                [
-                    "gh", "issue", "list",
-                    "--state", "all",
-                    "--limit", "200",
-                    "--json", "number,title,body,labels,state,url",
-                ],
-                cwd=str(Path(project_root).resolve()),
-                capture_output=True,
-                encoding="utf-8",
-                check=True,
-            )
-            issues = json.loads(result.stdout) if result.stdout else []
-        except subprocess.CalledProcessError as exc:
-            return {
-                "ok": False,
-                "error_code": "RUNTIME_ERROR",
-                "error": f"gh issue list failed: {(exc.stderr or '').strip()}",
-            }
-        except (json.JSONDecodeError, ValueError) as exc:
-            return {
-                "ok": False,
-                "error_code": "RUNTIME_ERROR",
-                "error": f"Failed to parse gh output: {exc}",
-            }
+        issues = _load_cached_issue_documents(repo_hash)
 
         client, collection = _make_chroma_collection(db_path, V2_ISSUES_COLLECTION)
         try:
@@ -1741,17 +1760,16 @@ def action_index_issues_v2(
             for issue in issues:
                 number = issue.get("number", 0)
                 title = issue.get("title", "")
-                body = (issue.get("body") or "")[:2000]
+                body = issue.get("body", "")
                 state = issue.get("state", "")
-                url = issue.get("url", "")
-                labels = [lbl.get("name", "") for lbl in issue.get("labels", [])]
+                labels = issue.get("labels", [])
                 ids.append(str(number))
                 documents.append(f"{title}\n{body}")
                 metadatas.append(
                     {
                         "number": number,
                         "title": title,
-                        "url": url,
+                        "url": "",
                         "state": state,
                         "labels": ",".join(labels),
                     }

--- a/crates/gwt-core/runtime/tests/test_issue_ttl.py
+++ b/crates/gwt-core/runtime/tests/test_issue_ttl.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -18,30 +19,30 @@ import chroma_index_runner as runner
 
 
 class IssueTtlTests(unittest.TestCase):
-    def _fake_gh_issue_list(self, *args, **kwargs):
-        # subprocess.run mock returning a fake gh issue list result
-        result = mock.MagicMock()
-        result.returncode = 0
-        result.stdout = json.dumps(
-            [
+    def _write_cached_issue(self, root: Path, number: int, title: str, body: str, labels):
+        issue = root / str(number)
+        issue.mkdir(parents=True, exist_ok=True)
+        (issue / "meta.json").write_text(
+            json.dumps(
                 {
-                    "number": 1,
-                    "title": "First issue",
-                    "body": "Body of issue 1",
-                    "labels": [{"name": "bug"}],
-                    "state": "OPEN",
-                    "url": "https://github.com/example/repo/issues/1",
+                    "number": number,
+                    "title": title,
+                    "labels": labels,
+                    "state": "open",
+                    "updated_at": "2026-04-13T00:00:00Z",
+                    "comment_ids": [],
                 }
-            ]
+            )
         )
-        result.stderr = ""
-        return result
+        (issue / "body.md").write_text(body)
 
     def test_index_issues_v2_writes_meta_last_full_refresh(self):
         with tempfile.TemporaryDirectory() as tmp:
             db_root = Path(tmp) / "index_root"
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(cache_root, 1, "First issue", "Body of issue 1", ["bug"])
 
-            with mock.patch("subprocess.run", side_effect=self._fake_gh_issue_list):
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
                 result = runner.action_index_issues_v2(
                     repo_hash="abc1234567890def",
                     project_root=tmp,
@@ -104,7 +105,7 @@ class IssueTtlTests(unittest.TestCase):
                 )
             )
 
-            with mock.patch("subprocess.run", side_effect=self._fake_gh_issue_list) as gh:
+            with mock.patch("subprocess.run") as gh:
                 result = runner.action_index_issues_v2(
                     repo_hash="abc1234567890def",
                     project_root=tmp,
@@ -121,6 +122,14 @@ class IssueTtlTests(unittest.TestCase):
             db_root = Path(tmp) / "index_root"
             issues = db_root / "abc1234567890def" / "issues"
             issues.mkdir(parents=True)
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(
+                cache_root,
+                1,
+                "First issue",
+                "Body of issue 1",
+                ["bug"],
+            )
             now = datetime.datetime.now(datetime.timezone.utc)
             stale = now - datetime.timedelta(minutes=20)
             (issues / "meta.json").write_text(
@@ -133,17 +142,45 @@ class IssueTtlTests(unittest.TestCase):
                 )
             )
 
-            with mock.patch("subprocess.run", side_effect=self._fake_gh_issue_list) as gh:
-                result = runner.action_index_issues_v2(
-                    repo_hash="abc1234567890def",
-                    project_root=tmp,
-                    db_root=db_root,
-                    respect_ttl=True,
-                )
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                with mock.patch("subprocess.run") as gh:
+                    result = runner.action_index_issues_v2(
+                        repo_hash="abc1234567890def",
+                        project_root=tmp,
+                        db_root=db_root,
+                        respect_ttl=True,
+                    )
 
             self.assertTrue(result["ok"], result)
             self.assertFalse(result.get("skipped"))
-            gh.assert_called()
+            gh.assert_not_called()
+
+    def test_index_issues_v2_reads_repo_scoped_issue_cache_without_gh(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_root = Path(tmp) / "index_root"
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(
+                cache_root,
+                1776,
+                "Launch Agent issue linkage",
+                "Body from cache",
+                ["ux"],
+            )
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                with mock.patch("subprocess.run") as gh:
+                    result = runner.action_index_issues_v2(
+                        repo_hash="abc1234567890def",
+                        project_root=tmp,
+                        db_root=db_root,
+                        respect_ttl=False,
+                    )
+
+            self.assertTrue(result["ok"], result)
+            self.assertFalse(
+                any(call.args and call.args[0] == "gh" for call in gh.call_args_list),
+                gh.call_args_list,
+            )
 
 
 if __name__ == "__main__":

--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -6,7 +6,7 @@
 //! `pull`-like commands.
 //!
 //! Filesystem layout (rooted at a configurable directory, typically
-//! `~/.gwt/cache/issues/`):
+//! `~/.gwt/cache/issues/<repo-hash>/`):
 //!
 //! ```text
 //! <root>/

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -1251,7 +1251,23 @@ where
 {
     schedule_startup_version_cache_refresh();
     let has_git_remote = repo_has_git_remote(&model.repo_path);
-    reload_cached_issues(model);
+    let issue_cache_root = default_issue_cache_root(&model.repo_path);
+    if let Err(err) = crate::issue_cache::sync_issue_cache_from_remote_if_missing(
+        &model.repo_path,
+        &issue_cache_root,
+    ) {
+        tracing::warn!("startup issue cache sync failed: {err}");
+    }
+    reload_cached_issues_with_paths(
+        model,
+        issue_cache_root.clone(),
+        default_issue_linkage_store_path(&model.repo_path),
+    );
+    model.specs.cache_root = issue_cache_root.clone();
+    model.specs.reload_from_cache();
+    if !issue_cache_root.exists() {
+        model.specs.last_error = None;
+    }
 
     // -- Branches --
     if let Ok(branches) = gwt_git::branch::list_branches(&model.repo_path) {
@@ -3199,7 +3215,7 @@ fn route_key_to_management(model: &mut Model, key: crossterm::event::KeyEvent) {
         }
         ManagementTab::Specs => {
             // SPEC-12 Phase 9: Specs tab is cache-only. `r` triggers a
-            // local cache reload from `~/.gwt/cache/issues/`.
+            // local cache reload from `~/.gwt/cache/issues/<repo-hash>/`.
             match key.code {
                 KeyCode::Char('r') => {
                     model.specs.reload_from_cache();
@@ -6314,7 +6330,7 @@ fn open_wizard_with_prefill(
             Some(issue_number),
             detected_agents,
             &cache,
-            default_issue_cache_root(),
+            default_issue_cache_root(&model.repo_path),
         )
     } else {
         prepare_wizard_startup(&model.repo_path, spec_context, detected_agents, &cache)
@@ -6722,7 +6738,7 @@ fn prepare_wizard_startup(
         None,
         detected_agents,
         cache,
-        default_issue_cache_root(),
+        default_issue_cache_root(repo_path),
     )
 }
 
@@ -6895,12 +6911,8 @@ struct IssueBranchLinkStore {
     branches: HashMap<String, u64>,
 }
 
-fn default_issue_cache_root() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".gwt")
-        .join("cache")
-        .join("issues")
+fn default_issue_cache_root(repo_path: &std::path::Path) -> PathBuf {
+    crate::issue_cache::issue_cache_root_for_repo_path_or_detached(repo_path)
 }
 
 fn default_issue_linkage_store_path(repo_path: &std::path::Path) -> Option<PathBuf> {
@@ -6916,7 +6928,7 @@ fn handle_issues_message(model: &mut Model, msg: screens::issues::IssuesMessage)
     handle_issues_message_with_paths(
         model,
         msg,
-        default_issue_cache_root(),
+        default_issue_cache_root(&model.repo_path),
         default_issue_linkage_store_path(&model.repo_path),
     );
 }
@@ -6938,7 +6950,7 @@ fn handle_issues_message_with_paths(
 fn reload_cached_issues(model: &mut Model) {
     reload_cached_issues_with_paths(
         model,
-        default_issue_cache_root(),
+        default_issue_cache_root(&model.repo_path),
         default_issue_linkage_store_path(&model.repo_path),
     );
 }
@@ -14441,6 +14453,28 @@ services:
         fs::write(dir.join("body.md"), body).expect("write issue cache body");
     }
 
+    fn write_cached_spec(
+        root: &std::path::Path,
+        number: u64,
+        title: &str,
+        state: gwt_github::IssueState,
+        labels: &[&str],
+    ) {
+        gwt_github::Cache::new(root.to_path_buf())
+            .write_snapshot(&gwt_github::client::IssueSnapshot {
+                number: gwt_github::IssueNumber(number),
+                title: title.to_string(),
+                body: format!(
+                    "<!-- gwt-spec id={number} version=1 -->\n<!-- sections:\nspec=body\n-->\n<!-- artifact:spec BEGIN -->\nbody\n<!-- artifact:spec END -->\n"
+                ),
+                labels: labels.iter().map(|label| label.to_string()).collect(),
+                state,
+                updated_at: gwt_github::UpdatedAt::new("2026-04-12T00:00:00Z"),
+                comments: vec![],
+            })
+            .expect("write cached spec");
+    }
+
     #[test]
     fn prepare_wizard_startup_loads_cached_issues_and_prefills_selected_issue() {
         let cache = VersionCache::new();
@@ -19945,10 +19979,24 @@ services:
     #[test]
     fn route_key_to_management_issues_refresh_reloads_issue_cache() {
         with_temp_home(|home| {
-            let issue_cache_root = home.join(".gwt").join("cache").join("issues");
+            let repo_url = "https://github.com/example/repo.git";
+            let issue_cache_root = home
+                .join(".gwt")
+                .join("cache")
+                .join("issues")
+                .join(gwt_core::repo_hash::compute_repo_hash(repo_url).as_str());
             write_issue_cache_meta(&issue_cache_root, 42, "Fix login bug", "open", &["bug"]);
 
-            let mut model = test_model();
+            let dir = tempfile::tempdir().expect("temp repo");
+            init_git_repo(dir.path());
+            let add_remote = std::process::Command::new("git")
+                .args(["remote", "add", "origin", repo_url])
+                .current_dir(dir.path())
+                .output()
+                .expect("add github remote");
+            assert!(add_remote.status.success(), "git remote add failed");
+
+            let mut model = Model::new(dir.path().to_path_buf());
             model.management_tab = ManagementTab::Issues;
             model.issues.last_error = Some("stale".to_string());
 
@@ -19990,7 +20038,17 @@ services:
     #[test]
     fn load_initial_data_populates_issues_from_issue_cache() {
         with_temp_home(|home| {
-            let issue_cache_root = home.join(".gwt").join("cache").join("issues");
+            let repo_url = "https://github.com/example/repo.git";
+            let repo_hash = gwt_core::repo_hash::compute_repo_hash(repo_url);
+            let issue_cache_root = home
+                .join(".gwt")
+                .join("cache")
+                .join("issues")
+                .join(repo_hash.as_str());
+            let other_cache_root = home.join(".gwt").join("cache").join("issues").join(
+                gwt_core::repo_hash::compute_repo_hash("https://github.com/example/other.git")
+                    .as_str(),
+            );
             write_issue_cache_meta(
                 &issue_cache_root,
                 1776,
@@ -19998,9 +20056,16 @@ services:
                 "open",
                 &["ux"],
             );
+            write_issue_cache_meta(&other_cache_root, 42, "Other repo issue", "open", &["bug"]);
 
             let dir = tempfile::tempdir().expect("temp repo");
             init_git_repo(dir.path());
+            let add_remote = std::process::Command::new("git")
+                .args(["remote", "add", "origin", repo_url])
+                .current_dir(dir.path())
+                .output()
+                .expect("add github remote");
+            assert!(add_remote.status.success(), "git remote add failed");
 
             let mut model = Model::new(dir.path().to_path_buf());
             load_initial_data_with(&mut model, |_| Ok(None), |_| Ok(vec![]));
@@ -20008,6 +20073,91 @@ services:
             assert_eq!(model.issues.issues.len(), 1);
             assert_eq!(model.issues.issues[0].number, 1776);
             assert!(model.issues.last_error.is_none());
+        });
+    }
+
+    #[test]
+    fn load_initial_data_syncs_repo_scoped_issue_cache_when_missing() {
+        with_temp_home(|_home| {
+            let dir = tempfile::tempdir().expect("temp repo");
+            init_git_repo(dir.path());
+            let add_remote = std::process::Command::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/example/repo.git",
+                ])
+                .current_dir(dir.path())
+                .output()
+                .expect("add github remote");
+            assert!(add_remote.status.success(), "git remote add failed");
+
+            let script = r#"#!/bin/sh
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  printf '[{"number":1776,"title":"Launch Agent issue linkage","body":"Body from startup sync","labels":[{"name":"ux"}],"state":"OPEN","url":"https://github.com/example/repo/issues/1776","updatedAt":"2026-04-13T00:00:00Z"}]'
+  exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+"#;
+
+            with_fake_gh(script, || {
+                let mut model = Model::new(dir.path().to_path_buf());
+                load_initial_data_with(&mut model, |_| Ok(None), |_| Ok(vec![]));
+
+                assert_eq!(model.issues.issues.len(), 1);
+                assert_eq!(model.issues.issues[0].number, 1776);
+                assert_eq!(model.issues.issues[0].title, "Launch Agent issue linkage");
+                assert_eq!(model.issues.issues[0].body, "Body from startup sync");
+            });
+        });
+    }
+
+    #[test]
+    fn model_new_loads_specs_from_repo_scoped_cache_only() {
+        with_temp_home(|home| {
+            let repo_url = "https://github.com/example/specs.git";
+            let repo_hash = gwt_core::repo_hash::compute_repo_hash(repo_url);
+            let relevant_root = home
+                .join(".gwt")
+                .join("cache")
+                .join("issues")
+                .join(repo_hash.as_str());
+            let other_root = home.join(".gwt").join("cache").join("issues").join(
+                gwt_core::repo_hash::compute_repo_hash(
+                    "https://github.com/example/other-specs.git",
+                )
+                .as_str(),
+            );
+            write_cached_spec(
+                &relevant_root,
+                1776,
+                "Current repo spec",
+                gwt_github::IssueState::Open,
+                &["gwt-spec", "phase/draft"],
+            );
+            write_cached_spec(
+                &other_root,
+                42,
+                "Other repo spec",
+                gwt_github::IssueState::Open,
+                &["gwt-spec", "phase/draft"],
+            );
+
+            let dir = tempfile::tempdir().expect("temp repo");
+            init_git_repo(dir.path());
+            let add_remote = std::process::Command::new("git")
+                .args(["remote", "add", "origin", repo_url])
+                .current_dir(dir.path())
+                .output()
+                .expect("add github remote");
+            assert!(add_remote.status.success(), "git remote add failed");
+
+            let model = Model::new(dir.path().to_path_buf());
+            assert_eq!(model.specs.items.len(), 1);
+            assert_eq!(model.specs.items[0].number, 1776);
+            assert_eq!(model.specs.items[0].title, "Current repo spec");
         });
     }
 

--- a/crates/gwt-tui/src/cli/env.rs
+++ b/crates/gwt-tui/src/cli/env.rs
@@ -142,7 +142,8 @@ impl DefaultCliEnv {
         repo_path: PathBuf,
     ) -> Result<Self, gwt_github::client::ApiError> {
         let client = HttpIssueClient::from_gh_auth(owner, repo)?;
-        let cache_root = Self::default_cache_root();
+        let cache_root = crate::issue_cache::issue_cache_root_for_repo_path(&repo_path)
+            .unwrap_or_else(|| crate::issue_cache::issue_cache_root_for_repo_slug(owner, repo));
         Ok(DefaultCliEnv {
             client,
             cache_root,
@@ -169,21 +170,13 @@ impl DefaultCliEnv {
         let client = HttpIssueClient::with_transport(transport, String::new(), "", "");
         Ok(DefaultCliEnv {
             client,
-            cache_root: Self::default_cache_root(),
+            cache_root: crate::issue_cache::detached_issue_cache_root(),
             repo_path: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             owner: String::new(),
             repo: String::new(),
             stdout: io::stdout(),
             stderr: io::stderr(),
         })
-    }
-
-    fn default_cache_root() -> PathBuf {
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".gwt")
-            .join("cache")
-            .join("issues")
     }
 }
 

--- a/crates/gwt-tui/src/cli/hook/block_bash_policy.rs
+++ b/crates/gwt-tui/src/cli/hook/block_bash_policy.rs
@@ -76,7 +76,7 @@ fn github_issue_block_decision(command: &str) -> BlockDecision {
 Recommended alternatives:\n\
 - read: `gwt issue view <number>`, `gwt issue comments <number>`, `gwt issue linked-prs <number>`\n\
 - write: `gwt issue create --title ... -f <file>`, `gwt issue comment <number> -f <file>`\n\
-- discovery: `gwt-search`, `~/.gwt/cache/issues/`\n\n\
+- discovery: `gwt-search`, `~/.gwt/cache/issues/<repo-hash>/`\n\n\
 Blocked command: {command}"
         ),
     )

--- a/crates/gwt-tui/src/index_worker.rs
+++ b/crates/gwt-tui/src/index_worker.rs
@@ -169,8 +169,8 @@ type ScopeMask = u8;
 const SCOPE_FILES: ScopeMask = 1 << 0;
 const SCOPE_FILES_DOCS: ScopeMask = 1 << 1;
 // SPEC-12: SCOPE_SPECS removed. SPECs are now GitHub Issues cached at
-// ~/.gwt/cache/issues/ and indexed through the Issue search scope, not
-// the local specs/ directory watcher.
+// ~/.gwt/cache/issues/<repo-hash>/ and indexed through the Issue search
+// scope, not the local specs/ directory watcher.
 const SCOPE_ALL: ScopeMask = SCOPE_FILES | SCOPE_FILES_DOCS;
 
 const DOC_FILE_EXTENSIONS: &[&str] = &["md", "mdx", "rst", "adoc", "txt"];

--- a/crates/gwt-tui/src/issue_cache.rs
+++ b/crates/gwt-tui/src/issue_cache.rs
@@ -1,0 +1,198 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use gwt_core::{
+    paths::gwt_cache_dir,
+    repo_hash::{compute_repo_hash, RepoHash},
+};
+use gwt_github::{client::IssueSnapshot, Cache, IssueNumber, IssueState, UpdatedAt};
+use serde_json::Value;
+
+const DETACHED_REPO_CACHE_DIR: &str = "__detached__";
+
+pub(crate) fn issue_cache_base_root() -> PathBuf {
+    gwt_cache_dir().join("issues")
+}
+
+pub(crate) fn detached_issue_cache_root() -> PathBuf {
+    issue_cache_base_root().join(DETACHED_REPO_CACHE_DIR)
+}
+
+pub(crate) fn issue_cache_root_for_repo_hash(repo_hash: &RepoHash) -> PathBuf {
+    issue_cache_base_root().join(repo_hash.as_str())
+}
+
+pub(crate) fn issue_cache_root_for_repo_slug(owner: &str, repo: &str) -> PathBuf {
+    let remote = format!("https://github.com/{owner}/{repo}.git");
+    issue_cache_root_for_repo_hash(&compute_repo_hash(&remote))
+}
+
+pub(crate) fn issue_cache_root_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
+    crate::index_worker::detect_repo_hash(repo_path)
+        .map(|repo_hash| issue_cache_root_for_repo_hash(&repo_hash))
+}
+
+pub(crate) fn issue_cache_root_for_repo_path_or_detached(repo_path: &Path) -> PathBuf {
+    issue_cache_root_for_repo_path(repo_path).unwrap_or_else(detached_issue_cache_root)
+}
+
+pub(crate) fn sync_issue_cache_from_remote_if_missing(
+    repo_path: &Path,
+    cache_root: &Path,
+) -> Result<(), String> {
+    if issue_cache_has_entries(cache_root) {
+        return Ok(());
+    }
+    if issue_cache_root_for_repo_path(repo_path).is_none() {
+        return Ok(());
+    }
+
+    let snapshots = fetch_issue_list_snapshots(repo_path)?;
+    if snapshots.is_empty() {
+        fs::create_dir_all(cache_root).map_err(|err| err.to_string())?;
+        return Ok(());
+    }
+
+    let cache = Cache::new(cache_root.to_path_buf());
+    for snapshot in &snapshots {
+        cache
+            .write_snapshot(snapshot)
+            .map_err(|err| format!("write issue cache: {err}"))?;
+    }
+    Ok(())
+}
+
+fn issue_cache_has_entries(cache_root: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(cache_root) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .file_type()
+            .map(|file_type| file_type.is_dir())
+            .unwrap_or(false)
+            && entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.parse::<u64>().is_ok())
+    })
+}
+
+fn fetch_issue_list_snapshots(repo_path: &Path) -> Result<Vec<IssueSnapshot>, String> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,body,labels,state,url,updatedAt",
+        ])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|err| format!("gh issue list: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue list: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    parse_issue_list_snapshots(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_issue_list_snapshots(json: &str) -> Result<Vec<IssueSnapshot>, String> {
+    let raw: Vec<Value> = serde_json::from_str(json).map_err(|err| err.to_string())?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|issue| {
+            let number = issue.get("number")?.as_u64()?;
+            let title = issue
+                .get("title")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let body = issue
+                .get("body")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let labels = issue
+                .get("labels")
+                .and_then(|value| value.as_array())
+                .map(|labels| {
+                    labels
+                        .iter()
+                        .filter_map(|label| {
+                            label
+                                .get("name")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string)
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let state = match issue.get("state").and_then(|value| value.as_str()) {
+                Some("CLOSED") | Some("closed") => IssueState::Closed,
+                _ => IssueState::Open,
+            };
+            let updated_at = issue
+                .get("updatedAt")
+                .and_then(|value| value.as_str())
+                .unwrap_or("1970-01-01T00:00:00Z")
+                .to_string();
+
+            Some(IssueSnapshot {
+                number: IssueNumber(number),
+                title,
+                body,
+                labels,
+                state,
+                updated_at: UpdatedAt::new(updated_at),
+                comments: vec![],
+            })
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_slug_root_uses_repo_hash_subdirectory() {
+        let root = issue_cache_root_for_repo_slug("example", "repo");
+        let expected = compute_repo_hash("https://github.com/example/repo.git");
+        assert!(root.ends_with(format!("issues/{}", expected.as_str())));
+    }
+
+    #[test]
+    fn detached_root_uses_isolated_subdirectory() {
+        assert!(detached_issue_cache_root().ends_with("issues/__detached__"));
+    }
+
+    #[test]
+    fn parse_issue_list_snapshots_parses_list_payload() {
+        let snapshots = parse_issue_list_snapshots(
+            r#"[{
+                "number": 1776,
+                "title": "Launch Agent issue linkage",
+                "body": "Body",
+                "labels": [{"name": "ux"}],
+                "state": "OPEN",
+                "url": "https://github.com/example/repo/issues/1776",
+                "updatedAt": "2026-04-13T00:00:00Z"
+            }]"#,
+        )
+        .expect("parse snapshots");
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].number.0, 1776);
+        assert_eq!(snapshots[0].title, "Launch Agent issue linkage");
+        assert_eq!(snapshots[0].body, "Body");
+        assert_eq!(snapshots[0].labels, vec!["ux".to_string()]);
+        assert_eq!(snapshots[0].updated_at.0, "2026-04-13T00:00:00Z");
+    }
+}

--- a/crates/gwt-tui/src/lib.rs
+++ b/crates/gwt-tui/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ime_probe;
 pub mod index_worker;
 pub mod input;
 pub mod input_trace;
+pub(crate) mod issue_cache;
 pub mod logs_watcher;
 pub mod message;
 pub mod model;

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -214,7 +214,8 @@ pub enum ManagementTab {
     Branches,
     Issues,
     PrDashboard,
-    /// SPEC-12 Phase 9: dedicated Specs tab backed by `~/.gwt/cache/issues/`.
+    /// SPEC-12 Phase 9: dedicated Specs tab backed by the repo-scoped issue
+    /// cache under `~/.gwt/cache/issues/<repo-hash>/`.
     /// Displayed as a top-level peer of Branches/Issues/PRs now that SPECs
     /// live as GitHub Issues rather than worktree-local files.
     Specs,
@@ -1950,6 +1951,8 @@ impl std::fmt::Debug for Model {
 impl Model {
     /// Create a new Model with sensible defaults.
     pub fn new(repo_path: PathBuf) -> Self {
+        let specs_cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path_or_detached(&repo_path);
         let default_session = SessionTab {
             id: "shell-0".to_string(),
             name: "Shell".to_string(),
@@ -1986,12 +1989,7 @@ impl Model {
             logs: LogsState::default(),
             versions: VersionsState::default(),
             specs: {
-                let cache_root = dirs::home_dir()
-                    .unwrap_or_else(|| std::path::PathBuf::from("."))
-                    .join(".gwt")
-                    .join("cache")
-                    .join("issues");
-                let mut specs = crate::screens::specs::SpecsState::new(cache_root);
+                let mut specs = crate::screens::specs::SpecsState::new(specs_cache_root);
                 // Silently attempt to load cached SPECs. If the cache
                 // directory doesn't exist yet (first startup before any
                 // `gwt issue spec pull`), we leave the list empty rather

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,30 @@
 # Lessons Learned
 
+## 2026-04-13 — fix: Issue / SPEC cache と index は repo 単位の exact cache を唯一の入力にする
+
+### 事象
+
+Branches 一覧や Launch Agent の Issue 選択、Specs 一覧が global cache
+(`~/.gwt/cache/issues/`) を横断しており、開いている repo と無関係な Issue / SPEC が混在した。
+さらに issue index は cache ではなく `gh issue list` から直接作っていたため、
+`GitHub/gh -> cache -> index -> UI` の一方向フローを外していた。
+
+### 原因
+
+- `~/.gwt/cache/issues/` を gwt 専用または global な一覧 source と誤認し、
+  repo hash ごとの境界を consumer 側で維持していなかった。
+- index builder が cache consumer ではなく direct fetcher になっており、
+  UI と index が別の truth source を見ていた。
+
+### 再発防止策
+
+1. `~/.gwt/cache/issues/` を触る変更では、最初に `repo-hash` 配下が current repo の
+   exact cache root であることを確認する。
+2. Issue / SPEC / Launch Agent / index の consumer は全て同じ repo-scoped cache root を
+   共有し、remote fetch は cache 更新レイヤーに閉じ込める。
+3. cache path や startup refresh を変えるときは、consumer 側の Rust test と
+   index runner 側の Python test を同じ変更で固定する。
+
 ## 2026-04-12 — fix: 端末喪失時の crossterm 内部スピンによる CPU 100%
 
 ### 事象


### PR DESCRIPTION
## Summary

- Scope Issues and Specs to the current repository cache root so branch lists and Launch Agent stop mixing entries from unrelated repositories.
- Seed the repo-scoped issue cache on startup when missing and build the issue index from exact cache contents so UI and search share one source of truth.
- Update docs, tests, and the related SPEC to reflect `~/.gwt/cache/issues/<repo-hash>/` as the canonical local cache path.

## Changes

- `crates/gwt-tui/src/issue_cache.rs`: added repo-scoped cache root helpers plus startup sync from `gh issue list` into the local issue cache.
- `crates/gwt-tui/src/app.rs`, `crates/gwt-tui/src/model.rs`, `crates/gwt-tui/src/cli/env.rs`: wired Issues, Specs, Launch Agent, and CLI cache resolution to the current repository cache root.
- `crates/gwt-core/runtime/chroma_index_runner.py` and `crates/gwt-core/runtime/tests/test_issue_ttl.py`: changed issue indexing to read repo-scoped cache data instead of calling `gh issue list` directly and added regression coverage.
- `README.md`, `README.ja.md`, `tasks/lessons.md`: documented the repo-scoped cache path and recorded the cache/index source-of-truth lesson.

## Testing

- [x] `cargo test -p gwt-core -p gwt-tui` — all Rust tests pass.
- [x] `PYTHONPATH=crates/gwt-core/runtime ~/.gwt/runtime/chroma-venv/bin/python -m unittest crates/gwt-core/runtime/tests/test_issue_ttl.py` — issue index runtime tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no clippy warnings remain.
- [x] `cargo fmt -- --check` — formatting is clean.
- [x] `cargo build -p gwt-tui` — target builds successfully.
- [x] `bunx markdownlint-cli README.md README.ja.md tasks/lessons.md` — Markdown lint passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — commit message passes commitlint.

## Closing Issues

- None

## Related Issues / Links

- #1938
- #1930

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (repo-scoped cache rebuilds from existing remote/cache state; no manual migration is required)
- [x] CHANGELOG impact considered (patch-level fix; no breaking change)

## Context

- Issue and SPEC cache consumers were still reading the global cache root, which let unrelated repository entries leak into branch list Issue badges and Launch Agent Issue selection.
- The issue index builder also bypassed the cache and read `gh issue list` directly, which broke the intended `GitHub API -> cache -> index -> UI` flow.
- This PR aligns the TUI, CLI, and index runtime on the same repo-scoped cache contract and updates SPEC #1938 accordingly.

## Risk / Impact

- **Affected areas**: Issue list loading, Specs list loading, Launch Agent Issue prefill, issue index build, cache path documentation.
- **Rollback plan**: Revert commit `5009f6c9` and allow startup cache/index rebuild to restore the previous behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cache directory path references from `~/.gwt/cache/issues/` to `~/.gwt/cache/issues/<repo-hash>/`.

* **New Features**
  * Issues are now cached per-repository using a hash-based subdirectory, isolating caches across different repositories.

* **Refactor**
  * Issue caching mechanism updated to support repository-scoped cache storage and synchronization from remote when cache is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->