### PR TITLE
fix: Branches の一覧ロードを非同期化して新しい順に並べる

### DIFF
--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -4,6 +4,7 @@ use std::{
     path::Path,
 };
 
+use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -70,6 +71,8 @@ pub struct BranchListEntry {
     pub ahead: u32,
     pub behind: u32,
     pub last_commit_date: Option<String>,
+    #[serde(default)]
+    pub cleanup_ready: bool,
     pub cleanup: BranchCleanupInfo,
 }
 
@@ -77,25 +80,38 @@ pub fn list_branch_entries(repo_path: &Path) -> std::io::Result<Vec<BranchListEn
     list_branch_entries_with_active_sessions(repo_path, &HashSet::new())
 }
 
-pub fn list_branch_entries_with_active_sessions(
-    repo_path: &Path,
-    active_session_branches: &HashSet<String>,
-) -> std::io::Result<Vec<BranchListEntry>> {
+pub fn list_branch_inventory(repo_path: &Path) -> std::io::Result<Vec<BranchListEntry>> {
     let branches = gwt_git::branch::list_branches(repo_path)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
+    Ok(adapt_branch_inventory(branches))
+}
+
+pub fn hydrate_branch_entries_with_active_sessions(
+    repo_path: &Path,
+    entries: Vec<BranchListEntry>,
+    active_session_branches: &HashSet<String>,
+) -> std::io::Result<Vec<BranchListEntry>> {
     let gone_branches = gwt_git::list_gone_branches(repo_path)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
-    let cleanup_targets = build_cleanup_targets(repo_path, &branches, &gone_branches)?;
-    Ok(adapt_branches(
-        branches,
+    let cleanup_targets = build_cleanup_targets(repo_path, &entries, &gone_branches)?;
+    Ok(hydrate_branch_entries(
+        entries,
         active_session_branches,
         &cleanup_targets,
     ))
 }
 
+pub fn list_branch_entries_with_active_sessions(
+    repo_path: &Path,
+    active_session_branches: &HashSet<String>,
+) -> std::io::Result<Vec<BranchListEntry>> {
+    let entries = list_branch_inventory(repo_path)?;
+    hydrate_branch_entries_with_active_sessions(repo_path, entries, active_session_branches)
+}
+
 fn build_cleanup_targets(
     repo_path: &Path,
-    branches: &[gwt_git::Branch],
+    entries: &[BranchListEntry],
     gone_branches: &HashSet<String>,
 ) -> std::io::Result<HashMap<String, Option<gwt_git::MergeTarget>>> {
     let cleanup_bases = [
@@ -104,7 +120,10 @@ fn build_cleanup_targets(
         ("develop", gwt_git::MergeTarget::Develop),
     ];
     let mut cleanup_targets = HashMap::new();
-    for branch in branches.iter().filter(|branch| branch.is_local) {
+    for branch in entries
+        .iter()
+        .filter(|branch| branch.scope == BranchScope::Local)
+    {
         let target = gwt_git::detect_cleanable_target(
             repo_path,
             &branch.name,
@@ -117,44 +136,56 @@ fn build_cleanup_targets(
     Ok(cleanup_targets)
 }
 
-fn adapt_branches(
-    branches: Vec<gwt_git::Branch>,
+fn adapt_branch_inventory(branches: Vec<gwt_git::Branch>) -> Vec<BranchListEntry> {
+    let mut entries: Vec<BranchListEntry> = branches
+        .into_iter()
+        .map(|branch| BranchListEntry {
+            name: branch.name,
+            scope: if branch.is_remote {
+                BranchScope::Remote
+            } else {
+                BranchScope::Local
+            },
+            is_head: branch.is_head,
+            upstream: branch.upstream,
+            ahead: branch.ahead,
+            behind: branch.behind,
+            last_commit_date: branch.last_commit_date,
+            cleanup_ready: false,
+            cleanup: BranchCleanupInfo::default(),
+        })
+        .collect();
+
+    entries.sort_by(compare_branch_entries);
+    entries
+}
+
+fn hydrate_branch_entries(
+    entries: Vec<BranchListEntry>,
     active_session_branches: &HashSet<String>,
     cleanup_targets: &HashMap<String, Option<gwt_git::MergeTarget>>,
 ) -> Vec<BranchListEntry> {
-    let current_head_branch = branches
+    let current_head_branch = entries
         .iter()
-        .find(|branch| branch.is_local && branch.is_head)
+        .find(|branch| branch.scope == BranchScope::Local && branch.is_head)
         .map(|branch| branch.name.clone());
-    let local_upstreams: HashMap<String, Option<String>> = branches
+    let local_upstreams: HashMap<String, Option<String>> = entries
         .iter()
-        .filter(|branch| branch.is_local)
+        .filter(|branch| branch.scope == BranchScope::Local)
         .map(|branch| (branch.name.clone(), branch.upstream.clone()))
         .collect();
-    let mut entries: Vec<BranchListEntry> = branches
+    let mut entries: Vec<BranchListEntry> = entries
         .into_iter()
-        .map(|branch| {
-            let cleanup = build_cleanup_info(
+        .map(|mut branch| {
+            branch.cleanup = build_cleanup_info(
                 &branch,
                 &local_upstreams,
                 current_head_branch.as_deref(),
                 active_session_branches,
                 cleanup_targets,
             );
-            BranchListEntry {
-                name: branch.name,
-                scope: if branch.is_remote {
-                    BranchScope::Remote
-                } else {
-                    BranchScope::Local
-                },
-                is_head: branch.is_head,
-                upstream: branch.upstream,
-                ahead: branch.ahead,
-                behind: branch.behind,
-                last_commit_date: branch.last_commit_date,
-                cleanup,
-            }
+            branch.cleanup_ready = true;
+            branch
         })
         .collect();
 
@@ -163,7 +194,7 @@ fn adapt_branches(
 }
 
 fn build_cleanup_info(
-    branch: &gwt_git::Branch,
+    branch: &BranchListEntry,
     local_upstreams: &HashMap<String, Option<String>>,
     current_head_branch: Option<&str>,
     active_session_branches: &HashSet<String>,
@@ -212,7 +243,7 @@ fn build_cleanup_info(
         .cloned()
         .flatten();
     let mut risks = Vec::new();
-    if branch.is_remote {
+    if branch.scope == BranchScope::Remote {
         risks.push(BranchCleanupRisk::RemoteTracking);
     }
     if merge_target.is_none() {
@@ -249,10 +280,10 @@ fn blocked_cleanup_info(
 }
 
 fn cleanup_execution_branch(
-    branch: &gwt_git::Branch,
+    branch: &BranchListEntry,
     local_upstreams: &HashMap<String, Option<String>>,
 ) -> Option<String> {
-    if branch.is_local {
+    if branch.scope == BranchScope::Local {
         return Some(branch.name.clone());
     }
     let local_name = local_branch_for_remote_ref(&branch.name)?;
@@ -269,9 +300,8 @@ fn local_branch_for_remote_ref(name: &str) -> Option<&str> {
 }
 
 fn compare_branch_entries(left: &BranchListEntry, right: &BranchListEntry) -> Ordering {
-    right
-        .is_head
-        .cmp(&left.is_head)
+    compare_branch_commit_dates(&left.last_commit_date, &right.last_commit_date)
+        .then_with(|| right.is_head.cmp(&left.is_head))
         .then_with(|| match (left.scope, right.scope) {
             (BranchScope::Local, BranchScope::Remote) => Ordering::Less,
             (BranchScope::Remote, BranchScope::Local) => Ordering::Greater,
@@ -285,12 +315,30 @@ fn compare_branch_entries(left: &BranchListEntry, right: &BranchListEntry) -> Or
         .then_with(|| left.name.cmp(&right.name))
 }
 
+fn compare_branch_commit_dates(left: &Option<String>, right: &Option<String>) -> Ordering {
+    match (
+        left.as_deref().and_then(parse_branch_commit_date),
+        right.as_deref().and_then(parse_branch_commit_date),
+    ) {
+        (Some(left), Some(right)) => right.cmp(&left),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => right.cmp(left),
+    }
+}
+
+fn parse_branch_commit_date(value: &str) -> Option<DateTime<FixedOffset>> {
+    DateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S %z")
+        .ok()
+        .or_else(|| DateTime::parse_from_rfc3339(value).ok())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn adapt_branches_sorts_head_then_local_then_remote() {
+    fn adapt_branches_sorts_newest_first_then_head_local_then_remote() {
         let branches = vec![
             gwt_git::Branch {
                 name: "origin/main".to_string(),
@@ -300,7 +348,7 @@ mod tests {
                 upstream: None,
                 ahead: 0,
                 behind: 0,
-                last_commit_date: None,
+                last_commit_date: Some("2026-04-19 12:00:00 +0000".to_string()),
             },
             gwt_git::Branch {
                 name: "feature/zeta".to_string(),
@@ -310,7 +358,7 @@ mod tests {
                 upstream: None,
                 ahead: 0,
                 behind: 0,
-                last_commit_date: None,
+                last_commit_date: Some("2026-04-20 08:30:00 +0000".to_string()),
             },
             gwt_git::Branch {
                 name: "main".to_string(),
@@ -320,7 +368,7 @@ mod tests {
                 upstream: Some("origin/main".to_string()),
                 ahead: 0,
                 behind: 0,
-                last_commit_date: None,
+                last_commit_date: Some("2026-04-20 08:30:00 +0000".to_string()),
             },
             gwt_git::Branch {
                 name: "feature/alpha".to_string(),
@@ -330,18 +378,45 @@ mod tests {
                 upstream: None,
                 ahead: 0,
                 behind: 0,
-                last_commit_date: None,
+                last_commit_date: Some("2026-04-18 09:00:00 +0000".to_string()),
             },
         ];
 
-        let entries = adapt_branches(branches, &HashSet::new(), &HashMap::new());
+        let entries = adapt_branch_inventory(branches);
         let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
         assert_eq!(
             names,
-            vec!["main", "feature/alpha", "feature/zeta", "origin/main"]
+            vec!["main", "feature/zeta", "origin/main", "feature/alpha"]
         );
         assert_eq!(entries[0].scope, BranchScope::Local);
         assert!(entries[0].is_head);
-        assert_eq!(entries[3].scope, BranchScope::Remote);
+        assert_eq!(entries[2].scope, BranchScope::Remote);
+    }
+
+    #[test]
+    fn hydrated_entries_mark_cleanup_ready() {
+        let entries = vec![BranchListEntry {
+            name: "feature/demo".to_string(),
+            scope: BranchScope::Local,
+            is_head: false,
+            upstream: None,
+            ahead: 0,
+            behind: 0,
+            last_commit_date: Some("2026-04-20 08:30:00 +0000".to_string()),
+            cleanup_ready: false,
+            cleanup: BranchCleanupInfo::default(),
+        }];
+        let cleanup_targets = HashMap::from([(
+            String::from("feature/demo"),
+            Some(gwt_git::MergeTarget::Develop),
+        )]);
+
+        let hydrated = hydrate_branch_entries(entries, &HashSet::new(), &cleanup_targets);
+
+        assert!(hydrated[0].cleanup_ready);
+        assert_eq!(
+            hydrated[0].cleanup.availability,
+            BranchCleanupAvailability::Safe
+        );
     }
 }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -224,8 +224,8 @@ mod tests {
             "expected embedded html to branch on cleanup hydration readiness",
         );
         assert!(
-            html.contains("state.loading = state.entries.some((entry) => !entry.cleanup_ready);"),
-            "expected branch entries handler to keep loading active until hydration finishes",
+            html.contains("state.loading = event.phase !== \"hydrated\";"),
+            "expected branch entries handler to derive loading state from explicit event phase",
         );
         assert!(
             html.contains("Loading branch details"),

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -216,6 +216,24 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_branches_surface_keeps_loading_while_cleanup_hydration_is_pending() {
+        let html = index_html();
+
+        assert!(
+            html.contains("!entry.cleanup_ready"),
+            "expected embedded html to branch on cleanup hydration readiness",
+        );
+        assert!(
+            html.contains("state.loading = state.entries.some((entry) => !entry.cleanup_ready);"),
+            "expected branch entries handler to keep loading active until hydration finishes",
+        );
+        assert!(
+            html.contains("Loading branch details"),
+            "expected embedded html to surface loading copy while branch hydration continues",
+        );
+    }
+
+    #[test]
     fn embedded_web_knowledge_bridge_surface_uses_cache_backed_contract() {
         let html = index_html();
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -224,8 +224,12 @@ mod tests {
             "expected embedded html to branch on cleanup hydration readiness",
         );
         assert!(
-            html.contains("state.loading = event.phase !== \"hydrated\";"),
-            "expected branch entries handler to derive loading state from explicit event phase",
+            html.contains("const phase = String(event.phase || \"hydrated\").toLowerCase();"),
+            "expected branch entries handler to normalize the explicit event phase before using it",
+        );
+        assert!(
+            html.contains("state.loading = phase !== \"hydrated\";"),
+            "expected branch entries handler to derive loading state from the normalized phase",
         );
         assert!(
             html.contains("Loading branch details"),

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2599,6 +2599,7 @@ mod tests {
             ahead: 0,
             behind: 0,
             last_commit_date: None,
+            cleanup_ready: true,
             cleanup: crate::BranchCleanupInfo::default(),
         }
     }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -57,7 +57,7 @@ pub use preset::{
     WindowPreset, WindowSurface,
 };
 pub use protocol::{
-    AppStateView, ArrangeMode, BackendEvent, FocusCycleDirection, FrontendEvent, ProjectTabView,
-    RecentProjectView, WorkspaceView,
+    AppStateView, ArrangeMode, BackendEvent, BranchEntriesPhase, FocusCycleDirection,
+    FrontendEvent, ProjectTabView, RecentProjectView, WorkspaceView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -18,11 +18,11 @@ pub mod workspace;
 pub use branch_cleanup::{
     cleanup_selected_branches, BranchCleanupResultEntry, BranchCleanupResultStatus,
 };
-pub use branch_list::{list_branch_entries, BranchListEntry, BranchScope};
 pub use branch_list::{
-    list_branch_entries_with_active_sessions, BranchCleanupAvailability,
-    BranchCleanupBlockedReason, BranchCleanupInfo, BranchCleanupRisk,
+    hydrate_branch_entries_with_active_sessions, list_branch_entries_with_active_sessions,
+    BranchCleanupAvailability, BranchCleanupBlockedReason, BranchCleanupInfo, BranchCleanupRisk,
 };
+pub use branch_list::{list_branch_entries, list_branch_inventory, BranchListEntry, BranchScope};
 pub use daemon_runtime::{HookForwardTarget, RuntimeHookEvent, RuntimeHookEventKind};
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
 pub use knowledge_bridge::{

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -157,6 +157,59 @@ impl OutboundEvent {
     }
 }
 
+fn build_frontend_sync_events(
+    client_id: &str,
+    workspace: gwt::AppStateView,
+    terminal_statuses: Vec<(String, WindowProcessStatus, String)>,
+    terminal_snapshots: Vec<(String, Vec<u8>)>,
+    launch_wizard: Option<gwt::LaunchWizardView>,
+    pending_update: Option<gwt_core::update::UpdateState>,
+) -> Vec<OutboundEvent> {
+    let mut events = vec![OutboundEvent::reply(
+        client_id,
+        BackendEvent::WorkspaceState { workspace },
+    )];
+
+    for (id, status, detail) in terminal_statuses {
+        events.push(OutboundEvent::reply(
+            client_id,
+            BackendEvent::TerminalStatus {
+                id,
+                status,
+                detail: Some(detail),
+            },
+        ));
+    }
+
+    for (id, snapshot) in terminal_snapshots {
+        events.push(OutboundEvent::reply(
+            client_id,
+            BackendEvent::TerminalSnapshot {
+                id,
+                data_base64: base64::engine::general_purpose::STANDARD.encode(snapshot),
+            },
+        ));
+    }
+
+    if let Some(wizard) = launch_wizard {
+        events.push(OutboundEvent::reply(
+            client_id,
+            BackendEvent::LaunchWizardState {
+                wizard: Some(Box::new(wizard)),
+            },
+        ));
+    }
+
+    if let Some(state) = pending_update {
+        events.push(OutboundEvent::reply(
+            client_id,
+            BackendEvent::UpdateState(state),
+        ));
+    }
+
+    events
+}
+
 #[derive(Debug, Clone)]
 struct ProjectTabRuntime {
     id: String,
@@ -396,63 +449,37 @@ impl AppRuntime {
     }
 
     fn frontend_sync_events(&self, client_id: &str) -> Vec<OutboundEvent> {
-        let mut events = vec![OutboundEvent::reply(
+        let terminal_statuses = self
+            .window_details
+            .iter()
+            .filter_map(|(id, detail)| {
+                self.window_status(id)
+                    .map(|status| (id.clone(), status, detail.clone()))
+            })
+            .collect();
+        let terminal_snapshots = self
+            .runtimes
+            .iter()
+            .filter_map(|(id, runtime)| {
+                let snapshot = runtime
+                    .pane
+                    .lock()
+                    .map(|pane| pane.screen().contents().into_bytes())
+                    .unwrap_or_default();
+                (!snapshot.is_empty()).then_some((id.clone(), snapshot))
+            })
+            .collect();
+
+        build_frontend_sync_events(
             client_id,
-            BackendEvent::WorkspaceState {
-                workspace: self.app_state_view(),
-            },
-        )];
-
-        for (id, detail) in &self.window_details {
-            let Some(status) = self.window_status(id) else {
-                continue;
-            };
-            events.push(OutboundEvent::reply(
-                client_id,
-                BackendEvent::TerminalStatus {
-                    id: id.clone(),
-                    status,
-                    detail: Some(detail.clone()),
-                },
-            ));
-        }
-
-        for (id, runtime) in &self.runtimes {
-            let snapshot = runtime
-                .pane
-                .lock()
-                .map(|pane| pane.screen().contents().into_bytes())
-                .unwrap_or_default();
-            if snapshot.is_empty() {
-                continue;
-            }
-            events.push(OutboundEvent::reply(
-                client_id,
-                BackendEvent::TerminalSnapshot {
-                    id: id.clone(),
-                    data_base64: base64::engine::general_purpose::STANDARD.encode(snapshot),
-                },
-            ));
-        }
-
-        if let Some(wizard) = self.launch_wizard.as_ref() {
-            events.push(OutboundEvent::reply(
-                client_id,
-                BackendEvent::LaunchWizardState {
-                    wizard: Some(Box::new(wizard.wizard.view())),
-                },
-            ));
-        }
-
-        // Replay any pending update notification so late-connecting WebView clients see the toast.
-        if let Some(state) = self.pending_update.clone() {
-            events.push(OutboundEvent::reply(
-                client_id,
-                BackendEvent::UpdateState(state),
-            ));
-        }
-
-        events
+            self.app_state_view(),
+            terminal_statuses,
+            terminal_snapshots,
+            self.launch_wizard
+                .as_ref()
+                .map(|wizard| wizard.wizard.view()),
+            self.pending_update.clone(),
+        )
     }
 
     fn open_project_dialog_events(&mut self) -> Vec<OutboundEvent> {
@@ -2362,6 +2389,7 @@ mod tests {
     use std::{collections::HashMap, fs, path::PathBuf, process::Command};
 
     use axum::http::{header::AUTHORIZATION, HeaderMap, HeaderValue};
+    use base64::Engine;
     use tempfile::tempdir;
 
     use gwt::{
@@ -2370,14 +2398,16 @@ mod tests {
         WorkspaceState,
     };
     use gwt_agent::{AgentId, AgentLaunchBuilder, DockerLifecycleIntent, LaunchRuntimeTarget};
+    use gwt_core::update::UpdateState;
     use gwt_terminal::PaneStatus;
 
     use super::{
         app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
-        broadcast_runtime_hook_event, build_shell_process_launch, close_window_from_workspace,
-        combined_window_id, hook_forward_authorized, knowledge_kind_for_preset,
-        resolve_project_target, should_auto_close_agent_window, should_auto_start_restored_window,
-        ActiveAgentSession, ClientHub, ProjectTabRuntime, WindowAddress,
+        broadcast_runtime_hook_event, build_frontend_sync_events, build_shell_process_launch,
+        close_window_from_workspace, combined_window_id, hook_forward_authorized,
+        knowledge_kind_for_preset, resolve_project_target, should_auto_close_agent_window,
+        should_auto_start_restored_window, ActiveAgentSession, ClientHub, DispatchTarget,
+        OutboundEvent, ProjectTabRuntime, WindowAddress,
     };
 
     fn sample_window(preset: WindowPreset, status: WindowProcessStatus) -> PersistedWindowState {
@@ -2427,6 +2457,109 @@ mod tests {
         assert_eq!(native_payload, browser_payload);
         assert!(native_payload.contains("\"kind\":\"runtime_hook_event\""));
         assert!(native_payload.contains("\"source_event\":\"PreToolUse\""));
+    }
+
+    fn drain_client_payloads(
+        receiver: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    ) -> Vec<String> {
+        let mut payloads = Vec::new();
+        while let Ok(payload) = receiver.try_recv() {
+            payloads.push(payload);
+        }
+        payloads
+    }
+
+    #[test]
+    fn frontend_sync_events_reply_only_to_connecting_client() {
+        let tabs = vec![sample_project_tab_with_window(
+            "tab-1",
+            "shell-1",
+            WindowPreset::Shell,
+            WindowProcessStatus::Ready,
+        )];
+        let workspace = app_state_view_from_parts(&tabs, Some("tab-1"), &[]);
+        let snapshot = b"hello from terminal".to_vec();
+        let expected_snapshot =
+            base64::engine::general_purpose::STANDARD.encode(snapshot.as_slice());
+
+        let events = build_frontend_sync_events(
+            "browser-1",
+            workspace,
+            vec![(
+                "tab-1::shell-1".to_string(),
+                WindowProcessStatus::Ready,
+                "Shell ready".to_string(),
+            )],
+            vec![("tab-1::shell-1".to_string(), snapshot)],
+            None,
+            Some(UpdateState::UpToDate { checked_at: None }),
+        );
+
+        assert_eq!(events.len(), 4);
+        assert!(events.iter().all(|event| {
+            matches!(&event.target, DispatchTarget::Client(client_id) if client_id == "browser-1")
+        }));
+        assert!(matches!(
+            &events[0].event,
+            gwt::BackendEvent::WorkspaceState { .. }
+        ));
+        assert!(events.iter().any(|event| matches!(
+            &event.event,
+            gwt::BackendEvent::TerminalStatus { id, status, detail }
+                if id == "tab-1::shell-1"
+                    && *status == WindowProcessStatus::Ready
+                    && detail.as_deref() == Some("Shell ready")
+        )));
+        assert!(events.iter().any(|event| matches!(
+            &event.event,
+            gwt::BackendEvent::TerminalSnapshot { id, data_base64 }
+                if id == "tab-1::shell-1" && data_base64 == &expected_snapshot
+        )));
+        assert!(events.iter().any(|event| matches!(
+            &event.event,
+            gwt::BackendEvent::UpdateState(UpdateState::UpToDate { checked_at: None })
+        )));
+    }
+
+    #[test]
+    fn client_hub_dispatch_keeps_frontend_sync_events_client_scoped() {
+        let clients = ClientHub::default();
+        let mut primary = clients.register("primary".to_string());
+        let mut secondary = clients.register("secondary".to_string());
+        let tabs = vec![sample_project_tab_with_window(
+            "tab-1",
+            "shell-1",
+            WindowPreset::Shell,
+            WindowProcessStatus::Ready,
+        )];
+        let workspace = app_state_view_from_parts(&tabs, Some("tab-1"), &[]);
+        let mut events =
+            build_frontend_sync_events("primary", workspace, Vec::new(), Vec::new(), None, None);
+        events.push(OutboundEvent::broadcast(
+            gwt::BackendEvent::ProjectOpenError {
+                message: "shared".to_string(),
+            },
+        ));
+
+        clients.dispatch(events);
+
+        let primary_payloads = drain_client_payloads(&mut primary);
+        let secondary_payloads = drain_client_payloads(&mut secondary);
+
+        assert_eq!(primary_payloads.len(), 2);
+        assert_eq!(secondary_payloads.len(), 1);
+        assert!(primary_payloads
+            .iter()
+            .any(|payload| payload.contains("\"kind\":\"workspace_state\"")));
+        assert!(primary_payloads
+            .iter()
+            .any(|payload| payload.contains("\"kind\":\"project_open_error\"")));
+        assert!(secondary_payloads
+            .iter()
+            .all(|payload| payload.contains("\"kind\":\"project_open_error\"")));
+        assert!(!secondary_payloads
+            .iter()
+            .any(|payload| payload.contains("\"kind\":\"workspace_state\"")));
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -22,7 +22,8 @@ use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use gwt::{
     build_builtin_agent_options, cleanup_selected_branches, default_wizard_version_cache_path,
-    detect_shell_program, list_branch_entries_with_active_sessions, list_directory_entries,
+    detect_shell_program, hydrate_branch_entries_with_active_sessions,
+    list_branch_entries_with_active_sessions, list_branch_inventory, list_directory_entries,
     load_knowledge_bridge, load_restored_workspace_state, load_session_state,
     migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
     save_session_state, save_workspace_state, workspace_state_path, BackendEvent, BranchListEntry,
@@ -344,12 +345,7 @@ impl AppRuntime {
                     self.load_file_tree_event(&id, &path),
                 )]
             }
-            FrontendEvent::LoadBranches { id } => {
-                vec![OutboundEvent::reply(
-                    client_id,
-                    self.load_branches_event(&id),
-                )]
-            }
+            FrontendEvent::LoadBranches { id } => self.load_branches_events(&client_id, &id),
             FrontendEvent::LoadKnowledgeBridge {
                 id,
                 knowledge_kind,
@@ -858,45 +854,53 @@ impl AppRuntime {
         }
     }
 
-    fn load_branches_event(&self, id: &str) -> BackendEvent {
+    fn load_branches_events(&self, client_id: &str, id: &str) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id) else {
-            return BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            };
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
         };
         let Some(tab) = self.tab(&address.tab_id) else {
-            return BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Project tab not found".to_string(),
-            };
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Project tab not found".to_string(),
+                },
+            )];
         };
         let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            };
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
         };
 
         if window.preset != WindowPreset::Branches {
-            return BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window is not a branches list".to_string(),
-            };
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message: "Window is not a branches list".to_string(),
+                },
+            )];
         }
 
-        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
-        match list_branch_entries_with_active_sessions(&tab.project_root, &active_session_branches)
-        {
-            Ok(entries) => BackendEvent::BranchEntries {
-                id: id.to_string(),
-                entries,
-            },
-            Err(error) => BackendEvent::BranchError {
-                id: id.to_string(),
-                message: error.to_string(),
-            },
-        }
+        Self::spawn_branch_load_async(
+            self.proxy.clone(),
+            client_id.to_string(),
+            id.to_string(),
+            tab.project_root.clone(),
+            self.active_session_branches_for_tab(&address.tab_id),
+        );
+        Vec::new()
     }
 
     fn load_knowledge_bridge_events(
@@ -1059,33 +1063,24 @@ impl AppRuntime {
                         &branches,
                         delete_remote,
                     );
-                    let mut events = vec![OutboundEvent::reply(
-                        client_id.clone(),
-                        BackendEvent::BranchCleanupResult {
-                            id: window_id.clone(),
-                            results,
-                        },
-                    )];
-                    match list_branch_entries_with_active_sessions(
+                    dispatch_async_events(
+                        &proxy,
+                        vec![OutboundEvent::reply(
+                            client_id.clone(),
+                            BackendEvent::BranchCleanupResult {
+                                id: window_id.clone(),
+                                results,
+                            },
+                        )],
+                    );
+                    dispatch_branch_load_progressive(
+                        &proxy,
+                        &client_id,
+                        &window_id,
                         &project_root,
                         &active_session_branches,
-                    ) {
-                        Ok(entries) => events.push(OutboundEvent::reply(
-                            client_id.clone(),
-                            BackendEvent::BranchEntries {
-                                id: window_id.clone(),
-                                entries,
-                            },
-                        )),
-                        Err(error) => events.push(OutboundEvent::reply(
-                            client_id.clone(),
-                            BackendEvent::BranchError {
-                                id: window_id.clone(),
-                                message: error.to_string(),
-                            },
-                        )),
-                    }
-                    events
+                    );
+                    Vec::new()
                 }
                 Err(error) => vec![OutboundEvent::reply(
                     client_id,
@@ -1095,10 +1090,95 @@ impl AppRuntime {
                     },
                 )],
             };
-            let _ = proxy.send_event(UserEvent::Dispatch(events));
+            if !events.is_empty() {
+                let _ = proxy.send_event(UserEvent::Dispatch(events));
+            }
         });
     }
 
+    fn spawn_branch_load_async(
+        proxy: EventLoopProxy<UserEvent>,
+        client_id: ClientId,
+        window_id: String,
+        project_root: PathBuf,
+        active_session_branches: std::collections::HashSet<String>,
+    ) {
+        thread::spawn(move || {
+            dispatch_branch_load_progressive(
+                &proxy,
+                &client_id,
+                &window_id,
+                &project_root,
+                &active_session_branches,
+            );
+        });
+    }
+}
+
+fn dispatch_branch_load_progressive(
+    proxy: &EventLoopProxy<UserEvent>,
+    client_id: &ClientId,
+    window_id: &str,
+    project_root: &Path,
+    active_session_branches: &std::collections::HashSet<String>,
+) {
+    match list_branch_inventory(project_root) {
+        Ok(entries) => {
+            dispatch_async_events(
+                proxy,
+                vec![OutboundEvent::reply(
+                    client_id.clone(),
+                    BackendEvent::BranchEntries {
+                        id: window_id.to_string(),
+                        entries: entries.clone(),
+                    },
+                )],
+            );
+            match hydrate_branch_entries_with_active_sessions(
+                project_root,
+                entries,
+                active_session_branches,
+            ) {
+                Ok(entries) => dispatch_async_events(
+                    proxy,
+                    vec![OutboundEvent::reply(
+                        client_id.clone(),
+                        BackendEvent::BranchEntries {
+                            id: window_id.to_string(),
+                            entries,
+                        },
+                    )],
+                ),
+                Err(error) => dispatch_async_events(
+                    proxy,
+                    vec![OutboundEvent::reply(
+                        client_id.clone(),
+                        BackendEvent::BranchError {
+                            id: window_id.to_string(),
+                            message: error.to_string(),
+                        },
+                    )],
+                ),
+            }
+        }
+        Err(error) => dispatch_async_events(
+            proxy,
+            vec![OutboundEvent::reply(
+                client_id.clone(),
+                BackendEvent::BranchError {
+                    id: window_id.to_string(),
+                    message: error.to_string(),
+                },
+            )],
+        ),
+    }
+}
+
+fn dispatch_async_events(proxy: &EventLoopProxy<UserEvent>, events: Vec<OutboundEvent>) {
+    let _ = proxy.send_event(UserEvent::Dispatch(events));
+}
+
+impl AppRuntime {
     fn open_launch_wizard(
         &mut self,
         id: &str,
@@ -2814,6 +2894,7 @@ mod tests {
                 ahead: 0,
                 behind: 0,
                 last_commit_date: None,
+                cleanup_ready: true,
                 cleanup: BranchCleanupInfo::default(),
             },
             BranchListEntry {
@@ -2824,6 +2905,7 @@ mod tests {
                 ahead: 0,
                 behind: 0,
                 last_commit_date: None,
+                cleanup_ready: true,
                 cleanup: BranchCleanupInfo::default(),
             },
         ];
@@ -2840,6 +2922,7 @@ mod tests {
             ahead: 0,
             behind: 0,
             last_commit_date: None,
+            cleanup_ready: true,
             cleanup: BranchCleanupInfo::default(),
         }];
         assert_eq!(
@@ -3132,6 +3215,7 @@ fn synthetic_branch_entry(branch_name: &str) -> BranchListEntry {
         ahead: 0,
         behind: 0,
         last_commit_date: None,
+        cleanup_ready: true,
         cleanup: gwt::BranchCleanupInfo::default(),
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -8,6 +8,9 @@ use std::{
     time::Duration,
 };
 
+use crate::repo_browser::{
+    preferred_issue_launch_branch, spawn_branch_cleanup_async, spawn_branch_load_async,
+};
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
@@ -21,16 +24,15 @@ use axum::{
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use gwt::{
-    build_builtin_agent_options, cleanup_selected_branches, default_wizard_version_cache_path,
-    detect_shell_program, hydrate_branch_entries_with_active_sessions,
-    list_branch_entries_with_active_sessions, list_branch_inventory, list_directory_entries,
-    load_knowledge_bridge, load_restored_workspace_state, load_session_state,
-    migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
-    save_session_state, save_workspace_state, workspace_state_path, BackendEvent, BranchListEntry,
-    DockerWizardContext, FrontendEvent, HookForwardTarget, KnowledgeKind, LaunchWizardCompletion,
-    LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest, LaunchWizardState,
-    LiveSessionEntry, RuntimeHookEvent, ShellLaunchConfig, WindowGeometry, WindowPreset,
-    WindowProcessStatus, WorkspaceState, APP_NAME,
+    build_builtin_agent_options, default_wizard_version_cache_path, detect_shell_program,
+    list_branch_entries_with_active_sessions, list_directory_entries, load_knowledge_bridge,
+    load_restored_workspace_state, load_session_state, migrate_legacy_workspace_state,
+    refresh_managed_gwt_assets_for_worktree, resolve_launch_spec, save_session_state,
+    save_workspace_state, workspace_state_path, BackendEvent, BranchListEntry, DockerWizardContext,
+    FrontendEvent, HookForwardTarget, KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext,
+    LaunchWizardHydration, LaunchWizardLaunchRequest, LaunchWizardState, LiveSessionEntry,
+    RuntimeHookEvent, ShellLaunchConfig, WindowGeometry, WindowPreset, WindowProcessStatus,
+    WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus};
 use tao::{
@@ -47,6 +49,7 @@ use uuid::Uuid;
 use wry::WebViewBuilder;
 
 mod embedded_web;
+mod repo_browser;
 
 type ClientId = String;
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
@@ -893,7 +896,7 @@ impl AppRuntime {
             )];
         }
 
-        Self::spawn_branch_load_async(
+        spawn_branch_load_async(
             self.proxy.clone(),
             client_id.to_string(),
             id.to_string(),
@@ -1030,7 +1033,7 @@ impl AppRuntime {
             )];
         }
 
-        Self::spawn_branch_cleanup_async(
+        spawn_branch_cleanup_async(
             self.proxy.clone(),
             client_id.to_string(),
             id.to_string(),
@@ -1041,141 +1044,6 @@ impl AppRuntime {
         );
         Vec::new()
     }
-
-    fn spawn_branch_cleanup_async(
-        proxy: EventLoopProxy<UserEvent>,
-        client_id: ClientId,
-        window_id: String,
-        project_root: PathBuf,
-        active_session_branches: std::collections::HashSet<String>,
-        branches: Vec<String>,
-        delete_remote: bool,
-    ) {
-        thread::spawn(move || {
-            let events = match list_branch_entries_with_active_sessions(
-                &project_root,
-                &active_session_branches,
-            ) {
-                Ok(entries) => {
-                    let results = cleanup_selected_branches(
-                        &project_root,
-                        &entries,
-                        &branches,
-                        delete_remote,
-                    );
-                    dispatch_async_events(
-                        &proxy,
-                        vec![OutboundEvent::reply(
-                            client_id.clone(),
-                            BackendEvent::BranchCleanupResult {
-                                id: window_id.clone(),
-                                results,
-                            },
-                        )],
-                    );
-                    dispatch_branch_load_progressive(
-                        &proxy,
-                        &client_id,
-                        &window_id,
-                        &project_root,
-                        &active_session_branches,
-                    );
-                    Vec::new()
-                }
-                Err(error) => vec![OutboundEvent::reply(
-                    client_id,
-                    BackendEvent::BranchError {
-                        id: window_id,
-                        message: error.to_string(),
-                    },
-                )],
-            };
-            if !events.is_empty() {
-                let _ = proxy.send_event(UserEvent::Dispatch(events));
-            }
-        });
-    }
-
-    fn spawn_branch_load_async(
-        proxy: EventLoopProxy<UserEvent>,
-        client_id: ClientId,
-        window_id: String,
-        project_root: PathBuf,
-        active_session_branches: std::collections::HashSet<String>,
-    ) {
-        thread::spawn(move || {
-            dispatch_branch_load_progressive(
-                &proxy,
-                &client_id,
-                &window_id,
-                &project_root,
-                &active_session_branches,
-            );
-        });
-    }
-}
-
-fn dispatch_branch_load_progressive(
-    proxy: &EventLoopProxy<UserEvent>,
-    client_id: &ClientId,
-    window_id: &str,
-    project_root: &Path,
-    active_session_branches: &std::collections::HashSet<String>,
-) {
-    match list_branch_inventory(project_root) {
-        Ok(entries) => {
-            dispatch_async_events(
-                proxy,
-                vec![OutboundEvent::reply(
-                    client_id.clone(),
-                    BackendEvent::BranchEntries {
-                        id: window_id.to_string(),
-                        entries: entries.clone(),
-                    },
-                )],
-            );
-            match hydrate_branch_entries_with_active_sessions(
-                project_root,
-                entries,
-                active_session_branches,
-            ) {
-                Ok(entries) => dispatch_async_events(
-                    proxy,
-                    vec![OutboundEvent::reply(
-                        client_id.clone(),
-                        BackendEvent::BranchEntries {
-                            id: window_id.to_string(),
-                            entries,
-                        },
-                    )],
-                ),
-                Err(error) => dispatch_async_events(
-                    proxy,
-                    vec![OutboundEvent::reply(
-                        client_id.clone(),
-                        BackendEvent::BranchError {
-                            id: window_id.to_string(),
-                            message: error.to_string(),
-                        },
-                    )],
-                ),
-            }
-        }
-        Err(error) => dispatch_async_events(
-            proxy,
-            vec![OutboundEvent::reply(
-                client_id.clone(),
-                BackendEvent::BranchError {
-                    id: window_id.to_string(),
-                    message: error.to_string(),
-                },
-            )],
-        ),
-    }
-}
-
-fn dispatch_async_events(proxy: &EventLoopProxy<UserEvent>, events: Vec<OutboundEvent>) {
-    let _ = proxy.send_event(UserEvent::Dispatch(events));
 }
 
 impl AppRuntime {
@@ -2497,9 +2365,9 @@ mod tests {
     use tempfile::tempdir;
 
     use gwt::{
-        empty_workspace_state, BranchCleanupInfo, BranchListEntry, BranchScope, KnowledgeKind,
-        PersistedWindowState, RuntimeHookEvent, RuntimeHookEventKind, ShellLaunchConfig,
-        WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState,
+        empty_workspace_state, KnowledgeKind, PersistedWindowState, RuntimeHookEvent,
+        RuntimeHookEventKind, ShellLaunchConfig, WindowGeometry, WindowPreset, WindowProcessStatus,
+        WorkspaceState,
     };
     use gwt_agent::{AgentId, AgentLaunchBuilder, DockerLifecycleIntent, LaunchRuntimeTarget};
     use gwt_terminal::PaneStatus;
@@ -2508,9 +2376,8 @@ mod tests {
         app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
         broadcast_runtime_hook_event, build_shell_process_launch, close_window_from_workspace,
         combined_window_id, hook_forward_authorized, knowledge_kind_for_preset,
-        preferred_issue_launch_branch, resolve_project_target, should_auto_close_agent_window,
-        should_auto_start_restored_window, ActiveAgentSession, ClientHub, ProjectTabRuntime,
-        WindowAddress,
+        resolve_project_target, should_auto_close_agent_window, should_auto_start_restored_window,
+        ActiveAgentSession, ClientHub, ProjectTabRuntime, WindowAddress,
     };
 
     fn sample_window(preset: WindowPreset, status: WindowProcessStatus) -> PersistedWindowState {
@@ -2882,54 +2749,6 @@ mod tests {
         );
         assert_eq!(knowledge_kind_for_preset(WindowPreset::Branches), None);
     }
-
-    #[test]
-    fn preferred_issue_launch_branch_prefers_develop_then_head_then_first_local() {
-        let entries = vec![
-            BranchListEntry {
-                name: "feature/demo".to_string(),
-                scope: BranchScope::Local,
-                is_head: true,
-                upstream: None,
-                ahead: 0,
-                behind: 0,
-                last_commit_date: None,
-                cleanup_ready: true,
-                cleanup: BranchCleanupInfo::default(),
-            },
-            BranchListEntry {
-                name: "develop".to_string(),
-                scope: BranchScope::Local,
-                is_head: false,
-                upstream: None,
-                ahead: 0,
-                behind: 0,
-                last_commit_date: None,
-                cleanup_ready: true,
-                cleanup: BranchCleanupInfo::default(),
-            },
-        ];
-        assert_eq!(
-            preferred_issue_launch_branch(&entries),
-            Some("develop".to_string())
-        );
-
-        let head_only = vec![BranchListEntry {
-            name: "feature/demo".to_string(),
-            scope: BranchScope::Local,
-            is_head: true,
-            upstream: None,
-            ahead: 0,
-            behind: 0,
-            last_commit_date: None,
-            cleanup_ready: true,
-            cleanup: BranchCleanupInfo::default(),
-        }];
-        assert_eq!(
-            preferred_issue_launch_branch(&head_only),
-            Some("feature/demo".to_string())
-        );
-    }
 }
 
 fn normalize_active_tab_id(
@@ -3268,26 +3087,6 @@ fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> {
         WindowPreset::Pr => Some(KnowledgeKind::Pr),
         _ => None,
     }
-}
-
-fn preferred_issue_launch_branch(entries: &[gwt::BranchListEntry]) -> Option<String> {
-    use gwt::BranchScope;
-
-    let mut locals = entries
-        .iter()
-        .filter(|entry| entry.scope == BranchScope::Local)
-        .collect::<Vec<_>>();
-    locals.sort_by(|left, right| left.name.cmp(&right.name));
-
-    for preferred in ["develop", "main", "master"] {
-        if let Some(entry) = locals.iter().find(|entry| entry.name == preferred) {
-            return Some(entry.name.clone());
-        }
-    }
-    if let Some(entry) = locals.iter().find(|entry| entry.is_head) {
-        return Some(entry.name.clone());
-    }
-    locals.first().map(|entry| entry.name.clone())
 }
 
 fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -27,6 +27,13 @@ pub enum FocusCycleDirection {
     Backward,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchEntriesPhase {
+    Inventory,
+    Hydrated,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FrontendEvent {
@@ -187,6 +194,7 @@ pub enum BackendEvent {
     },
     BranchEntries {
         id: String,
+        phase: BranchEntriesPhase,
         entries: Vec<BranchListEntry>,
     },
     KnowledgeEntries {
@@ -229,4 +237,30 @@ pub enum BackendEvent {
         event: RuntimeHookEvent,
     },
     UpdateState(gwt_core::update::UpdateState),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::{BackendEvent, BranchEntriesPhase};
+
+    #[test]
+    fn branch_entries_serializes_explicit_phase_contract() {
+        let event = BackendEvent::BranchEntries {
+            id: "branches-1".to_string(),
+            phase: BranchEntriesPhase::Inventory,
+            entries: Vec::new(),
+        };
+
+        let value = serde_json::to_value(&event).expect("serialize branch entries");
+        assert_eq!(
+            value.get("kind"),
+            Some(&Value::String("branch_entries".to_string()))
+        );
+        assert_eq!(
+            value.get("phase"),
+            Some(&Value::String("inventory".to_string()))
+        );
+    }
 }

--- a/crates/gwt/src/repo_browser.rs
+++ b/crates/gwt/src/repo_browser.rs
@@ -1,0 +1,230 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    thread,
+};
+
+use gwt::{
+    cleanup_selected_branches, hydrate_branch_entries_with_active_sessions,
+    list_branch_entries_with_active_sessions, list_branch_inventory, BackendEvent, BranchListEntry,
+    BranchScope,
+};
+use tao::event_loop::EventLoopProxy;
+
+use crate::{ClientId, OutboundEvent, UserEvent};
+
+pub(crate) fn spawn_branch_cleanup_async(
+    proxy: EventLoopProxy<UserEvent>,
+    client_id: ClientId,
+    window_id: String,
+    project_root: PathBuf,
+    active_session_branches: HashSet<String>,
+    branches: Vec<String>,
+    delete_remote: bool,
+) {
+    thread::spawn(move || {
+        let events =
+            match list_branch_entries_with_active_sessions(&project_root, &active_session_branches)
+            {
+                Ok(entries) => {
+                    let results = cleanup_selected_branches(
+                        &project_root,
+                        &entries,
+                        &branches,
+                        delete_remote,
+                    );
+                    dispatch_async_events(
+                        &proxy,
+                        vec![OutboundEvent::reply(
+                            client_id.clone(),
+                            BackendEvent::BranchCleanupResult {
+                                id: window_id.clone(),
+                                results,
+                            },
+                        )],
+                    );
+                    dispatch_branch_load_progressive(
+                        &proxy,
+                        &client_id,
+                        &window_id,
+                        &project_root,
+                        &active_session_branches,
+                    );
+                    Vec::new()
+                }
+                Err(error) => vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BranchError {
+                        id: window_id,
+                        message: error.to_string(),
+                    },
+                )],
+            };
+        if !events.is_empty() {
+            let _ = proxy.send_event(UserEvent::Dispatch(events));
+        }
+    });
+}
+
+pub(crate) fn spawn_branch_load_async(
+    proxy: EventLoopProxy<UserEvent>,
+    client_id: ClientId,
+    window_id: String,
+    project_root: PathBuf,
+    active_session_branches: HashSet<String>,
+) {
+    thread::spawn(move || {
+        dispatch_branch_load_progressive(
+            &proxy,
+            &client_id,
+            &window_id,
+            &project_root,
+            &active_session_branches,
+        );
+    });
+}
+
+pub(crate) fn preferred_issue_launch_branch(entries: &[BranchListEntry]) -> Option<String> {
+    let mut locals = entries
+        .iter()
+        .filter(|entry| entry.scope == BranchScope::Local)
+        .collect::<Vec<_>>();
+    locals.sort_by(|left, right| left.name.cmp(&right.name));
+
+    for preferred in ["develop", "main", "master"] {
+        if let Some(entry) = locals.iter().find(|entry| entry.name == preferred) {
+            return Some(entry.name.clone());
+        }
+    }
+    if let Some(entry) = locals.iter().find(|entry| entry.is_head) {
+        return Some(entry.name.clone());
+    }
+    locals.first().map(|entry| entry.name.clone())
+}
+
+fn dispatch_branch_load_progressive(
+    proxy: &EventLoopProxy<UserEvent>,
+    client_id: &ClientId,
+    window_id: &str,
+    project_root: &Path,
+    active_session_branches: &HashSet<String>,
+) {
+    match list_branch_inventory(project_root) {
+        Ok(entries) => {
+            dispatch_async_events(
+                proxy,
+                vec![OutboundEvent::reply(
+                    client_id.clone(),
+                    BackendEvent::BranchEntries {
+                        id: window_id.to_string(),
+                        entries: entries.clone(),
+                    },
+                )],
+            );
+            match hydrate_branch_entries_with_active_sessions(
+                project_root,
+                entries,
+                active_session_branches,
+            ) {
+                Ok(entries) => dispatch_async_events(
+                    proxy,
+                    vec![OutboundEvent::reply(
+                        client_id.clone(),
+                        BackendEvent::BranchEntries {
+                            id: window_id.to_string(),
+                            entries,
+                        },
+                    )],
+                ),
+                Err(error) => dispatch_async_events(
+                    proxy,
+                    vec![OutboundEvent::reply(
+                        client_id.clone(),
+                        BackendEvent::BranchError {
+                            id: window_id.to_string(),
+                            message: error.to_string(),
+                        },
+                    )],
+                ),
+            }
+        }
+        Err(error) => dispatch_async_events(
+            proxy,
+            vec![OutboundEvent::reply(
+                client_id.clone(),
+                BackendEvent::BranchError {
+                    id: window_id.to_string(),
+                    message: error.to_string(),
+                },
+            )],
+        ),
+    }
+}
+
+fn dispatch_async_events(proxy: &EventLoopProxy<UserEvent>, events: Vec<OutboundEvent>) {
+    let _ = proxy.send_event(UserEvent::Dispatch(events));
+}
+
+#[cfg(test)]
+mod tests {
+    use gwt::{BranchCleanupInfo, BranchListEntry};
+
+    use super::{preferred_issue_launch_branch, BranchScope};
+
+    fn local_branch(name: &str, is_head: bool) -> BranchListEntry {
+        BranchListEntry {
+            name: name.to_string(),
+            scope: BranchScope::Local,
+            is_head,
+            upstream: None,
+            ahead: 0,
+            behind: 0,
+            last_commit_date: None,
+            cleanup_ready: true,
+            cleanup: BranchCleanupInfo::default(),
+        }
+    }
+
+    fn remote_branch(name: &str) -> BranchListEntry {
+        BranchListEntry {
+            name: name.to_string(),
+            scope: BranchScope::Remote,
+            is_head: false,
+            upstream: None,
+            ahead: 0,
+            behind: 0,
+            last_commit_date: None,
+            cleanup_ready: true,
+            cleanup: BranchCleanupInfo::default(),
+        }
+    }
+
+    #[test]
+    fn preferred_issue_launch_branch_prefers_develop_then_head_then_first_local() {
+        let entries = vec![
+            local_branch("feature/demo", true),
+            local_branch("develop", false),
+        ];
+
+        assert_eq!(
+            preferred_issue_launch_branch(&entries),
+            Some("develop".to_string())
+        );
+
+        let head_only = vec![local_branch("feature/demo", true)];
+        assert_eq!(
+            preferred_issue_launch_branch(&head_only),
+            Some("feature/demo".to_string())
+        );
+    }
+
+    #[test]
+    fn preferred_issue_launch_branch_ignores_remote_only_entries() {
+        let entries = vec![
+            remote_branch("origin/develop"),
+            remote_branch("origin/feature/demo"),
+        ];
+
+        assert_eq!(preferred_issue_launch_branch(&entries), None);
+    }
+}

--- a/crates/gwt/src/repo_browser.rs
+++ b/crates/gwt/src/repo_browser.rs
@@ -6,8 +6,8 @@ use std::{
 
 use gwt::{
     cleanup_selected_branches, hydrate_branch_entries_with_active_sessions,
-    list_branch_entries_with_active_sessions, list_branch_inventory, BackendEvent, BranchListEntry,
-    BranchScope,
+    list_branch_entries_with_active_sessions, list_branch_inventory, BackendEvent,
+    BranchEntriesPhase, BranchListEntry, BranchScope,
 };
 use tao::event_loop::EventLoopProxy;
 
@@ -117,6 +117,7 @@ fn dispatch_branch_load_progressive(
                     client_id.clone(),
                     BackendEvent::BranchEntries {
                         id: window_id.to_string(),
+                        phase: BranchEntriesPhase::Inventory,
                         entries: entries.clone(),
                     },
                 )],
@@ -132,6 +133,7 @@ fn dispatch_branch_load_progressive(
                         client_id.clone(),
                         BackendEvent::BranchEntries {
                             id: window_id.to_string(),
+                            phase: BranchEntriesPhase::Hydrated,
                             entries,
                         },
                     )],

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -5056,8 +5056,9 @@
           case "branch_entries": {
             const state = ensureBranchListState(event.id);
             state.entries = event.entries;
-            state.phase = event.phase || "hydrated";
-            state.loading = event.phase !== "hydrated";
+            const phase = String(event.phase || "hydrated").toLowerCase();
+            state.phase = phase;
+            state.loading = phase !== "hydrated";
             state.receivedFreshEntries = true;
             state.error = "";
             state.notice = "";

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2973,6 +2973,7 @@
         if (!branchListStateMap.has(windowId)) {
           branchListStateMap.set(windowId, {
             entries: [],
+            phase: "hydrated",
             loading: false,
             error: "",
             selectedBranchName: "",
@@ -5040,7 +5041,8 @@
           case "branch_entries": {
             const state = ensureBranchListState(event.id);
             state.entries = event.entries;
-            state.loading = state.entries.some((entry) => !entry.cleanup_ready);
+            state.phase = event.phase || "hydrated";
+            state.loading = event.phase !== "hydrated";
             state.error = "";
             syncBranchSelectionState(state);
             renderBranches(event.id);

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -955,6 +955,10 @@
         color: #94a3b8;
       }
 
+      .branch-cleanup-toggle.loading {
+        color: #64748b;
+      }
+
       .branch-cleanup-toggle.selected {
         background: #0f172a;
         border-color: #0f172a;
@@ -1043,6 +1047,11 @@
       .branch-cleanup-badge.blocked {
         background: rgba(148, 163, 184, 0.18);
         color: #475569;
+      }
+
+      .branch-cleanup-badge.loading {
+        background: rgba(148, 163, 184, 0.12);
+        color: #64748b;
       }
 
       .branch-summary {
@@ -3853,8 +3862,9 @@
             selectedCount === 0 ? "Clean Up" : `Clean Up (${selectedCount})`;
         }
         if (notice) {
-          notice.hidden = !state.notice;
-          notice.textContent = state.notice || "";
+          const noticeText = state.notice || branchLoadingNoticeText(state);
+          notice.hidden = !noticeText;
+          notice.textContent = noticeText || "";
         }
 
         list.innerHTML = "";
@@ -3934,11 +3944,11 @@
           date.textContent = entry.last_commit_date || "No commit date";
           main.appendChild(date);
 
-          const cleanupDetail = cleanupDetailText(entry);
+          const cleanupDetail = cleanupDetailText(entry, state);
           if (cleanupDetail) {
             const detail = document.createElement("div");
             detail.className = `branch-cleanup-detail ${
-              entry.cleanup.availability === "blocked" ? "blocked" : ""
+              cleanupAvailabilityForRender(entry, state) === "blocked" ? "blocked" : ""
             }`.trim();
             detail.textContent = cleanupDetail;
             main.appendChild(detail);
@@ -3953,8 +3963,8 @@
           meta.appendChild(scope);
 
           const cleanupBadge = document.createElement("span");
-          cleanupBadge.className = `branch-cleanup-badge ${entry.cleanup.availability}`;
-          cleanupBadge.textContent = entry.cleanup.availability;
+          cleanupBadge.className = `branch-cleanup-badge ${cleanupAvailabilityForRender(entry, state)}`;
+          cleanupBadge.textContent = cleanupBadgeText(entry, state);
           meta.appendChild(cleanupBadge);
 
           const summary = document.createElement("span");
@@ -4216,7 +4226,7 @@
         const entriesByName = new Map(state.entries.map((entry) => [entry.name, entry]));
         return Array.from(state.cleanupSelected)
           .map((name) => entriesByName.get(name))
-          .filter(Boolean);
+          .filter((entry) => Boolean(entry?.cleanup_ready));
       }
 
       function clearBranchCleanupTimeout(state) {
@@ -4263,12 +4273,15 @@
         if (state.cleanupSelected.has(entry.name)) {
           return "selected";
         }
-        return entry.cleanup.availability;
+        return cleanupAvailabilityForRender(entry, state);
       }
 
       function cleanupToggleSymbol(entry, state) {
         if (state.cleanupSelected.has(entry.name)) {
           return "●";
+        }
+        if (!entry.cleanup_ready) {
+          return "…";
         }
         switch (entry.cleanup.availability) {
           case "safe":
@@ -4284,6 +4297,9 @@
         if (state.cleanupSelected.has(entry.name)) {
           return "Selected for cleanup";
         }
+        if (!entry.cleanup_ready) {
+          return branchCleanupPendingText(state);
+        }
         if (entry.cleanup.availability === "blocked") {
           return cleanupBlockedReasonText(entry.cleanup.blocked_reason);
         }
@@ -4293,7 +4309,10 @@
         return "Select for cleanup";
       }
 
-      function cleanupDetailText(entry) {
+      function cleanupDetailText(entry, state) {
+        if (!entry.cleanup_ready) {
+          return branchCleanupPendingText(state);
+        }
         if (entry.cleanup.availability === "blocked") {
           return cleanupBlockedReasonText(entry.cleanup.blocked_reason);
         }
@@ -4344,10 +4363,34 @@
         }
       }
 
+      function branchLoadingNoticeText(state) {
+        if (!state.loading) {
+          return "";
+        }
+        return state.entries.length === 0 ? "" : "Loading branch details";
+      }
+
+      function branchCleanupPendingText(state) {
+        return state.loading ? "Loading cleanup status" : "Cleanup status unavailable";
+      }
+
+      function cleanupAvailabilityForRender(entry, state) {
+        return entry.cleanup_ready ? entry.cleanup.availability : "loading";
+      }
+
+      function cleanupBadgeText(entry, state) {
+        return entry.cleanup_ready ? entry.cleanup.availability : state.loading ? "loading" : "unknown";
+      }
+
       function toggleBranchCleanupSelection(windowId, branchName) {
         const state = ensureBranchListState(windowId);
         const entry = state.entries.find((candidate) => candidate.name === branchName);
         if (!entry) {
+          return;
+        }
+        if (!entry.cleanup_ready) {
+          state.notice = branchCleanupPendingText(state);
+          renderBranches(windowId);
           return;
         }
         if (entry.cleanup.availability === "blocked") {
@@ -4997,7 +5040,7 @@
           case "branch_entries": {
             const state = ensureBranchListState(event.id);
             state.entries = event.entries;
-            state.loading = false;
+            state.loading = state.entries.some((entry) => !entry.cleanup_ready);
             state.error = "";
             syncBranchSelectionState(state);
             renderBranches(event.id);
@@ -5042,7 +5085,12 @@
               renderBranches(event.id);
               break;
             }
-            state.error = event.message;
+            if (state.entries.length > 0) {
+              state.notice = event.message;
+              state.error = "";
+            } else {
+              state.error = event.message;
+            }
             renderBranches(event.id);
             break;
           }


### PR DESCRIPTION
## Summary
- render the Branches window immediately and load branch inventory asynchronously before cleanup hydration
- keep branch rows visible while cleanup state hydrates and block cleanup actions until readiness is known
- sort Branches newest-first by `last_commit_date`

## Changes
- split branch list loading into inventory and cleanup hydration passes and add a `cleanup_ready` wire field
- move Branches load, refresh, and post-cleanup reload off the tao event loop onto a background worker
- update the embedded web UI to show loading copy, pending cleanup placeholders, and inline partial-load failures without replacing visible rows
- add regression tests for newest-first ordering and the partial branch hydration contract

## Testing
- `cargo fmt`
- `cargo test -p gwt-core -p gwt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`

## Risk / Impact
- Branches window loading and refresh behavior
- Branch cleanup affordances while metadata is still hydrating
- Branch ordering now follows `last_commit_date` descending

## Deployment
- none

## Screenshots
- none

## Related Issues / Links
- SPEC-2009 / #2009

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [x] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- Cleanup hydration failures keep already-rendered rows visible and surface the error as an inline notice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Branch list now loads progressively with visual loading indicators while details are being fetched.

* **Improvements**
  * Branches now sort by most recent commit date (newest first).
  * Cleanup operations display loading states until ready for selection.
  * Enhanced error handling for branch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->