### PR TITLE
fix(tui): show welcome state when no terminal sessions exist

### DIFF
--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -9468,28 +9468,62 @@ fn render_welcome_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
         return;
     }
 
-    let content = welcome_session_content_area(inner);
+    let intro_lines = welcome_session_intro_lines();
+    let command_lines = welcome_session_command_lines();
+    let content_height = (intro_lines.len() + command_lines.len())
+        .try_into()
+        .unwrap_or(u16::MAX);
+    let content_height = content_height.min(inner.height);
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(content_height),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+    let content = vertical[1];
+
     if content.width == 0 || content.height == 0 {
         return;
     }
 
-    let paragraph = Paragraph::new(welcome_session_lines());
-    frame.render_widget(paragraph, content);
+    let intro_height = (intro_lines.len() as u16).min(content.height);
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(intro_height), Constraint::Min(0)])
+        .split(content);
+
+    if sections[0].width > 0 && sections[0].height > 0 {
+        let intro = Paragraph::new(intro_lines).alignment(ratatui::layout::Alignment::Center);
+        frame.render_widget(intro, sections[0]);
+    }
+
+    let commands = welcome_session_content_area(sections[1]);
+    if commands.width > 0 && commands.height > 0 {
+        let paragraph = Paragraph::new(command_lines);
+        frame.render_widget(paragraph, commands);
+    }
 }
 
-fn welcome_session_lines() -> Vec<Line<'static>> {
+fn welcome_session_intro_lines() -> Vec<Line<'static>> {
+    let body_style = Style::default().fg(theme::color::TEXT_SECONDARY);
+
+    vec![
+        Line::from(Span::styled("Welcome", theme::style::header())),
+        Line::from(""),
+        Line::from(Span::styled("No terminal windows are open.", body_style)),
+        Line::from(""),
+    ]
+}
+
+fn welcome_session_command_lines() -> Vec<Line<'static>> {
     const WELCOME_KEY_WIDTH: usize = 24;
     let command_style = Style::default()
         .fg(theme::color::ACTIVE)
         .add_modifier(Modifier::BOLD);
     let body_style = Style::default().fg(theme::color::TEXT_SECONDARY);
-
-    let mut lines = vec![
-        Line::from(Span::styled("Welcome", theme::style::header())),
-        Line::from(""),
-        Line::from(Span::styled("No terminal windows are open.", body_style)),
-        Line::from(""),
-    ];
+    let mut lines = Vec::new();
 
     for binding in KeybindRegistry::new().all_bindings() {
         lines.push(Line::from(vec![
@@ -13866,7 +13900,7 @@ services:
     }
 
     #[test]
-    fn render_model_text_zero_sessions_left_aligns_welcome_content() {
+    fn render_model_text_zero_sessions_centers_intro_but_left_aligns_commands() {
         let mut model = test_model();
         model.sessions.clear();
         model.active_layer = ActiveLayer::Main;
@@ -13874,7 +13908,8 @@ services:
 
         let rendered = render_model_text(&model, 80, 24);
 
-        assert!(rendered.contains("║  Welcome"));
+        assert!(rendered.contains("║                                    Welcome"));
+        assert!(rendered.contains("║                         No terminal windows are open."));
         assert!(rendered.contains("║  Ctrl+G, g"));
         assert!(rendered.contains("║  Ctrl+G, c"));
     }

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -1006,17 +1006,11 @@ pub fn update(model: &mut Model, msg: Message) {
             };
         }
         Message::NewShell => {
-            let idx = model.sessions.len();
-            let session = crate::model::SessionTab {
-                id: format!("shell-{idx}"),
-                name: format!("Shell {}", idx + 1),
-                tab_type: SessionTabType::Shell,
-                vt: crate::model::VtState::new(24, 80),
-                created_at: std::time::Instant::now(),
-            };
+            let shell_index = next_shell_index(model);
+            let session = crate::model::shell_session(shell_index);
             let session_id = session.id.clone();
             model.sessions.push(session);
-            model.active_session = idx;
+            model.active_session = model.sessions.len().saturating_sub(1);
 
             // Use actual pane content area for PTY size.
             let (cols, rows) = session_content_size(model);
@@ -5709,7 +5703,7 @@ where
 }
 
 fn close_active_session_with(model: &mut Model, sessions_dir: &Path) {
-    if model.sessions.len() <= 1 {
+    if model.sessions.is_empty() {
         return;
     }
 
@@ -5726,10 +5720,28 @@ fn close_active_session_with(model: &mut Model, sessions_dir: &Path) {
     }
     clear_discussion_resume_state_for_session(model, &id);
     model.sessions.remove(model.active_session);
-    if model.active_session >= model.sessions.len() {
+    if model.sessions.is_empty() {
+        model.active_session = 0;
+    } else if model.active_session >= model.sessions.len() {
         model.active_session = model.sessions.len() - 1;
     }
     refresh_branch_live_session_summaries_with(model, sessions_dir);
+}
+
+fn next_shell_index(model: &Model) -> usize {
+    model
+        .sessions
+        .iter()
+        .filter_map(|session| match session.tab_type {
+            SessionTabType::Shell => session
+                .id
+                .strip_prefix("shell-")
+                .and_then(|suffix| suffix.parse::<usize>().ok()),
+            SessionTabType::Agent { .. } => None,
+        })
+        .max()
+        .map(|index| index + 1)
+        .unwrap_or(0)
 }
 
 fn resolve_launch_worktree(repo_path: &Path, config: &mut LaunchConfig) -> Result<(), String> {
@@ -9423,6 +9435,11 @@ fn render_management_tab_content(model: &Model, frame: &mut Frame, area: Rect) {
 
 /// Render the session pane (right side, or full screen).
 fn render_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
+    if model.sessions.is_empty() {
+        render_welcome_session_pane(model, frame, area);
+        return;
+    }
+
     let terminal_focused = model.active_focus == FocusPane::Terminal;
     match model.session_layout {
         SessionLayout::Tab => {
@@ -9437,6 +9454,75 @@ fn render_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
         SessionLayout::Grid => {
             render_grid_sessions(model, frame, area);
         }
+    }
+}
+
+fn render_welcome_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
+    let pane_focused =
+        model.active_layer == ActiveLayer::Main || model.active_focus == FocusPane::Terminal;
+    let block = pane_block(Line::from(" Welcome "), pane_focused);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let lines = welcome_session_lines(inner.width <= 56 || inner.height <= 8);
+    let content_height = (lines.len() as u16).min(inner.height);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(content_height),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+    frame.render_widget(paragraph, chunks[1]);
+}
+
+fn welcome_session_lines(compact: bool) -> Vec<Line<'static>> {
+    let command_style = Style::default()
+        .fg(theme::color::ACTIVE)
+        .add_modifier(Modifier::BOLD);
+    let body_style = Style::default().fg(theme::color::TEXT_SECONDARY);
+
+    if compact {
+        vec![
+            Line::from(Span::styled("Welcome", theme::style::header())),
+            Line::from(""),
+            Line::from(Span::styled("No terminal windows are open.", body_style)),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Ctrl+G, c", command_style),
+                Span::styled("  New shell", body_style),
+            ]),
+            Line::from(vec![
+                Span::styled("Ctrl+G, g", command_style),
+                Span::styled("  Management", body_style),
+            ]),
+        ]
+    } else {
+        vec![
+            Line::from(Span::styled("Welcome", theme::style::header())),
+            Line::from(""),
+            Line::from(Span::styled("No terminal windows are open.", body_style)),
+            Line::from(Span::styled(
+                "Open a shell or return to the management panel.",
+                body_style,
+            )),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Ctrl+G, c", command_style),
+                Span::styled("  New shell session", body_style),
+            ]),
+            Line::from(vec![
+                Span::styled("Ctrl+G, g", command_style),
+                Span::styled("  Open management panel", body_style),
+            ]),
+        ]
     }
 }
 
@@ -9556,16 +9642,22 @@ fn should_compact_session_title(width: u16, entries: &[(String, Style, &'static 
 /// The status bar keeps session context visible and appends the relevant hints.
 fn render_keybind_hints(model: &Model, frame: &mut Frame, area: Rect) {
     let compact = area.width <= 80;
-    let hints = match model.active_focus {
-        FocusPane::TabContent if model.management_tab == ManagementTab::Branches => {
-            branches_list_hint_text_with_selection(
-                compact,
-                model.branches.cleanup_selection_count(),
-            )
+    let hints = if model.sessions.is_empty()
+        && (model.active_layer == ActiveLayer::Main || model.active_focus == FocusPane::Terminal)
+    {
+        welcome_hint_text(compact)
+    } else {
+        match model.active_focus {
+            FocusPane::TabContent if model.management_tab == ManagementTab::Branches => {
+                branches_list_hint_text_with_selection(
+                    compact,
+                    model.branches.cleanup_selection_count(),
+                )
+            }
+            FocusPane::TabContent => management_hint_text(model, compact),
+            FocusPane::BranchDetail => branch_detail_hint_text(model, compact),
+            FocusPane::Terminal => terminal_hint_text(),
         }
-        FocusPane::TabContent => management_hint_text(model, compact),
-        FocusPane::BranchDetail => branch_detail_hint_text(model, compact),
-        FocusPane::Terminal => terminal_hint_text(),
     };
 
     crate::widgets::status_bar::render_with_notification_and_hints(
@@ -9579,6 +9671,14 @@ fn render_keybind_hints(model: &Model, frame: &mut Frame, area: Rect) {
 
 fn terminal_hint_text() -> String {
     "Ctrl+G:b/i/s g c []/1-9 z ?  C-g Tab:focus  ^C×2".to_string()
+}
+
+fn welcome_hint_text(compact: bool) -> String {
+    if compact {
+        "C-g,c shell  C-g,g manage  ?:help".to_string()
+    } else {
+        "Ctrl+G, c:new shell  Ctrl+G, g:management  ?:help".to_string()
+    }
 }
 
 fn branches_list_hint_text_with_selection(compact: bool, selection_count: usize) -> String {
@@ -13762,6 +13862,34 @@ services:
     }
 
     #[test]
+    fn render_model_text_zero_sessions_shows_welcome_actions() {
+        let mut model = test_model();
+        model.sessions.clear();
+        model.active_layer = ActiveLayer::Main;
+        model.active_focus = FocusPane::Terminal;
+
+        let rendered = render_model_text(&model, 80, 24);
+
+        assert!(rendered.contains("Welcome"));
+        assert!(rendered.contains("No terminal windows are open."));
+        assert!(rendered.contains("Ctrl+G, c"));
+        assert!(rendered.contains("Ctrl+G, g"));
+    }
+
+    #[test]
+    fn render_model_text_management_with_zero_sessions_shows_welcome_pane() {
+        let mut model = test_model();
+        model.sessions.clear();
+        model.active_layer = ActiveLayer::Management;
+        model.active_focus = FocusPane::Terminal;
+
+        let rendered = render_model_text(&model, 120, 24);
+
+        assert!(rendered.contains("Welcome"));
+        assert!(rendered.contains("No terminal windows are open."));
+    }
+
+    #[test]
     fn render_model_text_branches_list_hints_remain_visible_at_standard_width() {
         let mut model = test_model();
         model.active_layer = ActiveLayer::Management;
@@ -14357,12 +14485,27 @@ services:
     }
 
     #[test]
-    fn update_close_session_wont_remove_last() {
+    fn update_close_session_removes_last() {
         let mut model = test_model();
         assert_eq!(model.session_count(), 1);
 
         update(&mut model, Message::CloseSession);
+        assert_eq!(model.session_count(), 0);
+        assert_eq!(model.active_session, 0);
+    }
+
+    #[test]
+    fn update_new_shell_recreates_primary_shell_after_zero_sessions() {
+        let mut model = test_model();
+        model.sessions.clear();
+        model.active_session = 0;
+
+        update(&mut model, Message::NewShell);
+
         assert_eq!(model.session_count(), 1);
+        assert_eq!(model.active_session, 0);
+        assert_eq!(model.sessions[0].id, "shell-0");
+        assert_eq!(model.sessions[0].name, "Shell");
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -52,7 +52,7 @@ use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEven
 use crate::{
     custom_agents::load_custom_agents,
     discussion_resume::{build_resume_prompt, park_pending_resume},
-    input::voice::VoiceInputMessage,
+    input::{keybind::KeybindRegistry, voice::VoiceInputMessage},
     input_trace,
     message::{GridSessionDirection, Message},
     model::{
@@ -9468,7 +9468,7 @@ fn render_welcome_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
         return;
     }
 
-    let lines = welcome_session_lines(inner.width <= 56 || inner.height <= 8);
+    let lines = welcome_session_lines();
     let content_height = (lines.len() as u16).min(inner.height);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -9483,47 +9483,28 @@ fn render_welcome_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
     frame.render_widget(paragraph, chunks[1]);
 }
 
-fn welcome_session_lines(compact: bool) -> Vec<Line<'static>> {
+fn welcome_session_lines() -> Vec<Line<'static>> {
     let command_style = Style::default()
         .fg(theme::color::ACTIVE)
         .add_modifier(Modifier::BOLD);
     let body_style = Style::default().fg(theme::color::TEXT_SECONDARY);
 
-    if compact {
-        vec![
-            Line::from(Span::styled("Welcome", theme::style::header())),
-            Line::from(""),
-            Line::from(Span::styled("No terminal windows are open.", body_style)),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled("Ctrl+G, c", command_style),
-                Span::styled("  New shell", body_style),
-            ]),
-            Line::from(vec![
-                Span::styled("Ctrl+G, g", command_style),
-                Span::styled("  Management", body_style),
-            ]),
-        ]
-    } else {
-        vec![
-            Line::from(Span::styled("Welcome", theme::style::header())),
-            Line::from(""),
-            Line::from(Span::styled("No terminal windows are open.", body_style)),
-            Line::from(Span::styled(
-                "Open a shell or return to the management panel.",
-                body_style,
-            )),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled("Ctrl+G, c", command_style),
-                Span::styled("  New shell session", body_style),
-            ]),
-            Line::from(vec![
-                Span::styled("Ctrl+G, g", command_style),
-                Span::styled("  Open management panel", body_style),
-            ]),
-        ]
+    let mut lines = vec![
+        Line::from(Span::styled("Welcome", theme::style::header())),
+        Line::from(""),
+        Line::from(Span::styled("No terminal windows are open.", body_style)),
+        Line::from(""),
+    ];
+
+    for binding in KeybindRegistry::new().all_bindings() {
+        lines.push(Line::from(vec![
+            Span::styled(binding.keys.clone(), command_style),
+            Span::styled("  ", body_style),
+            Span::styled(binding.description.clone(), body_style),
+        ]));
     }
+
+    lines
 }
 
 /// Build session tab title line (same pattern as management tabs in Block title).
@@ -22020,6 +22001,33 @@ exit 1
             assert!(
                 text.contains(&binding.description),
                 "expected help overlay to contain description {}",
+                binding.description
+            );
+        }
+    }
+
+    #[test]
+    fn render_welcome_session_lists_all_registered_keybindings() {
+        let mut model = test_model();
+        model.sessions.clear();
+        model.active_session = 0;
+        model.active_layer = ActiveLayer::Main;
+        model.active_focus = FocusPane::Terminal;
+
+        let text = render_model_text(&model, 80, 24);
+        let registry = crate::input::keybind::KeybindRegistry::new();
+
+        assert!(text.contains("Welcome"));
+        assert!(text.contains("No terminal windows are open."));
+        for binding in registry.all_bindings() {
+            assert!(
+                text.contains(&binding.keys),
+                "expected welcome screen to contain binding {}",
+                binding.keys
+            );
+            assert!(
+                text.contains(&binding.description),
+                "expected welcome screen to contain description {}",
                 binding.description
             );
         }

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -9470,10 +9470,9 @@ fn render_welcome_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
 
     let intro_lines = welcome_session_intro_lines();
     let command_lines = welcome_session_command_lines();
-    let content_height = (intro_lines.len() + command_lines.len())
-        .try_into()
-        .unwrap_or(u16::MAX);
-    let content_height = content_height.min(inner.height);
+    let content_height = (intro_lines.len() as u16)
+        .saturating_add(welcome_session_command_box_height(&command_lines))
+        .min(inner.height);
     let vertical = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -9499,8 +9498,16 @@ fn render_welcome_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
         frame.render_widget(intro, sections[0]);
     }
 
-    let commands = welcome_session_content_area(sections[1]);
-    if commands.width > 0 && commands.height > 0 {
+    let command_box_area = welcome_session_command_box_area(sections[1], &command_lines);
+    if command_box_area.width > 0 && command_box_area.height > 0 {
+        let command_block = welcome_session_command_block();
+        let commands = welcome_session_command_content_area(command_block.inner(command_box_area));
+        frame.render_widget(command_block, command_box_area);
+
+        if commands.width == 0 || commands.height == 0 {
+            return;
+        }
+
         let paragraph = Paragraph::new(command_lines);
         frame.render_widget(paragraph, commands);
     }
@@ -9511,9 +9518,7 @@ fn welcome_session_intro_lines() -> Vec<Line<'static>> {
 
     vec![
         Line::from(Span::styled("Welcome", theme::style::header())),
-        Line::from(""),
         Line::from(Span::styled("No terminal windows are open.", body_style)),
-        Line::from(""),
     ]
 }
 
@@ -9538,13 +9543,46 @@ fn welcome_session_command_lines() -> Vec<Line<'static>> {
     lines
 }
 
-fn welcome_session_content_area(inner: Rect) -> Rect {
-    let left_padding = if inner.width > 4 { 2 } else { 0 };
+fn welcome_session_command_block() -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(theme::border::default())
+        .border_style(Style::default().fg(theme::color::BORDER_UNFOCUSED))
+        .title(Line::from(Span::styled(
+            " Commands ",
+            theme::style::header(),
+        )))
+}
+
+fn welcome_session_command_box_height(lines: &[Line<'_>]) -> u16 {
+    (lines.len() as u16).saturating_add(2)
+}
+
+fn welcome_session_command_box_area(area: Rect, lines: &[Line<'_>]) -> Rect {
+    let content_width = lines.iter().map(title_line_width).max().unwrap_or(0);
+    let desired_width = content_width.saturating_add(4).min(area.width as usize) as u16;
+    let height = welcome_session_command_box_height(lines).min(area.height);
+    let x = area
+        .x
+        .saturating_add(area.width.saturating_sub(desired_width) / 2);
 
     Rect {
-        x: inner.x.saturating_add(left_padding),
+        x,
+        y: area.y,
+        width: desired_width,
+        height,
+    }
+}
+
+fn welcome_session_command_content_area(inner: Rect) -> Rect {
+    let horizontal_padding = if inner.width > 2 { 1 } else { 0 };
+
+    Rect {
+        x: inner.x.saturating_add(horizontal_padding),
         y: inner.y,
-        width: inner.width.saturating_sub(left_padding),
+        width: inner
+            .width
+            .saturating_sub(horizontal_padding.saturating_mul(2)),
         height: inner.height,
     }
 }
@@ -13900,7 +13938,7 @@ services:
     }
 
     #[test]
-    fn render_model_text_zero_sessions_centers_intro_but_left_aligns_commands() {
+    fn render_model_text_zero_sessions_centers_intro_and_command_box() {
         let mut model = test_model();
         model.sessions.clear();
         model.active_layer = ActiveLayer::Main;
@@ -13910,8 +13948,9 @@ services:
 
         assert!(rendered.contains("║                                    Welcome"));
         assert!(rendered.contains("║                         No terminal windows are open."));
-        assert!(rendered.contains("║  Ctrl+G, g"));
-        assert!(rendered.contains("║  Ctrl+G, c"));
+        assert!(rendered.contains("║           ╭ Commands"));
+        assert!(rendered.contains("║           │ Ctrl+G, g"));
+        assert!(rendered.contains("║           │ Ctrl+G, c"));
     }
 
     #[test]

--- a/crates/gwt-tui/src/app.rs
+++ b/crates/gwt-tui/src/app.rs
@@ -9468,22 +9468,17 @@ fn render_welcome_session_pane(model: &Model, frame: &mut Frame, area: Rect) {
         return;
     }
 
-    let lines = welcome_session_lines();
-    let content_height = (lines.len() as u16).min(inner.height);
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Min(0),
-            Constraint::Length(content_height),
-            Constraint::Min(0),
-        ])
-        .split(inner);
+    let content = welcome_session_content_area(inner);
+    if content.width == 0 || content.height == 0 {
+        return;
+    }
 
-    let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
-    frame.render_widget(paragraph, chunks[1]);
+    let paragraph = Paragraph::new(welcome_session_lines());
+    frame.render_widget(paragraph, content);
 }
 
 fn welcome_session_lines() -> Vec<Line<'static>> {
+    const WELCOME_KEY_WIDTH: usize = 24;
     let command_style = Style::default()
         .fg(theme::color::ACTIVE)
         .add_modifier(Modifier::BOLD);
@@ -9498,13 +9493,26 @@ fn welcome_session_lines() -> Vec<Line<'static>> {
 
     for binding in KeybindRegistry::new().all_bindings() {
         lines.push(Line::from(vec![
-            Span::styled(binding.keys.clone(), command_style),
-            Span::styled("  ", body_style),
+            Span::styled(
+                format!("{:<WELCOME_KEY_WIDTH$}", binding.keys),
+                command_style,
+            ),
             Span::styled(binding.description.clone(), body_style),
         ]));
     }
 
     lines
+}
+
+fn welcome_session_content_area(inner: Rect) -> Rect {
+    let left_padding = if inner.width > 4 { 2 } else { 0 };
+
+    Rect {
+        x: inner.x.saturating_add(left_padding),
+        y: inner.y,
+        width: inner.width.saturating_sub(left_padding),
+        height: inner.height,
+    }
 }
 
 /// Build session tab title line (same pattern as management tabs in Block title).
@@ -13855,6 +13863,20 @@ services:
         assert!(rendered.contains("No terminal windows are open."));
         assert!(rendered.contains("Ctrl+G, c"));
         assert!(rendered.contains("Ctrl+G, g"));
+    }
+
+    #[test]
+    fn render_model_text_zero_sessions_left_aligns_welcome_content() {
+        let mut model = test_model();
+        model.sessions.clear();
+        model.active_layer = ActiveLayer::Main;
+        model.active_focus = FocusPane::Terminal;
+
+        let rendered = render_model_text(&model, 80, 24);
+
+        assert!(rendered.contains("║  Welcome"));
+        assert!(rendered.contains("║  Ctrl+G, g"));
+        assert!(rendered.contains("║  Ctrl+G, c"));
     }
 
     #[test]

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -423,10 +423,10 @@ fn run_app(
 ) -> io::Result<()> {
     // Detect repo type and create appropriate model
     let mut model = match gwt_git::detect_repo_type(&repo_path) {
-        RepoType::Normal(root) => Model::new(root),
+        RepoType::Normal(root) => Model::new_startup(root),
         RepoType::Bare {
             develop_worktree: Some(wt),
-        } => Model::new(wt),
+        } => Model::new_startup(wt),
         RepoType::Bare {
             develop_worktree: None,
         } => Model::new_initialization(repo_path, true),
@@ -811,6 +811,17 @@ session_count = 0
         assert_eq!(restored.session_count(), 0);
         assert!(restored.active_session_tab().is_none());
         assert!(!should_spawn_default_shell(&restored));
+    }
+
+    #[test]
+    fn startup_welcome_skips_default_shell_spawn() {
+        let model = Model::new_startup(PathBuf::from("/tmp/repo"));
+
+        assert_eq!(model.active_layer, ActiveLayer::Main);
+        assert_eq!(model.active_focus, FocusPane::Terminal);
+        assert_eq!(model.session_count(), 0);
+        assert!(model.active_session_tab().is_none());
+        assert!(!should_spawn_default_shell(&model));
     }
 
     #[test]

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -669,7 +669,9 @@ fn run_app(
 }
 
 fn restore_startup_session_state_with(model: &mut Model, path: &Path) -> Option<String> {
-    model.restore_session_state_from_path(path)
+    let warning = model.restore_session_state_from_path(path);
+    model.apply_startup_welcome_state();
+    warning
 }
 
 fn should_spawn_default_shell(model: &Model) -> bool {
@@ -808,6 +810,34 @@ session_count = 0
         let warning = restore_startup_session_state_with(&mut restored, &path);
 
         assert!(warning.is_none());
+        assert_eq!(restored.session_count(), 0);
+        assert!(restored.active_session_tab().is_none());
+        assert!(!should_spawn_default_shell(&restored));
+    }
+
+    #[test]
+    fn restore_startup_session_state_with_saved_sessions_still_starts_in_welcome() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("session.toml");
+        std::fs::write(
+            &path,
+            r#"
+display_mode = "grid"
+panel_visible = true
+active_management_tab = "Logs"
+session_count = 3
+"#,
+        )
+        .expect("write saved session state");
+
+        let mut restored = Model::new_startup(PathBuf::from("/tmp/repo"));
+        let warning = restore_startup_session_state_with(&mut restored, &path);
+
+        assert!(warning.is_none());
+        assert_eq!(restored.session_layout, SessionLayout::Grid);
+        assert_eq!(restored.management_tab, ManagementTab::Logs);
+        assert_eq!(restored.active_layer, ActiveLayer::Main);
+        assert_eq!(restored.active_focus, FocusPane::Terminal);
         assert_eq!(restored.session_count(), 0);
         assert!(restored.active_session_tab().is_none());
         assert!(!should_spawn_default_shell(&restored));

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -540,7 +540,7 @@ fn run_app(
     }
 
     // Spawn PTY for the default shell-0 session.
-    if model.active_layer != ActiveLayer::Initialization {
+    if should_spawn_default_shell(&model) {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let (cols, rows) = app::session_content_size(&model);
         // Resize default VtState to match actual pane area.
@@ -672,6 +672,10 @@ fn restore_startup_session_state_with(model: &mut Model, path: &Path) -> Option<
     model.restore_session_state_from_path(path)
 }
 
+fn should_spawn_default_shell(model: &Model) -> bool {
+    model.active_layer != ActiveLayer::Initialization && model.session_count() > 0
+}
+
 fn reset_startup_runtime_state_with(sessions_dir: &Path) -> Option<String> {
     reset_runtime_state_dir(sessions_dir)
         .err()
@@ -783,6 +787,30 @@ mod tests {
         let warning = restore_startup_session_state_with(&mut restored, &path);
 
         assert!(warning.is_some());
+    }
+
+    #[test]
+    fn restore_startup_session_state_with_zero_sessions_skips_default_shell_spawn() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("session.toml");
+        std::fs::write(
+            &path,
+            r#"
+display_mode = "tab"
+panel_visible = false
+active_management_tab = "Branches"
+session_count = 0
+"#,
+        )
+        .expect("write zero-session state");
+
+        let mut restored = Model::new(PathBuf::from("/tmp/repo"));
+        let warning = restore_startup_session_state_with(&mut restored, &path);
+
+        assert!(warning.is_none());
+        assert_eq!(restored.session_count(), 0);
+        assert!(restored.active_session_tab().is_none());
+        assert!(!should_spawn_default_shell(&restored));
     }
 
     #[test]

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -316,6 +316,20 @@ pub struct SessionTab {
     pub created_at: std::time::Instant,
 }
 
+pub(crate) fn shell_session(index: usize) -> SessionTab {
+    SessionTab {
+        id: format!("shell-{index}"),
+        name: if index == 0 {
+            "Shell".to_string()
+        } else {
+            format!("Shell {}", index + 1)
+        },
+        tab_type: SessionTabType::Shell,
+        vt: VtState::new(24, 80),
+        created_at: std::time::Instant::now(),
+    }
+}
+
 /// Buffered PTY input waiting to be written to the active session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingPtyInput {
@@ -1968,13 +1982,7 @@ impl Model {
     pub fn new(repo_path: PathBuf) -> Self {
         let specs_cache_root =
             crate::issue_cache::issue_cache_root_for_repo_path_or_detached(&repo_path);
-        let default_session = SessionTab {
-            id: "shell-0".to_string(),
-            name: "Shell".to_string(),
-            tab_type: SessionTabType::Shell,
-            vt: VtState::new(24, 80),
-            created_at: std::time::Instant::now(),
-        };
+        let default_session = shell_session(0);
         let (notification_bus, notification_receiver) = unbounded_channel::<Notification>();
         let (pty_output_tx, pty_output_rx) = std::sync::mpsc::channel();
         Self {
@@ -2355,6 +2363,11 @@ impl Model {
         } else {
             ActiveLayer::Main
         };
+        self.active_focus = if state.panel_visible {
+            FocusPane::TabContent
+        } else {
+            FocusPane::Terminal
+        };
         self.management_tab = if state.active_management_tab == "Specs" {
             ManagementTab::Branches
         } else {
@@ -2373,6 +2386,17 @@ impl Model {
                 }
             }
         };
+        if state.session_count == 0 {
+            self.sessions.clear();
+            self.active_session = 0;
+        } else {
+            if self.sessions.is_empty() {
+                self.sessions.push(shell_session(0));
+            }
+            if self.active_session >= self.sessions.len() {
+                self.active_session = self.sessions.len().saturating_sub(1);
+            }
+        }
 
         if warnings.is_empty() {
             None
@@ -3329,6 +3353,19 @@ mod tests {
     }
 
     #[test]
+    fn save_session_state_tracks_zero_session_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.toml");
+
+        let mut model = Model::new(PathBuf::from("/tmp/repo"));
+        model.sessions.clear();
+        model.save_session_state(&path).unwrap();
+
+        let loaded = Model::load_session_state(&path).expect("load state");
+        assert_eq!(loaded.session_count, 0);
+    }
+
+    #[test]
     fn save_session_state_creates_missing_parent_directory() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nested").join("state.toml");
@@ -3395,5 +3432,29 @@ session_count = 1
 
         assert!(warning.is_none());
         assert_eq!(restored.management_tab, ManagementTab::Branches);
+    }
+
+    #[test]
+    fn restore_session_state_from_path_zero_session_state_clears_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.toml");
+        std::fs::write(
+            &path,
+            r#"
+display_mode = "tab"
+panel_visible = false
+active_management_tab = "Branches"
+session_count = 0
+"#,
+        )
+        .unwrap();
+
+        let mut restored = Model::new(PathBuf::from("/tmp/repo"));
+        let warning = restored.restore_session_state_from_path(&path);
+
+        assert!(warning.is_none());
+        assert_eq!(restored.active_layer, ActiveLayer::Main);
+        assert_eq!(restored.session_count(), 0);
+        assert_eq!(restored.active_session, 0);
     }
 }

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -2055,6 +2055,16 @@ impl Model {
         }
     }
 
+    /// Create the startup model shown before any terminal window exists.
+    pub fn new_startup(repo_path: PathBuf) -> Self {
+        let mut model = Self::new(repo_path);
+        model.sessions.clear();
+        model.active_session = 0;
+        model.active_layer = ActiveLayer::Main;
+        model.active_focus = FocusPane::Terminal;
+        model
+    }
+
     /// Attach a logs-watcher receiver produced by
     /// [`crate::logs_watcher::spawn`]. Called exactly once from `main`.
     pub fn set_logs_watcher_rx(
@@ -2473,6 +2483,17 @@ mod tests {
                 "queued",
             ))
             .is_ok());
+    }
+
+    #[test]
+    fn model_new_startup_defaults_to_welcome_without_sessions() {
+        let model = Model::new_startup(PathBuf::from("/tmp/repo"));
+
+        assert_eq!(model.active_layer, ActiveLayer::Main);
+        assert_eq!(model.active_focus, FocusPane::Terminal);
+        assert_eq!(model.session_count(), 0);
+        assert_eq!(model.active_session, 0);
+        assert!(model.active_session_tab().is_none());
     }
 
     #[test]

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -2055,13 +2055,18 @@ impl Model {
         }
     }
 
+    /// Normalize the model into the startup Welcome state.
+    pub fn apply_startup_welcome_state(&mut self) {
+        self.sessions.clear();
+        self.active_session = 0;
+        self.active_layer = ActiveLayer::Main;
+        self.active_focus = FocusPane::Terminal;
+    }
+
     /// Create the startup model shown before any terminal window exists.
     pub fn new_startup(repo_path: PathBuf) -> Self {
         let mut model = Self::new(repo_path);
-        model.sessions.clear();
-        model.active_session = 0;
-        model.active_layer = ActiveLayer::Main;
-        model.active_focus = FocusPane::Terminal;
+        model.apply_startup_welcome_state();
         model
     }
 

--- a/crates/gwt-tui/tests/snapshot_e2e.rs
+++ b/crates/gwt-tui/tests/snapshot_e2e.rs
@@ -527,6 +527,15 @@ fn snapshot_toggle_to_main_layer() {
 }
 
 #[test]
+fn snapshot_zero_sessions_show_welcome() {
+    let mut model = test_model();
+    app::update(&mut model, Message::ToggleLayer);
+    app::update(&mut model, Message::CloseSession);
+    let output = render_to_string(&model, 80, 24);
+    insta::assert_snapshot!("main_layer_welcome_zero_sessions", output);
+}
+
+#[test]
 fn snapshot_tab_grid_toggle() {
     let mut model = test_model();
     // Switch to main layer first

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
@@ -3,9 +3,9 @@ source: crates/gwt-tui/tests/snapshot_e2e.rs
 expression: output
 ---
 ╔ Welcome ═════════════════════════════════════════════════════════════════════╗
-║  Welcome                                                                     ║
+║                                    Welcome                                   ║
 ║                                                                              ║
-║  No terminal windows are open.                                               ║
+║                         No terminal windows are open.                        ║
 ║                                                                              ║
 ║  Ctrl+G, g               Toggle management panel                             ║
 ║  Ctrl+G, Tab/Shift+Tab   Cycle focus                                         ║

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
@@ -4,25 +4,25 @@ expression: output
 ---
 ╔ Welcome ═════════════════════════════════════════════════════════════════════╗
 ║                                    Welcome                                   ║
-║                                                                              ║
 ║                         No terminal windows are open.                        ║
-║                                                                              ║
-║  Ctrl+G, g               Toggle management panel                             ║
-║  Ctrl+G, Tab/Shift+Tab   Cycle focus                                         ║
-║  Ctrl+G, ]               Next session                                        ║
-║  Ctrl+G, [               Previous session                                    ║
-║  Ctrl+G, 1-9             Switch to session N                                 ║
-║  Ctrl+G, arrows          Move active grid session                            ║
-║  Ctrl+G, z               Toggle Tab/Grid layout                              ║
-║  Ctrl+G, c               New shell session                                   ║
-║  Ctrl+G, x               Close active session                                ║
-║  Ctrl+G, q               Quit                                                ║
-║  Ctrl+G, v               Start voice input                                   ║
-║  Ctrl+G, a               Convert active agent session                        ║
-║  Ctrl+G, ?               Show help                                           ║
-║  Ctrl+G, b               Switch to Branches tab                              ║
-║  Ctrl+G, s               Switch to Settings tab                              ║
-║  Ctrl+G, i               Switch to Issues tab                                ║
-║  Ctrl+C, Ctrl+C          Quit                                                ║
+║           ╭ Commands ────────────────────────────────────────────╮           ║
+║           │ Ctrl+G, g               Toggle management panel      │           ║
+║           │ Ctrl+G, Tab/Shift+Tab   Cycle focus                  │           ║
+║           │ Ctrl+G, ]               Next session                 │           ║
+║           │ Ctrl+G, [               Previous session             │           ║
+║           │ Ctrl+G, 1-9             Switch to session N          │           ║
+║           │ Ctrl+G, arrows          Move active grid session     │           ║
+║           │ Ctrl+G, z               Toggle Tab/Grid layout       │           ║
+║           │ Ctrl+G, c               New shell session            │           ║
+║           │ Ctrl+G, x               Close active session         │           ║
+║           │ Ctrl+G, q               Quit                         │           ║
+║           │ Ctrl+G, v               Start voice input            │           ║
+║           │ Ctrl+G, a               Convert active agent session │           ║
+║           │ Ctrl+G, ?               Show help                    │           ║
+║           │ Ctrl+G, b               Switch to Branches tab       │           ║
+║           │ Ctrl+G, s               Switch to Settings tab       │           ║
+║           │ Ctrl+G, i               Switch to Issues tab         │           ║
+║           │ Ctrl+C, Ctrl+C          Quit                         │           ║
+║           ╰──────────────────────────────────────────────────────╯           ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
  ⎇n/a  │  P:default  │  C-g,c shell  C-g,g manage  ?:help

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
@@ -3,26 +3,26 @@ source: crates/gwt-tui/tests/snapshot_e2e.rs
 expression: output
 ---
 ╔ Welcome ═════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
 ║                                    Welcome                                   ║
 ║                                                                              ║
 ║                         No terminal windows are open.                        ║
-║                Open a shell or return to the management panel.               ║
 ║                                                                              ║
+║                      Ctrl+G, g  Toggle management panel                      ║
+║                      Ctrl+G, Tab/Shift+Tab  Cycle focus                      ║
+║                            Ctrl+G, ]  Next session                           ║
+║                          Ctrl+G, [  Previous session                         ║
+║                       Ctrl+G, 1-9  Switch to session N                       ║
+║                   Ctrl+G, arrows  Move active grid session                   ║
+║                       Ctrl+G, z  Toggle Tab/Grid layout                      ║
 ║                         Ctrl+G, c  New shell session                         ║
-║                       Ctrl+G, g  Open management panel                       ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
-║                                                                              ║
+║                        Ctrl+G, x  Close active session                       ║
+║                                Ctrl+G, q  Quit                               ║
+║                         Ctrl+G, v  Start voice input                         ║
+║                    Ctrl+G, a  Convert active agent session                   ║
+║                             Ctrl+G, ?  Show help                             ║
+║                       Ctrl+G, b  Switch to Branches tab                      ║
+║                       Ctrl+G, s  Switch to Settings tab                      ║
+║                        Ctrl+G, i  Switch to Issues tab                       ║
+║                             Ctrl+C, Ctrl+C  Quit                             ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
  ⎇n/a  │  P:default  │  C-g,c shell  C-g,g manage  ?:help

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
@@ -1,0 +1,28 @@
+---
+source: crates/gwt-tui/tests/snapshot_e2e.rs
+expression: output
+---
+╔ Welcome ═════════════════════════════════════════════════════════════════════╗
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                    Welcome                                   ║
+║                                                                              ║
+║                         No terminal windows are open.                        ║
+║                Open a shell or return to the management panel.               ║
+║                                                                              ║
+║                         Ctrl+G, c  New shell session                         ║
+║                       Ctrl+G, g  Open management panel                       ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+║                                                                              ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+ ⎇n/a  │  P:default  │  C-g,c shell  C-g,g manage  ?:help

--- a/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
+++ b/crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap
@@ -3,26 +3,26 @@ source: crates/gwt-tui/tests/snapshot_e2e.rs
 expression: output
 ---
 ╔ Welcome ═════════════════════════════════════════════════════════════════════╗
-║                                    Welcome                                   ║
+║  Welcome                                                                     ║
 ║                                                                              ║
-║                         No terminal windows are open.                        ║
+║  No terminal windows are open.                                               ║
 ║                                                                              ║
-║                      Ctrl+G, g  Toggle management panel                      ║
-║                      Ctrl+G, Tab/Shift+Tab  Cycle focus                      ║
-║                            Ctrl+G, ]  Next session                           ║
-║                          Ctrl+G, [  Previous session                         ║
-║                       Ctrl+G, 1-9  Switch to session N                       ║
-║                   Ctrl+G, arrows  Move active grid session                   ║
-║                       Ctrl+G, z  Toggle Tab/Grid layout                      ║
-║                         Ctrl+G, c  New shell session                         ║
-║                        Ctrl+G, x  Close active session                       ║
-║                                Ctrl+G, q  Quit                               ║
-║                         Ctrl+G, v  Start voice input                         ║
-║                    Ctrl+G, a  Convert active agent session                   ║
-║                             Ctrl+G, ?  Show help                             ║
-║                       Ctrl+G, b  Switch to Branches tab                      ║
-║                       Ctrl+G, s  Switch to Settings tab                      ║
-║                        Ctrl+G, i  Switch to Issues tab                       ║
-║                             Ctrl+C, Ctrl+C  Quit                             ║
+║  Ctrl+G, g               Toggle management panel                             ║
+║  Ctrl+G, Tab/Shift+Tab   Cycle focus                                         ║
+║  Ctrl+G, ]               Next session                                        ║
+║  Ctrl+G, [               Previous session                                    ║
+║  Ctrl+G, 1-9             Switch to session N                                 ║
+║  Ctrl+G, arrows          Move active grid session                            ║
+║  Ctrl+G, z               Toggle Tab/Grid layout                              ║
+║  Ctrl+G, c               New shell session                                   ║
+║  Ctrl+G, x               Close active session                                ║
+║  Ctrl+G, q               Quit                                                ║
+║  Ctrl+G, v               Start voice input                                   ║
+║  Ctrl+G, a               Convert active agent session                        ║
+║  Ctrl+G, ?               Show help                                           ║
+║  Ctrl+G, b               Switch to Branches tab                              ║
+║  Ctrl+G, s               Switch to Settings tab                              ║
+║  Ctrl+G, i               Switch to Issues tab                                ║
+║  Ctrl+C, Ctrl+C          Quit                                                ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
  ⎇n/a  │  P:default  │  C-g,c shell  C-g,g manage  ?:help


### PR DESCRIPTION
## Summary

- Show the Welcome state instead of spawning a shell when startup or session restore results in zero terminal sessions.
- Keep startup in the Welcome state even when persisted session metadata exists, so the initial screen matches the zero-session contract.
- Render the Welcome command list inside a centered `Commands` box so the screen stays centered while command rows remain readable.

## Changes

- `crates/gwt-tui/src/model.rs`: added startup Welcome model state and zero-session persistence/restore behavior so the app can boot without a shell session.
- `crates/gwt-tui/src/main.rs`: updated startup restore flow to preserve the Welcome state instead of recreating a shell from saved session count metadata.
- `crates/gwt-tui/src/app.rs`: rendered the zero-session Welcome pane in the main layer, listed all registered keybindings, and moved the command list into a centered inner box with left-aligned rows.
- `crates/gwt-tui/tests/snapshot_e2e.rs`: expanded Welcome coverage for startup and zero-session rendering behavior.
- `crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap`: updated the terminal snapshot for the centered Welcome command box layout.

## Testing

- [x] `cargo test -p gwt-core -p gwt-tui` — all Rust unit, integration, and snapshot tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clippy completes without warnings.
- [x] `cargo build -p gwt-tui` — `gwt-tui` builds successfully.
- [x] `cargo fmt -- --check` — formatting check passes.

## Closing Issues

- None

## Related Issues / Links

- #1920

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — Not needed: the change is covered by the updated SPEC and snapshot tests, and no README flow changed.
- [ ] Migration/backfill plan included (if schema/data change) — Not applicable: no schema or persisted data migration was introduced.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- The branch implements the approved zero-session Welcome behavior from SPEC #1920, including startup, restore, close-last-session, and Welcome readability follow-ups.
- `origin/develop` was merged into this branch before PR creation to satisfy the PR workflow baseline and keep merge state current.

## Risk / Impact

- **Affected areas**: `gwt-tui` startup flow, session restore behavior, Welcome pane rendering, zero-session snapshots.
- **Rollback plan**: Revert this PR branch commits to restore default shell startup and the previous Welcome rendering.

## Screenshots

| Before | After |
|--------|-------|
| Welcome commands rendered directly in the pane body. | Welcome commands rendered inside a centered `Commands` box; see `crates/gwt-tui/tests/snapshots/snapshot_e2e__main_layer_welcome_zero_sessions.snap`. |

## Notes

- The worktree still contains unrelated local changes under `.claude/` and `.codex/`; they were intentionally left out of this PR.
