### PR TITLE
refactor(gwt): isolate custom agents settings state

### DIFF
--- a/crates/gwt/src/custom_agents_controller.rs
+++ b/crates/gwt/src/custom_agents_controller.rs
@@ -15,11 +15,24 @@ impl CustomAgentsController {
         }
     }
 
+    pub(crate) fn supports(event: &FrontendEvent) -> bool {
+        matches!(
+            event,
+            FrontendEvent::ListCustomAgents
+                | FrontendEvent::ListCustomAgentPresets
+                | FrontendEvent::AddCustomAgentFromPreset { .. }
+                | FrontendEvent::UpdateCustomAgent { .. }
+                | FrontendEvent::DeleteCustomAgent { .. }
+                | FrontendEvent::TestBackendConnection { .. }
+        )
+    }
+
     pub(crate) fn handle_event(
         &self,
         client_id: ClientId,
         event: FrontendEvent,
     ) -> Vec<OutboundEvent> {
+        debug_assert!(Self::supports(&event));
         match event {
             FrontendEvent::ListCustomAgents => {
                 vec![self.reply(client_id, gwt::custom_agents_dispatch::list_event())]

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -319,4 +319,30 @@ mod tests {
             "expected issue launch wizard event in embedded html",
         );
     }
+
+    #[test]
+    fn embedded_web_settings_custom_agents_surface_tracks_probe_and_save_activity() {
+        let html = index_html();
+
+        assert!(
+            html.contains("probeInFlight"),
+            "expected embedded html to track backend probe state separately from generic status",
+        );
+        assert!(
+            html.contains("saveInFlight"),
+            "expected embedded html to track preset save state separately from generic status",
+        );
+        assert!(
+            html.contains("lastProbeModels"),
+            "expected embedded html to retain the last successful probe model list",
+        );
+        assert!(
+            html.contains("function renderSettingsActivitySection(scroll)"),
+            "expected settings activity rendering to be isolated behind a named helper",
+        );
+        assert!(
+            html.contains("Last probe"),
+            "expected settings surface to expose the last probe summary",
+        );
+    }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -462,6 +462,9 @@ impl AppRuntime {
         client_id: ClientId,
         event: FrontendEvent,
     ) -> Vec<OutboundEvent> {
+        if custom_agents_controller::CustomAgentsController::supports(&event) {
+            return self.custom_agents.handle_event(client_id, event);
+        }
         match event {
             FrontendEvent::FrontendReady => self.frontend_sync_events(&client_id),
             FrontendEvent::OpenProjectDialog => self.open_project_dialog_events(),
@@ -548,14 +551,7 @@ impl AppRuntime {
                 std::thread::spawn(apply_update_and_exit);
                 vec![]
             }
-            custom_agents_event @ (FrontendEvent::ListCustomAgents
-            | FrontendEvent::ListCustomAgentPresets
-            | FrontendEvent::AddCustomAgentFromPreset { .. }
-            | FrontendEvent::UpdateCustomAgent { .. }
-            | FrontendEvent::DeleteCustomAgent { .. }
-            | FrontendEvent::TestBackendConnection { .. }) => self
-                .custom_agents
-                .handle_event(client_id, custom_agents_event),
+            other => unreachable!("custom agents handled before main match: {other:?}"),
         }
     }
 
@@ -2701,7 +2697,10 @@ mod tests {
         ProjectKind, QuickStartEntry, QuickStartLaunchMode, RuntimeHookEvent, RuntimeHookEventKind,
         ShellLaunchConfig, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState,
     };
-    use gwt_agent::{AgentId, AgentLaunchBuilder, DockerLifecycleIntent, LaunchRuntimeTarget};
+    use gwt_agent::custom::CustomAgentType;
+    use gwt_agent::{
+        AgentId, AgentLaunchBuilder, CustomCodingAgent, DockerLifecycleIntent, LaunchRuntimeTarget,
+    };
     use gwt_core::update::UpdateState;
     use gwt_terminal::PaneStatus;
 
@@ -4261,6 +4260,75 @@ mod tests {
             BackendEvent::CustomAgentPresetList { presets } => assert!(!presets.is_empty()),
             other => panic!("expected CustomAgentPresetList, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn custom_agents_controller_supports_only_custom_agent_events() {
+        assert!(
+            super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::ListCustomAgents,
+            )
+        );
+        assert!(
+            super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::ListCustomAgentPresets,
+            )
+        );
+        assert!(
+            super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::AddCustomAgentFromPreset {
+                    preset_id: gwt::PresetId::ClaudeCodeOpenaiCompat,
+                    payload: serde_json::json!({
+                        "id": "claude-code-openai",
+                        "display_name": "Claude Code (OpenAI-compat)",
+                        "base_url": "http://127.0.0.1:8000",
+                        "api_key": "secret",
+                        "default_model": "openai/gpt-oss-20b",
+                    }),
+                },
+            )
+        );
+        assert!(
+            super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::UpdateCustomAgent {
+                    agent: Box::new(CustomCodingAgent {
+                        id: "custom-1".to_string(),
+                        display_name: "Custom 1".to_string(),
+                        agent_type: CustomAgentType::Command,
+                        command: "codex".to_string(),
+                        default_args: Vec::new(),
+                        mode_args: None,
+                        skip_permissions_args: Vec::new(),
+                        env: HashMap::new(),
+                    }),
+                },
+            )
+        );
+        assert!(
+            super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::DeleteCustomAgent {
+                    agent_id: "custom-1".to_string(),
+                },
+            )
+        );
+        assert!(
+            super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::TestBackendConnection {
+                    base_url: "http://127.0.0.1:8000".to_string(),
+                    api_key: "secret".to_string(),
+                },
+            )
+        );
+        assert!(
+            !super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::FrontendReady,
+            )
+        );
+        assert!(
+            !super::custom_agents_controller::CustomAgentsController::supports(
+                &gwt::FrontendEvent::ApplyUpdate,
+            )
+        );
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -529,9 +529,6 @@ impl AppRuntime {
         client_id: ClientId,
         event: FrontendEvent,
     ) -> Vec<OutboundEvent> {
-        if custom_agents_controller::CustomAgentsController::supports(&event) {
-            return self.custom_agents.handle_event(client_id, event);
-        }
         match event {
             FrontendEvent::FrontendReady => self.frontend_sync_events(&client_id),
             FrontendEvent::OpenProjectDialog => self.open_project_dialog_events(),
@@ -707,7 +704,14 @@ impl AppRuntime {
             } => vec![OutboundEvent::broadcast(
                 gwt::profiles_dispatch::delete_disabled_env_event(id, profile_name, key),
             )],
-            other => unreachable!("feature-scoped event handled before main match: {other:?}"),
+            custom_agents_event @ (FrontendEvent::ListCustomAgents
+            | FrontendEvent::ListCustomAgentPresets
+            | FrontendEvent::AddCustomAgentFromPreset { .. }
+            | FrontendEvent::UpdateCustomAgent { .. }
+            | FrontendEvent::DeleteCustomAgent { .. }
+            | FrontendEvent::TestBackendConnection { .. }) => self
+                .custom_agents
+                .handle_event(client_id, custom_agents_event),
         }
     }
 

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -4906,6 +4906,9 @@
         presetsLoading: false,
         statusMessage: "",
         statusKind: "",
+        probeInFlight: false,
+        saveInFlight: false,
+        lastProbeModels: [],
       };
       const settingsWindowBodies = new Set();
       let pendingAddFromPreset = null;
@@ -4948,9 +4951,11 @@
         });
         settingsWindowBodies.add(body);
         renderSettingsAgentList();
+        let needsRefresh = false;
         if (!customAgentsState.loading && customAgentsState.agents.length === 0) {
           customAgentsState.loading = true;
           send({ kind: "list_custom_agents" });
+          needsRefresh = true;
         }
         if (
           !customAgentsState.presetsLoading &&
@@ -4958,6 +4963,10 @@
         ) {
           customAgentsState.presetsLoading = true;
           send({ kind: "list_custom_agent_presets" });
+          needsRefresh = true;
+        }
+        if (needsRefresh) {
+          renderSettingsAgentList();
         }
       }
 
@@ -5001,6 +5010,8 @@
             section.appendChild(row);
             scroll.appendChild(section);
           }
+
+          renderSettingsActivitySection(scroll);
 
           if (customAgentsState.loading && customAgentsState.agents.length === 0) {
             const section = createDiv("mock-section");
@@ -5055,6 +5066,55 @@
         }
       }
 
+      function renderSettingsActivitySection(scroll) {
+        if (
+          !customAgentsState.presetsLoading &&
+          !customAgentsState.probeInFlight &&
+          !customAgentsState.saveInFlight &&
+          customAgentsState.lastProbeModels.length === 0
+        ) {
+          return;
+        }
+        const section = createDiv("mock-section");
+        const label = createDiv("mock-label");
+        label.textContent = "Activity";
+        section.appendChild(label);
+
+        if (customAgentsState.presetsLoading) {
+          const row = createDiv("mock-row");
+          const text = document.createElement("span");
+          text.textContent = "Loading preset catalog…";
+          row.appendChild(text);
+          section.appendChild(row);
+        }
+
+        if (customAgentsState.probeInFlight) {
+          const row = createDiv("mock-row");
+          const text = document.createElement("span");
+          text.textContent = "Probe status · Probing /v1/models…";
+          row.appendChild(text);
+          section.appendChild(row);
+        }
+
+        if (customAgentsState.lastProbeModels.length > 0) {
+          const row = createDiv("mock-row");
+          const text = document.createElement("span");
+          text.textContent = `Last probe · ${customAgentsState.lastProbeModels.length} model(s) discovered`;
+          row.appendChild(text);
+          section.appendChild(row);
+        }
+
+        if (customAgentsState.saveInFlight) {
+          const row = createDiv("mock-row");
+          const text = document.createElement("span");
+          text.textContent = "Save status · Saving preset…";
+          row.appendChild(text);
+          section.appendChild(row);
+        }
+
+        scroll.appendChild(section);
+      }
+
       function startAddFromPresetFlow(preset) {
         const baseUrl = window.prompt(
           "Upstream base_url (http:// or https://)\n\nExample: http://192.168.100.166:32768",
@@ -5065,6 +5125,9 @@
           "API key (forwarded as Bearer on /v1/models probe and ANTHROPIC_API_KEY at launch):",
         );
         if (!apiKey) return;
+        customAgentsState.probeInFlight = true;
+        customAgentsState.saveInFlight = false;
+        customAgentsState.lastProbeModels = [];
         setSettingsStatus("Probing /v1/models…", "info");
         pendingAddFromPreset = { presetId: preset.id, baseUrl, apiKey };
         send({ kind: "test_backend_connection", base_url: baseUrl, api_key: apiKey });
@@ -5078,11 +5141,14 @@
 
       function completeAddFromPreset(discoveredModels) {
         if (!pendingAddFromPreset) return;
+        customAgentsState.probeInFlight = false;
         if (!discoveredModels || discoveredModels.length === 0) {
+          customAgentsState.lastProbeModels = [];
           setSettingsStatus("Upstream /v1/models returned no entries.", "error");
           pendingAddFromPreset = null;
           return;
         }
+        customAgentsState.lastProbeModels = Array.from(discoveredModels);
         const modelList = discoveredModels.join("\n");
         const model = window.prompt(
           `Discovered ${discoveredModels.length} model(s). Choose default_model (copy one ID):\n\n${modelList}`,
@@ -5105,6 +5171,7 @@
           setSettingsStatus("Cancelled.", "info");
           return;
         }
+        customAgentsState.saveInFlight = true;
         setSettingsStatus("Saving preset…", "info");
         send({
           kind: "add_custom_agent_from_preset",
@@ -5420,6 +5487,7 @@
               }
             }
             customAgentsState.loading = false;
+            customAgentsState.saveInFlight = false;
             setSettingsStatus(
               `Saved custom agent "${event.agent ? event.agent.id : "?"}".`,
               "success",
@@ -5432,6 +5500,10 @@
             setSettingsStatus(`Deleted custom agent "${event.agent_id}".`, "success");
             break;
           case "backend_connection_result":
+            customAgentsState.probeInFlight = false;
+            customAgentsState.lastProbeModels = Array.isArray(event.models)
+              ? Array.from(event.models)
+              : [];
             setSettingsStatus(
               `/v1/models returned ${event.models.length} model(s).`,
               "success",
@@ -5445,6 +5517,11 @@
             break;
           case "custom_agent_error":
             customAgentsState.loading = false;
+            customAgentsState.probeInFlight = false;
+            customAgentsState.saveInFlight = false;
+            if (event.code === "probe") {
+              customAgentsState.lastProbeModels = [];
+            }
             pendingAddFromPreset = null;
             setSettingsStatus(`Error [${event.code}]: ${event.message}`, "error");
             break;


### PR DESCRIPTION
## Summary

- move Custom Agents frontend-event classification into `CustomAgentsController` so `AppRuntime` no longer enumerates that surface inline
- split Settings > Custom Agents activity from the generic status line by tracking probe/save progress and last probe results separately
- add regression coverage for controller ownership and embedded HTML activity contract

## Changes

- added `CustomAgentsController::supports()` and delegated supported events before the main `match` in `AppRuntime`
- rendered a dedicated `Activity` section in Settings for preset catalog loading, `/v1/models` probing, save progress, and last probe summary
- merged the latest `origin/develop` into `feature/issue-2102` and reconciled the new Profiles event routes with the Custom Agents delegation path

## Testing

- `cargo test -p gwt --bin gwt`
- `cargo test -p gwt-core -p gwt`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Closing Issues

None

## Related Issues

- #1784
- #1921
- #2015
- #2102

## Checklist

- [x] Self-reviewed diff and merge resolution
- [x] Verification commands completed locally
- [x] No intentional protocol-breaking change
