### PR TITLE
chore(release): v9.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.5.1] - 2026-04-17
+
+### Bug Fixes
+
+- **update:** MacOS DMG インストーラの install_result 型推論を明示して macOS ビルド失敗を解消
+
 ## [9.5.0] - 2026-04-17
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "axum",
  "base64",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "chrono",
  "gwt-core",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "dirs",
  "serde",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "fs2",
  "regex",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.5.0"
+version = "9.5.1"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.5.0"
+version = "9.5.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -1201,7 +1201,7 @@ fn run_macos_dmg_installer_with_privileges(
         return Err(format!("hdiutil attach exited with {attach_status}"));
     }
 
-    let install_result = (|| {
+    let install_result: Result<PathBuf, String> = (|| {
         let source_app = find_first_app_bundle(&mount_dir)?
             .ok_or_else(|| "Mounted dmg does not contain an .app bundle".to_string())?;
         let source_name = source_app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.5.1 は v9.5.0 リリースワークフローで発生した macOS ビルド失敗を解消する patch リリースです。`crates/gwt-core/src/update.rs` の DMG インストーラ処理で `install_result` の型推論が曖昧だった問題に明示的な型注釈を付与しました。

## Changes

### Bug Fixes
- **update:** macOS DMG インストーラの `install_result` 型推論を明示して macOS ビルド失敗を解消

## Version

v9.5.1

## Background

v9.5.0 のリリースワークフロー (run `24553846960`) で macOS x86_64 / aarch64 のビルドが E0282 / E0283 で失敗し、`upload-release` と `publish-npm` がスキップされた。これは v9.4.1 でも同じ場所で失敗していた既存の潜在バグ。v9.5.0 タグと draft release は削除し、本 PR で v9.5.1 として再リリースする。

## Closing Issues

None

## Related Issues / Links

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 9.5.1

* **Bug Fixes**
  * Resolved macOS build failures with the DMG installer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->