### PR TITLE
fix: gate SIGHUP and CI runner for Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,12 @@ jobs:
 
   check-windows:
     name: Check (Windows)
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-pc-windows-msvc
       - uses: Swatinem/rust-cache@v2
         with:
           key: check-windows
       - name: Check Windows compilation
-        run: cargo check -p gwt-core -p gwt-tui --target x86_64-pc-windows-msvc
+        run: cargo check -p gwt-core -p gwt-tui

--- a/crates/gwt-tui/src/main.rs
+++ b/crates/gwt-tui/src/main.rs
@@ -573,10 +573,11 @@ fn run_app(
         }
     }
 
-    // Register SIGHUP handler to detect terminal closure.
+    // Register SIGHUP handler to detect terminal closure (unix only).
     // Defence-in-depth: even if tcgetattr pre-check misses the condition,
     // the signal flag will catch it on the next outer-loop iteration.
     let sighup_flag = Arc::new(AtomicBool::new(false));
+    #[cfg(unix)]
     let _ = signal_hook::flag::register(signal_hook::consts::SIGHUP, Arc::clone(&sighup_flag));
 
     let mut keybinds = KeybindRegistry::new();


### PR DESCRIPTION
## Summary

v9.0.0 リリースの Windows ビルド修正の続き。

## Changes

- `gwt-tui/main.rs`: `SIGHUP` シグナルハンドラを `#[cfg(unix)]` でゲート（Windows に SIGHUP は存在しない）
- `.github/workflows/build.yml`: Windows チェックジョブを `windows-latest` ランナーに変更（Linux 上のクロスコンパイルは MSVC ツールチェーン不在で失敗するため）

## Test plan

- [x] `cargo clippy -p gwt-tui` クリーン
- [ ] CI の Check (Windows) ジョブが通過
- [ ] main マージ後に release workflow を re-run → Windows ビルド成功