### PR TITLE
fix(skills): move .gwt/discussion.md exclude to info/exclude managed block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ PLANS.md
 .gwt-session.toml
 .gwt/index/
 .gwt/index.crashed-*/
-.gwt/discussion.md
 
 # Serena MCP tool cache directory
 .serena/

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -10,11 +10,19 @@ const BEGIN_MARKER: &str = "# gwt-managed-begin";
 const END_MARKER: &str = "# gwt-managed-end";
 
 /// Patterns to exclude gwt-managed assets from git tracking.
+///
+/// `.gwt/discussion.md` is the gwt-discussion skill's working artifact, which
+/// is always created under the active worktree. gwt owns its exclusion via
+/// this managed block rather than `.gitignore`, because a project-level
+/// `.gitignore` cannot assume every worktree using a gwt skill has the same
+/// repo-wide rule (some consumers run gwt without committing to the
+/// repository's `.gitignore`).
 const GWT_EXCLUDE_PATTERNS: &[&str] = &[
     ".claude/skills/gwt-*",
     ".claude/commands/gwt-*",
     ".claude/settings.local.json",
     ".codex/skills/gwt-*",
+    ".gwt/discussion.md",
 ];
 
 /// Update `.git/info/exclude` to include gwt-managed asset exclusions.
@@ -149,6 +157,7 @@ mod tests {
         assert!(result.contains(END_MARKER));
         assert!(result.contains(".claude/skills/gwt-*"));
         assert!(result.contains(".codex/skills/gwt-*"));
+        assert!(result.contains(".gwt/discussion.md"));
         assert!(!result.contains(".codex/hooks.json"));
         assert!(!result.contains(".codex/hooks/scripts/gwt-*"));
         assert!(!result.contains(".agents/skills/gwt-*"));


### PR DESCRIPTION
## Summary

- PR #2084 で誤って project `.gitignore` に追加した `.gwt/discussion.md` を、gwt-skills の `GWT_EXCLUDE_PATTERNS` に移し、`info/exclude` の `gwt-managed-begin`〜`gwt-managed-end` ブロックで管理する正規運用に揃える。
- gwt の運用ルール: **`.gitignore` はプロジェクト所有、skill / agent が触らない。skill 自動生成 artifact の非追跡化は `info/exclude` の managed block 一本化**。他プロジェクトで gwt skill を使う場合 `.gitignore` に該当行がある保証がないため。

## Changes

- `crates/gwt-skills/src/git_exclude.rs`: `GWT_EXCLUDE_PATTERNS` に `.gwt/discussion.md` を追加。なぜ `.gitignore` ではなく managed block に置くのかを doc コメントで明示。`adds_managed_block_to_empty_file` テストに `.gwt/discussion.md` の存在アサートを追加。
- `.gitignore`: `.gwt/discussion.md` 行を削除（#2084 の誤追加を取り消し）。

## Testing

- [x] `cargo test -p gwt-skills` — 98 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p gwt` — OK

動作確認（次回 agent launch 時に自動反映）:
1. `cargo run -p gwt` で起動 → `refresh_managed_gwt_assets_for_worktree` が発火
2. `E:/gwt/gwt.git/info/exclude` の `# gwt-managed-begin` ブロック内に `.gwt/discussion.md` が追加されることを確認
3. `gwt-discussion` skill で `.gwt/discussion.md` が生成されても `git status` に出ないこと

## Closing Issues

- None

## Related Issues / Links

- 前段: PR #2084（`.gwt/discussion.md` を `.gitignore` に誤追加）
- 関連: PR #2087（同ブランチで入れた fast-path 本体、既にマージ済み）

## Checklist

- [x] Tests added/updated — `adds_managed_block_to_empty_file` に assertion 追加
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated — N/A: 運用方針は `git_exclude.rs` の doc コメントに埋め込み
- [x] Migration/backfill plan included — 次回 agent launch で `info/exclude` の managed block が自動更新され、既存 clone でも追加作業不要
- [x] CHANGELOG impact considered — `fix:` パッチ扱い

## Context

- 発端: ユーザー指摘「gwt では `.gitignore` は触らない。`info/exclude` のみ」
- 当初の PR #2084 で私（エージェント）が誤って project `.gitignore` に `.gwt/discussion.md` 行を追加していたため、本 PR で原状回復 + 正規経路への移行を同時に行う。
- ルールを `git_exclude.rs` の doc コメントに刻むことで、将来の agent が同じ誤りを繰り返さないようにした。
