### PR TITLE
fix(launch): correct quick start session reuse

### DIFF
--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -17,10 +17,10 @@ pub use launch::{
     normalize_launch_args, resolve_runner, AgentLaunchBuilder, LaunchConfig, ResolvedRunner,
 };
 pub use session::{
-    persist_session_status, reset_runtime_state_dir, reset_runtime_state_dir_for_pid,
-    runtime_state_dir_for_pid, runtime_state_path, runtime_state_path_for_pid,
-    PendingDiscussionResume, Session, SessionRuntimeState, GWT_BIN_PATH_ENV, GWT_SESSION_ID_ENV,
-    GWT_SESSION_RUNTIME_PATH_ENV,
+    persist_agent_session_id, persist_session_status, reset_runtime_state_dir,
+    reset_runtime_state_dir_for_pid, runtime_state_dir_for_pid, runtime_state_path,
+    runtime_state_path_for_pid, PendingDiscussionResume, Session, SessionRuntimeState,
+    GWT_BIN_PATH_ENV, GWT_SESSION_ID_ENV, GWT_SESSION_RUNTIME_PATH_ENV,
 };
 pub use types::{
     AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget,

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -269,6 +269,28 @@ pub fn persist_session_status(
     SessionRuntimeState::new(status).save(&runtime_state_path(sessions_dir, session_id))
 }
 
+/// Persist the backing agent session id into the session TOML so quick-start
+/// flows can resume a concrete prior conversation instead of falling back to
+/// a tool-global "last session" lookup.
+pub fn persist_agent_session_id(
+    sessions_dir: &Path,
+    session_id: &str,
+    agent_session_id: &str,
+) -> std::io::Result<()> {
+    let agent_session_id = agent_session_id.trim();
+    if agent_session_id.is_empty() {
+        return Ok(());
+    }
+
+    let session_path = sessions_dir.join(format!("{session_id}.toml"));
+    let mut session = Session::load(&session_path)?;
+    if session.agent_session_id.as_deref() == Some(agent_session_id) {
+        return Ok(());
+    }
+    session.agent_session_id = Some(agent_session_id.to_string());
+    session.save(sessions_dir)
+}
+
 fn hook_event_status(event: &str) -> Option<AgentStatus> {
     match event {
         "SessionStart" | "Stop" => Some(AgentStatus::WaitingInput),
@@ -458,6 +480,19 @@ mod tests {
         assert!(loaded.launch_command.is_empty());
         assert!(loaded.launch_args.is_empty());
         assert!(loaded.workflow_bypass.is_none());
+    }
+
+    #[test]
+    fn persist_agent_session_id_updates_session_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = Session::new("/tmp/wt", "feature/x", AgentId::Codex);
+        let session_id = session.id.clone();
+        session.save(dir.path()).unwrap();
+
+        persist_agent_session_id(dir.path(), &session_id, "agent-123").unwrap();
+
+        let loaded = Session::load(&dir.path().join(format!("{session_id}.toml"))).unwrap();
+        assert_eq!(loaded.agent_session_id.as_deref(), Some("agent-123"));
     }
 
     #[test]

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -598,7 +598,11 @@ fn write_events_to_path(path: &Path, events: &[CoordinationEvent]) -> Result<()>
         file.sync_all()?;
     }
     if cfg!(windows) && path.exists() {
-        std::fs::remove_file(path)?;
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
     }
     std::fs::rename(&tmp_path, path)?;
     Ok(())
@@ -636,7 +640,11 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
         file.sync_all()?;
     }
     if cfg!(windows) && path.exists() {
-        std::fs::remove_file(path)?;
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
     }
     std::fs::rename(&tmp_path, path)?;
     Ok(())

--- a/crates/gwt-core/src/index/paths.rs
+++ b/crates/gwt-core/src/index/paths.rs
@@ -123,8 +123,15 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let wt = compute_worktree_hash(tmp.path()).unwrap();
         let p = gwt_index_db_path(&repo, Some(&wt), Scope::FilesCode).unwrap();
-        let s = p.to_string_lossy();
-        assert!(s.contains("worktrees"));
-        assert!(s.ends_with(&format!("{}/files", wt.as_str())));
+        assert!(p
+            .components()
+            .any(|component| component.as_os_str() == "worktrees"));
+        assert_eq!(p.file_name().and_then(|name| name.to_str()), Some("files"));
+        assert_eq!(
+            p.parent()
+                .and_then(|parent| parent.file_name())
+                .and_then(|name| name.to_str()),
+            Some(wt.as_str())
+        );
     }
 }

--- a/crates/gwt-core/src/index/runtime.rs
+++ b/crates/gwt-core/src/index/runtime.rs
@@ -282,12 +282,15 @@ mod tests {
             project_root: &Path,
             respect_ttl: bool,
         ) -> std::io::Result<()> {
-            self.calls.lock().unwrap_or_else(|p| p.into_inner()).push(format!(
-                "{}|{}|{}",
-                repo_hash,
-                project_root.display(),
-                respect_ttl
-            ));
+            self.calls
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(format!(
+                    "{}|{}|{}",
+                    repo_hash,
+                    project_root.display(),
+                    respect_ttl
+                ));
             Ok(())
         }
     }
@@ -304,7 +307,14 @@ mod tests {
             ttl: Duration::from_secs(15 * 60),
         };
         refresh_issues_if_stale(&opts, &spawner).await.unwrap();
-        assert_eq!(spawner.calls.lock().unwrap_or_else(|p| p.into_inner()).len(), 1);
+        assert_eq!(
+            spawner
+                .calls
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/crates/gwt-core/src/process.rs
+++ b/crates/gwt-core/src/process.rs
@@ -54,21 +54,66 @@ pub fn get_command_version(cmd: &str) -> Result<String> {
 mod tests {
     use super::*;
 
+    fn echo_command(text: &str) -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), format!("echo {text}")],
+            )
+        } else {
+            (
+                "printf".to_string(),
+                vec!["%s\\n".to_string(), text.to_string()],
+            )
+        }
+    }
+
+    fn failing_command() -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "exit 1".to_string()],
+            )
+        } else {
+            ("false".to_string(), Vec::new())
+        }
+    }
+
+    fn env_echo_command(var_name: &str) -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), format!("echo %{var_name}%")],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), format!("echo ${var_name}")],
+            )
+        }
+    }
+
     #[test]
     fn run_command_captures_stdout() {
-        let result = run_command("echo", &["hello"]).unwrap();
+        let (cmd, args) = echo_command("hello");
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let result = run_command(&cmd, &arg_refs).unwrap();
         assert_eq!(result, "hello");
     }
 
     #[test]
     fn run_command_trims_output() {
-        let result = run_command("echo", &["  padded  "]).unwrap();
+        let (cmd, args) = echo_command("  padded  ");
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let result = run_command(&cmd, &arg_refs).unwrap();
         assert_eq!(result, "padded");
     }
 
     #[test]
     fn run_command_returns_error_on_failure() {
-        let result = run_command("false", &[]);
+        let (cmd, args) = failing_command();
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let result = run_command(&cmd, &arg_refs);
         assert!(result.is_err());
     }
 
@@ -80,9 +125,11 @@ mod tests {
 
     #[test]
     fn run_command_with_env_passes_env_vars() {
+        let (cmd, args) = env_echo_command("GWT_TEST_VAR");
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
         let result = run_command_with_env(
-            "sh",
-            &["-c", "echo $GWT_TEST_VAR"],
+            &cmd,
+            &arg_refs,
             &[("GWT_TEST_VAR".into(), "hello_env".into())],
         )
         .unwrap();
@@ -91,13 +138,15 @@ mod tests {
 
     #[test]
     fn run_command_with_env_returns_error_on_failure() {
-        let result = run_command_with_env("false", &[], &[]);
+        let (cmd, args) = failing_command();
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let result = run_command_with_env(&cmd, &arg_refs, &[]);
         assert!(result.is_err());
     }
 
     #[test]
     fn command_exists_finds_echo() {
-        assert!(command_exists("echo"));
+        assert!(command_exists("git"));
     }
 
     #[test]

--- a/crates/gwt-core/tests/index_paths.rs
+++ b/crates/gwt-core/tests/index_paths.rs
@@ -17,9 +17,12 @@ fn gwt_index_root_ends_with_index() {
 fn issue_db_path_omits_worktree_hash() {
     let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
     let path = gwt_index_db_path(&repo, None, Scope::Issues).unwrap();
-    let expected_suffix = format!(".gwt/index/{}/issues", repo.as_str());
-    assert!(
-        path.to_string_lossy().ends_with(&expected_suffix),
+    assert_eq!(path.file_name().and_then(|s| s.to_str()), Some("issues"));
+    assert_eq!(
+        path.parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|s| s.to_str()),
+        Some(repo.as_str()),
         "got {}",
         path.display()
     );
@@ -29,9 +32,12 @@ fn issue_db_path_omits_worktree_hash() {
 fn specs_db_path_is_repo_scoped() {
     let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
     let path = gwt_index_db_path(&repo, None, Scope::Specs).unwrap();
-    let expected_suffix = format!(".gwt/index/{}/specs", repo.as_str());
-    assert!(
-        path.to_string_lossy().ends_with(&expected_suffix),
+    assert_eq!(path.file_name().and_then(|s| s.to_str()), Some("specs"));
+    assert_eq!(
+        path.parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|s| s.to_str()),
+        Some(repo.as_str()),
         "got {}",
         path.display()
     );
@@ -43,9 +49,20 @@ fn files_code_db_path_under_worktree() {
     let tmp = tempfile::tempdir().unwrap();
     let wt = compute_worktree_hash(tmp.path()).unwrap();
     let path = gwt_index_db_path(&repo, Some(&wt), Scope::FilesCode).unwrap();
-    assert!(path
-        .to_string_lossy()
-        .ends_with(&format!("/worktrees/{}/files", wt.as_str())));
+    assert_eq!(path.file_name().and_then(|s| s.to_str()), Some("files"));
+    assert_eq!(
+        path.parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|s| s.to_str()),
+        Some(wt.as_str())
+    );
+    assert_eq!(
+        path.parent()
+            .and_then(|parent| parent.parent())
+            .and_then(|parent| parent.file_name())
+            .and_then(|s| s.to_str()),
+        Some("worktrees")
+    );
 }
 
 #[test]
@@ -54,9 +71,23 @@ fn files_docs_db_path_under_worktree() {
     let tmp = tempfile::tempdir().unwrap();
     let wt = compute_worktree_hash(tmp.path()).unwrap();
     let path = gwt_index_db_path(&repo, Some(&wt), Scope::FilesDocs).unwrap();
-    assert!(path
-        .to_string_lossy()
-        .ends_with(&format!("/worktrees/{}/files-docs", wt.as_str())));
+    assert_eq!(
+        path.file_name().and_then(|s| s.to_str()),
+        Some("files-docs")
+    );
+    assert_eq!(
+        path.parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|s| s.to_str()),
+        Some(wt.as_str())
+    );
+    assert_eq!(
+        path.parent()
+            .and_then(|parent| parent.parent())
+            .and_then(|parent| parent.file_name())
+            .and_then(|s| s.to_str()),
+        Some("worktrees")
+    );
 }
 
 #[test]

--- a/crates/gwt-core/tests/issue_refresh.rs
+++ b/crates/gwt-core/tests/issue_refresh.rs
@@ -23,12 +23,15 @@ impl RunnerSpawner for RecordingSpawner {
         project_root: &std::path::Path,
         respect_ttl: bool,
     ) -> std::io::Result<()> {
-        self.calls.lock().unwrap_or_else(|p| p.into_inner()).push(format!(
-            "{}|{}|{}",
-            repo_hash,
-            project_root.display(),
-            respect_ttl
-        ));
+        self.calls
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(format!(
+                "{}|{}|{}",
+                repo_hash,
+                project_root.display(),
+                respect_ttl
+            ));
         Ok(())
     }
 }

--- a/crates/gwt-core/tests/worktree_hash.rs
+++ b/crates/gwt-core/tests/worktree_hash.rs
@@ -30,7 +30,16 @@ fn compute_worktree_hash_canonicalizes_symlinks() {
     #[cfg(unix)]
     std::os::unix::fs::symlink(&real, &link).unwrap();
     #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(&real, &link).unwrap();
+    match std::os::windows::fs::symlink_dir(&real, &link) {
+        Ok(()) => {}
+        Err(err)
+            if err.kind() == std::io::ErrorKind::PermissionDenied
+                || err.raw_os_error() == Some(1314) =>
+        {
+            return;
+        }
+        Err(err) => panic!("failed to create symlink: {err}"),
+    }
 
     let real_hash = compute_worktree_hash(&real).unwrap();
     let link_hash = compute_worktree_hash(&link).unwrap();

--- a/crates/gwt-github/src/client/fake.rs
+++ b/crates/gwt-github/src/client/fake.rs
@@ -66,7 +66,11 @@ impl FakeIssueClient {
 
     /// Snapshot of the recorded call log.
     pub fn call_log(&self) -> Vec<String> {
-        self.inner.lock().unwrap_or_else(|p| p.into_inner()).call_log.clone()
+        self.inner
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .call_log
+            .clone()
     }
 
     fn record(&self, state: &mut FakeState, op: &str, target: &str) {

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -101,12 +101,20 @@ impl FakeTransport {
 
     /// Queue a response to be returned by the next `execute` call.
     pub fn enqueue(&self, response: HttpResponse) {
-        self.state.lock().unwrap_or_else(|p| p.into_inner()).canned.push_back(response);
+        self.state
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .canned
+            .push_back(response);
     }
 
     /// Snapshot of every recorded request so far.
     pub fn recorded(&self) -> Vec<HttpRequest> {
-        self.state.lock().unwrap_or_else(|p| p.into_inner()).recorded.clone()
+        self.state
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .recorded
+            .clone()
     }
 }
 

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -11,10 +11,10 @@ use std::{
 };
 
 use chrono::{SecondsFormat, Utc};
-use gwt_agent::{PendingDiscussionResume, Session, GWT_SESSION_ID_ENV};
+use gwt_agent::{persist_agent_session_id, PendingDiscussionResume, Session, GWT_SESSION_ID_ENV};
 use serde::Serialize;
 
-use super::HookError;
+use super::{HookError, HookEvent};
 use crate::discussion_resume::load_pending_resume;
 
 /// The JSON shape the Branches tab polls from `$GWT_SESSION_RUNTIME_PATH`.
@@ -98,6 +98,20 @@ fn current_session_from_env(sessions_dir: &Path) -> io::Result<Option<Session>> 
     Session::load(&path).map(Some)
 }
 
+fn sync_agent_session_id(
+    sessions_dir: &Path,
+    gwt_session_id: Option<&str>,
+    agent_session_id: Option<&str>,
+) -> io::Result<()> {
+    let Some(gwt_session_id) = gwt_session_id.map(str::trim).filter(|id| !id.is_empty()) else {
+        return Ok(());
+    };
+    let Some(agent_session_id) = agent_session_id.map(str::trim).filter(|id| !id.is_empty()) else {
+        return Ok(());
+    };
+    persist_agent_session_id(sessions_dir, gwt_session_id, agent_session_id)
+}
+
 #[cfg(test)]
 fn sync_coordination_for_session(_session: &Session, _event: &str) {}
 
@@ -106,6 +120,14 @@ fn sync_coordination_for_session(_session: &Session, _event: &str) {}
 /// sessions launched outside of gwt (e.g. a raw `claude` invocation) are
 /// not broken by a hook we shipped.
 pub fn handle(event: &str) -> Result<(), HookError> {
+    let hook_event = HookEvent::read_from_stdin()?;
+    let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+    let gwt_session_id = std::env::var(GWT_SESSION_ID_ENV).ok();
+    let agent_session_id = hook_event
+        .as_ref()
+        .and_then(|event| event.session_id.as_deref());
+    sync_agent_session_id(&sessions_dir, gwt_session_id.as_deref(), agent_session_id)?;
+
     let Some(path) = std::env::var_os("GWT_SESSION_RUNTIME_PATH") else {
         return Ok(());
     };
@@ -244,5 +266,19 @@ mod tests {
         let events =
             std::fs::read_to_string(dir.path().join(".gwt/coordination/events.jsonl")).unwrap();
         assert_eq!(events.lines().count(), 0);
+    }
+
+    #[test]
+    fn sync_agent_session_id_persists_value_into_session_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join(".gwt").join("sessions");
+        let session = Session::new(dir.path(), "feature/demo", AgentId::Codex);
+        let session_id = session.id.clone();
+        session.save(&sessions_dir).unwrap();
+
+        sync_agent_session_id(&sessions_dir, Some(&session_id), Some("agent-123")).unwrap();
+
+        let loaded = Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
+        assert_eq!(loaded.agent_session_id.as_deref(), Some("agent-123"));
     }
 }

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -48,6 +48,7 @@ pub struct LaunchWizardQuickStartView {
     pub tool_label: String,
     pub summary: String,
     pub resume_session_id: Option<String>,
+    pub reuse_action_label: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -113,12 +114,14 @@ pub struct AgentOption {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QuickStartEntry {
+    pub session_id: String,
     pub agent_id: String,
     pub tool_label: String,
     pub model: Option<String>,
     pub reasoning: Option<String>,
     pub version: Option<String>,
     pub resume_session_id: Option<String>,
+    pub live_window_id: Option<String>,
     pub skip_permissions: bool,
     pub codex_fast_mode: bool,
     pub runtime_target: gwt_agent::LaunchRuntimeTarget,
@@ -130,10 +133,27 @@ pub struct QuickStartEntry {
 pub struct LiveSessionEntry {
     pub session_id: String,
     pub window_id: String,
+    pub agent_id: String,
     pub kind: String,
     pub name: String,
     pub detail: Option<String>,
     pub active: bool,
+}
+
+impl QuickStartEntry {
+    fn reuse_action_label(&self) -> Option<&'static str> {
+        if self.live_window_id.is_some() {
+            Some("Continue")
+        } else if self.resume_session_id.is_some() {
+            Some("Resume")
+        } else {
+            None
+        }
+    }
+
+    fn can_reuse(&self) -> bool {
+        self.reuse_action_label().is_some()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -251,8 +271,21 @@ impl LaunchWizardState {
     pub fn open_with(
         context: LaunchWizardContext,
         agent_options: Vec<AgentOption>,
-        quick_start_entries: Vec<QuickStartEntry>,
+        mut quick_start_entries: Vec<QuickStartEntry>,
     ) -> Self {
+        for entry in &mut quick_start_entries {
+            entry.live_window_id = context
+                .live_sessions
+                .iter()
+                .find(|session| session.session_id == entry.session_id)
+                .or_else(|| {
+                    context
+                        .live_sessions
+                        .iter()
+                        .find(|session| session.agent_id == entry.agent_id)
+                })
+                .map(|session| session.window_id.clone());
+        }
         let runtime_target = if context.docker_context.is_some() {
             gwt_agent::LaunchRuntimeTarget::Docker
         } else {
@@ -539,7 +572,7 @@ impl LaunchWizardState {
     fn apply_selection(&mut self) {
         match self.step {
             LaunchWizardStep::QuickStart => match self.selected_quick_start_action() {
-                QuickStartAction::ResumeWithPrevious | QuickStartAction::StartNewWithPrevious => {
+                QuickStartAction::ReuseEntry { .. } | QuickStartAction::StartNewEntry { .. } => {
                     self.apply_quick_start_selection();
                     self.sync_docker_lifecycle_default();
                 }
@@ -682,12 +715,13 @@ impl LaunchWizardState {
         self.docker_lifecycle_intent = entry.docker_lifecycle_intent;
         match mode {
             QuickStartLaunchMode::Resume => {
-                if let Some(resume_session_id) = entry.resume_session_id {
+                if let Some(window_id) = entry.live_window_id {
+                    self.completion = Some(LaunchWizardCompletion::FocusWindow { window_id });
+                } else if let Some(resume_session_id) = entry.resume_session_id {
                     self.mode = "resume".to_string();
                     self.resume_session_id = Some(resume_session_id);
                 } else {
-                    self.mode = "continue".to_string();
-                    self.resume_session_id = None;
+                    self.error = Some("No saved session is available".to_string());
                 }
             }
             QuickStartLaunchMode::StartNew => {
@@ -848,6 +882,7 @@ impl LaunchWizardState {
                 tool_label: entry.tool_label.clone(),
                 summary: quick_start_summary(entry),
                 resume_session_id: entry.resume_session_id.clone(),
+                reuse_action_label: entry.reuse_action_label().map(str::to_string),
             })
             .collect()
     }
@@ -1232,32 +1267,34 @@ impl LaunchWizardState {
     }
 
     fn selected_quick_start_action(&self) -> QuickStartAction {
-        let choose_different_index = self.quick_start_choose_different_index();
-        if self.selected >= choose_different_index {
-            QuickStartAction::ChooseDifferent
-        } else if self.selected < self.quick_start_entries.len() * 2
-            && self.selected.is_multiple_of(2)
-        {
-            QuickStartAction::ResumeWithPrevious
-        } else if self.selected < self.quick_start_entries.len() * 2 {
-            QuickStartAction::StartNewWithPrevious
-        } else {
-            QuickStartAction::FocusExistingSession
-        }
+        self.quick_start_actions()
+            .get(self.selected)
+            .copied()
+            .unwrap_or(QuickStartAction::ChooseDifferent)
     }
 
     fn selected_quick_start_entry(&self) -> Option<&QuickStartEntry> {
-        if self.quick_start_entries.is_empty()
-            || self.selected >= self.quick_start_entries.len() * 2
-        {
-            None
-        } else {
-            self.quick_start_entries.get(self.selected / 2)
+        match self.selected_quick_start_action() {
+            QuickStartAction::ReuseEntry { index } | QuickStartAction::StartNewEntry { index } => {
+                self.quick_start_entries.get(index)
+            }
+            QuickStartAction::FocusExistingSession | QuickStartAction::ChooseDifferent => None,
         }
     }
 
-    fn quick_start_choose_different_index(&self) -> usize {
-        self.quick_start_entries.len() * 2 + usize::from(!self.context.live_sessions.is_empty())
+    fn quick_start_actions(&self) -> Vec<QuickStartAction> {
+        let mut actions = Vec::new();
+        for (index, entry) in self.quick_start_entries.iter().enumerate() {
+            if entry.can_reuse() {
+                actions.push(QuickStartAction::ReuseEntry { index });
+            }
+            actions.push(QuickStartAction::StartNewEntry { index });
+        }
+        if !self.context.live_sessions.is_empty() {
+            actions.push(QuickStartAction::FocusExistingSession);
+        }
+        actions.push(QuickStartAction::ChooseDifferent);
+        actions
     }
 
     fn apply_quick_start_selection(&mut self) {
@@ -1291,16 +1328,17 @@ impl LaunchWizardState {
         self.docker_lifecycle_intent = entry.docker_lifecycle_intent;
 
         match self.selected_quick_start_action() {
-            QuickStartAction::ResumeWithPrevious => {
-                if let Some(resume_session_id) = entry.resume_session_id {
+            QuickStartAction::ReuseEntry { .. } => {
+                if let Some(window_id) = entry.live_window_id {
+                    self.completion = Some(LaunchWizardCompletion::FocusWindow { window_id });
+                } else if let Some(resume_session_id) = entry.resume_session_id {
                     self.mode = "resume".to_string();
                     self.resume_session_id = Some(resume_session_id);
                 } else {
-                    self.mode = "continue".to_string();
-                    self.resume_session_id = None;
+                    self.error = Some("No saved session is available".to_string());
                 }
             }
-            QuickStartAction::StartNewWithPrevious => {
+            QuickStartAction::StartNewEntry { .. } => {
                 self.mode = "normal".to_string();
                 self.resume_session_id = None;
             }
@@ -1312,15 +1350,17 @@ impl LaunchWizardState {
         match self.step {
             LaunchWizardStep::QuickStart => {
                 let mut options = Vec::new();
-                for entry in &self.quick_start_entries {
+                for (index, entry) in self.quick_start_entries.iter().enumerate() {
                     let summary = quick_start_summary(entry);
+                    if let Some(reuse_action_label) = entry.reuse_action_label() {
+                        options.push(LaunchWizardOptionView {
+                            value: format!("reuse:{index}"),
+                            label: format!("{reuse_action_label} {}", entry.tool_label),
+                            description: Some(summary.clone()),
+                        });
+                    }
                     options.push(LaunchWizardOptionView {
-                        value: format!("resume:{index}", index = options.len() / 2),
-                        label: format!("Resume {}", entry.tool_label),
-                        description: Some(summary.clone()),
-                    });
-                    options.push(LaunchWizardOptionView {
-                        value: format!("start_new:{index}", index = options.len() / 2),
+                        value: format!("start_new:{index}"),
                         label: format!("Start new with {}", entry.tool_label),
                         description: Some(summary),
                     });
@@ -1500,8 +1540,8 @@ struct DockerLifecycleOption {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum QuickStartAction {
-    ResumeWithPrevious,
-    StartNewWithPrevious,
+    ReuseEntry { index: usize },
+    StartNewEntry { index: usize },
     FocusExistingSession,
     ChooseDifferent,
 }
@@ -1728,7 +1768,7 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
         LaunchWizardStep::QuickStart => match state.selected_quick_start_action() {
             QuickStartAction::ChooseDifferent => Some(LaunchWizardStep::BranchAction),
             QuickStartAction::FocusExistingSession => Some(LaunchWizardStep::FocusExistingSession),
-            QuickStartAction::ResumeWithPrevious | QuickStartAction::StartNewWithPrevious => {
+            QuickStartAction::ReuseEntry { .. } | QuickStartAction::StartNewEntry { .. } => {
                 Some(LaunchWizardStep::SkipPermissions)
             }
         },
@@ -2166,6 +2206,7 @@ pub fn load_quick_start_entries(
     sessions
         .into_iter()
         .map(|session| QuickStartEntry {
+            session_id: session.id.clone(),
             agent_id: session.agent_id.command().to_string(),
             tool_label: session.display_name.clone(),
             model: session.model.clone(),
@@ -2177,6 +2218,7 @@ pub fn load_quick_start_entries(
                     .map(|_| "installed".to_string())
             }),
             resume_session_id: session.agent_session_id.clone(),
+            live_window_id: None,
             skip_permissions: session.skip_permissions,
             codex_fast_mode: session.codex_fast_mode,
             runtime_target: session.runtime_target,
@@ -2281,12 +2323,14 @@ mod tests {
             context(branch("feature/gui"), "feature/gui"),
             sample_agent_options(),
             vec![QuickStartEntry {
+                session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
                 model: Some("gpt-5.4".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: Some("resume-1".to_string()),
+                live_window_id: None,
                 skip_permissions: true,
                 codex_fast_mode: true,
                 runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
@@ -2379,12 +2423,14 @@ mod tests {
             context(branch("feature/gui"), "feature/gui"),
             sample_agent_options(),
             vec![QuickStartEntry {
+                session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
                 model: Some("gpt-5.4".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: Some("resume-1".to_string()),
+                live_window_id: None,
                 skip_permissions: true,
                 codex_fast_mode: true,
                 runtime_target: gwt_agent::LaunchRuntimeTarget::Docker,
@@ -2408,6 +2454,84 @@ mod tests {
         assert_eq!(state.docker_service.as_deref(), Some("gwt"));
         assert!(state.skip_permissions);
         assert!(state.codex_fast_mode);
+    }
+
+    #[test]
+    fn quick_start_reuse_prefers_live_window_focus() {
+        let mut ctx = context(branch("feature/gui"), "feature/gui");
+        ctx.live_sessions = vec![LiveSessionEntry {
+            session_id: "gwt-session-1".to_string(),
+            window_id: "window-1".to_string(),
+            agent_id: "codex".to_string(),
+            kind: "agent".to_string(),
+            name: "Codex".to_string(),
+            detail: Some("/tmp/repo".to_string()),
+            active: true,
+        }];
+
+        let mut state = LaunchWizardState::open_with(
+            ctx,
+            sample_agent_options(),
+            vec![QuickStartEntry {
+                session_id: "gwt-session-1".to_string(),
+                agent_id: "codex".to_string(),
+                tool_label: "Codex".to_string(),
+                model: Some("gpt-5.4".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                resume_session_id: Some("resume-1".to_string()),
+                live_window_id: None,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+            }],
+        );
+
+        let view = state.view();
+        assert_eq!(
+            view.quick_start_entries[0].reuse_action_label.as_deref(),
+            Some("Continue")
+        );
+
+        state.apply(LaunchWizardAction::ApplyQuickStart {
+            index: 0,
+            mode: QuickStartLaunchMode::Resume,
+        });
+
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::FocusWindow { window_id }) => {
+                assert_eq!(window_id, "window-1");
+            }
+            other => panic!("expected focus completion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quick_start_view_hides_reuse_action_without_live_or_saved_session() {
+        let state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            vec![QuickStartEntry {
+                session_id: "gwt-session-1".to_string(),
+                agent_id: "codex".to_string(),
+                tool_label: "Codex".to_string(),
+                model: Some("gpt-5.4".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                resume_session_id: None,
+                live_window_id: None,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+            }],
+        );
+
+        let view = state.view();
+        assert!(view.quick_start_entries[0].reuse_action_label.is_none());
     }
 
     #[test]
@@ -2479,11 +2603,7 @@ mod tests {
         let mut ctx = context(branch("feature/gui"), "feature/gui");
         ctx.linked_issue_number = Some(1234);
 
-        let state = LaunchWizardState::open_with(
-            ctx,
-            sample_agent_options(),
-            Vec::new(),
-        );
+        let state = LaunchWizardState::open_with(ctx, sample_agent_options(), Vec::new());
 
         let config = state.build_launch_config().expect("config");
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -80,6 +80,7 @@ struct ProcessLaunch {
 struct ActiveAgentSession {
     window_id: String,
     session_id: String,
+    agent_id: String,
     branch_name: String,
     display_name: String,
     worktree_path: PathBuf,
@@ -288,9 +289,11 @@ impl AppRuntime {
                     self.load_branches_event(&id),
                 )]
             }
-            FrontendEvent::OpenLaunchWizard { id, branch_name, linked_issue_number } => {
-                self.open_launch_wizard(&id, &branch_name, linked_issue_number)
-            }
+            FrontendEvent::OpenLaunchWizard {
+                id,
+                branch_name,
+                linked_issue_number,
+            } => self.open_launch_wizard(&id, &branch_name, linked_issue_number),
             FrontendEvent::LaunchWizardAction { action } => {
                 self.handle_launch_wizard_action(action)
             }
@@ -787,7 +790,12 @@ impl AppRuntime {
         }
     }
 
-    fn open_launch_wizard(&mut self, id: &str, branch_name: &str, linked_issue_number: Option<u64>) -> Vec<OutboundEvent> {
+    fn open_launch_wizard(
+        &mut self,
+        id: &str,
+        branch_name: &str,
+        linked_issue_number: Option<u64>,
+    ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id).cloned() else {
             return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
                 id: id.to_string(),
@@ -925,6 +933,7 @@ impl AppRuntime {
             .map(|session| LiveSessionEntry {
                 session_id: session.session_id.clone(),
                 window_id: session.window_id.clone(),
+                agent_id: session.agent_id.clone(),
                 kind: "agent".to_string(),
                 name: session.display_name.clone(),
                 detail: Some(session.worktree_path.display().to_string()),
@@ -1207,16 +1216,18 @@ impl AppRuntime {
                                 serde_json::Map::new()
                             };
 
-                        let mut branches: serde_json::Map<String, serde_json::Value> =
-                            linkage_map.get("branches")
-                                .and_then(|v| v.as_object())
-                                .cloned()
-                                .unwrap_or_default();
+                        let mut branches: serde_json::Map<String, serde_json::Value> = linkage_map
+                            .get("branches")
+                            .and_then(|v| v.as_object())
+                            .cloned()
+                            .unwrap_or_default();
 
                         branches.insert(branch.to_string(), json!(issue_number));
-                        linkage_map.insert("branches".to_string(), serde_json::Value::Object(branches));
+                        linkage_map
+                            .insert("branches".to_string(), serde_json::Value::Object(branches));
 
-                        let json_content = serde_json::to_string_pretty(&linkage_map).unwrap_or_default();
+                        let json_content =
+                            serde_json::to_string_pretty(&linkage_map).unwrap_or_default();
                         let _ = fs::write(&cache_file, json_content);
                     }
                     Ok::<(), String>(())
@@ -1229,6 +1240,7 @@ impl AppRuntime {
             ActiveAgentSession {
                 window_id: window_id.clone(),
                 session_id: session.id.clone(),
+                agent_id: config.agent_id.command().to_string(),
                 branch_name,
                 display_name: config.display_name.clone(),
                 worktree_path,

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -571,6 +571,10 @@ mod tests {
         let session_path = dir.path().join("session.json");
         let project_one = dir.path().join("project-one");
         let project_two = dir.path().join("project-two");
+        let project_one_json =
+            serde_json::to_string(&project_one.display().to_string()).expect("project one json");
+        let project_two_json =
+            serde_json::to_string(&project_two.display().to_string()).expect("project two json");
         std::fs::create_dir_all(&project_one).expect("project one dir");
         std::fs::create_dir_all(&project_two).expect("project two dir");
         std::fs::write(
@@ -581,7 +585,7 @@ mod tests {
     {{
       "id": "project-1",
       "title": "project-one",
-      "project_root": "{}",
+      "project_root": {},
       "kind": "git",
       "workspace": {{
         "viewport": {{ "x": 12.0, "y": -8.0, "zoom": 1.1 }},
@@ -592,7 +596,7 @@ mod tests {
     {{
       "id": "project-2",
       "title": "project-two",
-      "project_root": "{}",
+      "project_root": {},
       "kind": "non_repo",
       "workspace": {{
         "viewport": {{ "x": 0.0, "y": 0.0, "zoom": 1.0 }},
@@ -603,12 +607,10 @@ mod tests {
   ],
   "active_tab_id": "project-2",
   "recent_projects": [
-    {{ "path": "{}", "title": "project-two", "kind": "non_repo" }}
+    {{ "path": {}, "title": "project-two", "kind": "non_repo" }}
   ]
 }}"#,
-                project_one.display(),
-                project_two.display(),
-                project_two.display()
+                project_one_json, project_two_json, project_two_json
             ),
         )
         .expect("legacy workspace write");
@@ -670,6 +672,8 @@ mod tests {
         let legacy_path = dir.path().join("legacy-workspace.json");
         let session_path = dir.path().join("session.json");
         let project_root = dir.path().join("project");
+        let project_root_json =
+            serde_json::to_string(&project_root.display().to_string()).expect("project root json");
         std::fs::create_dir_all(&project_root).expect("project dir");
         std::fs::write(
             &legacy_path,
@@ -679,7 +683,7 @@ mod tests {
     {{
       "id": "project-1",
       "title": "project",
-      "project_root": "{}",
+      "project_root": {},
       "kind": "git",
       "workspace": {{
         "viewport": {{ "x": 99.0, "y": 0.0, "zoom": 1.0 }},
@@ -691,7 +695,7 @@ mod tests {
   "active_tab_id": "project-1",
   "recent_projects": []
 }}"#,
-                project_root.display()
+                project_root_json
             ),
         )
         .expect("legacy workspace write");

--- a/crates/gwt/tests/hook_block_bash_policy_test.rs
+++ b/crates/gwt/tests/hook_block_bash_policy_test.rs
@@ -1,11 +1,18 @@
 //! T-035 (SPEC #1942 amendment) — block-bash-policy golden tests.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use gwt::cli::hook::block_bash_policy;
 
 fn root() -> PathBuf {
-    PathBuf::from("/tmp/gwt-test-worktree")
+    std::env::temp_dir().join("gwt-test-worktree")
+}
+
+fn outside_root() -> PathBuf {
+    root()
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("gwt-test-outside")
 }
 
 fn block(command: &str) {
@@ -30,13 +37,17 @@ fn blocks_branch_policy_commands() {
 
 #[test]
 fn blocks_cd_outside_worktree() {
-    block("cd /etc");
+    block(&format!("cd {}", outside_root().display()));
 }
 
 #[test]
 fn blocks_file_ops_outside_worktree() {
     block("rm -rf /");
-    block("cp /tmp/gwt-test-worktree/foo.txt /etc/foo.txt");
+    block(&format!(
+        "cp {}/foo.txt {}/foo.txt",
+        root().display(),
+        outside_root().display()
+    ));
 }
 
 #[test]
@@ -78,7 +89,7 @@ fn github_workflow_block_message_points_to_canonical_gwt_surfaces() {
 fn allows_read_only_and_in_worktree_commands() {
     allow("git branch --list");
     allow("git checkout HEAD -- foo.rs");
-    allow("mkdir /tmp/gwt-test-worktree/new-dir");
+    allow(&format!("mkdir {}/new-dir", root().display()));
 }
 
 #[test]

--- a/crates/gwt/tests/hook_block_cd_test.rs
+++ b/crates/gwt/tests/hook_block_cd_test.rs
@@ -1,21 +1,30 @@
 //! T-040 (SPEC #1942) — block-cd-command golden tests.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use gwt::cli::hook::block_cd_command;
 
 fn root() -> PathBuf {
-    // Use the tempdir's parent as a synthetic worktree root so that
-    // `/tmp/<worktree>/subdir` is considered inside and anything else
-    // is considered outside. We deliberately use a path that definitely
-    // exists so that component-wise comparisons are stable.
-    PathBuf::from("/tmp/gwt-test-worktree")
+    std::env::temp_dir().join("gwt-test-worktree")
+}
+
+fn outside_root() -> PathBuf {
+    root()
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("gwt-test-outside")
 }
 
 #[test]
 fn cd_to_absolute_path_outside_worktree_is_blocked() {
-    let decision = block_cd_command::evaluate_bash_command("cd /etc", &root());
-    assert!(decision.is_some(), "cd /etc should be blocked");
+    let decision = block_cd_command::evaluate_bash_command(
+        &format!("cd {}", outside_root().display()),
+        &root(),
+    );
+    assert!(
+        decision.is_some(),
+        "cd outside the worktree should be blocked"
+    );
 }
 
 #[test]
@@ -26,8 +35,10 @@ fn cd_to_home_shortcut_is_blocked() {
 
 #[test]
 fn cd_to_absolute_path_inside_worktree_is_allowed() {
-    let decision =
-        block_cd_command::evaluate_bash_command("cd /tmp/gwt-test-worktree/subdir", &root());
+    let decision = block_cd_command::evaluate_bash_command(
+        &format!("cd {}/subdir", root().display()),
+        &root(),
+    );
     assert!(
         decision.is_none(),
         "cd into a path strictly under the root should be allowed, got {decision:?}"
@@ -36,7 +47,8 @@ fn cd_to_absolute_path_inside_worktree_is_allowed() {
 
 #[test]
 fn cd_to_worktree_root_itself_is_allowed() {
-    let decision = block_cd_command::evaluate_bash_command("cd /tmp/gwt-test-worktree", &root());
+    let decision =
+        block_cd_command::evaluate_bash_command(&format!("cd {}", root().display()), &root());
     assert!(
         decision.is_none(),
         "cd to the root itself should be allowed"
@@ -45,7 +57,10 @@ fn cd_to_worktree_root_itself_is_allowed() {
 
 #[test]
 fn non_cd_command_is_not_examined() {
-    let decision = block_cd_command::evaluate_bash_command("echo cd /etc", &root());
+    let decision = block_cd_command::evaluate_bash_command(
+        &format!("echo cd {}", outside_root().display()),
+        &root(),
+    );
     assert!(
         decision.is_none(),
         "echo cd is not a cd command, must not be blocked"
@@ -63,9 +78,12 @@ fn grep_mentioning_cd_is_not_blocked() {
 
 #[test]
 fn adversarial_segment_after_innocuous_prefix_is_blocked() {
-    let decision = block_cd_command::evaluate_bash_command("echo hello && cd /etc", &root());
+    let decision = block_cd_command::evaluate_bash_command(
+        &format!("echo hello && cd {}", outside_root().display()),
+        &root(),
+    );
     assert!(
         decision.is_some(),
-        "cd /etc after an innocuous prefix must still be blocked"
+        "cd outside the worktree after an innocuous prefix must still be blocked"
     );
 }

--- a/crates/gwt/tests/hook_block_file_ops_test.rs
+++ b/crates/gwt/tests/hook_block_file_ops_test.rs
@@ -1,11 +1,18 @@
 //! T-050 (SPEC #1942) — block-file-ops golden tests.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use gwt::cli::hook::block_file_ops;
 
 fn root() -> PathBuf {
-    PathBuf::from("/tmp/gwt-test-worktree")
+    std::env::temp_dir().join("gwt-test-worktree")
+}
+
+fn outside_root() -> PathBuf {
+    root()
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("gwt-test-outside")
 }
 
 #[test]
@@ -24,11 +31,13 @@ fn rm_rf_home_shortcut_is_blocked() {
 fn rm_inside_worktree_relative_path_is_allowed() {
     // Relative paths resolve against the current process cwd, which
     // during test execution is the gwt repo. Because our synthetic
-    // `/tmp/gwt-test-worktree` root does NOT match that cwd, relative
+    // tempdir-backed root does NOT match that cwd, relative
     // paths will be considered *outside* — so for this test we use an
     // absolute path under the synthetic root.
-    let decision =
-        block_file_ops::evaluate_bash_command("rm -rf /tmp/gwt-test-worktree/target", &root());
+    let decision = block_file_ops::evaluate_bash_command(
+        &format!("rm -rf {}/target", root().display()),
+        &root(),
+    );
     assert!(
         decision.is_none(),
         "rm -rf <path-under-root> must be allowed, got {decision:?}"
@@ -37,8 +46,10 @@ fn rm_inside_worktree_relative_path_is_allowed() {
 
 #[test]
 fn mkdir_inside_worktree_is_allowed() {
-    let decision =
-        block_file_ops::evaluate_bash_command("mkdir /tmp/gwt-test-worktree/new-dir", &root());
+    let decision = block_file_ops::evaluate_bash_command(
+        &format!("mkdir {}/new-dir", root().display()),
+        &root(),
+    );
     assert!(decision.is_none(), "mkdir under the root must be allowed");
 }
 
@@ -54,22 +65,26 @@ fn non_file_op_command_is_ignored() {
 #[test]
 fn cp_to_path_outside_worktree_is_blocked() {
     let decision = block_file_ops::evaluate_bash_command(
-        "cp /tmp/gwt-test-worktree/foo.txt /etc/foo.txt",
+        &format!(
+            "cp {}/foo.txt {}/foo.txt",
+            root().display(),
+            outside_root().display()
+        ),
         &root(),
     );
     assert!(
         decision.is_some(),
-        "cp targeting /etc must be blocked even if the source is inside"
+        "cp targeting outside the worktree must be blocked even if the source is inside"
     );
 }
 
 #[test]
 fn flags_are_not_treated_as_file_paths() {
-    // `rm -rf --no-preserve-root /tmp/gwt-test-worktree/target` has only
-    // one path arg (`/tmp/...`) — the flags must not trigger a
+    // `rm -rf --no-preserve-root <root>/target` has only one path arg —
+    // the flags must not trigger a
     // false-positive block.
     let decision = block_file_ops::evaluate_bash_command(
-        "rm -rf --no-preserve-root /tmp/gwt-test-worktree/target",
+        &format!("rm -rf --no-preserve-root {}/target", root().display()),
         &root(),
     );
     assert!(decision.is_none(), "flags must not be treated as paths");

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -21,7 +21,14 @@ fn env_lock() -> &'static Mutex<()> {
 }
 
 fn root() -> PathBuf {
-    PathBuf::from("/tmp/gwt-test-worktree")
+    std::env::temp_dir().join("gwt-test-worktree")
+}
+
+fn outside_root() -> PathBuf {
+    root()
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("gwt-test-outside")
 }
 
 fn event(tool_name: &str, tool_input: serde_json::Value) -> HookEvent {
@@ -285,7 +292,7 @@ fn allows_verification_bash_even_without_owner() {
 fn allows_worktree_touch_bash_without_owner() {
     let event = event(
         "Bash",
-        json!({ "command": "touch /tmp/gwt-test-worktree/src/lib.rs" }),
+        json!({ "command": format!("touch {}/src/lib.rs", root().display()) }),
     );
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
     assert!(
@@ -298,7 +305,7 @@ fn allows_worktree_touch_bash_without_owner() {
 fn allows_worktree_rm_bash_without_owner() {
     let event = event(
         "Bash",
-        json!({ "command": "rm -f /tmp/gwt-test-worktree/.gwt/memory/constitution.md" }),
+        json!({ "command": format!("rm -f {}/.gwt/memory/constitution.md", root().display()) }),
     );
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown());
     assert!(
@@ -398,7 +405,10 @@ fn allows_git_push_in_chained_command() {
 
 #[test]
 fn worktree_external_file_op_is_blocked_before_owner_gate() {
-    let event = event("Bash", json!({ "command": "rm -rf /tmp/outside" }));
+    let event = event(
+        "Bash",
+        json!({ "command": format!("rm -rf {}", outside_root().display()) }),
+    );
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
         .expect("out-of-worktree file ops must be blocked");
     assert!(decision.reason.contains("outside worktree"));

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use gwt::refresh_managed_gwt_assets_for_worktree;
+use serde_json::Value;
 use tempfile::tempdir;
 
 #[test]
@@ -37,8 +38,12 @@ fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() 
     let codex_hooks =
         std::fs::read_to_string(dir.path().join(".codex/hooks.json")).expect("read codex");
     let cli_bin_text = cli_bin.display().to_string();
-    assert!(claude_settings.contains(&cli_bin_text));
-    assert!(codex_hooks.contains(&cli_bin_text));
+    assert!(json_commands(&claude_settings)
+        .iter()
+        .any(|command| command.contains(&cli_bin_text)));
+    assert!(json_commands(&codex_hooks)
+        .iter()
+        .any(|command| command.contains(&cli_bin_text)));
 
     let exclude_path = dir.path().join(".git/info/exclude");
     let exclude = std::fs::read_to_string(&exclude_path).expect("read exclude");
@@ -103,4 +108,30 @@ impl Drop for ScopedEnvVar {
             std::env::remove_var(self.key);
         }
     }
+}
+
+fn json_commands(raw: &str) -> Vec<String> {
+    fn collect(value: &Value, out: &mut Vec<String>) {
+        match value {
+            Value::Object(map) => {
+                if let Some(command) = map.get("command").and_then(Value::as_str) {
+                    out.push(command.to_string());
+                }
+                for value in map.values() {
+                    collect(value, out);
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    collect(value, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let value: Value = serde_json::from_str(raw).expect("valid json");
+    let mut out = Vec::new();
+    collect(&value, &mut out);
+    out
 }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2504,20 +2504,22 @@
               card.appendChild(head);
 
               const actions = createNode("div", "quick-start-actions");
-              const resumeButton = createNode(
-                "button",
-                "wizard-button",
-                entry.resume_session_id ? "Resume" : "Continue",
-              );
-              resumeButton.type = "button";
-              resumeButton.addEventListener("click", () => {
-                sendWizardAction({
-                  kind: "apply_quick_start",
-                  index: entry.index,
-                  mode: "resume",
+              if (entry.reuse_action_label) {
+                const reuseButton = createNode(
+                  "button",
+                  "wizard-button",
+                  entry.reuse_action_label,
+                );
+                reuseButton.type = "button";
+                reuseButton.addEventListener("click", () => {
+                  sendWizardAction({
+                    kind: "apply_quick_start",
+                    index: entry.index,
+                    mode: "resume",
+                  });
                 });
-              });
-              actions.appendChild(resumeButton);
+                actions.appendChild(reuseButton);
+              }
 
               const startNewButton = createNode(
                 "button",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,32 @@
 # Lessons Learned
 
+## 2026-04-15 — fix: Quick Start の resume は struct やテストではなく実 session TOML への保存実態で確認する
+
+### 事象
+
+Launch Agent の Quick Start で `Continue` を押すと、既に起動済みの agent window を
+再利用せず、新しい window を重ねて起動していた。
+あわせて `~/.gwt/sessions/*.toml` を実確認すると、`Session.agent_session_id` field は
+コード上に存在するのに、実ファイルには `agent_session_id` が1件も保存されていなかった。
+
+### 原因
+
+- Quick Start 側が `--continue` 的な新規起動経路へ寄っており、live window focus と
+  saved session resume を分けて扱っていなかった。
+- hook runtime が受け取る Codex/Agent 側の `session_id` を、gwt session TOML へ
+  書き戻す production path が存在しなかった。
+- struct 定義と unit test があることで、「保存されているはず」という前提を
+  実ファイル確認なしに置きやすい状態だった。
+
+### 再発防止策
+
+1. resume/continue 系の不具合では、まず `~/.gwt/sessions/*.toml` を直接確認し、
+   必要な key が実際に保存されているかを事実ベースで確認する。
+2. Quick Start の reuse は「live window があるなら focus」「保存済み session id が
+   あるなら resume」「どちらもなければボタン非表示」を明示的に分けて実装・テストする。
+3. session metadata を UI が参照する変更では、struct や fixture だけでなく
+   production hook/runtime から persistence まで通る回帰テストを必ず追加する。
+
 ## 2026-04-15 — fix: build.rs の skill frontmatter 検証で repo 管理外 skill を読まない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Fix Launch Agent Quick Start reuse so `Continue` focuses an already-running window and `Resume` uses a saved session id instead of falling back to `--continue`.
- Persist `agent_session_id` from runtime hook events into `~/.gwt/sessions/*.toml` so Quick Start resume can target the correct prior session.
- Harden Windows path and file-write handling uncovered during verification so the branch stays green after the Quick Start fix.

## Changes

- `crates/gwt/src/launch_wizard.rs`, `crates/gwt/web/index.html`, `crates/gwt/src/main.rs`: add live window matching, split `Continue` and `Resume`, and focus existing windows when possible.
- `crates/gwt-agent/src/session.rs`, `crates/gwt/src/cli/hook/runtime_state.rs`: persist hook `session_id` into session TOML and cover it with regression tests.
- `crates/gwt-core/src/coordination.rs`, `crates/gwt/src/persistence.rs`, Windows-oriented tests: handle Windows path and rename edge cases so full validation passes consistently.

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features` — passes
- [x] `cargo fmt -- --check` — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — no README change; behavior fix is limited to Launch Agent quick start.
- [ ] Migration/backfill plan included (if schema/data change) — existing session TOML files are not backfilled; `agent_session_id` is saved on the next hook event for each session.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- User report: Quick Start `Continue` opened a new overlapping window, and resume should use saved session ids rather than `--continue`.

## Risk / Impact

- **Affected areas**: Launch Wizard quick start reuse, hook runtime session persistence, Windows path-sensitive validation
- **Rollback plan**: Revert `c0f730ed`, `d8905cb7`, and `2cc2185f` from `bugfix/continue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Reuse" action in Quick Start wizard to focus or resume existing agent sessions

* **Bug Fixes**
  * Improved Windows file operation robustness by gracefully handling missing file cleanup scenarios
  * Enhanced Windows symlink creation to handle permission-related errors without failure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->