### PR TITLE
chore: remove nightly-only rustfmt options for stable Rust compatibility

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2479,11 +2479,7 @@ mod tests {
         let mut ctx = context(branch("feature/gui"), "feature/gui");
         ctx.linked_issue_number = Some(1234);
 
-        let state = LaunchWizardState::open_with(
-            ctx,
-            sample_agent_options(),
-            Vec::new(),
-        );
+        let state = LaunchWizardState::open_with(ctx, sample_agent_options(), Vec::new());
 
         let config = state.build_launch_config().expect("config");
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -288,9 +288,11 @@ impl AppRuntime {
                     self.load_branches_event(&id),
                 )]
             }
-            FrontendEvent::OpenLaunchWizard { id, branch_name, linked_issue_number } => {
-                self.open_launch_wizard(&id, &branch_name, linked_issue_number)
-            }
+            FrontendEvent::OpenLaunchWizard {
+                id,
+                branch_name,
+                linked_issue_number,
+            } => self.open_launch_wizard(&id, &branch_name, linked_issue_number),
             FrontendEvent::LaunchWizardAction { action } => {
                 self.handle_launch_wizard_action(action)
             }
@@ -787,7 +789,12 @@ impl AppRuntime {
         }
     }
 
-    fn open_launch_wizard(&mut self, id: &str, branch_name: &str, linked_issue_number: Option<u64>) -> Vec<OutboundEvent> {
+    fn open_launch_wizard(
+        &mut self,
+        id: &str,
+        branch_name: &str,
+        linked_issue_number: Option<u64>,
+    ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id).cloned() else {
             return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
                 id: id.to_string(),
@@ -1207,16 +1214,18 @@ impl AppRuntime {
                                 serde_json::Map::new()
                             };
 
-                        let mut branches: serde_json::Map<String, serde_json::Value> =
-                            linkage_map.get("branches")
-                                .and_then(|v| v.as_object())
-                                .cloned()
-                                .unwrap_or_default();
+                        let mut branches: serde_json::Map<String, serde_json::Value> = linkage_map
+                            .get("branches")
+                            .and_then(|v| v.as_object())
+                            .cloned()
+                            .unwrap_or_default();
 
                         branches.insert(branch.to_string(), json!(issue_number));
-                        linkage_map.insert("branches".to_string(), serde_json::Value::Object(branches));
+                        linkage_map
+                            .insert("branches".to_string(), serde_json::Value::Object(branches));
 
-                        let json_content = serde_json::to_string_pretty(&linkage_map).unwrap_or_default();
+                        let json_content =
+                            serde_json::to_string_pretty(&linkage_map).unwrap_or_default();
                         let _ = fs::write(&cache_file, json_content);
                     }
                     Ok::<(), String>(())

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,6 +3,4 @@ edition = "2021"
 max_width = 100
 tab_spaces = 4
 use_small_heuristics = "Default"
-imports_granularity = "Crate"
-group_imports = "StdExternalCrate"
 reorder_imports = true


### PR DESCRIPTION
## Summary

Remove nightly-only rustfmt configuration options to enable stable Rust CI compatibility.

## Changes

- Remove `imports_granularity = "Crate"` option (nightly-only)
- Remove `group_imports = "StdExternalCrate"` option (nightly-only)
- Retain `reorder_imports = true` for basic import organization on stable Rust

## Why

The current `rustfmt.toml` configuration includes two nightly-only options that cause rustfmt to fail on stable Rust CI. This blocks PR merges despite code quality checks passing. The removed options primarily affect import grouping rules; their removal has minimal impact since `reorder_imports = true` provides basic import sorting on stable.

## Testing

- [ ] Verify rustfmt passes on stable Rust: `cargo fmt --check`
- [ ] Verify imports remain properly ordered in modified files
- [ ] CI passes without rustfmt failures

## Closing Issues

None

## Related Issues

akiojin/gwt#2038 (prior PR with same rustfmt CI issue)

## Checklist

- [x] Self-review: changes are minimal and focused
- [x] No breaking changes or new dependencies
