### PR TITLE
fix: clamp terminal selection to visible snapshot

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -8741,11 +8741,35 @@ fn sgr_modifier_bits(modifiers: KeyModifiers) -> u16 {
 
 fn selected_text(session: &crate::model::SessionTab) -> Option<String> {
     let selection = session.vt.selection()?;
-    let (start, end) = normalize_selection(selection);
     session.vt.with_visible_screen(|screen| {
-        let end_col = end.col.saturating_add(1).min(screen.size().1);
+        let (start, end, end_col) = clamp_selection_to_screen(selection, screen)?;
         Some(screen.contents_between(start.row, start.col, end.row, end_col))
     })
+}
+
+fn clamp_selection_to_screen(
+    selection: TerminalSelection,
+    screen: &vt100::Screen,
+) -> Option<(TerminalCell, TerminalCell, u16)> {
+    let (rows, cols) = screen.size();
+    if rows == 0 || cols == 0 {
+        return None;
+    }
+
+    let max_row = rows.saturating_sub(1);
+    let max_col = cols.saturating_sub(1);
+    let clamp_cell = |mut cell: TerminalCell| {
+        cell.row = cell.row.min(max_row);
+        cell.col = cell.col.min(max_col);
+        cell
+    };
+    let clamped = TerminalSelection {
+        anchor: clamp_cell(selection.anchor),
+        focus: clamp_cell(selection.focus),
+    };
+    let (start, end) = normalize_selection(clamped);
+    let end_col = end.col.saturating_add(1).min(cols);
+    Some((start, end, end_col))
 }
 
 fn scroll_session_by_rows(model: &mut Model, session_idx: usize, delta_rows: i16) -> bool {
@@ -11722,6 +11746,68 @@ services:
             Some("line-1"),
             "selection copy should read from the visible snapshot surface instead of the live frame"
         );
+    }
+
+    #[test]
+    fn selected_text_clamps_selection_to_snapshot_width_after_resize() {
+        let mut model = test_model();
+        model.active_layer = ActiveLayer::Main;
+        model.active_focus = FocusPane::Terminal;
+        update(&mut model, Message::Resize(12, 8));
+
+        let initial_area = active_session_text_area(&model).expect("initial session text area");
+        let snapshot_cols = initial_area.width;
+        assert!(
+            snapshot_cols > 0,
+            "precondition: snapshot width must be non-zero"
+        );
+
+        let line_a = "A".repeat(snapshot_cols as usize);
+        let line_b = "B".repeat(snapshot_cols as usize);
+        let line_c = "C".repeat(snapshot_cols as usize);
+        let line_d = "D".repeat(snapshot_cols as usize);
+        let line_e = "E".repeat(snapshot_cols as usize);
+        enter_alt_screen_with_lines(
+            &mut model,
+            "shell-0",
+            &[&line_a, &line_b, &line_c, &line_d, &line_e],
+        );
+
+        let line_f = "F".repeat(snapshot_cols as usize);
+        let line_g = "G".repeat(snapshot_cols as usize);
+        let line_h = "H".repeat(snapshot_cols as usize);
+        let line_i = "I".repeat(snapshot_cols as usize);
+        let line_j = "J".repeat(snapshot_cols as usize);
+        replace_alt_screen_lines(
+            &mut model,
+            "shell-0",
+            &[&line_f, &line_g, &line_h, &line_i, &line_j],
+        );
+
+        let session = model.active_session_tab_mut().expect("active session");
+        assert!(session.vt.scroll_snapshot_up(1));
+
+        update(&mut model, Message::Resize(40, 8));
+        let resized_area = active_session_text_area(&model).expect("resized session text area");
+        assert!(
+            resized_area.width > snapshot_cols,
+            "precondition: resized viewport should be wider than the frozen snapshot"
+        );
+
+        let out_of_bounds_col = snapshot_cols.saturating_add(2);
+        let session = model.active_session_tab_mut().expect("active session");
+        session.vt.begin_selection(crate::model::TerminalCell {
+            row: 0,
+            col: out_of_bounds_col,
+        });
+        session.vt.update_selection(crate::model::TerminalCell {
+            row: 1,
+            col: out_of_bounds_col,
+        });
+
+        let copied = selected_text(model.active_session_tab().expect("active session"));
+        let expected = format!("A\n{line_b}");
+        assert_eq!(copied.as_deref(), Some(expected.as_str()));
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,27 @@
 # Lessons Learned
 
+## 2026-04-14 — fix: terminal selection copy は visible screen の実サイズに clamp してから vt100 へ渡す
+
+### 事象
+
+snapshot history を見ている状態で terminal viewport を広げたあと、広がった幅のまま複数行選択すると
+`vt100::Screen::contents_between()` が `attempt to subtract with overflow` で panic した。
+
+### 原因
+
+- selection の row/col は現在の TUI viewport 基準で保持していたが、コピー時に参照する visible screen は
+  過去 snapshot のままで、幅・高さが現在 viewport より小さい場合があった。
+- `selected_text()` が selection 座標を clamp せず、そのまま `contents_between()` に渡していたため、
+  `start_col > screen.cols()` となり `cols - start_col` が underflow した。
+
+### 再発防止策
+
+1. terminal selection を外部 crate (`vt100`) の row/col API に渡す前に、必ず visible screen の実サイズへ clamp する。
+2. snapshot/history と resize が絡む選択コピーでは、「現在 viewport より狭い snapshot に対する複数行選択」を
+   回帰テストで固定する。
+3. mouse 座標や selection state を保持する変更では、render surface と copy surface が同一サイズとは限らない前提で
+   境界条件を確認する。
+
 ## 2026-04-13 — tui: 常設入力欄では plain 文字ショートカットを残さない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Clamp terminal selection coordinates to the visible screen before copying text from snapshot history.
- Add a regression test covering resize after entering snapshot history so wide selections on narrow snapshots no longer panic.
- Record the root cause and guardrail in `tasks/lessons.md` to prevent the same vt100 underflow path from returning.

## Changes

- `crates/gwt-tui/src/app.rs`: clamp terminal selection rows and columns to the active visible screen before calling `vt100::Screen::contents_between()`.
- `crates/gwt-tui/src/app.rs`: add `selected_text_clamps_selection_to_snapshot_width_after_resize` to reproduce the crash and verify the fix.
- `tasks/lessons.md`: document the snapshot-resize-selection failure mode and the boundary-check rule for future terminal copy changes.

## Testing

- [x] `cargo test -p gwt-tui selected_text_clamps_selection_to_snapshot_width_after_resize -- --nocapture` — reproduces the panic before the fix and passes after the clamp.
- [x] `cargo test -p gwt-tui selection_copy_ -- --nocapture` — snapshot and scrollback selection-copy coverage stays green.
- [x] `cargo test -p gwt-tui left_click -- --nocapture` — local selection and PTY mouse routing stay green.
- [x] `cargo fmt --check` — formatting passes (nightly-only rustfmt config warnings only).
- [x] `cargo test -p gwt-core -p gwt-tui` — full targeted test suites pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes without warnings.

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (not user-facing; no README change needed)
- [ ] Migration/backfill plan included (no schema or data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` change only)

## Notes

- The branch has an unrelated local modification in `.codex/hooks.json`; it is intentionally excluded from this PR.
