### PR TITLE
fix(gui): bypass tao event loop for terminal_input WebSocket hot-path

### DIFF
--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -1,6 +1,6 @@
 //! Terminal pane: integrates PTY handle + vt100 parser + scrollback.
 
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use crate::{
     pty::{PtyHandle, SpawnConfig},
@@ -17,9 +17,15 @@ pub enum PaneStatus {
 }
 
 /// A terminal pane integrating PTY, vt100 parser, and scrollback.
+///
+/// `pty` is wrapped in an `Arc` so that callers who only need to write input
+/// or query process state can hold a lock-free clone without contending with
+/// the reader thread's exclusive `Mutex<Pane>` guard. The gwt GUI binary uses
+/// this to bypass the tao event loop for `terminal_input` hot path (see the
+/// fast-path write in `client_session`).
 pub struct Pane {
     id: String,
-    pty: PtyHandle,
+    pty: Arc<PtyHandle>,
     parser: vt100::Parser,
     scrollback: ScrollbackStorage,
     status: PaneStatus,
@@ -47,7 +53,7 @@ impl Pane {
             remove_env: Vec::new(),
             cwd,
         };
-        let pty = PtyHandle::spawn(config)?;
+        let pty = Arc::new(PtyHandle::spawn(config)?);
         let parser = vt100::Parser::new(rows, cols, 0);
         let scrollback = ScrollbackStorage::new(ScrollbackStorage::DEFAULT_CAPACITY);
 
@@ -69,6 +75,15 @@ impl Pane {
     /// Get a reference to the PTY handle.
     pub fn pty(&self) -> &PtyHandle {
         &self.pty
+    }
+
+    /// Get a shared handle to the underlying PTY.
+    ///
+    /// Callers on threads that do not own the surrounding `Mutex<Pane>` guard
+    /// can clone this `Arc` and invoke `write_input` / `resize` / `process_id`
+    /// without contending with the reader thread.
+    pub fn shared_pty(&self) -> Arc<PtyHandle> {
+        Arc::clone(&self.pty)
     }
 
     /// Feed raw bytes from PTY output through the vt100 parser and scrollback.

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, Read},
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::{atomic::AtomicU64, mpsc as std_mpsc, Arc, Mutex},
+    sync::{atomic::AtomicU64, mpsc as std_mpsc, Arc, Mutex, RwLock},
     thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
@@ -31,7 +31,7 @@ use gwt::{
     LiveSessionEntry, RuntimeHookEvent, ShellLaunchConfig, WindowGeometry, WindowPreset,
     WindowProcessStatus, WorkspaceState, APP_NAME,
 };
-use gwt_terminal::{Pane, PaneStatus};
+use gwt_terminal::{Pane, PaneStatus, PtyHandle};
 use tao::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy},
@@ -49,6 +49,18 @@ mod embedded_web;
 
 type ClientId = String;
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
+
+/// Shared lock-free PTY writer registry used by the WebSocket fast-path.
+///
+/// The WS receiver task (tokio async) looks up the `Arc<PtyHandle>` by window
+/// id and calls `write_input` directly, bypassing the tao event loop and the
+/// surrounding `Mutex<Pane>` guard. This eliminates the two main contention
+/// sources for intermittent key drops under heavy output bursts
+/// (bugfix/input-key): (a) FIFO queue behind many `RuntimeOutput` events on
+/// the single-threaded tao main loop, and (b) pane mutex held by the reader
+/// thread while parsing vt100 chunks. Reads are hot (every keystroke), writes
+/// are rare (pane create/destroy), so `RwLock` is the natural fit.
+type PtyWriterRegistry = Arc<RwLock<HashMap<String, Arc<PtyHandle>>>>;
 
 #[derive(Debug, Clone)]
 enum UserEvent {
@@ -208,6 +220,8 @@ struct AppRuntime {
     hook_forward_target: Option<HookForwardTarget>,
     /// Cached update state so late-connecting WebView clients get the toast.
     pending_update: Option<gwt_core::update::UpdateState>,
+    /// Shared PTY writer registry published to the WebSocket fast-path.
+    pty_writers: PtyWriterRegistry,
 }
 
 impl ProjectTabRuntime {
@@ -226,7 +240,10 @@ impl ProjectTabRuntime {
 }
 
 impl AppRuntime {
-    fn new(proxy: EventLoopProxy<UserEvent>) -> std::io::Result<Self> {
+    fn new(
+        proxy: EventLoopProxy<UserEvent>,
+        pty_writers: PtyWriterRegistry,
+    ) -> std::io::Result<Self> {
         let session_state_path = gwt_core::paths::gwt_session_state_path();
         let launch_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         let legacy_target = resolve_project_target(&launch_dir)
@@ -264,6 +281,7 @@ impl AppRuntime {
             active_agent_sessions: HashMap::new(),
             hook_forward_target: None,
             pending_update: None,
+            pty_writers,
         };
         app.rebuild_window_lookup();
         app.seed_restored_window_details();
@@ -1499,6 +1517,7 @@ impl AppRuntime {
         let should_auto_close =
             should_auto_close_agent_window(&self.active_agent_sessions, &id, &status);
         let Some(address) = self.window_lookup.get(&id).cloned() else {
+            self.deregister_pty_writer(&id);
             self.runtimes.remove(&id);
             self.window_details.remove(&id);
             return Vec::new();
@@ -1773,6 +1792,12 @@ impl AppRuntime {
             );
         }
         self.window_details.remove(id);
+        // Publish the PTY handle to the WebSocket fast-path registry BEFORE
+        // inserting the runtime so that the first `terminal_input` from the
+        // frontend (which can arrive immediately after `TerminalStatus`) has a
+        // target to write to. Registry holds a cloned `Arc<PtyHandle>`; the
+        // real owner remains the `Mutex<Pane>` in `WindowRuntime`.
+        self.register_pty_writer(id, &pane);
         self.runtimes.insert(
             id.to_string(),
             WindowRuntime {
@@ -2069,8 +2094,54 @@ impl AppRuntime {
         );
     }
 
+    fn register_pty_writer(&self, id: &str, pane: &Arc<Mutex<Pane>>) {
+        let Ok(pane_guard) = pane.lock() else {
+            tracing::warn!(
+                target: "gwt_input_trace",
+                stage = "registry_lock_poisoned",
+                window_id = %id,
+                "failed to register PTY writer: pane mutex poisoned"
+            );
+            return;
+        };
+        let pty = pane_guard.shared_pty();
+        drop(pane_guard);
+        match self.pty_writers.write() {
+            Ok(mut guard) => {
+                guard.insert(id.to_string(), pty);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "gwt_input_trace",
+                    stage = "registry_write_poisoned",
+                    window_id = %id,
+                    error = %error,
+                    "failed to register PTY writer: registry poisoned"
+                );
+            }
+        }
+    }
+
+    fn deregister_pty_writer(&self, id: &str) {
+        match self.pty_writers.write() {
+            Ok(mut guard) => {
+                guard.remove(id);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "gwt_input_trace",
+                    stage = "registry_deregister_poisoned",
+                    window_id = %id,
+                    error = %error,
+                    "failed to deregister PTY writer: registry poisoned"
+                );
+            }
+        }
+    }
+
     fn stop_window_runtime(&mut self, window_id: &str) {
         self.mark_agent_session_stopped(window_id);
+        self.deregister_pty_writer(window_id);
         if let Some(mut runtime) = self.runtimes.remove(window_id) {
             if let Ok(pane) = runtime.pane.lock() {
                 let _ = pane.kill();
@@ -3027,6 +3098,8 @@ struct ServerState {
     proxy: EventLoopProxy<UserEvent>,
     clients: ClientHub,
     hook_forward_token: String,
+    /// Shared PTY writer registry for the `terminal_input` fast-path.
+    pty_writers: PtyWriterRegistry,
 }
 
 struct EmbeddedServer {
@@ -3040,6 +3113,7 @@ impl EmbeddedServer {
         runtime: &Runtime,
         proxy: EventLoopProxy<UserEvent>,
         clients: ClientHub,
+        pty_writers: PtyWriterRegistry,
     ) -> std::io::Result<Self> {
         let listener = runtime.block_on(TcpListener::bind(("127.0.0.1", 0)))?;
         let addr = listener.local_addr()?;
@@ -3055,6 +3129,7 @@ impl EmbeddedServer {
                 proxy,
                 clients,
                 hook_forward_token: hook_forward_token.clone(),
+                pty_writers,
             });
 
         runtime.spawn(async move {
@@ -3141,42 +3216,13 @@ async fn client_session(socket: WebSocket, state: ServerState) {
                         let text_len = text.len();
                         match serde_json::from_str::<FrontendEvent>(text.as_ref()) {
                             Ok(event) => {
-                                let (ti_seq, ti_id, ti_len) = match &event {
-                                    FrontendEvent::TerminalInput { id, data } => {
-                                        let seq = input_seq.fetch_add(
-                                            1,
-                                            std::sync::atomic::Ordering::Relaxed,
-                                        ) + 1;
-                                        tracing::debug!(
-                                            target: "gwt_input_trace",
-                                            stage = "ws_recv",
-                                            client_id = %client_id,
-                                            seq,
-                                            window_id = %id,
-                                            data_len = data.len(),
-                                            text_len,
-                                            "terminal_input received over WebSocket"
-                                        );
-                                        (Some(seq), Some(id.clone()), Some(data.len()))
-                                    }
-                                    _ => (None, None, None),
-                                };
-                                let send_result = state.proxy.send_event(UserEvent::Frontend {
-                                    client_id: client_id.clone(),
+                                handle_frontend_message(
+                                    &state,
+                                    &client_id,
+                                    &input_seq,
+                                    text_len,
                                     event,
-                                });
-                                if let (Some(seq), Some(id), Some(len)) = (ti_seq, ti_id, ti_len) {
-                                    tracing::debug!(
-                                        target: "gwt_input_trace",
-                                        stage = "ws_dispatch",
-                                        client_id = %client_id,
-                                        seq,
-                                        window_id = %id,
-                                        data_len = len,
-                                        ok = send_result.is_ok(),
-                                        "terminal_input forwarded to event loop proxy"
-                                    );
-                                }
+                                );
                             }
                             Err(error) => {
                                 eprintln!("invalid frontend message: {error}");
@@ -3195,6 +3241,127 @@ async fn client_session(socket: WebSocket, state: ServerState) {
     }
 
     state.clients.unregister(&client_id);
+}
+
+/// Dispatch a parsed `FrontendEvent` from the WebSocket receiver task.
+///
+/// `TerminalInput` takes the fast-path: the pane's PTY handle is looked up in
+/// the shared registry and written to directly, bypassing the single-threaded
+/// tao event loop. Other events still flow through `UserEvent::Frontend` so
+/// they can mutate `AppRuntime` on the main thread.
+///
+/// If the fast-path fails (unknown window, PTY write error, or poisoned
+/// registry lock), the input is forwarded to the proxy so the existing
+/// error-reporting path in `terminal_input_events` still runs.
+fn handle_frontend_message(
+    state: &ServerState,
+    client_id: &str,
+    input_seq: &AtomicU64,
+    text_len: usize,
+    event: FrontendEvent,
+) {
+    // Fast-path only applies to TerminalInput. For every other variant, just
+    // forward to the main-thread event loop as before.
+    let (id, data) = match event {
+        FrontendEvent::TerminalInput { id, data } => (id, data),
+        other => {
+            let _ = state.proxy.send_event(UserEvent::Frontend {
+                client_id: client_id.to_string(),
+                event: other,
+            });
+            return;
+        }
+    };
+
+    let seq = input_seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+    let data_len = data.len();
+    tracing::debug!(
+        target: "gwt_input_trace",
+        stage = "ws_recv",
+        client_id = %client_id,
+        seq,
+        window_id = %id,
+        data_len,
+        text_len,
+        "terminal_input received over WebSocket"
+    );
+
+    let pty_handle = match state.pty_writers.read() {
+        Ok(guard) => guard.get(&id).cloned(),
+        Err(error) => {
+            tracing::warn!(
+                target: "gwt_input_trace",
+                stage = "fast_path_lock_poisoned",
+                client_id = %client_id,
+                seq,
+                window_id = %id,
+                error = %error,
+                "pty_writers read lock poisoned; falling back to event loop"
+            );
+            None
+        }
+    };
+
+    if let Some(pty) = pty_handle {
+        let write_started = Instant::now();
+        match pty.write_input(data.as_bytes()) {
+            Ok(()) => {
+                tracing::debug!(
+                    target: "gwt_input_trace",
+                    stage = "fast_path_write",
+                    client_id = %client_id,
+                    seq,
+                    window_id = %id,
+                    data_len,
+                    write_us = write_started.elapsed().as_micros() as u64,
+                    "terminal_input written to PTY via WS fast-path"
+                );
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "gwt_input_trace",
+                    stage = "fast_path_write_err",
+                    client_id = %client_id,
+                    seq,
+                    window_id = %id,
+                    data_len,
+                    error = %error,
+                    "fast-path PTY write failed; forwarding to event loop for error handling"
+                );
+                // fall through to proxy path so `terminal_input_events` can
+                // route the error through `handle_runtime_status`.
+            }
+        }
+    } else {
+        tracing::debug!(
+            target: "gwt_input_trace",
+            stage = "fast_path_miss",
+            client_id = %client_id,
+            seq,
+            window_id = %id,
+            data_len,
+            "pty_writers registry miss; falling back to event loop"
+        );
+    }
+
+    let send_result = state.proxy.send_event(UserEvent::Frontend {
+        client_id: client_id.to_string(),
+        event: FrontendEvent::TerminalInput {
+            id: id.clone(),
+            data,
+        },
+    });
+    tracing::debug!(
+        target: "gwt_input_trace",
+        stage = "ws_dispatch",
+        client_id = %client_id,
+        seq,
+        window_id = %id,
+        data_len,
+        ok = send_result.is_ok(),
+        "terminal_input forwarded to event loop proxy (fallback)"
+    );
 }
 
 fn hook_forward_authorized(headers: &HeaderMap, expected_token: &str) -> bool {
@@ -4354,11 +4521,17 @@ fn main() -> wry::Result<()> {
     let clients = ClientHub::default();
     #[cfg(target_os = "macos")]
     let clients = ClientHub::default();
-    let mut app = AppRuntime::new(proxy.clone()).expect("app runtime");
+    let pty_writers: PtyWriterRegistry = Arc::new(RwLock::new(HashMap::new()));
+    let mut app = AppRuntime::new(proxy.clone(), pty_writers.clone()).expect("app runtime");
     app.bootstrap();
 
-    let mut server =
-        EmbeddedServer::start(&runtime, proxy.clone(), clients.clone()).expect("embedded server");
+    let mut server = EmbeddedServer::start(
+        &runtime,
+        proxy.clone(),
+        clients.clone(),
+        pty_writers.clone(),
+    )
+    .expect("embedded server");
     app.set_hook_forward_target(server.hook_forward_target());
     eprintln!("gwt browser URL: {}", server.url());
 


### PR DESCRIPTION
## Summary

- Codex ペインで「処理落ちし始めるとキー入力が何回かに一回しか通らない」intermittent drop の根本原因（M1: event-loop 輻輳）を解消する。
- 全ペインの `FrontendEvent::TerminalInput` を、単一 tao main thread を経由させずに WS 受信 tokio async task から直接 PTY writer に書く fast-path を追加する。
- 従来の proxy → event loop → `pane.lock()` → `pty.write_input` 経路はエラー時の fallback として温存。計測ポイントも fast-path stage を追加して維持。

## Changes

- `crates/gwt-terminal/src/pane.rs`: `Pane.pty` を `PtyHandle` から `Arc<PtyHandle>` 化。新規 `Pane::shared_pty(&self) -> Arc<PtyHandle>` で lock-free な clone を提供。
- `crates/gwt/src/main.rs`:
  - 新型 `PtyWriterRegistry = Arc<RwLock<HashMap<String, Arc<PtyHandle>>>>` を `ServerState` と `AppRuntime` で共有。
  - `AppRuntime::register_pty_writer` / `deregister_pty_writer` を追加し、pane 起動 (`start_runtime_for_pane` 相当) と停止 (`stop_window_runtime` / `handle_runtime_status` の未知 id 経路) と同期。
  - WS 受信ループ内の `FrontendEvent` 捌きを `handle_frontend_message` に抽出。`TerminalInput` は registry から `Arc<PtyHandle>` を lookup して `write_input` を直接呼ぶ。miss・write エラー時は従来の proxy 経路に fallback。
  - トレースに `fast_path_write` / `fast_path_miss` / `fast_path_write_err` / `fast_path_lock_poisoned` stages を追加。`RUST_LOG=gwt_input_trace=debug` で有効化。

## Testing

- [x] `cargo check -p gwt` — warning なし
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p gwt --lib --bins` — 26 passed
- [x] `cargo test -p gwt-terminal --lib` — 29 passed / 19 failed（`/bin/echo` 等を使う Unix 前提の pre-existing Windows failures のみ。baseline と同一）
- [x] `cargo build -p gwt` — OK
- [ ] 体感確認: `RUST_LOG=gwt_input_trace=debug cargo run -p gwt` で起動し Codex を複数同時実行 → 打鍵が詰まらないことを確認（ユーザー側で別途）
- [ ] ログ確認: `fast_path_write` が `ws_recv` とほぼ 1:1 になり、event loop 経由 fallback (`ws_dispatch`) がほぼ 0 であること

## Closing Issues

- None

## Related Issues / Links

- 前段の診断計測 PR: #2084（既に develop にマージ済み、本修正で stage が機能する）
- bugfix/input-key ブランチ全体の背景メモ: `.gwt/discussion.md`（gitignored）

## Checklist

- [x] Tests added/updated — N/A: 既存 test は維持。本 PR は hot-path の構造的バイパスで、単体 test で再現困難な race 条件への対処。計測 stage で検証する設計。
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated — N/A: ユーザー観測挙動は「打鍵が詰まらなくなる」のみで README 追記不要
- [x] Migration/backfill plan included — N/A: スキーマ/データ変更なし
- [x] CHANGELOG impact considered — `fix:` パッチ扱い

## Context

- 症状: Codex ペインで特に複数ターミナル同時実行時、キー入力が「何回かに一回しか通らない」状態になる
- 切り分け（前 PR #2084 の計測準備後に、ユーザー証言と実装調査で）:
  - フォーカス喪失ではない（クリックで復活しない、叩き続ければ通る）
  - タイミング依存（重出力と相関）
  - 複数ターミナルで悪化
- 原因: `UserEvent::Frontend { TerminalInput }` が `UserEvent::RuntimeOutput` と同一の tao event proxy を単一スレッドで FIFO 処理する構造。N ペインの reader threads が大量の `RuntimeOutput` を積み、入力イベントの処理開始が秒単位で遅延する。

## Risk / Impact

- **Affected areas**: PTY 入力経路のみ。出力経路と pane lifecycle は無変更。エラーパスは既存 `handle_runtime_status` に fallback するので失敗シグナルは失われない。
- **Rollback plan**: `fix(gui): bypass tao event loop for terminal_input WebSocket hot-path` を revert。registry 登録/解除と `Pane::shared_pty` は残っても害なし（未使用）。

## Notes

- `Pane.pty` の型変更は破壊的変更に見えるが、Arc の Deref coercion により既存呼び出し (`pane.pty.write_input(...)`, `pane.pty.kill()` 等) は無改修で動作。外部 test は `pty_lifecycle_test.rs` の 1 箇所のみで、`.process_id()` 呼び出しは `&PtyHandle` methods で deref 経由そのまま動く。
- fast-path の PTY write は tokio worker thread 上で `std::sync::Mutex` を短時間ロックする。典型的な数バイト write + flush は µs オーダーで、spawn_blocking は過剰と判断。継続観測で長尾が出れば別途移動。
