### PR TITLE
test(gwt): cover custom agents dispatch config path errors

### DIFF
--- a/crates/gwt-config/src/settings.rs
+++ b/crates/gwt-config/src/settings.rs
@@ -60,9 +60,14 @@ impl Default for Settings {
 }
 
 impl Settings {
+    /// Build the global config file path for a known home directory.
+    pub fn global_config_path_for_home(home: &Path) -> PathBuf {
+        home.join(".gwt").join("config.toml")
+    }
+
     /// Return the global config file path: `~/.gwt/config.toml`.
     pub fn global_config_path() -> Option<PathBuf> {
-        dirs::home_dir().map(|home| home.join(".gwt").join("config.toml"))
+        dirs::home_dir().map(|home| Self::global_config_path_for_home(&home))
     }
 
     /// Load settings from `~/.gwt/config.toml`, falling back to defaults.
@@ -139,6 +144,16 @@ mod tests {
         assert!(s.protected_branches.contains(&"main".to_string()));
         assert!(!s.debug);
         assert!(!s.profiling);
+    }
+
+    #[test]
+    fn global_config_path_for_home_uses_canonical_layout() {
+        let home = PathBuf::from("home-dir");
+
+        assert_eq!(
+            Settings::global_config_path_for_home(&home),
+            home.join(".gwt").join("config.toml")
+        );
     }
 
     #[test]

--- a/crates/gwt-git/src/pr_status.rs
+++ b/crates/gwt-git/src/pr_status.rs
@@ -32,10 +32,23 @@ pub struct PrStatus {
     pub url: String,
     /// Overall CI status: "SUCCESS", "FAILURE", "PENDING", or "UNKNOWN".
     pub ci_status: String,
-    /// Whether the PR can be merged: "MERGEABLE", "CONFLICTING", "UNKNOWN".
+    /// Raw `mergeable` field from GitHub: "MERGEABLE", "CONFLICTING", "UNKNOWN".
     pub mergeable: String,
+    /// Raw `mergeStateStatus` field from GitHub: "CLEAN", "BEHIND", "UNKNOWN", etc.
+    pub merge_state_status: String,
     /// Review verdict: "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", or "UNKNOWN".
     pub review_status: String,
+}
+
+impl PrStatus {
+    /// Return the merge state label that CLI summaries should display.
+    pub fn effective_merge_status(&self) -> &str {
+        effective_merge_status_label(&self.mergeable, &self.merge_state_status)
+    }
+
+    pub fn requires_update_branch(&self) -> bool {
+        self.merge_state_status == "BEHIND"
+    }
 }
 
 /// Fetch the status of a PR by number using `gh pr view --json`.
@@ -50,7 +63,7 @@ pub fn fetch_pr_status(repo_slug: &str, number: u64) -> Result<PrStatus> {
             "--repo",
             repo_slug,
             "--json",
-            "number,title,state,url,mergeable,statusCheckRollup,reviewDecision",
+            "number,title,state,url,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision",
         ])
         .output()
         .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
@@ -79,6 +92,10 @@ pub fn parse_pr_status_json(json: &str) -> Result<PrStatus> {
     };
     let url = v["url"].as_str().unwrap_or("").to_string();
     let mergeable = v["mergeable"].as_str().unwrap_or("UNKNOWN").to_string();
+    let merge_state_status = v["mergeStateStatus"]
+        .as_str()
+        .unwrap_or("UNKNOWN")
+        .to_string();
 
     // Determine CI status from statusCheckRollup
     let ci_status = v["statusCheckRollup"]
@@ -118,8 +135,24 @@ pub fn parse_pr_status_json(json: &str) -> Result<PrStatus> {
         url,
         ci_status,
         mergeable,
+        merge_state_status,
         review_status,
     })
+}
+
+fn effective_merge_status_label<'a>(mergeable: &'a str, merge_state_status: &'a str) -> &'a str {
+    match merge_state_status {
+        "BEHIND" => "BEHIND",
+        "" | "UNKNOWN" => {
+            if mergeable.is_empty() {
+                "UNKNOWN"
+            } else {
+                mergeable
+            }
+        }
+        _ if mergeable.is_empty() || mergeable == "UNKNOWN" => merge_state_status,
+        _ => mergeable,
+    }
 }
 
 /// Fetch a list of open PRs for the repository at `repo_path`.
@@ -161,7 +194,7 @@ where
             "pr",
             "list",
             "--json",
-            "number,title,state,url,statusCheckRollup,mergeable,reviewDecision",
+            "number,title,state,url,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision",
             "--limit",
             "20",
         ],
@@ -230,6 +263,7 @@ fn parse_rest_pr_list_json(json: &str) -> Result<Vec<PrStatus>> {
                     .to_string(),
                 ci_status: "UNKNOWN".to_string(),
                 mergeable: "UNKNOWN".to_string(),
+                merge_state_status: "UNKNOWN".to_string(),
                 review_status: "UNKNOWN".to_string(),
             }
         })
@@ -251,6 +285,7 @@ pub enum CiStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MergeStatus {
     Ready,
+    Behind,
     Blocked,
     Conflicts,
     Unknown,
@@ -284,7 +319,7 @@ pub fn pr_check_report(repo_path: &Path) -> Result<PrCheckReport> {
             "pr",
             "view",
             "--json",
-            "statusCheckRollup,mergeable,reviewDecision,state,title",
+            "statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,state,title",
         ])
         .current_dir(repo_path)
         .output()
@@ -334,11 +369,20 @@ pub fn parse_pr_check_report_json(json: &str) -> Result<PrCheckReport> {
         _ => CiStatus::Unknown,
     };
 
-    let merge = match json.get("mergeable").and_then(|v| v.as_str()) {
-        Some("MERGEABLE") => MergeStatus::Ready,
-        Some("CONFLICTING") => MergeStatus::Conflicts,
-        Some(_) => MergeStatus::Blocked,
-        None => MergeStatus::Unknown,
+    let mergeable = json
+        .get("mergeable")
+        .and_then(|v| v.as_str())
+        .unwrap_or("UNKNOWN");
+    let merge_state_status = json
+        .get("mergeStateStatus")
+        .and_then(|v| v.as_str())
+        .unwrap_or("UNKNOWN");
+    let merge = match effective_merge_status_label(mergeable, merge_state_status) {
+        "MERGEABLE" => MergeStatus::Ready,
+        "BEHIND" => MergeStatus::Behind,
+        "CONFLICTING" | "DIRTY" => MergeStatus::Conflicts,
+        "UNKNOWN" => MergeStatus::Unknown,
+        _ => MergeStatus::Blocked,
     };
 
     let review = match json.get("reviewDecision").and_then(|v| v.as_str()) {
@@ -378,6 +422,7 @@ mod tests {
             "state": "OPEN",
             "url": "https://github.com/owner/repo/pull/123",
             "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
             "statusCheckRollup": [
                 {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
             ],
@@ -390,6 +435,8 @@ mod tests {
         assert_eq!(pr.state, PrState::Open);
         assert_eq!(pr.ci_status, "SUCCESS");
         assert_eq!(pr.mergeable, "MERGEABLE");
+        assert_eq!(pr.merge_state_status, "CLEAN");
+        assert_eq!(pr.effective_merge_status(), "MERGEABLE");
         assert_eq!(pr.review_status, "APPROVED");
     }
 
@@ -401,6 +448,7 @@ mod tests {
             "state": "MERGED",
             "url": "https://github.com/owner/repo/pull/456",
             "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
             "statusCheckRollup": [],
             "reviewDecision": "APPROVED"
         }"#;
@@ -418,6 +466,7 @@ mod tests {
             "state": "OPEN",
             "url": "",
             "mergeable": "CONFLICTING",
+            "mergeStateStatus": "DIRTY",
             "statusCheckRollup": [
                 {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
                 {"name": "lint", "status": "COMPLETED", "conclusion": "FAILURE"}
@@ -432,6 +481,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_pr_status_branch_behind_prefers_merge_state_status_for_cli() {
+        let json = r#"{
+            "number": 102,
+            "title": "Update branch required",
+            "state": "OPEN",
+            "url": "",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "BEHIND",
+            "statusCheckRollup": [],
+            "reviewDecision": "REVIEW_REQUIRED"
+        }"#;
+
+        let pr = parse_pr_status_json(json).unwrap();
+        assert_eq!(pr.mergeable, "MERGEABLE");
+        assert_eq!(pr.merge_state_status, "BEHIND");
+        assert_eq!(pr.effective_merge_status(), "BEHIND");
+        assert!(pr.requires_update_branch());
+    }
+
+    #[test]
     fn parse_pr_status_ci_pending() {
         let json = r#"{
             "number": 101,
@@ -439,6 +508,7 @@ mod tests {
             "state": "OPEN",
             "url": "",
             "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
             "statusCheckRollup": [
                 {"name": "ci", "status": "IN_PROGRESS", "conclusion": null}
             ],
@@ -460,6 +530,7 @@ mod tests {
         let json = r#"{
             "title": "Add feature",
             "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
             "reviewDecision": "APPROVED",
             "statusCheckRollup": [
                 {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
@@ -479,10 +550,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_pr_check_report_branch_behind_uses_merge_state_status() {
+        let json = r#"{
+            "title": "Update branch required",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "BEHIND",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "statusCheckRollup": []
+        }"#;
+
+        let report = parse_pr_check_report_json(json).unwrap();
+
+        assert_eq!(report.ci, CiStatus::Pending);
+        assert_eq!(report.merge, MergeStatus::Behind);
+        assert_eq!(report.review, ReviewStatus::Pending);
+        assert_eq!(
+            report.summary,
+            "PR: Update branch required | CI: Pending | Merge: Behind | Review: Pending"
+        );
+    }
+
+    #[test]
     fn parse_pr_check_report_empty_checks() {
         let json = r#"{
             "title": "Waiting on CI",
             "mergeable": "CONFLICTING",
+            "mergeStateStatus": "DIRTY",
             "reviewDecision": "REVIEW_REQUIRED",
             "statusCheckRollup": []
         }"#;
@@ -513,6 +606,7 @@ mod tests {
                 "state": "OPEN",
                 "url": "https://github.com/o/r/pull/1",
                 "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
                 "statusCheckRollup": [],
                 "reviewDecision": "APPROVED"
             },
@@ -522,6 +616,7 @@ mod tests {
                 "state": "OPEN",
                 "url": "https://github.com/o/r/pull/2",
                 "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
                 "statusCheckRollup": [
                     {"name": "ci", "status": "COMPLETED", "conclusion": "FAILURE"}
                 ],
@@ -535,6 +630,8 @@ mod tests {
         assert_eq!(prs[0].title, "First PR");
         assert_eq!(prs[1].number, 2);
         assert_eq!(prs[1].ci_status, "FAILURE");
+        assert_eq!(prs[0].merge_state_status, "CLEAN");
+        assert_eq!(prs[1].merge_state_status, "DIRTY");
     }
 
     #[test]
@@ -561,6 +658,7 @@ mod tests {
         assert_eq!(prs[0].url, "https://github.com/o/r/pull/11");
         assert_eq!(prs[0].ci_status, "UNKNOWN");
         assert_eq!(prs[0].mergeable, "UNKNOWN");
+        assert_eq!(prs[0].merge_state_status, "UNKNOWN");
         assert_eq!(prs[0].review_status, "UNKNOWN");
     }
 
@@ -582,6 +680,7 @@ mod tests {
                             "state": "OPEN",
                             "url": "https://github.com/o/r/pull/7",
                             "mergeable": "MERGEABLE",
+                            "mergeStateStatus": "CLEAN",
                             "statusCheckRollup": [],
                             "reviewDecision": "APPROVED"
                         }

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -474,7 +474,8 @@ fn render_pr(out: &mut String, pr: &PrStatus) {
     out.push_str(&format!("#{} [{}] {}\n", pr.number, pr.state, pr.title));
     out.push_str(&format!("url: {}\n", pr.url));
     out.push_str(&format!("ci: {}\n", pr.ci_status));
-    out.push_str(&format!("mergeable: {}\n", pr.mergeable));
+    out.push_str(&format!("mergeable: {}\n", pr.effective_merge_status()));
+    out.push_str(&format!("merge_state: {}\n", pr.merge_state_status));
     out.push_str(&format!("review: {}\n", pr.review_status));
 }
 
@@ -754,7 +755,7 @@ fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option<PrS
             "pr",
             "view",
             "--json",
-            "number,title,state,url,mergeable,statusCheckRollup,reviewDecision",
+            "number,title,state,url,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision",
         ])
         .current_dir(repo_path)
         .output()?;
@@ -1218,14 +1219,15 @@ fn fetch_pr_checks_via_gh(
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let checks = parse_pr_checks_items_response(&stdout, &stderr, output.status.success())?;
+    let merge_status = pr.effective_merge_status().to_string();
 
     Ok(PrChecksSummary {
         summary: format!(
             "PR #{} | CI: {} | Merge: {} | Review: {}",
-            pr.number, pr.ci_status, pr.mergeable, pr.review_status
+            pr.number, pr.ci_status, merge_status, pr.review_status
         ),
         ci_status: pr.ci_status,
-        merge_status: pr.mergeable,
+        merge_status,
         review_status: pr.review_status,
         checks,
     })
@@ -1582,7 +1584,13 @@ use std::{env, fs, process::ExitCode};
 
 fn pr_json(number: &str, title: &str) -> String {
     format!(
-        "{{\"number\":{number},\"title\":\"{title}\",\"state\":\"OPEN\",\"url\":\"https://github.com/akiojin/gwt/pull/{number}\",\"mergeable\":\"MERGEABLE\",\"statusCheckRollup\":[{{\"name\":\"ci\",\"status\":\"COMPLETED\",\"conclusion\":\"SUCCESS\"}}],\"reviewDecision\":\"APPROVED\"}}"
+        "{{\"number\":{number},\"title\":\"{title}\",\"state\":\"OPEN\",\"url\":\"https://github.com/akiojin/gwt/pull/{number}\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"statusCheckRollup\":[{{\"name\":\"ci\",\"status\":\"COMPLETED\",\"conclusion\":\"SUCCESS\"}}],\"reviewDecision\":\"APPROVED\"}}"
+    )
+}
+
+fn behind_pr_json(number: &str, title: &str) -> String {
+    format!(
+        "{{\"number\":{number},\"title\":\"{title}\",\"state\":\"OPEN\",\"url\":\"https://github.com/akiojin/gwt/pull/{number}\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"BEHIND\",\"statusCheckRollup\":[{{\"name\":\"ci\",\"status\":\"COMPLETED\",\"conclusion\":\"SUCCESS\"}}],\"reviewDecision\":\"REVIEW_REQUIRED\"}}"
     )
 }
 
@@ -1606,13 +1614,21 @@ fn main() -> ExitCode {
                 eprintln!("no pull requests found for branch");
                 return ExitCode::from(1);
             }
-            println!("{}", pr_json("12", "Current PR"));
+            if mode == "behind" {
+                println!("{}", behind_pr_json("12", "Current PR"));
+            } else {
+                println!("{}", pr_json("12", "Current PR"));
+            }
             return ExitCode::SUCCESS;
         }
         [pr, view, number, repo_flag, _, json_flag, ..]
             if pr == "pr" && view == "view" && repo_flag == "--repo" && json_flag == "--json" =>
         {
-            println!("{}", pr_json(number, "Fetched PR"));
+            if mode == "behind" {
+                println!("{}", behind_pr_json(number, "Fetched PR"));
+            } else {
+                println!("{}", pr_json(number, "Fetched PR"));
+            }
             return ExitCode::SUCCESS;
         }
         [pr, create, ..] if pr == "pr" && create == "create" => {
@@ -1852,6 +1868,7 @@ fn main() -> ExitCode {
             url: "https://github.com/akiojin/gwt/pull/128".to_string(),
             ci_status: "SUCCESS".to_string(),
             mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
             review_status: "APPROVED".to_string(),
         }
     }
@@ -1921,6 +1938,7 @@ fn main() -> ExitCode {
         assert!(out.contains("=== comment:7 (2026-04-20T01:00:00Z) ==="));
         assert!(out.contains("#128 [OPEN] Enforce coverage"));
         assert!(out.contains("ci: SUCCESS"));
+        assert!(out.contains("merge_state: CLEAN"));
         assert!(out.contains("workflow: coverage"));
         assert!(out.contains("=== review:review-1 [APPROVED] by reviewer"));
         assert!(out.contains(
@@ -2130,6 +2148,7 @@ fn main() -> ExitCode {
                 .expect("current pr")
                 .expect("current pr exists");
             assert_eq!(current.number, 12);
+            assert_eq!(current.merge_state_status, "CLEAN");
 
             let created = create_pr_via_gh(
                 "akiojin/gwt",
@@ -2199,6 +2218,17 @@ fn main() -> ExitCode {
             assert_eq!(checks.checks.len(), 1);
             assert_eq!(checks.checks[0].workflow, "coverage");
             assert_eq!(checks.checks[0].url, "https://example.test/checks/12");
+        });
+
+        with_fake_gh("behind", |repo_path| {
+            let current = fetch_current_pr_via_gh(repo_path)
+                .expect("current pr")
+                .expect("current pr exists");
+            assert_eq!(current.effective_merge_status(), "BEHIND");
+
+            let checks = fetch_pr_checks_via_gh("akiojin/gwt", repo_path, 12).expect("checks");
+            assert!(checks.summary.contains("Merge: BEHIND"));
+            assert_eq!(checks.merge_status, "BEHIND");
         });
 
         with_fake_gh("job-log-zip", |repo_path| {

--- a/crates/gwt/src/cli/env.rs
+++ b/crates/gwt/src/cli/env.rs
@@ -826,6 +826,7 @@ mod tests {
             url: "https://github.com/akiojin/gwt/pull/128".to_string(),
             ci_status: "SUCCESS".to_string(),
             mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
             review_status: "APPROVED".to_string(),
         }
     }
@@ -852,7 +853,7 @@ use std::{env, process::ExitCode};
 
 fn pr_json(number: &str, title: &str) -> String {
     format!(
-        "{{\"number\":{number},\"title\":\"{title}\",\"state\":\"OPEN\",\"url\":\"https://github.com/akiojin/gwt/pull/{number}\",\"mergeable\":\"MERGEABLE\",\"statusCheckRollup\":[{{\"name\":\"ci\",\"status\":\"COMPLETED\",\"conclusion\":\"SUCCESS\"}}],\"reviewDecision\":\"APPROVED\"}}"
+        "{{\"number\":{number},\"title\":\"{title}\",\"state\":\"OPEN\",\"url\":\"https://github.com/akiojin/gwt/pull/{number}\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"statusCheckRollup\":[{{\"name\":\"ci\",\"status\":\"COMPLETED\",\"conclusion\":\"SUCCESS\"}}],\"reviewDecision\":\"APPROVED\"}}"
     )
 }
 

--- a/crates/gwt/src/cli/pr.rs
+++ b/crates/gwt/src/cli/pr.rs
@@ -274,6 +274,7 @@ mod tests {
             url: "https://example.com/pr/7".to_string(),
             ci_status: "SUCCESS".to_string(),
             mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
             review_status: "APPROVED".to_string(),
         }
     }

--- a/crates/gwt/src/custom_agents_dispatch.rs
+++ b/crates/gwt/src/custom_agents_dispatch.rs
@@ -21,6 +21,8 @@ use crate::{
 
 #[cfg(test)]
 thread_local! {
+    // Tests exercise dispatch helpers synchronously; spawned probe paths do
+    // not read this override.
     static TEST_HOME_DIR_OVERRIDE: std::cell::RefCell<Option<Option<PathBuf>>> =
         const { std::cell::RefCell::new(None) };
 }
@@ -35,7 +37,7 @@ fn missing_home_dir_error() -> CustomAgentsServiceError {
 
 #[cfg(test)]
 fn config_path_from_home(home: Option<PathBuf>) -> Result<PathBuf, CustomAgentsServiceError> {
-    home.map(|home| home.join(".gwt").join("config.toml"))
+    home.map(|home| Settings::global_config_path_for_home(&home))
         .ok_or_else(missing_home_dir_error)
 }
 
@@ -56,7 +58,7 @@ fn set_test_home_dir_override(home: Option<Option<PathBuf>>) {
 /// `./config.toml` would write `api_key` secrets into the current working
 /// directory, which diverges from the app's canonical `~/.gwt/config.toml`
 /// source of truth.
-pub fn config_path() -> Result<PathBuf, CustomAgentsServiceError> {
+fn config_path() -> Result<PathBuf, CustomAgentsServiceError> {
     #[cfg(test)]
     if let Some(home) = test_home_dir_override() {
         return config_path_from_home(home);
@@ -78,7 +80,7 @@ where
 }
 
 /// Map a service-layer error to a `CustomAgentError` event.
-pub fn error_to_event(err: CustomAgentsServiceError) -> BackendEvent {
+fn error_to_event(err: CustomAgentsServiceError) -> BackendEvent {
     use CustomAgentsServiceError as E;
     let code = match &err {
         E::Storage(_) => CustomAgentErrorCode::Storage,

--- a/crates/gwt/src/custom_agents_dispatch.rs
+++ b/crates/gwt/src/custom_agents_dispatch.rs
@@ -160,6 +160,7 @@ pub fn test_connection_event(base_url: &str, api_key: &str) -> BackendEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gwt_agent::ClaudeCodeOpenaiCompatInput;
     use std::path::PathBuf;
 
     fn sample_input() -> ClaudeCodeOpenaiCompatInput {
@@ -170,6 +171,14 @@ mod tests {
             api_key: "sk-real-secret".to_string(),
             default_model: "openai/gpt-oss-20b".to_string(),
         }
+    }
+
+    fn sample_payload() -> Value {
+        serde_json::to_value(sample_input()).unwrap()
+    }
+
+    fn add_sample_from_preset_event() -> BackendEvent {
+        add_from_preset_event(PresetId::ClaudeCodeOpenaiCompat, sample_payload())
     }
 
     fn sample_agent(id: &str) -> CustomCodingAgent {
@@ -183,7 +192,7 @@ mod tests {
     }
 
     fn home_config_path(home: PathBuf) -> PathBuf {
-        home.join(".gwt").join("config.toml")
+        Settings::global_config_path_for_home(&home)
     }
 
     struct HomeDirOverrideGuard;
@@ -287,7 +296,7 @@ mod tests {
     fn add_from_preset_event_returns_storage_error_when_config_path_is_unavailable() {
         let _guard = override_home_dir(None);
 
-        assert_storage_error(add_from_preset_event(sample_input()));
+        assert_storage_error(add_sample_from_preset_event());
     }
 
     #[test]
@@ -323,7 +332,7 @@ mod tests {
         let config_path = home_config_path(dir.path().to_path_buf());
         let _guard = override_home_dir(Some(dir.path().to_path_buf()));
 
-        match add_from_preset_event(sample_input()) {
+        match add_sample_from_preset_event() {
             BackendEvent::CustomAgentSaved { agent } => {
                 assert_eq!(agent.id, "claude-proxy");
                 assert_eq!(agent.env["ANTHROPIC_API_KEY"], REDACTED_PLACEHOLDER);
@@ -343,7 +352,7 @@ mod tests {
         let config_path = home_config_path(dir.path().to_path_buf());
         let _guard = override_home_dir(Some(dir.path().to_path_buf()));
 
-        add_from_preset_event(sample_input());
+        add_sample_from_preset_event();
         let mut agent = crate::custom_agents_service::list_custom_agents(&config_path)
             .expect("reload")
             .pop()
@@ -368,7 +377,7 @@ mod tests {
         let config_path = home_config_path(dir.path().to_path_buf());
         let _guard = override_home_dir(Some(dir.path().to_path_buf()));
 
-        add_from_preset_event(sample_input());
+        add_sample_from_preset_event();
 
         match delete_event("claude-proxy".to_string()) {
             BackendEvent::CustomAgentDeleted { agent_id } => assert_eq!(agent_id, "claude-proxy"),

--- a/crates/gwt/src/custom_agents_dispatch.rs
+++ b/crates/gwt/src/custom_agents_dispatch.rs
@@ -19,19 +19,50 @@ use crate::{
     protocol::{BackendEvent, CustomAgentErrorCode},
 };
 
+#[cfg(test)]
+thread_local! {
+    static TEST_HOME_DIR_OVERRIDE: std::cell::RefCell<Option<Option<PathBuf>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+fn missing_home_dir_error() -> CustomAgentsServiceError {
+    CustomAgentsServiceError::Storage(
+        "unable to resolve home directory (`~/.gwt/config.toml`); \
+         set HOME/USERPROFILE before managing custom agents"
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+fn config_path_from_home(home: Option<PathBuf>) -> Result<PathBuf, CustomAgentsServiceError> {
+    home.map(|home| home.join(".gwt").join("config.toml"))
+        .ok_or_else(missing_home_dir_error)
+}
+
+#[cfg(test)]
+fn test_home_dir_override() -> Option<Option<PathBuf>> {
+    TEST_HOME_DIR_OVERRIDE.with(|override_home| override_home.borrow().clone())
+}
+
+#[cfg(test)]
+fn set_test_home_dir_override(home: Option<Option<PathBuf>>) {
+    TEST_HOME_DIR_OVERRIDE.with(|override_home| {
+        *override_home.borrow_mut() = home;
+    });
+}
+
 /// Resolve the custom-agent config file path. Returns `Storage` error when
 /// the home directory cannot be discovered — silently falling back to
 /// `./config.toml` would write `api_key` secrets into the current working
 /// directory, which diverges from the app's canonical `~/.gwt/config.toml`
 /// source of truth.
 pub fn config_path() -> Result<PathBuf, CustomAgentsServiceError> {
-    Settings::global_config_path().ok_or_else(|| {
-        CustomAgentsServiceError::Storage(
-            "unable to resolve home directory (`~/.gwt/config.toml`); \
-             set HOME/USERPROFILE before managing custom agents"
-                .to_string(),
-        )
-    })
+    #[cfg(test)]
+    if let Some(home) = test_home_dir_override() {
+        return config_path_from_home(home);
+    }
+
+    Settings::global_config_path().ok_or_else(missing_home_dir_error)
 }
 
 /// Resolve the config path or produce a `CustomAgentError` event — eliminates
@@ -129,6 +160,57 @@ pub fn test_connection_event(base_url: &str, api_key: &str) -> BackendEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    fn sample_input() -> ClaudeCodeOpenaiCompatInput {
+        ClaudeCodeOpenaiCompatInput {
+            id: "claude-proxy".to_string(),
+            display_name: "Claude Proxy".to_string(),
+            base_url: "http://proxy.local:32768".to_string(),
+            api_key: "sk-real-secret".to_string(),
+            default_model: "openai/gpt-oss-20b".to_string(),
+        }
+    }
+
+    fn sample_agent(id: &str) -> CustomCodingAgent {
+        gwt_agent::claude_code_openai_compat_preset(
+            id,
+            "Claude Proxy",
+            "http://proxy.local:32768",
+            "sk-real-secret",
+            "openai/gpt-oss-20b",
+        )
+    }
+
+    fn home_config_path(home: PathBuf) -> PathBuf {
+        home.join(".gwt").join("config.toml")
+    }
+
+    struct HomeDirOverrideGuard;
+
+    impl Drop for HomeDirOverrideGuard {
+        fn drop(&mut self) {
+            set_test_home_dir_override(None);
+        }
+    }
+
+    fn override_home_dir(home: Option<PathBuf>) -> HomeDirOverrideGuard {
+        set_test_home_dir_override(Some(home));
+        HomeDirOverrideGuard
+    }
+
+    fn assert_storage_error(event: BackendEvent) {
+        match event {
+            BackendEvent::CustomAgentError { code, message } => {
+                assert_eq!(code, CustomAgentErrorCode::Storage);
+                assert!(
+                    message.contains("unable to resolve home directory"),
+                    "unexpected storage error message: {message}"
+                );
+            }
+            other => panic!("expected CustomAgentError, got {other:?}"),
+        }
+    }
 
     #[test]
     fn error_to_event_preserves_code_per_variant() {
@@ -192,5 +274,109 @@ mod tests {
         assert_eq!(wired.env["ANTHROPIC_API_KEY"], REDACTED_PLACEHOLDER);
         // Non-secret entries pass through.
         assert_eq!(wired.env["ANTHROPIC_BASE_URL"], "http://proxy.local:32768");
+    }
+
+    #[test]
+    fn list_event_returns_storage_error_when_config_path_is_unavailable() {
+        let _guard = override_home_dir(None);
+
+        assert_storage_error(list_event());
+    }
+
+    #[test]
+    fn add_from_preset_event_returns_storage_error_when_config_path_is_unavailable() {
+        let _guard = override_home_dir(None);
+
+        assert_storage_error(add_from_preset_event(sample_input()));
+    }
+
+    #[test]
+    fn update_event_returns_storage_error_when_config_path_is_unavailable() {
+        let _guard = override_home_dir(None);
+
+        assert_storage_error(update_event(sample_agent("claude-proxy")));
+    }
+
+    #[test]
+    fn delete_event_returns_storage_error_when_config_path_is_unavailable() {
+        let _guard = override_home_dir(None);
+
+        assert_storage_error(delete_event("claude-proxy".to_string()));
+    }
+
+    #[test]
+    fn list_event_uses_resolved_config_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = override_home_dir(Some(dir.path().to_path_buf()));
+
+        match list_event() {
+            BackendEvent::CustomAgentList { agents } => assert!(agents.is_empty()),
+            other => panic!("expected CustomAgentList, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn add_from_preset_event_uses_resolved_config_path() {
+        use gwt_agent::REDACTED_PLACEHOLDER;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = home_config_path(dir.path().to_path_buf());
+        let _guard = override_home_dir(Some(dir.path().to_path_buf()));
+
+        match add_from_preset_event(sample_input()) {
+            BackendEvent::CustomAgentSaved { agent } => {
+                assert_eq!(agent.id, "claude-proxy");
+                assert_eq!(agent.env["ANTHROPIC_API_KEY"], REDACTED_PLACEHOLDER);
+            }
+            other => panic!("expected CustomAgentSaved, got {other:?}"),
+        }
+
+        let persisted =
+            crate::custom_agents_service::list_custom_agents(&config_path).expect("reload");
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].env["ANTHROPIC_API_KEY"], "sk-real-secret");
+    }
+
+    #[test]
+    fn update_event_uses_resolved_config_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = home_config_path(dir.path().to_path_buf());
+        let _guard = override_home_dir(Some(dir.path().to_path_buf()));
+
+        add_from_preset_event(sample_input());
+        let mut agent = crate::custom_agents_service::list_custom_agents(&config_path)
+            .expect("reload")
+            .pop()
+            .expect("agent");
+        agent.display_name = "Renamed Proxy".to_string();
+
+        match update_event(agent) {
+            BackendEvent::CustomAgentSaved { agent } => {
+                assert_eq!(agent.display_name, "Renamed Proxy");
+            }
+            other => panic!("expected CustomAgentSaved, got {other:?}"),
+        }
+
+        let persisted =
+            crate::custom_agents_service::list_custom_agents(&config_path).expect("reload");
+        assert_eq!(persisted[0].display_name, "Renamed Proxy");
+    }
+
+    #[test]
+    fn delete_event_uses_resolved_config_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = home_config_path(dir.path().to_path_buf());
+        let _guard = override_home_dir(Some(dir.path().to_path_buf()));
+
+        add_from_preset_event(sample_input());
+
+        match delete_event("claude-proxy".to_string()) {
+            BackendEvent::CustomAgentDeleted { agent_id } => assert_eq!(agent_id, "claude-proxy"),
+            other => panic!("expected CustomAgentDeleted, got {other:?}"),
+        }
+
+        let persisted =
+            crate::custom_agents_service::list_custom_agents(&config_path).expect("reload");
+        assert!(persisted.is_empty());
     }
 }

--- a/crates/gwt/tests/cli_test.rs
+++ b/crates/gwt/tests/cli_test.rs
@@ -1214,6 +1214,7 @@ fn red_108_dispatch_pr_current_is_live_first() {
         url: "https://example.com/pr/77".to_string(),
         ci_status: "SUCCESS".to_string(),
         mergeable: "MERGEABLE".to_string(),
+        merge_state_status: "CLEAN".to_string(),
         review_status: "APPROVED".to_string(),
     }));
 
@@ -1224,6 +1225,7 @@ fn red_108_dispatch_pr_current_is_live_first() {
     let out = String::from_utf8(env.stdout.clone()).unwrap();
     assert!(out.contains("#77 [OPEN] Current PR"));
     assert!(out.contains("https://example.com/pr/77"));
+    assert!(out.contains("merge_state: CLEAN"));
 }
 
 #[test]
@@ -1241,6 +1243,7 @@ fn red_108a_dispatch_pr_create_uses_live_transport() {
         url: "https://example.com/pr/88".to_string(),
         ci_status: "PENDING".to_string(),
         mergeable: "UNKNOWN".to_string(),
+        merge_state_status: "UNKNOWN".to_string(),
         review_status: "REVIEW_REQUIRED".to_string(),
     });
 
@@ -1298,6 +1301,7 @@ fn red_108b_dispatch_pr_edit_uses_live_transport() {
             url: "https://example.com/pr/42".to_string(),
             ci_status: "SUCCESS".to_string(),
             mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
             review_status: "APPROVED".to_string(),
         },
     );
@@ -1346,6 +1350,7 @@ fn red_109_dispatch_pr_view_reads_live_data() {
             url: "https://example.com/pr/42".to_string(),
             ci_status: "SUCCESS".to_string(),
             mergeable: "UNKNOWN".to_string(),
+            merge_state_status: "UNKNOWN".to_string(),
             review_status: "APPROVED".to_string(),
         },
     );
@@ -1357,6 +1362,30 @@ fn red_109_dispatch_pr_view_reads_live_data() {
     let out = String::from_utf8(env.stdout.clone()).unwrap();
     assert!(out.contains("#42 [MERGED] Viewed PR"));
     assert!(out.contains("mergeable: UNKNOWN"));
+    assert!(out.contains("merge_state: UNKNOWN"));
+}
+
+#[test]
+fn red_109_dispatch_pr_current_surfaces_branch_behind_as_effective_merge_state() {
+    let tmp = TempDir::new().unwrap();
+    let mut env = TestEnv::new(tmp.path().to_path_buf());
+    env.seed_current_pr(Some(PrStatus {
+        number: 91,
+        title: "Update branch required".to_string(),
+        state: gwt_git::pr_status::PrState::Open,
+        url: "https://example.com/pr/91".to_string(),
+        ci_status: "SUCCESS".to_string(),
+        mergeable: "MERGEABLE".to_string(),
+        merge_state_status: "BEHIND".to_string(),
+        review_status: "REVIEW_REQUIRED".to_string(),
+    }));
+
+    let code = dispatch(&mut env, &argv(&["gwt", "pr", "current"]));
+    assert_eq!(code, 0);
+
+    let out = String::from_utf8(env.stdout.clone()).unwrap();
+    assert!(out.contains("mergeable: BEHIND"));
+    assert!(out.contains("merge_state: BEHIND"));
 }
 
 #[test]
@@ -1493,10 +1522,9 @@ fn red_110_dispatch_pr_checks_renders_summary_and_checks() {
     env.seed_pr_checks(
         42,
         PrChecksSummary {
-            summary: "PR #42 | CI: FAILURE | Merge: CONFLICTING | Review: CHANGES_REQUESTED"
-                .to_string(),
+            summary: "PR #42 | CI: FAILURE | Merge: BEHIND | Review: CHANGES_REQUESTED".to_string(),
             ci_status: "FAILURE".to_string(),
-            merge_status: "CONFLICTING".to_string(),
+            merge_status: "BEHIND".to_string(),
             review_status: "CHANGES_REQUESTED".to_string(),
             checks: vec![PrCheckItem {
                 name: "test".to_string(),
@@ -1516,6 +1544,7 @@ fn red_110_dispatch_pr_checks_renders_summary_and_checks() {
 
     let out = String::from_utf8(env.stdout.clone()).unwrap();
     assert!(out.contains("summary: PR #42 | CI: FAILURE"));
+    assert!(out.contains("merge: BEHIND"));
     assert!(out.contains("- test [COMPLETED / FAILURE]"));
     assert!(out.contains("workflow: CI"));
 }


### PR DESCRIPTION
## Summary
- Adds a test-only home-dir override for custom agent dispatch config path resolution.
- Covers storage error mapping for list/add/update/delete dispatch helpers and success path usage through resolved config paths.

## Changes
- Factored missing home-dir storage error construction for `config_path()`.
- Added a `#[cfg(test)]` thread-local home override so dispatch tests can simulate missing and temporary home directories.
- Expanded `custom_agents_dispatch` unit coverage from 4 to 12 tests.

## Testing
- `cargo test -p gwt --lib custom_agents_dispatch::tests -j 1`
- `cargo test -p gwt-core -p gwt -j 1`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -j 1 -- -D warnings`
- `cargo build -p gwt -j 1`
- `bunx commitlint --from origin/develop --to HEAD`

## Closing Issues
Closes #2099

## Related Issues
- Related: #1921
- Related PR: #2103

## Checklist
- [x] Tests updated and passing.
- [x] Lint and format checks passing.
- [x] Branch synced with `origin/develop`.
- [x] No user-facing protocol or settings behavior changed.
