### PR TITLE
fix(gui): harden embedded repo browser wheel routing

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -102,4 +102,50 @@ mod tests {
             "expected repo browser wheel routing to stop using edge fallback heuristics",
         );
     }
+
+    #[test]
+    fn embedded_web_canvas_wheel_routing_is_installed_through_named_handler() {
+        let html = index_html();
+
+        assert!(
+            html.contains("function handleCanvasWheelEvent(event)"),
+            "expected canvas wheel routing to live in a named handler",
+        );
+        assert!(
+            html.contains("function installCanvasWheelRouting()"),
+            "expected wheel routing bootstrap to be isolated behind an installer",
+        );
+        assert!(
+            html.contains("document.addEventListener(\"wheel\", handleCanvasWheelEvent, { capture: true, passive: false })"),
+            "expected capture-phase wheel routing to be installed through the named handler",
+        );
+    }
+
+    #[test]
+    fn embedded_web_socket_protocol_wiring_uses_named_handlers() {
+        let html = index_html();
+
+        assert!(
+            html.contains("function handleSocketOpen()"),
+            "expected socket open flow to live in a named handler",
+        );
+        assert!(
+            html.contains("function handleSocketMessage(event)"),
+            "expected socket message flow to live in a named handler",
+        );
+        assert!(
+            html.contains("function handleSocketClose()"),
+            "expected socket close flow to live in a named handler",
+        );
+        assert!(
+            html.contains("function installSocketEventHandlers(activeSocket)"),
+            "expected socket listener registration to be isolated behind an installer",
+        );
+        assert!(
+            html.contains("activeSocket.addEventListener(\"open\", handleSocketOpen)")
+                && html.contains("activeSocket.addEventListener(\"message\", handleSocketMessage)")
+                && html.contains("activeSocket.addEventListener(\"close\", handleSocketClose)"),
+            "expected socket listeners to be registered through named handlers",
+        );
+    }
 }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1,0 +1,105 @@
+use axum::response::Html;
+
+pub(crate) fn index_html() -> &'static str {
+    include_str!("../web/index.html")
+}
+
+pub(crate) async fn index_handler() -> Html<&'static str> {
+    Html(index_html())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::index_html;
+
+    #[test]
+    fn embedded_web_terminal_copy_shortcut_uses_ctrl_shift_c() {
+        let html = index_html();
+
+        assert!(
+            html.contains("function installTerminalCopyHandlers"),
+            "expected web terminal copy handler bootstrap in embedded html",
+        );
+        assert!(
+            html.contains("terminal.attachCustomKeyEventHandler"),
+            "expected xterm custom key handler for copy shortcut",
+        );
+        assert!(
+            html.contains("event.ctrlKey"),
+            "expected Ctrl modifier handling in embedded html",
+        );
+        assert!(
+            html.contains("event.shiftKey"),
+            "expected Shift modifier handling in embedded html",
+        );
+    }
+
+    #[test]
+    fn embedded_web_terminal_drag_selection_copies_on_mouseup() {
+        let html = index_html();
+
+        assert!(
+            html.contains("terminalRoot.addEventListener(\"mousedown\""),
+            "expected drag selection tracking in embedded html",
+        );
+        assert!(
+            html.contains("window.addEventListener(\"mouseup\"") && html.contains("handleMouseUp"),
+            "expected mouse release copy handling in embedded html",
+        );
+        assert!(
+            html.contains("function copyTerminalSelection"),
+            "expected clipboard copy helper in embedded html",
+        );
+        assert!(
+            html.contains("navigator.clipboard.writeText"),
+            "expected clipboard write path in embedded html",
+        );
+    }
+
+    #[test]
+    fn embedded_web_terminal_clipboard_fallback_restores_terminal_focus() {
+        let html = index_html();
+
+        assert!(
+            html.contains("restoreFocus"),
+            "expected clipboard fallback to invoke restoreFocus after textarea copy",
+        );
+        assert!(
+            html.contains("writeClipboardText(selection")
+                && html.contains("runtime.terminal.focus()"),
+            "expected selection copy path to pass terminal focus restoration",
+        );
+    }
+
+    #[test]
+    fn embedded_web_repo_browser_scroll_surfaces_block_canvas_pan_at_edges() {
+        let html = index_html();
+        let scroll_gate = regex::Regex::new(
+            r"if\s*\(\s*!event\.ctrlKey\s*&&\s*!event\.metaKey\s*&&\s*nativeWheelScrollSurface\s*\)\s*\{\s*return;\s*\}",
+        )
+        .expect("valid regex");
+
+        assert!(
+            html.contains("function findNativeWheelScrollSurface"),
+            "expected embedded html to define a repo browser wheel routing helper",
+        );
+        assert!(
+            html.contains(".branch-scroll") && html.contains(".file-tree-scroll"),
+            "expected embedded html to reference repo browser scroll containers",
+        );
+        assert!(
+            html.contains(
+                "const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);",
+            ),
+            "expected plain wheel handling to route repo browser surfaces through the shared helper",
+        );
+        assert!(
+            scroll_gate.is_match(html),
+            "expected plain wheel input on repo browser surfaces to stay within the window even at scroll edges",
+        );
+        assert!(
+            !html.contains("canScrollSurfaceConsumeWheelDelta"),
+            "expected repo browser wheel routing to stop using edge fallback heuristics",
+        );
+    }
+}

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1888,10 +1888,10 @@ mod tests {
     }
 
     #[test]
-    fn embedded_web_repo_browser_scroll_surfaces_bypass_canvas_pan() {
+    fn embedded_web_repo_browser_scroll_surfaces_block_canvas_pan_at_edges() {
         let html = include_str!("../web/index.html");
         let scroll_gate = regex::Regex::new(
-            r"nativeWheelScrollSurface\s*&&\s*canScrollSurfaceConsumeWheelDelta\(\s*nativeWheelScrollSurface,\s*event\s*\)",
+            r"if\s*\(\s*!event\.ctrlKey\s*&&\s*!event\.metaKey\s*&&\s*nativeWheelScrollSurface\s*\)\s*\{\s*return;\s*\}",
         )
         .expect("valid regex");
 
@@ -1900,21 +1900,20 @@ mod tests {
             "expected embedded html to define a repo browser wheel routing helper",
         );
         assert!(
-            html.contains("function canScrollSurfaceConsumeWheelDelta"),
-            "expected embedded html to gate native scrolling on actual scrollability",
-        );
-        assert!(
             html.contains(".branch-scroll") && html.contains(".file-tree-scroll"),
             "expected embedded html to reference repo browser scroll containers",
         );
         assert!(
-            html.contains("surface.scrollHeight > surface.clientHeight")
-                && html.contains("surface.scrollWidth > surface.clientWidth"),
-            "expected wheel helper to inspect vertical and horizontal overflow before bypassing canvas pan",
+            html.contains("const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);"),
+            "expected plain wheel handling to route repo browser surfaces through the shared helper",
         );
         assert!(
             scroll_gate.is_match(html),
-            "expected plain wheel input to bypass canvas pan only when the repo browser surface can consume the delta",
+            "expected plain wheel input on repo browser surfaces to stay within the window even at scroll edges",
+        );
+        assert!(
+            !html.contains("canScrollSurfaceConsumeWheelDelta"),
+            "expected repo browser wheel routing to stop using edge fallback heuristics",
         );
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -13,7 +13,7 @@ use axum::{
         ws::{Message, WebSocket, WebSocketUpgrade},
         State,
     },
-    response::{Html, IntoResponse},
+    response::IntoResponse,
     routing::get,
     Router,
 };
@@ -41,6 +41,8 @@ use tokio::{
 };
 use uuid::Uuid;
 use wry::WebViewBuilder;
+
+mod embedded_web;
 
 type ClientId = String;
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
@@ -1827,95 +1829,6 @@ mod tests {
             dunce::canonicalize(&repo).expect("canonical repo root"),
         );
     }
-
-    #[test]
-    fn embedded_web_terminal_copy_shortcut_uses_ctrl_shift_c() {
-        let html = include_str!("../web/index.html");
-
-        assert!(
-            html.contains("function installTerminalCopyHandlers"),
-            "expected web terminal copy handler bootstrap in embedded html",
-        );
-        assert!(
-            html.contains("terminal.attachCustomKeyEventHandler"),
-            "expected xterm custom key handler for copy shortcut",
-        );
-        assert!(
-            html.contains("event.ctrlKey"),
-            "expected Ctrl modifier handling in embedded html",
-        );
-        assert!(
-            html.contains("event.shiftKey"),
-            "expected Shift modifier handling in embedded html",
-        );
-    }
-
-    #[test]
-    fn embedded_web_terminal_drag_selection_copies_on_mouseup() {
-        let html = include_str!("../web/index.html");
-
-        assert!(
-            html.contains("terminalRoot.addEventListener(\"mousedown\""),
-            "expected drag selection tracking in embedded html",
-        );
-        assert!(
-            html.contains("window.addEventListener(\"mouseup\"") && html.contains("handleMouseUp"),
-            "expected mouse release copy handling in embedded html",
-        );
-        assert!(
-            html.contains("function copyTerminalSelection"),
-            "expected clipboard copy helper in embedded html",
-        );
-        assert!(
-            html.contains("navigator.clipboard.writeText"),
-            "expected clipboard write path in embedded html",
-        );
-    }
-
-    #[test]
-    fn embedded_web_terminal_clipboard_fallback_restores_terminal_focus() {
-        let html = include_str!("../web/index.html");
-
-        assert!(
-            html.contains("restoreFocus"),
-            "expected clipboard fallback to invoke restoreFocus after textarea copy",
-        );
-        assert!(
-            html.contains("writeClipboardText(selection")
-                && html.contains("runtime.terminal.focus()"),
-            "expected selection copy path to pass terminal focus restoration",
-        );
-    }
-
-    #[test]
-    fn embedded_web_repo_browser_scroll_surfaces_block_canvas_pan_at_edges() {
-        let html = include_str!("../web/index.html");
-        let scroll_gate = regex::Regex::new(
-            r"if\s*\(\s*!event\.ctrlKey\s*&&\s*!event\.metaKey\s*&&\s*nativeWheelScrollSurface\s*\)\s*\{\s*return;\s*\}",
-        )
-        .expect("valid regex");
-
-        assert!(
-            html.contains("function findNativeWheelScrollSurface"),
-            "expected embedded html to define a repo browser wheel routing helper",
-        );
-        assert!(
-            html.contains(".branch-scroll") && html.contains(".file-tree-scroll"),
-            "expected embedded html to reference repo browser scroll containers",
-        );
-        assert!(
-            html.contains("const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);"),
-            "expected plain wheel handling to route repo browser surfaces through the shared helper",
-        );
-        assert!(
-            scroll_gate.is_match(html),
-            "expected plain wheel input on repo browser surfaces to stay within the window even at scroll edges",
-        );
-        assert!(
-            !html.contains("canScrollSurfaceConsumeWheelDelta"),
-            "expected repo browser wheel routing to stop using edge fallback heuristics",
-        );
-    }
 }
 
 fn normalize_active_tab_id(
@@ -2053,7 +1966,7 @@ impl EmbeddedServer {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
         let app = Router::new()
-            .route("/", get(index_handler))
+            .route("/", get(embedded_web::index_handler))
             .route("/healthz", get(health_handler))
             .route("/ws", get(websocket_handler))
             .with_state(ServerState { proxy, clients });
@@ -2082,10 +1995,6 @@ impl EmbeddedServer {
             let _ = tx.send(());
         }
     }
-}
-
-async fn index_handler() -> Html<&'static str> {
-    Html(include_str!("../web/index.html"))
 }
 
 async fn health_handler() -> &'static str {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1538,32 +1538,39 @@
         return url.toString();
       }
 
+      function handleSocketOpen() {
+        setConnectionState(true);
+        send({ kind: "frontend_ready" });
+        while (pendingMessages.length > 0) {
+          socket.send(JSON.stringify(pendingMessages.shift()));
+        }
+      }
+
+      function handleSocketMessage(event) {
+        receive(JSON.parse(event.data));
+      }
+
+      function handleSocketClose() {
+        setConnectionState(false);
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+        }
+        reconnectTimer = window.setTimeout(connectSocket, 1000);
+      }
+
+      function installSocketEventHandlers(activeSocket) {
+        activeSocket.addEventListener("open", handleSocketOpen);
+        activeSocket.addEventListener("message", handleSocketMessage);
+        activeSocket.addEventListener("close", handleSocketClose);
+      }
+
       function connectSocket() {
         if (socket && socket.readyState <= WebSocket.OPEN) {
           return;
         }
         socket = new WebSocket(websocketUrl());
         setConnectionState(false);
-
-        socket.addEventListener("open", () => {
-          setConnectionState(true);
-          send({ kind: "frontend_ready" });
-          while (pendingMessages.length > 0) {
-            socket.send(JSON.stringify(pendingMessages.shift()));
-          }
-        });
-
-        socket.addEventListener("message", (event) => {
-          receive(JSON.parse(event.data));
-        });
-
-        socket.addEventListener("close", () => {
-          setConnectionState(false);
-          if (reconnectTimer) {
-            clearTimeout(reconnectTimer);
-          }
-          reconnectTimer = window.setTimeout(connectSocket, 1000);
-        });
+        installSocketEventHandlers(socket);
       }
 
       function emptyWorkspace() {
@@ -3808,48 +3815,50 @@
         return element.closest(".branch-scroll, .file-tree-scroll");
       }
 
-      // Capture phase so wheel events on child elements (windows, terminals)
-      // are intercepted before they reach xterm.js or other consumers.
-      document.addEventListener(
-        "wheel",
-        (event) => {
-          const targetElement = eventTargetElement(event.target);
-          if (!targetElement || !canvas.contains(targetElement)) {
-            return;
-          }
-          // Let terminal windows handle their own scroll (xterm.js scrollback)
-          if (
-            !event.ctrlKey &&
-            !event.metaKey &&
-            targetElement.closest(".surface-terminal")
-          ) {
-            return;
-          }
-          const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);
-          if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface) {
-            return;
-          }
-          if (event.ctrlKey || event.metaKey) {
-            // Ctrl/Cmd + wheel = zoom
-            event.preventDefault();
-            event.stopPropagation();
-            const rect = canvas.getBoundingClientRect();
-            const anchorX = event.clientX - rect.left;
-            const anchorY = event.clientY - rect.top;
-            const factor = event.deltaY < 0 ? 1.1 : 0.9;
-            zoomCanvasAt(anchorX, anchorY, viewport.zoom * factor);
-          } else {
-            // Plain wheel (trackpad two-finger scroll) = pan
-            event.preventDefault();
-            event.stopPropagation();
-            viewport.x -= event.deltaX;
-            viewport.y -= event.deltaY;
-            applyViewport();
-            persistViewport();
-          }
-        },
-        { capture: true, passive: false },
-      );
+      function handleCanvasWheelEvent(event) {
+        const targetElement = eventTargetElement(event.target);
+        if (!targetElement || !canvas.contains(targetElement)) {
+          return;
+        }
+        // Let terminal windows handle their own scroll (xterm.js scrollback)
+        if (
+          !event.ctrlKey &&
+          !event.metaKey &&
+          targetElement.closest(".surface-terminal")
+        ) {
+          return;
+        }
+        const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);
+        if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface) {
+          return;
+        }
+        if (event.ctrlKey || event.metaKey) {
+          // Ctrl/Cmd + wheel = zoom
+          event.preventDefault();
+          event.stopPropagation();
+          const rect = canvas.getBoundingClientRect();
+          const anchorX = event.clientX - rect.left;
+          const anchorY = event.clientY - rect.top;
+          const factor = event.deltaY < 0 ? 1.1 : 0.9;
+          zoomCanvasAt(anchorX, anchorY, viewport.zoom * factor);
+        } else {
+          // Plain wheel (trackpad two-finger scroll) = pan
+          event.preventDefault();
+          event.stopPropagation();
+          viewport.x -= event.deltaX;
+          viewport.y -= event.deltaY;
+          applyViewport();
+          persistViewport();
+        }
+      }
+
+      function installCanvasWheelRouting() {
+        // Capture phase so wheel events on child elements (windows, terminals)
+        // are intercepted before they reach xterm.js or other consumers.
+        document.addEventListener("wheel", handleCanvasWheelEvent, { capture: true, passive: false });
+      }
+
+      installCanvasWheelRouting();
 
       window.addEventListener(
         "keydown",

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3808,37 +3808,6 @@
         return element.closest(".branch-scroll, .file-tree-scroll");
       }
 
-      function canScrollSurfaceConsumeWheelDelta(surface, event) {
-        const maxScrollTop = Math.max(0, surface.scrollHeight - surface.clientHeight);
-        const maxScrollLeft = Math.max(0, surface.scrollWidth - surface.clientWidth);
-        const epsilon = 1;
-
-        const canScrollDown =
-          surface.scrollHeight > surface.clientHeight &&
-          surface.scrollTop < maxScrollTop - epsilon;
-        const canScrollUp =
-          surface.scrollHeight > surface.clientHeight && surface.scrollTop > epsilon;
-        const canScrollRight =
-          surface.scrollWidth > surface.clientWidth &&
-          surface.scrollLeft < maxScrollLeft - epsilon;
-        const canScrollLeft =
-          surface.scrollWidth > surface.clientWidth && surface.scrollLeft > epsilon;
-
-        if (event.deltaY > 0 && canScrollDown) {
-          return true;
-        }
-        if (event.deltaY < 0 && canScrollUp) {
-          return true;
-        }
-        if (event.deltaX > 0 && canScrollRight) {
-          return true;
-        }
-        if (event.deltaX < 0 && canScrollLeft) {
-          return true;
-        }
-        return false;
-      }
-
       // Capture phase so wheel events on child elements (windows, terminals)
       // are intercepted before they reach xterm.js or other consumers.
       document.addEventListener(
@@ -3856,14 +3825,8 @@
           ) {
             return;
           }
-          const nativeWheelScrollSurface =
-            !event.ctrlKey && !event.metaKey
-              ? findNativeWheelScrollSurface(targetElement)
-              : null;
-          if (
-            nativeWheelScrollSurface &&
-            canScrollSurfaceConsumeWheelDelta(nativeWheelScrollSurface, event)
-          ) {
+          const nativeWheelScrollSurface = findNativeWheelScrollSurface(event.target);
+          if (!event.ctrlKey && !event.metaKey && nativeWheelScrollSurface) {
             return;
           }
           if (event.ctrlKey || event.metaKey) {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,25 @@
 # Lessons Learned
 
+## 2026-04-20 — fix: repo browser の wheel ownership を generic な edge fallback へ一般化しない
+
+### 事象
+
+Branches ウィンドウで一覧を最上端/最下端までスクロールしたあと、さらに同じ方向へ wheel/trackpad scroll すると、
+内部リストは止まる一方で canvas pan が始まり、repo browser surface 上の操作が window 内で完結しなかった。
+
+### 原因
+
+- 4/17 の修正で「surface が delta を実際に消費できるときだけ native scroll を優先する」という一般則を入れた。
+- この一般則を repo browser surface にもそのまま適用した結果、scroll edge では capture-phase handler が
+  canvas pan 経路へフォールバックしてしまった。
+- Branches / File Tree の UX では、surface 上の plain wheel は canvas に流さず no-op に留める契約だった。
+
+### 再発防止策
+
+1. wheel ownership は surface ごとに決める。repo browser list は「scroll 可能時は native scroll、edge では no-op」、canvas 背景だけが pan owner。
+2. `can surface consume delta? -> else canvas` のような generic fallback を、window 内 scroll surface へ無条件に再利用しない。
+3. repo browser の回帰テストには「内部スクロール可能」「edge で no-op」「canvas 背景で pan」の 3 観点をセットで入れる。
+
 ## 2026-04-17 — fix: scrollable pane の wheel 奪取は「surface が実際に消費できる delta」だけに限定する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Keep repo browser wheel input inside the window at scroll edges so Branches and File Tree no longer fall through to canvas pan.
- Move embedded WebView HTML contract ownership out of `main.rs` and into a dedicated `embedded_web` module so protocol-sensitive behaviors are tested in one place.
- Split canvas wheel routing and WebSocket event wiring in `index.html` into named handlers/installers so follow-up frontend hardening can stay narrow.

## Changes

- `crates/gwt/web/index.html`: keep repo browser wheel input local at scroll edges and split canvas wheel / socket event wiring into named handlers and installers.
- `crates/gwt/src/embedded_web.rs`: centralize embedded HTML access and contract tests for clipboard, wheel routing, socket wiring, and branch scope/cleanup flows.
- `crates/gwt/src/main.rs`: delegate `/` to the embedded web module and remove entrypoint-coupled embedded HTML tests.
- `tasks/lessons.md`: record the repo browser wheel ownership lesson.

## Testing

- [x] `cargo test -p gwt --bin gwt embedded_web_` — embedded WebView contract tests pass
- [x] `cargo test -p gwt-core -p gwt` — full Rust test suites pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes cleanly
- [x] `cargo build -p gwt` — GUI binary builds successfully
- [x] `cargo fmt --all -- --check` — formatting is clean

## Closing Issues

- None

## Related Issues / Links

- #2009
- #2012
- https://github.com/akiojin/gwt/pull/2060

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — Not required: no README or user-facing docs changed.
- [ ] Migration/backfill plan included (if schema/data change) — Not applicable: no schema or persisted data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- PR #2060 restored repo browser scrolling, but the embedded WebView contract tests and event wiring still lived in `main.rs`.
- This follow-up keeps the wheel ownership fix in place while moving protocol-sensitive behavior under the #2012 owner surface.

## Risk / Impact

- **Affected areas**: embedded WebView event routing, repo browser wheel handling, branch surface contract tests
- **Rollback plan**: Revert `b9d5ffc0`, `d0542db5`, `621db19f`, and `7eb88c40` or revert the eventual merge commit.