### PR TITLE
fix(index): harden project index health checks

### DIFF
--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -1208,10 +1208,15 @@ def _open_chroma_collection(db_path: Path, collection_name: str):
 
     client = chromadb.PersistentClient(path=str(db_path))
     ef = E5EmbeddingFunction()
-    return client, client.get_collection(
-        name=collection_name,
-        embedding_function=ef,
-    )
+    try:
+        collection = client.get_collection(
+            name=collection_name,
+            embedding_function=ef,
+        )
+    except Exception:
+        _close_chroma_client(client)
+        raise
+    return client, collection
 
 
 # ---------------------------------------------------------------------
@@ -2050,6 +2055,52 @@ def _scope_status_v2(
     }
 
 
+def _issue_status_v2(
+    repo_hash: str,
+    db_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    db_path = resolve_db_path(repo_hash, None, "issues", db_root=db_root)
+    meta = _read_issue_meta(db_path) or {}
+    exists = (db_path / "chroma.sqlite3").exists() or (db_path / META_FILENAME).is_file()
+    count_ok, document_count = _scope_document_count(db_path, "issues")
+
+    reason = "ready"
+    healthy = True
+    repair_required = False
+
+    if not exists or not count_ok:
+        reason = "collection_missing"
+        healthy = False
+        repair_required = True
+    elif not meta:
+        reason = "metadata_missing"
+        healthy = False
+        repair_required = True
+
+    status: Dict[str, Any] = {
+        "exists": exists,
+        "healthy": healthy,
+        "repair_required": repair_required,
+        "document_count": document_count,
+        "reason": reason,
+        "legacy_residue_detected": False,
+        "last_repair_at": meta.get("last_full_refresh"),
+    }
+    if meta:
+        status.update(
+            {
+                "last_full_refresh": meta.get("last_full_refresh"),
+                "ttl_minutes": meta.get("ttl_minutes", ISSUE_TTL_MINUTES_DEFAULT),
+            }
+        )
+        last = _parse_iso(meta.get("last_full_refresh", "")) if meta.get("last_full_refresh") else None
+        if last is not None:
+            age = (_now_utc() - last).total_seconds()
+            ttl_secs = meta.get("ttl_minutes", ISSUE_TTL_MINUTES_DEFAULT) * 60
+            status["ttl_remaining_seconds"] = max(0, int(ttl_secs - age))
+    return status
+
+
 def action_index_issues_v2(
     repo_hash: str,
     project_root: str,
@@ -2138,6 +2189,7 @@ def action_index_issues_v2(
                     "schema_version": INDEX_SCHEMA_VERSION,
                     "last_full_refresh": _now_utc().isoformat(),
                     "ttl_minutes": ttl_minutes,
+                    "document_count": len(issues),
                 },
             )
         finally:
@@ -2266,7 +2318,7 @@ def action_search_v2(
 
     db_path = resolve_db_path(repo_hash, worktree_hash, scope, db_root=db_root)
     if scope == "issues":
-        health = {"exists": (db_path / "chroma.sqlite3").exists(), "repair_required": False, "healthy": True}
+        health = _issue_status_v2(repo_hash, db_root=db_root)
     else:
         health = _scope_status_v2(repo_hash, worktree_hash, scope, db_root=db_root)
 
@@ -2348,27 +2400,8 @@ def action_status_v2(
     worktree_hash: Optional[str],
     db_root: Optional[Path] = None,
 ) -> dict:
-    issues_path = resolve_db_path(repo_hash, None, "issues", db_root=db_root)
-    issues_status: Dict[str, Any] = {
-        "exists": (issues_path / "chroma.sqlite3").exists()
-        or (issues_path / META_FILENAME).is_file(),
-    }
-    meta = _read_issue_meta(issues_path)
-    if meta:
-        issues_status.update(
-            {
-                "last_full_refresh": meta.get("last_full_refresh"),
-                "ttl_minutes": meta.get("ttl_minutes", ISSUE_TTL_MINUTES_DEFAULT),
-            }
-        )
-        last = _parse_iso(meta.get("last_full_refresh", "")) if meta.get("last_full_refresh") else None
-        if last is not None:
-            age = (_now_utc() - last).total_seconds()
-            ttl_secs = meta.get("ttl_minutes", ISSUE_TTL_MINUTES_DEFAULT) * 60
-            issues_status["ttl_remaining_seconds"] = max(0, int(ttl_secs - age))
-
     out: Dict[str, Any] = {
-        "issues": issues_status,
+        "issues": _issue_status_v2(repo_hash, db_root=db_root),
         "specs": _scope_status_v2(repo_hash, None, "specs", db_root=db_root),
     }
     if worktree_hash:

--- a/crates/gwt-core/runtime/tests/test_index_health.py
+++ b/crates/gwt-core/runtime/tests/test_index_health.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
+
+import chromadb
 
 import chroma_index_runner as runner
 
@@ -23,6 +27,15 @@ class IndexHealthTests(unittest.TestCase):
             "# Project index health\n"
             "Docs repair details live here.\n"
         )
+
+    def _write_cached_issue(self, cache_root: Path) -> None:
+        issue = cache_root / "77"
+        issue.mkdir(parents=True, exist_ok=True)
+        (issue / "meta.json").write_text(
+            '{"number":77,"title":"Broken issue index",'
+            '"labels":["bug"],"state":"open","updated_at":"2026-04-21T00:00:00Z"}'
+        )
+        (issue / "body.md").write_text("Search should repair missing issue collection.")
 
     def _files_db_path(self, db_root: Path) -> Path:
         return runner.resolve_db_path(
@@ -165,6 +178,61 @@ class IndexHealthTests(unittest.TestCase):
                 worktree_hash=self.WORKTREE_HASH,
                 project_root=str(root),
                 query="watcher",
+                n_results=5,
+                no_auto_build=True,
+                db_root=db_root,
+            )
+
+            self.assertFalse(search["ok"])
+            self.assertEqual(search.get("error_code"), "INDEX_UNHEALTHY")
+
+    def test_search_issues_rebuilds_when_sqlite_exists_without_collection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            db_root = Path(tmp) / "index_root"
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / self.REPO_HASH
+            self._write_cached_issue(cache_root)
+
+            db_path = runner.resolve_db_path(self.REPO_HASH, None, "issues", db_root=db_root)
+            db_path.mkdir(parents=True, exist_ok=True)
+            client = chromadb.PersistentClient(path=str(db_path))
+            client.close()
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                search = runner.action_search_v2(
+                    action="search-issues",
+                    repo_hash=self.REPO_HASH,
+                    worktree_hash=None,
+                    project_root=str(root),
+                    query="missing issue collection",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
+
+            self.assertTrue(search["ok"], search)
+            self.assertTrue(
+                any(item["number"] == 77 for item in search["issueResults"]),
+                search["issueResults"],
+            )
+
+    def test_search_issues_no_auto_build_reports_unhealthy_collection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            db_root = Path(tmp) / "index_root"
+            db_path = runner.resolve_db_path(self.REPO_HASH, None, "issues", db_root=db_root)
+            db_path.mkdir(parents=True, exist_ok=True)
+            client = chromadb.PersistentClient(path=str(db_path))
+            client.close()
+
+            search = runner.action_search_v2(
+                action="search-issues",
+                repo_hash=self.REPO_HASH,
+                worktree_hash=None,
+                project_root=str(root),
+                query="issue",
                 n_results=5,
                 no_auto_build=True,
                 db_root=db_root,

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -25,10 +25,15 @@ fn resolve_home_dir(
     userprofile: Option<OsString>,
     fallback: Option<PathBuf>,
 ) -> PathBuf {
-    home.or(userprofile)
+    non_empty_os(home)
+        .or_else(|| non_empty_os(userprofile))
         .map(PathBuf::from)
         .or(fallback)
         .expect("home directory must be resolvable")
+}
+
+fn non_empty_os(value: Option<OsString>) -> Option<OsString> {
+    value.filter(|value| !value.is_empty())
 }
 
 /// Return the path to the global config file (`~/.gwt/config.toml`).
@@ -181,6 +186,27 @@ mod tests {
             .join(".gwt");
 
         assert_eq!(home, override_profile.join(".gwt"));
+    }
+
+    #[test]
+    fn gwt_home_treats_empty_env_values_as_unset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let override_profile = tmp.path().join("custom-userprofile");
+        let fallback = tmp.path().join("fallback-home");
+
+        let userprofile_home = resolve_home_dir(
+            Some(OsString::from("")),
+            Some(override_profile.clone().into_os_string()),
+            Some(fallback.clone()),
+        );
+        let fallback_home = resolve_home_dir(
+            Some(OsString::from("")),
+            Some(OsString::from("")),
+            Some(fallback.clone()),
+        );
+
+        assert_eq!(userprofile_home, override_profile);
+        assert_eq!(fallback_home, fallback);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Hardened issue index health checks so `search-issues` repairs sqlite-only or missing-collection Chroma stores instead of treating them as healthy.
- Aligned Rust home resolution with the Python runner by treating empty `HOME` and `USERPROFILE` values as unset.

## Changes

- `crates/gwt-core/runtime/chroma_index_runner.py`: added issue-scope health validation through the actual `issues` collection and reused it for `search-issues` and `status`.
- `crates/gwt-core/runtime/tests/test_index_health.py`: added regression coverage for broken issue collections with and without auto-build.
- `crates/gwt-core/src/paths.rs`: ignored empty environment home values before falling back to the next configured home source.

## Testing

- [x] `$env:PYTHONPATH = (Resolve-Path 'crates/gwt-core/runtime').Path; $env:GWT_INDEX_FAKE_EMBEDDING = '1'; $p = Join-Path $HOME '.gwt/runtime/chroma-venv/Scripts/python.exe'; & $p -m unittest crates/gwt-core/runtime/tests/test_index_health.py` — passed, 6 tests.
- [x] `$env:PYTHONPATH = (Resolve-Path 'crates/gwt-core/runtime').Path; $env:GWT_INDEX_FAKE_EMBEDDING = '1'; $p = Join-Path $HOME '.gwt/runtime/chroma-venv/Scripts/python.exe'; & $p -m unittest discover -s crates/gwt-core/runtime/tests -p 'test_*.py'` — passed, 53 tests.
- [x] `cargo test -p gwt-core paths::tests::gwt_home_treats_empty_env_values_as_unset` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.

## Closing Issues

- None

## Related Issues / Links

- #1939
- #2106

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation not required because this is an internal diagnostic and path-resolution follow-up.
- [x] Migration/backfill not required because this changes health detection and repair triggering only.
- [x] CHANGELOG impact considered; this is a patch-level fix.

## Context

- This PR follows up on Codex review feedback from #2106 after the self-healing diagnostics PR was merged.

## Risk / Impact

- **Affected areas**: project index issue search/status health checks and Rust global `.gwt` home resolution.
- **Rollback plan**: revert `ae7f3b11` if the health checks cause unexpected repair behavior.
