### PR TITLE
feat: gwtとgwtdのbundle配布を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,31 +90,26 @@ jobs:
           - platform: linux-x86_64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            binary: gwt
             release_name: gwt-linux-x86_64
             archive_name: gwt-linux-x86_64.tar.gz
           - platform: linux-aarch64
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            binary: gwt
             release_name: gwt-linux-aarch64
             archive_name: gwt-linux-aarch64.tar.gz
           - platform: macos-x86_64
             os: macos-14
             target: x86_64-apple-darwin
-            binary: gwt
             release_name: gwt-macos-x86_64
             archive_name: gwt-macos-x86_64.tar.gz
           - platform: macos-aarch64
             os: macos-14
             target: aarch64-apple-darwin
-            binary: gwt
             release_name: gwt-macos-arm64
             archive_name: gwt-macos-arm64.tar.gz
           - platform: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary: gwt.exe
             release_name: gwt-windows-x86_64
             archive_name: gwt-windows-x86_64.zip
     steps:
@@ -130,25 +125,27 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
-      - name: Build gwt binary
-        run: cargo build --release -p gwt --target ${{ matrix.target }}
+      - name: Build gwt bundle binaries
+        run: cargo build --release -p gwt --target ${{ matrix.target }} --bin gwt --bin gwtd
       - name: Prepare artifact (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
-          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist/${{ matrix.binary }}"
-          Compress-Archive -Path "dist/${{ matrix.binary }}" -DestinationPath "dist/${{ matrix.archive_name }}" -Force
-          Remove-Item "dist/${{ matrix.binary }}"
+          Copy-Item "target/${{ matrix.target }}/release/gwt.exe" "dist/gwt.exe"
+          Copy-Item "target/${{ matrix.target }}/release/gwtd.exe" "dist/gwtd.exe"
+          Compress-Archive -Path @("dist/gwt.exe", "dist/gwtd.exe") -DestinationPath "dist/${{ matrix.archive_name }}" -Force
+          Remove-Item "dist/gwt.exe", "dist/gwtd.exe"
       - name: Prepare artifact (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |
           mkdir -p dist
           cd dist
-          cp ../target/${{ matrix.target }}/release/${{ matrix.binary }} .
-          tar -czf ${{ matrix.archive_name }} ${{ matrix.binary }}
-          rm ${{ matrix.binary }}
+          cp ../target/${{ matrix.target }}/release/gwt .
+          cp ../target/${{ matrix.target }}/release/gwtd .
+          tar -czf ${{ matrix.archive_name }} gwt gwtd
+          rm gwt gwtd
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -172,8 +169,8 @@ jobs:
       - name: Install WiX Toolset
         run: |
           dotnet tool install --global wix --version 6.0.2
-      - name: Build gwt binary
-        run: cargo build --release -p gwt --target x86_64-pc-windows-msvc
+      - name: Build gwt bundle binaries
+        run: cargo build --release -p gwt --target x86_64-pc-windows-msvc --bin gwt --bin gwtd
       - name: Build MSI
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
@@ -198,17 +195,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: gwt-dmg
-      - name: Build gwt for aarch64
-        run: cargo build --release -p gwt --target aarch64-apple-darwin
-      - name: Build gwt for x86_64
-        run: cargo build --release -p gwt --target x86_64-apple-darwin
-      - name: Create universal binary
+      - name: Build gwt bundle binaries for aarch64
+        run: cargo build --release -p gwt --target aarch64-apple-darwin --bin gwt --bin gwtd
+      - name: Build gwt bundle binaries for x86_64
+        run: cargo build --release -p gwt --target x86_64-apple-darwin --bin gwt --bin gwtd
+      - name: Create universal binaries
         run: |
           mkdir -p dist
           lipo -create \
             target/aarch64-apple-darwin/release/gwt \
             target/x86_64-apple-darwin/release/gwt \
             -output dist/gwt
+          lipo -create \
+            target/aarch64-apple-darwin/release/gwtd \
+            target/x86_64-apple-darwin/release/gwtd \
+            -output dist/gwtd
       - name: Create app bundle
         run: |
           mkdir -p dist/GWT.app/Contents/MacOS
@@ -235,7 +236,9 @@ jobs:
           </plist>
           EOF
           cp dist/gwt dist/GWT.app/Contents/MacOS/gwt
+          cp dist/gwtd dist/GWT.app/Contents/MacOS/gwtd
           chmod +x dist/GWT.app/Contents/MacOS/gwt
+          chmod +x dist/GWT.app/Contents/MacOS/gwtd
       - name: Create DMG
         run: |
           mkdir -p dmg_temp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run Windows PTY regression tests
         run: cargo test -p gwt-core terminal::pty
+        timeout-minutes: 15
+      - name: Run release asset contract tests
+        run: node scripts/test_release_assets.cjs
         timeout-minutes: 15

--- a/bin/gwt.cjs
+++ b/bin/gwt.cjs
@@ -10,6 +10,7 @@ const path = require("path");
 const fs = require("fs");
 
 const {
+  bundleBinaryNamesForPlatform,
   binaryNameForPlatform,
   installReleaseBinary,
   releaseAssetUrl,
@@ -19,6 +20,7 @@ const REPO = "akiojin/gwt";
 const BIN_DIR = __dirname;
 const BIN_NAME = binaryNameForPlatform(process.platform);
 const BIN_PATH = path.join(BIN_DIR, BIN_NAME);
+const BUNDLE_BINARIES = bundleBinaryNamesForPlatform(process.platform);
 
 function readVersion() {
   const pkg = path.join(__dirname, "..", "package.json");
@@ -26,24 +28,25 @@ function readVersion() {
 }
 
 async function ensureBinary() {
-  if (fs.existsSync(BIN_PATH)) return;
+  if (BUNDLE_BINARIES.every((name) => fs.existsSync(path.join(BIN_DIR, name)))) {
+    return;
+  }
 
   const version = readVersion();
   const { url } = releaseAssetUrl(REPO, version, process.platform, process.arch);
 
-  console.log(`Downloading gwt binary for ${process.platform}-${process.arch}...`);
+  console.log(`Downloading gwt bundle for ${process.platform}-${process.arch}...`);
   console.log(`Downloading from: ${url}`);
 
   await installReleaseBinary({
     repo: REPO,
     version,
     binDir: BIN_DIR,
-    binaryName: BIN_NAME,
     platform: process.platform,
     arch: process.arch,
   });
 
-  console.log("gwt binary installed successfully!");
+  console.log(`gwt bundle installed successfully: ${BUNDLE_BINARIES.join(", ")}`);
 }
 
 async function main() {

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -371,12 +371,10 @@ impl UpdateManager {
             extract_archive(&dest, &extract_dir)?;
             let platform = Platform::detect();
             let binary_name = platform.binary_name();
-            let Some(binary_path) = find_extracted_binary(&extract_dir, &binary_name)? else {
-                return Err(format!(
-                    "Extracted payload does not contain expected binary: {binary_name}"
-                ));
-            };
+            let (binary_path, daemon_path) =
+                find_extracted_bundle_binaries(&extract_dir, &binary_name)?;
             ensure_executable(&binary_path)?;
+            ensure_executable(&daemon_path)?;
             return Ok(PreparedPayload::PortableBinary { path: binary_path });
         }
 
@@ -588,7 +586,7 @@ pub fn internal_apply_update(
 ) -> Result<(), String> {
     wait_for_pid_exit(old_pid, Duration::from_secs(300))?;
     let args = UpdateManager::read_restart_args_file(args_file)?;
-    replace_executable(target_exe, source_exe)?;
+    replace_bundle_executables(target_exe, source_exe)?;
 
     std::process::Command::new(target_exe)
         .args(args)
@@ -964,6 +962,26 @@ fn find_extracted_binary(extract_dir: &Path, binary_name: &str) -> Result<Option
     Ok(None)
 }
 
+fn find_extracted_bundle_binaries(
+    extract_dir: &Path,
+    primary_binary_name: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    let Some(primary_path) = find_extracted_binary(extract_dir, primary_binary_name)? else {
+        return Err(format!(
+            "Extracted payload does not contain expected binary: {primary_binary_name}"
+        ));
+    };
+
+    let daemon_binary_name = companion_binary_name(primary_binary_name);
+    let Some(daemon_path) = find_extracted_binary(extract_dir, &daemon_binary_name)? else {
+        return Err(format!(
+            "Extracted payload does not contain expected daemon binary: {daemon_binary_name}"
+        ));
+    };
+
+    Ok((primary_path, daemon_path))
+}
+
 fn ensure_executable(_path: &Path) -> Result<(), String> {
     #[cfg(unix)]
     {
@@ -1270,10 +1288,67 @@ fn run_windows_msi_with_uac(installer: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn replace_executable(target_exe: &Path, source_exe: &Path) -> Result<(), String> {
+#[derive(Debug, Clone)]
+struct PlannedReplacement {
+    target: PathBuf,
+    backup: PathBuf,
+    tmp: PathBuf,
+    had_target: bool,
+}
+
+fn replace_bundle_executables(target_exe: &Path, source_exe: &Path) -> Result<(), String> {
+    let target_daemon = companion_binary_path(target_exe)?;
+    let source_daemon = companion_binary_path(source_exe)?;
+    replace_executables_with_retry(&[
+        (target_daemon.as_path(), source_daemon.as_path()),
+        (target_exe, source_exe),
+    ])
+}
+
+fn replace_executables_with_retry(pairs: &[(&Path, &Path)]) -> Result<(), String> {
+    // Windows: file replacement can fail while the parent app is still shutting down.
+    const MAX_RETRIES: usize = 200;
+    const SLEEP_MS: u64 = 50;
+
+    for attempt in 0..MAX_RETRIES {
+        let replacements = stage_replacement_plan(pairs)?;
+        match apply_replacement_plan(&replacements) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                if attempt + 1 == MAX_RETRIES {
+                    return Err(e);
+                }
+                std::thread::sleep(Duration::from_millis(SLEEP_MS));
+            }
+        }
+    }
+
+    Err("Failed to replace executable".to_string())
+}
+
+fn companion_binary_name(primary_binary_name: &str) -> String {
+    if primary_binary_name.ends_with(".exe") {
+        "gwtd.exe".to_string()
+    } else {
+        "gwtd".to_string()
+    }
+}
+
+fn companion_binary_path(primary_binary_path: &Path) -> Result<PathBuf, String> {
+    let file_name = primary_binary_path
+        .file_name()
+        .and_then(OsStr::to_str)
+        .ok_or_else(|| "Target executable has invalid filename".to_string())?;
+    Ok(primary_binary_path.with_file_name(companion_binary_name(file_name)))
+}
+
+fn stage_replacement(target_exe: &Path, source_exe: &Path) -> Result<PlannedReplacement, String> {
     let source_meta = fs::metadata(source_exe).map_err(|e| format!("Source missing: {e}"))?;
     if source_meta.len() == 0 {
-        return Err("Source executable is empty".to_string());
+        return Err(format!(
+            "Source executable is empty: {}",
+            source_exe.display()
+        ));
     }
 
     let target_dir = target_exe
@@ -1282,7 +1357,11 @@ fn replace_executable(target_exe: &Path, source_exe: &Path) -> Result<(), String
     fs::create_dir_all(target_dir)
         .map_err(|e| format!("Failed to ensure target dir exists: {e}"))?;
 
-    let tmp_name = format!(".gwt-update-{}.tmp", std::process::id());
+    let file_name = target_exe
+        .file_name()
+        .and_then(OsStr::to_str)
+        .ok_or_else(|| "Target executable has invalid filename".to_string())?;
+    let tmp_name = format!(".{file_name}.gwt-update-{}.tmp", std::process::id());
     let tmp_path = target_dir.join(tmp_name);
     let _ = fs::remove_file(&tmp_path);
     fs::copy(source_exe, &tmp_path).map_err(|e| format!("Failed to copy new executable: {e}"))?;
@@ -1301,31 +1380,66 @@ fn replace_executable(target_exe: &Path, source_exe: &Path) -> Result<(), String
         let _ = fs::set_permissions(&tmp_path, perms);
     }
 
-    let file_name = target_exe
-        .file_name()
-        .and_then(OsStr::to_str)
-        .ok_or_else(|| "Target executable has invalid filename".to_string())?;
     let backup_path = target_dir.join(format!("{file_name}.old"));
     let _ = fs::remove_file(&backup_path);
 
-    // Windows: file replacement can fail while the parent app is still shutting down.
-    const MAX_RETRIES: usize = 200;
-    const SLEEP_MS: u64 = 50;
+    Ok(PlannedReplacement {
+        target: target_exe.to_path_buf(),
+        backup: backup_path,
+        tmp: tmp_path,
+        had_target: target_exe.exists(),
+    })
+}
 
-    for attempt in 0..MAX_RETRIES {
-        match replace_paths(target_exe, &backup_path, &tmp_path) {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                if attempt + 1 == MAX_RETRIES {
-                    let _ = fs::remove_file(&tmp_path);
-                    return Err(format!("Failed to replace executable: {e}"));
-                }
-                std::thread::sleep(Duration::from_millis(SLEEP_MS));
+fn stage_replacement_plan(pairs: &[(&Path, &Path)]) -> Result<Vec<PlannedReplacement>, String> {
+    let mut staged = Vec::with_capacity(pairs.len());
+    for (target, source) in pairs {
+        match stage_replacement(target, source) {
+            Ok(replacement) => staged.push(replacement),
+            Err(err) => {
+                cleanup_staged_replacements(&staged);
+                return Err(err);
             }
         }
     }
+    Ok(staged)
+}
 
-    Err("Failed to replace executable".to_string())
+fn cleanup_staged_replacements(replacements: &[PlannedReplacement]) {
+    for replacement in replacements {
+        let _ = fs::remove_file(&replacement.tmp);
+    }
+}
+
+fn rollback_applied_replacements(replacements: &[PlannedReplacement]) {
+    for replacement in replacements.iter().rev() {
+        let _ = fs::remove_file(&replacement.target);
+        if replacement.had_target && replacement.backup.exists() {
+            let _ = fs::rename(&replacement.backup, &replacement.target);
+        }
+    }
+}
+
+fn apply_replacement_plan(replacements: &[PlannedReplacement]) -> Result<(), String> {
+    apply_replacement_plan_with(replacements, replace_paths)
+}
+
+fn apply_replacement_plan_with<F>(
+    replacements: &[PlannedReplacement],
+    mut replace_one: F,
+) -> Result<(), String>
+where
+    F: FnMut(&Path, &Path, &Path) -> io::Result<()>,
+{
+    for (idx, replacement) in replacements.iter().enumerate() {
+        if let Err(err) = replace_one(&replacement.target, &replacement.backup, &replacement.tmp) {
+            let _ = fs::remove_file(&replacement.tmp);
+            cleanup_staged_replacements(&replacements[idx + 1..]);
+            rollback_applied_replacements(&replacements[..idx]);
+            return Err(format!("Failed to replace executable: {err}"));
+        }
+    }
+    Ok(())
 }
 
 fn replace_paths(target_exe: &Path, backup_path: &Path, tmp_path: &Path) -> io::Result<()> {
@@ -1579,6 +1693,62 @@ mod tests {
 
         let url = find_installer_asset_url(&platform, &assets);
         assert_eq!(url.as_deref(), Some("https://example.com/macos-arm64.dmg"));
+    }
+
+    #[test]
+    fn find_extracted_bundle_binaries_requires_primary_and_daemon() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("gwt"), b"bundle-gwt").unwrap();
+
+        let err = find_extracted_bundle_binaries(temp.path(), "gwt")
+            .expect_err("bundle without gwtd companion must fail");
+        assert!(
+            err.contains("gwtd"),
+            "missing daemon companion must be named in the error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn apply_replacement_plan_rolls_back_when_later_bundle_swap_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let install_dir = temp.path().join("install");
+        let bundle_dir = temp.path().join("bundle");
+        fs::create_dir_all(&install_dir).unwrap();
+        fs::create_dir_all(&bundle_dir).unwrap();
+
+        let target_gwt = install_dir.join("gwt");
+        let target_gwtd = install_dir.join("gwtd");
+        let source_gwt = bundle_dir.join("gwt");
+        let source_gwtd = bundle_dir.join("gwtd");
+
+        fs::write(&target_gwt, b"old-gwt").unwrap();
+        fs::write(&target_gwtd, b"old-gwtd").unwrap();
+        fs::write(&source_gwt, b"new-gwt").unwrap();
+        fs::write(&source_gwtd, b"new-gwtd").unwrap();
+
+        let replacements = stage_replacement_plan(&[
+            (target_gwt.as_path(), source_gwt.as_path()),
+            (target_gwtd.as_path(), source_gwtd.as_path()),
+        ])
+        .expect("stage bundle replacements");
+
+        let mut calls = 0usize;
+        let err = apply_replacement_plan_with(&replacements, |target, backup, tmp| {
+            calls += 1;
+            if calls == 1 {
+                replace_paths(target, backup, tmp)
+            } else {
+                Err(io::Error::other("simulated second swap failure"))
+            }
+        })
+        .expect_err("second replacement failure must bubble up");
+
+        assert!(
+            err.contains("simulated second swap failure"),
+            "expected injected failure, got: {err}"
+        );
+        assert_eq!(fs::read_to_string(&target_gwt).unwrap(), "old-gwt");
+        assert_eq!(fs::read_to_string(&target_gwtd).unwrap(), "old-gwtd");
     }
 
     #[cfg(unix)]

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -13,6 +13,10 @@ default-run = "gwt"
 name = "gwt"
 path = "src/main.rs"
 
+[[bin]]
+name = "gwtd"
+path = "src/bin/gwtd.rs"
+
 [dependencies]
 gwt-agent.workspace = true
 gwt-core.workspace = true

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -1,0 +1,15 @@
+fn main() {
+    let arg = std::env::args().nth(1);
+    match arg.as_deref() {
+        Some("-V") | Some("--version") | Some("version") => {
+            println!("gwtd {}", env!("CARGO_PKG_VERSION"));
+        }
+        Some("-h") | Some("--help") => {
+            println!("gwtd {}", env!("CARGO_PKG_VERSION"));
+            println!("Internal runtime daemon binary. Launch `gwt` instead.");
+        }
+        _ => {
+            println!("gwtd is reserved for internal runtime daemon use. Launch `gwt` instead.");
+        }
+    }
+}

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -5,14 +5,14 @@ const fs = require("fs");
 const path = require("path");
 
 const {
-  binaryNameForPlatform,
+  bundleBinaryNamesForPlatform,
   installReleaseBinary,
   releaseAssetUrl,
 } = require("./release-assets.cjs");
 
 const REPO = "akiojin/gwt";
 const BIN_DIR = path.join(__dirname, "..", "bin");
-const BINARY_NAME = binaryNameForPlatform();
+const BUNDLE_BINARIES = bundleBinaryNamesForPlatform();
 
 function readVersion() {
   const pkg = path.join(__dirname, "..", "package.json");
@@ -29,7 +29,7 @@ async function main() {
   const version = readVersion();
   const { url } = releaseAssetUrl(REPO, version);
 
-  console.log(`Downloading gwt binary for ${process.platform}-${process.arch}...`);
+  console.log(`Downloading gwt bundle for ${process.platform}-${process.arch}...`);
   console.log(`Downloading from: ${url}`);
 
   try {
@@ -37,9 +37,8 @@ async function main() {
       repo: REPO,
       version,
       binDir: BIN_DIR,
-      binaryName: BINARY_NAME,
     });
-    console.log("gwt binary installed successfully!");
+    console.log(`gwt bundle installed successfully: ${BUNDLE_BINARIES.join(", ")}`);
   } catch (err) {
     console.error(`gwt: failed to download binary - ${err.message}`);
     console.error("gwt: you can build from source with: cargo build --release -p gwt");

--- a/scripts/release-assets.cjs
+++ b/scripts/release-assets.cjs
@@ -8,6 +8,14 @@ function binaryNameForPlatform(platform = os.platform()) {
   return platform === "win32" ? "gwt.exe" : "gwt";
 }
 
+function daemonBinaryNameForPlatform(platform = os.platform()) {
+  return platform === "win32" ? "gwtd.exe" : "gwtd";
+}
+
+function bundleBinaryNamesForPlatform(platform = os.platform()) {
+  return [binaryNameForPlatform(platform), daemonBinaryNameForPlatform(platform)];
+}
+
 function releaseAssetName(platform = os.platform(), arch = os.arch()) {
   if (platform === "darwin" && arch === "arm64") {
     return "gwt-macos-arm64.tar.gz";
@@ -120,16 +128,15 @@ function cleanupTempDir(tempRoot) {
   }
 }
 
-function installBinaryFromArchive({
+function installBundleFromArchive({
   archivePath,
   asset,
   binDir,
-  binaryName = binaryNameForPlatform(),
   platform = os.platform(),
+  binaryNames = bundleBinaryNamesForPlatform(platform),
 }) {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gwt-extract-"));
   const extractDir = path.join(tempRoot, "extract");
-  const dest = path.join(binDir, binaryName);
 
   fs.mkdirSync(binDir, { recursive: true });
   fs.mkdirSync(extractDir, { recursive: true });
@@ -137,17 +144,22 @@ function installBinaryFromArchive({
   try {
     extractArchive(archivePath, extractDir, asset);
 
-    const extractedBinary = findFileRecursive(extractDir, binaryName);
-    if (!extractedBinary) {
-      throw new Error(`Extracted archive does not contain ${binaryName}`);
+    const destinations = {};
+    for (const binaryName of binaryNames) {
+      const extractedBinary = findFileRecursive(extractDir, binaryName);
+      if (!extractedBinary) {
+        throw new Error(`Extracted archive does not contain ${binaryName}`);
+      }
+
+      const dest = path.join(binDir, binaryName);
+      fs.copyFileSync(extractedBinary, dest);
+      if (platform !== "win32") {
+        fs.chmodSync(dest, 0o755);
+      }
+      destinations[binaryName] = dest;
     }
 
-    fs.copyFileSync(extractedBinary, dest);
-    if (platform !== "win32") {
-      fs.chmodSync(dest, 0o755);
-    }
-
-    return { asset, dest };
+    return { asset, destinations };
   } finally {
     cleanupTempDir(tempRoot);
   }
@@ -157,7 +169,6 @@ async function installReleaseBinary({
   repo,
   version,
   binDir,
-  binaryName = binaryNameForPlatform(),
   platform = os.platform(),
   arch = os.arch(),
 }) {
@@ -167,11 +178,10 @@ async function installReleaseBinary({
 
   try {
     await download(url, archivePath);
-    return installBinaryFromArchive({
+    return installBundleFromArchive({
       archivePath,
       asset,
       binDir,
-      binaryName,
       platform,
     });
   } finally {
@@ -181,8 +191,11 @@ async function installReleaseBinary({
 
 module.exports = {
   binaryNameForPlatform,
+  bundleBinaryNamesForPlatform,
+  daemonBinaryNameForPlatform,
   download,
-  installBinaryFromArchive,
+  installBinaryFromArchive: installBundleFromArchive,
+  installBundleFromArchive,
   installReleaseBinary,
   releaseAssetName,
   releaseAssetUrl,

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -6,7 +6,8 @@ const { execFileSync } = require("child_process");
 
 const {
   binaryNameForPlatform,
-  installBinaryFromArchive,
+  bundleBinaryNamesForPlatform,
+  installBundleFromArchive,
   releaseAssetName,
 } = require("./release-assets.cjs");
 const postinstall = require("./postinstall.cjs");
@@ -39,57 +40,82 @@ run("release helper keeps platform binary names stable", () => {
   assert.equal(binaryNameForPlatform("darwin"), "gwt");
 });
 
+run("release helper keeps bundle binary names stable", () => {
+  assert.deepEqual(bundleBinaryNamesForPlatform("win32"), ["gwt.exe", "gwtd.exe"]);
+  assert.deepEqual(bundleBinaryNamesForPlatform("linux"), ["gwt", "gwtd"]);
+  assert.deepEqual(bundleBinaryNamesForPlatform("darwin"), ["gwt", "gwtd"]);
+});
+
 run("installer entrypoints are loadable under package type module", () => {
   assert.equal(typeof postinstall.main, "function");
   assert.equal(typeof launcher.main, "function");
 });
 
-run("portable tarball extraction installs the unix binary", () => {
+run("windows installer definition includes the gwtd companion binary", () => {
+  const wix = fs.readFileSync(path.join(__dirname, "..", "wix", "main.wxs"), "utf8");
+  assert.match(wix, /gwtd\.exe/);
+});
+
+run("release workflow packages gwtd alongside gwt", () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, "..", ".github", "workflows", "release.yml"),
+    "utf8"
+  );
+  assert.match(workflow, /--bin gwt --bin gwtd/);
+  assert.match(workflow, /Compress-Archive -Path @\("dist\/gwt\.exe", "dist\/gwtd\.exe"\)/);
+  assert.match(workflow, /tar -czf \$\{\{ matrix\.archive_name \}\} gwt gwtd/);
+  assert.match(workflow, /Contents\/MacOS\/gwtd/);
+});
+
+run("portable tarball extraction installs the unix bundle", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "gwt-release-test-"));
   const sourceDir = path.join(root, "source");
   const binDir = path.join(root, "bin");
   const archivePath = path.join(root, "gwt-linux-x86_64.tar.gz");
   fs.mkdirSync(sourceDir, { recursive: true });
   fs.writeFileSync(path.join(sourceDir, "gwt"), "unix-binary");
+  fs.writeFileSync(path.join(sourceDir, "gwtd"), "unix-daemon");
 
-  execFileSync("tar", ["-czf", archivePath, "-C", sourceDir, "gwt"]);
+  execFileSync("tar", ["-czf", archivePath, "-C", sourceDir, "gwt", "gwtd"]);
 
-  installBinaryFromArchive({
+  installBundleFromArchive({
     archivePath,
     asset: path.basename(archivePath),
     binDir,
-    binaryName: "gwt",
     platform: "linux",
   });
 
   assert.equal(fs.readFileSync(path.join(binDir, "gwt"), "utf8"), "unix-binary");
+  assert.equal(fs.readFileSync(path.join(binDir, "gwtd"), "utf8"), "unix-daemon");
 });
 
-run("portable zip extraction installs the windows binary", () => {
+run("portable zip extraction installs the windows bundle", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "gwt-release-test-"));
   const sourceDir = path.join(root, "source");
   const binDir = path.join(root, "bin");
   const archivePath = path.join(root, "gwt-windows-x86_64.zip");
   const sourceBinary = path.join(sourceDir, "gwt.exe");
+  const sourceDaemon = path.join(sourceDir, "gwtd.exe");
   fs.mkdirSync(sourceDir, { recursive: true });
   fs.writeFileSync(sourceBinary, "windows-binary");
+  fs.writeFileSync(sourceDaemon, "windows-daemon");
 
   execFileSync("powershell.exe", [
     "-NoProfile",
     "-NonInteractive",
     "-Command",
-    `Compress-Archive -LiteralPath '${sourceBinary.replace(/'/g, "''")}' -DestinationPath '${archivePath.replace(/'/g, "''")}' -Force`,
+    `Compress-Archive -LiteralPath @('${sourceBinary.replace(/'/g, "''")}','${sourceDaemon.replace(/'/g, "''")}') -DestinationPath '${archivePath.replace(/'/g, "''")}' -Force`,
   ]);
 
-  installBinaryFromArchive({
+  installBundleFromArchive({
     archivePath,
     asset: path.basename(archivePath),
     binDir,
-    binaryName: "gwt.exe",
     platform: "win32",
   });
 
   assert.equal(fs.readFileSync(path.join(binDir, "gwt.exe"), "utf8"), "windows-binary");
+  assert.equal(fs.readFileSync(path.join(binDir, "gwtd.exe"), "utf8"), "windows-daemon");
 });
 
 if (failed) {

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -25,6 +25,7 @@
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component>
         <File Id="GwtExecutable" Source="!(bindpath.gwt)gwt.exe" KeyPath="yes" />
+        <File Id="GwtdExecutable" Source="!(bindpath.gwt)gwtd.exe" />
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
## Summary
- SPEC-2077 Phase 5 として gwt と gwtd を同一 bundle として更新・配布する契約を追加
- portable archive / npm-bunx / WiX / GitHub Actions release packaging を dual-binary 前提に更新
- updater に bundle-aware rollback を追加し、片側だけ差し替わる定常状態を防止

## Verification
- cargo fmt
- cargo test -p gwt-skills -p gwt-core -p gwt
- cargo build -p gwt --bin gwt --bin gwtd
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- npx -y markdownlint-cli README.md README.ja.md
- node scripts/test_release_assets.cjs