### PR TITLE
fix(hook): emit systemMessage for Stop board-reminder

### DIFF
--- a/crates/gwt/src/cli/hook/board_reminder.rs
+++ b/crates/gwt/src/cli/hook/board_reminder.rs
@@ -1,10 +1,18 @@
 //! `gwt hook board-reminder <event>` — intent-boundary reminder and
 //! cross-agent Board read injection for SPEC-1974 Phase 8 (US-6 / US-7).
 //!
-//! This hook emits Claude Code / Codex `hookSpecificOutput.additionalContext`
-//! on the three intent-boundary events (`SessionStart`, `UserPromptSubmit`,
-//! `Stop`). It does nothing for `PreToolUse` / `PostToolUse`: tool-level
-//! events are not intent boundaries.
+//! This hook injects reminder text on the three intent-boundary events
+//! (`SessionStart`, `UserPromptSubmit`, `Stop`). It does nothing for
+//! `PreToolUse` / `PostToolUse`: tool-level events are not intent
+//! boundaries.
+//!
+//! Per Claude Code's hook schema, the envelope differs by event:
+//! `SessionStart` / `UserPromptSubmit` emit
+//! `hookSpecificOutput.additionalContext`, which is injected into the
+//! agent's context. `Stop` cannot use that envelope — Claude Code's Stop
+//! schema rejects `hookSpecificOutput` — so the Stop reminder is emitted
+//! as top-level `systemMessage`. That surfaces to the user as a warning
+//! notification but is **not** injected into the agent's context.
 //!
 //! The hook is read-only against the shared Board projection (it never
 //! writes Board entries itself) and persists only per-agent-session
@@ -61,18 +69,15 @@ const USER_PROMPT_REMINDER_SHORT: &str = "# Board Post Reminder\n\
 You posted to the Board recently. Post again only if a new reasoning milestone \
 (phase change, alternative chosen, concern raised) has emerged.\n";
 
-const STOP_REMINDER: &str = "# Board Post Reminder (Stop)\n\
-\n\
-You are about to stop or hand off. Before stopping, post to the shared Board:\n\
-- What you completed (reasoning-level summary, not a tool log).\n\
-- What phase comes next if work continues, or the handoff signal if you are done.\n\
-\n\
-Use: gwt board post --kind status --body '<summary>'\n";
+// Stop reminders are emitted as `systemMessage` (user-facing) because
+// Claude Code's Stop hook schema does not accept `hookSpecificOutput`.
+// Phrasing is therefore user-oriented rather than agent-oriented.
+const STOP_REMINDER: &str = "Board Post Reminder (Stop): the agent is stopping. If you \
+expected a board status post, prompt the agent to run `gwt board post --kind status` \
+before handing off.";
 
-const STOP_REMINDER_SHORT: &str = "# Board Post Reminder (Stop)\n\
-\n\
-You posted to the Board recently. If the final status is unchanged, no additional \
-Board entry is required before stopping.\n";
+const STOP_REMINDER_SHORT: &str = "Board Post Reminder (Stop): the agent posted to the \
+Board recently; no additional post is required before stopping.";
 
 const INJECTION_HEADER: &str = "# Recent Board updates\n\n\
 The following reasoning posts were made by other Agents since your last Board context. \
@@ -94,6 +99,12 @@ struct HookSpecificOutput<'a> {
 struct HookOutputJson<'a> {
     #[serde(rename = "hookSpecificOutput")]
     hook_specific_output: HookSpecificOutput<'a>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SystemMessageOutput {
+    #[serde(rename = "systemMessage")]
+    system_message: String,
 }
 
 #[derive(Debug, Clone)]
@@ -352,13 +363,20 @@ fn emit_output<W: Write + ?Sized>(
     output: &ComputedOutput,
     writer: &mut W,
 ) -> Result<(), HookError> {
-    let payload = HookOutputJson {
-        hook_specific_output: HookSpecificOutput {
-            hook_event_name: event,
-            additional_context: output.additional_context.clone(),
-        },
+    let bytes = match event {
+        // Stop cannot use hookSpecificOutput per Claude Code's schema, so
+        // fall back to systemMessage. This surfaces the reminder to the
+        // user but does not inject it into the agent's context.
+        "Stop" => serde_json::to_vec(&SystemMessageOutput {
+            system_message: output.additional_context.clone(),
+        })?,
+        _ => serde_json::to_vec(&HookOutputJson {
+            hook_specific_output: HookSpecificOutput {
+                hook_event_name: event,
+                additional_context: output.additional_context.clone(),
+            },
+        })?,
     };
-    let bytes = serde_json::to_vec(&payload)?;
     writer.write_all(&bytes)?;
     writer.write_all(b"\n")?;
     Ok(())
@@ -446,7 +464,10 @@ mod tests {
     }
 
     #[test]
-    fn plan_stop_contains_completed_label() {
+    fn plan_stop_reminder_is_user_facing() {
+        // Stop reminders surface to the user via `systemMessage` (see
+        // `emit_output`), so the text is phrased for the user, not the
+        // agent. Guard the key phrases that make the reminder actionable.
         let plan = plan_reminder(ReminderInputs {
             event: "Stop".into(),
             now: Utc::now(),
@@ -458,7 +479,8 @@ mod tests {
         })
         .unwrap();
         assert!(plan.output.additional_context.contains("Stop"));
-        assert!(plan.output.additional_context.contains("completed"));
+        assert!(plan.output.additional_context.contains("Board"));
+        assert!(plan.output.additional_context.contains("gwt board post"));
     }
 
     #[test]
@@ -728,5 +750,114 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("Board Post Reminder"));
+    }
+
+    // ---- emit_output envelope shape per event (regression guard) ----
+
+    #[test]
+    fn emit_output_stop_uses_system_message_envelope() {
+        // Claude Code's Stop hook schema rejects `hookSpecificOutput`. The
+        // only legal text-bearing field is `systemMessage`, which surfaces
+        // the reminder to the user (not to Claude's context).
+        let output = ComputedOutput {
+            additional_context: "stop reminder body".into(),
+        };
+        let mut buf = Vec::new();
+        emit_output("Stop", &output, &mut buf).unwrap();
+
+        let text = String::from_utf8(buf).unwrap();
+        let json: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+        let obj = json.as_object().expect("Stop output must be a JSON object");
+        assert!(
+            !obj.contains_key("hookSpecificOutput"),
+            "Stop must not emit hookSpecificOutput (invalid per Claude Code schema), got: {json}"
+        );
+        assert_eq!(
+            obj.get("systemMessage").and_then(|v| v.as_str()),
+            Some("stop reminder body"),
+            "Stop must emit the reminder as systemMessage, got: {json}"
+        );
+    }
+
+    #[test]
+    fn emit_output_session_start_uses_hook_specific_output() {
+        let output = ComputedOutput {
+            additional_context: "session start body".into(),
+        };
+        let mut buf = Vec::new();
+        emit_output("SessionStart", &output, &mut buf).unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
+        assert_eq!(
+            json["hookSpecificOutput"]["hookEventName"],
+            serde_json::json!("SessionStart")
+        );
+        assert_eq!(
+            json["hookSpecificOutput"]["additionalContext"],
+            serde_json::json!("session start body")
+        );
+        assert!(
+            !json.as_object().unwrap().contains_key("systemMessage"),
+            "SessionStart must not emit systemMessage"
+        );
+    }
+
+    #[test]
+    fn emit_output_user_prompt_submit_uses_hook_specific_output() {
+        let output = ComputedOutput {
+            additional_context: "prompt body".into(),
+        };
+        let mut buf = Vec::new();
+        emit_output("UserPromptSubmit", &output, &mut buf).unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
+        assert_eq!(
+            json["hookSpecificOutput"]["hookEventName"],
+            serde_json::json!("UserPromptSubmit")
+        );
+        assert_eq!(
+            json["hookSpecificOutput"]["additionalContext"],
+            serde_json::json!("prompt body")
+        );
+        assert!(
+            !json.as_object().unwrap().contains_key("systemMessage"),
+            "UserPromptSubmit must not emit systemMessage"
+        );
+    }
+
+    #[test]
+    fn emit_output_stop_carries_plan_stop_reminder_text() {
+        // Integration with the real plan_reminder output: feeding the Stop
+        // reminder text through emit_output must still land in systemMessage.
+        let plan = plan_reminder(ReminderInputs {
+            event: "Stop".into(),
+            now: Utc::now(),
+            self_session_id: "sess-1".into(),
+            display_name: "Codex".into(),
+            recent_entries: vec![],
+            reminders: RemindersState::default(),
+            has_recent_own_status: false,
+        })
+        .unwrap();
+
+        let mut buf = Vec::new();
+        emit_output("Stop", &plan.output, &mut buf).unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
+        let sys = json
+            .get("systemMessage")
+            .and_then(|v| v.as_str())
+            .expect("Stop must carry reminder via systemMessage");
+        assert!(
+            sys.contains("Board"),
+            "systemMessage should include the Board reminder text, got: {sys}"
+        );
+        assert!(
+            !json.as_object().unwrap().contains_key("hookSpecificOutput"),
+            "Stop must never include hookSpecificOutput"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Claude Code の Stop hook スキーマが `hookSpecificOutput` を受け付けないため、`gwt hook board-reminder Stop` が schema 違反で拒否されていたのを修正。
- Stop のみ top-level `systemMessage` で reminder を emit するよう `emit_output` を event 分岐化し、SessionStart / UserPromptSubmit は従来通りの envelope を維持。
- 同種スキーマ違反の構造的再発を抑えるため、別途 SPEC-1935 に Phase 9（Hook Envelope 型安全化）を追加起票済み（本 PR スコープ外、後続で TDD 実装予定）。

## Changes

- `crates/gwt/src/cli/hook/board_reminder.rs`:
  - `emit_output` を event 分岐化。`"Stop"` は `{"systemMessage": ...}`、それ以外は従来の `{"hookSpecificOutput": {hookEventName, additionalContext}}`。
  - `SystemMessageOutput` struct を追加。
  - `STOP_REMINDER` / `STOP_REMINDER_SHORT` を user 向け文言に書換（`systemMessage` は user への通知であり agent context へは届かないため）。
  - モジュール docstring に Stop の envelope 縮退理由を追記。
  - 回帰防止テストを 4 件追加: `emit_output_stop_uses_system_message_envelope` / `emit_output_session_start_uses_hook_specific_output` / `emit_output_user_prompt_submit_uses_hook_specific_output` / `emit_output_stop_carries_plan_stop_reminder_text`。
  - 既存 `plan_stop_contains_completed_label` を新 reminder 文言に合わせて `plan_stop_reminder_is_user_facing` にリネーム＋更新。

## Testing

- [x] `cargo test -p gwt-core -p gwt` — 全 270+ テスト通過。
- [x] `cargo test -p gwt-skills` — 101 テスト通過。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings。
- [x] Manual smoke: `echo '{}' | cargo run -q -p gwt -- hook board-reminder Stop` が `{"systemMessage":"Board Post Reminder (Stop): ..."}` を出力、`hookSpecificOutput` キーを含まないこと。
- [x] Manual smoke: `... SessionStart` / `... UserPromptSubmit` が従来通り `hookSpecificOutput.additionalContext` を emit することを確認（回帰なし）。

## Closing Issues

- None

## Related Issues / Links

- SPEC-1935 (#1935) Phase 9 — 同種再発を構造的に防ぐ envelope 型安全化の後続起票（2026-04-21 更新で追加）。
- Claude Code 公式 hook schema: https://code.claude.com/docs/en/hooks

## Checklist

- [x] Tests added/updated — 4 件追加、1 件更新
- [x] Lint/format passed — `cargo clippy -- -D warnings` / `cargo fmt --check` クリア
- [x] Documentation updated — モジュール docstring に Stop envelope の扱いを追記 / SPEC-1935 spec section に 2026-04-21 更新 Note を追加
- [ ] Migration/backfill plan included — 不要（スキーマ変更なし、hook 出力形式は下位互換的な縮退）
- [x] CHANGELOG impact considered — `fix:` prefix で patch バージョン対象

## Context

- Claude Code の Stop hook JSON output schema は `continue` / `stopReason` / `suppressOutput` / `systemMessage` / `decision` / `reason` の 6 フィールドのみを top-level で受け付け、`hookSpecificOutput` は PreToolUse / UserPromptSubmit / PostToolUse 専用（公式 docs 確認済み）。
- 直前の board-reminder hook 実装は 3 event 全てで `hookSpecificOutput.additionalContext` を emit する前提で設計されており、Stop event で `(root): Invalid input` エラーを発生させていた。
- 修正は最小侵襲 — envelope 分岐のみ。文言は user 向けに言い換えたが、reminder の機能自体は維持。agent context への注入は Stop では仕様上不可能なため、`systemMessage` の user 向け通知に意図的に縮退。

## Risk / Impact

- **Affected areas**: `crates/gwt/src/cli/hook/board_reminder.rs` のみ。他 hook ハンドラ（block_* / workflow_policy / runtime_state / coordination_event / forward）は影響なし。
- **Rollback plan**: `git revert 2518d868` で元に戻せる。Stop で schema 違反が再発するだけで他機能への副作用はない。
