### PR TITLE
feat(gui): split session and project workspace state

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -122,9 +122,11 @@ gwt issue spec <number> --section spec|plan|tasks
 ## ログ
 
 - アプリログ:
-  `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD`
-- GUI 状態:
-  `~/.gwt/workspace-state.json`
+  `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD`
+- セッション状態:
+  `~/.gwt/session.json`
+- プロジェクト単位のワークスペース状態:
+  `~/.gwt/projects/<repo-hash>/workspace.json`
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ gwt issue spec <number> --section spec|plan|tasks
 ## Logs
 
 - App logs:
-  `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD`
-- Workspace state:
-  `~/.gwt/workspace-state.json`
+  `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD`
+- Session state:
+  `~/.gwt/session.json`
+- Project workspace state:
+  `~/.gwt/projects/<repo-hash>/workspace.json`
 
 ## Development
 

--- a/crates/gwt-core/src/logging/mod.rs
+++ b/crates/gwt-core/src/logging/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! 1. A reloadable `EnvFilter` (level control via `reload::Handle`)
 //! 2. A JSONL formatting layer writing to
-//!    `~/.gwt/logs/<repo-hash>/gwt.log.YYYY-MM-DD` via a non-blocking,
+//!    `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD` via a non-blocking,
 //!    daily-rolling appender (`tracing_appender`)
 //! 3. A UI forwarder layer that sends `LogEvent`s to an
 //!    `UnboundedSender<LogEvent>` so that TUI surfaces (toasts, error

--- a/crates/gwt-core/src/logging/writer.rs
+++ b/crates/gwt-core/src/logging/writer.rs
@@ -97,8 +97,9 @@ fn tighten_log_dir_permissions(log_dir: &Path) {
 #[cfg(not(unix))]
 fn tighten_log_dir_permissions(_log_dir: &Path) {
     // Windows ACLs default to user-only access for files under
-    // `%USERPROFILE%`, which already covers `~/.gwt/logs/`. No
-    // additional hardening is required.
+    // `%USERPROFILE%`, which already covers the project-scoped
+    // `~/.gwt/projects/<repo-hash>/logs/` directory. No additional
+    // hardening is required.
 }
 
 #[cfg(test)]

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::Result;
-use crate::repo_hash::{detect_repo_hash, RepoHash};
+use crate::repo_hash::{compute_path_hash, detect_repo_hash, RepoHash};
 
 /// Return the gwt home directory (`~/.gwt/`).
 pub fn gwt_home() -> PathBuf {
@@ -27,19 +27,45 @@ pub fn gwt_cache_dir() -> PathBuf {
     gwt_home().join("cache")
 }
 
-/// Return the logs directory (`~/.gwt/logs/`).
+/// Return the project data root (`~/.gwt/projects/`).
+pub fn gwt_projects_dir() -> PathBuf {
+    gwt_home().join("projects")
+}
+
+/// Return the project data directory for a repository hash.
+pub fn gwt_project_dir(repo_hash: &RepoHash) -> PathBuf {
+    gwt_projects_dir().join(repo_hash.as_str())
+}
+
+/// Return the project scope hash for a repository path.
+pub fn project_scope_hash(repo_path: &Path) -> RepoHash {
+    detect_repo_hash(repo_path).unwrap_or_else(|| compute_path_hash(repo_path))
+}
+
+/// Return the project data directory for a repository path.
+pub fn gwt_project_dir_for_repo_path(repo_path: &Path) -> PathBuf {
+    let repo_hash = project_scope_hash(repo_path);
+    gwt_project_dir(&repo_hash)
+}
+
+/// Return the global session state path (`~/.gwt/session.json`).
+pub fn gwt_session_state_path() -> PathBuf {
+    gwt_home().join("session.json")
+}
+
+/// Return the legacy logs root (`~/.gwt/logs/`).
 pub fn gwt_logs_dir() -> PathBuf {
     gwt_home().join("logs")
 }
 
-/// Return the coordination root (`~/.gwt/coordination/`).
+/// Return the legacy coordination root (`~/.gwt/coordination/`).
 pub fn gwt_coordination_root() -> PathBuf {
     gwt_home().join("coordination")
 }
 
 /// Return the coordination directory for a repository hash.
 pub fn gwt_coordination_dir(repo_hash: &RepoHash) -> PathBuf {
-    gwt_coordination_root().join(repo_hash.as_str())
+    gwt_project_dir(repo_hash).join("coordination")
 }
 
 /// Return the coordination directory for a repository path, if `origin` exists.
@@ -49,7 +75,7 @@ pub fn gwt_coordination_dir_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
 
 /// Return the structured-log directory for a repository hash.
 pub fn gwt_project_logs_dir(repo_hash: &RepoHash) -> PathBuf {
-    gwt_logs_dir().join(repo_hash.as_str())
+    gwt_project_dir(repo_hash).join("logs")
 }
 
 /// Return the structured-log directory for a repository path, if `origin` exists.
@@ -124,6 +150,39 @@ mod tests {
     }
 
     #[test]
+    fn gwt_projects_dir_is_under_home() {
+        let p = gwt_projects_dir();
+        assert!(p.starts_with(gwt_home()));
+        assert!(p.ends_with("projects"));
+    }
+
+    #[test]
+    fn gwt_project_dir_scopes_by_repo_hash() {
+        let repo_hash = compute_repo_hash("https://github.com/example/project.git");
+        let p = gwt_project_dir(&repo_hash);
+        assert!(p.starts_with(gwt_projects_dir()));
+        assert!(p.ends_with(format!("projects/{}", repo_hash.as_str())));
+    }
+
+    #[test]
+    fn gwt_session_state_path_is_under_home() {
+        let p = gwt_session_state_path();
+        assert!(p.starts_with(gwt_home()));
+        assert!(p.ends_with("session.json"));
+    }
+
+    #[test]
+    fn project_scope_hash_falls_back_for_non_repo_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hash = project_scope_hash(tmp.path());
+        assert_eq!(hash.as_str().len(), 16);
+        assert!(hash
+            .as_str()
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
     fn gwt_logs_dir_is_under_home() {
         let p = gwt_logs_dir();
         assert!(p.starts_with(gwt_home()));
@@ -134,16 +193,16 @@ mod tests {
     fn gwt_project_logs_dir_scopes_by_repo_hash() {
         let repo_hash = compute_repo_hash("https://github.com/example/project.git");
         let p = gwt_project_logs_dir(&repo_hash);
-        assert!(p.starts_with(gwt_logs_dir()));
-        assert!(p.ends_with(format!("logs/{}", repo_hash.as_str())));
+        assert!(p.starts_with(gwt_project_dir(&repo_hash)));
+        assert!(p.ends_with(format!("projects/{}/logs", repo_hash.as_str())));
     }
 
     #[test]
     fn gwt_coordination_dir_scopes_by_repo_hash() {
         let repo_hash = compute_repo_hash("https://github.com/example/project.git");
         let p = gwt_coordination_dir(&repo_hash);
-        assert!(p.starts_with(gwt_home()));
-        assert!(p.ends_with(format!("coordination/{}", repo_hash.as_str())));
+        assert!(p.starts_with(gwt_project_dir(&repo_hash)));
+        assert!(p.ends_with(format!("projects/{}/coordination", repo_hash.as_str())));
     }
 
     #[test]

--- a/crates/gwt-core/src/repo_hash.rs
+++ b/crates/gwt-core/src/repo_hash.rs
@@ -97,6 +97,17 @@ pub fn compute_repo_hash(origin_url: &str) -> RepoHash {
     RepoHash(hex_full[..HASH_HEX_LEN].to_string())
 }
 
+/// Compute a deterministic fallback hash from a canonical filesystem path.
+pub fn compute_path_hash(path: &Path) -> RepoHash {
+    let canonical = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let normalized = canonical.to_string_lossy().replace('\\', "/");
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    let hex_full = hex::encode(digest);
+    RepoHash(hex_full[..HASH_HEX_LEN].to_string())
+}
+
 /// Detect a `RepoHash` from the `origin` remote configured for `repo_root`.
 pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
     let output = std::process::Command::new("git")
@@ -204,6 +215,14 @@ mod tests {
         let repo_hash = detect_repo_hash(&repo).expect("repo hash");
         let wt_hash = detect_repo_hash(&wt).expect("worktree hash");
         assert_eq!(repo_hash.as_str(), wt_hash.as_str());
+    }
+
+    #[test]
+    fn compute_path_hash_is_deterministic_for_same_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = compute_path_hash(dir.path());
+        let b = compute_path_hash(dir.path());
+        assert_eq!(a.as_str(), b.as_str());
     }
 
     fn init_git_repo(path: &Path) {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -29,11 +29,12 @@ pub use native_app::{
     NativeMenuCommand, APP_NAME, MACOS_BUNDLE_IDENTIFIER, OPEN_PROJECT_MENU_ID, RELOAD_MENU_ID,
 };
 pub use persistence::{
-    default_app_state, default_workspace_state, empty_workspace_state, load_app_state,
-    pause_process_windows_for_restore, project_title_from_path, save_app_state,
-    workspace_state_path, CanvasViewport, PersistedAppState, PersistedProjectTabState,
-    PersistedWindowState, PersistedWorkspaceState, ProjectKind, RecentProjectEntry, WindowGeometry,
-    WindowProcessStatus,
+    default_session_state, default_workspace_state, empty_workspace_state,
+    legacy_workspace_state_path, load_restored_workspace_state, load_session_state,
+    load_workspace_state, migrate_legacy_workspace_state, pause_process_windows_for_restore,
+    project_title_from_path, save_session_state, save_workspace_state, workspace_state_path,
+    CanvasViewport, PersistedSessionState, PersistedSessionTabState, PersistedWindowState,
+    PersistedWorkspaceState, ProjectKind, RecentProjectEntry, WindowGeometry, WindowProcessStatus,
 };
 pub use preset::{
     detect_shell_program, resolve_launch_spec, LaunchSpec, PresetResolveError, ShellProgram,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -20,10 +20,12 @@ use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use gwt::{
     default_wizard_version_cache_path, detect_shell_program, list_branch_entries,
-    list_directory_entries, load_app_state, refresh_managed_gwt_assets_for_worktree,
-    resolve_launch_spec, save_app_state, workspace_state_path, BackendEvent, DockerWizardContext,
-    FrontendEvent, LaunchWizardCompletion, LaunchWizardContext, LaunchWizardState,
-    LiveSessionEntry, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
+    list_directory_entries, load_restored_workspace_state, load_session_state,
+    migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
+    save_session_state, save_workspace_state, workspace_state_path, BackendEvent,
+    DockerWizardContext, FrontendEvent, LaunchWizardCompletion, LaunchWizardContext,
+    LaunchWizardState, LiveSessionEntry, WindowGeometry, WindowPreset, WindowProcessStatus,
+    WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus};
 use tao::{
@@ -146,7 +148,7 @@ struct AppRuntime {
     runtimes: HashMap<String, WindowRuntime>,
     window_details: HashMap<String, String>,
     window_lookup: HashMap<String, WindowAddress>,
-    state_path: PathBuf,
+    session_state_path: PathBuf,
     proxy: EventLoopProxy<UserEvent>,
     sessions_dir: PathBuf,
     launch_wizard: Option<LaunchWizardSession>,
@@ -154,31 +156,41 @@ struct AppRuntime {
 }
 
 impl ProjectTabRuntime {
-    fn from_persisted(tab: gwt::PersistedProjectTabState) -> Self {
+    fn from_persisted(
+        tab: gwt::PersistedSessionTabState,
+        workspace: gwt::PersistedWorkspaceState,
+    ) -> Self {
         Self {
             id: tab.id,
             title: tab.title,
             project_root: tab.project_root,
             kind: tab.kind,
-            workspace: WorkspaceState::from_persisted(tab.workspace),
+            workspace: WorkspaceState::from_persisted(workspace),
         }
     }
 }
 
 impl AppRuntime {
     fn new(proxy: EventLoopProxy<UserEvent>) -> std::io::Result<Self> {
-        let state_path = workspace_state_path();
+        let session_state_path = gwt_core::paths::gwt_session_state_path();
         let launch_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         let legacy_target = resolve_project_target(&launch_dir)
             .unwrap_or_else(|_| fallback_project_target(launch_dir.clone()));
-        let mut persisted =
-            load_app_state(&state_path, &legacy_target.project_root, legacy_target.kind)?;
-        gwt::pause_process_windows_for_restore(&mut persisted);
+        migrate_legacy_workspace_state(
+            &gwt::legacy_workspace_state_path(),
+            &session_state_path,
+            &legacy_target.project_root,
+            legacy_target.kind,
+        )?;
+        let persisted = load_session_state(&session_state_path)?;
         let tabs = persisted
             .tabs
             .into_iter()
-            .map(ProjectTabRuntime::from_persisted)
-            .collect::<Vec<_>>();
+            .map(|tab| {
+                let workspace = load_restored_workspace_state(&tab.project_root)?;
+                Ok(ProjectTabRuntime::from_persisted(tab, workspace))
+            })
+            .collect::<std::io::Result<Vec<_>>>()?;
         let active_tab_id = normalize_active_tab_id(&tabs, persisted.active_tab_id);
         let sessions_dir = gwt_core::paths::gwt_sessions_dir();
         let _ = gwt_agent::reset_runtime_state_dir(&sessions_dir);
@@ -190,7 +202,7 @@ impl AppRuntime {
             runtimes: HashMap::new(),
             window_details: HashMap::new(),
             window_lookup: HashMap::new(),
-            state_path,
+            session_state_path,
             proxy,
             sessions_dir,
             launch_wizard: None,
@@ -379,7 +391,10 @@ impl AppRuntime {
             title: target.title.clone(),
             project_root: target.project_root.clone(),
             kind: target.kind,
-            workspace: WorkspaceState::from_persisted(gwt::empty_workspace_state()),
+            workspace: WorkspaceState::from_persisted({
+                load_restored_workspace_state(&target.project_root)
+                    .map_err(|error| error.to_string())?
+            }),
         });
         self.active_tab_id = Some(tab_id);
         self.remember_recent_project(&target);
@@ -1457,24 +1472,32 @@ impl AppRuntime {
     }
 
     fn persist(&self) -> std::io::Result<()> {
-        save_app_state(
-            &self.state_path,
-            &gwt::PersistedAppState {
+        save_session_state(
+            &self.session_state_path,
+            &gwt::PersistedSessionState {
                 tabs: self
                     .tabs
                     .iter()
-                    .map(|tab| gwt::PersistedProjectTabState {
+                    .map(|tab| gwt::PersistedSessionTabState {
                         id: tab.id.clone(),
                         title: tab.title.clone(),
                         project_root: tab.project_root.clone(),
                         kind: tab.kind,
-                        workspace: tab.workspace.persistable_state(),
                     })
                     .collect(),
                 active_tab_id: normalize_active_tab_id(&self.tabs, self.active_tab_id.clone()),
                 recent_projects: self.recent_projects.clone(),
             },
-        )
+        )?;
+
+        for tab in &self.tabs {
+            save_workspace_state(
+                &workspace_state_path(&tab.project_root),
+                &tab.workspace.persistable_state(),
+            )?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -77,7 +77,24 @@ pub struct RecentProjectEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct PersistedProjectTabState {
+pub struct PersistedSessionTabState {
+    pub id: String,
+    pub title: String,
+    pub project_root: PathBuf,
+    pub kind: ProjectKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PersistedSessionState {
+    #[serde(default)]
+    pub tabs: Vec<PersistedSessionTabState>,
+    pub active_tab_id: Option<String>,
+    #[serde(default)]
+    pub recent_projects: Vec<RecentProjectEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct LegacyPersistedProjectTabState {
     pub id: String,
     pub title: String,
     pub project_root: PathBuf,
@@ -86,9 +103,9 @@ pub struct PersistedProjectTabState {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct PersistedAppState {
+struct LegacyPersistedAppState {
     #[serde(default)]
-    pub tabs: Vec<PersistedProjectTabState>,
+    pub tabs: Vec<LegacyPersistedProjectTabState>,
     pub active_tab_id: Option<String>,
     #[serde(default)]
     pub recent_projects: Vec<RecentProjectEntry>,
@@ -145,20 +162,18 @@ pub fn default_workspace_state() -> PersistedWorkspaceState {
     }
 }
 
-pub fn default_app_state() -> PersistedAppState {
-    PersistedAppState {
+pub fn default_session_state() -> PersistedSessionState {
+    PersistedSessionState {
         tabs: Vec::new(),
         active_tab_id: None,
         recent_projects: Vec::new(),
     }
 }
 
-pub fn pause_process_windows_for_restore(state: &mut PersistedAppState) {
-    for tab in &mut state.tabs {
-        for window in &mut tab.workspace.windows {
-            if window.preset.requires_process() {
-                window.status = WindowProcessStatus::Exited;
-            }
+pub fn pause_process_windows_for_restore(state: &mut PersistedWorkspaceState) {
+    for window in &mut state.windows {
+        if window.preset.requires_process() {
+            window.status = WindowProcessStatus::Exited;
         }
     }
 }
@@ -167,57 +182,135 @@ fn default_persist_window() -> bool {
     true
 }
 
-pub fn workspace_state_path() -> PathBuf {
+pub fn legacy_workspace_state_path() -> PathBuf {
     gwt_core::paths::gwt_home()
         .join("poc")
         .join("terminal")
         .join("workspace.json")
 }
 
-pub fn load_app_state(
-    path: &Path,
-    legacy_project_root: &Path,
-    legacy_kind: ProjectKind,
-) -> std::io::Result<PersistedAppState> {
+pub fn workspace_state_path(project_root: &Path) -> PathBuf {
+    let repo_hash = gwt_core::paths::project_scope_hash(project_root);
+    gwt_core::paths::gwt_project_dir(&repo_hash).join("workspace.json")
+}
+
+pub fn load_session_state(path: &Path) -> std::io::Result<PersistedSessionState> {
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(default_app_state());
+            return Ok(default_session_state());
         }
         Err(error) => return Err(error),
     };
-
-    let value: serde_json::Value = serde_json::from_str(&content)?;
-    if value.get("tabs").is_some() {
-        return Ok(serde_json::from_value(value)?);
-    }
-
-    let workspace: PersistedWorkspaceState = serde_json::from_value(value)?;
-    let title = project_title_from_path(legacy_project_root);
-    Ok(PersistedAppState {
-        active_tab_id: Some("project-1".to_string()),
-        recent_projects: vec![RecentProjectEntry {
-            path: legacy_project_root.to_path_buf(),
-            title: title.clone(),
-            kind: legacy_kind,
-        }],
-        tabs: vec![PersistedProjectTabState {
-            id: "project-1".to_string(),
-            title,
-            project_root: legacy_project_root.to_path_buf(),
-            kind: legacy_kind,
-            workspace,
-        }],
-    })
+    serde_json::from_str(&content).map_err(Into::into)
 }
 
-pub fn save_app_state(path: &Path, state: &PersistedAppState) -> std::io::Result<()> {
+pub fn save_session_state(path: &Path, state: &PersistedSessionState) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         gwt_core::paths::ensure_dir(parent)
             .map_err(|error| std::io::Error::other(error.to_string()))?;
     }
     let content = serde_json::to_string_pretty(state)?;
     std::fs::write(path, content)?;
+    Ok(())
+}
+
+pub fn load_workspace_state(path: &Path) -> std::io::Result<PersistedWorkspaceState> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(empty_workspace_state());
+        }
+        Err(error) => return Err(error),
+    };
+    serde_json::from_str(&content).map_err(Into::into)
+}
+
+pub fn load_restored_workspace_state(
+    project_root: &Path,
+) -> std::io::Result<PersistedWorkspaceState> {
+    let mut workspace = load_workspace_state(&workspace_state_path(project_root))?;
+    pause_process_windows_for_restore(&mut workspace);
+    Ok(workspace)
+}
+
+pub fn save_workspace_state(path: &Path, state: &PersistedWorkspaceState) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        gwt_core::paths::ensure_dir(parent)
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+    }
+    let content = serde_json::to_string_pretty(state)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+pub fn migrate_legacy_workspace_state(
+    legacy_path: &Path,
+    session_path: &Path,
+    fallback_project_root: &Path,
+    fallback_kind: ProjectKind,
+) -> std::io::Result<()> {
+    if session_path.exists() || !legacy_path.exists() {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(legacy_path)?;
+    let value: serde_json::Value = serde_json::from_str(&content)?;
+    let (session_state, workspaces) = if value.get("tabs").is_some() {
+        let legacy: LegacyPersistedAppState = serde_json::from_value(value)?;
+        (
+            PersistedSessionState {
+                tabs: legacy
+                    .tabs
+                    .iter()
+                    .map(|tab| PersistedSessionTabState {
+                        id: tab.id.clone(),
+                        title: tab.title.clone(),
+                        project_root: tab.project_root.clone(),
+                        kind: tab.kind,
+                    })
+                    .collect(),
+                active_tab_id: legacy.active_tab_id,
+                recent_projects: legacy.recent_projects,
+            },
+            legacy
+                .tabs
+                .into_iter()
+                .map(|tab| (tab.project_root, tab.workspace))
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        let workspace: PersistedWorkspaceState = serde_json::from_value(value)?;
+        let title = project_title_from_path(fallback_project_root);
+        (
+            PersistedSessionState {
+                tabs: vec![PersistedSessionTabState {
+                    id: "project-1".to_string(),
+                    title: title.clone(),
+                    project_root: fallback_project_root.to_path_buf(),
+                    kind: fallback_kind,
+                }],
+                active_tab_id: Some("project-1".to_string()),
+                recent_projects: vec![RecentProjectEntry {
+                    path: fallback_project_root.to_path_buf(),
+                    title,
+                    kind: fallback_kind,
+                }],
+            },
+            vec![(fallback_project_root.to_path_buf(), workspace)],
+        )
+    };
+
+    for (project_root, workspace) in workspaces {
+        let path = workspace_state_path(&project_root);
+        if path.exists() {
+            continue;
+        }
+        save_workspace_state(&path, &workspace)?;
+    }
+
+    save_session_state(session_path, &session_state)?;
+    std::fs::remove_file(legacy_path)?;
     Ok(())
 }
 
@@ -261,21 +354,20 @@ mod tests {
     }
 
     #[test]
-    fn load_app_state_defaults_to_empty_state_for_missing_file() {
+    fn load_session_state_defaults_to_empty_state_for_missing_file() {
         let dir = tempdir().expect("tempdir");
-        let path = dir.path().join("workspace.json");
+        let path = dir.path().join("session.json");
 
-        let loaded =
-            load_app_state(&path, &dir.path().join("workspace"), ProjectKind::Git).expect("load");
-        assert_eq!(loaded, default_app_state());
+        let loaded = load_session_state(&path).expect("load");
+        assert_eq!(loaded, default_session_state());
     }
 
     #[test]
-    fn save_and_load_app_state_round_trip() {
+    fn save_and_load_session_state_round_trip() {
         let dir = tempdir().expect("tempdir");
-        let path = dir.path().join("workspace.json");
+        let path = dir.path().join("session.json");
         let project_root = dir.path().join("demo");
-        let state = PersistedAppState {
+        let state = PersistedSessionState {
             active_tab_id: Some("project-2".to_string()),
             recent_projects: vec![
                 RecentProjectEntry {
@@ -290,81 +382,98 @@ mod tests {
                 },
             ],
             tabs: vec![
-                PersistedProjectTabState {
+                PersistedSessionTabState {
                     id: "project-1".to_string(),
                     title: "demo".to_string(),
                     project_root: project_root.clone(),
                     kind: ProjectKind::Git,
-                    workspace: PersistedWorkspaceState {
-                        viewport: CanvasViewport {
-                            x: 120.0,
-                            y: -48.0,
-                            zoom: 1.4,
-                        },
-                        windows: vec![
-                            PersistedWindowState {
-                                id: "shell-1".to_string(),
-                                title: "Shell".to_string(),
-                                preset: WindowPreset::Shell,
-                                geometry: WindowGeometry {
-                                    x: 10.0,
-                                    y: 20.0,
-                                    width: 640.0,
-                                    height: 420.0,
-                                },
-                                z_index: 4,
-                                status: WindowProcessStatus::Running,
-                                minimized: false,
-                                maximized: true,
-                                pre_maximize_geometry: Some(WindowGeometry {
-                                    x: 48.0,
-                                    y: 64.0,
-                                    width: 720.0,
-                                    height: 480.0,
-                                }),
-                                persist: true,
-                            },
-                            PersistedWindowState {
-                                id: "branches-1".to_string(),
-                                title: "Branches".to_string(),
-                                preset: WindowPreset::Branches,
-                                geometry: WindowGeometry {
-                                    x: 36.0,
-                                    y: 48.0,
-                                    width: 540.0,
-                                    height: 360.0,
-                                },
-                                z_index: 5,
-                                status: WindowProcessStatus::Ready,
-                                minimized: true,
-                                maximized: false,
-                                pre_maximize_geometry: None,
-                                persist: true,
-                            },
-                        ],
-                        next_z_index: 6,
-                    },
                 },
-                PersistedProjectTabState {
+                PersistedSessionTabState {
                     id: "project-2".to_string(),
                     title: "notes".to_string(),
                     project_root: dir.path().join("notes"),
                     kind: ProjectKind::NonRepo,
-                    workspace: empty_workspace_state(),
                 },
             ],
         };
 
-        save_app_state(&path, &state).expect("save should succeed");
-        let loaded = load_app_state(&path, &project_root, ProjectKind::Git).expect("load");
+        save_session_state(&path, &state).expect("save should succeed");
+        let loaded = load_session_state(&path).expect("load");
         assert_eq!(loaded, state);
     }
 
     #[test]
-    fn load_app_state_migrates_legacy_workspace_file_to_single_project_tab() {
+    fn load_workspace_state_defaults_to_empty_state_for_missing_file() {
         let dir = tempdir().expect("tempdir");
         let path = dir.path().join("workspace.json");
-        let legacy_project_root = dir.path().join("workspace");
+
+        let loaded = load_workspace_state(&path).expect("load");
+        assert_eq!(loaded, empty_workspace_state());
+    }
+
+    #[test]
+    fn save_and_load_workspace_state_round_trip() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("workspace.json");
+        let state = PersistedWorkspaceState {
+            viewport: CanvasViewport {
+                x: 120.0,
+                y: -48.0,
+                zoom: 1.4,
+            },
+            windows: vec![
+                PersistedWindowState {
+                    id: "shell-1".to_string(),
+                    title: "Shell".to_string(),
+                    preset: WindowPreset::Shell,
+                    geometry: WindowGeometry {
+                        x: 10.0,
+                        y: 20.0,
+                        width: 640.0,
+                        height: 420.0,
+                    },
+                    z_index: 4,
+                    status: WindowProcessStatus::Running,
+                    minimized: false,
+                    maximized: true,
+                    pre_maximize_geometry: Some(WindowGeometry {
+                        x: 48.0,
+                        y: 64.0,
+                        width: 720.0,
+                        height: 480.0,
+                    }),
+                    persist: true,
+                },
+                PersistedWindowState {
+                    id: "branches-1".to_string(),
+                    title: "Branches".to_string(),
+                    preset: WindowPreset::Branches,
+                    geometry: WindowGeometry {
+                        x: 36.0,
+                        y: 48.0,
+                        width: 540.0,
+                        height: 360.0,
+                    },
+                    z_index: 5,
+                    status: WindowProcessStatus::Ready,
+                    minimized: true,
+                    maximized: false,
+                    pre_maximize_geometry: None,
+                    persist: true,
+                },
+            ],
+            next_z_index: 6,
+        };
+
+        save_workspace_state(&path, &state).expect("save should succeed");
+        let loaded = load_workspace_state(&path).expect("load");
+        assert_eq!(loaded, state);
+    }
+
+    #[test]
+    fn load_workspace_state_accepts_legacy_workspace_payload_without_new_fields() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("workspace.json");
         std::fs::write(
             &path,
             r#"{
@@ -384,85 +493,277 @@ mod tests {
         )
         .expect("legacy workspace write");
 
-        let loaded =
-            load_app_state(&path, &legacy_project_root, ProjectKind::Git).expect("legacy load");
-        assert_eq!(loaded.active_tab_id.as_deref(), Some("project-1"));
-        assert_eq!(loaded.tabs.len(), 1);
-        assert_eq!(loaded.recent_projects.len(), 1);
-        assert_eq!(loaded.tabs[0].project_root, legacy_project_root);
-        assert_eq!(loaded.tabs[0].title, "workspace");
-        assert_eq!(loaded.tabs[0].kind, ProjectKind::Git);
-        assert_eq!(loaded.tabs[0].workspace.viewport, default_canvas_viewport());
-        assert_eq!(loaded.tabs[0].workspace.next_z_index, 2);
-        assert!(!loaded.tabs[0].workspace.windows[0].minimized);
-        assert!(!loaded.tabs[0].workspace.windows[0].maximized);
-        assert!(loaded.tabs[0].workspace.windows[0]
-            .pre_maximize_geometry
-            .is_none());
+        let loaded = load_workspace_state(&path).expect("legacy load");
+        assert_eq!(loaded.viewport, default_canvas_viewport());
+        assert_eq!(loaded.next_z_index, 2);
+        assert!(!loaded.windows[0].minimized);
+        assert!(!loaded.windows[0].maximized);
+        assert!(loaded.windows[0].pre_maximize_geometry.is_none());
+    }
+
+    #[test]
+    fn workspace_state_path_uses_project_scoped_storage() {
+        let dir = tempdir().expect("tempdir");
+        let path = workspace_state_path(dir.path());
+        let hash = gwt_core::paths::project_scope_hash(dir.path());
+        assert!(path.ends_with(format!("projects/{}/workspace.json", hash.as_str())));
+    }
+
+    #[test]
+    fn load_restored_workspace_state_pauses_process_windows() {
+        let dir = tempdir().expect("tempdir");
+        let project_root = dir.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project dir");
+        let state = PersistedWorkspaceState {
+            viewport: default_canvas_viewport(),
+            windows: vec![
+                PersistedWindowState {
+                    id: "shell-1".to_string(),
+                    title: "Shell".to_string(),
+                    preset: WindowPreset::Shell,
+                    geometry: WindowGeometry {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 640.0,
+                        height: 420.0,
+                    },
+                    z_index: 1,
+                    status: WindowProcessStatus::Running,
+                    minimized: false,
+                    maximized: false,
+                    pre_maximize_geometry: None,
+                    persist: true,
+                },
+                PersistedWindowState {
+                    id: "file-tree-1".to_string(),
+                    title: "Files".to_string(),
+                    preset: WindowPreset::FileTree,
+                    geometry: WindowGeometry {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 400.0,
+                        height: 500.0,
+                    },
+                    z_index: 2,
+                    status: WindowProcessStatus::Ready,
+                    minimized: false,
+                    maximized: false,
+                    pre_maximize_geometry: None,
+                    persist: true,
+                },
+            ],
+            next_z_index: 3,
+        };
+        save_workspace_state(&workspace_state_path(&project_root), &state).expect("save");
+
+        let restored = load_restored_workspace_state(&project_root).expect("restore");
+        assert_eq!(restored.windows[0].status, WindowProcessStatus::Exited);
+        assert_eq!(restored.windows[1].status, WindowProcessStatus::Ready);
+    }
+
+    #[test]
+    fn migrate_legacy_app_state_splits_session_and_project_workspaces() {
+        let dir = tempdir().expect("tempdir");
+        let legacy_path = dir.path().join("legacy-workspace.json");
+        let session_path = dir.path().join("session.json");
+        let project_one = dir.path().join("project-one");
+        let project_two = dir.path().join("project-two");
+        std::fs::create_dir_all(&project_one).expect("project one dir");
+        std::fs::create_dir_all(&project_two).expect("project two dir");
+        std::fs::write(
+            &legacy_path,
+            format!(
+                r#"{{
+  "tabs": [
+    {{
+      "id": "project-1",
+      "title": "project-one",
+      "project_root": "{}",
+      "kind": "git",
+      "workspace": {{
+        "viewport": {{ "x": 12.0, "y": -8.0, "zoom": 1.1 }},
+        "windows": [],
+        "next_z_index": 3
+      }}
+    }},
+    {{
+      "id": "project-2",
+      "title": "project-two",
+      "project_root": "{}",
+      "kind": "non_repo",
+      "workspace": {{
+        "viewport": {{ "x": 0.0, "y": 0.0, "zoom": 1.0 }},
+        "windows": [],
+        "next_z_index": 5
+      }}
+    }}
+  ],
+  "active_tab_id": "project-2",
+  "recent_projects": [
+    {{ "path": "{}", "title": "project-two", "kind": "non_repo" }}
+  ]
+}}"#,
+                project_one.display(),
+                project_two.display(),
+                project_two.display()
+            ),
+        )
+        .expect("legacy workspace write");
+
+        migrate_legacy_workspace_state(&legacy_path, &session_path, &project_one, ProjectKind::Git)
+            .expect("migrate");
+
+        let session = load_session_state(&session_path).expect("session");
+        assert_eq!(session.tabs.len(), 2);
+        assert_eq!(session.active_tab_id.as_deref(), Some("project-2"));
+        assert_eq!(session.recent_projects.len(), 1);
+
+        let workspace_one = load_workspace_state(&workspace_state_path(&project_one)).expect("one");
+        let workspace_two = load_workspace_state(&workspace_state_path(&project_two)).expect("two");
+        assert_eq!(workspace_one.viewport.x, 12.0);
+        assert_eq!(workspace_one.next_z_index, 3);
+        assert_eq!(workspace_two.next_z_index, 5);
+        assert!(!legacy_path.exists());
+    }
+
+    #[test]
+    fn migrate_legacy_single_workspace_uses_fallback_project_target() {
+        let dir = tempdir().expect("tempdir");
+        let legacy_path = dir.path().join("legacy-workspace.json");
+        let session_path = dir.path().join("session.json");
+        let project_root = dir.path().join("workspace");
+        std::fs::create_dir_all(&project_root).expect("project dir");
+        std::fs::write(
+            &legacy_path,
+            r#"{
+  "windows": [],
+  "next_z_index": 2
+}"#,
+        )
+        .expect("legacy workspace write");
+
+        migrate_legacy_workspace_state(
+            &legacy_path,
+            &session_path,
+            &project_root,
+            ProjectKind::NonRepo,
+        )
+        .expect("migrate");
+
+        let session = load_session_state(&session_path).expect("session");
+        assert_eq!(session.tabs.len(), 1);
+        assert_eq!(session.tabs[0].project_root, project_root);
+        assert_eq!(session.tabs[0].kind, ProjectKind::NonRepo);
+        assert_eq!(session.tabs[0].title, "workspace");
+        let workspace =
+            load_workspace_state(&workspace_state_path(&project_root)).expect("workspace");
+        assert_eq!(workspace.next_z_index, 2);
+        assert!(!legacy_path.exists());
+    }
+
+    #[test]
+    fn migrate_legacy_workspace_state_keeps_existing_new_workspace() {
+        let dir = tempdir().expect("tempdir");
+        let legacy_path = dir.path().join("legacy-workspace.json");
+        let session_path = dir.path().join("session.json");
+        let project_root = dir.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project dir");
+        std::fs::write(
+            &legacy_path,
+            format!(
+                r#"{{
+  "tabs": [
+    {{
+      "id": "project-1",
+      "title": "project",
+      "project_root": "{}",
+      "kind": "git",
+      "workspace": {{
+        "viewport": {{ "x": 99.0, "y": 0.0, "zoom": 1.0 }},
+        "windows": [],
+        "next_z_index": 7
+      }}
+    }}
+  ],
+  "active_tab_id": "project-1",
+  "recent_projects": []
+}}"#,
+                project_root.display()
+            ),
+        )
+        .expect("legacy workspace write");
+
+        let existing = PersistedWorkspaceState {
+            viewport: CanvasViewport {
+                x: 10.0,
+                y: 20.0,
+                zoom: 1.0,
+            },
+            windows: Vec::new(),
+            next_z_index: 3,
+        };
+        save_workspace_state(&workspace_state_path(&project_root), &existing).expect("existing");
+
+        migrate_legacy_workspace_state(
+            &legacy_path,
+            &session_path,
+            &project_root,
+            ProjectKind::Git,
+        )
+        .expect("migrate");
+
+        let workspace =
+            load_workspace_state(&workspace_state_path(&project_root)).expect("workspace");
+        assert_eq!(workspace, existing);
+        assert!(!legacy_path.exists());
     }
 
     #[test]
     fn pause_process_windows_for_restore_marks_only_process_windows_exited() {
-        let mut state = PersistedAppState {
-            active_tab_id: Some("project-1".to_string()),
-            recent_projects: Vec::new(),
-            tabs: vec![PersistedProjectTabState {
-                id: "project-1".to_string(),
-                title: "demo".to_string(),
-                project_root: PathBuf::from("/tmp/demo"),
-                kind: ProjectKind::Git,
-                workspace: PersistedWorkspaceState {
-                    viewport: default_canvas_viewport(),
-                    windows: vec![
-                        PersistedWindowState {
-                            id: "shell-1".to_string(),
-                            title: "Shell".to_string(),
-                            preset: WindowPreset::Shell,
-                            geometry: WindowGeometry {
-                                x: 0.0,
-                                y: 0.0,
-                                width: 640.0,
-                                height: 420.0,
-                            },
-                            z_index: 1,
-                            status: WindowProcessStatus::Running,
-                            minimized: false,
-                            maximized: false,
-                            pre_maximize_geometry: None,
-                            persist: true,
-                        },
-                        PersistedWindowState {
-                            id: "branches-1".to_string(),
-                            title: "Branches".to_string(),
-                            preset: WindowPreset::Branches,
-                            geometry: WindowGeometry {
-                                x: 0.0,
-                                y: 0.0,
-                                width: 640.0,
-                                height: 420.0,
-                            },
-                            z_index: 2,
-                            status: WindowProcessStatus::Ready,
-                            minimized: false,
-                            maximized: false,
-                            pre_maximize_geometry: None,
-                            persist: true,
-                        },
-                    ],
-                    next_z_index: 3,
+        let mut state = PersistedWorkspaceState {
+            viewport: default_canvas_viewport(),
+            windows: vec![
+                PersistedWindowState {
+                    id: "shell-1".to_string(),
+                    title: "Shell".to_string(),
+                    preset: WindowPreset::Shell,
+                    geometry: WindowGeometry {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 640.0,
+                        height: 420.0,
+                    },
+                    z_index: 1,
+                    status: WindowProcessStatus::Running,
+                    minimized: false,
+                    maximized: false,
+                    pre_maximize_geometry: None,
+                    persist: true,
                 },
-            }],
+                PersistedWindowState {
+                    id: "branches-1".to_string(),
+                    title: "Branches".to_string(),
+                    preset: WindowPreset::Branches,
+                    geometry: WindowGeometry {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 640.0,
+                        height: 420.0,
+                    },
+                    z_index: 2,
+                    status: WindowProcessStatus::Ready,
+                    minimized: false,
+                    maximized: false,
+                    pre_maximize_geometry: None,
+                    persist: true,
+                },
+            ],
+            next_z_index: 3,
         };
 
         pause_process_windows_for_restore(&mut state);
 
-        assert_eq!(
-            state.tabs[0].workspace.windows[0].status,
-            WindowProcessStatus::Exited
-        );
-        assert_eq!(
-            state.tabs[0].workspace.windows[1].status,
-            WindowProcessStatus::Ready
-        );
+        assert_eq!(state.windows[0].status, WindowProcessStatus::Exited);
+        assert_eq!(state.windows[1].status, WindowProcessStatus::Ready);
     }
 }


### PR DESCRIPTION
## Summary

- split GUI persistence between global `~/.gwt/session.json` and project-scoped `~/.gwt/projects/<repo-hash>/workspace.json`
- add legacy migration from `~/.gwt/poc/terminal/workspace.json` into session/workspace targets with non-Git path hash fallback
- update README and owner specs #2021, #2020, #2013 to match the new storage boundary

## Changes

- add `gwt_projects_dir`, `gwt_project_dir`, `project_scope_hash`, and `gwt_session_state_path` path helpers
- replace the old app-level workspace payload with `PersistedSessionState` + project-scoped `PersistedWorkspaceState`
- load/save session and per-project workspace separately during startup, project open, and persist
- move log path documentation to `projects/<repo-hash>/logs/`

## Testing

- `cargo fmt -- --check`
- `cargo test -p gwt-core -p gwt --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`

## Closing Issues

None

## Related Issues

- #2021
- #2020
- #2013

## Checklist

- [x] tests added or updated for migration / restore behavior
- [x] README updated for user-facing storage path changes
- [x] related specs updated to match the implementation boundary
- [x] no remaining unchecked follow-up in this change set


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for application logs and state file storage locations.

* **Improvements**
  * Reorganized internal data storage structure to use project-scoped directories for improved organization.
  * Restructured session and workspace state management for better separation of concerns.
  * Added automatic migration for legacy user data to new storage structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->