### PR TITLE
feat(gui): add cache-backed knowledge bridge windows

### DIFF
--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -52,6 +52,13 @@ pub(crate) fn sync_issue_cache_from_remote_if_missing(
         return Ok(());
     }
 
+    sync_issue_cache_from_remote(repo_path, cache_root)
+}
+
+pub(crate) fn sync_issue_cache_from_remote(
+    repo_path: &Path,
+    cache_root: &Path,
+) -> Result<(), String> {
     let snapshots = fetch_issue_list_snapshots(repo_path)?;
     if snapshots.is_empty() {
         fs::create_dir_all(cache_root).map_err(|err| err.to_string())?;

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1,0 +1,441 @@
+use std::{collections::HashMap, path::Path};
+
+use gwt_core::paths::gwt_cache_dir;
+use gwt_github::{Cache, CacheEntry, IssueState, SectionName};
+use serde::{Deserialize, Serialize};
+
+use crate::issue_cache::{
+    issue_cache_root_for_repo_path, issue_cache_root_for_repo_path_or_detached,
+    sync_issue_cache_from_remote,
+};
+
+const SPEC_LABEL: &str = "gwt-spec";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeKind {
+    Issue,
+    Spec,
+    Pr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeListItem {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub meta: String,
+    pub labels: Vec<String>,
+    pub linked_branch_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeDetailSection {
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeDetailView {
+    pub number: Option<u64>,
+    pub title: String,
+    pub subtitle: String,
+    pub state: String,
+    pub labels: Vec<String>,
+    pub sections: Vec<KnowledgeDetailSection>,
+    pub launch_issue_number: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeBridgeView {
+    pub kind: KnowledgeKind,
+    pub entries: Vec<KnowledgeListItem>,
+    pub selected_number: Option<u64>,
+    pub empty_message: Option<String>,
+    pub refresh_enabled: bool,
+    pub detail: KnowledgeDetailView,
+}
+
+pub fn load_knowledge_bridge(
+    repo_path: &Path,
+    kind: KnowledgeKind,
+    selected_number: Option<u64>,
+    refresh: bool,
+) -> Result<KnowledgeBridgeView, String> {
+    if !repo_path.is_dir() {
+        return Err(format!(
+            "project root is not available: {}",
+            repo_path.display()
+        ));
+    }
+
+    if matches!(kind, KnowledgeKind::Pr) {
+        return Ok(disabled_pr_view());
+    }
+
+    if issue_cache_root_for_repo_path(repo_path).is_none() {
+        return Ok(non_repo_view(kind));
+    }
+
+    let cache_root = issue_cache_root_for_repo_path_or_detached(repo_path);
+    if refresh {
+        sync_issue_cache_from_remote(repo_path, &cache_root)?;
+    }
+
+    let cache = Cache::new(cache_root);
+    let entries = load_cache_entries(&cache)?;
+    let linked_branches = load_linked_branches(repo_path);
+    Ok(match kind {
+        KnowledgeKind::Issue => build_issue_view(entries, linked_branches, selected_number),
+        KnowledgeKind::Spec => build_spec_view(entries, linked_branches, selected_number),
+        KnowledgeKind::Pr => disabled_pr_view(),
+    })
+}
+
+fn load_cache_entries(cache: &Cache) -> Result<Vec<CacheEntry>, String> {
+    match cache.list_entries() {
+        Ok(entries) => Ok(entries),
+        Err(gwt_github::CacheError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(Vec::new())
+        }
+        Err(error) => Err(format!("failed to read issue cache: {error}")),
+    }
+}
+
+fn build_issue_view(
+    mut entries: Vec<CacheEntry>,
+    linked_branches: HashMap<u64, Vec<String>>,
+    selected_number: Option<u64>,
+) -> KnowledgeBridgeView {
+    entries.retain(|entry| !is_spec_entry(entry));
+    entries.sort_by(issue_entry_sort);
+
+    let list_items = entries
+        .iter()
+        .map(|entry| KnowledgeListItem {
+            number: entry.snapshot.number.0,
+            title: entry.snapshot.title.clone(),
+            state: issue_state_label(entry.snapshot.state),
+            meta: format!("Updated {}", short_updated_at(&entry.snapshot.updated_at.0)),
+            labels: entry.snapshot.labels.clone(),
+            linked_branch_count: linked_branches
+                .get(&entry.snapshot.number.0)
+                .map(Vec::len)
+                .unwrap_or_default(),
+        })
+        .collect::<Vec<_>>();
+    let selected_number = resolve_selected_number(&entries, selected_number);
+    let detail = entries
+        .iter()
+        .find(|entry| Some(entry.snapshot.number.0) == selected_number)
+        .map(|entry| issue_detail_view(entry, linked_branches.get(&entry.snapshot.number.0)))
+        .unwrap_or_else(|| empty_detail("Issue Bridge", "No cached issues available."));
+
+    KnowledgeBridgeView {
+        kind: KnowledgeKind::Issue,
+        entries: list_items,
+        selected_number,
+        empty_message: if selected_number.is_none() {
+            Some("No cached issues. Use Refresh to sync the cache.".to_string())
+        } else {
+            None
+        },
+        refresh_enabled: true,
+        detail,
+    }
+}
+
+fn build_spec_view(
+    mut entries: Vec<CacheEntry>,
+    linked_branches: HashMap<u64, Vec<String>>,
+    selected_number: Option<u64>,
+) -> KnowledgeBridgeView {
+    entries.retain(is_spec_entry);
+    entries.sort_by(issue_entry_sort);
+
+    let list_items = entries
+        .iter()
+        .map(|entry| KnowledgeListItem {
+            number: entry.snapshot.number.0,
+            title: entry.snapshot.title.clone(),
+            state: issue_state_label(entry.snapshot.state),
+            meta: spec_list_meta(entry),
+            labels: entry.snapshot.labels.clone(),
+            linked_branch_count: linked_branches
+                .get(&entry.snapshot.number.0)
+                .map(Vec::len)
+                .unwrap_or_default(),
+        })
+        .collect::<Vec<_>>();
+    let selected_number = resolve_selected_number(&entries, selected_number);
+    let detail = entries
+        .iter()
+        .find(|entry| Some(entry.snapshot.number.0) == selected_number)
+        .map(spec_detail_view)
+        .unwrap_or_else(|| empty_detail("SPEC Bridge", "No cached SPECs available."));
+
+    KnowledgeBridgeView {
+        kind: KnowledgeKind::Spec,
+        entries: list_items,
+        selected_number,
+        empty_message: if selected_number.is_none() {
+            Some("No cached SPECs. Use Refresh to sync the cache.".to_string())
+        } else {
+            None
+        },
+        refresh_enabled: true,
+        detail,
+    }
+}
+
+fn disabled_pr_view() -> KnowledgeBridgeView {
+    KnowledgeBridgeView {
+        kind: KnowledgeKind::Pr,
+        entries: Vec::new(),
+        selected_number: None,
+        empty_message: Some(
+            "PR Bridge is waiting for cache-backed PR list support before it can render data."
+                .to_string(),
+        ),
+        refresh_enabled: false,
+        detail: KnowledgeDetailView {
+            number: None,
+            title: "PR Bridge".to_string(),
+            subtitle: "Unavailable".to_string(),
+            state: "unavailable".to_string(),
+            labels: Vec::new(),
+            sections: vec![KnowledgeDetailSection {
+                title: "Status".to_string(),
+                body: "PR Bridge is waiting for cache-backed PR list support before it can render data."
+                    .to_string(),
+            }],
+            launch_issue_number: None,
+        },
+    }
+}
+
+fn non_repo_view(kind: KnowledgeKind) -> KnowledgeBridgeView {
+    let title = match kind {
+        KnowledgeKind::Issue => "Issue Bridge",
+        KnowledgeKind::Spec => "SPEC Bridge",
+        KnowledgeKind::Pr => "PR Bridge",
+    };
+    KnowledgeBridgeView {
+        kind,
+        entries: Vec::new(),
+        selected_number: None,
+        empty_message: Some("Knowledge Bridge is available only for Git projects.".to_string()),
+        refresh_enabled: false,
+        detail: empty_detail(
+            title,
+            "Knowledge Bridge is available only for Git projects.",
+        ),
+    }
+}
+
+fn empty_detail(title: &str, body: &str) -> KnowledgeDetailView {
+    KnowledgeDetailView {
+        number: None,
+        title: title.to_string(),
+        subtitle: String::new(),
+        state: "idle".to_string(),
+        labels: Vec::new(),
+        sections: vec![KnowledgeDetailSection {
+            title: "Status".to_string(),
+            body: body.to_string(),
+        }],
+        launch_issue_number: None,
+    }
+}
+
+fn issue_detail_view(
+    entry: &CacheEntry,
+    linked_branches: Option<&Vec<String>>,
+) -> KnowledgeDetailView {
+    let mut sections = Vec::new();
+    let body = entry.snapshot.body.trim();
+    if !body.is_empty() {
+        sections.push(KnowledgeDetailSection {
+            title: "Description".to_string(),
+            body: body.to_string(),
+        });
+    }
+    for (index, comment) in entry.snapshot.comments.iter().enumerate() {
+        let comment_body = comment.body.trim();
+        if comment_body.is_empty() {
+            continue;
+        }
+        sections.push(KnowledgeDetailSection {
+            title: format!("Comment {}", index + 1),
+            body: comment_body.to_string(),
+        });
+    }
+    if let Some(branches) = linked_branches.filter(|branches| !branches.is_empty()) {
+        sections.push(KnowledgeDetailSection {
+            title: "Linked branches".to_string(),
+            body: branches.join("\n"),
+        });
+    }
+    if sections.is_empty() {
+        sections.push(KnowledgeDetailSection {
+            title: "Status".to_string(),
+            body: "No cached issue details available.".to_string(),
+        });
+    }
+
+    KnowledgeDetailView {
+        number: Some(entry.snapshot.number.0),
+        title: entry.snapshot.title.clone(),
+        subtitle: format!(
+            "#{} · {} · Updated {}",
+            entry.snapshot.number.0,
+            issue_state_label(entry.snapshot.state),
+            short_updated_at(&entry.snapshot.updated_at.0)
+        ),
+        state: issue_state_label(entry.snapshot.state),
+        labels: entry.snapshot.labels.clone(),
+        sections,
+        launch_issue_number: Some(entry.snapshot.number.0),
+    }
+}
+
+fn spec_detail_view(entry: &CacheEntry) -> KnowledgeDetailView {
+    let mut sections = Vec::new();
+    for name in ["spec", "plan", "tasks"] {
+        if let Some(body) = entry.spec_body.sections.get(&SectionName(name.to_string())) {
+            if !body.trim().is_empty() {
+                sections.push(KnowledgeDetailSection {
+                    title: name.to_string(),
+                    body: body.trim().to_string(),
+                });
+            }
+        }
+    }
+    for (name, body) in &entry.spec_body.sections {
+        if matches!(name.0.as_str(), "spec" | "plan" | "tasks") || body.trim().is_empty() {
+            continue;
+        }
+        sections.push(KnowledgeDetailSection {
+            title: name.0.clone(),
+            body: body.trim().to_string(),
+        });
+    }
+    if sections.is_empty() {
+        sections.push(KnowledgeDetailSection {
+            title: "Status".to_string(),
+            body: "No cached SPEC sections available.".to_string(),
+        });
+    }
+
+    let phase = entry
+        .snapshot
+        .labels
+        .iter()
+        .find(|label| label.starts_with("phase/"))
+        .cloned()
+        .unwrap_or_else(|| "phase/unspecified".to_string());
+    KnowledgeDetailView {
+        number: Some(entry.snapshot.number.0),
+        title: entry.snapshot.title.clone(),
+        subtitle: format!(
+            "#{} · {} · Updated {}",
+            entry.snapshot.number.0,
+            phase,
+            short_updated_at(&entry.snapshot.updated_at.0)
+        ),
+        state: issue_state_label(entry.snapshot.state),
+        labels: entry.snapshot.labels.clone(),
+        sections,
+        launch_issue_number: Some(entry.snapshot.number.0),
+    }
+}
+
+fn spec_list_meta(entry: &CacheEntry) -> String {
+    let phase = entry
+        .snapshot
+        .labels
+        .iter()
+        .find(|label| label.starts_with("phase/"))
+        .cloned()
+        .unwrap_or_else(|| "phase/unspecified".to_string());
+    format!(
+        "{phase} · Updated {}",
+        short_updated_at(&entry.snapshot.updated_at.0)
+    )
+}
+
+fn resolve_selected_number(entries: &[CacheEntry], selected_number: Option<u64>) -> Option<u64> {
+    selected_number
+        .filter(|selected| {
+            entries
+                .iter()
+                .any(|entry| entry.snapshot.number.0 == *selected)
+        })
+        .or_else(|| entries.first().map(|entry| entry.snapshot.number.0))
+}
+
+fn issue_entry_sort(left: &CacheEntry, right: &CacheEntry) -> std::cmp::Ordering {
+    let left_state = if left.snapshot.state == IssueState::Open {
+        0
+    } else {
+        1
+    };
+    let right_state = if right.snapshot.state == IssueState::Open {
+        0
+    } else {
+        1
+    };
+    left_state
+        .cmp(&right_state)
+        .then_with(|| right.snapshot.updated_at.0.cmp(&left.snapshot.updated_at.0))
+        .then_with(|| left.snapshot.number.0.cmp(&right.snapshot.number.0))
+}
+
+fn issue_state_label(state: IssueState) -> String {
+    match state {
+        IssueState::Open => "open".to_string(),
+        IssueState::Closed => "closed".to_string(),
+    }
+}
+
+fn short_updated_at(updated_at: &str) -> String {
+    updated_at.get(..10).unwrap_or(updated_at).to_string()
+}
+
+fn is_spec_entry(entry: &CacheEntry) -> bool {
+    entry
+        .snapshot
+        .labels
+        .iter()
+        .any(|label| label == SPEC_LABEL)
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct IssueBranchLinkStore {
+    #[serde(default)]
+    branches: HashMap<String, u64>,
+}
+
+fn load_linked_branches(repo_path: &Path) -> HashMap<u64, Vec<String>> {
+    let Some(repo_hash) = crate::index_worker::detect_repo_hash(repo_path) else {
+        return HashMap::new();
+    };
+    let path = gwt_cache_dir()
+        .join("issue-links")
+        .join(format!("{}.json", repo_hash.as_str()));
+    let Ok(bytes) = std::fs::read(path) else {
+        return HashMap::new();
+    };
+    let Ok(store) = serde_json::from_slice::<IssueBranchLinkStore>(&bytes) else {
+        return HashMap::new();
+    };
+
+    let mut linked = HashMap::<u64, Vec<String>>::new();
+    for (branch, issue_number) in store.branches {
+        linked.entry(issue_number).or_default().push(branch);
+    }
+    for branches in linked.values_mut() {
+        branches.sort();
+    }
+    linked
+}

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -5,6 +5,7 @@ mod discussion_resume;
 pub mod file_tree;
 pub mod index_worker;
 mod issue_cache;
+pub mod knowledge_bridge;
 pub mod launch_wizard;
 pub mod managed_assets;
 pub mod native_app;
@@ -22,6 +23,10 @@ pub use branch_list::{
     BranchCleanupBlockedReason, BranchCleanupInfo, BranchCleanupRisk,
 };
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
+pub use knowledge_bridge::{
+    load_knowledge_bridge, KnowledgeBridgeView, KnowledgeDetailSection, KnowledgeDetailView,
+    KnowledgeKind, KnowledgeListItem,
+};
 pub use launch_wizard::{
     build_builtin_agent_options, default_wizard_version_cache_path, AgentOption,
     DockerWizardContext, LaunchWizardAction, LaunchWizardCompletion, LaunchWizardContext,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2201,7 +2201,7 @@ mod tests {
             .working_dir("E:/gwt/develop")
             .version("latest")
             .build();
-        config.command = r"C:\Users\test\AppData\Roaming\npm\bunx.cmd".to_string();
+        config.command = "bunx".to_string();
         config.args = vec![
             "@anthropic-ai/claude-code@latest".to_string(),
             "--print".to_string(),
@@ -2221,7 +2221,7 @@ mod tests {
             &mut config,
             "npx".to_string(),
             |command, args, _env, cwd| {
-                assert!(command.ends_with("bunx.cmd"), "command: {command}");
+                assert_eq!(command, "bunx");
                 assert_eq!(
                     args,
                     vec![

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -21,12 +21,12 @@ use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use gwt::{
     cleanup_selected_branches, default_wizard_version_cache_path, detect_shell_program,
-    list_branch_entries_with_active_sessions, list_directory_entries,
+    list_branch_entries_with_active_sessions, list_directory_entries, load_knowledge_bridge,
     load_restored_workspace_state, load_session_state, migrate_legacy_workspace_state,
     refresh_managed_gwt_assets_for_worktree, resolve_launch_spec, save_session_state,
     save_workspace_state, workspace_state_path, BackendEvent, DockerWizardContext, FrontendEvent,
-    LaunchWizardCompletion, LaunchWizardContext, LaunchWizardState, LiveSessionEntry,
-    WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
+    KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext, LaunchWizardState,
+    LiveSessionEntry, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus};
 use tao::{
@@ -318,11 +318,37 @@ impl AppRuntime {
                     self.load_branches_event(&id),
                 )]
             }
+            FrontendEvent::LoadKnowledgeBridge {
+                id,
+                knowledge_kind,
+                selected_number,
+                refresh,
+            } => self.load_knowledge_bridge_events(
+                &client_id,
+                &id,
+                knowledge_kind,
+                selected_number,
+                refresh,
+            ),
+            FrontendEvent::SelectKnowledgeBridgeEntry {
+                id,
+                knowledge_kind,
+                number,
+            } => self.load_knowledge_bridge_events(
+                &client_id,
+                &id,
+                knowledge_kind,
+                Some(number),
+                false,
+            ),
             FrontendEvent::RunBranchCleanup {
                 id,
                 branches,
                 delete_remote,
             } => self.run_branch_cleanup_events(&client_id, &id, &branches, delete_remote),
+            FrontendEvent::OpenIssueLaunchWizard { id, issue_number } => {
+                self.open_issue_launch_wizard_events(&client_id, &id, issue_number)
+            }
             FrontendEvent::OpenLaunchWizard {
                 id,
                 branch_name,
@@ -846,6 +872,88 @@ impl AppRuntime {
         }
     }
 
+    fn load_knowledge_bridge_events(
+        &self,
+        client_id: &str,
+        id: &str,
+        kind: KnowledgeKind,
+        selected_number: Option<u64>,
+        refresh: bool,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        if knowledge_kind_for_preset(window.preset) != Some(kind) {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Window is not a knowledge bridge".to_string(),
+                },
+            )];
+        }
+
+        match load_knowledge_bridge(&tab.project_root, kind, selected_number, refresh) {
+            Ok(view) => vec![
+                OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::KnowledgeEntries {
+                        id: id.to_string(),
+                        knowledge_kind: kind,
+                        entries: view.entries,
+                        selected_number: view.selected_number,
+                        empty_message: view.empty_message,
+                        refresh_enabled: view.refresh_enabled,
+                    },
+                ),
+                OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::KnowledgeDetail {
+                        id: id.to_string(),
+                        knowledge_kind: kind,
+                        detail: view.detail,
+                    },
+                ),
+            ],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: error,
+                },
+            )],
+        }
+    }
+
     fn run_branch_cleanup_events(
         &self,
         client_id: &str,
@@ -996,38 +1104,48 @@ impl AppRuntime {
             })];
         }
 
-        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
-        let entries = match list_branch_entries_with_active_sessions(
-            &tab.project_root,
-            &active_session_branches,
+        let project_root = tab.project_root.clone();
+        let tab_id = address.tab_id.clone();
+        match self.open_launch_wizard_for_branch(
+            &tab_id,
+            &project_root,
+            branch_name,
+            linked_issue_number,
         ) {
-            Ok(entries) => entries,
-            Err(error) => {
-                return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                    id: id.to_string(),
-                    message: error.to_string(),
-                })];
-            }
-        };
-
-        let Some(selected_branch) = entries.into_iter().find(|entry| entry.name == branch_name)
-        else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+            Ok(()) => vec![self.launch_wizard_state_outbound()],
+            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::BranchError {
                 id: id.to_string(),
-                message: format!("Branch not found: {branch_name}"),
-            })];
-        };
+                message: error,
+            })],
+        }
+    }
+
+    fn open_launch_wizard_for_branch(
+        &mut self,
+        tab_id: &str,
+        project_root: &Path,
+        branch_name: &str,
+        linked_issue_number: Option<u64>,
+    ) -> Result<(), String> {
+        let active_session_branches = self.active_session_branches_for_tab(tab_id);
+        let entries =
+            list_branch_entries_with_active_sessions(project_root, &active_session_branches)
+                .map_err(|error| error.to_string())?;
+        let selected_branch = entries
+            .into_iter()
+            .find(|entry| entry.name == branch_name)
+            .ok_or_else(|| format!("Branch not found: {branch_name}"))?;
 
         let normalized_branch_name = normalize_branch_name(&selected_branch.name);
-        let worktree_path = branch_worktree_path(&tab.project_root, &normalized_branch_name);
+        let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
         let quick_start_root = worktree_path
             .clone()
-            .unwrap_or_else(|| tab.project_root.clone());
-        let live_sessions = self.live_sessions_for_branch(&address.tab_id, &normalized_branch_name);
+            .unwrap_or_else(|| project_root.to_path_buf());
+        let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
         let (docker_context, docker_service_status) =
             detect_wizard_docker_context_and_status(&quick_start_root);
         self.launch_wizard = Some(LaunchWizardSession {
-            tab_id: address.tab_id,
+            tab_id: tab_id.to_string(),
             wizard: LaunchWizardState::open(
                 LaunchWizardContext {
                     selected_branch,
@@ -1044,7 +1162,102 @@ impl AppRuntime {
             ),
         });
 
-        vec![self.launch_wizard_state_outbound()]
+        Ok(())
+    }
+
+    fn open_issue_launch_wizard_events(
+        &mut self,
+        client_id: &str,
+        id: &str,
+        issue_number: u64,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id).cloned() else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(kind) = knowledge_kind_for_preset(window.preset) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Window is not a knowledge bridge".to_string(),
+                },
+            )];
+        };
+
+        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
+        let branches = match list_branch_entries_with_active_sessions(
+            &tab.project_root,
+            &active_session_branches,
+        ) {
+            Ok(entries) => entries,
+            Err(error) => {
+                return vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::KnowledgeError {
+                        id: id.to_string(),
+                        knowledge_kind: kind,
+                        message: error.to_string(),
+                    },
+                )]
+            }
+        };
+        let Some(branch_name) = preferred_issue_launch_branch(&branches) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "No local branch is available for launch".to_string(),
+                },
+            )];
+        };
+
+        let project_root = tab.project_root.clone();
+        let tab_id = address.tab_id.clone();
+        match self.open_launch_wizard_for_branch(
+            &tab_id,
+            &project_root,
+            &branch_name,
+            Some(issue_number),
+        ) {
+            Ok(()) => vec![self.launch_wizard_state_outbound()],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: error,
+                },
+            )],
+        }
     }
 
     fn handle_launch_wizard_action(
@@ -1893,10 +2106,16 @@ fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool
 mod tests {
     use std::{fs, process::Command};
 
-    use gwt::{PersistedWindowState, WindowGeometry, WindowPreset, WindowProcessStatus};
+    use gwt::{
+        BranchCleanupInfo, BranchListEntry, BranchScope, KnowledgeKind, PersistedWindowState,
+        WindowGeometry, WindowPreset, WindowProcessStatus,
+    };
     use tempfile::tempdir;
 
-    use super::{resolve_project_target, should_auto_start_restored_window};
+    use super::{
+        knowledge_kind_for_preset, preferred_issue_launch_branch, resolve_project_target,
+        should_auto_start_restored_window,
+    };
 
     fn sample_window(preset: WindowPreset, status: WindowProcessStatus) -> PersistedWindowState {
         PersistedWindowState {
@@ -2089,6 +2308,90 @@ mod tests {
         assert!(
             html.contains("branch_cleanup_result"),
             "expected branch cleanup result handler in embedded html",
+        );
+    }
+
+    #[test]
+    fn embedded_web_knowledge_bridge_surface_uses_cache_backed_contract() {
+        let html = include_str!("../web/index.html");
+
+        assert!(
+            html.contains("knowledge-root"),
+            "expected knowledge bridge root scaffold in embedded html",
+        );
+        assert!(
+            html.contains("load_knowledge_bridge"),
+            "expected knowledge bridge load event in embedded html",
+        );
+        assert!(
+            html.contains("select_knowledge_bridge_entry"),
+            "expected knowledge bridge detail selection event in embedded html",
+        );
+        assert!(
+            html.contains("open_issue_launch_wizard"),
+            "expected issue launch wizard event in embedded html",
+        );
+    }
+
+    #[test]
+    fn issue_and_spec_presets_route_to_knowledge_bridge_kind() {
+        assert_eq!(
+            knowledge_kind_for_preset(WindowPreset::Issue),
+            Some(KnowledgeKind::Issue)
+        );
+        assert_eq!(
+            knowledge_kind_for_preset(WindowPreset::Spec),
+            Some(KnowledgeKind::Spec)
+        );
+        assert_eq!(
+            knowledge_kind_for_preset(WindowPreset::Pr),
+            Some(KnowledgeKind::Pr)
+        );
+        assert_eq!(knowledge_kind_for_preset(WindowPreset::Branches), None);
+    }
+
+    #[test]
+    fn preferred_issue_launch_branch_prefers_develop_then_head_then_first_local() {
+        let entries = vec![
+            BranchListEntry {
+                name: "feature/demo".to_string(),
+                scope: BranchScope::Local,
+                is_head: true,
+                upstream: None,
+                ahead: 0,
+                behind: 0,
+                last_commit_date: None,
+                cleanup: BranchCleanupInfo::default(),
+            },
+            BranchListEntry {
+                name: "develop".to_string(),
+                scope: BranchScope::Local,
+                is_head: false,
+                upstream: None,
+                ahead: 0,
+                behind: 0,
+                last_commit_date: None,
+                cleanup: BranchCleanupInfo::default(),
+            },
+        ];
+        assert_eq!(
+            preferred_issue_launch_branch(&entries),
+            Some("develop".to_string())
+        );
+
+        let head_only = vec![BranchListEntry {
+            name: "feature/demo".to_string(),
+            scope: BranchScope::Local,
+            is_head: true,
+            upstream: None,
+            ahead: 0,
+            behind: 0,
+            last_commit_date: None,
+            cleanup: BranchCleanupInfo::default(),
+        }];
+        assert_eq!(
+            preferred_issue_launch_branch(&head_only),
+            Some("feature/demo".to_string())
         );
     }
 }
@@ -2326,6 +2629,35 @@ fn normalize_branch_name(branch_name: &str) -> String {
         return name.to_string();
     }
     branch_name.to_string()
+}
+
+fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> {
+    match preset {
+        WindowPreset::Issue => Some(KnowledgeKind::Issue),
+        WindowPreset::Spec => Some(KnowledgeKind::Spec),
+        WindowPreset::Pr => Some(KnowledgeKind::Pr),
+        _ => None,
+    }
+}
+
+fn preferred_issue_launch_branch(entries: &[gwt::BranchListEntry]) -> Option<String> {
+    use gwt::BranchScope;
+
+    let mut locals = entries
+        .iter()
+        .filter(|entry| entry.scope == BranchScope::Local)
+        .collect::<Vec<_>>();
+    locals.sort_by(|left, right| left.name.cmp(&right.name));
+
+    for preferred in ["develop", "main", "master"] {
+        if let Some(entry) = locals.iter().find(|entry| entry.name == preferred) {
+            return Some(entry.name.clone());
+        }
+    }
+    if let Some(entry) = locals.iter().find(|entry| entry.is_head) {
+        return Some(entry.name.clone());
+    }
+    locals.first().map(|entry| entry.name.clone())
 }
 
 fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -4,6 +4,7 @@ use crate::{
     branch_cleanup::BranchCleanupResultEntry,
     branch_list::BranchListEntry,
     file_tree::FileTreeEntry,
+    knowledge_bridge::{KnowledgeDetailView, KnowledgeKind, KnowledgeListItem},
     launch_wizard::{LaunchWizardAction, LaunchWizardView},
     persistence::{
         CanvasViewport, PersistedWindowState, ProjectKind, WindowGeometry, WindowProcessStatus,
@@ -89,10 +90,25 @@ pub enum FrontendEvent {
     LoadBranches {
         id: String,
     },
+    LoadKnowledgeBridge {
+        id: String,
+        knowledge_kind: KnowledgeKind,
+        selected_number: Option<u64>,
+        refresh: bool,
+    },
+    SelectKnowledgeBridgeEntry {
+        id: String,
+        knowledge_kind: KnowledgeKind,
+        number: u64,
+    },
     RunBranchCleanup {
         id: String,
         branches: Vec<String>,
         delete_remote: bool,
+    },
+    OpenIssueLaunchWizard {
+        id: String,
+        issue_number: u64,
     },
     OpenLaunchWizard {
         id: String,
@@ -171,12 +187,30 @@ pub enum BackendEvent {
         id: String,
         entries: Vec<BranchListEntry>,
     },
+    KnowledgeEntries {
+        id: String,
+        knowledge_kind: KnowledgeKind,
+        entries: Vec<KnowledgeListItem>,
+        selected_number: Option<u64>,
+        empty_message: Option<String>,
+        refresh_enabled: bool,
+    },
+    KnowledgeDetail {
+        id: String,
+        knowledge_kind: KnowledgeKind,
+        detail: KnowledgeDetailView,
+    },
     BranchCleanupResult {
         id: String,
         results: Vec<BranchCleanupResultEntry>,
     },
     BranchError {
         id: String,
+        message: String,
+    },
+    KnowledgeError {
+        id: String,
+        knowledge_kind: KnowledgeKind,
         message: String,
     },
     ProjectOpenError {

--- a/crates/gwt/tests/knowledge_bridge_test.rs
+++ b/crates/gwt/tests/knowledge_bridge_test.rs
@@ -1,0 +1,214 @@
+use std::{collections::HashMap, fs};
+
+use gwt::{load_knowledge_bridge, KnowledgeKind};
+use gwt_core::{paths::gwt_cache_dir, repo_hash::detect_repo_hash};
+use gwt_github::{
+    Cache, CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt,
+};
+use tempfile::tempdir;
+
+fn sample_issue(
+    number: u64,
+    title: &str,
+    labels: &[&str],
+    body: &str,
+    updated_at: &str,
+) -> IssueSnapshot {
+    IssueSnapshot {
+        number: IssueNumber(number),
+        title: title.to_string(),
+        body: body.to_string(),
+        labels: labels.iter().map(|label| (*label).to_string()).collect(),
+        state: IssueState::Open,
+        updated_at: UpdatedAt::new(updated_at),
+        comments: vec![CommentSnapshot {
+            id: CommentId(number * 10),
+            body: format!("Comment for #{number}"),
+            updated_at: UpdatedAt::new(updated_at),
+        }],
+    }
+}
+
+#[test]
+fn load_knowledge_bridge_filters_plain_issues_and_counts_linked_branches() {
+    let dir = tempdir().expect("tempdir");
+    let repo_path = dir.path().join("repo");
+    fs::create_dir_all(&repo_path).expect("create repo");
+    init_repo(&repo_path);
+
+    let cache = Cache::new(issue_cache_root(&repo_path));
+    cache
+        .write_snapshot(&sample_issue(
+            42,
+            "Issue bridge",
+            &["bug"],
+            "Issue body",
+            "2026-04-20T10:00:00Z",
+        ))
+        .expect("write issue");
+    cache
+        .write_snapshot(&sample_issue(
+            2017,
+            "SPEC bridge",
+            &["gwt-spec", "phase/draft"],
+            concat!(
+                "<!-- gwt-spec id=2017 version=1 -->\n",
+                "<!-- sections:\n",
+                "spec=body\n",
+                "-->\n\n",
+                "<!-- artifact:spec BEGIN -->\n",
+                "# Spec body\n",
+                "<!-- artifact:spec END -->\n"
+            ),
+            "2026-04-19T09:00:00Z",
+        ))
+        .expect("write spec");
+
+    write_issue_link_store(
+        &repo_path,
+        HashMap::from([("feature/issue-bridge".to_string(), 42)]),
+    );
+
+    let loaded =
+        load_knowledge_bridge(&repo_path, KnowledgeKind::Issue, Some(42), false).expect("load");
+
+    assert_eq!(loaded.kind, KnowledgeKind::Issue);
+    assert_eq!(loaded.entries.len(), 1);
+    assert_eq!(loaded.entries[0].number, 42);
+    assert_eq!(loaded.entries[0].linked_branch_count, 1);
+    assert_eq!(loaded.selected_number, Some(42));
+    assert_eq!(loaded.detail.launch_issue_number, Some(42));
+    assert!(loaded
+        .detail
+        .sections
+        .iter()
+        .any(|section| section.title == "Linked branches"
+            && section.body.contains("feature/issue-bridge")));
+}
+
+#[test]
+fn load_knowledge_bridge_filters_specs_and_exposes_cached_sections() {
+    let dir = tempdir().expect("tempdir");
+    let repo_path = dir.path().join("repo");
+    fs::create_dir_all(&repo_path).expect("create repo");
+    init_repo(&repo_path);
+
+    let cache = Cache::new(issue_cache_root(&repo_path));
+    cache
+        .write_snapshot(&sample_issue(
+            2017,
+            "SPEC-2017: Knowledge Bridge",
+            &["gwt-spec", "phase/draft"],
+            concat!(
+                "<!-- gwt-spec id=2017 version=1 -->\n",
+                "<!-- sections:\n",
+                "spec=body\n",
+                "tasks=body\n",
+                "-->\n\n",
+                "<!-- artifact:spec BEGIN -->\n",
+                "# Spec body\n",
+                "## Summary\n",
+                "Cache-backed issue view\n",
+                "<!-- artifact:spec END -->\n\n",
+                "<!-- artifact:tasks BEGIN -->\n",
+                "- [ ] T-001\n",
+                "<!-- artifact:tasks END -->\n"
+            ),
+            "2026-04-20T10:00:00Z",
+        ))
+        .expect("write spec");
+
+    let loaded =
+        load_knowledge_bridge(&repo_path, KnowledgeKind::Spec, Some(2017), false).expect("load");
+
+    assert_eq!(loaded.kind, KnowledgeKind::Spec);
+    assert_eq!(loaded.entries.len(), 1);
+    assert_eq!(loaded.entries[0].number, 2017);
+    assert!(
+        loaded.entries[0].meta.contains("phase/draft"),
+        "expected phase label in list metadata"
+    );
+    assert!(
+        loaded
+            .detail
+            .sections
+            .iter()
+            .any(|section| section.title == "spec"
+                && section.body.contains("Cache-backed issue view")),
+        "sections: {:?}",
+        loaded.detail.sections
+    );
+}
+
+#[test]
+fn load_knowledge_bridge_returns_disabled_pr_surface_until_cache_support_exists() {
+    let dir = tempdir().expect("tempdir");
+    let repo_path = dir.path().join("repo");
+    fs::create_dir_all(&repo_path).expect("create repo");
+    init_repo(&repo_path);
+
+    let loaded = load_knowledge_bridge(&repo_path, KnowledgeKind::Pr, None, false).expect("load");
+
+    assert_eq!(loaded.kind, KnowledgeKind::Pr);
+    assert!(loaded.entries.is_empty());
+    assert!(!loaded.refresh_enabled);
+    assert!(loaded
+        .empty_message
+        .as_deref()
+        .is_some_and(|message| message.contains("cache-backed PR list support")));
+    assert!(loaded
+        .detail
+        .sections
+        .iter()
+        .any(|section| section.body.contains("cache-backed PR list support")));
+}
+
+fn init_repo(repo_path: &std::path::Path) {
+    let remote = format!(
+        "https://github.com/example/repo-{:x}.git",
+        remote_suffix(repo_path)
+    );
+    for args in [
+        ["init", "-q"].as_slice(),
+        ["remote", "add", "origin", remote.as_str()].as_slice(),
+    ] {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo_path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn remote_suffix(repo_path: &std::path::Path) -> u64 {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    repo_path.display().to_string().hash(&mut hasher);
+    hasher.finish()
+}
+
+fn write_issue_link_store(repo_path: &std::path::Path, branches: HashMap<String, u64>) {
+    let repo_hash = detect_repo_hash(repo_path).expect("repo hash");
+    let path = gwt_cache_dir()
+        .join("issue-links")
+        .join(format!("{}.json", repo_hash.as_str()));
+    fs::create_dir_all(path.parent().expect("parent")).expect("create link dir");
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&serde_json::json!({ "branches": branches }))
+            .expect("serialize store"),
+    )
+    .expect("write link store");
+}
+
+fn issue_cache_root(repo_path: &std::path::Path) -> std::path::PathBuf {
+    let repo_hash = detect_repo_hash(repo_path).expect("repo hash");
+    gwt_cache_dir().join("issues").join(repo_hash.as_str())
+}

--- a/crates/gwt/tests/window_controls_protocol_test.rs
+++ b/crates/gwt/tests/window_controls_protocol_test.rs
@@ -57,4 +57,41 @@ fn frontend_event_deserializes_window_state_commands() {
         FrontendEvent::ListWindows => {}
         other => panic!("unexpected event: {other:?}"),
     }
+
+    let knowledge = serde_json::from_value::<FrontendEvent>(json!({
+        "kind": "load_knowledge_bridge",
+        "id": "project-1::issue-1",
+        "knowledge_kind": "issue",
+        "selected_number": 2017,
+        "refresh": true
+    }))
+    .expect("load_knowledge_bridge should deserialize");
+    match knowledge {
+        FrontendEvent::LoadKnowledgeBridge {
+            id,
+            knowledge_kind,
+            selected_number,
+            refresh,
+        } => {
+            assert_eq!(id, "project-1::issue-1");
+            assert_eq!(knowledge_kind, gwt::KnowledgeKind::Issue);
+            assert_eq!(selected_number, Some(2017));
+            assert!(refresh);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    let launch = serde_json::from_value::<FrontendEvent>(json!({
+        "kind": "open_issue_launch_wizard",
+        "id": "project-1::issue-1",
+        "issue_number": 2017
+    }))
+    .expect("open_issue_launch_wizard should deserialize");
+    match launch {
+        FrontendEvent::OpenIssueLaunchWizard { id, issue_number } => {
+            assert_eq!(id, "project-1::issue-1");
+            assert_eq!(issue_number, 2017);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
 }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -372,6 +372,7 @@
 
       .surface-file-tree .status-chip,
       .surface-branches .status-chip,
+      .surface-knowledge .status-chip,
       .surface-mock .status-chip {
         color: #334155;
       }
@@ -420,6 +421,7 @@
 
       .surface-file-tree .icon-button,
       .surface-branches .icon-button,
+      .surface-knowledge .icon-button,
       .surface-mock .icon-button {
         color: #334155;
       }
@@ -448,6 +450,7 @@
 
       .surface-file-tree .window-body,
       .surface-branches .window-body,
+      .surface-knowledge .window-body,
       .surface-mock .window-body {
         background: #ffffff;
       }
@@ -507,6 +510,7 @@
 
       .file-tree-root,
       .branch-list-root,
+      .knowledge-root,
       .mock-root {
         position: absolute;
         inset: 0;
@@ -516,6 +520,7 @@
 
       .file-tree-toolbar,
       .branch-toolbar,
+      .knowledge-toolbar,
       .mock-toolbar {
         display: flex;
         align-items: center;
@@ -542,6 +547,23 @@
         gap: 8px;
         flex-wrap: wrap;
         justify-content: flex-end;
+      }
+
+      .knowledge-toolbar {
+        align-items: flex-start;
+      }
+
+      .knowledge-toolbar-main {
+        min-width: 0;
+        flex: 1;
+        display: grid;
+        gap: 8px;
+      }
+
+      .knowledge-toolbar-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
       }
 
       .branch-filter-group {
@@ -576,6 +598,7 @@
 
       .file-tree-path,
       .branch-heading,
+      .knowledge-heading,
       .mock-heading {
         min-width: 0;
         font-size: 12px;
@@ -591,6 +614,224 @@
       .mock-scroll {
         flex: 1;
         overflow: auto;
+      }
+
+      .knowledge-search {
+        width: min(320px, 100%);
+        min-width: 0;
+        height: 32px;
+        padding: 0 10px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: #ffffff;
+        font-size: 12px;
+        color: #0f172a;
+      }
+
+      .knowledge-status {
+        display: none;
+        padding: 10px 12px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        font-size: 12px;
+      }
+
+      .knowledge-status.visible {
+        display: block;
+      }
+
+      .knowledge-status.info {
+        background: rgba(59, 130, 246, 0.08);
+        color: #1d4ed8;
+      }
+
+      .knowledge-status.error {
+        background: rgba(239, 68, 68, 0.08);
+        color: #b91c1c;
+      }
+
+      .knowledge-split {
+        flex: 1;
+        min-height: 0;
+        display: grid;
+        grid-template-columns: minmax(220px, 38%) minmax(0, 1fr);
+      }
+
+      .knowledge-list-pane,
+      .knowledge-detail-pane {
+        min-width: 0;
+        min-height: 0;
+      }
+
+      .knowledge-list-pane {
+        border-right: 1px solid rgba(148, 163, 184, 0.18);
+        overflow: auto;
+      }
+
+      .knowledge-detail-pane {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .knowledge-list {
+        display: grid;
+      }
+
+      .knowledge-row {
+        display: grid;
+        gap: 6px;
+        width: 100%;
+        padding: 12px;
+        border: none;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        background: transparent;
+        cursor: pointer;
+        text-align: left;
+      }
+
+      .knowledge-row:hover {
+        background: rgba(59, 130, 246, 0.06);
+      }
+
+      .knowledge-row.selected {
+        background: rgba(59, 130, 246, 0.12);
+      }
+
+      .knowledge-row:last-child {
+        border-bottom: none;
+      }
+
+      .knowledge-row-main,
+      .knowledge-row-meta,
+      .knowledge-detail-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+
+      .knowledge-row-main {
+        align-items: flex-start;
+      }
+
+      .knowledge-row-title {
+        min-width: 0;
+        font-size: 13px;
+        font-weight: 600;
+        color: #0f172a;
+        overflow-wrap: anywhere;
+      }
+
+      .knowledge-row-number,
+      .knowledge-detail-subtitle {
+        font-size: 11px;
+        color: #64748b;
+      }
+
+      .knowledge-row-meta {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+      }
+
+      .knowledge-meta-copy {
+        font-size: 11px;
+        color: #475569;
+      }
+
+      .knowledge-chip,
+      .knowledge-state-chip {
+        padding: 4px 8px;
+        border-radius: 999px;
+        font-size: 11px;
+      }
+
+      .knowledge-chip {
+        background: rgba(59, 130, 246, 0.1);
+        color: #1d4ed8;
+      }
+
+      .knowledge-state-chip.open {
+        background: rgba(16, 185, 129, 0.12);
+        color: #047857;
+      }
+
+      .knowledge-state-chip.closed {
+        background: rgba(148, 163, 184, 0.18);
+        color: #475569;
+      }
+
+      .knowledge-state-chip.unavailable,
+      .knowledge-state-chip.idle {
+        background: rgba(245, 158, 11, 0.14);
+        color: #b45309;
+      }
+
+      .knowledge-detail-empty,
+      .knowledge-empty {
+        padding: 16px 12px;
+        font-size: 12px;
+        color: #64748b;
+      }
+
+      .knowledge-detail-header {
+        padding: 12px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        display: grid;
+        gap: 8px;
+      }
+
+      .knowledge-detail-title {
+        margin: 0;
+        font-size: 16px;
+        color: #0f172a;
+      }
+
+      .knowledge-detail-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .knowledge-label-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        flex-wrap: wrap;
+      }
+
+      .knowledge-detail-scroll {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        display: grid;
+        gap: 12px;
+        padding: 12px;
+      }
+
+      .knowledge-section {
+        display: grid;
+        gap: 8px;
+        padding: 12px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        background: #f8fafc;
+      }
+
+      .knowledge-section-title {
+        font-size: 12px;
+        font-weight: 700;
+        color: #334155;
+        text-transform: none;
+      }
+
+      .knowledge-section-body {
+        margin: 0;
+        font-family: inherit;
+        font-size: 12px;
+        line-height: 1.5;
+        color: #334155;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
       }
 
       .file-tree-list,
@@ -1668,6 +1909,7 @@
       const windowMap = new Map();
       const fileTreeStateMap = new Map();
       const branchListStateMap = new Map();
+      const knowledgeBridgeStateMap = new Map();
       const pendingMessages = [];
 
       let socket = null;
@@ -1706,7 +1948,17 @@
         if (preset === "branches") {
           return "branches";
         }
+        if (preset === "issue" || preset === "spec" || preset === "pr") {
+          return "knowledge";
+        }
         return "mock";
+      }
+
+      function knowledgeKindForPreset(preset) {
+        if (preset === "issue" || preset === "spec" || preset === "pr") {
+          return preset;
+        }
+        return null;
       }
 
       function send(message) {
@@ -2660,6 +2912,26 @@
         return branchListStateMap.get(windowId);
       }
 
+      function ensureKnowledgeBridgeState(windowId, knowledgeKind) {
+        if (!knowledgeBridgeStateMap.has(windowId)) {
+          knowledgeBridgeStateMap.set(windowId, {
+            kind: knowledgeKind,
+            entries: [],
+            selectedNumber: null,
+            detail: null,
+            query: "",
+            loading: false,
+            detailLoading: false,
+            error: "",
+            emptyMessage: "",
+            refreshEnabled: true,
+          });
+        }
+        const state = knowledgeBridgeStateMap.get(windowId);
+        state.kind = knowledgeKind || state.kind;
+        return state;
+      }
+
       function requestFileTree(windowId, path = "") {
         const state = ensureFileTreeState(windowId);
         if (state.loading.has(path)) {
@@ -2682,6 +2954,42 @@
         send({
           kind: "load_branches",
           id: windowId,
+        });
+      }
+
+      function requestKnowledgeBridge(windowId, knowledgeKind, refresh = false) {
+        const state = ensureKnowledgeBridgeState(windowId, knowledgeKind);
+        if (state.loading) {
+          return;
+        }
+        state.loading = true;
+        state.error = "";
+        send({
+          kind: "load_knowledge_bridge",
+          id: windowId,
+          knowledge_kind: knowledgeKind,
+          selected_number: state.selectedNumber ?? null,
+          refresh,
+        });
+      }
+
+      function requestKnowledgeDetail(windowId, knowledgeKind, number) {
+        const state = ensureKnowledgeBridgeState(windowId, knowledgeKind);
+        state.selectedNumber = number;
+        state.detailLoading = true;
+        send({
+          kind: "select_knowledge_bridge_entry",
+          id: windowId,
+          knowledge_kind: knowledgeKind,
+          number,
+        });
+      }
+
+      function openIssueLaunchWizard(windowId, issueNumber) {
+        send({
+          kind: "open_issue_launch_wizard",
+          id: windowId,
+          issue_number: issueNumber,
         });
       }
 
@@ -3567,6 +3875,213 @@
         renderBranchCleanupModal();
       }
 
+      function knowledgeHeading(kind) {
+        switch (kind) {
+          case "issue":
+            return "Cached issues";
+          case "spec":
+            return "Cached SPECs";
+          case "pr":
+            return "PR bridge";
+          default:
+            return "Knowledge Bridge";
+        }
+      }
+
+      function knowledgeSearchPlaceholder(kind) {
+        switch (kind) {
+          case "issue":
+            return "Search cached issues";
+          case "spec":
+            return "Search cached SPECs";
+          case "pr":
+            return "Search unavailable";
+          default:
+            return "Search";
+        }
+      }
+
+      function filteredKnowledgeEntries(state) {
+        const query = state.query.trim().toLowerCase();
+        if (!query) {
+          return state.entries;
+        }
+        return state.entries.filter((entry) =>
+          [
+            `#${entry.number}`,
+            entry.title,
+            entry.meta,
+            ...(entry.labels || []),
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(query),
+        );
+      }
+
+      function renderKnowledgeBridge(windowId) {
+        const element = windowMap.get(windowId);
+        if (!element) {
+          return;
+        }
+        const state = ensureKnowledgeBridgeState(
+          windowId,
+          knowledgeKindForPreset(workspaceWindowById(windowId)?.preset),
+        );
+        const list = element.querySelector(".knowledge-list");
+        const detailPane = element.querySelector(".knowledge-detail-pane");
+        const status = element.querySelector(".knowledge-status");
+        const refreshButton = element.querySelector("[data-action='refresh-knowledge']");
+        const searchInput = element.querySelector(".knowledge-search");
+        if (!list || !detailPane || !status || !refreshButton || !searchInput) {
+          return;
+        }
+
+        refreshButton.disabled = !state.refreshEnabled || state.loading;
+        searchInput.placeholder = knowledgeSearchPlaceholder(state.kind);
+
+        status.className = "knowledge-status";
+        status.textContent = "";
+        if (state.error) {
+          status.classList.add("visible", "error");
+          status.textContent = state.error;
+        } else if (state.loading && state.entries.length === 0) {
+          status.classList.add("visible", "info");
+          status.textContent = "Loading cache-backed data";
+        } else if (state.emptyMessage && state.entries.length === 0) {
+          status.classList.add("visible", "info");
+          status.textContent = state.emptyMessage;
+        }
+
+        list.innerHTML = "";
+        const visibleEntries = filteredKnowledgeEntries(state);
+        if (visibleEntries.length === 0) {
+          const empty = createNode("div", "knowledge-empty");
+          if (state.entries.length === 0) {
+            empty.textContent = state.emptyMessage || "No cached items";
+          } else {
+            empty.textContent = "No matching cached items";
+          }
+          list.appendChild(empty);
+        } else {
+          for (const entry of visibleEntries) {
+            const row = createNode("button", "knowledge-row");
+            row.type = "button";
+            if (state.selectedNumber === entry.number) {
+              row.classList.add("selected");
+            }
+            const main = createNode("div", "knowledge-row-main");
+            const titleWrap = createNode("div", "");
+            titleWrap.appendChild(
+              createNode("div", "knowledge-row-number", `#${entry.number}`),
+            );
+            titleWrap.appendChild(
+              createNode("div", "knowledge-row-title", entry.title),
+            );
+            main.appendChild(titleWrap);
+            const stateChip = createNode(
+              "span",
+              `knowledge-state-chip ${entry.state}`,
+              entry.state,
+            );
+            main.appendChild(stateChip);
+            row.appendChild(main);
+
+            const meta = createNode("div", "knowledge-row-meta");
+            meta.appendChild(createNode("span", "knowledge-meta-copy", entry.meta));
+            if ((entry.linked_branch_count || 0) > 0) {
+              meta.appendChild(
+                createNode(
+                  "span",
+                  "knowledge-chip",
+                  `${entry.linked_branch_count} linked branch${entry.linked_branch_count === 1 ? "" : "es"}`,
+                ),
+              );
+            }
+            for (const label of entry.labels || []) {
+              meta.appendChild(createNode("span", "knowledge-chip", label));
+            }
+            row.appendChild(meta);
+            row.addEventListener("click", () => {
+              if (state.selectedNumber === entry.number && !state.detailLoading) {
+                return;
+              }
+              requestKnowledgeDetail(windowId, state.kind, entry.number);
+              renderKnowledgeBridge(windowId);
+            });
+            list.appendChild(row);
+          }
+        }
+
+        detailPane.innerHTML = "";
+        const detail = state.detail;
+        if (!detail) {
+          detailPane.appendChild(
+            createNode("div", "knowledge-detail-empty", "Select a cached item"),
+          );
+          return;
+        }
+
+        const header = createNode("div", "knowledge-detail-header");
+        const head = createNode("div", "");
+        const headRow = createNode("div", "knowledge-detail-head");
+        headRow.appendChild(createNode("h3", "knowledge-detail-title", detail.title));
+        headRow.appendChild(
+          createNode("span", `knowledge-state-chip ${detail.state}`, detail.state),
+        );
+        head.appendChild(headRow);
+        if (detail.subtitle) {
+          head.appendChild(
+            createNode("div", "knowledge-detail-subtitle", detail.subtitle),
+          );
+        }
+        if ((detail.labels || []).length > 0) {
+          const labelRow = createNode("div", "knowledge-label-row");
+          for (const label of detail.labels) {
+            labelRow.appendChild(createNode("span", "knowledge-chip", label));
+          }
+          head.appendChild(labelRow);
+        }
+        header.appendChild(head);
+
+        const actions = createNode("div", "knowledge-detail-actions");
+        if (detail.launch_issue_number !== null && detail.launch_issue_number !== undefined) {
+          const launchButton = createNode("button", "wizard-button primary", "Launch Agent");
+          launchButton.type = "button";
+          launchButton.addEventListener("click", () =>
+            openIssueLaunchWizard(windowId, detail.launch_issue_number),
+          );
+          actions.appendChild(launchButton);
+        }
+        if (actions.childElementCount > 0) {
+          header.appendChild(actions);
+        }
+        detailPane.appendChild(header);
+
+        const scroll = createNode("div", "knowledge-detail-scroll");
+        if (state.detailLoading) {
+          scroll.appendChild(
+            createNode("div", "knowledge-detail-empty", "Loading detail"),
+          );
+        }
+        for (const section of detail.sections || []) {
+          const card = createNode("section", "knowledge-section");
+          card.appendChild(
+            createNode("div", "knowledge-section-title", section.title),
+          );
+          card.appendChild(
+            createNode("pre", "knowledge-section-body", section.body),
+          );
+          scroll.appendChild(card);
+        }
+        if (scroll.childElementCount === 0) {
+          scroll.appendChild(
+            createNode("div", "knowledge-detail-empty", "No cached detail available"),
+          );
+        }
+        detailPane.appendChild(scroll);
+      }
+
       function filteredBranchEntries(state) {
         if (state.filter === "all") {
           return state.entries;
@@ -3969,6 +4484,7 @@
           "surface-terminal",
           "surface-file-tree",
           "surface-branches",
+          "surface-knowledge",
           "surface-mock",
         );
         element.classList.add(`surface-${surface}`);
@@ -4093,6 +4609,53 @@
             requestBranches(windowData.id);
           }
           renderBranches(windowData.id);
+          return;
+        }
+
+        if (surface === "knowledge") {
+          const knowledgeKind = knowledgeKindForPreset(windowData.preset);
+          body.innerHTML = `
+            <div class="knowledge-root">
+              <div class="knowledge-toolbar">
+                <div class="knowledge-toolbar-main">
+                  <div class="knowledge-heading">${knowledgeHeading(knowledgeKind)}</div>
+                  <input class="knowledge-search" type="search" placeholder="${knowledgeSearchPlaceholder(knowledgeKind)}" />
+                </div>
+                <div class="knowledge-toolbar-actions">
+                  <button class="icon-button" data-action="refresh-knowledge" aria-label="Refresh cached knowledge">↻</button>
+                </div>
+              </div>
+              <div class="knowledge-status"></div>
+              <div class="knowledge-split">
+                <div class="knowledge-list-pane">
+                  <div class="knowledge-list"></div>
+                </div>
+                <div class="knowledge-detail-pane"></div>
+              </div>
+            </div>
+          `;
+          body.addEventListener("mousedown", () => {
+            focusWindowLocally(windowData.id);
+            send({ kind: "focus_window", id: windowData.id });
+          });
+          const state = ensureKnowledgeBridgeState(windowData.id, knowledgeKind);
+          const search = body.querySelector(".knowledge-search");
+          search.value = state.query;
+          search.addEventListener("input", () => {
+            state.query = search.value;
+            renderKnowledgeBridge(windowData.id);
+          });
+          body
+            .querySelector("[data-action='refresh-knowledge']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              requestKnowledgeBridge(windowData.id, knowledgeKind, true);
+              renderKnowledgeBridge(windowData.id);
+            });
+          if (!state.detail && !state.loading) {
+            requestKnowledgeBridge(windowData.id, knowledgeKind, false);
+          }
+          renderKnowledgeBridge(windowData.id);
           return;
         }
 
@@ -4250,6 +4813,7 @@
           pendingSnapshotMap.delete(windowId);
           fileTreeStateMap.delete(windowId);
           branchListStateMap.delete(windowId);
+          knowledgeBridgeStateMap.delete(windowId);
           if (branchCleanupWindowId === windowId) {
             branchCleanupWindowId = null;
             renderBranchCleanupModal();
@@ -4329,6 +4893,26 @@
             renderBranches(event.id);
             break;
           }
+          case "knowledge_entries": {
+            const state = ensureKnowledgeBridgeState(event.id, event.knowledge_kind);
+            state.entries = event.entries || [];
+            state.selectedNumber = event.selected_number ?? null;
+            state.emptyMessage = event.empty_message || "";
+            state.refreshEnabled = Boolean(event.refresh_enabled);
+            state.loading = false;
+            state.error = "";
+            renderKnowledgeBridge(event.id);
+            break;
+          }
+          case "knowledge_detail": {
+            const state = ensureKnowledgeBridgeState(event.id, event.knowledge_kind);
+            state.detail = event.detail;
+            state.selectedNumber = event.detail?.number ?? state.selectedNumber ?? null;
+            state.loading = false;
+            state.detailLoading = false;
+            renderKnowledgeBridge(event.id);
+            break;
+          }
           case "branch_cleanup_result": {
             const state = ensureBranchListState(event.id);
             clearBranchCleanupTimeout(state);
@@ -4350,6 +4934,14 @@
             }
             state.error = event.message;
             renderBranches(event.id);
+            break;
+          }
+          case "knowledge_error": {
+            const state = ensureKnowledgeBridgeState(event.id, event.knowledge_kind);
+            state.loading = false;
+            state.detailLoading = false;
+            state.error = event.message;
+            renderKnowledgeBridge(event.id);
             break;
           }
           case "project_open_error":


### PR DESCRIPTION
## Summary

- Replace the mock Issue and SPEC canvas windows with a cache-backed knowledge bridge so the GUI reads repo-scoped issue/spec data instead of rendering placeholders.
- Add Issue/SPEC detail panes, linked-branch indicators, and launch-wizard handoff so users can move from cached knowledge directly into agent launch flow.
- Route the PR window to a dependency-aware disabled state until a cache-backed PR source exists, which removes misleading mock data from the GUI.

## Changes

- `crates/gwt/src/knowledge_bridge.rs`: add the shared backend loader for Issue, SPEC, and PR knowledge bridge surfaces.
- `crates/gwt/src/main.rs`: wire the knowledge bridge frontend events, detail loading flow, and issue launch-wizard handoff into the native app runtime.
- `crates/gwt/src/protocol.rs`: add websocket contract types for knowledge bridge list/detail/error events.
- `crates/gwt/src/issue_cache.rs`: expose cache refresh support so manual refresh follows the GitHub API -> cache -> GUI path.
- `crates/gwt/web/index.html`: replace Issue/SPEC/PR mock panes with the shared knowledge bridge list/detail/search UI.
- `crates/gwt/src/embedded_web.rs`: move embedded HTML contract coverage into the dedicated module and add the knowledge bridge contract check.
- `crates/gwt/tests/knowledge_bridge_test.rs`: add backend coverage for issue/spec filtering, cached section detail, linked-branch counts, and PR disabled state.
- `crates/gwt/tests/window_controls_protocol_test.rs`: extend protocol coverage for the new knowledge bridge frontend events.

## Testing

- [x] `cargo test -p gwt-core -p gwt` — all workspace tests for `gwt-core` and `gwt` pass after merging `origin/develop`.
- [x] `cargo fmt -- --check` — formatting check passes.
- [x] `cargo test -p gwt --test knowledge_bridge_test` — knowledge bridge loader behavior stays covered.
- [x] `cargo test -p gwt --test window_controls_protocol_test` — frontend event contract deserialization stays covered.

## Closing Issues

- Closes #2017

## Related Issues / Links

- #1784
- #1930
- #1938

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (not needed: no README-facing user workflow changed)
- [ ] Migration/backfill plan included (not needed: no schema or persisted data format changed)
- [x] CHANGELOG impact considered (feature change only, no breaking change)

## Context

- This PR implements SPEC-2017 for the GUI knowledge bridge windows on top of the existing Issue/SPEC cache owners from SPEC-1938 and SPEC-1930.
- During PR preparation the branch was 8 commits behind `origin/develop`, so the branch was merged forward and the embedded HTML contract tests were aligned with the new `embedded_web.rs` layout from develop.

## Risk / Impact

- **Affected areas**: GUI canvas workspace windows, websocket event protocol, issue/spec cache read path, launch wizard entrypoints.
- **Rollback plan**: Revert this PR to restore the previous mock window surfaces.

## Screenshots

| Before | After |
|--------|-------|
| Not captured in this CLI environment. | Not captured in this CLI environment. |

## Notes

- The PR window intentionally remains disabled until a cache-backed PR source is available; this is deliberate and covered by tests.
