### PR TITLE
feat: managed hookのforward互換移行を追加

### DIFF
--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -254,28 +254,37 @@ fn managed_hooks(target: ManagedHookTarget, shell: HookShell) -> Map<String, Val
         "SessionStart".to_string(),
         Value::Array(vec![
             runtime_hook("SessionStart", shell),
+            forward_hook(shell),
             coordination_hook("SessionStart", shell),
         ]),
     );
     hooks.insert(
         "UserPromptSubmit".to_string(),
-        Value::Array(vec![runtime_hook("UserPromptSubmit", shell)]),
+        Value::Array(vec![
+            runtime_hook("UserPromptSubmit", shell),
+            forward_hook(shell),
+        ]),
     );
     hooks.insert(
         "PreToolUse".to_string(),
         Value::Array(vec![
             runtime_hook("PreToolUse", shell),
+            forward_hook(shell),
             workflow_policy_hook(target),
         ]),
     );
     hooks.insert(
         "PostToolUse".to_string(),
-        Value::Array(vec![runtime_hook("PostToolUse", shell)]),
+        Value::Array(vec![
+            runtime_hook("PostToolUse", shell),
+            forward_hook(shell),
+        ]),
     );
     hooks.insert(
         "Stop".to_string(),
         Value::Array(vec![
             runtime_hook("Stop", shell),
+            forward_hook(shell),
             coordination_hook("Stop", shell),
         ]),
     );
@@ -300,6 +309,18 @@ fn coordination_hook(event: &str, shell: HookShell) -> Value {
         "hooks": [
             {
                 "command": coordination_hook_command(event, shell),
+                "type": CLAUDE_HOOK_COMMAND_TYPE,
+            }
+        ]
+    })
+}
+
+fn forward_hook(shell: HookShell) -> Value {
+    json!({
+        "matcher": "*",
+        "hooks": [
+            {
+                "command": forward_hook_command(shell),
                 "type": CLAUDE_HOOK_COMMAND_TYPE,
             }
         ]
@@ -399,6 +420,17 @@ fn coordination_hook_command(event: &str, shell: HookShell) -> String {
     }
 }
 
+fn forward_hook_command(shell: HookShell) -> String {
+    forward_hook_command_with_bin(&gwt_hook_bin_path(), shell)
+}
+
+fn forward_hook_command_with_bin(bin: &str, shell: HookShell) -> String {
+    match shell {
+        HookShell::Posix => posix_forward_hook_command_with_bin(bin),
+        HookShell::PowerShell => powershell_forward_hook_command_with_bin(bin),
+    }
+}
+
 fn workflow_policy_hook_command(shell: HookShell) -> String {
     workflow_policy_hook_command_with_bin(&gwt_hook_bin_path(), shell)
 }
@@ -425,6 +457,11 @@ fn posix_workflow_policy_hook_command_with_bin(bin: &str) -> String {
     format!("{bin} hook workflow-policy")
 }
 
+fn posix_forward_hook_command_with_bin(bin: &str) -> String {
+    let bin = posix_shell_quote(bin);
+    format!("{bin} hook forward")
+}
+
 fn posix_coordination_hook_command(event: &str) -> String {
     let bin = posix_shell_quote(&gwt_hook_bin_path());
     format!("{bin} hook coordination-event {event}")
@@ -444,6 +481,11 @@ fn powershell_workflow_policy_hook_command_with_bin(bin: &str) -> String {
     format!("powershell -NoProfile -Command \"& {{ & {bin} hook workflow-policy }}\"")
 }
 
+fn powershell_forward_hook_command_with_bin(bin: &str) -> String {
+    let bin = powershell_quote(bin);
+    format!("powershell -NoProfile -Command \"& {{ & {bin} hook forward }}\"")
+}
+
 fn powershell_coordination_hook_command(event: &str) -> String {
     let bin = powershell_quote(&gwt_hook_bin_path());
     format!("powershell -NoProfile -Command \"& {{ & {bin} hook coordination-event {event} }}\"")
@@ -454,6 +496,16 @@ mod tests {
     use std::process::Command;
 
     use super::*;
+
+    fn commands_for_event<'a>(value: &'a Value, event: &str) -> Vec<&'a str> {
+        value["hooks"][event]
+            .as_array()
+            .unwrap_or_else(|| panic!("hooks missing for event {event}"))
+            .iter()
+            .flat_map(|entry| entry["hooks"].as_array().into_iter().flatten())
+            .filter_map(|hook| hook["command"].as_str())
+            .collect()
+    }
 
     #[test]
     fn creates_settings_local_with_managed_hooks() {
@@ -466,11 +518,16 @@ mod tests {
         let content = fs::read_to_string(&path).unwrap();
         let value: Value = serde_json::from_str(&content).unwrap();
 
-        let command = value["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
-            .as_str()
-            .expect("command string");
-        assert!(command.contains(" hook runtime-state UserPromptSubmit"));
-        assert!(!command.contains("node"));
+        let user_prompt_commands = commands_for_event(&value, "UserPromptSubmit");
+        assert!(user_prompt_commands
+            .iter()
+            .any(|command| command.contains(" hook runtime-state UserPromptSubmit")));
+        assert!(user_prompt_commands
+            .iter()
+            .any(|command| command.contains(" hook forward")));
+        assert!(user_prompt_commands
+            .iter()
+            .all(|command| !command.contains("node")));
         assert!(value["hooks"]["SessionStart"].is_array());
         let session_start_hooks = value["hooks"]["SessionStart"]
             .as_array()
@@ -486,10 +543,13 @@ mod tests {
             "SessionStart must include a coordination-event hook"
         );
         assert!(value["hooks"].get("Notification").is_none());
-        assert_eq!(
-            value["hooks"]["PreToolUse"][1]["matcher"],
-            Value::String("*".to_string())
-        );
+        let pre_tool_commands = commands_for_event(&value, "PreToolUse");
+        assert!(pre_tool_commands
+            .iter()
+            .any(|command| command.contains(" hook workflow-policy")));
+        assert!(pre_tool_commands
+            .iter()
+            .any(|command| command.contains(" hook forward")));
     }
 
     // T-080 / T-082 (SPEC #1942): the Claude settings.local.json must
@@ -524,8 +584,11 @@ mod tests {
             "PostToolUse",
             "Stop",
         ] {
-            let cmd = value["hooks"][event][0]["hooks"][0]["command"]
-                .as_str()
+            let commands = commands_for_event(&value, event);
+            let cmd = commands
+                .iter()
+                .copied()
+                .find(|cmd| cmd.contains(&format!(" hook runtime-state {event}")))
                 .unwrap_or_else(|| panic!("runtime command missing for event {event}"));
             // SPEC #1942 amendment: runtime hook command embeds an
             // absolute path to gwt rather than the literal `gwt`.
@@ -549,6 +612,38 @@ mod tests {
                 !cmd.contains(" gwt hook "),
                 "runtime hook must not use the PATH-dependent literal `gwt`, got: {cmd}"
             );
+
+            let forward_commands: Vec<&str> = commands
+                .iter()
+                .copied()
+                .filter(|cmd| cmd.contains(" hook forward"))
+                .collect();
+            assert_eq!(
+                forward_commands.len(),
+                1,
+                "exactly one forward hook expected for {event}, got: {forward_commands:?}"
+            );
+            let forward = forward_commands[0];
+            assert!(
+                !forward.contains("gwtd"),
+                "forward hook must stay on the public gwt CLI, got: {forward}"
+            );
+            assert!(
+                !forward.contains("/internal/hook-live"),
+                "forward hook must not expose daemon endpoints, got: {forward}"
+            );
+            assert!(
+                !forward.contains("GWT_HOOK_FORWARD_URL"),
+                "forward hook must not expose transport env names, got: {forward}"
+            );
+            assert!(
+                !forward.contains("GWT_HOOK_FORWARD_TOKEN"),
+                "forward hook must not expose transport env names, got: {forward}"
+            );
+            assert!(
+                !forward.contains(" gwt hook "),
+                "forward hook must not use the PATH-dependent literal `gwt`, got: {forward}"
+            );
         }
 
         for event in ["SessionStart", "Stop"] {
@@ -569,12 +664,9 @@ mod tests {
 
         // T-080 + SPEC #1942 amendment: workflow-policy hooks dispatch
         // through absolute path `'<bin>' hook workflow-policy`.
-        let pre_tool_block_hooks = value["hooks"]["PreToolUse"][1]["hooks"]
-            .as_array()
-            .expect("workflow policy hooks array");
-        let actual: Vec<&str> = pre_tool_block_hooks
-            .iter()
-            .map(|h| h["command"].as_str().unwrap_or(""))
+        let actual: Vec<&str> = commands_for_event(&value, "PreToolUse")
+            .into_iter()
+            .filter(|command| command.contains(" hook workflow-policy"))
             .collect();
         assert_eq!(
             actual.len(),
@@ -643,6 +735,14 @@ mod tests {
             "exactly one workflow-policy entry expected, got {}: {:?}",
             workflow_entries.len(),
             workflow_entries
+        );
+        let forward_count = commands_for_event(&value, "PreToolUse")
+            .iter()
+            .filter(|command| command.contains(" hook forward"))
+            .count();
+        assert_eq!(
+            forward_count, 1,
+            "exactly one forward entry expected in PreToolUse after regeneration"
         );
     }
 
@@ -931,17 +1031,27 @@ mod tests {
         let path = dir.path().join(".codex/hooks.json");
         let content = fs::read_to_string(&path).unwrap();
         let value: Value = serde_json::from_str(&content).unwrap();
-        let command = value["hooks"]["SessionStart"][0]["hooks"][0]["command"]
-            .as_str()
-            .expect("command string");
+        let session_start_commands = commands_for_event(&value, "SessionStart");
+        let pre_tool_commands = commands_for_event(&value, "PreToolUse");
 
-        assert!(command.contains(" hook runtime-state SessionStart"));
-        assert!(!command.contains("GWT_MANAGED_HOOK"));
-        assert!(!command.contains("node"));
-        assert_eq!(
-            value["hooks"]["PreToolUse"][1]["matcher"],
-            Value::String("*".to_string())
-        );
+        assert!(session_start_commands
+            .iter()
+            .any(|command| command.contains(" hook runtime-state SessionStart")));
+        assert!(session_start_commands
+            .iter()
+            .any(|command| command.contains(" hook forward")));
+        assert!(session_start_commands
+            .iter()
+            .all(|command| !command.contains("GWT_MANAGED_HOOK")));
+        assert!(session_start_commands
+            .iter()
+            .all(|command| !command.contains("node")));
+        assert!(pre_tool_commands
+            .iter()
+            .any(|command| command.contains(" hook workflow-policy")));
+        assert!(pre_tool_commands
+            .iter()
+            .any(|command| command.contains(" hook forward")));
     }
 
     #[test]
@@ -1129,22 +1239,23 @@ mod tests {
 
         let content = fs::read_to_string(&path).unwrap();
         let value: Value = serde_json::from_str(&content).unwrap();
-        let session_start_command = value["hooks"]["SessionStart"][0]["hooks"][0]["command"]
-            .as_str()
-            .expect("session start command");
-        let pre_tool_commands: Vec<&str> = value["hooks"]["PreToolUse"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .flat_map(|entry| entry["hooks"].as_array().unwrap().iter())
-            .filter_map(|hook| hook["command"].as_str())
-            .collect();
+        let session_start_commands = commands_for_event(&value, "SessionStart");
+        let pre_tool_commands = commands_for_event(&value, "PreToolUse");
 
-        assert!(session_start_command.contains(" hook runtime-state SessionStart"));
-        assert!(!session_start_command.contains("GWT_MANAGED_HOOK"));
+        assert!(session_start_commands
+            .iter()
+            .any(|command| command.contains(" hook forward")));
+        assert!(session_start_commands
+            .iter()
+            .all(|command| !command.contains("GWT_MANAGED_HOOK")));
         assert!(!content.contains("hooks/scripts/gwt-"));
-        assert!(!session_start_command.contains("node"));
+        assert!(session_start_commands
+            .iter()
+            .all(|command| !command.contains("node")));
         assert!(pre_tool_commands.contains(&"my-custom-hook"));
+        assert!(pre_tool_commands
+            .iter()
+            .any(|command| command.contains(" hook forward")));
         assert!(pre_tool_commands
             .iter()
             .any(|command| command.contains(" hook workflow-policy")));
@@ -1332,6 +1443,131 @@ mod tests {
         assert!(stop_commands.contains(&"my-custom-hook"));
     }
 
+    #[test]
+    fn generate_codex_hooks_migrates_tracked_hooks_missing_forward_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".codex/hooks.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "command": runtime_hook_command("SessionStart", managed_hook_shell()),
+                                    "type": "command"
+                                },
+                                {
+                                    "command": coordination_hook_command("SessionStart", managed_hook_shell()),
+                                    "type": "command"
+                                }
+                            ]
+                        }
+                    ],
+                    "UserPromptSubmit": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "command": runtime_hook_command("UserPromptSubmit", managed_hook_shell()),
+                                    "type": "command"
+                                }
+                            ]
+                        }
+                    ],
+                    "PreToolUse": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "command": runtime_hook_command("PreToolUse", managed_hook_shell()),
+                                    "type": "command"
+                                }
+                            ]
+                        },
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "command": workflow_policy_hook_command(managed_hook_shell()),
+                                    "type": "command"
+                                },
+                                {
+                                    "command": "my-custom-hook",
+                                    "type": "command"
+                                }
+                            ]
+                        }
+                    ],
+                    "PostToolUse": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "command": runtime_hook_command("PostToolUse", managed_hook_shell()),
+                                    "type": "command"
+                                }
+                            ]
+                        }
+                    ],
+                    "Stop": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "command": runtime_hook_command("Stop", managed_hook_shell()),
+                                    "type": "command"
+                                },
+                                {
+                                    "command": coordination_hook_command("Stop", managed_hook_shell()),
+                                    "type": "command"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert!(Command::new("git")
+            .arg("init")
+            .arg(dir.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .arg("add")
+            .arg(".codex/hooks.json")
+            .status()
+            .unwrap()
+            .success());
+
+        generate_codex_hooks(dir.path()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        for event in MANAGED_EVENT_ORDER {
+            let commands = commands_for_event(&value, event);
+            let forward_count = commands
+                .iter()
+                .filter(|command| command.contains(" hook forward"))
+                .count();
+            assert_eq!(
+                forward_count, 1,
+                "migration must restore exactly one forward hook for {event}, got: {commands:?}"
+            );
+        }
+        assert!(commands_for_event(&value, "PreToolUse").contains(&"my-custom-hook"));
+        assert!(!content.contains("gwtd"));
+    }
+
     // SPEC #1942 T-083: the inline POSIX shell JSON writer has been
     // replaced by a single `gwt hook runtime-state <event>` CLI call.
     // The sidecar-write behaviour is now covered end-to-end by
@@ -1437,12 +1673,27 @@ mod tests {
     }
 
     #[test]
+    fn forward_hook_command_matches_shell_shape() {
+        assert_eq!(
+            forward_hook_command_with_bin("gwt", HookShell::Posix),
+            "'gwt' hook forward"
+        );
+        assert_eq!(
+            forward_hook_command_with_bin("gwt", HookShell::PowerShell),
+            "powershell -NoProfile -Command \"& { & 'gwt' hook forward }\""
+        );
+    }
+
+    #[test]
     fn is_gwt_managed_command_recognizes_absolute_path_form() {
         assert!(is_gwt_managed_command(
             "'/Users/x/.bun/bin/gwt' hook workflow-policy"
         ));
         assert!(is_gwt_managed_command(
             "'/Users/x/.bun/bin/gwt' hook runtime-state PreToolUse"
+        ));
+        assert!(is_gwt_managed_command(
+            "'/Users/x/.bun/bin/gwt' hook forward"
         ));
         // Negative: unrelated `hook` substring must not match.
         assert!(!is_gwt_managed_command("echo 'fish hook ornament'"));

--- a/crates/gwt/src/cli/hook/forward.rs
+++ b/crates/gwt/src/cli/hook/forward.rs
@@ -1,9 +1,9 @@
-//! `gwt hook forward` — stub.
+//! `gwt hook forward` payload parser.
 //!
-//! A follow-up SPEC will wire Claude Code hook events through to other
-//! consumers (another gwt session, external IDE
-//! listeners, etc). Until then this handler is a silent no-op that
-//! exits 0, so settings_local.rs can reference it without breakage.
+//! The public CLI surface stays fail-open and only drains/parses the hook
+//! payload. Runtime fanout to the daemon-owned live event bridge is layered in
+//! `crate::daemon_runtime`, so this module remains a no-op on malformed or
+//! absent input.
 
 use super::{HookError, HookEvent};
 use std::io::Read;

--- a/crates/gwt/tests/daemon_runtime_hook_test.rs
+++ b/crates/gwt/tests/daemon_runtime_hook_test.rs
@@ -43,6 +43,13 @@ impl EnvGuard {
         }
         std::env::set_var(key, value.into());
     }
+
+    fn unset(&mut self, key: &'static str) {
+        if !self.saved.iter().any(|(saved, _)| *saved == key) {
+            self.saved.push((key, std::env::var_os(key)));
+        }
+        std::env::remove_var(key);
+    }
 }
 
 impl Drop for EnvGuard {
@@ -281,4 +288,50 @@ fn forward_owner_forwards_live_event_to_loopback_target() {
     assert_eq!(payload["gwt_session_id"], session.id);
     assert_eq!(payload["agent_session_id"], "agent-session-2");
     assert_eq!(payload["tool_name"], "Bash");
+}
+
+#[test]
+fn forward_owner_is_fail_open_without_live_target_env() {
+    let _lock = env_lock();
+    let mut env = EnvGuard::new();
+    env.unset("GWT_HOOK_FORWARD_URL");
+    env.unset("GWT_HOOK_FORWARD_TOKEN");
+
+    let input = serde_json::json!({
+        "session_id": "agent-session-missing-target",
+        "cwd": "E:/gwt/feature/gwt-cli",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "echo ok"
+        }
+    })
+    .to_string();
+
+    handle_forward(&input).expect("missing live target env must fail open");
+}
+
+#[test]
+fn forward_owner_is_fail_open_when_live_target_is_unreachable() {
+    let _lock = env_lock();
+    let mut env = EnvGuard::new();
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve loopback port");
+    let port = listener.local_addr().expect("listener addr").port();
+    drop(listener);
+    env.set(
+        "GWT_HOOK_FORWARD_URL",
+        format!("http://127.0.0.1:{port}/hook-live"),
+    );
+    env.set("GWT_HOOK_FORWARD_TOKEN", "secret-token");
+
+    let input = serde_json::json!({
+        "session_id": "agent-session-unreachable-target",
+        "cwd": "E:/gwt/feature/gwt-cli",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "echo ok"
+        }
+    })
+    .to_string();
+
+    handle_forward(&input).expect("unreachable live target must fail open");
 }


### PR DESCRIPTION
## Summary
- add managed `gwt hook forward` generation for Claude/Codex hook configs
- converge tracked legacy and stale hook entries onto the public `gwt hook ...` surface without duplicates
- add fail-open coverage for missing or unreachable daemon live-event targets

## Verification
- cargo fmt
- cargo test -p gwt-skills -p gwt-core -p gwt
- cargo build -p gwt
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- npx -y markdownlint-cli README.md README.ja.md

## Spec
- SPEC-2077 Phase 4 (T-030..T-033)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forward hooks now generated for managed hook events (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop) alongside existing runtime and coordination hooks.

* **Documentation**
  * Updated forward hook handler documentation to describe payload parsing behavior.

* **Tests**
  * Added validation tests for forward hook fail-open behavior when environment variables or endpoints are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->