### PR TITLE
feat(agent,ai): Claude Code OpenAI-compat backend (SPEC-1921 Phase 52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ PLANS.md
 .gwt/index/
 .gwt/index.crashed-*/
 .gwt/discussion.md
+.gwt/draft/
 
 # Serena MCP tool cache directory
 .serena/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,8 @@ dependencies = [
  "dunce",
  "futures-util",
  "gwt-agent",
+ "gwt-ai",
+ "gwt-config",
  "gwt-core",
  "gwt-docker",
  "gwt-git",

--- a/crates/gwt-agent/src/audit.rs
+++ b/crates/gwt-agent/src/audit.rs
@@ -1,0 +1,164 @@
+//! Secret-name classifier for the agent launch audit log (FR-047, FR-063).
+//!
+//! The launch audit log writes a JSONL line per agent launch that includes the
+//! resolved command, args, cwd, and environment. To prevent plaintext API keys
+//! from ending up in `~/.gwt/logs/agent-launch.jsonl`, env entries whose keys
+//! match a known secret pattern are masked before the line is written.
+
+/// Placeholder string that replaces a secret value in the audit record.
+pub const REDACTED_PLACEHOLDER: &str = "***REDACTED***";
+
+/// Exact env var names that are always treated as secrets (case-insensitive).
+///
+/// Maintained as a list rather than a single regex so the set is trivially
+/// auditable and easy to extend when new provider SDKs appear.
+const EXACT_SECRET_NAMES: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+];
+
+/// Case-insensitive suffix patterns that classify an env var as a secret.
+const SECRET_SUFFIXES: &[&str] = &["_API_KEY", "_TOKEN", "_SECRET"];
+
+/// Returns `true` if the given env var key should be masked in audit logs.
+///
+/// Matching is case-insensitive. The following keys are considered secret:
+///
+/// - Exact match against [`EXACT_SECRET_NAMES`].
+/// - Any key that ends with `_API_KEY`, `_TOKEN`, or `_SECRET`.
+///
+/// Non-secret keys such as `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`,
+/// `CLAUDE_CODE_SUBAGENT_MODEL`, and `CLAUDE_CODE_ATTRIBUTION_HEADER` are
+/// returned as-is.
+pub fn is_secret_env_key(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    if EXACT_SECRET_NAMES.iter().any(|exact| upper == *exact) {
+        return true;
+    }
+    SECRET_SUFFIXES.iter().any(|suffix| upper.ends_with(suffix))
+}
+
+/// Returns a redaction-safe representation of the given env value. Non-secret
+/// keys return the original value unchanged; secret keys return
+/// [`REDACTED_PLACEHOLDER`] regardless of input.
+pub fn redact_env_value_for_audit<'a>(key: &str, value: &'a str) -> std::borrow::Cow<'a, str> {
+    if is_secret_env_key(key) {
+        std::borrow::Cow::Owned(REDACTED_PLACEHOLDER.to_string())
+    } else {
+        std::borrow::Cow::Borrowed(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_secret_names_are_masked() {
+        assert!(is_secret_env_key("ANTHROPIC_API_KEY"));
+        assert!(is_secret_env_key("OPENAI_API_KEY"));
+        assert!(is_secret_env_key("GEMINI_API_KEY"));
+        assert!(is_secret_env_key("GOOGLE_API_KEY"));
+        assert!(is_secret_env_key("ANTHROPIC_AUTH_TOKEN"));
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        assert!(is_secret_env_key("anthropic_api_key"));
+        assert!(is_secret_env_key("Anthropic_Api_Key"));
+        assert!(is_secret_env_key("openai_api_KEY"));
+    }
+
+    #[test]
+    fn api_key_suffix_is_masked() {
+        assert!(is_secret_env_key("MY_CUSTOM_API_KEY"));
+        assert!(is_secret_env_key("AZURE_OPENAI_API_KEY"));
+        assert!(is_secret_env_key("internal_service_api_key"));
+    }
+
+    #[test]
+    fn token_suffix_is_masked() {
+        assert!(is_secret_env_key("GITHUB_TOKEN"));
+        assert!(is_secret_env_key("ANTHROPIC_AUTH_TOKEN"));
+        assert!(is_secret_env_key("CIRCLE_CI_TOKEN"));
+    }
+
+    #[test]
+    fn secret_suffix_is_masked() {
+        assert!(is_secret_env_key("DATABASE_SECRET"));
+        assert!(is_secret_env_key("SESSION_SECRET"));
+        assert!(is_secret_env_key("jwt_secret"));
+    }
+
+    #[test]
+    fn non_secret_preset_env_pass_through() {
+        // These are the non-secret entries seeded by the
+        // Claude Code (OpenAI-compat backend) preset (SPEC-1921 FR-062).
+        let allowed = [
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "CLAUDE_CODE_SUBAGENT_MODEL",
+            "CLAUDE_CODE_ATTRIBUTION_HEADER",
+            "DISABLE_TELEMETRY",
+            "CLAUDE_CODE_NO_FLICKER",
+            "DISABLE_ERROR_REPORTING",
+            "DISABLE_FEEDBACK_COMMAND",
+            "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+        ];
+        for key in allowed {
+            assert!(
+                !is_secret_env_key(key),
+                "expected {key} to NOT be classified as secret"
+            );
+        }
+    }
+
+    #[test]
+    fn redact_env_value_masks_secrets() {
+        assert_eq!(
+            redact_env_value_for_audit("ANTHROPIC_API_KEY", "sk_real_secret_value"),
+            REDACTED_PLACEHOLDER
+        );
+        assert_eq!(
+            redact_env_value_for_audit("MY_CUSTOM_TOKEN", "ghp_abc123"),
+            REDACTED_PLACEHOLDER
+        );
+    }
+
+    #[test]
+    fn redact_env_value_passes_through_non_secrets() {
+        assert_eq!(
+            redact_env_value_for_audit("ANTHROPIC_BASE_URL", "http://proxy.local:32768"),
+            "http://proxy.local:32768"
+        );
+        assert_eq!(
+            redact_env_value_for_audit("ANTHROPIC_DEFAULT_OPUS_MODEL", "openai/gpt-oss-20b"),
+            "openai/gpt-oss-20b"
+        );
+    }
+
+    #[test]
+    fn empty_value_still_masked_for_secret_keys() {
+        // Even if the value is empty, a secret key must be masked so that
+        // upstream log readers cannot tell whether a secret was empty.
+        assert_eq!(
+            redact_env_value_for_audit("OPENAI_API_KEY", ""),
+            REDACTED_PLACEHOLDER
+        );
+    }
+
+    #[test]
+    fn keys_without_secret_suffix_not_masked() {
+        assert!(!is_secret_env_key("PATH"));
+        assert!(!is_secret_env_key("HOME"));
+        assert!(!is_secret_env_key("TERM"));
+        assert!(!is_secret_env_key("GWT_PROJECT_ROOT"));
+        assert!(!is_secret_env_key("CLAUDE_CODE_EFFORT_LEVEL"));
+    }
+}

--- a/crates/gwt-agent/src/custom.rs
+++ b/crates/gwt-agent/src/custom.rs
@@ -177,4 +177,75 @@ mod tests {
             "\"bunx\""
         );
     }
+
+    #[test]
+    fn toml_roundtrip_preserves_env_subtable() {
+        let mut agent = sample_agent();
+        agent.env.clear();
+        agent
+            .env
+            .insert("ANTHROPIC_API_KEY".to_string(), "sk-test".to_string());
+        agent.env.insert(
+            "ANTHROPIC_BASE_URL".to_string(),
+            "http://proxy.local:32768".to_string(),
+        );
+        agent.env.insert(
+            "ANTHROPIC_DEFAULT_OPUS_MODEL".to_string(),
+            "openai/gpt-oss-20b".to_string(),
+        );
+
+        let toml_text = toml::to_string(&agent).expect("serialize to TOML");
+        let decoded: CustomCodingAgent = toml::from_str(&toml_text).expect("deserialize TOML");
+
+        assert_eq!(decoded.id, agent.id);
+        assert_eq!(decoded.env.len(), 3);
+        assert_eq!(decoded.env.get("ANTHROPIC_API_KEY").unwrap(), "sk-test");
+        assert_eq!(
+            decoded.env.get("ANTHROPIC_BASE_URL").unwrap(),
+            "http://proxy.local:32768"
+        );
+        assert_eq!(
+            decoded.env.get("ANTHROPIC_DEFAULT_OPUS_MODEL").unwrap(),
+            "openai/gpt-oss-20b"
+        );
+    }
+
+    #[test]
+    fn toml_without_env_deserializes_with_empty_map() {
+        // Legacy custom agent TOML without an [env] table must remain
+        // readable (FR-059: backwards-compatible with existing custom agent rows).
+        let toml_text = r#"
+id = "legacy-agent"
+display_name = "Legacy"
+type = "command"
+command = "legacy-cli"
+"#;
+        let decoded: CustomCodingAgent =
+            toml::from_str(toml_text).expect("legacy TOML deserializes");
+        assert_eq!(decoded.id, "legacy-agent");
+        assert!(
+            decoded.env.is_empty(),
+            "missing env sub-table must default to empty map"
+        );
+    }
+
+    #[test]
+    fn toml_env_roundtrip_is_stable_across_multiple_cycles() {
+        let mut agent = sample_agent();
+        agent.env.clear();
+        for i in 0..10 {
+            agent.env.insert(format!("KEY_{i}"), format!("value_{i}"));
+        }
+        let t1 = toml::to_string(&agent).unwrap();
+        let decoded1: CustomCodingAgent = toml::from_str(&t1).unwrap();
+        let t2 = toml::to_string(&decoded1).unwrap();
+        let decoded2: CustomCodingAgent = toml::from_str(&t2).unwrap();
+        assert_eq!(decoded2.env.len(), 10);
+        for i in 0..10 {
+            assert_eq!(
+                decoded2.env.get(&format!("KEY_{i}")).unwrap(),
+                &format!("value_{i}")
+            );
+        }
+    }
 }

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -204,6 +204,12 @@ pub struct AgentLaunchBuilder {
     resume_session_id: Option<String>,
     permission_mode: Option<PermissionMode>,
     env_overrides: HashMap<String, String>,
+    /// Env table from a `CustomCodingAgent`. Merged into the spawn env AFTER
+    /// the SPEC-1921 Common family (TERM / GWT_*) and agent-specific env
+    /// (Claude / Codex / …), and BEFORE [`env_overrides`], so preset-seeded
+    /// custom entries win over built-in defaults but never clobber explicit
+    /// caller-provided overrides.
+    custom_agent_env: HashMap<String, String>,
     extra_args: Vec<String>,
     runtime_target: LaunchRuntimeTarget,
     docker_service: Option<String>,
@@ -227,6 +233,7 @@ impl AgentLaunchBuilder {
             resume_session_id: None,
             permission_mode: None,
             env_overrides: HashMap::new(),
+            custom_agent_env: HashMap::new(),
             extra_args: Vec::new(),
             runtime_target: LaunchRuntimeTarget::Host,
             docker_service: None,
@@ -288,6 +295,16 @@ impl AgentLaunchBuilder {
 
     pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.env_overrides.insert(key.into(), value.into());
+        self
+    }
+
+    /// Supply a `CustomCodingAgent.env` table that should flow into the
+    /// spawn env. Intended for SPEC-1921 FR-063: preset-seeded env tables
+    /// merge AFTER Common and agent-specific env, BEFORE [`env_overrides`],
+    /// so preset entries win over built-in defaults but never clobber
+    /// explicit caller overrides.
+    pub fn custom_agent_env(mut self, env: HashMap<String, String>) -> Self {
+        self.custom_agent_env = env;
         self
     }
 
@@ -375,6 +392,11 @@ impl AgentLaunchBuilder {
         args.extend(self.extra_args);
 
         normalize_launch_args(&self.agent_id, &runner.executable, &mut args);
+
+        // SPEC-1921 FR-063: merge CustomCodingAgent.env AFTER Common and
+        // agent-specific env so preset entries win over built-in defaults
+        // but BEFORE env_overrides (explicit caller overrides still win).
+        env_vars.extend(self.custom_agent_env);
 
         // Apply env overrides last (user wins)
         env_vars.extend(self.env_overrides);
@@ -1102,5 +1124,101 @@ mod tests {
         assert_eq!(config.display_name, "aider");
         assert_eq!(config.color, AgentColor::Gray);
         assert!(config.args.contains(&"--no-git".to_string()));
+    }
+
+    #[test]
+    fn custom_agent_env_is_merged_into_spawn_env() {
+        let mut env = HashMap::new();
+        env.insert(
+            "ANTHROPIC_BASE_URL".to_string(),
+            "http://proxy.local:32768".to_string(),
+        );
+        env.insert("ANTHROPIC_API_KEY".to_string(), "sk-test".to_string());
+
+        let config = AgentLaunchBuilder::new(AgentId::Custom("my-custom".into()))
+            .custom_agent_env(env)
+            .build();
+
+        assert_eq!(
+            config
+                .env_vars
+                .get("ANTHROPIC_BASE_URL")
+                .map(String::as_str),
+            Some("http://proxy.local:32768")
+        );
+        assert_eq!(
+            config.env_vars.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("sk-test")
+        );
+    }
+
+    #[test]
+    fn custom_agent_env_wins_over_common_env_on_collision() {
+        // TERM is set by the Common env layer to xterm-256color.
+        // A custom agent env entry for TERM must override it (FR-063 merge order).
+        let mut env = HashMap::new();
+        env.insert("TERM".to_string(), "xterm-kitty".to_string());
+
+        let config = AgentLaunchBuilder::new(AgentId::Custom("x".into()))
+            .custom_agent_env(env)
+            .build();
+
+        assert_eq!(
+            config.env_vars.get("TERM").map(String::as_str),
+            Some("xterm-kitty"),
+            "custom env must win over Common env (FR-063 merge order)"
+        );
+    }
+
+    #[test]
+    fn env_override_still_wins_over_custom_agent_env() {
+        // env() override is the explicit caller-provided layer and must remain
+        // authoritative over preset-seeded custom agent env (FR-063).
+        let mut env = HashMap::new();
+        env.insert("FOO".to_string(), "from-custom".to_string());
+
+        let config = AgentLaunchBuilder::new(AgentId::Custom("x".into()))
+            .custom_agent_env(env)
+            .env("FOO", "from-override")
+            .build();
+
+        assert_eq!(
+            config.env_vars.get("FOO").map(String::as_str),
+            Some("from-override"),
+            "env_overrides must remain authoritative over custom_agent_env"
+        );
+    }
+
+    #[test]
+    fn custom_agent_env_can_override_claude_builtin_env() {
+        // If a user somehow applies custom_agent_env to a built-in Claude
+        // launch, the custom value should win over the built-in Claude
+        // defaults. This is consistent with FR-063 "custom wins over Common".
+        let mut env = HashMap::new();
+        env.insert("CLAUDE_CODE_NO_FLICKER".to_string(), "0".to_string());
+
+        let config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .custom_agent_env(env)
+            .build();
+
+        assert_eq!(
+            config
+                .env_vars
+                .get("CLAUDE_CODE_NO_FLICKER")
+                .map(String::as_str),
+            Some("0"),
+            "custom_agent_env must win over agent-specific built-in env"
+        );
+    }
+
+    #[test]
+    fn custom_agent_env_empty_does_not_affect_other_env() {
+        // Absent custom_agent_env (default empty HashMap) must not change
+        // the env_vars produced for a built-in Claude launch.
+        let without = AgentLaunchBuilder::new(AgentId::ClaudeCode).build();
+        let with_empty = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .custom_agent_env(HashMap::new())
+            .build();
+        assert_eq!(without.env_vars, with_empty.env_vars);
     }
 }

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub mod detect;
 pub mod launch;
 pub mod presets;
 pub mod session;
+pub mod store;
 pub mod types;
 pub mod version_cache;
 
@@ -26,6 +27,10 @@ pub use session::{
     runtime_state_path_for_pid, PendingDiscussionResume, Session, SessionRuntimeState,
     GWT_BIN_PATH_ENV, GWT_HOOK_FORWARD_TOKEN_ENV, GWT_HOOK_FORWARD_URL_ENV, GWT_SESSION_ID_ENV,
     GWT_SESSION_RUNTIME_PATH_ENV,
+};
+pub use store::{
+    load_custom_agents_from_path, load_stored_custom_agents_from_path,
+    save_stored_custom_agents_to_path, StoredCustomAgent, DISABLE_GLOBAL_CUSTOM_AGENTS_ENV,
 };
 pub use types::{
     AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget,

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -4,18 +4,22 @@
 //! launching, and tracking coding agent sessions (Claude Code, Codex,
 //! Gemini, OpenCode, Copilot, and custom agents).
 
+pub mod audit;
 pub mod custom;
 pub mod detect;
 pub mod launch;
+pub mod presets;
 pub mod session;
 pub mod types;
 pub mod version_cache;
 
+pub use audit::{is_secret_env_key, redact_env_value_for_audit, REDACTED_PLACEHOLDER};
 pub use custom::CustomCodingAgent;
 pub use detect::{AgentDetector, DetectedAgent};
 pub use launch::{
     normalize_launch_args, resolve_runner, AgentLaunchBuilder, LaunchConfig, ResolvedRunner,
 };
+pub use presets::claude_code_openai_compat_preset;
 pub use session::{
     persist_agent_session_id, persist_session_status, reset_runtime_state_dir,
     reset_runtime_state_dir_for_pid, runtime_state_dir_for_pid, runtime_state_path,

--- a/crates/gwt-agent/src/presets.rs
+++ b/crates/gwt-agent/src/presets.rs
@@ -1,0 +1,204 @@
+//! Custom coding agent presets — factory helpers that seed well-known agent configurations.
+//!
+//! Presets are pure constructors: they return a `CustomCodingAgent` value that
+//! callers persist through the ordinary custom-agent save path. Preset output is
+//! not itself privileged at launch time; the seeded `env` table is applied
+//! through `AgentLaunchBuilder` like any other custom-agent env set.
+
+use std::collections::HashMap;
+
+use crate::custom::{CustomAgentType, CustomCodingAgent};
+
+/// Seed a `CustomCodingAgent` that routes Claude Code's Anthropic Messages API
+/// traffic through an OpenAI-compatible upstream (local LLM runtime, self-hosted
+/// gateway, etc.).
+///
+/// SPEC-1921 FR-062: the preset populates all four model-role env vars
+/// (`ANTHROPIC_DEFAULT_HAIKU_MODEL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`,
+/// `ANTHROPIC_DEFAULT_SONNET_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`) with the
+/// single `default_model` ID chosen in the Settings form.
+pub fn claude_code_openai_compat_preset(
+    id: impl Into<String>,
+    display_name: impl Into<String>,
+    base_url: impl Into<String>,
+    api_key: impl Into<String>,
+    default_model: impl Into<String>,
+) -> CustomCodingAgent {
+    let base_url = base_url.into();
+    let api_key = api_key.into();
+    let default_model = default_model.into();
+
+    let mut env = HashMap::with_capacity(13);
+    env.insert("ANTHROPIC_API_KEY".to_string(), api_key);
+    env.insert("ANTHROPIC_BASE_URL".to_string(), base_url);
+    env.insert(
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL".to_string(),
+        default_model.clone(),
+    );
+    env.insert(
+        "ANTHROPIC_DEFAULT_OPUS_MODEL".to_string(),
+        default_model.clone(),
+    );
+    env.insert(
+        "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+        default_model.clone(),
+    );
+    env.insert("CLAUDE_CODE_SUBAGENT_MODEL".to_string(), default_model);
+    env.insert(
+        "CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(),
+        "0".to_string(),
+    );
+    env.insert("DISABLE_TELEMETRY".to_string(), "1".to_string());
+    env.insert("CLAUDE_CODE_NO_FLICKER".to_string(), "1".to_string());
+    env.insert("DISABLE_ERROR_REPORTING".to_string(), "1".to_string());
+    env.insert("DISABLE_FEEDBACK_COMMAND".to_string(), "1".to_string());
+    env.insert(
+        "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY".to_string(),
+        "1".to_string(),
+    );
+    env.insert(
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
+        "1".to_string(),
+    );
+
+    CustomCodingAgent {
+        id: id.into(),
+        display_name: display_name.into(),
+        agent_type: CustomAgentType::Bunx,
+        command: "@anthropic-ai/claude-code@latest".to_string(),
+        default_args: vec![],
+        mode_args: None,
+        skip_permissions_args: vec!["--dangerously-skip-permissions".to_string()],
+        env,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preset_has_expected_shape() {
+        let preset = claude_code_openai_compat_preset(
+            "claude-code-openai",
+            "Claude Code (OpenAI-compat)",
+            "http://192.168.100.166:32768",
+            "sk-test-123",
+            "openai/gpt-oss-20b",
+        );
+
+        assert_eq!(preset.id, "claude-code-openai");
+        assert_eq!(preset.display_name, "Claude Code (OpenAI-compat)");
+        assert_eq!(preset.agent_type, CustomAgentType::Bunx);
+        assert_eq!(preset.command, "@anthropic-ai/claude-code@latest");
+        assert!(preset.default_args.is_empty());
+        assert!(preset.mode_args.is_none());
+        assert_eq!(
+            preset.skip_permissions_args,
+            vec!["--dangerously-skip-permissions".to_string()]
+        );
+    }
+
+    #[test]
+    fn preset_env_contains_thirteen_entries() {
+        let preset = claude_code_openai_compat_preset("x", "X", "http://a", "k", "m");
+        assert_eq!(
+            preset.env.len(),
+            13,
+            "preset must seed exactly 13 env vars (FR-062)"
+        );
+    }
+
+    #[test]
+    fn preset_env_includes_all_required_keys() {
+        let preset = claude_code_openai_compat_preset(
+            "x",
+            "X",
+            "http://proxy.local:32768",
+            "sk-test-123",
+            "openai/gpt-oss-20b",
+        );
+        let expected_keys = [
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "CLAUDE_CODE_SUBAGENT_MODEL",
+            "CLAUDE_CODE_ATTRIBUTION_HEADER",
+            "DISABLE_TELEMETRY",
+            "CLAUDE_CODE_NO_FLICKER",
+            "DISABLE_ERROR_REPORTING",
+            "DISABLE_FEEDBACK_COMMAND",
+            "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+        ];
+        for key in expected_keys {
+            assert!(
+                preset.env.contains_key(key),
+                "preset env is missing key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn preset_propagates_base_url_and_api_key_verbatim() {
+        let preset = claude_code_openai_compat_preset(
+            "x",
+            "X",
+            "http://192.168.100.166:32768",
+            "sk_cwPkycrPTZBYQ8vFXsc3O0wkrvt36VSh",
+            "openai/gpt-oss-20b",
+        );
+        assert_eq!(
+            preset.env["ANTHROPIC_BASE_URL"],
+            "http://192.168.100.166:32768"
+        );
+        assert_eq!(
+            preset.env["ANTHROPIC_API_KEY"],
+            "sk_cwPkycrPTZBYQ8vFXsc3O0wkrvt36VSh"
+        );
+    }
+
+    #[test]
+    fn preset_default_model_propagates_to_all_four_roles() {
+        let preset = claude_code_openai_compat_preset("x", "X", "http://a", "k", "my-custom-model");
+        assert_eq!(
+            preset.env["ANTHROPIC_DEFAULT_HAIKU_MODEL"],
+            "my-custom-model"
+        );
+        assert_eq!(
+            preset.env["ANTHROPIC_DEFAULT_OPUS_MODEL"],
+            "my-custom-model"
+        );
+        assert_eq!(
+            preset.env["ANTHROPIC_DEFAULT_SONNET_MODEL"],
+            "my-custom-model"
+        );
+        assert_eq!(preset.env["CLAUDE_CODE_SUBAGENT_MODEL"], "my-custom-model");
+    }
+
+    #[test]
+    fn preset_attribution_and_telemetry_flags_are_off() {
+        let preset = claude_code_openai_compat_preset("x", "X", "http://a", "k", "m");
+        assert_eq!(preset.env["CLAUDE_CODE_ATTRIBUTION_HEADER"], "0");
+        assert_eq!(preset.env["DISABLE_TELEMETRY"], "1");
+        assert_eq!(preset.env["CLAUDE_CODE_NO_FLICKER"], "1");
+        assert_eq!(preset.env["DISABLE_ERROR_REPORTING"], "1");
+        assert_eq!(preset.env["DISABLE_FEEDBACK_COMMAND"], "1");
+        assert_eq!(preset.env["CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY"], "1");
+        assert_eq!(preset.env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"], "1");
+    }
+
+    #[test]
+    fn preset_id_passes_custom_agent_validate() {
+        let preset = claude_code_openai_compat_preset(
+            "claude-code-openai",
+            "Claude Code (OpenAI-compat)",
+            "https://example.com",
+            "key",
+            "model-a",
+        );
+        assert!(preset.validate());
+    }
+}

--- a/crates/gwt-agent/src/store.rs
+++ b/crates/gwt-agent/src/store.rs
@@ -1,0 +1,610 @@
+//! TOML persistence for custom coding agents.
+//!
+//! Custom agents live under `[tools.customCodingAgents.<id>]` in the gwt
+//! global config TOML (`~/.gwt/config.toml` by default). This module provides
+//! a load/save surface that preserves unknown sibling tables (e.g. `models`)
+//! so third-party additions are not silently dropped on round-trip.
+//!
+//! Ports the behavior that lived in `crates/gwt-tui/src/custom_agents.rs`
+//! before commit 10ff990f ("feat: promote desktop app as gwt") deleted the
+//! legacy TUI crate. See SPEC-1921 US-4 and FR-059.
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use toml::{Table, Value};
+use tracing::warn;
+
+use crate::custom::{CustomAgentType, CustomCodingAgent, ModeArgs};
+
+/// Env var that disables loading custom agents from the global config (for
+/// tests and isolated runs).
+pub const DISABLE_GLOBAL_CUSTOM_AGENTS_ENV: &str = "GWT_DISABLE_GLOBAL_CUSTOM_AGENTS";
+
+/// A custom agent as loaded from TOML, paired with its raw sibling-field table
+/// so sibling keys such as `models` survive a load/save round-trip.
+#[derive(Debug, Clone)]
+pub struct StoredCustomAgent {
+    /// Parsed custom agent.
+    pub agent: CustomCodingAgent,
+    /// Raw TOML table as read from disk. Used to preserve unknown keys
+    /// (e.g. `models`, future sibling fields) when the entry is re-serialized.
+    raw: Table,
+}
+
+impl StoredCustomAgent {
+    /// Wrap a freshly-built `CustomCodingAgent` with an empty raw table.
+    pub fn new(agent: CustomCodingAgent) -> Self {
+        Self {
+            agent,
+            raw: Table::new(),
+        }
+    }
+}
+
+/// Canonical TOML shape for a single custom agent entry. Accepts both
+/// camelCase (preferred, SPEC-1921 Custom Agent Schema) and snake_case forms
+/// for backwards-compatibility with older configs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CustomAgentToml {
+    #[serde(default)]
+    id: String,
+    #[serde(rename = "displayName", alias = "display_name")]
+    display_name: String,
+    #[serde(rename = "agentType", alias = "type", alias = "agent_type", default)]
+    agent_type: CustomAgentType,
+    command: String,
+    #[serde(
+        default,
+        rename = "defaultArgs",
+        alias = "default_args",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    default_args: Vec<String>,
+    #[serde(
+        default,
+        rename = "skipPermissionsArgs",
+        alias = "skip_permissions_args",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    skip_permissions_args: Vec<String>,
+    #[serde(
+        default,
+        rename = "modeArgs",
+        alias = "mode_args",
+        skip_serializing_if = "Option::is_none"
+    )]
+    mode_args: Option<ModeArgs>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    env: HashMap<String, String>,
+}
+
+impl CustomAgentToml {
+    fn into_custom_agent(self, key: &str) -> Option<CustomCodingAgent> {
+        let agent = CustomCodingAgent {
+            id: if self.id.trim().is_empty() {
+                key.to_string()
+            } else {
+                self.id
+            },
+            display_name: self.display_name,
+            agent_type: self.agent_type,
+            command: self.command,
+            default_args: self.default_args,
+            skip_permissions_args: self.skip_permissions_args,
+            mode_args: self.mode_args,
+            env: self.env,
+        };
+
+        agent.validate().then_some(agent)
+    }
+}
+
+impl From<&CustomCodingAgent> for CustomAgentToml {
+    fn from(agent: &CustomCodingAgent) -> Self {
+        Self {
+            id: agent.id.clone(),
+            display_name: agent.display_name.clone(),
+            agent_type: agent.agent_type,
+            command: agent.command.clone(),
+            default_args: agent.default_args.clone(),
+            skip_permissions_args: agent.skip_permissions_args.clone(),
+            mode_args: agent.mode_args.clone(),
+            env: agent.env.clone(),
+        }
+    }
+}
+
+/// Load plain custom agents (no sibling-preservation bookkeeping) from the
+/// given config path. Returns an empty `Vec` when the path does not exist.
+pub fn load_custom_agents_from_path(path: &Path) -> Result<Vec<CustomCodingAgent>, String> {
+    Ok(load_stored_custom_agents_from_path(path)?
+        .into_iter()
+        .map(|entry| entry.agent)
+        .collect())
+}
+
+/// Load stored custom agents (with raw sibling-field tables) from the given
+/// path. Used by callers that later want to re-save with
+/// [`save_stored_custom_agents_to_path`].
+pub fn load_stored_custom_agents_from_path(path: &Path) -> Result<Vec<StoredCustomAgent>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = std::fs::read_to_string(path)
+        .map_err(|err| format!("failed to read config {}: {err}", path.display()))?;
+    let root: Value = toml::from_str(&content)
+        .map_err(|err| format!("failed to parse custom agents in {}: {err}", path.display()))?;
+    let Some(custom_table) = custom_agents_table(&root) else {
+        return Ok(Vec::new());
+    };
+
+    let mut agents = Vec::new();
+    for (key, raw_value) in custom_table {
+        let Some(raw_table) = raw_value.as_table() else {
+            warn!(custom_agent = %key, "skipping non-table custom agent entry");
+            continue;
+        };
+        let parsed: CustomAgentToml = match raw_value.clone().try_into() {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                warn!(custom_agent = %key, error = %err, "skipping unparsable custom agent");
+                continue;
+            }
+        };
+        if let Some(agent) = parsed.into_custom_agent(key) {
+            agents.push(StoredCustomAgent {
+                agent,
+                raw: raw_table.clone(),
+            });
+        } else {
+            warn!(custom_agent = %key, "skipping invalid custom agent");
+        }
+    }
+
+    Ok(agents)
+}
+
+/// Save the provided custom agents into the given config path. Preserves
+/// sibling root-level tables (e.g. top-level `debug = true`) and
+/// sibling tables under each custom agent (e.g. `models`). Rejects
+/// duplicate IDs.
+pub fn save_stored_custom_agents_to_path(
+    path: &Path,
+    agents: &[StoredCustomAgent],
+) -> Result<(), String> {
+    validate_unique_custom_agents(agents)?;
+
+    let mut root = load_root_document(path)?;
+    let root_table = root
+        .as_table_mut()
+        .ok_or_else(|| format!("config {} must contain a TOML table root", path.display()))?;
+
+    let tools_entry = root_table
+        .entry("tools".to_string())
+        .or_insert_with(|| Value::Table(Table::new()));
+    let tools_table = tools_entry
+        .as_table_mut()
+        .ok_or_else(|| format!("config {} has a non-table [tools] section", path.display()))?;
+
+    tools_table.remove("customCodingAgents");
+    tools_table.remove("custom_coding_agents");
+
+    if !agents.is_empty() {
+        let mut custom_table = Table::new();
+        for entry in agents {
+            custom_table.insert(
+                entry.agent.id.clone(),
+                Value::Table(normalized_custom_agent_table(entry)?),
+            );
+        }
+        tools_table.insert("customCodingAgents".to_string(), Value::Table(custom_table));
+    }
+
+    if tools_table.is_empty() {
+        root_table.remove("tools");
+    }
+
+    let content = toml::to_string_pretty(&root)
+        .map_err(|err| format!("failed to serialize config {}: {err}", path.display()))?;
+    write_atomic(path, &content)
+}
+
+fn validate_unique_custom_agents(agents: &[StoredCustomAgent]) -> Result<(), String> {
+    let mut seen = BTreeSet::new();
+    for entry in agents {
+        if !entry.agent.validate() {
+            return Err(format!("invalid custom agent: {}", entry.agent.id));
+        }
+        if !seen.insert(entry.agent.id.clone()) {
+            return Err(format!("duplicate custom agent id: {}", entry.agent.id));
+        }
+    }
+    Ok(())
+}
+
+/// Canonicalize the TOML representation of a single agent entry, preserving
+/// any unknown sibling keys (e.g. `models`).
+fn normalized_custom_agent_table(entry: &StoredCustomAgent) -> Result<Table, String> {
+    let mut raw = entry.raw.clone();
+    for key in [
+        "id",
+        "displayName",
+        "display_name",
+        "agentType",
+        "agent_type",
+        "type",
+        "command",
+        "defaultArgs",
+        "default_args",
+        "skipPermissionsArgs",
+        "skip_permissions_args",
+        "modeArgs",
+        "mode_args",
+        "env",
+    ] {
+        raw.remove(key);
+    }
+
+    let canonical: Value = Value::try_from(CustomAgentToml::from(&entry.agent))
+        .map_err(|err| format!("failed to serialize custom agent {}: {err}", entry.agent.id))?;
+    let canonical_table = canonical.as_table().ok_or_else(|| {
+        format!(
+            "custom agent {} did not serialize as a table",
+            entry.agent.id
+        )
+    })?;
+    for (key, value) in canonical_table {
+        raw.insert(key.clone(), value.clone());
+    }
+
+    Ok(raw)
+}
+
+fn custom_agents_table(root: &Value) -> Option<&Table> {
+    let tools = root.get("tools")?.as_table()?;
+    tools
+        .get("customCodingAgents")
+        .and_then(Value::as_table)
+        .or_else(|| tools.get("custom_coding_agents").and_then(Value::as_table))
+}
+
+fn load_root_document(path: &Path) -> Result<Value, String> {
+    if !path.exists() {
+        return Ok(Value::Table(Table::new()));
+    }
+
+    let content = std::fs::read_to_string(path)
+        .map_err(|err| format!("failed to read config {}: {err}", path.display()))?;
+    toml::from_str(&content)
+        .map_err(|err| format!("failed to parse config {}: {err}", path.display()))
+}
+
+fn write_atomic(path: &Path, content: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create config dir {}: {err}", parent.display()))?;
+    }
+
+    let temp_path = temp_path_for(path);
+    std::fs::write(&temp_path, content)
+        .map_err(|err| format!("failed to write temp config {}: {err}", temp_path.display()))?;
+    std::fs::rename(&temp_path, path).map_err(|err| {
+        format!(
+            "failed to replace config {} with {}: {err}",
+            path.display(),
+            temp_path.display()
+        )
+    })
+}
+
+fn temp_path_for(path: &Path) -> PathBuf {
+    let suffix = format!(
+        "{}.{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    );
+    path.with_file_name(format!(
+        ".{}.tmp.{suffix}",
+        path.file_name().unwrap_or_default().to_string_lossy()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::presets::claude_code_openai_compat_preset;
+
+    #[test]
+    fn load_custom_agents_parses_camelcase_schema() {
+        let dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[tools.customCodingAgents.my-agent]
+id = "my-agent"
+displayName = "My Agent"
+agentType = "command"
+command = "my-agent-cli"
+defaultArgs = ["--flag"]
+skipPermissionsArgs = ["--yolo"]
+
+[tools.customCodingAgents.my-agent.modeArgs]
+normal = ["--normal"]
+continue = ["--continue"]
+resume = ["--resume"]
+
+[tools.customCodingAgents.my-agent.env]
+CUSTOM_ENV = "enabled"
+"#,
+        )
+        .expect("write config");
+
+        let agents = load_custom_agents_from_path(&config_path).expect("load custom agents");
+
+        assert_eq!(agents.len(), 1);
+        let agent = &agents[0];
+        assert_eq!(agent.id, "my-agent");
+        assert_eq!(agent.display_name, "My Agent");
+        assert_eq!(agent.agent_type, CustomAgentType::Command);
+        assert_eq!(agent.command, "my-agent-cli");
+        assert_eq!(agent.default_args, vec!["--flag"]);
+        assert_eq!(agent.skip_permissions_args, vec!["--yolo"]);
+        assert_eq!(
+            agent
+                .mode_args
+                .as_ref()
+                .map(|args| args.continue_mode.clone()),
+            Some(vec!["--continue".to_string()])
+        );
+        assert_eq!(
+            agent.env.get("CUSTOM_ENV").map(String::as_str),
+            Some("enabled")
+        );
+    }
+
+    #[test]
+    fn load_custom_agents_accepts_snake_case_for_backwards_compat() {
+        let dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[tools.custom_coding_agents.legacy]
+id = "legacy"
+display_name = "Legacy Agent"
+type = "bunx"
+command = "@legacy/cli"
+default_args = ["--x"]
+"#,
+        )
+        .expect("write config");
+
+        let agents = load_custom_agents_from_path(&config_path).expect("load");
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].id, "legacy");
+        assert_eq!(agents[0].agent_type, CustomAgentType::Bunx);
+        assert_eq!(agents[0].command, "@legacy/cli");
+    }
+
+    #[test]
+    fn load_returns_empty_when_no_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("missing.toml");
+        let agents = load_custom_agents_from_path(&path).expect("load");
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn load_returns_empty_when_no_section() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "debug = true\n").expect("write");
+        let agents = load_custom_agents_from_path(&path).expect("load");
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn save_preserves_sibling_root_fields_and_custom_agent_subtables() {
+        let dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+debug = true
+
+[tools.customCodingAgents.my-agent]
+id = "my-agent"
+displayName = "My Agent"
+agentType = "command"
+command = "my-agent-cli"
+
+[tools.customCodingAgents.my-agent.models]
+default = { id = "default", label = "Default", arg = "" }
+"#,
+        )
+        .expect("write config");
+
+        let mut agents = load_stored_custom_agents_from_path(&config_path).expect("load stored");
+        assert_eq!(agents.len(), 1);
+        agents[0].agent.display_name = "Updated Agent".to_string();
+
+        save_stored_custom_agents_to_path(&config_path, &agents).expect("save stored");
+
+        let content = std::fs::read_to_string(&config_path).expect("read config");
+        assert!(content.contains("debug = true"));
+        assert!(content.contains("displayName = \"Updated Agent\""));
+        let parsed: Value = toml::from_str(&content).expect("parse saved config");
+        assert_eq!(
+            parsed["tools"]["customCodingAgents"]["my-agent"]["models"]["default"]["label"]
+                .as_str(),
+            Some("Default")
+        );
+    }
+
+    #[test]
+    fn save_rejects_duplicate_ids() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("config.toml");
+        let a1 = StoredCustomAgent::new(CustomCodingAgent {
+            id: "dup".to_string(),
+            display_name: "D1".to_string(),
+            agent_type: CustomAgentType::Command,
+            command: "c1".to_string(),
+            default_args: vec![],
+            mode_args: None,
+            skip_permissions_args: vec![],
+            env: HashMap::new(),
+        });
+        let a2 = StoredCustomAgent::new(CustomCodingAgent {
+            id: "dup".to_string(),
+            display_name: "D2".to_string(),
+            agent_type: CustomAgentType::Command,
+            command: "c2".to_string(),
+            default_args: vec![],
+            mode_args: None,
+            skip_permissions_args: vec![],
+            env: HashMap::new(),
+        });
+        let err = save_stored_custom_agents_to_path(&path, &[a1, a2]).unwrap_err();
+        assert!(err.contains("duplicate"));
+    }
+
+    #[test]
+    fn save_rejects_invalid_agent_id() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("config.toml");
+        let entry = StoredCustomAgent::new(CustomCodingAgent {
+            id: "has spaces".to_string(),
+            display_name: "X".to_string(),
+            agent_type: CustomAgentType::Command,
+            command: "cmd".to_string(),
+            default_args: vec![],
+            mode_args: None,
+            skip_permissions_args: vec![],
+            env: HashMap::new(),
+        });
+        let err = save_stored_custom_agents_to_path(&path, &[entry]).unwrap_err();
+        assert!(err.contains("invalid"));
+    }
+
+    #[test]
+    fn preset_roundtrip_preserves_all_thirteen_env_entries() {
+        let dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = dir.path().join("config.toml");
+
+        let preset = claude_code_openai_compat_preset(
+            "claude-code-openai",
+            "Claude Code (OpenAI-compat)",
+            "http://192.168.100.166:32768",
+            "sk-test-key",
+            "openai/gpt-oss-20b",
+        );
+        let entries = vec![StoredCustomAgent::new(preset)];
+        save_stored_custom_agents_to_path(&config_path, &entries).expect("save preset");
+
+        let reloaded = load_custom_agents_from_path(&config_path).expect("reload");
+        assert_eq!(reloaded.len(), 1);
+        let agent = &reloaded[0];
+        assert_eq!(agent.id, "claude-code-openai");
+        assert_eq!(agent.agent_type, CustomAgentType::Bunx);
+        assert_eq!(agent.command, "@anthropic-ai/claude-code@latest");
+        assert_eq!(
+            agent.skip_permissions_args,
+            vec!["--dangerously-skip-permissions".to_string()]
+        );
+        assert_eq!(
+            agent.env.len(),
+            13,
+            "all 13 preset env entries survive TOML round-trip"
+        );
+        assert_eq!(
+            agent.env.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("sk-test-key")
+        );
+        assert_eq!(
+            agent.env.get("ANTHROPIC_BASE_URL").map(String::as_str),
+            Some("http://192.168.100.166:32768")
+        );
+        assert_eq!(
+            agent
+                .env
+                .get("ANTHROPIC_DEFAULT_OPUS_MODEL")
+                .map(String::as_str),
+            Some("openai/gpt-oss-20b")
+        );
+        assert_eq!(
+            agent
+                .env
+                .get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
+                .map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn save_then_load_produces_camelcase_keys_on_disk() {
+        let dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = dir.path().join("config.toml");
+
+        let entry = StoredCustomAgent::new(CustomCodingAgent {
+            id: "agent-x".to_string(),
+            display_name: "Agent X".to_string(),
+            agent_type: CustomAgentType::Bunx,
+            command: "@foo/bar@latest".to_string(),
+            default_args: vec!["--debug".to_string()],
+            mode_args: None,
+            skip_permissions_args: vec!["--yolo".to_string()],
+            env: HashMap::from([("FOO".to_string(), "BAR".to_string())]),
+        });
+        save_stored_custom_agents_to_path(&config_path, &[entry]).expect("save");
+
+        let content = std::fs::read_to_string(&config_path).expect("read");
+        assert!(content.contains("displayName = \"Agent X\""));
+        assert!(content.contains("agentType = \"bunx\""));
+        assert!(content.contains("defaultArgs = [\"--debug\"]"));
+        assert!(content.contains("skipPermissionsArgs = [\"--yolo\"]"));
+    }
+
+    #[test]
+    fn save_with_empty_vec_removes_section_but_keeps_other_root_keys() {
+        let dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+debug = true
+
+[tools.customCodingAgents.to-remove]
+id = "to-remove"
+displayName = "Old"
+agentType = "command"
+command = "old-cli"
+"#,
+        )
+        .expect("write");
+
+        save_stored_custom_agents_to_path(&config_path, &[]).expect("save empty");
+
+        let content = std::fs::read_to_string(&config_path).expect("read");
+        assert!(content.contains("debug = true"));
+        assert!(!content.contains("to-remove"));
+        assert!(!content.contains("customCodingAgents"));
+    }
+
+    #[test]
+    fn disable_env_is_documented() {
+        // Not a behavior test per se; fails if the const is renamed or removed
+        // since callers in the UI will rely on it verbatim.
+        assert_eq!(
+            DISABLE_GLOBAL_CUSTOM_AGENTS_ENV,
+            "GWT_DISABLE_GLOBAL_CUSTOM_AGENTS"
+        );
+    }
+}

--- a/crates/gwt-ai/src/anthropic_backend.rs
+++ b/crates/gwt-ai/src/anthropic_backend.rs
@@ -1,0 +1,300 @@
+//! Probe client for Anthropic Messages API compatible backends that also expose
+//! the OpenAI-compatible `/v1/models` endpoint.
+//!
+//! This module supports SPEC-1921 FR-061: Settings > Custom Agents > Add from
+//! preset > "Claude Code (OpenAI-compat backend)" saves only after a
+//! `GET {base_url}/v1/models` call returns HTTP 200 with parseable JSON
+//! containing `data[].id`.
+
+use std::time::Duration;
+
+use reqwest::{
+    blocking::Client,
+    header::{HeaderMap, HeaderValue, AUTHORIZATION},
+};
+use serde::{Deserialize, Serialize};
+
+/// Connect + read timeout for the `/v1/models` probe. SPEC-1921 FR-061.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// A single model entry returned by `/v1/models`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelInfo {
+    /// Model ID. Callers should treat this string as opaque.
+    pub id: String,
+}
+
+/// Structured error taxonomy for the `/v1/models` probe.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ProbeError {
+    /// `base_url` could not be parsed or has a non-http(s) scheme.
+    #[error("invalid base_url: {0}")]
+    InvalidUrl(String),
+
+    /// Connect or read timed out (>= `PROBE_TIMEOUT`).
+    #[error("probe timed out after {0:?}")]
+    Timeout(Duration),
+
+    /// Upstream returned a non-2xx status.
+    #[error("http status {code}: {body}")]
+    HttpStatus {
+        /// HTTP status code.
+        code: u16,
+        /// Truncated body string for diagnostic use.
+        body: String,
+    },
+
+    /// Response body was not valid JSON.
+    #[error("invalid JSON: {0}")]
+    InvalidJson(String),
+
+    /// JSON did not contain a `data` array, or an entry was missing `id`.
+    #[error("response missing `data[].id`")]
+    MissingData,
+
+    /// Low-level transport failure (DNS, TLS, connection refused, etc.).
+    #[error("transport error: {0}")]
+    Transport(String),
+}
+
+/// Internal wire type for `{ "data": [ { "id": "..." }, ... ] }`.
+#[derive(Debug, Deserialize)]
+struct ModelsResponseWire {
+    data: Option<Vec<ModelEntryWire>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelEntryWire {
+    id: Option<String>,
+}
+
+/// Parse a `/v1/models` response body.
+///
+/// Returns all discovered `data[].id` entries in document order. An empty
+/// `data` array yields an empty `Vec`. An entry without `id` (or a payload
+/// without `data`) yields `ProbeError::MissingData`.
+pub fn parse_models_response(body: &str) -> Result<Vec<ModelInfo>, ProbeError> {
+    let parsed: ModelsResponseWire =
+        serde_json::from_str(body).map_err(|e| ProbeError::InvalidJson(e.to_string()))?;
+    let Some(data) = parsed.data else {
+        return Err(ProbeError::MissingData);
+    };
+    let mut out = Vec::with_capacity(data.len());
+    for entry in data {
+        let Some(id) = entry.id else {
+            return Err(ProbeError::MissingData);
+        };
+        out.push(ModelInfo { id });
+    }
+    Ok(out)
+}
+
+/// Validate the `base_url` scheme. SPEC-1921 FR-060.
+fn validate_base_url(base_url: &str) -> Result<(), ProbeError> {
+    let lower = base_url.trim().to_ascii_lowercase();
+    if lower.starts_with("http://") || lower.starts_with("https://") {
+        Ok(())
+    } else {
+        Err(ProbeError::InvalidUrl(format!(
+            "base_url must start with http:// or https://, got: {base_url}"
+        )))
+    }
+}
+
+/// Build the `/v1/models` URL from `base_url`.
+fn build_models_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    format!("{trimmed}/v1/models")
+}
+
+/// Blocking `GET {base_url}/v1/models` call.
+///
+/// Uses a 3-second connect+read timeout (FR-061) and no retry. Returns the
+/// parsed list of models, or a structured `ProbeError`. Callers in the
+/// Settings UI use the return value to populate the default_model dropdown
+/// and to gate the form's Save button.
+pub fn list_models_blocking(base_url: &str, api_key: &str) -> Result<Vec<ModelInfo>, ProbeError> {
+    validate_base_url(base_url)?;
+    let url = build_models_url(base_url);
+
+    let mut headers = HeaderMap::new();
+    if !api_key.is_empty() {
+        let header_value = HeaderValue::from_str(&format!("Bearer {api_key}"))
+            .map_err(|e| ProbeError::InvalidUrl(format!("invalid api_key header: {e}")))?;
+        headers.insert(AUTHORIZATION, header_value);
+    }
+
+    let client = Client::builder()
+        .timeout(PROBE_TIMEOUT)
+        .connect_timeout(PROBE_TIMEOUT)
+        .default_headers(headers)
+        .build()
+        .map_err(|e| ProbeError::Transport(e.to_string()))?;
+
+    let response = client.get(&url).send().map_err(map_reqwest_error)?;
+    let status = response.status();
+    let body = response
+        .text()
+        .map_err(|e| ProbeError::Transport(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(ProbeError::HttpStatus {
+            code: status.as_u16(),
+            body: truncate_for_diagnostic(&body),
+        });
+    }
+
+    parse_models_response(&body)
+}
+
+fn map_reqwest_error(err: reqwest::Error) -> ProbeError {
+    if err.is_timeout() {
+        return ProbeError::Timeout(PROBE_TIMEOUT);
+    }
+    if let Some(status) = err.status() {
+        return ProbeError::HttpStatus {
+            code: status.as_u16(),
+            body: err.to_string(),
+        };
+    }
+    if err.is_connect() || err.is_request() {
+        return ProbeError::Transport(err.to_string());
+    }
+    ProbeError::Transport(err.to_string())
+}
+
+fn truncate_for_diagnostic(body: &str) -> String {
+    const MAX: usize = 512;
+    if body.len() <= MAX {
+        body.to_string()
+    } else {
+        let mut out = body[..MAX].to_string();
+        out.push_str("...<truncated>");
+        out
+    }
+}
+
+/// Shorthand that lists models and returns only the `id` strings. Useful for
+/// wiring directly into UI dropdowns.
+pub fn list_model_ids_blocking(base_url: &str, api_key: &str) -> Result<Vec<String>, ProbeError> {
+    list_models_blocking(base_url, api_key).map(|ms| ms.into_iter().map(|m| m.id).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_response_returns_ids_in_order() {
+        let body = r#"{"data":[{"id":"openai/gpt-oss-20b"},{"id":"openai/gpt-oss-120b"}]}"#;
+        let models = parse_models_response(body).expect("should parse");
+        assert_eq!(
+            models,
+            vec![
+                ModelInfo {
+                    id: "openai/gpt-oss-20b".to_string(),
+                },
+                ModelInfo {
+                    id: "openai/gpt-oss-120b".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_empty_data_array_returns_empty_vec() {
+        let body = r#"{"data":[]}"#;
+        let models = parse_models_response(body).expect("should parse");
+        assert!(models.is_empty());
+    }
+
+    #[test]
+    fn parse_missing_data_field_is_missing_data_error() {
+        let body = r#"{"object":"list"}"#;
+        let err = parse_models_response(body).unwrap_err();
+        assert_eq!(err, ProbeError::MissingData);
+    }
+
+    #[test]
+    fn parse_entry_missing_id_is_missing_data_error() {
+        let body = r#"{"data":[{"id":"a"},{"object":"model"}]}"#;
+        let err = parse_models_response(body).unwrap_err();
+        assert_eq!(err, ProbeError::MissingData);
+    }
+
+    #[test]
+    fn parse_invalid_json_is_invalid_json_error() {
+        let body = "<html><body>Not Found</body></html>";
+        let err = parse_models_response(body).unwrap_err();
+        assert!(matches!(err, ProbeError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn parse_ignores_extra_fields() {
+        let body = r#"{"object":"list","data":[{"id":"m1","object":"model","created":123}]}"#;
+        let models = parse_models_response(body).expect("should parse");
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "m1");
+    }
+
+    #[test]
+    fn validate_base_url_accepts_http_and_https() {
+        assert!(validate_base_url("http://192.168.100.166:32768").is_ok());
+        assert!(validate_base_url("https://api.example.com").is_ok());
+        assert!(validate_base_url("HTTP://upper.case").is_ok());
+        assert!(validate_base_url("  https://trimmed.com  ").is_ok());
+    }
+
+    #[test]
+    fn validate_base_url_rejects_other_schemes() {
+        assert!(matches!(
+            validate_base_url("ws://example.com"),
+            Err(ProbeError::InvalidUrl(_))
+        ));
+        assert!(matches!(
+            validate_base_url("file:///etc/passwd"),
+            Err(ProbeError::InvalidUrl(_))
+        ));
+        assert!(matches!(
+            validate_base_url("no-scheme.example"),
+            Err(ProbeError::InvalidUrl(_))
+        ));
+    }
+
+    #[test]
+    fn build_models_url_strips_trailing_slash() {
+        assert_eq!(
+            build_models_url("http://host:1234/"),
+            "http://host:1234/v1/models"
+        );
+        assert_eq!(
+            build_models_url("http://host:1234"),
+            "http://host:1234/v1/models"
+        );
+        assert_eq!(
+            build_models_url("https://a.b/c/"),
+            "https://a.b/c/v1/models"
+        );
+    }
+
+    #[test]
+    fn list_models_blocking_rejects_invalid_scheme() {
+        let err =
+            list_models_blocking("ws://example.com", "k").expect_err("should reject ws scheme");
+        assert!(matches!(err, ProbeError::InvalidUrl(_)));
+    }
+
+    #[test]
+    fn truncate_for_diagnostic_caps_long_bodies() {
+        let long = "a".repeat(1024);
+        let truncated = truncate_for_diagnostic(&long);
+        assert!(truncated.len() <= 540);
+        assert!(truncated.ends_with("...<truncated>"));
+    }
+
+    #[test]
+    fn truncate_for_diagnostic_leaves_short_bodies_alone() {
+        let body = "short body";
+        assert_eq!(truncate_for_diagnostic(body), "short body");
+    }
+}

--- a/crates/gwt-ai/src/lib.rs
+++ b/crates/gwt-ai/src/lib.rs
@@ -7,12 +7,17 @@
 //! - [`session_converter`] — Session format conversion between agents
 //! - [`error::AIError`] — Unified error type
 
+pub mod anthropic_backend;
 pub mod branch_suggest;
 pub mod client;
 pub mod error;
 pub mod issue_classify;
 pub mod session_converter;
 
+pub use anthropic_backend::{
+    list_model_ids_blocking, list_models_blocking, parse_models_response, ModelInfo, ProbeError,
+    PROBE_TIMEOUT,
+};
 pub use branch_suggest::{parse_suggestions, suggest_branch_name};
 pub use client::{AIClient, ChatMessage};
 pub use error::AIError;

--- a/crates/gwt-ai/src/lib.rs
+++ b/crates/gwt-ai/src/lib.rs
@@ -7,21 +7,21 @@
 //! - [`session_converter`] — Session format conversion between agents
 //! - [`error::AIError`] — Unified error type
 
-pub mod anthropic_backend;
 pub mod branch_suggest;
 pub mod client;
 pub mod error;
 pub mod issue_classify;
+pub mod models_probe;
 pub mod session_converter;
 
-pub use anthropic_backend::{
-    list_model_ids_blocking, list_models_blocking, parse_models_response, ModelInfo, ProbeError,
-    PROBE_TIMEOUT,
-};
 pub use branch_suggest::{parse_suggestions, suggest_branch_name};
 pub use client::{AIClient, ChatMessage};
 pub use error::AIError;
 pub use issue_classify::{classify_issue, parse_classify_response};
+pub use models_probe::{
+    is_valid_base_url, list_model_ids_blocking, list_models_blocking, parse_models_response,
+    ModelInfo, ProbeError, PROBE_TIMEOUT,
+};
 pub use session_converter::{
     convert_session, get_encoder, ClaudeEncoder, CodexEncoder, GeminiEncoder, OpenCodeEncoder,
     Role, SessionEncoder, SessionMessage,

--- a/crates/gwt-ai/src/models_probe.rs
+++ b/crates/gwt-ai/src/models_probe.rs
@@ -1,8 +1,9 @@
-//! Probe client for Anthropic Messages API compatible backends that also expose
-//! the OpenAI-compatible `/v1/models` endpoint.
+//! `/v1/models` probe client for OpenAI-compatible upstreams (including
+//! Anthropic Messages API compatible proxies that expose the OpenAI model
+//! listing endpoint).
 //!
-//! This module supports SPEC-1921 FR-061: Settings > Custom Agents > Add from
-//! preset > "Claude Code (OpenAI-compat backend)" saves only after a
+//! Supports SPEC-1921 FR-061: Settings > Custom Agents > Add from preset >
+//! "Claude Code (OpenAI-compat backend)" saves only after a
 //! `GET {base_url}/v1/models` call returns HTTP 200 with parseable JSON
 //! containing `data[].id`.
 
@@ -13,6 +14,14 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION},
 };
 use serde::{Deserialize, Serialize};
+
+/// Validate that `base_url` uses the `http://` or `https://` scheme.
+/// SPEC-1921 FR-060. Accepts leading/trailing whitespace and is case-insensitive
+/// on the scheme portion only.
+pub fn is_valid_base_url(base_url: &str) -> bool {
+    let lower = base_url.trim().to_ascii_lowercase();
+    lower.starts_with("http://") || lower.starts_with("https://")
+}
 
 /// Connect + read timeout for the `/v1/models` probe. SPEC-1921 FR-061.
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -89,10 +98,10 @@ pub fn parse_models_response(body: &str) -> Result<Vec<ModelInfo>, ProbeError> {
     Ok(out)
 }
 
-/// Validate the `base_url` scheme. SPEC-1921 FR-060.
+/// Validate the `base_url` scheme and return the structured probe error on
+/// failure. Thin wrapper over [`is_valid_base_url`].
 fn validate_base_url(base_url: &str) -> Result<(), ProbeError> {
-    let lower = base_url.trim().to_ascii_lowercase();
-    if lower.starts_with("http://") || lower.starts_with("https://") {
+    if is_valid_base_url(base_url) {
         Ok(())
     } else {
         Err(ProbeError::InvalidUrl(format!(

--- a/crates/gwt-config/src/atomic.rs
+++ b/crates/gwt-config/src/atomic.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+#[cfg(unix)]
 use tracing::warn;
 
 use crate::error::{ConfigError, Result};

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -19,6 +19,8 @@ path = "src/bin/gwtd.rs"
 
 [dependencies]
 gwt-agent.workspace = true
+gwt-ai.workspace = true
+gwt-config.workspace = true
 gwt-core.workspace = true
 gwt-docker.workspace = true
 gwt-git.workspace = true

--- a/crates/gwt/src/custom_agents_dispatch.rs
+++ b/crates/gwt/src/custom_agents_dispatch.rs
@@ -1,0 +1,146 @@
+//! WebSocket dispatch helpers for Custom Agent Settings requests.
+//!
+//! Extracted from `main.rs` so the 6 request variants have a single owner
+//! instead of being inlined alongside the rest of the frontend event router.
+//! Each helper takes strongly-typed request data and returns a
+//! [`BackendEvent`] reply that the caller wraps in a client-targeted
+//! `OutboundEvent`.
+//!
+//! Error mapping: every `CustomAgentsServiceError` variant maps to a stable
+//! `code` string in [`BackendEvent::CustomAgentError`] so the frontend can
+//! branch on failure type without string matching on messages.
+
+use std::path::PathBuf;
+
+use gwt_agent::CustomCodingAgent;
+use gwt_config::Settings;
+
+use crate::{
+    custom_agents_service::{
+        add_from_claude_code_openai_compat_preset, delete_custom_agent, list_custom_agents,
+        list_presets, probe_backend, update_custom_agent, ClaudeCodeOpenaiCompatInput,
+        CustomAgentsServiceError,
+    },
+    protocol::BackendEvent,
+};
+
+/// Resolve the custom-agent config file path. Falls back to `./config.toml`
+/// when the home directory cannot be discovered, keeping the code path
+/// exercisable in sandboxes and tests.
+pub fn config_path() -> PathBuf {
+    Settings::global_config_path().unwrap_or_else(|| PathBuf::from("config.toml"))
+}
+
+/// Map a service-layer error to the `CustomAgentError` backend event with
+/// a stable `code` string.
+pub fn error_to_event(err: CustomAgentsServiceError) -> BackendEvent {
+    use CustomAgentsServiceError as E;
+    let code = match &err {
+        E::Storage(_) => "storage",
+        E::Duplicate(_) => "duplicate",
+        E::InvalidInput(_) => "invalid_input",
+        E::NotFound(_) => "not_found",
+        E::Probe(_) => "probe",
+    };
+    BackendEvent::CustomAgentError {
+        code: code.to_string(),
+        message: err.to_string(),
+    }
+}
+
+/// Respond to `FrontendEvent::ListCustomAgents`.
+pub fn list_event() -> BackendEvent {
+    match list_custom_agents(&config_path()) {
+        Ok(agents) => BackendEvent::CustomAgentList { agents },
+        Err(err) => error_to_event(err),
+    }
+}
+
+/// Respond to `FrontendEvent::ListCustomAgentPresets`.
+pub fn list_presets_event() -> BackendEvent {
+    BackendEvent::CustomAgentPresetList {
+        presets: list_presets(),
+    }
+}
+
+/// Respond to `FrontendEvent::AddCustomAgentFromPreset`.
+pub fn add_from_preset_event(input: ClaudeCodeOpenaiCompatInput) -> BackendEvent {
+    match add_from_claude_code_openai_compat_preset(&config_path(), &input) {
+        Ok(agent) => BackendEvent::CustomAgentSaved {
+            agent: Box::new(agent),
+        },
+        Err(err) => error_to_event(err),
+    }
+}
+
+/// Respond to `FrontendEvent::UpdateCustomAgent`.
+pub fn update_event(agent: CustomCodingAgent) -> BackendEvent {
+    let saved = agent.clone();
+    match update_custom_agent(&config_path(), agent) {
+        Ok(()) => BackendEvent::CustomAgentSaved {
+            agent: Box::new(saved),
+        },
+        Err(err) => error_to_event(err),
+    }
+}
+
+/// Respond to `FrontendEvent::DeleteCustomAgent`.
+pub fn delete_event(agent_id: String) -> BackendEvent {
+    match delete_custom_agent(&config_path(), &agent_id) {
+        Ok(()) => BackendEvent::CustomAgentDeleted { agent_id },
+        Err(err) => error_to_event(err),
+    }
+}
+
+/// Respond to `FrontendEvent::TestBackendConnection`.
+pub fn test_connection_event(base_url: &str, api_key: &str) -> BackendEvent {
+    match probe_backend(base_url, api_key) {
+        Ok(models) => BackendEvent::BackendConnectionResult { models },
+        Err(err) => BackendEvent::CustomAgentError {
+            code: "probe".to_string(),
+            message: err.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_to_event_preserves_code_per_variant() {
+        let cases = [
+            (CustomAgentsServiceError::Storage("x".into()), "storage"),
+            (CustomAgentsServiceError::Duplicate("x".into()), "duplicate"),
+            (
+                CustomAgentsServiceError::InvalidInput("x".into()),
+                "invalid_input",
+            ),
+            (CustomAgentsServiceError::NotFound("x".into()), "not_found"),
+        ];
+        for (err, expected_code) in cases {
+            match error_to_event(err) {
+                BackendEvent::CustomAgentError { code, .. } => assert_eq!(code, expected_code),
+                other => panic!("expected CustomAgentError, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_connection_event_invalid_scheme_returns_probe_error_code() {
+        match test_connection_event("ws://example.com", "k") {
+            BackendEvent::CustomAgentError { code, .. } => assert_eq!(code, "probe"),
+            other => panic!("expected CustomAgentError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_presets_event_returns_preset_list_variant() {
+        match list_presets_event() {
+            BackendEvent::CustomAgentPresetList { presets } => {
+                assert!(!presets.is_empty());
+            }
+            other => panic!("expected CustomAgentPresetList, got {other:?}"),
+        }
+    }
+}

--- a/crates/gwt/src/custom_agents_service.rs
+++ b/crates/gwt/src/custom_agents_service.rs
@@ -6,7 +6,7 @@
 //!
 //! - `gwt-agent::store` for TOML persistence
 //! - `gwt-agent::presets::claude_code_openai_compat_preset` for preset seeding
-//! - `gwt-ai::anthropic_backend::list_model_ids_blocking` for `/v1/models` probe
+//! - `gwt-ai::models_probe::list_model_ids_blocking` for `/v1/models` probe
 //!
 //! SPEC-1921 Phase 52, tasks T226-T232: this is the backend side of the
 //! Settings UI. The HTML/JS surface that drives these functions is still to
@@ -19,7 +19,7 @@ use gwt_agent::{
     load_stored_custom_agents_from_path, save_stored_custom_agents_to_path, CustomCodingAgent,
     StoredCustomAgent,
 };
-use gwt_ai::anthropic_backend::{list_model_ids_blocking, ProbeError};
+use gwt_ai::models_probe::{is_valid_base_url, list_model_ids_blocking, ProbeError};
 use serde::{Deserialize, Serialize};
 
 /// Stable identifier for a built-in preset. Keep this set small — every new
@@ -214,17 +214,7 @@ fn validate_preset_input(
             "display_name must not be empty".to_string(),
         ));
     }
-    if !input
-        .base_url
-        .trim()
-        .to_ascii_lowercase()
-        .starts_with("http://")
-        && !input
-            .base_url
-            .trim()
-            .to_ascii_lowercase()
-            .starts_with("https://")
-    {
+    if !is_valid_base_url(&input.base_url) {
         return Err(CustomAgentsServiceError::InvalidInput(format!(
             "base_url must start with http:// or https://, got: {}",
             input.base_url

--- a/crates/gwt/src/custom_agents_service.rs
+++ b/crates/gwt/src/custom_agents_service.rs
@@ -1,0 +1,422 @@
+//! Service layer for Custom Agent CRUD operations exposed to the Settings UI.
+//!
+//! This module is the single library surface the desktop app's WebSocket
+//! handler (and any future TUI/CLI consumer) calls into to manage custom
+//! agents. It composes:
+//!
+//! - `gwt-agent::store` for TOML persistence
+//! - `gwt-agent::presets::claude_code_openai_compat_preset` for preset seeding
+//! - `gwt-ai::anthropic_backend::list_model_ids_blocking` for `/v1/models` probe
+//!
+//! SPEC-1921 Phase 52, tasks T226-T232: this is the backend side of the
+//! Settings UI. The HTML/JS surface that drives these functions is still to
+//! be implemented.
+
+use std::path::Path;
+
+use gwt_agent::{
+    claude_code_openai_compat_preset, load_custom_agents_from_path,
+    load_stored_custom_agents_from_path, save_stored_custom_agents_to_path, CustomCodingAgent,
+    StoredCustomAgent,
+};
+use gwt_ai::anthropic_backend::{list_model_ids_blocking, ProbeError};
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a built-in preset. Keep this set small — every new
+/// id is a frontend-visible contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PresetId {
+    /// Claude Code routed through an Anthropic Messages API compatible proxy
+    /// that speaks `/v1/models`. SPEC-1921 FR-062.
+    ClaudeCodeOpenaiCompat,
+}
+
+/// Metadata that the Settings UI shows in the "Add from preset" picker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PresetDefinition {
+    /// Stable id used by the `AddFromPreset` request.
+    pub id: PresetId,
+    /// Display label rendered in the picker.
+    pub label: &'static str,
+    /// Short description rendered below the label in the picker.
+    pub description: &'static str,
+}
+
+impl PresetDefinition {
+    fn catalog() -> [PresetDefinition; 1] {
+        [PresetDefinition {
+            id: PresetId::ClaudeCodeOpenaiCompat,
+            label: "Claude Code (OpenAI-compat backend)",
+            description: concat!(
+                "Route Claude Code to an Anthropic Messages API compatible ",
+                "proxy backed by an OpenAI-compatible upstream."
+            ),
+        }]
+    }
+}
+
+/// Return the catalog of built-in presets.
+pub fn list_presets() -> Vec<PresetDefinition> {
+    PresetDefinition::catalog().to_vec()
+}
+
+/// Input payload for adding a custom agent from the
+/// `ClaudeCodeOpenaiCompat` preset. SPEC-1921 FR-060 / FR-062.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ClaudeCodeOpenaiCompatInput {
+    /// TOML key / stable id for the new custom agent. Must match
+    /// `CustomCodingAgent::validate()` (alphanumeric + `-`).
+    pub id: String,
+    /// Human-readable name shown in the agent picker.
+    pub display_name: String,
+    /// Upstream base URL (http/https).
+    pub base_url: String,
+    /// API key forwarded as `Bearer <api_key>` during `/v1/models` probe and
+    /// injected as `ANTHROPIC_API_KEY` at launch.
+    pub api_key: String,
+    /// Model ID chosen from the probe-populated dropdown.
+    pub default_model: String,
+}
+
+/// Structured error variant exposed to the Settings UI.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CustomAgentsServiceError {
+    /// The supplied config path could not be read / written / parsed.
+    #[error("storage error: {0}")]
+    Storage(String),
+    /// A custom agent with the requested id already exists.
+    #[error("a custom agent with id `{0}` already exists")]
+    Duplicate(String),
+    /// The payload failed validation (empty / non-matching id, invalid url, …).
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+    /// No matching custom agent was found for the given id.
+    #[error("custom agent `{0}` not found")]
+    NotFound(String),
+    /// `/v1/models` probe failure, forwarded verbatim.
+    #[error("probe error: {0}")]
+    Probe(#[from] ProbeError),
+}
+
+impl From<String> for CustomAgentsServiceError {
+    fn from(value: String) -> Self {
+        Self::Storage(value)
+    }
+}
+
+/// List every custom agent currently stored in the given config file.
+pub fn list_custom_agents(
+    config_path: &Path,
+) -> Result<Vec<CustomCodingAgent>, CustomAgentsServiceError> {
+    Ok(load_custom_agents_from_path(config_path)?)
+}
+
+/// Probe an OpenAI-compatible `/v1/models` endpoint. Returns the discovered
+/// model IDs verbatim, or a [`ProbeError`] wrapped in the service error enum.
+/// SPEC-1921 FR-061.
+pub fn probe_backend(base_url: &str, api_key: &str) -> Result<Vec<String>, ProbeError> {
+    list_model_ids_blocking(base_url, api_key)
+}
+
+/// Persist a new custom agent seeded from the Claude Code (OpenAI-compat
+/// backend) preset. Fails if the id already exists or fails validation.
+/// Does NOT re-run the `/v1/models` probe; callers are expected to call
+/// [`probe_backend`] first and only invoke this function once the Save
+/// button's `last_probe_ok` gate is true (SPEC-1921 FR-061).
+pub fn add_from_claude_code_openai_compat_preset(
+    config_path: &Path,
+    input: &ClaudeCodeOpenaiCompatInput,
+) -> Result<CustomCodingAgent, CustomAgentsServiceError> {
+    validate_preset_input(input)?;
+
+    let mut entries = load_stored_custom_agents_from_path(config_path)?;
+    if entries.iter().any(|entry| entry.agent.id == input.id) {
+        return Err(CustomAgentsServiceError::Duplicate(input.id.clone()));
+    }
+
+    let agent = claude_code_openai_compat_preset(
+        input.id.clone(),
+        input.display_name.clone(),
+        input.base_url.clone(),
+        input.api_key.clone(),
+        input.default_model.clone(),
+    );
+    if !agent.validate() {
+        return Err(CustomAgentsServiceError::InvalidInput(format!(
+            "preset produced an invalid agent id: {}",
+            input.id
+        )));
+    }
+
+    entries.push(StoredCustomAgent::new(agent.clone()));
+    save_stored_custom_agents_to_path(config_path, &entries)?;
+    Ok(agent)
+}
+
+/// Update an existing custom agent in place. The agent id must match an
+/// existing entry; returns `NotFound` otherwise. Preserves any sibling
+/// TOML tables (e.g. `models`) via the stored `raw` table.
+pub fn update_custom_agent(
+    config_path: &Path,
+    updated: CustomCodingAgent,
+) -> Result<(), CustomAgentsServiceError> {
+    if !updated.validate() {
+        return Err(CustomAgentsServiceError::InvalidInput(format!(
+            "invalid agent id or fields: {}",
+            updated.id
+        )));
+    }
+    let mut entries = load_stored_custom_agents_from_path(config_path)?;
+    let Some(entry) = entries
+        .iter_mut()
+        .find(|entry| entry.agent.id == updated.id)
+    else {
+        return Err(CustomAgentsServiceError::NotFound(updated.id));
+    };
+    entry.agent = updated;
+    save_stored_custom_agents_to_path(config_path, &entries)?;
+    Ok(())
+}
+
+/// Remove the custom agent with the given id. Returns `NotFound` if no
+/// matching entry exists.
+pub fn delete_custom_agent(
+    config_path: &Path,
+    agent_id: &str,
+) -> Result<(), CustomAgentsServiceError> {
+    let mut entries = load_stored_custom_agents_from_path(config_path)?;
+    let original_len = entries.len();
+    entries.retain(|entry| entry.agent.id != agent_id);
+    if entries.len() == original_len {
+        return Err(CustomAgentsServiceError::NotFound(agent_id.to_string()));
+    }
+    save_stored_custom_agents_to_path(config_path, &entries)?;
+    Ok(())
+}
+
+fn validate_preset_input(
+    input: &ClaudeCodeOpenaiCompatInput,
+) -> Result<(), CustomAgentsServiceError> {
+    if input.id.trim().is_empty() {
+        return Err(CustomAgentsServiceError::InvalidInput(
+            "id must not be empty".to_string(),
+        ));
+    }
+    if !input.id.chars().all(|c| c.is_alphanumeric() || c == '-') {
+        return Err(CustomAgentsServiceError::InvalidInput(format!(
+            "id `{}` contains invalid characters (allowed: alphanumeric, `-`)",
+            input.id
+        )));
+    }
+    if input.display_name.trim().is_empty() {
+        return Err(CustomAgentsServiceError::InvalidInput(
+            "display_name must not be empty".to_string(),
+        ));
+    }
+    if !input
+        .base_url
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with("http://")
+        && !input
+            .base_url
+            .trim()
+            .to_ascii_lowercase()
+            .starts_with("https://")
+    {
+        return Err(CustomAgentsServiceError::InvalidInput(format!(
+            "base_url must start with http:// or https://, got: {}",
+            input.base_url
+        )));
+    }
+    if input.api_key.trim().is_empty() {
+        return Err(CustomAgentsServiceError::InvalidInput(
+            "api_key must not be empty".to_string(),
+        ));
+    }
+    if input.default_model.trim().is_empty() {
+        return Err(CustomAgentsServiceError::InvalidInput(
+            "default_model must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_input() -> ClaudeCodeOpenaiCompatInput {
+        ClaudeCodeOpenaiCompatInput {
+            id: "claude-code-openai".to_string(),
+            display_name: "Claude Code (OpenAI-compat)".to_string(),
+            base_url: "http://192.168.100.166:32768".to_string(),
+            api_key: "sk_cwPkycrPTZBYQ8vFXsc3O0wkrvt36VSh".to_string(),
+            default_model: "openai/gpt-oss-20b".to_string(),
+        }
+    }
+
+    #[test]
+    fn list_presets_includes_claude_code_openai_compat() {
+        let presets = list_presets();
+        assert_eq!(presets.len(), 1);
+        assert_eq!(presets[0].id, PresetId::ClaudeCodeOpenaiCompat);
+        assert!(presets[0].label.contains("OpenAI-compat"));
+    }
+
+    #[test]
+    fn add_from_preset_creates_entry_and_persists_all_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let input = sample_input();
+
+        let agent = add_from_claude_code_openai_compat_preset(&path, &input).expect("save");
+
+        assert_eq!(agent.id, input.id);
+        assert_eq!(agent.env.len(), 13);
+        assert_eq!(agent.env["ANTHROPIC_API_KEY"], input.api_key);
+        assert_eq!(agent.env["ANTHROPIC_BASE_URL"], input.base_url);
+
+        let reloaded = list_custom_agents(&path).unwrap();
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded[0].env.len(), 13);
+        assert_eq!(
+            reloaded[0].env["ANTHROPIC_DEFAULT_OPUS_MODEL"],
+            input.default_model
+        );
+    }
+
+    #[test]
+    fn add_from_preset_rejects_duplicate_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let input = sample_input();
+
+        add_from_claude_code_openai_compat_preset(&path, &input).expect("first save");
+        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::Duplicate(_)));
+    }
+
+    #[test]
+    fn add_from_preset_rejects_empty_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut input = sample_input();
+        input.id = String::new();
+        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn add_from_preset_rejects_id_with_spaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut input = sample_input();
+        input.id = "has spaces".to_string();
+        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn add_from_preset_rejects_non_http_base_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut input = sample_input();
+        input.base_url = "ws://example.com".to_string();
+        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn add_from_preset_rejects_empty_api_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut input = sample_input();
+        input.api_key = String::new();
+        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn add_from_preset_rejects_empty_default_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut input = sample_input();
+        input.default_model = String::new();
+        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn update_custom_agent_modifies_existing_entry_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let input = sample_input();
+        let mut agent = add_from_claude_code_openai_compat_preset(&path, &input).unwrap();
+
+        agent.display_name = "Renamed Claude".to_string();
+        agent
+            .env
+            .insert("CUSTOM_EXTRA".to_string(), "value".to_string());
+        update_custom_agent(&path, agent).expect("update");
+
+        let reloaded = list_custom_agents(&path).unwrap();
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded[0].display_name, "Renamed Claude");
+        assert_eq!(
+            reloaded[0].env.get("CUSTOM_EXTRA").map(String::as_str),
+            Some("value")
+        );
+    }
+
+    #[test]
+    fn update_custom_agent_returns_not_found_for_unknown_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut agent = claude_code_openai_compat_preset("missing", "X", "http://a", "k", "m");
+        agent.id = "missing".to_string();
+        let err = update_custom_agent(&path, agent).unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::NotFound(_)));
+    }
+
+    #[test]
+    fn delete_custom_agent_removes_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let input = sample_input();
+        add_from_claude_code_openai_compat_preset(&path, &input).unwrap();
+
+        delete_custom_agent(&path, &input.id).expect("delete");
+        let reloaded = list_custom_agents(&path).unwrap();
+        assert!(reloaded.is_empty());
+    }
+
+    #[test]
+    fn delete_custom_agent_returns_not_found_for_unknown_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let err = delete_custom_agent(&path, "ghost").unwrap_err();
+        assert!(matches!(err, CustomAgentsServiceError::NotFound(_)));
+    }
+
+    #[test]
+    fn list_custom_agents_returns_empty_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.toml");
+        let agents = list_custom_agents(&path).expect("list");
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn probe_backend_rejects_non_http_scheme() {
+        let err = probe_backend("ws://example.com", "k").unwrap_err();
+        assert!(matches!(err, ProbeError::InvalidUrl(_)));
+    }
+
+    #[test]
+    fn preset_id_serializes_as_snake_case() {
+        let json = serde_json::to_string(&PresetId::ClaudeCodeOpenaiCompat).unwrap();
+        assert_eq!(json, "\"claude_code_openai_compat\"");
+    }
+}

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod branch_cleanup;
 pub mod branch_list;
 pub mod cli;
+pub mod custom_agents_service;
 pub mod daemon_runtime;
 mod discussion_resume;
 pub mod file_tree;
@@ -22,6 +23,11 @@ pub use branch_list::{list_branch_entries, BranchListEntry, BranchScope};
 pub use branch_list::{
     list_branch_entries_with_active_sessions, BranchCleanupAvailability,
     BranchCleanupBlockedReason, BranchCleanupInfo, BranchCleanupRisk,
+};
+pub use custom_agents_service::{
+    add_from_claude_code_openai_compat_preset, delete_custom_agent, list_custom_agents,
+    list_presets, probe_backend, update_custom_agent, ClaudeCodeOpenaiCompatInput,
+    CustomAgentsServiceError, PresetDefinition, PresetId,
 };
 pub use daemon_runtime::{HookForwardTarget, RuntimeHookEvent, RuntimeHookEventKind};
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod branch_cleanup;
 pub mod branch_list;
 pub mod cli;
+pub mod custom_agents_dispatch;
 pub mod custom_agents_service;
 pub mod daemon_runtime;
 mod discussion_resume;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -421,6 +421,33 @@ impl AppRuntime {
                 std::thread::spawn(apply_update_and_exit);
                 vec![]
             }
+            FrontendEvent::ListCustomAgents => {
+                vec![OutboundEvent::reply(client_id, list_custom_agents_event())]
+            }
+            FrontendEvent::ListCustomAgentPresets => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::CustomAgentPresetList {
+                    presets: gwt::list_presets(),
+                },
+            )],
+            FrontendEvent::AddCustomAgentFromPreset { input } => vec![OutboundEvent::reply(
+                client_id,
+                add_custom_agent_from_preset_event(input),
+            )],
+            FrontendEvent::UpdateCustomAgent { agent } => vec![OutboundEvent::reply(
+                client_id,
+                update_custom_agent_event(*agent),
+            )],
+            FrontendEvent::DeleteCustomAgent { agent_id } => vec![OutboundEvent::reply(
+                client_id,
+                delete_custom_agent_event(agent_id),
+            )],
+            FrontendEvent::TestBackendConnection { base_url, api_key } => {
+                vec![OutboundEvent::reply(
+                    client_id,
+                    test_backend_connection_event(&base_url, &api_key),
+                )]
+            }
         }
     }
 
@@ -4832,6 +4859,76 @@ fn main() -> wry::Result<()> {
             _ => {}
         }
     });
+}
+
+/// Resolve the custom-agent config file path. Falls back to `./config.toml`
+/// if the home directory cannot be discovered so the code path remains
+/// exercisable in sandbox environments.
+fn custom_agents_config_path() -> std::path::PathBuf {
+    gwt_config::Settings::global_config_path()
+        .unwrap_or_else(|| std::path::PathBuf::from("config.toml"))
+}
+
+fn map_custom_agent_error(err: gwt::CustomAgentsServiceError) -> BackendEvent {
+    use gwt::CustomAgentsServiceError as E;
+    let code = match &err {
+        E::Storage(_) => "storage",
+        E::Duplicate(_) => "duplicate",
+        E::InvalidInput(_) => "invalid_input",
+        E::NotFound(_) => "not_found",
+        E::Probe(_) => "probe",
+    };
+    BackendEvent::CustomAgentError {
+        code: code.to_string(),
+        message: err.to_string(),
+    }
+}
+
+fn list_custom_agents_event() -> BackendEvent {
+    let path = custom_agents_config_path();
+    match gwt::list_custom_agents(&path) {
+        Ok(agents) => BackendEvent::CustomAgentList { agents },
+        Err(err) => map_custom_agent_error(err),
+    }
+}
+
+fn add_custom_agent_from_preset_event(input: gwt::ClaudeCodeOpenaiCompatInput) -> BackendEvent {
+    let path = custom_agents_config_path();
+    match gwt::add_from_claude_code_openai_compat_preset(&path, &input) {
+        Ok(agent) => BackendEvent::CustomAgentSaved {
+            agent: Box::new(agent),
+        },
+        Err(err) => map_custom_agent_error(err),
+    }
+}
+
+fn update_custom_agent_event(agent: gwt_agent::CustomCodingAgent) -> BackendEvent {
+    let path = custom_agents_config_path();
+    let agent_clone = agent.clone();
+    match gwt::update_custom_agent(&path, agent) {
+        Ok(()) => BackendEvent::CustomAgentSaved {
+            agent: Box::new(agent_clone),
+        },
+        Err(err) => map_custom_agent_error(err),
+    }
+}
+
+fn delete_custom_agent_event(agent_id: String) -> BackendEvent {
+    let path = custom_agents_config_path();
+    match gwt::delete_custom_agent(&path, &agent_id) {
+        Ok(()) => BackendEvent::CustomAgentDeleted { agent_id },
+        Err(err) => map_custom_agent_error(err),
+    }
+}
+
+fn test_backend_connection_event(base_url: &str, api_key: &str) -> BackendEvent {
+    match gwt::probe_backend(base_url, api_key) {
+        Ok(models) => BackendEvent::BackendConnectionResult { models },
+        Err(err) => BackendEvent::CustomAgentError {
+            code: "probe".to_string(),
+            message: err.to_string(),
+        },
+    }
 }
 
 /// Download and apply a pending update, then exit.

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -421,31 +421,30 @@ impl AppRuntime {
                 std::thread::spawn(apply_update_and_exit);
                 vec![]
             }
-            FrontendEvent::ListCustomAgents => {
-                vec![OutboundEvent::reply(client_id, list_custom_agents_event())]
-            }
+            FrontendEvent::ListCustomAgents => vec![OutboundEvent::reply(
+                client_id,
+                gwt::custom_agents_dispatch::list_event(),
+            )],
             FrontendEvent::ListCustomAgentPresets => vec![OutboundEvent::reply(
                 client_id,
-                BackendEvent::CustomAgentPresetList {
-                    presets: gwt::list_presets(),
-                },
+                gwt::custom_agents_dispatch::list_presets_event(),
             )],
             FrontendEvent::AddCustomAgentFromPreset { input } => vec![OutboundEvent::reply(
                 client_id,
-                add_custom_agent_from_preset_event(input),
+                gwt::custom_agents_dispatch::add_from_preset_event(input),
             )],
             FrontendEvent::UpdateCustomAgent { agent } => vec![OutboundEvent::reply(
                 client_id,
-                update_custom_agent_event(*agent),
+                gwt::custom_agents_dispatch::update_event(*agent),
             )],
             FrontendEvent::DeleteCustomAgent { agent_id } => vec![OutboundEvent::reply(
                 client_id,
-                delete_custom_agent_event(agent_id),
+                gwt::custom_agents_dispatch::delete_event(agent_id),
             )],
             FrontendEvent::TestBackendConnection { base_url, api_key } => {
                 vec![OutboundEvent::reply(
                     client_id,
-                    test_backend_connection_event(&base_url, &api_key),
+                    gwt::custom_agents_dispatch::test_connection_event(&base_url, &api_key),
                 )]
             }
         }
@@ -4859,76 +4858,6 @@ fn main() -> wry::Result<()> {
             _ => {}
         }
     });
-}
-
-/// Resolve the custom-agent config file path. Falls back to `./config.toml`
-/// if the home directory cannot be discovered so the code path remains
-/// exercisable in sandbox environments.
-fn custom_agents_config_path() -> std::path::PathBuf {
-    gwt_config::Settings::global_config_path()
-        .unwrap_or_else(|| std::path::PathBuf::from("config.toml"))
-}
-
-fn map_custom_agent_error(err: gwt::CustomAgentsServiceError) -> BackendEvent {
-    use gwt::CustomAgentsServiceError as E;
-    let code = match &err {
-        E::Storage(_) => "storage",
-        E::Duplicate(_) => "duplicate",
-        E::InvalidInput(_) => "invalid_input",
-        E::NotFound(_) => "not_found",
-        E::Probe(_) => "probe",
-    };
-    BackendEvent::CustomAgentError {
-        code: code.to_string(),
-        message: err.to_string(),
-    }
-}
-
-fn list_custom_agents_event() -> BackendEvent {
-    let path = custom_agents_config_path();
-    match gwt::list_custom_agents(&path) {
-        Ok(agents) => BackendEvent::CustomAgentList { agents },
-        Err(err) => map_custom_agent_error(err),
-    }
-}
-
-fn add_custom_agent_from_preset_event(input: gwt::ClaudeCodeOpenaiCompatInput) -> BackendEvent {
-    let path = custom_agents_config_path();
-    match gwt::add_from_claude_code_openai_compat_preset(&path, &input) {
-        Ok(agent) => BackendEvent::CustomAgentSaved {
-            agent: Box::new(agent),
-        },
-        Err(err) => map_custom_agent_error(err),
-    }
-}
-
-fn update_custom_agent_event(agent: gwt_agent::CustomCodingAgent) -> BackendEvent {
-    let path = custom_agents_config_path();
-    let agent_clone = agent.clone();
-    match gwt::update_custom_agent(&path, agent) {
-        Ok(()) => BackendEvent::CustomAgentSaved {
-            agent: Box::new(agent_clone),
-        },
-        Err(err) => map_custom_agent_error(err),
-    }
-}
-
-fn delete_custom_agent_event(agent_id: String) -> BackendEvent {
-    let path = custom_agents_config_path();
-    match gwt::delete_custom_agent(&path, &agent_id) {
-        Ok(()) => BackendEvent::CustomAgentDeleted { agent_id },
-        Err(err) => map_custom_agent_error(err),
-    }
-}
-
-fn test_backend_connection_event(base_url: &str, api_key: &str) -> BackendEvent {
-    match gwt::probe_backend(base_url, api_key) {
-        Ok(models) => BackendEvent::BackendConnectionResult { models },
-        Err(err) => BackendEvent::CustomAgentError {
-            code: "probe".to_string(),
-            message: err.to_string(),
-        },
-    }
 }
 
 /// Download and apply a pending update, then exit.

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1,8 +1,10 @@
+use gwt_agent::CustomCodingAgent;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     branch_cleanup::BranchCleanupResultEntry,
     branch_list::BranchListEntry,
+    custom_agents_service::{ClaudeCodeOpenaiCompatInput, PresetDefinition},
     daemon_runtime::RuntimeHookEvent,
     file_tree::FileTreeEntry,
     knowledge_bridge::{KnowledgeDetailView, KnowledgeKind, KnowledgeListItem},
@@ -121,6 +123,38 @@ pub enum FrontendEvent {
         bounds: Option<WindowGeometry>,
     },
     ApplyUpdate,
+    /// Settings > Custom Agents: list every stored custom agent. Response is
+    /// [`BackendEvent::CustomAgentList`].
+    ListCustomAgents,
+    /// Settings > Custom Agents > Add from preset: enumerate built-in preset
+    /// definitions for the picker. Response is
+    /// [`BackendEvent::CustomAgentPresetList`].
+    ListCustomAgentPresets,
+    /// Settings > Custom Agents > Add > Claude Code (OpenAI-compat backend):
+    /// persist a new custom agent seeded from the preset payload. Response
+    /// is [`BackendEvent::CustomAgentSaved`] on success or
+    /// [`BackendEvent::CustomAgentError`] on failure.
+    AddCustomAgentFromPreset {
+        input: ClaudeCodeOpenaiCompatInput,
+    },
+    /// Settings > Custom Agents > Edit: replace an existing custom agent in
+    /// place. The agent id must match an existing entry.
+    UpdateCustomAgent {
+        agent: Box<CustomCodingAgent>,
+    },
+    /// Settings > Custom Agents > Delete: remove the custom agent with the
+    /// given id.
+    DeleteCustomAgent {
+        agent_id: String,
+    },
+    /// Settings > Custom Agents > Test connection: probe
+    /// `GET {base_url}/v1/models` with the provided api key. Response is
+    /// [`BackendEvent::BackendConnectionResult`] on success or
+    /// [`BackendEvent::CustomAgentError`] on failure.
+    TestBackendConnection {
+        base_url: String,
+        api_key: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -229,4 +263,31 @@ pub enum BackendEvent {
         event: RuntimeHookEvent,
     },
     UpdateState(gwt_core::update::UpdateState),
+    /// Response to [`FrontendEvent::ListCustomAgents`].
+    CustomAgentList {
+        agents: Vec<CustomCodingAgent>,
+    },
+    /// Response to [`FrontendEvent::ListCustomAgentPresets`].
+    CustomAgentPresetList {
+        presets: Vec<PresetDefinition>,
+    },
+    /// Response to [`FrontendEvent::AddCustomAgentFromPreset`] /
+    /// [`FrontendEvent::UpdateCustomAgent`] (save success).
+    CustomAgentSaved {
+        agent: Box<CustomCodingAgent>,
+    },
+    /// Response to [`FrontendEvent::DeleteCustomAgent`].
+    CustomAgentDeleted {
+        agent_id: String,
+    },
+    /// Response to [`FrontendEvent::TestBackendConnection`] (success).
+    BackendConnectionResult {
+        models: Vec<String>,
+    },
+    /// Error reply for any custom-agent mutation or probe request.
+    /// `code` is a stable machine-readable tag; `message` is human-readable.
+    CustomAgentError {
+        code: String,
+        message: String,
+    },
 }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -4782,6 +4782,11 @@
           return;
         }
 
+        if (windowData.preset === "settings") {
+          renderSettingsWindow(body, windowData);
+          return;
+        }
+
         const mock = mockContentForPreset(windowData.preset);
         body.innerHTML = `
           <div class="mock-root">
@@ -4809,6 +4814,212 @@
           `;
           scroll.appendChild(section);
         }
+      }
+
+      // SPEC-1921 Phase 52 — Settings > Custom Agents backend bridge.
+      //
+      // All DOM nodes are built via createElement + textContent to avoid
+      // innerHTML with mixed trust. The UI is intentionally minimal (prompt()
+      // driven) so the backend protocol can be exercised end-to-end before a
+      // richer form layout is designed.
+      const customAgentsState = {
+        agents: [],
+        loading: false,
+        statusMessage: "",
+        statusKind: "",
+      };
+      const settingsWindowBodies = new Set();
+      let pendingAddFromPreset = null;
+
+      function createDiv(className) {
+        const el = document.createElement("div");
+        if (className) el.className = className;
+        return el;
+      }
+
+      function renderSettingsWindow(body, windowData) {
+        while (body.firstChild) body.removeChild(body.firstChild);
+        const root = createDiv("mock-root");
+        const toolbar = createDiv("mock-toolbar");
+        const heading = createDiv("mock-heading");
+        heading.textContent = "Custom Agents";
+        const chip = document.createElement("span");
+        chip.className = "mock-chip";
+        chip.textContent = windowData.title || "Settings";
+        toolbar.appendChild(heading);
+        toolbar.appendChild(chip);
+        const scroll = createDiv("mock-scroll");
+        scroll.dataset.role = "settings-scroll";
+        root.appendChild(toolbar);
+        root.appendChild(scroll);
+        body.appendChild(root);
+
+        body.addEventListener("mousedown", () => {
+          focusWindowLocally(windowData.id);
+          send({ kind: "focus_window", id: windowData.id });
+        });
+        settingsWindowBodies.add(body);
+        renderSettingsAgentList();
+        if (!customAgentsState.loading && customAgentsState.agents.length === 0) {
+          customAgentsState.loading = true;
+          send({ kind: "list_custom_agents" });
+        }
+      }
+
+      function renderSettingsAgentList() {
+        for (const body of Array.from(settingsWindowBodies)) {
+          if (!body.isConnected) {
+            settingsWindowBodies.delete(body);
+            continue;
+          }
+          const scroll = body.querySelector("[data-role='settings-scroll']");
+          if (!scroll) continue;
+          while (scroll.firstChild) scroll.removeChild(scroll.firstChild);
+
+          const addBtn = document.createElement("button");
+          addBtn.className = "wizard-button";
+          addBtn.style.margin = "8px 0";
+          addBtn.textContent = "＋ Add Claude Code (OpenAI-compat backend)";
+          addBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            startAddClaudeCodeOpenaiCompatFlow();
+          });
+          scroll.appendChild(addBtn);
+
+          if (customAgentsState.statusMessage) {
+            const section = createDiv("mock-section");
+            const label = createDiv("mock-label");
+            label.textContent = "Status";
+            label.style.color =
+              customAgentsState.statusKind === "error"
+                ? "#ff6b6b"
+                : customAgentsState.statusKind === "success"
+                  ? "#7abf7a"
+                  : "#999";
+            section.appendChild(label);
+            const row = createDiv("mock-row");
+            const text = document.createElement("span");
+            text.textContent = customAgentsState.statusMessage;
+            row.appendChild(text);
+            section.appendChild(row);
+            scroll.appendChild(section);
+          }
+
+          if (customAgentsState.loading && customAgentsState.agents.length === 0) {
+            const section = createDiv("mock-section");
+            const row = createDiv("mock-row");
+            const text = document.createElement("span");
+            text.textContent = "Loading custom agents…";
+            row.appendChild(text);
+            section.appendChild(row);
+            scroll.appendChild(section);
+            continue;
+          }
+
+          if (customAgentsState.agents.length === 0) {
+            const section = createDiv("mock-section");
+            const row = createDiv("mock-row");
+            const text = document.createElement("span");
+            text.textContent = "No custom agents configured yet.";
+            row.appendChild(text);
+            section.appendChild(row);
+            scroll.appendChild(section);
+            continue;
+          }
+
+          for (const agent of customAgentsState.agents) {
+            const section = createDiv("mock-section");
+            const label = createDiv("mock-label");
+            label.textContent = agent.display_name || agent.id;
+            section.appendChild(label);
+            const row = createDiv("mock-row");
+            const text = document.createElement("span");
+            const envCount = Object.keys(agent.env || {}).length;
+            const baseUrl =
+              agent.env && agent.env.ANTHROPIC_BASE_URL
+                ? ` · ${agent.env.ANTHROPIC_BASE_URL}`
+                : "";
+            text.textContent = `${agent.id} · ${agent.command} · ${envCount} env entries${baseUrl}`;
+            row.appendChild(text);
+            const delBtn = document.createElement("button");
+            delBtn.className = "icon-button";
+            delBtn.setAttribute("aria-label", "Delete agent");
+            delBtn.textContent = "×";
+            delBtn.addEventListener("click", (e) => {
+              e.stopPropagation();
+              if (window.confirm(`Delete custom agent "${agent.id}"?`)) {
+                send({ kind: "delete_custom_agent", agent_id: agent.id });
+              }
+            });
+            row.appendChild(delBtn);
+            section.appendChild(row);
+            scroll.appendChild(section);
+          }
+        }
+      }
+
+      function startAddClaudeCodeOpenaiCompatFlow() {
+        const baseUrl = window.prompt(
+          "Upstream base_url (http:// or https://)\n\nExample: http://192.168.100.166:32768",
+          "http://",
+        );
+        if (!baseUrl) return;
+        const apiKey = window.prompt(
+          "API key (forwarded as Bearer on /v1/models probe and ANTHROPIC_API_KEY at launch):",
+        );
+        if (!apiKey) return;
+        setSettingsStatus("Probing /v1/models…", "info");
+        pendingAddFromPreset = { baseUrl, apiKey };
+        send({ kind: "test_backend_connection", base_url: baseUrl, api_key: apiKey });
+      }
+
+      function setSettingsStatus(message, kind) {
+        customAgentsState.statusMessage = message;
+        customAgentsState.statusKind = kind;
+        renderSettingsAgentList();
+      }
+
+      function completeAddFromPreset(discoveredModels) {
+        if (!pendingAddFromPreset) return;
+        if (!discoveredModels || discoveredModels.length === 0) {
+          setSettingsStatus("Upstream /v1/models returned no entries.", "error");
+          pendingAddFromPreset = null;
+          return;
+        }
+        const modelList = discoveredModels.join("\n");
+        const model = window.prompt(
+          `Discovered ${discoveredModels.length} model(s). Choose default_model (copy one ID):\n\n${modelList}`,
+          discoveredModels[0],
+        );
+        if (!model) {
+          pendingAddFromPreset = null;
+          setSettingsStatus("Cancelled.", "info");
+          return;
+        }
+        const id = window.prompt("Custom agent id (alphanumeric + `-`):", "claude-code-openai");
+        if (!id) {
+          pendingAddFromPreset = null;
+          setSettingsStatus("Cancelled.", "info");
+          return;
+        }
+        const displayName = window.prompt("Display name:", "Claude Code (OpenAI-compat)");
+        if (!displayName) {
+          pendingAddFromPreset = null;
+          setSettingsStatus("Cancelled.", "info");
+          return;
+        }
+        setSettingsStatus("Saving preset…", "info");
+        send({
+          kind: "add_custom_agent_from_preset",
+          input: {
+            id,
+            display_name: displayName,
+            base_url: pendingAddFromPreset.baseUrl,
+            api_key: pendingAddFromPreset.apiKey,
+            default_model: model,
+          },
+        });
+        pendingAddFromPreset = null;
       }
 
       function ensureWindow(windowData) {
@@ -5081,6 +5292,50 @@
               setVersionState(event.current, event.latest);
               showUpdateToast(event.latest);
             }
+            break;
+          case "custom_agent_list":
+            customAgentsState.agents = event.agents || [];
+            customAgentsState.loading = false;
+            renderSettingsAgentList();
+            break;
+          case "custom_agent_saved":
+            if (event.agent) {
+              const idx = customAgentsState.agents.findIndex(
+                (a) => a.id === event.agent.id,
+              );
+              if (idx >= 0) {
+                customAgentsState.agents[idx] = event.agent;
+              } else {
+                customAgentsState.agents.push(event.agent);
+              }
+            }
+            customAgentsState.loading = false;
+            setSettingsStatus(
+              `Saved custom agent "${event.agent ? event.agent.id : "?"}".`,
+              "success",
+            );
+            break;
+          case "custom_agent_deleted":
+            customAgentsState.agents = customAgentsState.agents.filter(
+              (a) => a.id !== event.agent_id,
+            );
+            setSettingsStatus(`Deleted custom agent "${event.agent_id}".`, "success");
+            break;
+          case "backend_connection_result":
+            setSettingsStatus(
+              `/v1/models returned ${event.models.length} model(s).`,
+              "success",
+            );
+            completeAddFromPreset(event.models);
+            break;
+          case "custom_agent_preset_list":
+            // Reserved for a future "Add from preset" picker — the current
+            // UI hardcodes the one preset.
+            break;
+          case "custom_agent_error":
+            customAgentsState.loading = false;
+            pendingAddFromPreset = null;
+            setSettingsStatus(`Error [${event.code}]: ${event.message}`, "error");
             break;
         }
       }


### PR DESCRIPTION
## Summary

SPEC-1921 Phase 52 (FR-059〜FR-063 / US-4 AS 5-9 / SC-013) の実装一式。Settings > Custom Agents から「Claude Code (OpenAI-compat backend)」プリセットを登録すると、Claude Code を任意の Anthropic Messages API 互換プロキシ (例: ローカル LLM ランタイム + OpenAI-compatible 上流) 経由で起動できるようになる。

ユーザが PowerShell で手動設定していた env 一式 (`ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` / `ANTHROPIC_DEFAULT_{HAIKU,OPUS,SONNET}_MODEL` / `CLAUDE_CODE_SUBAGENT_MODEL` / `CLAUDE_CODE_ATTRIBUTION_HEADER` / テレメトリ無効化 6 本) を Settings UI から入力して永続化し、カスタムエージェントの launch 時に PTY 環境へ正しい優先順で注入する。

## Context

Owner: SPEC-1921 (エージェント管理 — 検出・起動ウィザード・カスタムエージェント・バージョンキャッシュ). Phase 52 として既存の US-4 カスタムエージェント機能を拡張し、preset 駆動の登録フローと `/v1/models` 動的モデル取得を追加した。既存の Phase 0-51 (T001-T210) は影響しない。

## Changes

### Library 層 (gwt-agent / gwt-ai)

- `crates/gwt-agent/src/presets.rs` (新規) — `claude_code_openai_compat_preset` ファクトリ。base_url / api_key / default_model から 13 本の env を seed し、`bunx @anthropic-ai/claude-code@latest` を起動する `CustomCodingAgent` を生成。4 本のモデル役割 (HAIKU/OPUS/SONNET/SUBAGENT) に同一 ID を注入 (FR-062)。
- `crates/gwt-ai/src/models_probe.rs` (新規) — `GET {base_url}/v1/models` の 3 秒 timeout 付き blocking probe client。`ProbeError::{InvalidUrl, Timeout, HttpStatus, InvalidJson, MissingData, Transport}` の構造化エラー (FR-061)。`is_valid_base_url(&str) -> bool` を pub 共有ヘルパーとして公開。
- `crates/gwt-agent/src/audit.rs` (新規) — FR-047 拡張 (FR-063)。`is_secret_env_key` / `redact_env_value_for_audit` で `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` / `ANTHROPIC_AUTH_TOKEN` と `*_API_KEY` / `*_TOKEN` / `*_SECRET` サフィックス (case-insensitive) を audit log から mask。
- `crates/gwt-agent/src/store.rs` (新規) — `~/.gwt/config.toml` の `[tools.customCodingAgents.<id>]` 入出力を再構築 (commit `10ff990f` 削除分のポート)。camelCase / snake_case を両受け入れ。sibling 不明キー (`models` 等) を保存ラウンドトリップで保持。atomic rename write。重複 id と無効 id を reject (FR-059)。
- `crates/gwt-agent/src/custom.rs` — TOML `[env]` サブテーブルの round-trip / 欠落時のデフォルト空マップ / 連続 round-trip の安定性を検証するテスト 3 本を追加 (FR-059)。
- `crates/gwt-agent/src/launch.rs` — `AgentLaunchBuilder::custom_agent_env(HashMap)` を追加。build 時に `Common (TERM/GWT_*) -> agent-specific (Claude/Codex 組込) -> custom_agent_env -> env_overrides` の順で merge し、preset 由来 env が built-in default を上書きできる一方 caller override は最優先という FR-063 の precedence を保証する 5 ケースで検証。

### Service 層 + Protocol (gwt)

- `crates/gwt/src/custom_agents_service.rs` (新規) — 上記 4 モジュールを composite する単一ファサード。`list_presets` / `list_custom_agents` / `probe_backend` / `add_from_claude_code_openai_compat_preset` / `update_custom_agent` / `delete_custom_agent` を export。id / display_name / base_url scheme / api_key / default_model の前段 validation と重複 id 検知を提供。
- `crates/gwt/src/custom_agents_dispatch.rs` (新規) — 6 つの `FrontendEvent` 変種を受けて `BackendEvent` を返す dispatch helper。`CustomAgentsServiceError` を stable `code` string (`storage` / `duplicate` / `invalid_input` / `not_found` / `probe`) に map。main.rs から分離して dispatch arms の可読性を確保。
- `crates/gwt/src/protocol.rs` — `FrontendEvent` に `ListCustomAgents` / `ListCustomAgentPresets` / `AddCustomAgentFromPreset { input }` / `UpdateCustomAgent { agent }` / `DeleteCustomAgent { agent_id }` / `TestBackendConnection { base_url, api_key }` の 6 variant、`BackendEvent` に `CustomAgentList` / `CustomAgentPresetList` / `CustomAgentSaved` / `CustomAgentDeleted` / `BackendConnectionResult` / `CustomAgentError { code, message }` の 6 variant を追加。

### Frontend MVP (gwt/web/index.html)

- `renderSettingsWindow` / `renderSettingsAgentList` / `completeAddFromPreset` を新設し、Settings ウィンドウの placeholder mock を置き換え。`＋ Add Claude Code (OpenAI-compat backend)` ボタンから prompt() ベースのフローで base_url / api_key → `/v1/models` probe → モデル選択 → id / display_name 入力 → 保存まで到達。一覧と削除も接続済み。DOM は `createElement` + `textContent` で構築し `innerHTML` は静的テンプレート部のみに限定 (security-hook 準拠)。styled form / env key/value editor / 複数 preset picker は SPEC-2015 (Settings & Profile Window) 再設計サイクルに継続 (T231)。

### SPEC 側

- SPEC-1921 `spec.md` — FR-059〜FR-063 追加、US-4 に AS 5-9 追加、Custom Agent Schema TOML 例を env サブテーブル付きに更新、SC-013 追加。
- SPEC-1921 `plan.md` — Phase 52 のスコープ / 設計ハイライト / 受け入れ検証を追加。
- SPEC-1921 `tasks.md` — T211-T236 を追加、実装状況をリアルタイム更新済み。
- SPEC-1921 phase label を `phase/done` → `phase/implementation` に変更、Issue を reopen。

## Testing

- `cargo test -p gwt -p gwt-agent -p gwt-ai -p gwt-config` = 399 passing (追加: presets 7 / models_probe 12 / custom TOML 3 / audit 10 / store 11 / launch merge 5 / custom_agents_service 15 / dispatch 3 = 66 新規ケース)
- `cargo clippy -p gwt --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo build -p gwt` 成功 (15.21s)

手動 E2E: 上記 protocol と Settings window MVP の end-to-end 動作は、ローカルプロキシ (例: `http://127.0.0.1:PORT`) を立てた上で frontend の prompt フローから probe / save / list refresh / delete を観測することで確認可能。ネットワーク部分は `models_probe::list_models_blocking` が同じ contract に乗るため、unit テストの 12 ケースでパース / scheme 検証 / エラー分類をカバー。

## Closing Issues

None (SPEC-1921 は phase/implementation のまま、T231 完了後に phase/review 昇格)

## Related Issues

- #1921 (SPEC-1921 エージェント管理)
- #2015 (SPEC-2015 Settings & Profile Window) — T231 styled env editor の継続先

## Checklist

- [x] Conventional Commits 形式のコミットメッセージ (`feat:` x4 / `refactor:` x1 / merge 1)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` 全通過 (399 passing)
- [x] origin/develop を merge 済み (behind 0)
- [x] SPEC-1921 spec / plan / tasks を最新状態に反映
- [ ] T231 styled env key/value editor — SPEC-2015 側で継続。本 PR スコープでは MVP UI で代替。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
