### PR TITLE
fix(gui): show app version in project bar

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -150,6 +150,36 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_project_bar_includes_app_version_surface() {
+        let html = index_html();
+
+        assert!(
+            html.contains("id=\"app-version\""),
+            "expected embedded html to expose a project bar surface for the app version",
+        );
+        assert!(
+            html.contains("function formatVersionLabel()"),
+            "expected version label formatting to live in a named helper",
+        );
+        assert!(
+            html.contains("function renderAppVersion()"),
+            "expected project bar version rendering to live in a named helper",
+        );
+        assert!(
+            html.contains("function setVersionState(current, latest = null)"),
+            "expected version state updates to be centralized behind a helper",
+        );
+        assert!(
+            html.contains("setVersionState(appState.app_version, versionState.latest);"),
+            "expected workspace state rendering to seed the current app version",
+        );
+        assert!(
+            html.contains("setVersionState(event.current, event.latest);"),
+            "expected update events to refresh both current and latest version labels",
+        );
+    }
+
+    #[test]
     fn embedded_web_branches_surface_includes_scope_filter_controls() {
         let html = index_html();
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2235,6 +2235,8 @@ mod tests {
     use std::{collections::HashMap, fs, path::PathBuf, process::Command};
 
     use tao::event_loop::EventLoopBuilder;
+    #[cfg(unix)]
+    use tao::platform::unix::EventLoopBuilderExtUnix;
     #[cfg(target_os = "windows")]
     use tao::platform::windows::EventLoopBuilderExtWindows;
     use tempfile::tempdir;
@@ -2331,6 +2333,8 @@ mod tests {
 
     fn test_proxy() -> tao::event_loop::EventLoopProxy<UserEvent> {
         let mut builder = EventLoopBuilder::<UserEvent>::with_user_event();
+        #[cfg(unix)]
+        builder.with_any_thread(true);
         #[cfg(target_os = "windows")]
         builder.with_any_thread(true);
         builder.build().create_proxy()

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -771,7 +771,7 @@ impl AppRuntime {
             .active_tab_id
             .as_ref()
             .and_then(|tab_id| self.tab(tab_id))
-            .map(|tab| self.workspace_view(tab).windows)
+            .map(|tab| workspace_view_for_tab(tab).windows)
             .unwrap_or_default();
         BackendEvent::WindowList { windows }
     }
@@ -1986,47 +1986,11 @@ impl AppRuntime {
     }
 
     fn app_state_view(&self) -> gwt::AppStateView {
-        gwt::AppStateView {
-            app_version: env!("CARGO_PKG_VERSION").to_string(),
-            tabs: self
-                .tabs
-                .iter()
-                .map(|tab| gwt::ProjectTabView {
-                    id: tab.id.clone(),
-                    title: tab.title.clone(),
-                    project_root: tab.project_root.display().to_string(),
-                    kind: tab.kind,
-                    workspace: self.workspace_view(tab),
-                })
-                .collect(),
-            active_tab_id: self.active_tab_id.clone(),
-            recent_projects: self
-                .recent_projects
-                .iter()
-                .map(|project| gwt::RecentProjectView {
-                    path: project.path.display().to_string(),
-                    title: project.title.clone(),
-                    kind: project.kind,
-                })
-                .collect(),
-        }
-    }
-
-    fn workspace_view(&self, tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
-        gwt::WorkspaceView {
-            viewport: tab.workspace.persisted().viewport.clone(),
-            windows: tab
-                .workspace
-                .persisted()
-                .windows
-                .iter()
-                .cloned()
-                .map(|mut window| {
-                    window.id = combined_window_id(&tab.id, &window.id);
-                    window
-                })
-                .collect(),
-        }
+        app_state_view_from_parts(
+            &self.tabs,
+            self.active_tab_id.as_deref(),
+            &self.recent_projects,
+        )
     }
 
     fn workspace_state_broadcast(&self) -> OutboundEvent {
@@ -2230,15 +2194,60 @@ fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool
         )
 }
 
+fn current_app_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
+    gwt::WorkspaceView {
+        viewport: tab.workspace.persisted().viewport.clone(),
+        windows: tab
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .cloned()
+            .map(|mut window| {
+                window.id = combined_window_id(&tab.id, &window.id);
+                window
+            })
+            .collect(),
+    }
+}
+
+fn app_state_view_from_parts(
+    tabs: &[ProjectTabRuntime],
+    active_tab_id: Option<&str>,
+    recent_projects: &[gwt::RecentProjectEntry],
+) -> gwt::AppStateView {
+    gwt::AppStateView {
+        app_version: current_app_version().to_string(),
+        tabs: tabs
+            .iter()
+            .map(|tab| gwt::ProjectTabView {
+                id: tab.id.clone(),
+                title: tab.title.clone(),
+                project_root: tab.project_root.display().to_string(),
+                kind: tab.kind,
+                workspace: workspace_view_for_tab(tab),
+            })
+            .collect(),
+        active_tab_id: active_tab_id.map(str::to_owned),
+        recent_projects: recent_projects
+            .iter()
+            .map(|project| gwt::RecentProjectView {
+                path: project.path.display().to_string(),
+                title: project.title.clone(),
+                kind: project.kind,
+            })
+            .collect(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::HashMap, fs, path::PathBuf, process::Command};
 
-    use tao::event_loop::EventLoopBuilder;
-    #[cfg(unix)]
-    use tao::platform::unix::EventLoopBuilderExtUnix;
-    #[cfg(target_os = "windows")]
-    use tao::platform::windows::EventLoopBuilderExtWindows;
     use tempfile::tempdir;
 
     use gwt::{
@@ -2249,10 +2258,10 @@ mod tests {
     use gwt_terminal::PaneStatus;
 
     use super::{
-        apply_host_package_runner_fallback_with_probe, close_window_from_workspace,
-        combined_window_id, knowledge_kind_for_preset, preferred_issue_launch_branch,
-        resolve_project_target, should_auto_close_agent_window, should_auto_start_restored_window,
-        ActiveAgentSession, AppRuntime, ProjectTabRuntime, UserEvent, WindowAddress,
+        app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
+        close_window_from_workspace, combined_window_id, knowledge_kind_for_preset,
+        preferred_issue_launch_branch, resolve_project_target, should_auto_close_agent_window,
+        should_auto_start_restored_window, ActiveAgentSession, ProjectTabRuntime, WindowAddress,
     };
 
     fn sample_window(preset: WindowPreset, status: WindowProcessStatus) -> PersistedWindowState {
@@ -2328,37 +2337,6 @@ mod tests {
             display_name: "Codex".to_string(),
             worktree_path: PathBuf::from("E:/gwt/test-repo"),
             tab_id: tab_id.to_string(),
-        }
-    }
-
-    fn test_proxy() -> tao::event_loop::EventLoopProxy<UserEvent> {
-        let mut builder = EventLoopBuilder::<UserEvent>::with_user_event();
-        #[cfg(unix)]
-        builder.with_any_thread(true);
-        #[cfg(target_os = "windows")]
-        builder.with_any_thread(true);
-        builder.build().create_proxy()
-    }
-
-    fn sample_app_runtime() -> AppRuntime {
-        AppRuntime {
-            tabs: vec![sample_project_tab_with_window(
-                "tab-1",
-                "shell-1",
-                WindowPreset::Shell,
-                WindowProcessStatus::Ready,
-            )],
-            active_tab_id: Some("tab-1".to_string()),
-            recent_projects: Vec::new(),
-            runtimes: HashMap::new(),
-            window_details: HashMap::new(),
-            window_lookup: HashMap::new(),
-            session_state_path: PathBuf::from("session.json"),
-            proxy: test_proxy(),
-            sessions_dir: PathBuf::from("sessions"),
-            launch_wizard: None,
-            active_agent_sessions: HashMap::new(),
-            pending_update: None,
         }
     }
 
@@ -2444,9 +2422,15 @@ mod tests {
 
     #[test]
     fn app_state_view_includes_current_app_version() {
-        let app = sample_app_runtime();
+        let tabs = vec![sample_project_tab_with_window(
+            "tab-1",
+            "shell-1",
+            WindowPreset::Shell,
+            WindowProcessStatus::Ready,
+        )];
+        let view = app_state_view_from_parts(&tabs, Some("tab-1"), &[]);
 
-        assert_eq!(app.app_state_view().app_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(view.app_version, env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1987,6 +1987,7 @@ impl AppRuntime {
 
     fn app_state_view(&self) -> gwt::AppStateView {
         gwt::AppStateView {
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
             tabs: self
                 .tabs
                 .iter()
@@ -2233,19 +2234,23 @@ fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool
 mod tests {
     use std::{collections::HashMap, fs, path::PathBuf, process::Command};
 
+    use tao::event_loop::EventLoopBuilder;
+    #[cfg(target_os = "windows")]
+    use tao::platform::windows::EventLoopBuilderExtWindows;
+    use tempfile::tempdir;
+
     use gwt::{
         empty_workspace_state, BranchCleanupInfo, BranchListEntry, BranchScope, KnowledgeKind,
         PersistedWindowState, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState,
     };
     use gwt_agent::{AgentId, AgentLaunchBuilder, DockerLifecycleIntent, LaunchRuntimeTarget};
     use gwt_terminal::PaneStatus;
-    use tempfile::tempdir;
 
     use super::{
         apply_host_package_runner_fallback_with_probe, close_window_from_workspace,
         combined_window_id, knowledge_kind_for_preset, preferred_issue_launch_branch,
         resolve_project_target, should_auto_close_agent_window, should_auto_start_restored_window,
-        ActiveAgentSession, ProjectTabRuntime, WindowAddress,
+        ActiveAgentSession, AppRuntime, ProjectTabRuntime, UserEvent, WindowAddress,
     };
 
     fn sample_window(preset: WindowPreset, status: WindowProcessStatus) -> PersistedWindowState {
@@ -2321,6 +2326,35 @@ mod tests {
             display_name: "Codex".to_string(),
             worktree_path: PathBuf::from("E:/gwt/test-repo"),
             tab_id: tab_id.to_string(),
+        }
+    }
+
+    fn test_proxy() -> tao::event_loop::EventLoopProxy<UserEvent> {
+        let mut builder = EventLoopBuilder::<UserEvent>::with_user_event();
+        #[cfg(target_os = "windows")]
+        builder.with_any_thread(true);
+        builder.build().create_proxy()
+    }
+
+    fn sample_app_runtime() -> AppRuntime {
+        AppRuntime {
+            tabs: vec![sample_project_tab_with_window(
+                "tab-1",
+                "shell-1",
+                WindowPreset::Shell,
+                WindowProcessStatus::Ready,
+            )],
+            active_tab_id: Some("tab-1".to_string()),
+            recent_projects: Vec::new(),
+            runtimes: HashMap::new(),
+            window_details: HashMap::new(),
+            window_lookup: HashMap::new(),
+            session_state_path: PathBuf::from("session.json"),
+            proxy: test_proxy(),
+            sessions_dir: PathBuf::from("sessions"),
+            launch_wizard: None,
+            active_agent_sessions: HashMap::new(),
+            pending_update: None,
         }
     }
 
@@ -2402,6 +2436,13 @@ mod tests {
         assert!(tabs[0].workspace.window(raw_window_id).is_none());
         assert!(!window_lookup.contains_key(&window_id));
         assert!(!window_details.contains_key(&window_id));
+    }
+
+    #[test]
+    fn app_state_view_includes_current_app_version() {
+        let app = sample_app_runtime();
+
+        assert_eq!(app.app_state_view().app_version, env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -146,6 +146,7 @@ pub struct RecentProjectView {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AppStateView {
+    pub app_version: String,
     pub tabs: Vec<ProjectTabView>,
     pub active_tab_id: Option<String>,
     pub recent_projects: Vec<RecentProjectView>,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -111,6 +111,24 @@
         gap: 8px;
       }
 
+      .app-version {
+        display: inline-flex;
+        align-items: center;
+        height: 32px;
+        padding: 0 10px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 6px;
+        background: #f8fafc;
+        color: #475569;
+        font-size: 12px;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+
+      .app-version[hidden] {
+        display: none;
+      }
+
       .canvas-area {
         position: relative;
         flex: 1;
@@ -1701,6 +1719,7 @@
         <div class="project-bar">
           <div class="project-tabs" id="project-tabs"></div>
           <div class="project-actions">
+            <span class="app-version" id="app-version" hidden></span>
             <button class="arrange-button" id="open-project-button" aria-label="Open project">
               Open Project
             </button>
@@ -1900,6 +1919,7 @@
       const branchCleanupDialog = branchCleanupModal.querySelector(".modal");
       const connectionDot = document.getElementById("connection-dot");
       const connectionLabel = document.getElementById("connection-label");
+      const appVersionLabel = document.getElementById("app-version");
 
       const decoderMap = new Map();
       const pendingOutputMap = new Map();
@@ -1928,10 +1948,47 @@
       let windowListOpen = false;
       let windowListEntries = [];
       let titlebarClickState = null;
-      let appState = { tabs: [], active_tab_id: null, recent_projects: [] };
+      let appState = {
+        app_version: "",
+        tabs: [],
+        active_tab_id: null,
+        recent_projects: [],
+      };
+      let versionState = { current: "", latest: "" };
       let projectError = "";
       const BRANCH_CLEANUP_TIMEOUT_MS = 30000;
       const TERMINAL_SELECTION_DRAG_THRESHOLD = 4;
+
+      function formatVersionLabel() {
+        const current = versionState.current;
+        const latest = versionState.latest;
+        if (!current) {
+          return "";
+        }
+        if (latest && latest !== current) {
+          return `v${current} -> v${latest}`;
+        }
+        return `v${current}`;
+      }
+
+      function renderAppVersion() {
+        const label = formatVersionLabel();
+        appVersionLabel.hidden = !label;
+        appVersionLabel.textContent = label;
+        appVersionLabel.title = label;
+      }
+
+      function setVersionState(current, latest = null) {
+        if (current) {
+          versionState.current = current;
+        }
+        if (!latest || latest === versionState.current) {
+          versionState.latest = "";
+        } else {
+          versionState.latest = latest;
+        }
+        renderAppVersion();
+      }
 
       function presetSurface(preset) {
         if (
@@ -2270,7 +2327,13 @@
       }
 
       function renderAppState(nextState) {
-        appState = nextState || { tabs: [], active_tab_id: null, recent_projects: [] };
+        appState = nextState || {
+          app_version: "",
+          tabs: [],
+          active_tab_id: null,
+          recent_projects: [],
+        };
+        setVersionState(appState.app_version, versionState.latest);
         renderProjectTabs();
         renderProjectPicker();
         updateActionAvailability();
@@ -4975,6 +5038,7 @@
             break;
           case "update_state":
             if (event.state === "available") {
+              setVersionState(event.current, event.latest);
               showUpdateToast(event.latest);
             }
             break;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,26 @@
 # Lessons Learned
 
+## 2026-04-20 — fix(gui): GUI unit test で EventLoop/GTK 初期化を持ち込まない
+
+### 事象
+
+PR #2074 の Linux CI で `tests::app_state_view_includes_current_app_version` が失敗した。
+最初は `tao` の EventLoop を main thread 外で初期化したことにより落ち、その場しのぎで
+`with_any_thread(true)` を入れると次は GTK 初期化失敗に変わった。
+
+### 原因
+
+- version 表示の回帰テストが、本来確認したい `AppStateView` の組み立てだけでなく、
+  GUI runtime (`AppRuntime`) の生成まで引き込んでいた。
+- `AppRuntime` のテスト補助が `tao::EventLoop` / platform backend 初期化を前提にしており、
+  headless Linux CI では GTK backend が使えず失敗した。
+
+### 再発防止策
+
+1. GUI state の unit test は EventLoop や WebView を生成せず、pure な state builder/helper に分離して検証する。
+2. `tao` / `wry` / GTK backend を触るテストは、thread 制約だけでなく headless backend 制約も前提に置く。
+3. 「表示用 state を確認したいだけ」のテストでは runtime 全体を組み立てず、必要な parts を直接渡す helper を先に用意する。
+
 ## 2026-04-20 — ci(release): cross-platform archive step は shell と runner の同梱コマンド差分を前提に分ける
 
 ### 事象


### PR DESCRIPTION
## Summary

- Exposed the running `gwt` version through the initial frontend workspace state so the WebView can render it before update checks complete.
- Added a project-bar version surface that shows `v<current>` normally and `v<current> -> v<latest>` when the shared update state reports an available release.
- Added regression tests for backend state wiring and embedded frontend markup so the version surface stays connected to the update contract.

## Changes

- `crates/gwt/src/protocol.rs`: added `app_version` to `AppStateView` so browser and native WebView clients receive the running version during initial sync.
- `crates/gwt/src/main.rs`: seeded `env!("CARGO_PKG_VERSION")` into the workspace sync payload and added a regression test for the exported app version.
- `crates/gwt/web/index.html`: added the project-bar version chip, version label formatting helpers, and `update_state` handling for current/latest display.
- `crates/gwt/src/embedded_web.rs`: added an embedded HTML regression test that locks the version surface and state-wiring contract.

## Testing

- [x] `cargo fmt` — completed without rewriting tracked files after the implementation.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt app_state_view_includes_current_app_version` — passed.
- [x] `cargo test -p gwt embedded_web_project_bar_includes_app_version_surface` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.

## Closing Issues

- None

## Related Issues / Links

- #1784

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (not needed: no README or user-facing docs changed)
- [ ] Migration/backfill plan included (not needed: no schema or persisted data change)
- [x] CHANGELOG impact considered (patch-level UI fix; no breaking change)

## Context

- `gwt` already carried current/latest version data in backend update state, but the WebView canvas chrome had no always-visible version surface.
- This change keeps the version signal in the shared backend/frontend contract instead of duplicating update logic in the frontend and aligns the visible chrome with #1784 ownership.

## Risk / Impact

- **Affected areas**: `project-bar` rendering, initial frontend sync payload, update-toast/version label coordination.
- **Rollback plan**: Revert commit `f6cdb69c` if the project-bar label causes layout or state-sync regressions.

## Screenshots

| Before | After |
|--------|-------|
| Project bar had no visible app version. | Project bar shows `v<current>` and upgrades to `v<current> -> v<latest>` when update state is available. |
