### PR TITLE
fix(cli): defer github auth for read-only commands

### DIFF
--- a/crates/gwt/src/cli/env.rs
+++ b/crates/gwt/src/cli/env.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     io::{self},
     path::PathBuf,
+    sync::{Arc, OnceLock},
 };
 
 use gwt_git::PrStatus;
@@ -16,6 +17,9 @@ use super::{
     CliParseError, LinkedPrSummary, PrChecksSummary, PrCreateCall, PrEditCall, PrReview,
     PrReviewThread,
 };
+
+type IssueClientFactory =
+    dyn Fn(&str, &str) -> Result<HttpIssueClient, gwt_github::client::ApiError> + Send + Sync;
 
 /// High-level runtime environment for the CLI. Kept as a trait so tests can
 /// inject a [`FakeIssueClient`] instead of spinning up real HTTP.
@@ -135,10 +139,117 @@ impl<'a, C: IssueClient> IssueClient for ClientRef<'a, C> {
 // DefaultCliEnv: production runtime wiring
 // ---------------------------------------------------------------------------
 
-/// Default production [`CliEnv`] that uses an [`HttpIssueClient`] with
-/// credentials from `gh auth token` and the user's home cache directory.
+#[doc(hidden)]
+pub struct LazyIssueClient {
+    owner: String,
+    repo: String,
+    factory: Arc<IssueClientFactory>,
+    resolved: OnceLock<HttpIssueClient>,
+}
+
+impl LazyIssueClient {
+    fn new_with_factory(owner: &str, repo: &str, factory: Arc<IssueClientFactory>) -> Self {
+        Self {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            factory,
+            resolved: OnceLock::new(),
+        }
+    }
+
+    fn resolve(&self) -> Result<&HttpIssueClient, gwt_github::client::ApiError> {
+        if let Some(client) = self.resolved.get() {
+            return Ok(client);
+        }
+
+        let client = (self.factory)(&self.owner, &self.repo)?;
+        let _ = self.resolved.set(client);
+        self.resolved.get().ok_or_else(|| {
+            gwt_github::client::ApiError::Unexpected(
+                "lazy issue client failed to initialize".to_string(),
+            )
+        })
+    }
+}
+
+impl IssueClient for LazyIssueClient {
+    fn fetch(
+        &self,
+        number: IssueNumber,
+        since: Option<&gwt_github::client::UpdatedAt>,
+    ) -> Result<gwt_github::client::FetchResult, gwt_github::client::ApiError> {
+        self.resolve()?.fetch(number, since)
+    }
+
+    fn patch_body(
+        &self,
+        number: IssueNumber,
+        new_body: &str,
+    ) -> Result<gwt_github::client::IssueSnapshot, gwt_github::client::ApiError> {
+        self.resolve()?.patch_body(number, new_body)
+    }
+
+    fn patch_title(
+        &self,
+        number: IssueNumber,
+        new_title: &str,
+    ) -> Result<gwt_github::client::IssueSnapshot, gwt_github::client::ApiError> {
+        self.resolve()?.patch_title(number, new_title)
+    }
+
+    fn patch_comment(
+        &self,
+        comment_id: gwt_github::client::CommentId,
+        new_body: &str,
+    ) -> Result<gwt_github::client::CommentSnapshot, gwt_github::client::ApiError> {
+        self.resolve()?.patch_comment(comment_id, new_body)
+    }
+
+    fn create_comment(
+        &self,
+        number: IssueNumber,
+        body: &str,
+    ) -> Result<gwt_github::client::CommentSnapshot, gwt_github::client::ApiError> {
+        self.resolve()?.create_comment(number, body)
+    }
+
+    fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        labels: &[String],
+    ) -> Result<gwt_github::client::IssueSnapshot, gwt_github::client::ApiError> {
+        self.resolve()?.create_issue(title, body, labels)
+    }
+
+    fn set_labels(
+        &self,
+        number: IssueNumber,
+        labels: &[String],
+    ) -> Result<gwt_github::client::IssueSnapshot, gwt_github::client::ApiError> {
+        self.resolve()?.set_labels(number, labels)
+    }
+
+    fn set_state(
+        &self,
+        number: IssueNumber,
+        state: gwt_github::client::IssueState,
+    ) -> Result<gwt_github::client::IssueSnapshot, gwt_github::client::ApiError> {
+        self.resolve()?.set_state(number, state)
+    }
+
+    fn list_spec_issues(
+        &self,
+        filter: &SpecListFilter,
+    ) -> Result<Vec<gwt_github::client::SpecSummary>, gwt_github::client::ApiError> {
+        self.resolve()?.list_spec_issues(filter)
+    }
+}
+
+/// Default production [`CliEnv`] that defers GitHub auth until a command
+/// actually needs the issue client and uses the user's home cache directory.
 pub struct DefaultCliEnv {
-    client: HttpIssueClient,
+    client: LazyIssueClient,
     cache_root: PathBuf,
     repo_path: PathBuf,
     owner: String,
@@ -148,23 +259,42 @@ pub struct DefaultCliEnv {
 }
 
 impl DefaultCliEnv {
-    pub fn new(
+    pub fn new(owner: &str, repo: &str, repo_path: PathBuf) -> Self {
+        Self::new_with_client_factory(
+            owner,
+            repo,
+            repo_path,
+            Arc::new(HttpIssueClient::from_gh_auth),
+        )
+    }
+
+    fn new_with_client_factory(
         owner: &str,
         repo: &str,
         repo_path: PathBuf,
-    ) -> Result<Self, gwt_github::client::ApiError> {
-        let client = HttpIssueClient::from_gh_auth(owner, repo)?;
+        factory: Arc<IssueClientFactory>,
+    ) -> Self {
         let cache_root = crate::issue_cache::issue_cache_root_for_repo_path(&repo_path)
             .unwrap_or_else(|| crate::issue_cache::issue_cache_root_for_repo_slug(owner, repo));
-        Ok(DefaultCliEnv {
-            client,
+        Self::new_with_client_factory_and_cache_root(owner, repo, repo_path, cache_root, factory)
+    }
+
+    fn new_with_client_factory_and_cache_root(
+        owner: &str,
+        repo: &str,
+        repo_path: PathBuf,
+        cache_root: PathBuf,
+        factory: Arc<IssueClientFactory>,
+    ) -> Self {
+        DefaultCliEnv {
+            client: LazyIssueClient::new_with_factory(owner, repo, factory),
             cache_root,
             repo_path,
             owner: owner.to_string(),
             repo: repo.to_string(),
             stdout: io::stdout(),
             stderr: io::stderr(),
-        })
+        }
     }
 
     /// Build an env for hook dispatch that deliberately skips
@@ -176,24 +306,28 @@ impl DefaultCliEnv {
     /// and empty owner/repo strings; any attempt to actually call it
     /// would fail (which is fine — the hook code paths go through
     /// `run_hook`, not the SPEC issue client).
-    pub fn new_for_hooks() -> Result<Self, gwt_github::client::ApiError> {
-        let transport = gwt_github::client::http::ReqwestTransport::new()
-            .map_err(|e| gwt_github::client::ApiError::Network(e.to_string()))?;
-        let client = HttpIssueClient::with_transport(transport, String::new(), "", "");
-        Ok(DefaultCliEnv {
-            client,
-            cache_root: crate::issue_cache::detached_issue_cache_root(),
-            repo_path: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            owner: String::new(),
-            repo: String::new(),
-            stdout: io::stdout(),
-            stderr: io::stderr(),
-        })
+    pub fn new_for_hooks() -> Self {
+        Self::new_with_client_factory_and_cache_root(
+            "",
+            "",
+            std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            crate::issue_cache::detached_issue_cache_root(),
+            Arc::new(|_, _| {
+                let transport = gwt_github::client::http::ReqwestTransport::new()
+                    .map_err(|e| gwt_github::client::ApiError::Network(e.to_string()))?;
+                Ok(HttpIssueClient::with_transport(
+                    transport,
+                    String::new(),
+                    "",
+                    "",
+                ))
+            }),
+        )
     }
 }
 
 impl CliEnv for DefaultCliEnv {
-    type Client = HttpIssueClient;
+    type Client = LazyIssueClient;
 
     fn client(&self) -> &Self::Client {
         &self.client
@@ -583,5 +717,65 @@ impl CliEnv for TestEnv {
             .get(&job_id)
             .cloned()
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("no job log: {job_id}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn failing_factory(counter: Arc<AtomicUsize>) -> Arc<IssueClientFactory> {
+        Arc::new(move |_, _| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err(gwt_github::client::ApiError::Unauthorized)
+        })
+    }
+
+    #[test]
+    fn lazy_issue_client_defers_resolution_until_first_issue_call() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client =
+            LazyIssueClient::new_with_factory("akiojin", "gwt", failing_factory(calls.clone()));
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        let result = client.list_spec_issues(&SpecListFilter::default());
+        assert!(matches!(
+            result,
+            Err(gwt_github::client::ApiError::Unauthorized)
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn default_cli_env_construction_does_not_touch_issue_client_factory() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let env = DefaultCliEnv::new_with_client_factory(
+            "akiojin",
+            "gwt",
+            PathBuf::from("."),
+            failing_factory(calls.clone()),
+        );
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        let result = env.client().list_spec_issues(&SpecListFilter::default());
+        assert!(matches!(
+            result,
+            Err(gwt_github::client::ApiError::Unauthorized)
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn new_for_hooks_keeps_detached_cache_root() {
+        let env = DefaultCliEnv::new_for_hooks();
+
+        assert_eq!(
+            env.cache_root(),
+            crate::issue_cache::detached_issue_cache_root()
+        );
     }
 }

--- a/crates/gwt/src/cli/pr.rs
+++ b/crates/gwt/src/cli/pr.rs
@@ -296,5 +296,6 @@ mod tests {
         assert_eq!(code, 0);
         assert!(out.contains("#7 [OPEN] CLI family split"));
         assert_eq!(env.pr_current_call_count, 1);
+        assert!(env.client.call_log().is_empty());
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2660,26 +2660,11 @@ fn run_cli(argv: &[String]) -> io::Result<()> {
                 std::process::exit(2);
             }
         };
-        let mut env = match gwt::cli::DefaultCliEnv::new(&owner, &repo, repo_path) {
-            Ok(env) => env,
-            Err(error) => {
-                eprintln!(
-                    "gwt {}: {error}",
-                    argv.get(1).map(String::as_str).unwrap_or("issue")
-                );
-                std::process::exit(1);
-            }
-        };
+        let mut env = gwt::cli::DefaultCliEnv::new(&owner, &repo, repo_path);
         std::process::exit(gwt::cli::dispatch(&mut env, argv));
     }
 
-    let mut env = match gwt::cli::DefaultCliEnv::new_for_hooks() {
-        Ok(env) => env,
-        Err(error) => {
-            eprintln!("gwt hook: {error}");
-            std::process::exit(1);
-        }
-    };
+    let mut env = gwt::cli::DefaultCliEnv::new_for_hooks();
     std::process::exit(gwt::cli::dispatch(&mut env, argv));
 }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,26 @@
 # Lessons Learned
 
+## 2026-04-16 — fix: read-only CLI は eager GitHub auth を起動時に解決しない
+
+### 事象
+
+`gwt pr current` が無応答に見えた。実際には `pr current` 本体ではなく、
+`DefaultCliEnv::new()` が command dispatch 前に
+`HttpIssueClient::from_gh_auth()` を通して `gh auth token` を同期実行していたことと、
+`cargo run -q` の無音ビルド待ちが重なって原因切り分けを難しくしていた。
+
+### 原因
+
+- read-only CLI と write-capable GitHub Issue client の初期化が分離されていなかった。
+- `gwt pr current` は `gh pr view` だけで成立するのに、起動時に Issue client auth を先に解決していた。
+- 外部 `gh` 呼び出しとビルド待ちに progress/timeout の観測点がなく、体感上は「固まった」ように見えた。
+
+### 再発防止策
+
+1. read-only command path では GitHub Issue client を lazy init し、`env.client()` を触るまで auth を発火させない。
+2. `PrCurrent` のような read-only command で Issue client を使っていないことをテストで固定する。
+3. CLI 無応答調査では、cargo build 待ちと外部 command 待ちを別々に計測してから原因を特定する。
+
 ## 2026-04-15 — fix: Quick Start の resume は struct やテストではなく実 session TOML への保存実態で確認する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Defer GitHub Issue client auth in `DefaultCliEnv` so read-only commands like `gwt pr current` stop blocking on startup.
- Keep PR and hook behavior stable by preserving the `gh pr view` transport and detached hook cache semantics.
- Add regression tests that fail if read-only PR paths touch the issue client eagerly.

## Changes

- `crates/gwt/src/cli/env.rs`: add `LazyIssueClient`, switch `DefaultCliEnv` and hook env construction to lazy issue-client resolution, and add regression tests.
- `crates/gwt/src/main.rs`: remove eager env-construction error handling now that auth/init is deferred until first issue-client use.
- `crates/gwt/src/cli/pr.rs`: assert that `pr current` does not touch the issue client on the read-only path.
- `tasks/lessons.md`: record the eager-auth startup failure mode and the prevention rules.

## Testing

- [x] `cargo fmt -- --check` — exits 0.
- [x] `cargo test -p gwt-core -p gwt --all-features` — all tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings.
- [x] `cargo build -p gwt` — build succeeds.
- [x] `.\\target\\debug\\gwt.exe pr current` — returns current PR status without startup stall.

## Closing Issues

- None

## Related Issues / Links

- #1942

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (not user-facing change)
- [ ] Migration/backfill plan included (not applicable; no schema/data change)
- [x] CHANGELOG impact considered (patch-level `fix:` change)

## Context

- This is the SPEC-1942 follow-up for the `gwt pr current` no-response investigation.
- The root cause was eager `gh auth token` resolution in `DefaultCliEnv::new()` before command dispatch, even though the read-only PR path only needs `gh pr view`.
