### PR TITLE
fix(storage): scope board and logs by repo hash

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -171,7 +171,7 @@ gh auth login
 
 ### ログとプロファイリング
 
-通常ログは `~/.gwt/logs/` 配下に JSON Lines 形式で保存されます。パフォーマンスプロファイリングは **Settings > Profiling** で有効化できます。
+通常ログはプロジェクトごとに `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD` へ JSON Lines 形式で保存されます。パフォーマンスプロファイリングは **Settings > Profiling** で有効化できます。
 ログ仕様の詳細は [#1758](https://github.com/akiojin/gwt/issues/1758) を参照してください。
 
 ## 開発

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For browse-only usage (no PR creation or branch management):
 
 ### Logging and profiling
 
-Normal logs are stored as JSON Lines under `~/.gwt/logs/`. Performance profiling can be enabled in **Settings > Profiling**.
+Normal logs are stored per project as JSON Lines under `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD`. Performance profiling can be enabled in **Settings > Profiling**.
 See [#1758](https://github.com/akiojin/gwt/issues/1758) for the logging specification.
 
 ## Development

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -9,11 +9,13 @@ use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::paths::gwt_coordination_dir_for_repo_path;
 use crate::{GwtError, Result};
 
 pub const COORDINATION_RELATIVE_DIR: &str = ".gwt/coordination";
 pub const EVENTS_FILE_NAME: &str = "events.jsonl";
 pub const BOARD_PROJECTION_FILE_NAME: &str = "board.latest.json";
+const MIGRATION_MARKER_FILE_NAME: &str = ".migration-complete";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -239,7 +241,8 @@ pub struct CoordinationSnapshot {
 }
 
 pub fn coordination_dir(worktree_root: &Path) -> PathBuf {
-    worktree_root.join(COORDINATION_RELATIVE_DIR)
+    gwt_coordination_dir_for_repo_path(worktree_root)
+        .unwrap_or_else(|| legacy_coordination_dir(worktree_root))
 }
 
 pub fn coordination_events_path(worktree_root: &Path) -> PathBuf {
@@ -255,6 +258,11 @@ fn coordination_lock_path(worktree_root: &Path) -> PathBuf {
 }
 
 pub fn ensure_repo_local_files(worktree_root: &Path) -> Result<()> {
+    if let Some(project_dir) = gwt_coordination_dir_for_repo_path(worktree_root) {
+        let legacy_dirs = discover_legacy_coordination_dirs(worktree_root);
+        migrate_legacy_coordination_dirs(&project_dir, &legacy_dirs)?;
+    }
+
     let dir = coordination_dir(worktree_root);
     std::fs::create_dir_all(&dir)?;
 
@@ -471,6 +479,132 @@ where
     serde_json::from_str(&raw).map_err(json_error)
 }
 
+fn legacy_coordination_dir(worktree_root: &Path) -> PathBuf {
+    worktree_root.join(COORDINATION_RELATIVE_DIR)
+}
+
+fn coordination_migration_marker_path(project_dir: &Path) -> PathBuf {
+    project_dir.join(MIGRATION_MARKER_FILE_NAME)
+}
+
+fn discover_legacy_coordination_dirs(worktree_root: &Path) -> Vec<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(worktree_root)
+        .output();
+    let mut dirs = match output {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            stdout
+                .lines()
+                .filter_map(|line| line.strip_prefix("worktree "))
+                .map(PathBuf::from)
+                .map(|path| legacy_coordination_dir(&path))
+                .collect::<Vec<_>>()
+        }
+        _ => vec![legacy_coordination_dir(worktree_root)],
+    };
+    dirs.sort();
+    dirs.dedup();
+    dirs
+}
+
+fn migrate_legacy_coordination_dirs(project_dir: &Path, legacy_dirs: &[PathBuf]) -> Result<()> {
+    if coordination_migration_marker_path(project_dir).exists() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(project_dir)?;
+    let event_path = project_dir.join(EVENTS_FILE_NAME);
+    let mut events = if event_path.exists() {
+        load_events_from_path(&event_path)?
+    } else {
+        Vec::new()
+    };
+    let mut consumed_dirs = Vec::new();
+
+    for legacy_dir in legacy_dirs {
+        if legacy_dir == project_dir || !legacy_dir.exists() {
+            continue;
+        }
+        let legacy_event_path = legacy_dir.join(EVENTS_FILE_NAME);
+        if !legacy_event_path.exists() {
+            continue;
+        }
+        events.extend(load_events_from_path(&legacy_event_path)?);
+        consumed_dirs.push(legacy_dir.clone());
+    }
+
+    if !events.is_empty() {
+        events.sort_by_key(coordination_event_timestamp);
+        write_events_to_path(&event_path, &events)?;
+        let snapshot = rebuild_snapshot_from_events(&event_path)?;
+        write_atomic_json(
+            &project_dir.join(BOARD_PROJECTION_FILE_NAME),
+            &snapshot.board,
+        )?;
+    }
+
+    for legacy_dir in consumed_dirs {
+        std::fs::remove_dir_all(legacy_dir)?;
+    }
+    std::fs::write(coordination_migration_marker_path(project_dir), b"complete")?;
+    Ok(())
+}
+
+fn load_events_from_path(path: &Path) -> Result<Vec<CoordinationEvent>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = OpenOptions::new().read(true).open(path)?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        events.push(serde_json::from_str(trimmed).map_err(json_error)?);
+    }
+    Ok(events)
+}
+
+fn write_events_to_path(path: &Path, events: &[CoordinationEvent]) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| GwtError::Other(format!("path has no parent: {}", path.display())))?;
+    std::fs::create_dir_all(parent)?;
+    let tmp_path = parent.join(format!(
+        ".{}.tmp-{}-{}",
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or(EVENTS_FILE_NAME),
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+    {
+        let mut file = File::create(&tmp_path)?;
+        for event in events {
+            serde_json::to_writer(&mut file, event).map_err(json_error)?;
+            file.write_all(b"\n")?;
+        }
+        file.sync_all()?;
+    }
+    if cfg!(windows) && path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn coordination_event_timestamp(event: &CoordinationEvent) -> DateTime<Utc> {
+    match event {
+        CoordinationEvent::MessageAppended { entry } => entry.created_at,
+        CoordinationEvent::AgentCardUpsert { card } => card.updated_at,
+    }
+}
+
 fn write_atomic_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     let bytes = serde_json::to_vec_pretty(value).map_err(json_error)?;
     write_atomic(path, &bytes)
@@ -509,6 +643,7 @@ fn json_error(err: serde_json::Error) -> GwtError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use std::sync::Arc;
     use std::thread;
 
@@ -669,5 +804,82 @@ mod tests {
                 "events.jsonl".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn migrate_legacy_coordination_dirs_merges_events_and_deletes_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path().join("home/.gwt/coordination/repo-hash");
+        let legacy_one = dir.path().join("repo/.gwt/coordination");
+        let legacy_two = dir.path().join("wt/.gwt/coordination");
+
+        std::fs::create_dir_all(&legacy_one).unwrap();
+        std::fs::create_dir_all(&legacy_two).unwrap();
+
+        let mut first = BoardEntry::new(
+            AuthorKind::User,
+            "user",
+            BoardEntryKind::Request,
+            "first",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        first.created_at = Utc.with_ymd_and_hms(2026, 4, 14, 0, 0, 0).unwrap();
+        first.updated_at = first.created_at;
+
+        let mut second = BoardEntry::new(
+            AuthorKind::Agent,
+            "codex",
+            BoardEntryKind::Status,
+            "second",
+            Some("running".into()),
+            None,
+            vec![],
+            vec![],
+        );
+        second.created_at = Utc.with_ymd_and_hms(2026, 4, 14, 0, 1, 0).unwrap();
+        second.updated_at = second.created_at;
+
+        write_events(
+            legacy_one.join(EVENTS_FILE_NAME).as_path(),
+            &[CoordinationEvent::MessageAppended {
+                entry: second.clone(),
+            }],
+        );
+        write_events(
+            legacy_two.join(EVENTS_FILE_NAME).as_path(),
+            &[CoordinationEvent::MessageAppended {
+                entry: first.clone(),
+            }],
+        );
+
+        migrate_legacy_coordination_dirs(&project_dir, &[legacy_one.clone(), legacy_two.clone()])
+            .unwrap();
+
+        let snapshot = rebuild_snapshot_from_events(&project_dir.join(EVENTS_FILE_NAME)).unwrap();
+        assert_eq!(
+            snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+        assert!(!legacy_one.exists());
+        assert!(!legacy_two.exists());
+        assert!(coordination_migration_marker_path(&project_dir).exists());
+    }
+
+    fn write_events(path: &std::path::Path, events: &[CoordinationEvent]) {
+        let parent = path.parent().unwrap();
+        std::fs::create_dir_all(parent).unwrap();
+        let mut file = std::fs::File::create(path).unwrap();
+        for event in events {
+            serde_json::to_writer(&mut file, event).unwrap();
+            file.write_all(b"\n").unwrap();
+        }
     }
 }

--- a/crates/gwt-core/src/logging/mod.rs
+++ b/crates/gwt-core/src/logging/mod.rs
@@ -4,8 +4,9 @@
 //! `tracing-subscriber` Registry with:
 //!
 //! 1. A reloadable `EnvFilter` (level control via `reload::Handle`)
-//! 2. A JSONL formatting layer writing to `~/.gwt/logs/gwt.log` via a
-//!    non-blocking, daily-rolling appender (`tracing_appender`)
+//! 2. A JSONL formatting layer writing to
+//!    `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD` via a non-blocking,
+//!    daily-rolling appender (`tracing_appender`)
 //! 3. A UI forwarder layer that sends `LogEvent`s to an
 //!    `UnboundedSender<LogEvent>` so that TUI surfaces (toasts, error
 //!    modal) can react to `Info`/`Warn`/`Error` events without

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::Result;
+use crate::repo_hash::{detect_repo_hash, RepoHash};
 
 /// Return the gwt home directory (`~/.gwt/`).
 pub fn gwt_home() -> PathBuf {
@@ -29,6 +30,31 @@ pub fn gwt_cache_dir() -> PathBuf {
 /// Return the logs directory (`~/.gwt/logs/`).
 pub fn gwt_logs_dir() -> PathBuf {
     gwt_home().join("logs")
+}
+
+/// Return the coordination root (`~/.gwt/coordination/`).
+pub fn gwt_coordination_root() -> PathBuf {
+    gwt_home().join("coordination")
+}
+
+/// Return the coordination directory for a repository hash.
+pub fn gwt_coordination_dir(repo_hash: &RepoHash) -> PathBuf {
+    gwt_coordination_root().join(repo_hash.as_str())
+}
+
+/// Return the coordination directory for a repository path, if `origin` exists.
+pub fn gwt_coordination_dir_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
+    detect_repo_hash(repo_path).map(|repo_hash| gwt_coordination_dir(&repo_hash))
+}
+
+/// Return the structured-log directory for a repository hash.
+pub fn gwt_project_logs_dir(repo_hash: &RepoHash) -> PathBuf {
+    gwt_logs_dir().join(repo_hash.as_str())
+}
+
+/// Return the structured-log directory for a repository path, if `origin` exists.
+pub fn gwt_project_logs_dir_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
+    detect_repo_hash(repo_path).map(|repo_hash| gwt_project_logs_dir(&repo_hash))
 }
 
 /// Return the shared runtime directory (`~/.gwt/runtime/`).
@@ -68,6 +94,7 @@ pub fn ensure_dir(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::repo_hash::compute_repo_hash;
 
     #[test]
     fn gwt_home_ends_with_dot_gwt() {
@@ -101,6 +128,22 @@ mod tests {
         let p = gwt_logs_dir();
         assert!(p.starts_with(gwt_home()));
         assert!(p.ends_with("logs"));
+    }
+
+    #[test]
+    fn gwt_project_logs_dir_scopes_by_repo_hash() {
+        let repo_hash = compute_repo_hash("https://github.com/example/project.git");
+        let p = gwt_project_logs_dir(&repo_hash);
+        assert!(p.starts_with(gwt_logs_dir()));
+        assert!(p.ends_with(format!("logs/{}", repo_hash.as_str())));
+    }
+
+    #[test]
+    fn gwt_coordination_dir_scopes_by_repo_hash() {
+        let repo_hash = compute_repo_hash("https://github.com/example/project.git");
+        let p = gwt_coordination_dir(&repo_hash);
+        assert!(p.starts_with(gwt_home()));
+        assert!(p.ends_with(format!("coordination/{}", repo_hash.as_str())));
     }
 
     #[test]

--- a/crates/gwt-core/src/repo_hash.rs
+++ b/crates/gwt-core/src/repo_hash.rs
@@ -5,6 +5,7 @@
 //! resolves to the same `RepoHash`.
 
 use std::fmt;
+use std::path::Path;
 
 use sha2::{Digest, Sha256};
 
@@ -96,9 +97,27 @@ pub fn compute_repo_hash(origin_url: &str) -> RepoHash {
     RepoHash(hex_full[..HASH_HEX_LEN].to_string())
 }
 
+/// Detect a `RepoHash` from the `origin` remote configured for `repo_root`.
+pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
+    let output = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if url.is_empty() {
+        return None;
+    }
+    Some(compute_repo_hash(&url))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn normalizes_https_https_form() {
@@ -139,5 +158,107 @@ mod tests {
             .as_str()
             .chars()
             .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn detect_repo_hash_reads_origin_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        init_git_repo(&repo);
+        add_origin(&repo, "git@github.com:example/project.git");
+
+        let actual = detect_repo_hash(&repo).expect("repo hash");
+
+        assert_eq!(
+            actual.as_str(),
+            compute_repo_hash("https://github.com/example/project.git").as_str()
+        );
+    }
+
+    #[test]
+    fn detect_repo_hash_returns_same_hash_for_linked_worktree() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let wt = dir.path().join("wt-feature");
+        init_git_repo(&repo);
+        add_origin(&repo, "https://github.com/example/project.git");
+        commit_file(&repo, "README.md", "# repo\n");
+
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "feature/shared",
+                wt.to_str().unwrap(),
+            ])
+            .current_dir(&repo)
+            .output()
+            .expect("git worktree add");
+        assert!(
+            output.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let repo_hash = detect_repo_hash(&repo).expect("repo hash");
+        let wt_hash = detect_repo_hash(&wt).expect("worktree hash");
+        assert_eq!(repo_hash.as_str(), wt_hash.as_str());
+    }
+
+    fn init_git_repo(path: &Path) {
+        let output = std::process::Command::new("git")
+            .args(["init", path.to_str().unwrap()])
+            .output()
+            .expect("git init");
+        assert!(output.status.success(), "git init failed");
+
+        let email = std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .output()
+            .expect("git config user.email");
+        assert!(email.status.success(), "git config user.email failed");
+
+        let name = std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path)
+            .output()
+            .expect("git config user.name");
+        assert!(name.status.success(), "git config user.name failed");
+    }
+
+    fn add_origin(path: &Path, url: &str) {
+        let output = std::process::Command::new("git")
+            .args(["remote", "add", "origin", url])
+            .current_dir(path)
+            .output()
+            .expect("git remote add origin");
+        assert!(
+            output.status.success(),
+            "git remote add origin failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn commit_file(path: &Path, name: &str, body: &str) {
+        std::fs::write(path.join(name), body).unwrap();
+        let add = std::process::Command::new("git")
+            .args(["add", name])
+            .current_dir(path)
+            .output()
+            .expect("git add");
+        assert!(add.status.success(), "git add failed");
+
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(path)
+            .output()
+            .expect("git commit");
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
     }
 }

--- a/crates/gwt-tui/src/index_worker.rs
+++ b/crates/gwt-tui/src/index_worker.rs
@@ -94,9 +94,9 @@ pub fn init_notification_bus(bus: NotificationBus) {
 /// SPEC-6 Phase 5: this used to write to a dedicated `~/.gwt/logs/index.log`
 /// file and push to the notification bus. Both have been replaced by a
 /// `tracing::debug!(target: "gwt_tui::index", ...)` call so the event lands
-/// in the unified `~/.gwt/logs/gwt.log.YYYY-MM-DD` JSONL file alongside
-/// every other tracing event. The Logs tab picks it up via the file
-/// watcher.
+/// in the active project's `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD`
+/// JSONL file alongside every other tracing event. The Logs tab picks
+/// it up via the file watcher.
 ///
 /// The legacy `~/.gwt/logs/index.log` writer is preserved as a best-effort
 /// secondary sink for shell-friendly tail-ability; it can be removed once

--- a/crates/gwt-tui/src/logs_watcher/mod.rs
+++ b/crates/gwt-tui/src/logs_watcher/mod.rs
@@ -1,7 +1,8 @@
 //! Logs tab file watcher (SPEC-6 Phase 5).
 //!
-//! Tails `~/.gwt/logs/gwt.log.YYYY-MM-DD`, parses each appended JSONL
-//! line into a `LogEvent`, and dispatches batches to the main TUI
+//! Tails the active project's
+//! `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD`, parses each appended
+//! JSONL line into a `LogEvent`, and dispatches batches to the main TUI
 //! loop over a `std::sync::mpsc::Sender<LogsWatcherPacket>`.
 //!
 //! The file is the single source of truth for the Logs tab; the

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -21,7 +21,7 @@ use gwt_agent::reset_runtime_state_dir_for_pid;
 use gwt_core::logging::{
     init as init_logging, LogEvent as Notification, LogLevel as Severity, LoggingConfig,
 };
-use gwt_core::paths::gwt_logs_dir;
+use gwt_core::paths::{gwt_logs_dir, gwt_project_logs_dir_for_repo_path};
 use gwt_git::RepoType;
 use gwt_terminal::runtime;
 use gwt_tui::{
@@ -207,6 +207,10 @@ fn tick_deadline_after_message(current_deadline: Instant, now: Instant, msg: &Me
     }
 }
 
+fn logging_dir_for_repo_path(repo_path: &Path) -> PathBuf {
+    gwt_project_logs_dir_for_repo_path(repo_path).unwrap_or_else(gwt_logs_dir)
+}
+
 #[cfg(test)]
 fn should_render_after_tick(model: &Model) -> bool {
     app::tick_redraw_required(model)
@@ -227,7 +231,11 @@ fn main() -> io::Result<()> {
     // JSONL file writer rolling daily, plus a UI forwarder layer. The
     // returned handles MUST be kept alive for the lifetime of main so
     // that the background writer thread stays up.
-    let logging_config = LoggingConfig::new(gwt_logs_dir());
+    let repo_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let logging_config = LoggingConfig::new(logging_dir_for_repo_path(&repo_path));
     let mut logging_handles = match init_logging(logging_config) {
         Ok(h) => Some(h),
         Err(err) => {
@@ -269,12 +277,6 @@ fn main() -> io::Result<()> {
     // Clone the reload handle so the Logs tab can cycle the global
     // log level live (SPEC-6 FR-011).
     let logging_reload_handle = logging_handles.as_ref().map(|h| h.reload_handle.clone());
-
-    // Parse CLI args: optional repo path
-    let repo_path = std::env::args()
-        .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
     // Initialize terminal
     runtime::enter_raw_mode()?;
@@ -434,12 +436,13 @@ fn run_app(
     };
     app::refresh_active_profile_state(&mut model);
     // SPEC-6 Phase 5: spawn the Logs-tab file watcher so the
-    // `~/.gwt/logs/gwt.log.YYYY-MM-DD` JSONL stream flows into
-    // `LogsState.entries`. Keeping the handle alive for the lifetime
-    // of run_app is enough — the watcher owns its own thread.
+    // The active project's `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD`
+    // JSONL stream flows into `LogsState.entries`. Keeping the handle
+    // alive for the lifetime of run_app is enough — the watcher owns
+    // its own thread.
     let (logs_tx, logs_rx) = std::sync::mpsc::channel();
     let _logs_watcher_handle =
-        gwt_tui::logs_watcher::spawn(gwt_core::paths::gwt_logs_dir(), logs_tx);
+        gwt_tui::logs_watcher::spawn(logging_dir_for_repo_path(model.repo_path()), logs_tx);
     model.set_logs_watcher_rx(logs_rx);
     let _board_watcher_handle = if model.active_layer == ActiveLayer::Initialization {
         None
@@ -724,6 +727,7 @@ mod tests {
         },
         Command,
     };
+    use gwt_core::repo_hash::compute_repo_hash;
     use gwt_tui::app;
     use gwt_tui::message::Message;
     use gwt_tui::model::{FocusPane, ManagementTab, SessionLayout};
@@ -792,6 +796,19 @@ mod tests {
     }
 
     #[test]
+    fn logging_dir_for_repo_path_uses_repo_hash_subdirectory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        init_git_repo(&repo);
+        add_origin(&repo, "https://github.com/example/project.git");
+
+        let actual = logging_dir_for_repo_path(&repo);
+        let expected_hash = compute_repo_hash("https://github.com/example/project.git");
+
+        assert!(actual.ends_with(format!("logs/{}", expected_hash.as_str())));
+    }
+
+    #[test]
     fn restore_startup_session_state_with_zero_sessions_skips_default_shell_spawn() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("session.toml");
@@ -852,6 +869,41 @@ session_count = 3
         assert_eq!(model.session_count(), 0);
         assert!(model.active_session_tab().is_none());
         assert!(!should_spawn_default_shell(&model));
+    }
+
+    fn init_git_repo(path: &Path) {
+        let output = std::process::Command::new("git")
+            .args(["init", path.to_str().unwrap()])
+            .output()
+            .expect("git init");
+        assert!(output.status.success(), "git init failed");
+
+        let email = std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .output()
+            .expect("git config user.email");
+        assert!(email.status.success(), "git config user.email failed");
+
+        let name = std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path)
+            .output()
+            .expect("git config user.name");
+        assert!(name.status.success(), "git config user.name failed");
+    }
+
+    fn add_origin(path: &Path, url: &str) {
+        let output = std::process::Command::new("git")
+            .args(["remote", "add", "origin", url])
+            .current_dir(path)
+            .output()
+            .expect("git remote add origin");
+        assert!(
+            output.status.success(),
+            "git remote add origin failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]

--- a/crates/gwt-tui/src/model.rs
+++ b/crates/gwt-tui/src/model.rs
@@ -38,9 +38,10 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 /// In-memory buffer of log events surfaced in the Logs tab.
 ///
 /// Replaces the old `gwt_notification::StructuredLog` ring buffer. The
-/// file on disk (`~/.gwt/logs/gwt.log.YYYY-MM-DD`) is the authoritative
-/// record; this in-memory copy only feeds the UI filter/render pipeline
-/// so that the Logs tab can display events without parsing the file.
+/// file on disk (`~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD`) is the
+/// authoritative record; this in-memory copy only feeds the UI
+/// filter/render pipeline so that the Logs tab can display events
+/// without parsing the file.
 #[derive(Debug, Default, Clone)]
 pub struct NotificationLog {
     entries: Vec<Notification>,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-14 — fix: shared coordination storage のスコープ変更では SPEC と保存キーを先に揃える
+
+### 事象
+
+Board を複数 worktree 間で共有したいのに、実装と SPEC の一部が `repo-local` /
+worktree 配下前提のまま残っており、`~/.gwt/` 配下の project-scoped storage へ
+寄せる判断と文面が食い違っていた。
+
+### 原因
+
+- 「同じ repo で共有したい」という要件に対して、保存キーを worktree path と
+  project identity のどちらに置くかを最初に固定していなかった。
+- path helper だけ直せばよいと見て、関連 SPEC と README の user-facing path を
+  同じ変更セットで更新する前提が弱かった。
+
+### 再発防止策
+
+1. shared Board / logs / cache の保存スコープを変えるときは、まず project key
+   (`RepoHash` など) を明示してから path helper を実装する。
+2. worktree-local から project-scoped へ移す変更では、legacy merge/delete 方針を
+   SPEC と data model に先に書き戻す。
+3. user-facing path が変わる変更では、README と Issue SPEC の更新をコード変更と
+   同じ変更セットに含める。
+
 ## 2026-04-14 — fix: terminal copy UX は host shortcut 前提より既存 selection 契約を優先する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Move shared Board storage to `~/.gwt/coordination/<repo-hash>/` so linked worktrees of the same repository share one coordination surface.
- Move structured logs to `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD` so linked worktrees share logs while unrelated projects are isolated by repo hash.
- Add one-shot Board migration and update the related docs/spec language so the runtime path, README, and SPEC artifacts all describe the same storage model.

## Changes

- `crates/gwt-core/src/repo_hash.rs`: add shared `detect_repo_hash(repo_root)` and tests proving linked worktrees resolve to the same repo hash.
- `crates/gwt-core/src/paths.rs`: add project-scoped coordination/log path helpers under `~/.gwt/.../<repo-hash>/`.
- `crates/gwt-core/src/coordination.rs`: switch Board persistence to the project-scoped directory, merge legacy `.gwt/coordination/events.jsonl` data from linked worktrees, and delete migrated legacy directories.
- `crates/gwt-tui/src/main.rs`: initialize structured logging and the Logs watcher from the resolved project-scoped log directory.
- `crates/gwt-tui/src/index_worker.rs`, `crates/gwt-tui/src/logs_watcher/mod.rs`, `crates/gwt-tui/src/model.rs`, `crates/gwt-core/src/logging/mod.rs`: update comments and helper wiring to describe/use the repo-hash scoped log layout.
- `README.md`, `README.ja.md`: document the new per-project log path.
- `tasks/lessons.md`: record the storage-scope lesson for future path migrations.

## Testing

- [x] `cargo fmt --all` — formatting completes successfully.
- [x] `cargo test -p gwt-core detect_repo_hash_returns_same_hash_for_linked_worktree -- --nocapture` — linked worktrees resolve to the same repo hash.
- [x] `cargo test -p gwt-core migrate_legacy_coordination_dirs_merges_events_and_deletes_sources -- --nocapture` — legacy Board data merges into the project-scoped store and legacy directories are removed.
- [x] `cargo test -p gwt-tui logging_dir_for_repo_path_uses_repo_hash_subdirectory -- --nocapture` — TUI logging resolves to `~/.gwt/logs/<repo-hash>/`.
- [x] `cargo test -p gwt-core -p gwt-tui` — focused crates pass their full test suites.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings.
- [x] `cargo build -p gwt-tui` — build succeeds.
- [x] `bunx markdownlint-cli README.md README.ja.md` — markdown docs pass linting.

## Closing Issues

- None

## Related Issues / Links

- #1974
- #1924

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Board state was still effectively worktree-scoped even though the coordination surface is meant to be shared across multiple agent worktrees working on the same repository.
- Structured logs already lived under `~/.gwt/logs/`, but without a repo-hash boundary unrelated projects could share the same namespace while linked worktrees could not be treated as one project-scoped unit.
- This PR aligns runtime behavior, docs, and SPEC cache updates around `RepoHash` as the shared project identity.

## Risk / Impact

- **Affected areas**: Board persistence, Board migration on first access, structured logging initialization, Logs-tab file watching, README path guidance.
- **Rollback plan**: Revert this PR to restore worktree-local Board storage and flat log directories; migrated Board history remains preserved in the project-scoped event log if rollback is needed.

## Notes

- Existing flat files under `~/.gwt/logs/` are intentionally left untouched; this change is forward-only for new structured log writes.
