### PR TITLE
feat(branches): add cleanup flow and scope filters

### DIFF
--- a/crates/gwt/src/branch_cleanup.rs
+++ b/crates/gwt/src/branch_cleanup.rs
@@ -1,0 +1,141 @@
+use std::{collections::HashMap, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{BranchCleanupAvailability, BranchCleanupBlockedReason, BranchListEntry};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchCleanupResultStatus {
+    Success,
+    Partial,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchCleanupResultEntry {
+    pub branch: String,
+    pub execution_branch: Option<String>,
+    pub status: BranchCleanupResultStatus,
+    pub message: String,
+}
+
+pub fn cleanup_selected_branches(
+    repo_path: &Path,
+    entries: &[BranchListEntry],
+    selected_branches: &[String],
+    delete_remote: bool,
+) -> std::io::Result<Vec<BranchCleanupResultEntry>> {
+    let manager = gwt_git::WorktreeManager::new(repo_path);
+    let lookup: HashMap<&str, &BranchListEntry> = entries
+        .iter()
+        .map(|entry| (entry.name.as_str(), entry))
+        .collect();
+
+    Ok(selected_branches
+        .iter()
+        .map(|branch_name| {
+            let Some(entry) = lookup.get(branch_name.as_str()).copied() else {
+                return BranchCleanupResultEntry {
+                    branch: branch_name.clone(),
+                    execution_branch: None,
+                    status: BranchCleanupResultStatus::Failed,
+                    message: "Branch not found".to_string(),
+                };
+            };
+            let execution_branch = entry.cleanup.execution_branch.clone();
+            let Some(target_branch) = execution_branch.clone() else {
+                return BranchCleanupResultEntry {
+                    branch: entry.name.clone(),
+                    execution_branch,
+                    status: BranchCleanupResultStatus::Failed,
+                    message: blocked_reason_message(
+                        entry
+                            .cleanup
+                            .blocked_reason
+                            .unwrap_or(BranchCleanupBlockedReason::Unknown),
+                    ),
+                };
+            };
+            if entry.cleanup.availability == BranchCleanupAvailability::Blocked {
+                return BranchCleanupResultEntry {
+                    branch: entry.name.clone(),
+                    execution_branch: Some(target_branch),
+                    status: BranchCleanupResultStatus::Failed,
+                    message: blocked_reason_message(
+                        entry
+                            .cleanup
+                            .blocked_reason
+                            .unwrap_or(BranchCleanupBlockedReason::Unknown),
+                    ),
+                };
+            }
+
+            match manager.cleanup_branch(&target_branch) {
+                Ok(()) => {
+                    if delete_remote && entry.cleanup.upstream.is_some() {
+                        match manager
+                            .delete_remote_branch(&target_branch, entry.cleanup.upstream.as_deref())
+                        {
+                            Ok(gwt_git::RemoteDeleteOutcome::Deleted) => BranchCleanupResultEntry {
+                                branch: entry.name.clone(),
+                                execution_branch: Some(target_branch),
+                                status: BranchCleanupResultStatus::Success,
+                                message: "Deleted local and remote branches".to_string(),
+                            },
+                            Ok(gwt_git::RemoteDeleteOutcome::SkippedMissing) => {
+                                BranchCleanupResultEntry {
+                                    branch: entry.name.clone(),
+                                    execution_branch: Some(target_branch),
+                                    status: BranchCleanupResultStatus::Success,
+                                    message:
+                                        "Deleted local branch; remote branch was already missing"
+                                            .to_string(),
+                                }
+                            }
+                            Err(error) => BranchCleanupResultEntry {
+                                branch: entry.name.clone(),
+                                execution_branch: Some(target_branch),
+                                status: BranchCleanupResultStatus::Partial,
+                                message: format!(
+                                    "Deleted local branch; remote delete failed: {error}"
+                                ),
+                            },
+                        }
+                    } else {
+                        BranchCleanupResultEntry {
+                            branch: entry.name.clone(),
+                            execution_branch: Some(target_branch),
+                            status: BranchCleanupResultStatus::Success,
+                            message: "Deleted local branch".to_string(),
+                        }
+                    }
+                }
+                Err(error) => BranchCleanupResultEntry {
+                    branch: entry.name.clone(),
+                    execution_branch: Some(target_branch),
+                    status: BranchCleanupResultStatus::Failed,
+                    message: format!("Cleanup failed: {error}"),
+                },
+            }
+        })
+        .collect())
+}
+
+fn blocked_reason_message(reason: BranchCleanupBlockedReason) -> String {
+    match reason {
+        BranchCleanupBlockedReason::ProtectedBranch => {
+            "Cannot clean up a protected branch".to_string()
+        }
+        BranchCleanupBlockedReason::CurrentHead => {
+            "Cannot clean up the current HEAD branch".to_string()
+        }
+        BranchCleanupBlockedReason::ActiveSession => {
+            "Cannot clean up a branch with an active session".to_string()
+        }
+        BranchCleanupBlockedReason::RemoteTrackingWithoutLocal => {
+            "Cannot clean up a remote-tracking branch without a local counterpart".to_string()
+        }
+        BranchCleanupBlockedReason::Unknown => "Cannot clean up this branch".to_string(),
+    }
+}

--- a/crates/gwt/src/branch_cleanup.rs
+++ b/crates/gwt/src/branch_cleanup.rs
@@ -25,14 +25,14 @@ pub fn cleanup_selected_branches(
     entries: &[BranchListEntry],
     selected_branches: &[String],
     delete_remote: bool,
-) -> std::io::Result<Vec<BranchCleanupResultEntry>> {
+) -> Vec<BranchCleanupResultEntry> {
     let manager = gwt_git::WorktreeManager::new(repo_path);
     let lookup: HashMap<&str, &BranchListEntry> = entries
         .iter()
         .map(|entry| (entry.name.as_str(), entry))
         .collect();
 
-    Ok(selected_branches
+    selected_branches
         .iter()
         .map(|branch_name| {
             let Some(entry) = lookup.get(branch_name.as_str()).copied() else {
@@ -119,7 +119,7 @@ pub fn cleanup_selected_branches(
                 },
             }
         })
-        .collect())
+        .collect()
 }
 
 fn blocked_reason_message(reason: BranchCleanupBlockedReason) -> String {

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -1,6 +1,58 @@
-use std::{cmp::Ordering, path::Path};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    path::Path,
+};
 
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchCleanupAvailability {
+    Safe,
+    Risky,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchCleanupBlockedReason {
+    ProtectedBranch,
+    CurrentHead,
+    ActiveSession,
+    RemoteTrackingWithoutLocal,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchCleanupRisk {
+    Unmerged,
+    RemoteTracking,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchCleanupInfo {
+    pub availability: BranchCleanupAvailability,
+    pub execution_branch: Option<String>,
+    pub merge_target: Option<gwt_git::MergeTarget>,
+    pub upstream: Option<String>,
+    pub blocked_reason: Option<BranchCleanupBlockedReason>,
+    pub risks: Vec<BranchCleanupRisk>,
+}
+
+impl Default for BranchCleanupInfo {
+    fn default() -> Self {
+        Self {
+            availability: BranchCleanupAvailability::Blocked,
+            execution_branch: None,
+            merge_target: None,
+            upstream: None,
+            blocked_reason: Some(BranchCleanupBlockedReason::Unknown),
+            risks: Vec::new(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -18,34 +70,198 @@ pub struct BranchListEntry {
     pub ahead: u32,
     pub behind: u32,
     pub last_commit_date: Option<String>,
+    pub cleanup: BranchCleanupInfo,
 }
 
 pub fn list_branch_entries(repo_path: &Path) -> std::io::Result<Vec<BranchListEntry>> {
-    let branches = gwt_git::branch::list_branches(repo_path)
-        .map_err(|error| std::io::Error::other(error.to_string()))?;
-    Ok(adapt_branches(branches))
+    list_branch_entries_with_active_sessions(repo_path, &HashSet::new())
 }
 
-fn adapt_branches(branches: Vec<gwt_git::Branch>) -> Vec<BranchListEntry> {
+pub fn list_branch_entries_with_active_sessions(
+    repo_path: &Path,
+    active_session_branches: &HashSet<String>,
+) -> std::io::Result<Vec<BranchListEntry>> {
+    let branches = gwt_git::branch::list_branches(repo_path)
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    let gone_branches = gwt_git::list_gone_branches(repo_path)
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    let cleanup_targets = build_cleanup_targets(repo_path, &branches, &gone_branches)?;
+    Ok(adapt_branches(
+        branches,
+        active_session_branches,
+        &cleanup_targets,
+    ))
+}
+
+fn build_cleanup_targets(
+    repo_path: &Path,
+    branches: &[gwt_git::Branch],
+    gone_branches: &HashSet<String>,
+) -> std::io::Result<HashMap<String, Option<gwt_git::MergeTarget>>> {
+    let cleanup_bases = [
+        ("main", gwt_git::MergeTarget::Main),
+        ("master", gwt_git::MergeTarget::Main),
+        ("develop", gwt_git::MergeTarget::Develop),
+    ];
+    let mut cleanup_targets = HashMap::new();
+    for branch in branches.iter().filter(|branch| branch.is_local) {
+        let target = gwt_git::detect_cleanable_target(
+            repo_path,
+            &branch.name,
+            &cleanup_bases,
+            gone_branches,
+        )
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+        cleanup_targets.insert(branch.name.clone(), target);
+    }
+    Ok(cleanup_targets)
+}
+
+fn adapt_branches(
+    branches: Vec<gwt_git::Branch>,
+    active_session_branches: &HashSet<String>,
+    cleanup_targets: &HashMap<String, Option<gwt_git::MergeTarget>>,
+) -> Vec<BranchListEntry> {
+    let current_head_branch = branches
+        .iter()
+        .find(|branch| branch.is_local && branch.is_head)
+        .map(|branch| branch.name.clone());
+    let local_upstreams: HashMap<String, Option<String>> = branches
+        .iter()
+        .filter(|branch| branch.is_local)
+        .map(|branch| (branch.name.clone(), branch.upstream.clone()))
+        .collect();
     let mut entries: Vec<BranchListEntry> = branches
         .into_iter()
-        .map(|branch| BranchListEntry {
-            name: branch.name,
-            scope: if branch.is_remote {
-                BranchScope::Remote
-            } else {
-                BranchScope::Local
-            },
-            is_head: branch.is_head,
-            upstream: branch.upstream,
-            ahead: branch.ahead,
-            behind: branch.behind,
-            last_commit_date: branch.last_commit_date,
+        .map(|branch| {
+            let cleanup = build_cleanup_info(
+                &branch,
+                &local_upstreams,
+                current_head_branch.as_deref(),
+                active_session_branches,
+                cleanup_targets,
+            );
+            BranchListEntry {
+                name: branch.name,
+                scope: if branch.is_remote {
+                    BranchScope::Remote
+                } else {
+                    BranchScope::Local
+                },
+                is_head: branch.is_head,
+                upstream: branch.upstream,
+                ahead: branch.ahead,
+                behind: branch.behind,
+                last_commit_date: branch.last_commit_date,
+                cleanup,
+            }
         })
         .collect();
 
     entries.sort_by(compare_branch_entries);
     entries
+}
+
+fn build_cleanup_info(
+    branch: &gwt_git::Branch,
+    local_upstreams: &HashMap<String, Option<String>>,
+    current_head_branch: Option<&str>,
+    active_session_branches: &HashSet<String>,
+    cleanup_targets: &HashMap<String, Option<gwt_git::MergeTarget>>,
+) -> BranchCleanupInfo {
+    let execution_branch = cleanup_execution_branch(branch, local_upstreams);
+    let Some(execution_branch_name) = execution_branch.as_deref() else {
+        return BranchCleanupInfo {
+            availability: BranchCleanupAvailability::Blocked,
+            execution_branch: None,
+            merge_target: None,
+            upstream: None,
+            blocked_reason: Some(BranchCleanupBlockedReason::RemoteTrackingWithoutLocal),
+            risks: Vec::new(),
+        };
+    };
+    let upstream = local_upstreams
+        .get(execution_branch_name)
+        .cloned()
+        .flatten();
+
+    if gwt_git::is_protected_branch(execution_branch_name) {
+        return blocked_cleanup_info(
+            execution_branch,
+            upstream,
+            BranchCleanupBlockedReason::ProtectedBranch,
+        );
+    }
+    if current_head_branch.is_some_and(|head| head == execution_branch_name) {
+        return blocked_cleanup_info(
+            execution_branch,
+            upstream,
+            BranchCleanupBlockedReason::CurrentHead,
+        );
+    }
+    if active_session_branches.contains(execution_branch_name) {
+        return blocked_cleanup_info(
+            execution_branch,
+            upstream,
+            BranchCleanupBlockedReason::ActiveSession,
+        );
+    }
+
+    let merge_target = cleanup_targets
+        .get(execution_branch_name)
+        .cloned()
+        .flatten();
+    let mut risks = Vec::new();
+    if branch.is_remote {
+        risks.push(BranchCleanupRisk::RemoteTracking);
+    }
+    if merge_target.is_none() {
+        risks.push(BranchCleanupRisk::Unmerged);
+    }
+
+    BranchCleanupInfo {
+        availability: if risks.is_empty() {
+            BranchCleanupAvailability::Safe
+        } else {
+            BranchCleanupAvailability::Risky
+        },
+        execution_branch,
+        merge_target,
+        upstream,
+        blocked_reason: None,
+        risks,
+    }
+}
+
+fn blocked_cleanup_info(
+    execution_branch: Option<String>,
+    upstream: Option<String>,
+    blocked_reason: BranchCleanupBlockedReason,
+) -> BranchCleanupInfo {
+    BranchCleanupInfo {
+        availability: BranchCleanupAvailability::Blocked,
+        execution_branch,
+        merge_target: None,
+        upstream,
+        blocked_reason: Some(blocked_reason),
+        risks: Vec::new(),
+    }
+}
+
+fn cleanup_execution_branch(
+    branch: &gwt_git::Branch,
+    local_upstreams: &HashMap<String, Option<String>>,
+) -> Option<String> {
+    if branch.is_local {
+        return Some(branch.name.clone());
+    }
+    local_branch_for_remote_ref(&branch.name)
+        .filter(|local_name| local_upstreams.contains_key(*local_name))
+        .map(ToString::to_string)
+}
+
+fn local_branch_for_remote_ref(name: &str) -> Option<&str> {
+    name.split_once('/').map(|(_, branch_name)| branch_name)
 }
 
 fn compare_branch_entries(left: &BranchListEntry, right: &BranchListEntry) -> Ordering {
@@ -114,7 +330,7 @@ mod tests {
             },
         ];
 
-        let entries = adapt_branches(branches);
+        let entries = adapt_branches(branches, &HashSet::new(), &HashMap::new());
         let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
         assert_eq!(
             names,

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -255,9 +255,13 @@ fn cleanup_execution_branch(
     if branch.is_local {
         return Some(branch.name.clone());
     }
-    local_branch_for_remote_ref(&branch.name)
-        .filter(|local_name| local_upstreams.contains_key(*local_name))
-        .map(ToString::to_string)
+    let local_name = local_branch_for_remote_ref(&branch.name)?;
+    let upstream = local_upstreams.get(local_name)?;
+    if upstream.as_deref() == Some(branch.name.as_str()) {
+        Some(local_name.to_string())
+    } else {
+        None
+    }
 }
 
 fn local_branch_for_remote_ref(name: &str) -> Option<&str> {

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2301,6 +2301,7 @@ mod tests {
             ahead: 0,
             behind: 0,
             last_commit_date: None,
+            cleanup: crate::BranchCleanupInfo::default(),
         }
     }
 

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod branch_cleanup;
 pub mod branch_list;
 pub mod cli;
 mod discussion_resume;
@@ -12,7 +13,14 @@ pub mod preset;
 pub mod protocol;
 pub mod workspace;
 
+pub use branch_cleanup::{
+    cleanup_selected_branches, BranchCleanupResultEntry, BranchCleanupResultStatus,
+};
 pub use branch_list::{list_branch_entries, BranchListEntry, BranchScope};
+pub use branch_list::{
+    list_branch_entries_with_active_sessions, BranchCleanupAvailability,
+    BranchCleanupBlockedReason, BranchCleanupInfo, BranchCleanupRisk,
+};
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
 pub use launch_wizard::{
     build_builtin_agent_options, default_wizard_version_cache_path, AgentOption,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -78,6 +78,7 @@ enum UserEvent {
             String,
         >,
     },
+    Dispatch(Vec<OutboundEvent>),
     UpdateAvailable(gwt_core::update::UpdateState),
     #[cfg(target_os = "macos")]
     MenuEvent(muda::MenuEvent),
@@ -890,60 +891,77 @@ impl AppRuntime {
             )];
         }
 
-        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
-        let entries = match list_branch_entries_with_active_sessions(
-            &tab.project_root,
-            &active_session_branches,
-        ) {
-            Ok(entries) => entries,
-            Err(error) => {
-                return vec![OutboundEvent::reply(
-                    client_id,
-                    BackendEvent::BranchError {
-                        id: id.to_string(),
-                        message: error.to_string(),
-                    },
-                )];
-            }
-        };
-        let results =
-            match cleanup_selected_branches(&tab.project_root, &entries, branches, delete_remote) {
-                Ok(results) => results,
-                Err(error) => {
-                    return vec![OutboundEvent::reply(
-                        client_id,
-                        BackendEvent::BranchError {
-                            id: id.to_string(),
-                            message: error.to_string(),
+        Self::spawn_branch_cleanup_async(
+            self.proxy.clone(),
+            client_id.to_string(),
+            id.to_string(),
+            tab.project_root.clone(),
+            self.active_session_branches_for_tab(&address.tab_id),
+            branches.to_vec(),
+            delete_remote,
+        );
+        Vec::new()
+    }
+
+    fn spawn_branch_cleanup_async(
+        proxy: EventLoopProxy<UserEvent>,
+        client_id: ClientId,
+        window_id: String,
+        project_root: PathBuf,
+        active_session_branches: std::collections::HashSet<String>,
+        branches: Vec<String>,
+        delete_remote: bool,
+    ) {
+        thread::spawn(move || {
+            let events = match list_branch_entries_with_active_sessions(
+                &project_root,
+                &active_session_branches,
+            ) {
+                Ok(entries) => {
+                    let results = cleanup_selected_branches(
+                        &project_root,
+                        &entries,
+                        &branches,
+                        delete_remote,
+                    );
+                    let mut events = vec![OutboundEvent::reply(
+                        client_id.clone(),
+                        BackendEvent::BranchCleanupResult {
+                            id: window_id.clone(),
+                            results,
                         },
                     )];
+                    match list_branch_entries_with_active_sessions(
+                        &project_root,
+                        &active_session_branches,
+                    ) {
+                        Ok(entries) => events.push(OutboundEvent::reply(
+                            client_id.clone(),
+                            BackendEvent::BranchEntries {
+                                id: window_id.clone(),
+                                entries,
+                            },
+                        )),
+                        Err(error) => events.push(OutboundEvent::reply(
+                            client_id.clone(),
+                            BackendEvent::BranchError {
+                                id: window_id.clone(),
+                                message: error.to_string(),
+                            },
+                        )),
+                    }
+                    events
                 }
+                Err(error) => vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BranchError {
+                        id: window_id,
+                        message: error.to_string(),
+                    },
+                )],
             };
-        let mut events = vec![OutboundEvent::reply(
-            client_id,
-            BackendEvent::BranchCleanupResult {
-                id: id.to_string(),
-                results,
-            },
-        )];
-        match list_branch_entries_with_active_sessions(&tab.project_root, &active_session_branches)
-        {
-            Ok(entries) => events.push(OutboundEvent::reply(
-                client_id,
-                BackendEvent::BranchEntries {
-                    id: id.to_string(),
-                    entries,
-                },
-            )),
-            Err(error) => events.push(OutboundEvent::reply(
-                client_id,
-                BackendEvent::BranchError {
-                    id: id.to_string(),
-                    message: error.to_string(),
-                },
-            )),
-        }
-        events
+            let _ = proxy.send_event(UserEvent::Dispatch(events));
+        });
     }
 
     fn open_launch_wizard(
@@ -3282,6 +3300,9 @@ fn main() -> wry::Result<()> {
             }
             Event::UserEvent(UserEvent::LaunchComplete { window_id, result }) => {
                 let events = app.handle_launch_complete(window_id, result);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::Dispatch(events)) => {
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::UpdateAvailable(state)) => {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -20,13 +20,13 @@ use axum::{
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use gwt::{
-    default_wizard_version_cache_path, detect_shell_program, list_branch_entries,
-    list_directory_entries, load_restored_workspace_state, load_session_state,
-    migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
-    save_session_state, save_workspace_state, workspace_state_path, BackendEvent,
-    DockerWizardContext, FrontendEvent, LaunchWizardCompletion, LaunchWizardContext,
-    LaunchWizardState, LiveSessionEntry, WindowGeometry, WindowPreset, WindowProcessStatus,
-    WorkspaceState, APP_NAME,
+    cleanup_selected_branches, default_wizard_version_cache_path, detect_shell_program,
+    list_branch_entries_with_active_sessions, list_directory_entries,
+    load_restored_workspace_state, load_session_state, migrate_legacy_workspace_state,
+    refresh_managed_gwt_assets_for_worktree, resolve_launch_spec, save_session_state,
+    save_workspace_state, workspace_state_path, BackendEvent, DockerWizardContext, FrontendEvent,
+    LaunchWizardCompletion, LaunchWizardContext, LaunchWizardState, LiveSessionEntry,
+    WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus};
 use tao::{
@@ -317,6 +317,11 @@ impl AppRuntime {
                     self.load_branches_event(&id),
                 )]
             }
+            FrontendEvent::RunBranchCleanup {
+                id,
+                branches,
+                delete_remote,
+            } => self.run_branch_cleanup_events(&client_id, &id, &branches, delete_remote),
             FrontendEvent::OpenLaunchWizard {
                 id,
                 branch_name,
@@ -826,7 +831,9 @@ impl AppRuntime {
             };
         }
 
-        match list_branch_entries(&tab.project_root) {
+        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
+        match list_branch_entries_with_active_sessions(&tab.project_root, &active_session_branches)
+        {
             Ok(entries) => BackendEvent::BranchEntries {
                 id: id.to_string(),
                 entries,
@@ -836,6 +843,107 @@ impl AppRuntime {
                 message: error.to_string(),
             },
         }
+    }
+
+    fn run_branch_cleanup_events(
+        &self,
+        client_id: &str,
+        id: &str,
+        branches: &[String],
+        delete_remote: bool,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+
+        if window.preset != WindowPreset::Branches {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Window is not a branches list".to_string(),
+                },
+            )];
+        }
+
+        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
+        let entries = match list_branch_entries_with_active_sessions(
+            &tab.project_root,
+            &active_session_branches,
+        ) {
+            Ok(entries) => entries,
+            Err(error) => {
+                return vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BranchError {
+                        id: id.to_string(),
+                        message: error.to_string(),
+                    },
+                )];
+            }
+        };
+        let results =
+            match cleanup_selected_branches(&tab.project_root, &entries, branches, delete_remote) {
+                Ok(results) => results,
+                Err(error) => {
+                    return vec![OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::BranchError {
+                            id: id.to_string(),
+                            message: error.to_string(),
+                        },
+                    )];
+                }
+            };
+        let mut events = vec![OutboundEvent::reply(
+            client_id,
+            BackendEvent::BranchCleanupResult {
+                id: id.to_string(),
+                results,
+            },
+        )];
+        match list_branch_entries_with_active_sessions(&tab.project_root, &active_session_branches)
+        {
+            Ok(entries) => events.push(OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchEntries {
+                    id: id.to_string(),
+                    entries,
+                },
+            )),
+            Err(error) => events.push(OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: error.to_string(),
+                },
+            )),
+        }
+        events
     }
 
     fn open_launch_wizard(
@@ -870,7 +978,11 @@ impl AppRuntime {
             })];
         }
 
-        let entries = match list_branch_entries(&tab.project_root) {
+        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
+        let entries = match list_branch_entries_with_active_sessions(
+            &tab.project_root,
+            &active_session_branches,
+        ) {
             Ok(entries) => entries,
             Err(error) => {
                 return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
@@ -991,6 +1103,14 @@ impl AppRuntime {
             .collect::<Vec<_>>();
         entries.sort_by(|left, right| left.name.cmp(&right.name));
         entries
+    }
+
+    fn active_session_branches_for_tab(&self, tab_id: &str) -> std::collections::HashSet<String> {
+        self.active_agent_sessions
+            .values()
+            .filter(|session| session.tab_id == tab_id)
+            .map(|session| session.branch_name.clone())
+            .collect()
     }
 
     fn handle_runtime_output(&mut self, id: String, data: Vec<u8>) -> Vec<OutboundEvent> {
@@ -1915,6 +2035,42 @@ mod tests {
         assert!(
             scroll_gate.is_match(html),
             "expected plain wheel input to bypass canvas pan only when the repo browser surface can consume the delta",
+        );
+    }
+
+    #[test]
+    fn embedded_web_branches_surface_includes_scope_filter_controls() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("data-branch-filter=\"local\""),
+            "expected Local branch filter control in embedded html",
+        );
+        assert!(
+            html.contains("data-branch-filter=\"remote\""),
+            "expected Remote branch filter control in embedded html",
+        );
+        assert!(
+            html.contains("data-branch-filter=\"all\""),
+            "expected All branch filter control in embedded html",
+        );
+    }
+
+    #[test]
+    fn embedded_web_branches_surface_includes_cleanup_flow_contract() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("branch-cleanup-modal"),
+            "expected cleanup modal scaffold in embedded html",
+        );
+        assert!(
+            html.contains("run_branch_cleanup"),
+            "expected branch cleanup frontend event in embedded html",
+        );
+        assert!(
+            html.contains("branch_cleanup_result"),
+            "expected branch cleanup result handler in embedded html",
         );
     }
 }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    branch_cleanup::BranchCleanupResultEntry,
     branch_list::BranchListEntry,
     file_tree::FileTreeEntry,
     launch_wizard::{LaunchWizardAction, LaunchWizardView},
@@ -88,6 +89,11 @@ pub enum FrontendEvent {
     LoadBranches {
         id: String,
     },
+    RunBranchCleanup {
+        id: String,
+        branches: Vec<String>,
+        delete_remote: bool,
+    },
     OpenLaunchWizard {
         id: String,
         branch_name: String,
@@ -164,6 +170,10 @@ pub enum BackendEvent {
     BranchEntries {
         id: String,
         entries: Vec<BranchListEntry>,
+    },
+    BranchCleanupResult {
+        id: String,
+        results: Vec<BranchCleanupResultEntry>,
     },
     BranchError {
         id: String,

--- a/crates/gwt/tests/branch_cleanup_test.rs
+++ b/crates/gwt/tests/branch_cleanup_test.rs
@@ -1,0 +1,109 @@
+use std::collections::HashSet;
+
+use gwt::{
+    cleanup_selected_branches, list_branch_entries_with_active_sessions, BranchCleanupResultStatus,
+};
+use tempfile::tempdir;
+
+#[test]
+fn cleanup_selected_branches_deletes_local_and_remote_branch() {
+    let temp = tempdir().expect("tempdir");
+    let remote = temp.path().join("origin.git");
+    let repo = temp.path().join("repo");
+
+    run_git(
+        temp.path(),
+        &["init", "--bare", remote.to_str().expect("remote path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("remote path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["checkout", "-qb", "feature/prune-me"]);
+    std::fs::write(repo.join("feature.txt"), "feature\n").expect("write feature");
+    run_git(&repo, &["add", "feature.txt"]);
+    run_git(&repo, &["commit", "-qm", "feature"]);
+    run_git(&repo, &["push", "-u", "origin", "feature/prune-me"]);
+    run_git(&repo, &["checkout", "main"]);
+    run_git(&repo, &["fetch", "origin", "--prune"]);
+
+    let entries =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let results =
+        cleanup_selected_branches(&repo, &entries, &[String::from("feature/prune-me")], true)
+            .expect("cleanup results");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].status, BranchCleanupResultStatus::Success);
+    assert!(
+        !branch_exists(&repo, "refs/heads/feature/prune-me"),
+        "local branch should be deleted"
+    );
+    assert!(
+        !branch_exists(&repo, "refs/remotes/origin/feature/prune-me"),
+        "remote-tracking branch should be deleted"
+    );
+}
+
+#[test]
+fn cleanup_selected_branches_rejects_blocked_branch() {
+    let repo = tempdir().expect("tempdir");
+
+    run_git(repo.path(), &["init", "-q"]);
+    init_repo(repo.path());
+
+    let entries =
+        list_branch_entries_with_active_sessions(repo.path(), &HashSet::new()).expect("entries");
+    let results = cleanup_selected_branches(repo.path(), &entries, &[String::from("main")], true)
+        .expect("cleanup results");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].status, BranchCleanupResultStatus::Failed);
+    assert!(
+        branch_exists(repo.path(), "refs/heads/main"),
+        "protected branch should remain"
+    );
+}
+
+fn init_repo(repo: &std::path::Path) {
+    run_git(repo, &["config", "user.name", "PoC Tester"]);
+    run_git(repo, &["config", "user.email", "poc@example.com"]);
+    std::fs::write(repo.join("README.md"), "# demo\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "-qm", "init"]);
+    run_git(repo, &["branch", "-M", "main"]);
+}
+
+fn branch_exists(repo: &std::path::Path, refname: &str) -> bool {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", refname])
+        .current_dir(repo)
+        .output()
+        .expect("run git rev-parse");
+    output.status.success()
+}
+
+fn run_git(repo: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/gwt/tests/branch_cleanup_test.rs
+++ b/crates/gwt/tests/branch_cleanup_test.rs
@@ -41,8 +41,7 @@ fn cleanup_selected_branches_deletes_local_and_remote_branch() {
     let entries =
         list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
     let results =
-        cleanup_selected_branches(&repo, &entries, &[String::from("feature/prune-me")], true)
-            .expect("cleanup results");
+        cleanup_selected_branches(&repo, &entries, &[String::from("feature/prune-me")], true);
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].status, BranchCleanupResultStatus::Success);
@@ -65,8 +64,7 @@ fn cleanup_selected_branches_rejects_blocked_branch() {
 
     let entries =
         list_branch_entries_with_active_sessions(repo.path(), &HashSet::new()).expect("entries");
-    let results = cleanup_selected_branches(repo.path(), &entries, &[String::from("main")], true)
-        .expect("cleanup results");
+    let results = cleanup_selected_branches(repo.path(), &entries, &[String::from("main")], true);
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].status, BranchCleanupResultStatus::Failed);

--- a/crates/gwt/tests/branch_list_test.rs
+++ b/crates/gwt/tests/branch_list_test.rs
@@ -118,6 +118,139 @@ fn list_branch_entries_marks_remote_tracking_row_with_local_counterpart_as_risky
 }
 
 #[test]
+fn list_branch_entries_blocks_remote_tracking_row_without_local_counterpart() {
+    let temp = tempdir().expect("tempdir");
+    let remote = temp.path().join("origin.git");
+    let repo = temp.path().join("repo");
+
+    run_git(
+        temp.path(),
+        &["init", "--bare", remote.to_str().expect("remote path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("remote path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["checkout", "-qb", "feature/alpha"]);
+    std::fs::write(repo.join("alpha.txt"), "alpha\n").expect("write alpha");
+    run_git(&repo, &["add", "alpha.txt"]);
+    run_git(&repo, &["commit", "-qm", "alpha"]);
+    run_git(&repo, &["push", "-u", "origin", "feature/alpha"]);
+    run_git(&repo, &["checkout", "main"]);
+    run_git(&repo, &["branch", "-D", "feature/alpha"]);
+    run_git(&repo, &["fetch", "origin", "--prune"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let remote_entry = branches
+        .iter()
+        .find(|branch| branch.name == "origin/feature/alpha")
+        .expect("remote branch");
+
+    assert_eq!(remote_entry.scope, BranchScope::Remote);
+    assert_eq!(
+        remote_entry.cleanup.availability,
+        BranchCleanupAvailability::Blocked
+    );
+    assert_eq!(remote_entry.cleanup.execution_branch, None);
+    assert_eq!(
+        remote_entry.cleanup.blocked_reason,
+        Some(BranchCleanupBlockedReason::RemoteTrackingWithoutLocal)
+    );
+}
+
+#[test]
+fn list_branch_entries_blocks_remote_tracking_row_when_local_branch_tracks_other_remote() {
+    let temp = tempdir().expect("tempdir");
+    let origin = temp.path().join("origin.git");
+    let upstream = temp.path().join("upstream.git");
+    let repo = temp.path().join("repo");
+
+    run_git(
+        temp.path(),
+        &["init", "--bare", origin.to_str().expect("origin path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "--bare", upstream.to_str().expect("upstream path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            origin.to_str().expect("origin path"),
+        ],
+    );
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "upstream",
+            upstream.to_str().expect("upstream path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["push", "-u", "upstream", "main"]);
+    run_git(&repo, &["checkout", "-qb", "feature/alpha"]);
+    std::fs::write(repo.join("alpha.txt"), "alpha\n").expect("write alpha");
+    run_git(&repo, &["add", "alpha.txt"]);
+    run_git(&repo, &["commit", "-qm", "alpha"]);
+    run_git(&repo, &["push", "origin", "HEAD:refs/heads/feature/alpha"]);
+    run_git(
+        &repo,
+        &["push", "-u", "upstream", "HEAD:refs/heads/feature/alpha"],
+    );
+    run_git(&repo, &["checkout", "main"]);
+    run_git(&repo, &["fetch", "origin", "--prune"]);
+    run_git(&repo, &["fetch", "upstream", "--prune"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let origin_entry = branches
+        .iter()
+        .find(|branch| branch.name == "origin/feature/alpha")
+        .expect("origin remote branch");
+    let upstream_entry = branches
+        .iter()
+        .find(|branch| branch.name == "upstream/feature/alpha")
+        .expect("upstream remote branch");
+
+    assert_eq!(origin_entry.scope, BranchScope::Remote);
+    assert_eq!(
+        origin_entry.cleanup.availability,
+        BranchCleanupAvailability::Blocked
+    );
+    assert_eq!(origin_entry.cleanup.execution_branch, None);
+    assert_eq!(
+        origin_entry.cleanup.blocked_reason,
+        Some(BranchCleanupBlockedReason::RemoteTrackingWithoutLocal)
+    );
+    assert_eq!(
+        upstream_entry.cleanup.execution_branch.as_deref(),
+        Some("feature/alpha")
+    );
+}
+
+#[test]
 fn list_branch_entries_blocks_active_session_branch_from_cleanup() {
     let dir = tempdir().expect("tempdir");
 

--- a/crates/gwt/tests/branch_list_test.rs
+++ b/crates/gwt/tests/branch_list_test.rs
@@ -1,4 +1,9 @@
-use gwt::{list_branch_entries, BranchScope};
+use std::collections::HashSet;
+
+use gwt::{
+    list_branch_entries, list_branch_entries_with_active_sessions, BranchCleanupAvailability,
+    BranchCleanupBlockedReason, BranchCleanupRisk, BranchScope,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -22,6 +27,135 @@ fn list_branch_entries_marks_head_and_returns_local_branches() {
     assert!(branches.iter().any(|branch| {
         branch.name == "feature/alpha" && !branch.is_head && branch.scope == BranchScope::Local
     }));
+}
+
+#[test]
+fn list_branch_entries_marks_unmerged_local_branch_as_risky_cleanup_candidate() {
+    let dir = tempdir().expect("tempdir");
+
+    run_git(dir.path(), &["init", "-q"]);
+    init_repo(dir.path());
+    run_git(dir.path(), &["checkout", "-qb", "feature/unmerged"]);
+    std::fs::write(dir.path().join("feature.txt"), "work\n").expect("write feature");
+    run_git(dir.path(), &["add", "feature.txt"]);
+    run_git(dir.path(), &["commit", "-qm", "feature work"]);
+    run_git(dir.path(), &["checkout", "main"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(dir.path(), &HashSet::new()).expect("entries");
+    let feature = branches
+        .iter()
+        .find(|branch| branch.name == "feature/unmerged")
+        .expect("feature branch");
+
+    assert_eq!(feature.scope, BranchScope::Local);
+    assert_eq!(
+        feature.cleanup.availability,
+        BranchCleanupAvailability::Risky
+    );
+    assert_eq!(
+        feature.cleanup.execution_branch.as_deref(),
+        Some("feature/unmerged")
+    );
+    assert_eq!(feature.cleanup.blocked_reason, None);
+    assert!(feature.cleanup.risks.contains(&BranchCleanupRisk::Unmerged));
+}
+
+#[test]
+fn list_branch_entries_marks_remote_tracking_row_with_local_counterpart_as_risky() {
+    let temp = tempdir().expect("tempdir");
+    let remote = temp.path().join("origin.git");
+    let repo = temp.path().join("repo");
+
+    run_git(
+        temp.path(),
+        &["init", "--bare", remote.to_str().expect("remote path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("remote path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["checkout", "-qb", "feature/alpha"]);
+    std::fs::write(repo.join("alpha.txt"), "alpha\n").expect("write alpha");
+    run_git(&repo, &["add", "alpha.txt"]);
+    run_git(&repo, &["commit", "-qm", "alpha"]);
+    run_git(&repo, &["push", "-u", "origin", "feature/alpha"]);
+    run_git(&repo, &["checkout", "main"]);
+    run_git(&repo, &["fetch", "origin", "--prune"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let remote_entry = branches
+        .iter()
+        .find(|branch| branch.name == "origin/feature/alpha")
+        .expect("remote branch");
+
+    assert_eq!(remote_entry.scope, BranchScope::Remote);
+    assert_eq!(
+        remote_entry.cleanup.availability,
+        BranchCleanupAvailability::Risky
+    );
+    assert_eq!(
+        remote_entry.cleanup.execution_branch.as_deref(),
+        Some("feature/alpha")
+    );
+    assert_eq!(remote_entry.cleanup.blocked_reason, None);
+    assert!(remote_entry
+        .cleanup
+        .risks
+        .contains(&BranchCleanupRisk::RemoteTracking));
+}
+
+#[test]
+fn list_branch_entries_blocks_active_session_branch_from_cleanup() {
+    let dir = tempdir().expect("tempdir");
+
+    run_git(dir.path(), &["init", "-q"]);
+    init_repo(dir.path());
+    run_git(dir.path(), &["checkout", "-qb", "feature/live"]);
+    std::fs::write(dir.path().join("live.txt"), "live\n").expect("write live");
+    run_git(dir.path(), &["add", "live.txt"]);
+    run_git(dir.path(), &["commit", "-qm", "live"]);
+    run_git(dir.path(), &["checkout", "main"]);
+
+    let branches = list_branch_entries_with_active_sessions(
+        dir.path(),
+        &HashSet::from([String::from("feature/live")]),
+    )
+    .expect("entries");
+    let feature = branches
+        .iter()
+        .find(|branch| branch.name == "feature/live")
+        .expect("feature branch");
+
+    assert_eq!(
+        feature.cleanup.availability,
+        BranchCleanupAvailability::Blocked
+    );
+    assert_eq!(
+        feature.cleanup.blocked_reason,
+        Some(BranchCleanupBlockedReason::ActiveSession)
+    );
+}
+
+fn init_repo(repo: &std::path::Path) {
+    run_git(repo, &["config", "user.name", "PoC Tester"]);
+    run_git(repo, &["config", "user.email", "poc@example.com"]);
+    std::fs::write(repo.join("README.md"), "# demo\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "-qm", "init"]);
+    run_git(repo, &["branch", "-M", "main"]);
 }
 
 fn run_git(repo: &std::path::Path, args: &[&str]) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -525,6 +525,55 @@
         border-bottom: 1px solid rgba(148, 163, 184, 0.25);
       }
 
+      .branch-toolbar {
+        align-items: flex-start;
+      }
+
+      .branch-toolbar-main {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .branch-toolbar-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      .branch-filter-group {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .branch-filter-button {
+        height: 28px;
+        padding: 0 10px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: #f8fafc;
+        color: #334155;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      .branch-filter-button.active {
+        background: #0f172a;
+        border-color: #0f172a;
+        color: #ffffff;
+      }
+
+      .branch-cleanup-trigger[disabled],
+      .branch-filter-button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+
       .file-tree-path,
       .branch-heading,
       .mock-heading {
@@ -599,7 +648,7 @@
 
       .branch-row {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-columns: auto minmax(0, 1fr) auto;
         gap: 10px;
         padding: 10px 12px;
         border-bottom: 1px solid rgba(148, 163, 184, 0.18);
@@ -614,8 +663,43 @@
         background: rgba(59, 130, 246, 0.12);
       }
 
+      .branch-row.cleanup-selected {
+        box-shadow: inset 2px 0 0 #0f172a;
+      }
+
       .branch-row:last-child {
         border-bottom: none;
+      }
+
+      .branch-cleanup-toggle {
+        width: 24px;
+        height: 24px;
+        margin-top: 2px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: #ffffff;
+        color: #475569;
+        font-size: 13px;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      .branch-cleanup-toggle.safe {
+        color: #047857;
+      }
+
+      .branch-cleanup-toggle.risky {
+        color: #b45309;
+      }
+
+      .branch-cleanup-toggle.blocked {
+        color: #94a3b8;
+      }
+
+      .branch-cleanup-toggle.selected {
+        background: #0f172a;
+        border-color: #0f172a;
+        color: #ffffff;
       }
 
       .branch-main {
@@ -654,6 +738,16 @@
         color: #475569;
       }
 
+      .branch-cleanup-detail {
+        margin-top: 4px;
+        font-size: 11px;
+        color: #64748b;
+      }
+
+      .branch-cleanup-detail.blocked {
+        color: #b45309;
+      }
+
       .branch-meta {
         display: flex;
         align-items: center;
@@ -670,9 +764,101 @@
         font-size: 11px;
       }
 
+      .branch-cleanup-badge {
+        padding: 4px 8px;
+        border-radius: 999px;
+        font-size: 11px;
+        text-transform: capitalize;
+      }
+
+      .branch-cleanup-badge.safe {
+        background: rgba(16, 185, 129, 0.12);
+        color: #047857;
+      }
+
+      .branch-cleanup-badge.risky {
+        background: rgba(245, 158, 11, 0.14);
+        color: #b45309;
+      }
+
+      .branch-cleanup-badge.blocked {
+        background: rgba(148, 163, 184, 0.18);
+        color: #475569;
+      }
+
       .branch-summary {
         font-size: 11px;
         color: #475569;
+      }
+
+      .branch-notice {
+        padding: 10px 12px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        font-size: 12px;
+        color: #b45309;
+        background: rgba(245, 158, 11, 0.1);
+      }
+
+      .branch-cleanup-list {
+        display: grid;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      .branch-cleanup-item {
+        padding: 10px 12px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        background: #f8fafc;
+      }
+
+      .branch-cleanup-item-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        margin-bottom: 4px;
+      }
+
+      .branch-cleanup-item-title {
+        min-width: 0;
+        font-size: 13px;
+        font-weight: 600;
+        color: #0f172a;
+      }
+
+      .branch-cleanup-item-copy {
+        font-size: 12px;
+        color: #475569;
+      }
+
+      .branch-cleanup-item-copy + .branch-cleanup-item-copy {
+        margin-top: 4px;
+      }
+
+      .branch-cleanup-toggle-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 12px;
+        font-size: 12px;
+        color: #334155;
+      }
+
+      .branch-cleanup-toggle-row input {
+        margin: 0;
+      }
+
+      .branch-cleanup-running {
+        margin-top: 12px;
+        font-size: 12px;
+        color: #475569;
+      }
+
+      .branch-cleanup-results-summary {
+        margin-top: 12px;
+        font-size: 12px;
+        color: #334155;
       }
 
       .file-tree-empty,
@@ -1424,6 +1610,9 @@
           </div>
         </div>
       </div>
+      <div class="modal-backdrop" id="branch-cleanup-modal">
+        <div class="modal"></div>
+      </div>
     </div>
 
     <script type="module">
@@ -1466,6 +1655,8 @@
       const wizardCloseButton = document.getElementById("wizard-close-button");
       const wizardCancelButton = document.getElementById("wizard-cancel-button");
       const wizardSubmitButton = document.getElementById("wizard-submit-button");
+      const branchCleanupModal = document.getElementById("branch-cleanup-modal");
+      const branchCleanupDialog = branchCleanupModal.querySelector(".modal");
       const connectionDot = document.getElementById("connection-dot");
       const connectionLabel = document.getElementById("connection-label");
 
@@ -1491,6 +1682,7 @@
       let wizardAdvancedOpen = false;
       let wizardBranchDraft = "";
       let wizardBranchBackendValue = "";
+      let branchCleanupWindowId = null;
       let windowListOpen = false;
       let windowListEntries = [];
       let titlebarClickState = null;
@@ -2440,6 +2632,15 @@
             loading: false,
             error: "",
             selectedBranchName: "",
+            filter: "local",
+            cleanupSelected: new Set(),
+            notice: "",
+            cleanupModal: {
+              open: false,
+              stage: "confirm",
+              deleteRemote: false,
+              results: [],
+            },
           });
         }
         return branchListStateMap.get(windowId);
@@ -3202,10 +3403,28 @@
           return;
         }
         const state = ensureBranchListState(windowId);
+        syncBranchSelectionState(state);
         const list = element.querySelector(".branch-list");
+        const notice = element.querySelector(".branch-notice");
+        const cleanupButton = element.querySelector("[data-action='open-branch-cleanup']");
         if (!list) {
           return;
         }
+
+        for (const button of element.querySelectorAll("[data-branch-filter]")) {
+          button.classList.toggle("active", button.dataset.branchFilter === state.filter);
+        }
+        if (cleanupButton) {
+          cleanupButton.disabled = selectedBranchCleanupEntries(windowId).length === 0;
+          cleanupButton.textContent = cleanupButton.disabled
+            ? "Clean Up"
+            : `Clean Up (${selectedBranchCleanupEntries(windowId).length})`;
+        }
+        if (notice) {
+          notice.hidden = !state.notice;
+          notice.textContent = state.notice || "";
+        }
+
         list.innerHTML = "";
 
         if (state.error) {
@@ -3213,6 +3432,7 @@
           errorRow.className = "branch-empty";
           errorRow.textContent = state.error;
           list.appendChild(errorRow);
+          renderBranchCleanupModal();
           return;
         }
 
@@ -3221,49 +3441,105 @@
           loadingRow.className = "branch-empty";
           loadingRow.textContent = "Loading branches";
           list.appendChild(loadingRow);
+          renderBranchCleanupModal();
           return;
         }
 
-        if (state.entries.length === 0) {
+        const visibleEntries = filteredBranchEntries(state);
+        if (visibleEntries.length === 0) {
           const emptyRow = document.createElement("div");
           emptyRow.className = "branch-empty";
-          emptyRow.textContent = "No branches";
+          emptyRow.textContent = state.entries.length === 0 ? "No branches" : "No branches in this filter";
           list.appendChild(emptyRow);
+          renderBranchCleanupModal();
           return;
         }
 
-        for (const entry of state.entries) {
+        for (const entry of visibleEntries) {
           const row = document.createElement("div");
           row.className = "branch-row";
           if (state.selectedBranchName === entry.name) {
             row.classList.add("selected");
           }
-          const summaryParts = [];
-          if (entry.ahead || entry.behind) {
-            summaryParts.push(`↑${entry.ahead} ↓${entry.behind}`);
-          } else {
-            summaryParts.push("synced");
+          if (state.cleanupSelected.has(entry.name)) {
+            row.classList.add("cleanup-selected");
           }
-          row.innerHTML = `
-            <div class="branch-main">
-              <div class="branch-name">
-                <span class="branch-name-text">${entry.name}</span>
-                ${entry.is_head ? '<span class="branch-head">HEAD</span>' : ""}
-              </div>
-              <div class="branch-upstream">${entry.upstream || "No upstream"}</div>
-              <div class="branch-date">${entry.last_commit_date || "No commit date"}</div>
-            </div>
-            <div class="branch-meta">
-              <span class="branch-scope">${entry.scope}</span>
-              <span class="branch-summary">${summaryParts.join(" · ")}</span>
-            </div>
-          `;
+
+          const toggle = document.createElement("button");
+          toggle.type = "button";
+          toggle.className = `branch-cleanup-toggle ${cleanupToggleClass(entry, state)}`;
+          toggle.textContent = cleanupToggleSymbol(entry, state);
+          toggle.title = cleanupToggleTitle(entry, state);
+          toggle.addEventListener("click", (event) => {
+            event.stopPropagation();
+            toggleBranchCleanupSelection(windowId, entry.name);
+          });
+          row.appendChild(toggle);
+
+          const main = document.createElement("div");
+          main.className = "branch-main";
+          const name = document.createElement("div");
+          name.className = "branch-name";
+          const nameText = document.createElement("span");
+          nameText.className = "branch-name-text";
+          nameText.textContent = entry.name;
+          name.appendChild(nameText);
+          if (entry.is_head) {
+            const head = document.createElement("span");
+            head.className = "branch-head";
+            head.textContent = "HEAD";
+            name.appendChild(head);
+          }
+          main.appendChild(name);
+
+          const upstream = document.createElement("div");
+          upstream.className = "branch-upstream";
+          upstream.textContent = entry.upstream || "No upstream";
+          main.appendChild(upstream);
+
+          const date = document.createElement("div");
+          date.className = "branch-date";
+          date.textContent = entry.last_commit_date || "No commit date";
+          main.appendChild(date);
+
+          const cleanupDetail = cleanupDetailText(entry);
+          if (cleanupDetail) {
+            const detail = document.createElement("div");
+            detail.className = `branch-cleanup-detail ${
+              entry.cleanup.availability === "blocked" ? "blocked" : ""
+            }`.trim();
+            detail.textContent = cleanupDetail;
+            main.appendChild(detail);
+          }
+          row.appendChild(main);
+
+          const meta = document.createElement("div");
+          meta.className = "branch-meta";
+          const scope = document.createElement("span");
+          scope.className = "branch-scope";
+          scope.textContent = entry.scope;
+          meta.appendChild(scope);
+
+          const cleanupBadge = document.createElement("span");
+          cleanupBadge.className = `branch-cleanup-badge ${entry.cleanup.availability}`;
+          cleanupBadge.textContent = entry.cleanup.availability;
+          meta.appendChild(cleanupBadge);
+
+          const summary = document.createElement("span");
+          summary.className = "branch-summary";
+          summary.textContent =
+            entry.ahead || entry.behind ? `↑${entry.ahead} ↓${entry.behind}` : "synced";
+          meta.appendChild(summary);
+          row.appendChild(meta);
+
           row.addEventListener("click", () => {
             state.selectedBranchName = entry.name;
+            state.notice = "";
             renderBranches(windowId);
           });
           row.addEventListener("dblclick", () => {
             state.selectedBranchName = entry.name;
+            state.notice = "";
             renderBranches(windowId);
             send({
               kind: "open_launch_wizard",
@@ -3273,6 +3549,349 @@
           });
           list.appendChild(row);
         }
+
+        renderBranchCleanupModal();
+      }
+
+      function filteredBranchEntries(state) {
+        if (state.filter === "all") {
+          return state.entries;
+        }
+        return state.entries.filter((entry) =>
+          state.filter === "local" ? entry.scope === "local" : entry.scope === "remote",
+        );
+      }
+
+      function syncBranchSelectionState(state) {
+        const validBranchNames = new Set(state.entries.map((entry) => entry.name));
+        state.cleanupSelected = new Set(
+          Array.from(state.cleanupSelected).filter((name) => validBranchNames.has(name)),
+        );
+        if (state.selectedBranchName && !validBranchNames.has(state.selectedBranchName)) {
+          state.selectedBranchName = "";
+        }
+      }
+
+      function selectedBranchCleanupEntries(windowId) {
+        const state = ensureBranchListState(windowId);
+        const entriesByName = new Map(state.entries.map((entry) => [entry.name, entry]));
+        return Array.from(state.cleanupSelected)
+          .map((name) => entriesByName.get(name))
+          .filter(Boolean);
+      }
+
+      function cleanupToggleClass(entry, state) {
+        if (state.cleanupSelected.has(entry.name)) {
+          return "selected";
+        }
+        return entry.cleanup.availability;
+      }
+
+      function cleanupToggleSymbol(entry, state) {
+        if (state.cleanupSelected.has(entry.name)) {
+          return "●";
+        }
+        switch (entry.cleanup.availability) {
+          case "safe":
+            return "✓";
+          case "risky":
+            return "·";
+          default:
+            return "–";
+        }
+      }
+
+      function cleanupToggleTitle(entry, state) {
+        if (state.cleanupSelected.has(entry.name)) {
+          return "Selected for cleanup";
+        }
+        if (entry.cleanup.availability === "blocked") {
+          return cleanupBlockedReasonText(entry.cleanup.blocked_reason);
+        }
+        if (entry.cleanup.risks?.length) {
+          return cleanupRiskLabels(entry.cleanup.risks).join(", ");
+        }
+        return "Select for cleanup";
+      }
+
+      function cleanupDetailText(entry) {
+        if (entry.cleanup.availability === "blocked") {
+          return cleanupBlockedReasonText(entry.cleanup.blocked_reason);
+        }
+        if (entry.cleanup.risks?.length) {
+          return cleanupRiskLabels(entry.cleanup.risks).join(", ");
+        }
+        return cleanupMergeTargetText(entry.cleanup.merge_target);
+      }
+
+      function cleanupBlockedReasonText(reason) {
+        switch (reason) {
+          case "protected_branch":
+            return "Protected branches cannot be cleaned up";
+          case "current_head":
+            return "The current HEAD branch cannot be cleaned up";
+          case "active_session":
+            return "A running agent session is using this branch";
+          case "remote_tracking_without_local":
+            return "Remote-tracking branch without a local counterpart";
+          default:
+            return "This branch cannot be cleaned up";
+        }
+      }
+
+      function cleanupRiskLabels(risks) {
+        return (risks || []).map((risk) => {
+          switch (risk) {
+            case "remote_tracking":
+              return "remote-tracking";
+            case "unmerged":
+              return "unmerged";
+            default:
+              return "warning";
+          }
+        });
+      }
+
+      function cleanupMergeTargetText(target) {
+        switch (target) {
+          case "main":
+            return "merged to main";
+          case "develop":
+            return "merged to develop";
+          case "gone":
+            return "upstream is gone";
+          default:
+            return "";
+        }
+      }
+
+      function toggleBranchCleanupSelection(windowId, branchName) {
+        const state = ensureBranchListState(windowId);
+        const entry = state.entries.find((candidate) => candidate.name === branchName);
+        if (!entry) {
+          return;
+        }
+        if (entry.cleanup.availability === "blocked") {
+          state.notice = cleanupBlockedReasonText(entry.cleanup.blocked_reason);
+          renderBranches(windowId);
+          return;
+        }
+        state.notice = "";
+        if (state.cleanupSelected.has(branchName)) {
+          state.cleanupSelected.delete(branchName);
+        } else {
+          state.cleanupSelected.add(branchName);
+        }
+        renderBranches(windowId);
+      }
+
+      function openBranchCleanupModal(windowId) {
+        const state = ensureBranchListState(windowId);
+        if (selectedBranchCleanupEntries(windowId).length === 0) {
+          state.notice = "Select at least one branch for cleanup";
+          renderBranches(windowId);
+          return;
+        }
+        state.notice = "";
+        state.cleanupModal.open = true;
+        state.cleanupModal.stage = "confirm";
+        state.cleanupModal.deleteRemote = false;
+        state.cleanupModal.results = [];
+        branchCleanupWindowId = windowId;
+        renderBranches(windowId);
+      }
+
+      function closeBranchCleanupModal(windowId = branchCleanupWindowId) {
+        if (!windowId) {
+          branchCleanupWindowId = null;
+          renderBranchCleanupModal();
+          return;
+        }
+        const state = ensureBranchListState(windowId);
+        if (state.cleanupModal.stage === "running") {
+          return;
+        }
+        state.cleanupModal.open = false;
+        state.cleanupModal.stage = "confirm";
+        state.cleanupModal.deleteRemote = false;
+        state.cleanupModal.results = [];
+        if (branchCleanupWindowId === windowId) {
+          branchCleanupWindowId = null;
+        }
+        renderBranchCleanupModal();
+      }
+
+      function runBranchCleanup(windowId) {
+        const state = ensureBranchListState(windowId);
+        const branches = Array.from(state.cleanupSelected);
+        if (branches.length === 0) {
+          state.notice = "Select at least one branch for cleanup";
+          renderBranches(windowId);
+          return;
+        }
+        state.notice = "";
+        state.cleanupModal.stage = "running";
+        state.cleanupModal.results = [];
+        renderBranchCleanupModal();
+        send({
+          kind: "run_branch_cleanup",
+          id: windowId,
+          branches,
+          delete_remote: state.cleanupModal.deleteRemote,
+        });
+      }
+
+      function branchCleanupResultSummary(results) {
+        const counts = { success: 0, partial: 0, failed: 0 };
+        for (const result of results || []) {
+          counts[result.status] = (counts[result.status] || 0) + 1;
+        }
+        return `success ${counts.success} · partial ${counts.partial} · failed ${counts.failed}`;
+      }
+
+      function renderBranchCleanupModal() {
+        const windowId = branchCleanupWindowId;
+        if (!windowId) {
+          branchCleanupModal.classList.remove("open");
+          branchCleanupDialog.innerHTML = "";
+          return;
+        }
+        const state = ensureBranchListState(windowId);
+        if (!state.cleanupModal.open) {
+          branchCleanupModal.classList.remove("open");
+          branchCleanupDialog.innerHTML = "";
+          return;
+        }
+
+        const selectedEntries = selectedBranchCleanupEntries(windowId);
+        const supportsRemoteDelete = selectedEntries.some((entry) => Boolean(entry.cleanup.upstream));
+        branchCleanupModal.classList.add("open");
+        branchCleanupDialog.innerHTML = "";
+
+        if (state.cleanupModal.stage === "running") {
+          const title = createNode("h2", "", "Cleaning up branches");
+          const copy = createNode(
+            "div",
+            "branch-cleanup-running",
+            `Running cleanup for ${Math.max(selectedEntries.length, 1)} branch${Math.max(
+              selectedEntries.length,
+              1,
+            ) === 1 ? "" : "es"}.`,
+          );
+          branchCleanupDialog.appendChild(title);
+          branchCleanupDialog.appendChild(copy);
+          return;
+        }
+
+        if (state.cleanupModal.stage === "result") {
+          const title = createNode("h2", "", "Cleanup result");
+          branchCleanupDialog.appendChild(title);
+          branchCleanupDialog.appendChild(
+            createNode(
+              "div",
+              "branch-cleanup-results-summary",
+              branchCleanupResultSummary(state.cleanupModal.results),
+            ),
+          );
+          const resultList = createNode("div", "branch-cleanup-list");
+          for (const result of state.cleanupModal.results || []) {
+            const item = createNode("div", "branch-cleanup-item");
+            const header = createNode("div", "branch-cleanup-item-header");
+            header.appendChild(
+              createNode("div", "branch-cleanup-item-title", result.branch),
+            );
+            const status = createNode(
+              "span",
+              `branch-cleanup-badge ${result.status === "partial" ? "risky" : result.status === "failed" ? "blocked" : "safe"}`,
+              result.status,
+            );
+            header.appendChild(status);
+            item.appendChild(header);
+            item.appendChild(
+              createNode("div", "branch-cleanup-item-copy", result.message),
+            );
+            if (result.execution_branch && result.execution_branch !== result.branch) {
+              item.appendChild(
+                createNode(
+                  "div",
+                  "branch-cleanup-item-copy",
+                  `Executed as ${result.execution_branch}`,
+                ),
+              );
+            }
+            resultList.appendChild(item);
+          }
+          branchCleanupDialog.appendChild(resultList);
+          const footer = createNode("div", "modal-footer");
+          const close = createNode("button", "wizard-button primary", "Close");
+          close.type = "button";
+          close.addEventListener("click", () => closeBranchCleanupModal(windowId));
+          footer.appendChild(close);
+          branchCleanupDialog.appendChild(footer);
+          return;
+        }
+
+        branchCleanupDialog.appendChild(createNode("h2", "", "Clean up branches"));
+        branchCleanupDialog.appendChild(
+          createNode(
+            "div",
+            "branch-cleanup-results-summary",
+            `Delete ${selectedEntries.length} selected branch${selectedEntries.length === 1 ? "" : "es"}.`,
+          ),
+        );
+        const list = createNode("div", "branch-cleanup-list");
+        for (const entry of selectedEntries) {
+          const item = createNode("div", "branch-cleanup-item");
+          const header = createNode("div", "branch-cleanup-item-header");
+          header.appendChild(createNode("div", "branch-cleanup-item-title", entry.name));
+          header.appendChild(
+            createNode("span", `branch-cleanup-badge ${entry.cleanup.availability}`, entry.cleanup.availability),
+          );
+          item.appendChild(header);
+          const target = cleanupMergeTargetText(entry.cleanup.merge_target) || "not merged";
+          item.appendChild(createNode("div", "branch-cleanup-item-copy", target));
+          if (entry.cleanup.execution_branch && entry.cleanup.execution_branch !== entry.name) {
+            item.appendChild(
+              createNode(
+                "div",
+                "branch-cleanup-item-copy",
+                `Executed as ${entry.cleanup.execution_branch}`,
+              ),
+            );
+          }
+          const risks = cleanupRiskLabels(entry.cleanup.risks);
+          if (risks.length > 0) {
+            item.appendChild(
+              createNode("div", "branch-cleanup-item-copy", risks.join(", ")),
+            );
+          }
+          list.appendChild(item);
+        }
+        branchCleanupDialog.appendChild(list);
+        if (supportsRemoteDelete) {
+          const toggleRow = createNode("label", "branch-cleanup-toggle-row");
+          const checkbox = document.createElement("input");
+          checkbox.type = "checkbox";
+          checkbox.checked = Boolean(state.cleanupModal.deleteRemote);
+          checkbox.addEventListener("change", () => {
+            state.cleanupModal.deleteRemote = checkbox.checked;
+          });
+          toggleRow.appendChild(checkbox);
+          toggleRow.appendChild(
+            createNode("span", "", "Also delete matching remote branches"),
+          );
+          branchCleanupDialog.appendChild(toggleRow);
+        }
+        const footer = createNode("div", "modal-footer");
+        const cancel = createNode("button", "wizard-button", "Cancel");
+        cancel.type = "button";
+        cancel.addEventListener("click", () => closeBranchCleanupModal(windowId));
+        footer.appendChild(cancel);
+        const submit = createNode("button", "wizard-button primary", "Run cleanup");
+        submit.type = "button";
+        submit.addEventListener("click", () => runBranchCleanup(windowId));
+        footer.appendChild(submit);
+        branchCleanupDialog.appendChild(footer);
       }
 
       function mountWindowBody(windowData, element) {
@@ -3355,9 +3974,20 @@
           body.innerHTML = `
             <div class="branch-list-root">
               <div class="branch-toolbar">
-                <div class="branch-heading">Repository branches · double-click to launch</div>
-                <button class="icon-button" data-action="refresh-branches" aria-label="Refresh branches">↻</button>
+                <div class="branch-toolbar-main">
+                  <div class="branch-heading">Repository branches · double-click to launch</div>
+                  <div class="branch-filter-group">
+                    <button class="branch-filter-button" type="button" data-branch-filter="local">Local</button>
+                    <button class="branch-filter-button" type="button" data-branch-filter="remote">Remote</button>
+                    <button class="branch-filter-button" type="button" data-branch-filter="all">All</button>
+                  </div>
+                </div>
+                <div class="branch-toolbar-actions">
+                  <button class="wizard-button branch-cleanup-trigger" type="button" data-action="open-branch-cleanup">Clean Up</button>
+                  <button class="icon-button" data-action="refresh-branches" aria-label="Refresh branches">↻</button>
+                </div>
               </div>
+              <div class="branch-notice" hidden></div>
               <div class="branch-scroll">
                 <div class="branch-list"></div>
               </div>
@@ -3372,11 +4002,24 @@
             .addEventListener("click", (event) => {
               event.stopPropagation();
               const state = ensureBranchListState(windowData.id);
-              state.entries = [];
-              state.loading = false;
               state.error = "";
+              state.notice = "";
               requestBranches(windowData.id);
               renderBranches(windowData.id);
+            });
+          for (const button of body.querySelectorAll("[data-branch-filter]")) {
+            button.addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = ensureBranchListState(windowData.id);
+              state.filter = button.dataset.branchFilter;
+              renderBranches(windowData.id);
+            });
+          }
+          body
+            .querySelector("[data-action='open-branch-cleanup']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              openBranchCleanupModal(windowData.id);
             });
           const state = ensureBranchListState(windowData.id);
           if (state.entries.length === 0 && !state.loading && !state.error) {
@@ -3540,6 +4183,10 @@
           pendingSnapshotMap.delete(windowId);
           fileTreeStateMap.delete(windowId);
           branchListStateMap.delete(windowId);
+          if (branchCleanupWindowId === windowId) {
+            branchCleanupWindowId = null;
+            renderBranchCleanupModal();
+          }
           element.remove();
           windowMap.delete(windowId);
         }
@@ -3611,6 +4258,17 @@
             state.entries = event.entries;
             state.loading = false;
             state.error = "";
+            syncBranchSelectionState(state);
+            renderBranches(event.id);
+            break;
+          }
+          case "branch_cleanup_result": {
+            const state = ensureBranchListState(event.id);
+            state.cleanupSelected.clear();
+            state.cleanupModal.open = true;
+            state.cleanupModal.stage = "result";
+            state.cleanupModal.results = event.results || [];
+            branchCleanupWindowId = event.id;
             renderBranches(event.id);
             break;
           }
@@ -3934,6 +4592,11 @@
       wizardModal.addEventListener("click", (event) => {
         if (event.target === wizardModal) {
           sendWizardAction({ kind: "cancel" });
+        }
+      });
+      branchCleanupModal.addEventListener("click", (event) => {
+        if (event.target === branchCleanupModal) {
+          closeBranchCleanupModal();
         }
       });
       window.addEventListener("resize", () => {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1688,6 +1688,7 @@
       let titlebarClickState = null;
       let appState = { tabs: [], active_tab_id: null, recent_projects: [] };
       let projectError = "";
+      const BRANCH_CLEANUP_TIMEOUT_MS = 30000;
       const TERMINAL_SELECTION_DRAG_THRESHOLD = 4;
 
       function presetSurface(preset) {
@@ -1719,6 +1720,18 @@
       function setConnectionState(connected) {
         connectionDot.classList.toggle("connected", connected);
         connectionLabel.textContent = connected ? "Connected" : "Reconnecting";
+        if (!connected) {
+          for (const [windowId] of branchListStateMap.entries()) {
+            if (
+              failRunningBranchCleanup(
+                windowId,
+                "Connection lost while cleaning up branches",
+              )
+            ) {
+              renderBranches(windowId);
+            }
+          }
+        }
       }
 
       function websocketUrl() {
@@ -2640,6 +2653,7 @@
               stage: "confirm",
               deleteRemote: false,
               results: [],
+              timeoutId: null,
             },
           });
         }
@@ -3415,10 +3429,10 @@
           button.classList.toggle("active", button.dataset.branchFilter === state.filter);
         }
         if (cleanupButton) {
-          cleanupButton.disabled = selectedBranchCleanupEntries(windowId).length === 0;
-          cleanupButton.textContent = cleanupButton.disabled
-            ? "Clean Up"
-            : `Clean Up (${selectedBranchCleanupEntries(windowId).length})`;
+          const selectedCount = selectedBranchCleanupEntries(windowId).length;
+          cleanupButton.disabled = selectedCount === 0;
+          cleanupButton.textContent =
+            selectedCount === 0 ? "Clean Up" : `Clean Up (${selectedCount})`;
         }
         if (notice) {
           notice.hidden = !state.notice;
@@ -3580,6 +3594,46 @@
           .filter(Boolean);
       }
 
+      function clearBranchCleanupTimeout(state) {
+        if (state.cleanupModal.timeoutId !== null) {
+          clearTimeout(state.cleanupModal.timeoutId);
+          state.cleanupModal.timeoutId = null;
+        }
+      }
+
+      function branchCleanupFailureResults(state, message) {
+        const selectedBranches = Array.from(state.cleanupSelected);
+        if (selectedBranches.length === 0) {
+          return [
+            {
+              branch: "Cleanup request",
+              execution_branch: null,
+              status: "failed",
+              message,
+            },
+          ];
+        }
+        return selectedBranches.map((branch) => ({
+          branch,
+          execution_branch: null,
+          status: "failed",
+          message,
+        }));
+      }
+
+      function failRunningBranchCleanup(windowId, message) {
+        const state = ensureBranchListState(windowId);
+        if (state.cleanupModal.stage !== "running") {
+          return false;
+        }
+        clearBranchCleanupTimeout(state);
+        state.cleanupModal.open = true;
+        state.cleanupModal.stage = "result";
+        state.cleanupModal.results = branchCleanupFailureResults(state, message);
+        branchCleanupWindowId = windowId;
+        return true;
+      }
+
       function cleanupToggleClass(entry, state) {
         if (state.cleanupSelected.has(entry.name)) {
           return "selected";
@@ -3697,6 +3751,7 @@
         state.cleanupModal.stage = "confirm";
         state.cleanupModal.deleteRemote = false;
         state.cleanupModal.results = [];
+        clearBranchCleanupTimeout(state);
         branchCleanupWindowId = windowId;
         renderBranches(windowId);
       }
@@ -3711,6 +3766,7 @@
         if (state.cleanupModal.stage === "running") {
           return;
         }
+        clearBranchCleanupTimeout(state);
         state.cleanupModal.open = false;
         state.cleanupModal.stage = "confirm";
         state.cleanupModal.deleteRemote = false;
@@ -3732,6 +3788,17 @@
         state.notice = "";
         state.cleanupModal.stage = "running";
         state.cleanupModal.results = [];
+        clearBranchCleanupTimeout(state);
+        state.cleanupModal.timeoutId = window.setTimeout(() => {
+          if (
+            failRunningBranchCleanup(
+              windowId,
+              "Branch cleanup timed out. Check the branch list and try again.",
+            )
+          ) {
+            renderBranches(windowId);
+          }
+        }, BRANCH_CLEANUP_TIMEOUT_MS);
         renderBranchCleanupModal();
         send({
           kind: "run_branch_cleanup",
@@ -4264,6 +4331,7 @@
           }
           case "branch_cleanup_result": {
             const state = ensureBranchListState(event.id);
+            clearBranchCleanupTimeout(state);
             state.cleanupSelected.clear();
             state.cleanupModal.open = true;
             state.cleanupModal.stage = "result";
@@ -4275,6 +4343,11 @@
           case "branch_error": {
             const state = ensureBranchListState(event.id);
             state.loading = false;
+            if (state.cleanupModal.stage === "running") {
+              failRunningBranchCleanup(event.id, event.message);
+              renderBranches(event.id);
+              break;
+            }
             state.error = event.message;
             renderBranches(event.id);
             break;


### PR DESCRIPTION
## Summary

- Add `Local` / `Remote` / `All` scope filters to the Branches window so branch browsing matches the production repo browser contract.
- Add a GUI branch cleanup flow with safe/risky/blocked metadata, confirm modal, and optional remote delete so the web surface regains the old cleanup capability.
- Refresh SPEC-2009 and branch cleanup tests so the web UI, backend protocol, and Git cleanup behavior stay aligned.

## Changes

- `crates/gwt/src/branch_list.rs`: add cleanup metadata, active-session aware branch loading, and remote-tracking to local execution mapping.
- `crates/gwt/src/branch_cleanup.rs`: add the cleanup execution helper and per-branch result reporting.
- `crates/gwt/src/protocol.rs` / `crates/gwt/src/main.rs`: add branch cleanup request/result events and refresh the Branches window after cleanup.
- `crates/gwt/web/index.html`: add scope filters, cleanup selection controls, confirm/result modal UI, and window-scoped cleanup state.
- `crates/gwt/tests/branch_list_test.rs` / `crates/gwt/tests/branch_cleanup_test.rs`: cover risky/blocked branch states and local+remote cleanup execution.
- `crates/gwt-core/src/update.rs`: add the explicit result type needed for the current toolchain to compile verification targets.

## Testing

- [x] `cargo test -p gwt-core -p gwt` — all tests pass
- [x] `cargo fmt --all -- --check` — formatting check passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo build -p gwt` — build succeeds

## Closing Issues

- None

## Related Issues / Links

- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — README changes not needed for this repo-browser iteration
- [ ] Migration/backfill plan included (if schema/data change) — no schema or data migration
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- The web Branches surface already listed branches and launched the wizard, but it still lacked the cleanup and filter behavior that existed in the older branch management flow.
- This PR keeps cleanup semantics in one shared model so the UI labels, selection rules, and destructive execution path do not drift apart again.

## Risk / Impact

- **Affected areas**: Branches window rendering, branch cleanup execution, web protocol events
- **Rollback plan**: Revert commit `fb49ad19`

## Notes

- Remote-tracking rows are not remote-only delete actions; when a local counterpart exists they map to the local cleanup target and remain warning-level selections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added branch cleanup functionality allowing users to delete local and remote branches with confirmation workflow
  * Added branch filtering controls (Local/Remote/All) to the branches view
  * Added multi-branch selection capability for batch cleanup operations

* **Tests**
  * Added comprehensive integration tests for branch cleanup and listing functionality with active session awareness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->