### PR TITLE
chore(release): v9.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,12 @@ jobs:
             binary: gwt
             release_name: gwt-linux-aarch64
           - platform: macos-x86_64
-            os: macos-latest
+            os: macos-14
             target: x86_64-apple-darwin
             binary: gwt
             release_name: gwt-macos-x86_64
           - platform: macos-aarch64
-            os: macos-latest
+            os: macos-14
             target: aarch64-apple-darwin
             binary: gwt
             release_name: gwt-macos-aarch64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.4.1] - 2026-04-16
+
+### Bug Fixes
+
+- **ci:** Pin macOS version to macos-14 to resolve Sequoia compatibility issues
+
 ## [9.4.0] - 2026-04-16
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "axum",
  "base64",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "chrono",
  "gwt-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "dirs",
  "serde",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "fs2",
  "regex",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "crossterm",
  "gwt-core",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.4.0"
+version = "9.4.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

This release fixes macOS build failures by pinning the macOS runner to `macos-14` (Sonoma) instead of `macos-latest`. This resolves compatibility issues with macOS 15 (Sequoia).

## Changes

- **ci:** Pin macOS version to macos-14 to resolve Sequoia compatibility issues

## Version

v9.4.1

## Closing Issues

None

## Related Issues / Links

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS build compatibility issue to ensure stable builds across all supported platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->