### PR TITLE
fix(branch-cleanup): keep remote rows risky when upstream is ahead

### DIFF
--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -170,12 +170,18 @@ fn hydrate_branch_entries(
         .filter(|branch| branch.scope == BranchScope::Local)
         .map(|branch| (branch.name.clone(), branch.upstream.clone()))
         .collect();
+    let local_behind_counts: HashMap<String, u32> = entries
+        .iter()
+        .filter(|branch| branch.scope == BranchScope::Local)
+        .map(|branch| (branch.name.clone(), branch.behind))
+        .collect();
     let mut entries: Vec<BranchListEntry> = entries
         .into_iter()
         .map(|mut branch| {
             branch.cleanup = build_cleanup_info(
                 &branch,
                 &local_upstreams,
+                &local_behind_counts,
                 current_head_branch.as_deref(),
                 active_session_branches,
                 cleanup_targets,
@@ -192,6 +198,7 @@ fn hydrate_branch_entries(
 fn build_cleanup_info(
     branch: &BranchListEntry,
     local_upstreams: &HashMap<String, Option<String>>,
+    local_behind_counts: &HashMap<String, u32>,
     current_head_branch: Option<&str>,
     active_session_branches: &HashSet<String>,
     cleanup_targets: &HashMap<String, Option<gwt_git::MergeTarget>>,
@@ -238,11 +245,17 @@ fn build_cleanup_info(
         .get(execution_branch_name)
         .cloned()
         .flatten();
+    let execution_branch_behind = local_behind_counts
+        .get(execution_branch_name)
+        .copied()
+        .unwrap_or_default();
     let mut risks = Vec::new();
     if upstream.is_none() {
         risks.push(BranchCleanupRisk::NoUpstream);
     }
-    if branch.scope == BranchScope::Remote && merge_target.is_none() {
+    if branch.scope == BranchScope::Remote
+        && (merge_target.is_none() || execution_branch_behind > 0)
+    {
         risks.push(BranchCleanupRisk::RemoteTracking);
     }
     if merge_target.is_none() && upstream.is_some() {

--- a/crates/gwt/tests/branch_list_test.rs
+++ b/crates/gwt/tests/branch_list_test.rs
@@ -224,6 +224,115 @@ fn list_branch_entries_marks_local_and_remote_rows_safe_when_upstream_remote_bas
 }
 
 #[test]
+fn list_branch_entries_keeps_remote_row_risky_when_local_branch_is_behind_upstream() {
+    let temp = tempdir().expect("tempdir");
+    let origin = temp.path().join("origin.git");
+    let repo = temp.path().join("repo");
+    let peer = temp.path().join("peer");
+
+    run_git(
+        temp.path(),
+        &["init", "--bare", origin.to_str().expect("origin path")],
+    );
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            origin.to_str().expect("origin path"),
+        ],
+    );
+    run_git(&repo, &["push", "-u", "origin", "main"]);
+    run_git(&repo, &["checkout", "-qb", "develop"]);
+    std::fs::write(repo.join("develop.txt"), "develop\n").expect("write develop");
+    run_git(&repo, &["add", "develop.txt"]);
+    run_git(&repo, &["commit", "-qm", "develop base"]);
+    run_git(&repo, &["push", "-u", "origin", "develop"]);
+    run_git(&repo, &["checkout", "-qb", "feature/alpha"]);
+    std::fs::write(repo.join("alpha.txt"), "alpha\n").expect("write alpha");
+    run_git(&repo, &["add", "alpha.txt"]);
+    run_git(&repo, &["commit", "-qm", "alpha"]);
+    run_git(&repo, &["push", "-u", "origin", "feature/alpha"]);
+    run_git(&repo, &["push", "origin", "HEAD:refs/heads/develop"]);
+    run_git(&repo, &["checkout", "main"]);
+
+    run_git(
+        temp.path(),
+        &[
+            "clone",
+            "-q",
+            origin.to_str().expect("origin path"),
+            peer.to_str().expect("peer path"),
+        ],
+    );
+    run_git(&peer, &["config", "user.name", "PoC Tester"]);
+    run_git(&peer, &["config", "user.email", "poc@example.com"]);
+    run_git(
+        &peer,
+        &["checkout", "-qb", "feature/alpha", "origin/feature/alpha"],
+    );
+    std::fs::write(peer.join("remote-only.txt"), "remote\n").expect("write remote-only");
+    run_git(&peer, &["add", "remote-only.txt"]);
+    run_git(&peer, &["commit", "-qm", "remote only"]);
+    run_git(&peer, &["push", "origin", "HEAD:refs/heads/feature/alpha"]);
+
+    run_git(&repo, &["fetch", "origin", "--prune"]);
+
+    let branches =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let local_entry = branches
+        .iter()
+        .find(|branch| branch.name == "feature/alpha")
+        .expect("local branch");
+    let remote_entry = branches
+        .iter()
+        .find(|branch| branch.name == "origin/feature/alpha")
+        .expect("remote branch");
+
+    assert_eq!(local_entry.behind, 1);
+    assert_eq!(
+        local_entry.cleanup.availability,
+        BranchCleanupAvailability::Safe
+    );
+    assert_eq!(
+        local_entry
+            .cleanup
+            .merge_target
+            .as_ref()
+            .map(|target| target.as_str()),
+        Some("origin/develop")
+    );
+
+    assert_eq!(remote_entry.scope, BranchScope::Remote);
+    assert_eq!(
+        remote_entry.cleanup.execution_branch.as_deref(),
+        Some("feature/alpha")
+    );
+    assert_eq!(
+        remote_entry.cleanup.availability,
+        BranchCleanupAvailability::Risky
+    );
+    assert_eq!(
+        remote_entry
+            .cleanup
+            .merge_target
+            .as_ref()
+            .map(|target| target.as_str()),
+        Some("origin/develop")
+    );
+    assert!(remote_entry
+        .cleanup
+        .risks
+        .contains(&BranchCleanupRisk::RemoteTracking));
+}
+
+#[test]
 fn list_branch_entries_blocks_remote_tracking_row_without_local_counterpart() {
     let temp = tempdir().expect("tempdir");
     let remote = temp.path().join("origin.git");

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,31 @@
 # Lessons Learned
 
+## 2026-04-21 — fix(branch-cleanup): remote row の `Safe` 継承は upstream 同値性まで確認する
+
+### 事象
+
+remote-tracking row の cleanup availability で、対応する local branch が canonical
+base に merge 済みなら `Safe` を継承していた。その結果、local branch が
+`origin/<branch>` より behind のときでも remote row が `Safe` になり、
+remote 側だけに残っている未マージ commit を削除対象に含め得た。
+
+### 原因
+
+- remote row の `merge_target` を execution local branch から流用し、
+  local と remote の tip が一致しているかを確認していなかった。
+- `Safe` 継承条件として「upstream ref が一致している」ことだけを見ており、
+  `behind > 0` の divergence を availability 判定に反映していなかった。
+
+### 再発防止策
+
+1. remote-tracking row が local execution branch の availability を継承するときは、
+   upstream 名だけでなく `ahead/behind` も見て remote-only commit の有無を確認する。
+2. cleanup が local + remote をまとめて削除し得る row では、local 側の
+   `merge_target` があるだけで `Safe` とせず、削除対象ごとの tip 同値性を
+   regression test で固定する。
+3. canonical base 判定を拡張した後は、`local safe / remote risky` になる
+   divergence case を必ず追加してから PR を出す。
+
 ## 2026-04-21 — fix(branch-cleanup): `Safe` は stale local base ではなく canonical remote base merge で判定する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Keep remote-tracking rows `Risky` when the execution local branch is behind its upstream so cleanup does not treat remote-only commits as safe to delete.
- Preserve the canonical remote-base `Safe` behavior for the local execution branch while separating remote-row safety from stale or divergent upstream state.
- Add a regression test and recurrence-prevention note for the `local safe / remote risky` divergence case found after #2128 merged.

## Changes

- `crates/gwt/src/branch_list.rs`: require the execution local branch to have `behind == 0` before a remote-tracking row can inherit `Safe`.
- `crates/gwt/tests/branch_list_test.rs`: add a regression where the local branch is merged to `origin/develop` but still behind `origin/feature/*`, and keep the remote row `Risky`.
- `tasks/lessons.md`: record the divergence-specific cleanup safety lesson.

## Testing

- [x] `cargo fmt --all` — formats successfully.
- [x] `cargo test -p gwt --test branch_list_test` — passes the branch cleanup regression suite.
- [x] `cargo test -p gwt branch_cleanup::tests` — passes cleanup execution guard tests.
- [x] `cargo fmt --all --check` — passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passes.

## Closing Issues

- None

## Related Issues / Links

- #2009
- #2128

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This is a follow-up to merged PR #2128. Post-merge review found that remote-tracking rows could inherit `Safe` from the local execution branch even when `origin/<branch>` had newer remote-only commits, which makes delete-remote cleanup too permissive.

## Notes

- The owner spec (#2009) was updated so remote-tracking rows only inherit `Safe` when the mapped local execution branch is not behind its upstream.