### PR TITLE
fix(launch-wizard): reuse resumable quick start session profile

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2800,35 +2800,61 @@ mod tests {
     }
 
     #[test]
-    fn collect_quick_start_entries_from_sessions_separates_display_and_resume_source() {
+    fn collect_quick_start_entries_from_sessions_reuses_resumable_session_profile() {
         let worktree = PathBuf::from("/tmp/repo");
+        let mut older = sample_session_record(
+            "feature/gui",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 9, 0, 0).unwrap(),
+            Some("resume-older"),
+        );
+        older.tool_version = Some("0.110.0".to_string());
+        older.model = Some("gpt-5.4".to_string());
+        older.reasoning_level = Some("high".to_string());
+        older.skip_permissions = true;
+        older.codex_fast_mode = true;
+        older.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+        older.docker_service = Some("gwt".to_string());
+
+        let mut newer = sample_session_record(
+            "feature/gui",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
+            None,
+        );
+        newer.tool_version = Some("0.111.0".to_string());
+        newer.model = Some("gpt-5.4-mini".to_string());
+        newer.reasoning_level = Some("low".to_string());
+        newer.skip_permissions = false;
+        newer.codex_fast_mode = false;
+        newer.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
+        newer.docker_service = None;
+
         let entries = super::quick_start::collect_quick_start_entries_from_sessions(
             &worktree,
             "feature/gui",
-            vec![
-                sample_session_record(
-                    "feature/gui",
-                    &worktree,
-                    gwt_agent::AgentId::Codex,
-                    Utc.with_ymd_and_hms(2026, 4, 14, 9, 0, 0).unwrap(),
-                    Some("resume-older"),
-                ),
-                sample_session_record(
-                    "feature/gui",
-                    &worktree,
-                    gwt_agent::AgentId::Codex,
-                    Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
-                    None,
-                ),
-            ],
+            vec![older.clone(), newer],
         );
 
         assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id, older.id);
         assert_eq!(entries[0].agent_id, "codex");
         assert_eq!(
             entries[0].resume_session_id.as_deref(),
             Some("resume-older")
         );
+        assert_eq!(entries[0].model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(entries[0].reasoning.as_deref(), Some("high"));
+        assert_eq!(entries[0].version.as_deref(), Some("0.110.0"));
+        assert_eq!(
+            entries[0].runtime_target,
+            gwt_agent::LaunchRuntimeTarget::Docker
+        );
+        assert_eq!(entries[0].docker_service.as_deref(), Some("gwt"));
+        assert!(entries[0].skip_permissions);
+        assert!(entries[0].codex_fast_mode);
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2505,6 +2505,7 @@ pub fn load_quick_start_entries(
     };
 
     let mut latest_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
+    let mut latest_resumable_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
     for entry in entries.flatten() {
         let path = entry.path();
         if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
@@ -2518,13 +2519,19 @@ pub fn load_quick_start_entries(
         }
 
         let agent_key = session.agent_id.command().to_string();
+        if agent_session_resume_id(&session).is_some() {
+            let replace = latest_resumable_by_agent
+                .get(&agent_key)
+                .map(|current| session_is_newer(&session, current))
+                .unwrap_or(true);
+            if replace {
+                latest_resumable_by_agent.insert(agent_key.clone(), session.clone());
+            }
+        }
+
         let replace = latest_by_agent
             .get(&agent_key)
-            .map(|current| {
-                session.updated_at > current.updated_at
-                    || (session.updated_at == current.updated_at
-                        && session.created_at > current.created_at)
-            })
+            .map(|current| session_is_newer(&session, current))
             .unwrap_or(true);
         if replace {
             latest_by_agent.insert(agent_key, session);
@@ -2539,29 +2546,56 @@ pub fn load_quick_start_entries(
             .then_with(|| right.created_at.cmp(&left.created_at))
     });
 
+    let fallback_resume_by_agent = latest_resumable_by_agent
+        .into_iter()
+        .filter_map(|(agent_key, session)| {
+            agent_session_resume_id(&session).map(|resume_id| (agent_key, resume_id))
+        })
+        .collect::<HashMap<_, _>>();
+
     sessions
         .into_iter()
-        .map(|session| QuickStartEntry {
-            session_id: session.id.clone(),
-            agent_id: session.agent_id.command().to_string(),
-            tool_label: session.display_name.clone(),
-            model: session.model.clone(),
-            reasoning: session.reasoning_level.clone(),
-            version: session.tool_version.clone().or_else(|| {
-                session
-                    .agent_id
-                    .package_name()
-                    .map(|_| "installed".to_string())
-            }),
-            resume_session_id: session.agent_session_id.clone(),
-            live_window_id: None,
-            skip_permissions: session.skip_permissions,
-            codex_fast_mode: session.codex_fast_mode,
-            runtime_target: session.runtime_target,
-            docker_service: session.docker_service.clone(),
-            docker_lifecycle_intent: session.docker_lifecycle_intent,
+        .map(|session| {
+            let agent_key = session.agent_id.command().to_string();
+            let resume_session_id = agent_session_resume_id(&session)
+                .or_else(|| fallback_resume_by_agent.get(&agent_key).cloned());
+
+            QuickStartEntry {
+                session_id: session.id.clone(),
+                agent_id: agent_key,
+                tool_label: session.display_name.clone(),
+                model: session.model.clone(),
+                reasoning: session.reasoning_level.clone(),
+                version: session.tool_version.clone().or_else(|| {
+                    session
+                        .agent_id
+                        .package_name()
+                        .map(|_| "installed".to_string())
+                }),
+                resume_session_id,
+                live_window_id: None,
+                skip_permissions: session.skip_permissions,
+                codex_fast_mode: session.codex_fast_mode,
+                runtime_target: session.runtime_target,
+                docker_service: session.docker_service.clone(),
+                docker_lifecycle_intent: session.docker_lifecycle_intent,
+            }
         })
         .collect()
+}
+
+fn session_is_newer(candidate: &gwt_agent::Session, current: &gwt_agent::Session) -> bool {
+    candidate.updated_at > current.updated_at
+        || (candidate.updated_at == current.updated_at && candidate.created_at > current.created_at)
+}
+
+fn agent_session_resume_id(session: &gwt_agent::Session) -> Option<String> {
+    session
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -2625,9 +2659,27 @@ mod tests {
         updated_at: chrono::DateTime<Utc>,
         resume_id: &str,
     ) {
+        sample_session_with_resume(
+            dir,
+            branch,
+            worktree_path,
+            agent_id,
+            updated_at,
+            Some(resume_id),
+        );
+    }
+
+    fn sample_session_with_resume(
+        dir: &Path,
+        branch: &str,
+        worktree_path: &Path,
+        agent_id: gwt_agent::AgentId,
+        updated_at: chrono::DateTime<Utc>,
+        resume_id: Option<&str>,
+    ) {
         let mut session = gwt_agent::Session::new(worktree_path, branch, agent_id);
         session.display_name = session.agent_id.display_name().to_string();
-        session.agent_session_id = Some(resume_id.to_string());
+        session.agent_session_id = resume_id.map(str::to_string);
         session.tool_version = Some("installed".to_string());
         session.model = Some("gpt-5.4".to_string());
         session.reasoning_level = Some("high".to_string());
@@ -2749,6 +2801,77 @@ mod tests {
         assert_eq!(entries[0].agent_id, "codex");
         assert_eq!(entries[0].resume_session_id.as_deref(), Some("newer"));
         assert_eq!(entries[0].docker_service.as_deref(), Some("gwt"));
+    }
+
+    #[test]
+    fn load_quick_start_entries_uses_latest_resumable_session_when_latest_lacks_resume_id() {
+        let dir = tempdir().expect("tempdir");
+        let worktree = dir.path().join("repo");
+        std::fs::create_dir_all(&worktree).expect("repo dir");
+        sample_session(
+            dir.path(),
+            "feature/gui",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 9, 0, 0).unwrap(),
+            "resume-older",
+        );
+        sample_session_with_resume(
+            dir.path(),
+            "feature/gui",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
+            None,
+        );
+
+        let entries = load_quick_start_entries(&worktree, dir.path(), "feature/gui");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].agent_id, "codex");
+        assert_eq!(
+            entries[0].resume_session_id.as_deref(),
+            Some("resume-older")
+        );
+    }
+
+    #[test]
+    fn load_quick_start_entries_does_not_reuse_resume_id_from_other_scope() {
+        let dir = tempdir().expect("tempdir");
+        let worktree = dir.path().join("repo");
+        let other_worktree = dir.path().join("other-repo");
+        std::fs::create_dir_all(&worktree).expect("repo dir");
+        std::fs::create_dir_all(&other_worktree).expect("other repo dir");
+        sample_session(
+            dir.path(),
+            "feature/other",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 9, 0, 0).unwrap(),
+            "wrong-branch",
+        );
+        sample_session(
+            dir.path(),
+            "feature/gui",
+            &other_worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 9, 30, 0).unwrap(),
+            "wrong-worktree",
+        );
+        sample_session_with_resume(
+            dir.path(),
+            "feature/gui",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
+            None,
+        );
+
+        let entries = load_quick_start_entries(&worktree, dir.path(), "feature/gui");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].agent_id, "codex");
+        assert!(entries[0].resume_session_id.is_none());
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -5,6 +5,10 @@ use std::{
 
 use crate::BranchListEntry;
 
+mod quick_start;
+
+pub use quick_start::load_quick_start_entries;
+
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
 const BRANCH_TYPE_PREFIXES: [&str; 4] = ["feature/", "bugfix/", "hotfix/", "release/"];
 
@@ -2495,109 +2499,6 @@ pub fn build_builtin_agent_options(
         .collect()
 }
 
-pub fn load_quick_start_entries(
-    repo_path: &Path,
-    sessions_dir: &Path,
-    branch_name: &str,
-) -> Vec<QuickStartEntry> {
-    let Ok(entries) = std::fs::read_dir(sessions_dir) else {
-        return Vec::new();
-    };
-
-    let mut latest_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
-    let mut latest_resumable_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
-            continue;
-        }
-        let Ok(session) = gwt_agent::Session::load_and_migrate(&path) else {
-            continue;
-        };
-        if session.branch != branch_name || session.worktree_path != repo_path {
-            continue;
-        }
-
-        let agent_key = session.agent_id.command().to_string();
-        if agent_session_resume_id(&session).is_some() {
-            let replace = latest_resumable_by_agent
-                .get(&agent_key)
-                .map(|current| session_is_newer(&session, current))
-                .unwrap_or(true);
-            if replace {
-                latest_resumable_by_agent.insert(agent_key.clone(), session.clone());
-            }
-        }
-
-        let replace = latest_by_agent
-            .get(&agent_key)
-            .map(|current| session_is_newer(&session, current))
-            .unwrap_or(true);
-        if replace {
-            latest_by_agent.insert(agent_key, session);
-        }
-    }
-
-    let mut sessions = latest_by_agent.into_values().collect::<Vec<_>>();
-    sessions.sort_by(|left, right| {
-        right
-            .updated_at
-            .cmp(&left.updated_at)
-            .then_with(|| right.created_at.cmp(&left.created_at))
-    });
-
-    let fallback_resume_by_agent = latest_resumable_by_agent
-        .into_iter()
-        .filter_map(|(agent_key, session)| {
-            agent_session_resume_id(&session).map(|resume_id| (agent_key, resume_id))
-        })
-        .collect::<HashMap<_, _>>();
-
-    sessions
-        .into_iter()
-        .map(|session| {
-            let agent_key = session.agent_id.command().to_string();
-            let resume_session_id = agent_session_resume_id(&session)
-                .or_else(|| fallback_resume_by_agent.get(&agent_key).cloned());
-
-            QuickStartEntry {
-                session_id: session.id.clone(),
-                agent_id: agent_key,
-                tool_label: session.display_name.clone(),
-                model: session.model.clone(),
-                reasoning: session.reasoning_level.clone(),
-                version: session.tool_version.clone().or_else(|| {
-                    session
-                        .agent_id
-                        .package_name()
-                        .map(|_| "installed".to_string())
-                }),
-                resume_session_id,
-                live_window_id: None,
-                skip_permissions: session.skip_permissions,
-                codex_fast_mode: session.codex_fast_mode,
-                runtime_target: session.runtime_target,
-                docker_service: session.docker_service.clone(),
-                docker_lifecycle_intent: session.docker_lifecycle_intent,
-            }
-        })
-        .collect()
-}
-
-fn session_is_newer(candidate: &gwt_agent::Session, current: &gwt_agent::Session) -> bool {
-    candidate.updated_at > current.updated_at
-        || (candidate.updated_at == current.updated_at && candidate.created_at > current.created_at)
-}
-
-fn agent_session_resume_id(session: &gwt_agent::Session) -> Option<String> {
-    session
-        .agent_session_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-        .map(str::to_string)
-}
-
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
@@ -2692,6 +2593,30 @@ mod tests {
         session.updated_at = updated_at;
         session.last_activity_at = updated_at;
         session.save(dir).expect("save session");
+    }
+
+    fn sample_session_record(
+        branch: &str,
+        worktree_path: &Path,
+        agent_id: gwt_agent::AgentId,
+        updated_at: chrono::DateTime<Utc>,
+        resume_id: Option<&str>,
+    ) -> gwt_agent::Session {
+        let mut session = gwt_agent::Session::new(worktree_path, branch, agent_id);
+        session.display_name = session.agent_id.display_name().to_string();
+        session.agent_session_id = resume_id.map(str::to_string);
+        session.tool_version = Some("installed".to_string());
+        session.model = Some("gpt-5.4".to_string());
+        session.reasoning_level = Some("high".to_string());
+        session.skip_permissions = true;
+        session.codex_fast_mode = true;
+        session.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+        session.docker_service = Some("gwt".to_string());
+        session.docker_lifecycle_intent = gwt_agent::DockerLifecycleIntent::Restart;
+        session.created_at = updated_at;
+        session.updated_at = updated_at;
+        session.last_activity_at = updated_at;
+        session
     }
 
     fn quick_start_entry(
@@ -2872,6 +2797,38 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].agent_id, "codex");
         assert!(entries[0].resume_session_id.is_none());
+    }
+
+    #[test]
+    fn collect_quick_start_entries_from_sessions_separates_display_and_resume_source() {
+        let worktree = PathBuf::from("/tmp/repo");
+        let entries = super::quick_start::collect_quick_start_entries_from_sessions(
+            &worktree,
+            "feature/gui",
+            vec![
+                sample_session_record(
+                    "feature/gui",
+                    &worktree,
+                    gwt_agent::AgentId::Codex,
+                    Utc.with_ymd_and_hms(2026, 4, 14, 9, 0, 0).unwrap(),
+                    Some("resume-older"),
+                ),
+                sample_session_record(
+                    "feature/gui",
+                    &worktree,
+                    gwt_agent::AgentId::Codex,
+                    Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
+                    None,
+                ),
+            ],
+        );
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].agent_id, "codex");
+        assert_eq!(
+            entries[0].resume_session_id.as_deref(),
+            Some("resume-older")
+        );
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard/quick_start.rs
+++ b/crates/gwt/src/launch_wizard/quick_start.rs
@@ -1,0 +1,117 @@
+use std::{collections::HashMap, path::Path};
+
+use super::QuickStartEntry;
+
+pub fn load_quick_start_entries(
+    repo_path: &Path,
+    sessions_dir: &Path,
+    branch_name: &str,
+) -> Vec<QuickStartEntry> {
+    let Ok(entries) = std::fs::read_dir(sessions_dir) else {
+        return Vec::new();
+    };
+
+    let sessions = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
+        })
+        .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
+        .collect::<Vec<_>>();
+
+    collect_quick_start_entries_from_sessions(repo_path, branch_name, sessions)
+}
+
+pub(super) fn collect_quick_start_entries_from_sessions(
+    repo_path: &Path,
+    branch_name: &str,
+    sessions: Vec<gwt_agent::Session>,
+) -> Vec<QuickStartEntry> {
+    let mut latest_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
+    let mut latest_resumable_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
+
+    for session in sessions {
+        if session.branch != branch_name || session.worktree_path != repo_path {
+            continue;
+        }
+
+        let agent_key = session.agent_id.command().to_string();
+        if agent_session_resume_id(&session).is_some() {
+            let replace = latest_resumable_by_agent
+                .get(&agent_key)
+                .map(|current| session_is_newer(&session, current))
+                .unwrap_or(true);
+            if replace {
+                latest_resumable_by_agent.insert(agent_key.clone(), session.clone());
+            }
+        }
+
+        let replace = latest_by_agent
+            .get(&agent_key)
+            .map(|current| session_is_newer(&session, current))
+            .unwrap_or(true);
+        if replace {
+            latest_by_agent.insert(agent_key, session);
+        }
+    }
+
+    let mut sessions = latest_by_agent.into_values().collect::<Vec<_>>();
+    sessions.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| right.created_at.cmp(&left.created_at))
+    });
+
+    let fallback_resume_by_agent = latest_resumable_by_agent
+        .into_iter()
+        .filter_map(|(agent_key, session)| {
+            agent_session_resume_id(&session).map(|resume_id| (agent_key, resume_id))
+        })
+        .collect::<HashMap<_, _>>();
+
+    sessions
+        .into_iter()
+        .map(|session| {
+            let agent_key = session.agent_id.command().to_string();
+            let resume_session_id = agent_session_resume_id(&session)
+                .or_else(|| fallback_resume_by_agent.get(&agent_key).cloned());
+
+            QuickStartEntry {
+                session_id: session.id.clone(),
+                agent_id: agent_key,
+                tool_label: session.display_name.clone(),
+                model: session.model.clone(),
+                reasoning: session.reasoning_level.clone(),
+                version: session.tool_version.clone().or_else(|| {
+                    session
+                        .agent_id
+                        .package_name()
+                        .map(|_| "installed".to_string())
+                }),
+                resume_session_id,
+                live_window_id: None,
+                skip_permissions: session.skip_permissions,
+                codex_fast_mode: session.codex_fast_mode,
+                runtime_target: session.runtime_target,
+                docker_service: session.docker_service.clone(),
+                docker_lifecycle_intent: session.docker_lifecycle_intent,
+            }
+        })
+        .collect()
+}
+
+fn session_is_newer(candidate: &gwt_agent::Session, current: &gwt_agent::Session) -> bool {
+    candidate.updated_at > current.updated_at
+        || (candidate.updated_at == current.updated_at && candidate.created_at > current.created_at)
+}
+
+fn agent_session_resume_id(session: &gwt_agent::Session) -> Option<String> {
+    session
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+}

--- a/crates/gwt/src/launch_wizard/quick_start.rs
+++ b/crates/gwt/src/launch_wizard/quick_start.rs
@@ -56,7 +56,19 @@ pub(super) fn collect_quick_start_entries_from_sessions(
         }
     }
 
-    let mut sessions = latest_by_agent.into_values().collect::<Vec<_>>();
+    let mut sessions = latest_by_agent
+        .into_iter()
+        .map(|(agent_key, latest_session)| {
+            if agent_session_resume_id(&latest_session).is_some() {
+                latest_session
+            } else {
+                latest_resumable_by_agent
+                    .get(&agent_key)
+                    .cloned()
+                    .unwrap_or(latest_session)
+            }
+        })
+        .collect::<Vec<_>>();
     sessions.sort_by(|left, right| {
         right
             .updated_at
@@ -64,40 +76,27 @@ pub(super) fn collect_quick_start_entries_from_sessions(
             .then_with(|| right.created_at.cmp(&left.created_at))
     });
 
-    let fallback_resume_by_agent = latest_resumable_by_agent
-        .into_iter()
-        .filter_map(|(agent_key, session)| {
-            agent_session_resume_id(&session).map(|resume_id| (agent_key, resume_id))
-        })
-        .collect::<HashMap<_, _>>();
-
     sessions
         .into_iter()
-        .map(|session| {
-            let agent_key = session.agent_id.command().to_string();
-            let resume_session_id = agent_session_resume_id(&session)
-                .or_else(|| fallback_resume_by_agent.get(&agent_key).cloned());
-
-            QuickStartEntry {
-                session_id: session.id.clone(),
-                agent_id: agent_key,
-                tool_label: session.display_name.clone(),
-                model: session.model.clone(),
-                reasoning: session.reasoning_level.clone(),
-                version: session.tool_version.clone().or_else(|| {
-                    session
-                        .agent_id
-                        .package_name()
-                        .map(|_| "installed".to_string())
-                }),
-                resume_session_id,
-                live_window_id: None,
-                skip_permissions: session.skip_permissions,
-                codex_fast_mode: session.codex_fast_mode,
-                runtime_target: session.runtime_target,
-                docker_service: session.docker_service.clone(),
-                docker_lifecycle_intent: session.docker_lifecycle_intent,
-            }
+        .map(|session| QuickStartEntry {
+            session_id: session.id.clone(),
+            agent_id: session.agent_id.command().to_string(),
+            tool_label: session.display_name.clone(),
+            model: session.model.clone(),
+            reasoning: session.reasoning_level.clone(),
+            version: session.tool_version.clone().or_else(|| {
+                session
+                    .agent_id
+                    .package_name()
+                    .map(|_| "installed".to_string())
+            }),
+            resume_session_id: agent_session_resume_id(&session),
+            live_window_id: None,
+            skip_permissions: session.skip_permissions,
+            codex_fast_mode: session.codex_fast_mode,
+            runtime_target: session.runtime_target,
+            docker_service: session.docker_service.clone(),
+            docker_lifecycle_intent: session.docker_lifecycle_intent,
         })
         .collect()
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3367,3 +3367,29 @@ Resume だった。
    `agent_session_id` を一次調査対象にする。
 3. ユーザーが UI 名を訂正した場合は、調査 plan とテスト観点を即座にその UI に
    切り替える。
+
+## 2026-04-21 — fix: Quick Start resume fallback で resume id だけを借りない
+
+### 事象
+
+Launch Agent の Quick Start で、最新 session に `agent_session_id` がない場合でも
+Resume ボタンは出るようになったが、older resumable session の resume id だけを借りて、
+launch profile は newer session のまま使ってしまう review 指摘が入った。
+
+### 原因
+
+- fallback 実装が「Resume ボタンを出せるか」のみを見ており、resume 対象 session と
+  launch profile の整合性を 1 セットとして扱えていなかった。
+- `apply_quick_start_action()` が `QuickStartEntry` の model / version / runtime target /
+  docker service をそのまま resume launch に使う契約を、fallback helper 側で
+  回帰テストに落とし込めていなかった。
+
+### 再発防止策
+
+1. Quick Start の resume fallback では、resume id だけを借りず、resume 元に選んだ
+   session 全体を entry source として再利用する。
+2. session fallback を実装する helper では、`session_id`、model、reasoning、version、
+   runtime target、docker service、permission flags まで同一 session 由来であることを
+   pure test で固定する。
+3. 「表示用 session」と「実行に使う session」を分ける設計にする場合は、Resume launch が
+   参照する全フィールドの provenance をコード上で明示し、部分的な borrow を禁止する。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3343,3 +3343,27 @@ Project index の manual quickstart で、Python runner は `HOME` 注入先の 
 1. Python と Rust の両方が同じ on-disk layout を読む場合、`HOME` / `USERPROFILE` / fallback の優先順を一致させる。
 2. runtime helper を manual verification する場合、fresh `HOME` では managed venv 作成に入るため、既存 runtime を使う通常 HOME と temp index subtree の cleanup も確認する。
 3. index root を注入する unit test だけでなく、public path resolver の環境変数 contract も regression test で固定する。
+
+## 2026-04-21 — fix: Launch Agent Resume と agent pane resume を混同しない
+
+### 事象
+
+Codex 起動後に Resume が有効にならないという報告を、最初に pane discussion
+側の resume 問題として扱いかけたが、実際の対象は Launch Agent の Quick Start
+Resume だった。
+
+### 原因
+
+- 「Codex」「Resume」という共通語だけで関連領域を推定し、Launch Wizard /
+  Quick Start の文脈確認が不足していた。
+- 既存の lesson に Quick Start resume の `agent_session_id` 確認が記録されていたが、
+  調査開始時の scope 固定に反映できていなかった。
+
+### 再発防止策
+
+1. Resume 不具合では最初に対象 UI を固定する。Launch Agent の Quick Start、
+   running pane の resume、session TOML の永続化を分けて扱う。
+2. Launch Agent の Resume は `launch_wizard` と session TOML の
+   `agent_session_id` を一次調査対象にする。
+3. ユーザーが UI 名を訂正した場合は、調査 plan とテスト観点を即座にその UI に
+   切り替える。


### PR DESCRIPTION
## Summary

- restore Launch Agent Quick Start resume availability when the latest session lacks `agent_session_id` by falling back to the latest resumable session on the same agent, branch, and worktree.
- keep resume launches consistent by reusing the entire resumable session profile instead of pairing an older resume id with newer launch settings.
- extract Quick Start session loading into a dedicated helper and lock the behavior with regression tests and lessons.

## Changes

- `crates/gwt/src/launch_wizard/quick_start.rs`: select Quick Start entries from session history and reuse the full latest resumable session when fallback is needed.
- `crates/gwt/src/launch_wizard.rs`: add regression coverage for resumable-session fallback, scope isolation, and launch profile reuse.
- `tasks/lessons.md`: record the scope mix-up lesson and the review-driven rule against borrowing only a resume id.

## Testing

- [x] `cargo test -p gwt launch_wizard -- --nocapture` — targeted Launch Wizard regressions pass on the merged HEAD.
- [x] `cargo test -p gwt-core -p gwt` — workspace Rust tests pass on the merged HEAD.
- [x] `cargo fmt --check` — formatting is clean on the merged HEAD.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes on the merged HEAD.
- [x] `bunx --bun markdownlint-cli tasks/lessons.md --config .markdownlint.json` — markdownlint passes for the lessons update.
- [x] `git diff --check` — no whitespace or conflict-marker issues remain.

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — not needed: behavior changed, but no README/user guide text changed.
- [ ] Migration/backfill plan included (if schema/data change) — not needed: no schema or persistent data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This branch fixes Launch Agent Quick Start resume for Codex sessions after the session id source moved to Session Start hooks.
- The initial fix restored the Resume action, and the follow-up review caught that the fallback could still mix an older resumable session id with a newer launch profile.
- The PR keeps the fallback within the same agent, branch, and worktree while making the resume source internally consistent.

## Risk / Impact

- **Affected areas**: Launch Wizard Quick Start hydration, session-backed resume launches, and related regression tests.
- **Rollback plan**: revert this PR; no migration or data cleanup is required.

## Notes

- No visual layout changes are included; the UI impact is limited to Resume availability and the launch profile used for resume actions.
