### PR TITLE
fix: Windows で npx 経由のエージェント起動が node.exe: bad option: --yes で失敗する問題を修正

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -157,23 +157,43 @@ pub fn resolve_runner(agent_id: &AgentId, version: &str) -> ResolvedRunner {
     }
 }
 
+/// Platform-specific priority list of package-runner executables to probe via
+/// `which::which`. Each entry is `(name, needs_yes)`.
+///
+/// On Windows, `.cmd` variants come first because `which::which` returns the
+/// bare POSIX-shim sibling first (see SPEC-1921 FR-080). `CreateProcess` can
+/// execute `.cmd` directly (via `cmd.exe` wrapping); the bare bash shim
+/// cannot. On non-Windows platforms the bare names are the canonical entry.
+fn package_runner_candidates() -> &'static [(&'static str, bool)] {
+    #[cfg(windows)]
+    {
+        &[
+            ("bunx.cmd", false),
+            ("bunx", false),
+            ("npx.cmd", true),
+            ("npx", true),
+        ]
+    }
+    #[cfg(not(windows))]
+    {
+        &[("bunx", false), ("npx", true)]
+    }
+}
+
 /// Find bunx or npx executable, preferring global bunx over local node_modules.
 ///
 /// Returns `(executable_name, needs_yes_flag)`.
 /// - bunx: no `--yes` needed
 /// - npx: `--yes` needed to suppress interactive prompt
 fn find_bunx_or_npx() -> (String, bool) {
-    // Try bunx first, but skip if it's a local node_modules/.bin/bunx
-    if let Ok(path) = which::which("bunx") {
-        let path_str = path.to_string_lossy();
-        if !path_str.contains("node_modules") {
-            return (path.to_string_lossy().into_owned(), false);
+    for (name, needs_yes) in package_runner_candidates() {
+        if let Ok(path) = which::which(name) {
+            let path_str = path.to_string_lossy();
+            if path_str.contains("node_modules") {
+                continue;
+            }
+            return (path_str.into_owned(), *needs_yes);
         }
-    }
-
-    // Fall back to npx (needs --yes)
-    if let Ok(path) = which::which("npx") {
-        return (path.to_string_lossy().into_owned(), true);
     }
 
     // Last resort: assume bunx is available
@@ -1139,6 +1159,33 @@ mod tests {
         let runner = resolve_runner(&AgentId::OpenCode, "latest");
         assert_eq!(runner.executable, "opencode");
         assert!(runner.base_args.is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_package_runner_candidates_prefer_cmd_variants() {
+        // SPEC-1921 FR-080. On Windows we must consult `bunx.cmd` / `npx.cmd`
+        // before the POSIX-shim bare-name siblings, because `which::which`
+        // returns the bare name first and that file is not spawnable through
+        // `CreateProcess` on its own.
+        let candidates = package_runner_candidates();
+        let names: Vec<&str> = candidates.iter().map(|(name, _)| *name).collect();
+
+        assert_eq!(names, vec!["bunx.cmd", "bunx", "npx.cmd", "npx"]);
+
+        let needs_yes: Vec<bool> = candidates.iter().map(|(_, yes)| *yes).collect();
+        assert_eq!(needs_yes, vec![false, false, true, true]);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn nonwindows_package_runner_candidates_use_bare_names() {
+        let candidates = package_runner_candidates();
+        let names: Vec<&str> = candidates.iter().map(|(name, _)| *name).collect();
+        assert_eq!(names, vec!["bunx", "npx"]);
+
+        let needs_yes: Vec<bool> = candidates.iter().map(|(_, yes)| *yes).collect();
+        assert_eq!(needs_yes, vec![false, true]);
     }
 
     #[test]

--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -1034,15 +1034,8 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_nodejs_distribution_npx_shim_does_not_collapse_to_node_exe() {
-        // Regression for `node.exe: bad option: --yes` on Windows launches of
-        // `npx --yes @pkg@version`. SPEC-1921 FR-081.
-        //
-        // Node.js's installer ships `npx` as a POSIX shell script whose
-        // $basedir lookup only locates `node.exe` -- the actual CLI script
-        // path is dereferenced via a separate `$CLI_BASEDIR` variable, so our
-        // `$basedir/`-marker scan never pairs it with `npx-cli.js`. The parser
-        // must refuse to substitute `node.exe` alone and fall back to the
-        // `.cmd` sibling.
+        // Regression for `node.exe: bad option: --yes` (SPEC-1921 FR-081).
+        // Mechanism is documented in `build_windows_shim_target`.
         let temp = tempfile::tempdir().expect("tempdir");
         let bin_dir = temp.path().join("Program Files").join("nodejs");
         std::fs::create_dir_all(&bin_dir).expect("bin dir");

--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -346,11 +346,15 @@ fn windows_spawn_wrapper(
     let comspec = windows_env_value("ComSpec", env, remove_env)
         .unwrap_or_else(|| std::ffi::OsString::from("cmd.exe"));
 
+    // SPEC-1921 FR-082: Do NOT pass `/s`. `/s` forces CMD to strip the
+    // quotes that surround the executable path, which breaks invocations
+    // with whitespace in the path (e.g. `C:\Program Files\nodejs\npx.cmd`).
+    // Without `/s`, CMD's default rule preserves the quotes when the
+    // command line has the typical `"<exe>" <args>` shape we emit here.
     Some((
         PathBuf::from(comspec).display().to_string(),
         vec![
             "/d".to_string(),
-            "/s".to_string(),
             "/c".to_string(),
             resolved.display().to_string(),
         ],
@@ -434,6 +438,15 @@ fn build_windows_shim_target(base_dir: &Path, raw_paths: &[String]) -> Option<Wi
                 args_prefix: vec![script.display().to_string()],
             })
         }
+        // SPEC-1921 FR-081: Node.js distribution shims (e.g.
+        // `C:\Program Files\nodejs\npx`) reference `$basedir/node.exe` but
+        // dereference the CLI script via a separate variable such as
+        // `$CLI_BASEDIR`. Our marker scan never pairs node with a `.js`
+        // script in that case. Substituting `node.exe` alone would drop the
+        // script and pass the caller's agent args (`--yes @pkg@version ...`)
+        // straight to node, yielding `bad option: --yes`. Refuse the
+        // substitution so resolution falls back to the `.cmd` sibling.
+        (Some(executable), None) if windows_is_node_runtime(&executable) => None,
         (Some(executable), _) if executable.exists() => Some(WindowsSpawnTarget {
             command: executable.display().to_string(),
             args_prefix: Vec::new(),
@@ -807,7 +820,6 @@ mod tests {
             normalized.args,
             vec![
                 "/d".to_string(),
-                "/s".to_string(),
                 "/c".to_string(),
                 cmd.display().to_string(),
                 "--dangerously-skip-permissions".to_string(),
@@ -1017,5 +1029,123 @@ mod tests {
 
         let handle = PtyHandle::spawn(config).expect("spawn failed");
         assert!(handle.process_id().is_some(), "expected spawned process id");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_nodejs_distribution_npx_shim_does_not_collapse_to_node_exe() {
+        // Regression for `node.exe: bad option: --yes` on Windows launches of
+        // `npx --yes @pkg@version`. SPEC-1921 FR-081.
+        //
+        // Node.js's installer ships `npx` as a POSIX shell script whose
+        // $basedir lookup only locates `node.exe` -- the actual CLI script
+        // path is dereferenced via a separate `$CLI_BASEDIR` variable, so our
+        // `$basedir/`-marker scan never pairs it with `npx-cli.js`. The parser
+        // must refuse to substitute `node.exe` alone and fall back to the
+        // `.cmd` sibling.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("Program Files").join("nodejs");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+
+        let npx_shim = bin_dir.join("npx");
+        let npx_cmd = bin_dir.join("npx.cmd");
+        let node_exe = bin_dir.join("node.exe");
+        std::fs::write(&node_exe, "not-a-real-pe").expect("node exe placeholder");
+        std::fs::write(
+            &npx_shim,
+            concat!(
+                "#!/usr/bin/env bash\n",
+                "basedir=`dirname \"$0\"`\n",
+                "NODE_EXE=\"$basedir/node.exe\"\n",
+                "if ! [ -x \"$NODE_EXE\" ]; then\n",
+                "  NODE_EXE=\"$basedir/node\"\n",
+                "fi\n",
+                "CLI_BASEDIR=\"$(\"$NODE_EXE\" -p 'require(\"path\").dirname(process.execPath)' 2> /dev/null)\"\n",
+                "NPX_CLI_JS=\"$CLI_BASEDIR/node_modules/npm/bin/npx-cli.js\"\n",
+                "\"$NODE_EXE\" \"$NPX_CLI_JS\" \"$@\"\n",
+            ),
+        )
+        .expect("npx shim");
+        std::fs::write(
+            &npx_cmd,
+            concat!(
+                "@ECHO OFF\n",
+                "SET \"NODE_EXE=%~dp0\\node.exe\"\n",
+                "\"%NODE_EXE%\" \"%~dp0\\node_modules\\npm\\bin\\npx-cli.js\" %*\n",
+            ),
+        )
+        .expect("npx.cmd");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), bin_dir.display().to_string());
+        env.insert("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string());
+
+        let normalized = normalize_windows_spawn_config(SpawnConfig {
+            command: "npx".to_string(),
+            args: vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+            ],
+            cols: 80,
+            rows: 24,
+            env,
+            remove_env: Vec::new(),
+            cwd: None,
+        });
+
+        assert_ne!(
+            normalized.command,
+            node_exe.display().to_string(),
+            "parser must not collapse a Node.js distribution shim to node.exe alone (FR-081): {:?} {:?}",
+            normalized.command,
+            normalized.args,
+        );
+        // The original agent args must survive unchanged somewhere in argv so
+        // they still reach npx, not node.exe.
+        assert!(
+            normalized
+                .args
+                .iter()
+                .any(|a| a == "@anthropic-ai/claude-code@latest"),
+            "expected original package spec preserved in argv, got {:?}",
+            normalized.args,
+        );
+        assert!(
+            normalized.args.iter().any(|a| a == "--yes"),
+            "expected --yes preserved in argv, got {:?}",
+            normalized.args,
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_cmd_wrapper_omits_slash_s_flag() {
+        // SPEC-1921 FR-082. `/s` makes CMD strip the quoting around the
+        // executable path, which breaks `.cmd` invocations where the path
+        // contains spaces (for example `C:\Program Files\nodejs\npx.cmd`).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("Program Files").join("nodejs");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let cmd_path = bin_dir.join("npx.cmd");
+        std::fs::write(&cmd_path, "@echo off\n").expect("cmd");
+
+        let env: HashMap<String, String> = HashMap::new();
+        let wrapped = windows_spawn_wrapper(&cmd_path, &env, &[]).expect("wrapper");
+
+        assert!(
+            !wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/s")),
+            "cmd.exe wrapper must not include /s (FR-082), got argv {:?}",
+            wrapped.1,
+        );
+        assert!(
+            wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/d")),
+            "wrapper should still include /d, got {:?}",
+            wrapped.1,
+        );
+        assert!(
+            wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/c")),
+            "wrapper should still include /c, got {:?}",
+            wrapped.1,
+        );
     }
 }


### PR DESCRIPTION
## Summary

Windows で `npx --yes @anthropic-ai/claude-code@latest` のようにエージェントを
起動すると `C:\Program Files\nodejs\node.exe: bad option: --yes` で失敗する
バグを修正する。develop に反映して通常フロー (develop → release → main) に
戻す補填 PR。

## 経緯

- 初回修正は誤って main ターゲットで PR #2116 (MERGED) を作成し、
  `check-source-branch` CI が `PRs to main must come from the 'develop'
  branch only.` で FAILURE。リポジトリ規約違反のまま merge された。
- 本 PR は同一ブランチから develop ターゲットで同じ 3 コミットを取り込み、
  通常のリリースフローに合流させる。

## 根本原因

1. `which::which("npx")` は Windows でも拡張子なしの POSIX bash スクリプト
   `C:\Program Files\nodejs\npx` を PATHEXT 付き候補より先に返す (which v8
   finder.rs:225-248 確認済)。
2. `crates/gwt-terminal/src/pty.rs::parse_windows_shell_shim` はこの bash
   スクリプトから `$basedir/node.exe` のみを抽出し、CLI スクリプト本体が
   `$CLI_BASEDIR/...` 経由で参照されているため `.js` の paired path を
   認識できない。
3. `build_windows_shim_target` が node ランタイム単体へ collapse し、
   `node.exe --yes @pkg@ver` を spawn してしまう。
4. 加えて cmd wrapper の `/s` フラグがパス内空白で quote を剥がすため
   `C:\Program Files\nodejs\npx.cmd` 経路でも failure が起きる。

## 変更内容

### SPEC 更新 (GitHub Issue #1921 は既に更新済み)

- US-1 に Acceptance Scenario 9 を追加。
- FR-080 / FR-081 / FR-082 を追加。

### コード

| File | Change | FR |
|------|--------|----|
| `crates/gwt-agent/src/launch.rs` | `package_runner_candidates()` を導入し Windows で `bunx.cmd → bunx → npx.cmd → npx` の順に解決 | FR-080 |
| `crates/gwt-terminal/src/pty.rs` | `build_windows_shim_target` に node-without-script ガード追加 | FR-081 |
| `crates/gwt-terminal/src/pty.rs` | `windows_spawn_wrapper` の argv から `/s` を削除 | FR-082 |

### テスト

- `pty::tests::windows_nodejs_distribution_npx_shim_does_not_collapse_to_node_exe` (新規)
- `pty::tests::windows_cmd_wrapper_omits_slash_s_flag` (新規)
- `launch::tests::windows_package_runner_candidates_prefer_cmd_variants` (新規)
- `launch::tests::nonwindows_package_runner_candidates_use_bare_names` (新規)
- 既存 `pty::tests::windows_wraps_cmd_shims_with_comspec` を新 argv に合わせて更新

### コミット

1. `fix(agent): prefer .cmd variants of bunx/npx on Windows`
2. `fix(terminal): harden Windows shim resolution for Node.js distribution shims`
3. `refactor(terminal): trim duplicate narrative from npx shim regression test`

## Closing Issues

None

## Related Issues

- SPEC-1921 (agent launch resolution owner)
- PR #2116 (先行して main に merge 済み。本 PR で develop を同期)

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p gwt-agent -p gwt-terminal --all-targets --all-features -- -D warnings`
- [x] `cargo test -p gwt-agent --lib` — 150/150 passed
- [x] `cargo test -p gwt-terminal --lib windows_ -- --test-threads=1` — 9/9 passed
- [x] `cargo test -p gwt-core --lib` — 142/142 passed
- [x] `cargo test -p gwt --lib` — 206/206 passed
- [ ] Windows 実機で Launch Wizard から Claude Code を `latest` で起動し、
      PTY で claude プロンプトが正常表示されることを確認

## Checklist

- [x] コミットメッセージが Conventional Commits 準拠
- [x] SPEC-1921 (GitHub Issue #1921) 更新済み
- [x] 単体テスト追加 (Windows gated)
- [x] 既存テストの破壊なし (Windows gated 9/9 通過)
- [ ] Windows 実機 E2E 手動確認 (リリース前に実施)
