### PR TITLE
fix: normalize windows pty shim launches

### DIFF
--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -3,10 +3,13 @@
 use std::{
     collections::HashMap,
     io::{Read, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, Mutex},
     time::Duration,
 };
+
+#[cfg(windows)]
+use std::path::Path;
 
 use portable_pty::{native_pty_system, CommandBuilder, ExitStatus, MasterPty, PtySize};
 use tracing::instrument;

--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::HashMap,
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -53,6 +53,7 @@ impl PtyHandle {
     /// Spawn a child process with a PTY.
     #[instrument(skip_all, fields(cmd = %config.command))]
     pub fn spawn(config: SpawnConfig) -> Result<Self, TerminalError> {
+        let config = normalize_spawn_config(config);
         let pty_system = native_pty_system();
         let pair = pty_system
             .openpty(PtySize {
@@ -195,6 +196,286 @@ impl PtyHandle {
             details: e.to_string(),
         })
     }
+}
+
+fn normalize_spawn_config(config: SpawnConfig) -> SpawnConfig {
+    #[cfg(windows)]
+    {
+        normalize_windows_spawn_config(config)
+    }
+
+    #[cfg(not(windows))]
+    {
+        config
+    }
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WindowsSpawnTarget {
+    command: String,
+    args_prefix: Vec<String>,
+}
+
+#[cfg(windows)]
+fn normalize_windows_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
+    let resolved = resolve_windows_spawn_target(&config.command, &config.env, &config.remove_env)
+        .unwrap_or_else(|| WindowsSpawnTarget {
+            command: config.command.clone(),
+            args_prefix: Vec::new(),
+        });
+
+    match windows_spawn_wrapper(
+        Path::new(&resolved.command),
+        &config.env,
+        &config.remove_env,
+    ) {
+        Some((command, mut args)) => {
+            args.extend(config.args);
+            config.command = command;
+            config.args = args;
+        }
+        None => {
+            let mut args = resolved.args_prefix;
+            args.extend(config.args);
+            config.command = resolved.command;
+            config.args = args;
+        }
+    }
+
+    config
+}
+
+#[cfg(windows)]
+fn resolve_windows_spawn_target(
+    command: &str,
+    env: &HashMap<String, String>,
+    remove_env: &[String],
+) -> Option<WindowsSpawnTarget> {
+    let command_path = Path::new(command);
+    let has_separator = command_path
+        .parent()
+        .is_some_and(|parent| !parent.as_os_str().is_empty());
+
+    if has_separator || command_path.is_absolute() {
+        return resolve_windows_path_candidate(command_path, env, remove_env);
+    }
+
+    let path_value = windows_env_value("PATH", env, remove_env)?;
+    for dir in std::env::split_paths(&path_value) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        let candidate = dir.join(command_path);
+        if let Some(resolved) = resolve_windows_path_candidate(&candidate, env, remove_env) {
+            return Some(resolved);
+        }
+    }
+
+    resolve_windows_path_candidate(command_path, env, remove_env)
+}
+
+#[cfg(windows)]
+fn resolve_windows_path_candidate(
+    candidate: &Path,
+    env: &HashMap<String, String>,
+    remove_env: &[String],
+) -> Option<WindowsSpawnTarget> {
+    if has_executable_extension(candidate) && candidate.exists() {
+        return Some(WindowsSpawnTarget {
+            command: candidate.display().to_string(),
+            args_prefix: Vec::new(),
+        });
+    }
+
+    if candidate.extension().is_none() {
+        if candidate.exists() {
+            if let Some(target) = parse_windows_npm_shim(candidate) {
+                return Some(target);
+            }
+        }
+        for ext in windows_path_extensions(env, remove_env) {
+            let with_ext = candidate.with_extension(ext.trim_start_matches('.'));
+            if let Some(target) = resolve_windows_existing_path(&with_ext) {
+                return Some(target);
+            }
+        }
+    }
+
+    resolve_windows_existing_path(candidate)
+}
+
+#[cfg(windows)]
+fn windows_spawn_wrapper(
+    resolved: &Path,
+    env: &HashMap<String, String>,
+    remove_env: &[String],
+) -> Option<(String, Vec<String>)> {
+    let ext = resolved
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())?;
+    if ext != "cmd" && ext != "bat" {
+        return None;
+    }
+
+    let comspec = windows_env_value("ComSpec", env, remove_env)
+        .unwrap_or_else(|| std::ffi::OsString::from("cmd.exe"));
+
+    Some((
+        PathBuf::from(comspec).display().to_string(),
+        vec![
+            "/d".to_string(),
+            "/s".to_string(),
+            "/c".to_string(),
+            resolved.display().to_string(),
+        ],
+    ))
+}
+
+#[cfg(windows)]
+fn resolve_windows_existing_path(candidate: &Path) -> Option<WindowsSpawnTarget> {
+    if !candidate.exists() {
+        return None;
+    }
+
+    if let Some(target) = parse_windows_npm_shim(candidate) {
+        return Some(target);
+    }
+
+    Some(WindowsSpawnTarget {
+        command: candidate.display().to_string(),
+        args_prefix: Vec::new(),
+    })
+}
+
+#[cfg(windows)]
+fn parse_windows_npm_shim(candidate: &Path) -> Option<WindowsSpawnTarget> {
+    match candidate
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("cmd") | Some("bat") => parse_windows_cmd_shim(candidate),
+        Some("exe") | Some("com") => None,
+        _ => parse_windows_shell_shim(candidate),
+    }
+}
+
+#[cfg(windows)]
+fn parse_windows_shell_shim(candidate: &Path) -> Option<WindowsSpawnTarget> {
+    let content = std::fs::read_to_string(candidate).ok()?;
+    let base_dir = candidate.parent()?;
+    let basedir_paths = collect_marker_paths(&content, "$basedir/");
+    if basedir_paths.is_empty() {
+        return None;
+    }
+    build_windows_shim_target(base_dir, &basedir_paths)
+}
+
+#[cfg(windows)]
+fn parse_windows_cmd_shim(candidate: &Path) -> Option<WindowsSpawnTarget> {
+    let content = std::fs::read_to_string(candidate).ok()?;
+    let base_dir = candidate.parent()?;
+    let dp0_paths = collect_marker_paths(&content, "%dp0%\\");
+    if dp0_paths.is_empty() {
+        return None;
+    }
+    build_windows_shim_target(base_dir, &dp0_paths)
+}
+
+#[cfg(windows)]
+fn build_windows_shim_target(base_dir: &Path, raw_paths: &[String]) -> Option<WindowsSpawnTarget> {
+    if let Some(executable) = raw_paths.iter().find(|path| {
+        let lower = path.to_ascii_lowercase();
+        lower.ends_with(".exe") || lower.ends_with(".com")
+    }) {
+        let resolved = base_dir.join(normalize_windows_rel_path(executable));
+        return Some(WindowsSpawnTarget {
+            command: resolved.display().to_string(),
+            args_prefix: Vec::new(),
+        });
+    }
+
+    let script = raw_paths.iter().find(|path| {
+        path.to_ascii_lowercase().ends_with(".js") || path.to_ascii_lowercase().ends_with(".cjs")
+    })?;
+    let script_path = base_dir.join(normalize_windows_rel_path(script));
+
+    let local_node = ["node.exe", "node"]
+        .into_iter()
+        .map(|name| base_dir.join(name))
+        .find(|path| path.exists())
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "node".to_string());
+
+    Some(WindowsSpawnTarget {
+        command: local_node,
+        args_prefix: vec![script_path.display().to_string()],
+    })
+}
+
+#[cfg(windows)]
+fn collect_marker_paths(content: &str, marker: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut remaining = content;
+    while let Some(index) = remaining.find(marker) {
+        let start = index + marker.len();
+        let tail = &remaining[start..];
+        let end = tail.find(['"', '\r', '\n']).unwrap_or(tail.len());
+        let value = tail[..end].trim();
+        if !value.is_empty() {
+            values.push(value.to_string());
+        }
+        remaining = &tail[end..];
+    }
+    values
+}
+
+#[cfg(windows)]
+fn normalize_windows_rel_path(value: &str) -> PathBuf {
+    PathBuf::from(value.replace('/', "\\"))
+}
+
+#[cfg(windows)]
+fn windows_env_value(
+    key: &str,
+    env: &HashMap<String, String>,
+    remove_env: &[String],
+) -> Option<std::ffi::OsString> {
+    if remove_env
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(key))
+    {
+        return None;
+    }
+
+    env.iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| std::ffi::OsString::from(value))
+        .or_else(|| std::env::var_os(key))
+}
+
+#[cfg(windows)]
+fn windows_path_extensions(env: &HashMap<String, String>, remove_env: &[String]) -> Vec<String> {
+    let raw = windows_env_value("PATHEXT", env, remove_env)
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+
+    raw.split(';')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.to_ascii_lowercase())
+        .collect()
+}
+
+#[cfg(windows)]
+fn has_executable_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .map(|value| matches!(value.to_ascii_lowercase().as_str(), "exe" | "com"))
+        .unwrap_or(false)
 }
 
 impl Drop for PtyHandle {
@@ -434,5 +715,159 @@ mod tests {
             !text.lines().any(|line| line.starts_with("HOME=")),
             "Expected inherited HOME to be removed from: {text}"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_wraps_cmd_shims_with_comspec() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let shim = bin_dir.join("claude");
+        let cmd = bin_dir.join("claude.cmd");
+        std::fs::write(&shim, "#!/bin/sh\n").expect("shim");
+        std::fs::write(&cmd, "@echo off\r\n").expect("cmd");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), bin_dir.display().to_string());
+        env.insert(
+            "PATHEXT".to_string(),
+            ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC".to_string(),
+        );
+        env.insert(
+            "ComSpec".to_string(),
+            r"C:\Windows\System32\cmd.exe".to_string(),
+        );
+
+        let normalized = normalize_windows_spawn_config(SpawnConfig {
+            command: "claude".to_string(),
+            args: vec!["--dangerously-skip-permissions".to_string()],
+            cols: 80,
+            rows: 24,
+            env,
+            remove_env: Vec::new(),
+            cwd: None,
+        });
+
+        assert_eq!(normalized.command, r"C:\Windows\System32\cmd.exe");
+        assert_eq!(
+            normalized.args,
+            vec![
+                "/d".to_string(),
+                "/s".to_string(),
+                "/c".to_string(),
+                cmd.display().to_string(),
+                "--dangerously-skip-permissions".to_string(),
+            ]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_prefers_real_exe_before_extensionless_shim() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let shim = bin_dir.join("codex");
+        let exe = bin_dir.join("codex.exe");
+        std::fs::write(&shim, "#!/bin/sh\n").expect("shim");
+        std::fs::write(&exe, "not-a-real-pe-but-good-enough-for-path-selection").expect("exe");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), bin_dir.display().to_string());
+        env.insert("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string());
+
+        let normalized = normalize_windows_spawn_config(SpawnConfig {
+            command: "codex".to_string(),
+            args: vec!["--no-alt-screen".to_string()],
+            cols: 80,
+            rows: 24,
+            env,
+            remove_env: Vec::new(),
+            cwd: None,
+        });
+
+        assert_eq!(normalized.command, exe.display().to_string());
+        assert_eq!(normalized.args, vec!["--no-alt-screen".to_string()]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_resolves_shell_shim_js_entry_to_node() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        let node_modules = bin_dir
+            .join("node_modules")
+            .join("@openai")
+            .join("codex")
+            .join("bin");
+        std::fs::create_dir_all(&node_modules).expect("node modules");
+        let shim = bin_dir.join("codex");
+        let local_node = bin_dir.join("node.exe");
+        let script = node_modules.join("codex.js");
+        std::fs::write(&local_node, "not-a-real-pe").expect("node exe");
+        std::fs::write(&script, "console.log('codex');\n").expect("script");
+        std::fs::write(
+            &shim,
+            "#!/bin/sh\nif [ -x \"$basedir/node\" ]; then\n  exec \"$basedir/node\" \"$basedir/node_modules/@openai/codex/bin/codex.js\" \"$@\"\nelse\n  exec node \"$basedir/node_modules/@openai/codex/bin/codex.js\" \"$@\"\nfi\n",
+        )
+        .expect("shim");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), bin_dir.display().to_string());
+        env.insert("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string());
+
+        let normalized = normalize_windows_spawn_config(SpawnConfig {
+            command: "codex".to_string(),
+            args: vec!["--no-alt-screen".to_string()],
+            cols: 80,
+            rows: 24,
+            env,
+            remove_env: Vec::new(),
+            cwd: None,
+        });
+
+        assert_eq!(normalized.command, local_node.display().to_string());
+        assert_eq!(
+            normalized.args,
+            vec![script.display().to_string(), "--no-alt-screen".to_string(),]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_spawn_succeeds_via_shell_shim_resolved_to_exe() {
+        let _pty_guard = lock_pty_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let shim = bin_dir.join("claude");
+        let tool = bin_dir.join("tool.exe");
+        let system_root = std::env::var_os("SystemRoot").expect("SystemRoot");
+        let whoami = PathBuf::from(system_root)
+            .join("System32")
+            .join("whoami.exe");
+        std::fs::copy(&whoami, &tool).expect("copy whoami");
+        std::fs::write(&shim, "#!/bin/sh\nexec \"$basedir/tool.exe\" \"$@\"\n").expect("shim");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), bin_dir.display().to_string());
+        env.insert(
+            "PATHEXT".to_string(),
+            ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC".to_string(),
+        );
+
+        let config = SpawnConfig {
+            command: "claude".to_string(),
+            args: Vec::new(),
+            cols: 80,
+            rows: 24,
+            env,
+            remove_env: Vec::new(),
+            cwd: None,
+        };
+
+        let handle = PtyHandle::spawn(config).expect("spawn failed");
+        assert!(handle.process_id().is_some(), "expected spawned process id");
     }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-20 — fix: Windows PTY で PATH 解決をそのまま信じると npm shim に吸われる
+
+### 事象
+
+Windows で installed Claude agent を PTY 起動すると、`CreateProcessW` が
+`%APPDATA%\\npm\\claude` を直接実行しようとして `os error 193`
+(`%1 は有効な Win32 アプリケーションではありません`) で失敗した。
+
+### 原因
+
+- `portable-pty` の Windows `search_path()` は PATHEXT 候補より先に「拡張子なしの実在ファイル」を返す。
+- npm global install は `claude` / `codex` の拡張子なし shim を配置するため、
+  Win32 実行可能ファイルではない shell shim が最優先になっていた。
+- `cmd.exe` ラップに逃がすだけでは ConPTY 上で挙動が不安定なケースがあり、
+  実体の `.exe` / `node + .js` まで解決した方が安定する。
+
+### 再発防止策
+
+1. Windows で PATH 検索結果を PTY に渡す前に、npm shim を実体コマンドへ正規化する。
+2. `.exe` / `.com` は直起動し、shell shim が `node_modules/.../*.js` を指す場合は
+   `node` と script path に分解して起動する。
+3. Windows の PTY 起動修正では、少なくとも「shim 解決」「spawn 成功」の両方を
+   回帰テストで固定する。
+
 ## 2026-04-17 — fix: scrollable pane の wheel 奪取は「surface が実際に消費できる delta」だけに限定する
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,24 @@
 # Lessons Learned
 
+## 2026-04-20 — fix: OS 固有実装を足したら import も同じ cfg 境界に置く
+
+### 事象
+
+Windows PTY shim 修正後、PR #2063 の `Clippy & Rustfmt` が Linux CI で失敗した。
+原因は `crates/gwt-terminal/src/pty.rs` の `Path` import がトップレベルにあり、
+Windows 専用関数でしか使わないのに Linux では unused import になっていたことだった。
+
+### 原因
+
+- 実装本体は `#[cfg(windows)]` で囲っていたが、use 宣言の cfg 境界を揃えていなかった。
+- 手元確認が Windows 実行中心で、Linux compile/lint 時の未使用 import を見落とした。
+
+### 再発防止策
+
+1. OS 固有 helper を追加するときは、type import / helper function / test を同じ cfg 境界で揃える。
+2. `cfg(windows)` 専用コードを触った後でも、CI と同じ package 指定の `cargo clippy` を必ず回す。
+3. クロスプラットフォーム crate のトップレベル import 追加では、「他 OS で unused にならないか」を差分確認に含める。
+
 ## 2026-04-20 — fix: Windows PTY で PATH 解決をそのまま信じると npm shim に吸われる
 
 ### 事象


### PR DESCRIPTION
## Summary
- Normalize Windows PTY launches so npm-installed agent shims resolve to a runnable executable or `node + script` before spawn.
- Prevent installed Claude/Codex launches from failing with `CreateProcessW ... os error 193` on Windows.

## Context
- The fix was pushed on `bugfix/agent-not-working`, but this branch had no PR, so it could not be merged through the normal review path.
- Background issue: #2062

## Changes
- Add Windows-only PTY spawn normalization before `portable-pty` receives the command.
- Prefer real `.exe` / `.com` targets, parse npm shell shims to resolve bundled executables or JS entrypoints, and keep `.cmd` / `.bat` only as a final fallback.
- Add Windows regression tests for cmd shim wrapping, exe preference, JS entrypoint resolution, and successful PTY spawn.
- Record the Windows shim resolution lesson in `tasks/lessons.md`.

## Testing
- `cargo test -p gwt-terminal windows_ -- --nocapture`
- `cargo clippy -p gwt-terminal --tests -- -D warnings`
- `cargo test -p gwt --lib --tests --no-run` with `CARGO_TARGET_DIR=target-verify-gwt`
- `npx --yes markdownlint-cli2 tasks/lessons.md`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Risk / Impact
- Impact is limited to Windows PTY command resolution in `gwt-terminal`.
- Main regression risk is mis-resolving non-npm commands on Windows; covered by keeping direct `.exe` / `.com` launches unchanged and adding targeted tests.

## Deployment
- None.

## Screenshots
- None.

## Related Issues / Links
- Fixes #2062

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [ ] Docs updated
- [x] Migration/backfill plan included (not needed)
- [x] Monitoring/alerts updated (not needed)

## Notes
- `cargo test -p gwt-terminal` still contains existing Unix-path-based tests that fail on Windows; this change only validates the Windows regression coverage added here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where installed command-line tools on Windows would fail to execute properly through the terminal. The system now correctly resolves and wraps command shims for proper execution.

* **Tests**
  * Added test cases covering Windows-specific command resolution and terminal spawning scenarios.

* **Documentation**
  * Updated lesson notes documenting Windows command resolution improvements and troubleshooting insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->