### PR TITLE
chore(release): v9.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.5.2] - 2026-04-20
+
+### Bug Fixes
+
+- Restore repo browser wheel scrolling
+- Restore canvas pan fallback for repo browser wheel
+
 ## [9.5.1] - 2026-04-17
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "axum",
  "base64",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "chrono",
  "gwt-core",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "dirs",
  "serde",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "fs2",
  "regex",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.5.1"
+version = "9.5.2"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.5.1"
+version = "9.5.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -1201,7 +1201,7 @@ fn run_macos_dmg_installer_with_privileges(
         return Err(format!("hdiutil attach exited with {attach_status}"));
     }
 
-    let install_result = (|| {
+    let install_result: Result<PathBuf, String> = (|| {
         let source_app = find_first_app_bundle(&mount_dir)?
             .ok_or_else(|| "Mounted dmg does not contain an .app bundle".to_string())?;
         let source_name = source_app

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1890,24 +1890,31 @@ mod tests {
     #[test]
     fn embedded_web_repo_browser_scroll_surfaces_bypass_canvas_pan() {
         let html = include_str!("../web/index.html");
+        let scroll_gate = regex::Regex::new(
+            r"nativeWheelScrollSurface\s*&&\s*canScrollSurfaceConsumeWheelDelta\(\s*nativeWheelScrollSurface,\s*event\s*\)",
+        )
+        .expect("valid regex");
 
         assert!(
             html.contains("function findNativeWheelScrollSurface"),
             "expected embedded html to define a repo browser wheel routing helper",
         );
         assert!(
+            html.contains("function canScrollSurfaceConsumeWheelDelta"),
+            "expected embedded html to gate native scrolling on actual scrollability",
+        );
+        assert!(
             html.contains(".branch-scroll") && html.contains(".file-tree-scroll"),
             "expected embedded html to reference repo browser scroll containers",
         );
         assert!(
-            html.contains(
-                "const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);"
-            ),
-            "expected wheel handler to consult the repo browser scroll helper",
+            html.contains("surface.scrollHeight > surface.clientHeight")
+                && html.contains("surface.scrollWidth > surface.clientWidth"),
+            "expected wheel helper to inspect vertical and horizontal overflow before bypassing canvas pan",
         );
         assert!(
-            html.contains("if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface)"),
-            "expected plain wheel input on repo browser scroll surfaces to skip canvas pan",
+            scroll_gate.is_match(html),
+            "expected plain wheel input to bypass canvas pan only when the repo browser surface can consume the delta",
         );
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1886,6 +1886,30 @@ mod tests {
             "expected selection copy path to pass terminal focus restoration",
         );
     }
+
+    #[test]
+    fn embedded_web_repo_browser_scroll_surfaces_bypass_canvas_pan() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("function findNativeWheelScrollSurface"),
+            "expected embedded html to define a repo browser wheel routing helper",
+        );
+        assert!(
+            html.contains(".branch-scroll") && html.contains(".file-tree-scroll"),
+            "expected embedded html to reference repo browser scroll containers",
+        );
+        assert!(
+            html.contains(
+                "const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);"
+            ),
+            "expected wheel handler to consult the repo browser scroll helper",
+        );
+        assert!(
+            html.contains("if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface)"),
+            "expected plain wheel input on repo browser scroll surfaces to skip canvas pan",
+        );
+    }
 }
 
 fn normalize_active_tab_id(

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3808,6 +3808,37 @@
         return element.closest(".branch-scroll, .file-tree-scroll");
       }
 
+      function canScrollSurfaceConsumeWheelDelta(surface, event) {
+        const maxScrollTop = Math.max(0, surface.scrollHeight - surface.clientHeight);
+        const maxScrollLeft = Math.max(0, surface.scrollWidth - surface.clientWidth);
+        const epsilon = 1;
+
+        const canScrollDown =
+          surface.scrollHeight > surface.clientHeight &&
+          surface.scrollTop < maxScrollTop - epsilon;
+        const canScrollUp =
+          surface.scrollHeight > surface.clientHeight && surface.scrollTop > epsilon;
+        const canScrollRight =
+          surface.scrollWidth > surface.clientWidth &&
+          surface.scrollLeft < maxScrollLeft - epsilon;
+        const canScrollLeft =
+          surface.scrollWidth > surface.clientWidth && surface.scrollLeft > epsilon;
+
+        if (event.deltaY > 0 && canScrollDown) {
+          return true;
+        }
+        if (event.deltaY < 0 && canScrollUp) {
+          return true;
+        }
+        if (event.deltaX > 0 && canScrollRight) {
+          return true;
+        }
+        if (event.deltaX < 0 && canScrollLeft) {
+          return true;
+        }
+        return false;
+      }
+
       // Capture phase so wheel events on child elements (windows, terminals)
       // are intercepted before they reach xterm.js or other consumers.
       document.addEventListener(
@@ -3825,8 +3856,14 @@
           ) {
             return;
           }
-          const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);
-          if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface) {
+          const nativeWheelScrollSurface =
+            !event.ctrlKey && !event.metaKey
+              ? findNativeWheelScrollSurface(targetElement)
+              : null;
+          if (
+            nativeWheelScrollSurface &&
+            canScrollSurfaceConsumeWheelDelta(nativeWheelScrollSurface, event)
+          ) {
             return;
           }
           if (event.ctrlKey || event.metaKey) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3790,20 +3790,43 @@
         canvas.setPointerCapture(event.pointerId);
       });
 
+      function eventTargetElement(target) {
+        if (target instanceof Element) {
+          return target;
+        }
+        if (target && target.parentElement instanceof Element) {
+          return target.parentElement;
+        }
+        return null;
+      }
+
+      function findNativeWheelScrollSurface(target) {
+        const element = eventTargetElement(target);
+        if (!element) {
+          return null;
+        }
+        return element.closest(".branch-scroll, .file-tree-scroll");
+      }
+
       // Capture phase so wheel events on child elements (windows, terminals)
       // are intercepted before they reach xterm.js or other consumers.
       document.addEventListener(
         "wheel",
         (event) => {
-          if (!canvas.contains(event.target)) {
+          const targetElement = eventTargetElement(event.target);
+          if (!targetElement || !canvas.contains(targetElement)) {
             return;
           }
           // Let terminal windows handle their own scroll (xterm.js scrollback)
           if (
             !event.ctrlKey &&
             !event.metaKey &&
-            event.target.closest(".surface-terminal")
+            targetElement.closest(".surface-terminal")
           ) {
+            return;
+          }
+          const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);
+          if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface) {
             return;
           }
           if (event.ctrlKey || event.metaKey) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.5.1",
+  "version": "9.5.2",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,25 @@
 # Lessons Learned
 
+## 2026-04-17 — fix: scrollable pane の wheel 奪取は「surface が実際に消費できる delta」だけに限定する
+
+### 事象
+
+Branches / File Tree の wheel 修正後、repo browser pane 上では内部スクロールを優先できるようになった一方、
+pane に overflow がない場合や scroll 端に達している場合でも canvas pan へ fall back せず、
+gesture が no-op になる回帰を reviewer に指摘された。
+
+### 原因
+
+- `wheel` handler が「scrollable pane 配下であること」だけで native scroll へ早期 return していた。
+- event target の面が scroll container であっても、その delta を実際に消費できるか
+  （overflow の有無、top/bottom/left/right の境界）を見ていなかった。
+
+### 再発防止策
+
+1. canvas から `wheel` を奪う条件は「pane 配下」ではなく「pane がその delta を実際に scroll できる」ことにする。
+2. trackpad / mouse wheel の routing では、vertical だけでなく horizontal delta と scroll 境界も確認する。
+3. repo pane の interaction 変更では、「scroll できる時は pane」「scroll できない時は canvas pan」の両方を回帰観点に入れる。
+
 ## 2026-04-17 — fix: CI lint 再現は workflow と同じ package / feature 範囲で実行する
 
 ### 事象


### PR DESCRIPTION
## Summary
Prepare release v9.5.2 with a patch bump for the repo browser wheel scrolling fixes.

## Changes
- Restore repo browser wheel scrolling
- Restore canvas pan fallback for repo browser wheel

## Version
- v9.5.2

## Closing Issues
None

## Related Issues / Links
- #2009
- Reference-only via PR #2060; it will not auto-close on merge.
