### PR TITLE
fix: strip trailing newline from GWT_REPO_HASH shell computation

### DIFF
--- a/.claude/skills/gwt-search/SKILL.md
+++ b/.claude/skills/gwt-search/SKILL.md
@@ -49,7 +49,7 @@ If you launch outside the TUI, recompute them:
 GWT_PROJECT_ROOT="$(pwd)"
 GWT_REPO_HASH=$(git remote get-url origin 2>/dev/null \
   | sed -E 's#^git@([^:]+):#https://\1/#; s#\.git$##; s#^https?://##' \
-  | tr 'A-Z' 'a-z' | sha256sum | cut -c1-16)
+  | tr 'A-Z' 'a-z' | tr -d '\n' | sha256sum | cut -c1-16)
 GWT_WORKTREE_HASH=$(printf '%s' "$(cd "$GWT_PROJECT_ROOT" && pwd -P)" | sha256sum | cut -c1-16)
 ```
 

--- a/.codex/skills/gwt-search/SKILL.md
+++ b/.codex/skills/gwt-search/SKILL.md
@@ -49,7 +49,7 @@ If you launch outside the TUI, recompute them:
 GWT_PROJECT_ROOT="$(pwd)"
 GWT_REPO_HASH=$(git remote get-url origin 2>/dev/null \
   | sed -E 's#^git@([^:]+):#https://\1/#; s#\.git$##; s#^https?://##' \
-  | tr 'A-Z' 'a-z' | sha256sum | cut -c1-16)
+  | tr 'A-Z' 'a-z' | tr -d '\n' | sha256sum | cut -c1-16)
 GWT_WORKTREE_HASH=$(printf '%s' "$(cd "$GWT_PROJECT_ROOT" && pwd -P)" | sha256sum | cut -c1-16)
 ```
 


### PR DESCRIPTION
## Summary

- `gwt-search` スキルのシェルスクリプトで `GWT_REPO_HASH` を算出する際、`git remote get-url origin` の出力に含まれる末尾改行を除去せずに `sha256sum` に渡していたため、Rust 側 (`gwt-core::compute_repo_hash`) と異なるハッシュが生成されていた
- `tr -d '\n'` を `sha256sum` の前に追加し、Rust と同一のハッシュを算出するよう修正
- `.claude/skills/gwt-search/SKILL.md` と `.codex/skills/gwt-search/SKILL.md` の両方を修正

Closes #1986

## Test plan

- [x] 修正後のシェルスクリプトで `GWT_REPO_HASH` を算出し、Rust 側と一致 (`99a8660247f5bc49`) を確認
- [x] `cargo test -p gwt-core` 通過
- [x] 孤立インデックス `~/.gwt/index/cc01b522a65e9c5b/` を削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)