### PR TITLE
refactor(gwt): dispatch custom agent presets by id

### DIFF
--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -23,7 +23,10 @@ pub use launch::{
     canonical_launch_args, normalize_launch_args, resolve_runner, AgentLaunchBuilder, LaunchConfig,
     ResolvedRunner,
 };
-pub use presets::claude_code_openai_compat_preset;
+pub use presets::{
+    claude_code_openai_compat_preset, list_presets, seed_agent, ClaudeCodeOpenaiCompatInput,
+    PresetDefinition, PresetError, PresetId,
+};
 pub use session::{
     persist_agent_session_id, persist_session_status, reset_runtime_state_dir,
     reset_runtime_state_dir_for_pid, runtime_state_dir_for_pid, runtime_state_path,

--- a/crates/gwt-agent/src/presets.rs
+++ b/crates/gwt-agent/src/presets.rs
@@ -5,9 +5,211 @@
 //! not itself privileged at launch time; the seeded `env` table is applied
 //! through `AgentLaunchBuilder` like any other custom-agent env set.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 use crate::custom::{CustomAgentType, CustomCodingAgent};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+
+/// Stable identifier for a built-in Custom Agent preset. Keep this set small:
+/// every id is a frontend-visible contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PresetId {
+    /// Claude Code routed through an Anthropic Messages API compatible proxy
+    /// that speaks `/v1/models`. SPEC-1921 FR-062.
+    ClaudeCodeOpenaiCompat,
+}
+
+impl PresetId {
+    /// Return the transport string used by the Settings UI.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            PresetId::ClaudeCodeOpenaiCompat => "claude_code_openai_compat",
+        }
+    }
+}
+
+impl fmt::Display for PresetId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Metadata that the Settings UI shows in the "Add from preset" picker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PresetDefinition {
+    /// Stable id used by the add-from-preset request.
+    pub id: PresetId,
+    /// Display label rendered in the picker.
+    pub label: &'static str,
+    /// Short description rendered below the label in the picker.
+    pub description: &'static str,
+}
+
+impl PresetDefinition {
+    const fn catalog() -> [PresetDefinition; 1] {
+        [PresetDefinition {
+            id: PresetId::ClaudeCodeOpenaiCompat,
+            label: "Claude Code (OpenAI-compat backend)",
+            description: concat!(
+                "Route Claude Code to an Anthropic Messages API compatible ",
+                "proxy backed by an OpenAI-compatible upstream."
+            ),
+        }]
+    }
+}
+
+/// Return the catalog of built-in Custom Agent presets.
+pub fn list_presets() -> Vec<PresetDefinition> {
+    PresetDefinition::catalog().to_vec()
+}
+
+/// Input payload for adding a custom agent from the
+/// `ClaudeCodeOpenaiCompat` preset. SPEC-1921 FR-060 / FR-062.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ClaudeCodeOpenaiCompatInput {
+    /// TOML key / stable id for the new custom agent. Must match
+    /// `CustomCodingAgent::validate()` (alphanumeric + `-`).
+    pub id: String,
+    /// Human-readable name shown in the agent picker.
+    pub display_name: String,
+    /// Upstream base URL (http/https).
+    pub base_url: String,
+    /// API key forwarded as `Bearer <api_key>` during `/v1/models` probe and
+    /// injected as `ANTHROPIC_API_KEY` at launch.
+    pub api_key: String,
+    /// Model ID chosen from the probe-populated dropdown.
+    pub default_model: String,
+}
+
+/// Error returned by preset payload parsing, validation, or seed construction.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PresetError {
+    /// The payload could not be deserialized as the selected preset's input.
+    #[error("invalid payload for preset `{preset_id}`: {message}")]
+    InvalidPayload {
+        preset_id: PresetId,
+        message: String,
+    },
+    /// The deserialized payload failed semantic validation.
+    #[error("invalid input for preset `{preset_id}`: {message}")]
+    InvalidInput {
+        preset_id: PresetId,
+        message: String,
+    },
+    /// The preset factory returned an invalid custom-agent definition.
+    #[error("preset `{preset_id}` produced an invalid agent id: {agent_id}")]
+    InvalidAgent {
+        preset_id: PresetId,
+        agent_id: String,
+    },
+}
+
+trait PresetFactory {
+    type Input: DeserializeOwned;
+
+    const ID: PresetId;
+
+    fn validate(input: &Self::Input) -> Result<(), PresetError>;
+
+    fn build(input: Self::Input) -> CustomCodingAgent;
+
+    fn parse_input(payload: &Value) -> Result<Self::Input, PresetError> {
+        serde_json::from_value(payload.clone()).map_err(|err| PresetError::InvalidPayload {
+            preset_id: Self::ID,
+            message: err.to_string(),
+        })
+    }
+
+    fn seed(payload: &Value) -> Result<CustomCodingAgent, PresetError> {
+        let input = Self::parse_input(payload)?;
+        Self::validate(&input)?;
+        let agent = Self::build(input);
+        if agent.validate() {
+            Ok(agent)
+        } else {
+            Err(PresetError::InvalidAgent {
+                preset_id: Self::ID,
+                agent_id: agent.id,
+            })
+        }
+    }
+}
+
+struct ClaudeCodeOpenaiCompatPreset;
+
+impl PresetFactory for ClaudeCodeOpenaiCompatPreset {
+    type Input = ClaudeCodeOpenaiCompatInput;
+
+    const ID: PresetId = PresetId::ClaudeCodeOpenaiCompat;
+
+    fn validate(input: &Self::Input) -> Result<(), PresetError> {
+        validate_claude_code_openai_compat_input(input)
+    }
+
+    fn build(input: Self::Input) -> CustomCodingAgent {
+        claude_code_openai_compat_preset(
+            input.id,
+            input.display_name,
+            input.base_url,
+            input.api_key,
+            input.default_model,
+        )
+    }
+}
+
+/// Seed a built-in preset by stable id and opaque JSON payload.
+pub fn seed_agent(preset_id: PresetId, payload: &Value) -> Result<CustomCodingAgent, PresetError> {
+    match preset_id {
+        PresetId::ClaudeCodeOpenaiCompat => ClaudeCodeOpenaiCompatPreset::seed(payload),
+    }
+}
+
+fn require_non_empty(preset_id: PresetId, field: &str, value: &str) -> Result<(), PresetError> {
+    if value.trim().is_empty() {
+        Err(PresetError::InvalidInput {
+            preset_id,
+            message: format!("{field} must not be empty"),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn is_valid_base_url(base_url: &str) -> bool {
+    let lower = base_url.trim().to_ascii_lowercase();
+    lower.starts_with("http://") || lower.starts_with("https://")
+}
+
+fn validate_claude_code_openai_compat_input(
+    input: &ClaudeCodeOpenaiCompatInput,
+) -> Result<(), PresetError> {
+    let preset_id = PresetId::ClaudeCodeOpenaiCompat;
+    require_non_empty(preset_id, "id", &input.id)?;
+    if !input.id.chars().all(|c| c.is_alphanumeric() || c == '-') {
+        return Err(PresetError::InvalidInput {
+            preset_id,
+            message: format!(
+                "id `{}` contains invalid characters (allowed: alphanumeric, `-`)",
+                input.id
+            ),
+        });
+    }
+    require_non_empty(preset_id, "display_name", &input.display_name)?;
+    if !is_valid_base_url(&input.base_url) {
+        return Err(PresetError::InvalidInput {
+            preset_id,
+            message: format!(
+                "base_url must start with http:// or https://, got: {}",
+                input.base_url
+            ),
+        });
+    }
+    require_non_empty(preset_id, "api_key", &input.api_key)?;
+    require_non_empty(preset_id, "default_model", &input.default_model)?;
+    Ok(())
+}
 
 /// Seed a `CustomCodingAgent` that routes Claude Code's Anthropic Messages API
 /// traffic through an OpenAI-compatible upstream (local LLM runtime, self-hosted
@@ -76,6 +278,7 @@ pub fn claude_code_openai_compat_preset(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn preset_has_expected_shape() {
@@ -200,5 +403,42 @@ mod tests {
             "model-a",
         );
         assert!(preset.validate());
+    }
+
+    #[test]
+    fn seed_agent_dispatches_by_preset_id_and_payload() {
+        let payload = json!({
+            "id": "claude-code-openai",
+            "display_name": "Claude Code (OpenAI-compat)",
+            "base_url": "https://proxy.example.com",
+            "api_key": "sk-test-123",
+            "default_model": "openai/gpt-oss-20b"
+        });
+
+        let preset = seed_agent(PresetId::ClaudeCodeOpenaiCompat, &payload).expect("seed preset");
+
+        assert_eq!(preset.id, "claude-code-openai");
+        assert_eq!(preset.command, "@anthropic-ai/claude-code@latest");
+        assert_eq!(preset.env.len(), 13);
+        assert_eq!(
+            preset.env["ANTHROPIC_BASE_URL"],
+            "https://proxy.example.com"
+        );
+        assert_eq!(preset.env["ANTHROPIC_API_KEY"], "sk-test-123");
+        assert_eq!(
+            preset.env["CLAUDE_CODE_SUBAGENT_MODEL"],
+            "openai/gpt-oss-20b"
+        );
+    }
+
+    #[test]
+    fn seed_agent_rejects_malformed_payload() {
+        let payload = json!({
+            "id": "claude-code-openai"
+        });
+
+        let err = seed_agent(PresetId::ClaudeCodeOpenaiCompat, &payload).unwrap_err();
+
+        assert!(matches!(err, PresetError::InvalidPayload { .. }));
     }
 }

--- a/crates/gwt-agent/src/presets.rs
+++ b/crates/gwt-agent/src/presets.rs
@@ -37,7 +37,7 @@ impl fmt::Display for PresetId {
 }
 
 /// Metadata that the Settings UI shows in the "Add from preset" picker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct PresetDefinition {
     /// Stable id used by the add-from-preset request.
     pub id: PresetId,

--- a/crates/gwt/src/custom_agents_dispatch.rs
+++ b/crates/gwt/src/custom_agents_dispatch.rs
@@ -7,14 +7,14 @@
 
 use std::path::{Path, PathBuf};
 
-use gwt_agent::{redact_secrets_in_agent, CustomCodingAgent};
+use gwt_agent::{redact_secrets_in_agent, CustomCodingAgent, PresetId};
 use gwt_config::Settings;
+use serde_json::Value;
 
 use crate::{
     custom_agents_service::{
-        add_from_claude_code_openai_compat_preset, delete_custom_agent, list_custom_agents,
-        list_presets, probe_backend, update_custom_agent, ClaudeCodeOpenaiCompatInput,
-        CustomAgentsServiceError,
+        add_from_preset, delete_custom_agent, list_custom_agents, list_presets, probe_backend,
+        update_custom_agent, CustomAgentsServiceError,
     },
     protocol::{BackendEvent, CustomAgentErrorCode},
 };
@@ -88,15 +88,13 @@ pub fn list_presets_event() -> BackendEvent {
 }
 
 /// Respond to `FrontendEvent::AddCustomAgentFromPreset`.
-pub fn add_from_preset_event(input: ClaudeCodeOpenaiCompatInput) -> BackendEvent {
-    with_config_path(
-        |path| match add_from_claude_code_openai_compat_preset(path, &input) {
-            Ok(agent) => BackendEvent::CustomAgentSaved {
-                agent: Box::new(redacted_for_wire(agent)),
-            },
-            Err(err) => error_to_event(err),
+pub fn add_from_preset_event(preset_id: PresetId, payload: Value) -> BackendEvent {
+    with_config_path(|path| match add_from_preset(path, preset_id, &payload) {
+        Ok(agent) => BackendEvent::CustomAgentSaved {
+            agent: Box::new(redacted_for_wire(agent)),
         },
-    )
+        Err(err) => error_to_event(err),
+    })
 }
 
 /// Respond to `FrontendEvent::UpdateCustomAgent`.

--- a/crates/gwt/src/custom_agents_service.rs
+++ b/crates/gwt/src/custom_agents_service.rs
@@ -3,74 +3,22 @@
 //! Single library surface that composes:
 //!
 //! - `gwt-agent::store` for TOML persistence
-//! - `gwt-agent::presets::claude_code_openai_compat_preset` for preset seeding
+//! - `gwt-agent::presets` for preset catalog and seed dispatch
 //! - `gwt-ai::models_probe::list_model_ids_blocking` for `/v1/models` probe
 
 use std::path::Path;
 
 use gwt_agent::{
-    claude_code_openai_compat_preset, load_custom_agents_from_path,
-    load_stored_custom_agents_from_path, save_stored_custom_agents_to_path, CustomCodingAgent,
-    StoredCustomAgent,
+    list_presets as agent_list_presets, load_custom_agents_from_path,
+    load_stored_custom_agents_from_path, save_stored_custom_agents_to_path, seed_agent,
+    CustomCodingAgent, PresetDefinition, PresetError, PresetId, StoredCustomAgent,
 };
-use gwt_ai::models_probe::{is_valid_base_url, list_model_ids_blocking, ProbeError};
-use serde::{Deserialize, Serialize};
-
-/// Stable identifier for a built-in preset. Keep this set small — every new
-/// id is a frontend-visible contract.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PresetId {
-    /// Claude Code routed through an Anthropic Messages API compatible proxy
-    /// that speaks `/v1/models`. SPEC-1921 FR-062.
-    ClaudeCodeOpenaiCompat,
-}
-
-/// Metadata that the Settings UI shows in the "Add from preset" picker.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PresetDefinition {
-    /// Stable id used by the `AddFromPreset` request.
-    pub id: PresetId,
-    /// Display label rendered in the picker.
-    pub label: &'static str,
-    /// Short description rendered below the label in the picker.
-    pub description: &'static str,
-}
-
-impl PresetDefinition {
-    fn catalog() -> [PresetDefinition; 1] {
-        [PresetDefinition {
-            id: PresetId::ClaudeCodeOpenaiCompat,
-            label: "Claude Code (OpenAI-compat backend)",
-            description: concat!(
-                "Route Claude Code to an Anthropic Messages API compatible ",
-                "proxy backed by an OpenAI-compatible upstream."
-            ),
-        }]
-    }
-}
+use gwt_ai::models_probe::{list_model_ids_blocking, ProbeError};
+use serde_json::Value;
 
 /// Return the catalog of built-in presets.
 pub fn list_presets() -> Vec<PresetDefinition> {
-    PresetDefinition::catalog().to_vec()
-}
-
-/// Input payload for adding a custom agent from the
-/// `ClaudeCodeOpenaiCompat` preset. SPEC-1921 FR-060 / FR-062.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ClaudeCodeOpenaiCompatInput {
-    /// TOML key / stable id for the new custom agent. Must match
-    /// `CustomCodingAgent::validate()` (alphanumeric + `-`).
-    pub id: String,
-    /// Human-readable name shown in the agent picker.
-    pub display_name: String,
-    /// Upstream base URL (http/https).
-    pub base_url: String,
-    /// API key forwarded as `Bearer <api_key>` during `/v1/models` probe and
-    /// injected as `ANTHROPIC_API_KEY` at launch.
-    pub api_key: String,
-    /// Model ID chosen from the probe-populated dropdown.
-    pub default_model: String,
+    agent_list_presets()
 }
 
 /// Structured error variant exposed to the Settings UI.
@@ -99,6 +47,12 @@ impl From<String> for CustomAgentsServiceError {
     }
 }
 
+impl From<PresetError> for CustomAgentsServiceError {
+    fn from(value: PresetError) -> Self {
+        Self::InvalidInput(value.to_string())
+    }
+}
+
 /// List every custom agent currently stored in the given config file.
 pub fn list_custom_agents(
     config_path: &Path,
@@ -113,34 +67,21 @@ pub fn probe_backend(base_url: &str, api_key: &str) -> Result<Vec<String>, Probe
     list_model_ids_blocking(base_url, api_key)
 }
 
-/// Persist a new custom agent seeded from the Claude Code (OpenAI-compat
-/// backend) preset. Fails if the id already exists or fails validation.
+/// Persist a new custom agent seeded from the selected preset. Fails if the id
+/// already exists or the preset payload fails validation.
 /// Does NOT re-run the `/v1/models` probe; callers are expected to call
 /// [`probe_backend`] first and only invoke this function once the Save
 /// button's `last_probe_ok` gate is true (SPEC-1921 FR-061).
-pub fn add_from_claude_code_openai_compat_preset(
+pub fn add_from_preset(
     config_path: &Path,
-    input: &ClaudeCodeOpenaiCompatInput,
+    preset_id: PresetId,
+    payload: &Value,
 ) -> Result<CustomCodingAgent, CustomAgentsServiceError> {
-    validate_preset_input(input)?;
+    let agent = seed_agent(preset_id, payload)?;
 
     let mut entries = load_stored_custom_agents_from_path(config_path)?;
-    if entries.iter().any(|entry| entry.agent.id == input.id) {
-        return Err(CustomAgentsServiceError::Duplicate(input.id.clone()));
-    }
-
-    let agent = claude_code_openai_compat_preset(
-        input.id.clone(),
-        input.display_name.clone(),
-        input.base_url.clone(),
-        input.api_key.clone(),
-        input.default_model.clone(),
-    );
-    if !agent.validate() {
-        return Err(CustomAgentsServiceError::InvalidInput(format!(
-            "preset produced an invalid agent id: {}",
-            input.id
-        )));
+    if entries.iter().any(|entry| entry.agent.id == agent.id) {
+        return Err(CustomAgentsServiceError::Duplicate(agent.id));
     }
 
     entries.push(StoredCustomAgent::new(agent.clone()));
@@ -191,41 +132,10 @@ pub fn delete_custom_agent(
     Ok(())
 }
 
-fn require_non_empty(field: &str, value: &str) -> Result<(), CustomAgentsServiceError> {
-    if value.trim().is_empty() {
-        Err(CustomAgentsServiceError::InvalidInput(format!(
-            "{field} must not be empty"
-        )))
-    } else {
-        Ok(())
-    }
-}
-
-fn validate_preset_input(
-    input: &ClaudeCodeOpenaiCompatInput,
-) -> Result<(), CustomAgentsServiceError> {
-    require_non_empty("id", &input.id)?;
-    if !input.id.chars().all(|c| c.is_alphanumeric() || c == '-') {
-        return Err(CustomAgentsServiceError::InvalidInput(format!(
-            "id `{}` contains invalid characters (allowed: alphanumeric, `-`)",
-            input.id
-        )));
-    }
-    require_non_empty("display_name", &input.display_name)?;
-    if !is_valid_base_url(&input.base_url) {
-        return Err(CustomAgentsServiceError::InvalidInput(format!(
-            "base_url must start with http:// or https://, got: {}",
-            input.base_url
-        )));
-    }
-    require_non_empty("api_key", &input.api_key)?;
-    require_non_empty("default_model", &input.default_model)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gwt_agent::ClaudeCodeOpenaiCompatInput;
 
     fn sample_input() -> ClaudeCodeOpenaiCompatInput {
         ClaudeCodeOpenaiCompatInput {
@@ -235,6 +145,21 @@ mod tests {
             api_key: "sk_cwPkycrPTZBYQ8vFXsc3O0wkrvt36VSh".to_string(),
             default_model: "openai/gpt-oss-20b".to_string(),
         }
+    }
+
+    fn sample_payload(input: &ClaudeCodeOpenaiCompatInput) -> Value {
+        serde_json::to_value(input).unwrap()
+    }
+
+    fn add_sample_from_preset(
+        path: &Path,
+        input: &ClaudeCodeOpenaiCompatInput,
+    ) -> Result<CustomCodingAgent, CustomAgentsServiceError> {
+        add_from_preset(
+            path,
+            PresetId::ClaudeCodeOpenaiCompat,
+            &sample_payload(input),
+        )
     }
 
     #[test]
@@ -251,7 +176,7 @@ mod tests {
         let path = dir.path().join("config.toml");
         let input = sample_input();
 
-        let agent = add_from_claude_code_openai_compat_preset(&path, &input).expect("save");
+        let agent = add_sample_from_preset(&path, &input).expect("save");
 
         assert_eq!(agent.id, input.id);
         assert_eq!(agent.env.len(), 13);
@@ -268,13 +193,50 @@ mod tests {
     }
 
     #[test]
+    fn generic_add_from_preset_creates_entry_and_persists_all_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let input = sample_input();
+        let payload = sample_payload(&input);
+
+        let agent =
+            add_from_preset(&path, PresetId::ClaudeCodeOpenaiCompat, &payload).expect("save");
+
+        assert_eq!(agent.id, input.id);
+        assert_eq!(agent.env.len(), 13);
+        assert_eq!(agent.env["ANTHROPIC_API_KEY"], input.api_key);
+        assert_eq!(agent.env["ANTHROPIC_BASE_URL"], input.base_url);
+
+        let reloaded = list_custom_agents(&path).unwrap();
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(
+            reloaded[0].env["ANTHROPIC_DEFAULT_OPUS_MODEL"],
+            input.default_model
+        );
+    }
+
+    #[test]
+    fn generic_add_from_preset_rejects_malformed_payload_as_invalid_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let payload = serde_json::json!({
+            "id": "claude-code-openai"
+        });
+
+        let err = add_from_preset(&path, PresetId::ClaudeCodeOpenaiCompat, &payload).unwrap_err();
+
+        assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
+        assert!(list_custom_agents(&path).unwrap().is_empty());
+    }
+
+    #[test]
     fn add_from_preset_rejects_duplicate_id() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
         let input = sample_input();
 
-        add_from_claude_code_openai_compat_preset(&path, &input).expect("first save");
-        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        add_sample_from_preset(&path, &input).expect("first save");
+        let err = add_sample_from_preset(&path, &input).unwrap_err();
         assert!(matches!(err, CustomAgentsServiceError::Duplicate(_)));
     }
 
@@ -284,7 +246,7 @@ mod tests {
         let path = dir.path().join("config.toml");
         let mut input = sample_input();
         input.id = String::new();
-        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        let err = add_sample_from_preset(&path, &input).unwrap_err();
         assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
     }
 
@@ -294,7 +256,7 @@ mod tests {
         let path = dir.path().join("config.toml");
         let mut input = sample_input();
         input.id = "has spaces".to_string();
-        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        let err = add_sample_from_preset(&path, &input).unwrap_err();
         assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
     }
 
@@ -304,7 +266,7 @@ mod tests {
         let path = dir.path().join("config.toml");
         let mut input = sample_input();
         input.base_url = "ws://example.com".to_string();
-        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        let err = add_sample_from_preset(&path, &input).unwrap_err();
         assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
     }
 
@@ -314,7 +276,7 @@ mod tests {
         let path = dir.path().join("config.toml");
         let mut input = sample_input();
         input.api_key = String::new();
-        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        let err = add_sample_from_preset(&path, &input).unwrap_err();
         assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
     }
 
@@ -324,7 +286,7 @@ mod tests {
         let path = dir.path().join("config.toml");
         let mut input = sample_input();
         input.default_model = String::new();
-        let err = add_from_claude_code_openai_compat_preset(&path, &input).unwrap_err();
+        let err = add_sample_from_preset(&path, &input).unwrap_err();
         assert!(matches!(err, CustomAgentsServiceError::InvalidInput(_)));
     }
 
@@ -333,7 +295,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
         let input = sample_input();
-        let mut agent = add_from_claude_code_openai_compat_preset(&path, &input).unwrap();
+        let mut agent = add_sample_from_preset(&path, &input).unwrap();
 
         agent.display_name = "Renamed Claude".to_string();
         agent
@@ -354,7 +316,8 @@ mod tests {
     fn update_custom_agent_returns_not_found_for_unknown_id() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
-        let mut agent = claude_code_openai_compat_preset("missing", "X", "http://a", "k", "m");
+        let mut agent =
+            gwt_agent::claude_code_openai_compat_preset("missing", "X", "http://a", "k", "m");
         agent.id = "missing".to_string();
         let err = update_custom_agent(&path, agent).unwrap_err();
         assert!(matches!(err, CustomAgentsServiceError::NotFound(_)));
@@ -365,7 +328,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
         let input = sample_input();
-        add_from_claude_code_openai_compat_preset(&path, &input).unwrap();
+        add_sample_from_preset(&path, &input).unwrap();
 
         delete_custom_agent(&path, &input.id).expect("delete");
         let reloaded = list_custom_agents(&path).unwrap();

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -26,12 +26,12 @@ pub use branch_list::{
 };
 pub use branch_list::{list_branch_entries, list_branch_inventory, BranchListEntry, BranchScope};
 pub use custom_agents_service::{
-    add_from_claude_code_openai_compat_preset, delete_custom_agent, list_custom_agents,
-    list_presets, probe_backend, update_custom_agent, ClaudeCodeOpenaiCompatInput,
-    CustomAgentsServiceError, PresetDefinition, PresetId,
+    add_from_preset, delete_custom_agent, list_custom_agents, list_presets, probe_backend,
+    update_custom_agent, CustomAgentsServiceError,
 };
 pub use daemon_runtime::{HookForwardTarget, RuntimeHookEvent, RuntimeHookEventKind};
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
+pub use gwt_agent::{ClaudeCodeOpenaiCompatInput, PresetDefinition, PresetId};
 pub use knowledge_bridge::{
     load_knowledge_bridge, KnowledgeBridgeView, KnowledgeDetailSection, KnowledgeDetailView,
     KnowledgeKind, KnowledgeListItem,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -512,10 +512,12 @@ impl AppRuntime {
                 client_id,
                 gwt::custom_agents_dispatch::list_presets_event(),
             )],
-            FrontendEvent::AddCustomAgentFromPreset { input } => vec![OutboundEvent::reply(
-                client_id,
-                gwt::custom_agents_dispatch::add_from_preset_event(input),
-            )],
+            FrontendEvent::AddCustomAgentFromPreset { preset_id, payload } => {
+                vec![OutboundEvent::reply(
+                    client_id,
+                    gwt::custom_agents_dispatch::add_from_preset_event(preset_id, payload),
+                )]
+            }
             FrontendEvent::UpdateCustomAgent { agent } => vec![OutboundEvent::reply(
                 client_id,
                 gwt::custom_agents_dispatch::update_event(*agent),

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1,10 +1,10 @@
-use gwt_agent::CustomCodingAgent;
+use gwt_agent::{CustomCodingAgent, PresetDefinition, PresetId};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::{
     branch_cleanup::BranchCleanupResultEntry,
     branch_list::BranchListEntry,
-    custom_agents_service::{ClaudeCodeOpenaiCompatInput, PresetDefinition},
     daemon_runtime::RuntimeHookEvent,
     file_tree::FileTreeEntry,
     knowledge_bridge::{KnowledgeDetailView, KnowledgeKind, KnowledgeListItem},
@@ -137,12 +137,13 @@ pub enum FrontendEvent {
     /// definitions for the picker. Response is
     /// [`BackendEvent::CustomAgentPresetList`].
     ListCustomAgentPresets,
-    /// Settings > Custom Agents > Add > Claude Code (OpenAI-compat backend):
-    /// persist a new custom agent seeded from the preset payload. Response
-    /// is [`BackendEvent::CustomAgentSaved`] on success or
+    /// Settings > Custom Agents > Add from preset: persist a new custom agent
+    /// seeded from the selected preset payload. Response is
+    /// [`BackendEvent::CustomAgentSaved`] on success or
     /// [`BackendEvent::CustomAgentError`] on failure.
     AddCustomAgentFromPreset {
-        input: ClaudeCodeOpenaiCompatInput,
+        preset_id: PresetId,
+        payload: Value,
     },
     /// Settings > Custom Agents > Edit: replace an existing custom agent in
     /// place. The agent id must match an existing entry.
@@ -317,7 +318,7 @@ pub enum CustomAgentErrorCode {
 mod tests {
     use serde_json::Value;
 
-    use super::{BackendEvent, BranchEntriesPhase};
+    use super::{BackendEvent, BranchEntriesPhase, FrontendEvent, PresetId};
 
     #[test]
     fn branch_entries_serializes_explicit_phase_contract() {
@@ -336,5 +337,32 @@ mod tests {
             value.get("phase"),
             Some(&Value::String("inventory".to_string()))
         );
+    }
+
+    #[test]
+    fn add_custom_agent_from_preset_deserializes_preset_id_and_payload() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "add_custom_agent_from_preset",
+            "preset_id": "claude_code_openai_compat",
+            "payload": {
+                "id": "claude-code-openai",
+                "display_name": "Claude Code (OpenAI-compat)",
+                "base_url": "https://proxy.example.com",
+                "api_key": "sk-test-123",
+                "default_model": "openai/gpt-oss-20b"
+            }
+        }))
+        .expect("deserialize frontend event");
+
+        match event {
+            FrontendEvent::AddCustomAgentFromPreset { preset_id, payload } => {
+                assert_eq!(preset_id, PresetId::ClaudeCodeOpenaiCompat);
+                assert_eq!(
+                    payload.get("default_model"),
+                    Some(&Value::String("openai/gpt-oss-20b".to_string()))
+                );
+            }
+            other => panic!("expected AddCustomAgentFromPreset, got {other:?}"),
+        }
     }
 }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -4875,7 +4875,9 @@
       // the backend before reaching this layer (see redact_secrets_in_agent).
       const customAgentsState = {
         agents: [],
+        presets: [],
         loading: false,
+        presetsLoading: false,
         statusMessage: "",
         statusKind: "",
       };
@@ -4924,6 +4926,13 @@
           customAgentsState.loading = true;
           send({ kind: "list_custom_agents" });
         }
+        if (
+          !customAgentsState.presetsLoading &&
+          customAgentsState.presets.length === 0
+        ) {
+          customAgentsState.presetsLoading = true;
+          send({ kind: "list_custom_agent_presets" });
+        }
       }
 
       function renderSettingsAgentList() {
@@ -4936,15 +4945,17 @@
           if (!scroll) continue;
           while (scroll.firstChild) scroll.removeChild(scroll.firstChild);
 
-          const addBtn = document.createElement("button");
-          addBtn.className = "wizard-button";
-          addBtn.style.margin = "8px 0";
-          addBtn.textContent = "＋ Add Claude Code (OpenAI-compat backend)";
-          addBtn.addEventListener("click", (e) => {
-            e.stopPropagation();
-            startAddClaudeCodeOpenaiCompatFlow();
-          });
-          scroll.appendChild(addBtn);
+          for (const preset of customAgentsState.presets) {
+            const addBtn = document.createElement("button");
+            addBtn.className = "wizard-button";
+            addBtn.style.margin = "8px 0";
+            addBtn.textContent = `＋ Add ${preset.label}`;
+            addBtn.addEventListener("click", (e) => {
+              e.stopPropagation();
+              startAddFromPresetFlow(preset);
+            });
+            scroll.appendChild(addBtn);
+          }
 
           if (customAgentsState.statusMessage) {
             const section = createDiv("mock-section");
@@ -5018,7 +5029,7 @@
         }
       }
 
-      function startAddClaudeCodeOpenaiCompatFlow() {
+      function startAddFromPresetFlow(preset) {
         const baseUrl = window.prompt(
           "Upstream base_url (http:// or https://)\n\nExample: http://192.168.100.166:32768",
           "http://",
@@ -5029,7 +5040,7 @@
         );
         if (!apiKey) return;
         setSettingsStatus("Probing /v1/models…", "info");
-        pendingAddFromPreset = { baseUrl, apiKey };
+        pendingAddFromPreset = { presetId: preset.id, baseUrl, apiKey };
         send({ kind: "test_backend_connection", base_url: baseUrl, api_key: apiKey });
       }
 
@@ -5071,7 +5082,7 @@
         setSettingsStatus("Saving preset…", "info");
         send({
           kind: "add_custom_agent_from_preset",
-          preset_id: "claude_code_openai_compat",
+          preset_id: pendingAddFromPreset.presetId,
           payload: {
             id,
             display_name: displayName,
@@ -5399,8 +5410,9 @@
             completeAddFromPreset(event.models);
             break;
           case "custom_agent_preset_list":
-            // Reserved for a future "Add from preset" picker — the current
-            // UI hardcodes the one preset.
+            customAgentsState.presets = event.presets || [];
+            customAgentsState.presetsLoading = false;
+            renderSettingsAgentList();
             break;
           case "custom_agent_error":
             customAgentsState.loading = false;

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -5071,7 +5071,8 @@
         setSettingsStatus("Saving preset…", "info");
         send({
           kind: "add_custom_agent_from_preset",
-          input: {
+          preset_id: "claude_code_openai_compat",
+          payload: {
             id,
             display_name: displayName,
             base_url: pendingAddFromPreset.baseUrl,


### PR DESCRIPTION
## Summary

- Refactored Custom Agent preset registration to dispatch by stable preset id and payload so future presets do not require new protocol or service entry points.
- Moved preset catalog metadata, payload parsing, validation, and seed construction into `gwt-agent::presets` so preset ownership stays in one module.

## Changes

- `crates/gwt-agent/src/presets.rs`: Added `PresetId`, `PresetDefinition`, `PresetError`, generic preset factory dispatch, and focused tests for JSON payload seeding.
- `crates/gwt/src/custom_agents_service.rs`: Replaced the Claude-specific add wrapper with generic `add_from_preset` while preserving duplicate checks and persisted env output.
- `crates/gwt/src/protocol.rs`, `crates/gwt/src/main.rs`, `crates/gwt/src/custom_agents_dispatch.rs`: Updated the WebSocket event and dispatch path to use `preset_id` plus `payload`.
- `crates/gwt/web/index.html`: Updated the existing Settings MVP flow to send the new add-from-preset payload shape.
- `crates/gwt-agent/src/lib.rs` and `crates/gwt/src/lib.rs`: Re-exported the preset catalog and payload types from their new owner.

## Testing

- [x] `cargo test -p gwt-agent seed_agent` — focused preset dispatch tests pass.
- [x] `cargo test -p gwt generic_add_from_preset` — focused service tests pass.
- [x] `cargo test -p gwt add_custom_agent_from_preset_deserializes_preset_id_and_payload` — focused protocol test passes.
- [x] `cargo fmt` — formatting applied.
- [x] `cargo fmt -- --check` — formatting check passes after base merge.
- [x] `cargo test -p gwt -p gwt-agent` — full relevant test suite passes after base merge.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes after base merge.
- [x] `cargo build -p gwt` — build passes after base merge.
- [x] `bunx commitlint --from HEAD~2 --to HEAD` — commit messages pass.

## Closing Issues

- Closes #2100

## Related Issues / Links

- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #1921 US-14 / Phase 54 updated)
- [ ] Migration/backfill plan included (N/A: no persisted schema or data migration)
- [x] CHANGELOG impact considered (refactor only; no breaking change flagged)

## Context

- Issue #2100 came from architecture review feedback that the current Claude-specific preset registration flow would require six touch points for each future preset.
- The implementation keeps the existing Claude Code OpenAI-compatible preset behavior intact while reducing future preset additions to the preset catalog/factory layer and UI entry.

## Risk / Impact

- **Affected areas**: Settings Custom Agents add-from-preset WebSocket flow, preset catalog exports, and custom-agent service persistence.
- **Rollback plan**: Revert this PR to restore the previous Claude-specific event and service wrapper; no data rollback is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured the custom agent preset system from a single hard-coded configuration to a flexible, extensible preset catalog architecture.

* **New Features**
  * Added preset discovery capability to list available custom agent configurations.
  * Enhanced preset configuration with improved error handling and validation for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->