### PR TITLE
fix(settings): align profiles and auto-save flow

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3237,6 +3237,8 @@ fn route_key_to_management(model: &mut Model, key: crossterm::event::KeyEvent) {
                     KeyCode::Up => Some(SettingsMessage::MoveUp),
                     KeyCode::Enter => Some(SettingsMessage::StartEdit),
                     KeyCode::Char(' ') => Some(SettingsMessage::ToggleBool),
+                    KeyCode::Char('[') => Some(SettingsMessage::PrevCategory),
+                    KeyCode::Char(']') => Some(SettingsMessage::NextCategory),
                     KeyCode::Char('S') if key.modifiers.contains(KeyModifiers::SHIFT) => {
                         Some(SettingsMessage::Save)
                     }
@@ -9683,9 +9685,9 @@ fn generic_management_hint_text(
 
 fn settings_list_hint_text(compact: bool) -> String {
     if compact {
-        "↑↓ sel  ↵ edit  Sp tog  C-←→ sub  S save  C-g Tab  Esc term  ?".to_string()
+        "↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t  ?".to_string()
     } else {
-        "↑↓:select  Enter:edit  Space:toggle  Ctrl+←→:sub-tab  Shift+S:save  Ctrl+G, Tab:focus  Esc:term  ?:help".to_string()
+        "↑↓:select  Enter:edit  Space:toggle  []:sub-tab  Shift+S:save  Ctrl+G, Tab:focus  Esc:term  ?:help".to_string()
     }
 }
 
@@ -13012,7 +13014,7 @@ services:
 
         let rendered = render_model_text(&model, 220, 24);
 
-        assert!(rendered.contains("Ctrl+←→:sub-tab"));
+        assert!(rendered.contains("[]:sub-tab"));
     }
 
     #[test]
@@ -21234,6 +21236,30 @@ services:
         assert_eq!(
             model.profiles.focus,
             screens::profiles::ProfilesFocus::ProfileList
+        );
+    }
+
+    #[test]
+    fn route_key_to_management_settings_brackets_cycle_categories() {
+        let mut model = test_model();
+        model.management_tab = ManagementTab::Settings;
+        model.active_focus = FocusPane::TabContent;
+
+        assert_eq!(
+            model.settings.category,
+            screens::settings::SettingsCategory::General
+        );
+
+        route_key_to_management(&mut model, key(KeyCode::Char(']'), KeyModifiers::NONE));
+        assert_eq!(
+            model.settings.category,
+            screens::settings::SettingsCategory::Worktree
+        );
+
+        route_key_to_management(&mut model, key(KeyCode::Char('['), KeyModifiers::NONE));
+        assert_eq!(
+            model.settings.category,
+            screens::settings::SettingsCategory::General
         );
     }
 

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -3239,9 +3239,6 @@ fn route_key_to_management(model: &mut Model, key: crossterm::event::KeyEvent) {
                     KeyCode::Char(' ') => Some(SettingsMessage::ToggleBool),
                     KeyCode::Char('[') => Some(SettingsMessage::PrevCategory),
                     KeyCode::Char(']') => Some(SettingsMessage::NextCategory),
-                    KeyCode::Char('S') if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                        Some(SettingsMessage::Save)
-                    }
                     KeyCode::Left if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         Some(SettingsMessage::PrevCategory)
                     }
@@ -9685,17 +9682,18 @@ fn generic_management_hint_text(
 
 fn settings_list_hint_text(compact: bool) -> String {
     if compact {
-        "↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t  ?".to_string()
+        "↑↓ sel  ↵ apply  Sp tog  [] cat  C-g Tab  Esc t  ?".to_string()
     } else {
-        "↑↓:select  Enter:edit  Space:toggle  []:sub-tab  Shift+S:save  Ctrl+G, Tab:focus  Esc:term  ?:help".to_string()
+        "↑↓:select  Enter:apply  Space:toggle  []:sub-tab  Ctrl+G, Tab:focus  Esc:term  ?:help"
+            .to_string()
     }
 }
 
 fn settings_edit_hint_text(compact: bool) -> String {
     if compact {
-        "↵ save  ⌫ del  Esc cancel  ?".to_string()
+        "↵ apply  ⌫ del  Esc cancel  ?".to_string()
     } else {
-        "Enter:save  Backspace:delete  Esc:cancel  ?:help".to_string()
+        "Enter:apply  Backspace:delete  Esc:cancel  ?:help".to_string()
     }
 }
 
@@ -21261,6 +21259,22 @@ services:
             model.settings.category,
             screens::settings::SettingsCategory::General
         );
+    }
+
+    #[test]
+    fn route_key_to_management_settings_shift_s_is_noop() {
+        with_temp_home(|_home| {
+            let mut model = test_model();
+            model.management_tab = ManagementTab::Settings;
+            model.active_focus = FocusPane::TabContent;
+            model.settings.category = screens::settings::SettingsCategory::Voice;
+            model.settings.load_category_fields();
+            model.settings.fields[0].value = "/nonexistent/model".to_string();
+
+            route_key_to_management(&mut model, key(KeyCode::Char('S'), KeyModifiers::SHIFT));
+
+            assert!(model.settings.save_error.is_none());
+        });
     }
 
     #[test]

--- a/crates/gwt-tui/src/screens/profiles.rs
+++ b/crates/gwt-tui/src/screens/profiles.rs
@@ -505,7 +505,7 @@ fn render_list(state: &ProfilesState, frame: &mut Frame, areas: LayoutAreas) {
 fn render_detail(state: &ProfilesState, frame: &mut Frame, areas: LayoutAreas) {
     let Some(profile) = state.selected_profile() else {
         let block = Block::default()
-            .title("Environment")
+            .title("Profile Variables")
             .borders(Borders::ALL)
             .border_type(theme::border::default());
         frame.render_widget(
@@ -538,7 +538,7 @@ fn render_environment_block(
     let (border_style, border_type) = theme::pane_border(state.focus == ProfilesFocus::Environment);
     frame.render_widget(
         Block::default()
-            .title("Environment")
+            .title("Profile Variables")
             .borders(Borders::ALL)
             .border_style(border_style)
             .border_type(border_type),
@@ -552,7 +552,7 @@ fn render_environment_block(
     );
     let items: Vec<ListItem> = if profile.env_rows.is_empty() {
         vec![ListItem::new(Line::from(vec![Span::styled(
-            "No environment rows. Press n to add one.".to_string(),
+            "No profile variables. Press n to add one.".to_string(),
             theme::style::muted_text(),
         )]))]
     } else {
@@ -617,10 +617,10 @@ fn render_form(state: &ProfilesState, frame: &mut Frame, area: Rect) {
     let title = match state.mode {
         ProfileMode::CreateProfile => "Create Profile",
         ProfileMode::EditProfile => "Edit Profile",
-        ProfileMode::CreateEnvVar => "Add Environment Variable",
-        ProfileMode::EditEnvVar => "Edit Environment Variable",
-        ProfileMode::CreateDisabledEnv => "Add Disabled OS Environment",
-        ProfileMode::EditDisabledEnv => "Edit Disabled OS Environment",
+        ProfileMode::CreateEnvVar => "Add Profile Variable",
+        ProfileMode::EditEnvVar => "Edit Profile Variable",
+        ProfileMode::CreateDisabledEnv => "Disable OS Variable",
+        ProfileMode::EditDisabledEnv => "Edit Disabled OS Variable",
         _ => "Profile Form",
     };
 
@@ -750,11 +750,11 @@ fn render_confirm_delete(state: &ProfilesState, frame: &mut Frame, area: Rect) {
             state.selected_profile().map(|profile| profile.name.clone()),
         ),
         ProfileMode::ConfirmDeleteEnvVar => (
-            "Delete Environment Variable",
+            "Delete Profile Variable",
             state.selected_env_var().map(|env| env.key.clone()),
         ),
         ProfileMode::ConfirmDeleteDisabledEnv => (
-            "Delete Disabled OS Environment",
+            "Delete Disabled OS Variable",
             state.selected_disabled_env().map(str::to_string),
         ),
         _ => ("Delete", None),
@@ -959,7 +959,8 @@ mod tests {
             .map(|cell| cell.symbol().to_string())
             .collect::<String>();
         assert!(text.contains("Profiles"), "{text}");
-        assert!(text.contains("Environment"), "{text}");
+        assert!(text.contains("Profile Variables"), "{text}");
+        assert!(!text.contains("Environment"), "{text}");
         assert!(!text.contains("Profile Detail"), "{text}");
         assert!(!text.contains("Name:"), "{text}");
         assert!(!text.contains("Desc:"), "{text}");

--- a/crates/gwt-tui/src/screens/settings.rs
+++ b/crates/gwt-tui/src/screens/settings.rs
@@ -748,6 +748,14 @@ fn finish_custom_agent_edit(state: &mut SettingsState) {
     });
 }
 
+fn persist_settings_change(state: &mut SettingsState) {
+    if let Err(e) = save_settings_to_config(state) {
+        state.save_error = Some(e);
+    } else {
+        state.save_error = None;
+    }
+}
+
 /// Update settings state in response to a message.
 pub fn update(state: &mut SettingsState, msg: SettingsMessage) {
     match msg {
@@ -782,6 +790,7 @@ pub fn update(state: &mut SettingsState, msg: SettingsMessage) {
                 if let Some(field) = state.fields.get(state.selected) {
                     if field.field_type == FieldType::Bool {
                         toggle_bool_field(&mut state.fields[state.selected]);
+                        persist_settings_change(state);
                     } else {
                         state.edit_buffer = field.value.clone();
                         state.editing = true;
@@ -800,6 +809,7 @@ pub fn update(state: &mut SettingsState, msg: SettingsMessage) {
                 }
                 state.editing = false;
                 state.edit_buffer.clear();
+                persist_settings_change(state);
             }
         }
         SettingsMessage::CancelEdit => {
@@ -820,15 +830,12 @@ pub fn update(state: &mut SettingsState, msg: SettingsMessage) {
             if !state.editing {
                 if let Some(field) = state.fields.get_mut(state.selected) {
                     toggle_bool_field(field);
+                    persist_settings_change(state);
                 }
             }
         }
         SettingsMessage::Save => {
-            if let Err(e) = save_settings_to_config(state) {
-                state.save_error = Some(e);
-            } else {
-                state.save_error = None;
-            }
+            persist_settings_change(state);
         }
     }
 }
@@ -942,11 +949,11 @@ fn render_fields(state: &SettingsState, frame: &mut Frame, area: Rect) {
         .collect();
 
     let hints = if state.editing {
-        " Enter: save | Esc: cancel"
+        " Enter: apply | Esc: cancel"
     } else if state.category == SettingsCategory::CustomAgents {
         " Enter: cycle/edit/action | [/]: category"
     } else {
-        " Enter: edit | Space: toggle bool | [/]: category"
+        " Enter: edit/apply | Space: toggle bool | [/]: category"
     };
 
     let block = Block::default().title(format!("{}{}", state.category.label(), hints));
@@ -987,6 +994,17 @@ mod tests {
     fn voice_state_with_fields() -> SettingsState {
         let mut state = SettingsState::default();
         state.category = SettingsCategory::Voice;
+        state.load_category_fields();
+        state
+    }
+
+    fn state_with_category_and_path(
+        category: SettingsCategory,
+        config_path: &Path,
+    ) -> SettingsState {
+        let mut state = SettingsState::default();
+        state.category = category;
+        state.config_path_override = Some(config_path.to_path_buf());
         state.load_category_fields();
         state
     }
@@ -1133,6 +1151,23 @@ mod tests {
     }
 
     #[test]
+    fn end_edit_persists_agent_field_without_explicit_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        Settings::default().save(&config_path).unwrap();
+
+        let mut state = state_with_category_and_path(SettingsCategory::Agent, &config_path);
+        update(&mut state, SettingsMessage::StartEdit);
+        state.edit_buffer = "codex".to_string();
+
+        update(&mut state, SettingsMessage::EndEdit);
+
+        let loaded = Settings::load_from_path(&config_path).unwrap();
+        assert_eq!(loaded.agent.default_agent.as_deref(), Some("codex"));
+        assert!(state.save_error.is_none());
+    }
+
+    #[test]
     fn cancel_edit_discards() {
         let mut state = state_with_fields();
         let original = state.fields[0].value.clone();
@@ -1194,6 +1229,45 @@ mod tests {
 
         update(&mut state, SettingsMessage::ToggleBool);
         assert_eq!(state.fields[2].value, "true");
+    }
+
+    #[test]
+    fn toggle_bool_persists_voice_config_without_explicit_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let model_dir = dir.path().join("model");
+        std::fs::create_dir(&model_dir).unwrap();
+
+        let mut settings = Settings::default();
+        settings.voice.model_path = Some(model_dir.clone());
+        settings.save(&config_path).unwrap();
+
+        let mut state = state_with_category_and_path(SettingsCategory::Voice, &config_path);
+        state.selected = 4;
+
+        update(&mut state, SettingsMessage::ToggleBool);
+
+        let loaded = Settings::load_from_path(&config_path).unwrap();
+        assert!(loaded.voice.enabled);
+        assert!(state.save_error.is_none());
+    }
+
+    #[test]
+    fn end_edit_auto_save_surfaces_validation_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        Settings::default().save(&config_path).unwrap();
+
+        let mut state = state_with_category_and_path(SettingsCategory::Voice, &config_path);
+        state.selected = 0;
+        update(&mut state, SettingsMessage::StartEdit);
+        state.edit_buffer = "/nonexistent/model".to_string();
+
+        update(&mut state, SettingsMessage::EndEdit);
+
+        assert!(state.save_error.is_some());
+        let loaded = Settings::load_from_path(&config_path).unwrap();
+        assert!(loaded.voice.model_path.is_none());
     }
 
     #[test]

--- a/crates/gwt-tui/src/screens/settings.rs
+++ b/crates/gwt-tui/src/screens/settings.rs
@@ -944,9 +944,9 @@ fn render_fields(state: &SettingsState, frame: &mut Frame, area: Rect) {
     let hints = if state.editing {
         " Enter: save | Esc: cancel"
     } else if state.category == SettingsCategory::CustomAgents {
-        " Enter: cycle/edit/action | Ctrl+Left/Right: category"
+        " Enter: cycle/edit/action | [/]: category"
     } else {
-        " Enter: edit | Space: toggle bool | Ctrl+Left/Right: category"
+        " Enter: edit | Space: toggle bool | [/]: category"
     };
 
     let block = Block::default().title(format!("{}{}", state.category.label(), hints));

--- a/crates/gwt-tui/src/screens/settings.rs
+++ b/crates/gwt-tui/src/screens/settings.rs
@@ -28,7 +28,6 @@ pub enum SettingsCategory {
     Worktree,
     Agent,
     CustomAgents,
-    Environment,
     Ai,
     Skills,
     Voice,
@@ -36,12 +35,11 @@ pub enum SettingsCategory {
 
 impl SettingsCategory {
     /// All categories in display order.
-    pub const ALL: [SettingsCategory; 8] = [
+    pub const ALL: [SettingsCategory; 7] = [
         SettingsCategory::General,
         SettingsCategory::Worktree,
         SettingsCategory::Agent,
         SettingsCategory::CustomAgents,
-        SettingsCategory::Environment,
         SettingsCategory::Ai,
         SettingsCategory::Skills,
         SettingsCategory::Voice,
@@ -54,7 +52,6 @@ impl SettingsCategory {
             Self::Worktree => "Worktree",
             Self::Agent => "Agent",
             Self::CustomAgents => "Custom Agents",
-            Self::Environment => "Environment",
             Self::Ai => "AI",
             Self::Skills => "Skills",
             Self::Voice => "Voice",
@@ -274,23 +271,6 @@ pub fn fields_for_category_with_settings(
                 label: CUSTOM_AGENT_ADD_LABEL.to_string(),
                 value: "Create new custom agent".to_string(),
                 field_type: FieldType::Action,
-            },
-        ],
-        SettingsCategory::Environment => vec![
-            SettingField {
-                label: "Shell".to_string(),
-                value: "/bin/zsh".to_string(),
-                field_type: FieldType::Path,
-            },
-            SettingField {
-                label: "PATH prefix".to_string(),
-                value: String::new(),
-                field_type: FieldType::Text,
-            },
-            SettingField {
-                label: "Inherit env".to_string(),
-                value: "true".to_string(),
-                field_type: FieldType::Bool,
             },
         ],
         SettingsCategory::Ai => vec![
@@ -1246,6 +1226,16 @@ mod tests {
     }
 
     #[test]
+    fn settings_categories_exclude_environment() {
+        let labels: Vec<_> = SettingsCategory::ALL
+            .iter()
+            .map(|category| category.label())
+            .collect();
+
+        assert!(!labels.contains(&"Environment"));
+    }
+
+    #[test]
     fn voice_category_has_expected_fields() {
         let fields = fields_for_category(SettingsCategory::Voice);
         let labels: Vec<_> = fields.iter().map(|field| field.label.as_str()).collect();
@@ -1309,7 +1299,7 @@ mod tests {
     #[test]
     fn category_cycle_full_round() {
         let mut cat = SettingsCategory::General;
-        for _ in 0..8 {
+        for _ in 0..SettingsCategory::ALL.len() {
             cat = cat.next();
         }
         assert_eq!(cat, SettingsCategory::General); // full cycle
@@ -1317,15 +1307,15 @@ mod tests {
 
     #[test]
     fn voice_and_skills_categories_are_last_in_sidebar_order() {
-        assert_eq!(SettingsCategory::ALL.len(), 8);
-        assert_eq!(SettingsCategory::ALL[6], SettingsCategory::Skills);
-        assert_eq!(SettingsCategory::ALL[7], SettingsCategory::Voice);
+        assert_eq!(SettingsCategory::ALL.len(), 7);
+        assert_eq!(SettingsCategory::ALL[5], SettingsCategory::Skills);
+        assert_eq!(SettingsCategory::ALL[6], SettingsCategory::Voice);
     }
 
     #[test]
     fn category_prev_full_round() {
         let mut cat = SettingsCategory::General;
-        for _ in 0..8 {
+        for _ in 0..SettingsCategory::ALL.len() {
             cat = cat.prev();
         }
         assert_eq!(cat, SettingsCategory::General); // full cycle

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__e2e_key_flow_settings.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__e2e_key_flow_settings.snap
@@ -5,7 +5,7 @@ expression: output
 ---
 ╔...│ Versions │ Settings │ Logs ══════╗╭ › Shell ─────────────────────────────╮
 ║ General │ Worktree │ Agent │ Custom A║│Session: Shell (78x21)                │
-║General Enter: edit | Space: toggle bo║│                                      │
+║General Enter: edit/apply | Space: tog║│                                      │
 ║[T] Theme: dark                       ║│                                      │
 ║[T] Language: en                      ║│                                      │
 ║[B] Auto-save: true                   ║│                                      │
@@ -26,4 +26,4 @@ expression: output
 ║                                      ║│                                      │
 ║                                      ║│                                      │
 ╚══════════════════════════════════════╝╰──────────────────────────────────────╯
- ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t
+ ⎇n/a  │  P:default  │  ↑↓ sel  ↵ apply  Sp tog  [] cat  C-g Tab  Esc t  ?

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__e2e_key_flow_settings.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__e2e_key_flow_settings.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/gwt-tui/tests/snapshot_e2e.rs
+assertion_line: 883
 expression: output
 ---
 ╔...│ Versions │ Settings │ Logs ══════╗╭ › Shell ─────────────────────────────╮
@@ -25,4 +26,4 @@ expression: output
 ║                                      ║│                                      │
 ║                                      ║│                                      │
 ╚══════════════════════════════════════╝╰──────────────────────────────────────╯
- ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  C-←→ sub  S save  C-g Tab  Esc t
+ ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__profiles_tab.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__profiles_tab.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/gwt-tui/tests/snapshot_e2e.rs
+assertion_line: 455
 expression: output
 ---
 ╔...│ Specs │ Profiles │ Git View │...═╗╭ › Shell ─────────────────────────────╮
-║╔Profiles═══╗╭Environment────────────╮║│Session: Shell (80x24)                │
+║╔Profiles═══╗╭Profile Variables──────╮║│Session: Shell (80x24)                │
 ║║Tab | ↵ |  ║│↵/e | n | d            │║│                                      │
 ║║[*] default║│A00_BASE=/usr/bin      │║│                                      │
 ║║           ║│A01_BASE=/bin          │║│                                      │

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__settings_tab.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__settings_tab.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/gwt-tui/tests/snapshot_e2e.rs
+assertion_line: 304
 expression: output
 ---
 ╔...│ Versions │ Settings │ Logs ══════╗╭ › Shell ─────────────────────────────╮
@@ -25,4 +26,4 @@ expression: output
 ║                                      ║│                                      │
 ║                                      ║│                                      │
 ╚══════════════════════════════════════╝╰──────────────────────────────────────╯
- ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  C-←→ sub  S save  C-g Tab  Esc t
+ ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__settings_tab.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__settings_tab.snap
@@ -26,4 +26,4 @@ expression: output
 ║                                      ║│                                      │
 ║                                      ║│                                      │
 ╚══════════════════════════════════════╝╰──────────────────────────────────────╯
- ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t
+ ⎇n/a  │  P:default  │  ↑↓ sel  ↵ apply  Sp tog  [] cat  C-g Tab  Esc t  ?

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__switched_to_settings.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__switched_to_settings.snap
@@ -5,7 +5,7 @@ expression: output
 ---
 ╔...│ Versions │ Settings │ Logs ══════╗╭ › Shell ─────────────────────────────╮
 ║ General │ Worktree │ Agent │ Custom A║│Session: Shell (80x24)                │
-║General Enter: edit | Space: toggle bo║│                                      │
+║General Enter: edit/apply | Space: tog║│                                      │
 ║[T] Theme: dark                       ║│                                      │
 ║[T] Language: en                      ║│                                      │
 ║[B] Auto-save: true                   ║│                                      │
@@ -26,4 +26,4 @@ expression: output
 ║                                      ║│                                      │
 ║                                      ║│                                      │
 ╚══════════════════════════════════════╝╰──────────────────────────────────────╯
- ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t
+ ⎇n/a  │  P:default  │  ↑↓ sel  ↵ apply  Sp tog  [] cat  C-g Tab  Esc t  ?

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__switched_to_settings.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__switched_to_settings.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/gwt-tui/tests/snapshot_e2e.rs
+assertion_line: 608
 expression: output
 ---
 ╔...│ Versions │ Settings │ Logs ══════╗╭ › Shell ─────────────────────────────╮
@@ -25,4 +26,4 @@ expression: output
 ║                                      ║│                                      │
 ║                                      ║│                                      │
 ╚══════════════════════════════════════╝╰──────────────────────────────────────╯
- ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  C-←→ sub  S save  C-g Tab  Esc t
+ ⎇n/a  │  P:default  │  ↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t


### PR DESCRIPTION
## Summary

- Removed the stale `Settings > Environment` surface so profile environment editing lives only in `Profiles`, which matches SPEC #1933 and avoids duplicated configuration paths.
- Added `[` / `]` category shortcuts and aligned the settings hints so the TUI advertises the keys that actually work.
- Changed settings edits to auto-save on apply/toggle so `Shift+S` is no longer required, while validation failures still surface inline.

## Changes

- `crates/gwt-tui/src/screens/settings.rs`: persist text commits and bool toggles immediately, keep inline save errors, and add regression tests for auto-save behavior.
- `crates/gwt-tui/src/app.rs`: update settings hint copy, remove the stale `Shift+S` save binding, and add a routing test that keeps `Shift+S` as a no-op.
- `crates/gwt-tui/tests/snapshots/snapshot_e2e__settings_tab.snap`, `crates/gwt-tui/tests/snapshots/snapshot_e2e__switched_to_settings.snap`, `crates/gwt-tui/tests/snapshots/snapshot_e2e__e2e_key_flow_settings.snap`: refresh TUI snapshots for the new settings hints.

## Testing

- [x] `cargo fmt -- --check` — passes with the repo's existing stable-toolchain rustfmt warnings only.
- [x] `cargo test -p gwt-core -p gwt-tui` — passes.
- [x] `cargo build -p gwt-tui` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.

## Closing Issues

- Closes #1933

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — README was not changed; the behavior change is limited to the existing Settings workflow and SPEC #1933 was updated instead.
- [ ] Migration/backfill plan included (if schema/data change) — No schema or stored-data migration is required.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This branch already carried the earlier settings-category PR (#956), and these three follow-up commits finish the remaining Settings/Profiles cleanup by removing the stale environment editor, matching the key routing, and documenting the new auto-save contract in SPEC #1933.

## Risk / Impact

- **Affected areas**: `gwt-tui` Settings screen, config persistence, settings snapshots, SPEC #1933.
- **Rollback plan**: Revert this PR if settings navigation or persistence regresses; no data migration rollback is needed.

## Screenshots

| Before | After |
|--------|-------|
| `↑↓ sel  ↵ edit  Sp tog  [] cat  S save  C-g Tab  Esc t` | `↑↓ sel  ↵ apply  Sp tog  [] cat  C-g Tab  Esc t  ?` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Settings changes now auto-save automatically.
  * Added [ and ] keyboard shortcuts for navigating settings categories.

* **UI Improvements**
  * Removed Environment category from settings panel.
  * Renamed "Environment" terminology to "Profile Variables" in profiles screen.
  * Updated UI hints to reflect new keyboard shortcuts and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->