### PR TITLE
fix(hooks): PreToolUse block 理由を hookSpecificOutput で可視化する

### DIFF
--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -94,21 +94,64 @@ impl HookEvent {
 }
 
 /// JSON shape a block hook writes to stdout when it vetoes a tool call.
+///
+/// Uses the Claude Code PreToolUse `hookSpecificOutput` contract so that
+/// `permissionDecisionReason` is the single visible field. The legacy
+/// `{"decision":"block","reason":"...","stopReason":"..."}` shape is
+/// deliberately not emitted: `stopReason` is a Stop/SubagentStop-only
+/// field and was silently dropped on PreToolUse, so only the short
+/// summary ever reached the user.
+///
+/// `reason` and `stop_reason` are kept as `#[serde(skip)]` internal fields
+/// so tests and call sites can still inspect the short summary and the
+/// detailed guidance independently, while the wire format emits only the
+/// merged `permissionDecisionReason`.
 #[derive(Debug, Clone, Serialize)]
 pub struct BlockDecision {
-    pub decision: &'static str,
+    #[serde(rename = "hookSpecificOutput")]
+    hook_specific_output: HookSpecificOutput,
+    #[serde(skip)]
     pub reason: String,
-    #[serde(rename = "stopReason")]
+    #[serde(skip)]
     pub stop_reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct HookSpecificOutput {
+    #[serde(rename = "hookEventName")]
+    hook_event_name: &'static str,
+    #[serde(rename = "permissionDecision")]
+    permission_decision: &'static str,
+    #[serde(rename = "permissionDecisionReason")]
+    permission_decision_reason: String,
 }
 
 impl BlockDecision {
     pub fn new(reason: impl Into<String>, stop_reason: impl Into<String>) -> Self {
+        let reason = reason.into();
+        let stop_reason = stop_reason.into();
+        let permission_decision_reason = if stop_reason.is_empty() {
+            reason.clone()
+        } else if reason.is_empty() {
+            stop_reason.clone()
+        } else {
+            format!("{reason}\n\n{stop_reason}")
+        };
         Self {
-            decision: "block",
-            reason: reason.into(),
-            stop_reason: stop_reason.into(),
+            hook_specific_output: HookSpecificOutput {
+                hook_event_name: "PreToolUse",
+                permission_decision: "deny",
+                permission_decision_reason,
+            },
+            reason,
+            stop_reason,
         }
+    }
+
+    /// The merged text that Claude Code / Codex actually show to the
+    /// LLM and user when the tool call is denied.
+    pub fn permission_decision_reason(&self) -> &str {
+        &self.hook_specific_output.permission_decision_reason
     }
 }
 

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -93,27 +93,19 @@ impl HookEvent {
     }
 }
 
-/// JSON shape a block hook writes to stdout when it vetoes a tool call.
+/// PreToolUse `hookSpecificOutput` denial payload.
 ///
-/// Uses the Claude Code PreToolUse `hookSpecificOutput` contract so that
-/// `permissionDecisionReason` is the single visible field. The legacy
-/// `{"decision":"block","reason":"...","stopReason":"..."}` shape is
-/// deliberately not emitted: `stopReason` is a Stop/SubagentStop-only
-/// field and was silently dropped on PreToolUse, so only the short
-/// summary ever reached the user.
-///
-/// `reason` and `stop_reason` are kept as `#[serde(skip)]` internal fields
-/// so tests and call sites can still inspect the short summary and the
-/// detailed guidance independently, while the wire format emits only the
-/// merged `permissionDecisionReason`.
+/// The wire format exposes only `permissionDecisionReason` because the
+/// legacy top-level `stopReason` is ignored on PreToolUse and only the
+/// short `reason` was reaching the user before this was introduced.
 #[derive(Debug, Clone, Serialize)]
 pub struct BlockDecision {
     #[serde(rename = "hookSpecificOutput")]
     hook_specific_output: HookSpecificOutput,
     #[serde(skip)]
-    pub reason: String,
+    summary: String,
     #[serde(skip)]
-    pub stop_reason: String,
+    detail: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -126,30 +118,43 @@ struct HookSpecificOutput {
     permission_decision_reason: String,
 }
 
+impl HookSpecificOutput {
+    const EVENT_NAME: &'static str = "PreToolUse";
+    const DECISION_DENY: &'static str = "deny";
+}
+
 impl BlockDecision {
-    pub fn new(reason: impl Into<String>, stop_reason: impl Into<String>) -> Self {
-        let reason = reason.into();
-        let stop_reason = stop_reason.into();
-        let permission_decision_reason = if stop_reason.is_empty() {
-            reason.clone()
-        } else if reason.is_empty() {
-            stop_reason.clone()
-        } else {
-            format!("{reason}\n\n{stop_reason}")
+    pub fn new(summary: impl Into<String>, detail: impl Into<String>) -> Self {
+        let summary = summary.into();
+        let detail = detail.into();
+        let permission_decision_reason = match (summary.is_empty(), detail.is_empty()) {
+            (true, _) => detail.clone(),
+            (_, true) => summary.clone(),
+            _ => format!("{summary}\n\n{detail}"),
         };
         Self {
             hook_specific_output: HookSpecificOutput {
-                hook_event_name: "PreToolUse",
-                permission_decision: "deny",
+                hook_event_name: HookSpecificOutput::EVENT_NAME,
+                permission_decision: HookSpecificOutput::DECISION_DENY,
                 permission_decision_reason,
             },
-            reason,
-            stop_reason,
+            summary,
+            detail,
         }
     }
 
-    /// The merged text that Claude Code / Codex actually show to the
-    /// LLM and user when the tool call is denied.
+    /// Short headline. Kept separate from `detail` so tests can assert the
+    /// rule name without scanning the merged reason.
+    pub fn summary(&self) -> &str {
+        &self.summary
+    }
+
+    /// Full guidance (alternatives, blocked command, etc.).
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+
+    /// The merged text Claude Code / Codex surface to the LLM and user.
     pub fn permission_decision_reason(&self) -> &str {
         &self.hook_specific_output.permission_decision_reason
     }

--- a/crates/gwt/tests/hook_block_bash_policy_test.rs
+++ b/crates/gwt/tests/hook_block_bash_policy_test.rs
@@ -76,13 +76,38 @@ fn blocks_workflow_focused_github_cli_commands() {
 
 #[test]
 fn github_workflow_block_message_points_to_canonical_gwt_surfaces() {
+    // All guidance must land inside `permissionDecisionReason` because the
+    // legacy `stopReason` field is ignored on PreToolUse hooks. If the
+    // canonical `gwt` alternatives are not in that single visible field,
+    // the LLM/user sees only the short summary and has no idea how to
+    // recover.
     let decision = block_bash_policy::evaluate_bash_command("gh pr view 1949", &root())
         .expect("workflow gh command must block");
-    assert!(decision.reason.contains("GitHub workflow CLI"));
-    assert!(decision.stop_reason.contains("gwt issue view"));
-    assert!(decision.stop_reason.contains("gwt pr view"));
-    assert!(decision.stop_reason.contains("gwt actions logs"));
-    assert!(decision.stop_reason.contains("gwt-search"));
+    let visible = decision.permission_decision_reason();
+    assert!(
+        visible.contains("GitHub workflow CLI"),
+        "summary must appear in permissionDecisionReason, got: {visible}"
+    );
+    assert!(
+        visible.contains("gwt issue view"),
+        "gwt issue view alternative missing from visible reason: {visible}"
+    );
+    assert!(
+        visible.contains("gwt pr view"),
+        "gwt pr view alternative missing from visible reason: {visible}"
+    );
+    assert!(
+        visible.contains("gwt actions logs"),
+        "gwt actions logs alternative missing from visible reason: {visible}"
+    );
+    assert!(
+        visible.contains("gwt-search"),
+        "gwt-search alternative missing from visible reason: {visible}"
+    );
+    assert!(
+        visible.contains("Blocked command: gh pr view 1949"),
+        "the blocked command must be echoed in the visible reason: {visible}"
+    );
 }
 
 #[test]

--- a/crates/gwt/tests/hook_block_bash_policy_test.rs
+++ b/crates/gwt/tests/hook_block_bash_policy_test.rs
@@ -76,38 +76,27 @@ fn blocks_workflow_focused_github_cli_commands() {
 
 #[test]
 fn github_workflow_block_message_points_to_canonical_gwt_surfaces() {
-    // All guidance must land inside `permissionDecisionReason` because the
-    // legacy `stopReason` field is ignored on PreToolUse hooks. If the
-    // canonical `gwt` alternatives are not in that single visible field,
-    // the LLM/user sees only the short summary and has no idea how to
-    // recover.
+    // `permissionDecisionReason` is the single field PreToolUse actually
+    // surfaces, so the canonical alternatives and the blocked command
+    // must all land inside it — otherwise the LLM/user only sees the
+    // short rule name and has no recovery path.
     let decision = block_bash_policy::evaluate_bash_command("gh pr view 1949", &root())
         .expect("workflow gh command must block");
     let visible = decision.permission_decision_reason();
-    assert!(
-        visible.contains("GitHub workflow CLI"),
-        "summary must appear in permissionDecisionReason, got: {visible}"
-    );
-    assert!(
-        visible.contains("gwt issue view"),
-        "gwt issue view alternative missing from visible reason: {visible}"
-    );
-    assert!(
-        visible.contains("gwt pr view"),
-        "gwt pr view alternative missing from visible reason: {visible}"
-    );
-    assert!(
-        visible.contains("gwt actions logs"),
-        "gwt actions logs alternative missing from visible reason: {visible}"
-    );
-    assert!(
-        visible.contains("gwt-search"),
-        "gwt-search alternative missing from visible reason: {visible}"
-    );
-    assert!(
-        visible.contains("Blocked command: gh pr view 1949"),
-        "the blocked command must be echoed in the visible reason: {visible}"
-    );
+
+    for required in [
+        "GitHub workflow CLI",
+        "gwt issue view",
+        "gwt pr view",
+        "gwt actions logs",
+        "gwt-search",
+        "Blocked command: gh pr view 1949",
+    ] {
+        assert!(
+            visible.contains(required),
+            "{required:?} missing from permission_decision_reason: {visible}"
+        );
+    }
 }
 
 #[test]

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -134,8 +134,31 @@ fn delegated_block_hook_preserves_block_json_contract() {
 
     let stdout = String::from_utf8(env.stdout).unwrap();
     assert!(
-        stdout.contains("\"decision\":\"block\""),
-        "stdout: {stdout}"
+        stdout.contains("\"hookSpecificOutput\""),
+        "stdout must emit hookSpecificOutput wrapper, got: {stdout}"
     );
-    assert!(stdout.contains("Direct GitHub workflow CLI commands are not allowed"));
+    assert!(
+        stdout.contains("\"hookEventName\":\"PreToolUse\""),
+        "stdout must declare PreToolUse event, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"permissionDecision\":\"deny\""),
+        "stdout must deny the tool, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Direct GitHub workflow CLI commands are not allowed"),
+        "short summary must remain in the visible reason: {stdout}"
+    );
+    assert!(
+        stdout.contains("gwt pr view"),
+        "canonical gwt alternative must be present in the visible reason: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"decision\":\"block\""),
+        "legacy decision:block output must not be emitted, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"stopReason\""),
+        "legacy stopReason output must not be emitted, got: {stdout}"
+    );
 }

--- a/crates/gwt/tests/hook_types_test.rs
+++ b/crates/gwt/tests/hook_types_test.rs
@@ -105,8 +105,8 @@ fn block_decision_serializes_as_hook_specific_output() {
 #[test]
 fn block_decision_accessors_expose_summary_and_detail() {
     let decision = BlockDecision::new("forbidden command", "policy violation");
-    assert_eq!(decision.reason, "forbidden command");
-    assert_eq!(decision.stop_reason, "policy violation");
+    assert_eq!(decision.summary(), "forbidden command");
+    assert_eq!(decision.detail(), "policy violation");
     assert!(decision
         .permission_decision_reason()
         .contains("forbidden command"));

--- a/crates/gwt/tests/hook_types_test.rs
+++ b/crates/gwt/tests/hook_types_test.rs
@@ -57,16 +57,62 @@ fn hook_event_command_returns_none_when_command_field_is_not_a_string() {
 }
 
 #[test]
-fn block_decision_new_serializes_with_camelcase_stop_reason() {
+fn block_decision_serializes_as_hook_specific_output() {
+    // Claude Code PreToolUse contract: the hook must emit
+    // `hookSpecificOutput.permissionDecisionReason` so the reason text is
+    // actually surfaced to the LLM/user. The legacy `decision`/`reason`/
+    // `stopReason` top-level fields are intentionally dropped because
+    // `stopReason` is ignored on PreToolUse and only `reason` was visible.
     let decision = BlockDecision::new("forbidden command", "policy violation");
     let json = serde_json::to_value(&decision).unwrap();
-    assert_eq!(json["decision"], "block");
-    assert_eq!(json["reason"], "forbidden command");
-    assert_eq!(json["stopReason"], "policy violation");
+
+    assert!(
+        json.get("decision").is_none(),
+        "legacy top-level `decision` field must not be emitted, got: {json}"
+    );
+    assert!(
+        json.get("reason").is_none(),
+        "legacy top-level `reason` field must not be emitted"
+    );
+    assert!(
+        json.get("stopReason").is_none(),
+        "legacy top-level `stopReason` field must not be emitted (Stop-hook only)"
+    );
     assert!(
         json.get("stop_reason").is_none(),
-        "must not expose snake_case field"
+        "snake_case field must never leak into the wire format"
     );
+
+    let hook_output = json
+        .get("hookSpecificOutput")
+        .expect("hookSpecificOutput must be the top-level payload");
+    assert_eq!(hook_output["hookEventName"], "PreToolUse");
+    assert_eq!(hook_output["permissionDecision"], "deny");
+
+    let reason = hook_output["permissionDecisionReason"]
+        .as_str()
+        .expect("permissionDecisionReason must be a string");
+    assert!(
+        reason.contains("forbidden command"),
+        "summary must be part of the visible reason, got: {reason}"
+    );
+    assert!(
+        reason.contains("policy violation"),
+        "detail must be part of the visible reason, got: {reason}"
+    );
+}
+
+#[test]
+fn block_decision_accessors_expose_summary_and_detail() {
+    let decision = BlockDecision::new("forbidden command", "policy violation");
+    assert_eq!(decision.reason, "forbidden command");
+    assert_eq!(decision.stop_reason, "policy violation");
+    assert!(decision
+        .permission_decision_reason()
+        .contains("forbidden command"));
+    assert!(decision
+        .permission_decision_reason()
+        .contains("policy violation"));
 }
 
 #[test]

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -411,7 +411,9 @@ fn worktree_external_file_op_is_blocked_before_owner_gate() {
     );
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
         .expect("out-of-worktree file ops must be blocked");
-    assert!(decision.reason.contains("outside worktree"));
+    assert!(decision
+        .permission_decision_reason()
+        .contains("outside worktree"));
 }
 
 #[test]
@@ -422,7 +424,9 @@ fn reuses_legacy_bash_policy_rules_before_spec_gate() {
         workflow_policy::WorkflowContext::spec_issue(1935, true, true),
     )
     .expect("issue cli must still be blocked");
-    assert!(decision.reason.contains("GitHub workflow CLI"));
+    assert!(decision
+        .permission_decision_reason()
+        .contains("GitHub workflow CLI"));
 }
 
 #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,38 @@
 # Lessons Learned
 
+## 2026-04-20 — fix(hooks): PreToolUse で `stopReason` は表示されない。`hookSpecificOutput.permissionDecisionReason` を使う
+
+### 事象
+
+`gwt hook block-bash-policy` が `gh issue/pr/run` をブロックした際、ユーザーには
+`Direct GitHub workflow CLI commands are not allowed` という短文しか表示されず、
+詳細な代替コマンド一覧 (`gwt issue view` / `gwt pr view` / `gwt actions logs` /
+`gwt-search`) と `Blocked command: ...` 原文が届かなかった。他の block 系フック
+(cd / file-ops / branch-ops / git-dir) も同じ欠陥を抱えていたが、短文自体が自己
+説明的だったため見落とされていた。
+
+### 原因
+
+- `BlockDecision` が stdout へ `{"decision":"block","reason":"<short>","stopReason":"<long>"}` を
+  emit していた。
+- Claude Code の PreToolUse フックでは `stopReason` はパースされない
+  (`stopReason` は Stop/SubagentStop 専用)。長文はどこにも届いていなかった。
+- Codex も同様に Claude Code 仕様を踏襲しており、`stopReason` は PreToolUse で
+  無視される。
+
+### 再発防止策
+
+1. PreToolUse フックの block 出力は `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"<all text>"}}` の
+   正式形を使い、visible 情報は必ず `permissionDecisionReason` に集約する。
+   レガシーの top-level `decision` / `reason` / `stopReason` は emit しない。
+2. `BlockDecision::new(short, long)` の call API を維持し、構造体内部で
+   `short + "\n\n" + long` を `permissionDecisionReason` に畳み込む。
+3. ブロック理由をユーザーが本当に見ているかを、個別フックに頼らず
+   `hook_types_test` 層で wire format 契約として固定する。
+4. Stop / SubagentStop 用の `stopReason` / `continue:false` と、PreToolUse 用の
+   `permissionDecision` / `permissionDecisionReason` は別物であることを前提として
+   フックを設計する。
+
 ## 2026-04-20 — fix: discussion の深さは「継続質問する」と書くだけでは維持できない
 
 ### 事象


### PR DESCRIPTION
## Summary

- PreToolUse フックがブロックした際にユーザーと LLM へ可視化されるフィールドを Claude Code / Codex 正式仕様の `hookSpecificOutput.permissionDecisionReason` に移行し、従来 `stopReason` に埋もれていた代替コマンド一覧と `Blocked command: ...` 原文を単一フィールドに統合する。
- 併せて `BlockDecision` の公開フィールドを整理し drift リスクを排除、stringly-typed な定数を分離し、重複アサートをテーブル駆動化する。

## Changes

- `crates/gwt/src/cli/hook/mod.rs`: `BlockDecision` を `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}` 形式へ移行。legacy top-level `decision`/`reason`/`stopReason` は emit しない。`reason`/`stop_reason` は private な `summary`/`detail` に改め、`summary()`/`detail()`/`permission_decision_reason()` アクセサを追加。`"PreToolUse"` / `"deny"` を `HookSpecificOutput::EVENT_NAME` / `DECISION_DENY` 定数へ寄せる。
- `crates/gwt/tests/hook_types_test.rs`: wire format 契約を `hookSpecificOutput` 形式で固定。legacy フィールドが出ないこと、新アクセサが動作することを追加アサート。
- `crates/gwt/tests/hook_block_bash_policy_test.rs`: `github_workflow_block_message_points_to_canonical_gwt_surfaces` を `permission_decision_reason()` 経由のテーブル駆動アサートに置き換え、`Blocked command: gh pr view 1949` と代替コマンド 4 種 (`gwt issue view` / `gwt pr view` / `gwt actions logs` / `gwt-search`) の包含を強制。
- `crates/gwt/tests/hook_exit_codes_test.rs`: `delegated_block_hook_preserves_block_json_contract` が `"hookSpecificOutput"` / `"hookEventName":"PreToolUse"` / `"permissionDecision":"deny"` の肯定アサートと `"decision":"block"` / `"stopReason"` の否定アサートを固定。
- `crates/gwt/tests/hook_workflow_policy_test.rs`: `decision.reason` 参照を `permission_decision_reason()` アクセサに追従。
- `tasks/lessons.md`: 「PreToolUse では `stopReason` は表示されない。`hookSpecificOutput.permissionDecisionReason` を使う」再発防止策を追記。

## Testing

- [x] `cargo test -p gwt-core -p gwt` — 全スイート pass (hook_types 8 / hook_block_bash_policy 6 / hook_exit_codes 6 / hook_workflow_policy 24 含む)
- [x] `cargo fmt --all -- --check` — 差分なし
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 警告・エラーなし
- [x] `bunx commitlint --from HEAD~2 --to HEAD` — 両コミットとも合格
- [ ] Claude Code 実機で `gh pr view <n>` を実行し、表示に `Direct GitHub workflow CLI commands are not allowed` と代替コマンド一覧、`Blocked command: ...` が全て含まれることを目視確認 — マージ後の手動スモーク

## Closing Issues

- None

## Related Issues / Links

- SPEC #1942 (spec セクションに FR-082 / FR-083 / SC-020 / SC-021 を追記)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — SPEC #1942 と `tasks/lessons.md` に反映。README は設計寄りの内容のため対象外。
- [ ] Migration/backfill plan included (if schema/data change) — 該当なし (スキーマ変更なし)
- [x] CHANGELOG impact considered (breaking change flagged in commit) — 破壊的変更なし。hook JSON 出力形式は内部通信で外部利用者 API ではないため semver 影響なし。

## Risk / Impact

- **Affected areas**: `gwt hook block-bash-policy` / `gwt hook workflow-policy` の stdout JSON ペイロードのみ。CLI/GUI のユーザー向け surface には変更なし。
- **Rollback plan**: `crates/gwt/src/cli/hook/mod.rs` の `BlockDecision` を旧形式に revert するだけで復元可能。マイグレーションデータなし。

## Notes

- 古い Claude Code クライアント (hookSpecificOutput 未対応) に対する後方互換は本 PR の対象外。必要なら後続で legacy `reason` の同時出力を追加する余地を残している。
- Codex CLI は Windows では hooks 無効のため Windows ローカルでは実機確認不可。Linux/macOS 環境があれば別途確認推奨。
