### PR TITLE
ci(release): use Compress-Archive for Windows artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,22 +132,23 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
       - name: Build gwt binary
         run: cargo build --release -p gwt --target ${{ matrix.target }}
-      - name: Prepare artifact
+      - name: Prepare artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist/${{ matrix.binary }}"
+          Compress-Archive -Path "dist/${{ matrix.binary }}" -DestinationPath "dist/${{ matrix.archive_name }}" -Force
+          Remove-Item "dist/${{ matrix.binary }}"
+      - name: Prepare artifact (Unix)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           mkdir -p dist
           cd dist
           cp ../target/${{ matrix.target }}/release/${{ matrix.binary }} .
-          case "${{ matrix.platform }}" in
-            windows-*)
-              zip -q ${{ matrix.archive_name }} ${{ matrix.binary }}
-              rm ${{ matrix.binary }}
-              ;;
-            *)
-              tar -czf ${{ matrix.archive_name }} ${{ matrix.binary }}
-              rm ${{ matrix.binary }}
-              ;;
-          esac
+          tar -czf ${{ matrix.archive_name }} ${{ matrix.binary }}
+          rm ${{ matrix.binary }}
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-20 — ci(release): cross-platform archive step は shell と runner の同梱コマンド差分を前提に分ける
+
+### 事象
+
+`main` へ release PR #2072 を merge した後、Release workflow `24650370386` の
+`Build gwt (windows-x86_64)` が `Prepare artifact` で失敗し、`v9.6.0` の
+Windows zip asset だけ GitHub Release に載らなかった。
+
+### 原因
+
+- `.github/workflows/release.yml` の artifact 作成が全 OS 共通で `shell: bash` になっていた。
+- Windows 分岐では `zip` を呼んでいたが、GitHub の Windows runner + Git Bash 環境には
+  `zip` binary が常にある前提を置けなかった。
+- build 自体は成功しており、最後の packaging だけ shell 依存で壊れていた。
+
+### 再発防止策
+
+1. cross-platform workflow の packaging / file operation は「同じ shell で書けるか」ではなく、
+   各 runner に標準であるコマンドを基準に step を分ける。
+2. Windows artifact 作成では `zip` のような Unix 由来コマンドを前提にせず、
+   `Compress-Archive` など OS 標準機能を優先する。
+3. release workflow を触ったら、job ごとの最後の packaging/upload step までログを確認し、
+   「ビルド成功で安心しない」を checklist に入れる。
+
 ## 2026-04-20 — fix: canvas window ID を「同 preset 件数 + 1」で採番すると欠番で live window に衝突する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Fix the Windows release packaging step so `develop -> main` merges can finish the v9.6.0 release instead of failing in artifact preparation.
- Replace the Windows `zip` call with `Compress-Archive` because the GitHub Windows runner does not provide a `zip` binary in the Git Bash step.

## Changes

- `.github/workflows/release.yml`: split artifact preparation into a Windows `pwsh` path using `Compress-Archive` and a Unix `bash` path using `tar`.

## Testing

- [x] `gwt actions job-logs --job 72071709204` — confirmed the failing release job exited with `zip: command not found`.
- [x] `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text(encoding='utf-8')); print('ok')"` — parsed the workflow YAML successfully.
- [x] PowerShell `Compress-Archive` smoke test with a temporary `gwt.exe` file — created the expected `.zip` archive successfully.
- [x] `git diff --check` — no whitespace or merge-marker issues.

## Closing Issues

None

## Related Issues / Links

- https://github.com/akiojin/gwt/actions/runs/24650370386
- https://github.com/akiojin/gwt/actions/runs/24650370386/job/72071709204
- #2072

## Checklist

- [ ] Tests added/updated — Workflow-only fix; no product code or automated test target changed.
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — No user-facing behavior or docs changed.
- [ ] Migration/backfill plan included (if schema/data change) — No schema or data migration is involved.
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — CI/workflow-only fix; no release note entry is needed.

## Context

- Release workflow `24650370386` for `v9.6.0` created the tag and draft release successfully, but `Build gwt (windows-x86_64)` failed before uploading the Windows zip asset.
- After this PR merges to `main`, the release workflow can run again against the existing `v9.6.0` tag and publish the missing Windows artifact.
