### PR TITLE
feat: skillとdockerのgwt入口契約を追加

### DIFF
--- a/.claude/commands/gwt-manage-pr.md
+++ b/.claude/commands/gwt-manage-pr.md
@@ -20,7 +20,7 @@ Steps
 -----
 
 1. Load `.claude/skills/gwt-manage-pr/SKILL.md` and follow the workflow.
-2. `gwt pr current` should succeed before acting so auth and current-branch PR state are known.
+2. Resolve `GWT_BIN="${GWT_BIN_PATH:-gwt}"` and make sure `"$GWT_BIN" pr current` succeeds before acting so auth and current-branch PR state are known.
 3. Use the current branch and PR state to choose create, status, or unblock actions.
 4. If the PR is conflicting or behind, route directly into the fix flow.
 5. Keep PR work behind this visible entrypoint.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -286,16 +286,17 @@ Closes #456
 まず現在の develop 向け PR を確認：
 
 ```bash
-gwt pr current
+GWT_BIN="${GWT_BIN_PATH:-gwt}"
+"$GWT_BIN" pr current
 ```
 
 #### 既存PRがある場合
 
-`gwt pr current` の出力に PR 番号が含まれている場合、以下を実行してタイトル・ラベル・本文を更新（`## Closing Issues` を反映）：
+`"$GWT_BIN" pr current` の出力に PR 番号が含まれている場合、以下を実行してタイトル・ラベル・本文を更新（`## Closing Issues` を反映）：
 本文は事前に temp file へ書き出し、その path を `{PR_BODY_FILE}` として扱うこと。
 
 ```bash
-gwt pr edit {PR番号} \
+"$GWT_BIN" pr edit {PR番号} \
   --title "chore(release): v{NEW_VERSION}" \
   -f {PR_BODY_FILE} \
   --add-label release
@@ -309,7 +310,7 @@ gwt pr edit {PR番号} \
 PRを作成：
 
 ```bash
-gwt pr create \
+"$GWT_BIN" pr create \
   --base main \
   --head develop \
   --title "chore(release): v{NEW_VERSION}" \
@@ -333,21 +334,23 @@ PR bodyには以下を含めてください：
 
 `ISSUE_NUMBERS` が空でない場合、各 Issue に対してリリースに含まれる旨のコメントを追加する。
 
-まず、ステップ10の直後に `gwt pr current` を再実行し、出力 1 行目の `#<number>` から PR 番号を取得する：
+まず、ステップ10の直後に `"$GWT_BIN" pr current` を再実行し、出力 1 行目の `#<number>` から PR 番号を取得する：
 
 ```bash
-PR_CURRENT=$(gwt pr current)
+GWT_BIN="${GWT_BIN_PATH:-gwt}"
+PR_CURRENT=$("$GWT_BIN" pr current)
 PR_NUMBER=$(printf '%s\n' "$PR_CURRENT" | sed -n 's/^#\([0-9]\+\).*/\1/p' | head -1)
 ```
 
 各 Issue にコメントを追記：
 
 ```bash
+GWT_BIN="${GWT_BIN_PATH:-gwt}"
 COMMENT_FILE=$(mktemp)
 printf 'Included in release v%s (#%s)\n' "{NEW_VERSION}" "$PR_NUMBER" > "$COMMENT_FILE"
 
 for NUM in $ISSUE_NUMBERS; do
-  gwt issue comment "$NUM" -f "$COMMENT_FILE" || true
+  "$GWT_BIN" issue comment "$NUM" -f "$COMMENT_FILE" || true
 done
 
 rm -f "$COMMENT_FILE"

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -1051,20 +1051,24 @@ mod tests {
 
         let release_command = include_str!("../../../.claude/commands/release.md");
         assert!(
-            release_command.contains("gwt issue comment"),
-            "expected release command to use gwt issue comment"
+            release_command.contains("GWT_BIN_PATH"),
+            "expected release command to route shell snippets through GWT_BIN_PATH"
         );
         assert!(
-            release_command.contains("gwt pr current"),
-            "expected release command to use gwt pr current"
+            release_command.contains("\"$GWT_BIN\" issue comment"),
+            "expected release command to use the canonical gwt issue comment via GWT_BIN"
         );
         assert!(
-            release_command.contains("gwt pr create"),
-            "expected release command to use gwt pr create"
+            release_command.contains("\"$GWT_BIN\" pr current"),
+            "expected release command to use the canonical gwt pr current via GWT_BIN"
         );
         assert!(
-            release_command.contains("gwt pr edit"),
-            "expected release command to use gwt pr edit"
+            release_command.contains("\"$GWT_BIN\" pr create"),
+            "expected release command to use the canonical gwt pr create via GWT_BIN"
+        );
+        assert!(
+            release_command.contains("\"$GWT_BIN\" pr edit"),
+            "expected release command to use the canonical gwt pr edit via GWT_BIN"
         );
         assert!(
             !release_command.contains("gh issue comment"),
@@ -1073,8 +1077,8 @@ mod tests {
 
         let pr_command = include_str!("../../../.claude/commands/gwt-manage-pr.md");
         assert!(
-            pr_command.contains("`gwt pr current` should succeed"),
-            "expected gwt-manage-pr command wrapper to point to canonical gwt auth check"
+            pr_command.contains("GWT_BIN_PATH"),
+            "expected gwt-manage-pr command wrapper to point to canonical GWT_BIN_PATH auth check"
         );
         assert!(
             pr_command.contains("conflicting") || pr_command.contains("behind"),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -49,6 +49,16 @@ mod embedded_web;
 
 type ClientId = String;
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
+const DOCKER_GWT_BIN_PATH: &str = "/usr/local/bin/gwt";
+const DOCKER_GWTD_BIN_PATH: &str = "/usr/local/bin/gwtd";
+const DOCKER_HOST_GWT_BIN_NAME: &str = "gwt-linux";
+const DOCKER_HOST_GWTD_BIN_NAME: &str = "gwtd-linux";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DockerBundleMounts {
+    host_gwt: PathBuf,
+    host_gwtd: PathBuf,
+}
 
 #[derive(Debug, Clone)]
 enum UserEvent {
@@ -1931,6 +1941,7 @@ impl AppRuntime {
                     message: "bunx unavailable, switching to npx...".to_string(),
                 });
             }
+            install_launch_gwt_bin_env(&mut config.env_vars, config.runtime_target)?;
 
             let branch_name = config
                 .branch
@@ -1977,6 +1988,7 @@ impl AppRuntime {
                 .env_vars
                 .entry("COLORTERM".to_string())
                 .or_insert_with(|| "truecolor".to_string());
+            finalize_docker_agent_launch_config(Path::new(&project_root), &mut config)?;
 
             session
                 .save(&sessions_dir)
@@ -2487,7 +2499,8 @@ mod tests {
     use super::{
         app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
         broadcast_runtime_hook_event, build_shell_process_launch, close_window_from_workspace,
-        combined_window_id, hook_forward_authorized, knowledge_kind_for_preset,
+        combined_window_id, docker_bundle_mounts_for_home, docker_bundle_override_content,
+        hook_forward_authorized, install_launch_gwt_bin_env_with_lookup, knowledge_kind_for_preset,
         preferred_issue_launch_branch, resolve_project_target, should_auto_close_agent_window,
         should_auto_start_restored_window, ActiveAgentSession, ClientHub, ProjectTabRuntime,
         WindowAddress,
@@ -2844,6 +2857,42 @@ mod tests {
             config.env_vars.get("GWT_PROJECT_ROOT").map(String::as_str),
             Some(worktree.display().to_string().as_str())
         );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_prefers_public_gwt_binary_for_host_sessions() {
+        let current_exe = PathBuf::from(
+            r"C:\Users\Example\AppData\Local\Temp\bunx-1234567890-@akiojin\gwt@latest\node_modules\@akiojin\gwt\bin\gwt.exe",
+        );
+        let stable = PathBuf::from(r"C:\Users\Example\.bun\bin\gwt.exe");
+        let mut env = HashMap::new();
+
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |command| {
+                assert_eq!(command, "gwt");
+                Some(stable.clone())
+            },
+        )
+        .expect("install GWT_BIN_PATH");
+
+        assert_eq!(
+            env.get(gwt_agent::GWT_BIN_PATH_ENV).map(String::as_str),
+            Some(stable.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn docker_bundle_override_content_mounts_front_door_and_daemon() {
+        let home = PathBuf::from("/home/example");
+        let bundle = docker_bundle_mounts_for_home(&home);
+        let content = docker_bundle_override_content("app", &bundle);
+
+        assert!(content.contains("/home/example/.gwt/bin/gwt-linux:/usr/local/bin/gwt:ro"));
+        assert!(content.contains("/home/example/.gwt/bin/gwtd-linux:/usr/local/bin/gwtd:ro"));
+        assert!(!content.contains("gwtd-linux:/usr/local/bin/gwt:ro"));
     }
 
     #[test]
@@ -3542,9 +3591,36 @@ fn apply_docker_runtime_to_launch_config(
     let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
     ensure_docker_launch_runtime_ready()?;
     ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
-    ensure_docker_gwt_binary_setup(&worktree)?;
+    ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
     maybe_inject_docker_sandbox_env(&launch, config)?;
+    install_launch_gwt_bin_env(&mut config.env_vars, gwt_agent::LaunchRuntimeTarget::Docker)?;
     let runtime_program = resolve_docker_exec_program(&launch, config)?;
+    config.command = runtime_program.executable;
+    config.args = runtime_program.args;
+    config
+        .env_vars
+        .insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
+    config.docker_service = Some(launch.service);
+    Ok(())
+}
+
+fn finalize_docker_agent_launch_config(
+    repo_path: &Path,
+    config: &mut gwt_agent::LaunchConfig,
+) -> Result<(), String> {
+    if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Docker {
+        return Ok(());
+    }
+
+    let worktree = config
+        .working_dir
+        .clone()
+        .unwrap_or_else(|| repo_path.to_path_buf());
+    let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
+    let runtime_program = PackageRunnerProgram {
+        executable: config.command.clone(),
+        args: config.args.clone(),
+    };
 
     let mut args = vec![
         "compose".to_string(),
@@ -3552,24 +3628,15 @@ fn apply_docker_runtime_to_launch_config(
         launch.compose_file.display().to_string(),
         "exec".to_string(),
         "-w".to_string(),
-        launch.container_cwd.clone(),
+        launch.container_cwd,
     ];
     args.extend(docker_compose_exec_env_args(&config.env_vars));
-    args.push(launch.service.clone());
+    args.push(launch.service);
     args.push(runtime_program.executable);
     args.extend(runtime_program.args);
 
     config.command = docker_binary_for_launch();
     config.args = args;
-    config
-        .env_vars
-        .insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
-    // Override GWT_BIN_PATH for Docker containers to use the mounted binary
-    config.env_vars.insert(
-        gwt_agent::session::GWT_BIN_PATH_ENV.to_string(),
-        "/usr/local/bin/gwt".to_string(),
-    );
-    config.docker_service = Some(launch.service);
     Ok(())
 }
 
@@ -3588,6 +3655,7 @@ fn build_shell_process_launch(
         let shell = detect_shell_program().map_err(|error| error.to_string())?;
         env.entry("GWT_PROJECT_ROOT".to_string())
             .or_insert_with(|| worktree.display().to_string());
+        install_launch_gwt_bin_env(&mut env, gwt_agent::LaunchRuntimeTarget::Host)?;
         config.env_vars = env.clone();
         return Ok(ProcessLaunch {
             command: shell.command,
@@ -3600,8 +3668,10 @@ fn build_shell_process_launch(
     let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
     ensure_docker_launch_runtime_ready()?;
     ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
+    ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
     let shell_command = resolve_docker_shell_command(&launch)?;
     env.insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
+    install_launch_gwt_bin_env(&mut env, gwt_agent::LaunchRuntimeTarget::Docker)?;
     config.docker_service = Some(launch.service.clone());
     config.env_vars = env.clone();
 
@@ -3719,9 +3789,44 @@ fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
     Ok(())
 }
 
-fn ensure_docker_gwt_binary_setup(repo_path: &Path) -> Result<(), String> {
-    use std::{fs, path::PathBuf};
+fn install_launch_gwt_bin_env(
+    env_vars: &mut HashMap<String, String>,
+    runtime_target: gwt_agent::LaunchRuntimeTarget,
+) -> Result<(), String> {
+    let current_exe = std::env::current_exe().map_err(|error| format!("current_exe: {error}"))?;
+    install_launch_gwt_bin_env_with_lookup(env_vars, runtime_target, &current_exe, |command| {
+        which::which(command).ok()
+    })
+}
 
+fn install_launch_gwt_bin_env_with_lookup(
+    env_vars: &mut HashMap<String, String>,
+    runtime_target: gwt_agent::LaunchRuntimeTarget,
+    current_exe: &Path,
+    lookup: impl FnOnce(&str) -> Option<PathBuf>,
+) -> Result<(), String> {
+    let gwt_bin = match runtime_target {
+        gwt_agent::LaunchRuntimeTarget::Docker => DOCKER_GWT_BIN_PATH.to_string(),
+        gwt_agent::LaunchRuntimeTarget::Host => {
+            gwt::managed_assets::resolve_public_gwt_bin_with_lookup(current_exe, lookup)
+                .to_string_lossy()
+                .into_owned()
+        }
+    };
+    match runtime_target {
+        gwt_agent::LaunchRuntimeTarget::Docker => {
+            env_vars.insert(gwt_agent::session::GWT_BIN_PATH_ENV.to_string(), gwt_bin);
+        }
+        gwt_agent::LaunchRuntimeTarget::Host => {
+            env_vars
+                .entry(gwt_agent::session::GWT_BIN_PATH_ENV.to_string())
+                .or_insert(gwt_bin);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_user_home_dir() -> Result<PathBuf, String> {
     let home = if cfg!(windows) {
         std::env::var("USERPROFILE")
     } else {
@@ -3729,40 +3834,64 @@ fn ensure_docker_gwt_binary_setup(repo_path: &Path) -> Result<(), String> {
     }
     .map(PathBuf::from)
     .map_err(|_| "Could not determine home directory".to_string())?;
+    Ok(home)
+}
 
+fn docker_bundle_mounts_for_home(home: &Path) -> DockerBundleMounts {
     let gwt_bin_dir = home.join(".gwt").join("bin");
-    let gwt_linux = gwt_bin_dir.join("gwt-linux");
+    DockerBundleMounts {
+        host_gwt: gwt_bin_dir.join(DOCKER_HOST_GWT_BIN_NAME),
+        host_gwtd: gwt_bin_dir.join(DOCKER_HOST_GWTD_BIN_NAME),
+    }
+}
 
-    // Check if Linux gwt binary exists
-    if !gwt_linux.exists() {
-        // TODO: Download Linux gwt binary from GitHub Release
-        // For now, create a note for the user
+fn docker_compose_mount_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) -> String {
+    let host_gwt = docker_compose_mount_path(&bundle.host_gwt);
+    let host_gwtd = docker_compose_mount_path(&bundle.host_gwtd);
+    format!(
+        "# Auto-generated docker-compose override for gwt bundle mounting\n\
+         version: '3.8'\n\
+         services:\n\
+           {service}:\n\
+             volumes:\n\
+               - \"{host_gwt}:{DOCKER_GWT_BIN_PATH}:ro\"\n\
+               - \"{host_gwtd}:{DOCKER_GWTD_BIN_PATH}:ro\"\n"
+    )
+}
+
+fn ensure_docker_gwt_binary_setup(repo_path: &Path, service: &str) -> Result<(), String> {
+    use std::fs;
+
+    let home = resolve_user_home_dir()?;
+    let bundle = docker_bundle_mounts_for_home(&home);
+
+    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
         let override_path = repo_path.join("docker-compose.override.yml");
         if !override_path.exists() {
             eprintln!(
-                "Note: Linux gwt binary not found at ~/.gwt/bin/gwt-linux\n\
+                "Note: Linux gwt bundle not found at {} and {}\n\
                  This is required for Docker agent support.\n\
                  You can either:\n\
-                 1. Download gwt-linux-x86_64 from GitHub Releases and place it at ~/.gwt/bin/gwt-linux\n\
+                 1. Download the Linux release bundle and place the extracted binaries at these paths\n\
                  2. Run 'gwt setup docker' to set up Docker integration automatically"
+                ,
+                bundle.host_gwt.display(),
+                bundle.host_gwtd.display()
             );
         }
     }
 
-    // Ensure docker-compose.override.yml exists with gwt volume mount
     let override_path = repo_path.join("docker-compose.override.yml");
     if !override_path.exists() {
-        let override_content = "# Auto-generated docker-compose override for gwt binary mounting\n\
-                                version: '3.8'\n\
-                                services:\n\
-                                  # Add your service name and uncomment the volumes section\n\
-                                  # <service>:\n\
-                                  #   volumes:\n\
-                                  #     - ~/.gwt/bin/gwt-linux:/usr/local/bin/gwt:ro\n";
+        let override_content = docker_bundle_override_content(service, &bundle);
         fs::write(&override_path, override_content).map_err(|err| {
             format!(
                 "Failed to create docker-compose.override.yml: {err}\n\
-                 Manually create {} with gwt volume mount",
+                 Manually create {} with gwt/gwtd bundle mounts",
                 override_path.display()
             )
         })?;

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -30,14 +30,20 @@ fn install_hook_bin_override() -> io::Result<EnvVarGuard> {
     if std::env::var_os("GWT_HOOK_BIN").is_some() {
         return Ok(EnvVarGuard::noop("GWT_HOOK_BIN"));
     }
-    let current_exe = std::env::current_exe()
-        .map_err(|error| io::Error::other(format!("current_exe: {error}")))?;
-    let hook_bin =
-        resolve_managed_hook_bin_with_lookup(&current_exe, |command| which::which(command).ok());
+    let hook_bin = resolve_public_gwt_bin_path()?;
     Ok(EnvVarGuard::set("GWT_HOOK_BIN", hook_bin))
 }
 
-fn resolve_managed_hook_bin_with_lookup(
+pub fn resolve_public_gwt_bin_path() -> io::Result<PathBuf> {
+    let current_exe = std::env::current_exe()
+        .map_err(|error| io::Error::other(format!("current_exe: {error}")))?;
+    Ok(resolve_public_gwt_bin_with_lookup(
+        &current_exe,
+        |command| which::which(command).ok(),
+    ))
+}
+
+pub fn resolve_public_gwt_bin_with_lookup(
     current_exe: &Path,
     lookup: impl FnOnce(&str) -> Option<PathBuf>,
 ) -> PathBuf {
@@ -127,7 +133,7 @@ impl Drop for EnvVarGuard {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::resolve_managed_hook_bin_with_lookup;
+    use super::resolve_public_gwt_bin_with_lookup;
 
     #[test]
     fn bunx_temp_current_exe_prefers_stable_path_gwt() {
@@ -136,7 +142,7 @@ mod tests {
         );
         let stable = PathBuf::from(r"C:\Users\Example\.bun\bin\gwt.exe");
 
-        let resolved = resolve_managed_hook_bin_with_lookup(current_exe, |command| {
+        let resolved = resolve_public_gwt_bin_with_lookup(current_exe, |command| {
             assert_eq!(command, "gwt");
             Some(stable.clone())
         });
@@ -148,7 +154,7 @@ mod tests {
     fn stable_gwt_current_exe_is_kept_without_path_lookup() {
         let current_exe = Path::new(r"C:\Users\Example\.bun\bin\gwt.exe");
 
-        let resolved = resolve_managed_hook_bin_with_lookup(current_exe, |_command| {
+        let resolved = resolve_public_gwt_bin_with_lookup(current_exe, |_command| {
             panic!("stable gwt binary should not hit PATH lookup");
         });
 
@@ -164,7 +170,7 @@ mod tests {
             r"C:\Users\Example\AppData\Local\Temp\bunx-2222222222-@akiojin\gwt@latest\node_modules\@akiojin\gwt\bin\gwt.exe",
         );
 
-        let resolved = resolve_managed_hook_bin_with_lookup(current_exe, |_command| {
+        let resolved = resolve_public_gwt_bin_with_lookup(current_exe, |_command| {
             Some(path_candidate.clone())
         });
 

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -66,6 +66,36 @@ fn refresh_managed_gwt_assets_reports_the_failed_step() {
         .contains("failed to distribute gwt managed assets"));
 }
 
+#[test]
+fn refresh_managed_gwt_assets_keeps_command_assets_on_gwt_bin_path_front_door() {
+    let dir = tempdir().expect("tempdir");
+    run_git(dir.path(), &["init", "-q"]);
+
+    refresh_managed_gwt_assets_for_worktree(dir.path()).expect("refresh managed assets");
+
+    let manage_pr = std::fs::read_to_string(dir.path().join(".claude/commands/gwt-manage-pr.md"))
+        .expect("read gwt-manage-pr");
+    assert!(
+        manage_pr.contains("GWT_BIN_PATH"),
+        "PR command asset should tell managed sessions to use GWT_BIN_PATH, got: {manage_pr}"
+    );
+    assert!(
+        !manage_pr.contains("gwtd"),
+        "PR command asset must not expose gwtd, got: {manage_pr}"
+    );
+
+    let release = std::fs::read_to_string(dir.path().join(".claude/commands/release.md"))
+        .expect("read release command");
+    assert!(
+        release.contains("GWT_BIN_PATH"),
+        "release command asset should shell out through GWT_BIN_PATH, got: {release}"
+    );
+    assert!(
+        !release.contains("gwtd"),
+        "release command asset must not expose gwtd, got: {release}"
+    );
+}
+
 fn run_git(repo: &Path, args: &[&str]) {
     let output = std::process::Command::new("git")
         .args(args)

--- a/docs/docker-usage.md
+++ b/docs/docker-usage.md
@@ -15,6 +15,15 @@ Linux向けの共通依存は `scripts/install-linux-deps.sh` で管理されて
 docker compose build --no-cache
 ```
 
+## Docker agent bundle
+
+Docker-backed agent sessions expect the Linux `gwt` bundle to be available on the host and mounted into the container as the public front door plus its internal daemon companion.
+
+- `~/.gwt/bin/gwt-linux` -> `/usr/local/bin/gwt`
+- `~/.gwt/bin/gwtd-linux` -> `/usr/local/bin/gwtd`
+
+`gwt` remains the only operator-facing entrypoint inside the container. Skills and scripts should prefer `GWT_BIN_PATH` when it is present instead of calling `gwtd` directly.
+
 ## エラー対応
 
 ### `exec /entrypoint.sh: no such file or directory` エラーが発生した場合


### PR DESCRIPTION
## Summary
- SPEC-2077 Phase 6 として agent / shell launch に GWT_BIN_PATH を配り、managed command assets も gwt front door を使い続けるよう更新
- Docker agent launch は session env 完成後に docker compose exec を組み立てるように直し、docker-compose.override.yml の bootstrap で gwt-linux と gwtd-linux を同時 mount
- Docker bundle mount 契約と command asset routing の RED-first tests を追加し、Docker usage docs を更新

## Verification
- cargo fmt
- cargo test -p gwt --test managed_assets_test refresh_managed_gwt_assets_keeps_command_assets_on_gwt_bin_path_front_door -- --nocapture
- cargo test -p gwt install_launch_gwt_bin_env_prefers_public_gwt_binary_for_host_sessions -- --nocapture
- cargo test -p gwt docker_bundle_override_content_mounts_front_door_and_daemon -- --nocapture
- cargo test -p gwt-skills local_github_issue_workflows_use_canonical_gwt_surfaces -- --nocapture
- cargo test -p gwt-skills full_distribution_pipeline_creates_all_targets -- --nocapture
- cargo test -p gwt-skills -p gwt-core -p gwt
- cargo build -p gwt --bin gwt --bin gwtd
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- npx -y markdownlint-cli README.md README.ja.md docs/docker-usage.md .claude/commands/gwt-manage-pr.md .claude/commands/release.md
- bunx commitlint --from HEAD~2 --to HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker agent bundle support with automatic binary mounting and environment configuration.
  * Enabled configurable `gwt` binary path resolution via environment variables for both Docker and host environments.

* **Documentation**
  * Added Docker agent bundle usage guidance, including host-to-container path mappings and best practices for binary invocation.

* **Tests**
  * Enhanced test coverage for binary path resolution and Docker command asset generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->