### PR TITLE
fix: restore repo browser wheel scrolling

### DIFF
--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -1201,7 +1201,7 @@ fn run_macos_dmg_installer_with_privileges(
         return Err(format!("hdiutil attach exited with {attach_status}"));
     }
 
-    let install_result = (|| {
+    let install_result: Result<PathBuf, String> = (|| {
         let source_app = find_first_app_bundle(&mount_dir)?
             .ok_or_else(|| "Mounted dmg does not contain an .app bundle".to_string())?;
         let source_name = source_app

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1890,24 +1890,31 @@ mod tests {
     #[test]
     fn embedded_web_repo_browser_scroll_surfaces_bypass_canvas_pan() {
         let html = include_str!("../web/index.html");
+        let scroll_gate = regex::Regex::new(
+            r"nativeWheelScrollSurface\s*&&\s*canScrollSurfaceConsumeWheelDelta\(\s*nativeWheelScrollSurface,\s*event\s*\)",
+        )
+        .expect("valid regex");
 
         assert!(
             html.contains("function findNativeWheelScrollSurface"),
             "expected embedded html to define a repo browser wheel routing helper",
         );
         assert!(
+            html.contains("function canScrollSurfaceConsumeWheelDelta"),
+            "expected embedded html to gate native scrolling on actual scrollability",
+        );
+        assert!(
             html.contains(".branch-scroll") && html.contains(".file-tree-scroll"),
             "expected embedded html to reference repo browser scroll containers",
         );
         assert!(
-            html.contains(
-                "const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);"
-            ),
-            "expected wheel handler to consult the repo browser scroll helper",
+            html.contains("surface.scrollHeight > surface.clientHeight")
+                && html.contains("surface.scrollWidth > surface.clientWidth"),
+            "expected wheel helper to inspect vertical and horizontal overflow before bypassing canvas pan",
         );
         assert!(
-            html.contains("if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface)"),
-            "expected plain wheel input on repo browser scroll surfaces to skip canvas pan",
+            scroll_gate.is_match(html),
+            "expected plain wheel input to bypass canvas pan only when the repo browser surface can consume the delta",
         );
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1886,6 +1886,30 @@ mod tests {
             "expected selection copy path to pass terminal focus restoration",
         );
     }
+
+    #[test]
+    fn embedded_web_repo_browser_scroll_surfaces_bypass_canvas_pan() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("function findNativeWheelScrollSurface"),
+            "expected embedded html to define a repo browser wheel routing helper",
+        );
+        assert!(
+            html.contains(".branch-scroll") && html.contains(".file-tree-scroll"),
+            "expected embedded html to reference repo browser scroll containers",
+        );
+        assert!(
+            html.contains(
+                "const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);"
+            ),
+            "expected wheel handler to consult the repo browser scroll helper",
+        );
+        assert!(
+            html.contains("if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface)"),
+            "expected plain wheel input on repo browser scroll surfaces to skip canvas pan",
+        );
+    }
 }
 
 fn normalize_active_tab_id(

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3808,6 +3808,37 @@
         return element.closest(".branch-scroll, .file-tree-scroll");
       }
 
+      function canScrollSurfaceConsumeWheelDelta(surface, event) {
+        const maxScrollTop = Math.max(0, surface.scrollHeight - surface.clientHeight);
+        const maxScrollLeft = Math.max(0, surface.scrollWidth - surface.clientWidth);
+        const epsilon = 1;
+
+        const canScrollDown =
+          surface.scrollHeight > surface.clientHeight &&
+          surface.scrollTop < maxScrollTop - epsilon;
+        const canScrollUp =
+          surface.scrollHeight > surface.clientHeight && surface.scrollTop > epsilon;
+        const canScrollRight =
+          surface.scrollWidth > surface.clientWidth &&
+          surface.scrollLeft < maxScrollLeft - epsilon;
+        const canScrollLeft =
+          surface.scrollWidth > surface.clientWidth && surface.scrollLeft > epsilon;
+
+        if (event.deltaY > 0 && canScrollDown) {
+          return true;
+        }
+        if (event.deltaY < 0 && canScrollUp) {
+          return true;
+        }
+        if (event.deltaX > 0 && canScrollRight) {
+          return true;
+        }
+        if (event.deltaX < 0 && canScrollLeft) {
+          return true;
+        }
+        return false;
+      }
+
       // Capture phase so wheel events on child elements (windows, terminals)
       // are intercepted before they reach xterm.js or other consumers.
       document.addEventListener(
@@ -3825,8 +3856,14 @@
           ) {
             return;
           }
-          const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);
-          if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface) {
+          const nativeWheelScrollSurface =
+            !event.ctrlKey && !event.metaKey
+              ? findNativeWheelScrollSurface(targetElement)
+              : null;
+          if (
+            nativeWheelScrollSurface &&
+            canScrollSurfaceConsumeWheelDelta(nativeWheelScrollSurface, event)
+          ) {
             return;
           }
           if (event.ctrlKey || event.metaKey) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3790,20 +3790,43 @@
         canvas.setPointerCapture(event.pointerId);
       });
 
+      function eventTargetElement(target) {
+        if (target instanceof Element) {
+          return target;
+        }
+        if (target && target.parentElement instanceof Element) {
+          return target.parentElement;
+        }
+        return null;
+      }
+
+      function findNativeWheelScrollSurface(target) {
+        const element = eventTargetElement(target);
+        if (!element) {
+          return null;
+        }
+        return element.closest(".branch-scroll, .file-tree-scroll");
+      }
+
       // Capture phase so wheel events on child elements (windows, terminals)
       // are intercepted before they reach xterm.js or other consumers.
       document.addEventListener(
         "wheel",
         (event) => {
-          if (!canvas.contains(event.target)) {
+          const targetElement = eventTargetElement(event.target);
+          if (!targetElement || !canvas.contains(targetElement)) {
             return;
           }
           // Let terminal windows handle their own scroll (xterm.js scrollback)
           if (
             !event.ctrlKey &&
             !event.metaKey &&
-            event.target.closest(".surface-terminal")
+            targetElement.closest(".surface-terminal")
           ) {
+            return;
+          }
+          const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);
+          if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface) {
             return;
           }
           if (event.ctrlKey || event.metaKey) {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,25 @@
 # Lessons Learned
 
+## 2026-04-17 — fix: scrollable pane の wheel 奪取は「surface が実際に消費できる delta」だけに限定する
+
+### 事象
+
+Branches / File Tree の wheel 修正後、repo browser pane 上では内部スクロールを優先できるようになった一方、
+pane に overflow がない場合や scroll 端に達している場合でも canvas pan へ fall back せず、
+gesture が no-op になる回帰を reviewer に指摘された。
+
+### 原因
+
+- `wheel` handler が「scrollable pane 配下であること」だけで native scroll へ早期 return していた。
+- event target の面が scroll container であっても、その delta を実際に消費できるか
+  （overflow の有無、top/bottom/left/right の境界）を見ていなかった。
+
+### 再発防止策
+
+1. canvas から `wheel` を奪う条件は「pane 配下」ではなく「pane がその delta を実際に scroll できる」ことにする。
+2. trackpad / mouse wheel の routing では、vertical だけでなく horizontal delta と scroll 境界も確認する。
+3. repo pane の interaction 変更では、「scroll できる時は pane」「scroll できない時は canvas pan」の両方を回帰観点に入れる。
+
 ## 2026-04-17 — fix: CI lint 再現は workflow と同じ package / feature 範囲で実行する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Restore wheel scrolling inside Branches and File Tree panes when the repo browser surface can actually consume the gesture.
- Preserve canvas pan when the repo browser pane has no remaining overflow, so wheel and trackpad gestures do not become no-ops over small or boundary lists.
- Make the embedded HTML contract test resilient to formatting-only JavaScript reflow.

## Changes

- `crates/gwt/web/index.html`: gate repo browser native wheel scrolling on actual overflow and fall back to canvas pan when the current surface cannot consume the delta.
- `crates/gwt/src/main.rs`: replace exact-string embedded HTML assertions with whitespace-agnostic contract checks for wheel routing behavior.
- `tasks/lessons.md`: record the review follow-up lesson about wheel routing and scroll-surface eligibility.

## Testing

- [x] `cargo test -p gwt embedded_web_repo_browser_scroll_surfaces_bypass_canvas_pan` — passes and exercises the embedded HTML wheel-routing contract.
- [x] `cargo test -p gwt-core -p gwt` — passes after merging `origin/develop`.
- [x] `cargo fmt --check` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo build -p gwt` — passes.

## Closing Issues

- None

## Related Issues / Links

- #2009
- https://linear.app/akiojin/issue/AKI-42/gui-spec-repository-workflow-windows

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — No user-facing docs required for this behavior-only fix.
- [ ] Migration/backfill plan included (if schema/data change) — No schema or data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Review follow-up found that the initial wheel-routing fix swallowed wheel events even when repo browser panes had no remaining overflow, which regressed canvas pan on small lists and at scroll boundaries.
- The same review pointed out that the embedded HTML contract test was coupled to exact source formatting rather than the wheel-routing contract.

## Risk / Impact

- **Affected areas**: WebView repo browser wheel routing for Branches and File Tree panes; embedded HTML contract test coverage.
- **Rollback plan**: Revert `78cc9f64` and `f787befd` if repo browser wheel routing regresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wheel scroll routing to properly detect whether scrollable panes can consume scroll events, preventing unresponsive gestures when panes are at scroll boundaries or lack overflow.
  * Improved fallback behavior to canvas pan when scroll surfaces cannot consume wheel delta.

* **Tests**
  * Added test validating wheel event routing and scroll surface detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->