### PR TITLE
fix(index): align spec search with repo-scoped issue cache

### DIFF
--- a/.claude/commands/gwt-search.md
+++ b/.claude/commands/gwt-search.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Glob, Grep, Bash
 
 # Search Command
 
-Unified semantic search over local SPECs, GitHub Issues, and project source files using ChromaDB vector embeddings. Use as mandatory preflight before creating new SPECs or Issues.
+Unified semantic search over SPEC Issues, GitHub Issues, and project source files using ChromaDB vector embeddings. Use as mandatory preflight before creating new SPECs or Issues.
 
 ## Usage
 

--- a/.claude/commands/gwt-spec-search.md
+++ b/.claude/commands/gwt-spec-search.md
@@ -1,12 +1,12 @@
 ---
-description: Semantic search over local SPEC files using the gwt-spec-search skill
+description: Semantic search over cached SPEC Issues using the gwt-spec-search skill
 author: akiojin
 allowed-tools: Read, Glob, Grep, Bash
 ---
 
 # GWT SPEC Search Command
 
-Use this command to run semantic search against the local SPEC index.
+Use this command to run semantic search against the cached SPEC Issue index.
 
 ## Usage
 

--- a/.claude/skills/gwt-search/SKILL.md
+++ b/.claude/skills/gwt-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gwt-search
-description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches local SPECs, GitHub Issues, and project files via ChromaDB. Triggers: 'search', 'find related', 'check duplicates'."
+description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches SPEC Issues, GitHub Issues, and project files via ChromaDB. Triggers: 'search', 'find related', 'check duplicates'."
 ---
 
 # Unified Search

--- a/.claude/skills/gwt-spec-search/SKILL.md
+++ b/.claude/skills/gwt-spec-search/SKILL.md
@@ -43,7 +43,7 @@ When the gwt TUI launches an agent pane, the following env vars are exported aut
   --n-results 10
 ```
 
-If the SPEC index does not yet exist, the runner builds it inline (full mode) and emits NDJSON progress on stderr before returning the search result.
+If the SPEC index does not yet exist, the runner builds it inline (full mode) from the repo-scoped Issue cache and emits NDJSON progress on stderr before returning the search result.
 
 To force a full re-index (normally handled by the watcher / auto-build):
 
@@ -60,7 +60,7 @@ To force a full re-index (normally handled by the watcher / auto-build):
 
 ```json
 {"ok": true, "specResults": [
-  {"spec_id": "10", "title": "Project workspace", "status": "in-progress", "phase": "Implementation", "dir_name": "SPEC-10", "distance": 0.08}
+  {"spec_id": "1939", "title": "gwt-spec: Semantic search platform", "status": "open", "phase": "phase/review", "dir_name": "#1939", "distance": 0.08}
 ]}
 ```
 
@@ -73,7 +73,7 @@ To force a full re-index (normally handled by the watcher / auto-build):
 
 ## Notes
 
-- SPEC index is maintained by the TUI watcher; non-TUI sessions get an mtime+size diff per call
+- `search-specs` refreshes the worktree-scoped SPEC index from the repo-scoped Issue cache before non-TUI searches
 - The runner auto-builds the index when missing (use `--no-auto-build` to suppress)
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance

--- a/.codex/skills/gwt-search/SKILL.md
+++ b/.codex/skills/gwt-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gwt-search
-description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches local SPECs, GitHub Issues, and project files via ChromaDB. Triggers: 'search', 'find related', 'check duplicates'."
+description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches SPEC Issues, GitHub Issues, and project files via ChromaDB. Triggers: 'search', 'find related', 'check duplicates'."
 ---
 
 # Unified Search

--- a/.codex/skills/gwt-spec-search/SKILL.md
+++ b/.codex/skills/gwt-spec-search/SKILL.md
@@ -43,7 +43,7 @@ When the gwt TUI launches an agent pane, the following env vars are exported aut
   --n-results 10
 ```
 
-If the SPEC index does not yet exist, the runner builds it inline (full mode) and emits NDJSON progress on stderr before returning the search result.
+If the SPEC index does not yet exist, the runner builds it inline (full mode) from the repo-scoped Issue cache and emits NDJSON progress on stderr before returning the search result.
 
 To force a full re-index (normally handled by the watcher / auto-build):
 
@@ -60,7 +60,7 @@ To force a full re-index (normally handled by the watcher / auto-build):
 
 ```json
 {"ok": true, "specResults": [
-  {"spec_id": "10", "title": "Project workspace", "status": "in-progress", "phase": "Implementation", "dir_name": "SPEC-10", "distance": 0.08}
+  {"spec_id": "1939", "title": "gwt-spec: Semantic search platform", "status": "open", "phase": "phase/review", "dir_name": "#1939", "distance": 0.08}
 ]}
 ```
 
@@ -73,7 +73,7 @@ To force a full re-index (normally handled by the watcher / auto-build):
 
 ## Notes
 
-- SPEC index is maintained by the TUI watcher; non-TUI sessions get an mtime+size diff per call
+- `search-specs` refreshes the worktree-scoped SPEC index from the repo-scoped Issue cache before non-TUI searches
 - The runner auto-builds the index when missing (use `--no-auto-build` to suppress)
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -792,7 +792,7 @@ def action_search_issues(db_path: str, query: str, n_results: int = 10) -> dict:
 
 
 def action_index_specs(project_root: str, db_path: str) -> dict:
-    """Index local SPEC directories into ChromaDB collection 'specs'."""
+    """Legacy entrypoint: index local SPEC directories into collection 'specs'."""
     import chromadb  # type: ignore
 
     root = Path(project_root).resolve()
@@ -869,7 +869,7 @@ def action_index_specs(project_root: str, db_path: str) -> dict:
 
 
 def action_search_specs(db_path: str, query: str, n_results: int = 10) -> dict:
-    """Search the local SPEC index (legacy entrypoint with v2 fallback)."""
+    """Search the SPEC index (legacy entrypoint with v2 fallback)."""
     import chromadb  # type: ignore
 
     db = Path(db_path).resolve()
@@ -1510,73 +1510,10 @@ def action_index_specs_v2(
     mode: str = "full",
     db_root: Optional[Path] = None,
 ) -> dict:
-    """Index local SPEC directories into ChromaDB under the v2 layout."""
-    root = Path(project_root).resolve()
+    """Index cached `gwt-spec` Issues into ChromaDB under the v2 layout."""
     db_path = resolve_db_path(repo_hash, worktree_hash, "specs", db_root=db_root)
-
-    specs_dir = root / "specs"
-    spec_dirs = sorted(specs_dir.glob("SPEC-*")) if specs_dir.is_dir() else []
-
-    new_entries: List[Dict[str, Any]] = []
-    spec_records: List[Dict[str, Any]] = []
-    for spec_path in spec_dirs:
-        metadata_file = spec_path / "metadata.json"
-        if not metadata_file.is_file():
-            continue
-        try:
-            meta = json.loads(metadata_file.read_text(errors="replace"))
-        except (json.JSONDecodeError, ValueError, OSError):
-            continue
-        spec_id = str(meta.get("id", ""))
-        title = meta.get("title", "")
-        status = meta.get("status", "")
-        phase = meta.get("phase", "")
-        dir_name = spec_path.name
-
-        spec_md = spec_path / "spec.md"
-        spec_content = ""
-        if spec_md.is_file():
-            try:
-                spec_content = spec_md.read_text(errors="replace")
-                stat = spec_md.stat()
-                rel = str(spec_md.relative_to(root))
-                new_entries.append(
-                    {"path": rel, "mtime": int(stat.st_mtime), "size": int(stat.st_size)}
-                )
-            except OSError:
-                pass
-
-        # Chunk spec.md by ## sections so large SPECs (like SPEC-10's
-        # 300+ line Phase 8 additions) do not silently drop content past
-        # the first 2000 characters. Each chunk is embedded separately;
-        # duplicate spec_ids in search results are collapsed in
-        # `_format_spec_results`.
-        chunks = _chunk_spec_content(spec_content)
-        if not chunks:
-            chunks = [{"heading": "(empty)", "body": ""}]
-        total_chunks = len(chunks)
-        for idx, chunk in enumerate(chunks):
-            # Prepend title + heading so semantic search picks up both the
-            # SPEC identity and the section context.
-            document = f"{title}\n{chunk['heading']}\n{chunk['body']}"
-            spec_records.append(
-                {
-                    "id": f"spec-{spec_id}:chunk-{idx}",
-                    "document": document,
-                    "metadata": {
-                        "spec_id": spec_id,
-                        "title": title,
-                        "status": status,
-                        "phase": phase,
-                        "dir_name": dir_name,
-                        "chunk_idx": idx,
-                        "total_chunks": total_chunks,
-                        "chunk_heading": chunk["heading"],
-                    },
-                }
-            )
-
-    new_entries.sort(key=lambda e: e["path"])
+    spec_documents, new_entries = _load_cached_spec_documents(repo_hash)
+    new_entries.sort(key=lambda entry: entry["path"])
 
     emit_progress(
         {
@@ -1584,20 +1521,42 @@ def action_index_specs_v2(
             "scope": "specs",
             "mode": mode,
             "done": 0,
-            "total": len(spec_records),
+            "total": len(spec_documents),
         }
     )
 
     with acquire_lock(db_path, exclusive=True):
         client, collection = _make_chroma_collection(db_path, V2_SPECS_COLLECTION)
 
-        if mode == "full":
+        if mode == "incremental":
+            old_entries = read_manifest(db_path, scope="specs")
+            diff = compute_manifest_diff(old_entries, new_entries)
+            changed_spec_ids = set(diff["added"] + diff["changed"])
+            _delete_spec_records(collection, diff["changed"] + diff["removed"])
+            spec_records = _build_spec_records(
+                [
+                    spec
+                    for spec in spec_documents
+                    if spec["spec_id"] in changed_spec_ids
+                ]
+            )
+            emit_progress(
+                {
+                    "phase": "diff",
+                    "scope": "specs",
+                    "added": len(diff["added"]),
+                    "changed": len(diff["changed"]),
+                    "removed": len(diff["removed"]),
+                }
+            )
+        else:
             try:
                 existing = collection.get()
                 if existing.get("ids"):
                     collection.delete(ids=existing["ids"])
             except Exception:
                 pass
+            spec_records = _build_spec_records(spec_documents)
 
         if spec_records:
             ids = [r["id"] for r in spec_records]
@@ -1660,6 +1619,40 @@ def _issue_cache_root(repo_hash: str) -> Path:
     return Path.home() / ".gwt" / "cache" / "issues" / repo_hash
 
 
+def _normalize_labels(labels: Any) -> List[str]:
+    if isinstance(labels, str):
+        return [labels]
+    if isinstance(labels, list):
+        return [label for label in labels if isinstance(label, str)]
+    return []
+
+
+def _phase_label(labels: Sequence[str]) -> str:
+    for label in labels:
+        if label.startswith("phase/"):
+            return label
+    return ""
+
+
+def _build_cache_manifest_entry(name: str, paths: Sequence[Path]) -> Optional[Dict[str, Any]]:
+    mtimes: List[int] = []
+    total_size = 0
+    for path in paths:
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        mtimes.append(int(stat.st_mtime))
+        total_size += int(stat.st_size)
+    if not mtimes:
+        return None
+    return {
+        "path": name,
+        "mtime": max(mtimes),
+        "size": total_size,
+    }
+
+
 def _load_cached_issue_documents(repo_hash: str) -> List[Dict[str, Any]]:
     root = _issue_cache_root(repo_hash)
     if not root.is_dir():
@@ -1698,6 +1691,117 @@ def _load_cached_issue_documents(repo_hash: str) -> List[Dict[str, Any]]:
             }
         )
     return issues
+
+
+def _load_cached_spec_documents(
+    repo_hash: str,
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    root = _issue_cache_root(repo_hash)
+    if not root.is_dir():
+        return [], []
+
+    specs: List[Dict[str, Any]] = []
+    manifest_entries: List[Dict[str, Any]] = []
+    for entry in sorted(root.iterdir(), key=lambda item: item.name):
+        if not entry.is_dir():
+            continue
+        try:
+            number = int(entry.name)
+        except ValueError:
+            continue
+        meta_path = entry / "meta.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError, ValueError):
+            continue
+
+        labels = _normalize_labels(meta.get("labels", []))
+        if "gwt-spec" not in labels:
+            continue
+
+        spec_path = entry / "sections" / "spec.md"
+        body_path = entry / "body.md"
+        source_path = spec_path if spec_path.is_file() else body_path
+        try:
+            content = source_path.read_text() if source_path.is_file() else ""
+        except OSError:
+            content = ""
+
+        manifest_entry = _build_cache_manifest_entry(
+            str(number),
+            [meta_path, source_path],
+        )
+        if manifest_entry is not None:
+            manifest_entries.append(manifest_entry)
+
+        specs.append(
+            {
+                "spec_id": str(meta.get("number", number)),
+                "title": meta.get("title", ""),
+                "status": meta.get("state", ""),
+                "phase": _phase_label(labels),
+                "dir_name": f"#{number}",
+                "content": content,
+            }
+        )
+
+    return specs, manifest_entries
+
+
+def _build_spec_records(specs: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for spec in specs:
+        chunks = _chunk_spec_content(spec.get("content", ""))
+        if not chunks:
+            chunks = [{"heading": "(empty)", "body": ""}]
+        total_chunks = len(chunks)
+        for idx, chunk in enumerate(chunks):
+            document = f"{spec.get('title', '')}\n{chunk['heading']}\n{chunk['body']}"
+            records.append(
+                {
+                    "id": f"spec-{spec.get('spec_id', '')}:chunk-{idx}",
+                    "document": document,
+                    "metadata": {
+                        "spec_id": spec.get("spec_id", ""),
+                        "title": spec.get("title", ""),
+                        "status": spec.get("status", ""),
+                        "phase": spec.get("phase", ""),
+                        "dir_name": spec.get("dir_name", ""),
+                        "chunk_idx": idx,
+                        "total_chunks": total_chunks,
+                        "chunk_heading": chunk["heading"],
+                    },
+                }
+            )
+    return records
+
+
+def _delete_spec_records(collection, spec_ids: Sequence[str]) -> None:
+    if not spec_ids:
+        return
+    targets = {str(spec_id) for spec_id in spec_ids}
+    try:
+        existing = collection.get()
+    except Exception:
+        return
+
+    ids = existing.get("ids") or []
+    metadatas = existing.get("metadatas") or []
+    to_delete: List[str] = []
+    for idx, record_id in enumerate(ids):
+        meta = metadatas[idx] if idx < len(metadatas) else {}
+        spec_id = str((meta or {}).get("spec_id", ""))
+        if not spec_id and record_id.startswith("spec-"):
+            spec_id = record_id[5:].split(":chunk-", 1)[0]
+        if spec_id in targets:
+            to_delete.append(record_id)
+    if to_delete:
+        try:
+            collection.delete(ids=to_delete)
+        except Exception:
+            pass
 
 
 def action_index_issues_v2(
@@ -1914,8 +2018,11 @@ def action_search_v2(
     db_path = resolve_db_path(repo_hash, worktree_hash, scope, db_root=db_root)
     chroma_sqlite = db_path / "chroma.sqlite3"
 
-    if not chroma_sqlite.exists():
-        if no_auto_build:
+    needs_build = not chroma_sqlite.exists()
+    needs_spec_refresh = scope == "specs" and chroma_sqlite.exists() and not no_auto_build
+
+    if needs_build or needs_spec_refresh:
+        if no_auto_build and needs_build:
             return {
                 "ok": False,
                 "error_code": "INDEX_MISSING",
@@ -1940,7 +2047,7 @@ def action_search_v2(
                 project_root=project_root,
                 repo_hash=repo_hash,
                 worktree_hash=worktree_hash or "",
-                mode="full",
+                mode="full" if needs_build else "incremental",
                 db_root=db_root,
             )
         else:

--- a/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
+++ b/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -26,6 +27,33 @@ class AutoBuildFallbackTests(unittest.TestCase):
             "fn debounce_events() {}\n"
         )
         (root / "README.md").write_text("# project\n")
+
+    def _write_cached_issue(
+        self,
+        cache_root: Path,
+        number: int,
+        title: str,
+        body: str,
+        labels,
+    ) -> None:
+        issue = cache_root / str(number)
+        issue.mkdir(parents=True, exist_ok=True)
+        (issue / "meta.json").write_text(
+            json.dumps(
+                {
+                    "number": number,
+                    "title": title,
+                    "labels": labels,
+                    "state": "open",
+                    "updated_at": "2026-04-14T00:00:00Z",
+                    "comment_ids": [],
+                }
+            )
+        )
+        (issue / "body.md").write_text(body)
+        sections = issue / "sections"
+        sections.mkdir(exist_ok=True)
+        (sections / "spec.md").write_text(body)
 
     def test_search_files_auto_builds_when_index_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -117,35 +145,92 @@ class AutoBuildFallbackTests(unittest.TestCase):
     def test_search_specs_auto_builds_when_index_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"
-            (root / "specs" / "SPEC-1").mkdir(parents=True)
-            (root / "specs" / "SPEC-1" / "spec.md").write_text(
-                "# Test SPEC\nWatcher debounce semantics.\n"
+            root.mkdir()
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(
+                cache_root,
+                1939,
+                "gwt-spec: Semantic search platform",
+                "# Semantic search platform\nWatcher debounce semantics.\n",
+                ["gwt-spec", "phase/review"],
             )
-            (root / "specs" / "SPEC-1" / "metadata.json").write_text(
-                json.dumps(
-                    {
-                        "id": "1",
-                        "title": "Test SPEC",
-                        "status": "open",
-                        "phase": "draft",
-                    }
-                )
+            self._write_cached_issue(
+                cache_root,
+                2000,
+                "Plain issue",
+                "# Plain issue\nWatcher noise that must not appear in spec search.\n",
+                ["bug"],
             )
 
             db_root = Path(tmp) / "index_root"
-            result = runner.action_search_v2(
-                action="search-specs",
-                repo_hash="abc1234567890def",
-                worktree_hash="111122223333ffff",
-                project_root=str(root),
-                query="watcher",
-                n_results=5,
-                no_auto_build=False,
-                db_root=db_root,
-            )
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                result = runner.action_search_v2(
+                    action="search-specs",
+                    repo_hash="abc1234567890def",
+                    worktree_hash="111122223333ffff",
+                    project_root=str(root),
+                    query="watcher debounce",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
 
             self.assertTrue(result["ok"], result)
             self.assertIn("specResults", result)
+            self.assertEqual(len(result["specResults"]), 1, result["specResults"])
+            self.assertEqual(result["specResults"][0]["spec_id"], "1939")
+            self.assertEqual(
+                result["specResults"][0]["title"],
+                "gwt-spec: Semantic search platform",
+            )
+
+    def test_search_specs_refreshes_existing_index_from_issue_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(
+                cache_root,
+                1939,
+                "gwt-spec: Semantic search platform",
+                "# Semantic search platform\nWatcher debounce semantics.\n",
+                ["gwt-spec", "phase/review"],
+            )
+
+            db_root = Path(tmp) / "index_root"
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                initial = runner.action_search_v2(
+                    action="search-specs",
+                    repo_hash="abc1234567890def",
+                    worktree_hash="111122223333ffff",
+                    project_root=str(root),
+                    query="watcher debounce",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
+
+                self.assertTrue(initial["ok"], initial)
+                self.assertEqual(initial["specResults"][0]["spec_id"], "1939")
+
+                spec_path = cache_root / "1939" / "sections" / "spec.md"
+                spec_path.write_text(
+                    "# Semantic search platform\nIssue cache refresh contract.\n"
+                )
+                refreshed = runner.action_search_v2(
+                    action="search-specs",
+                    repo_hash="abc1234567890def",
+                    worktree_hash="111122223333ffff",
+                    project_root=str(root),
+                    query="issue cache refresh contract",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
+
+            self.assertTrue(refreshed["ok"], refreshed)
+            self.assertEqual(len(refreshed["specResults"]), 1, refreshed["specResults"])
+            self.assertEqual(refreshed["specResults"][0]["spec_id"], "1939")
 
 
 if __name__ == "__main__":

--- a/crates/gwt-core/src/index/paths.rs
+++ b/crates/gwt-core/src/index/paths.rs
@@ -32,7 +32,7 @@ use crate::worktree_hash::WorktreeHash;
 pub enum Scope {
     /// Worktree-independent: GitHub Issues.
     Issues,
-    /// Worktree-scoped: local SPEC files.
+    /// Worktree-scoped: SPEC Issue search index.
     Specs,
     /// Worktree-scoped: project source code files.
     FilesCode,

--- a/crates/gwt-core/tests/index_runner_spawn.rs
+++ b/crates/gwt-core/tests/index_runner_spawn.rs
@@ -100,23 +100,32 @@ fn search_specs_e2e_with_real_e5_auto_builds() {
 
     let tmp = tempfile::tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
-    let spec_dir = repo_root.join("specs/SPEC-1");
-    fs::create_dir_all(&spec_dir).unwrap();
-    fs::write(
-        spec_dir.join("spec.md"),
-        "# Watcher SPEC\nFilesystem watcher debounce semantics for indexing.\n",
-    )
-    .unwrap();
-    fs::write(
-        spec_dir.join("metadata.json"),
-        r#"{"id":"1","title":"Watcher SPEC","status":"open","phase":"draft"}"#,
-    )
-    .unwrap();
+    fs::create_dir_all(&repo_root).unwrap();
 
     let repo = compute_repo_hash("https://github.com/example/test.git");
     let wt = compute_worktree_hash(&repo_root).unwrap();
     let fake_home = tmp.path().join("fake_home");
     fs::create_dir_all(&fake_home).unwrap();
+    let cache_dir = fake_home
+        .join(".gwt/cache/issues")
+        .join(repo.as_str())
+        .join("1939");
+    fs::create_dir_all(cache_dir.join("sections")).unwrap();
+    fs::write(
+        cache_dir.join("meta.json"),
+        r#"{"number":1939,"title":"gwt-spec: Watcher SPEC","labels":["gwt-spec","phase/review"],"state":"open","updated_at":"2026-04-14T00:00:00Z","comment_ids":[]}"#,
+    )
+    .unwrap();
+    fs::write(
+        cache_dir.join("body.md"),
+        "<!-- gwt-spec id=1939 version=1 -->\nWatcher SPEC\n",
+    )
+    .unwrap();
+    fs::write(
+        cache_dir.join("sections/spec.md"),
+        "# Watcher SPEC\nFilesystem watcher debounce semantics for indexing.\n",
+    )
+    .unwrap();
 
     let output = Command::new(runner_python())
         .arg(runner_script())
@@ -139,5 +148,5 @@ fn search_specs_e2e_with_real_e5_auto_builds() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Watcher SPEC") || stdout.contains("SPEC-1"));
+    assert!(stdout.contains("Watcher SPEC") || stdout.contains("1939"));
 }


### PR DESCRIPTION
## Summary

- Align `search-specs` with the current Issue-first SPEC storage so spec search no longer returns zero results when only `~/.gwt/cache/issues/<repo-hash>/` is populated.
- Rebuild the SPEC index from repo-scoped `gwt-spec` cache entries and refresh existing indexes from cache diffs before non-TUI searches.
- Update the public `gwt-search` / `gwt-spec-search` surface and runner e2e coverage so the documented contract matches runtime behavior.

## Changes

- `crates/gwt-core/runtime/chroma_index_runner.py`: load SPEC documents from repo-scoped Issue cache, filter to `gwt-spec`, and refresh existing SPEC indexes from cache-backed manifest diffs.
- `crates/gwt-core/runtime/tests/test_auto_build_fallback.py`: add regressions for auto-build from Issue cache and for refreshing an existing SPEC index after cache changes.
- `crates/gwt-core/tests/index_runner_spawn.rs`: seed ignored e2e SPEC search from Issue cache instead of `specs/SPEC-*`.
- `.claude/commands/gwt-search.md`, `.claude/commands/gwt-spec-search.md`, `.claude/skills/gwt-search/SKILL.md`, `.claude/skills/gwt-spec-search/SKILL.md`, `.codex/skills/gwt-search/SKILL.md`, `.codex/skills/gwt-spec-search/SKILL.md`: update wording to the cached SPEC Issue contract.
- `crates/gwt-core/src/index/paths.rs`: fix the `Scope::Specs` description to match the Issue-backed index.

## Testing

- [x] `~/.gwt/runtime/chroma-venv/bin/python3 -m pytest -q crates/gwt-core/runtime/tests/test_auto_build_fallback.py crates/gwt-core/runtime/tests/test_issue_ttl.py crates/gwt-core/runtime/tests/test_repo_layout.py` — 21 passed
- [x] `cargo test -q -p gwt-core --test index_runner_spawn search_specs_e2e_with_real_e5_auto_builds -- --ignored` — 1 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed
- [x] `cargo fmt --check` — passed
- [x] `~/.gwt/runtime/chroma-venv/bin/python3 ~/.gwt/runtime/chroma_index_runner.py --action search-specs --repo-hash 99a8660247f5bc49 --worktree-hash b36b1c2c5c54157f --project-root /Users/akiojin/Workbench/gwt/bugfix/not-work-index --query 'chroma watcher runtime contract' --n-results 5` — returns SPEC `#1939`

## Closing Issues

- None

## Related Issues / Links

- #1939

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — `svelte-check` not applicable; no Svelte files changed
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — No schema or data migration is involved
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- The current `develop` branch no longer tracks local `specs/` directories as the canonical SPEC source.
- The regression was that `~/.gwt/cache/issues/<repo-hash>/` already contained `gwt-spec` entries, but `index-specs` still indexed `project_root/specs/SPEC-*`, so `gwt-spec-search` returned zero results in non-TUI flows.

## Risk / Impact

- **Affected areas**: project index runtime, SPEC semantic search, bundled search skill docs
- **Rollback plan**: revert commit `df58dcf5`
