### PR TITLE
feat(launch-wizard): add shell target and direct quick start

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -16,6 +16,7 @@ pub enum LaunchWizardStep {
     BranchAction,
     BranchTypeSelect,
     BranchNameInput,
+    LaunchTarget,
     AgentSelect,
     ModelSelect,
     ReasoningLevel,
@@ -33,6 +34,13 @@ pub struct LaunchWizardOptionView {
     pub value: String,
     pub label: String,
     pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaunchTargetKind {
+    Agent,
+    Shell,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -78,6 +86,8 @@ pub struct LaunchWizardView {
     pub branch_mode: String,
     pub branch_type_options: Vec<LaunchWizardOptionView>,
     pub selected_branch_type: Option<String>,
+    pub launch_target_options: Vec<LaunchWizardOptionView>,
+    pub selected_launch_target: String,
     pub agent_options: Vec<LaunchWizardOptionView>,
     pub selected_agent_id: String,
     pub model_options: Vec<LaunchWizardOptionView>,
@@ -95,11 +105,14 @@ pub struct LaunchWizardView {
     pub execution_mode_options: Vec<LaunchWizardOptionView>,
     pub selected_execution_mode: String,
     pub skip_permissions: bool,
+    pub show_agent_settings: bool,
     pub show_reasoning: bool,
     pub show_runtime_target: bool,
     pub show_docker_service: bool,
     pub show_docker_lifecycle: bool,
     pub show_version: bool,
+    pub show_execution_mode: bool,
+    pub show_skip_permissions: bool,
     pub show_codex_fast_mode: bool,
     pub codex_fast_mode: bool,
     pub launch_summary: Vec<LaunchWizardSummaryView>,
@@ -130,6 +143,18 @@ pub struct QuickStartEntry {
     pub runtime_target: gwt_agent::LaunchRuntimeTarget,
     pub docker_service: Option<String>,
     pub docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellLaunchConfig {
+    pub working_dir: Option<PathBuf>,
+    pub branch: Option<String>,
+    pub base_branch: Option<String>,
+    pub display_name: String,
+    pub runtime_target: gwt_agent::LaunchRuntimeTarget,
+    pub docker_service: Option<String>,
+    pub docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
+    pub env_vars: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -189,8 +214,14 @@ pub struct LaunchWizardHydration {
 }
 
 #[derive(Debug, Clone)]
+pub enum LaunchWizardLaunchRequest {
+    Agent(Box<gwt_agent::LaunchConfig>),
+    Shell(Box<ShellLaunchConfig>),
+}
+
+#[derive(Debug, Clone)]
 pub enum LaunchWizardCompletion {
-    Launch(Box<gwt_agent::LaunchConfig>),
+    Launch(Box<LaunchWizardLaunchRequest>),
     FocusWindow { window_id: String },
     Cancelled,
 }
@@ -221,6 +252,9 @@ pub enum LaunchWizardAction {
     },
     SetBranchName {
         value: String,
+    },
+    SetLaunchTarget {
+        target: LaunchTargetKind,
     },
     SetAgent {
         agent_id: String,
@@ -268,6 +302,7 @@ pub struct LaunchWizardState {
     pub quick_start_entries: Vec<QuickStartEntry>,
     pub is_new_branch: bool,
     pub base_branch_name: Option<String>,
+    pub launch_target: LaunchTargetKind,
     pub agent_id: String,
     pub model: String,
     pub reasoning: String,
@@ -340,6 +375,7 @@ impl LaunchWizardState {
             quick_start_entries,
             is_new_branch: false,
             base_branch_name: None,
+            launch_target: LaunchTargetKind::Agent,
             agent_id: String::new(),
             model: String::new(),
             reasoning: String::new(),
@@ -406,6 +442,8 @@ impl LaunchWizardState {
             },
             branch_type_options: branch_type_options_view(),
             selected_branch_type: self.selected_branch_type_prefix().map(str::to_string),
+            launch_target_options: launch_target_options_view(),
+            selected_launch_target: launch_target_value(self.launch_target).to_string(),
             agent_options: self.agent_options_view(),
             selected_agent_id: self.effective_agent_id().to_string(),
             model_options: self.model_options_view(),
@@ -424,13 +462,17 @@ impl LaunchWizardState {
             execution_mode_options: execution_mode_options_view(),
             selected_execution_mode: self.mode.clone(),
             skip_permissions: self.skip_permissions,
-            show_reasoning: self.agent_uses_reasoning_step(),
+            show_agent_settings: self.launch_target_is_agent(),
+            show_reasoning: self.launch_target_is_agent() && self.agent_uses_reasoning_step(),
             show_runtime_target: self.has_docker_workflow(),
             show_docker_service: self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker
                 && self.docker_service_prompt_required(),
             show_docker_lifecycle: self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker,
-            show_version: agent_has_npm_package(self.effective_agent_id()),
-            show_codex_fast_mode: self.agent_is_codex(),
+            show_version: self.launch_target_is_agent()
+                && agent_has_npm_package(self.effective_agent_id()),
+            show_execution_mode: self.launch_target_is_agent(),
+            show_skip_permissions: self.launch_target_is_agent(),
+            show_codex_fast_mode: self.launch_target_is_agent() && self.agent_is_codex(),
             codex_fast_mode: self.codex_fast_mode,
             launch_summary: self.launch_summary_view(),
             error: self.error.clone(),
@@ -509,6 +551,9 @@ impl LaunchWizardState {
             LaunchWizardAction::SetBranchName { value } => {
                 self.branch_name = value;
             }
+            LaunchWizardAction::SetLaunchTarget { target } => {
+                self.set_launch_target(target);
+            }
             LaunchWizardAction::SetAgent { agent_id } => {
                 self.set_agent_id(&agent_id);
             }
@@ -580,6 +625,9 @@ impl LaunchWizardState {
         if self.is_hydrating {
             return Err("Launch options are still loading".to_string());
         }
+        if !self.launch_target_is_agent() {
+            return Err("Agent launch target is not selected".to_string());
+        }
         let agent_id = agent_id_from_key(&self.agent_id);
         let mut builder = gwt_agent::AgentLaunchBuilder::new(agent_id.clone());
 
@@ -649,6 +697,50 @@ impl LaunchWizardState {
         Ok(config)
     }
 
+    fn build_shell_launch_config(&self) -> Result<ShellLaunchConfig, String> {
+        if self.is_hydrating {
+            return Err("Launch options are still loading".to_string());
+        }
+
+        let working_dir = if !self.is_new_branch {
+            self.context.worktree_path.clone()
+        } else {
+            None
+        };
+        let branch = (!self.branch_name.is_empty()).then(|| self.branch_name.clone());
+        let base_branch = self.is_new_branch.then(|| {
+            self.base_branch_name
+                .clone()
+                .unwrap_or_else(|| DEFAULT_NEW_BRANCH_BASE_BRANCH.to_string())
+        });
+        let mut env_vars = HashMap::new();
+        if let Some(dir) = working_dir.as_ref() {
+            env_vars.insert("GWT_PROJECT_ROOT".to_string(), dir.display().to_string());
+        }
+
+        Ok(ShellLaunchConfig {
+            working_dir,
+            branch: branch.clone(),
+            base_branch,
+            display_name: "Shell".to_string(),
+            runtime_target: self.runtime_target,
+            docker_service: self.docker_service.clone(),
+            docker_lifecycle_intent: self.docker_lifecycle_intent,
+            env_vars,
+        })
+    }
+
+    fn build_launch_request(&self) -> Result<LaunchWizardLaunchRequest, String> {
+        match self.launch_target {
+            LaunchTargetKind::Agent => Ok(LaunchWizardLaunchRequest::Agent(Box::new(
+                self.build_launch_config()?,
+            ))),
+            LaunchTargetKind::Shell => Ok(LaunchWizardLaunchRequest::Shell(Box::new(
+                self.build_shell_launch_config()?,
+            ))),
+        }
+    }
+
     fn advance_after_current_step(&mut self) {
         if self.completion.is_some() {
             return;
@@ -660,7 +752,7 @@ impl LaunchWizardState {
             return;
         }
 
-        match self.build_launch_config() {
+        match self.build_launch_request() {
             Ok(config) => {
                 self.completion = Some(LaunchWizardCompletion::Launch(Box::new(config)));
             }
@@ -708,6 +800,13 @@ impl LaunchWizardState {
                     };
                     self.branch_name = apply_branch_prefix(&seed, prefix);
                 }
+            }
+            LaunchWizardStep::LaunchTarget => {
+                self.set_launch_target(if self.selected == 0 {
+                    LaunchTargetKind::Agent
+                } else {
+                    LaunchTargetKind::Shell
+                });
             }
             LaunchWizardStep::AgentSelect => {
                 if let Some(agent) = self.detected_agents.get(self.selected) {
@@ -782,7 +881,7 @@ impl LaunchWizardState {
             self.branch_name = trimmed.to_string();
         }
 
-        match self.build_launch_config() {
+        match self.build_launch_request() {
             Ok(config) => {
                 self.completion = Some(LaunchWizardCompletion::Launch(Box::new(config)));
             }
@@ -798,6 +897,7 @@ impl LaunchWizardState {
             return;
         };
 
+        self.launch_target = LaunchTargetKind::Agent;
         self.agent_id = entry.agent_id.clone();
         self.sync_selected_agent_options();
         if let Some(model) = entry.model {
@@ -814,6 +914,7 @@ impl LaunchWizardState {
         self.runtime_target = entry.runtime_target;
         self.docker_service = entry.docker_service.clone();
         self.docker_lifecycle_intent = entry.docker_lifecycle_intent;
+        self.sync_docker_lifecycle_default();
         match mode {
             QuickStartLaunchMode::Resume => {
                 if let Some(window_id) = entry.live_window_id {
@@ -821,6 +922,13 @@ impl LaunchWizardState {
                 } else if let Some(resume_session_id) = entry.resume_session_id {
                     self.mode = "resume".to_string();
                     self.resume_session_id = Some(resume_session_id);
+                    match self.build_launch_request() {
+                        Ok(config) => {
+                            self.completion =
+                                Some(LaunchWizardCompletion::Launch(Box::new(config)));
+                        }
+                        Err(error) => self.error = Some(error),
+                    }
                 } else {
                     self.error = Some("No saved session is available".to_string());
                 }
@@ -828,9 +936,14 @@ impl LaunchWizardState {
             QuickStartLaunchMode::StartNew => {
                 self.mode = "normal".to_string();
                 self.resume_session_id = None;
+                match self.build_launch_request() {
+                    Ok(config) => {
+                        self.completion = Some(LaunchWizardCompletion::Launch(Box::new(config)));
+                    }
+                    Err(error) => self.error = Some(error),
+                }
             }
         }
-        self.sync_docker_lifecycle_default();
     }
 
     fn focus_existing_session(&mut self, index: usize) {
@@ -872,6 +985,18 @@ impl LaunchWizardState {
             self.branch_name.clone()
         };
         self.branch_name = apply_branch_prefix(&seed, prefix);
+    }
+
+    fn set_launch_target(&mut self, target: LaunchTargetKind) {
+        self.launch_target = target;
+        if self.launch_target_is_shell() {
+            self.mode = "normal".to_string();
+            self.resume_session_id = None;
+            self.skip_permissions = false;
+            self.codex_fast_mode = false;
+        } else {
+            self.sync_selected_agent_options();
+        }
     }
 
     fn set_agent_id(&mut self, agent_id: &str) {
@@ -1075,40 +1200,49 @@ impl LaunchWizardState {
                 value: self.branch_name.clone(),
             },
             LaunchWizardSummaryView {
+                label: "Target".to_string(),
+                value: match self.launch_target {
+                    LaunchTargetKind::Agent => "Agent".to_string(),
+                    LaunchTargetKind::Shell => "Shell".to_string(),
+                },
+            },
+        ];
+
+        if self.launch_target_is_agent() {
+            summary.push(LaunchWizardSummaryView {
                 label: "Agent".to_string(),
                 value: self
                     .selected_agent()
                     .map(|agent| agent.name.clone())
                     .unwrap_or_else(|| "Unavailable".to_string()),
-            },
-        ];
-
-        if is_explicit_model_selection(&self.model) {
+            });
+            if is_explicit_model_selection(&self.model) {
+                summary.push(LaunchWizardSummaryView {
+                    label: "Model".to_string(),
+                    value: self.model.clone(),
+                });
+            }
+            if let Some(reasoning) = self.reasoning_level_for_launch() {
+                summary.push(LaunchWizardSummaryView {
+                    label: if self.agent_is_codex() {
+                        "Reasoning".to_string()
+                    } else {
+                        "Effort".to_string()
+                    },
+                    value: reasoning.to_string(),
+                });
+            }
+            if !self.version.is_empty() {
+                summary.push(LaunchWizardSummaryView {
+                    label: "Version".to_string(),
+                    value: self.version.clone(),
+                });
+            }
             summary.push(LaunchWizardSummaryView {
-                label: "Model".to_string(),
-                value: self.model.clone(),
+                label: "Mode".to_string(),
+                value: self.mode.clone(),
             });
         }
-        if let Some(reasoning) = self.reasoning_level_for_launch() {
-            summary.push(LaunchWizardSummaryView {
-                label: if self.agent_is_codex() {
-                    "Reasoning".to_string()
-                } else {
-                    "Effort".to_string()
-                },
-                value: reasoning.to_string(),
-            });
-        }
-        if !self.version.is_empty() {
-            summary.push(LaunchWizardSummaryView {
-                label: "Version".to_string(),
-                value: self.version.clone(),
-            });
-        }
-        summary.push(LaunchWizardSummaryView {
-            label: "Mode".to_string(),
-            value: self.mode.clone(),
-        });
         summary.push(LaunchWizardSummaryView {
             label: "Runtime".to_string(),
             value: if self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
@@ -1120,14 +1254,16 @@ impl LaunchWizardState {
                 "host".to_string()
             },
         });
-        summary.push(LaunchWizardSummaryView {
-            label: "Permissions".to_string(),
-            value: if self.skip_permissions {
-                "skip".to_string()
-            } else {
-                "prompt".to_string()
-            },
-        });
+        if self.launch_target_is_agent() {
+            summary.push(LaunchWizardSummaryView {
+                label: "Permissions".to_string(),
+                value: if self.skip_permissions {
+                    "skip".to_string()
+                } else {
+                    "prompt".to_string()
+                },
+            });
+        }
         if self.agent_is_codex() {
             summary.push(LaunchWizardSummaryView {
                 label: "Fast mode".to_string(),
@@ -1229,6 +1365,14 @@ impl LaunchWizardState {
         }
     }
 
+    fn launch_target_is_agent(&self) -> bool {
+        self.launch_target == LaunchTargetKind::Agent
+    }
+
+    fn launch_target_is_shell(&self) -> bool {
+        self.launch_target == LaunchTargetKind::Shell
+    }
+
     fn selected_agent(&self) -> Option<&AgentOption> {
         if self.step == LaunchWizardStep::AgentSelect {
             return self.detected_agents.get(self.selected);
@@ -1249,14 +1393,18 @@ impl LaunchWizardState {
     }
 
     fn agent_is_codex(&self) -> bool {
-        self.effective_agent_id() == "codex"
+        self.launch_target_is_agent() && self.effective_agent_id() == "codex"
     }
 
     fn agent_has_models(&self) -> bool {
-        matches!(self.effective_agent_id(), "claude" | "codex" | "gemini")
+        self.launch_target_is_agent()
+            && matches!(self.effective_agent_id(), "claude" | "codex" | "gemini")
     }
 
     fn agent_uses_reasoning_step(&self) -> bool {
+        if !self.launch_target_is_agent() {
+            return false;
+        }
         if self.agent_is_codex() {
             return true;
         }
@@ -1395,6 +1543,7 @@ impl LaunchWizardState {
             return;
         };
 
+        self.launch_target = LaunchTargetKind::Agent;
         self.agent_id = entry.agent_id.clone();
         if let Some(index) = self
             .detected_agents
@@ -1419,6 +1568,7 @@ impl LaunchWizardState {
         self.runtime_target = entry.runtime_target;
         self.docker_service = entry.docker_service.clone();
         self.docker_lifecycle_intent = entry.docker_lifecycle_intent;
+        self.sync_docker_lifecycle_default();
 
         match self.selected_quick_start_action() {
             QuickStartAction::ReuseEntry { .. } => {
@@ -1427,6 +1577,13 @@ impl LaunchWizardState {
                 } else if let Some(resume_session_id) = entry.resume_session_id {
                     self.mode = "resume".to_string();
                     self.resume_session_id = Some(resume_session_id);
+                    match self.build_launch_request() {
+                        Ok(config) => {
+                            self.completion =
+                                Some(LaunchWizardCompletion::Launch(Box::new(config)));
+                        }
+                        Err(error) => self.error = Some(error),
+                    }
                 } else {
                     self.error = Some("No saved session is available".to_string());
                 }
@@ -1434,6 +1591,12 @@ impl LaunchWizardState {
             QuickStartAction::StartNewEntry { .. } => {
                 self.mode = "normal".to_string();
                 self.resume_session_id = None;
+                match self.build_launch_request() {
+                    Ok(config) => {
+                        self.completion = Some(LaunchWizardCompletion::Launch(Box::new(config)));
+                    }
+                    Err(error) => self.error = Some(error),
+                }
             }
             QuickStartAction::FocusExistingSession | QuickStartAction::ChooseDifferent => {}
         }
@@ -1507,6 +1670,7 @@ impl LaunchWizardState {
                     )),
                 })
                 .collect(),
+            LaunchWizardStep::LaunchTarget => launch_target_options_view(),
             LaunchWizardStep::AgentSelect => self
                 .detected_agents
                 .iter()
@@ -1904,13 +2068,22 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
         LaunchWizardStep::FocusExistingSession => None,
         LaunchWizardStep::BranchAction => {
             if state.selected == 0 {
-                Some(LaunchWizardStep::AgentSelect)
+                Some(LaunchWizardStep::LaunchTarget)
             } else {
                 Some(LaunchWizardStep::BranchTypeSelect)
             }
         }
         LaunchWizardStep::BranchTypeSelect => Some(LaunchWizardStep::BranchNameInput),
-        LaunchWizardStep::BranchNameInput => Some(LaunchWizardStep::AgentSelect),
+        LaunchWizardStep::BranchNameInput => Some(LaunchWizardStep::LaunchTarget),
+        LaunchWizardStep::LaunchTarget => {
+            if state.launch_target_is_agent() {
+                Some(LaunchWizardStep::AgentSelect)
+            } else if state.has_docker_workflow() {
+                Some(LaunchWizardStep::RuntimeTarget)
+            } else {
+                None
+            }
+        }
         LaunchWizardStep::AgentSelect => {
             if state.agent_has_models() {
                 Some(LaunchWizardStep::ModelSelect)
@@ -1949,6 +2122,8 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
                 Some(LaunchWizardStep::DockerServiceSelect)
             } else if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
                 Some(LaunchWizardStep::DockerLifecycle)
+            } else if state.launch_target_is_shell() {
+                None
             } else if agent_has_npm_package(state.effective_agent_id()) {
                 Some(LaunchWizardStep::VersionSelect)
             } else {
@@ -1957,7 +2132,9 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
         }
         LaunchWizardStep::DockerServiceSelect => Some(LaunchWizardStep::DockerLifecycle),
         LaunchWizardStep::DockerLifecycle => {
-            if agent_has_npm_package(state.effective_agent_id()) {
+            if state.launch_target_is_shell() {
+                None
+            } else if agent_has_npm_package(state.effective_agent_id()) {
                 Some(LaunchWizardStep::VersionSelect)
             } else {
                 Some(LaunchWizardStep::ExecutionMode)
@@ -1989,17 +2166,20 @@ fn prev_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
         }
         LaunchWizardStep::BranchTypeSelect => Some(LaunchWizardStep::BranchAction),
         LaunchWizardStep::BranchNameInput => Some(LaunchWizardStep::BranchTypeSelect),
-        LaunchWizardStep::AgentSelect => {
+        LaunchWizardStep::LaunchTarget => {
             if state.is_new_branch {
                 Some(LaunchWizardStep::BranchNameInput)
             } else {
                 Some(LaunchWizardStep::BranchAction)
             }
         }
+        LaunchWizardStep::AgentSelect => Some(LaunchWizardStep::LaunchTarget),
         LaunchWizardStep::ModelSelect => Some(LaunchWizardStep::AgentSelect),
         LaunchWizardStep::ReasoningLevel => Some(LaunchWizardStep::ModelSelect),
         LaunchWizardStep::RuntimeTarget => {
-            if state.agent_uses_reasoning_step() {
+            if state.launch_target_is_shell() {
+                Some(LaunchWizardStep::LaunchTarget)
+            } else if state.agent_uses_reasoning_step() {
                 Some(LaunchWizardStep::ReasoningLevel)
             } else if state.agent_has_models() {
                 Some(LaunchWizardStep::ModelSelect)
@@ -2055,6 +2235,7 @@ fn step_default_selection(step: LaunchWizardStep, state: &LaunchWizardState) -> 
         LaunchWizardStep::BranchAction => 0,
         LaunchWizardStep::BranchTypeSelect => 0,
         LaunchWizardStep::BranchNameInput => 0,
+        LaunchWizardStep::LaunchTarget => usize::from(state.launch_target_is_shell()),
         LaunchWizardStep::AgentSelect => state
             .detected_agents
             .iter()
@@ -2170,6 +2351,21 @@ fn branch_type_options_view() -> Vec<LaunchWizardOptionView> {
         .collect()
 }
 
+fn launch_target_options_view() -> Vec<LaunchWizardOptionView> {
+    vec![
+        LaunchWizardOptionView {
+            value: "agent".to_string(),
+            label: "Agent".to_string(),
+            description: Some("Launch a coding agent terminal".to_string()),
+        },
+        LaunchWizardOptionView {
+            value: "shell".to_string(),
+            label: "Shell".to_string(),
+            description: Some("Open a plain shell terminal".to_string()),
+        },
+    ]
+}
+
 fn runtime_target_options_view() -> Vec<LaunchWizardOptionView> {
     RUNTIME_TARGET_OPTIONS
         .iter()
@@ -2190,6 +2386,13 @@ fn execution_mode_options_view() -> Vec<LaunchWizardOptionView> {
             description: Some(option.description.to_string()),
         })
         .collect()
+}
+
+fn launch_target_value(target: LaunchTargetKind) -> &'static str {
+    match target {
+        LaunchTargetKind::Agent => "agent",
+        LaunchTargetKind::Shell => "shell",
+    }
 }
 
 fn runtime_target_value(target: gwt_agent::LaunchRuntimeTarget) -> &'static str {
@@ -2676,9 +2879,18 @@ mod tests {
             mode: QuickStartLaunchMode::StartNew,
         });
 
-        assert!(state.completion.is_none());
         assert_eq!(state.mode, "normal");
         assert!(state.resume_session_id.is_none());
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::Launch(config)) => match config.as_ref() {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    assert_eq!(config.session_mode, gwt_agent::SessionMode::Normal);
+                    assert!(config.resume_session_id.is_none());
+                }
+                other => panic!("expected agent launch request, got {other:?}"),
+            },
+            other => panic!("expected launch completion, got {other:?}"),
+        }
     }
 
     #[test]
@@ -2769,6 +2981,42 @@ mod tests {
             .launch_summary
             .iter()
             .any(|item| item.label == "Fast mode" && item.value == "on"));
+    }
+
+    #[test]
+    fn shell_target_hides_agent_specific_controls_and_builds_shell_request() {
+        let mut ctx = context(branch("feature/gui"), "feature/gui");
+        ctx.worktree_path = Some(PathBuf::from("/tmp/repo-feature"));
+        let mut state = LaunchWizardState::open_with(ctx, sample_agent_options(), Vec::new());
+
+        state.apply(LaunchWizardAction::SetLaunchTarget {
+            target: LaunchTargetKind::Shell,
+        });
+
+        let view = state.view();
+        assert_eq!(view.selected_launch_target, "shell");
+        assert!(!view.show_agent_settings);
+        assert!(!view.show_execution_mode);
+        assert!(!view.show_skip_permissions);
+        assert!(!view.show_version);
+        assert!(view
+            .launch_summary
+            .iter()
+            .any(|item| item.label == "Target" && item.value == "Shell"));
+        assert!(!view.launch_summary.iter().any(|item| item.label == "Agent"));
+
+        match state.build_launch_request().expect("shell launch request") {
+            LaunchWizardLaunchRequest::Shell(config) => {
+                assert_eq!(
+                    config.working_dir.as_deref(),
+                    Some(Path::new("/tmp/repo-feature"))
+                );
+                assert_eq!(config.branch.as_deref(), Some("feature/gui"));
+                assert_eq!(config.display_name, "Shell");
+                assert_eq!(config.runtime_target, gwt_agent::LaunchRuntimeTarget::Host);
+            }
+            other => panic!("expected shell launch request, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -29,10 +29,11 @@ pub use knowledge_bridge::{
 };
 pub use launch_wizard::{
     build_builtin_agent_options, default_wizard_version_cache_path, AgentOption,
-    DockerWizardContext, LaunchWizardAction, LaunchWizardCompletion, LaunchWizardContext,
-    LaunchWizardHydration, LaunchWizardLiveSessionView, LaunchWizardOptionView,
-    LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView,
-    LaunchWizardView, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
+    DockerWizardContext, LaunchTargetKind, LaunchWizardAction, LaunchWizardCompletion,
+    LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest,
+    LaunchWizardLiveSessionView, LaunchWizardOptionView, LaunchWizardQuickStartView,
+    LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView, LaunchWizardView,
+    LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode, ShellLaunchConfig,
 };
 pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
 #[cfg(target_os = "macos")]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -26,8 +26,8 @@ use gwt::{
     migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
     save_session_state, save_workspace_state, workspace_state_path, BackendEvent, BranchListEntry,
     DockerWizardContext, FrontendEvent, KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext,
-    LaunchWizardHydration, LaunchWizardState, LiveSessionEntry, WindowGeometry, WindowPreset,
-    WindowProcessStatus, WorkspaceState, APP_NAME,
+    LaunchWizardHydration, LaunchWizardLaunchRequest, LaunchWizardState, LiveSessionEntry,
+    ShellLaunchConfig, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus};
 use tao::{
@@ -80,6 +80,10 @@ enum UserEvent {
             ),
             String,
         >,
+    },
+    ShellLaunchComplete {
+        window_id: String,
+        result: Result<ProcessLaunch, String>,
     },
     LaunchWizardHydrated {
         wizard_id: String,
@@ -1369,19 +1373,34 @@ impl AppRuntime {
                     self.launch_wizard_state_broadcast(None),
                 ]
             }
-            Some(LaunchWizardCompletion::Launch(config)) => {
-                match self.spawn_agent_window(&session.tab_id, *config, bounds) {
-                    Ok(mut events) => {
-                        events.push(self.launch_wizard_state_broadcast(None));
-                        events
-                    }
-                    Err(error) => {
-                        session.wizard.error = Some(error);
-                        self.launch_wizard = Some(session);
-                        vec![self.launch_wizard_state_outbound()]
+            Some(LaunchWizardCompletion::Launch(config)) => match *config {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    match self.spawn_agent_window(&session.tab_id, *config, bounds) {
+                        Ok(mut events) => {
+                            events.push(self.launch_wizard_state_broadcast(None));
+                            events
+                        }
+                        Err(error) => {
+                            session.wizard.error = Some(error);
+                            self.launch_wizard = Some(session);
+                            vec![self.launch_wizard_state_outbound()]
+                        }
                     }
                 }
-            }
+                LaunchWizardLaunchRequest::Shell(config) => {
+                    match self.spawn_wizard_shell_window(&session.tab_id, *config, bounds) {
+                        Ok(mut events) => {
+                            events.push(self.launch_wizard_state_broadcast(None));
+                            events
+                        }
+                        Err(error) => {
+                            session.wizard.error = Some(error);
+                            self.launch_wizard = Some(session);
+                            vec![self.launch_wizard_state_outbound()]
+                        }
+                    }
+                }
+            },
             None => {
                 self.launch_wizard = Some(session);
                 vec![self.launch_wizard_state_outbound()]
@@ -1540,6 +1559,56 @@ impl AppRuntime {
                 );
 
                 let _ = self.persist();
+
+                match self.spawn_process_window(&window_id, geometry, process_launch) {
+                    Ok(event) => vec![
+                        self.workspace_state_broadcast(),
+                        OutboundEvent::broadcast(event),
+                    ],
+                    Err(error) => vec![OutboundEvent::broadcast(BackendEvent::TerminalStatus {
+                        id: window_id,
+                        status: WindowProcessStatus::Error,
+                        detail: Some(error),
+                    })],
+                }
+            }
+            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::TerminalStatus {
+                id: window_id,
+                status: WindowProcessStatus::Error,
+                detail: Some(error),
+            })],
+        }
+    }
+
+    fn handle_shell_launch_complete(
+        &mut self,
+        window_id: String,
+        result: Result<ProcessLaunch, String>,
+    ) -> Vec<OutboundEvent> {
+        match result {
+            Ok(process_launch) => {
+                let Some(address) = self.window_lookup.get(&window_id).cloned() else {
+                    return vec![OutboundEvent::broadcast(BackendEvent::TerminalStatus {
+                        id: window_id,
+                        status: WindowProcessStatus::Error,
+                        detail: Some("Window not found".to_string()),
+                    })];
+                };
+                let Some(tab) = self.tab(&address.tab_id) else {
+                    return vec![OutboundEvent::broadcast(BackendEvent::TerminalStatus {
+                        id: window_id,
+                        status: WindowProcessStatus::Error,
+                        detail: Some("Project tab not found".to_string()),
+                    })];
+                };
+                let Some(window) = tab.workspace.window(&address.raw_id) else {
+                    return vec![OutboundEvent::broadcast(BackendEvent::TerminalStatus {
+                        id: window_id,
+                        status: WindowProcessStatus::Error,
+                        detail: Some("Window not found".to_string()),
+                    })];
+                };
+                let geometry = window.geometry.clone();
 
                 match self.spawn_process_window(&window_id, geometry, process_launch) {
                     Ok(event) => vec![
@@ -1722,6 +1791,53 @@ impl AppRuntime {
         Ok(events)
     }
 
+    fn spawn_wizard_shell_window(
+        &mut self,
+        tab_id: &str,
+        config: ShellLaunchConfig,
+        bounds: Option<WindowGeometry>,
+    ) -> Result<Vec<OutboundEvent>, String> {
+        let tab = self
+            .tab_mut(tab_id)
+            .ok_or_else(|| "Project tab not found".to_string())?;
+        let project_root = tab.project_root.display().to_string();
+        let title = format!(
+            "{} · {}",
+            config.display_name,
+            config.branch.as_ref().unwrap_or(&"workspace".to_string())
+        );
+        let default_bounds = WindowGeometry {
+            x: 100.0,
+            y: 40.0,
+            width: 1000.0,
+            height: 760.0,
+        };
+        let window = tab.workspace.add_window_with_title(
+            WindowPreset::Shell,
+            title,
+            false,
+            bounds.unwrap_or(default_bounds),
+        );
+        self.register_window(tab_id, &window.id);
+        let window_id = combined_window_id(tab_id, &window.id);
+
+        let events = vec![
+            self.workspace_state_broadcast(),
+            OutboundEvent::broadcast(BackendEvent::TerminalStatus {
+                id: window_id.clone(),
+                status: WindowProcessStatus::Starting,
+                detail: None,
+            }),
+        ];
+
+        let proxy = self.proxy.clone();
+        thread::spawn(move || {
+            Self::spawn_wizard_shell_window_async(proxy, project_root, window_id, config)
+        });
+
+        Ok(events)
+    }
+
     fn spawn_agent_window_async(
         proxy: EventLoopProxy<UserEvent>,
         sessions_dir: PathBuf,
@@ -1851,6 +1967,32 @@ impl AppRuntime {
                 });
             }
         }
+    }
+
+    fn spawn_wizard_shell_window_async(
+        proxy: EventLoopProxy<UserEvent>,
+        project_root: String,
+        window_id: String,
+        mut config: ShellLaunchConfig,
+    ) {
+        let result = (|| {
+            let _ = proxy.send_event(UserEvent::LaunchProgress {
+                window_id: window_id.clone(),
+                message: "Preparing worktree...".to_string(),
+            });
+            resolve_shell_launch_worktree(Path::new(&project_root), &mut config)?;
+
+            if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
+                let _ = proxy.send_event(UserEvent::LaunchProgress {
+                    window_id: window_id.clone(),
+                    message: "Starting Docker service...".to_string(),
+                });
+            }
+
+            build_shell_process_launch(Path::new(&project_root), &mut config)
+        })();
+
+        let _ = proxy.send_event(UserEvent::ShellLaunchComplete { window_id, result });
     }
 
     fn mark_agent_session_stopped(&mut self, window_id: &str) {
@@ -2235,17 +2377,18 @@ mod tests {
 
     use gwt::{
         empty_workspace_state, BranchCleanupInfo, BranchListEntry, BranchScope, KnowledgeKind,
-        PersistedWindowState, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState,
+        PersistedWindowState, ShellLaunchConfig, WindowGeometry, WindowPreset, WindowProcessStatus,
+        WorkspaceState,
     };
     use gwt_agent::{AgentId, AgentLaunchBuilder, DockerLifecycleIntent, LaunchRuntimeTarget};
     use gwt_terminal::PaneStatus;
     use tempfile::tempdir;
 
     use super::{
-        apply_host_package_runner_fallback_with_probe, close_window_from_workspace,
-        combined_window_id, knowledge_kind_for_preset, preferred_issue_launch_branch,
-        resolve_project_target, should_auto_close_agent_window, should_auto_start_restored_window,
-        ActiveAgentSession, ProjectTabRuntime, WindowAddress,
+        apply_host_package_runner_fallback_with_probe, build_shell_process_launch,
+        close_window_from_workspace, combined_window_id, knowledge_kind_for_preset,
+        preferred_issue_launch_branch, resolve_project_target, should_auto_close_agent_window,
+        should_auto_start_restored_window, ActiveAgentSession, ProjectTabRuntime, WindowAddress,
     };
 
     fn sample_window(preset: WindowPreset, status: WindowProcessStatus) -> PersistedWindowState {
@@ -2514,6 +2657,37 @@ mod tests {
         assert!(!changed);
         assert_eq!(config.command, original_command);
         assert_eq!(config.args, original_args);
+    }
+
+    #[test]
+    fn build_shell_process_launch_for_host_uses_worktree_env() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo-feature");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let mut config = ShellLaunchConfig {
+            working_dir: Some(worktree.clone()),
+            branch: Some("feature/gui".to_string()),
+            base_branch: None,
+            display_name: "Shell".to_string(),
+            runtime_target: LaunchRuntimeTarget::Host,
+            docker_service: None,
+            docker_lifecycle_intent: DockerLifecycleIntent::Connect,
+            env_vars: HashMap::from([("EXTRA_FLAG".to_string(), "1".to_string())]),
+        };
+
+        let launch = build_shell_process_launch(&worktree, &mut config).expect("shell launch");
+
+        assert!(!launch.command.is_empty());
+        assert_eq!(launch.cwd.as_deref(), Some(worktree.as_path()));
+        assert_eq!(launch.env.get("EXTRA_FLAG").map(String::as_str), Some("1"));
+        assert_eq!(
+            launch.env.get("GWT_PROJECT_ROOT").map(String::as_str),
+            Some(worktree.display().to_string().as_str())
+        );
+        assert_eq!(
+            config.env_vars.get("GWT_PROJECT_ROOT").map(String::as_str),
+            Some(worktree.display().to_string().as_str())
+        );
     }
 
     #[test]
@@ -2947,27 +3121,30 @@ fn detect_wizard_docker_context_and_status(
     )
 }
 
-fn resolve_launch_worktree(
+fn resolve_launch_worktree_request(
     repo_path: &Path,
-    config: &mut gwt_agent::LaunchConfig,
+    branch_name: Option<&str>,
+    base_branch: Option<&str>,
+    working_dir: &mut Option<PathBuf>,
+    env_vars: &mut HashMap<String, String>,
 ) -> Result<(), String> {
-    let Some(branch_name) = config.branch.clone() else {
+    let Some(branch_name) = branch_name.map(str::to_string) else {
         return Ok(());
     };
-    if config.working_dir.is_some() {
+    if working_dir.is_some() {
         return Ok(());
     }
 
     let current_branch = current_git_branch(repo_path);
-    if current_branch.is_err() && config.base_branch.is_none() {
+    if current_branch.is_err() && base_branch.is_none() {
         return Ok(());
     }
     if current_branch
         .as_ref()
         .is_ok_and(|current| current == &branch_name)
     {
-        config.working_dir = Some(repo_path.to_path_buf());
-        config.env_vars.insert(
+        *working_dir = Some(repo_path.to_path_buf());
+        env_vars.insert(
             "GWT_PROJECT_ROOT".to_string(),
             repo_path.display().to_string(),
         );
@@ -2983,17 +3160,16 @@ fn resolve_launch_worktree(
         .find(|worktree| worktree.branch.as_deref() == Some(branch_name.as_str()))
         .map(|worktree| worktree.path.clone())
     {
-        config.working_dir = Some(existing_worktree.clone());
-        config.env_vars.insert(
+        *working_dir = Some(existing_worktree.clone());
+        env_vars.insert(
             "GWT_PROJECT_ROOT".to_string(),
             existing_worktree.display().to_string(),
         );
         return Ok(());
     }
 
-    let base_branch = config
-        .base_branch
-        .clone()
+    let base_branch = base_branch
+        .map(str::to_string)
         .unwrap_or_else(|| DEFAULT_NEW_BRANCH_BASE_BRANCH.to_string());
     let remote_base_ref = origin_remote_ref(&base_branch);
     let remote_branch_ref = origin_remote_ref(&branch_name);
@@ -3043,12 +3219,38 @@ fn resolve_launch_worktree(
             .map_err(|err| err.to_string())?;
     }
 
-    config.working_dir = Some(worktree_path.clone());
-    config.env_vars.insert(
+    *working_dir = Some(worktree_path.clone());
+    env_vars.insert(
         "GWT_PROJECT_ROOT".to_string(),
         worktree_path.display().to_string(),
     );
     Ok(())
+}
+
+fn resolve_launch_worktree(
+    repo_path: &Path,
+    config: &mut gwt_agent::LaunchConfig,
+) -> Result<(), String> {
+    resolve_launch_worktree_request(
+        repo_path,
+        config.branch.as_deref(),
+        config.base_branch.as_deref(),
+        &mut config.working_dir,
+        &mut config.env_vars,
+    )
+}
+
+fn resolve_shell_launch_worktree(
+    repo_path: &Path,
+    config: &mut ShellLaunchConfig,
+) -> Result<(), String> {
+    resolve_launch_worktree_request(
+        repo_path,
+        config.branch.as_deref(),
+        config.base_branch.as_deref(),
+        &mut config.working_dir,
+        &mut config.env_vars,
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -3127,6 +3329,58 @@ fn apply_docker_runtime_to_launch_config(
     );
     config.docker_service = Some(launch.service);
     Ok(())
+}
+
+fn build_shell_process_launch(
+    repo_path: &Path,
+    config: &mut ShellLaunchConfig,
+) -> Result<ProcessLaunch, String> {
+    let worktree = config
+        .working_dir
+        .clone()
+        .unwrap_or_else(|| repo_path.to_path_buf());
+    let mut env = spawn_env();
+    env.extend(config.env_vars.clone());
+
+    if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Docker {
+        let shell = detect_shell_program().map_err(|error| error.to_string())?;
+        env.entry("GWT_PROJECT_ROOT".to_string())
+            .or_insert_with(|| worktree.display().to_string());
+        config.env_vars = env.clone();
+        return Ok(ProcessLaunch {
+            command: shell.command,
+            args: shell.args,
+            env,
+            cwd: Some(worktree),
+        });
+    }
+
+    let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
+    ensure_docker_launch_runtime_ready()?;
+    ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
+    let shell_command = resolve_docker_shell_command(&launch)?;
+    env.insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
+    config.docker_service = Some(launch.service.clone());
+    config.env_vars = env.clone();
+
+    let mut args = vec![
+        "compose".to_string(),
+        "-f".to_string(),
+        launch.compose_file.display().to_string(),
+        "exec".to_string(),
+        "-w".to_string(),
+        launch.container_cwd.clone(),
+    ];
+    args.extend(docker_compose_exec_env_args(&env));
+    args.push(launch.service);
+    args.push(shell_command);
+
+    Ok(ProcessLaunch {
+        command: docker_binary_for_launch(),
+        args,
+        env,
+        cwd: Some(worktree),
+    })
 }
 
 fn apply_host_package_runner_fallback(config: &mut gwt_agent::LaunchConfig) -> bool {
@@ -3400,6 +3654,25 @@ fn strip_package_runner_args(args: &[String], version_spec: &str) -> Vec<String>
         return args[1..].to_vec();
     }
     args.to_vec()
+}
+
+fn resolve_docker_shell_command(launch: &DockerLaunchPlan) -> Result<String, String> {
+    for candidate in ["bash", "sh"] {
+        let available = gwt_docker::compose_service_has_command(
+            &launch.compose_file,
+            &launch.service,
+            candidate,
+        )
+        .map_err(|err| err.to_string())?;
+        if available {
+            return Ok(candidate.to_string());
+        }
+    }
+
+    Err(format!(
+        "Selected Docker runtime has no interactive shell in service '{}'",
+        launch.service
+    ))
 }
 
 fn ensure_docker_launch_command_ready(
@@ -3947,6 +4220,10 @@ fn main() -> wry::Result<()> {
             }
             Event::UserEvent(UserEvent::LaunchComplete { window_id, result }) => {
                 let events = app.handle_launch_complete(window_id, result);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::ShellLaunchComplete { window_id, result }) => {
+                let events = app.handle_shell_launch_complete(window_id, result);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::LaunchWizardHydrated { wizard_id, result }) => {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3446,62 +3446,87 @@
         {
           const section = createLaunchSection(
             "Launch",
-            "Choose the agent and default execution behavior.",
+            "Choose what to launch on the selected branch.",
           );
           const grid = createNode("div", "launch-form-grid");
           appendSelectField(
             grid,
-            "Agent",
-            launchWizard.agent_options || [],
-            launchWizard.selected_agent_id,
+            "Target",
+            launchWizard.launch_target_options || [],
+            launchWizard.selected_launch_target,
             (value) =>
               sendWizardAction({
-                kind: "set_agent",
-                agent_id: value,
+                kind: "set_launch_target",
+                target: value === "shell" ? "shell" : "agent",
               }),
           );
-          if ((launchWizard.model_options || []).length > 0) {
+          if (launchWizard.show_agent_settings) {
             appendSelectField(
               grid,
-              "Model",
-              launchWizard.model_options || [],
-              launchWizard.selected_model,
+              "Agent",
+              launchWizard.agent_options || [],
+              launchWizard.selected_agent_id,
               (value) =>
                 sendWizardAction({
-                  kind: "set_model",
-                  model: value,
+                  kind: "set_agent",
+                  agent_id: value,
                 }),
             );
-          }
-          if (launchWizard.show_reasoning) {
-            appendSelectField(
-              grid,
-              "Reasoning",
-              launchWizard.reasoning_options || [],
-              launchWizard.selected_reasoning,
-              (value) =>
-                sendWizardAction({
-                  kind: "set_reasoning",
-                  reasoning: value,
-                }),
+            if ((launchWizard.model_options || []).length > 0) {
+              appendSelectField(
+                grid,
+                "Model",
+                launchWizard.model_options || [],
+                launchWizard.selected_model,
+                (value) =>
+                  sendWizardAction({
+                    kind: "set_model",
+                    model: value,
+                  }),
+              );
+            }
+            if (launchWizard.show_reasoning) {
+              appendSelectField(
+                grid,
+                "Reasoning",
+                launchWizard.reasoning_options || [],
+                launchWizard.selected_reasoning,
+                (value) =>
+                  sendWizardAction({
+                    kind: "set_reasoning",
+                    reasoning: value,
+                  }),
+              );
+            }
+            if (launchWizard.show_execution_mode) {
+              appendSelectField(
+                grid,
+                "Execution mode",
+                launchWizard.execution_mode_options || [],
+                launchWizard.selected_execution_mode,
+                (value) =>
+                  sendWizardAction({
+                    kind: "set_execution_mode",
+                    mode: value,
+                  }),
+              );
+            }
+          } else {
+            const note = createLaunchField("Shell", true);
+            note.appendChild(
+              createNode(
+                "div",
+                "launch-note",
+                "Open a plain shell in the selected branch and runtime.",
+              ),
             );
+            grid.appendChild(note);
           }
-          appendSelectField(
-            grid,
-            "Execution mode",
-            launchWizard.execution_mode_options || [],
-            launchWizard.selected_execution_mode,
-            (value) =>
-              sendWizardAction({
-                kind: "set_execution_mode",
-                mode: value,
-              }),
-          );
           section.appendChild(grid);
           panel.appendChild(section);
         }
 
-        {
+        if (launchWizard.show_agent_settings) {
           const section = createLaunchSection(
             "Linked issue",
             "Optional: Link an issue to this launch session.",
@@ -3620,17 +3645,19 @@
                   }),
               );
             }
-            appendCheckboxField(
-              grid,
-              "Permissions",
-              "Skip permission prompts",
-              launchWizard.skip_permissions,
-              (enabled) =>
-                sendWizardAction({
-                  kind: "set_skip_permissions",
-                  enabled,
-                }),
-            );
+            if (launchWizard.show_skip_permissions) {
+              appendCheckboxField(
+                grid,
+                "Permissions",
+                "Skip permission prompts",
+                launchWizard.skip_permissions,
+                (enabled) =>
+                  sendWizardAction({
+                    kind: "set_skip_permissions",
+                    enabled,
+                  }),
+              );
+            }
             if (launchWizard.show_codex_fast_mode) {
               appendCheckboxField(
                 grid,


### PR DESCRIPTION
## Summary

- Add a `Target` selector to Launch Wizard so users can launch either an agent or a plain shell from the selected branch and worktree.
- Make Quick Start `Resume` and `Start new` execute immediately so relaunching a saved session no longer requires a second submit.
- Reuse the existing worktree and runtime resolution path for shell launches so host and Docker entrypoints stay consistent with agent launch behavior.

## Changes

- `crates/gwt/src/launch_wizard.rs`: add `LaunchTargetKind`, `ShellLaunchConfig`, `LaunchWizardLaunchRequest`, shell-aware view flags, direct Quick Start completion, and focused tests for shell/direct-launch flows.
- `crates/gwt/src/main.rs`: add shell launch completion handling, host and Docker shell process launch builders, Docker interactive-shell probing, and backend launch tests.
- `crates/gwt/src/lib.rs`: export the new launch wizard types across the GUI/backend boundary.
- `crates/gwt/web/index.html`: add the `Target` selector, hide agent-only controls for shell launches, and keep Quick Start buttons on the direct-launch path.

## Testing

- [x] `cargo fmt` — formatting completed without changes left over.
- [x] `cargo test -p gwt -- --nocapture` — Launch Wizard and backend tests passed.
- [x] `cargo test -p gwt-core -p gwt` — workspace test suites passed.
- [x] `cargo build -p gwt` — `gwt` built successfully.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no lint warnings remained.
- [x] `node --check %TEMP%\\gwt-launch-wizard-check.mjs` — extracted inline launch-wizard module parsed successfully.

## Closing Issues

- None

## Related Issues / Links

- #2014
- #1921
- https://github.com/akiojin/gwt/pull/925

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — README guidance was not updated in this slice because the request was limited to the launch flow implementation and PR preparation.
- [ ] Migration/backfill plan included (if schema/data change) — no schema change or persisted data migration is required for this feature.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This change follows the Launch Wizard work already merged in #925 and fills the remaining gap where the GUI could launch agents only.
- The implementation keeps one launch-completion contract across wizard state, frontend payloads, and backend window spawning so branch/runtime behavior does not fork between agent and shell paths.

## Risk / Impact

- **Affected areas**: Launch Wizard GUI, backend shell window spawning, Docker shell execution, Quick Start relaunch behavior.
- **Rollback plan**: Revert the feature commit on this branch before merge, or revert the merged PR if the new launch target flow regresses wizard behavior after release.

## Screenshots

| Before | After |
|--------|-------|
| Launch Wizard could only launch agents, and Quick Start restored settings before waiting for another submit. | Launch Wizard exposes a `Target` selector, hides agent-only fields for `Shell`, and Quick Start actions complete directly into focus or launch. |

## Notes

- SPEC sections for #2014 and #1921 were updated in the issue cache during implementation so reviewers can compare the code against the refreshed contract.
