### PR TITLE
fix(workspace-shell): keep cleanup progress updating without Ctrl+G

### DIFF
--- a/crates/gwt-tui/src/event.rs
+++ b/crates/gwt-tui/src/event.rs
@@ -287,7 +287,12 @@ fn decode_sgr_modifiers(cb: u16) -> KeyModifiers {
 
 /// Calculate the next tick deadline.
 pub fn next_tick_deadline() -> Instant {
-    Instant::now() + TICK_RATE
+    next_tick_deadline_from(Instant::now())
+}
+
+/// Calculate the next tick deadline relative to `now`.
+pub fn next_tick_deadline_from(now: Instant) -> Instant {
+    now + TICK_RATE
 }
 
 /// Convert a raw key event into a high-level Message via the keybind system,

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -128,6 +128,7 @@ fn dispatch_post_normalized_message(
     keybinds: &mut KeybindRegistry,
     msg: Message,
     needs_render: &mut bool,
+    tick_deadline: &mut Instant,
 ) {
     let msg = match msg {
         Message::KeyInput(key) if model.active_layer != ActiveLayer::Initialization => {
@@ -139,6 +140,8 @@ fn dispatch_post_normalized_message(
         other => other,
     };
 
+    let handled_at = Instant::now();
+    *tick_deadline = tick_deadline_after_message(*tick_deadline, handled_at, &msg);
     let was_tick = matches!(msg, Message::Tick);
     let visible_branch_signature_before =
         was_tick.then(|| app::visible_branch_live_indicator_signature(model));
@@ -158,6 +161,7 @@ fn handle_post_normalized_message<F>(
     keybinds: &mut KeybindRegistry,
     first: Message,
     needs_render: &mut bool,
+    tick_deadline: &mut Instant,
     pending_messages: &mut VecDeque<Message>,
     next_message: F,
 ) where
@@ -165,7 +169,7 @@ fn handle_post_normalized_message<F>(
 {
     let burst = drain_mouse_scroll_burst(first, pending_messages, next_message);
     for msg in burst {
-        dispatch_post_normalized_message(model, keybinds, msg, needs_render);
+        dispatch_post_normalized_message(model, keybinds, msg, needs_render, tick_deadline);
         if model.quit {
             break;
         }
@@ -226,6 +230,14 @@ where
 
 fn pty_redraw_poll_slice(now: Instant, last_draw_at: Instant) -> Duration {
     PTY_REDRAW_FRAME_INTERVAL.saturating_sub(now.saturating_duration_since(last_draw_at))
+}
+
+fn tick_deadline_after_message(current_deadline: Instant, now: Instant, msg: &Message) -> Instant {
+    if matches!(msg, Message::Tick) {
+        event::next_tick_deadline_from(now)
+    } else {
+        current_deadline
+    }
 }
 
 #[cfg(test)]
@@ -673,6 +685,7 @@ fn run_app(
     let mut pending_messages = VecDeque::new();
     let mut needs_render = true;
     let mut last_draw_at = None;
+    let mut tick_deadline = event::next_tick_deadline();
 
     loop {
         if sighup_flag.load(Ordering::Relaxed) {
@@ -697,7 +710,6 @@ fn run_app(
         }
 
         // Event: poll
-        let deadline = event::next_tick_deadline();
         loop {
             if let Some(msg) = input_normalizer.pop_pending(std::time::Instant::now()) {
                 handle_post_normalized_message(
@@ -705,6 +717,7 @@ fn run_app(
                     &mut keybinds,
                     msg,
                     &mut needs_render,
+                    &mut tick_deadline,
                     &mut pending_messages,
                     || input_normalizer.pop_pending(std::time::Instant::now()),
                 );
@@ -715,7 +728,7 @@ fn run_app(
 
             let Some(msg) = next_message_for_loop_iteration(
                 &mut pending_messages,
-                deadline,
+                tick_deadline,
                 had_pty_output,
                 last_draw_at,
                 event::poll_event_slice,
@@ -734,15 +747,18 @@ fn run_app(
                 continue;
             };
 
+            let burst_deadline = tick_deadline;
+
             handle_post_normalized_message(
                 &mut model,
                 &mut keybinds,
                 msg,
                 &mut needs_render,
+                &mut tick_deadline,
                 &mut pending_messages,
                 || {
                     poll_immediate_message_for_scroll_burst(
-                        deadline,
+                        burst_deadline,
                         &mut input_normalizer,
                         terminal_focused,
                     )
@@ -1180,6 +1196,7 @@ mod tests {
         model.active_focus = FocusPane::TabContent;
         let mut keybinds = KeybindRegistry::new();
         let mut needs_render = false;
+        let mut tick_deadline = Instant::now();
 
         dispatch_post_normalized_message(
             &mut model,
@@ -1189,6 +1206,7 @@ mod tests {
                 KeyModifiers::CONTROL,
             )),
             &mut needs_render,
+            &mut tick_deadline,
         );
         dispatch_post_normalized_message(
             &mut model,
@@ -1198,6 +1216,7 @@ mod tests {
                 KeyModifiers::NONE,
             )),
             &mut needs_render,
+            &mut tick_deadline,
         );
 
         assert_eq!(
@@ -1288,6 +1307,44 @@ mod tests {
         assert!(
             should_render_after_tick(&model),
             "visible overlays that depend on tick-driven updates should still redraw"
+        );
+    }
+
+    #[test]
+    fn non_tick_messages_do_not_delay_the_pending_tick_deadline() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_millis(100);
+
+        let next = tick_deadline_after_message(
+            deadline,
+            now + Duration::from_millis(90),
+            &Message::KeyInput(crossterm::event::KeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::NONE,
+            )),
+        );
+
+        assert_eq!(
+            next, deadline,
+            "non-tick events must preserve the original deadline so tick-driven cleanup updates do not starve behind unrelated input/output"
+        );
+    }
+
+    #[test]
+    fn tick_messages_schedule_the_next_deadline_from_now() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_millis(100);
+        let tick_handled_at = now + Duration::from_millis(90);
+
+        let next = tick_deadline_after_message(deadline, tick_handled_at, &Message::Tick);
+
+        assert!(
+            next >= tick_handled_at + Duration::from_millis(95),
+            "tick handling should move the deadline forward from the time the tick was consumed"
+        );
+        assert!(
+            next <= tick_handled_at + Duration::from_millis(105),
+            "the next deadline should stay close to one tick interval after the consumed tick"
         );
     }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,30 @@
 # Lessons Learned
 
+## 2026-04-13 — fix: tick 駆動の更新は redraw gate だけでなく deadline の寿命も固定する
+
+### 事象
+
+Cleanup progress モーダルが実際には進んでいても、`Ctrl+G` を押すまで進捗件数や
+`Cleanup Complete` への切り替わりが画面に出なかった。
+
+### 原因
+
+- cleanup worker のイベント drain は `Message::Tick` に依存していた。
+- main loop 側は outer loop を 1 周するたびに `Instant::now() + 100ms` で
+  tick deadline を作り直しており、PTY output や他イベントでループが回り続けると
+  Tick 自体が飢餓した。
+- `Ctrl+G` prefix は keybind 上 `Message::Tick` を直接発行するため、手動で
+  cleanup queue をポンプしたときだけ画面が更新されていた。
+
+### 再発防止策
+
+1. tick 駆動の overlay / modal を追加するときは、redraw gate だけでなく
+   「tick deadline を non-tick イベントで延長しない」ことまでテストで固定する。
+2. event loop の定期処理が `Tick` 依存なら、deadline は Tick を実際に消費するまで
+   保持し、外側ループの都度 `now + interval` で再計算しない。
+3. `Ctrl+G` のような prefix 消費でだけ UI が進む報告は、「手動で Tick を注入すると
+   直る」シグナルとして扱い、queue drain と scheduler の両方を確認する。
+
 ## 2026-04-12 — fix: 端末喪失時の crossterm 内部スピンによる CPU 100%
 
 ### 事象


### PR DESCRIPTION
## Summary

- preserve pending tick deadlines across outer-loop iterations so cleanup progress updates are not starved behind unrelated input/output
- advance the next tick deadline only when `Message::Tick` is actually consumed, which removes the `Ctrl+G`-to-refresh regression in the cleanup progress modal
- update SPEC #1920 artifacts so US-9, Phase 67, tasks, and progress all describe the cleanup progress redraw contract

## Changes

- `crates/gwt-tui/src/main.rs`: keep the tick deadline as loop state and only move it forward after a consumed tick
- `crates/gwt-tui/src/event.rs`: add `next_tick_deadline_from()` so the main loop can reschedule from the actual handling instant
- `SPEC #1920`: update `spec`, `plan`, `tasks`, and `progress` for the cleanup progress tick-scheduling fix

## Testing

- [x] `cargo test -p gwt-tui deadline -- --nocapture` — event loop deadline scheduling tests pass
- [x] `cargo test -p gwt-tui tick_redraw_required_stays_true_while_cleanup_progress_is_visible -- --nocapture` — cleanup modal redraw gate remains green
- [x] `cargo test -p gwt-tui cleanup_progress -- --nocapture` — cleanup progress modal tests pass
- [x] `cargo fmt -- --check` — formatting check passes
- [x] `cargo build -p gwt-tui` — gwt-tui builds successfully
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clippy passes without warnings
- [x] `cargo test -p gwt-tui deadline -- --nocapture` (after merging `origin/develop`) — still passes on the synced branch
- [x] `cargo test -p gwt-tui cleanup_progress -- --nocapture` (after merging `origin/develop`) — still passes on the synced branch

## Closing Issues

None

## Related Issues / Links

- #1920

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- cleanup progress state was already being updated from worker events, but the dirty-driven event loop recreated its tick deadline on each non-tick iteration
- `Ctrl+G` injects `Message::Tick` through the prefix state machine, which is why the modal only appeared to refresh after that key sequence
- the branch was synced with `origin/develop` before creating this PR, and the only merge conflict was a `tasks/lessons.md` append at the file head

## Risk / Impact

- **Affected areas**: workspace shell event loop, Branch Cleanup progress modal, SPEC #1920 artifact set
- **Rollback plan**: revert `fix: preserve cleanup progress ticks under event activity` and the merge commit if the cleanup progress regression needs to be backed out

## Notes

- the worktree still has an unrelated untracked `.codex/hooks/` directory that is not part of this PR
