### PR TITLE
fix(wizard): add quick start live session focus

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -699,6 +699,21 @@ fn check_pty_exits(model: &mut Model) {
     check_pty_exits_with(model, &gwt_sessions_dir());
 }
 
+fn focus_session_by_id(model: &mut Model, session_id: &str) -> bool {
+    if let Some(index) = model
+        .sessions
+        .iter()
+        .position(|session| session.id == session_id)
+    {
+        model.active_layer = ActiveLayer::Main;
+        model.active_session = index;
+        model.active_focus = FocusPane::Terminal;
+        true
+    } else {
+        false
+    }
+}
+
 fn check_pty_exits_with(model: &mut Model, sessions_dir: &Path) {
     let exited: Vec<String> = model
         .pty_handles
@@ -1057,7 +1072,7 @@ pub fn update(model: &mut Model, msg: Message) {
             screens::versions::update(&mut model.versions, msg);
         }
         Message::Wizard(msg) => {
-            let launch_config = if let Some(ref mut wizard) = model.wizard {
+            let (launch_config, focus_session_id) = if let Some(ref mut wizard) = model.wizard {
                 screens::wizard::update(wizard, msg);
                 let project_root = wizard
                     .worktree_path
@@ -1066,7 +1081,12 @@ pub fn update(model: &mut Model, msg: Message) {
                 sync_wizard_docker_status(wizard, &project_root);
                 maybe_start_wizard_branch_suggestions(wizard);
                 let completed = wizard.completed;
-                let launch_config = if completed {
+                let focus_session_id = if completed {
+                    wizard.focus_session_id.clone()
+                } else {
+                    None
+                };
+                let launch_config = if completed && focus_session_id.is_none() {
                     Some(build_launch_config_from_wizard(wizard))
                 } else {
                     None
@@ -1074,11 +1094,22 @@ pub fn update(model: &mut Model, msg: Message) {
                 if wizard.completed || wizard.cancelled {
                     model.wizard = None;
                 }
-                launch_config
+                (launch_config, focus_session_id)
             } else {
-                None
+                (None, None)
             };
-            if let Some(config) = launch_config {
+            if let Some(session_id) = focus_session_id {
+                if !focus_session_by_id(model, &session_id) {
+                    apply_notification(
+                        model,
+                        Notification::new(
+                            Severity::Warn,
+                            "session",
+                            format!("Session {session_id} is no longer available"),
+                        ),
+                    );
+                }
+            } else if let Some(config) = launch_config {
                 model.pending_launch_config = Some(config);
                 materialize_pending_launch(model);
                 model.active_focus = FocusPane::Terminal;
@@ -3273,14 +3304,16 @@ fn check_branch_pending_actions(model: &mut Model) {
                 .clone()
                 .unwrap_or_else(|| model.repo_path.clone());
             open_wizard(model, None);
-            if let Some(ref mut wizard) = model.wizard {
+            if let Some(mut wizard) = model.wizard.take() {
                 wizard.worktree_path = worktree_path;
                 configure_existing_branch_wizard_with_sessions(
-                    wizard,
+                    &mut wizard,
+                    model,
                     &quick_start_root,
                     &gwt_sessions_dir(),
                     &branch_name,
                 );
+                model.wizard = Some(wizard);
             }
         }
     }
@@ -3482,8 +3515,20 @@ fn branch_session_matches_with(model: &Model, sessions_dir: &Path) -> Vec<Branch
         return Vec::new();
     };
 
-    let branch_name = branch.name.as_str();
-    let branch_worktree = branch.worktree_path.as_deref().unwrap_or(model.repo_path());
+    branch_session_matches_for(
+        model,
+        sessions_dir,
+        branch.name.as_str(),
+        branch.worktree_path.as_deref().unwrap_or(model.repo_path()),
+    )
+}
+
+fn branch_session_matches_for(
+    model: &Model,
+    sessions_dir: &Path,
+    branch_name: &str,
+    branch_worktree: &Path,
+) -> Vec<BranchSessionMatch> {
     let branch_shell_name = format!("Shell: {branch_name}");
 
     model
@@ -3537,6 +3582,24 @@ fn branch_session_matches_with(model: &Model, sessions_dir: &Path) -> Vec<Branch
                 })
             }
             _ => None,
+        })
+        .collect()
+}
+
+fn branch_live_session_entries_with(
+    model: &Model,
+    sessions_dir: &Path,
+    branch_name: &str,
+    branch_worktree: &Path,
+) -> Vec<screens::wizard::LiveSessionEntry> {
+    branch_session_matches_for(model, sessions_dir, branch_name, branch_worktree)
+        .into_iter()
+        .map(|entry| screens::wizard::LiveSessionEntry {
+            session_id: model.sessions[entry.session_index].id.clone(),
+            kind: entry.summary.kind.to_string(),
+            name: entry.summary.name,
+            detail: entry.summary.detail,
+            active: entry.summary.active,
         })
         .collect()
 }
@@ -6207,6 +6270,7 @@ fn local_branch_exists(repo_path: &Path, branch_name: &str) -> Result<bool, Stri
 
 fn configure_existing_branch_wizard_with_sessions(
     wizard: &mut screens::wizard::WizardState,
+    model: &Model,
     repo_path: &std::path::Path,
     sessions_dir: &std::path::Path,
     branch_name: &str,
@@ -6215,7 +6279,11 @@ fn configure_existing_branch_wizard_with_sessions(
     wizard.branch_name = branch_name.to_string();
     apply_wizard_docker_context(wizard, repo_path);
     wizard.quick_start_entries = load_quick_start_entries(repo_path, sessions_dir, branch_name);
-    wizard.has_quick_start = !wizard.quick_start_entries.is_empty();
+    wizard.live_session_entries =
+        branch_live_session_entries_with(model, sessions_dir, branch_name, repo_path);
+    wizard.has_quick_start =
+        !wizard.quick_start_entries.is_empty() || !wizard.live_session_entries.is_empty();
+    wizard.focus_session_id = None;
     wizard.step = if wizard.has_quick_start {
         screens::wizard::WizardStep::QuickStart
     } else {
@@ -14759,7 +14827,14 @@ services:
         );
 
         let (mut wizard, _) = prepare_wizard_startup(repo_path.as_path(), None, detected, &cache);
-        configure_existing_branch_wizard_with_sessions(&mut wizard, &repo_path, dir.path(), branch);
+        let model = test_model();
+        configure_existing_branch_wizard_with_sessions(
+            &mut wizard,
+            &model,
+            &repo_path,
+            dir.path(),
+            branch,
+        );
 
         assert_eq!(wizard.step, screens::wizard::WizardStep::QuickStart);
         assert!(wizard.has_quick_start);
@@ -14786,6 +14861,106 @@ services:
         );
         assert_eq!(wizard.quick_start_entries[1].agent_id, "claude");
         assert!(!wizard.quick_start_entries[1].codex_fast_mode);
+    }
+
+    #[test]
+    fn configure_existing_branch_wizard_with_sessions_loads_branch_live_sessions() {
+        let dir = tempfile::tempdir().expect("temp sessions dir");
+        let cache = VersionCache::new();
+        let repo_path = PathBuf::from("/tmp/repo");
+        let worktree_path = repo_path.join("wt-feature-test");
+        let branch = "feature/test";
+        let now = Utc::now();
+
+        let mut persisted =
+            AgentSession::new(worktree_path.to_str().unwrap(), branch, AgentId::Codex);
+        persisted.id = "agent-1".to_string();
+        persisted.model = Some("gpt-5.3-codex".to_string());
+        persisted.reasoning_level = Some("high".to_string());
+        persisted.tool_version = Some("latest".to_string());
+        persisted.agent_session_id = Some("sess-live".to_string());
+        persisted.skip_permissions = true;
+        persisted.codex_fast_mode = true;
+        persisted.updated_at = now;
+        persisted.created_at = now;
+        persisted.last_activity_at = now;
+        persisted.save(dir.path()).expect("persist live session");
+
+        let detected = vec![detected_agent(AgentId::Codex, Some("0.5.1"))];
+        let (mut wizard, _) = prepare_wizard_startup(repo_path.as_path(), None, detected, &cache);
+        let mut model = test_model();
+        model.sessions = vec![crate::model::SessionTab {
+            id: "agent-1".to_string(),
+            name: "Codex".to_string(),
+            tab_type: SessionTabType::Agent {
+                agent_id: "codex".to_string(),
+                color: crate::model::AgentColor::Cyan,
+            },
+            vt: crate::model::VtState::new(24, 80),
+            created_at: std::time::Instant::now(),
+        }];
+        model.active_session = 0;
+
+        configure_existing_branch_wizard_with_sessions(
+            &mut wizard,
+            &model,
+            &worktree_path,
+            dir.path(),
+            branch,
+        );
+
+        assert_eq!(wizard.live_session_entries.len(), 1);
+        assert_eq!(wizard.live_session_entries[0].session_id, "agent-1");
+        assert_eq!(wizard.live_session_entries[0].name, "Codex");
+    }
+
+    #[test]
+    fn wizard_select_focus_existing_session_switches_active_session_without_launching() {
+        let mut model = test_model();
+        model.sessions = vec![
+            crate::model::SessionTab {
+                id: "shell-0".to_string(),
+                name: "Shell: feature/test".to_string(),
+                tab_type: SessionTabType::Shell,
+                vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
+            },
+            crate::model::SessionTab {
+                id: "agent-1".to_string(),
+                name: "Codex".to_string(),
+                tab_type: SessionTabType::Agent {
+                    agent_id: "codex".to_string(),
+                    color: crate::model::AgentColor::Cyan,
+                },
+                vt: crate::model::VtState::new(24, 80),
+                created_at: std::time::Instant::now(),
+            },
+        ];
+        model.active_session = 0;
+        model.active_focus = FocusPane::BranchDetail;
+        model.active_layer = ActiveLayer::Management;
+        model.wizard = Some(screens::wizard::WizardState {
+            step: screens::wizard::WizardStep::FocusExistingSession,
+            live_session_entries: vec![screens::wizard::LiveSessionEntry {
+                session_id: "agent-1".to_string(),
+                kind: "Agent".to_string(),
+                name: "Codex".to_string(),
+                detail: Some("gpt-5.3-codex · high".to_string()),
+                active: false,
+            }],
+            ..screens::wizard::WizardState::default()
+        });
+
+        update(
+            &mut model,
+            Message::Wizard(screens::wizard::WizardMessage::Select),
+        );
+
+        assert!(model.wizard.is_none());
+        assert_eq!(model.active_layer, ActiveLayer::Main);
+        assert_eq!(model.active_session, 1);
+        assert_eq!(model.active_focus, FocusPane::Terminal);
+        assert!(model.pending_launch_config.is_none());
     }
 
     #[test]

--- a/crates/gwt-tui/src/screens/wizard.rs
+++ b/crates/gwt-tui/src/screens/wizard.rs
@@ -14,6 +14,7 @@ use crate::{screens::issues::IssueItem, theme};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WizardStep {
     QuickStart,
+    FocusExistingSession,
     #[default]
     BranchAction,
     AgentSelect,
@@ -39,6 +40,7 @@ impl WizardStep {
     pub fn title(self) -> &'static str {
         match self {
             Self::QuickStart => "Quick Start",
+            Self::FocusExistingSession => "Focus Existing Session",
             Self::BranchAction => "Branch Action",
             Self::AgentSelect => "Select Coding Agent",
             Self::ModelSelect => "Select Model",
@@ -83,10 +85,12 @@ fn next_step(current: WizardStep, state: &WizardState) -> Option<WizardStep> {
     match current {
         WizardStep::QuickStart => match state.selected_quick_start_action() {
             QuickStartAction::ChooseDifferent => Some(WizardStep::BranchAction),
+            QuickStartAction::FocusExistingSession => Some(WizardStep::FocusExistingSession),
             QuickStartAction::ResumeWithPrevious | QuickStartAction::StartNewWithPrevious => {
                 Some(WizardStep::SkipPermissions)
             }
         },
+        WizardStep::FocusExistingSession => None,
         WizardStep::BranchAction => {
             if state.selected == 1 {
                 Some(WizardStep::BranchTypeSelect)
@@ -189,8 +193,9 @@ fn next_step(current: WizardStep, state: &WizardState) -> Option<WizardStep> {
 fn prev_step(current: WizardStep, state: &WizardState) -> Option<WizardStep> {
     match current {
         WizardStep::QuickStart => None,
+        WizardStep::FocusExistingSession => Some(WizardStep::QuickStart),
         WizardStep::BranchAction => {
-            if state.has_quick_start && !state.quick_start_entries.is_empty() {
+            if state.has_quick_start && state.has_quick_start_actions() {
                 Some(WizardStep::QuickStart)
             } else {
                 None
@@ -369,6 +374,7 @@ impl AgentOption {
 enum QuickStartAction {
     ResumeWithPrevious,
     StartNewWithPrevious,
+    FocusExistingSession,
     ChooseDifferent,
 }
 
@@ -386,6 +392,15 @@ pub struct QuickStartEntry {
     pub runtime_target: gwt_agent::LaunchRuntimeTarget,
     pub docker_service: Option<String>,
     pub docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveSessionEntry {
+    pub session_id: String,
+    pub kind: String,
+    pub name: String,
+    pub detail: Option<String>,
+    pub active: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -439,6 +454,7 @@ pub struct WizardState {
     pub selected: usize,
     pub has_quick_start: bool,
     pub quick_start_entries: Vec<QuickStartEntry>,
+    pub live_session_entries: Vec<LiveSessionEntry>,
     pub is_new_branch: bool,
     pub base_branch_name: Option<String>,
     pub gh_cli_available: bool,
@@ -451,6 +467,7 @@ pub struct WizardState {
     pub version_options: Vec<VersionOption>,
     pub mode: String,
     pub resume_session_id: Option<String>,
+    pub focus_session_id: Option<String>,
     pub branch_name: String,
     pub issue_id: String,
     pub runtime_target: gwt_agent::LaunchRuntimeTarget,
@@ -483,6 +500,7 @@ impl Default for WizardState {
             selected: 0,
             has_quick_start: false,
             quick_start_entries: Vec::new(),
+            live_session_entries: Vec::new(),
             is_new_branch: false,
             base_branch_name: None,
             gh_cli_available: true,
@@ -494,6 +512,7 @@ impl Default for WizardState {
             version_options: Vec::new(),
             mode: "normal".to_string(),
             resume_session_id: None,
+            focus_session_id: None,
             branch_name: String::new(),
             issue_id: String::new(),
             runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
@@ -519,19 +538,40 @@ impl WizardState {
     fn flow_start_step(&self) -> WizardStep {
         if self.is_new_branch {
             WizardStep::BranchTypeSelect
-        } else if self.has_quick_start && !self.quick_start_entries.is_empty() {
+        } else if self.has_quick_start && self.has_quick_start_actions() {
             WizardStep::QuickStart
         } else {
             WizardStep::BranchAction
         }
     }
 
+    fn has_quick_start_actions(&self) -> bool {
+        !self.quick_start_entries.is_empty() || !self.live_session_entries.is_empty()
+    }
+
+    fn has_live_session_focus_option(&self) -> bool {
+        !self.live_session_entries.is_empty()
+    }
+
     fn quick_start_option_count(&self) -> usize {
-        if self.quick_start_entries.is_empty() {
+        if !self.has_quick_start_actions() {
             0
         } else {
-            self.quick_start_entries.len() * 2 + 1
+            self.quick_start_entries.len() * 2
+                + usize::from(self.has_live_session_focus_option())
+                + 1
         }
+    }
+
+    fn quick_start_focus_existing_index(&self) -> Option<usize> {
+        self.has_live_session_focus_option()
+            .then_some(self.quick_start_entries.len() * 2)
+    }
+
+    fn quick_start_choose_different_index(&self) -> Option<usize> {
+        self.has_quick_start_actions().then_some(
+            self.quick_start_entries.len() * 2 + usize::from(self.has_live_session_focus_option()),
+        )
     }
 
     fn issue_picker_option_count(&self) -> usize {
@@ -583,29 +623,52 @@ impl WizardState {
     }
 
     fn selected_quick_start_action(&self) -> QuickStartAction {
-        let choose_different_index = self.quick_start_entries.len() * 2;
-        if self.quick_start_entries.is_empty() || self.selected >= choose_different_index {
+        let choose_different_index = match self.quick_start_choose_different_index() {
+            Some(index) => index,
+            None => return QuickStartAction::ChooseDifferent,
+        };
+        if self.selected >= choose_different_index {
             QuickStartAction::ChooseDifferent
-        } else if self.selected.is_multiple_of(2) {
+        } else if self.selected < self.quick_start_entries.len() * 2
+            && self.selected.is_multiple_of(2)
+        {
             QuickStartAction::ResumeWithPrevious
-        } else {
+        } else if self.selected < self.quick_start_entries.len() * 2 {
             QuickStartAction::StartNewWithPrevious
+        } else {
+            QuickStartAction::FocusExistingSession
         }
     }
 
     fn selected_quick_start_entry(&self) -> Option<&QuickStartEntry> {
-        if self.quick_start_entries.is_empty() {
+        if self.quick_start_entries.is_empty()
+            || self.selected >= self.quick_start_entries.len() * 2
+        {
             None
         } else {
             self.quick_start_entries.get(self.selected / 2)
         }
     }
 
+    fn selected_live_session_entry(&self) -> Option<&LiveSessionEntry> {
+        self.live_session_entries.get(self.selected)
+    }
+
     fn apply_quick_start_selection(&mut self) {
         let action = self.selected_quick_start_action();
+        if matches!(
+            action,
+            QuickStartAction::ChooseDifferent | QuickStartAction::FocusExistingSession
+        ) {
+            self.mode = "normal".to_string();
+            self.resume_session_id = None;
+            self.focus_session_id = None;
+            return;
+        }
         let Some(entry) = self.selected_quick_start_entry().cloned() else {
             self.mode = "normal".to_string();
             self.resume_session_id = None;
+            self.focus_session_id = None;
             return;
         };
 
@@ -647,18 +710,23 @@ impl WizardState {
                 if let Some(session_id) = entry.resume_session_id {
                     self.mode = "resume".to_string();
                     self.resume_session_id = Some(session_id);
+                    self.focus_session_id = None;
                 } else {
                     self.mode = "continue".to_string();
                     self.resume_session_id = None;
+                    self.focus_session_id = None;
                 }
             }
             QuickStartAction::StartNewWithPrevious => {
                 self.mode = "normal".to_string();
                 self.resume_session_id = None;
+                self.focus_session_id = None;
             }
+            QuickStartAction::FocusExistingSession => unreachable!(),
             QuickStartAction::ChooseDifferent => {
                 self.mode = "normal".to_string();
                 self.resume_session_id = None;
+                self.focus_session_id = None;
             }
         }
     }
@@ -923,6 +991,7 @@ impl WizardState {
     pub fn option_count(&self) -> usize {
         match self.step {
             WizardStep::QuickStart => self.quick_start_option_count(),
+            WizardStep::FocusExistingSession => self.live_session_entries.len().max(1),
             WizardStep::BranchAction => 2, // existing branch / create new branch
             WizardStep::AgentSelect => self.detected_agents.len().max(1),
             WizardStep::ModelSelect => self.current_model_options().len(),
@@ -992,10 +1061,23 @@ impl WizardState {
                     ));
                     options.push(quick_start_action_label(entry, "Start new", false, false));
                 }
-                if !self.quick_start_entries.is_empty() {
+                if self.has_live_session_focus_option() {
+                    options.push("Focus existing session".to_string());
+                }
+                if self.has_quick_start_actions() {
                     options.push("Choose different".to_string());
                 }
                 options
+            }
+            WizardStep::FocusExistingSession => {
+                if self.live_session_entries.is_empty() {
+                    vec!["(no live sessions available)".to_string()]
+                } else {
+                    self.live_session_entries
+                        .iter()
+                        .map(live_session_option_label)
+                        .collect()
+                }
             }
             WizardStep::AgentSelect => {
                 if self.detected_agents.is_empty() {
@@ -1317,14 +1399,21 @@ fn step_default_selection(step: WizardStep, state: &WizardState) -> usize {
 fn apply_selection(state: &mut WizardState) {
     let options = state.current_options();
     match state.step {
-        WizardStep::QuickStart => {
-            if !matches!(
-                state.selected_quick_start_action(),
-                QuickStartAction::ChooseDifferent
-            ) {
+        WizardStep::QuickStart => match state.selected_quick_start_action() {
+            QuickStartAction::ResumeWithPrevious | QuickStartAction::StartNewWithPrevious => {
                 state.apply_quick_start_selection();
                 state.sync_docker_lifecycle_default();
             }
+            QuickStartAction::FocusExistingSession | QuickStartAction::ChooseDifferent => {
+                state.focus_session_id = None;
+            }
+        },
+        WizardStep::FocusExistingSession => {
+            state.focus_session_id = state
+                .selected_live_session_entry()
+                .map(|entry| entry.session_id.clone());
+            state.resume_session_id = None;
+            state.mode = "normal".to_string();
         }
         WizardStep::BranchAction => {
             if state.selected == 0 {
@@ -2164,6 +2253,20 @@ fn quick_start_start_new_marker(is_selected: bool, single_entry: bool) -> &'stat
     }
 }
 
+fn live_session_option_label(entry: &LiveSessionEntry) -> String {
+    let mut label = format!(
+        "{}  {} ({})",
+        entry.kind,
+        entry.name,
+        &entry.session_id[..entry.session_id.len().min(8)]
+    );
+    if let Some(detail) = entry.detail.as_deref() {
+        label.push_str(" · ");
+        label.push_str(detail);
+    }
+    label
+}
+
 /// Compute popup width based on actual content (title + options + hints).
 ///
 /// Mirrors old-TUI `wizard_popup_width`: measure the widest content line,
@@ -2330,7 +2433,24 @@ fn render_quick_start_step(state: &WizardState, frame: &mut Frame, area: Rect) {
         );
     }
 
-    let choose_index = state.quick_start_entries.len() * 2;
+    let choose_index = state
+        .quick_start_choose_different_index()
+        .unwrap_or_default();
+    if let Some(focus_index) = state.quick_start_focus_existing_index() {
+        let focus_marker = if state.selected == focus_index {
+            "> "
+        } else {
+            "  "
+        };
+        let focus_text = format!("{focus_marker}Focus existing session");
+        items.push(
+            ListItem::new(truncate_with_ellipsis(
+                &focus_text,
+                list_area.width as usize,
+            ))
+            .style(wizard_row_style(state.selected == focus_index)),
+        );
+    }
     let choose_marker = if state.selected >= choose_index {
         "> "
     } else {
@@ -2346,6 +2466,36 @@ fn render_quick_start_step(state: &WizardState, frame: &mut Frame, area: Rect) {
     );
 
     frame.render_widget(List::new(items), list_area);
+}
+
+fn render_focus_existing_session_step(state: &WizardState, frame: &mut Frame, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    frame.render_widget(
+        Paragraph::new(truncate_with_ellipsis(
+            &state.branch_name,
+            area.width as usize,
+        ))
+        .style(theme::style::header()),
+        Rect::new(area.x, area.y, area.width, 1),
+    );
+
+    if area.height <= 1 {
+        return;
+    }
+
+    render_option_list(
+        state,
+        frame,
+        Rect::new(
+            area.x,
+            area.y + 1,
+            area.width,
+            area.height.saturating_sub(1),
+        ),
+    );
 }
 
 fn render_agent_select_step(state: &WizardState, frame: &mut Frame, area: Rect) {
@@ -2472,6 +2622,7 @@ pub fn render(state: &WizardState, frame: &mut Frame, area: Rect) {
 fn render_step_content(state: &WizardState, frame: &mut Frame, area: Rect) {
     match state.step {
         WizardStep::QuickStart => render_quick_start_step(state, frame, area),
+        WizardStep::FocusExistingSession => render_focus_existing_session_step(state, frame, area),
         WizardStep::AgentSelect => render_agent_select_step(state, frame, area),
         WizardStep::BranchNameInput => {
             render_input_step(state, frame, area, "Branch Name:", &state.branch_name);
@@ -2726,6 +2877,25 @@ mod tests {
                 runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
                 docker_service: None,
                 docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+            },
+        ]
+    }
+
+    fn sample_live_session_entries() -> Vec<LiveSessionEntry> {
+        vec![
+            LiveSessionEntry {
+                session_id: "agent-1".to_string(),
+                kind: "Agent".to_string(),
+                name: "Codex".to_string(),
+                detail: Some("gpt-5.3-codex · high".to_string()),
+                active: false,
+            },
+            LiveSessionEntry {
+                session_id: "shell-2".to_string(),
+                kind: "Shell".to_string(),
+                name: "Shell: feature/test".to_string(),
+                detail: None,
+                active: true,
             },
         ]
     }
@@ -3506,8 +3676,9 @@ mod tests {
         state.step = WizardStep::QuickStart;
         state.has_quick_start = true;
         state.quick_start_entries = sample_quick_start_entries();
+        state.live_session_entries = sample_live_session_entries();
 
-        assert_eq!(state.option_count(), 5);
+        assert_eq!(state.option_count(), 6);
     }
 
     #[test]
@@ -3530,6 +3701,36 @@ mod tests {
         assert_eq!(state.resume_session_id.as_deref(), Some("sess-12345678"));
         assert!(state.skip_perms);
         assert!(state.codex_fast_mode);
+    }
+
+    #[test]
+    fn select_on_quick_start_focus_existing_session_moves_to_live_session_selector() {
+        let mut state = WizardState::default();
+        state.step = WizardStep::QuickStart;
+        state.has_quick_start = true;
+        state.quick_start_entries = sample_quick_start_entries();
+        state.live_session_entries = sample_live_session_entries();
+        state.selected = 4;
+
+        update(&mut state, WizardMessage::Select);
+
+        assert_eq!(state.step, WizardStep::FocusExistingSession);
+        assert_eq!(state.selected, 0);
+        assert!(state.focus_session_id.is_none());
+        assert!(!state.completed);
+    }
+
+    #[test]
+    fn select_on_live_session_selector_marks_focus_target_and_completes() {
+        let mut state = WizardState::default();
+        state.step = WizardStep::FocusExistingSession;
+        state.live_session_entries = sample_live_session_entries();
+        state.selected = 1;
+
+        update(&mut state, WizardMessage::Select);
+
+        assert!(state.completed);
+        assert_eq!(state.focus_session_id.as_deref(), Some("shell-2"));
     }
 
     #[test]
@@ -3670,6 +3871,19 @@ mod tests {
     }
 
     #[test]
+    fn back_from_live_session_selector_returns_to_quick_start() {
+        let mut state = WizardState::default();
+        state.step = WizardStep::FocusExistingSession;
+        state.has_quick_start = true;
+        state.quick_start_entries = sample_quick_start_entries();
+        state.live_session_entries = sample_live_session_entries();
+
+        update(&mut state, WizardMessage::Back);
+
+        assert_eq!(state.step, WizardStep::QuickStart);
+    }
+
+    #[test]
     fn render_overlay_does_not_panic() {
         let state = WizardState::default();
         let backend = TestBackend::new(80, 24);
@@ -3791,6 +4005,7 @@ mod tests {
         state.has_quick_start = true;
         state.branch_name = "feature/test".to_string();
         state.quick_start_entries = sample_quick_start_entries();
+        state.live_session_entries = sample_live_session_entries();
 
         let text = render_text(&state, 100, 24);
 
@@ -3800,8 +4015,24 @@ mod tests {
         assert!(text.contains("> Codex Resume (sess-123...)"));
         assert!(text.contains("  Start new"));
         assert!(text.contains("  Claude Code Resume"));
+        assert!(text.contains("Focus existing session"));
         assert!(!text.contains("  Claude Code Start new"));
         assert!(text.contains("Choose different"));
+    }
+
+    #[test]
+    fn render_focus_existing_session_step_lists_live_sessions_for_branch() {
+        let mut state = WizardState::default();
+        state.step = WizardStep::FocusExistingSession;
+        state.branch_name = "feature/test".to_string();
+        state.live_session_entries = sample_live_session_entries();
+
+        let text = render_text(&state, 100, 24);
+
+        assert!(text.contains("Focus Existing Session"));
+        assert!(text.contains("feature/test"));
+        assert!(text.contains("Codex (agent-1)"));
+        assert!(text.contains("Shell: feature/test (shell-2)"));
     }
 
     #[test]
@@ -4049,6 +4280,7 @@ mod tests {
         state.has_quick_start = true;
         state.branch_name = "feature/test".to_string();
         state.quick_start_entries = sample_quick_start_entries();
+        state.live_session_entries = sample_live_session_entries();
         state.selected = 0;
 
         let options = state.current_options();
@@ -4057,7 +4289,8 @@ mod tests {
         assert_eq!(options[1], "Start new");
         assert_eq!(options[2], "Claude Code Resume");
         assert_eq!(options[3], "Start new");
-        assert_eq!(options[4], "Choose different");
+        assert_eq!(options[4], "Focus existing session");
+        assert_eq!(options[5], "Choose different");
     }
 
     #[test]

--- a/specs-archive/SPEC-1782/plan.md
+++ b/specs-archive/SPEC-1782/plan.md
@@ -3,3 +3,7 @@
 ## Summary
 
 Keep Quick Start as the branch-scoped fast-launch contract, but integrate it with the rebuilt `no/one/many` branch enter flow so it coexists with active sessions and the session selector.
+
+- Preserve persisted Quick Start entries for `Resume` / `Start new`
+- Add a separate `Focus existing session` branch that opens a live-session selector and switches the active session without spawning a new launch
+- Restrict the selector to current live sessions for the selected branch/worktree

--- a/specs-archive/SPEC-1782/spec.md
+++ b/specs-archive/SPEC-1782/spec.md
@@ -14,13 +14,17 @@ rebuilt TUI では `1ブランチ = Nセッション` を許可するため、Qu
 
 ### US-3: 必要ならフル Wizard へ落ちたい
 
+### US-4: 同一ブランチで既に開いている live session にすぐ戻りたい
+
 ## Acceptance Scenarios
 
 1. branch に active session がなく、resume 可能な履歴がある場合、Quick Start fast path を提示できる
 2. branch に active session が複数ある場合、selector から `追加起動` を選ぶと Quick Start fast path へ進める
 3. Resume は保存済み session_id を使って起動する
 4. Start New は保存済み設定を使って新規 session を追加する
-5. いつでも Full Wizard へフォールバックできる
+5. branch に紐づく live session がある場合、Quick Start から `Focus existing session` を選んで対象 session selector へ進める
+6. `Focus existing session` は現在の session workspace に存在する live session のみを候補にし、選択すると launch を発生させず active session と terminal focus を切り替える
+7. いつでも Full Wizard へフォールバックできる
 
 ## Functional Requirements
 
@@ -29,9 +33,11 @@ rebuilt TUI では `1ブランチ = Nセッション` を許可するため、Qu
 - FR-003: branch `Enter` の selector から `追加起動` fast path として呼び出せなければならない
 - FR-004: Resume は session_id を使って起動する
 - FR-005: Start New は保存済み設定を使って新規 session を追加する
-- FR-006: Full Wizard へのフォールバックを常に提供する
+- FR-006: Quick Start は live session へのフォーカス導線を Resume / Start New と別アクションとして提供しなければならない
+- FR-007: live session selector は branch/worktree に一致する current live session だけを表示しなければならない
+- FR-008: Full Wizard へのフォールバックを常に提供する
 
 ## Success Criteria
 
 - SC-001: Quick Start が branch-first parent UX と矛盾しない
-- SC-002: active session の有無にかかわらず、resume / add session / full wizard の関係が一貫する
+- SC-002: active session の有無にかかわらず、resume / focus existing session / add session / full wizard の関係が一貫する

--- a/specs-archive/SPEC-1782/tasks.md
+++ b/specs-archive/SPEC-1782/tasks.md
@@ -1,5 +1,8 @@
 # Tasks: SPEC-1782 — branch-scoped Quick Start in a multi-session shell
 
-- [ ] T001: Rewrite spec.md around branch-scoped fast-launch instead of single-result branch Enter.
-- [ ] T002: Align Quick Start with the `no/one/many` branch selector flow.
-- [ ] T003: Preserve resume / start new / full wizard semantics under the new shell model.
+- [x] T001: Rewrite spec.md around branch-scoped fast-launch instead of single-result branch Enter.
+- [x] T002: Align Quick Start with the `no/one/many` branch selector flow.
+- [x] T003: Preserve resume / start new / full wizard semantics under the new shell model.
+- [x] T004: Add `Focus existing session` to Quick Start and route it to a dedicated live-session selector step.
+- [x] T005: Filter live-session selector candidates to branch/worktree-matching current sessions only.
+- [x] T006: Completing the selector switches `active_session` + terminal focus without creating a launch config.


### PR DESCRIPTION
## Summary

- Add a `Focus existing session` path to Launch Agent Quick Start so users can jump back to an already-open live session from the selected branch.
- Keep `Resume` and `Start new` unchanged while separating live-session focus into its own selector step.
- Update SPEC-1782 to document the live-session selector contract and the no-new-launch focus behavior.

## Changes

- `crates/gwt-tui/src/screens/wizard.rs`: add the live-session selector step, wizard state, Quick Start option wiring, and render/test coverage for the new flow.
- `crates/gwt-tui/src/app.rs`: load branch-matching live sessions into the wizard, complete the selector by switching `active_session`, and keep launch creation reserved for actual launches.
- `specs-archive/SPEC-1782/*`: update the spec, plan, and tasks to cover `Focus existing session` and mark the implementation tasks complete.

## Testing

- [x] `cargo fmt --all -- --check` — passes (rustfmt emits only the existing nightly-option warnings).
- [x] `cargo test -p gwt-core -p gwt-tui` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo build -p gwt-tui` — passes.

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — no README update; this change is limited to the Launch Agent wizard flow and the owning SPEC was updated.
- [ ] Migration/backfill plan included (if schema/data change) — no schema or stored-data change.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This follows `SPEC-1782`, which defines Quick Start as the branch-scoped fast-launch contract in the multi-session shell.
- The existing implementation only exposed the latest persisted launch metadata per agent, so branches with several already-open sessions had no direct way to focus one of them from Quick Start.
