### PR TITLE
fix(gui): avoid blocking when opening launch wizard

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -70,6 +70,9 @@ pub struct LaunchWizardView {
     pub title: String,
     pub branch_name: String,
     pub selected_branch_name: String,
+    pub linked_issue_number: Option<u64>,
+    pub is_hydrating: bool,
+    pub hydration_error: Option<String>,
     pub quick_start_entries: Vec<LaunchWizardQuickStartView>,
     pub live_sessions: Vec<LaunchWizardLiveSessionView>,
     pub branch_mode: String,
@@ -175,6 +178,17 @@ pub struct LaunchWizardContext {
 }
 
 #[derive(Debug, Clone)]
+pub struct LaunchWizardHydration {
+    pub selected_branch: Option<BranchListEntry>,
+    pub normalized_branch_name: String,
+    pub worktree_path: Option<PathBuf>,
+    pub quick_start_root: PathBuf,
+    pub docker_context: Option<DockerWizardContext>,
+    pub docker_service_status: gwt_docker::ComposeServiceStatus,
+    pub quick_start_entries: Vec<QuickStartEntry>,
+}
+
+#[derive(Debug, Clone)]
 pub enum LaunchWizardCompletion {
     Launch(Box<gwt_agent::LaunchConfig>),
     FocusWindow { window_id: String },
@@ -268,16 +282,17 @@ pub struct LaunchWizardState {
     pub branch_name: String,
     pub completion: Option<LaunchWizardCompletion>,
     pub error: Option<String>,
+    pub is_hydrating: bool,
+    pub hydration_error: Option<String>,
     pub linked_issue_number: Option<u64>,
 }
 
 impl LaunchWizardState {
-    pub fn open_with(
-        context: LaunchWizardContext,
-        agent_options: Vec<AgentOption>,
-        mut quick_start_entries: Vec<QuickStartEntry>,
-    ) -> Self {
-        for entry in &mut quick_start_entries {
+    fn hydrate_live_window_ids(
+        context: &LaunchWizardContext,
+        quick_start_entries: &mut [QuickStartEntry],
+    ) {
+        for entry in quick_start_entries {
             entry.live_window_id = context
                 .live_sessions
                 .iter()
@@ -290,6 +305,15 @@ impl LaunchWizardState {
                 })
                 .map(|session| session.window_id.clone());
         }
+    }
+
+    fn new_with(
+        context: LaunchWizardContext,
+        agent_options: Vec<AgentOption>,
+        mut quick_start_entries: Vec<QuickStartEntry>,
+        is_hydrating: bool,
+    ) -> Self {
+        Self::hydrate_live_window_ids(&context, &mut quick_start_entries);
         let runtime_target = if context.docker_context.is_some() {
             gwt_agent::LaunchRuntimeTarget::Docker
         } else {
@@ -330,12 +354,26 @@ impl LaunchWizardState {
             branch_name: String::new(),
             completion: None,
             error: None,
+            is_hydrating,
+            hydration_error: None,
             linked_issue_number: context.linked_issue_number,
         };
         state.branch_name = state.context.normalized_branch_name.clone();
         state.sync_selected_agent_options();
         state.selected = step_default_selection(state.step, &state);
         state
+    }
+
+    pub fn open_with(
+        context: LaunchWizardContext,
+        agent_options: Vec<AgentOption>,
+        quick_start_entries: Vec<QuickStartEntry>,
+    ) -> Self {
+        Self::new_with(context, agent_options, quick_start_entries, false)
+    }
+
+    pub fn open_loading(context: LaunchWizardContext, agent_options: Vec<AgentOption>) -> Self {
+        Self::new_with(context, agent_options, Vec::new(), true)
     }
 
     pub fn open(context: LaunchWizardContext, sessions_dir: &Path, cache_path: &Path) -> Self {
@@ -356,6 +394,9 @@ impl LaunchWizardState {
             title: "Launch Agent".to_string(),
             branch_name: self.branch_name.clone(),
             selected_branch_name: self.context.selected_branch.name.clone(),
+            linked_issue_number: self.linked_issue_number,
+            is_hydrating: self.is_hydrating,
+            hydration_error: self.hydration_error.clone(),
             quick_start_entries: self.quick_start_entries_view(),
             live_sessions: self.live_sessions_view(),
             branch_mode: if self.is_new_branch {
@@ -394,6 +435,53 @@ impl LaunchWizardState {
             launch_summary: self.launch_summary_view(),
             error: self.error.clone(),
         }
+    }
+
+    pub fn apply_hydration(&mut self, hydration: LaunchWizardHydration) {
+        let LaunchWizardHydration {
+            selected_branch,
+            normalized_branch_name,
+            worktree_path,
+            quick_start_root,
+            docker_context,
+            docker_service_status,
+            mut quick_start_entries,
+        } = hydration;
+        if let Some(selected_branch) = selected_branch {
+            self.context.selected_branch = selected_branch;
+        }
+        self.context.normalized_branch_name = normalized_branch_name;
+        self.context.worktree_path = worktree_path;
+        self.context.quick_start_root = quick_start_root;
+        self.context.docker_context = docker_context;
+        self.context.docker_service_status = docker_service_status;
+        Self::hydrate_live_window_ids(&self.context, &mut quick_start_entries);
+        self.quick_start_entries = quick_start_entries;
+        self.is_hydrating = false;
+        self.hydration_error = None;
+        self.branch_name = if self.is_new_branch {
+            self.branch_name.clone()
+        } else {
+            self.context.normalized_branch_name.clone()
+        };
+        if self.has_docker_workflow() {
+            self.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+            if self.docker_service.is_none() {
+                self.docker_service = self.preferred_docker_service().map(str::to_string);
+            }
+        } else {
+            self.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
+            self.docker_service = None;
+        }
+        self.sync_docker_lifecycle_default();
+        self.selected = self
+            .selected
+            .min(self.current_options().len().saturating_sub(1));
+    }
+
+    pub fn set_hydration_error(&mut self, error: String) {
+        self.is_hydrating = false;
+        self.hydration_error = Some(error);
     }
 
     pub fn apply(&mut self, action: LaunchWizardAction) {
@@ -489,6 +577,9 @@ impl LaunchWizardState {
     }
 
     pub fn build_launch_config(&self) -> Result<gwt_agent::LaunchConfig, String> {
+        if self.is_hydrating {
+            return Err("Launch options are still loading".to_string());
+        }
         let agent_id = agent_id_from_key(&self.agent_id);
         let mut builder = gwt_agent::AgentLaunchBuilder::new(agent_id.clone());
 
@@ -2647,6 +2738,87 @@ mod tests {
         let config = state.build_launch_config().expect("config");
 
         assert_eq!(config.linked_issue_number, Some(1234));
+    }
+
+    #[test]
+    fn open_loading_marks_wizard_as_hydrating() {
+        let state = LaunchWizardState::open_loading(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+        );
+
+        let view = state.view();
+        assert!(state.is_hydrating);
+        assert!(view.is_hydrating);
+        assert!(state.quick_start_entries.is_empty());
+        assert!(!view.show_runtime_target);
+        assert!(view.hydration_error.is_none());
+    }
+
+    #[test]
+    fn apply_hydration_updates_docker_defaults_and_quick_start_entries() {
+        let mut state = LaunchWizardState::open_loading(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+        );
+        let worktree = PathBuf::from("/tmp/repo-feature");
+        state.apply_hydration(LaunchWizardHydration {
+            selected_branch: Some(branch("origin/feature/gui")),
+            normalized_branch_name: "feature/gui".to_string(),
+            worktree_path: Some(worktree.clone()),
+            quick_start_root: worktree.clone(),
+            docker_context: Some(DockerWizardContext {
+                services: vec!["app".to_string(), "worker".to_string()],
+                suggested_service: Some("app".to_string()),
+            }),
+            docker_service_status: gwt_docker::ComposeServiceStatus::Running,
+            quick_start_entries: vec![QuickStartEntry {
+                session_id: "gwt-session-1".to_string(),
+                agent_id: "codex".to_string(),
+                tool_label: "Codex".to_string(),
+                model: Some("gpt-5.4".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                resume_session_id: Some("resume-1".to_string()),
+                live_window_id: None,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+            }],
+        });
+
+        let view = state.view();
+        assert!(!state.is_hydrating);
+        assert_eq!(
+            state.context.worktree_path.as_deref(),
+            Some(worktree.as_path())
+        );
+        assert_eq!(state.context.normalized_branch_name, "feature/gui");
+        assert_eq!(state.runtime_target, gwt_agent::LaunchRuntimeTarget::Docker);
+        assert_eq!(state.docker_service.as_deref(), Some("app"));
+        assert_eq!(
+            state.docker_lifecycle_intent,
+            gwt_agent::DockerLifecycleIntent::Connect
+        );
+        assert_eq!(state.quick_start_entries.len(), 1);
+        assert!(view.show_runtime_target);
+        assert!(!view.is_hydrating);
+        assert_eq!(view.selected_runtime_target, "docker");
+    }
+
+    #[test]
+    fn build_launch_config_rejects_loading_state() {
+        let state = LaunchWizardState::open_loading(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+        );
+
+        let error = state
+            .build_launch_config()
+            .expect_err("loading must block launch");
+        assert_eq!(error, "Launch options are still loading");
     }
 
     #[test]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -30,9 +30,9 @@ pub use knowledge_bridge::{
 pub use launch_wizard::{
     build_builtin_agent_options, default_wizard_version_cache_path, AgentOption,
     DockerWizardContext, LaunchWizardAction, LaunchWizardCompletion, LaunchWizardContext,
-    LaunchWizardLiveSessionView, LaunchWizardOptionView, LaunchWizardQuickStartView,
-    LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView, LaunchWizardView,
-    LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
+    LaunchWizardHydration, LaunchWizardLiveSessionView, LaunchWizardOptionView,
+    LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView,
+    LaunchWizardView, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
 };
 pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
 #[cfg(target_os = "macos")]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -20,13 +20,14 @@ use axum::{
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use gwt::{
-    cleanup_selected_branches, default_wizard_version_cache_path, detect_shell_program,
-    list_branch_entries_with_active_sessions, list_directory_entries, load_knowledge_bridge,
-    load_restored_workspace_state, load_session_state, migrate_legacy_workspace_state,
-    refresh_managed_gwt_assets_for_worktree, resolve_launch_spec, save_session_state,
-    save_workspace_state, workspace_state_path, BackendEvent, DockerWizardContext, FrontendEvent,
-    KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext, LaunchWizardState,
-    LiveSessionEntry, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
+    build_builtin_agent_options, cleanup_selected_branches, default_wizard_version_cache_path,
+    detect_shell_program, list_branch_entries_with_active_sessions, list_directory_entries,
+    load_knowledge_bridge, load_restored_workspace_state, load_session_state,
+    migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
+    save_session_state, save_workspace_state, workspace_state_path, BackendEvent, BranchListEntry,
+    DockerWizardContext, FrontendEvent, KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext,
+    LaunchWizardHydration, LaunchWizardState, LiveSessionEntry, WindowGeometry, WindowPreset,
+    WindowProcessStatus, WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus};
 use tao::{
@@ -80,6 +81,11 @@ enum UserEvent {
             String,
         >,
     },
+    LaunchWizardHydrated {
+        wizard_id: String,
+        result: Result<LaunchWizardHydration, String>,
+    },
+    IssueLaunchWizardPrepared(IssueLaunchWizardPrepared),
     Dispatch(Vec<OutboundEvent>),
     UpdateAvailable(gwt_core::update::UpdateState),
     #[cfg(target_os = "macos")]
@@ -159,7 +165,19 @@ struct WindowAddress {
 #[derive(Debug, Clone)]
 struct LaunchWizardSession {
     tab_id: String,
+    wizard_id: String,
     wizard: LaunchWizardState,
+}
+
+#[derive(Debug, Clone)]
+struct IssueLaunchWizardPrepared {
+    client_id: ClientId,
+    id: String,
+    knowledge_kind: KnowledgeKind,
+    tab_id: String,
+    project_root: PathBuf,
+    issue_number: u64,
+    result: Result<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1129,39 +1147,43 @@ impl AppRuntime {
         branch_name: &str,
         linked_issue_number: Option<u64>,
     ) -> Result<(), String> {
-        let active_session_branches = self.active_session_branches_for_tab(tab_id);
-        let entries =
-            list_branch_entries_with_active_sessions(project_root, &active_session_branches)
-                .map_err(|error| error.to_string())?;
-        let selected_branch = entries
-            .into_iter()
-            .find(|entry| entry.name == branch_name)
-            .ok_or_else(|| format!("Branch not found: {branch_name}"))?;
-
-        let normalized_branch_name = normalize_branch_name(&selected_branch.name);
-        let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
-        let quick_start_root = worktree_path
-            .clone()
-            .unwrap_or_else(|| project_root.to_path_buf());
+        let normalized_branch_name = normalize_branch_name(branch_name);
         let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
-        let (docker_context, docker_service_status) =
-            detect_wizard_docker_context_and_status(&quick_start_root);
+        let wizard_id = Uuid::new_v4().to_string();
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
-            wizard: LaunchWizardState::open(
+            wizard_id: wizard_id.clone(),
+            wizard: LaunchWizardState::open_loading(
                 LaunchWizardContext {
-                    selected_branch,
+                    selected_branch: synthetic_branch_entry(branch_name),
                     normalized_branch_name,
-                    worktree_path,
-                    quick_start_root,
+                    worktree_path: None,
+                    quick_start_root: project_root.to_path_buf(),
                     live_sessions,
-                    docker_context,
-                    docker_service_status,
+                    docker_context: None,
+                    docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                     linked_issue_number,
                 },
-                &self.sessions_dir,
-                &default_wizard_version_cache_path(),
+                build_builtin_agent_options(
+                    gwt_agent::AgentDetector::detect_all(),
+                    &gwt_agent::VersionCache::load(&default_wizard_version_cache_path()),
+                ),
             ),
+        });
+
+        let proxy = self.proxy.clone();
+        let sessions_dir = self.sessions_dir.clone();
+        let project_root = project_root.to_path_buf();
+        let branch_name = branch_name.to_string();
+        let active_session_branches = self.active_session_branches_for_tab(tab_id);
+        thread::spawn(move || {
+            let result = resolve_launch_wizard_hydration(
+                &project_root,
+                &branch_name,
+                &active_session_branches,
+                &sessions_dir,
+            );
+            let _ = proxy.send_event(UserEvent::LaunchWizardHydrated { wizard_id, result });
         });
 
         Ok(())
@@ -1214,48 +1236,101 @@ impl AppRuntime {
             )];
         };
 
-        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
-        let branches = match list_branch_entries_with_active_sessions(
-            &tab.project_root,
-            &active_session_branches,
-        ) {
-            Ok(entries) => entries,
-            Err(error) => {
-                return vec![OutboundEvent::reply(
-                    client_id,
-                    BackendEvent::KnowledgeError {
-                        id: id.to_string(),
-                        knowledge_kind: kind,
-                        message: error.to_string(),
-                    },
-                )]
-            }
-        };
-        let Some(branch_name) = preferred_issue_launch_branch(&branches) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::KnowledgeError {
-                    id: id.to_string(),
-                    knowledge_kind: kind,
-                    message: "No local branch is available for launch".to_string(),
-                },
-            )];
-        };
-
         let project_root = tab.project_root.clone();
         let tab_id = address.tab_id.clone();
-        match self.open_launch_wizard_for_branch(
-            &tab_id,
-            &project_root,
-            &branch_name,
-            Some(issue_number),
-        ) {
-            Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::KnowledgeError {
-                    id: id.to_string(),
+        let proxy = self.proxy.clone();
+        let client_id = client_id.to_string();
+        let id = id.to_string();
+        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
+        thread::spawn(move || {
+            let result =
+                list_branch_entries_with_active_sessions(&project_root, &active_session_branches)
+                    .map_err(|error| error.to_string())
+                    .and_then(|entries| {
+                        preferred_issue_launch_branch(&entries)
+                            .ok_or_else(|| "No local branch is available for launch".to_string())
+                    });
+            let _ = proxy.send_event(UserEvent::IssueLaunchWizardPrepared(
+                IssueLaunchWizardPrepared {
+                    client_id,
+                    id,
                     knowledge_kind: kind,
+                    tab_id,
+                    project_root,
+                    issue_number,
+                    result,
+                },
+            ));
+        });
+        Vec::new()
+    }
+
+    fn handle_launch_wizard_hydrated(
+        &mut self,
+        wizard_id: String,
+        result: Result<LaunchWizardHydration, String>,
+    ) -> Vec<OutboundEvent> {
+        let Some(session) = self.launch_wizard.as_mut() else {
+            return Vec::new();
+        };
+        if session.wizard_id != wizard_id {
+            return Vec::new();
+        }
+
+        match result {
+            Ok(hydration) => session.wizard.apply_hydration(hydration),
+            Err(error) => session.wizard.set_hydration_error(error),
+        }
+
+        vec![self.launch_wizard_state_outbound()]
+    }
+
+    fn handle_issue_launch_wizard_prepared(
+        &mut self,
+        prepared: IssueLaunchWizardPrepared,
+    ) -> Vec<OutboundEvent> {
+        let IssueLaunchWizardPrepared {
+            client_id,
+            id,
+            knowledge_kind,
+            tab_id,
+            project_root,
+            issue_number,
+            result,
+        } = prepared;
+        if self.tab(&tab_id).is_none() {
+            return vec![OutboundEvent::reply(
+                &client_id,
+                BackendEvent::KnowledgeError {
+                    id,
+                    knowledge_kind,
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        }
+
+        match result {
+            Ok(branch_name) => match self.open_launch_wizard_for_branch(
+                &tab_id,
+                &project_root,
+                &branch_name,
+                Some(issue_number),
+            ) {
+                Ok(()) => vec![self.launch_wizard_state_outbound()],
+                Err(error) => vec![OutboundEvent::reply(
+                    &client_id,
+                    BackendEvent::KnowledgeError {
+                        id,
+                        knowledge_kind,
+                        message: error,
+                    },
+                )],
+            },
+            Err(error) => vec![OutboundEvent::reply(
+                &client_id,
+                BackendEvent::KnowledgeError {
+                    id,
+                    knowledge_kind,
                     message: error,
                 },
             )],
@@ -2579,6 +2654,55 @@ fn normalize_branch_name(branch_name: &str) -> String {
     branch_name.to_string()
 }
 
+fn synthetic_branch_entry(branch_name: &str) -> BranchListEntry {
+    BranchListEntry {
+        name: branch_name.to_string(),
+        scope: gwt::BranchScope::Local,
+        is_head: false,
+        upstream: None,
+        ahead: 0,
+        behind: 0,
+        last_commit_date: None,
+        cleanup: gwt::BranchCleanupInfo::default(),
+    }
+}
+
+fn resolve_launch_wizard_hydration(
+    project_root: &Path,
+    branch_name: &str,
+    active_session_branches: &std::collections::HashSet<String>,
+    sessions_dir: &Path,
+) -> Result<LaunchWizardHydration, String> {
+    let entries = list_branch_entries_with_active_sessions(project_root, active_session_branches)
+        .map_err(|error| error.to_string())?;
+    let selected_branch = entries
+        .into_iter()
+        .find(|entry| entry.name == branch_name)
+        .ok_or_else(|| format!("Branch not found: {branch_name}"))?;
+    let normalized_branch_name = normalize_branch_name(&selected_branch.name);
+    let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
+    let quick_start_root = worktree_path
+        .clone()
+        .unwrap_or_else(|| project_root.to_path_buf());
+    let quick_start_entries = gwt::launch_wizard::load_quick_start_entries(
+        &quick_start_root,
+        sessions_dir,
+        &normalized_branch_name,
+    );
+    let (docker_context, docker_service_status) =
+        detect_wizard_docker_context_and_status(&quick_start_root);
+
+    Ok(LaunchWizardHydration {
+        selected_branch: Some(selected_branch),
+        normalized_branch_name,
+        worktree_path,
+        quick_start_root,
+        docker_context,
+        docker_service_status,
+        quick_start_entries,
+    })
+}
+
 fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> {
     match preset {
         WindowPreset::Issue => Some(KnowledgeKind::Issue),
@@ -3667,6 +3791,14 @@ fn main() -> wry::Result<()> {
             }
             Event::UserEvent(UserEvent::LaunchComplete { window_id, result }) => {
                 let events = app.handle_launch_complete(window_id, result);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::LaunchWizardHydrated { wizard_id, result }) => {
+                let events = app.handle_launch_wizard_hydrated(wizard_id, result);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::IssueLaunchWizardPrepared(prepared)) => {
+                let events = app.handle_issue_launch_wizard_prepared(prepared);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::Dispatch(events)) => {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3214,6 +3214,7 @@
           wizardError.hidden = true;
           wizardError.textContent = "";
           wizardSubmitButton.textContent = "Launch";
+          wizardSubmitButton.disabled = false;
           syncWizardDraftState();
           return;
         }
@@ -3224,14 +3225,17 @@
         wizardMeta.textContent = `Selected branch · ${
           launchWizard.selected_branch_name || launchWizard.branch_name || "Workspace"
         }`;
-        wizardSubmitButton.textContent =
-          launchWizard.branch_mode === "create_new"
+        wizardSubmitButton.textContent = launchWizard.is_hydrating
+          ? "Loading..."
+          : launchWizard.branch_mode === "create_new"
             ? "Create and launch"
             : "Launch";
+        wizardSubmitButton.disabled = Boolean(launchWizard.is_hydrating);
 
-        if (launchWizard.error) {
+        if (launchWizard.error || launchWizard.hydration_error) {
           wizardError.hidden = false;
-          wizardError.textContent = launchWizard.error;
+          wizardError.textContent =
+            launchWizard.error || launchWizard.hydration_error;
         } else {
           wizardError.hidden = true;
           wizardError.textContent = "";
@@ -3240,6 +3244,15 @@
         renderWizardSummary();
         wizardBody.innerHTML = "";
         const panel = createNode("div", "launch-panel");
+        if (launchWizard.is_hydrating) {
+          panel.appendChild(
+            createNode(
+              "div",
+              "launch-note",
+              "Loading branch workspace, recent sessions, and Docker options...",
+            ),
+          );
+        }
 
         if (
           (launchWizard.quick_start_entries || []).length > 0 ||


### PR DESCRIPTION
## Summary

- open the Launch Wizard immediately and move branch/worktree/session hydration off the UI thread so Launch Agent no longer blocks the app.
- keep the wizard in a loading state until hydration finishes, and surface hydration failures in the existing error area.
- cover the loading-state contract with launch wizard tests so the async path does not regress.

## Changes

- `crates/gwt/src/main.rs`: open the wizard with a synthetic branch entry first, hydrate it on a background thread, and ignore stale hydration results with `wizard_id`.
- `crates/gwt/src/launch_wizard.rs`: add `LaunchWizardHydration`, loading/error state, hydration application, and guards that reject launch while options are still loading.
- `crates/gwt/web/index.html`: disable submit while hydrating and show loading copy in the wizard.
- `crates/gwt/src/lib.rs`: re-export `LaunchWizardHydration`.

## Testing

- [x] `cargo test -p gwt launch_wizard -- --nocapture` — launch wizard unit tests pass, including the new hydration/loading cases.
- [x] `cargo test -p gwt-core -p gwt` — workspace test coverage for `gwt-core` and `gwt` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes with no warnings.
- [x] `cargo fmt -- --check` — formatting is clean.
- [x] `cargo build -p gwt` — app builds successfully.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (not needed: no user-facing workflow changed)
- [ ] Migration/backfill plan included (not needed: no schema or persisted data format change)
- [x] CHANGELOG impact considered (patch-level `fix:` change)

## Context

- Launch Agent was doing branch listing, worktree lookup, recent session scan, and Docker option resolution before the wizard opened. On slower repositories or environments this blocked the desktop app event loop.
- The fix keeps the existing wizard flow but changes initialization order so the UI can respond immediately.

## Risk / Impact

- **Affected areas**: Launch Wizard opening flow, Issue-to-launch flow, loading-state handling in the web UI.
- **Rollback plan**: revert commit `fe1771114d5b0ff11c6bf610aa99d08dd9cd5234` if async hydration causes regressions.

## Notes

- SPEC issue `#2014` could not be updated in this turn because `gwt issue spec 2014` and the local issue cache returned mismatched content. The implementation is scoped to the runtime fix only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch wizard now displays a loading state during workspace initialization.
  * Submit button shows "Loading..." text and is disabled while hydrating.
  * Added error handling to display hydration failures to users.
  * Displays progress message: "Loading branch workspace, recent sessions, and Docker options..."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->