### PR TITLE
fix(core): prevent poisoned lock cascades by recovering from panic poison

### DIFF
--- a/crates/gwt-core/src/index/runtime.rs
+++ b/crates/gwt-core/src/index/runtime.rs
@@ -253,7 +253,7 @@ mod tests {
             project_root: &Path,
             respect_ttl: bool,
         ) -> std::io::Result<()> {
-            self.calls.lock().unwrap().push(format!(
+            self.calls.lock().unwrap_or_else(|p| p.into_inner()).push(format!(
                 "{}|{}|{}",
                 repo_hash,
                 project_root.display(),
@@ -275,7 +275,7 @@ mod tests {
             ttl: Duration::from_secs(15 * 60),
         };
         refresh_issues_if_stale(&opts, &spawner).await.unwrap();
-        assert_eq!(spawner.calls.lock().unwrap().len(), 1);
+        assert_eq!(spawner.calls.lock().unwrap_or_else(|p| p.into_inner()).len(), 1);
     }
 
     #[test]

--- a/crates/gwt-core/tests/issue_refresh.rs
+++ b/crates/gwt-core/tests/issue_refresh.rs
@@ -19,7 +19,7 @@ impl RunnerSpawner for RecordingSpawner {
         project_root: &std::path::Path,
         respect_ttl: bool,
     ) -> std::io::Result<()> {
-        self.calls.lock().unwrap().push(format!(
+        self.calls.lock().unwrap_or_else(|p| p.into_inner()).push(format!(
             "{}|{}|{}",
             repo_hash,
             project_root.display(),
@@ -57,7 +57,7 @@ async fn refresh_kicks_runner_when_ttl_expired() {
     };
     refresh_issues_if_stale(&opts, &spawner).await.unwrap();
 
-    let calls = spawner.calls.lock().unwrap();
+    let calls = spawner.calls.lock().unwrap_or_else(|p| p.into_inner());
     assert_eq!(calls.len(), 1, "expected one runner spawn call");
 }
 
@@ -77,7 +77,7 @@ async fn refresh_skipped_within_ttl() {
     };
     refresh_issues_if_stale(&opts, &spawner).await.unwrap();
 
-    let calls = spawner.calls.lock().unwrap();
+    let calls = spawner.calls.lock().unwrap_or_else(|p| p.into_inner());
     assert_eq!(calls.len(), 0, "must not spawn runner within TTL window");
 }
 
@@ -95,7 +95,7 @@ async fn refresh_kicks_runner_when_meta_missing() {
     };
     refresh_issues_if_stale(&opts, &spawner).await.unwrap();
 
-    let calls = spawner.calls.lock().unwrap();
+    let calls = spawner.calls.lock().unwrap_or_else(|p| p.into_inner());
     assert_eq!(calls.len(), 1, "missing meta means stale");
 }
 

--- a/crates/gwt-github/src/client/fake.rs
+++ b/crates/gwt-github/src/client/fake.rs
@@ -43,7 +43,7 @@ impl FakeIssueClient {
 
     /// Preload an Issue snapshot. Used by tests to set up fixtures.
     pub fn seed(&self, snapshot: IssueSnapshot) {
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         // Ensure next_issue_number stays ahead of seeded numbers.
         let current_next = self.next_issue_number.load(Ordering::SeqCst);
         if snapshot.number.0 >= current_next {
@@ -62,7 +62,7 @@ impl FakeIssueClient {
 
     /// Snapshot of the recorded call log.
     pub fn call_log(&self) -> Vec<String> {
-        self.inner.lock().unwrap().call_log.clone()
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).call_log.clone()
     }
 
     fn record(&self, state: &mut FakeState, op: &str, target: &str) {
@@ -87,7 +87,7 @@ impl IssueClient for FakeIssueClient {
         number: IssueNumber,
         since: Option<&UpdatedAt>,
     ) -> Result<FetchResult, ApiError> {
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "fetch", &number.to_string());
         let issue = state
             .issues
@@ -106,7 +106,7 @@ impl IssueClient for FakeIssueClient {
         if new_body.len() > 65_536 {
             return Err(ApiError::BodyTooLarge);
         }
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "patch_body", &number.to_string());
         let issue = state
             .issues
@@ -118,7 +118,7 @@ impl IssueClient for FakeIssueClient {
     }
 
     fn patch_title(&self, number: IssueNumber, new_title: &str) -> Result<IssueSnapshot, ApiError> {
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "patch_title", &number.to_string());
         let issue = state
             .issues
@@ -137,7 +137,7 @@ impl IssueClient for FakeIssueClient {
         if new_body.len() > 65_536 {
             return Err(ApiError::BodyTooLarge);
         }
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "patch_comment", &comment_id.to_string());
         // Find the issue owning this comment and update it in place.
         for issue in state.issues.values_mut() {
@@ -158,7 +158,7 @@ impl IssueClient for FakeIssueClient {
             return Err(ApiError::BodyTooLarge);
         }
         let new_id = CommentId(self.next_comment_id.fetch_add(1, Ordering::SeqCst));
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "create_comment", &number.to_string());
         let issue = state
             .issues
@@ -184,7 +184,7 @@ impl IssueClient for FakeIssueClient {
             return Err(ApiError::BodyTooLarge);
         }
         let number = IssueNumber(self.next_issue_number.fetch_add(1, Ordering::SeqCst));
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "create_issue", &number.to_string());
         let snapshot = IssueSnapshot {
             number,
@@ -204,7 +204,7 @@ impl IssueClient for FakeIssueClient {
         number: IssueNumber,
         labels: &[String],
     ) -> Result<IssueSnapshot, ApiError> {
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "set_labels", &number.to_string());
         let issue = state
             .issues
@@ -220,7 +220,7 @@ impl IssueClient for FakeIssueClient {
         number: IssueNumber,
         new_state: IssueState,
     ) -> Result<IssueSnapshot, ApiError> {
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "set_state", &number.to_string());
         let issue = state
             .issues
@@ -232,7 +232,7 @@ impl IssueClient for FakeIssueClient {
     }
 
     fn list_spec_issues(&self, filter: &SpecListFilter) -> Result<Vec<SpecSummary>, ApiError> {
-        let mut state = self.inner.lock().unwrap();
+        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         self.record(&mut state, "list_spec_issues", "*");
         let mut out: Vec<SpecSummary> = state
             .issues

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -102,12 +102,12 @@ impl FakeTransport {
 
     /// Queue a response to be returned by the next `execute` call.
     pub fn enqueue(&self, response: HttpResponse) {
-        self.state.lock().unwrap().canned.push_back(response);
+        self.state.lock().unwrap_or_else(|p| p.into_inner()).canned.push_back(response);
     }
 
     /// Snapshot of every recorded request so far.
     pub fn recorded(&self) -> Vec<HttpRequest> {
-        self.state.lock().unwrap().recorded.clone()
+        self.state.lock().unwrap_or_else(|p| p.into_inner()).recorded.clone()
     }
 }
 
@@ -119,7 +119,7 @@ impl Default for FakeTransport {
 
 impl HttpTransport for FakeTransport {
     fn execute(&self, request: HttpRequest) -> Result<HttpResponse, HttpError> {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.lock().unwrap_or_else(|p| p.into_inner());
         state.recorded.push(request);
         state
             .canned

--- a/crates/gwt-terminal/src/test_util.rs
+++ b/crates/gwt-terminal/src/test_util.rs
@@ -10,7 +10,7 @@ pub fn lock_pty_test() -> MutexGuard<'static, ()> {
     PTY_TEST_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
-        .expect("pty test lock poisoned")
+        .unwrap_or_else(|p| p.into_inner())
 }
 
 /// Read from a PTY reader in a separate thread with timeout.

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1670,7 +1670,7 @@ impl ClientHub {
         let (tx, rx) = mpsc::unbounded_channel();
         self.clients
             .lock()
-            .expect("client hub lock")
+            .unwrap_or_else(|p| p.into_inner())
             .insert(client_id, tx);
         rx
     }
@@ -1678,12 +1678,12 @@ impl ClientHub {
     fn unregister(&self, client_id: &str) {
         self.clients
             .lock()
-            .expect("client hub lock")
+            .unwrap_or_else(|p| p.into_inner())
             .remove(client_id);
     }
 
     fn dispatch(&self, events: Vec<OutboundEvent>) {
-        let clients = self.clients.lock().expect("client hub lock");
+        let clients = self.clients.lock().unwrap_or_else(|p| p.into_inner());
         for outbound in events {
             let payload = serde_json::to_string(&outbound.event).expect("backend event json");
             match outbound.target {

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -37,7 +37,7 @@ fn evaluate(
 }
 
 fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
-    let _guard = env_lock().lock().expect("env lock");
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let home = tempfile::tempdir().expect("temp home");
     let previous_home = std::env::var_os("HOME");
     let previous_session_id = std::env::var_os(GWT_SESSION_ID_ENV);

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -80,7 +80,7 @@ fn env_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
         .lock()
-        .expect("env lock")
+        .unwrap_or_else(|p| p.into_inner())
 }
 
 struct ScopedEnvVar {


### PR DESCRIPTION
## Summary

- Replace all `.lock().unwrap()` and `.lock().expect()` with `.unwrap_or_else(|p| p.into_inner())` to recover poisoned mutex locks
- Prevents cascading test failures when one test panics while holding a Mutex
- Follows existing recovery pattern in gwt-config and gwt-docker for consistency

## Changes

- `crates/gwt-terminal/src/test_util.rs`: Recover from poisoned lock in PTY test synchronization
- `crates/gwt/tests/hook_workflow_policy_test.rs`: Recover from poisoned env lock in test fixture
- `crates/gwt/tests/managed_assets_test.rs`: Recover from poisoned env lock in asset refresh tests
- `crates/gwt-github/src/client/fake.rs`: Recover from poisoned locks in 11 test double methods
- `crates/gwt-github/src/client/http.rs`: Recover from poisoned locks in 3 fake transport methods
- `crates/gwt-core/tests/issue_refresh.rs`: Recover from poisoned locks in 4 test assertions
- `crates/gwt-core/src/index/runtime.rs`: Recover from poisoned locks in 2 test runner recordings
- `crates/gwt/src/main.rs`: Recover from poisoned locks in 2 client hub methods for production stability

## Testing

- [x] `cargo test -p gwt-terminal` — All tests pass
- [x] `cargo test -p gwt-github` — All tests pass
- [x] `cargo test -p gwt-core` — All tests pass
- [x] `cargo test -p gwt` — All tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — No warnings
- [x] `cargo fmt --check` — Formatting compliant

## Closing Issues

- None

## Related Issues / Links

- Related: AGENTS.md guidance on poison lock recovery in gwt-config/settings.rs

## Context

Rust Mutex locks become "poisoned" when a thread panics while holding the lock. After poisoning, all subsequent lock acquisitions fail with `"poisoned lock: another task failed inside"` error, causing cascading test failures.

The `.unwrap_or_else(|p| p.into_inner())` pattern recovers the lock's inner data even when poisoned, allowing execution to continue. This is consistent with existing patterns in:
- `crates/gwt-config/src/settings.rs:121-123`
- `crates/gwt-docker/src/container.rs:706-708`
- `crates/gwt-core/src/logging/config.rs:194,207,219`

## Checklist

- [x] Tests added/updated (verified all test suites pass)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A — internal implementation)
- [x] Migration/backfill plan included (N/A — no schema/data change)
- [x] CHANGELOG impact considered (bug fix, non-breaking)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved robustness of internal synchronization mechanisms by enhancing error recovery in mutex lock handling across multiple components, preventing potential application failures during concurrent execution scenarios while maintaining existing functionality and performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->