### PR TITLE
fix(gui): refresh terminal viewport after xterm writes

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -72,6 +72,44 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_terminal_writes_refresh_viewport_after_xterm_parse() {
+        let html = index_html();
+        let streaming_write = regex::Regex::new(
+            r"runtime\.terminal\.write\(\s*decoder\.decode\(decodeBase64\(base64\),\s*\{\s*stream:\s*true\s*\}\),\s*\(\)\s*=>\s*\{\s*scheduleTerminalViewportRefresh\(windowId\);\s*\}\s*\);",
+        )
+        .expect("valid regex");
+        let snapshot_write = regex::Regex::new(
+            r"runtime\.terminal\.write\(\s*decoder\.decode\(decodeBase64\(base64\)\),\s*\(\)\s*=>\s*\{\s*scheduleTerminalViewportRefresh\(windowId\);\s*\}\s*\);",
+        )
+        .expect("valid regex");
+
+        assert!(
+            html.contains("function scheduleTerminalViewportRefresh(windowId)"),
+            "expected terminal viewport refresh scheduling helper",
+        );
+        assert!(
+            html.contains("viewportRefreshFrame"),
+            "expected terminal runtime to debounce viewport refreshes",
+        );
+        assert!(
+            streaming_write.is_match(html),
+            "expected streaming terminal output to refresh viewport after xterm parses it",
+        );
+        assert!(
+            snapshot_write.is_match(html),
+            "expected terminal snapshots to refresh viewport after xterm parses them",
+        );
+        assert!(
+            html.contains("cancelAnimationFrame(runtime.viewportRefreshFrame)"),
+            "expected pending terminal viewport refresh frames to be cancelled during cleanup",
+        );
+        assert!(
+            html.contains("if (runtime && runtime.viewportRefreshFrame !== null)"),
+            "expected terminal cleanup to guard non-terminal windows before cancelling refresh frames",
+        );
+    }
+
+    #[test]
     fn embedded_web_repo_browser_scroll_surfaces_block_canvas_pan_at_edges() {
         let html = index_html();
         let scroll_gate = regex::Regex::new(

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2494,6 +2494,17 @@
         sendGeometry(windowId, runtime.terminal.cols, runtime.terminal.rows);
       }
 
+      function scheduleTerminalViewportRefresh(windowId) {
+        const runtime = terminalMap.get(windowId);
+        if (!runtime || runtime.viewportRefreshFrame !== null) {
+          return;
+        }
+        runtime.viewportRefreshFrame = requestAnimationFrame(() => {
+          runtime.viewportRefreshFrame = null;
+          fitTerminal(windowId, false);
+        });
+      }
+
       function sendGeometry(windowId, cols, rows) {
         const element = windowMap.get(windowId);
         if (!element) {
@@ -2847,7 +2858,7 @@
           });
           send({ kind: "terminal_input", id: windowId, data });
         });
-        const runtime = { terminal, fitAddon, cleanup };
+        const runtime = { terminal, fitAddon, cleanup, viewportRefreshFrame: null };
         terminalMap.set(windowId, runtime);
         decoderMap.set(windowId, new TextDecoder());
         requestAnimationFrame(() => fitTerminal(windowId, true));
@@ -2877,7 +2888,9 @@
           return;
         }
         const decoder = decoderMap.get(windowId);
-        runtime.terminal.write(decoder.decode(decodeBase64(base64), { stream: true }));
+        runtime.terminal.write(decoder.decode(decodeBase64(base64), { stream: true }), () => {
+          scheduleTerminalViewportRefresh(windowId);
+        });
       }
 
       function replaceTerminalSnapshot(windowId, base64) {
@@ -2888,7 +2901,9 @@
         }
         const decoder = decoderMap.get(windowId);
         runtime.terminal.reset();
-        runtime.terminal.write(decoder.decode(decodeBase64(base64)));
+        runtime.terminal.write(decoder.decode(decodeBase64(base64)), () => {
+          scheduleTerminalViewportRefresh(windowId);
+        });
       }
 
       function mockContentForPreset(preset) {
@@ -5198,6 +5213,9 @@
             continue;
           }
           const runtime = terminalMap.get(windowId);
+          if (runtime && runtime.viewportRefreshFrame !== null) {
+            cancelAnimationFrame(runtime.viewportRefreshFrame);
+          }
           runtime?.cleanup?.();
           runtime?.terminal.dispose();
           terminalMap.delete(windowId);


### PR DESCRIPTION
## Summary

- Refresh the embedded xterm.js viewport after terminal output and snapshots are parsed so Plan mode scrollback works without a manual resize.
- Keep terminal and canvas wheel ownership unchanged while making the automatic refresh mirror the resize path that recovered scrolling.

## Changes

- `crates/gwt/web/index.html`: add a debounced terminal viewport refresh scheduled from xterm `write()` callbacks, and cancel pending frames when terminal runtimes are removed.
- `crates/gwt/src/embedded_web.rs`: add an embedded Web contract test covering the refresh hook, write callbacks, and cleanup guard.

## Testing

- [x] `cargo test -p gwt embedded_web_terminal_writes_refresh_viewport_after_xterm_parse -j1` — passes.
- [x] `cargo test -p gwt embedded_web::tests -j1` — passes.
- [x] `cargo fmt` — passes.
- [x] `cargo test -p gwt-core -p gwt` — passes before and after merging `origin/develop`.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes before and after merging `origin/develop`.
- [x] `cargo build -p gwt` — passes before and after merging `origin/develop`.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passes.

## Closing Issues

- Closes #2096

## Related Issues / Links

- #2091
- #2008
- #1919

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation not required because this is an internal terminal host behavior fix
- [x] Migration/backfill not required because no schema or data format changed
- [x] CHANGELOG impact considered as a patch-level GUI fix with no breaking change

## Context

- Issue #2096 showed that Plan mode scrollback could become inert until a manual resize forced xterm.js to recompute its viewport. This change schedules that same refresh path after xterm parses new terminal data.
