### PR TITLE
chore(release): v9.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,3 +161,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release edit "${{ needs.create-tag.outputs.tag_name }}" --draft=false
+
+  publish-npm:
+    name: Publish to npm
+    needs: [create-tag, upload-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,17 +5,5 @@ set -e
 echo "Validating SKILL.md frontmatter..."
 pnpm lint:skills
 
-echo "Running frontend type check (svelte-check)..."
-(cd gwt-gui && npx svelte-check --tsconfig ./tsconfig.json --fail-on-warnings false)
-
-echo "Running frontend unit tests..."
-(cd gwt-gui && pnpm test)
-
 echo "Running commit-time backend tests..."
 bash scripts/run-local-backend-tests-on-commit.sh
-
-echo "Running commit-time UX E2E..."
-bash scripts/run-local-e2e-on-commit.sh
-
-echo "Running commit-time E2E coverage..."
-bash scripts/run-local-e2e-coverage-on-commit.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,7 +9,4 @@ cargo fmt --all -- --check
 bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md
 pnpm lint:skills
 
-echo "Running frontend build check..."
-(cd gwt-gui && pnpm run build)
-
 echo "All pre-push checks passed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.0.1] - 2026-04-14
+
+### Bug Fixes
+
+- Workflow-policy フックのワークツリー内操作の過剰ブロックを緩和
+- Gate Unix-specific APIs with #[cfg(unix)] for Windows compilation by @akiojin
+- **ci:** Use windows-latest runner for Windows compilation check by @akiojin
+- Gate SIGHUP handler with #[cfg(unix)] for Windows compilation by @akiojin
+- Restore npm publish in release workflow
+
 ## [9.0.0] - 2026-04-14
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "chrono",
  "gwt-core",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "dirs",
  "serde",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "gwt-core",
  "serde",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "fs2",
  "regex",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "crossterm",
  "gwt-core",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-tui"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "base64",
  "chrono",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.0.0"
+version = "9.0.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -22,6 +22,6 @@ pub use session::{
 };
 pub use types::{
     AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget,
-    SessionMode,
+    SessionMode, WorkflowBypass,
 };
 pub use version_cache::{build_version_options, VersionCache, VersionOption};

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -7,7 +7,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::{AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget};
+use crate::types::{
+    AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, WorkflowBypass,
+};
 
 /// Idle duration (in seconds) after which a session is considered stopped.
 const IDLE_TIMEOUT_SECS: i64 = 60;
@@ -44,6 +46,8 @@ pub struct Session {
     pub docker_lifecycle_intent: DockerLifecycleIntent,
     #[serde(default)]
     pub linked_issue_number: Option<u64>,
+    #[serde(default)]
+    pub workflow_bypass: Option<WorkflowBypass>,
     #[serde(default)]
     pub launch_command: String,
     #[serde(default)]
@@ -100,6 +104,7 @@ impl Session {
             docker_service: None,
             docker_lifecycle_intent: DockerLifecycleIntent::Connect,
             linked_issue_number: None,
+            workflow_bypass: None,
             launch_command: String::new(),
             launch_args: Vec::new(),
             created_at: now,
@@ -291,6 +296,7 @@ mod tests {
             session.docker_lifecycle_intent,
             DockerLifecycleIntent::Connect
         );
+        assert!(session.workflow_bypass.is_none());
     }
 
     #[test]
@@ -338,6 +344,7 @@ mod tests {
         session.runtime_target = LaunchRuntimeTarget::Docker;
         session.docker_service = Some("web".into());
         session.docker_lifecycle_intent = DockerLifecycleIntent::Restart;
+        session.workflow_bypass = Some(WorkflowBypass::Release);
         session.launch_command = "codex".into();
         session.launch_args = vec![
             "--no-alt-screen".into(),
@@ -377,6 +384,7 @@ mod tests {
                 "--last".to_string()
             ]
         );
+        assert_eq!(loaded.workflow_bypass, Some(WorkflowBypass::Release));
         assert_eq!(loaded.display_name, "Gemini CLI");
     }
 
@@ -437,6 +445,7 @@ mod tests {
         );
         assert!(loaded.launch_command.is_empty());
         assert!(loaded.launch_args.is_empty());
+        assert!(loaded.workflow_bypass.is_none());
     }
 
     #[test]

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -142,6 +142,13 @@ pub enum DockerLifecycleIntent {
     CreateAndStart,
 }
 
+/// Session-level workflow policy bypass for ownerless operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkflowBypass {
+    Release,
+    Chore,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,5 +236,14 @@ mod tests {
         let json = serde_json::to_string(&color).unwrap();
         let parsed: AgentColor = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, color);
+    }
+
+    #[test]
+    fn workflow_bypass_serde_roundtrip() {
+        for bypass in [WorkflowBypass::Release, WorkflowBypass::Chore] {
+            let json = serde_json::to_string(&bypass).unwrap();
+            let parsed: WorkflowBypass = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, bypass);
+        }
     }
 }

--- a/crates/gwt-tui/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt-tui/src/cli/hook/workflow_policy.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use gwt_agent::session::{Session, GWT_SESSION_ID_ENV};
+use gwt_agent::types::WorkflowBypass;
 use gwt_core::paths::{gwt_cache_dir, gwt_sessions_dir};
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;
@@ -30,6 +31,7 @@ pub struct WorkflowContext {
     pub owner: WorkflowOwner,
     pub has_plan: bool,
     pub has_tasks: bool,
+    pub bypass: Option<WorkflowBypass>,
 }
 
 impl WorkflowContext {
@@ -38,6 +40,7 @@ impl WorkflowContext {
             owner: WorkflowOwner::Unknown,
             has_plan: false,
             has_tasks: false,
+            bypass: None,
         }
     }
 
@@ -46,6 +49,7 @@ impl WorkflowContext {
             owner: WorkflowOwner::Issue(issue_number),
             has_plan: false,
             has_tasks: false,
+            bypass: None,
         }
     }
 
@@ -54,6 +58,16 @@ impl WorkflowContext {
             owner: WorkflowOwner::Spec(issue_number),
             has_plan,
             has_tasks,
+            bypass: None,
+        }
+    }
+
+    pub fn with_bypass(bypass: WorkflowBypass) -> Self {
+        Self {
+            owner: WorkflowOwner::Unknown,
+            has_plan: false,
+            has_tasks: false,
+            bypass: Some(bypass),
         }
     }
 }
@@ -68,14 +82,27 @@ pub fn evaluate_with_context(
     worktree_root: &Path,
     context: &WorkflowContext,
 ) -> Result<Option<BlockDecision>, HookError> {
+    // 1. Legacy safety (gh issue CLI, branch ops, worktree-external file ops)
     if let Some(decision) = block_bash_policy::evaluate(event, worktree_root)? {
         return Ok(Some(decision));
     }
 
+    // 2. Docs/chore path exemption + non-mutating tools
     if is_exempt_chore_change(event) || !is_mutating_tool_call(event, worktree_root) {
         return Ok(None);
     }
 
+    // 3. Worktree-internal operations are allowed without owner
+    if is_worktree_internal_operation(event, worktree_root) {
+        return Ok(None);
+    }
+
+    // 4. Session-level bypass (release/chore workflows)
+    if context.bypass.is_some() {
+        return Ok(None);
+    }
+
+    // 5. Owner gate (only reached for external operations like git push)
     match context.owner {
         WorkflowOwner::Unknown => Ok(Some(missing_owner_decision())),
         WorkflowOwner::Issue(_) => Ok(None),
@@ -104,20 +131,28 @@ pub fn handle() -> Result<Option<BlockDecision>, HookError> {
 
 fn resolve_workflow_context(worktree_root: &Path) -> WorkflowContext {
     let session = load_session_from_env();
+    let bypass = session.as_ref().and_then(|s| s.workflow_bypass);
+
     let Some(issue_number) = session
         .as_ref()
         .and_then(|session| session.linked_issue_number)
         .or_else(|| resolve_issue_from_linkage_store(worktree_root, session.as_ref()))
     else {
-        return WorkflowContext::unknown();
+        let mut ctx = WorkflowContext::unknown();
+        ctx.bypass = bypass;
+        return ctx;
     };
 
     let Some(cache_root) = crate::issue_cache::issue_cache_root_for_repo_path(worktree_root) else {
-        return WorkflowContext::plain_issue(issue_number);
+        let mut ctx = WorkflowContext::plain_issue(issue_number);
+        ctx.bypass = bypass;
+        return ctx;
     };
     let cache = Cache::new(cache_root);
     let Some(entry) = cache.load_entry(IssueNumber(issue_number)) else {
-        return WorkflowContext::plain_issue(issue_number);
+        let mut ctx = WorkflowContext::plain_issue(issue_number);
+        ctx.bypass = bypass;
+        return ctx;
     };
     if !entry
         .snapshot
@@ -125,14 +160,18 @@ fn resolve_workflow_context(worktree_root: &Path) -> WorkflowContext {
         .iter()
         .any(|label| label == "gwt-spec")
     {
-        return WorkflowContext::plain_issue(issue_number);
+        let mut ctx = WorkflowContext::plain_issue(issue_number);
+        ctx.bypass = bypass;
+        return ctx;
     }
 
-    WorkflowContext::spec_issue(
+    let mut ctx = WorkflowContext::spec_issue(
         issue_number,
         has_nonempty_section(&entry.spec_body, "plan"),
         has_nonempty_section(&entry.spec_body, "tasks"),
-    )
+    );
+    ctx.bypass = bypass;
+    ctx
 }
 
 fn load_session_from_env() -> Option<Session> {
@@ -174,6 +213,57 @@ fn has_nonempty_section(spec_body: &SpecBody, name: &str) -> bool {
         .sections
         .get(&SectionName(name.to_string()))
         .is_some_and(|content| !content.trim().is_empty())
+}
+
+fn is_worktree_internal_operation(event: &HookEvent, worktree_root: &Path) -> bool {
+    match event.tool_name.as_deref() {
+        Some("Edit" | "Write" | "MultiEdit") => extract_target_path(event)
+            .is_some_and(|path| is_path_within_worktree(&path, worktree_root)),
+        Some("Bash") => event
+            .command()
+            .is_some_and(|cmd| !has_external_side_effects(cmd)),
+        _ => true,
+    }
+}
+
+fn has_external_side_effects(command: &str) -> bool {
+    for segment in super::segments::split_command_segments(command) {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        if tokens.first().copied() == Some("git") && tokens.get(1).copied() == Some("push") {
+            return true;
+        }
+    }
+    false
+}
+
+fn normalize_path(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        use std::path::Component::*;
+        match comp {
+            ParentDir => {
+                out.pop();
+            }
+            CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+fn is_path_within_worktree(path: &Path, worktree_root: &Path) -> bool {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        worktree_root.join(path)
+    };
+    let abs = normalize_path(&abs);
+    let root = normalize_path(worktree_root);
+    abs == root || abs.starts_with(&root)
 }
 
 fn is_mutating_tool_call(event: &HookEvent, worktree_root: &Path) -> bool {

--- a/crates/gwt-tui/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt-tui/tests/hook_workflow_policy_test.rs
@@ -164,15 +164,41 @@ fn allows_read_only_tools_without_owner() {
 }
 
 #[test]
-fn blocks_mutating_tools_when_owner_is_unknown() {
+fn allows_worktree_internal_edit_without_owner() {
+    let wt = root();
+    let event = event(
+        "Edit",
+        json!({ "file_path": format!("{}/src/lib.rs", wt.display()), "old_string": "x", "new_string": "y" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "worktree-internal edits must be allowed without owner"
+    );
+}
+
+#[test]
+fn allows_worktree_internal_edit_with_relative_path() {
     let event = event(
         "Edit",
         json!({ "file_path": "src/lib.rs", "old_string": "x", "new_string": "y" }),
     );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "relative worktree-internal edits must be allowed without owner"
+    );
+}
+
+#[test]
+fn blocks_edit_outside_worktree_without_owner() {
+    let event = event(
+        "Edit",
+        json!({ "file_path": "/outside/project/src/lib.rs", "old_string": "x", "new_string": "y" }),
+    );
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
-        .expect("unknown owner must block edits");
+        .expect("edit outside worktree must block without owner");
     assert!(decision.reason.contains("owner"));
-    assert!(decision.stop_reason.contains("gwt-discussion"));
 }
 
 #[test]
@@ -199,48 +225,39 @@ fn allows_mutation_for_plain_issue_owner() {
 }
 
 #[test]
-fn blocks_spec_owner_without_plan() {
-    let event = event(
-        "Write",
-        json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-    );
+fn blocks_spec_owner_without_plan_on_external_op() {
+    let event = event("Bash", json!({ "command": "git push" }));
     let decision = evaluate(
         &event,
         workflow_policy::WorkflowContext::spec_issue(1935, false, true),
     )
-    .expect("spec without plan must block");
+    .expect("spec without plan must block external ops");
     assert!(decision.reason.contains("plan"));
     assert!(decision.stop_reason.contains("gwt-plan-spec"));
 }
 
 #[test]
-fn blocks_spec_owner_without_tasks() {
-    let event = event(
-        "Write",
-        json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-    );
+fn blocks_spec_owner_without_tasks_on_external_op() {
+    let event = event("Bash", json!({ "command": "git push" }));
     let decision = evaluate(
         &event,
         workflow_policy::WorkflowContext::spec_issue(1935, true, false),
     )
-    .expect("spec without tasks must block");
+    .expect("spec without tasks must block external ops");
     assert!(decision.reason.contains("tasks"));
     assert!(decision.stop_reason.contains("gwt-plan-spec"));
 }
 
 #[test]
 fn allows_spec_owner_when_plan_and_tasks_exist() {
-    let event = event(
-        "Write",
-        json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-    );
+    let event = event("Bash", json!({ "command": "git push origin main" }));
     let decision = evaluate(
         &event,
         workflow_policy::WorkflowContext::spec_issue(1935, true, true),
     );
     assert!(
         decision.is_none(),
-        "ready spec owner should allow implementation"
+        "ready spec owner should allow external ops"
     );
 }
 
@@ -281,10 +298,87 @@ fn allows_worktree_rm_bash_without_owner() {
 }
 
 #[test]
-fn blocks_non_file_op_mutating_bash_even_without_owner() {
+fn allows_cargo_fmt_without_owner() {
     let event = event("Bash", json!({ "command": "cargo fmt" }));
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "cargo fmt is worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn allows_git_commit_without_owner() {
+    let event = event(
+        "Bash",
+        json!({ "command": "git add . && git commit -m 'chore: release'" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "git add/commit are worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn blocks_git_push_without_owner() {
+    let event = event("Bash", json!({ "command": "git push origin main" }));
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
-        .expect("non-file-op mutating bash command must block");
+        .expect("git push must block without owner");
+    assert!(decision.reason.contains("owner"));
+}
+
+#[test]
+fn allows_git_push_with_session_bypass() {
+    let event = event("Bash", json!({ "command": "git push origin main" }));
+    let decision = evaluate(
+        &event,
+        workflow_policy::WorkflowContext::with_bypass(gwt_agent::types::WorkflowBypass::Release),
+    );
+    assert!(decision.is_none(), "session bypass must allow git push");
+}
+
+#[test]
+fn allows_git_push_with_chore_bypass() {
+    let event = event("Bash", json!({ "command": "git push" }));
+    let decision = evaluate(
+        &event,
+        workflow_policy::WorkflowContext::with_bypass(gwt_agent::types::WorkflowBypass::Chore),
+    );
+    assert!(decision.is_none(), "chore bypass must allow git push");
+}
+
+#[test]
+fn allows_sed_in_place_without_owner() {
+    let event = event(
+        "Bash",
+        json!({ "command": "sed -i 's/old/new/' Cargo.toml" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "sed -i is worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn allows_shell_redirect_without_owner() {
+    let event = event("Bash", json!({ "command": "echo '1.0.0' > version.txt" }));
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
+    assert!(
+        decision.is_none(),
+        "shell redirects are worktree-internal and must be allowed"
+    );
+}
+
+#[test]
+fn blocks_git_push_in_chained_command() {
+    let event = event(
+        "Bash",
+        json!({ "command": "cargo fmt && git push origin main" }),
+    );
+    let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
+        .expect("chained command with git push must block");
     assert!(decision.reason.contains("owner"));
 }
 
@@ -315,13 +409,10 @@ fn evaluate_resolves_spec_owner_from_session_cache() {
         let session_id = save_session(&repo_path, "feature/workflow", Some(1935));
         std::env::set_var(GWT_SESSION_ID_ENV, session_id);
 
-        let event = event(
-            "Write",
-            json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
-        );
+        let event = event("Bash", json!({ "command": "git push" }));
         let decision =
             workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
-        let decision = decision.expect("missing plan must block");
+        let decision = decision.expect("missing plan must block external ops");
         assert!(decision.reason.contains("plan"));
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "gwt",
+  "name": "@akiojin/gwt",
   "version": "9.0.0",
-  "private": true,
   "description": "TUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "TUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/scripts/run-local-backend-tests-on-commit.sh
+++ b/scripts/run-local-backend-tests-on-commit.sh
@@ -8,8 +8,8 @@ echo "Running commit-time backend tests..."
 
 (
   cd "$ROOT_DIR"
-  cargo test -p gwt-tauri commands::branches::tests:: -- --nocapture
-  cargo test -p gwt-tauri commands::project::tests:: -- --nocapture
+  cargo test -p gwt-tui commands::branches::tests:: -- --nocapture
+  cargo test -p gwt-tui commands::project::tests:: -- --nocapture
 )
 
 echo "Commit-time backend tests passed."


### PR DESCRIPTION
## Summary

v9.0.1 パッチリリース。v9.0.0 で発覚した Windows ビルド失敗の修正、npm publish の復元、husky フックの修正を含む。

## Changes

- fix: Unix 固有 API に `#[cfg(unix)]` ゲートを追加（Windows コンパイル修正）
- fix: SIGHUP ハンドラに `#[cfg(unix)]` ゲートを追加
- fix(ci): PR CI に Windows コンパイルチェックを追加（再発防止）
- fix: npm publish を release workflow に復元
- fix: workflow-policy フックのワークツリー内操作の過剰ブロック緩和
- chore: husky フックから削除済み gwt-gui 参照を除去

## Version

v9.0.1

## Closing Issues

None

## Related Issues / Links

None
