### PR TITLE
feat(gui): implement profile window management

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -276,4 +276,30 @@ mod tests {
             "expected issue launch wizard event in embedded html",
         );
     }
+
+    #[test]
+    fn embedded_web_profile_surface_uses_config_backed_contract() {
+        let html = index_html();
+
+        assert!(
+            html.contains("profile-root"),
+            "expected Profile window to render a dedicated non-mock root",
+        );
+        assert!(
+            html.contains("list_profiles"),
+            "expected Profile window to request a backend profile snapshot",
+        );
+        assert!(
+            html.contains("profile_snapshot"),
+            "expected Profile window to handle backend profile snapshots",
+        );
+        assert!(
+            html.contains("profile-add"),
+            "expected Profile window to expose inline profile add controls",
+        );
+        assert!(
+            html.contains("profile-merged-env"),
+            "expected Profile window to expose an effective environment preview",
+        );
+    }
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -14,6 +14,8 @@ pub mod managed_assets;
 pub mod native_app;
 pub mod persistence;
 pub mod preset;
+pub mod profiles_dispatch;
+pub mod profiles_service;
 pub mod protocol;
 pub mod workspace;
 
@@ -63,8 +65,15 @@ pub use preset::{
     detect_shell_program, resolve_launch_spec, LaunchSpec, PresetResolveError, ShellProgram,
     WindowPreset, WindowSurface,
 };
+pub use profiles_service::{
+    add_disabled_env, add_profile, delete_disabled_env, delete_env_var, delete_profile,
+    load_profile_snapshot, set_env_var, switch_profile, update_disabled_env, update_env_var,
+    update_profile, ProfileEnvVarSource, ProfileEnvVarView, ProfileServiceError, ProfileSnapshot,
+    ProfileView,
+};
 pub use protocol::{
     AppStateView, ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode,
-    FocusCycleDirection, FrontendEvent, ProjectTabView, RecentProjectView, WorkspaceView,
+    FocusCycleDirection, FrontendEvent, ProfileErrorCode, ProjectTabView, RecentProjectView,
+    WorkspaceView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -530,6 +530,95 @@ impl AppRuntime {
                     gwt::custom_agents_dispatch::test_connection_event(&base_url, &api_key),
                 )]
             }
+            FrontendEvent::ListProfiles {
+                id,
+                selected_profile,
+            } => vec![OutboundEvent::reply(
+                client_id,
+                gwt::profiles_dispatch::list_event(id, selected_profile),
+            )],
+            FrontendEvent::SwitchProfile { id, profile_name } => {
+                vec![OutboundEvent::broadcast(
+                    gwt::profiles_dispatch::switch_event(id, profile_name),
+                )]
+            }
+            FrontendEvent::AddProfile {
+                id,
+                name,
+                description,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::add_profile_event(id, name, description),
+            )],
+            FrontendEvent::UpdateProfile {
+                id,
+                current_name,
+                name,
+                description,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::update_profile_event(id, current_name, name, description),
+            )],
+            FrontendEvent::DeleteProfile { id, profile_name } => {
+                vec![OutboundEvent::broadcast(
+                    gwt::profiles_dispatch::delete_profile_event(id, profile_name),
+                )]
+            }
+            FrontendEvent::SetProfileEnvVar {
+                id,
+                profile_name,
+                key,
+                value,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::set_env_var_event(id, profile_name, key, value),
+            )],
+            FrontendEvent::UpdateProfileEnvVar {
+                id,
+                profile_name,
+                current_key,
+                key,
+                value,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::update_env_var_event(
+                    id,
+                    profile_name,
+                    current_key,
+                    key,
+                    value,
+                ),
+            )],
+            FrontendEvent::DeleteProfileEnvVar {
+                id,
+                profile_name,
+                key,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::delete_env_var_event(id, profile_name, key),
+            )],
+            FrontendEvent::AddDisabledEnv {
+                id,
+                profile_name,
+                key,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::add_disabled_env_event(id, profile_name, key),
+            )],
+            FrontendEvent::UpdateDisabledEnv {
+                id,
+                profile_name,
+                current_key,
+                key,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::update_disabled_env_event(
+                    id,
+                    profile_name,
+                    current_key,
+                    key,
+                ),
+            )],
+            FrontendEvent::DeleteDisabledEnv {
+                id,
+                profile_name,
+                key,
+            } => vec![OutboundEvent::broadcast(
+                gwt::profiles_dispatch::delete_disabled_env_event(id, profile_name, key),
+            )],
         }
     }
 

--- a/crates/gwt/src/preset.rs
+++ b/crates/gwt/src/preset.rs
@@ -26,6 +26,7 @@ pub enum WindowSurface {
     Terminal,
     FileTree,
     Branches,
+    Profile,
     Mock,
 }
 
@@ -75,7 +76,7 @@ impl WindowPreset {
             Self::Branches => "Browse repository branches and launch agents",
             Self::Settings => "Placeholder settings surface",
             Self::Memo => "Placeholder notes surface",
-            Self::Profile => "Placeholder profile surface",
+            Self::Profile => "Manage environment profiles",
             Self::Logs => "Placeholder logs surface",
             Self::Issue => "Placeholder issue surface",
             Self::Spec => "Placeholder SPEC surface",
@@ -108,9 +109,9 @@ impl WindowPreset {
             Self::Shell | Self::Claude | Self::Codex | Self::Agent => WindowSurface::Terminal,
             Self::FileTree => WindowSurface::FileTree,
             Self::Branches => WindowSurface::Branches,
+            Self::Profile => WindowSurface::Profile,
             Self::Settings
             | Self::Memo
-            | Self::Profile
             | Self::Logs
             | Self::Issue
             | Self::Spec
@@ -128,6 +129,7 @@ impl WindowPreset {
             WindowSurface::Terminal => (720.0, 420.0),
             WindowSurface::FileTree => (420.0, 520.0),
             WindowSurface::Branches => (520.0, 420.0),
+            WindowSurface::Profile => (680.0, 520.0),
             WindowSurface::Mock => (420.0, 300.0),
         }
     }
@@ -388,7 +390,7 @@ mod tests {
         assert!(!WindowPreset::Issue.requires_process());
         assert_eq!(
             WindowPreset::Profile.subtitle(),
-            "Placeholder profile surface"
+            "Manage environment profiles"
         );
     }
 
@@ -471,9 +473,12 @@ mod tests {
                     assert_eq!(preset.surface(), WindowSurface::Branches);
                     assert!(!preset.requires_process());
                 }
+                WindowPreset::Profile => {
+                    assert_eq!(preset.surface(), WindowSurface::Profile);
+                    assert!(!preset.requires_process());
+                }
                 WindowPreset::Settings
                 | WindowPreset::Memo
-                | WindowPreset::Profile
                 | WindowPreset::Logs
                 | WindowPreset::Issue
                 | WindowPreset::Spec

--- a/crates/gwt/src/profiles_dispatch.rs
+++ b/crates/gwt/src/profiles_dispatch.rs
@@ -1,0 +1,205 @@
+//! WebSocket dispatch helpers for Profile window requests.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
+
+use gwt_config::Settings;
+
+use crate::{
+    profiles_service::{
+        add_disabled_env, add_profile, delete_disabled_env, delete_env_var, delete_profile,
+        load_profile_snapshot, set_env_var, switch_profile, update_disabled_env, update_env_var,
+        update_profile, ProfileServiceError,
+    },
+    protocol::{BackendEvent, ProfileErrorCode},
+};
+
+static CONFIG_PATH_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+
+pub fn set_config_path_override_for_tests(path: PathBuf) {
+    let _ = CONFIG_PATH_OVERRIDE.set(path);
+}
+
+pub fn config_path() -> Result<PathBuf, ProfileServiceError> {
+    if let Some(path) = CONFIG_PATH_OVERRIDE.get() {
+        return Ok(path.clone());
+    }
+    Settings::global_config_path().ok_or_else(|| {
+        ProfileServiceError::Storage(
+            "unable to resolve home directory (`~/.gwt/config.toml`); \
+             set HOME/USERPROFILE before managing profiles"
+                .to_string(),
+        )
+    })
+}
+
+fn with_config_path<F>(id: String, f: F) -> BackendEvent
+where
+    F: FnOnce(&Path, String) -> BackendEvent,
+{
+    match config_path() {
+        Ok(path) => f(&path, id),
+        Err(err) => error_to_event(id, err),
+    }
+}
+
+pub fn error_to_event(id: String, err: ProfileServiceError) -> BackendEvent {
+    use ProfileServiceError as E;
+    let code = match &err {
+        E::Storage(_) => ProfileErrorCode::Storage,
+        E::InvalidInput(_) => ProfileErrorCode::InvalidInput,
+        E::NotFound(_) => ProfileErrorCode::NotFound,
+        E::Duplicate(_) => ProfileErrorCode::Duplicate,
+        E::Protected(_) => ProfileErrorCode::Protected,
+    };
+    BackendEvent::ProfileError {
+        id,
+        code,
+        message: err.to_string(),
+    }
+}
+
+fn snapshot_result(
+    id: String,
+    result: Result<crate::profiles_service::ProfileSnapshot, ProfileServiceError>,
+) -> BackendEvent {
+    match result {
+        Ok(snapshot) => BackendEvent::ProfileSnapshot { id, snapshot },
+        Err(err) => error_to_event(id, err),
+    }
+}
+
+pub fn list_event(id: String, selected_profile: Option<String>) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, load_profile_snapshot(path, selected_profile.as_deref()))
+    })
+}
+
+pub fn switch_event(id: String, profile_name: String) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, switch_profile(path, &profile_name))
+    })
+}
+
+pub fn add_profile_event(id: String, name: String, description: String) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, add_profile(path, &name, &description))
+    })
+}
+
+pub fn update_profile_event(
+    id: String,
+    current_name: String,
+    name: String,
+    description: String,
+) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, update_profile(path, &current_name, &name, &description))
+    })
+}
+
+pub fn delete_profile_event(id: String, profile_name: String) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, delete_profile(path, &profile_name))
+    })
+}
+
+pub fn set_env_var_event(
+    id: String,
+    profile_name: String,
+    key: String,
+    value: String,
+) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, set_env_var(path, &profile_name, &key, &value))
+    })
+}
+
+pub fn update_env_var_event(
+    id: String,
+    profile_name: String,
+    current_key: String,
+    key: String,
+    value: String,
+) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(
+            id,
+            update_env_var(path, &profile_name, &current_key, &key, &value),
+        )
+    })
+}
+
+pub fn delete_env_var_event(id: String, profile_name: String, key: String) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, delete_env_var(path, &profile_name, &key))
+    })
+}
+
+pub fn add_disabled_env_event(id: String, profile_name: String, key: String) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, add_disabled_env(path, &profile_name, &key))
+    })
+}
+
+pub fn update_disabled_env_event(
+    id: String,
+    profile_name: String,
+    current_key: String,
+    key: String,
+) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(
+            id,
+            update_disabled_env(path, &profile_name, &current_key, &key),
+        )
+    })
+}
+
+pub fn delete_disabled_env_event(id: String, profile_name: String, key: String) -> BackendEvent {
+    with_config_path(id, |path, id| {
+        snapshot_result(id, delete_disabled_env(path, &profile_name, &key))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_to_event_preserves_code_per_variant() {
+        let cases = [
+            (
+                ProfileServiceError::Storage("x".into()),
+                ProfileErrorCode::Storage,
+            ),
+            (
+                ProfileServiceError::InvalidInput("x".into()),
+                ProfileErrorCode::InvalidInput,
+            ),
+            (
+                ProfileServiceError::NotFound("x".into()),
+                ProfileErrorCode::NotFound,
+            ),
+            (
+                ProfileServiceError::Duplicate("x".into()),
+                ProfileErrorCode::Duplicate,
+            ),
+            (
+                ProfileServiceError::Protected("x".into()),
+                ProfileErrorCode::Protected,
+            ),
+        ];
+        for (err, expected) in cases {
+            match error_to_event("profile-1".to_string(), err) {
+                BackendEvent::ProfileError { id, code, .. } => {
+                    assert_eq!(id, "profile-1");
+                    assert_eq!(code, expected);
+                }
+                other => panic!("expected ProfileError, got {other:?}"),
+            }
+        }
+    }
+}

--- a/crates/gwt/src/profiles_service.rs
+++ b/crates/gwt/src/profiles_service.rs
@@ -1,0 +1,446 @@
+//! Profile window service backed by `gwt-config`.
+
+use std::{collections::BTreeMap, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+use gwt_config::{Profile, Settings};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileEnvVarView {
+    pub key: String,
+    pub value: String,
+    pub source: ProfileEnvVarSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileEnvVarSource {
+    Os,
+    Profile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileView {
+    pub name: String,
+    pub description: String,
+    pub active: bool,
+    pub env_vars: Vec<ProfileEnvVarView>,
+    pub disabled_env: Vec<String>,
+    pub merged_env: Vec<ProfileEnvVarView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileSnapshot {
+    pub active: String,
+    pub selected: String,
+    pub profiles: Vec<ProfileView>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ProfileServiceError {
+    #[error("storage error: {0}")]
+    Storage(String),
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("duplicate profile: {0}")]
+    Duplicate(String),
+    #[error("protected profile: {0}")]
+    Protected(String),
+}
+
+fn load_settings(path: &Path) -> Result<Settings, ProfileServiceError> {
+    if path.exists() {
+        Settings::load_from_path(path).map_err(|error| {
+            ProfileServiceError::Storage(format!("failed to load {}: {error}", path.display()))
+        })
+    } else {
+        Ok(Settings::default())
+    }
+}
+
+fn save_settings(path: &Path, settings: &Settings) -> Result<(), ProfileServiceError> {
+    settings.save(path).map_err(|error| {
+        ProfileServiceError::Storage(format!("failed to save {}: {error}", path.display()))
+    })
+}
+
+fn map_profile_error(message: String) -> ProfileServiceError {
+    if message.contains("default profile cannot") {
+        ProfileServiceError::Protected(message)
+    } else if message.contains("already exists") {
+        ProfileServiceError::Duplicate(message)
+    } else if message.contains("not found") {
+        ProfileServiceError::NotFound(message)
+    } else {
+        ProfileServiceError::InvalidInput(message)
+    }
+}
+
+fn validate_profile_name(name: &str) -> Result<&str, ProfileServiceError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(ProfileServiceError::InvalidInput(
+            "profile name cannot be empty".to_string(),
+        ));
+    }
+    Ok(trimmed)
+}
+
+fn sorted_env_vars(profile: &Profile) -> Vec<ProfileEnvVarView> {
+    profile
+        .env_vars
+        .iter()
+        .collect::<BTreeMap<_, _>>()
+        .into_iter()
+        .map(|(key, value)| ProfileEnvVarView {
+            key: key.clone(),
+            value: value.clone(),
+            source: ProfileEnvVarSource::Profile,
+        })
+        .collect()
+}
+
+fn sorted_disabled_env(profile: &Profile) -> Vec<String> {
+    let mut disabled = profile.disabled_env.clone();
+    disabled.sort();
+    disabled.dedup();
+    disabled
+}
+
+fn merged_env(profile: &Profile, base_env: &[(String, String)]) -> Vec<ProfileEnvVarView> {
+    profile
+        .merged_env_pairs(base_env.iter().cloned())
+        .into_iter()
+        .map(|(key, value)| {
+            let source = if profile.env_vars.contains_key(&key) {
+                ProfileEnvVarSource::Profile
+            } else {
+                ProfileEnvVarSource::Os
+            };
+            ProfileEnvVarView { key, value, source }
+        })
+        .collect()
+}
+
+fn snapshot_from_settings_with_env<I>(
+    settings: &Settings,
+    selected_profile: Option<&str>,
+    base_env: I,
+) -> ProfileSnapshot
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let base_env = base_env.into_iter().collect::<Vec<_>>();
+    let active = settings
+        .profiles
+        .active_profile()
+        .map(|profile| profile.name.clone())
+        .unwrap_or_else(|| "default".to_string());
+    let selected = selected_profile
+        .filter(|name| settings.profiles.get(name).is_some())
+        .unwrap_or(active.as_str())
+        .to_string();
+    let mut profiles = settings
+        .profiles
+        .profiles
+        .iter()
+        .map(|profile| ProfileView {
+            name: profile.name.clone(),
+            description: profile.description.clone(),
+            active: profile.name == active,
+            env_vars: sorted_env_vars(profile),
+            disabled_env: sorted_disabled_env(profile),
+            merged_env: merged_env(profile, &base_env),
+        })
+        .collect::<Vec<_>>();
+    profiles.sort_by(
+        |left, right| match (left.name.as_str(), right.name.as_str()) {
+            ("default", "default") => std::cmp::Ordering::Equal,
+            ("default", _) => std::cmp::Ordering::Less,
+            (_, "default") => std::cmp::Ordering::Greater,
+            _ => left.name.cmp(&right.name),
+        },
+    );
+
+    ProfileSnapshot {
+        active,
+        selected,
+        profiles,
+    }
+}
+
+fn snapshot_from_settings(settings: &Settings, selected_profile: Option<&str>) -> ProfileSnapshot {
+    snapshot_from_settings_with_env(settings, selected_profile, std::env::vars())
+}
+
+pub fn load_profile_snapshot(
+    config_path: &Path,
+    selected_profile: Option<&str>,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let mut settings = load_settings(config_path)?;
+    let had_default = settings.profiles.get("default").is_some();
+    let active_before = settings.profiles.active.clone();
+    let resolution = settings.profiles.normalize_active_profile();
+    if config_path.exists()
+        && (!had_default || resolution.fallback || active_before != settings.profiles.active)
+    {
+        save_settings(config_path, &settings)?;
+    }
+    Ok(snapshot_from_settings(&settings, selected_profile))
+}
+
+fn mutate_profile_settings<F>(
+    config_path: &Path,
+    selected_profile: Option<&str>,
+    mutate: F,
+) -> Result<ProfileSnapshot, ProfileServiceError>
+where
+    F: FnOnce(&mut Settings) -> Result<(), ProfileServiceError>,
+{
+    let mut settings = load_settings(config_path)?;
+    settings.profiles.normalize_active_profile();
+    mutate(&mut settings)?;
+    settings.profiles.normalize_active_profile();
+    save_settings(config_path, &settings)?;
+    Ok(snapshot_from_settings(&settings, selected_profile))
+}
+
+pub fn switch_profile(
+    config_path: &Path,
+    profile_name: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some(&profile_name), |settings| {
+        settings
+            .profiles
+            .switch(&profile_name)
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn add_profile(
+    config_path: &Path,
+    name: &str,
+    description: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let name = validate_profile_name(name)?.to_string();
+    mutate_profile_settings(config_path, Some(&name), |settings| {
+        let mut profile = Profile::new(name.clone());
+        profile.description = description.to_string();
+        settings.profiles.add(profile).map_err(map_profile_error)
+    })
+}
+
+pub fn update_profile(
+    config_path: &Path,
+    current_name: &str,
+    name: &str,
+    description: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let current_name = validate_profile_name(current_name)?.to_string();
+    let name = validate_profile_name(name)?.to_string();
+    mutate_profile_settings(config_path, Some(&name), |settings| {
+        settings
+            .profiles
+            .update_profile(&current_name, &name, description)
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn delete_profile(
+    config_path: &Path,
+    profile_name: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some("default"), |settings| {
+        settings
+            .profiles
+            .delete_profile(&profile_name)
+            .map(|_| ())
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn set_env_var(
+    config_path: &Path,
+    profile_name: &str,
+    key: &str,
+    value: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some(&profile_name), |settings| {
+        settings
+            .profiles
+            .set_env_var(&profile_name, key, value)
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn update_env_var(
+    config_path: &Path,
+    profile_name: &str,
+    current_key: &str,
+    key: &str,
+    value: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some(&profile_name), |settings| {
+        settings
+            .profiles
+            .update_env_var(&profile_name, current_key, key, value)
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn delete_env_var(
+    config_path: &Path,
+    profile_name: &str,
+    key: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some(&profile_name), |settings| {
+        settings
+            .profiles
+            .remove_env_var(&profile_name, key)
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn add_disabled_env(
+    config_path: &Path,
+    profile_name: &str,
+    key: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some(&profile_name), |settings| {
+        settings
+            .profiles
+            .add_disabled_env(&profile_name, key)
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn update_disabled_env(
+    config_path: &Path,
+    profile_name: &str,
+    current_key: &str,
+    key: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some(&profile_name), |settings| {
+        settings
+            .profiles
+            .update_disabled_env(&profile_name, current_key, key)
+            .map_err(map_profile_error)
+    })
+}
+
+pub fn delete_disabled_env(
+    config_path: &Path,
+    profile_name: &str,
+    key: &str,
+) -> Result<ProfileSnapshot, ProfileServiceError> {
+    let profile_name = validate_profile_name(profile_name)?.to_string();
+    mutate_profile_settings(config_path, Some(&profile_name), |settings| {
+        settings
+            .profiles
+            .remove_disabled_env(&profile_name, key)
+            .map_err(map_profile_error)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use gwt_config::{Profile, Settings};
+
+    use super::*;
+
+    fn config_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        dir.path().join("config.toml")
+    }
+
+    fn profile<'a>(snapshot: &'a ProfileSnapshot, name: &str) -> &'a ProfileView {
+        snapshot
+            .profiles
+            .iter()
+            .find(|profile| profile.name == name)
+            .expect("profile present")
+    }
+
+    #[test]
+    fn add_profile_persists_and_returns_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(&dir);
+
+        let snapshot = add_profile(&path, "dev", "Development").expect("add profile");
+
+        assert_eq!(snapshot.active, "default");
+        assert_eq!(snapshot.selected, "dev");
+        assert_eq!(profile(&snapshot, "dev").description, "Development");
+
+        let stored = Settings::load_from_path(&path).expect("stored config");
+        assert!(stored.profiles.get("dev").is_some());
+    }
+
+    #[test]
+    fn switch_profile_persists_active_selection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(&dir);
+        let mut settings = Settings::default();
+        settings.profiles.add(Profile::new("dev")).unwrap();
+        settings.save(&path).unwrap();
+
+        let snapshot = switch_profile(&path, "dev").expect("switch profile");
+
+        assert_eq!(snapshot.active, "dev");
+        assert!(profile(&snapshot, "dev").active);
+        let stored = Settings::load_from_path(&path).expect("stored config");
+        assert_eq!(stored.profiles.active.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn default_profile_rename_and_delete_are_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(&dir);
+        Settings::default().save(&path).unwrap();
+
+        assert!(matches!(
+            update_profile(&path, "default", "renamed", "Nope"),
+            Err(ProfileServiceError::Protected(_))
+        ));
+        assert!(matches!(
+            delete_profile(&path, "default"),
+            Err(ProfileServiceError::Protected(_))
+        ));
+    }
+
+    #[test]
+    fn env_and_disabled_env_edits_update_preview() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(&dir);
+        let mut settings = Settings::default();
+        settings.profiles.add(Profile::new("dev")).unwrap();
+        settings.save(&path).unwrap();
+
+        set_env_var(&path, "dev", "API_URL", "https://example.test").expect("set env");
+        add_disabled_env(&path, "dev", "PATH").expect("disable env");
+        let snapshot = load_profile_snapshot(&path, Some("dev")).expect("snapshot");
+        let dev = profile(&snapshot, "dev");
+
+        assert!(dev.env_vars.iter().any(|entry| {
+            entry.key == "API_URL"
+                && entry.value == "https://example.test"
+                && entry.source == ProfileEnvVarSource::Profile
+        }));
+        assert!(dev.disabled_env.iter().any(|entry| entry == "PATH"));
+        assert!(dev.merged_env.iter().any(|entry| {
+            entry.key == "API_URL"
+                && entry.value == "https://example.test"
+                && entry.source == ProfileEnvVarSource::Profile
+        }));
+        assert!(!dev.merged_env.iter().any(|entry| entry.key == "PATH"));
+    }
+}

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -13,6 +13,7 @@ use crate::{
         CanvasViewport, PersistedWindowState, ProjectKind, WindowGeometry, WindowProcessStatus,
     },
     preset::WindowPreset,
+    profiles_service::ProfileSnapshot,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -162,6 +163,63 @@ pub enum FrontendEvent {
         base_url: String,
         api_key: String,
     },
+    ListProfiles {
+        id: String,
+        selected_profile: Option<String>,
+    },
+    SwitchProfile {
+        id: String,
+        profile_name: String,
+    },
+    AddProfile {
+        id: String,
+        name: String,
+        description: String,
+    },
+    UpdateProfile {
+        id: String,
+        current_name: String,
+        name: String,
+        description: String,
+    },
+    DeleteProfile {
+        id: String,
+        profile_name: String,
+    },
+    SetProfileEnvVar {
+        id: String,
+        profile_name: String,
+        key: String,
+        value: String,
+    },
+    UpdateProfileEnvVar {
+        id: String,
+        profile_name: String,
+        current_key: String,
+        key: String,
+        value: String,
+    },
+    DeleteProfileEnvVar {
+        id: String,
+        profile_name: String,
+        key: String,
+    },
+    AddDisabledEnv {
+        id: String,
+        profile_name: String,
+        key: String,
+    },
+    UpdateDisabledEnv {
+        id: String,
+        profile_name: String,
+        current_key: String,
+        key: String,
+    },
+    DeleteDisabledEnv {
+        id: String,
+        profile_name: String,
+        key: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -298,6 +356,15 @@ pub enum BackendEvent {
         code: CustomAgentErrorCode,
         message: String,
     },
+    ProfileSnapshot {
+        id: String,
+        snapshot: ProfileSnapshot,
+    },
+    ProfileError {
+        id: String,
+        code: ProfileErrorCode,
+        message: String,
+    },
 }
 
 /// Stable machine-readable error code on [`BackendEvent::CustomAgentError`].
@@ -313,9 +380,23 @@ pub enum CustomAgentErrorCode {
     Probe,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileErrorCode {
+    Storage,
+    Duplicate,
+    InvalidInput,
+    NotFound,
+    Protected,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::Value;
+
+    use crate::profiles_service::{
+        ProfileEnvVarSource, ProfileEnvVarView, ProfileSnapshot, ProfileView,
+    };
 
     use super::{BackendEvent, BranchEntriesPhase};
 
@@ -335,6 +416,43 @@ mod tests {
         assert_eq!(
             value.get("phase"),
             Some(&Value::String("inventory".to_string()))
+        );
+    }
+
+    #[test]
+    fn profile_snapshot_serializes_explicit_contract() {
+        let event = BackendEvent::ProfileSnapshot {
+            id: "profile-1".to_string(),
+            snapshot: ProfileSnapshot {
+                active: "default".to_string(),
+                selected: "default".to_string(),
+                profiles: vec![ProfileView {
+                    name: "default".to_string(),
+                    description: "Default profile".to_string(),
+                    active: true,
+                    env_vars: vec![ProfileEnvVarView {
+                        key: "API_URL".to_string(),
+                        value: "https://example.test".to_string(),
+                        source: ProfileEnvVarSource::Profile,
+                    }],
+                    disabled_env: vec!["SECRET".to_string()],
+                    merged_env: Vec::new(),
+                }],
+            },
+        };
+
+        let value = serde_json::to_value(&event).expect("serialize profile snapshot");
+        assert_eq!(
+            value.get("kind"),
+            Some(&Value::String("profile_snapshot".to_string()))
+        );
+        assert_eq!(
+            value.pointer("/snapshot/profiles/0/env_vars/0/source"),
+            Some(&Value::String("profile".to_string()))
+        );
+        assert_eq!(
+            value.pointer("/snapshot/profiles/0/disabled_env/0"),
+            Some(&Value::String("SECRET".to_string()))
         );
     }
 }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -325,6 +325,7 @@
 
       .workspace-window.surface-file-tree,
       .workspace-window.surface-branches,
+      .workspace-window.surface-profile,
       .workspace-window.surface-mock {
         background: rgba(255, 255, 255, 0.98);
       }
@@ -347,6 +348,7 @@
 
       .surface-file-tree .titlebar,
       .surface-branches .titlebar,
+      .surface-profile .titlebar,
       .surface-mock .titlebar {
         background: rgba(248, 250, 252, 0.98);
         color: #0f172a;
@@ -390,6 +392,7 @@
       .surface-file-tree .status-chip,
       .surface-branches .status-chip,
       .surface-knowledge .status-chip,
+      .surface-profile .status-chip,
       .surface-mock .status-chip {
         color: #334155;
       }
@@ -439,6 +442,7 @@
       .surface-file-tree .icon-button,
       .surface-branches .icon-button,
       .surface-knowledge .icon-button,
+      .surface-profile .icon-button,
       .surface-mock .icon-button {
         color: #334155;
       }
@@ -468,6 +472,7 @@
       .surface-file-tree .window-body,
       .surface-branches .window-body,
       .surface-knowledge .window-body,
+      .surface-profile .window-body,
       .surface-mock .window-body {
         background: #ffffff;
       }
@@ -528,6 +533,7 @@
       .file-tree-root,
       .branch-list-root,
       .knowledge-root,
+      .profile-root,
       .mock-root {
         position: absolute;
         inset: 0;
@@ -538,6 +544,7 @@
       .file-tree-toolbar,
       .branch-toolbar,
       .knowledge-toolbar,
+      .profile-toolbar,
       .mock-toolbar {
         display: flex;
         align-items: center;
@@ -570,6 +577,10 @@
         align-items: flex-start;
       }
 
+      .profile-toolbar {
+        align-items: flex-start;
+      }
+
       .knowledge-toolbar-main {
         min-width: 0;
         flex: 1;
@@ -577,7 +588,19 @@
         gap: 8px;
       }
 
+      .profile-toolbar-main {
+        min-width: 0;
+        display: grid;
+        gap: 4px;
+      }
+
       .knowledge-toolbar-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .profile-toolbar-actions {
         display: flex;
         align-items: center;
         gap: 8px;
@@ -616,6 +639,7 @@
       .file-tree-path,
       .branch-heading,
       .knowledge-heading,
+      .profile-heading,
       .mock-heading {
         min-width: 0;
         font-size: 12px;
@@ -628,9 +652,201 @@
 
       .file-tree-scroll,
       .branch-scroll,
+      .profile-scroll,
       .mock-scroll {
         flex: 1;
         overflow: auto;
+      }
+
+      .profile-status {
+        display: none;
+        padding: 10px 12px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        font-size: 12px;
+      }
+
+      .profile-status.visible {
+        display: block;
+      }
+
+      .profile-status.info {
+        background: rgba(59, 130, 246, 0.08);
+        color: #1d4ed8;
+      }
+
+      .profile-status.error {
+        background: rgba(239, 68, 68, 0.08);
+        color: #b91c1c;
+      }
+
+      .profile-layout {
+        flex: 1;
+        min-height: 0;
+        display: grid;
+        grid-template-columns: minmax(180px, 32%) minmax(0, 1fr);
+      }
+
+      .profile-list-pane,
+      .profile-detail-pane {
+        min-width: 0;
+        min-height: 0;
+        overflow: auto;
+      }
+
+      .profile-list-pane {
+        border-right: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .profile-list {
+        display: grid;
+      }
+
+      .profile-row {
+        display: grid;
+        gap: 4px;
+        width: 100%;
+        padding: 10px 12px;
+        border: none;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        background: transparent;
+        text-align: left;
+        cursor: pointer;
+      }
+
+      .profile-row.selected {
+        background: rgba(59, 130, 246, 0.1);
+      }
+
+      .profile-row-main,
+      .profile-section-head,
+      .profile-form-row,
+      .profile-table-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+
+      .profile-name {
+        min-width: 0;
+        font-size: 13px;
+        font-weight: 600;
+        color: #0f172a;
+        overflow-wrap: anywhere;
+      }
+
+      .profile-description,
+      .profile-subtle {
+        font-size: 11px;
+        color: #64748b;
+        overflow-wrap: anywhere;
+      }
+
+      .profile-detail {
+        display: grid;
+        gap: 12px;
+        padding: 12px;
+      }
+
+      .profile-section {
+        display: grid;
+        gap: 8px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .profile-section:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+      }
+
+      .profile-section-title {
+        font-size: 12px;
+        font-weight: 700;
+        color: #334155;
+      }
+
+      .profile-form-grid {
+        display: grid;
+        grid-template-columns: minmax(92px, 1fr) minmax(120px, 1.4fr) auto;
+        gap: 8px;
+      }
+
+      .profile-form-grid.two {
+        grid-template-columns: minmax(120px, 1fr) auto;
+      }
+
+      .profile-input {
+        min-width: 0;
+        height: 30px;
+        padding: 0 8px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.42);
+        background: #ffffff;
+        color: #0f172a;
+        font-size: 12px;
+      }
+
+      .profile-input[disabled] {
+        background: #f8fafc;
+        color: #64748b;
+      }
+
+      .profile-button {
+        height: 30px;
+        padding: 0 10px;
+        border-radius: 6px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: #f8fafc;
+        color: #334155;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      .profile-button.primary {
+        background: #0f172a;
+        border-color: #0f172a;
+        color: #ffffff;
+      }
+
+      .profile-button.danger {
+        color: #b91c1c;
+      }
+
+      .profile-button:disabled {
+        opacity: 0.45;
+        cursor: default;
+      }
+
+      .profile-table {
+        display: grid;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+
+      .profile-table-row {
+        padding: 8px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .profile-table-row:last-child {
+        border-bottom: none;
+      }
+
+      .profile-table-row.preview {
+        justify-content: flex-start;
+        align-items: flex-start;
+        display: grid;
+        grid-template-columns: minmax(92px, 0.9fr) minmax(120px, 1.4fr) auto;
+      }
+
+      .profile-value {
+        min-width: 0;
+        overflow-wrap: anywhere;
+        font-size: 12px;
+        color: #0f172a;
       }
 
       .knowledge-search {
@@ -1938,6 +2154,8 @@
       const fileTreeStateMap = new Map();
       const branchListStateMap = new Map();
       const knowledgeBridgeStateMap = new Map();
+      const profileWindowStateMap = new Map();
+      const profileWindowBodies = new Map();
       const pendingMessages = [];
 
       // Diagnostic counter for intermittent key-input drops (bugfix/input-key).
@@ -1962,6 +2180,7 @@
       let windowListOpen = false;
       let windowListEntries = [];
       let titlebarClickState = null;
+      let profileSnapshot = null;
       let appState = {
         app_version: "",
         tabs: [],
@@ -2021,6 +2240,9 @@
         }
         if (preset === "issue" || preset === "spec" || preset === "pr") {
           return "knowledge";
+        }
+        if (preset === "profile") {
+          return "profile";
         }
         return "mock";
       }
@@ -4662,6 +4884,7 @@
           "surface-file-tree",
           "surface-branches",
           "surface-knowledge",
+          "surface-profile",
           "surface-mock",
         );
         element.classList.add(`surface-${surface}`);
@@ -4836,6 +5059,11 @@
           return;
         }
 
+        if (surface === "profile") {
+          renderProfileWindow(body, windowData);
+          return;
+        }
+
         if (windowData.preset === "settings") {
           renderSettingsWindow(body, windowData);
           return;
@@ -4868,6 +5096,446 @@
           `;
           scroll.appendChild(section);
         }
+      }
+
+      function ensureProfileWindowState(windowId) {
+        if (!profileWindowStateMap.has(windowId)) {
+          profileWindowStateMap.set(windowId, {
+            selected: "",
+            loading: false,
+            statusMessage: "",
+            statusKind: "",
+          });
+        }
+        return profileWindowStateMap.get(windowId);
+      }
+
+      function selectedProfileForWindow(windowId) {
+        const state = ensureProfileWindowState(windowId);
+        if (state.selected && profileSnapshot) {
+          const exists = profileSnapshot.profiles.some(
+            (profile) => profile.name === state.selected,
+          );
+          if (exists) {
+            return state.selected;
+          }
+        }
+        return profileSnapshot?.selected || profileSnapshot?.active || "default";
+      }
+
+      function profileByName(name) {
+        return (
+          profileSnapshot?.profiles.find((profile) => profile.name === name) ||
+          profileSnapshot?.profiles[0] ||
+          null
+        );
+      }
+
+      function requestProfiles(windowId, selectedProfile = null) {
+        const state = ensureProfileWindowState(windowId);
+        state.loading = true;
+        state.statusMessage = "Loading profiles...";
+        state.statusKind = "info";
+        send({
+          kind: "list_profiles",
+          id: windowId,
+          selected_profile: selectedProfile,
+        });
+      }
+
+      function setProfileStatus(windowId, message, kind = "info") {
+        const state = ensureProfileWindowState(windowId);
+        state.statusMessage = message;
+        state.statusKind = kind;
+        renderProfileWindows();
+      }
+
+      function createProfileButton(label, action, extraClass = "") {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = `profile-button ${extraClass}`.trim();
+        button.dataset.action = action;
+        button.textContent = label;
+        return button;
+      }
+
+      function createProfileInput(value, placeholder = "") {
+        const input = document.createElement("input");
+        input.className = "profile-input";
+        input.value = value || "";
+        input.placeholder = placeholder;
+        return input;
+      }
+
+      function appendProfileStatus(root, windowId) {
+        const state = ensureProfileWindowState(windowId);
+        const status = createDiv("profile-status");
+        status.classList.toggle("visible", Boolean(state.statusMessage));
+        status.classList.toggle("error", state.statusKind === "error");
+        status.classList.toggle("info", state.statusKind !== "error");
+        status.textContent = state.statusMessage;
+        root.appendChild(status);
+      }
+
+      function renderProfileWindow(body, windowData) {
+        while (body.firstChild) body.removeChild(body.firstChild);
+        profileWindowBodies.set(windowData.id, body);
+        const state = ensureProfileWindowState(windowData.id);
+        const root = createDiv("profile-root");
+        const toolbar = createDiv("profile-toolbar");
+        const toolbarMain = createDiv("profile-toolbar-main");
+        const heading = createDiv("profile-heading");
+        heading.textContent = "Profiles";
+        const summary = createDiv("profile-subtle");
+        summary.textContent = profileSnapshot
+          ? `Active: ${profileSnapshot.active}`
+          : "Waiting for profile data";
+        toolbarMain.appendChild(heading);
+        toolbarMain.appendChild(summary);
+        toolbar.appendChild(toolbarMain);
+        const actions = createDiv("profile-toolbar-actions");
+        const refresh = document.createElement("button");
+        refresh.className = "icon-button";
+        refresh.type = "button";
+        refresh.setAttribute("aria-label", "Refresh profiles");
+        refresh.textContent = "↻";
+        refresh.addEventListener("click", (event) => {
+          event.stopPropagation();
+          requestProfiles(windowData.id, selectedProfileForWindow(windowData.id));
+          renderProfileWindows();
+        });
+        actions.appendChild(refresh);
+        toolbar.appendChild(actions);
+        root.appendChild(toolbar);
+        appendProfileStatus(root, windowData.id);
+
+        const layout = createDiv("profile-layout");
+        const listPane = createDiv("profile-list-pane");
+        const detailPane = createDiv("profile-detail-pane");
+        layout.appendChild(listPane);
+        layout.appendChild(detailPane);
+        root.appendChild(layout);
+        body.appendChild(root);
+        if (!body.dataset.profileFocusBound) {
+          body.dataset.profileFocusBound = "true";
+          body.addEventListener("mousedown", () => {
+            focusWindowLocally(windowData.id);
+            send({ kind: "focus_window", id: windowData.id });
+          });
+        }
+
+        if (!profileSnapshot) {
+          const empty = createDiv("mock-empty");
+          empty.textContent = state.loading ? "Loading profiles..." : "No profile data loaded.";
+          detailPane.appendChild(empty);
+          if (!state.loading) {
+            requestProfiles(windowData.id, state.selected || null);
+          }
+          renderProfileList(windowData.id, listPane);
+          return;
+        }
+
+        renderProfileList(windowData.id, listPane);
+        renderProfileDetail(windowData.id, detailPane);
+      }
+
+      function renderProfileWindows() {
+        for (const [windowId, body] of Array.from(profileWindowBodies.entries())) {
+          if (!body.isConnected) {
+            profileWindowBodies.delete(windowId);
+            profileWindowStateMap.delete(windowId);
+            continue;
+          }
+          const windowData = windowMap.get(windowId)?.__windowData;
+          if (windowData) {
+            renderProfileWindow(body, windowData);
+          }
+        }
+      }
+
+      function renderProfileList(windowId, pane) {
+        const list = createDiv("profile-list");
+        const state = ensureProfileWindowState(windowId);
+        const selected = selectedProfileForWindow(windowId);
+        const profiles = profileSnapshot?.profiles || [];
+        for (const profile of profiles) {
+          const row = document.createElement("button");
+          row.type = "button";
+          row.className = "profile-row";
+          row.classList.toggle("selected", profile.name === selected);
+          row.addEventListener("click", (event) => {
+            event.stopPropagation();
+            state.selected = profile.name;
+            state.statusMessage = "";
+            renderProfileWindows();
+          });
+          const main = createDiv("profile-row-main");
+          const name = createDiv("profile-name");
+          name.textContent = profile.name;
+          main.appendChild(name);
+          if (profile.active) {
+            const chip = document.createElement("span");
+            chip.className = "mock-chip";
+            chip.textContent = "active";
+            main.appendChild(chip);
+          }
+          row.appendChild(main);
+          const description = createDiv("profile-description");
+          description.textContent = profile.description || "No description";
+          row.appendChild(description);
+          list.appendChild(row);
+        }
+        const add = createDiv("profile-section");
+        const title = createDiv("profile-section-title");
+        title.textContent = "Add profile";
+        add.appendChild(title);
+        const form = createDiv("profile-form-grid");
+        const nameInput = createProfileInput("", "name");
+        const descriptionInput = createProfileInput("", "description");
+        const button = createProfileButton("Add", "profile-add", "primary");
+        button.addEventListener("click", (event) => {
+          event.stopPropagation();
+          send({
+            kind: "add_profile",
+            id: windowId,
+            name: nameInput.value,
+            description: descriptionInput.value,
+          });
+        });
+        form.appendChild(nameInput);
+        form.appendChild(descriptionInput);
+        form.appendChild(button);
+        add.appendChild(form);
+        list.appendChild(add);
+        pane.appendChild(list);
+      }
+
+      function renderProfileDetail(windowId, pane) {
+        const selected = selectedProfileForWindow(windowId);
+        const profile = profileByName(selected);
+        const detail = createDiv("profile-detail");
+        pane.appendChild(detail);
+        if (!profile) {
+          const empty = createDiv("mock-empty");
+          empty.textContent = "No profiles configured.";
+          detail.appendChild(empty);
+          return;
+        }
+        renderProfileMetadata(windowId, detail, profile);
+        renderProfileEnvVars(windowId, detail, profile);
+        renderProfileDisabledEnv(windowId, detail, profile);
+        renderProfileMergedEnv(detail, profile);
+      }
+
+      function renderProfileMetadata(windowId, detail, profile) {
+        const section = createDiv("profile-section");
+        const head = createDiv("profile-section-head");
+        const title = createDiv("profile-section-title");
+        title.textContent = "Metadata";
+        head.appendChild(title);
+        if (!profile.active) {
+          const activate = createProfileButton("Set active", "profile-switch", "primary");
+          activate.addEventListener("click", (event) => {
+            event.stopPropagation();
+            send({
+              kind: "switch_profile",
+              id: windowId,
+              profile_name: profile.name,
+            });
+          });
+          head.appendChild(activate);
+        }
+        section.appendChild(head);
+        const form = createDiv("profile-form-grid");
+        const nameInput = createProfileInput(profile.name, "name");
+        const descriptionInput = createProfileInput(profile.description, "description");
+        const save = createProfileButton("Save", "profile-save", "primary");
+        save.addEventListener("click", (event) => {
+          event.stopPropagation();
+          send({
+            kind: "update_profile",
+            id: windowId,
+            current_name: profile.name,
+            name: nameInput.value,
+            description: descriptionInput.value,
+          });
+        });
+        if (profile.name === "default") {
+          nameInput.disabled = true;
+        }
+        form.appendChild(nameInput);
+        form.appendChild(descriptionInput);
+        form.appendChild(save);
+        section.appendChild(form);
+        const deleteButton = createProfileButton("Delete profile", "profile-delete", "danger");
+        deleteButton.disabled = profile.name === "default";
+        deleteButton.addEventListener("click", (event) => {
+          event.stopPropagation();
+          if (profile.name !== "default") {
+            send({
+              kind: "delete_profile",
+              id: windowId,
+              profile_name: profile.name,
+            });
+          }
+        });
+        section.appendChild(deleteButton);
+        detail.appendChild(section);
+      }
+
+      function renderProfileEnvVars(windowId, detail, profile) {
+        const section = createDiv("profile-section");
+        const title = createDiv("profile-section-title");
+        title.textContent = "Profile variables";
+        section.appendChild(title);
+        const add = createDiv("profile-form-grid");
+        const keyInput = createProfileInput("", "KEY");
+        const valueInput = createProfileInput("", "value");
+        const addButton = createProfileButton("Add", "profile-env-add", "primary");
+        addButton.addEventListener("click", (event) => {
+          event.stopPropagation();
+          send({
+            kind: "set_profile_env_var",
+            id: windowId,
+            profile_name: profile.name,
+            key: keyInput.value,
+            value: valueInput.value,
+          });
+        });
+        add.appendChild(keyInput);
+        add.appendChild(valueInput);
+        add.appendChild(addButton);
+        section.appendChild(add);
+        const table = createDiv("profile-table");
+        if (profile.env_vars.length === 0) {
+          const row = createDiv("profile-table-row");
+          const empty = createDiv("profile-subtle");
+          empty.textContent = "No profile variables.";
+          row.appendChild(empty);
+          table.appendChild(row);
+        }
+        for (const entry of profile.env_vars) {
+          const row = createDiv("profile-table-row");
+          const key = createProfileInput(entry.key, "KEY");
+          const value = createProfileInput(entry.value, "value");
+          const save = createProfileButton("Save", "profile-env-save");
+          save.addEventListener("click", (event) => {
+            event.stopPropagation();
+            send({
+              kind: "update_profile_env_var",
+              id: windowId,
+              profile_name: profile.name,
+              current_key: entry.key,
+              key: key.value,
+              value: value.value,
+            });
+          });
+          const remove = createProfileButton("×", "profile-env-delete", "danger");
+          remove.setAttribute("aria-label", `Delete ${entry.key}`);
+          remove.addEventListener("click", (event) => {
+            event.stopPropagation();
+            send({
+              kind: "delete_profile_env_var",
+              id: windowId,
+              profile_name: profile.name,
+              key: entry.key,
+            });
+          });
+          row.appendChild(key);
+          row.appendChild(value);
+          row.appendChild(save);
+          row.appendChild(remove);
+          table.appendChild(row);
+        }
+        section.appendChild(table);
+        detail.appendChild(section);
+      }
+
+      function renderProfileDisabledEnv(windowId, detail, profile) {
+        const section = createDiv("profile-section");
+        const title = createDiv("profile-section-title");
+        title.textContent = "Disabled OS variables";
+        section.appendChild(title);
+        const add = createDiv("profile-form-grid two");
+        const keyInput = createProfileInput("", "KEY");
+        const addButton = createProfileButton("Add", "profile-disabled-add", "primary");
+        addButton.addEventListener("click", (event) => {
+          event.stopPropagation();
+          send({
+            kind: "add_disabled_env",
+            id: windowId,
+            profile_name: profile.name,
+            key: keyInput.value,
+          });
+        });
+        add.appendChild(keyInput);
+        add.appendChild(addButton);
+        section.appendChild(add);
+        const table = createDiv("profile-table");
+        if (profile.disabled_env.length === 0) {
+          const row = createDiv("profile-table-row");
+          const empty = createDiv("profile-subtle");
+          empty.textContent = "No disabled OS variables.";
+          row.appendChild(empty);
+          table.appendChild(row);
+        }
+        for (const disabledKey of profile.disabled_env) {
+          const row = createDiv("profile-table-row");
+          const key = createProfileInput(disabledKey, "KEY");
+          const save = createProfileButton("Save", "profile-disabled-save");
+          save.addEventListener("click", (event) => {
+            event.stopPropagation();
+            send({
+              kind: "update_disabled_env",
+              id: windowId,
+              profile_name: profile.name,
+              current_key: disabledKey,
+              key: key.value,
+            });
+          });
+          const remove = createProfileButton("×", "profile-disabled-delete", "danger");
+          remove.setAttribute("aria-label", `Delete ${disabledKey}`);
+          remove.addEventListener("click", (event) => {
+            event.stopPropagation();
+            send({
+              kind: "delete_disabled_env",
+              id: windowId,
+              profile_name: profile.name,
+              key: disabledKey,
+            });
+          });
+          row.appendChild(key);
+          row.appendChild(save);
+          row.appendChild(remove);
+          table.appendChild(row);
+        }
+        section.appendChild(table);
+        detail.appendChild(section);
+      }
+
+      function renderProfileMergedEnv(detail, profile) {
+        const section = createDiv("profile-section");
+        const title = createDiv("profile-section-title");
+        title.textContent = "Effective environment preview";
+        section.appendChild(title);
+        const table = createDiv("profile-table");
+        table.dataset.role = "profile-merged-env";
+        for (const entry of profile.merged_env) {
+          const row = createDiv("profile-table-row preview");
+          const key = createDiv("profile-value");
+          key.textContent = entry.key;
+          const value = createDiv("profile-value");
+          value.textContent = entry.value;
+          const chip = document.createElement("span");
+          chip.className = "mock-chip";
+          chip.textContent = entry.source === "profile" ? "profile" : "os";
+          row.appendChild(key);
+          row.appendChild(value);
+          row.appendChild(chip);
+          table.appendChild(row);
+        }
+        section.appendChild(table);
+        detail.appendChild(section);
       }
 
       // All DOM nodes are built via createElement + textContent to avoid
@@ -5163,6 +5831,7 @@
           });
         }
 
+        element.__windowData = windowData;
         if (!element.dataset.preset || element.dataset.preset !== windowData.preset) {
           element.dataset.preset = windowData.preset;
           mountWindowBody(windowData, element);
@@ -5208,6 +5877,8 @@
           fileTreeStateMap.delete(windowId);
           branchListStateMap.delete(windowId);
           knowledgeBridgeStateMap.delete(windowId);
+          profileWindowStateMap.delete(windowId);
+          profileWindowBodies.delete(windowId);
           if (branchCleanupWindowId === windowId) {
             branchCleanupWindowId = null;
             renderBranchCleanupModal();
@@ -5406,6 +6077,36 @@
             pendingAddFromPreset = null;
             setSettingsStatus(`Error [${event.code}]: ${event.message}`, "error");
             break;
+          case "profile_snapshot": {
+            const hadProfileSnapshot = Boolean(profileSnapshot);
+            profileSnapshot = event.snapshot;
+            const state = ensureProfileWindowState(event.id);
+            state.loading = false;
+            state.selected = event.snapshot.selected || event.snapshot.active;
+            state.statusMessage = hadProfileSnapshot ? "Profiles saved." : "Profiles loaded.";
+            state.statusKind = "info";
+            for (const [windowId, otherState] of profileWindowStateMap.entries()) {
+              if (windowId === event.id) continue;
+              otherState.loading = false;
+              if (
+                otherState.selected &&
+                !event.snapshot.profiles.some(
+                  (profile) => profile.name === otherState.selected,
+                )
+              ) {
+                otherState.selected = event.snapshot.active;
+              }
+            }
+            renderProfileWindows();
+            break;
+          }
+          case "profile_error":
+            setProfileStatus(
+              event.id,
+              `Error [${event.code}]: ${event.message}`,
+              "error",
+            );
+            break;
         }
       }
 
@@ -5576,7 +6277,9 @@
         if (!element) {
           return null;
         }
-        return element.closest(".branch-scroll, .file-tree-scroll");
+        return element.closest(
+          ".branch-scroll, .file-tree-scroll, .profile-list-pane, .profile-detail-pane",
+        );
       }
 
       function handleCanvasWheelEvent(event) {


### PR DESCRIPTION
## Summary

- Replace the mock Profile window with a config-backed GUI surface that lists profiles, switches the active profile, and edits profile metadata.
- Add backend profile service, dispatch, and protocol events so profile CRUD, `env_vars`, and `disabled_env` mutations persist immediately through `gwt-config`.
- Merge the latest `origin/develop` into this branch and reconcile the custom-agent routing changes with the new Profile window flow.

## Changes

- `crates/gwt/src/profiles_service.rs`: add snapshot loading, profile CRUD, env var editing, disabled env editing, and error mapping backed by `gwt-config::Settings`.
- `crates/gwt/src/profiles_dispatch.rs`: add frontend event handlers that return profile snapshots or profile errors for all profile operations.
- `crates/gwt/src/protocol.rs`: extend the WebSocket contract with profile request/reply events and explicit profile error codes.
- `crates/gwt/src/main.rs`: wire profile events into the runtime dispatcher while preserving the develop-side custom agent controller flow.
- `crates/gwt/src/preset.rs`: promote the Profile preset from a mock surface to a dedicated Profile window surface.
- `crates/gwt/web/index.html`: replace the mock profile content with list, editor, env/disabled env tables, and merged preview UI.
- `crates/gwt/src/embedded_web.rs`: add embedded web contract coverage for the Profile surface wiring.
- `crates/gwt-agent` + custom agent modules: include the develop-side custom agent controller changes brought in by the merge from `origin/develop`.

## Testing

- [x] `cargo test -p gwt-agent -p gwt-config -p gwt` — all tests pass after resolving the merge and keeping both the Profile window and custom-agent flows.
- [x] `cargo fmt -- --check` — formatting check passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes with warnings denied.
- [x] `cargo build -p gwt` — desktop app crate builds successfully.

## Closing Issues

- Closes #2015

## Related Issues / Links

- #1933
- #1784

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — no README change is needed because this work stays inside the existing canvas UI surface.
- [ ] Migration/backfill plan included (if schema/data change) — no schema or stored data migration is introduced.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- SPEC-2015 owns the GUI Settings/Profile window scope. This PR completes the Profile window slice only; the broader Settings window editing work remains outside this change.
- SPEC-1933 already owns the profile domain model and persistence contract, so this PR intentionally reuses that backend source of truth instead of adding frontend-owned profile state.

## Risk / Impact

- **Affected areas**: GUI canvas window routing, embedded web contract, profile persistence, and custom agent dispatch integration in `main.rs`.
- **Rollback plan**: Revert this branch or the merge commit plus the profile feature commit to restore the previous mock Profile surface.

## Screenshots

| Before | After |
|--------|-------|
| Mock Profile placeholder surface | Config-backed Profile management surface with list, editor, env tables, and merged preview |

## Notes

- This branch includes a merge from `origin/develop` because it was 17 commits behind the base branch before PR creation.
