### PR TITLE
fix: workflow-policy フックのワークツリー内操作の過剰ブロックを緩和

### DIFF
--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -22,6 +22,6 @@ pub use session::{
 };
 pub use types::{
     AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget,
-    SessionMode,
+    SessionMode, WorkflowBypass,
 };
 pub use version_cache::{build_version_options, VersionCache, VersionOption};

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -7,7 +7,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::{AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget};
+use crate::types::{
+    AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, WorkflowBypass,
+};
 
 /// Idle duration (in seconds) after which a session is considered stopped.
 const IDLE_TIMEOUT_SECS: i64 = 60;
@@ -44,6 +46,8 @@ pub struct Session {
     pub docker_lifecycle_intent: DockerLifecycleIntent,
     #[serde(default)]
     pub linked_issue_number: Option<u64>,
+    #[serde(default)]
+    pub workflow_bypass: Option<WorkflowBypass>,
     #[serde(default)]
     pub launch_command: String,
     #[serde(default)]
@@ -100,6 +104,7 @@ impl Session {
             docker_service: None,
             docker_lifecycle_intent: DockerLifecycleIntent::Connect,
             linked_issue_number: None,
+            workflow_bypass: None,
             launch_command: String::new(),
             launch_args: Vec::new(),
             created_at: now,
@@ -291,6 +296,7 @@ mod tests {
             session.docker_lifecycle_intent,
             DockerLifecycleIntent::Connect
         );
+        assert!(session.workflow_bypass.is_none());
     }
 
     #[test]
@@ -338,6 +344,7 @@ mod tests {
         session.runtime_target = LaunchRuntimeTarget::Docker;
         session.docker_service = Some("web".into());
         session.docker_lifecycle_intent = DockerLifecycleIntent::Restart;
+        session.workflow_bypass = Some(WorkflowBypass::Release);
         session.launch_command = "codex".into();
         session.launch_args = vec![
             "--no-alt-screen".into(),
@@ -377,6 +384,7 @@ mod tests {
                 "--last".to_string()
             ]
         );
+        assert_eq!(loaded.workflow_bypass, Some(WorkflowBypass::Release));
         assert_eq!(loaded.display_name, "Gemini CLI");
     }
 
@@ -437,6 +445,7 @@ mod tests {
         );
         assert!(loaded.launch_command.is_empty());
         assert!(loaded.launch_args.is_empty());
+        assert!(loaded.workflow_bypass.is_none());
     }
 
     #[test]

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -142,6 +142,13 @@ pub enum DockerLifecycleIntent {
     CreateAndStart,
 }
 
+/// Session-level workflow policy bypass for ownerless operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkflowBypass {
+    Release,
+    Chore,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,5 +236,14 @@ mod tests {
         let json = serde_json::to_string(&color).unwrap();
         let parsed: AgentColor = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, color);
+    }
+
+    #[test]
+    fn workflow_bypass_serde_roundtrip() {
+        for bypass in [WorkflowBypass::Release, WorkflowBypass::Chore] {
+            let json = serde_json::to_string(&bypass).unwrap();
+            let parsed: WorkflowBypass = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, bypass);
+        }
     }
 }

--- a/crates/gwt-tui/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt-tui/src/cli/hook/workflow_policy.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use gwt_agent::session::{Session, GWT_SESSION_ID_ENV};
+use gwt_agent::types::WorkflowBypass;
 use gwt_core::paths::{gwt_cache_dir, gwt_sessions_dir};
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;
@@ -30,6 +31,7 @@ pub struct WorkflowContext {
     pub owner: WorkflowOwner,
     pub has_plan: bool,
     pub has_tasks: bool,
+    pub bypass: Option<WorkflowBypass>,
 }
 
 impl WorkflowContext {
@@ -38,6 +40,7 @@ impl WorkflowContext {
             owner: WorkflowOwner::Unknown,
             has_plan: false,
             has_tasks: false,
+            bypass: None,
         }
     }
 
@@ -46,6 +49,7 @@ impl WorkflowContext {
             owner: WorkflowOwner::Issue(issue_number),
             has_plan: false,
             has_tasks: false,
+            bypass: None,
         }
     }
 
@@ -54,6 +58,16 @@ impl WorkflowContext {
             owner: WorkflowOwner::Spec(issue_number),
             has_plan,
             has_tasks,
+            bypass: None,
+        }
+    }
+
+    pub fn with_bypass(bypass: WorkflowBypass) -> Self {
+        Self {
+            owner: WorkflowOwner::Unknown,
+            has_plan: false,
+            has_tasks: false,
+            bypass: Some(bypass),
         }
     }
 }
@@ -68,14 +82,27 @@ pub fn evaluate_with_context(
     worktree_root: &Path,
     context: &WorkflowContext,
 ) -> Result<Option<BlockDecision>, HookError> {
+    // 1. Legacy safety (gh issue CLI, branch ops, worktree-external file ops)
     if let Some(decision) = block_bash_policy::evaluate(event, worktree_root)? {
         return Ok(Some(decision));
     }
 
+    // 2. Docs/chore path exemption + non-mutating tools
     if is_exempt_chore_change(event) || !is_mutating_tool_call(event, worktree_root) {
         return Ok(None);
     }
 
+    // 3. Worktree-internal operations are allowed without owner
+    if is_worktree_internal_operation(event, worktree_root) {
+        return Ok(None);
+    }
+
+    // 4. Session-level bypass (release/chore workflows)
+    if context.bypass.is_some() {
+        return Ok(None);
+    }
+
+    // 5. Owner gate (only reached for external operations like git push)
     match context.owner {
         WorkflowOwner::Unknown => Ok(Some(missing_owner_decision())),
         WorkflowOwner::Issue(_) => Ok(None),
@@ -104,20 +131,28 @@ pub fn handle() -> Result<Option<BlockDecision>, HookError> {
 
 fn resolve_workflow_context(worktree_root: &Path) -> WorkflowContext {
     let session = load_session_from_env();
+    let bypass = session.as_ref().and_then(|s| s.workflow_bypass);
+
     let Some(issue_number) = session
         .as_ref()
         .and_then(|session| session.linked_issue_number)
         .or_else(|| resolve_issue_from_linkage_store(worktree_root, session.as_ref()))
     else {
-        return WorkflowContext::unknown();
+        let mut ctx = WorkflowContext::unknown();
+        ctx.bypass = bypass;
+        return ctx;
     };
 
     let Some(cache_root) = crate::issue_cache::issue_cache_root_for_repo_path(worktree_root) else {
-        return WorkflowContext::plain_issue(issue_number);
+        let mut ctx = WorkflowContext::plain_issue(issue_number);
+        ctx.bypass = bypass;
+        return ctx;
     };
     let cache = Cache::new(cache_root);
     let Some(entry) = cache.load_entry(IssueNumber(issue_number)) else {
-        return WorkflowContext::plain_issue(issue_number);
+        let mut ctx = WorkflowContext::plain_issue(issue_number);
+        ctx.bypass = bypass;
+        return ctx;
     };
     if !entry
         .snapshot
@@ -125,14 +160,18 @@ fn resolve_workflow_context(worktree_root: &Path) -> WorkflowContext {
         .iter()
         .any(|label| label == "gwt-spec")
     {
-        return WorkflowContext::plain_issue(issue_number);
+        let mut ctx = WorkflowContext::plain_issue(issue_number);
+        ctx.bypass = bypass;
+        return ctx;
     }
 
-    WorkflowContext::spec_issue(
+    let mut ctx = WorkflowContext::spec_issue(
         issue_number,
         has_nonempty_section(&entry.spec_body, "plan"),
         has_nonempty_section(&entry.spec_body, "tasks"),
-    )
+    );
+    ctx.bypass = bypass;
+    ctx
 }
 
 fn load_session_from_env() -> Option<Session> {
@@ -174,6 +213,57 @@ fn has_nonempty_section(spec_body: &SpecBody, name: &str) -> bool {
         .sections
         .get(&SectionName(name.to_string()))
         .is_some_and(|content| !content.trim().is_empty())
+}
+
+fn is_worktree_internal_operation(event: &HookEvent, worktree_root: &Path) -> bool {
+    match event.tool_name.as_deref() {
+        Some("Edit" | "Write" | "MultiEdit") => extract_target_path(event)
+            .is_some_and(|path| is_path_within_worktree(&path, worktree_root)),
+        Some("Bash") => event
+            .command()
+            .is_some_and(|cmd| !has_external_side_effects(cmd)),
+        _ => true,
+    }
+}
+
+fn has_external_side_effects(command: &str) -> bool {
+    for segment in super::segments::split_command_segments(command) {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        if tokens.first().copied() == Some("git") && tokens.get(1).copied() == Some("push") {
+            return true;
+        }
+    }
+    false
+}
+
+fn normalize_path(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        use std::path::Component::*;
+        match comp {
+            ParentDir => {
+                out.pop();
+            }
+            CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+fn is_path_within_worktree(path: &Path, worktree_root: &Path) -> bool {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        worktree_root.join(path)
+    };
+    let abs = normalize_path(&abs);
+    let root = normalize_path(worktree_root);
+    abs == root || abs.starts_with(&root)
 }
 
 fn is_mutating_tool_call(event: &HookEvent, worktree_root: &Path) -> bool {

--- a/crates/gwt-tui/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt-tui/tests/hook_workflow_policy_test.rs
@@ -164,15 +164,41 @@ fn allows_read_only_tools_without_owner() {
 }
 
 #[test]
-fn blocks_mutating_tools_when_owner_is_unknown() {
+fn allows_worktree_internal_edit_without_owner() {
+    let wt = root();
+    let event = event(
+        "Edit",
+        json!({ "file_path": format!("{}/src/lib.rs", wt.display()), "old_string": "x", "new_string": "y" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "worktree-internal edits must be allowed without owner"
+    );
+}
+
+#[test]
+fn allows_worktree_internal_edit_with_relative_path() {
     let event = event(
         "Edit",
         json!({ "file_path": "src/lib.rs", "old_string": "x", "new_string": "y" }),
     );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "relative worktree-internal edits must be allowed without owner"
+    );
+}
+
+#[test]
+fn blocks_edit_outside_worktree_without_owner() {
+    let event = event(
+        "Edit",
+        json!({ "file_path": "/outside/project/src/lib.rs", "old_string": "x", "new_string": "y" }),
+    );
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
-        .expect("unknown owner must block edits");
+        .expect("edit outside worktree must block without owner");
     assert!(decision.reason.contains("owner"));
-    assert!(decision.stop_reason.contains("gwt-discussion"));
 }
 
 #[test]
@@ -199,48 +225,39 @@ fn allows_mutation_for_plain_issue_owner() {
 }
 
 #[test]
-fn blocks_spec_owner_without_plan() {
-    let event = event(
-        "Write",
-        json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-    );
+fn blocks_spec_owner_without_plan_on_external_op() {
+    let event = event("Bash", json!({ "command": "git push" }));
     let decision = evaluate(
         &event,
         workflow_policy::WorkflowContext::spec_issue(1935, false, true),
     )
-    .expect("spec without plan must block");
+    .expect("spec without plan must block external ops");
     assert!(decision.reason.contains("plan"));
     assert!(decision.stop_reason.contains("gwt-plan-spec"));
 }
 
 #[test]
-fn blocks_spec_owner_without_tasks() {
-    let event = event(
-        "Write",
-        json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-    );
+fn blocks_spec_owner_without_tasks_on_external_op() {
+    let event = event("Bash", json!({ "command": "git push" }));
     let decision = evaluate(
         &event,
         workflow_policy::WorkflowContext::spec_issue(1935, true, false),
     )
-    .expect("spec without tasks must block");
+    .expect("spec without tasks must block external ops");
     assert!(decision.reason.contains("tasks"));
     assert!(decision.stop_reason.contains("gwt-plan-spec"));
 }
 
 #[test]
 fn allows_spec_owner_when_plan_and_tasks_exist() {
-    let event = event(
-        "Write",
-        json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-    );
+    let event = event("Bash", json!({ "command": "git push origin main" }));
     let decision = evaluate(
         &event,
         workflow_policy::WorkflowContext::spec_issue(1935, true, true),
     );
     assert!(
         decision.is_none(),
-        "ready spec owner should allow implementation"
+        "ready spec owner should allow external ops"
     );
 }
 
@@ -281,10 +298,87 @@ fn allows_worktree_rm_bash_without_owner() {
 }
 
 #[test]
-fn blocks_non_file_op_mutating_bash_even_without_owner() {
+fn allows_cargo_fmt_without_owner() {
     let event = event("Bash", json!({ "command": "cargo fmt" }));
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "cargo fmt is worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn allows_git_commit_without_owner() {
+    let event = event(
+        "Bash",
+        json!({ "command": "git add . && git commit -m 'chore: release'" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "git add/commit are worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn blocks_git_push_without_owner() {
+    let event = event("Bash", json!({ "command": "git push origin main" }));
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
-        .expect("non-file-op mutating bash command must block");
+        .expect("git push must block without owner");
+    assert!(decision.reason.contains("owner"));
+}
+
+#[test]
+fn allows_git_push_with_session_bypass() {
+    let event = event("Bash", json!({ "command": "git push origin main" }));
+    let decision = evaluate(
+        &event,
+        workflow_policy::WorkflowContext::with_bypass(gwt_agent::types::WorkflowBypass::Release),
+    );
+    assert!(decision.is_none(), "session bypass must allow git push");
+}
+
+#[test]
+fn allows_git_push_with_chore_bypass() {
+    let event = event("Bash", json!({ "command": "git push" }));
+    let decision = evaluate(
+        &event,
+        workflow_policy::WorkflowContext::with_bypass(gwt_agent::types::WorkflowBypass::Chore),
+    );
+    assert!(decision.is_none(), "chore bypass must allow git push");
+}
+
+#[test]
+fn allows_sed_in_place_without_owner() {
+    let event = event(
+        "Bash",
+        json!({ "command": "sed -i 's/old/new/' Cargo.toml" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "sed -i is worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn allows_shell_redirect_without_owner() {
+    let event = event("Bash", json!({ "command": "echo '1.0.0' > version.txt" }));
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "shell redirects are worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn blocks_git_push_in_chained_command() {
+    let event = event(
+        "Bash",
+        json!({ "command": "cargo fmt && git push origin main" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
+        .expect("chained command with git push must block");
     assert!(decision.reason.contains("owner"));
 }
 
@@ -315,13 +409,10 @@ fn evaluate_resolves_spec_owner_from_session_cache() {
         let session_id = save_session(&repo_path, "feature/workflow", Some(1935));
         std::env::set_var(GWT_SESSION_ID_ENV, session_id);
 
-        let event = event(
-            "Write",
-            json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-        );
+        let event = event("Bash", json!({ "command": "git push" }));
         let decision =
             workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
-        let decision = decision.expect("missing plan must block");
+        let decision = decision.expect("missing plan must block external ops");
         assert!(decision.reason.contains("plan"));
     });
 }


### PR DESCRIPTION
## Summary

- workflow-policy フックがワークツリー内のファイル操作（Edit/Write/MultiEdit、cargo fmt、git commit 等）を owner 未解決時に過剰ブロックしていた問題を修正
- ワークツリーを隔離境界として扱い、外部副作用のある操作（git push）のみを owner ゲートで制御する設計に変更
- Session に `workflow_bypass` フィールドを追加し、release/chore ワークフローが git push の owner 要件をバイパス可能に

## Changes

- `crates/gwt-agent/src/types.rs`: `WorkflowBypass` enum（Release, Chore）を追加
- `crates/gwt-agent/src/lib.rs`: `WorkflowBypass` の re-export を追加
- `crates/gwt-agent/src/session.rs`: Session struct に `workflow_bypass: Option<WorkflowBypass>` フィールドを追加、テスト更新
- `crates/gwt-tui/src/cli/hook/workflow_policy.rs`: `is_worktree_internal_operation()`、`has_external_side_effects()`、`is_path_within_worktree()` を追加。`evaluate_with_context()` にワークツリー内操作 bypass と session bypass レイヤーを追加。`WorkflowContext` に bypass フィールドを追加
- `crates/gwt-tui/tests/hook_workflow_policy_test.rs`: 既存テストを新しい評価フローに合わせて更新、新規テスト 11 件追加（24 テスト合計）

## Testing

- [x] `cargo test -p gwt-agent` — 99 passed
- [x] `cargo test -p gwt-tui --test hook_workflow_policy_test` — 24 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 通過
- [x] `cargo fmt --all --check` — 通過
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — 通過

## Closing Issues

None

## Related Issues / Links

- SPEC #1935 (スキルシステムとフック — T-180〜T-195)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — hook 動作の変更であり、ユーザー向けドキュメント変更は不要
- [ ] Migration/backfill plan included (if schema/data change) — `#[serde(default)]` で後方互換
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — patch レベル fix、breaking change なし

## Context

- workflow-policy フックは SPEC #1935 の T-180〜T-195 で実装されたが、ワークツリー内の Bash file-op（touch/rm）は免除されるのに Edit/Write は同じファイルでもブロックされる矛盾があった
- chore(release) ワークフローで Cargo.toml、package.json、git commit/push がすべてブロックされ、リリース作業が実行不能になる問題が発生していた
- AGENTS.md の `chore:` / `docs:` 適用除外ポリシーとフック実装のギャップを解消
