### PR TITLE
fix(search): make spec index repo-scoped

### DIFF
--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -968,7 +968,7 @@ LOCK_FILENAME = ".lock"
 META_FILENAME = "meta.json"
 
 V2_SCOPES = ("issues", "specs", "files", "files-docs")
-WORKTREE_SCOPED = {"specs", "files", "files-docs"}
+WORKTREE_SCOPED = {"files", "files-docs"}
 
 V2_FILES_CODE_COLLECTION = "files_code"
 V2_FILES_DOCS_COLLECTION = "files_docs"
@@ -997,8 +997,8 @@ def resolve_db_path(
     root = (db_root or gwt_index_root()).resolve()
     repo_dir = root / repo_hash
 
-    if scope == "issues":
-        return repo_dir / "issues"
+    if scope in {"issues", "specs"}:
+        return repo_dir / scope
 
     return repo_dir / "worktrees" / worktree_hash / scope
 
@@ -1506,7 +1506,7 @@ def _chunk_spec_content(content: str, max_chunk_len: int = 1800) -> List[Dict[st
 def action_index_specs_v2(
     project_root: str,
     repo_hash: str,
-    worktree_hash: str,
+    worktree_hash: Optional[str],
     mode: str = "full",
     db_root: Optional[Path] = None,
 ) -> dict:

--- a/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
+++ b/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
@@ -167,7 +167,7 @@ class AutoBuildFallbackTests(unittest.TestCase):
                 result = runner.action_search_v2(
                     action="search-specs",
                     repo_hash="abc1234567890def",
-                    worktree_hash="111122223333ffff",
+                    worktree_hash=None,
                     project_root=str(root),
                     query="watcher debounce",
                     n_results=5,
@@ -183,6 +183,8 @@ class AutoBuildFallbackTests(unittest.TestCase):
                 result["specResults"][0]["title"],
                 "gwt-spec: Semantic search platform",
             )
+            db = db_root / "abc1234567890def" / "specs"
+            self.assertTrue(db.exists(), f"index dir was not created: {db}")
 
     def test_search_specs_refreshes_existing_index_from_issue_cache(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -202,7 +204,7 @@ class AutoBuildFallbackTests(unittest.TestCase):
                 initial = runner.action_search_v2(
                     action="search-specs",
                     repo_hash="abc1234567890def",
-                    worktree_hash="111122223333ffff",
+                    worktree_hash=None,
                     project_root=str(root),
                     query="watcher debounce",
                     n_results=5,
@@ -220,7 +222,7 @@ class AutoBuildFallbackTests(unittest.TestCase):
                 refreshed = runner.action_search_v2(
                     action="search-specs",
                     repo_hash="abc1234567890def",
-                    worktree_hash="111122223333ffff",
+                    worktree_hash=None,
                     project_root=str(root),
                     query="issue cache refresh contract",
                     n_results=5,

--- a/crates/gwt-core/runtime/tests/test_repo_layout.py
+++ b/crates/gwt-core/runtime/tests/test_repo_layout.py
@@ -23,18 +23,16 @@ class ResolveDbPathTests(unittest.TestCase):
         expected = (".gwt", "index", "abc1234567890def", "issues")
         self.assertEqual(path.parts[-len(expected) :], expected)
 
-    def test_specs_scope_includes_worktree_hash(self):
+    def test_specs_scope_is_repo_scoped(self):
         path = runner.resolve_db_path(
             repo_hash="abc1234567890def",
-            worktree_hash="111122223333ffff",
+            worktree_hash=None,
             scope="specs",
         )
         expected = (
             ".gwt",
             "index",
             "abc1234567890def",
-            "worktrees",
-            "111122223333ffff",
             "specs",
         )
         self.assertEqual(path.parts[-len(expected) :], expected)
@@ -71,12 +69,12 @@ class ResolveDbPathTests(unittest.TestCase):
         )
         self.assertEqual(path.parts[-len(expected) :], expected)
 
-    def test_specs_scope_without_worktree_hash_raises(self):
+    def test_files_scope_without_worktree_hash_raises(self):
         with self.assertRaises(ValueError):
             runner.resolve_db_path(
                 repo_hash="abc1234567890def",
                 worktree_hash=None,
-                scope="specs",
+                scope="files",
             )
 
     def test_unknown_scope_raises(self):

--- a/crates/gwt-core/src/index/paths.rs
+++ b/crates/gwt-core/src/index/paths.rs
@@ -9,13 +9,15 @@
 //!     chroma.sqlite3
 //!     .lock
 //!     meta.json
+//!   manifest-specs.json
+//!   specs/
+//!     chroma.sqlite3
+//!     .lock
 //!   worktrees/
 //!     <wt-hash>/
 //!       meta.json
 //!       manifest-files.json
-//!       manifest-specs.json
 //!       .lock
-//!       specs/chroma.sqlite3
 //!       files/chroma.sqlite3
 //!       files-docs/chroma.sqlite3
 //! ```
@@ -32,7 +34,7 @@ use crate::worktree_hash::WorktreeHash;
 pub enum Scope {
     /// Worktree-independent: GitHub Issues.
     Issues,
-    /// Worktree-scoped: SPEC Issue search index.
+    /// Repo-scoped: cached SPEC Issue search index.
     Specs,
     /// Worktree-scoped: project source code files.
     FilesCode,
@@ -42,7 +44,7 @@ pub enum Scope {
 
 impl Scope {
     pub fn requires_worktree(self) -> bool {
-        !matches!(self, Scope::Issues)
+        matches!(self, Scope::FilesCode | Scope::FilesDocs)
     }
 
     /// Subdirectory leaf name relative to the worktree-or-repo prefix.
@@ -83,7 +85,7 @@ pub fn gwt_index_db_path(
     worktree: Option<&WorktreeHash>,
     scope: Scope,
 ) -> Result<PathBuf> {
-    if scope == Scope::Issues {
+    if matches!(scope, Scope::Issues | Scope::Specs) {
         return Ok(gwt_index_repo_dir(repo).join(scope.subdir()));
     }
     let wt = worktree.ok_or_else(|| {
@@ -111,7 +113,7 @@ mod tests {
     #[test]
     fn worktree_scope_requires_hash() {
         let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
-        assert!(gwt_index_db_path(&repo, None, Scope::Specs).is_err());
+        assert!(gwt_index_db_path(&repo, None, Scope::FilesCode).is_err());
     }
 
     #[test]

--- a/crates/gwt-core/src/index/runtime.rs
+++ b/crates/gwt-core/src/index/runtime.rs
@@ -3,6 +3,8 @@
 //! This module owns the Rust side of:
 //! - Reconciling `~/.gwt/index/<repo-hash>/worktrees/` against `git worktree list`
 //!   and removing orphans + legacy `$WORKTREE/.gwt/index/` directories
+//! - Cleaning up legacy worktree-scoped SPEC index artifacts after SPEC index
+//!   moved to the repo root
 //! - Refreshing the Issue index according to a TTL window
 //! - Spawning the Python runner as background tokio tasks
 //!
@@ -45,7 +47,9 @@ pub fn reconcile_repo(opts: &ReconcileOptions) -> Result<()> {
     let mut valid_hashes = std::collections::HashSet::new();
     for path in &opts.active_worktree_paths {
         if let Ok(h) = compute_worktree_hash(path) {
-            valid_hashes.insert(h.as_str().to_string());
+            let hash = h.as_str().to_string();
+            remove_legacy_worktree_specs_artifacts(&opts.index_root, &opts.repo_hash, &hash)?;
+            valid_hashes.insert(hash);
         }
     }
 
@@ -76,6 +80,26 @@ pub fn reconcile_repo(opts: &ReconcileOptions) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+fn remove_legacy_worktree_specs_artifacts(
+    index_root: &Path,
+    repo: &RepoHash,
+    worktree_hash: &str,
+) -> Result<()> {
+    let worktree_dir = index_root
+        .join(repo.as_str())
+        .join("worktrees")
+        .join(worktree_hash);
+    let legacy_specs = worktree_dir.join("specs");
+    if legacy_specs.exists() {
+        std::fs::remove_dir_all(&legacy_specs)?;
+    }
+    let legacy_manifest = worktree_dir.join("manifest-specs.json");
+    if legacy_manifest.exists() {
+        std::fs::remove_file(&legacy_manifest)?;
+    }
     Ok(())
 }
 

--- a/crates/gwt-core/tests/index_paths.rs
+++ b/crates/gwt-core/tests/index_paths.rs
@@ -24,16 +24,10 @@ fn issue_db_path_omits_worktree_hash() {
 }
 
 #[test]
-fn specs_db_path_includes_worktree_hash() {
+fn specs_db_path_is_repo_scoped() {
     let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
-    let tmp = tempfile::tempdir().unwrap();
-    let wt = compute_worktree_hash(tmp.path()).unwrap();
-    let path = gwt_index_db_path(&repo, Some(&wt), Scope::Specs).unwrap();
-    let expected_suffix = format!(
-        ".gwt/index/{}/worktrees/{}/specs",
-        repo.as_str(),
-        wt.as_str()
-    );
+    let path = gwt_index_db_path(&repo, None, Scope::Specs).unwrap();
+    let expected_suffix = format!(".gwt/index/{}/specs", repo.as_str());
     assert!(
         path.to_string_lossy().ends_with(&expected_suffix),
         "got {}",
@@ -64,9 +58,9 @@ fn files_docs_db_path_under_worktree() {
 }
 
 #[test]
-fn worktree_scope_without_worktree_hash_errors() {
+fn files_scope_without_worktree_hash_errors() {
     let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
-    let result = gwt_index_db_path(&repo, None, Scope::Specs);
+    let result = gwt_index_db_path(&repo, None, Scope::FilesCode);
     assert!(result.is_err());
 }
 

--- a/crates/gwt-core/tests/index_runner_spawn.rs
+++ b/crates/gwt-core/tests/index_runner_spawn.rs
@@ -103,7 +103,6 @@ fn search_specs_e2e_with_real_e5_auto_builds() {
     fs::create_dir_all(&repo_root).unwrap();
 
     let repo = compute_repo_hash("https://github.com/example/test.git");
-    let wt = compute_worktree_hash(&repo_root).unwrap();
     let fake_home = tmp.path().join("fake_home");
     fs::create_dir_all(&fake_home).unwrap();
     let cache_dir = fake_home
@@ -133,8 +132,6 @@ fn search_specs_e2e_with_real_e5_auto_builds() {
         .arg("search-specs")
         .arg("--repo-hash")
         .arg(repo.as_str())
-        .arg("--worktree-hash")
-        .arg(wt.as_str())
         .arg("--project-root")
         .arg(&repo_root)
         .arg("--query")

--- a/crates/gwt-core/tests/worktree_gc.rs
+++ b/crates/gwt-core/tests/worktree_gc.rs
@@ -78,3 +78,53 @@ fn reconcile_is_idempotent() {
     reconcile_repo(&opts).unwrap();
     reconcile_repo(&opts).unwrap();
 }
+
+#[test]
+fn legacy_worktree_scoped_specs_directory_is_removed_for_live_worktree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let index_root = tmp.path().join("index");
+    let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
+
+    let live_wt = tmp.path().join("live");
+    fs::create_dir(&live_wt).unwrap();
+    let live_hash = compute_worktree_hash(&live_wt).unwrap();
+
+    let legacy_specs = index_root
+        .join(repo.as_str())
+        .join("worktrees")
+        .join(live_hash.as_str())
+        .join("specs");
+    fs::create_dir_all(&legacy_specs).unwrap();
+    fs::write(legacy_specs.join("chroma.sqlite3"), "data").unwrap();
+    let legacy_manifest = index_root
+        .join(repo.as_str())
+        .join("worktrees")
+        .join(live_hash.as_str())
+        .join("manifest-specs.json");
+    fs::write(&legacy_manifest, "[]").unwrap();
+
+    let live_files = index_root
+        .join(repo.as_str())
+        .join("worktrees")
+        .join(live_hash.as_str())
+        .join("files");
+    fs::create_dir_all(&live_files).unwrap();
+
+    let opts = ReconcileOptions {
+        index_root: index_root.clone(),
+        repo_hash: repo,
+        active_worktree_paths: vec![live_wt],
+        legacy_worktree_dirs: Vec::new(),
+    };
+    reconcile_repo(&opts).unwrap();
+
+    assert!(
+        !legacy_specs.exists(),
+        "legacy worktree-scoped specs dir should be removed"
+    );
+    assert!(
+        !legacy_manifest.exists(),
+        "legacy worktree-scoped specs manifest should be removed"
+    );
+    assert!(live_files.exists(), "live files dir must be preserved");
+}


### PR DESCRIPTION
## Summary

- Move the SPEC search index from worktree-scoped storage to repo-scoped storage so it matches the GitHub Issue cache ownership model.
- Keep `files` and `files-docs` worktree-scoped, and clean up legacy worktree-local SPEC index artifacts during reconcile.
- Update the SPEC-1939 owner artifact so the documented storage contract matches the implementation and tests.

## Changes

- `crates/gwt-core/src/index/paths.rs`: make `Scope::Specs` repo-scoped and update the documented on-disk layout.
- `crates/gwt-core/src/index/runtime.rs`: remove legacy `worktrees/<wt-hash>/specs/` and `manifest-specs.json` during reconcile for live worktrees.
- `crates/gwt-core/runtime/chroma_index_runner.py`: resolve `search-specs` / `index-specs` under `~/.gwt/index/<repo-hash>/specs/` and stop requiring `worktree-hash` for specs.
- `crates/gwt-core/tests/index_paths.rs`: update path expectations so specs resolve under the repo root.
- `crates/gwt-core/tests/worktree_gc.rs`: add coverage for removing legacy worktree-scoped SPEC index artifacts.
- `crates/gwt-core/runtime/tests/test_repo_layout.py`: update runner path resolution tests for repo-scoped specs.
- `crates/gwt-core/runtime/tests/test_auto_build_fallback.py`: verify `search-specs` auto-builds a repo-scoped index without `worktree-hash`.
- `crates/gwt-core/tests/index_runner_spawn.rs`: update the ignored specs E2E invocation to the new runner contract.

## Testing

- [x] `cargo test -p gwt-core` — all gwt-core unit and integration tests pass
- [x] `PYTHONPATH=crates/gwt-core/runtime ~/.gwt/runtime/chroma-venv/bin/python3 -m unittest crates.gwt-core.runtime.tests.test_repo_layout crates.gwt-core.runtime.tests.test_auto_build_fallback -v` — repo-scoped specs runner tests pass
- [x] `cargo clippy -p gwt-core --all-targets --all-features -- -D warnings` — no clippy warnings remain
- [x] `cargo fmt -- --check` — formatting is clean
- [x] `cargo build -p gwt` — gwt builds successfully
- [x] `~/.gwt/runtime/chroma-venv/bin/python3 crates/gwt-core/runtime/chroma_index_runner.py --action search-specs --repo-hash <repo-hash> --project-root <cwd> --query 'semantic search platform' --n-results 3` — repo-scoped `~/.gwt/index/<repo-hash>/specs/` is created and queried successfully

## Closing Issues

- Closes #1939

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — README は変更なし。owner SPEC は更新済み
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- SPEC-1939 では `specs` が worktree-scoped と定義されていましたが、実際の入力 source は repo-scoped な GitHub Issue cache のみでした。
- そのため worktree ごとに同じ SPEC index を重複生成しており、データの所有権と保存スコープが一致していませんでした。
- この PR で `issues` / `specs` を repo-scoped、`files` / `files-docs` を worktree-scoped に整理しています。

## Risk / Impact

- **Affected areas**: semantic search runtime, repo/worktree index layout, SPEC search auto-build, reconcile cleanup
- **Rollback plan**: revert this PR, then restart gwt to restore the prior runtime assets and rebuild worktree-scoped SPEC indexes as needed

## Notes

- `~/.gwt/runtime/chroma_index_runner.py` の共有コピーは gwt 起動時/ワークスペース初期化時に自己修復されます。この PR では repo 内の正本を更新しています。
