### PR TITLE
fix: managed excludeにdocker overrideを追加

### DIFF
--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -15,6 +15,7 @@ const GWT_EXCLUDE_PATTERNS: &[&str] = &[
     ".claude/commands/gwt-*",
     ".claude/settings.local.json",
     ".codex/skills/gwt-*",
+    "docker-compose.override.yml",
 ];
 
 /// Update `.git/info/exclude` to include gwt-managed asset exclusions.
@@ -149,6 +150,7 @@ mod tests {
         assert!(result.contains(END_MARKER));
         assert!(result.contains(".claude/skills/gwt-*"));
         assert!(result.contains(".codex/skills/gwt-*"));
+        assert!(result.contains("docker-compose.override.yml"));
         assert!(!result.contains(".codex/hooks.json"));
         assert!(!result.contains(".codex/hooks/scripts/gwt-*"));
         assert!(!result.contains(".agents/skills/gwt-*"));
@@ -187,6 +189,7 @@ mod tests {
         let content = fs::read_to_string(git_resolved_exclude_path(worktree)).unwrap();
         assert!(content.contains(BEGIN_MARKER));
         assert!(content.contains(".claude/skills/gwt-*"));
+        assert!(content.contains("docker-compose.override.yml"));
     }
 
     #[test]
@@ -209,6 +212,7 @@ mod tests {
         let exclude_path = git_resolved_exclude_path(&worktree);
         let content = fs::read_to_string(&exclude_path).unwrap();
         assert!(content.contains(BEGIN_MARKER));
+        assert!(content.contains("docker-compose.override.yml"));
         assert!(!content.contains(".codex/hooks.json"));
         assert!(
             !worktree.join(".git/info/exclude").exists(),

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -1220,8 +1220,8 @@ mod tests {
                 "unexpected retired distributed asset {retired}"
             );
         }
-        assert_no_gwt_hook_scripts(&wt, ".claude");
-        assert_no_gwt_hook_scripts(&wt, ".codex");
+        assert_no_gwt_hook_scripts(wt, ".claude");
+        assert_no_gwt_hook_scripts(wt, ".codex");
     }
 
     // ── helpers ──


### PR DESCRIPTION
## Summary

- Add `docker-compose.override.yml` to the gwt-managed `.git/info/exclude` block so generated Docker overrides are treated like the other managed local assets.
- Extend the `git_exclude` tests to cover empty repos, linked worktrees, and regenerated managed blocks for the Docker override pattern.
- Fix two `needless_borrow` test calls in `gwt-skills` that surfaced while running `cargo clippy` for this follow-up.

## Changes

- `crates/gwt-skills/src/git_exclude.rs`: add `docker-compose.override.yml` to `GWT_EXCLUDE_PATTERNS` and assert it in the managed exclude tests.
- `crates/gwt-skills/src/lib.rs`: remove redundant borrows in the distributed-asset test helper calls so `cargo clippy -D warnings` stays green.

## Testing

- [x] `cargo test -p gwt-skills -- --nocapture` — 98 tests pass after the managed exclude update and post-merge verification.
- [x] `cargo test -p gwt --test managed_assets_test -- --nocapture` — managed asset regeneration and exclude materialization stay green after syncing with `origin/develop`.
- [x] `cargo fmt -- --check` — formatting check passes.
- [x] `cargo clippy -p gwt-skills --all-targets --all-features -- -D warnings` — `gwt-skills` passes clippy without warnings.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — commit message passes commitlint.

## Closing Issues

- None

## Related Issues / Links

- #2077

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — no user-facing documentation change was needed for this follow-up.
- [ ] Migration/backfill plan included (if schema/data change) — no schema or stored data migration is involved.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Notes

- Synced `feature/gwt-cli` with `origin/develop` before opening this follow-up PR and re-ran the phase-relevant tests afterward.