### PR TITLE
fix: gate Unix-specific APIs for Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build workspace targets
         run: cargo build -p gwt-core -p gwt-tui --all-features
+
+  check-windows:
+    name: Check (Windows)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: check-windows
+      - name: Check Windows compilation
+        run: cargo check -p gwt-core -p gwt-tui --target x86_64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,6 @@ dependencies = [
  "gwt-terminal",
  "gwt-voice",
  "insta",
- "libc",
  "notify",
  "notify-debouncer-mini",
  "ratatui",

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -1,7 +1,6 @@
 //! Git repository discovery and inspection
 
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -199,9 +198,13 @@ pub fn install_develop_protection(repo_path: &Path) -> Result<()> {
 
     fs::write(&hook_path, new_content).map_err(GwtError::Io)?;
 
-    // Set executable permission
-    let perms = fs::Permissions::from_mode(0o755);
-    fs::set_permissions(&hook_path, perms).map_err(GwtError::Io)?;
+    // Set executable permission (unix only; no-op on Windows)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o755);
+        fs::set_permissions(&hook_path, perms).map_err(GwtError::Io)?;
+    }
 
     Ok(())
 }
@@ -462,9 +465,13 @@ mod tests {
         assert!(content.starts_with("#!/bin/sh"));
         assert!(!content.contains("\"$branch\" = \"develop\""));
 
-        // Check executable permission
-        let perms = std::fs::metadata(&hook_path).unwrap().permissions();
-        assert!(perms.mode() & 0o111 != 0);
+        // Check executable permission (unix only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::metadata(&hook_path).unwrap().permissions();
+            assert!(perms.mode() & 0o111 != 0);
+        }
     }
 
     #[test]

--- a/crates/gwt-terminal/Cargo.toml
+++ b/crates/gwt-terminal/Cargo.toml
@@ -16,6 +16,8 @@ thiserror.workspace = true
 tracing.workspace = true
 vt100 = "0.15"
 crossterm = "0.29"
+
+[target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
 [dev-dependencies]

--- a/crates/gwt-terminal/src/runtime.rs
+++ b/crates/gwt-terminal/src/runtime.rs
@@ -142,11 +142,22 @@ pub fn is_tty_alive() -> bool {
         return true;
     }
 
+    is_tty_alive_platform()
+}
+
+#[cfg(unix)]
+fn is_tty_alive_platform() -> bool {
     use std::os::unix::io::AsRawFd;
 
     let fd = std::io::stdin().as_raw_fd();
     let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
     unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) == 0 }
+}
+
+#[cfg(not(unix))]
+fn is_tty_alive_platform() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal()
 }
 
 pub fn next_tick_deadline() -> Instant {

--- a/crates/gwt-tui/Cargo.toml
+++ b/crates/gwt-tui/Cargo.toml
@@ -41,7 +41,6 @@ toml = { workspace = true }
 base64 = { workspace = true }
 dirs = { workspace = true }
 unicode-width = "0.2"
-libc = "0.2"
 signal-hook = "0.3"
 
 [lints.rust]


### PR DESCRIPTION
## Summary

- Windows ビルド失敗の修正（v9.0.0 リリースで発覚）
- Unix 固有 API に `#[cfg(unix)]` ゲートを追加
- PR CI に Windows クロスコンパイルチェックを追加（再発防止）

## Changes

- `gwt-terminal/runtime.rs`: `is_tty_alive()` を platform-aware に分離
- `gwt-terminal/Cargo.toml`: `libc` を `[target.'cfg(unix)'.dependencies]` に移動
- `gwt-git/repository.rs`: `PermissionsExt` を `#[cfg(unix)]` ゲート
- `gwt-tui/Cargo.toml`: 未使用 `libc` 依存を削除
- `.github/workflows/build.yml`: Windows (`x86_64-pc-windows-msvc`) コンパイルチェックを追加

## Test plan

- [x] `cargo build -p gwt-tui` 成功
- [x] `cargo clippy -p gwt-terminal -p gwt-git -p gwt-tui` クリーン
- [x] `cargo test -p gwt-git -p gwt-terminal` 全テスト通過
- [ ] CI の Windows check-windows ジョブが通過することを確認
- [ ] main マージ後に release workflow を re-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cross-platform support with improved Windows compatibility for filesystem operations and terminal detection.

* **Chores**
  * Added Windows (MSVC) compilation checks to CI pipeline.
  * Optimized platform-specific dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->