### PR TITLE
fix: linux-aarch64 をネイティブ ARM64 ランナーに切り替え

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
             binary: gwt
             release_name: gwt-linux-x86_64
           - platform: linux-aarch64
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             binary: gwt
             release_name: gwt-linux-aarch64
@@ -120,24 +120,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: gwt-${{ matrix.platform }}
-      - name: Install WebView dependencies (Linux x86_64)
-        if: matrix.platform == 'linux-x86_64'
+      - name: Install WebView dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
-      - name: Install cross-compilation tools and WebView dependencies (Linux aarch64)
-        if: matrix.platform == 'linux-aarch64'
-        run: |
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          sudo apt-get install -y libgtk-3-dev:arm64 libwebkit2gtk-4.1-dev:arm64 libayatana-appindicator3-dev:arm64 || true
-          echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
       - name: Build gwt binary
-        env:
-          PKG_CONFIG_ALLOW_CROSS: ${{ matrix.platform == 'linux-aarch64' && '1' || '' }}
-          PKG_CONFIG_PATH: ${{ matrix.platform == 'linux-aarch64' && '/usr/lib/aarch64-linux-gnu/pkgconfig' || '' }}
         run: cargo build --release -p gwt --target ${{ matrix.target }}
       - name: Prepare artifact
         shell: bash

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -1,10 +1,14 @@
 //! Agent launch builder: construct launch configurations for coding agents.
 
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
-use crate::session::GWT_SESSION_RUNTIME_PATH_ENV;
-use crate::types::{AgentColor, AgentId, DockerLifecycleIntent, LaunchRuntimeTarget, SessionMode};
+use crate::{
+    session::GWT_SESSION_RUNTIME_PATH_ENV,
+    types::{AgentColor, AgentId, DockerLifecycleIntent, LaunchRuntimeTarget, SessionMode},
+};
 
 /// Resolve the gwt repo hash for the directory by shelling out to
 /// `git remote get-url origin`. Returns `None` when no origin is configured.

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -19,8 +19,8 @@ pub use launch::{
 pub use session::{
     persist_session_status, reset_runtime_state_dir, reset_runtime_state_dir_for_pid,
     runtime_state_dir_for_pid, runtime_state_path, runtime_state_path_for_pid,
-    PendingDiscussionResume, Session, SessionRuntimeState, GWT_SESSION_ID_ENV,
-    GWT_SESSION_RUNTIME_PATH_ENV, GWT_BIN_PATH_ENV,
+    PendingDiscussionResume, Session, SessionRuntimeState, GWT_BIN_PATH_ENV, GWT_SESSION_ID_ENV,
+    GWT_SESSION_RUNTIME_PATH_ENV,
 };
 pub use types::{
     AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget,

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -20,7 +20,7 @@ pub use session::{
     persist_session_status, reset_runtime_state_dir, reset_runtime_state_dir_for_pid,
     runtime_state_dir_for_pid, runtime_state_path, runtime_state_path_for_pid,
     PendingDiscussionResume, Session, SessionRuntimeState, GWT_SESSION_ID_ENV,
-    GWT_SESSION_RUNTIME_PATH_ENV,
+    GWT_SESSION_RUNTIME_PATH_ENV, GWT_BIN_PATH_ENV,
 };
 pub use types::{
     AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget,

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -1,15 +1,17 @@
 //! Agent session persistence: save/load sessions as TOML files.
 
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::launch::normalize_launch_args;
-use crate::types::{
-    AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, WorkflowBypass,
+use crate::{
+    launch::normalize_launch_args,
+    types::{AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, WorkflowBypass},
 };
 
 /// Idle duration (in seconds) after which a session is considered stopped.

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -21,6 +21,9 @@ pub const GWT_SESSION_ID_ENV: &str = "GWT_SESSION_ID";
 /// Environment variable injected into agent PTYs so hooks can write the
 /// matching runtime sidecar without discovering gwt paths on their own.
 pub const GWT_SESSION_RUNTIME_PATH_ENV: &str = "GWT_SESSION_RUNTIME_PATH";
+/// Environment variable injected into agent PTYs so skills can locate the
+/// gwt binary for calling gwt CLI (GitHub operations, etc.).
+pub const GWT_BIN_PATH_ENV: &str = "GWT_BIN_PATH";
 
 /// Represents a single agent session.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/gwt-agent/src/version_cache.rs
+++ b/crates/gwt-agent/src/version_cache.rs
@@ -1,8 +1,10 @@
 //! Agent version cache: caches detected versions with a 24-hour TTL.
 
-use std::collections::HashMap;
-use std::future::Future;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    future::Future,
+    path::{Path, PathBuf},
+};
 
 use chrono::{DateTime, Utc};
 use semver::Version;

--- a/crates/gwt-ai/src/branch_suggest.rs
+++ b/crates/gwt-ai/src/branch_suggest.rs
@@ -5,8 +5,10 @@
 
 use serde::Deserialize;
 
-use crate::client::{AIClient, ChatMessage};
-use crate::error::AIError;
+use crate::{
+    client::{AIClient, ChatMessage},
+    error::AIError,
+};
 
 const SYSTEM_PROMPT: &str = "\
 You are a git branch naming assistant. Generate 3 to 5 branch name suggestions \
@@ -136,8 +138,9 @@ pub fn suggest_branch_name(client: &AIClient, context: &str) -> Result<Vec<Strin
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::process::Command;
+
+    use super::*;
 
     // ── validate_branch_name ───────────────────────────────────────────
 

--- a/crates/gwt-ai/src/issue_classify.rs
+++ b/crates/gwt-ai/src/issue_classify.rs
@@ -3,8 +3,10 @@
 //! Determines the branch-type category prefix for a GitHub issue
 //! (feature, bugfix, hotfix, or release) based on title and body.
 
-use crate::client::{AIClient, ChatMessage};
-use crate::error::AIError;
+use crate::{
+    client::{AIClient, ChatMessage},
+    error::AIError,
+};
 
 const SYSTEM_PROMPT: &str = "\
 You are a branch prefix classifier for GitHub issues. Based on the issue title \

--- a/crates/gwt-clipboard/src/file_paste.rs
+++ b/crates/gwt-clipboard/src/file_paste.rs
@@ -1,7 +1,9 @@
 //! Extract file paths from the system clipboard.
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 /// Parsed clipboard paste payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -193,8 +195,7 @@ pub(crate) fn run_command(cmd: &str, args: &[&str]) -> Result<String, ClipboardE
 
 /// Pipe text into a command's stdin.
 fn pipe_to_command(cmd: &str, args: &[&str], text: &str) -> Result<(), ClipboardError> {
-    use std::io::Write;
-    use std::process::Stdio;
+    use std::{io::Write, process::Stdio};
 
     let mut child = Command::new(cmd)
         .args(args)

--- a/crates/gwt-clipboard/src/lib.rs
+++ b/crates/gwt-clipboard/src/lib.rs
@@ -11,8 +11,9 @@ pub use text::ClipboardText;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::PathBuf;
+
+    use super::*;
 
     #[test]
     fn parse_clipboard_paste_returns_file_paths_when_every_line_is_absolute() {

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -1,16 +1,17 @@
 //! Repo-local coordination storage for a shared board chat timeline.
 
-use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
-use std::path::{Path, PathBuf};
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufRead, BufReader, Write},
+    path::{Path, PathBuf},
+};
 
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::paths::gwt_coordination_dir_for_repo_path;
-use crate::{GwtError, Result};
+use crate::{paths::gwt_coordination_dir_for_repo_path, GwtError, Result};
 
 pub const COORDINATION_RELATIVE_DIR: &str = ".gwt/coordination";
 pub const EVENTS_FILE_NAME: &str = "events.jsonl";
@@ -647,10 +648,11 @@ fn json_error(err: serde_json::Error) -> GwtError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{sync::Arc, thread};
+
     use chrono::TimeZone;
-    use std::sync::Arc;
-    use std::thread;
+
+    use super::*;
 
     #[test]
     fn load_snapshot_bootstraps_empty_files() {

--- a/crates/gwt-core/src/index/paths.rs
+++ b/crates/gwt-core/src/index/paths.rs
@@ -24,10 +24,12 @@
 
 use std::path::PathBuf;
 
-use crate::error::{GwtError, Result};
-use crate::paths::gwt_home;
-use crate::repo_hash::RepoHash;
-use crate::worktree_hash::WorktreeHash;
+use crate::{
+    error::{GwtError, Result},
+    paths::gwt_home,
+    repo_hash::RepoHash,
+    worktree_hash::WorktreeHash,
+};
 
 /// Index scope discriminator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -100,8 +102,7 @@ pub fn gwt_index_db_path(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::repo_hash::compute_repo_hash;
-    use crate::worktree_hash::compute_worktree_hash;
+    use crate::{repo_hash::compute_repo_hash, worktree_hash::compute_worktree_hash};
 
     #[test]
     fn issue_scope_resolution() {

--- a/crates/gwt-core/src/index/runtime.rs
+++ b/crates/gwt-core/src/index/runtime.rs
@@ -11,16 +11,20 @@
 //! The actual ChromaDB writes happen inside the Python runner. This module
 //! never touches sqlite directly.
 
-use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::error::{GwtError, Result};
-use crate::index::paths::gwt_index_worktree_dir;
-use crate::repo_hash::RepoHash;
-use crate::worktree_hash::compute_worktree_hash;
+use crate::{
+    error::{GwtError, Result},
+    index::paths::gwt_index_worktree_dir,
+    repo_hash::RepoHash,
+    worktree_hash::compute_worktree_hash,
+};
 
 // =====================================================================
 // reconcile_repo
@@ -261,9 +265,10 @@ fn _layout_anchor(repo: &RepoHash, wt_hash: &str) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use crate::repo_hash::compute_repo_hash;
-    use std::sync::{Arc, Mutex};
 
     #[derive(Default, Clone)]
     struct RecordingSpawner {

--- a/crates/gwt-core/src/index/watcher.rs
+++ b/crates/gwt-core/src/index/watcher.rs
@@ -9,8 +9,10 @@
 //! drain `WatcherHandle::recv_batch()` and dispatch the appropriate
 //! `runner index-* --mode incremental` job per batch.
 
-use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::RecursiveMode;

--- a/crates/gwt-core/src/logging/config.rs
+++ b/crates/gwt-core/src/logging/config.rs
@@ -1,7 +1,6 @@
 //! Logging configuration: level resolution from env / config / default.
 
-use std::fmt;
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
@@ -142,8 +141,9 @@ impl LoggingConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::Mutex;
+
+    use super::*;
 
     // Serialize all tests that mutate RUST_LOG so they do not stomp on
     // each other. `cargo test` runs tests in parallel by default.

--- a/crates/gwt-core/src/logging/housekeep.rs
+++ b/crates/gwt-core/src/logging/housekeep.rs
@@ -1,7 +1,9 @@
 //! Startup housekeeping: delete rotated log files older than the retention window.
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use chrono::{NaiveDate, Utc};
 

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -2,8 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::error::Result;
-use crate::repo_hash::{compute_path_hash, detect_repo_hash, RepoHash};
+use crate::{
+    error::Result,
+    repo_hash::{compute_path_hash, detect_repo_hash, RepoHash},
+};
 
 /// Return the gwt home directory (`~/.gwt/`).
 pub fn gwt_home() -> PathBuf {

--- a/crates/gwt-core/src/repo_hash.rs
+++ b/crates/gwt-core/src/repo_hash.rs
@@ -4,8 +4,7 @@
 //! upstream repository (HTTPS clone, SSH clone, second worktree) always
 //! resolves to the same `RepoHash`.
 
-use std::fmt;
-use std::path::Path;
+use std::{fmt, path::Path};
 
 use sha2::{Digest, Sha256};
 
@@ -127,8 +126,9 @@ pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::Path;
+
+    use super::*;
 
     #[test]
     fn normalizes_https_https_form() {

--- a/crates/gwt-core/src/runtime.rs
+++ b/crates/gwt-core/src/runtime.rs
@@ -1,9 +1,10 @@
 //! Bootstrap and repair the shared project-index runtime under `~/.gwt/runtime`.
 
-use std::fs;
-use std::path::Component;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+    process::Command,
+};
 
 use crate::{GwtError, Result};
 
@@ -495,10 +496,12 @@ fn run_checked(command: &mut Command, label: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::cell::{Cell, RefCell};
-    use std::fs;
+    use std::{
+        cell::{Cell, RefCell},
+        fs,
+    };
 
+    use super::*;
     use crate::paths::{gwt_project_index_venv_dir_from, gwt_runtime_runner_path_from};
 
     #[derive(Default)]

--- a/crates/gwt-core/src/worktree_hash.rs
+++ b/crates/gwt-core/src/worktree_hash.rs
@@ -1,7 +1,6 @@
 //! Worktree identification via canonicalized absolute path hashing.
 
-use std::fmt;
-use std::path::Path;
+use std::{fmt, path::Path};
 
 use sha2::{Digest, Sha256};
 

--- a/crates/gwt-core/tests/index_paths.rs
+++ b/crates/gwt-core/tests/index_paths.rs
@@ -1,8 +1,10 @@
 //! Phase 8: integration tests for `gwt_core::index::paths`.
 
-use gwt_core::index::paths::{gwt_index_db_path, gwt_index_repo_dir, gwt_index_root, Scope};
-use gwt_core::repo_hash::compute_repo_hash;
-use gwt_core::worktree_hash::compute_worktree_hash;
+use gwt_core::{
+    index::paths::{gwt_index_db_path, gwt_index_repo_dir, gwt_index_root, Scope},
+    repo_hash::compute_repo_hash,
+    worktree_hash::compute_worktree_hash,
+};
 
 #[test]
 fn gwt_index_root_ends_with_index() {

--- a/crates/gwt-core/tests/index_runner_spawn.rs
+++ b/crates/gwt-core/tests/index_runner_spawn.rs
@@ -5,12 +5,9 @@
 //! run (~440 MB) and runs much slower than unit tests. CI invokes it with
 //! `cargo test -- --ignored` after restoring the HuggingFace cache.
 
-use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
+use std::{fs, path::PathBuf, process::Command};
 
-use gwt_core::repo_hash::compute_repo_hash;
-use gwt_core::worktree_hash::compute_worktree_hash;
+use gwt_core::{repo_hash::compute_repo_hash, worktree_hash::compute_worktree_hash};
 
 fn runner_python() -> PathBuf {
     let home = dirs::home_dir().expect("home");

--- a/crates/gwt-core/tests/issue_refresh.rs
+++ b/crates/gwt-core/tests/issue_refresh.rs
@@ -1,10 +1,14 @@
 //! Phase 8: integration tests for `gwt_core::index::runtime::refresh_issues_if_stale`.
 
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
-use gwt_core::index::runtime::{refresh_issues_if_stale, RefreshIssuesOptions, RunnerSpawner};
-use gwt_core::repo_hash::compute_repo_hash;
+use gwt_core::{
+    index::runtime::{refresh_issues_if_stale, RefreshIssuesOptions, RunnerSpawner},
+    repo_hash::compute_repo_hash,
+};
 
 /// A test double that records calls instead of actually spawning the python runner.
 #[derive(Clone, Default)]

--- a/crates/gwt-core/tests/watcher_debounce.rs
+++ b/crates/gwt-core/tests/watcher_debounce.rs
@@ -3,8 +3,7 @@
 //! These tests exercise the debounce-and-batch behavior of the per-Worktree
 //! filesystem watcher. They use the real `notify` crate against a tempdir.
 
-use std::fs;
-use std::time::Duration;
+use std::{fs, time::Duration};
 
 use gwt_core::index::watcher::{start_watcher, WatcherConfig};
 

--- a/crates/gwt-core/tests/worktree_gc.rs
+++ b/crates/gwt-core/tests/worktree_gc.rs
@@ -2,9 +2,11 @@
 
 use std::fs;
 
-use gwt_core::index::runtime::{reconcile_repo, ReconcileOptions};
-use gwt_core::repo_hash::compute_repo_hash;
-use gwt_core::worktree_hash::compute_worktree_hash;
+use gwt_core::{
+    index::runtime::{reconcile_repo, ReconcileOptions},
+    repo_hash::compute_repo_hash,
+    worktree_hash::compute_worktree_hash,
+};
 
 #[test]
 fn orphan_worktree_directory_is_removed() {

--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -3,13 +3,16 @@
 //! Provides data structures for representing Docker containers and functions
 //! to list, start, stop, and restart them via the Docker CLI.
 
+use std::{
+    ffi::OsString,
+    io::{BufRead, BufReader, Read},
+    process::{Command, Output, Stdio},
+    sync::mpsc::{self, RecvTimeoutError},
+    thread,
+    time::{Duration, Instant},
+};
+
 use gwt_core::{GwtError, Result};
-use std::ffi::OsString;
-use std::io::{BufRead, BufReader, Read};
-use std::process::{Command, Output, Stdio};
-use std::sync::mpsc::{self, RecvTimeoutError};
-use std::thread;
-use std::time::{Duration, Instant};
 use tracing::debug;
 
 /// Status of a Docker container.
@@ -675,12 +678,11 @@ pub fn restart(id: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::fs;
-    use std::io::Write;
-    use std::path::PathBuf;
-    use std::sync::Mutex;
+    use std::{fs, io::Write, path::PathBuf, sync::Mutex};
+
     use tempfile::TempDir;
+
+    use super::*;
 
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 

--- a/crates/gwt-docker/src/detect.rs
+++ b/crates/gwt-docker/src/detect.rs
@@ -3,8 +3,10 @@
 //! Checks for Docker CLI availability, daemon status, and discovers
 //! Docker-related files (Dockerfile, docker-compose.yml, .devcontainer/).
 
-use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
 use tracing::debug;
 

--- a/crates/gwt-git/src/branch.rs
+++ b/crates/gwt-git/src/branch.rs
@@ -1,7 +1,6 @@
 //! Branch information and tracking
 
-use std::collections::HashSet;
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
 use gwt_core::{GwtError, Result};
 use serde::{Deserialize, Serialize};

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -1,8 +1,10 @@
 //! Git repository discovery and inspection
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use gwt_core::{GwtError, Result};
 

--- a/crates/gwt-github/src/body.rs
+++ b/crates/gwt-github/src/body.rs
@@ -5,8 +5,7 @@
 //! routing index map, and each section's raw markdown content (regardless of
 //! whether the content physically lives in the body or a comment).
 
-use std::collections::BTreeMap;
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use regex::Regex;
 

--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -24,17 +24,19 @@
 //! All writes use a tmp-then-rename pattern so concurrent readers never see a
 //! half-written file. Directories are created on demand.
 
-use std::fs;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
-use crate::body::{ParseError, SpecBody, SpecMeta};
-use crate::client::{
-    CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt,
+use crate::{
+    body::{ParseError, SpecBody, SpecMeta},
+    client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},
+    sections::SectionName,
 };
-use crate::sections::SectionName;
 
 /// Errors reported by cache operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/gwt-github/src/client/fake.rs
+++ b/crates/gwt-github/src/client/fake.rs
@@ -5,9 +5,13 @@
 //! patterns. It is intentionally minimal — just enough to exercise the
 //! [`IssueClient`] contract in a predictable, deterministic way.
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex,
+    },
+};
 
 use crate::client::{
     ApiError, CommentId, CommentSnapshot, FetchResult, IssueClient, IssueNumber, IssueSnapshot,

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -16,8 +16,7 @@
 //! so one network round-trip covers "issue body + every comment"; mutations
 //! go through the REST endpoints.
 
-use std::process::Command;
-use std::sync::Mutex;
+use std::{process::Command, sync::Mutex};
 
 use serde_json::{json, Value};
 

--- a/crates/gwt-github/src/migration.rs
+++ b/crates/gwt-github/src/migration.rs
@@ -36,17 +36,17 @@
 //!   ...
 //! ```
 
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
-use crate::cache::Cache;
-use crate::client::IssueClient;
-use crate::sections::SectionName;
-use crate::spec_ops::SpecOps;
-use crate::SpecOpsError;
+use crate::{
+    cache::Cache, client::IssueClient, sections::SectionName, spec_ops::SpecOps, SpecOpsError,
+};
 
 /// Mapping of legacy `status` field values in `metadata.json` to the canonical
 /// `phase/*` labels used by SPEC-12.
@@ -285,8 +285,9 @@ pub struct MigratedSpec {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use tempfile::TempDir;
+
+    use super::*;
 
     fn write_spec(
         root: &Path,

--- a/crates/gwt-github/src/routing.rs
+++ b/crates/gwt-github/src/routing.rs
@@ -8,8 +8,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::body::SectionLocation;
-use crate::sections::SectionName;
+use crate::{body::SectionLocation, sections::SectionName};
 
 /// A section is auto-promoted to comment placement once its serialized size
 /// exceeds this threshold.

--- a/crates/gwt-github/src/spec_ops.rs
+++ b/crates/gwt-github/src/spec_ops.rs
@@ -7,14 +7,16 @@
 
 use std::collections::BTreeMap;
 
-use crate::body::{Comment as BodyComment, SectionLocation, SectionsIndex, SpecMeta};
-use crate::cache::{Cache, CacheError};
-use crate::client::{
-    ApiError, CommentSnapshot, FetchResult, IssueClient, IssueNumber, IssueSnapshot, IssueState,
-    UpdatedAt,
+use crate::{
+    body::{Comment as BodyComment, SectionLocation, SectionsIndex, SpecMeta},
+    cache::{Cache, CacheError},
+    client::{
+        ApiError, CommentSnapshot, FetchResult, IssueClient, IssueNumber, IssueSnapshot,
+        IssueState, UpdatedAt,
+    },
+    routing::decide_routing,
+    sections::SectionName,
 };
-use crate::routing::decide_routing;
-use crate::sections::SectionName;
 
 /// Errors surfaced by [`SpecOps`] operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/gwt-github/tests/body_test.rs
+++ b/crates/gwt-github/tests/body_test.rs
@@ -1,7 +1,9 @@
 //! Contract tests for the `body` module (SPEC-12 tdd.md Layer 2).
 
-use gwt_github::body::{Comment, ParseError, SectionLocation, SectionsIndex, SpecBody, SpecMeta};
-use gwt_github::sections::SectionName;
+use gwt_github::{
+    body::{Comment, ParseError, SectionLocation, SectionsIndex, SpecBody, SpecMeta},
+    sections::SectionName,
+};
 
 fn n(s: &str) -> SectionName {
     SectionName(s.to_string())

--- a/crates/gwt-github/tests/cache_test.rs
+++ b/crates/gwt-github/tests/cache_test.rs
@@ -1,14 +1,13 @@
 //! Contract tests for the `cache` module (SPEC-12 tdd.md Layer 6).
 
-use std::collections::BTreeMap;
-use std::fs;
+use std::{collections::BTreeMap, fs};
 
-use gwt_github::body::{Comment, SectionLocation, SectionsIndex, SpecBody, SpecMeta};
-use gwt_github::cache::{Cache, CacheEntry};
-use gwt_github::client::{
-    CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt,
+use gwt_github::{
+    body::{Comment, SectionLocation, SectionsIndex, SpecBody, SpecMeta},
+    cache::{Cache, CacheEntry},
+    client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},
+    sections::SectionName,
 };
-use gwt_github::sections::SectionName;
 use tempfile::TempDir;
 
 fn n(s: &str) -> SectionName {

--- a/crates/gwt-github/tests/client_test.rs
+++ b/crates/gwt-github/tests/client_test.rs
@@ -1,10 +1,9 @@
 //! Contract tests for the `IssueClient` trait via [`FakeIssueClient`]
 //! (SPEC-12 tdd.md Layer 4).
 
-use gwt_github::client::fake::FakeIssueClient;
 use gwt_github::client::{
-    ApiError, CommentId, CommentSnapshot, FetchResult, IssueClient, IssueNumber, IssueSnapshot,
-    IssueState, SpecListFilter, UpdatedAt,
+    fake::FakeIssueClient, ApiError, CommentId, CommentSnapshot, FetchResult, IssueClient,
+    IssueNumber, IssueSnapshot, IssueState, SpecListFilter, UpdatedAt,
 };
 
 fn seed_simple(client: &FakeIssueClient, number: u64, title: &str, body: &str) -> IssueSnapshot {

--- a/crates/gwt-github/tests/http_client_test.rs
+++ b/crates/gwt-github/tests/http_client_test.rs
@@ -6,8 +6,8 @@
 //! parsing path handles GraphQL / REST responses correctly and that status
 //! code mapping matches [`ApiError`].
 
-use gwt_github::client::http::{FakeTransport, HttpIssueClient, HttpMethod, HttpResponse};
 use gwt_github::client::{
+    http::{FakeTransport, HttpIssueClient, HttpMethod, HttpResponse},
     ApiError, CommentId, FetchResult, IssueClient, IssueNumber, IssueState, SpecListFilter,
     UpdatedAt,
 };

--- a/crates/gwt-github/tests/routing_test.rs
+++ b/crates/gwt-github/tests/routing_test.rs
@@ -2,9 +2,11 @@
 
 use std::collections::BTreeMap;
 
-use gwt_github::body::SectionLocation;
-use gwt_github::routing::{decide_routing, ROUTING_PROMOTE_THRESHOLD_BYTES};
-use gwt_github::sections::SectionName;
+use gwt_github::{
+    body::SectionLocation,
+    routing::{decide_routing, ROUTING_PROMOTE_THRESHOLD_BYTES},
+    sections::SectionName,
+};
 
 fn n(s: &str) -> SectionName {
     SectionName(s.to_string())

--- a/crates/gwt-github/tests/spec_ops_test.rs
+++ b/crates/gwt-github/tests/spec_ops_test.rs
@@ -1,10 +1,13 @@
 //! Contract tests for the `spec_ops` module (SPEC-12 tdd.md Layer 7).
 
-use gwt_github::client::fake::FakeIssueClient;
-use gwt_github::client::{IssueClient, IssueNumber, IssueSnapshot, IssueState, UpdatedAt};
-use gwt_github::sections::SectionName;
-use gwt_github::spec_ops::{SpecOps, SpecOpsError};
-use gwt_github::Cache;
+use gwt_github::{
+    client::{
+        fake::FakeIssueClient, IssueClient, IssueNumber, IssueSnapshot, IssueState, UpdatedAt,
+    },
+    sections::SectionName,
+    spec_ops::{SpecOps, SpecOpsError},
+    Cache,
+};
 use tempfile::TempDir;
 
 fn n(s: &str) -> SectionName {

--- a/crates/gwt-skills/src/distribute.rs
+++ b/crates/gwt-skills/src/distribute.rs
@@ -1,12 +1,15 @@
 //! Distribute bundled skill assets to a target worktree.
 
-use crate::assets::{CLAUDE_COMMANDS, CLAUDE_SKILLS};
+use std::{
+    collections::HashSet,
+    fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
 use include_dir::Dir;
-use std::collections::HashSet;
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+
+use crate::assets::{CLAUDE_COMMANDS, CLAUDE_SKILLS};
 
 const TRACKED_ROOTS: &[&str] = &[".claude/skills", ".claude/commands", ".codex/skills"];
 

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -1,9 +1,10 @@
 //! Manage `.git/info/exclude` entries for gwt-distributed assets.
 
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 const BEGIN_MARKER: &str = "# gwt-managed-begin";
 const END_MARKER: &str = "# gwt-managed-end";

--- a/crates/gwt-skills/src/hooks.rs
+++ b/crates/gwt-skills/src/hooks.rs
@@ -1,11 +1,14 @@
 //! Hooks management — merge managed and user hooks while preserving ownership.
 
+use std::{
+    fs::OpenOptions,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
 use chrono::Utc;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::{Path, PathBuf};
 
 /// Marker prefix that identifies gwt-managed hooks.
 const GWT_MANAGED_MARKER: &str = "# gwt-managed";

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -19,9 +19,11 @@ pub use settings_local::{generate_codex_hooks, generate_settings_local};
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use fs2::FileExt;
     use std::path::PathBuf;
+
+    use fs2::FileExt;
+
+    use super::*;
 
     // ── SkillRegistry tests ──
 

--- a/crates/gwt-skills/src/registry.rs
+++ b/crates/gwt-skills/src/registry.rs
@@ -1,7 +1,8 @@
 //! Skill registry for embedded skill management.
 
-use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
 
 /// A single embedded skill definition.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -1,10 +1,12 @@
 //! Generate `.claude/settings.local.json` with gwt-managed Claude hooks.
 
+use std::{
+    fs, io,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
 use serde_json::{json, Map, Value};
-use std::fs;
-use std::io;
-use std::io::Write;
-use std::path::{Path, PathBuf};
 
 const GWT_MANAGED_RUNTIME_MARKER: &str = "GWT_MANAGED_HOOK";
 const GWT_HOOK_CLI_PREFIX: &str = "gwt hook ";
@@ -449,8 +451,9 @@ fn powershell_coordination_hook_command(event: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::process::Command;
+
+    use super::*;
 
     #[test]
     fn creates_settings_local_with_managed_hooks() {

--- a/crates/gwt-terminal/src/lib.rs
+++ b/crates/gwt-terminal/src/lib.rs
@@ -22,7 +22,6 @@ pub use manager::PaneManager;
 pub use pane::{Pane, PaneStatus};
 pub use pty::PtyHandle;
 pub use scrollback::ScrollbackStorage;
-
 use thiserror::Error;
 
 /// Errors from the gwt-terminal subsystem.

--- a/crates/gwt-terminal/src/manager.rs
+++ b/crates/gwt-terminal/src/manager.rs
@@ -1,10 +1,8 @@
 //! Pane manager: manages multiple terminal panes.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
-use crate::pane::Pane;
-use crate::TerminalError;
+use crate::{pane::Pane, TerminalError};
 
 /// Configuration for launching an agent pane.
 pub struct LaunchConfig {

--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -1,11 +1,12 @@
 //! Terminal pane: integrates PTY handle + vt100 parser + scrollback.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
-use crate::pty::{PtyHandle, SpawnConfig};
-use crate::scrollback::{ScrollbackLine, ScrollbackStorage};
-use crate::TerminalError;
+use crate::{
+    pty::{PtyHandle, SpawnConfig},
+    scrollback::{ScrollbackLine, ScrollbackStorage},
+    TerminalError,
+};
 
 /// Status of a pane's child process.
 #[derive(Debug, Clone, PartialEq)]
@@ -159,9 +160,10 @@ impl Pane {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use crate::test_util::{lock_pty_test, read_with_timeout};
-    use std::time::Duration;
 
     #[test]
     fn test_pane_creation() {

--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -160,9 +160,10 @@ impl PtyHandle {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use crate::test_util::{lock_pty_test, read_with_timeout};
-    use std::time::Duration;
 
     fn echo_config(msg: &str) -> SpawnConfig {
         SpawnConfig {

--- a/crates/gwt-terminal/src/runtime.rs
+++ b/crates/gwt-terminal/src/runtime.rs
@@ -1,18 +1,21 @@
 //! Host terminal lifecycle and crossterm event normalization.
 
-use std::collections::VecDeque;
-use std::io;
-use std::time::{Duration, Instant};
+use std::{
+    collections::VecDeque,
+    io,
+    time::{Duration, Instant},
+};
 
-use crossterm::event::{
-    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-    Event, KeyCode, KeyEvent, KeyModifiers, KeyboardEnhancementFlags, MouseEvent, MouseEventKind,
-    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+use crossterm::{
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, KeyCode, KeyEvent, KeyModifiers, KeyboardEnhancementFlags, MouseEvent,
+        MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    Command,
 };
-use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
-};
-use crossterm::{execute, Command};
 
 const TICK_RATE: Duration = Duration::from_millis(100);
 pub const ESCAPE_SEQUENCE_TIMEOUT: Duration = Duration::from_millis(120);
@@ -129,8 +132,7 @@ fn disable_keyboard_enhancements(writer: &mut impl io::Write) {
 }
 
 fn stdin_was_initially_terminal() -> bool {
-    use std::io::IsTerminal;
-    use std::sync::OnceLock;
+    use std::{io::IsTerminal, sync::OnceLock};
 
     static WAS_TERMINAL: OnceLock<bool> = OnceLock::new();
     *WAS_TERMINAL.get_or_init(|| std::io::stdin().is_terminal())

--- a/crates/gwt-terminal/src/test_util.rs
+++ b/crates/gwt-terminal/src/test_util.rs
@@ -1,8 +1,10 @@
 //! Shared test utilities for gwt-terminal.
 
-use std::io::Read;
-use std::sync::{mpsc, Mutex, MutexGuard, OnceLock};
-use std::time::Duration;
+use std::{
+    io::Read,
+    sync::{mpsc, Mutex, MutexGuard, OnceLock},
+    time::Duration,
+};
 
 static PTY_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 

--- a/crates/gwt-terminal/tests/runtime_boundary_test.rs
+++ b/crates/gwt-terminal/tests/runtime_boundary_test.rs
@@ -3,12 +3,12 @@ use std::time::{Duration, Instant};
 use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
 };
-use gwt_terminal::protocol::{
-    build_paste_input_bytes, key_event_to_bytes, screen_requests_bracketed_paste,
-};
-use gwt_terminal::runtime::{
-    next_tick_deadline, terminal_enter_commands_ansi, terminal_leave_commands_ansi,
-    translate_crossterm_event, InputNormalizer, TerminalEvent, ESCAPE_SEQUENCE_TIMEOUT,
+use gwt_terminal::{
+    protocol::{build_paste_input_bytes, key_event_to_bytes, screen_requests_bracketed_paste},
+    runtime::{
+        next_tick_deadline, terminal_enter_commands_ansi, terminal_leave_commands_ansi,
+        translate_crossterm_event, InputNormalizer, TerminalEvent, ESCAPE_SEQUENCE_TIMEOUT,
+    },
 };
 
 fn key(code: KeyCode) -> KeyEvent {

--- a/crates/gwt-voice/src/lib.rs
+++ b/crates/gwt-voice/src/lib.rs
@@ -14,8 +14,9 @@ pub mod session;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::cell::RefCell;
+
+    use super::*;
 
     #[test]
     fn noop_backend_is_not_available() {

--- a/crates/gwt-voice/src/session.rs
+++ b/crates/gwt-voice/src/session.rs
@@ -1,7 +1,9 @@
 //! Stateful voice session orchestration.
 
-use crate::backend::{VoiceBackend, VoiceError};
-use crate::config::VoiceState;
+use crate::{
+    backend::{VoiceBackend, VoiceError},
+    config::VoiceState,
+};
 
 /// A voice session that coordinates backend start/stop/transcription.
 pub struct VoiceSession<B: VoiceBackend> {
@@ -127,8 +129,9 @@ impl<B: VoiceBackend> VoiceSession<B> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::cell::Cell;
+
+    use super::*;
 
     #[derive(Default)]
     struct FakeBackend {

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -1,6 +1,6 @@
+use std::{cmp::Ordering, path::Path};
+
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
-use std::path::Path;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -27,20 +27,21 @@ mod issue;
 mod issue_spec;
 mod pr;
 
-use std::fs;
-use std::io::{self};
-use std::path::PathBuf;
-use std::process::Command;
-
-use gwt_git::PrStatus;
-use gwt_github::{
-    cache::write_atomic, ApiError, Cache, IssueClient, IssueNumber, IssueSnapshot, IssueState,
-    SpecOpsError,
+use std::{
+    fs,
+    io::{self},
+    path::PathBuf,
+    process::Command,
 };
 
 pub(crate) use board::parse as parse_board_args;
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
+use gwt_git::PrStatus;
+use gwt_github::{
+    cache::write_atomic, ApiError, Cache, IssueClient, IssueNumber, IssueSnapshot, IssueState,
+    SpecOpsError,
+};
 
 /// Compact linked PR summary used by `gwt issue linked-prs`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -1,8 +1,10 @@
 use std::io;
 
 use gwt_agent::{session::GWT_SESSION_ID_ENV, Session};
-use gwt_core::coordination::{load_snapshot, post_entry, AuthorKind, BoardEntry};
-use gwt_core::paths::gwt_sessions_dir;
+use gwt_core::{
+    coordination::{load_snapshot, post_entry, AuthorKind, BoardEntry},
+    paths::gwt_sessions_dir,
+};
 use gwt_github::SpecOpsError;
 
 use crate::cli::{CliCommand, CliEnv, CliParseError};
@@ -197,8 +199,9 @@ fn gwt_error_to_spec_ops_error(err: gwt_core::GwtError) -> SpecOpsError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use gwt_core::coordination::BoardEntryKind;
+
+    use super::*;
 
     fn s(value: &str) -> String {
         value.to_string()

--- a/crates/gwt/src/cli/env.rs
+++ b/crates/gwt/src/cli/env.rs
@@ -1,13 +1,15 @@
-use std::collections::HashMap;
-use std::fs;
-use std::io::{self};
-use std::path::PathBuf;
+use std::{
+    collections::HashMap,
+    fs,
+    io::{self},
+    path::PathBuf,
+};
 
 use gwt_git::PrStatus;
-use gwt_github::client::fake::FakeIssueClient;
-use gwt_github::client::http::HttpIssueClient;
-use gwt_github::client::IssueClient;
-use gwt_github::{IssueNumber, SpecListFilter};
+use gwt_github::{
+    client::{fake::FakeIssueClient, http::HttpIssueClient, IssueClient},
+    IssueNumber, SpecListFilter,
+};
 
 use super::{
     parse_actions_args, parse_board_args, parse_hook_args, parse_issue_args, parse_pr_args, run,

--- a/crates/gwt/src/cli/hook/block_cd_command.rs
+++ b/crates/gwt/src/cli/hook/block_cd_command.rs
@@ -5,8 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use super::segments::split_command_segments;
-use super::{BlockDecision, HookError, HookEvent};
+use super::{segments::split_command_segments, BlockDecision, HookError, HookEvent};
 
 /// Pure evaluation: given a raw Bash command and the worktree root,
 /// return `Some(BlockDecision)` if any segment `cd`s outside the root.

--- a/crates/gwt/src/cli/hook/block_file_ops.rs
+++ b/crates/gwt/src/cli/hook/block_file_ops.rs
@@ -5,8 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use super::segments::split_command_segments;
-use super::{BlockDecision, HookError, HookEvent};
+use super::{segments::split_command_segments, BlockDecision, HookError, HookEvent};
 
 const FILE_OPS: &[&str] = &["mkdir", "rmdir", "rm", "touch", "cp", "mv"];
 

--- a/crates/gwt/src/cli/hook/block_git_branch_ops.rs
+++ b/crates/gwt/src/cli/hook/block_git_branch_ops.rs
@@ -12,8 +12,7 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
-use super::segments::split_command_segments;
-use super::{BlockDecision, HookError, HookEvent};
+use super::{segments::split_command_segments, BlockDecision, HookError, HookEvent};
 
 /// Evaluate a single raw command string. Returns `Some` if any segment
 /// triggers a block rule, `None` if every segment is allowed.

--- a/crates/gwt/src/cli/hook/coordination_event.rs
+++ b/crates/gwt/src/cli/hook/coordination_event.rs
@@ -1,9 +1,11 @@
 //! `gwt hook coordination-event <event>` — append meaningful coordination
 //! summaries to the shared Board timeline.
 
-use std::collections::HashMap;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    io,
+    path::{Path, PathBuf},
+};
 
 use gwt_agent::{Session, GWT_SESSION_ID_ENV};
 use gwt_core::{
@@ -193,13 +195,14 @@ fn coordination_as_hook_error(err: gwt_core::GwtError) -> HookError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use chrono::TimeZone;
     use gwt_agent::{AgentId, Session};
     use gwt_core::coordination::{
         coordination_events_path, load_snapshot, BoardEntry, BoardEntryKind,
     };
     use gwt_github::{CommentSnapshot, IssueSnapshot, IssueState, UpdatedAt};
+
+    use super::*;
 
     fn sample_issue_snapshot(number: u64, title: &str, labels: Vec<&str>) -> IssueSnapshot {
         IssueSnapshot {

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -5,13 +5,14 @@
 //! Ported from the retired external runtime hook and now used as the
 //! managed runtime hook implementation wired from settings.
 
-use std::io;
-use std::path::{Path, PathBuf};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 
 use chrono::{SecondsFormat, Utc};
-use serde::Serialize;
-
 use gwt_agent::{PendingDiscussionResume, Session, GWT_SESSION_ID_ENV};
+use serde::Serialize;
 
 use super::HookError;
 use crate::discussion_resume::load_pending_resume;
@@ -114,9 +115,10 @@ pub fn handle(event: &str) -> Result<(), HookError> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use gwt_agent::{AgentId, Session};
     use gwt_core::coordination::load_snapshot;
+
+    use super::*;
 
     #[test]
     fn pending_discussion_for_session_reads_active_discussion_candidate() {

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -8,11 +8,12 @@
 //!   sections before code implementation proceeds
 //! - allow read-only investigation and docs/chore-style edits
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
-use gwt_agent::session::{Session, GWT_SESSION_ID_ENV};
-use gwt_agent::types::WorkflowBypass;
+use gwt_agent::{
+    session::{Session, GWT_SESSION_ID_ENV},
+    types::WorkflowBypass,
+};
 use gwt_core::paths::{gwt_cache_dir, gwt_sessions_dir};
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;

--- a/crates/gwt/src/cli/hook/worktree.rs
+++ b/crates/gwt/src/cli/hook/worktree.rs
@@ -2,8 +2,7 @@
 //! `block-file-ops`. Shells out to `git rev-parse --show-toplevel`
 //! exactly like the Node helpers did.
 
-use std::path::PathBuf;
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 /// Return the worktree root as reported by `git rev-parse
 /// --show-toplevel`. Falls back to the current process cwd if git is

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -164,9 +164,10 @@ fn parse_issue_comment_args(args: &[&String]) -> Result<CliCommand, CliParseErro
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use gwt_github::client::{IssueSnapshot, IssueState, UpdatedAt};
     use tempfile::TempDir;
+
+    use super::*;
 
     fn s(value: &str) -> String {
         value.to_string()

--- a/crates/gwt/src/discussion_resume.rs
+++ b/crates/gwt/src/discussion_resume.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use std::io;
-use std::path::Path;
+use std::{io, path::Path};
 
 use gwt_agent::PendingDiscussionResume;
 

--- a/crates/gwt/src/file_tree.rs
+++ b/crates/gwt/src/file_tree.rs
@@ -1,8 +1,11 @@
+use std::{
+    cmp::Ordering,
+    io,
+    path::{Component, Path, PathBuf},
+};
+
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
-use std::io;
-use std::path::{Component, Path, PathBuf};
 
 const BUILTIN_SKIP_PREFIXES: &[&str] = &[
     ".git",

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use gwt_core::{
     paths::gwt_cache_dir,

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use crate::BranchListEntry;
 
@@ -2179,9 +2181,10 @@ pub fn load_quick_start_entries(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use chrono::{TimeZone, Utc};
     use tempfile::tempdir;
+
+    use super::*;
 
     fn sample_agent_options() -> Vec<AgentOption> {
         vec![

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1137,7 +1137,7 @@ impl AppRuntime {
         );
         if let Ok(gwt_bin) = std::env::current_exe() {
             config.env_vars.insert(
-                gwt_agent::GWT_BIN_PATH_ENV.to_string(),
+                gwt_agent::session::GWT_BIN_PATH_ENV.to_string(),
                 gwt_bin.display().to_string(),
             );
         }
@@ -2058,7 +2058,7 @@ fn apply_docker_runtime_to_launch_config(
         .insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
     // Override GWT_BIN_PATH for Docker containers to use the mounted binary
     config.env_vars.insert(
-        gwt_agent::GWT_BIN_PATH_ENV.to_string(),
+        gwt_agent::session::GWT_BIN_PATH_ENV.to_string(),
         "/usr/local/bin/gwt".to_string(),
     );
     config.docker_service = Some(launch.service);

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1135,6 +1135,12 @@ impl AppRuntime {
             gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV.to_string(),
             runtime_path.display().to_string(),
         );
+        if let Ok(gwt_bin) = std::env::current_exe() {
+            config.env_vars.insert(
+                gwt_agent::GWT_BIN_PATH_ENV.to_string(),
+                gwt_bin.display().to_string(),
+            );
+        }
         config
             .env_vars
             .entry("COLORTERM".to_string())
@@ -2028,6 +2034,7 @@ fn apply_docker_runtime_to_launch_config(
     let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
     ensure_docker_launch_runtime_ready()?;
     ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
+    ensure_docker_gwt_binary_setup(&worktree)?;
     maybe_inject_docker_sandbox_env(&launch, config)?;
     let runtime_program = resolve_docker_exec_program(&launch, config)?;
 
@@ -2049,6 +2056,11 @@ fn apply_docker_runtime_to_launch_config(
     config
         .env_vars
         .insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
+    // Override GWT_BIN_PATH for Docker containers to use the mounted binary
+    config.env_vars.insert(
+        gwt_agent::GWT_BIN_PATH_ENV.to_string(),
+        "/usr/local/bin/gwt".to_string(),
+    );
     config.docker_service = Some(launch.service);
     Ok(())
 }
@@ -2063,6 +2075,59 @@ fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
     if !gwt_docker::daemon_running() {
         return Err("Docker daemon is not running".to_string());
     }
+    Ok(())
+}
+
+fn ensure_docker_gwt_binary_setup(repo_path: &Path) -> Result<(), String> {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let home = if cfg!(windows) {
+        std::env::var("USERPROFILE")
+    } else {
+        std::env::var("HOME")
+    }
+    .map(PathBuf::from)
+    .map_err(|_| "Could not determine home directory".to_string())?;
+
+    let gwt_bin_dir = home.join(".gwt").join("bin");
+    let gwt_linux = gwt_bin_dir.join("gwt-linux");
+
+    // Check if Linux gwt binary exists
+    if !gwt_linux.exists() {
+        // TODO: Download Linux gwt binary from GitHub Release
+        // For now, create a note for the user
+        let override_path = repo_path.join("docker-compose.override.yml");
+        if !override_path.exists() {
+            eprintln!(
+                "Note: Linux gwt binary not found at ~/.gwt/bin/gwt-linux\n\
+                 This is required for Docker agent support.\n\
+                 You can either:\n\
+                 1. Download gwt-linux-x86_64 from GitHub Releases and place it at ~/.gwt/bin/gwt-linux\n\
+                 2. Run 'gwt setup docker' to set up Docker integration automatically"
+            );
+        }
+    }
+
+    // Ensure docker-compose.override.yml exists with gwt volume mount
+    let override_path = repo_path.join("docker-compose.override.yml");
+    if !override_path.exists() {
+        let override_content = "# Auto-generated docker-compose override for gwt binary mounting\n\
+                                version: '3.8'\n\
+                                services:\n\
+                                  # Add your service name and uncomment the volumes section\n\
+                                  # <service>:\n\
+                                  #   volumes:\n\
+                                  #     - ~/.gwt/bin/gwt-linux:/usr/local/bin/gwt:ro\n";
+        fs::write(&override_path, override_content).map_err(|err| {
+            format!(
+                "Failed to create docker-compose.override.yml: {err}\n\
+                 Manually create {} with gwt volume mount",
+                override_path.display()
+            )
+        })?;
+    }
+
     Ok(())
 }
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1521,10 +1521,12 @@ fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_project_target, should_auto_start_restored_window};
-    use gwt::{PersistedWindowState, WindowGeometry, WindowPreset, WindowProcessStatus};
     use std::{fs, process::Command};
+
+    use gwt::{PersistedWindowState, WindowGeometry, WindowPreset, WindowProcessStatus};
     use tempfile::tempdir;
+
+    use super::{resolve_project_target, should_auto_start_restored_window};
 
     fn sample_window(preset: WindowPreset, status: WindowProcessStatus) -> PersistedWindowState {
         PersistedWindowState {
@@ -2079,8 +2081,7 @@ fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
 }
 
 fn ensure_docker_gwt_binary_setup(repo_path: &Path) -> Result<(), String> {
-    use std::fs;
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
 
     let home = if cfg!(windows) {
         std::env::var("USERPROFILE")

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::path::Path;
+use std::{io, path::Path};
 
 use gwt_skills::{
     distribute_to_worktree, generate_codex_hooks, generate_settings_local, update_git_exclude,

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -1,6 +1,8 @@
-use crate::preset::WindowPreset;
-use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::preset::WindowPreset;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WindowGeometry {
@@ -323,8 +325,9 @@ pub fn project_title_from_path(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use tempfile::tempdir;
+
+    use super::*;
 
     #[test]
     fn empty_workspace_contains_no_windows() {

--- a/crates/gwt/src/preset.rs
+++ b/crates/gwt/src/preset.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::path::Path;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1,11 +1,14 @@
-use crate::branch_list::BranchListEntry;
-use crate::file_tree::FileTreeEntry;
-use crate::launch_wizard::{LaunchWizardAction, LaunchWizardView};
-use crate::persistence::{
-    CanvasViewport, PersistedWindowState, ProjectKind, WindowGeometry, WindowProcessStatus,
-};
-use crate::preset::WindowPreset;
 use serde::{Deserialize, Serialize};
+
+use crate::{
+    branch_list::BranchListEntry,
+    file_tree::FileTreeEntry,
+    launch_wizard::{LaunchWizardAction, LaunchWizardView},
+    persistence::{
+        CanvasViewport, PersistedWindowState, ProjectKind, WindowGeometry, WindowProcessStatus,
+    },
+    preset::WindowPreset,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -1,9 +1,11 @@
-use crate::persistence::{
-    CanvasViewport, PersistedWindowState, PersistedWorkspaceState, WindowGeometry,
-    WindowProcessStatus,
+use crate::{
+    persistence::{
+        CanvasViewport, PersistedWindowState, PersistedWorkspaceState, WindowGeometry,
+        WindowProcessStatus,
+    },
+    preset::WindowPreset,
+    protocol::{ArrangeMode, FocusCycleDirection},
 };
-use crate::preset::WindowPreset;
-use crate::protocol::{ArrangeMode, FocusCycleDirection};
 
 const ARRANGE_PADDING: f64 = 24.0;
 const STACK_OFFSET_X: f64 = 28.0;
@@ -348,8 +350,10 @@ impl WorkspaceState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::persistence::{default_workspace_state, WindowProcessStatus};
-    use crate::protocol::FocusCycleDirection;
+    use crate::{
+        persistence::{default_workspace_state, WindowProcessStatus},
+        protocol::FocusCycleDirection,
+    };
 
     fn arrange_bounds() -> WindowGeometry {
         WindowGeometry {

--- a/crates/gwt/tests/cli_test.rs
+++ b/crates/gwt/tests/cli_test.rs
@@ -6,10 +6,10 @@ use gwt::cli::{
     PrReview, PrReviewThread, PrReviewThreadComment, TestEnv,
 };
 use gwt_git::PrStatus;
-use gwt_github::client::{
-    CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt,
+use gwt_github::{
+    client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},
+    Cache, SectionName,
 };
-use gwt_github::{Cache, SectionName};
 use tempfile::TempDir;
 
 fn s(v: &str) -> String {

--- a/crates/gwt/tests/hook_runtime_state_test.rs
+++ b/crates/gwt/tests/hook_runtime_state_test.rs
@@ -14,8 +14,10 @@
 
 use std::fs;
 
-use gwt::cli::hook::runtime_state::{self, RuntimeState};
-use gwt::cli::hook::HookError;
+use gwt::cli::hook::{
+    runtime_state::{self, RuntimeState},
+    HookError,
+};
 
 #[test]
 fn write_for_event_pretooluse_maps_to_running() {

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -1,13 +1,17 @@
 //! T-112 (SPEC #1935) — workflow-policy gating tests.
 
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::{
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
 
 use gwt::cli::hook::{workflow_policy, HookEvent};
 use gwt_agent::{session::GWT_SESSION_ID_ENV, AgentId, Session};
 use gwt_core::{paths::gwt_sessions_dir, repo_hash::compute_repo_hash};
-use gwt_github::client::{IssueNumber, IssueSnapshot, IssueState, UpdatedAt};
-use gwt_github::Cache;
+use gwt_github::{
+    client::{IssueNumber, IssueSnapshot, IssueState, UpdatedAt},
+    Cache,
+};
 use serde_json::json;
 use tempfile::TempDir;
 

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -3,9 +3,8 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use tempfile::tempdir;
-
 use gwt::refresh_managed_gwt_assets_for_worktree;
+use tempfile::tempdir;
 
 #[test]
 fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() {


### PR DESCRIPTION
## Summary

- linux-aarch64 ビルドをクロスコンパイルからネイティブ ARM64 ランナー (`ubuntu-24.04-arm`) に切り替え
- `gwt_agent::GWT_BIN_PATH_ENV` の参照パスを `gwt_agent::session::GWT_BIN_PATH_ENV` に修正

## Context

v9.1.0 release workflow で linux-aarch64 のクロスコンパイルが WebView 依存パッケージ不足で失敗。
ネイティブ ARM64 ランナーに切り替えることでクロスコンパイル依存を排除。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline with updated Linux ARM64 runner configuration and consolidated WebView dependency installation.

* **New Features**
  * Agent processes now expose the binary path through environment variables, enabling skills to access the CLI for GitHub operations.
  * Docker agent launches now automatically configure required binary mounts, streamlining containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->