### PR TITLE
fix(gui): canvas-stage の GPU レイヤーキャッシュ由来のテキストぼやけを解消

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -150,7 +150,6 @@
         position: absolute;
         inset: 0;
         transform-origin: 0 0;
-        will-change: transform;
         background-image:
           linear-gradient(rgba(15, 23, 42, 0.04) 1px, transparent 1px),
           linear-gradient(90deg, rgba(15, 23, 42, 0.04) 1px, transparent 1px);
@@ -1953,6 +1952,7 @@
       let panState = null;
       let resizeState = null;
       let viewport = { x: 0, y: 0, zoom: 1 };
+      let viewportRasterTimer = null;
       let launchWizard = null;
       let wizardWasOpen = false;
       let wizardAdvancedOpen = false;
@@ -2379,6 +2379,14 @@
 
       function applyViewport() {
         stage.style.transform = `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`;
+        stage.style.willChange = "transform";
+        if (viewportRasterTimer !== null) {
+          clearTimeout(viewportRasterTimer);
+        }
+        viewportRasterTimer = setTimeout(() => {
+          stage.style.willChange = "auto";
+          viewportRasterTimer = null;
+        }, 300);
       }
 
       function persistViewport() {


### PR DESCRIPTION
## Summary

- WebView 上のターミナルテキストが pan/zoom 後に「たまにぼやけ、OS ウィンドウを動かすと鮮明に戻る」症状を解消するため、`.canvas-stage` の GPU レイヤーキャッシュ由来の補間拡大縮小を静止時に再ラスタライズさせる。
- 常設の `will-change: transform` を除去し、`applyViewport()` 実行時のみ動的に付与、最終呼出から 300ms で `auto` に戻す debounce 方式へ変更。パン/ズーム中のフレームレートと静止時の鮮明度を両立する。

## Changes

- `crates/gwt/web/index.html`: `.canvas-stage` CSS から `will-change: transform;` を削除（line 149-）
- `crates/gwt/web/index.html`: `applyViewport()` で `stage.style.willChange` を `"transform"` に設定し、300ms debounce の `setTimeout` で `"auto"` へ戻す処理を追加（line 2380-）
- `crates/gwt/web/index.html`: モジュールスコープに `viewportRasterTimer` を追加し、debounce タイマー ID を保持（line 1955）

## Testing

- [x] `cargo fmt --check` — 差分なし（exit 0）
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 警告 0（exit 0）
- [x] `cargo test -p gwt-core -p gwt` — 全テスト通過（exit 0）
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — exit 0
- [ ] 手動検証: `cargo run -p gwt` で GUI 起動し、canvas を pan/zoom した後 300ms 以内にターミナルテキストが鮮明化すること、OS ウィンドウ移動なしで鮮明状態へ復帰することを確認（視覚挙動のため自動化対象外）

## Closing Issues

- None

## Related Issues / Links

- SPEC-2008 #2008（US-1 に受け入れシナリオ 4 を追加、`plan` に「Canvas レイヤー化のぼやけ対策」設計節追加、`tasks` に Phase 6 を追加済み）

## Context

WebView (wry + tao) 上の xterm.js ターミナルが「たまにぼやけるが OS ウィンドウを動かすと直る」症状を示していた。根本原因は `.canvas-stage` に常設された `will-change: transform` により、WebView (Chromium/WebView2) がこの要素を独立 GPU 合成レイヤーとして初期スケールでラスタライズしキャッシュし、`applyViewport()` による `transform: translate(...) scale(zoom)` 更新時に再ラスタライズせず補間拡大縮小のみを行うため。OS ウィンドウ移動で合成ツリー全体が再構築されるタイミングでだけ鮮明に戻る挙動と完全に一致する。

## Risk / Impact

- **Affected areas**: canvas workspace の描画レイヤー合成（全ウィンドウのテキスト鮮明度に影響するが、ターミナルが最も顕在化しやすい）
- **Performance**: 操作中は従来どおり GPU 合成。静止後 300ms で `will-change: auto` に戻るため CPU ラスタライズが走るが一度きりで、アイドル時の継続コストなし
- **Rollback plan**: 単一コミット `revert` で即時戻せる（スキーマ/データ変更なし）

## Checklist

- [ ] Tests added/updated — JS/CSS のみの変更で Rust 側ロジックに影響なし。視覚挙動を検証する自動テスト基盤がリポジトリに存在しないため新規テストは追加せず、既存 `cargo test` 全通過で回帰を担保
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — README は UI 挙動を記述しない方針のため該当なし。設計ドキュメントとして SPEC-2008 を更新済み
- [ ] Migration/backfill plan included (if schema/data change) — 該当なし
- [x] CHANGELOG impact considered — `fix:` のためリリースワークフローが自動でパッチ版を集約

## Notes

- 非対象（別 Issue 候補）: ① `viewport.zoom` の整数スナップ、② xterm.js `fontSize`/`lineHeight` のピクセル整数化、③ `wry`/`tao` の HiDPI 明示設定。いずれも今回の根本原因（レイヤーキャッシュ）とは別軸の改善
- debounce 値 300ms は「操作終了」の体感と「過剰な `will-change` toggle 抑制」のバランス。追従が遅い場合は値のみ変更で調整可能
