### PR TITLE
fix(gui): restore web terminal copy workflow

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -92,6 +92,10 @@ gwt hook workflow-policy
 `Shell` と `Agent` は実プロセスを持つウィンドウです。`File Tree` は実装済みの
 read-only ツリーです。それ以外は現時点では mock surface です。
 
+ターミナルウィンドウでは、テキストをドラッグ選択してマウスボタンを離すとコピー
+できます。Windows / Linux では `Ctrl+Shift+C` でも現在の選択をコピーできます。
+`Ctrl+C` は実行中のターミナルプロセス向けの割り込みのままです。
+
 ## キャンバス操作
 
 - 画面上の zoom ボタンでキャンバスを拡大・縮小

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Available windows include:
 tree view. The remaining windows are currently mock surfaces where production
 behavior has not been wired yet.
 
+In terminal windows, drag to select text and release the mouse button to copy.
+On Windows and Linux, `Ctrl+Shift+C` also copies the current terminal
+selection. `Ctrl+C` stays mapped to the running terminal process.
+
 ## Canvas Operations
 
 - Zoom the canvas with the on-screen zoom buttons

--- a/crates/gwt-core/src/runtime.rs
+++ b/crates/gwt-core/src/runtime.rs
@@ -1,6 +1,7 @@
 //! Bootstrap and repair the shared project-index runtime under `~/.gwt/runtime`.
 
 use std::{
+    cmp::Reverse,
     fs,
     path::{Component, Path, PathBuf},
     process::Command,
@@ -270,7 +271,7 @@ where
         }
     }
 
-    discovered.sort_by(|left, right| right.0.cmp(&left.0));
+    discovered.sort_by_key(|item| Reverse(item.0));
     discovered.dedup_by(|left, right| left.1 == right.1);
 
     discovered

--- a/crates/gwt-github/src/client/fake.rs
+++ b/crates/gwt-github/src/client/fake.rs
@@ -6,6 +6,7 @@
 //! [`IssueClient`] contract in a predictable, deterministic way.
 
 use std::{
+    cmp::Reverse,
     collections::HashMap,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -266,7 +267,7 @@ impl IssueClient for FakeIssueClient {
             })
             .collect();
         // Deterministic ordering: number desc (newest first).
-        out.sort_by(|a, b| b.number.cmp(&a.number));
+        out.sort_by_key(|item| Reverse(item.number));
         Ok(out)
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1820,7 +1820,7 @@ mod tests {
             "expected drag selection tracking in embedded html",
         );
         assert!(
-            html.contains("terminalRoot.addEventListener(\"mouseup\""),
+            html.contains("window.addEventListener(\"mouseup\"") && html.contains("handleMouseUp"),
             "expected mouse release copy handling in embedded html",
         );
         assert!(
@@ -1838,11 +1838,12 @@ mod tests {
         let html = include_str!("../web/index.html");
 
         assert!(
-            html.contains("restoreFocus?.();"),
-            "expected clipboard fallback to restore terminal focus after textarea copy",
+            html.contains("restoreFocus"),
+            "expected clipboard fallback to invoke restoreFocus after textarea copy",
         );
         assert!(
-            html.contains("writeClipboardText(selection, () => runtime.terminal.focus())"),
+            html.contains("writeClipboardText(selection")
+                && html.contains("runtime.terminal.focus()"),
             "expected selection copy path to pass terminal focus restoration",
         );
     }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1788,6 +1788,50 @@ mod tests {
             dunce::canonicalize(&repo).expect("canonical repo root"),
         );
     }
+
+    #[test]
+    fn embedded_web_terminal_copy_shortcut_uses_ctrl_shift_c() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("function installTerminalCopyHandlers"),
+            "expected web terminal copy handler bootstrap in embedded html",
+        );
+        assert!(
+            html.contains("terminal.attachCustomKeyEventHandler"),
+            "expected xterm custom key handler for copy shortcut",
+        );
+        assert!(
+            html.contains("event.ctrlKey"),
+            "expected Ctrl modifier handling in embedded html",
+        );
+        assert!(
+            html.contains("event.shiftKey"),
+            "expected Shift modifier handling in embedded html",
+        );
+    }
+
+    #[test]
+    fn embedded_web_terminal_drag_selection_copies_on_mouseup() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("terminalRoot.addEventListener(\"mousedown\""),
+            "expected drag selection tracking in embedded html",
+        );
+        assert!(
+            html.contains("terminalRoot.addEventListener(\"mouseup\""),
+            "expected mouse release copy handling in embedded html",
+        );
+        assert!(
+            html.contains("function copyTerminalSelection"),
+            "expected clipboard copy helper in embedded html",
+        );
+        assert!(
+            html.contains("navigator.clipboard.writeText"),
+            "expected clipboard write path in embedded html",
+        );
+    }
 }
 
 fn normalize_active_tab_id(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1832,6 +1832,20 @@ mod tests {
             "expected clipboard write path in embedded html",
         );
     }
+
+    #[test]
+    fn embedded_web_terminal_clipboard_fallback_restores_terminal_focus() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("restoreFocus?.();"),
+            "expected clipboard fallback to restore terminal focus after textarea copy",
+        );
+        assert!(
+            html.contains("writeClipboardText(selection, () => runtime.terminal.focus())"),
+            "expected selection copy path to pass terminal focus restoration",
+        );
+    }
 }
 
 fn normalize_active_tab_id(

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1496,6 +1496,7 @@
       let titlebarClickState = null;
       let appState = { tabs: [], active_tab_id: null, recent_projects: [] };
       let projectError = "";
+      const TERMINAL_SELECTION_DRAG_THRESHOLD = 4;
 
       function presetSurface(preset) {
         if (
@@ -2096,6 +2097,159 @@
         return Uint8Array.from(atob(base64), (value) => value.charCodeAt(0));
       }
 
+      function isMacPlatform() {
+        const platform = navigator.userAgentData?.platform || navigator.platform || "";
+        return /mac|iphone|ipad|ipod/i.test(platform);
+      }
+
+      function isTerminalCopyShortcut(event) {
+        if (isMacPlatform()) {
+          return false;
+        }
+        const key = typeof event.key === "string" ? event.key.toLowerCase() : "";
+        return (
+          event.ctrlKey &&
+          event.shiftKey &&
+          !event.altKey &&
+          !event.metaKey &&
+          key === "c"
+        );
+      }
+
+      async function writeClipboardText(text) {
+        if (!text) {
+          return false;
+        }
+        if (navigator.clipboard?.writeText) {
+          try {
+            await navigator.clipboard.writeText(text);
+            return true;
+          } catch (_error) {
+            // Fall back to a temporary textarea when the async clipboard API is unavailable.
+          }
+        }
+
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.top = "-1000px";
+        textarea.style.left = "-1000px";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+
+        try {
+          return document.execCommand("copy");
+        } catch (_error) {
+          return false;
+        } finally {
+          textarea.remove();
+        }
+      }
+
+      async function copyTerminalSelection(windowId) {
+        const runtime = terminalMap.get(windowId);
+        if (!runtime || !runtime.terminal.hasSelection()) {
+          return false;
+        }
+        const selection = runtime.terminal.getSelection();
+        if (!selection) {
+          return false;
+        }
+        return writeClipboardText(selection);
+      }
+
+      function installTerminalCopyHandlers(windowId, terminalRoot, terminal) {
+        const copyState = {
+          mouseDown: false,
+          dragged: false,
+          startX: 0,
+          startY: 0,
+        };
+
+        function resetCopyState() {
+          copyState.mouseDown = false;
+          copyState.dragged = false;
+          copyState.startX = 0;
+          copyState.startY = 0;
+        }
+
+        const handleMouseDown = (event) => {
+          if (event.button !== 0) {
+            return;
+          }
+          copyState.mouseDown = true;
+          copyState.dragged = false;
+          copyState.startX = event.clientX;
+          copyState.startY = event.clientY;
+        };
+
+        const handleMouseMove = (event) => {
+          if (!copyState.mouseDown || copyState.dragged) {
+            return;
+          }
+          const movedX = Math.abs(event.clientX - copyState.startX);
+          const movedY = Math.abs(event.clientY - copyState.startY);
+          if (
+            movedX >= TERMINAL_SELECTION_DRAG_THRESHOLD ||
+            movedY >= TERMINAL_SELECTION_DRAG_THRESHOLD
+          ) {
+            copyState.dragged = true;
+          }
+        };
+
+        const handleMouseUp = (event) => {
+          if (!copyState.mouseDown) {
+            return;
+          }
+          const shouldCopy = event.button === 0 && copyState.dragged;
+          resetCopyState();
+          if (!shouldCopy) {
+            return;
+          }
+          requestAnimationFrame(() => {
+            if (!terminal.hasSelection()) {
+              return;
+            }
+            void copyTerminalSelection(windowId);
+          });
+        };
+
+        const handleWindowBlur = () => {
+          resetCopyState();
+        };
+
+        terminal.attachCustomKeyEventHandler((event) => {
+          if (!isTerminalCopyShortcut(event)) {
+            return true;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          if (!terminal.hasSelection()) {
+            return false;
+          }
+          void copyTerminalSelection(windowId);
+          return false;
+        });
+
+        terminalRoot.addEventListener("mousedown", handleMouseDown);
+        terminalRoot.addEventListener("mouseup", handleMouseUp);
+        window.addEventListener("mousemove", handleMouseMove, true);
+        window.addEventListener("mouseup", handleMouseUp, true);
+        window.addEventListener("blur", handleWindowBlur);
+
+        return () => {
+          terminal.attachCustomKeyEventHandler(() => true);
+          terminalRoot.removeEventListener("mousedown", handleMouseDown);
+          terminalRoot.removeEventListener("mouseup", handleMouseUp);
+          window.removeEventListener("mousemove", handleMouseMove, true);
+          window.removeEventListener("mouseup", handleMouseUp, true);
+          window.removeEventListener("blur", handleWindowBlur);
+        };
+      }
+
       function createTerminalRuntime(windowId, terminalContainer) {
         if (terminalMap.has(windowId)) {
           return terminalMap.get(windowId);
@@ -2133,10 +2287,11 @@
         const fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
         terminal.open(terminalContainer);
+        const cleanup = installTerminalCopyHandlers(windowId, terminalContainer, terminal);
         terminal.onData((data) => {
           send({ kind: "terminal_input", id: windowId, data });
         });
-        terminalMap.set(windowId, { terminal, fitAddon });
+        terminalMap.set(windowId, { terminal, fitAddon, cleanup });
         decoderMap.set(windowId, new TextDecoder());
         requestAnimationFrame(() => fitTerminal(windowId, true));
 
@@ -3375,7 +3530,9 @@
           if (ids.has(windowId)) {
             continue;
           }
-          terminalMap.get(windowId)?.terminal.dispose();
+          const runtime = terminalMap.get(windowId);
+          runtime?.cleanup?.();
+          runtime?.terminal.dispose();
           terminalMap.delete(windowId);
           decoderMap.delete(windowId);
           detailMap.delete(windowId);

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2116,7 +2116,7 @@
         );
       }
 
-      async function writeClipboardText(text) {
+      async function writeClipboardText(text, restoreFocus = null) {
         if (!text) {
           return false;
         }
@@ -2146,6 +2146,7 @@
           return false;
         } finally {
           textarea.remove();
+          restoreFocus?.();
         }
       }
 
@@ -2158,7 +2159,7 @@
         if (!selection) {
           return false;
         }
-        return writeClipboardText(selection);
+        return writeClipboardText(selection, () => runtime.terminal.focus());
       }
 
       function installTerminalCopyHandlers(windowId, terminalRoot, terminal) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2236,7 +2236,6 @@
         });
 
         terminalRoot.addEventListener("mousedown", handleMouseDown);
-        terminalRoot.addEventListener("mouseup", handleMouseUp);
         window.addEventListener("mousemove", handleMouseMove, true);
         window.addEventListener("mouseup", handleMouseUp, true);
         window.addEventListener("blur", handleWindowBlur);
@@ -2244,7 +2243,6 @@
         return () => {
           terminal.attachCustomKeyEventHandler(() => true);
           terminalRoot.removeEventListener("mousedown", handleMouseDown);
-          terminalRoot.removeEventListener("mouseup", handleMouseUp);
           window.removeEventListener("mousemove", handleMouseMove, true);
           window.removeEventListener("mouseup", handleMouseUp, true);
           window.removeEventListener("blur", handleWindowBlur);
@@ -2292,7 +2290,8 @@
         terminal.onData((data) => {
           send({ kind: "terminal_input", id: windowId, data });
         });
-        terminalMap.set(windowId, { terminal, fitAddon, cleanup });
+        const runtime = { terminal, fitAddon, cleanup };
+        terminalMap.set(windowId, runtime);
         decoderMap.set(windowId, new TextDecoder());
         requestAnimationFrame(() => fitTerminal(windowId, true));
 
@@ -2309,7 +2308,7 @@
           }
           pendingOutputMap.delete(windowId);
         }
-        return { terminal, fitAddon };
+        return runtime;
       }
 
       function writeOutput(windowId, base64) {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2779,3 +2779,26 @@ v9.2.0 リリース実行中に `/release` コマンドの Step 9.2（`scripts/r
 3. Release PR の Closing Issues セクション生成時に「自動クローズ対象があるか」をユーザーに明示し、空の場合は明確に `None` と記載する
 4. release.md の Step 9 冒頭に「GitHub 自動クローズは Issue のみが対象であり、PR 番号は無視される」と注釈を追加し、PR/Issue 分類の重要性を強調する
 5. `tasks/lessons.md` にこの教訓を記録し、同種の長時間手順コマンド設計時の参考にする
+
+## 2026-04-17 — fix: clipboard fallback は focus を奪ったら必ず terminal へ戻す
+
+### 事象
+
+Web terminal の copy 実装で `navigator.clipboard.writeText()` が使えない環境では、
+hidden `textarea` + `document.execCommand("copy")` fallback を使っていたが、copy 後に
+terminal input focus が戻らず、次のキー入力が shell / agent に届かなくなった。
+
+### 原因
+
+- fallback 実装が clipboard 書き込み成功だけを見ており、focus ownership の回復を考慮していなかった。
+- async clipboard API が使える通常経路だけを前提にして、permission-restricted WebView の
+  fallback 実機セマンティクスをテストで固定していなかった。
+
+### 再発防止策
+
+1. hidden input / textarea を使う clipboard fallback では、cleanup 時に元の interactive surface
+   へ focus を戻す処理を必須で入れる。
+2. WebView の permission 差分がありうる API は、正常経路だけでなく fallback 後の focus /
+   input routing 契約も埋め込みテストで固定する。
+3. terminal copy UX の変更では、copy success だけでなく「直後の次キー入力が terminal へ届くか」
+   を review 観点に含める。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,25 @@
 # Lessons Learned
 
+## 2026-04-17 — fix: CI lint 再現は workflow と同じ package / feature 範囲で実行する
+
+### 事象
+
+PR #2052 の `Clippy & Rustfmt` が CI で失敗したが、手元では直前に `cargo clippy` を
+通したつもりだった。実際の失敗箇所は `crates/gwt-github/src/client/fake.rs` の
+`unnecessary_sort_by` で、`gwt` の feature 経由で lint 対象に入っていた。
+
+### 原因
+
+- 手元の確認で、workflow に書かれている package 指定と同じコマンドを厳密に再現していなかった。
+- 「workspace 全体を見ているはず」という前提で済ませ、CI job 定義をその場で確認しなかった。
+- transitive dependency / feature 経由で lint 対象になる crate を、変更ファイルだけ見て外していた。
+
+### 再発防止策
+
+1. CI 失敗の再現では、先に `.github/workflows/*.yml` の実コマンドを確認し、そのまま手元で実行する。
+2. `-p` 指定の lint/test でも、feature 経由で別 crate が対象に入る前提でログを確認する。
+3. 「ローカルで通った」は抽象化せず、最終報告では実行した正確なコマンド列を残す。
+
 ## 2026-04-17 — fix: embedded WebView JS の回帰確認は整形文字列ではなく契約と対称性を見る
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,28 @@
 # Lessons Learned
 
+## 2026-04-17 — fix: embedded WebView JS の回帰確認は整形文字列ではなく契約と対称性を見る
+
+### 事象
+
+Web terminal copy 修正の PR で、CodeRabbit から 3 件の follow-up 指摘が出た。
+`include_str!` ベースの HTML 回帰テストが単一行の exact string に依存していて
+整形変更に弱かったこと、`createTerminalRuntime()` の新規作成 path だけ返り値に
+`cleanup` を含めていなかったこと、copy 用の `mouseup` listener が capture/bubble の
+二重登録になっていたことが原因だった。
+
+### 原因
+
+- 埋め込み HTML の契約テストで、挙動ではなくフォーマット済み文字列そのものを固定していた。
+- JS helper の reuse path と create path の返り値形状を並べて確認していなかった。
+- event listener の追加/削除を対で見ず、window capture listener と terminalRoot listener の
+  役割重複を残していた。
+
+### 再発防止策
+
+1. `include_str!` で埋め込む HTML/JS の回帰テストは exact snippet ではなく、必要な token や契約を構造的に確認する。
+2. factory/helper 関数を変更するときは、既存再利用 path と新規作成 path の返り値 shape を揃えて確認する。
+3. DOM event handler 変更では、登録と cleanup を対で確認し、capture/bubble の重複 listener が本当に必要かを見直す。
+
 ## 2026-04-16 — fix: read-only CLI は eager GitHub auth を起動時に解決しない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Restores the Web terminal copy workflow so drag selection copies on mouse release while keeping `Ctrl+C` routed to the running terminal process.
- Adds a focused fallback fix for permission-restricted WebViews so clipboard copy does not leave xterm unfocused after the hidden textarea path runs.
- Documents the user-facing copy behavior and locks the terminal copy contract with embedded HTML regression tests.

## Changes

- `crates/gwt/web/index.html`: added xterm Web terminal copy handlers for drag auto-copy, `Ctrl+Shift+C`, and terminal focus restoration after the clipboard fallback path.
- `crates/gwt/src/main.rs`: added embedded HTML regression tests for the Web terminal copy shortcut, drag release copy, and fallback focus restoration.
- `README.md` and `README.ja.md`: documented the terminal copy behavior for Web terminal windows.
- `tasks/lessons.md`: recorded the clipboard fallback focus regression and the prevention rules for future terminal UX changes.

## Testing

- [x] `cargo test -p gwt tests::embedded_web_terminal_copy_shortcut_uses_ctrl_shift_c -- --exact` — passes and confirms the embedded HTML keeps the `Ctrl+Shift+C` copy path.
- [x] `cargo test -p gwt tests::embedded_web_terminal_drag_selection_copies_on_mouseup -- --exact` — passes and confirms drag selection still copies on mouse release.
- [x] `cargo test -p gwt tests::embedded_web_terminal_clipboard_fallback_restores_terminal_focus -- --exact` — passes and confirms the hidden textarea clipboard fallback restores terminal focus.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo build -p gwt` — passes.

## Closing Issues

- None

## Related Issues / Links

- #1919

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — not applicable: no schema/data change
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This branch implements the Web/xterm.js side of the `SPEC-1919` terminal copy contract.
- The follow-up focus fix came directly from review feedback on the initial copy workflow patch, where the hidden textarea clipboard fallback could leave the terminal unfocused in embedded WebViews.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal text selection: drag-select text in terminal windows and release to copy.
  * Added Ctrl+Shift+C keyboard shortcut on Windows/Linux to copy active terminal selection.
  * Implemented clipboard fallback for enhanced compatibility across environments.

* **Documentation**
  * Clarified terminal text manipulation behavior and keyboard shortcuts in README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->