### PR TITLE
chore(release): v9.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.0.3] - 2026-04-14
+
+### Bug Fixes
+
+- Add JS wrapper for npx/bunx binary execution
+
 ## [9.0.2] - 2026-04-14
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "chrono",
  "gwt-core",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "dirs",
  "serde",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "gwt-core",
  "serde",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "fs2",
  "regex",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "chrono",
  "fs2",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "crossterm",
  "gwt-core",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-tui"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "base64",
  "chrono",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.0.2"
+version = "9.0.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/bin/gwt.js
+++ b/bin/gwt.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Wrapper script to execute the gwt Rust binary.
+ * If the binary is not found (e.g., bunx skips postinstall),
+ * it will be downloaded on-demand from GitHub Releases.
+ */
+
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+const https = require("https");
+const os = require("os");
+
+const REPO = "akiojin/gwt";
+const BIN_DIR = __dirname;
+const BIN_NAME = process.platform === "win32" ? "gwt-tui.exe" : "gwt-tui";
+const BIN_PATH = path.join(BIN_DIR, BIN_NAME);
+
+function releaseAssetName() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  if (platform === "darwin" && arch === "arm64") return "gwt-macos-aarch64";
+  if (platform === "darwin" && arch === "x64") return "gwt-macos-x86_64";
+  if (platform === "linux" && arch === "x64") return "gwt-linux-x86_64";
+  if (platform === "linux" && arch === "arm64") return "gwt-linux-aarch64";
+  if (platform === "win32" && arch === "x64") return "gwt-windows-x86_64.exe";
+
+  console.error(`Unsupported platform: ${platform}-${arch}`);
+  process.exit(1);
+}
+
+function readVersion() {
+  const pkg = path.join(__dirname, "..", "package.json");
+  return JSON.parse(fs.readFileSync(pkg, "utf8")).version;
+}
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    const request = (u) => {
+      https
+        .get(u, { headers: { "User-Agent": "gwt-postinstall" } }, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            request(res.headers.location);
+            return;
+          }
+          if (res.statusCode !== 200) {
+            file.close();
+            fs.unlink(dest, () => {});
+            reject(new Error(`HTTP ${res.statusCode} for ${u}`));
+            return;
+          }
+          res.pipe(file);
+          file.on("finish", () => file.close(resolve));
+        })
+        .on("error", (err) => {
+          file.close();
+          fs.unlink(dest, () => {});
+          reject(err);
+        });
+    };
+    request(url);
+  });
+}
+
+async function ensureBinary() {
+  if (fs.existsSync(BIN_PATH)) return;
+
+  const version = readVersion();
+  const asset = releaseAssetName();
+  const tag = `v${version}`;
+  const url = `https://github.com/${REPO}/releases/download/${tag}/${asset}`;
+
+  console.log(`Downloading gwt binary for ${os.platform()}-${os.arch()}...`);
+  console.log(`Downloading from: ${url}`);
+
+  fs.mkdirSync(BIN_DIR, { recursive: true });
+  await download(url, BIN_PATH);
+
+  if (os.platform() !== "win32") {
+    fs.chmodSync(BIN_PATH, 0o755);
+  }
+
+  console.log("gwt binary installed successfully!");
+}
+
+async function main() {
+  try {
+    await ensureBinary();
+  } catch (err) {
+    console.error(`Failed to download gwt binary: ${err.message}`);
+    console.error(`https://github.com/${REPO}/releases`);
+    process.exit(1);
+  }
+
+  const child = spawn(BIN_PATH, process.argv.slice(2), {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  child.on("error", (err) => {
+    console.error(`Failed to start gwt: ${err.message}`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 0);
+    }
+  });
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "TUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {
-    "gwt": "bin/gwt-tui"
+    "gwt": "bin/gwt.js"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "TUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.0.3 パッチリリース。npx/bunx でバイナリが実行できない問題を修正（JS ラッパー復元）。

## Changes

- fix: npx/bunx 実行時にバイナリが見つからない問題を修正（bin/gwt.js ラッパーを復元）

## Version

v9.0.3

## Closing Issues

None

## Related Issues / Links

None
