### PR TITLE
fix(branch-cleanup): use canonical remote base for safe cleanup

### DIFF
--- a/crates/gwt-git/src/branch.rs
+++ b/crates/gwt-git/src/branch.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Mirrors the protected list from the current Branch Cleanup contract.
 const PROTECTED_BRANCHES: &[&str] = &["main", "master", "develop"];
+const CANONICAL_BASE_BRANCHES: &[&str] = &["develop", "main", "master"];
 
 /// Returns true when `name` matches one of the hard-coded protected branches
 /// (FR-018b). Comparisons strip a leading `origin/` so a remote tracking ref
@@ -19,23 +20,33 @@ pub fn is_protected_branch(name: &str) -> bool {
 }
 
 /// Where a cleanable branch was determined to be merged into (FR-018a).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MergeTarget {
-    /// Branch is merged into `main` / `master`.
-    Main,
-    /// Branch is merged into `develop`.
-    Develop,
-    /// Branch's upstream tracking ref is `[gone]`.
-    Gone,
-}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MergeTarget(String);
 
 impl MergeTarget {
+    pub fn from_ref(ref_name: impl Into<String>) -> Self {
+        Self(ref_name.into())
+    }
+
+    pub fn gone() -> Self {
+        Self("gone".to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_gone(&self) -> bool {
+        self.0 == "gone"
+    }
+
     /// Human-readable label used by the Cleanup confirm modal.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Main => "merged → main",
-            Self::Develop => "merged → develop",
-            Self::Gone => "gone",
+    pub fn label(&self) -> String {
+        if self.is_gone() {
+            "gone".to_string()
+        } else {
+            format!("merged → {}", self.0)
         }
     }
 }
@@ -70,26 +81,71 @@ pub fn is_branch_merged_into(repo_path: &Path, branch: &str, base: &str) -> Resu
     Ok(parse_cherry_output(&stdout))
 }
 
-/// Walks `bases` in order and returns the first base that already contains
-/// every commit on `branch` (FR-018a). When `gone_branches` reports `branch`
-/// as having a `[gone]` upstream and no positive merge match was found, the
-/// function returns `Some(MergeTarget::Gone)` so callers can still treat the
-/// branch as cleanable.
+/// Resolves the canonical cleanup target for `branch`.
+///
+/// Canonical base selection follows the current cleanup contract:
+/// 1. prefer the execution branch's upstream remote (`<remote>/develop|main|master`)
+/// 2. if that remote has no canonical base refs at all and is not `origin`,
+///    fall back to `origin/develop|main|master`
+/// 3. if the branch's upstream is `[gone]`, treat it as cleanable via `gone`
+///
+/// Branches without an upstream do not get a canonical remote fallback and
+/// remain unresolved here.
 pub fn detect_cleanable_target(
     repo_path: &Path,
     branch: &str,
-    bases: &[(&str, MergeTarget)],
+    upstream: Option<&str>,
     gone_branches: &HashSet<String>,
 ) -> Result<Option<MergeTarget>> {
-    for (base, target) in bases {
-        if is_branch_merged_into(repo_path, branch, base)? {
-            return Ok(Some(*target));
+    let Some(primary_remote) = upstream.and_then(remote_name_from_tracking_ref) else {
+        if gone_branches.contains(branch) {
+            return Ok(Some(MergeTarget::gone()));
+        }
+        return Ok(None);
+    };
+
+    let (primary_has_bases, primary_target) =
+        detect_cleanable_target_for_remote(repo_path, branch, primary_remote)?;
+    if let Some(target) = primary_target {
+        return Ok(Some(target));
+    }
+
+    if !primary_has_bases && primary_remote != "origin" {
+        let (_, fallback_target) = detect_cleanable_target_for_remote(repo_path, branch, "origin")?;
+        if let Some(target) = fallback_target {
+            return Ok(Some(target));
         }
     }
     if gone_branches.contains(branch) {
-        return Ok(Some(MergeTarget::Gone));
+        return Ok(Some(MergeTarget::gone()));
     }
     Ok(None)
+}
+
+fn detect_cleanable_target_for_remote(
+    repo_path: &Path,
+    branch: &str,
+    remote: &str,
+) -> Result<(bool, Option<MergeTarget>)> {
+    let mut has_canonical_base = false;
+    for base in CANONICAL_BASE_BRANCHES {
+        let refname = format!("{remote}/{base}");
+        if !ref_exists(repo_path, &refname)? {
+            continue;
+        }
+        has_canonical_base = true;
+        if is_branch_merged_into(repo_path, branch, &refname)? {
+            return Ok((true, Some(MergeTarget::from_ref(refname))));
+        }
+    }
+    Ok((has_canonical_base, None))
+}
+
+fn remote_name_from_tracking_ref(upstream: &str) -> Option<&str> {
+    upstream
+        .split_once('/')
+        .map(|(remote, _)| remote)
+        .filter(|remote| !remote.is_empty())
 }
 
 /// Returns the set of local branch names whose upstream tracking ref is
@@ -565,22 +621,34 @@ mod tests {
     #[test]
     fn detect_cleanable_target_walks_bases_in_order() {
         let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path();
-        init_named_repo(repo);
-        run(&["checkout", "-b", "develop"], repo);
-        run(&["checkout", "-b", "feature/d"], repo);
-        make_commit(repo, "d.txt", "d", "feat: d");
-        run(&["checkout", "develop"], repo);
-        run(&["merge", "--no-ff", "-m", "merge d", "feature/d"], repo);
+        let origin = tmp.path().join("origin.git");
+        let repo = tmp.path().join("repo");
+        run(&["init", "--bare", origin.to_str().unwrap()], tmp.path());
+        run(
+            &["init", "--initial-branch=main", repo.to_str().unwrap()],
+            tmp.path(),
+        );
+        run(&["config", "user.email", "test@example.com"], &repo);
+        run(&["config", "user.name", "Test"], &repo);
+        run(&["commit", "--allow-empty", "-m", "init"], &repo);
+        run(
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+            &repo,
+        );
+        run(&["push", "-u", "origin", "main"], &repo);
+        run(&["checkout", "-b", "develop"], &repo);
+        run(&["push", "-u", "origin", "develop"], &repo);
+        run(&["checkout", "-b", "feature/d"], &repo);
+        make_commit(&repo, "d.txt", "d", "feat: d");
+        run(&["checkout", "develop"], &repo);
+        run(&["merge", "--no-ff", "-m", "merge d", "feature/d"], &repo);
+        run(&["push", "origin", "develop"], &repo);
+        run(&["fetch", "origin", "--prune"], &repo);
 
-        let bases = [
-            ("main", MergeTarget::Main),
-            ("develop", MergeTarget::Develop),
-        ];
         let gone = HashSet::new();
         assert_eq!(
-            detect_cleanable_target(repo, "feature/d", &bases, &gone).unwrap(),
-            Some(MergeTarget::Develop)
+            detect_cleanable_target(&repo, "feature/d", Some("origin/feature/d"), &gone).unwrap(),
+            Some(MergeTarget::from_ref("origin/develop"))
         );
     }
 
@@ -592,10 +660,9 @@ mod tests {
         run(&["checkout", "-b", "feature/free"], repo);
         make_commit(repo, "f.txt", "f", "feat: f");
 
-        let bases = [("main", MergeTarget::Main)];
         let gone = HashSet::new();
         assert_eq!(
-            detect_cleanable_target(repo, "feature/free", &bases, &gone).unwrap(),
+            detect_cleanable_target(repo, "feature/free", None, &gone).unwrap(),
             None
         );
     }
@@ -608,12 +675,68 @@ mod tests {
         run(&["checkout", "-b", "feature/abandoned"], repo);
         make_commit(repo, "a.txt", "a", "feat: a");
 
-        let bases = [("main", MergeTarget::Main)];
         let mut gone = HashSet::new();
         gone.insert("feature/abandoned".to_string());
         assert_eq!(
-            detect_cleanable_target(repo, "feature/abandoned", &bases, &gone).unwrap(),
-            Some(MergeTarget::Gone)
+            detect_cleanable_target(
+                repo,
+                "feature/abandoned",
+                Some("origin/feature/abandoned"),
+                &gone
+            )
+            .unwrap(),
+            Some(MergeTarget::gone())
+        );
+    }
+
+    #[test]
+    fn detect_cleanable_target_uses_upstream_remote_before_origin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let origin = tmp.path().join("origin.git");
+        let upstream = tmp.path().join("upstream.git");
+        let repo = tmp.path().join("repo");
+        run(&["init", "--bare", origin.to_str().unwrap()], tmp.path());
+        run(&["init", "--bare", upstream.to_str().unwrap()], tmp.path());
+        run(
+            &["init", "--initial-branch=main", repo.to_str().unwrap()],
+            tmp.path(),
+        );
+        run(&["config", "user.email", "test@example.com"], &repo);
+        run(&["config", "user.name", "Test"], &repo);
+        run(&["commit", "--allow-empty", "-m", "init"], &repo);
+        run(
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+            &repo,
+        );
+        run(
+            &["remote", "add", "upstream", upstream.to_str().unwrap()],
+            &repo,
+        );
+        run(&["push", "-u", "origin", "main"], &repo);
+        run(&["push", "-u", "upstream", "main"], &repo);
+        run(&["checkout", "-b", "develop"], &repo);
+        make_commit(&repo, "develop.txt", "develop", "develop");
+        run(&["push", "-u", "origin", "develop"], &repo);
+        run(&["push", "-u", "upstream", "develop"], &repo);
+        run(&["checkout", "-b", "feature/alpha"], &repo);
+        make_commit(&repo, "alpha.txt", "alpha", "alpha");
+        run(
+            &["push", "-u", "upstream", "HEAD:refs/heads/feature/alpha"],
+            &repo,
+        );
+        run(&["push", "upstream", "HEAD:refs/heads/develop"], &repo);
+        run(&["fetch", "upstream", "--prune"], &repo);
+
+        let gone = HashSet::new();
+        assert_eq!(
+            detect_cleanable_target(
+                repo.as_path(),
+                "feature/alpha",
+                Some("upstream/feature/alpha"),
+                &gone
+            )
+            .unwrap(),
+            Some(MergeTarget::from_ref("upstream/develop"))
         );
     }
 

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -30,6 +30,7 @@ pub enum BranchCleanupBlockedReason {
 pub enum BranchCleanupRisk {
     Unmerged,
     RemoteTracking,
+    NoUpstream,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -114,11 +115,6 @@ fn build_cleanup_targets(
     entries: &[BranchListEntry],
     gone_branches: &HashSet<String>,
 ) -> std::io::Result<HashMap<String, Option<gwt_git::MergeTarget>>> {
-    let cleanup_bases = [
-        ("main", gwt_git::MergeTarget::Main),
-        ("master", gwt_git::MergeTarget::Main),
-        ("develop", gwt_git::MergeTarget::Develop),
-    ];
     let mut cleanup_targets = HashMap::new();
     for branch in entries
         .iter()
@@ -127,7 +123,7 @@ fn build_cleanup_targets(
         let target = gwt_git::detect_cleanable_target(
             repo_path,
             &branch.name,
-            &cleanup_bases,
+            branch.upstream.as_deref(),
             gone_branches,
         )
         .map_err(|error| std::io::Error::other(error.to_string()))?;
@@ -243,10 +239,13 @@ fn build_cleanup_info(
         .cloned()
         .flatten();
     let mut risks = Vec::new();
-    if branch.scope == BranchScope::Remote {
+    if upstream.is_none() {
+        risks.push(BranchCleanupRisk::NoUpstream);
+    }
+    if branch.scope == BranchScope::Remote && merge_target.is_none() {
         risks.push(BranchCleanupRisk::RemoteTracking);
     }
-    if merge_target.is_none() {
+    if merge_target.is_none() && upstream.is_some() {
         risks.push(BranchCleanupRisk::Unmerged);
     }
 
@@ -399,7 +398,7 @@ mod tests {
             name: "feature/demo".to_string(),
             scope: BranchScope::Local,
             is_head: false,
-            upstream: None,
+            upstream: Some("origin/feature/demo".to_string()),
             ahead: 0,
             behind: 0,
             last_commit_date: Some("2026-04-20 08:30:00 +0000".to_string()),
@@ -408,7 +407,7 @@ mod tests {
         }];
         let cleanup_targets = HashMap::from([(
             String::from("feature/demo"),
-            Some(gwt_git::MergeTarget::Develop),
+            Some(gwt_git::MergeTarget::from_ref("origin/develop")),
         )]);
 
         let hydrated = hydrate_branch_entries(entries, &HashSet::new(), &cleanup_targets);

--- a/crates/gwt/tests/branch_list_test.rs
+++ b/crates/gwt/tests/branch_list_test.rs
@@ -31,18 +31,39 @@ fn list_branch_entries_marks_head_and_returns_local_branches() {
 
 #[test]
 fn list_branch_entries_marks_unmerged_local_branch_as_risky_cleanup_candidate() {
-    let dir = tempdir().expect("tempdir");
+    let temp = tempdir().expect("tempdir");
+    let origin = temp.path().join("origin.git");
+    let repo = temp.path().join("repo");
 
-    run_git(dir.path(), &["init", "-q"]);
-    init_repo(dir.path());
-    run_git(dir.path(), &["checkout", "-qb", "feature/unmerged"]);
-    std::fs::write(dir.path().join("feature.txt"), "work\n").expect("write feature");
-    run_git(dir.path(), &["add", "feature.txt"]);
-    run_git(dir.path(), &["commit", "-qm", "feature work"]);
-    run_git(dir.path(), &["checkout", "main"]);
+    run_git(
+        temp.path(),
+        &["init", "--bare", origin.to_str().expect("origin path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            origin.to_str().expect("origin path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["checkout", "-qb", "feature/unmerged"]);
+    std::fs::write(repo.join("feature.txt"), "work\n").expect("write feature");
+    run_git(&repo, &["add", "feature.txt"]);
+    run_git(&repo, &["commit", "-qm", "feature work"]);
+    run_git(&repo, &["push", "-u", "origin", "feature/unmerged"]);
+    run_git(&repo, &["checkout", "main"]);
+    run_git(&repo, &["fetch", "origin", "--prune"]);
 
     let branches =
-        list_branch_entries_with_active_sessions(dir.path(), &HashSet::new()).expect("entries");
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
     let feature = branches
         .iter()
         .find(|branch| branch.name == "feature/unmerged")
@@ -115,6 +136,91 @@ fn list_branch_entries_marks_remote_tracking_row_with_local_counterpart_as_risky
         .cleanup
         .risks
         .contains(&BranchCleanupRisk::RemoteTracking));
+}
+
+#[test]
+fn list_branch_entries_marks_local_and_remote_rows_safe_when_upstream_remote_base_contains_branch()
+{
+    let temp = tempdir().expect("tempdir");
+    let origin = temp.path().join("origin.git");
+    let repo = temp.path().join("repo");
+
+    run_git(
+        temp.path(),
+        &["init", "--bare", origin.to_str().expect("origin path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            origin.to_str().expect("origin path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["checkout", "-qb", "develop"]);
+    std::fs::write(repo.join("develop.txt"), "develop\n").expect("write develop");
+    run_git(&repo, &["add", "develop.txt"]);
+    run_git(&repo, &["commit", "-qm", "develop base"]);
+    run_git(&repo, &["push", "-u", "origin", "develop"]);
+    run_git(&repo, &["checkout", "-qb", "feature/alpha"]);
+    std::fs::write(repo.join("alpha.txt"), "alpha\n").expect("write alpha");
+    run_git(&repo, &["add", "alpha.txt"]);
+    run_git(&repo, &["commit", "-qm", "alpha"]);
+    run_git(&repo, &["push", "-u", "origin", "feature/alpha"]);
+    run_git(&repo, &["push", "origin", "HEAD:refs/heads/develop"]);
+    run_git(&repo, &["checkout", "main"]);
+    run_git(&repo, &["fetch", "origin", "--prune"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let local_entry = branches
+        .iter()
+        .find(|branch| branch.name == "feature/alpha")
+        .expect("local branch");
+    let remote_entry = branches
+        .iter()
+        .find(|branch| branch.name == "origin/feature/alpha")
+        .expect("remote branch");
+
+    assert_eq!(
+        local_entry.cleanup.availability,
+        BranchCleanupAvailability::Safe
+    );
+    assert_eq!(
+        local_entry
+            .cleanup
+            .merge_target
+            .as_ref()
+            .map(|target| target.as_str()),
+        Some("origin/develop")
+    );
+    assert!(local_entry.cleanup.risks.is_empty());
+
+    assert_eq!(remote_entry.scope, BranchScope::Remote);
+    assert_eq!(
+        remote_entry.cleanup.execution_branch.as_deref(),
+        Some("feature/alpha")
+    );
+    assert_eq!(
+        remote_entry.cleanup.availability,
+        BranchCleanupAvailability::Safe
+    );
+    assert_eq!(
+        remote_entry
+            .cleanup
+            .merge_target
+            .as_ref()
+            .map(|target| target.as_str()),
+        Some("origin/develop")
+    );
+    assert!(remote_entry.cleanup.risks.is_empty());
 }
 
 #[test]
@@ -251,6 +357,103 @@ fn list_branch_entries_blocks_remote_tracking_row_when_local_branch_tracks_other
 }
 
 #[test]
+fn list_branch_entries_prefers_execution_upstream_remote_base_over_origin() {
+    let temp = tempdir().expect("tempdir");
+    let origin = temp.path().join("origin.git");
+    let upstream = temp.path().join("upstream.git");
+    let repo = temp.path().join("repo");
+
+    run_git(
+        temp.path(),
+        &["init", "--bare", origin.to_str().expect("origin path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "--bare", upstream.to_str().expect("upstream path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            origin.to_str().expect("origin path"),
+        ],
+    );
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "upstream",
+            upstream.to_str().expect("upstream path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["push", "-u", "upstream", "main"]);
+    run_git(&repo, &["checkout", "-qb", "develop"]);
+    std::fs::write(repo.join("develop.txt"), "develop\n").expect("write develop");
+    run_git(&repo, &["add", "develop.txt"]);
+    run_git(&repo, &["commit", "-qm", "develop base"]);
+    run_git(&repo, &["push", "-u", "origin", "develop"]);
+    run_git(&repo, &["push", "-u", "upstream", "develop"]);
+    run_git(&repo, &["checkout", "-qb", "feature/alpha"]);
+    std::fs::write(repo.join("alpha.txt"), "alpha\n").expect("write alpha");
+    run_git(&repo, &["add", "alpha.txt"]);
+    run_git(&repo, &["commit", "-qm", "alpha"]);
+    run_git(&repo, &["push", "origin", "HEAD:refs/heads/feature/alpha"]);
+    run_git(
+        &repo,
+        &["push", "-u", "upstream", "HEAD:refs/heads/feature/alpha"],
+    );
+    run_git(&repo, &["push", "upstream", "HEAD:refs/heads/develop"]);
+    run_git(&repo, &["checkout", "main"]);
+    run_git(&repo, &["fetch", "origin", "--prune"]);
+    run_git(&repo, &["fetch", "upstream", "--prune"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let local_entry = branches
+        .iter()
+        .find(|branch| branch.name == "feature/alpha")
+        .expect("local branch");
+    let upstream_entry = branches
+        .iter()
+        .find(|branch| branch.name == "upstream/feature/alpha")
+        .expect("upstream remote branch");
+
+    assert_eq!(
+        local_entry.cleanup.availability,
+        BranchCleanupAvailability::Safe
+    );
+    assert_eq!(
+        local_entry
+            .cleanup
+            .merge_target
+            .as_ref()
+            .map(|target| target.as_str()),
+        Some("upstream/develop")
+    );
+    assert_eq!(
+        upstream_entry.cleanup.availability,
+        BranchCleanupAvailability::Safe
+    );
+    assert_eq!(
+        upstream_entry
+            .cleanup
+            .merge_target
+            .as_ref()
+            .map(|target| target.as_str()),
+        Some("upstream/develop")
+    );
+}
+
+#[test]
 fn list_branch_entries_blocks_active_session_branch_from_cleanup() {
     let dir = tempdir().expect("tempdir");
 
@@ -280,6 +483,47 @@ fn list_branch_entries_blocks_active_session_branch_from_cleanup() {
         feature.cleanup.blocked_reason,
         Some(BranchCleanupBlockedReason::ActiveSession)
     );
+}
+
+#[test]
+fn list_branch_entries_marks_manual_local_branch_without_upstream_as_risky() {
+    let dir = tempdir().expect("tempdir");
+
+    run_git(dir.path(), &["init", "-q"]);
+    init_repo(dir.path());
+    run_git(dir.path(), &["checkout", "-qb", "develop"]);
+    std::fs::write(dir.path().join("develop.txt"), "develop\n").expect("write develop");
+    run_git(dir.path(), &["add", "develop.txt"]);
+    run_git(dir.path(), &["commit", "-qm", "develop base"]);
+    run_git(dir.path(), &["checkout", "-qb", "feature/manual"]);
+    std::fs::write(dir.path().join("manual.txt"), "manual\n").expect("write manual");
+    run_git(dir.path(), &["add", "manual.txt"]);
+    run_git(dir.path(), &["commit", "-qm", "manual"]);
+    run_git(dir.path(), &["checkout", "develop"]);
+    run_git(
+        dir.path(),
+        &["merge", "--no-ff", "-m", "merge manual", "feature/manual"],
+    );
+    run_git(dir.path(), &["checkout", "main"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(dir.path(), &HashSet::new()).expect("entries");
+    let feature = branches
+        .iter()
+        .find(|branch| branch.name == "feature/manual")
+        .expect("feature branch");
+
+    assert_eq!(feature.scope, BranchScope::Local);
+    assert_eq!(
+        feature.cleanup.availability,
+        BranchCleanupAvailability::Risky
+    );
+    assert_eq!(feature.cleanup.merge_target, None);
+    assert!(feature
+        .cleanup
+        .risks
+        .contains(&BranchCleanupRisk::NoUpstream));
+    assert!(!feature.cleanup.risks.contains(&BranchCleanupRisk::Unmerged));
 }
 
 fn init_repo(repo: &std::path::Path) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -4815,6 +4815,8 @@
           switch (risk) {
             case "remote_tracking":
               return "remote-tracking";
+            case "no_upstream":
+              return "no upstream";
             case "unmerged":
               return "unmerged";
             default:
@@ -4824,16 +4826,13 @@
       }
 
       function cleanupMergeTargetText(target) {
-        switch (target) {
-          case "main":
-            return "merged to main";
-          case "develop":
-            return "merged to develop";
-          case "gone":
-            return "upstream is gone";
-          default:
-            return "";
+        if (!target) {
+          return "";
         }
+        if (target === "gone") {
+          return "upstream is gone";
+        }
+        return `merged to ${target}`;
       }
 
       function branchLoadingNoticeText(state) {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,36 @@
 # Lessons Learned
 
+## 2026-04-21 — fix(branch-cleanup): `Safe` は stale local base ではなく canonical remote base merge で判定する
+
+### 事象
+
+Branches window の cleanup availability で、feature branch が `origin/develop` に
+取り込まれているのに local `develop` が古いだけで `Risky` と表示された。
+その結果、「安全に削除できない」理由が実際の Git 状態ではなく local base の
+鮮度に引きずられていた。
+
+### 原因
+
+- cleanup target 解決が local `develop/main/master` だけを見ており、gwt の通常
+  branch workflow（remote branch 作成後に local tracking branch を materialize）
+  を反映していなかった。
+- `Safe` の意味を「local base が最新であること」と暗黙に扱い、canonical remote
+  base に merge 済みかどうかという本来の削除安全性と切り分けていなかった。
+- remote-tracking row も row 種別だけで `remote_tracking` risk を付与しており、
+  execution local branch が `Safe` でも row 側が `Risky` から下がらなかった。
+
+### 再発防止策
+
+1. Branch Cleanup の `Safe` / `Risky` / `Blocked` を変更するときは、まず
+   「execution branch がどの canonical base に merge 済みなら safe か」を
+   SPEC で明文化する。
+2. gwt 管理 branch の cleanup 判定では upstream remote の
+   `develop -> main -> master` を優先し、その remote に canonical base がない
+   場合だけ `origin/*` を fallback に使う。
+3. remote-tracking row の availability は row 種別ではなく execution local
+   branch 基準で決め、manual local branch のような例外経路だけを別 risk
+   (`no upstream`) で表現する。
+
 ## 2026-04-21 — fix(review): vt100 shrink crash は parser 再構築で回避しない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Make Branch Cleanup evaluate `Safe` against canonical remote base refs instead of stale local base refs so merged feature branches do not appear risky when local `develop` is behind.
- Resolve cleanup merge targets to actual refs like `origin/develop` and show that target in the UI so the reason for `Safe` is explicit.
- Keep manual local branches without upstreams risky, while allowing matching remote-tracking rows to inherit the execution branch's safe status.

## Changes

- `crates/gwt-git/src/branch.rs`: replace local-only merge target detection with upstream-remote-first canonical base resolution and return actual merge target refs.
- `crates/gwt/src/branch_list.rs`: make cleanup availability remote-aware, add `no_upstream` risk handling, and stop marking remote rows risky when a safe execution branch is resolved.
- `crates/gwt/web/index.html`: show `merged to origin/develop` and add `no upstream` cleanup risk copy.
- `crates/gwt/tests/branch_list_test.rs`: add regressions for stale local base, upstream remote precedence, remote-row safe inheritance, and no-upstream local branches.
- `tasks/lessons.md`: record the recurrence-prevention note for canonical remote base cleanup safety.

## Testing

- [x] `cargo fmt --all` — formats successfully.
- [x] `cargo test -p gwt --test branch_list_test` — passes targeted branch cleanup regressions.
- [x] `cargo test -p gwt-git branch::tests` — passes branch target detection tests.
- [x] `$env:CARGO_TARGET_DIR='target\\branch-safe'; cargo test -p gwt-core -p gwt` — passes workspace tests for touched packages.
- [x] `$env:CARGO_TARGET_DIR='target\\branch-safe'; cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `$env:CARGO_TARGET_DIR='target\\branch-safe'; cargo build -p gwt` — succeeds.
- [x] `cargo fmt --all --check` — passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passes.

## Closing Issues

- None

## Related Issues / Links

- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- `Safe` was previously tied to local `develop/main/master`, so a branch already merged into `origin/develop` still appeared `Risky` when the local base was stale. #2009 now treats cleanup safety as canonical-base merge status instead.

## Notes

- Full `cargo test -p gwt-git` still has unrelated pre-existing Windows path normalization failures in `worktree::tests::main_worktree_root_*`; the branch cleanup changes are covered by the focused `branch::tests` run above.