### PR TITLE
feat(docker): auto-download gwt bundle for docker agents

### DIFF
--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -156,6 +156,14 @@ mod tests {
     use super::*;
     use crate::repo_hash::compute_repo_hash;
 
+    fn gwt_home_suffix(parts: &[&str]) -> PathBuf {
+        let mut path = PathBuf::from(".gwt");
+        for part in parts {
+            path.push(part);
+        }
+        path
+    }
+
     #[test]
     fn gwt_home_ends_with_dot_gwt() {
         let home = gwt_home();
@@ -213,43 +221,38 @@ mod tests {
     fn gwt_config_path_ends_with_config_toml() {
         let p = gwt_config_path();
         assert_eq!(p.file_name().unwrap(), "config.toml");
-        assert!(p.starts_with(gwt_home()));
+        assert!(p.ends_with(gwt_home_suffix(&["config.toml"])));
     }
 
     #[test]
     fn gwt_sessions_dir_is_under_home() {
         let p = gwt_sessions_dir();
-        assert!(p.starts_with(gwt_home()));
-        assert!(p.ends_with("sessions"));
+        assert!(p.ends_with(gwt_home_suffix(&["sessions"])));
     }
 
     #[test]
     fn gwt_cache_dir_is_under_home() {
         let p = gwt_cache_dir();
-        assert!(p.starts_with(gwt_home()));
-        assert!(p.ends_with("cache"));
+        assert!(p.ends_with(gwt_home_suffix(&["cache"])));
     }
 
     #[test]
     fn gwt_projects_dir_is_under_home() {
         let p = gwt_projects_dir();
-        assert!(p.starts_with(gwt_home()));
-        assert!(p.ends_with("projects"));
+        assert!(p.ends_with(gwt_home_suffix(&["projects"])));
     }
 
     #[test]
     fn gwt_project_dir_scopes_by_repo_hash() {
         let repo_hash = compute_repo_hash("https://github.com/example/project.git");
         let p = gwt_project_dir(&repo_hash);
-        assert!(p.starts_with(gwt_projects_dir()));
-        assert!(p.ends_with(format!("projects/{}", repo_hash.as_str())));
+        assert!(p.ends_with(gwt_home_suffix(&["projects", repo_hash.as_str()])));
     }
 
     #[test]
     fn gwt_session_state_path_is_under_home() {
         let p = gwt_session_state_path();
-        assert!(p.starts_with(gwt_home()));
-        assert!(p.ends_with("session.json"));
+        assert!(p.ends_with(gwt_home_suffix(&["session.json"])));
     }
 
     #[test]
@@ -266,45 +269,43 @@ mod tests {
     #[test]
     fn gwt_logs_dir_is_under_home() {
         let p = gwt_logs_dir();
-        assert!(p.starts_with(gwt_home()));
-        assert!(p.ends_with("logs"));
+        assert!(p.ends_with(gwt_home_suffix(&["logs"])));
     }
 
     #[test]
     fn gwt_project_logs_dir_scopes_by_repo_hash() {
         let repo_hash = compute_repo_hash("https://github.com/example/project.git");
         let p = gwt_project_logs_dir(&repo_hash);
-        assert!(p.starts_with(gwt_project_dir(&repo_hash)));
-        assert!(p.ends_with(format!("projects/{}/logs", repo_hash.as_str())));
+        assert!(p.ends_with(gwt_home_suffix(&["projects", repo_hash.as_str(), "logs"])));
     }
 
     #[test]
     fn gwt_coordination_dir_scopes_by_repo_hash() {
         let repo_hash = compute_repo_hash("https://github.com/example/project.git");
         let p = gwt_coordination_dir(&repo_hash);
-        assert!(p.starts_with(gwt_project_dir(&repo_hash)));
-        assert!(p.ends_with(format!("projects/{}/coordination", repo_hash.as_str())));
+        assert!(p.ends_with(gwt_home_suffix(&[
+            "projects",
+            repo_hash.as_str(),
+            "coordination",
+        ])));
     }
 
     #[test]
     fn gwt_runtime_dir_is_under_home() {
         let p = gwt_runtime_dir();
-        assert!(p.starts_with(gwt_home()));
-        assert!(p.ends_with("runtime"));
+        assert!(p.ends_with(gwt_home_suffix(&["runtime"])));
     }
 
     #[test]
     fn gwt_runtime_runner_path_is_under_runtime_dir() {
         let p = gwt_runtime_runner_path();
-        assert!(p.starts_with(gwt_runtime_dir()));
-        assert_eq!(p.file_name().unwrap(), "chroma_index_runner.py");
+        assert!(p.ends_with(gwt_home_suffix(&["runtime", "chroma_index_runner.py"])));
     }
 
     #[test]
     fn gwt_project_index_venv_dir_is_under_runtime_dir() {
         let p = gwt_project_index_venv_dir();
-        assert!(p.starts_with(gwt_runtime_dir()));
-        assert_eq!(p.file_name().unwrap(), "chroma-venv");
+        assert!(p.ends_with(gwt_home_suffix(&["runtime", "chroma-venv"])));
     }
 
     #[test]

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -30,6 +30,8 @@ const DEFAULT_OWNER: &str = "akiojin";
 const DEFAULT_REPO: &str = "gwt";
 const DEFAULT_TTL: Duration = Duration::from_secs(60 * 60 * 24);
 const DEFAULT_API_BASE_URL: &str = "https://api.github.com";
+const DOCKER_LINUX_BUNDLE_ASSET_NAME: &str = "gwt-linux-x86_64.tar.gz";
+const DOCKER_LINUX_PRIMARY_BINARY_NAME: &str = "gwt";
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -113,6 +115,13 @@ pub enum InstallerKind {
 pub enum PreparedPayload {
     PortableBinary { path: PathBuf },
     Installer { path: PathBuf, kind: InstallerKind },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledDockerLinuxBundle {
+    pub version: String,
+    pub gwt_path: PathBuf,
+    pub gwtd_path: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -342,25 +351,7 @@ impl UpdateManager {
         let asset_name = asset_name_from_url(asset_url).unwrap_or_else(|| "gwt-update".to_string());
         let dest = update_dir.join(&asset_name);
 
-        let res = self
-            .client
-            .get(asset_url)
-            .send()
-            .map_err(|e| format!("Download failed: {e}"))?;
-        if !res.status().is_success() {
-            return Err(format!("Download failed with status {}", res.status()));
-        }
-
-        let mut file =
-            fs::File::create(&dest).map_err(|e| format!("Failed to create payload file: {e}"))?;
-        let mut reader = res;
-        io::copy(&mut reader, &mut file).map_err(|e| format!("Failed to write payload: {e}"))?;
-
-        let size = fs::metadata(&dest).map(|m| m.len()).unwrap_or_default();
-        if size == 0 {
-            let _ = fs::remove_file(&dest);
-            return Err("Downloaded payload is empty".to_string());
-        }
+        self.download_asset(asset_url, &dest)?;
 
         let dest_str = dest.to_string_lossy().to_string();
         if dest_str.ends_with(".tar.gz") || dest_str.ends_with(".zip") {
@@ -402,6 +393,99 @@ impl UpdateManager {
         // Portable direct binary.
         ensure_executable(&dest)?;
         Ok(PreparedPayload::PortableBinary { path: dest })
+    }
+
+    pub fn install_latest_docker_linux_bundle(
+        &self,
+        target_gwt: &Path,
+        target_gwtd: &Path,
+    ) -> Result<InstalledDockerLinuxBundle, String> {
+        let release = self.fetch_latest_release()?;
+        let version = parse_tag_version(&release.tag_name)
+            .ok_or_else(|| {
+                format!(
+                    "Failed to parse release tag as version: {}",
+                    release.tag_name
+                )
+            })?
+            .to_string();
+        let asset_url = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == DOCKER_LINUX_BUNDLE_ASSET_NAME)
+            .map(|asset| asset.browser_download_url.as_str())
+            .ok_or_else(|| {
+                format!(
+                    "Latest release {} does not include required Docker bundle asset {DOCKER_LINUX_BUNDLE_ASSET_NAME}",
+                    release.html_url
+                )
+            })?;
+
+        self.install_docker_linux_bundle_from_url(&version, asset_url, target_gwt, target_gwtd)
+    }
+
+    fn install_docker_linux_bundle_from_url(
+        &self,
+        version: &str,
+        asset_url: &str,
+        target_gwt: &Path,
+        target_gwtd: &Path,
+    ) -> Result<InstalledDockerLinuxBundle, String> {
+        let update_dir = self
+            .updates_dir
+            .join("docker")
+            .join(format!("v{}", version.trim().trim_start_matches('v')));
+        fs::create_dir_all(&update_dir).map_err(|e| format!("Failed to create update dir: {e}"))?;
+
+        let dest = update_dir.join(DOCKER_LINUX_BUNDLE_ASSET_NAME);
+        self.download_asset(asset_url, &dest)?;
+
+        let extract_dir = update_dir.join("extract");
+        let _ = fs::remove_dir_all(&extract_dir);
+        fs::create_dir_all(&extract_dir)
+            .map_err(|e| format!("Failed to create extract dir: {e}"))?;
+        extract_archive(&dest, &extract_dir)?;
+        let (gwt_source, gwtd_source) =
+            find_extracted_bundle_binaries(&extract_dir, DOCKER_LINUX_PRIMARY_BINARY_NAME)?;
+        ensure_executable(&gwt_source)?;
+        ensure_executable(&gwtd_source)?;
+        replace_executables_with_retry(&[
+            (target_gwtd, gwtd_source.as_path()),
+            (target_gwt, gwt_source.as_path()),
+        ])?;
+
+        Ok(InstalledDockerLinuxBundle {
+            version: version.to_string(),
+            gwt_path: target_gwt.to_path_buf(),
+            gwtd_path: target_gwtd.to_path_buf(),
+        })
+    }
+
+    fn download_asset(&self, asset_url: &str, dest: &Path) -> Result<(), String> {
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("Failed to create payload dir: {e}"))?;
+        }
+
+        let res = self
+            .client
+            .get(asset_url)
+            .send()
+            .map_err(|e| format!("Download failed: {e}"))?;
+        if !res.status().is_success() {
+            return Err(format!("Download failed with status {}", res.status()));
+        }
+
+        let mut file =
+            fs::File::create(dest).map_err(|e| format!("Failed to create payload file: {e}"))?;
+        let mut reader = res;
+        io::copy(&mut reader, &mut file).map_err(|e| format!("Failed to write payload: {e}"))?;
+
+        let size = fs::metadata(dest).map(|m| m.len()).unwrap_or_default();
+        if size == 0 {
+            let _ = fs::remove_file(dest);
+            return Err("Downloaded payload is empty".to_string());
+        }
+        Ok(())
     }
 
     pub fn write_restart_args_file(&self, path: &Path, args: Vec<String>) -> Result<(), String> {
@@ -1515,6 +1599,35 @@ mod tests {
         writer.finish().expect("finish zip").into_inner()
     }
 
+    fn tar_gz_bundle_body(primary: &[u8], daemon: &[u8]) -> Vec<u8> {
+        let cursor = Cursor::new(Vec::new());
+        let encoder = flate2::write::GzEncoder::new(cursor, flate2::Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(primary.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, "dist/gwt-linux-x86_64/gwt", primary)
+            .expect("append gwt");
+
+        let mut daemon_header = tar::Header::new_gnu();
+        daemon_header.set_size(daemon.len() as u64);
+        daemon_header.set_mode(0o755);
+        daemon_header.set_cksum();
+        archive
+            .append_data(&mut daemon_header, "dist/gwt-linux-x86_64/gwtd", daemon)
+            .expect("append gwtd");
+
+        archive
+            .into_inner()
+            .expect("finish tar")
+            .finish()
+            .expect("finish gzip")
+            .into_inner()
+    }
+
     #[test]
     fn parse_tag_version_accepts_v_prefix() {
         assert_eq!(parse_tag_version("v1.2.3"), Some(Version::new(1, 2, 3)));
@@ -2319,6 +2432,46 @@ mod tests {
         let empty_url = serve_once("/empty.bin", "200 OK", "application/octet-stream", vec![]);
         let err = mgr.prepare_update("99.0.6", &empty_url).unwrap_err();
         assert!(err.contains("Downloaded payload is empty"));
+    }
+
+    #[test]
+    fn install_latest_docker_linux_bundle_downloads_release_tarball_to_cache_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let tarball_url = serve_once(
+            "/downloads/gwt-linux-x86_64.tar.gz",
+            "200 OK",
+            "application/gzip",
+            tar_gz_bundle_body(b"docker-gwt", b"docker-gwtd"),
+        );
+        let release_body = format!(
+            r#"{{
+  "tag_name": "v99.1.0",
+  "html_url": "https://github.com/akiojin/gwt/releases/tag/v99.1.0",
+  "assets": [
+    {{
+      "name": "gwt-linux-x86_64.tar.gz",
+      "browser_download_url": "{tarball_url}"
+    }}
+  ]
+}}"#
+        );
+        let base_url = serve_once("/", "200 OK", "application/json", release_body.into_bytes());
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+        let target_gwt = temp.path().join(".gwt").join("bin").join("gwt-linux");
+        let target_gwtd = temp.path().join(".gwt").join("bin").join("gwtd-linux");
+
+        let installed = mgr
+            .install_latest_docker_linux_bundle(&target_gwt, &target_gwtd)
+            .expect("install docker bundle");
+
+        assert_eq!(installed.version, "99.1.0");
+        assert_eq!(installed.gwt_path, target_gwt);
+        assert_eq!(installed.gwtd_path, target_gwtd);
+        assert_eq!(fs::read(&installed.gwt_path).unwrap(), b"docker-gwt");
+        assert_eq!(fs::read(&installed.gwtd_path).unwrap(), b"docker-gwtd");
     }
 
     #[test]

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -30,7 +30,6 @@ const DEFAULT_OWNER: &str = "akiojin";
 const DEFAULT_REPO: &str = "gwt";
 const DEFAULT_TTL: Duration = Duration::from_secs(60 * 60 * 24);
 const DEFAULT_API_BASE_URL: &str = "https://api.github.com";
-const DOCKER_LINUX_BUNDLE_ASSET_NAME: &str = "gwt-linux-x86_64.tar.gz";
 const DOCKER_LINUX_PRIMARY_BINARY_NAME: &str = "gwt";
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
@@ -170,6 +169,31 @@ impl Platform {
         } else {
             Some(format!("gwt-{artifact}.tar.gz"))
         }
+    }
+}
+
+fn normalize_docker_linux_arch(raw: &str) -> Option<&'static str> {
+    match raw
+        .trim()
+        .to_ascii_lowercase()
+        .split('/')
+        .next()
+        .unwrap_or_default()
+    {
+        "x86_64" | "amd64" | "x64" => Some("x86_64"),
+        "aarch64" | "arm64" => Some("aarch64"),
+        _ => None,
+    }
+}
+
+fn docker_linux_bundle_asset_name(arch: &str) -> Result<String, String> {
+    match normalize_docker_linux_arch(arch) {
+        Some("x86_64") => Ok("gwt-linux-x86_64.tar.gz".to_string()),
+        Some("aarch64") => Ok("gwt-linux-aarch64.tar.gz".to_string()),
+        Some(other) => Ok(format!("gwt-linux-{other}.tar.gz")),
+        None => Err(format!(
+            "Unsupported Docker Linux bundle architecture: {arch}. Expected x86_64/amd64 or aarch64/arm64"
+        )),
     }
 }
 
@@ -397,6 +421,7 @@ impl UpdateManager {
 
     pub fn install_latest_docker_linux_bundle(
         &self,
+        target_arch: &str,
         target_gwt: &Path,
         target_gwtd: &Path,
     ) -> Result<InstalledDockerLinuxBundle, String> {
@@ -409,24 +434,32 @@ impl UpdateManager {
                 )
             })?
             .to_string();
+        let asset_name = docker_linux_bundle_asset_name(target_arch)?;
         let asset_url = release
             .assets
             .iter()
-            .find(|asset| asset.name == DOCKER_LINUX_BUNDLE_ASSET_NAME)
+            .find(|asset| asset.name == asset_name)
             .map(|asset| asset.browser_download_url.as_str())
             .ok_or_else(|| {
                 format!(
-                    "Latest release {} does not include required Docker bundle asset {DOCKER_LINUX_BUNDLE_ASSET_NAME}",
-                    release.html_url
+                    "Latest release {} does not include required Docker bundle asset {}",
+                    release.html_url, asset_name
                 )
             })?;
 
-        self.install_docker_linux_bundle_from_url(&version, asset_url, target_gwt, target_gwtd)
+        self.install_docker_linux_bundle_from_url(
+            &version,
+            &asset_name,
+            asset_url,
+            target_gwt,
+            target_gwtd,
+        )
     }
 
     fn install_docker_linux_bundle_from_url(
         &self,
         version: &str,
+        asset_name: &str,
         asset_url: &str,
         target_gwt: &Path,
         target_gwtd: &Path,
@@ -437,7 +470,7 @@ impl UpdateManager {
             .join(format!("v{}", version.trim().trim_start_matches('v')));
         fs::create_dir_all(&update_dir).map_err(|e| format!("Failed to create update dir: {e}"))?;
 
-        let dest = update_dir.join(DOCKER_LINUX_BUNDLE_ASSET_NAME);
+        let dest = update_dir.join(asset_name);
         self.download_asset(asset_url, &dest)?;
 
         let extract_dir = update_dir.join("extract");
@@ -1933,6 +1966,19 @@ mod tests {
     }
 
     #[test]
+    fn docker_linux_bundle_asset_name_normalizes_common_arch_aliases() {
+        assert_eq!(
+            docker_linux_bundle_asset_name("amd64").as_deref(),
+            Ok("gwt-linux-x86_64.tar.gz")
+        );
+        assert_eq!(
+            docker_linux_bundle_asset_name("arm64/v8").as_deref(),
+            Ok("gwt-linux-aarch64.tar.gz")
+        );
+        assert!(docker_linux_bundle_asset_name("ppc64le").is_err());
+    }
+
+    #[test]
     fn choose_apply_plan_prefers_portable_for_macos_cli_install() {
         let platform = Platform {
             os: "macos".to_string(),
@@ -2464,7 +2510,7 @@ mod tests {
         let target_gwtd = temp.path().join(".gwt").join("bin").join("gwtd-linux");
 
         let installed = mgr
-            .install_latest_docker_linux_bundle(&target_gwt, &target_gwtd)
+            .install_latest_docker_linux_bundle("x86_64", &target_gwt, &target_gwtd)
             .expect("install docker bundle");
 
         assert_eq!(installed.version, "99.1.0");
@@ -2472,6 +2518,54 @@ mod tests {
         assert_eq!(installed.gwtd_path, target_gwtd);
         assert_eq!(fs::read(&installed.gwt_path).unwrap(), b"docker-gwt");
         assert_eq!(fs::read(&installed.gwtd_path).unwrap(), b"docker-gwtd");
+    }
+
+    #[test]
+    fn install_latest_docker_linux_bundle_uses_requested_arch_asset() {
+        let temp = tempfile::tempdir().unwrap();
+        let x64_url = serve_once(
+            "/downloads/gwt-linux-x86_64.tar.gz",
+            "200 OK",
+            "application/gzip",
+            tar_gz_bundle_body(b"x64-gwt", b"x64-gwtd"),
+        );
+        let arm64_url = serve_once(
+            "/downloads/gwt-linux-aarch64.tar.gz",
+            "200 OK",
+            "application/gzip",
+            tar_gz_bundle_body(b"arm64-gwt", b"arm64-gwtd"),
+        );
+        let release_body = format!(
+            r#"{{
+  "tag_name": "v99.1.1",
+  "html_url": "https://github.com/akiojin/gwt/releases/tag/v99.1.1",
+  "assets": [
+    {{
+      "name": "gwt-linux-x86_64.tar.gz",
+      "browser_download_url": "{x64_url}"
+    }},
+    {{
+      "name": "gwt-linux-aarch64.tar.gz",
+      "browser_download_url": "{arm64_url}"
+    }}
+  ]
+}}"#
+        );
+        let base_url = serve_once("/", "200 OK", "application/json", release_body.into_bytes());
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+        let target_gwt = temp.path().join(".gwt").join("bin").join("gwt-linux");
+        let target_gwtd = temp.path().join(".gwt").join("bin").join("gwtd-linux");
+
+        let installed = mgr
+            .install_latest_docker_linux_bundle("aarch64", &target_gwt, &target_gwtd)
+            .expect("install docker bundle for aarch64");
+
+        assert_eq!(installed.version, "99.1.1");
+        assert_eq!(fs::read(&installed.gwt_path).unwrap(), b"arm64-gwt");
+        assert_eq!(fs::read(&installed.gwtd_path).unwrap(), b"arm64-gwtd");
     }
 
     #[test]

--- a/crates/gwt-docker/src/compose.rs
+++ b/crates/gwt-docker/src/compose.rs
@@ -15,6 +15,8 @@ pub struct ComposeService {
     pub name: String,
     /// Image name (if specified).
     pub image: Option<String>,
+    /// Explicit target platform (if specified), e.g. `linux/arm64`.
+    pub platform: Option<String>,
     /// Published ports (raw strings, e.g. "8080:80").
     pub ports: Vec<String>,
     /// Services this service depends on.
@@ -61,6 +63,10 @@ fn parse_compose_content(content: &str) -> Result<Vec<ComposeService>> {
             .get("image")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let platform = value
+            .get("platform")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
 
         let ports = value
             .get("ports")
@@ -82,6 +88,7 @@ fn parse_compose_content(content: &str) -> Result<Vec<ComposeService>> {
         result.push(ComposeService {
             name,
             image,
+            platform,
             ports,
             depends_on,
             working_dir,
@@ -285,12 +292,14 @@ services:
 services:
   app:
     image: node:18
+    platform: linux/arm64/v8
     working_dir: /workspace
     volumes:
       - .:/workspace
       - cache:/cache:ro
 "#;
         let services = parse_compose_content(yaml).unwrap();
+        assert_eq!(services[0].platform.as_deref(), Some("linux/arm64/v8"));
         assert_eq!(services[0].working_dir.as_deref(), Some("/workspace"));
         assert_eq!(services[0].volumes.len(), 2);
         assert_eq!(services[0].volumes[0].source, ".");

--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -6,6 +6,7 @@
 use std::{
     ffi::OsString,
     io::{BufRead, BufReader, Read},
+    path::{Path, PathBuf},
     process::{Command, Output, Stdio},
     sync::mpsc::{self, RecvTimeoutError},
     thread,
@@ -289,36 +290,80 @@ where
     })
 }
 
-fn compose_parent_dir(compose_file: &std::path::Path) -> &std::path::Path {
-    compose_file
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."))
+fn compose_parent_dir(compose_file: &Path) -> &Path {
+    compose_file.parent().unwrap_or_else(|| Path::new("."))
+}
+
+fn compose_parent_dir_for_files(compose_files: &[PathBuf]) -> &Path {
+    compose_files
+        .first()
+        .map(|file| compose_parent_dir(file))
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn compose_file_args(compose_files: &[PathBuf]) -> Vec<String> {
+    compose_files
+        .iter()
+        .flat_map(|file| ["-f".to_string(), file.display().to_string()])
+        .collect()
+}
+
+fn compose_files_label(compose_files: &[PathBuf]) -> String {
+    compose_files
+        .iter()
+        .map(|file| file.display().to_string())
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// Start a compose service in detached mode.
-pub fn compose_up(compose_file: &std::path::Path, service: &str) -> Result<()> {
+pub fn compose_up(compose_file: &Path, service: &str) -> Result<()> {
     compose_up_with_output(compose_file, service, |_, _| {})
 }
 
+/// Start a compose service in detached mode using all provided Compose files.
+pub fn compose_up_with_files(compose_files: &[PathBuf], service: &str) -> Result<()> {
+    compose_up_with_files_output(compose_files, service, |_, _| {})
+}
+
 /// Start a compose service in detached mode and force container recreation.
-pub fn compose_up_force_recreate(compose_file: &std::path::Path, service: &str) -> Result<()> {
+pub fn compose_up_force_recreate(compose_file: &Path, service: &str) -> Result<()> {
     compose_up_force_recreate_with_output(compose_file, service, |_, _| {})
 }
 
+/// Start a compose service with all Compose files and force recreation.
+pub fn compose_up_force_recreate_with_files(
+    compose_files: &[PathBuf],
+    service: &str,
+) -> Result<()> {
+    compose_up_force_recreate_with_files_output(compose_files, service, |_, _| {})
+}
+
 /// Start a compose service in detached mode while streaming stdout/stderr lines.
-pub fn compose_up_with_output<F>(
-    compose_file: &std::path::Path,
+pub fn compose_up_with_output<F>(compose_file: &Path, service: &str, on_line: F) -> Result<()>
+where
+    F: FnMut(CommandOutputStream, &str),
+{
+    compose_up_with_files_output(&[compose_file.to_path_buf()], service, on_line)
+}
+
+/// Start a compose service using all Compose files while streaming output.
+pub fn compose_up_with_files_output<F>(
+    compose_files: &[PathBuf],
     service: &str,
     on_line: F,
 ) -> Result<()>
 where
     F: FnMut(CommandOutputStream, &str),
 {
-    let compose_file = compose_file.display().to_string();
+    let mut args = vec!["compose".to_string()];
+    args.extend(compose_file_args(compose_files));
+    args.extend(["up".to_string(), "-d".to_string(), service.to_string()]);
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
     let output = run_docker_with_output_streaming_in_dir_and_timeout(
-        &["compose", "-f", &compose_file, "up", "-d", service],
+        &arg_refs,
         "docker compose up",
-        Some(compose_parent_dir(std::path::Path::new(&compose_file))),
+        Some(compose_parent_dir_for_files(compose_files)),
         docker_compose_up_timeout(),
         on_line,
     )?;
@@ -330,6 +375,7 @@ where
             stderr
         }));
     }
+    let compose_file = compose_files_label(compose_files);
     debug!(
         category = "docker",
         service = service,
@@ -342,26 +388,39 @@ where
 /// Start a compose service in detached mode while forcing recreation and
 /// streaming stdout/stderr lines.
 pub fn compose_up_force_recreate_with_output<F>(
-    compose_file: &std::path::Path,
+    compose_file: &Path,
     service: &str,
     on_line: F,
 ) -> Result<()>
 where
     F: FnMut(CommandOutputStream, &str),
 {
-    let compose_file = compose_file.display().to_string();
+    compose_up_force_recreate_with_files_output(&[compose_file.to_path_buf()], service, on_line)
+}
+
+/// Start a compose service using all Compose files while forcing recreation and
+/// streaming stdout/stderr lines.
+pub fn compose_up_force_recreate_with_files_output<F>(
+    compose_files: &[PathBuf],
+    service: &str,
+    on_line: F,
+) -> Result<()>
+where
+    F: FnMut(CommandOutputStream, &str),
+{
+    let mut args = vec!["compose".to_string()];
+    args.extend(compose_file_args(compose_files));
+    args.extend([
+        "up".to_string(),
+        "-d".to_string(),
+        "--force-recreate".to_string(),
+        service.to_string(),
+    ]);
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
     let output = run_docker_with_output_streaming_in_dir_and_timeout(
-        &[
-            "compose",
-            "-f",
-            &compose_file,
-            "up",
-            "-d",
-            "--force-recreate",
-            service,
-        ],
+        &arg_refs,
         "docker compose up --force-recreate",
-        Some(compose_parent_dir(std::path::Path::new(&compose_file))),
+        Some(compose_parent_dir_for_files(compose_files)),
         docker_compose_up_timeout(),
         on_line,
     )?;
@@ -373,6 +432,7 @@ where
             stderr
         }));
     }
+    let compose_file = compose_files_label(compose_files);
     debug!(
         category = "docker",
         service = service,
@@ -382,22 +442,26 @@ where
     Ok(())
 }
 
-fn compose_service_statuses(
-    compose_file: &std::path::Path,
+fn compose_service_statuses(compose_file: &Path) -> Result<Vec<(String, ComposeServiceStatus)>> {
+    compose_service_statuses_with_files(&[compose_file.to_path_buf()])
+}
+
+fn compose_service_statuses_with_files(
+    compose_files: &[PathBuf],
 ) -> Result<Vec<(String, ComposeServiceStatus)>> {
-    let compose_file = compose_file.display().to_string();
+    let mut args = vec!["compose".to_string()];
+    args.extend(compose_file_args(compose_files));
+    args.extend([
+        "ps".to_string(),
+        "--all".to_string(),
+        "--format".to_string(),
+        "{{.Service}}\t{{.State}}".to_string(),
+    ]);
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
     let output = run_docker_with_timeout_in_dir(
-        &[
-            "compose",
-            "-f",
-            &compose_file,
-            "ps",
-            "--all",
-            "--format",
-            "{{.Service}}\t{{.State}}",
-        ],
+        &arg_refs,
         "docker compose ps",
-        Some(compose_parent_dir(std::path::Path::new(&compose_file))),
+        Some(compose_parent_dir_for_files(compose_files)),
     )?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -431,23 +495,39 @@ fn compose_service_statuses(
 }
 
 /// Return whether a compose service is currently running.
-pub fn compose_service_is_running(compose_file: &std::path::Path, service: &str) -> Result<bool> {
+pub fn compose_service_is_running(compose_file: &Path, service: &str) -> Result<bool> {
     Ok(compose_service_status(compose_file, service)? == ComposeServiceStatus::Running)
 }
 
-/// Return the current status of a compose service.
-pub fn compose_service_status(
-    compose_file: &std::path::Path,
+/// Return whether a compose service from all Compose files is currently running.
+pub fn compose_service_is_running_with_files(
+    compose_files: &[PathBuf],
     service: &str,
-) -> Result<ComposeServiceStatus> {
+) -> Result<bool> {
+    Ok(compose_service_status_with_files(compose_files, service)? == ComposeServiceStatus::Running)
+}
+
+/// Return the current status of a compose service.
+pub fn compose_service_status(compose_file: &Path, service: &str) -> Result<ComposeServiceStatus> {
     Ok(compose_service_statuses(compose_file)?
         .into_iter()
         .find_map(|(candidate, status)| (candidate == service).then_some(status))
         .unwrap_or(ComposeServiceStatus::NotFound))
 }
 
+/// Return the current status of a compose service using all Compose files.
+pub fn compose_service_status_with_files(
+    compose_files: &[PathBuf],
+    service: &str,
+) -> Result<ComposeServiceStatus> {
+    Ok(compose_service_statuses_with_files(compose_files)?
+        .into_iter()
+        .find_map(|(candidate, status)| (candidate == service).then_some(status))
+        .unwrap_or(ComposeServiceStatus::NotFound))
+}
+
 /// Return recent logs for a compose service.
-pub fn compose_service_logs(compose_file: &std::path::Path, service: &str) -> Result<String> {
+pub fn compose_service_logs(compose_file: &Path, service: &str) -> Result<String> {
     let compose_file = compose_file.display().to_string();
     let output = run_docker_with_timeout_in_dir(
         &[
@@ -476,27 +556,36 @@ pub fn compose_service_logs(compose_file: &std::path::Path, service: &str) -> Re
 
 /// Return whether a compose service can resolve a command inside the container.
 pub fn compose_service_has_command(
-    compose_file: &std::path::Path,
+    compose_file: &Path,
     service: &str,
     command: &str,
 ) -> Result<bool> {
-    let compose_file = compose_file.display().to_string();
+    compose_service_has_command_with_files(&[compose_file.to_path_buf()], service, command)
+}
+
+/// Return whether a compose service can resolve a command using all Compose files.
+pub fn compose_service_has_command_with_files(
+    compose_files: &[PathBuf],
+    service: &str,
+    command: &str,
+) -> Result<bool> {
+    let mut docker_args = vec!["compose".to_string()];
+    docker_args.extend(compose_file_args(compose_files));
+    docker_args.extend([
+        "exec".to_string(),
+        "-T".to_string(),
+        service.to_string(),
+        "sh".to_string(),
+        "-lc".to_string(),
+        "command -v \"$1\" >/dev/null 2>&1".to_string(),
+        "sh".to_string(),
+        command.to_string(),
+    ]);
+    let arg_refs = docker_args.iter().map(String::as_str).collect::<Vec<_>>();
     let output = run_docker_with_timeout_in_dir(
-        &[
-            "compose",
-            "-f",
-            &compose_file,
-            "exec",
-            "-T",
-            service,
-            "sh",
-            "-lc",
-            "command -v \"$1\" >/dev/null 2>&1",
-            "sh",
-            command,
-        ],
+        &arg_refs,
         "docker compose exec command check",
-        Some(compose_parent_dir(std::path::Path::new(&compose_file))),
+        Some(compose_parent_dir_for_files(compose_files)),
     )?;
     if output.status.success() {
         return Ok(true);
@@ -515,31 +604,56 @@ pub fn compose_service_has_command(
 /// Transport failures such as spawn errors and timeouts return `Err`. A
 /// non-zero exit status from the command itself is returned via `Output`.
 pub fn compose_service_exec_capture(
-    compose_file: &std::path::Path,
+    compose_file: &Path,
     service: &str,
     working_dir: Option<&str>,
     args: &[String],
 ) -> Result<Output> {
-    let compose_file = compose_file.display().to_string();
-    let mut docker_args = vec!["compose", "-f", &compose_file, "exec", "-T"];
+    compose_service_exec_capture_with_files(
+        &[compose_file.to_path_buf()],
+        service,
+        working_dir,
+        args,
+    )
+}
+
+/// Execute a command inside a compose service using all Compose files.
+pub fn compose_service_exec_capture_with_files(
+    compose_files: &[PathBuf],
+    service: &str,
+    working_dir: Option<&str>,
+    args: &[String],
+) -> Result<Output> {
+    let mut docker_args = vec!["compose".to_string()];
+    docker_args.extend(compose_file_args(compose_files));
+    docker_args.extend(["exec".to_string(), "-T".to_string()]);
     if let Some(working_dir) = working_dir {
-        docker_args.push("-w");
-        docker_args.push(working_dir);
+        docker_args.push("-w".to_string());
+        docker_args.push(working_dir.to_string());
     }
-    docker_args.push(service);
-    docker_args.extend(args.iter().map(String::as_str));
+    docker_args.push(service.to_string());
+    docker_args.extend(args.iter().cloned());
+    let arg_refs = docker_args.iter().map(String::as_str).collect::<Vec<_>>();
 
     run_docker_with_timeout_in_dir(
-        &docker_args,
+        &arg_refs,
         "docker compose exec",
-        Some(compose_parent_dir(std::path::Path::new(&compose_file))),
+        Some(compose_parent_dir_for_files(compose_files)),
     )
 }
 
 /// Return whether a compose service executes as root inside the container.
-pub fn compose_service_user_is_root(compose_file: &std::path::Path, service: &str) -> Result<bool> {
-    let output = compose_service_exec_capture(
-        compose_file,
+pub fn compose_service_user_is_root(compose_file: &Path, service: &str) -> Result<bool> {
+    compose_service_user_is_root_with_files(&[compose_file.to_path_buf()], service)
+}
+
+/// Return whether a compose service executes as root using all Compose files.
+pub fn compose_service_user_is_root_with_files(
+    compose_files: &[PathBuf],
+    service: &str,
+) -> Result<bool> {
+    let output = compose_service_exec_capture_with_files(
+        compose_files,
         service,
         None,
         &["sh".to_string(), "-lc".to_string(), "id -u".to_string()],
@@ -562,7 +676,7 @@ pub fn compose_service_user_is_root(compose_file: &std::path::Path, service: &st
 }
 
 /// Stop a compose service.
-pub fn compose_stop(compose_file: &std::path::Path, service: &str) -> Result<()> {
+pub fn compose_stop(compose_file: &Path, service: &str) -> Result<()> {
     let compose_file = compose_file.display().to_string();
     let output = run_docker_with_timeout_in_dir(
         &["compose", "-f", &compose_file, "stop", service],
@@ -581,12 +695,20 @@ pub fn compose_stop(compose_file: &std::path::Path, service: &str) -> Result<()>
 }
 
 /// Restart a compose service.
-pub fn compose_restart(compose_file: &std::path::Path, service: &str) -> Result<()> {
-    let compose_file = compose_file.display().to_string();
+pub fn compose_restart(compose_file: &Path, service: &str) -> Result<()> {
+    compose_restart_with_files(&[compose_file.to_path_buf()], service)
+}
+
+/// Restart a compose service using all Compose files.
+pub fn compose_restart_with_files(compose_files: &[PathBuf], service: &str) -> Result<()> {
+    let mut args = vec!["compose".to_string()];
+    args.extend(compose_file_args(compose_files));
+    args.extend(["restart".to_string(), service.to_string()]);
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
     let output = run_docker_with_timeout_in_dir(
-        &["compose", "-f", &compose_file, "restart", service],
+        &arg_refs,
         "docker compose restart",
-        Some(compose_parent_dir(std::path::Path::new(&compose_file))),
+        Some(compose_parent_dir_for_files(compose_files)),
     )?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -678,7 +800,11 @@ pub fn restart(id: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, io::Write, path::PathBuf, sync::Mutex};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::Mutex,
+    };
 
     use tempfile::TempDir;
 
@@ -686,22 +812,80 @@ mod tests {
 
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    fn write_fake_docker(script_body: &str) -> (TempDir, PathBuf) {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        let script_path = dir.path().join("docker");
-        let mut file = fs::File::create(&script_path).expect("create fake docker");
-        file.write_all(script_body.as_bytes())
-            .expect("write fake docker");
+    #[cfg(windows)]
+    fn git_bash_path() -> PathBuf {
+        [
+            std::env::var_os("GWT_TEST_BASH").map(PathBuf::from),
+            std::env::var_os("GIT_BASH").map(PathBuf::from),
+            Some(PathBuf::from(r"C:\Program Files\Git\bin\bash.exe")),
+            Some(PathBuf::from(r"C:\Program Files\Git\usr\bin\bash.exe")),
+            Some(PathBuf::from(r"C:\Program Files (x86)\Git\bin\bash.exe")),
+            Some(PathBuf::from(
+                r"C:\Program Files (x86)\Git\usr\bin\bash.exe",
+            )),
+        ]
+        .into_iter()
+        .flatten()
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("Git Bash not found for gwt-docker fake docker tests"))
+    }
 
-        #[cfg(unix)]
+    #[cfg(windows)]
+    fn git_bash_script_path(path: &Path) -> String {
+        let normalized = path.to_string_lossy().replace('\\', "/");
+        let normalized = normalized.strip_prefix("//?/").unwrap_or(&normalized);
+        if let Some((drive, rest)) = normalized.split_once(":/") {
+            format!("/{}/{}", drive.to_ascii_lowercase(), rest)
+        } else {
+            normalized.to_string()
+        }
+    }
+
+    fn shell_script_path(path: &Path) -> String {
+        #[cfg(windows)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = file.metadata().expect("stat fake docker").permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&script_path, perms).expect("chmod fake docker");
+            git_bash_script_path(path)
         }
 
-        (dir, script_path)
+        #[cfg(not(windows))]
+        {
+            path.display().to_string()
+        }
+    }
+
+    fn write_fake_docker(script_body: &str) -> (TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        #[cfg(windows)]
+        {
+            let bash_script_path = dir.path().join("docker.sh");
+            fs::write(&bash_script_path, script_body).expect("write fake docker shell");
+
+            let script_path = dir.path().join("docker.cmd");
+            let wrapper = format!(
+                "@echo off\r\n\"{}\" \"{}\" %*\r\n",
+                git_bash_path().display(),
+                shell_script_path(&bash_script_path)
+            );
+            fs::write(&script_path, wrapper).expect("write fake docker wrapper");
+
+            (dir, script_path)
+        }
+
+        #[cfg(not(windows))]
+        {
+            let script_path = dir.path().join("docker");
+            fs::write(&script_path, script_body).expect("write fake docker");
+
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path)
+                .expect("stat fake docker")
+                .permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).expect("chmod fake docker");
+
+            (dir, script_path)
+        }
     }
 
     fn with_fake_docker<R>(script_body: &str, f: impl FnOnce(&PathBuf) -> R) -> R {
@@ -813,7 +997,7 @@ mod tests {
         let log_path = log_dir.path().join("args.txt");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {
@@ -829,7 +1013,7 @@ mod tests {
         let log_path = log_dir.path().join("args.txt");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {
@@ -845,7 +1029,7 @@ mod tests {
         let log_path = log_dir.path().join("args.txt");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {
@@ -935,7 +1119,7 @@ mod tests {
         .expect("compose");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {
@@ -945,6 +1129,24 @@ mod tests {
         assert_eq!(
             read_invocation(&log_path),
             format!("compose\n-f\n{}\nup\n-d\napp\n", compose_path.display())
+        );
+    }
+
+    #[test]
+    fn compose_file_args_includes_all_compose_files_in_order() {
+        let compose_files = vec![
+            PathBuf::from("docker-compose.yml"),
+            PathBuf::from("docker-compose.override.yml"),
+        ];
+
+        assert_eq!(
+            compose_file_args(&compose_files),
+            vec![
+                "-f".to_string(),
+                "docker-compose.yml".to_string(),
+                "-f".to_string(),
+                "docker-compose.override.yml".to_string(),
+            ]
         );
     }
 
@@ -961,7 +1163,7 @@ mod tests {
         .expect("compose");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {
@@ -1058,7 +1260,7 @@ mod tests {
         .expect("compose");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {
@@ -1084,7 +1286,7 @@ mod tests {
         .expect("compose");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {
@@ -1184,7 +1386,7 @@ mod tests {
         .expect("compose");
         let script = format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\nif [ \"$1\" = \"compose\" ] && [ \"$4\" = \"exec\" ] && [ \"$5\" = \"-T\" ] && [ \"$6\" = \"-w\" ] && [ \"$7\" = \"/workspace\" ] && [ \"$8\" = \"app\" ]; then\n  printf 'could not determine executable to run\\n' >&2\n  exit 1\nfi\nprintf 'unexpected invocation: %s\\n' \"$*\" >&2\nexit 1\n",
-            log_path.display()
+            shell_script_path(&log_path)
         );
 
         with_fake_docker(&script, |_| {

--- a/crates/gwt-docker/src/lib.rs
+++ b/crates/gwt-docker/src/lib.rs
@@ -11,11 +11,16 @@ pub mod port;
 
 pub use compose::{parse_compose_file, ComposeService};
 pub use container::{
-    compose_restart, compose_service_exec_capture, compose_service_has_command,
-    compose_service_is_running, compose_service_logs, compose_service_status,
-    compose_service_user_is_root, compose_stop, compose_up, compose_up_force_recreate,
-    compose_up_force_recreate_with_output, compose_up_with_output, list_containers, restart, start,
-    stop, CommandOutputStream, ComposeServiceStatus, ContainerInfo, ContainerStatus,
+    compose_restart, compose_restart_with_files, compose_service_exec_capture,
+    compose_service_exec_capture_with_files, compose_service_has_command,
+    compose_service_has_command_with_files, compose_service_is_running,
+    compose_service_is_running_with_files, compose_service_logs, compose_service_status,
+    compose_service_status_with_files, compose_service_user_is_root,
+    compose_service_user_is_root_with_files, compose_stop, compose_up, compose_up_force_recreate,
+    compose_up_force_recreate_with_files, compose_up_force_recreate_with_files_output,
+    compose_up_force_recreate_with_output, compose_up_with_files, compose_up_with_files_output,
+    compose_up_with_output, list_containers, restart, start, stop, CommandOutputStream,
+    ComposeServiceStatus, ContainerInfo, ContainerStatus,
 };
 pub use detect::{
     compose_available, daemon_running, detect_docker_files, docker_available, DockerFiles,

--- a/crates/gwt/src/docker_setup.rs
+++ b/crates/gwt/src/docker_setup.rs
@@ -85,7 +85,7 @@ fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) ->
 pub(super) fn ensure_docker_gwt_binary_setup(
     repo_path: &Path,
     service: &str,
-) -> Result<(), String> {
+) -> Result<PathBuf, String> {
     let gwt_home = gwt_core::paths::gwt_home();
     ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, |bundle| {
         eprintln!(
@@ -103,13 +103,17 @@ pub(super) fn ensure_docker_gwt_binary_setup(
     })
 }
 
+pub(super) fn docker_compose_override_path(repo_path: &Path) -> PathBuf {
+    repo_path.join("docker-compose.override.yml")
+}
+
 #[cfg(test)]
 fn ensure_docker_gwt_binary_setup_for_home<F>(
     repo_path: &Path,
     service: &str,
     home: &Path,
     install_bundle: F,
-) -> Result<(), String>
+) -> Result<PathBuf, String>
 where
     F: FnMut(&DockerBundleMounts) -> Result<(), String>,
 {
@@ -122,7 +126,7 @@ fn ensure_docker_gwt_binary_setup_for_gwt_home<F>(
     service: &str,
     gwt_home: &Path,
     mut install_bundle: F,
-) -> Result<(), String>
+) -> Result<PathBuf, String>
 where
     F: FnMut(&DockerBundleMounts) -> Result<(), String>,
 {
@@ -130,7 +134,9 @@ where
 
     let bundle = docker_bundle_mounts_for_gwt_home(gwt_home);
 
-    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
+    if !docker_bundle_binary_ready(&bundle.host_gwt)
+        || !docker_bundle_binary_ready(&bundle.host_gwtd)
+    {
         install_bundle(&bundle).map_err(|err| {
             format!(
                 "Failed to install Linux gwt bundle for Docker: {err}\n\
@@ -141,7 +147,9 @@ where
         })?;
     }
 
-    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
+    if !docker_bundle_binary_ready(&bundle.host_gwt)
+        || !docker_bundle_binary_ready(&bundle.host_gwtd)
+    {
         return Err(format!(
             "Linux gwt bundle setup did not create expected Docker binaries at {} and {}",
             bundle.host_gwt.display(),
@@ -149,7 +157,7 @@ where
         ));
     }
 
-    let override_path = repo_path.join("docker-compose.override.yml");
+    let override_path = docker_compose_override_path(repo_path);
     if !override_path.exists() {
         let override_content = docker_bundle_override_content(service, &bundle);
         fs::write(&override_path, override_content).map_err(|err| {
@@ -161,7 +169,12 @@ where
         })?;
     }
 
-    Ok(())
+    Ok(override_path)
+}
+
+fn docker_bundle_binary_ready(path: &Path) -> bool {
+    path.metadata()
+        .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
 }
 
 #[cfg(test)]
@@ -239,6 +252,37 @@ mod tests {
             .expect("override content");
         assert!(override_content.contains("gwt-linux:/usr/local/bin/gwt:ro"));
         assert!(override_content.contains("gwtd-linux:/usr/local/bin/gwtd:ro"));
+    }
+
+    #[test]
+    fn docker_binary_setup_repairs_directory_placeholders_before_writing_override() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let bundle = docker_bundle_mounts_for_home(home.path());
+        fs::create_dir_all(&bundle.host_gwt).expect("create gwt placeholder dir");
+        fs::create_dir_all(&bundle.host_gwtd).expect("create gwtd placeholder dir");
+        let mut installer_calls = 0;
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |bundle| {
+            installer_calls += 1;
+            if bundle.host_gwt.is_dir() {
+                fs::remove_dir_all(&bundle.host_gwt).expect("remove gwt placeholder");
+            }
+            if bundle.host_gwtd.is_dir() {
+                fs::remove_dir_all(&bundle.host_gwtd).expect("remove gwtd placeholder");
+            }
+            fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent"))
+                .expect("create bin dir");
+            fs::write(&bundle.host_gwt, b"linux-gwt").expect("write gwt");
+            fs::write(&bundle.host_gwtd, b"linux-gwtd").expect("write gwtd");
+            Ok(())
+        })
+        .expect("docker setup");
+
+        assert_eq!(installer_calls, 1);
+        assert!(bundle.host_gwt.is_file());
+        assert!(bundle.host_gwtd.is_file());
+        assert!(repo.path().join("docker-compose.override.yml").is_file());
     }
 
     #[test]

--- a/crates/gwt/src/docker_setup.rs
+++ b/crates/gwt/src/docker_setup.rs
@@ -7,6 +7,10 @@ const DOCKER_GWT_BIN_PATH: &str = "/usr/local/bin/gwt";
 const DOCKER_GWTD_BIN_PATH: &str = "/usr/local/bin/gwtd";
 const DOCKER_HOST_GWT_BIN_NAME: &str = "gwt-linux";
 const DOCKER_HOST_GWTD_BIN_NAME: &str = "gwtd-linux";
+const DOCKER_GWT_OVERRIDE_HEADER: &str =
+    "# Auto-generated docker-compose override for gwt bundle mounting";
+const DOCKER_GWT_OVERRIDE_FILE_NAME: &str = "docker-compose.gwt.override.yml";
+const DOCKER_USER_OVERRIDE_FILE_NAME: &str = "docker-compose.override.yml";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DockerBundleMounts {
@@ -72,7 +76,7 @@ fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) ->
     let host_gwt = docker_compose_mount_path(&bundle.host_gwt);
     let host_gwtd = docker_compose_mount_path(&bundle.host_gwtd);
     format!(
-        "# Auto-generated docker-compose override for gwt bundle mounting\n\
+        "{DOCKER_GWT_OVERRIDE_HEADER}\n\
          version: '3.8'\n\
          services:\n\
            {service}:\n\
@@ -108,7 +112,16 @@ pub(super) fn ensure_docker_gwt_binary_setup(
 }
 
 pub(super) fn docker_compose_override_path(repo_path: &Path) -> PathBuf {
-    repo_path.join("docker-compose.override.yml")
+    repo_path.join(DOCKER_GWT_OVERRIDE_FILE_NAME)
+}
+
+pub(super) fn docker_compose_user_override_path(repo_path: &Path) -> PathBuf {
+    repo_path.join(DOCKER_USER_OVERRIDE_FILE_NAME)
+}
+
+pub(super) fn is_legacy_gwt_generated_override(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .is_ok_and(|content| content.starts_with(DOCKER_GWT_OVERRIDE_HEADER))
 }
 
 #[cfg(test)]
@@ -169,7 +182,7 @@ where
     if rewrite_override {
         fs::write(&override_path, override_content).map_err(|err| {
             format!(
-                "Failed to write docker-compose.override.yml: {err}\n\
+                "Failed to write generated Docker compose override: {err}\n\
                  Manually create {} with gwt/gwtd bundle mounts",
                 override_path.display()
             )
@@ -192,6 +205,7 @@ mod tests {
 
     use super::{
         docker_bundle_mounts_for_home, docker_bundle_override_content,
+        docker_compose_override_path, docker_compose_user_override_path,
         ensure_docker_gwt_binary_setup_for_home, install_launch_gwt_bin_env_with_lookup,
     };
 
@@ -255,7 +269,7 @@ mod tests {
             b"linux-gwtd"
         );
 
-        let override_content = fs::read_to_string(repo.path().join("docker-compose.override.yml"))
+        let override_content = fs::read_to_string(docker_compose_override_path(repo.path()))
             .expect("override content");
         assert!(override_content.contains("gwt-linux:/usr/local/bin/gwt:ro"));
         assert!(override_content.contains("gwtd-linux:/usr/local/bin/gwtd:ro"));
@@ -289,7 +303,7 @@ mod tests {
         assert_eq!(installer_calls, 1);
         assert!(bundle.host_gwt.is_file());
         assert!(bundle.host_gwtd.is_file());
-        assert!(repo.path().join("docker-compose.override.yml").is_file());
+        assert!(docker_compose_override_path(repo.path()).is_file());
     }
 
     #[test]
@@ -314,7 +328,32 @@ mod tests {
             fs::read(&bundle.host_gwtd).expect("read gwtd"),
             b"existing-gwtd"
         );
-        assert!(repo.path().join("docker-compose.override.yml").exists());
+        assert!(docker_compose_override_path(repo.path()).exists());
+    }
+
+    #[test]
+    fn docker_binary_setup_preserves_existing_user_override_file() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let bundle = docker_bundle_mounts_for_home(home.path());
+        let user_override = docker_compose_user_override_path(repo.path());
+        let user_override_content =
+            "services:\n  app:\n    environment:\n      KEEP_ME: \"true\"\n";
+        fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent")).expect("create bin dir");
+        fs::write(&bundle.host_gwt, b"existing-gwt").expect("write gwt");
+        fs::write(&bundle.host_gwtd, b"existing-gwtd").expect("write gwtd");
+        fs::write(&user_override, user_override_content).expect("write user override");
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |_| {
+            panic!("installer should not run when both bundle binaries exist");
+        })
+        .expect("docker setup");
+
+        assert_eq!(
+            fs::read_to_string(&user_override).expect("read user override"),
+            user_override_content
+        );
+        assert!(docker_compose_override_path(repo.path()).is_file());
     }
 
     #[test]
@@ -336,7 +375,7 @@ mod tests {
         })
         .expect("docker setup for worker");
 
-        let override_content = fs::read_to_string(repo.path().join("docker-compose.override.yml"))
+        let override_content = fs::read_to_string(docker_compose_override_path(repo.path()))
             .expect("override content");
         assert!(override_content.contains("worker:"));
         assert!(!override_content.contains("app:"));

--- a/crates/gwt/src/docker_setup.rs
+++ b/crates/gwt/src/docker_setup.rs
@@ -85,6 +85,7 @@ fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) ->
 pub(super) fn ensure_docker_gwt_binary_setup(
     repo_path: &Path,
     service: &str,
+    target_arch: &str,
 ) -> Result<PathBuf, String> {
     let gwt_home = gwt_core::paths::gwt_home();
     ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, |bundle| {
@@ -93,8 +94,11 @@ pub(super) fn ensure_docker_gwt_binary_setup(
             bundle.host_gwt.display(),
             bundle.host_gwtd.display()
         );
-        let installed = gwt_core::update::UpdateManager::new()
-            .install_latest_docker_linux_bundle(&bundle.host_gwt, &bundle.host_gwtd)?;
+        let installed = gwt_core::update::UpdateManager::new().install_latest_docker_linux_bundle(
+            target_arch,
+            &bundle.host_gwt,
+            &bundle.host_gwtd,
+        )?;
         eprintln!(
             "Installed Linux gwt bundle v{} for Docker",
             installed.version
@@ -158,11 +162,14 @@ where
     }
 
     let override_path = docker_compose_override_path(repo_path);
-    if !override_path.exists() {
-        let override_content = docker_bundle_override_content(service, &bundle);
+    let override_content = docker_bundle_override_content(service, &bundle);
+    let rewrite_override = fs::read_to_string(&override_path)
+        .map(|existing| existing != override_content)
+        .unwrap_or(true);
+    if rewrite_override {
         fs::write(&override_path, override_content).map_err(|err| {
             format!(
-                "Failed to create docker-compose.override.yml: {err}\n\
+                "Failed to write docker-compose.override.yml: {err}\n\
                  Manually create {} with gwt/gwtd bundle mounts",
                 override_path.display()
             )
@@ -308,5 +315,30 @@ mod tests {
             b"existing-gwtd"
         );
         assert!(repo.path().join("docker-compose.override.yml").exists());
+    }
+
+    #[test]
+    fn docker_binary_setup_rewrites_override_for_selected_service() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let bundle = docker_bundle_mounts_for_home(home.path());
+        fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent")).expect("create bin dir");
+        fs::write(&bundle.host_gwt, b"existing-gwt").expect("write gwt");
+        fs::write(&bundle.host_gwtd, b"existing-gwtd").expect("write gwtd");
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |_| {
+            panic!("installer should not run when both bundle binaries exist");
+        })
+        .expect("docker setup for app");
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "worker", home.path(), |_| {
+            panic!("installer should not run when both bundle binaries exist");
+        })
+        .expect("docker setup for worker");
+
+        let override_content = fs::read_to_string(repo.path().join("docker-compose.override.yml"))
+            .expect("override content");
+        assert!(override_content.contains("worker:"));
+        assert!(!override_content.contains("app:"));
     }
 }

--- a/crates/gwt/src/docker_setup.rs
+++ b/crates/gwt/src/docker_setup.rs
@@ -1,0 +1,268 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+const DOCKER_GWT_BIN_PATH: &str = "/usr/local/bin/gwt";
+const DOCKER_GWTD_BIN_PATH: &str = "/usr/local/bin/gwtd";
+const DOCKER_HOST_GWT_BIN_NAME: &str = "gwt-linux";
+const DOCKER_HOST_GWTD_BIN_NAME: &str = "gwtd-linux";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DockerBundleMounts {
+    host_gwt: PathBuf,
+    host_gwtd: PathBuf,
+}
+
+pub(super) fn install_launch_gwt_bin_env(
+    env_vars: &mut HashMap<String, String>,
+    runtime_target: gwt_agent::LaunchRuntimeTarget,
+) -> Result<(), String> {
+    let current_exe = std::env::current_exe().map_err(|error| format!("current_exe: {error}"))?;
+    install_launch_gwt_bin_env_with_lookup(env_vars, runtime_target, &current_exe, |command| {
+        which::which(command).ok()
+    })
+}
+
+fn install_launch_gwt_bin_env_with_lookup(
+    env_vars: &mut HashMap<String, String>,
+    runtime_target: gwt_agent::LaunchRuntimeTarget,
+    current_exe: &Path,
+    lookup: impl FnOnce(&str) -> Option<PathBuf>,
+) -> Result<(), String> {
+    let gwt_bin = match runtime_target {
+        gwt_agent::LaunchRuntimeTarget::Docker => DOCKER_GWT_BIN_PATH.to_string(),
+        gwt_agent::LaunchRuntimeTarget::Host => {
+            gwt::managed_assets::resolve_public_gwt_bin_with_lookup(current_exe, lookup)
+                .to_string_lossy()
+                .into_owned()
+        }
+    };
+    match runtime_target {
+        gwt_agent::LaunchRuntimeTarget::Docker => {
+            env_vars.insert(gwt_agent::session::GWT_BIN_PATH_ENV.to_string(), gwt_bin);
+        }
+        gwt_agent::LaunchRuntimeTarget::Host => {
+            env_vars
+                .entry(gwt_agent::session::GWT_BIN_PATH_ENV.to_string())
+                .or_insert(gwt_bin);
+        }
+    }
+    Ok(())
+}
+
+fn docker_bundle_mounts_for_gwt_home(gwt_home: &Path) -> DockerBundleMounts {
+    let gwt_bin_dir = gwt_home.join("bin");
+    DockerBundleMounts {
+        host_gwt: gwt_bin_dir.join(DOCKER_HOST_GWT_BIN_NAME),
+        host_gwtd: gwt_bin_dir.join(DOCKER_HOST_GWTD_BIN_NAME),
+    }
+}
+
+#[cfg(test)]
+fn docker_bundle_mounts_for_home(home: &Path) -> DockerBundleMounts {
+    docker_bundle_mounts_for_gwt_home(&home.join(".gwt"))
+}
+
+fn docker_compose_mount_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) -> String {
+    let host_gwt = docker_compose_mount_path(&bundle.host_gwt);
+    let host_gwtd = docker_compose_mount_path(&bundle.host_gwtd);
+    format!(
+        "# Auto-generated docker-compose override for gwt bundle mounting\n\
+         version: '3.8'\n\
+         services:\n\
+           {service}:\n\
+             volumes:\n\
+               - \"{host_gwt}:{DOCKER_GWT_BIN_PATH}:ro\"\n\
+               - \"{host_gwtd}:{DOCKER_GWTD_BIN_PATH}:ro\"\n"
+    )
+}
+
+pub(super) fn ensure_docker_gwt_binary_setup(
+    repo_path: &Path,
+    service: &str,
+) -> Result<(), String> {
+    let gwt_home = gwt_core::paths::gwt_home();
+    ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, |bundle| {
+        eprintln!(
+            "Installing Linux gwt bundle for Docker at {} and {}",
+            bundle.host_gwt.display(),
+            bundle.host_gwtd.display()
+        );
+        let installed = gwt_core::update::UpdateManager::new()
+            .install_latest_docker_linux_bundle(&bundle.host_gwt, &bundle.host_gwtd)?;
+        eprintln!(
+            "Installed Linux gwt bundle v{} for Docker",
+            installed.version
+        );
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+fn ensure_docker_gwt_binary_setup_for_home<F>(
+    repo_path: &Path,
+    service: &str,
+    home: &Path,
+    install_bundle: F,
+) -> Result<(), String>
+where
+    F: FnMut(&DockerBundleMounts) -> Result<(), String>,
+{
+    let gwt_home = home.join(".gwt");
+    ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, install_bundle)
+}
+
+fn ensure_docker_gwt_binary_setup_for_gwt_home<F>(
+    repo_path: &Path,
+    service: &str,
+    gwt_home: &Path,
+    mut install_bundle: F,
+) -> Result<(), String>
+where
+    F: FnMut(&DockerBundleMounts) -> Result<(), String>,
+{
+    use std::fs;
+
+    let bundle = docker_bundle_mounts_for_gwt_home(gwt_home);
+
+    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
+        install_bundle(&bundle).map_err(|err| {
+            format!(
+                "Failed to install Linux gwt bundle for Docker: {err}\n\
+                 Expected cached binaries at {} and {}",
+                bundle.host_gwt.display(),
+                bundle.host_gwtd.display()
+            )
+        })?;
+    }
+
+    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
+        return Err(format!(
+            "Linux gwt bundle setup did not create expected Docker binaries at {} and {}",
+            bundle.host_gwt.display(),
+            bundle.host_gwtd.display()
+        ));
+    }
+
+    let override_path = repo_path.join("docker-compose.override.yml");
+    if !override_path.exists() {
+        let override_content = docker_bundle_override_content(service, &bundle);
+        fs::write(&override_path, override_content).map_err(|err| {
+            format!(
+                "Failed to create docker-compose.override.yml: {err}\n\
+                 Manually create {} with gwt/gwtd bundle mounts",
+                override_path.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, fs, path::PathBuf};
+
+    use tempfile::tempdir;
+
+    use super::{
+        docker_bundle_mounts_for_home, docker_bundle_override_content,
+        ensure_docker_gwt_binary_setup_for_home, install_launch_gwt_bin_env_with_lookup,
+    };
+
+    #[test]
+    fn install_launch_gwt_bin_env_prefers_public_gwt_binary_for_host_sessions() {
+        let current_exe = PathBuf::from(
+            r"C:\Users\Example\AppData\Local\Temp\bunx-1234567890-@akiojin\gwt@latest\node_modules\@akiojin\gwt\bin\gwt.exe",
+        );
+        let stable = PathBuf::from(r"C:\Users\Example\.bun\bin\gwt.exe");
+        let mut env = HashMap::new();
+
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |command| {
+                assert_eq!(command, "gwt");
+                Some(stable.clone())
+            },
+        )
+        .expect("install GWT_BIN_PATH");
+
+        assert_eq!(
+            env.get(gwt_agent::GWT_BIN_PATH_ENV).map(String::as_str),
+            Some(stable.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn docker_bundle_override_content_mounts_front_door_and_daemon() {
+        let home = PathBuf::from("/home/example");
+        let bundle = docker_bundle_mounts_for_home(&home);
+        let content = docker_bundle_override_content("app", &bundle);
+
+        assert!(content.contains("/home/example/.gwt/bin/gwt-linux:/usr/local/bin/gwt:ro"));
+        assert!(content.contains("/home/example/.gwt/bin/gwtd-linux:/usr/local/bin/gwtd:ro"));
+        assert!(!content.contains("gwtd-linux:/usr/local/bin/gwt:ro"));
+    }
+
+    #[test]
+    fn docker_binary_setup_installs_missing_bundle_before_writing_override() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let mut installer_calls = 0;
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |bundle| {
+            installer_calls += 1;
+            fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent"))
+                .expect("create bin dir");
+            fs::write(&bundle.host_gwt, b"linux-gwt").expect("write gwt");
+            fs::write(&bundle.host_gwtd, b"linux-gwtd").expect("write gwtd");
+            Ok(())
+        })
+        .expect("docker setup");
+
+        let bundle = docker_bundle_mounts_for_home(home.path());
+        assert_eq!(installer_calls, 1);
+        assert_eq!(fs::read(&bundle.host_gwt).expect("read gwt"), b"linux-gwt");
+        assert_eq!(
+            fs::read(&bundle.host_gwtd).expect("read gwtd"),
+            b"linux-gwtd"
+        );
+
+        let override_content = fs::read_to_string(repo.path().join("docker-compose.override.yml"))
+            .expect("override content");
+        assert!(override_content.contains("gwt-linux:/usr/local/bin/gwt:ro"));
+        assert!(override_content.contains("gwtd-linux:/usr/local/bin/gwtd:ro"));
+    }
+
+    #[test]
+    fn docker_binary_setup_skips_installer_when_bundle_exists() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let bundle = docker_bundle_mounts_for_home(home.path());
+        fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent")).expect("create bin dir");
+        fs::write(&bundle.host_gwt, b"existing-gwt").expect("write gwt");
+        fs::write(&bundle.host_gwtd, b"existing-gwtd").expect("write gwtd");
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |_| {
+            panic!("installer should not run when both bundle binaries exist");
+        })
+        .expect("docker setup");
+
+        assert_eq!(
+            fs::read(&bundle.host_gwt).expect("read gwt"),
+            b"existing-gwt"
+        );
+        assert_eq!(
+            fs::read(&bundle.host_gwtd).expect("read gwtd"),
+            b"existing-gwtd"
+        );
+        assert!(repo.path().join("docker-compose.override.yml").exists());
+    }
+}

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -9,7 +9,8 @@ use std::{
 };
 
 use crate::docker_setup::{
-    docker_compose_override_path, ensure_docker_gwt_binary_setup, install_launch_gwt_bin_env,
+    docker_compose_override_path, docker_compose_user_override_path,
+    ensure_docker_gwt_binary_setup, install_launch_gwt_bin_env, is_legacy_gwt_generated_override,
 };
 use crate::repo_browser::{preferred_issue_launch_branch, spawn_branch_load_async};
 use axum::{
@@ -5784,6 +5785,18 @@ mod tests {
             super::resolve_docker_launch_plan(&arm64, Some("app")).expect("arm64 plan");
         assert_eq!(arm64_plan.target_arch, "aarch64");
 
+        let unsupported = temp.path().join("unsupported-platform");
+        fs::create_dir_all(&unsupported).expect("create unsupported project");
+        fs::write(
+            unsupported.join("docker-compose.yml"),
+            "services:\n  app:\n    image: alpine:3.19\n    platform: linux/ppc64le\n    working_dir: /workspace/app\n",
+        )
+        .expect("write unsupported compose");
+        let unsupported_err = super::resolve_docker_launch_plan(&unsupported, Some("app"))
+            .expect_err("unsupported platform");
+        assert!(unsupported_err.contains("unsupported platform"));
+        assert!(unsupported_err.contains("linux/ppc64le"));
+
         let missing_compose =
             super::resolve_docker_launch_plan(temp.path(), None).expect_err("missing compose");
         assert!(missing_compose.contains("docker-compose.yml"));
@@ -5859,17 +5872,23 @@ mod tests {
         let project = temp.path().join("project");
         fs::create_dir_all(&project).expect("create project");
         let compose_file = project.join("docker-compose.yml");
-        let override_file = project.join("docker-compose.override.yml");
+        let user_override_file = super::docker_compose_user_override_path(&project);
+        let generated_override_file = super::docker_compose_override_path(&project);
         fs::write(
             &compose_file,
             "services:\n  app:\n    image: alpine:3.19\n    working_dir: /workspace/app\n",
         )
         .expect("write compose");
         fs::write(
-            &override_file,
+            &user_override_file,
+            "services:\n  app:\n    environment:\n      KEEP_ME: \"true\"\n",
+        )
+        .expect("write user override");
+        fs::write(
+            &generated_override_file,
             "services:\n  app:\n    volumes:\n      - /host/gwt:/usr/local/bin/gwt:ro\n",
         )
-        .expect("write override");
+        .expect("write generated override");
 
         let mut config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
             .runtime_target(LaunchRuntimeTarget::Docker)
@@ -5884,13 +5903,15 @@ mod tests {
 
         assert_eq!(config.command, super::docker_binary_for_launch());
         assert_eq!(
-            &config.args[..5],
+            &config.args[..7],
             vec![
                 "compose".to_string(),
                 "-f".to_string(),
                 compose_file.display().to_string(),
                 "-f".to_string(),
-                override_file.display().to_string(),
+                user_override_file.display().to_string(),
+                "-f".to_string(),
+                generated_override_file.display().to_string(),
             ]
         );
         assert_eq!(
@@ -5910,6 +5931,33 @@ mod tests {
         assert!(config.args.windows(3).any(|window| {
             window[0] == "exec" && window[1] == "-w" && window[2] == "/workspace/app"
         }));
+    }
+
+    #[test]
+    fn docker_launch_compose_files_skips_legacy_generated_default_override() {
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).expect("create project");
+        let compose_file = project.join("docker-compose.yml");
+        let legacy_override_file = super::docker_compose_user_override_path(&project);
+        let generated_override_file = super::docker_compose_override_path(&project);
+        fs::write(&compose_file, "services:\n  app:\n    image: alpine:3.19\n")
+            .expect("write compose");
+        fs::write(
+            &legacy_override_file,
+            "# Auto-generated docker-compose override for gwt bundle mounting\nservices:\n  app:\n",
+        )
+        .expect("write legacy override");
+        fs::write(
+            &generated_override_file,
+            "services:\n  app:\n    volumes:\n      - /host/gwt:/usr/local/bin/gwt:ro\n",
+        )
+        .expect("write generated override");
+
+        assert_eq!(
+            super::docker_launch_compose_files(&project, &compose_file),
+            vec![compose_file, generated_override_file]
+        );
     }
 
     #[test]
@@ -7317,7 +7365,7 @@ fn resolve_docker_launch_plan(
         compose_files: docker_launch_compose_files(worktree, &compose_file),
         service: service.name.clone(),
         container_cwd,
-        target_arch: docker_bundle_target_arch(service),
+        target_arch: docker_bundle_target_arch(service)?,
     })
 }
 
@@ -7325,12 +7373,16 @@ fn docker_binary_for_launch() -> String {
     std::env::var("GWT_DOCKER_BIN").unwrap_or_else(|_| "docker".to_string())
 }
 
-fn docker_bundle_target_arch(service: &gwt_docker::ComposeService) -> String {
-    service
-        .platform
-        .as_deref()
-        .and_then(docker_platform_target_arch)
-        .unwrap_or_else(host_docker_target_arch)
+fn docker_bundle_target_arch(service: &gwt_docker::ComposeService) -> Result<String, String> {
+    if let Some(platform) = service.platform.as_deref() {
+        return docker_platform_target_arch(platform).ok_or_else(|| {
+            format!(
+                "Docker service {} specifies unsupported platform {}; expected x86_64/amd64 or aarch64/arm64",
+                service.name, platform
+            )
+        });
+    }
+    Ok(host_docker_target_arch())
 }
 
 fn docker_platform_target_arch(platform: &str) -> Option<String> {
@@ -7364,9 +7416,13 @@ fn normalize_docker_target_arch(raw: &str) -> Option<String> {
 
 fn docker_launch_compose_files(worktree: &Path, compose_file: &Path) -> Vec<PathBuf> {
     let mut files = vec![compose_file.to_path_buf()];
-    let override_file = docker_compose_override_path(worktree);
-    if override_file.is_file() {
-        files.push(override_file);
+    let user_override_file = docker_compose_user_override_path(worktree);
+    if user_override_file.is_file() && !is_legacy_gwt_generated_override(&user_override_file) {
+        files.push(user_override_file);
+    }
+    let generated_override_file = docker_compose_override_path(worktree);
+    if generated_override_file.is_file() {
+        files.push(generated_override_file);
     }
     files
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -5004,6 +5004,7 @@ mod tests {
         let service = gwt_docker::ComposeService {
             name: "app".to_string(),
             image: Some("alpine:3.20".to_string()),
+            platform: None,
             ports: Vec::new(),
             depends_on: Vec::new(),
             working_dir: None,
@@ -5338,6 +5339,17 @@ mod tests {
             super::resolve_docker_launch_plan(&no_cwd, Some("app")).expect_err("no cwd");
         assert!(no_cwd_err.contains("missing working_dir/workspaceFolder"));
 
+        let arm64 = temp.path().join("arm64");
+        fs::create_dir_all(&arm64).expect("create arm64 project");
+        fs::write(
+            arm64.join("docker-compose.yml"),
+            "services:\n  app:\n    image: alpine:3.19\n    platform: linux/arm64/v8\n    working_dir: /workspace/app\n",
+        )
+        .expect("write arm64 compose");
+        let arm64_plan =
+            super::resolve_docker_launch_plan(&arm64, Some("app")).expect("arm64 plan");
+        assert_eq!(arm64_plan.target_arch, "aarch64");
+
         let missing_compose =
             super::resolve_docker_launch_plan(temp.path(), None).expect_err("missing compose");
         assert!(missing_compose.contains("docker-compose.yml"));
@@ -5525,6 +5537,7 @@ mod tests {
         let service = gwt_docker::ComposeService {
             name: "app".to_string(),
             image: Some("alpine:3.19".to_string()),
+            platform: None,
             ports: Vec::new(),
             depends_on: Vec::new(),
             working_dir: Some("/workspace".to_string()),
@@ -6325,6 +6338,7 @@ struct DockerLaunchPlan {
     compose_files: Vec<PathBuf>,
     service: String,
     container_cwd: String,
+    target_arch: String,
 }
 
 impl DockerLaunchPlan {
@@ -6375,7 +6389,8 @@ fn apply_docker_runtime_to_launch_config(
     let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
     ensure_docker_launch_runtime_ready()?;
     let mut launch = launch;
-    let compose_override_file = ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
+    let compose_override_file =
+        ensure_docker_gwt_binary_setup(&worktree, &launch.service, &launch.target_arch)?;
     launch.include_compose_override(compose_override_file);
     ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
     maybe_inject_docker_sandbox_env(&launch, config)?;
@@ -6448,7 +6463,8 @@ fn build_shell_process_launch(
     let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
     ensure_docker_launch_runtime_ready()?;
     let mut launch = launch;
-    let compose_override_file = ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
+    let compose_override_file =
+        ensure_docker_gwt_binary_setup(&worktree, &launch.service, &launch.target_arch)?;
     launch.include_compose_override(compose_override_file);
     ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
     let shell_command = resolve_docker_shell_command(&launch)?;
@@ -6867,11 +6883,49 @@ fn resolve_docker_launch_plan(
         compose_files: docker_launch_compose_files(worktree, &compose_file),
         service: service.name.clone(),
         container_cwd,
+        target_arch: docker_bundle_target_arch(service),
     })
 }
 
 fn docker_binary_for_launch() -> String {
     std::env::var("GWT_DOCKER_BIN").unwrap_or_else(|_| "docker".to_string())
+}
+
+fn docker_bundle_target_arch(service: &gwt_docker::ComposeService) -> String {
+    service
+        .platform
+        .as_deref()
+        .and_then(docker_platform_target_arch)
+        .unwrap_or_else(host_docker_target_arch)
+}
+
+fn docker_platform_target_arch(platform: &str) -> Option<String> {
+    let platform = platform.trim();
+    let arch = platform
+        .split('/')
+        .nth(1)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(platform);
+    normalize_docker_target_arch(arch)
+}
+
+fn host_docker_target_arch() -> String {
+    normalize_docker_target_arch(std::env::consts::ARCH)
+        .unwrap_or_else(|| std::env::consts::ARCH.to_string())
+}
+
+fn normalize_docker_target_arch(raw: &str) -> Option<String> {
+    match raw
+        .trim()
+        .to_ascii_lowercase()
+        .split('/')
+        .next()
+        .unwrap_or_default()
+    {
+        "x86_64" | "amd64" | "x64" => Some("x86_64".to_string()),
+        "aarch64" | "arm64" => Some("aarch64".to_string()),
+        _ => None,
+    }
 }
 
 fn docker_launch_compose_files(worktree: &Path, compose_file: &Path) -> Vec<PathBuf> {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2683,7 +2683,8 @@ mod tests {
         app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
         broadcast_runtime_hook_event, build_frontend_sync_events, build_shell_process_launch,
         close_window_from_workspace, combined_window_id, current_git_branch,
-        docker_bundle_mounts_for_home, docker_bundle_override_content, hook_forward_authorized,
+        docker_bundle_mounts_for_home, docker_bundle_override_content,
+        ensure_docker_gwt_binary_setup_for_home, hook_forward_authorized,
         install_launch_gwt_bin_env_with_lookup, knowledge_kind_for_preset, resolve_project_target,
         should_auto_close_agent_window, should_auto_start_restored_window, ActiveAgentSession,
         AppEventProxy, AppRuntime, ClientHub, DispatchTarget, LaunchWizardSession, OutboundEvent,
@@ -4754,6 +4755,61 @@ mod tests {
     }
 
     #[test]
+    fn docker_binary_setup_installs_missing_bundle_before_writing_override() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let mut installer_calls = 0;
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |bundle| {
+            installer_calls += 1;
+            fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent"))
+                .expect("create bin dir");
+            fs::write(&bundle.host_gwt, b"linux-gwt").expect("write gwt");
+            fs::write(&bundle.host_gwtd, b"linux-gwtd").expect("write gwtd");
+            Ok(())
+        })
+        .expect("docker setup");
+
+        let bundle = docker_bundle_mounts_for_home(home.path());
+        assert_eq!(installer_calls, 1);
+        assert_eq!(fs::read(&bundle.host_gwt).expect("read gwt"), b"linux-gwt");
+        assert_eq!(
+            fs::read(&bundle.host_gwtd).expect("read gwtd"),
+            b"linux-gwtd"
+        );
+
+        let override_content = fs::read_to_string(repo.path().join("docker-compose.override.yml"))
+            .expect("override content");
+        assert!(override_content.contains("gwt-linux:/usr/local/bin/gwt:ro"));
+        assert!(override_content.contains("gwtd-linux:/usr/local/bin/gwtd:ro"));
+    }
+
+    #[test]
+    fn docker_binary_setup_skips_installer_when_bundle_exists() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let bundle = docker_bundle_mounts_for_home(home.path());
+        fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent")).expect("create bin dir");
+        fs::write(&bundle.host_gwt, b"existing-gwt").expect("write gwt");
+        fs::write(&bundle.host_gwtd, b"existing-gwtd").expect("write gwtd");
+
+        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |_| {
+            panic!("installer should not run when both bundle binaries exist");
+        })
+        .expect("docker setup");
+
+        assert_eq!(
+            fs::read(&bundle.host_gwt).expect("read gwt"),
+            b"existing-gwt"
+        );
+        assert_eq!(
+            fs::read(&bundle.host_gwtd).expect("read gwtd"),
+            b"existing-gwtd"
+        );
+        assert!(repo.path().join("docker-compose.override.yml").exists());
+    }
+
+    #[test]
     fn issue_and_spec_presets_route_to_knowledge_bridge_kind() {
         assert_eq!(
             knowledge_kind_for_preset(WindowPreset::Issue),
@@ -6586,23 +6642,17 @@ fn install_launch_gwt_bin_env_with_lookup(
     Ok(())
 }
 
-fn resolve_user_home_dir() -> Result<PathBuf, String> {
-    let home = if cfg!(windows) {
-        std::env::var("USERPROFILE")
-    } else {
-        std::env::var("HOME")
-    }
-    .map(PathBuf::from)
-    .map_err(|_| "Could not determine home directory".to_string())?;
-    Ok(home)
-}
-
-fn docker_bundle_mounts_for_home(home: &Path) -> DockerBundleMounts {
-    let gwt_bin_dir = home.join(".gwt").join("bin");
+fn docker_bundle_mounts_for_gwt_home(gwt_home: &Path) -> DockerBundleMounts {
+    let gwt_bin_dir = gwt_home.join("bin");
     DockerBundleMounts {
         host_gwt: gwt_bin_dir.join(DOCKER_HOST_GWT_BIN_NAME),
         host_gwtd: gwt_bin_dir.join(DOCKER_HOST_GWTD_BIN_NAME),
     }
+}
+
+#[cfg(test)]
+fn docker_bundle_mounts_for_home(home: &Path) -> DockerBundleMounts {
+    docker_bundle_mounts_for_gwt_home(&home.join(".gwt"))
 }
 
 fn docker_compose_mount_path(path: &Path) -> String {
@@ -6624,25 +6674,67 @@ fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) ->
 }
 
 fn ensure_docker_gwt_binary_setup(repo_path: &Path, service: &str) -> Result<(), String> {
+    let gwt_home = gwt_core::paths::gwt_home();
+    ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, |bundle| {
+        eprintln!(
+            "Installing Linux gwt bundle for Docker at {} and {}",
+            bundle.host_gwt.display(),
+            bundle.host_gwtd.display()
+        );
+        let installed = gwt_core::update::UpdateManager::new()
+            .install_latest_docker_linux_bundle(&bundle.host_gwt, &bundle.host_gwtd)?;
+        eprintln!(
+            "Installed Linux gwt bundle v{} for Docker",
+            installed.version
+        );
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+fn ensure_docker_gwt_binary_setup_for_home<F>(
+    repo_path: &Path,
+    service: &str,
+    home: &Path,
+    install_bundle: F,
+) -> Result<(), String>
+where
+    F: FnMut(&DockerBundleMounts) -> Result<(), String>,
+{
+    let gwt_home = home.join(".gwt");
+    ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, install_bundle)
+}
+
+fn ensure_docker_gwt_binary_setup_for_gwt_home<F>(
+    repo_path: &Path,
+    service: &str,
+    gwt_home: &Path,
+    mut install_bundle: F,
+) -> Result<(), String>
+where
+    F: FnMut(&DockerBundleMounts) -> Result<(), String>,
+{
     use std::fs;
 
-    let home = resolve_user_home_dir()?;
-    let bundle = docker_bundle_mounts_for_home(&home);
+    let bundle = docker_bundle_mounts_for_gwt_home(gwt_home);
 
     if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
-        let override_path = repo_path.join("docker-compose.override.yml");
-        if !override_path.exists() {
-            eprintln!(
-                "Note: Linux gwt bundle not found at {} and {}\n\
-                 This is required for Docker agent support.\n\
-                 You can either:\n\
-                 1. Download the Linux release bundle and place the extracted binaries at these paths\n\
-                 2. Run 'gwt setup docker' to set up Docker integration automatically"
-                ,
+        install_bundle(&bundle).map_err(|err| {
+            format!(
+                "Failed to install Linux gwt bundle for Docker: {err}\n\
+                 Expected cached binaries at {} and {}",
                 bundle.host_gwt.display(),
                 bundle.host_gwtd.display()
-            );
-        }
+            )
+        })?;
+    }
+
+    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
+        return Err(format!(
+            "Linux gwt bundle setup did not create expected Docker binaries at {} and {}",
+            bundle.host_gwt.display(),
+            bundle.host_gwtd.display()
+        ));
     }
 
     let override_path = repo_path.join("docker-compose.override.yml");

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -8,7 +8,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::docker_setup::{ensure_docker_gwt_binary_setup, install_launch_gwt_bin_env};
+use crate::docker_setup::{
+    docker_compose_override_path, ensure_docker_gwt_binary_setup, install_launch_gwt_bin_env,
+};
 use crate::repo_browser::{preferred_issue_launch_branch, spawn_branch_load_async};
 use axum::{
     extract::{
@@ -5303,7 +5305,7 @@ mod tests {
         let plan = super::resolve_docker_launch_plan(&project, None).expect("launch plan");
         assert_eq!(plan.service, "app");
         assert_eq!(plan.container_cwd, "/workspace/dev");
-        assert_eq!(plan.compose_file, project.join("docker-compose.yml"));
+        assert_eq!(plan.compose_files, vec![project.join("docker-compose.yml")]);
 
         let (context, status) = super::detect_wizard_docker_context_and_status(&project);
         let context = context.expect("docker context");
@@ -5403,6 +5405,65 @@ mod tests {
             Some(value) => std::env::set_var("GWT_DOCKER_BIN", value),
             None => std::env::remove_var("GWT_DOCKER_BIN"),
         }
+    }
+
+    #[test]
+    fn finalized_docker_agent_launch_includes_generated_override_file() {
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).expect("create project");
+        let compose_file = project.join("docker-compose.yml");
+        let override_file = project.join("docker-compose.override.yml");
+        fs::write(
+            &compose_file,
+            "services:\n  app:\n    image: alpine:3.19\n    working_dir: /workspace/app\n",
+        )
+        .expect("write compose");
+        fs::write(
+            &override_file,
+            "services:\n  app:\n    volumes:\n      - /host/gwt:/usr/local/bin/gwt:ro\n",
+        )
+        .expect("write override");
+
+        let mut config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .runtime_target(LaunchRuntimeTarget::Docker)
+            .working_dir(project.clone())
+            .docker_service("app")
+            .build();
+        config.command = "claude".to_string();
+        config.args = vec!["--version".to_string()];
+
+        super::finalize_docker_agent_launch_config(&project, &mut config)
+            .expect("finalize docker launch");
+
+        assert_eq!(config.command, super::docker_binary_for_launch());
+        assert_eq!(
+            &config.args[..5],
+            vec![
+                "compose".to_string(),
+                "-f".to_string(),
+                compose_file.display().to_string(),
+                "-f".to_string(),
+                override_file.display().to_string(),
+            ]
+        );
+        assert_eq!(
+            config
+                .args
+                .iter()
+                .rev()
+                .take(3)
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                "--version".to_string(),
+                "claude".to_string(),
+                "app".to_string(),
+            ]
+        );
+        assert!(config.args.windows(3).any(|window| {
+            window[0] == "exec" && window[1] == "-w" && window[2] == "/workspace/app"
+        }));
     }
 
     #[test]
@@ -6261,9 +6322,17 @@ fn resolve_shell_launch_worktree(
 
 #[derive(Debug, Clone)]
 struct DockerLaunchPlan {
-    compose_file: PathBuf,
+    compose_files: Vec<PathBuf>,
     service: String,
     container_cwd: String,
+}
+
+impl DockerLaunchPlan {
+    fn include_compose_override(&mut self, override_file: PathBuf) {
+        if !self.compose_files.iter().any(|file| file == &override_file) {
+            self.compose_files.push(override_file);
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -6305,8 +6374,10 @@ fn apply_docker_runtime_to_launch_config(
         .unwrap_or_else(|| repo_path.to_path_buf());
     let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
     ensure_docker_launch_runtime_ready()?;
+    let mut launch = launch;
+    let compose_override_file = ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
+    launch.include_compose_override(compose_override_file);
     ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
-    ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
     maybe_inject_docker_sandbox_env(&launch, config)?;
     install_launch_gwt_bin_env(&mut config.env_vars, gwt_agent::LaunchRuntimeTarget::Docker)?;
     let runtime_program = resolve_docker_exec_program(&launch, config)?;
@@ -6337,14 +6408,8 @@ fn finalize_docker_agent_launch_config(
         args: config.args.clone(),
     };
 
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        launch.compose_file.display().to_string(),
-        "exec".to_string(),
-        "-w".to_string(),
-        launch.container_cwd,
-    ];
+    let mut args = docker_compose_command_prefix(&launch);
+    args.extend(["exec".to_string(), "-w".to_string(), launch.container_cwd]);
     args.extend(docker_compose_exec_env_args(&config.env_vars));
     args.push(launch.service);
     args.push(runtime_program.executable);
@@ -6382,22 +6447,22 @@ fn build_shell_process_launch(
 
     let launch = resolve_docker_launch_plan(&worktree, config.docker_service.as_deref())?;
     ensure_docker_launch_runtime_ready()?;
+    let mut launch = launch;
+    let compose_override_file = ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
+    launch.include_compose_override(compose_override_file);
     ensure_docker_launch_service_ready(&launch, config.docker_lifecycle_intent)?;
-    ensure_docker_gwt_binary_setup(&worktree, &launch.service)?;
     let shell_command = resolve_docker_shell_command(&launch)?;
     env.insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
     install_launch_gwt_bin_env(&mut env, gwt_agent::LaunchRuntimeTarget::Docker)?;
     config.docker_service = Some(launch.service.clone());
     config.env_vars = env.clone();
 
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        launch.compose_file.display().to_string(),
+    let mut args = docker_compose_command_prefix(&launch);
+    args.extend([
         "exec".to_string(),
         "-w".to_string(),
         launch.container_cwd.clone(),
-    ];
+    ]);
     args.extend(docker_compose_exec_env_args(&env));
     args.push(launch.service);
     args.push(shell_command);
@@ -6515,13 +6580,14 @@ fn maybe_inject_docker_sandbox_env(
         return Ok(());
     }
 
-    let is_root = gwt_docker::compose_service_user_is_root(&launch.compose_file, &launch.service)
-        .map_err(|err| {
-        format!(
-            "Failed to determine Docker user for service '{}': {err}",
-            launch.service
-        )
-    })?;
+    let is_root =
+        gwt_docker::compose_service_user_is_root_with_files(&launch.compose_files, &launch.service)
+            .map_err(|err| {
+                format!(
+                    "Failed to determine Docker user for service '{}': {err}",
+                    launch.service
+                )
+            })?;
     if is_root {
         config
             .env_vars
@@ -6601,8 +6667,8 @@ fn resolve_docker_package_runner(
     ];
 
     for candidate in candidates {
-        let output = gwt_docker::compose_service_exec_capture(
-            &launch.compose_file,
+        let output = gwt_docker::compose_service_exec_capture_with_files(
+            &launch.compose_files,
             &launch.service,
             Some(&launch.container_cwd),
             &candidate.probe_args(),
@@ -6633,8 +6699,8 @@ fn strip_package_runner_args(args: &[String], version_spec: &str) -> Vec<String>
 
 fn resolve_docker_shell_command(launch: &DockerLaunchPlan) -> Result<String, String> {
     for candidate in ["bash", "sh"] {
-        let available = gwt_docker::compose_service_has_command(
-            &launch.compose_file,
+        let available = gwt_docker::compose_service_has_command_with_files(
+            &launch.compose_files,
             &launch.service,
             candidate,
         )
@@ -6654,9 +6720,12 @@ fn ensure_docker_launch_command_ready(
     launch: &DockerLaunchPlan,
     command: &str,
 ) -> Result<(), String> {
-    let available =
-        gwt_docker::compose_service_has_command(&launch.compose_file, &launch.service, command)
-            .map_err(|err| err.to_string())?;
+    let available = gwt_docker::compose_service_has_command_with_files(
+        &launch.compose_files,
+        &launch.service,
+        command,
+    )
+    .map_err(|err| err.to_string())?;
     if available {
         Ok(())
     } else {
@@ -6689,21 +6758,22 @@ fn ensure_docker_launch_service_ready(
     launch: &DockerLaunchPlan,
     intent: gwt_agent::DockerLifecycleIntent,
 ) -> Result<(), String> {
-    let status = gwt_docker::compose_service_status(&launch.compose_file, &launch.service)
-        .map_err(|err| err.to_string())?;
+    let status =
+        gwt_docker::compose_service_status_with_files(&launch.compose_files, &launch.service)
+            .map_err(|err| err.to_string())?;
     match normalize_docker_launch_action(intent, status) {
         DockerLaunchServiceAction::Connect => Ok(()),
         DockerLaunchServiceAction::Start => {
-            gwt_docker::compose_up(&launch.compose_file, &launch.service)
+            gwt_docker::compose_up_with_files(&launch.compose_files, &launch.service)
                 .map_err(|err| err.to_string())?;
             Ok(())
         }
         DockerLaunchServiceAction::Restart => {
-            gwt_docker::compose_restart(&launch.compose_file, &launch.service)
+            gwt_docker::compose_restart_with_files(&launch.compose_files, &launch.service)
                 .map_err(|err| err.to_string())
         }
         DockerLaunchServiceAction::Recreate => {
-            gwt_docker::compose_up_force_recreate(&launch.compose_file, &launch.service)
+            gwt_docker::compose_up_force_recreate_with_files(&launch.compose_files, &launch.service)
                 .map_err(|err| err.to_string())
         }
     }
@@ -6794,7 +6864,7 @@ fn resolve_docker_launch_plan(
         })?;
 
     Ok(DockerLaunchPlan {
-        compose_file,
+        compose_files: docker_launch_compose_files(worktree, &compose_file),
         service: service.name.clone(),
         container_cwd,
     })
@@ -6802,6 +6872,24 @@ fn resolve_docker_launch_plan(
 
 fn docker_binary_for_launch() -> String {
     std::env::var("GWT_DOCKER_BIN").unwrap_or_else(|_| "docker".to_string())
+}
+
+fn docker_launch_compose_files(worktree: &Path, compose_file: &Path) -> Vec<PathBuf> {
+    let mut files = vec![compose_file.to_path_buf()];
+    let override_file = docker_compose_override_path(worktree);
+    if override_file.is_file() {
+        files.push(override_file);
+    }
+    files
+}
+
+fn docker_compose_command_prefix(launch: &DockerLaunchPlan) -> Vec<String> {
+    let mut args = vec!["compose".to_string()];
+    for compose_file in &launch.compose_files {
+        args.push("-f".to_string());
+        args.push(compose_file.display().to_string());
+    }
+    args
 }
 
 fn docker_compose_file_for_launch(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -8,6 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::docker_setup::{ensure_docker_gwt_binary_setup, install_launch_gwt_bin_env};
 use crate::repo_browser::{preferred_issue_launch_branch, spawn_branch_load_async};
 use axum::{
     extract::{
@@ -46,21 +47,12 @@ use tokio::{
 use uuid::Uuid;
 use wry::WebViewBuilder;
 
+mod docker_setup;
 mod embedded_web;
 mod repo_browser;
 
 type ClientId = String;
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
-const DOCKER_GWT_BIN_PATH: &str = "/usr/local/bin/gwt";
-const DOCKER_GWTD_BIN_PATH: &str = "/usr/local/bin/gwtd";
-const DOCKER_HOST_GWT_BIN_NAME: &str = "gwt-linux";
-const DOCKER_HOST_GWTD_BIN_NAME: &str = "gwtd-linux";
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DockerBundleMounts {
-    host_gwt: PathBuf,
-    host_gwtd: PathBuf,
-}
 
 /// Shared lock-free PTY writer registry used by the WebSocket fast-path.
 ///
@@ -2683,9 +2675,7 @@ mod tests {
         app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
         broadcast_runtime_hook_event, build_frontend_sync_events, build_shell_process_launch,
         close_window_from_workspace, combined_window_id, current_git_branch,
-        docker_bundle_mounts_for_home, docker_bundle_override_content,
-        ensure_docker_gwt_binary_setup_for_home, hook_forward_authorized,
-        install_launch_gwt_bin_env_with_lookup, knowledge_kind_for_preset, resolve_project_target,
+        hook_forward_authorized, knowledge_kind_for_preset, resolve_project_target,
         should_auto_close_agent_window, should_auto_start_restored_window, ActiveAgentSession,
         AppEventProxy, AppRuntime, ClientHub, DispatchTarget, LaunchWizardSession, OutboundEvent,
         ProcessLaunch, ProjectTabRuntime, UserEvent, WindowAddress,
@@ -4719,97 +4709,6 @@ mod tests {
     }
 
     #[test]
-    fn install_launch_gwt_bin_env_prefers_public_gwt_binary_for_host_sessions() {
-        let current_exe = PathBuf::from(
-            r"C:\Users\Example\AppData\Local\Temp\bunx-1234567890-@akiojin\gwt@latest\node_modules\@akiojin\gwt\bin\gwt.exe",
-        );
-        let stable = PathBuf::from(r"C:\Users\Example\.bun\bin\gwt.exe");
-        let mut env = HashMap::new();
-
-        install_launch_gwt_bin_env_with_lookup(
-            &mut env,
-            LaunchRuntimeTarget::Host,
-            &current_exe,
-            |command| {
-                assert_eq!(command, "gwt");
-                Some(stable.clone())
-            },
-        )
-        .expect("install GWT_BIN_PATH");
-
-        assert_eq!(
-            env.get(gwt_agent::GWT_BIN_PATH_ENV).map(String::as_str),
-            Some(stable.to_string_lossy().as_ref())
-        );
-    }
-
-    #[test]
-    fn docker_bundle_override_content_mounts_front_door_and_daemon() {
-        let home = PathBuf::from("/home/example");
-        let bundle = docker_bundle_mounts_for_home(&home);
-        let content = docker_bundle_override_content("app", &bundle);
-
-        assert!(content.contains("/home/example/.gwt/bin/gwt-linux:/usr/local/bin/gwt:ro"));
-        assert!(content.contains("/home/example/.gwt/bin/gwtd-linux:/usr/local/bin/gwtd:ro"));
-        assert!(!content.contains("gwtd-linux:/usr/local/bin/gwt:ro"));
-    }
-
-    #[test]
-    fn docker_binary_setup_installs_missing_bundle_before_writing_override() {
-        let repo = tempdir().expect("repo tempdir");
-        let home = tempdir().expect("home tempdir");
-        let mut installer_calls = 0;
-
-        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |bundle| {
-            installer_calls += 1;
-            fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent"))
-                .expect("create bin dir");
-            fs::write(&bundle.host_gwt, b"linux-gwt").expect("write gwt");
-            fs::write(&bundle.host_gwtd, b"linux-gwtd").expect("write gwtd");
-            Ok(())
-        })
-        .expect("docker setup");
-
-        let bundle = docker_bundle_mounts_for_home(home.path());
-        assert_eq!(installer_calls, 1);
-        assert_eq!(fs::read(&bundle.host_gwt).expect("read gwt"), b"linux-gwt");
-        assert_eq!(
-            fs::read(&bundle.host_gwtd).expect("read gwtd"),
-            b"linux-gwtd"
-        );
-
-        let override_content = fs::read_to_string(repo.path().join("docker-compose.override.yml"))
-            .expect("override content");
-        assert!(override_content.contains("gwt-linux:/usr/local/bin/gwt:ro"));
-        assert!(override_content.contains("gwtd-linux:/usr/local/bin/gwtd:ro"));
-    }
-
-    #[test]
-    fn docker_binary_setup_skips_installer_when_bundle_exists() {
-        let repo = tempdir().expect("repo tempdir");
-        let home = tempdir().expect("home tempdir");
-        let bundle = docker_bundle_mounts_for_home(home.path());
-        fs::create_dir_all(bundle.host_gwt.parent().expect("gwt parent")).expect("create bin dir");
-        fs::write(&bundle.host_gwt, b"existing-gwt").expect("write gwt");
-        fs::write(&bundle.host_gwtd, b"existing-gwtd").expect("write gwtd");
-
-        ensure_docker_gwt_binary_setup_for_home(repo.path(), "app", home.path(), |_| {
-            panic!("installer should not run when both bundle binaries exist");
-        })
-        .expect("docker setup");
-
-        assert_eq!(
-            fs::read(&bundle.host_gwt).expect("read gwt"),
-            b"existing-gwt"
-        );
-        assert_eq!(
-            fs::read(&bundle.host_gwtd).expect("read gwtd"),
-            b"existing-gwtd"
-        );
-        assert!(repo.path().join("docker-compose.override.yml").exists());
-    }
-
-    #[test]
     fn issue_and_spec_presets_route_to_knowledge_bridge_kind() {
         assert_eq!(
             knowledge_kind_for_preset(WindowPreset::Issue),
@@ -6602,153 +6501,6 @@ fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
     if !gwt_docker::daemon_running() {
         return Err("Docker daemon is not running".to_string());
     }
-    Ok(())
-}
-
-fn install_launch_gwt_bin_env(
-    env_vars: &mut HashMap<String, String>,
-    runtime_target: gwt_agent::LaunchRuntimeTarget,
-) -> Result<(), String> {
-    let current_exe = std::env::current_exe().map_err(|error| format!("current_exe: {error}"))?;
-    install_launch_gwt_bin_env_with_lookup(env_vars, runtime_target, &current_exe, |command| {
-        which::which(command).ok()
-    })
-}
-
-fn install_launch_gwt_bin_env_with_lookup(
-    env_vars: &mut HashMap<String, String>,
-    runtime_target: gwt_agent::LaunchRuntimeTarget,
-    current_exe: &Path,
-    lookup: impl FnOnce(&str) -> Option<PathBuf>,
-) -> Result<(), String> {
-    let gwt_bin = match runtime_target {
-        gwt_agent::LaunchRuntimeTarget::Docker => DOCKER_GWT_BIN_PATH.to_string(),
-        gwt_agent::LaunchRuntimeTarget::Host => {
-            gwt::managed_assets::resolve_public_gwt_bin_with_lookup(current_exe, lookup)
-                .to_string_lossy()
-                .into_owned()
-        }
-    };
-    match runtime_target {
-        gwt_agent::LaunchRuntimeTarget::Docker => {
-            env_vars.insert(gwt_agent::session::GWT_BIN_PATH_ENV.to_string(), gwt_bin);
-        }
-        gwt_agent::LaunchRuntimeTarget::Host => {
-            env_vars
-                .entry(gwt_agent::session::GWT_BIN_PATH_ENV.to_string())
-                .or_insert(gwt_bin);
-        }
-    }
-    Ok(())
-}
-
-fn docker_bundle_mounts_for_gwt_home(gwt_home: &Path) -> DockerBundleMounts {
-    let gwt_bin_dir = gwt_home.join("bin");
-    DockerBundleMounts {
-        host_gwt: gwt_bin_dir.join(DOCKER_HOST_GWT_BIN_NAME),
-        host_gwtd: gwt_bin_dir.join(DOCKER_HOST_GWTD_BIN_NAME),
-    }
-}
-
-#[cfg(test)]
-fn docker_bundle_mounts_for_home(home: &Path) -> DockerBundleMounts {
-    docker_bundle_mounts_for_gwt_home(&home.join(".gwt"))
-}
-
-fn docker_compose_mount_path(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
-
-fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) -> String {
-    let host_gwt = docker_compose_mount_path(&bundle.host_gwt);
-    let host_gwtd = docker_compose_mount_path(&bundle.host_gwtd);
-    format!(
-        "# Auto-generated docker-compose override for gwt bundle mounting\n\
-         version: '3.8'\n\
-         services:\n\
-           {service}:\n\
-             volumes:\n\
-               - \"{host_gwt}:{DOCKER_GWT_BIN_PATH}:ro\"\n\
-               - \"{host_gwtd}:{DOCKER_GWTD_BIN_PATH}:ro\"\n"
-    )
-}
-
-fn ensure_docker_gwt_binary_setup(repo_path: &Path, service: &str) -> Result<(), String> {
-    let gwt_home = gwt_core::paths::gwt_home();
-    ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, |bundle| {
-        eprintln!(
-            "Installing Linux gwt bundle for Docker at {} and {}",
-            bundle.host_gwt.display(),
-            bundle.host_gwtd.display()
-        );
-        let installed = gwt_core::update::UpdateManager::new()
-            .install_latest_docker_linux_bundle(&bundle.host_gwt, &bundle.host_gwtd)?;
-        eprintln!(
-            "Installed Linux gwt bundle v{} for Docker",
-            installed.version
-        );
-        Ok(())
-    })
-}
-
-#[cfg(test)]
-fn ensure_docker_gwt_binary_setup_for_home<F>(
-    repo_path: &Path,
-    service: &str,
-    home: &Path,
-    install_bundle: F,
-) -> Result<(), String>
-where
-    F: FnMut(&DockerBundleMounts) -> Result<(), String>,
-{
-    let gwt_home = home.join(".gwt");
-    ensure_docker_gwt_binary_setup_for_gwt_home(repo_path, service, &gwt_home, install_bundle)
-}
-
-fn ensure_docker_gwt_binary_setup_for_gwt_home<F>(
-    repo_path: &Path,
-    service: &str,
-    gwt_home: &Path,
-    mut install_bundle: F,
-) -> Result<(), String>
-where
-    F: FnMut(&DockerBundleMounts) -> Result<(), String>,
-{
-    use std::fs;
-
-    let bundle = docker_bundle_mounts_for_gwt_home(gwt_home);
-
-    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
-        install_bundle(&bundle).map_err(|err| {
-            format!(
-                "Failed to install Linux gwt bundle for Docker: {err}\n\
-                 Expected cached binaries at {} and {}",
-                bundle.host_gwt.display(),
-                bundle.host_gwtd.display()
-            )
-        })?;
-    }
-
-    if !bundle.host_gwt.exists() || !bundle.host_gwtd.exists() {
-        return Err(format!(
-            "Linux gwt bundle setup did not create expected Docker binaries at {} and {}",
-            bundle.host_gwt.display(),
-            bundle.host_gwtd.display()
-        ));
-    }
-
-    let override_path = repo_path.join("docker-compose.override.yml");
-    if !override_path.exists() {
-        let override_content = docker_bundle_override_content(service, &bundle);
-        fs::write(&override_path, override_content).map_err(|err| {
-            format!(
-                "Failed to create docker-compose.override.yml: {err}\n\
-                 Manually create {} with gwt/gwtd bundle mounts",
-                override_path.display()
-            )
-        })?;
-    }
-
     Ok(())
 }
 

--- a/docs/docker-usage.md
+++ b/docs/docker-usage.md
@@ -17,12 +17,20 @@ docker compose build --no-cache
 
 ## Docker agent bundle
 
-Docker-backed agent sessions expect the Linux `gwt` bundle to be available on the host and mounted into the container as the public front door plus its internal daemon companion.
+Docker-backed agent sessions automatically download the latest Linux x86_64
+`gwt` bundle from GitHub Releases when the host cache is missing. The bundle is
+cached on the host and mounted into the container as the public front door plus
+its internal daemon companion.
 
 - `~/.gwt/bin/gwt-linux` -> `/usr/local/bin/gwt`
 - `~/.gwt/bin/gwtd-linux` -> `/usr/local/bin/gwtd`
 
-`gwt` remains the only operator-facing entrypoint inside the container. Skills and scripts should prefer `GWT_BIN_PATH` when it is present instead of calling `gwtd` directly.
+`gwt` remains the only operator-facing entrypoint inside the container. Skills
+and scripts should prefer `GWT_BIN_PATH` when it is present instead of calling
+`gwtd` directly.
+
+`docker-compose.override.yml` is generated next to the project compose file on
+first Docker launch when it does not already exist.
 
 ## エラー対応
 

--- a/docs/docker-usage.md
+++ b/docs/docker-usage.md
@@ -17,10 +17,10 @@ docker compose build --no-cache
 
 ## Docker agent bundle
 
-Docker-backed agent sessions automatically download the latest Linux x86_64
-`gwt` bundle from GitHub Releases when the host cache is missing. The bundle is
-cached on the host and mounted into the container as the public front door plus
-its internal daemon companion.
+Docker-backed agent sessions automatically download the latest Linux `gwt`
+bundle for the selected container architecture from GitHub Releases when the
+host cache is missing. The bundle is cached on the host and mounted into the
+container as the public front door plus its internal daemon companion.
 
 - `~/.gwt/bin/gwt-linux` -> `/usr/local/bin/gwt`
 - `~/.gwt/bin/gwtd-linux` -> `/usr/local/bin/gwtd`
@@ -29,8 +29,10 @@ its internal daemon companion.
 and scripts should prefer `GWT_BIN_PATH` when it is present instead of calling
 `gwtd` directly.
 
-`docker-compose.override.yml` is generated next to the project compose file on
-first Docker launch when it does not already exist.
+gwt writes its generated mounts into `docker-compose.gwt.override.yml` next to
+the project compose file. If the repo already has a user-managed
+`docker-compose.override.yml`, gwt layers that file first and keeps it
+unchanged.
 
 ## エラー対応
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,59 @@
 # Lessons Learned
 
+## 2026-04-21 — fix(docker): 生成した compose override は全 Docker compose 経路へ流す
+
+### 事象
+
+Issue #2035 のレビューで、`docker-compose.override.yml` 自体は生成していたが、
+初回 `docker compose up` と後続の `exec` / status 判定が base compose file
+だけを見ており、`/usr/local/bin/gwt` と `/usr/local/bin/gwtd` の bind mount が
+実際には有効になっていなかった。加えて、Docker が存在しない mount source を
+ディレクトリとして自動生成したケースを `exists()` で有効バイナリ扱いしていた。
+
+### 原因
+
+- Docker bundle setup が override path を返さず、launch 側も compose file を
+  単一パスで保持していたため、runtime setup で生成した override を
+  `up` / `restart` / `exec` / probe へ伝播できなかった。
+- Linux bundle cache の健全性判定が `exists()` ベースで、regular file かどうかと
+  中身があるかを確認していなかった。
+
+### 再発防止策
+
+1. runtime 中に compose override を生成する処理は、生成直後の `up` だけでなく
+   status / recreate / exec / command probe まで同じ compose file set
+   (`-f base -f override`) を使う contract test を追加する。
+2. bind mount source として再利用するキャッシュ判定は `exists()` を使わず、
+   regular file かつ非空であることを確認する。
+3. Docker が placeholder directory を作る失敗パスを RED test で固定し、
+   installer の再実行と override 生成の両方を確認してから完了とする。
+
+## 2026-04-21 — test(gwt-docker): Windows の fake docker は Git Bash に渡す script path と埋め込み path を揃える
+
+### 事象
+
+`cargo test -p gwt-docker` を Windows で実行すると、fake docker script を
+そのまま実行していた既存テストが `%1 is not a valid Win32 application`
+(`os error 193`) でまとまって失敗した。Git Bash wrapper を足した後も、
+`\\?\` 付きの Windows path をそのまま `/...` へ変換してしまい、
+`docker.sh: No such file or directory` で落ちた。
+
+### 原因
+
+- test harness が POSIX shell script を前提にしており、Windows 実行パスを
+  用意していなかった。
+- shell script 内に埋め込む log file path と wrapper から Git Bash へ渡す
+  script path の両方で、Windows path をそのまま使っていた。
+
+### 再発防止策
+
+1. Windows で shell-script based fake command を使う test harness では、
+   wrapper (`.cmd`) と Git Bash path 解決を helper に閉じ込める。
+2. shell script に埋め込む file path は helper 経由で Git Bash 互換
+   (`/c/...`) へ正規化し、`\\?\` prefix を落としてから使う。
+3. cross-platform にした test helper を触ったら、対象 crate の full test を
+   Windows でも 1 回回して `os error 193` 系の latent failure を残さない。
+
 ## 2026-04-21 — test: process-global HOME/USERPROFILE を読む assertion は並列テスト中に再読しない
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,54 @@
 # Lessons Learned
 
+## 2026-04-21 — fix(docker): gwt generated compose mount は user override と分離して所有する
+
+### 事象
+
+Issue #2035 の PR review で、gwt が `docker-compose.override.yml` を直接再生成しており、
+repo 利用者が自分で管理している override を launch 時に上書きし得ることが分かった。
+
+### 原因
+
+- generated mount layer と user-managed override layer の ownership を分離せず、
+  両方を同じ `docker-compose.override.yml` に載せていた。
+- generated file の更新要件だけを見て、既存の user file を gwt が触ってよいという
+  誤った前提で実装していた。
+
+### 再発防止策
+
+1. runtime が自動生成する compose layer は専用 file
+   (`docker-compose.gwt.override.yml`) に分離し、`docker-compose.override.yml` は
+   user-managed file として扱う。
+2. compose file の layering 順を `base -> user override -> generated override` で固定し、
+   既存 repo の local customization を壊さない contract test を追加する。
+3. 既に field に出た legacy generated override は header で判定して読み飛ばし、
+   stale mount を二重適用しない。
+
+## 2026-04-21 — fix(docker): explicit compose platform は unsupported 値で host fallback しない
+
+### 事象
+
+Issue #2035 の PR review で、compose service に `platform:` が明示されていても、
+unsupported value を parse できない場合に host arch fallback していることが分かった。
+そのまま進むと Docker bundle installer が誤った asset を選び、mount 後に
+`exec format error` を起こし得る。
+
+### 原因
+
+- `platform:` の有無と parse 成否を同じ `Option` に畳み込み、`None` を
+  「platform 未指定」と「unsupported platform」の両方に使っていた。
+- fallback を便利側に寄せたまま、explicit user input の validation failure を
+  runtime error として表に出していなかった。
+
+### 再発防止策
+
+1. compose service が `platform:` を明示した場合は、normalize 失敗を
+   即座にエラーとして返し、host fallback は未指定時だけに限定する。
+2. supported arch alias (`x86_64/amd64/x64`, `aarch64/arm64`) と unsupported
+   platform failure の両方を regression test で固定する。
+3. user-supplied runtime selector を parse する helper では、「未指定」と
+   「不正値」を別の戻り値で表現する。
+
 ## 2026-04-21 — fix(docker): Linux bundle asset は host 固定ではなく target/container arch で選ぶ
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,55 @@
 # Lessons Learned
 
+## 2026-04-21 — fix(docker): Linux bundle asset は host 固定ではなく target/container arch で選ぶ
+
+### 事象
+
+Issue #2035 の review follow-up で、Docker bundle auto-download が常に
+`gwt-linux-x86_64.tar.gz` を選んでいた。Apple Silicon / ARM Linux host で
+native arm64 container を起動すると、`/usr/local/bin/gwt` に mount された
+binary が `exec format error` で起動できなかった。
+
+### 原因
+
+- Docker bundle installer が target architecture を引数で受け取らず、
+  release asset 名を x86_64 固定文字列で引いていた。
+- compose service の `platform:` を parse しておらず、container target arch を
+  launch plan に保持していなかった。
+
+### 再発防止策
+
+1. Docker 向け release asset を選ぶ API は、bundle path だけでなく target arch を
+   明示的に受け取る。
+2. compose service が `platform:` を持つ場合はそこから container arch を解決し、
+   未指定時のみ host arch fallback を使う。
+3. x86_64 と aarch64 の両 asset を含む release fixture で、要求した arch の
+   tarball が実際に選ばれる regression test を追加する。
+
+## 2026-04-21 — fix(docker): service 名を埋め込む auto-generated override は内容差分で再生成する
+
+### 事象
+
+Issue #2035 の review follow-up で、`docker-compose.override.yml` が最初に起動した
+service 名のまま固定されることが分かった。multi-service repo で別 service を
+選ぶと、`GWT_BIN_PATH=/usr/local/bin/gwt` だけが新 service に渡り、対応する mount
+は stale override 側の旧 service に残ったままで binary が見つからなかった。
+
+### 原因
+
+- override file の生成条件が `!exists()` だけで、service 名や mount 内容が
+  現在の launch target と一致するかを比較していなかった。
+- 「auto-generated file だから毎回同じ内容」という前提で create-only contract に
+  してしまい、service ごとに内容が変わることを見落としていた。
+
+### 再発防止策
+
+1. service 名や mount path を埋め込む auto-generated file は、存在有無だけでなく
+   expected content との差分で write する。
+2. multi-service repo の regression test では、同じ repo で service を切り替えた
+   2 回目の launch でも generated override が更新されることを確認する。
+3. runtime setup が「初回だけ create」なのか「毎回 reconcile」なのかを review 時に
+   明示し、入力パラメータが変わる file を create-only にしない。
+
 ## 2026-04-21 — fix(docker): 生成した compose override は全 Docker compose 経路へ流す
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-21 — test: process-global HOME/USERPROFILE を読む assertion は並列テスト中に再読しない
+
+### 事象
+
+Issue #2035 の全体検証で `cargo test -p gwt-core -p gwt` を実行したところ、
+`paths::tests::gwt_config_path_ends_with_config_toml` などが失敗した。失敗した
+assertion は `let p = gwt_config_path(); assert!(p.starts_with(gwt_home()))` のように、
+同一 assertion 内で process-global な home 解決を 2 回読んでいた。
+
+### 原因
+
+別の並列テストが `HOME` / `USERPROFILE` を一時変更しており、`p` を作った時点の
+home と assertion 側で再読した `gwt_home()` が一致しなかった。`gwt_home()` 自体の
+契約ではなく、テスト assertion が process-global env の再読に依存していた。
+
+### 再発防止策
+
+1. `HOME` / `USERPROFILE` など process-global env に依存する path test では、
+   1 つの assertion 内で public resolver を再読して比較しない。
+2. path helper の layout test は、必要なら `.gwt/...` の suffix や file name など
+   env 変更に影響されない構造を検証する。
+3. env を実際に mutate するテストを追加する場合は、同じ process 内の path test と
+   競合しないよう、共有 lock か再読しない assertion 形式を先に確認する。
+
 ## 2026-04-21 — fix(ci): WiX Component に複数 File を入れるときは未バージョン化 keypath で auto GUID を破綻させない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Add automatic Docker Linux bundle installation so Docker-backed sessions can resolve `gwt` and `gwtd` through `GWT_BIN_PATH` without manual setup.
- Reconcile generated compose override usage across first launch, exec/status flows, and multi-service repos so bind mounts stay attached to the selected Docker service.
- Select the Docker bundle asset by target architecture and lock the regressions with x86_64/aarch64, stale override rewrite, and cross-platform fake-docker tests.

## Changes

- `crates/gwt-core/src/update.rs`, `crates/gwt-core/src/paths.rs`: install Docker bundles from an arch-specific release asset and keep path-related tests stable under parallel env mutation.
- `crates/gwt/src/docker_setup.rs`, `crates/gwt/src/main.rs`: extract Docker setup orchestration, resolve target arch from compose `platform` or host fallback, and regenerate `docker-compose.override.yml` when the selected service changes.
- `crates/gwt-docker/src/compose.rs`, `crates/gwt-docker/src/container.rs`, `crates/gwt-docker/src/lib.rs`: parse compose `platform`, propagate multiple compose files through status/up/restart/exec helpers, and keep the fake docker test harness working on Windows.
- `docs/docker-usage.md`, `tasks/lessons.md`: document the Docker bundle flow and record the regressions found during review and verification.

## Testing

- [x] `cargo test -p gwt-docker` — passes.
- [x] `cargo test -p gwt-core -p gwt` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo fmt -- --check` — passes.
- [x] `git diff --check origin/develop..HEAD` — passes.

## Closing Issues

- Closes #2035

## Related Issues / Links

- #2077

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — No schema or persisted data change.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Docker `GWT_BIN_PATH` support landed in stages on this branch: bundle auto-download, Docker setup extraction, override propagation, and the review follow-ups for target architecture and per-service override regeneration.
- This PR keeps the operator-facing entrypoint on `gwt` while aligning the Docker bundle/install contract with SPEC-2077 daemon groundwork.

## Risk / Impact

- **Affected areas**: Docker launch preparation, release asset installation, compose helper argument wiring, and related regression tests.
- **Rollback plan**: Revert this PR to remove the Docker bundle auto-download and compose override reconciliation together.
