### PR TITLE
fix(gui): skip minimized terminal viewport refresh

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -107,6 +107,11 @@ mod tests {
             html.contains("if (runtime && runtime.viewportRefreshFrame !== null)"),
             "expected terminal cleanup to guard non-terminal windows before cancelling refresh frames",
         );
+        assert!(
+            html.contains("function canRefreshTerminalViewport(windowId)")
+                && html.contains("!workspaceWindowById(windowId)?.minimized"),
+            "expected terminal viewport refresh to skip minimized windows",
+        );
     }
 
     #[test]

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2481,10 +2481,14 @@
         });
       }
 
+      function canRefreshTerminalViewport(windowId) {
+        return !workspaceWindowById(windowId)?.minimized;
+      }
+
       function fitTerminal(windowId, persist = false) {
         const runtime = terminalMap.get(windowId);
         const element = windowMap.get(windowId);
-        if (!runtime || !element) {
+        if (!runtime || !element || !canRefreshTerminalViewport(windowId)) {
           return;
         }
         runtime.fitAddon.fit();
@@ -2496,11 +2500,18 @@
 
       function scheduleTerminalViewportRefresh(windowId) {
         const runtime = terminalMap.get(windowId);
-        if (!runtime || runtime.viewportRefreshFrame !== null) {
+        if (
+          !runtime ||
+          runtime.viewportRefreshFrame !== null ||
+          !canRefreshTerminalViewport(windowId)
+        ) {
           return;
         }
         runtime.viewportRefreshFrame = requestAnimationFrame(() => {
           runtime.viewportRefreshFrame = null;
+          if (!canRefreshTerminalViewport(windowId)) {
+            return;
+          }
           fitTerminal(windowId, false);
         });
       }


### PR DESCRIPTION
## Summary

- Skip automatic xterm.js viewport refreshes while a terminal window is minimized.
- Prevent FitAddon from measuring hidden terminal bodies after the Issue #2096 viewport refresh fix.

## Changes

- `crates/gwt/web/index.html`: add a minimized-window guard for terminal viewport refresh scheduling and fitting.
- `crates/gwt/src/embedded_web.rs`: extend the embedded Web contract test to require the minimized-window guard.

## Testing

- [x] `cargo test -p gwt embedded_web_terminal_writes_refresh_viewport_after_xterm_parse -j1` — passes.
- [x] `cargo test -p gwt embedded_web::tests -j1` — passes.
- [x] `cargo fmt` — passes.
- [x] `cargo test -p gwt-core -p gwt` — passes before and after merging `origin/develop`.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo build -p gwt` — passes.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passes.

## Closing Issues

- None

## Related Issues / Links

- #2110
- #2096

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation not required because this is an internal terminal host behavior fix
- [x] Migration/backfill not required because no schema or data format changed
- [x] CHANGELOG impact considered as part of the existing patch-level GUI fix

## Context

- Follow-up for Codex review on #2110: the refresh path must not call FitAddon while terminal bodies are hidden by minimization.
