### PR TITLE
fix(release): sign macos dmg assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
           CERT_PATH="${RUNNER_TEMP}/gwt-app-signing.p12"
           KEYCHAIN_PASSWORD="$(uuidgen)"
 
-          echo "$APPLE_CERT_APP_BASE64" | base64 --decode > "$CERT_PATH"
+          echo "$APPLE_CERT_APP_BASE64" | base64 -D > "$CERT_PATH"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
@@ -278,7 +278,7 @@ jobs:
           CERT_PATH="${RUNNER_TEMP}/gwt-dmg-signing.p12"
           KEYCHAIN_PASSWORD="$(uuidgen)"
 
-          echo "$APPLE_CERT_APP_BASE64" | base64 --decode > "$CERT_PATH"
+          echo "$APPLE_CERT_APP_BASE64" | base64 -D > "$CERT_PATH"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,64 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
       - name: Build gwt bundle binaries
         run: cargo build --release -p gwt --target ${{ matrix.target }} --bin gwt --bin gwtd
+      - name: Prepare macOS signing keychain
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_CERT_APP_BASE64: ${{ secrets.APPLE_CERT_APP_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${APPLE_CERT_APP_BASE64:-}" || -z "${APPLE_CERTIFICATE_PASSWORD:-}" ]]; then
+            echo "macOS signing requires APPLE_CERT_APP_BASE64 and APPLE_CERTIFICATE_PASSWORD" >&2
+            exit 1
+          fi
+
+          KEYCHAIN_PATH="${RUNNER_TEMP}/gwt-app-signing.keychain-db"
+          CERT_PATH="${RUNNER_TEMP}/gwt-app-signing.p12"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+
+          echo "$APPLE_CERT_APP_BASE64" | base64 --decode > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$CERT_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
+            | awk '/Developer ID Application/ { print $2; exit }')"
+          if [[ -z "$CODESIGN_IDENTITY" ]]; then
+            CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
+              | awk 'NR == 1 { print $2; exit }')"
+          fi
+          if [[ -z "$CODESIGN_IDENTITY" ]]; then
+            echo "No codesigning identity found in temporary keychain" >&2
+            exit 1
+          fi
+
+          {
+            echo "GWT_MACOS_KEYCHAIN_PATH=$KEYCHAIN_PATH"
+            echo "GWT_CODESIGN_IDENTITY=$CODESIGN_IDENTITY"
+          } >> "$GITHUB_ENV"
+      - name: Sign macOS portable binaries
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
+            "target/${{ matrix.target }}/release/gwt"
+          codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
+            "target/${{ matrix.target }}/release/gwtd"
+          codesign --verify --strict --verbose=4 "target/${{ matrix.target }}/release/gwt"
+          codesign --verify --strict --verbose=4 "target/${{ matrix.target }}/release/gwtd"
       - name: Prepare artifact (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -151,6 +209,14 @@ jobs:
         with:
           name: ${{ matrix.archive_name }}
           path: dist/${{ matrix.archive_name }}
+      - name: Cleanup macOS signing keychain
+        if: always() && runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${GWT_MACOS_KEYCHAIN_PATH:-}" && -f "$GWT_MACOS_KEYCHAIN_PATH" ]]; then
+            security delete-keychain "$GWT_MACOS_KEYCHAIN_PATH" || true
+          fi
 
   build-msi:
     name: Build MSI installer (Windows)
@@ -195,6 +261,52 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: gwt-dmg
+      - name: Prepare macOS signing keychain
+        shell: bash
+        env:
+          APPLE_CERT_APP_BASE64: ${{ secrets.APPLE_CERT_APP_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${APPLE_CERT_APP_BASE64:-}" || -z "${APPLE_CERTIFICATE_PASSWORD:-}" ]]; then
+            echo "macOS signing requires APPLE_CERT_APP_BASE64 and APPLE_CERTIFICATE_PASSWORD" >&2
+            exit 1
+          fi
+
+          KEYCHAIN_PATH="${RUNNER_TEMP}/gwt-dmg-signing.keychain-db"
+          CERT_PATH="${RUNNER_TEMP}/gwt-dmg-signing.p12"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+
+          echo "$APPLE_CERT_APP_BASE64" | base64 --decode > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$CERT_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
+            | awk '/Developer ID Application/ { print $2; exit }')"
+          if [[ -z "$CODESIGN_IDENTITY" ]]; then
+            CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
+              | awk 'NR == 1 { print $2; exit }')"
+          fi
+          if [[ -z "$CODESIGN_IDENTITY" ]]; then
+            echo "No codesigning identity found in temporary keychain" >&2
+            exit 1
+          fi
+
+          {
+            echo "GWT_MACOS_KEYCHAIN_PATH=$KEYCHAIN_PATH"
+            echo "GWT_CODESIGN_IDENTITY=$CODESIGN_IDENTITY"
+          } >> "$GITHUB_ENV"
       - name: Build gwt bundle binaries for aarch64
         run: cargo build --release -p gwt --target aarch64-apple-darwin --bin gwt --bin gwtd
       - name: Build gwt bundle binaries for x86_64
@@ -239,17 +351,76 @@ jobs:
           cp dist/gwtd dist/GWT.app/Contents/MacOS/gwtd
           chmod +x dist/GWT.app/Contents/MacOS/gwt
           chmod +x dist/GWT.app/Contents/MacOS/gwtd
+      - name: Sign app bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
+            dist/GWT.app/Contents/MacOS/gwt
+          codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
+            dist/GWT.app/Contents/MacOS/gwtd
+          codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
+            dist/GWT.app
+          codesign --verify --deep --strict --verbose=4 dist/GWT.app
       - name: Create DMG
         run: |
           mkdir -p dmg_temp
           cp -R dist/GWT.app dmg_temp/GWT.app
           ln -s /Applications dmg_temp/Applications
           hdiutil create -volname GWT -srcfolder dmg_temp -ov -format UDZO dist/gwt-macos-universal.dmg
+      - name: Sign and notarize DMG
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          for var in APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID; do
+            if [[ -z "${!var:-}" ]]; then
+              echo "macOS notarization requires ${var}" >&2
+              exit 1
+            fi
+          done
+
+          codesign --force --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
+            dist/gwt-macos-universal.dmg
+          codesign --verify --strict --verbose=4 dist/gwt-macos-universal.dmg
+
+          xcrun notarytool submit dist/gwt-macos-universal.dmg \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple dist/gwt-macos-universal.dmg
+          xcrun stapler validate dist/gwt-macos-universal.dmg
+          spctl --assess --type execute --verbose=4 dist/GWT.app
+          spctl --assess --type open --context context:primary-signature --verbose=4 \
+            dist/gwt-macos-universal.dmg
+      - name: Validate DMG contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          MOUNT_DIR="${RUNNER_TEMP}/gwt-dmg-verify"
+          mkdir -p "$MOUNT_DIR"
+          hdiutil attach dist/gwt-macos-universal.dmg -mountpoint "$MOUNT_DIR" -nobrowse -quiet
+          trap 'hdiutil detach "$MOUNT_DIR" -quiet 2>/dev/null || true' EXIT
+          test -d "$MOUNT_DIR/GWT.app"
+          codesign --verify --deep --strict --verbose=4 "$MOUNT_DIR/GWT.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: gwt-macos-universal.dmg
           path: dist/gwt-macos-universal.dmg
+      - name: Cleanup macOS signing keychain
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${GWT_MACOS_KEYCHAIN_PATH:-}" && -f "$GWT_MACOS_KEYCHAIN_PATH" ]]; then
+            security delete-keychain "$GWT_MACOS_KEYCHAIN_PATH" || true
+          fi
 
   upload-release:
     name: Upload to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,11 +162,7 @@ jobs:
           CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
             | awk '/Developer ID Application/ { print $2; exit }')"
           if [[ -z "$CODESIGN_IDENTITY" ]]; then
-            CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
-              | awk 'NR == 1 { print $2; exit }')"
-          fi
-          if [[ -z "$CODESIGN_IDENTITY" ]]; then
-            echo "No codesigning identity found in temporary keychain" >&2
+            echo "No Developer ID Application codesigning identity found in temporary keychain" >&2
             exit 1
           fi
 
@@ -261,52 +257,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: gwt-dmg
-      - name: Prepare macOS signing keychain
-        shell: bash
-        env:
-          APPLE_CERT_APP_BASE64: ${{ secrets.APPLE_CERT_APP_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${APPLE_CERT_APP_BASE64:-}" || -z "${APPLE_CERTIFICATE_PASSWORD:-}" ]]; then
-            echo "macOS signing requires APPLE_CERT_APP_BASE64 and APPLE_CERTIFICATE_PASSWORD" >&2
-            exit 1
-          fi
-
-          KEYCHAIN_PATH="${RUNNER_TEMP}/gwt-dmg-signing.keychain-db"
-          CERT_PATH="${RUNNER_TEMP}/gwt-dmg-signing.p12"
-          KEYCHAIN_PASSWORD="$(uuidgen)"
-
-          echo "$APPLE_CERT_APP_BASE64" | base64 -D > "$CERT_PATH"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" \
-            -k "$KEYCHAIN_PATH" \
-            -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security
-          rm -f "$CERT_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -s \
-            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
-            | awk '/Developer ID Application/ { print $2; exit }')"
-          if [[ -z "$CODESIGN_IDENTITY" ]]; then
-            CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
-              | awk 'NR == 1 { print $2; exit }')"
-          fi
-          if [[ -z "$CODESIGN_IDENTITY" ]]; then
-            echo "No codesigning identity found in temporary keychain" >&2
-            exit 1
-          fi
-
-          {
-            echo "GWT_MACOS_KEYCHAIN_PATH=$KEYCHAIN_PATH"
-            echo "GWT_CODESIGN_IDENTITY=$CODESIGN_IDENTITY"
-          } >> "$GITHUB_ENV"
       - name: Build gwt bundle binaries for aarch64
         run: cargo build --release -p gwt --target aarch64-apple-darwin --bin gwt --bin gwtd
       - name: Build gwt bundle binaries for x86_64
@@ -351,6 +301,48 @@ jobs:
           cp dist/gwtd dist/GWT.app/Contents/MacOS/gwtd
           chmod +x dist/GWT.app/Contents/MacOS/gwt
           chmod +x dist/GWT.app/Contents/MacOS/gwtd
+      - name: Prepare macOS signing keychain
+        shell: bash
+        env:
+          APPLE_CERT_APP_BASE64: ${{ secrets.APPLE_CERT_APP_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${APPLE_CERT_APP_BASE64:-}" || -z "${APPLE_CERTIFICATE_PASSWORD:-}" ]]; then
+            echo "macOS signing requires APPLE_CERT_APP_BASE64 and APPLE_CERTIFICATE_PASSWORD" >&2
+            exit 1
+          fi
+
+          KEYCHAIN_PATH="${RUNNER_TEMP}/gwt-dmg-signing.keychain-db"
+          CERT_PATH="${RUNNER_TEMP}/gwt-dmg-signing.p12"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+
+          echo "$APPLE_CERT_APP_BASE64" | base64 -D > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$CERT_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CODESIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" \
+            | awk '/Developer ID Application/ { print $2; exit }')"
+          if [[ -z "$CODESIGN_IDENTITY" ]]; then
+            echo "No Developer ID Application codesigning identity found in temporary keychain" >&2
+            exit 1
+          fi
+
+          {
+            echo "GWT_MACOS_KEYCHAIN_PATH=$KEYCHAIN_PATH"
+            echo "GWT_CODESIGN_IDENTITY=$CODESIGN_IDENTITY"
+          } >> "$GITHUB_ENV"
       - name: Sign app bundle
         shell: bash
         run: |

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,8 @@ gwt は Git worktree の管理と、`Claude Code` / `Codex` / `Gemini` /
 
 ### macOS
 
+macOS リリースには署名・notarization 済みの `gwt-macos-universal.dmg` が含まれます。
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/akiojin/gwt/main/installers/macos/install.sh | bash
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ your `PATH`.
 
 ### macOS
 
+macOS releases include a signed and notarized `gwt-macos-universal.dmg`.
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/akiojin/gwt/main/installers/macos/install.sh | bash
 ```

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -1,0 +1,398 @@
+use super::*;
+
+#[derive(Debug, Clone)]
+pub(super) struct LaunchWizardSession {
+    pub(super) tab_id: String,
+    pub(super) wizard_id: String,
+    pub(super) wizard: LaunchWizardState,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct IssueLaunchWizardPrepared {
+    pub(super) client_id: ClientId,
+    pub(super) id: String,
+    pub(super) knowledge_kind: KnowledgeKind,
+    pub(super) tab_id: String,
+    pub(super) project_root: PathBuf,
+    pub(super) issue_number: u64,
+    pub(super) result: Result<String, String>,
+}
+
+impl AppRuntime {
+    pub(super) fn open_launch_wizard(
+        &mut self,
+        id: &str,
+        branch_name: &str,
+        linked_issue_number: Option<u64>,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id).cloned() else {
+            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                id: id.to_string(),
+                message: "Window not found".to_string(),
+            })];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                id: id.to_string(),
+                message: "Project tab not found".to_string(),
+            })];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                id: id.to_string(),
+                message: "Window not found".to_string(),
+            })];
+        };
+
+        if window.preset != WindowPreset::Branches {
+            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                id: id.to_string(),
+                message: "Window is not a branches list".to_string(),
+            })];
+        }
+
+        let project_root = tab.project_root.clone();
+        let tab_id = address.tab_id.clone();
+        match self.open_launch_wizard_for_branch(
+            &tab_id,
+            &project_root,
+            branch_name,
+            linked_issue_number,
+        ) {
+            Ok(()) => vec![self.launch_wizard_state_outbound()],
+            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                id: id.to_string(),
+                message: error,
+            })],
+        }
+    }
+
+    fn open_launch_wizard_for_branch(
+        &mut self,
+        tab_id: &str,
+        project_root: &Path,
+        branch_name: &str,
+        linked_issue_number: Option<u64>,
+    ) -> Result<(), String> {
+        let normalized_branch_name = normalize_branch_name(branch_name);
+        let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
+        let wizard_id = Uuid::new_v4().to_string();
+        self.launch_wizard = Some(LaunchWizardSession {
+            tab_id: tab_id.to_string(),
+            wizard_id: wizard_id.clone(),
+            wizard: LaunchWizardState::open_loading(
+                LaunchWizardContext {
+                    selected_branch: synthetic_branch_entry(branch_name),
+                    normalized_branch_name,
+                    worktree_path: None,
+                    quick_start_root: project_root.to_path_buf(),
+                    live_sessions,
+                    docker_context: None,
+                    docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+                    linked_issue_number,
+                },
+                Vec::new(),
+            ),
+        });
+
+        let proxy = self.proxy.clone();
+        let sessions_dir = self.sessions_dir.clone();
+        let project_root = project_root.to_path_buf();
+        let branch_name = branch_name.to_string();
+        let active_session_branches = self.active_session_branches_for_tab(tab_id);
+        thread::spawn(move || {
+            let result = resolve_launch_wizard_hydration(
+                &project_root,
+                &branch_name,
+                &active_session_branches,
+                &sessions_dir,
+            );
+            proxy.send(UserEvent::LaunchWizardHydrated { wizard_id, result });
+        });
+
+        Ok(())
+    }
+
+    pub(super) fn open_issue_launch_wizard_events(
+        &mut self,
+        client_id: &str,
+        id: &str,
+        issue_number: u64,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id).cloned() else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(kind) = knowledge_kind_for_preset(window.preset) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: KnowledgeKind::Issue,
+                    message: "Window is not a knowledge bridge".to_string(),
+                },
+            )];
+        };
+
+        let project_root = tab.project_root.clone();
+        let tab_id = address.tab_id.clone();
+        let proxy = self.proxy.clone();
+        let client_id = client_id.to_string();
+        let id = id.to_string();
+        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
+        thread::spawn(move || {
+            let result =
+                list_branch_entries_with_active_sessions(&project_root, &active_session_branches)
+                    .map_err(|error| error.to_string())
+                    .and_then(|entries| {
+                        preferred_issue_launch_branch(&entries)
+                            .ok_or_else(|| "No local branch is available for launch".to_string())
+                    });
+            proxy.send(UserEvent::IssueLaunchWizardPrepared(
+                IssueLaunchWizardPrepared {
+                    client_id,
+                    id,
+                    knowledge_kind: kind,
+                    tab_id,
+                    project_root,
+                    issue_number,
+                    result,
+                },
+            ));
+        });
+        Vec::new()
+    }
+
+    pub(super) fn handle_launch_wizard_hydrated(
+        &mut self,
+        wizard_id: String,
+        result: Result<LaunchWizardHydration, String>,
+    ) -> Vec<OutboundEvent> {
+        let Some(session) = self.launch_wizard.as_mut() else {
+            return Vec::new();
+        };
+        if session.wizard_id != wizard_id {
+            return Vec::new();
+        }
+
+        match result {
+            Ok(hydration) => session.wizard.apply_hydration(hydration),
+            Err(error) => session.wizard.set_hydration_error(error),
+        }
+
+        vec![self.launch_wizard_state_outbound()]
+    }
+
+    pub(super) fn handle_issue_launch_wizard_prepared(
+        &mut self,
+        prepared: IssueLaunchWizardPrepared,
+    ) -> Vec<OutboundEvent> {
+        let IssueLaunchWizardPrepared {
+            client_id,
+            id,
+            knowledge_kind,
+            tab_id,
+            project_root,
+            issue_number,
+            result,
+        } = prepared;
+        if self.tab(&tab_id).is_none() {
+            return vec![OutboundEvent::reply(
+                &client_id,
+                BackendEvent::KnowledgeError {
+                    id,
+                    knowledge_kind,
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        }
+
+        match result {
+            Ok(branch_name) => match self.open_launch_wizard_for_branch(
+                &tab_id,
+                &project_root,
+                &branch_name,
+                Some(issue_number),
+            ) {
+                Ok(()) => vec![self.launch_wizard_state_outbound()],
+                Err(error) => vec![OutboundEvent::reply(
+                    &client_id,
+                    BackendEvent::KnowledgeError {
+                        id,
+                        knowledge_kind,
+                        message: error,
+                    },
+                )],
+            },
+            Err(error) => vec![OutboundEvent::reply(
+                &client_id,
+                BackendEvent::KnowledgeError {
+                    id,
+                    knowledge_kind,
+                    message: error,
+                },
+            )],
+        }
+    }
+
+    pub(super) fn handle_launch_wizard_action(
+        &mut self,
+        action: gwt::LaunchWizardAction,
+        bounds: Option<WindowGeometry>,
+    ) -> Vec<OutboundEvent> {
+        let Some(mut session) = self.launch_wizard.take() else {
+            return Vec::new();
+        };
+        session.wizard.apply(action);
+
+        match session.wizard.completion.take() {
+            Some(LaunchWizardCompletion::Cancelled) => {
+                vec![self.launch_wizard_state_broadcast(None)]
+            }
+            Some(LaunchWizardCompletion::FocusWindow { window_id }) => {
+                let Some(address) = self.window_lookup.get(&window_id).cloned() else {
+                    session.wizard.error =
+                        Some("The selected session window is no longer available".to_string());
+                    self.launch_wizard = Some(session);
+                    return vec![self.launch_wizard_state_outbound()];
+                };
+                let Some(tab) = self.tab_mut(&address.tab_id) else {
+                    return Vec::new();
+                };
+                if !tab.workspace.focus_window(&address.raw_id, None) {
+                    session.wizard.error =
+                        Some("The selected session window is no longer available".to_string());
+                    self.launch_wizard = Some(session);
+                    return vec![self.launch_wizard_state_outbound()];
+                }
+                self.active_tab_id = Some(address.tab_id);
+                let _ = self.persist();
+                vec![
+                    self.workspace_state_broadcast(),
+                    self.launch_wizard_state_broadcast(None),
+                ]
+            }
+            Some(LaunchWizardCompletion::Launch(config)) => match *config {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    match self.spawn_agent_window(&session.tab_id, *config, bounds) {
+                        Ok(mut events) => {
+                            events.push(self.launch_wizard_state_broadcast(None));
+                            events
+                        }
+                        Err(error) => {
+                            session.wizard.error = Some(error);
+                            self.launch_wizard = Some(session);
+                            vec![self.launch_wizard_state_outbound()]
+                        }
+                    }
+                }
+                LaunchWizardLaunchRequest::Shell(config) => {
+                    match self.spawn_wizard_shell_window(&session.tab_id, *config, bounds) {
+                        Ok(mut events) => {
+                            events.push(self.launch_wizard_state_broadcast(None));
+                            events
+                        }
+                        Err(error) => {
+                            session.wizard.error = Some(error);
+                            self.launch_wizard = Some(session);
+                            vec![self.launch_wizard_state_outbound()]
+                        }
+                    }
+                }
+            },
+            None => {
+                self.launch_wizard = Some(session);
+                vec![self.launch_wizard_state_outbound()]
+            }
+        }
+    }
+
+    pub(super) fn launch_wizard_state_outbound(&self) -> OutboundEvent {
+        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
+            wizard: self
+                .launch_wizard
+                .as_ref()
+                .map(|wizard| Box::new(wizard.wizard.view())),
+        })
+    }
+
+    pub(super) fn launch_wizard_state_broadcast(
+        &self,
+        wizard: Option<gwt::LaunchWizardView>,
+    ) -> OutboundEvent {
+        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
+            wizard: wizard.map(Box::new),
+        })
+    }
+
+    pub(super) fn clear_launch_wizard(&mut self) -> Option<LaunchWizardSession> {
+        self.launch_wizard.take()
+    }
+}
+
+fn resolve_launch_wizard_hydration(
+    project_root: &Path,
+    branch_name: &str,
+    active_session_branches: &std::collections::HashSet<String>,
+    sessions_dir: &Path,
+) -> Result<LaunchWizardHydration, String> {
+    let agent_options = build_builtin_agent_options(
+        gwt_agent::AgentDetector::detect_all(),
+        &gwt_agent::VersionCache::load(&default_wizard_version_cache_path()),
+    );
+    let entries = list_branch_entries_with_active_sessions(project_root, active_session_branches)
+        .map_err(|error| error.to_string())?;
+    let selected_branch = entries
+        .into_iter()
+        .find(|entry| entry.name == branch_name)
+        .ok_or_else(|| format!("Branch not found: {branch_name}"))?;
+    let normalized_branch_name = normalize_branch_name(&selected_branch.name);
+    let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
+    let quick_start_root = worktree_path
+        .clone()
+        .unwrap_or_else(|| project_root.to_path_buf());
+    let quick_start_entries = gwt::launch_wizard::load_quick_start_entries(
+        &quick_start_root,
+        sessions_dir,
+        &normalized_branch_name,
+    );
+    let (docker_context, docker_service_status) =
+        detect_wizard_docker_context_and_status(&quick_start_root);
+
+    Ok(LaunchWizardHydration {
+        selected_branch: Some(selected_branch),
+        normalized_branch_name,
+        worktree_path,
+        quick_start_root,
+        docker_context,
+        docker_service_status,
+        agent_options,
+        quick_start_entries,
+    })
+}

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -232,6 +232,24 @@ impl AppRuntime {
                 },
             )];
         }
+        let source_window_still_open = self
+            .window_lookup
+            .get(&id)
+            .and_then(|address| {
+                self.tab(&address.tab_id)
+                    .and_then(|tab| tab.workspace.window(&address.raw_id))
+            })
+            .is_some_and(|window| knowledge_kind_for_preset(window.preset) == Some(knowledge_kind));
+        if !source_window_still_open {
+            return vec![OutboundEvent::reply(
+                &client_id,
+                BackendEvent::KnowledgeError {
+                    id,
+                    knowledge_kind,
+                    message: "Issue/Knowledge window closed".to_string(),
+                },
+            )];
+        }
 
         match result {
             Ok(branch_name) => match self.open_launch_wizard_for_branch(
@@ -283,7 +301,10 @@ impl AppRuntime {
                     return vec![self.launch_wizard_state_outbound()];
                 };
                 let Some(tab) = self.tab_mut(&address.tab_id) else {
-                    return Vec::new();
+                    session.wizard.error =
+                        Some("The selected session tab is no longer available".to_string());
+                    self.launch_wizard = Some(session);
+                    return vec![self.launch_wizard_state_outbound()];
                 };
                 if !tab.workspace.focus_window(&address.raw_id, None) {
                     session.wizard.error =

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3929,6 +3929,7 @@ mod tests {
             )],
             Some("tab-1"),
         );
+        let issue_id = window_id_for_preset(&runtime, "tab-1", WindowPreset::Issue, 0);
         let claude_id = window_id_for_preset(&runtime, "tab-1", WindowPreset::Claude, 0);
 
         assert!(runtime
@@ -3991,7 +3992,7 @@ mod tests {
         let prepared_error =
             runtime.handle_issue_launch_wizard_prepared(super::IssueLaunchWizardPrepared {
                 client_id: "client-1".to_string(),
-                id: "issue-1".to_string(),
+                id: issue_id.clone(),
                 knowledge_kind: KnowledgeKind::Issue,
                 tab_id: "tab-1".to_string(),
                 project_root: repo.clone(),
@@ -4007,7 +4008,7 @@ mod tests {
         let prepared_ok =
             runtime.handle_issue_launch_wizard_prepared(super::IssueLaunchWizardPrepared {
                 client_id: "client-1".to_string(),
-                id: "issue-1".to_string(),
+                id: issue_id.clone(),
                 knowledge_kind: KnowledgeKind::Issue,
                 tab_id: "tab-1".to_string(),
                 project_root: repo.clone(),
@@ -4024,6 +4025,22 @@ mod tests {
                 .iter()
                 .any(|event| matches!(event, UserEvent::LaunchWizardHydrated { .. }))
         });
+        assert_eq!(runtime.close_window_events(&issue_id).len(), 1);
+        let prepared_closed =
+            runtime.handle_issue_launch_wizard_prepared(super::IssueLaunchWizardPrepared {
+                client_id: "client-1".to_string(),
+                id: issue_id.clone(),
+                knowledge_kind: KnowledgeKind::Issue,
+                tab_id: "tab-1".to_string(),
+                project_root: repo.clone(),
+                issue_number: 7,
+                result: Ok("feature/demo".to_string()),
+            });
+        assert!(matches!(
+            prepared_closed[0].event,
+            BackendEvent::KnowledgeError { ref message, .. }
+                if message == "Issue/Knowledge window closed"
+        ));
 
         runtime.launch_wizard = None;
         assert!(runtime
@@ -4043,6 +4060,51 @@ mod tests {
             None,
         );
         assert!(!missing_focus.is_empty());
+        runtime.window_lookup.insert(
+            "stale-focus".to_string(),
+            WindowAddress {
+                tab_id: "missing".to_string(),
+                raw_id: "claude-1".to_string(),
+            },
+        );
+        runtime.launch_wizard = Some(LaunchWizardSession {
+            tab_id: "tab-1".to_string(),
+            wizard_id: "wizard-stale-focus".to_string(),
+            wizard: LaunchWizardState::open_with(
+                LaunchWizardContext {
+                    selected_branch: sample_branch_entry("feature/demo"),
+                    normalized_branch_name: "feature/demo".to_string(),
+                    worktree_path: Some(repo.clone()),
+                    quick_start_root: repo.clone(),
+                    live_sessions: vec![gwt::LiveSessionEntry {
+                        session_id: "session-1".to_string(),
+                        window_id: "stale-focus".to_string(),
+                        agent_id: "codex".to_string(),
+                        kind: "agent".to_string(),
+                        name: "Codex".to_string(),
+                        detail: Some(repo.display().to_string()),
+                        active: true,
+                    }],
+                    docker_context: None,
+                    docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+                    linked_issue_number: Some(42),
+                },
+                sample_wizard_agent_options(),
+                Vec::new(),
+            ),
+        });
+        let stale_tab_focus = runtime.handle_launch_wizard_action(
+            LaunchWizardAction::FocusExistingSession { index: 0 },
+            None,
+        );
+        assert_eq!(stale_tab_focus.len(), 1);
+        assert_eq!(
+            runtime
+                .launch_wizard
+                .as_ref()
+                .and_then(|session| session.wizard.error.as_deref()),
+            Some("The selected session tab is no longer available")
+        );
 
         runtime.launch_wizard = Some(sample_focus_launch_wizard_session(
             "tab-1",

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -47,7 +47,10 @@ use uuid::Uuid;
 use wry::WebViewBuilder;
 
 mod embedded_web;
+mod launch_wizard_runtime;
 mod repo_browser;
+
+use launch_wizard_runtime::{IssueLaunchWizardPrepared, LaunchWizardSession};
 
 type ClientId = String;
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
@@ -312,24 +315,6 @@ struct ProjectTabRuntime {
 struct WindowAddress {
     tab_id: String,
     raw_id: String,
-}
-
-#[derive(Debug, Clone)]
-struct LaunchWizardSession {
-    tab_id: String,
-    wizard_id: String,
-    wizard: LaunchWizardState,
-}
-
-#[derive(Debug, Clone)]
-struct IssueLaunchWizardPrepared {
-    client_id: ClientId,
-    id: String,
-    knowledge_kind: KnowledgeKind,
-    tab_id: String,
-    project_root: PathBuf,
-    issue_number: u64,
-    result: Result<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1314,320 +1299,6 @@ fn spawn_branch_cleanup_async(
 }
 
 impl AppRuntime {
-    fn open_launch_wizard(
-        &mut self,
-        id: &str,
-        branch_name: &str,
-        linked_issue_number: Option<u64>,
-    ) -> Vec<OutboundEvent> {
-        let Some(address) = self.window_lookup.get(id).cloned() else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            })];
-        };
-        let Some(tab) = self.tab(&address.tab_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Project tab not found".to_string(),
-            })];
-        };
-        let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            })];
-        };
-
-        if window.preset != WindowPreset::Branches {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window is not a branches list".to_string(),
-            })];
-        }
-
-        let project_root = tab.project_root.clone();
-        let tab_id = address.tab_id.clone();
-        match self.open_launch_wizard_for_branch(
-            &tab_id,
-            &project_root,
-            branch_name,
-            linked_issue_number,
-        ) {
-            Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: error,
-            })],
-        }
-    }
-
-    fn open_launch_wizard_for_branch(
-        &mut self,
-        tab_id: &str,
-        project_root: &Path,
-        branch_name: &str,
-        linked_issue_number: Option<u64>,
-    ) -> Result<(), String> {
-        let normalized_branch_name = normalize_branch_name(branch_name);
-        let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
-        let wizard_id = Uuid::new_v4().to_string();
-        self.launch_wizard = Some(LaunchWizardSession {
-            tab_id: tab_id.to_string(),
-            wizard_id: wizard_id.clone(),
-            wizard: LaunchWizardState::open_loading(
-                LaunchWizardContext {
-                    selected_branch: synthetic_branch_entry(branch_name),
-                    normalized_branch_name,
-                    worktree_path: None,
-                    quick_start_root: project_root.to_path_buf(),
-                    live_sessions,
-                    docker_context: None,
-                    docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
-                    linked_issue_number,
-                },
-                Vec::new(),
-            ),
-        });
-
-        let proxy = self.proxy.clone();
-        let sessions_dir = self.sessions_dir.clone();
-        let project_root = project_root.to_path_buf();
-        let branch_name = branch_name.to_string();
-        let active_session_branches = self.active_session_branches_for_tab(tab_id);
-        thread::spawn(move || {
-            let result = resolve_launch_wizard_hydration(
-                &project_root,
-                &branch_name,
-                &active_session_branches,
-                &sessions_dir,
-            );
-            proxy.send(UserEvent::LaunchWizardHydrated { wizard_id, result });
-        });
-
-        Ok(())
-    }
-
-    fn open_issue_launch_wizard_events(
-        &mut self,
-        client_id: &str,
-        id: &str,
-        issue_number: u64,
-    ) -> Vec<OutboundEvent> {
-        let Some(address) = self.window_lookup.get(id).cloned() else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::KnowledgeError {
-                    id: id.to_string(),
-                    knowledge_kind: KnowledgeKind::Issue,
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        let Some(tab) = self.tab(&address.tab_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::KnowledgeError {
-                    id: id.to_string(),
-                    knowledge_kind: KnowledgeKind::Issue,
-                    message: "Project tab not found".to_string(),
-                },
-            )];
-        };
-        let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::KnowledgeError {
-                    id: id.to_string(),
-                    knowledge_kind: KnowledgeKind::Issue,
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        let Some(kind) = knowledge_kind_for_preset(window.preset) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::KnowledgeError {
-                    id: id.to_string(),
-                    knowledge_kind: KnowledgeKind::Issue,
-                    message: "Window is not a knowledge bridge".to_string(),
-                },
-            )];
-        };
-
-        let project_root = tab.project_root.clone();
-        let tab_id = address.tab_id.clone();
-        let proxy = self.proxy.clone();
-        let client_id = client_id.to_string();
-        let id = id.to_string();
-        let active_session_branches = self.active_session_branches_for_tab(&address.tab_id);
-        thread::spawn(move || {
-            let result =
-                list_branch_entries_with_active_sessions(&project_root, &active_session_branches)
-                    .map_err(|error| error.to_string())
-                    .and_then(|entries| {
-                        preferred_issue_launch_branch(&entries)
-                            .ok_or_else(|| "No local branch is available for launch".to_string())
-                    });
-            proxy.send(UserEvent::IssueLaunchWizardPrepared(
-                IssueLaunchWizardPrepared {
-                    client_id,
-                    id,
-                    knowledge_kind: kind,
-                    tab_id,
-                    project_root,
-                    issue_number,
-                    result,
-                },
-            ));
-        });
-        Vec::new()
-    }
-
-    fn handle_launch_wizard_hydrated(
-        &mut self,
-        wizard_id: String,
-        result: Result<LaunchWizardHydration, String>,
-    ) -> Vec<OutboundEvent> {
-        let Some(session) = self.launch_wizard.as_mut() else {
-            return Vec::new();
-        };
-        if session.wizard_id != wizard_id {
-            return Vec::new();
-        }
-
-        match result {
-            Ok(hydration) => session.wizard.apply_hydration(hydration),
-            Err(error) => session.wizard.set_hydration_error(error),
-        }
-
-        vec![self.launch_wizard_state_outbound()]
-    }
-
-    fn handle_issue_launch_wizard_prepared(
-        &mut self,
-        prepared: IssueLaunchWizardPrepared,
-    ) -> Vec<OutboundEvent> {
-        let IssueLaunchWizardPrepared {
-            client_id,
-            id,
-            knowledge_kind,
-            tab_id,
-            project_root,
-            issue_number,
-            result,
-        } = prepared;
-        if self.tab(&tab_id).is_none() {
-            return vec![OutboundEvent::reply(
-                &client_id,
-                BackendEvent::KnowledgeError {
-                    id,
-                    knowledge_kind,
-                    message: "Project tab not found".to_string(),
-                },
-            )];
-        }
-
-        match result {
-            Ok(branch_name) => match self.open_launch_wizard_for_branch(
-                &tab_id,
-                &project_root,
-                &branch_name,
-                Some(issue_number),
-            ) {
-                Ok(()) => vec![self.launch_wizard_state_outbound()],
-                Err(error) => vec![OutboundEvent::reply(
-                    &client_id,
-                    BackendEvent::KnowledgeError {
-                        id,
-                        knowledge_kind,
-                        message: error,
-                    },
-                )],
-            },
-            Err(error) => vec![OutboundEvent::reply(
-                &client_id,
-                BackendEvent::KnowledgeError {
-                    id,
-                    knowledge_kind,
-                    message: error,
-                },
-            )],
-        }
-    }
-
-    fn handle_launch_wizard_action(
-        &mut self,
-        action: gwt::LaunchWizardAction,
-        bounds: Option<WindowGeometry>,
-    ) -> Vec<OutboundEvent> {
-        let Some(mut session) = self.launch_wizard.take() else {
-            return Vec::new();
-        };
-        session.wizard.apply(action);
-
-        match session.wizard.completion.take() {
-            Some(LaunchWizardCompletion::Cancelled) => {
-                vec![self.launch_wizard_state_broadcast(None)]
-            }
-            Some(LaunchWizardCompletion::FocusWindow { window_id }) => {
-                let Some(address) = self.window_lookup.get(&window_id).cloned() else {
-                    session.wizard.error =
-                        Some("The selected session window is no longer available".to_string());
-                    self.launch_wizard = Some(session);
-                    return vec![self.launch_wizard_state_outbound()];
-                };
-                let Some(tab) = self.tab_mut(&address.tab_id) else {
-                    return Vec::new();
-                };
-                if !tab.workspace.focus_window(&address.raw_id, None) {
-                    session.wizard.error =
-                        Some("The selected session window is no longer available".to_string());
-                    self.launch_wizard = Some(session);
-                    return vec![self.launch_wizard_state_outbound()];
-                }
-                self.active_tab_id = Some(address.tab_id);
-                let _ = self.persist();
-                vec![
-                    self.workspace_state_broadcast(),
-                    self.launch_wizard_state_broadcast(None),
-                ]
-            }
-            Some(LaunchWizardCompletion::Launch(config)) => match *config {
-                LaunchWizardLaunchRequest::Agent(config) => {
-                    match self.spawn_agent_window(&session.tab_id, *config, bounds) {
-                        Ok(mut events) => {
-                            events.push(self.launch_wizard_state_broadcast(None));
-                            events
-                        }
-                        Err(error) => {
-                            session.wizard.error = Some(error);
-                            self.launch_wizard = Some(session);
-                            vec![self.launch_wizard_state_outbound()]
-                        }
-                    }
-                }
-                LaunchWizardLaunchRequest::Shell(config) => {
-                    match self.spawn_wizard_shell_window(&session.tab_id, *config, bounds) {
-                        Ok(mut events) => {
-                            events.push(self.launch_wizard_state_broadcast(None));
-                            events
-                        }
-                        Err(error) => {
-                            session.wizard.error = Some(error);
-                            self.launch_wizard = Some(session);
-                            vec![self.launch_wizard_state_outbound()]
-                        }
-                    }
-                }
-            },
-            None => {
-                self.launch_wizard = Some(session);
-                vec![self.launch_wizard_state_outbound()]
-            }
-        }
-    }
-
     fn live_sessions_for_branch(&self, tab_id: &str, branch_name: &str) -> Vec<LiveSessionEntry> {
         let mut entries = self
             .active_agent_sessions
@@ -2462,24 +2133,6 @@ impl AppRuntime {
         })
     }
 
-    fn launch_wizard_state_outbound(&self) -> OutboundEvent {
-        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
-            wizard: self
-                .launch_wizard
-                .as_ref()
-                .map(|wizard| Box::new(wizard.wizard.view())),
-        })
-    }
-
-    fn launch_wizard_state_broadcast(
-        &self,
-        wizard: Option<gwt::LaunchWizardView>,
-    ) -> OutboundEvent {
-        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
-            wizard: wizard.map(Box::new),
-        })
-    }
-
     fn window_status(&self, window_id: &str) -> Option<WindowProcessStatus> {
         let address = self.window_lookup.get(window_id)?;
         let tab = self.tab(&address.tab_id)?;
@@ -2547,10 +2200,6 @@ impl AppRuntime {
             self.launch_wizard = None;
         }
         wizard_closed
-    }
-
-    fn clear_launch_wizard(&mut self) -> Option<LaunchWizardSession> {
-        self.launch_wizard.take()
     }
 
     fn rebuild_window_lookup(&mut self) {
@@ -6156,47 +5805,6 @@ fn synthetic_branch_entry(branch_name: &str) -> BranchListEntry {
         cleanup_ready: true,
         cleanup: gwt::BranchCleanupInfo::default(),
     }
-}
-
-fn resolve_launch_wizard_hydration(
-    project_root: &Path,
-    branch_name: &str,
-    active_session_branches: &std::collections::HashSet<String>,
-    sessions_dir: &Path,
-) -> Result<LaunchWizardHydration, String> {
-    let agent_options = build_builtin_agent_options(
-        gwt_agent::AgentDetector::detect_all(),
-        &gwt_agent::VersionCache::load(&default_wizard_version_cache_path()),
-    );
-    let entries = list_branch_entries_with_active_sessions(project_root, active_session_branches)
-        .map_err(|error| error.to_string())?;
-    let selected_branch = entries
-        .into_iter()
-        .find(|entry| entry.name == branch_name)
-        .ok_or_else(|| format!("Branch not found: {branch_name}"))?;
-    let normalized_branch_name = normalize_branch_name(&selected_branch.name);
-    let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
-    let quick_start_root = worktree_path
-        .clone()
-        .unwrap_or_else(|| project_root.to_path_buf());
-    let quick_start_entries = gwt::launch_wizard::load_quick_start_entries(
-        &quick_start_root,
-        sessions_dir,
-        &normalized_branch_name,
-    );
-    let (docker_context, docker_service_status) =
-        detect_wizard_docker_context_and_status(&quick_start_root);
-
-    Ok(LaunchWizardHydration {
-        selected_branch: Some(selected_branch),
-        normalized_branch_name,
-        worktree_path,
-        quick_start_root,
-        docker_context,
-        docker_service_status,
-        agent_options,
-        quick_start_entries,
-    })
 }
 
 fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> {

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -77,6 +77,8 @@ run("release workflow signs and notarizes macOS distribution assets", () => {
   assert.match(workflow, /APPLE_ID_PASSWORD/);
   assert.match(workflow, /APPLE_TEAM_ID/);
   assert.match(workflow, /security create-keychain/);
+  assert.doesNotMatch(workflow, /base64 --decode/);
+  assert.equal((workflow.match(/base64 -D/g) || []).length, 2);
   assert.match(workflow, /codesign --force --options runtime --timestamp --sign/);
   assert.match(workflow, /xcrun notarytool submit/);
   assert.match(workflow, /xcrun stapler staple/);

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -72,12 +72,15 @@ run("release workflow signs and notarizes macOS distribution assets", () => {
     path.join(__dirname, "..", ".github", "workflows", "release.yml"),
     "utf8"
   );
+  const buildDmgSection = workflow.split("  build-dmg:\n")[1];
   assert.match(workflow, /APPLE_CERT_APP_BASE64/);
   assert.match(workflow, /APPLE_CERTIFICATE_PASSWORD/);
+  assert.match(workflow, /--apple-id\s+"\$APPLE_ID"/);
   assert.match(workflow, /APPLE_ID_PASSWORD/);
   assert.match(workflow, /APPLE_TEAM_ID/);
   assert.match(workflow, /security create-keychain/);
   assert.doesNotMatch(workflow, /base64 --decode/);
+  assert.doesNotMatch(workflow, /awk 'NR == 1/);
   assert.equal((workflow.match(/base64 -D/g) || []).length, 2);
   assert.match(workflow, /codesign --force --options runtime --timestamp --sign/);
   assert.match(workflow, /xcrun notarytool submit/);
@@ -85,6 +88,14 @@ run("release workflow signs and notarizes macOS distribution assets", () => {
   assert.match(workflow, /xcrun stapler validate/);
   assert.match(workflow, /spctl --assess/);
   assert.match(workflow, /hdiutil attach/);
+  assert.ok(
+    buildDmgSection.indexOf("Build gwt bundle binaries for x86_64") <
+      buildDmgSection.indexOf("Prepare macOS signing keychain")
+  );
+  assert.ok(
+    buildDmgSection.indexOf("Prepare macOS signing keychain") <
+      buildDmgSection.indexOf("Sign app bundle")
+  );
 });
 
 run("portable tarball extraction installs the unix bundle", () => {

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -67,6 +67,24 @@ run("release workflow packages gwtd alongside gwt", () => {
   assert.match(workflow, /Contents\/MacOS\/gwtd/);
 });
 
+run("release workflow signs and notarizes macOS distribution assets", () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, "..", ".github", "workflows", "release.yml"),
+    "utf8"
+  );
+  assert.match(workflow, /APPLE_CERT_APP_BASE64/);
+  assert.match(workflow, /APPLE_CERTIFICATE_PASSWORD/);
+  assert.match(workflow, /APPLE_ID_PASSWORD/);
+  assert.match(workflow, /APPLE_TEAM_ID/);
+  assert.match(workflow, /security create-keychain/);
+  assert.match(workflow, /codesign --force --options runtime --timestamp --sign/);
+  assert.match(workflow, /xcrun notarytool submit/);
+  assert.match(workflow, /xcrun stapler staple/);
+  assert.match(workflow, /xcrun stapler validate/);
+  assert.match(workflow, /spctl --assess/);
+  assert.match(workflow, /hdiutil attach/);
+});
+
 run("portable tarball extraction installs the unix bundle", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "gwt-release-test-"));
   const sourceDir = path.join(root, "source");


### PR DESCRIPTION
## Summary

- Sign and notarize macOS release assets so the published DMG matches the expected installer trust contract.
- Preserve the existing `gwt-macos-universal.dmg` asset name while using the configured Apple signing secrets.

## Changes

- `.github/workflows/release.yml`: imports `APPLE_CERT_APP_BASE64` into a temporary keychain, signs macOS binaries and `GWT.app`, signs/notarizes/staples the DMG, and validates the mounted DMG contents.
- `scripts/test_release_assets.cjs`: adds a release workflow contract test for codesign, notarytool, stapler, Gatekeeper, and DMG mount validation.
- `README.md` / `README.ja.md`: documents that macOS releases include a signed and notarized DMG.
- `SPEC-2041`: updates spec, plan, and tasks with the signed/notarized DMG contract.

## Testing

- [x] `node scripts/test_release_assets.cjs` — release asset contract tests pass.
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml', encoding='utf-8')); print('yaml ok')"` — release workflow YAML parses.
- [x] `git diff --check origin/develop...HEAD` — no whitespace errors.
- [x] `cargo fmt --all -- --check` — Rust formatting is clean.
- [x] `pnpm dlx markdownlint-cli2 README.md README.ja.md --config .markdownlint.json` — README markdown lint passes.
- [x] `cargo test -p gwt-core -p gwt` — Rust tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clippy passes.
- [x] `cargo build -p gwt` — gwt builds.
- [x] `bunx commitlint --from origin/develop --to HEAD` — PR commits pass commitlint.

## Closing Issues

None

## Related Issues / Links

- #2045
- #2041

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, markdownlint)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (not required; release workflow only)
- [x] CHANGELOG impact considered (patch-level release fix)

## Context

- The previous GUI release flow signed and notarized the macOS DMG through a temporary keychain and Developer ID Application certificate. The current release workflow had regressed to unsigned DMG creation, even though the repository has the required `APPLE_*` secrets.

## Risk / Impact

- **Affected areas**: GitHub Actions release jobs for macOS portable archives and `gwt-macos-universal.dmg`.
- **Rollback plan**: revert this PR to restore the previous unsigned DMG workflow.

## Deployment

- Standard release workflow. The implementation expects the existing `APPLE_CERT_APP_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, and `APPLE_TEAM_ID` secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS releases are now signed and notarized, enhancing security and trust.

* **Documentation**
  * Updated release notes in README files documenting signed and notarized macOS distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->