### PR TITLE
feat(hooks): skill単位のStop-block handler で LLM 自律継続を実現 (SPEC-1935 Phase 10)

### DIFF
--- a/.claude/skills/gwt-build-spec/SKILL.md
+++ b/.claude/skills/gwt-build-spec/SKILL.md
@@ -27,6 +27,23 @@ Use the current user's language for task summaries, completion reports, task
 check updates, and any user-facing text generated while executing the workflow,
 unless an existing artifact must keep its established language.
 
+## Exit CLI (Stop-block contract)
+
+SPEC-1935 FR-014r routes Stop through `skill-build-spec-stop-check`, which
+reads `.gwt/skill-state/build-spec.json` and blocks Stop while the skill is
+active. Register the skill lifecycle with the exit CLI:
+
+- `gwt build start --spec <n>` when the skill starts an implementation pass
+- `gwt build phase --spec <n> --label <red|green|refactor|verify|pr>` at each
+  TDD milestone (logging only)
+- `gwt build complete --spec <n>` once the PR is open and verification passed
+- `gwt build abort --spec <n> --reason '<text>'` when implementation cannot
+  proceed without a product decision or blocking merge conflict
+
+The Stop-block handler honours Claude Code / Codex's built-in
+`stop_hook_active` flag, so each Stop cycle allows at most one forced
+continuation; a genuinely stuck turn still terminates normally.
+
 ## Mode detection
 
 Determine the mode at entry:

--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -77,6 +77,25 @@ high-impact unknown behind it has been resolved.
   and `Action Bundle`, or a decision-complete `<proposed_plan>` when the
   discussion ends in a plan handoff) is ready.
 
+## Exit CLI (Stop-block contract)
+
+SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
+which inspects `.gwt/discussion.md` and blocks Stop (with
+`{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
+with a non-empty `Next Question:`. To let Stop succeed, mark each proposal
+explicitly using the exit CLI:
+
+- `gwt discuss resolve --proposal "Proposal A"` — active → chosen
+- `gwt discuss park --proposal "Proposal A"` — active → parked (resume later)
+- `gwt discuss reject --proposal "Proposal A"` — active → rejected
+- `gwt discuss clear-next-question --proposal "Proposal A"` — keep the
+  proposal active but pause Stop-block (exceptional; only when waiting on a
+  user answer the skill truly cannot resolve alone)
+
+When the `Action Bundle` is produced, call the matching exit command for each
+proposal before stopping. Claude Code's built-in `stop_hook_active` flag keeps
+the handler fail-safe: at most one forced continuation per Stop cycle.
+
 ## Resume hooks
 
 Managed hook settings in `.claude/settings.local.json` and `.codex/hooks.json`

--- a/.claude/skills/gwt-plan-spec/SKILL.md
+++ b/.claude/skills/gwt-plan-spec/SKILL.md
@@ -19,6 +19,25 @@ behind the visible `gwt-plan-spec` entrypoint.
   current working context (no spec.md required, skip traceability checks)
 - **Standalone:** works independently of the visible SPEC flow owner
 
+## Exit CLI (Stop-block contract)
+
+SPEC-1935 FR-014q routes Stop through `skill-plan-spec-stop-check`, which reads
+`.gwt/skill-state/plan-spec.json` and blocks Stop while the skill is active.
+Register the skill lifecycle explicitly with the exit CLI:
+
+- `gwt plan start --spec <n>` at the beginning of the skill invocation
+- `gwt plan phase --spec <n> --label <plan-draft|tasks-draft|quality-gate>`
+  at each internal milestone (logging only; does not affect blocking)
+- `gwt plan complete --spec <n>` once the quality gate verdict is `CLEAR`
+  and planning artifacts are written
+- `gwt plan abort --spec <n> --reason '<text>'` when planning cannot
+  proceed (e.g. spec gap discovered mid-planning)
+
+The Stop-block handler honours Claude Code / Codex's built-in
+`stop_hook_active` flag, so forced continuation is capped at one per Stop
+cycle and the skill will never infinitely loop even if the exit CLI is
+skipped.
+
 ## Prerequisites
 
 - If `spec.md` has critical `[NEEDS CLARIFICATION]` markers, use `gwt-discussion` first.

--- a/.codex/skills/gwt-build-spec/SKILL.md
+++ b/.codex/skills/gwt-build-spec/SKILL.md
@@ -27,6 +27,23 @@ Use the current user's language for task summaries, completion reports, task
 check updates, and any user-facing text generated while executing the workflow,
 unless an existing artifact must keep its established language.
 
+## Exit CLI (Stop-block contract)
+
+SPEC-1935 FR-014r routes Stop through `skill-build-spec-stop-check`, which
+reads `.gwt/skill-state/build-spec.json` and blocks Stop while the skill is
+active. Register the skill lifecycle with the exit CLI:
+
+- `gwt build start --spec <n>` when the skill starts an implementation pass
+- `gwt build phase --spec <n> --label <red|green|refactor|verify|pr>` at each
+  TDD milestone (logging only)
+- `gwt build complete --spec <n>` once the PR is open and verification passed
+- `gwt build abort --spec <n> --reason '<text>'` when implementation cannot
+  proceed without a product decision or blocking merge conflict
+
+The Stop-block handler honours Claude Code / Codex's built-in
+`stop_hook_active` flag, so each Stop cycle allows at most one forced
+continuation; a genuinely stuck turn still terminates normally.
+
 ## Mode detection
 
 Determine the mode at entry:

--- a/.codex/skills/gwt-discussion/SKILL.md
+++ b/.codex/skills/gwt-discussion/SKILL.md
@@ -77,6 +77,26 @@ high-impact unknown behind it has been resolved.
   and `Action Bundle`, or a decision-complete `<proposed_plan>` when the
   discussion ends in a plan handoff) is ready.
 
+## Exit CLI (Stop-block contract)
+
+SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
+which inspects `.gwt/discussion.md` and blocks Stop (with
+`{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
+with a non-empty `Next Question:`. To let Stop succeed, mark each proposal
+explicitly using the exit CLI:
+
+- `gwt discuss resolve --proposal "Proposal A"` — active → chosen
+- `gwt discuss park --proposal "Proposal A"` — active → parked (resume later)
+- `gwt discuss reject --proposal "Proposal A"` — active → rejected
+- `gwt discuss clear-next-question --proposal "Proposal A"` — keep the
+  proposal active but pause Stop-block (exceptional; only when waiting on a
+  user answer the skill truly cannot resolve alone)
+
+When the `Action Bundle` is produced, call the matching exit command for each
+proposal before stopping. Codex's `stop_hook_active` flag (shared with Claude
+Code via `codex_hooks`) keeps the handler fail-safe: at most one forced
+continuation per Stop cycle.
+
 ## Resume hooks
 
 Managed hook settings in `.claude/settings.local.json` and `.codex/hooks.json`

--- a/.codex/skills/gwt-plan-spec/SKILL.md
+++ b/.codex/skills/gwt-plan-spec/SKILL.md
@@ -19,6 +19,25 @@ behind the visible `gwt-plan-spec` entrypoint.
   current working context (no spec.md required, skip traceability checks)
 - **Standalone:** works independently of the visible SPEC flow owner
 
+## Exit CLI (Stop-block contract)
+
+SPEC-1935 FR-014q routes Stop through `skill-plan-spec-stop-check`, which reads
+`.gwt/skill-state/plan-spec.json` and blocks Stop while the skill is active.
+Register the skill lifecycle explicitly with the exit CLI:
+
+- `gwt plan start --spec <n>` at the beginning of the skill invocation
+- `gwt plan phase --spec <n> --label <plan-draft|tasks-draft|quality-gate>`
+  at each internal milestone (logging only; does not affect blocking)
+- `gwt plan complete --spec <n>` once the quality gate verdict is `CLEAR`
+  and planning artifacts are written
+- `gwt plan abort --spec <n> --reason '<text>'` when planning cannot
+  proceed (e.g. spec gap discovered mid-planning)
+
+The Stop-block handler honours Claude Code / Codex's built-in
+`stop_hook_active` flag, so forced continuation is capped at one per Stop
+cycle and the skill will never infinitely loop even if the exit CLI is
+skipped.
+
 ## Prerequisites
 
 - If `spec.md` has critical `[NEEDS CLARIFICATION]` markers, use `gwt-discussion` first.

--- a/crates/gwt-core/src/lib.rs
+++ b/crates/gwt-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod process;
 mod release_contract;
 pub mod repo_hash;
 pub mod runtime;
+pub mod skill_state;
 pub mod update;
 pub mod worktree_hash;
 

--- a/crates/gwt-core/src/skill_state.rs
+++ b/crates/gwt-core/src/skill_state.rs
@@ -1,0 +1,192 @@
+//! Per-skill Stop-block state file I/O used by SPEC-1935 Phase 10.
+//!
+//! Multi-turn skills (`gwt-plan-spec`, `gwt-build-spec`, and any future
+//! skill that needs autonomous Stop-block continuation) record a small
+//! JSON state file under `<worktree>/.gwt/skill-state/<skill>.json`. The
+//! Stop hook handler reads this file to decide whether to emit
+//! `HookOutput::StopBlock` or stay silent.
+//!
+//! State transitions:
+//!
+//! - `save` writes the current struct; use it for `start`, `phase`
+//!   updates, and transitions that keep the skill active.
+//! - `mark_inactive` flips an existing file to `active: false` without
+//!   deleting it — useful for `complete` / `abort` so later inspection
+//!   can see the skill's last state.
+//! - `load` returns `Ok(None)` when the file is missing; callers treat
+//!   that as "skill not active". Malformed JSON or other I/O failures
+//!   propagate via `io::Error` so handlers can decide how to fail open.
+//!
+//! `gwt-discussion` intentionally does **not** use this module; its
+//! existing `.gwt/discussion.md` Markdown artifact is the source of
+//! truth for the `skill-discussion-stop-check` handler.
+
+use std::{
+    fs,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Relative directory under the worktree where per-skill state files live.
+pub const SKILL_STATE_DIR: &str = ".gwt/skill-state";
+
+/// Persisted per-skill state file.
+///
+/// `session_id` is the gwt agent session identifier at the moment the
+/// skill was started. Handlers use it to skip the Stop-block decision
+/// when a different agent session observes the file (see FR-014t).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillState {
+    pub active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_spec: Option<u64>,
+    pub started_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    pub session_id: String,
+}
+
+/// Resolve the filesystem path for a given skill's state file.
+pub fn state_path(worktree: &Path, skill: &str) -> PathBuf {
+    worktree.join(SKILL_STATE_DIR).join(format!("{skill}.json"))
+}
+
+/// Load the per-skill state. Returns `Ok(None)` when the file is
+/// missing. Propagates I/O or JSON errors so the caller can decide
+/// whether to treat them as fail-open.
+pub fn load(worktree: &Path, skill: &str) -> io::Result<Option<SkillState>> {
+    let path = state_path(worktree, skill);
+    match fs::read_to_string(&path) {
+        Ok(contents) => {
+            let state = serde_json::from_str::<SkillState>(&contents)
+                .map_err(|err| io::Error::new(ErrorKind::InvalidData, err))?;
+            Ok(Some(state))
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+/// Persist the per-skill state, creating the directory if needed.
+pub fn save(worktree: &Path, skill: &str, state: &SkillState) -> io::Result<()> {
+    let path = state_path(worktree, skill);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let serialized = serde_json::to_string_pretty(state)
+        .map_err(|err| io::Error::new(ErrorKind::InvalidData, err))?;
+    fs::write(path, serialized)
+}
+
+/// Flip an existing skill-state file to `active: false`. Returns
+/// `Ok(false)` when no state file exists (idempotent exit).
+pub fn mark_inactive(worktree: &Path, skill: &str) -> io::Result<bool> {
+    let Some(mut state) = load(worktree, skill)? else {
+        return Ok(false);
+    };
+    if !state.active {
+        return Ok(true);
+    }
+    state.active = false;
+    save(worktree, skill, &state)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample_state(session: &str) -> SkillState {
+        SkillState {
+            active: true,
+            owner_spec: Some(1935),
+            started_at: Utc.with_ymd_and_hms(2026, 4, 21, 9, 0, 0).unwrap(),
+            phase: Some("plan-draft".to_string()),
+            session_id: session.to_string(),
+        }
+    }
+
+    #[test]
+    fn load_returns_none_when_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(load(dir.path(), "plan-spec").unwrap(), None);
+    }
+
+    #[test]
+    fn save_then_load_round_trips_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = sample_state("sess-1");
+        save(dir.path(), "plan-spec", &state).unwrap();
+        let loaded = load(dir.path(), "plan-spec").unwrap();
+        assert_eq!(loaded, Some(state));
+    }
+
+    #[test]
+    fn save_creates_nested_skill_state_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), "build-spec", &sample_state("sess-1")).unwrap();
+        assert!(dir.path().join(SKILL_STATE_DIR).exists());
+        assert!(dir
+            .path()
+            .join(SKILL_STATE_DIR)
+            .join("build-spec.json")
+            .exists());
+    }
+
+    #[test]
+    fn load_returns_invalid_data_for_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = state_path(dir.path(), "plan-spec");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "{not json").unwrap();
+        let err = load(dir.path(), "plan-spec").expect_err("expected InvalidData");
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn mark_inactive_flips_active_flag_and_preserves_other_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = sample_state("sess-1");
+        save(dir.path(), "plan-spec", &state).unwrap();
+
+        let changed = mark_inactive(dir.path(), "plan-spec").unwrap();
+        assert!(changed);
+
+        let loaded = load(dir.path(), "plan-spec").unwrap().unwrap();
+        assert!(!loaded.active);
+        assert_eq!(loaded.owner_spec, Some(1935));
+        assert_eq!(loaded.phase, Some("plan-draft".to_string()));
+        assert_eq!(loaded.session_id, "sess-1");
+    }
+
+    #[test]
+    fn mark_inactive_is_idempotent_without_state_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!mark_inactive(dir.path(), "plan-spec").unwrap());
+    }
+
+    #[test]
+    fn mark_inactive_on_already_inactive_state_is_noop_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = sample_state("sess-1");
+        state.active = false;
+        save(dir.path(), "plan-spec", &state).unwrap();
+        assert!(mark_inactive(dir.path(), "plan-spec").unwrap());
+        let loaded = load(dir.path(), "plan-spec").unwrap().unwrap();
+        assert!(!loaded.active);
+    }
+
+    #[test]
+    fn state_path_is_scoped_per_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = state_path(dir.path(), "plan-spec");
+        let b = state_path(dir.path(), "build-spec");
+        assert_ne!(a, b);
+        assert!(a.to_string_lossy().contains("plan-spec.json"));
+        assert!(b.to_string_lossy().contains("build-spec.json"));
+    }
+}

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -28,6 +28,9 @@ const MANAGED_HOOK_SUBCMD_SUFFIXES: &[&str] = &[
     " hook block-file-ops",
     " hook block-git-dir-override",
     " hook forward",
+    " hook skill-discussion-stop-check",
+    " hook skill-plan-spec-stop-check",
+    " hook skill-build-spec-stop-check",
 ];
 const CLAUDE_HOOK_COMMAND_TYPE: &str = "command";
 const MANAGED_EVENT_ORDER: &[&str] = &[
@@ -290,6 +293,9 @@ fn managed_hooks(target: ManagedHookTarget, shell: HookShell) -> Map<String, Val
             forward_hook(shell),
             coordination_hook("Stop", shell),
             board_reminder_hook("Stop", shell),
+            skill_stop_check_hook("skill-discussion-stop-check", shell),
+            skill_stop_check_hook("skill-plan-spec-stop-check", shell),
+            skill_stop_check_hook("skill-build-spec-stop-check", shell),
         ]),
     );
     hooks
@@ -341,6 +347,35 @@ fn forward_hook(shell: HookShell) -> Value {
             }
         ]
     })
+}
+
+/// Managed Stop-hook handler that lets a skill block the Stop event
+/// until the skill reports completion via its exit CLI
+/// (`gwt discuss|plan|build ...`). See SPEC-1935 FR-014n.
+fn skill_stop_check_hook(hook_name: &str, shell: HookShell) -> Value {
+    json!({
+        "matcher": "*",
+        "hooks": [
+            {
+                "command": skill_stop_check_hook_command(hook_name, shell),
+                "type": CLAUDE_HOOK_COMMAND_TYPE,
+            }
+        ]
+    })
+}
+
+fn skill_stop_check_hook_command(hook_name: &str, shell: HookShell) -> String {
+    let bin = gwt_hook_bin_path();
+    match shell {
+        HookShell::Posix => {
+            let bin_quoted = posix_shell_quote(&bin);
+            format!("{bin_quoted} hook {hook_name}")
+        }
+        HookShell::PowerShell => {
+            let bin_quoted = powershell_quote(&bin);
+            format!("powershell -NoProfile -Command \"& {{ & {bin_quoted} hook {hook_name} }}\"")
+        }
+    }
 }
 
 /// Environment variable that pins the absolute path of the gwt
@@ -563,6 +598,88 @@ mod tests {
                     .iter()
                     .all(|c| !c.contains(" hook board-reminder ")),
                 "board-reminder must NOT be registered on {event}; commands: {commands:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn managed_stop_chain_includes_three_skill_check_handlers_after_board_reminder() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_settings_local(dir.path()).unwrap();
+        let content = fs::read_to_string(dir.path().join(".claude/settings.local.json")).unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        let stop_commands = commands_for_event(&value, "Stop");
+        let suffixes = [
+            " hook skill-discussion-stop-check",
+            " hook skill-plan-spec-stop-check",
+            " hook skill-build-spec-stop-check",
+        ];
+        for suffix in &suffixes {
+            let count = stop_commands.iter().filter(|c| c.contains(suffix)).count();
+            assert_eq!(
+                count, 1,
+                "Stop chain must include exactly one {suffix} entry; got {count}: {stop_commands:?}"
+            );
+        }
+        let board_reminder_pos = stop_commands
+            .iter()
+            .position(|c| c.contains(" hook board-reminder Stop"))
+            .expect("Stop chain must include board-reminder");
+        for suffix in &suffixes {
+            let position = stop_commands
+                .iter()
+                .position(|c| c.contains(suffix))
+                .expect("suffix present (checked above)");
+            assert!(
+                position > board_reminder_pos,
+                "{suffix} must appear after board-reminder; chain: {stop_commands:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn managed_stop_chain_does_not_register_skill_checks_on_non_stop_events() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_settings_local(dir.path()).unwrap();
+        let content = fs::read_to_string(dir.path().join(".claude/settings.local.json")).unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        for event in [
+            "SessionStart",
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PostToolUse",
+        ] {
+            let commands = commands_for_event(&value, event);
+            for suffix in [
+                " hook skill-discussion-stop-check",
+                " hook skill-plan-spec-stop-check",
+                " hook skill-build-spec-stop-check",
+            ] {
+                assert!(
+                    commands.iter().all(|c| !c.contains(suffix)),
+                    "{suffix} must NOT be registered on {event}; commands: {commands:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn managed_stop_chain_does_not_register_short_lived_skill_handlers() {
+        // Regression guard for FR-014s: gwt-register-issue / gwt-fix-issue /
+        // gwt-issue-search / gwt-search must never have a Stop-check handler
+        // registered. We assert those hook names are not emitted anywhere.
+        let dir = tempfile::tempdir().unwrap();
+        generate_settings_local(dir.path()).unwrap();
+        let content = fs::read_to_string(dir.path().join(".claude/settings.local.json")).unwrap();
+        for forbidden in [
+            " hook skill-register-issue-stop-check",
+            " hook skill-fix-issue-stop-check",
+            " hook skill-issue-search-stop-check",
+            " hook skill-search-stop-check",
+        ] {
+            assert!(
+                !content.contains(forbidden),
+                "short-lived skill {forbidden} must not appear in managed hooks"
             );
         }
     }

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -21,11 +21,15 @@
 
 mod actions;
 mod board;
+mod build;
+mod discuss;
 mod env;
 pub mod hook;
 mod issue;
 mod issue_spec;
+mod plan;
 mod pr;
+mod skill_state_runtime;
 pub mod update;
 
 use std::{
@@ -243,6 +247,30 @@ pub enum CliCommand {
     InternalRunInstaller { rest: Vec<String> },
     /// `gwt __internal daemon-hook <name> [args...]` — hidden helper used by the front door.
     InternalDaemonHook { name: String, rest: Vec<String> },
+    /// `gwt discuss <resolve|park|reject|clear-next-question> --proposal <label>`.
+    Discuss(DiscussAction),
+    /// `gwt plan <start|phase|complete|abort> --spec <n> [...]`.
+    Plan(SkillStateAction),
+    /// `gwt build <start|phase|complete|abort> --spec <n> [...]`.
+    Build(SkillStateAction),
+}
+
+/// Sub-action for `gwt discuss ...` (SPEC-1935 FR-014p).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscussAction {
+    Resolve { proposal: String },
+    Park { proposal: String },
+    Reject { proposal: String },
+    ClearNextQuestion { proposal: String },
+}
+
+/// Sub-action for `gwt plan ...` / `gwt build ...` (SPEC-1935 FR-014q/r).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillStateAction {
+    Start { spec: u64 },
+    Phase { spec: u64, label: String },
+    Complete { spec: u64 },
+    Abort { spec: u64, reason: Option<String> },
 }
 
 /// Errors surfaced by argv parsing.
@@ -279,7 +307,16 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
         .map(|s| {
             matches!(
                 s.as_str(),
-                "issue" | "pr" | "actions" | "board" | "hook" | "update" | "__internal"
+                "issue"
+                    | "pr"
+                    | "actions"
+                    | "board"
+                    | "hook"
+                    | "update"
+                    | "__internal"
+                    | "discuss"
+                    | "plan"
+                    | "build"
             )
         })
         .unwrap_or(false)
@@ -346,6 +383,83 @@ pub fn parse_hook_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     })
 }
 
+/// Parse `gwt discuss <action> --proposal <label>` (SPEC-1935 FR-014p).
+pub fn parse_discuss_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
+    let proposal = parse_named_string(rest, "--proposal")?;
+    let action = match head.as_str() {
+        "resolve" => DiscussAction::Resolve { proposal },
+        "park" => DiscussAction::Park { proposal },
+        "reject" => DiscussAction::Reject { proposal },
+        "clear-next-question" => DiscussAction::ClearNextQuestion { proposal },
+        other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+    };
+    Ok(CliCommand::Discuss(action))
+}
+
+/// Parse `gwt plan <action> --spec <n> [...]` (SPEC-1935 FR-014q).
+pub fn parse_plan_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    parse_skill_state_args(args).map(CliCommand::Plan)
+}
+
+/// Parse `gwt build <action> --spec <n> [...]` (SPEC-1935 FR-014r).
+pub fn parse_build_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    parse_skill_state_args(args).map(CliCommand::Build)
+}
+
+fn parse_skill_state_args(args: &[String]) -> Result<SkillStateAction, CliParseError> {
+    let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
+    match head.as_str() {
+        "start" => {
+            let spec = parse_named_u64(rest, "--spec")?;
+            Ok(SkillStateAction::Start { spec })
+        }
+        "phase" => {
+            let spec = parse_named_u64(rest, "--spec")?;
+            let label = parse_named_string(rest, "--label")?;
+            Ok(SkillStateAction::Phase { spec, label })
+        }
+        "complete" => {
+            let spec = parse_named_u64(rest, "--spec")?;
+            Ok(SkillStateAction::Complete { spec })
+        }
+        "abort" => {
+            let spec = parse_named_u64(rest, "--spec")?;
+            let reason = parse_optional_named_string(rest, "--reason");
+            Ok(SkillStateAction::Abort { spec, reason })
+        }
+        other => Err(CliParseError::UnknownSubcommand(other.to_string())),
+    }
+}
+
+fn parse_named_string(args: &[String], flag: &'static str) -> Result<String, CliParseError> {
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == flag {
+            let value = args.get(i + 1).ok_or(CliParseError::MissingFlag(flag))?;
+            return Ok(value.clone());
+        }
+        i += 1;
+    }
+    Err(CliParseError::MissingFlag(flag))
+}
+
+fn parse_optional_named_string(args: &[String], flag: &'static str) -> Option<String> {
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == flag {
+            return args.get(i + 1).cloned();
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_named_u64(args: &[String], flag: &'static str) -> Result<u64, CliParseError> {
+    let raw = parse_named_string(args, flag)?;
+    raw.parse().map_err(|_| CliParseError::InvalidNumber(raw))
+}
+
 /// Dispatch a parsed [`CliCommand`] against the given [`CliEnv`].
 ///
 /// We collect output into a String buffer first so the [`SpecOps`] borrow of
@@ -385,6 +499,9 @@ pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError>
         cmd @ (CliCommand::BoardShow { .. } | CliCommand::BoardPost { .. }) => {
             board::run(env, cmd, &mut out)?
         }
+        CliCommand::Discuss(action) => discuss::run(env, action, &mut out)?,
+        CliCommand::Plan(action) => plan::run(env, action, &mut out)?,
+        CliCommand::Build(action) => build::run(env, action, &mut out)?,
         CliCommand::Hook { name, rest } => {
             return run_hook(env, &name, &rest);
         }
@@ -1467,7 +1584,10 @@ pub fn run_daemon_hook<E: CliEnv>(
     name: &str,
     rest: &[String],
 ) -> Result<i32, SpecOpsError> {
-    use crate::cli::hook::{block_bash_policy, workflow_policy, HookKind, HookOutput};
+    use crate::cli::hook::{
+        block_bash_policy, skill_build_spec_stop_check, skill_discussion_stop_check,
+        skill_plan_spec_stop_check, workflow_policy, HookKind, HookOutput,
+    };
 
     let Some(kind) = HookKind::from_name(name) else {
         let _ = writeln!(env.stderr(), "gwt hook: unknown hook '{name}'");
@@ -1541,6 +1661,31 @@ pub fn run_daemon_hook<E: CliEnv>(
             Ok(()) => Ok(0),
             Err(err) => Ok(emit_hook_error(env, name, err)),
         },
+        HookKind::SkillDiscussionStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let output = skill_discussion_stop_check::handle_with_input(&cwd, &stdin);
+            Ok(emit_hook_output(env, &output))
+        }
+        HookKind::SkillPlanSpecStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            let output = skill_plan_spec_stop_check::handle_with_input(
+                &cwd,
+                &stdin,
+                current_session.as_deref(),
+            );
+            Ok(emit_hook_output(env, &output))
+        }
+        HookKind::SkillBuildSpecStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            let output = skill_build_spec_stop_check::handle_with_input(
+                &cwd,
+                &stdin,
+                current_session.as_deref(),
+            );
+            Ok(emit_hook_output(env, &output))
+        }
     }
 }
 

--- a/crates/gwt/src/cli/build.rs
+++ b/crates/gwt/src/cli/build.rs
@@ -1,0 +1,21 @@
+//! `gwt build <start|phase|complete|abort> --spec <n> [...]`
+//!
+//! Exit CLI for the `gwt-build-spec` skill (SPEC-1935 FR-014r). Writes
+//! `.gwt/skill-state/build-spec.json` via [`gwt_core::skill_state`].
+
+use gwt_github::SpecOpsError;
+
+use super::skill_state_runtime;
+use crate::cli::{CliEnv, SkillStateAction};
+
+pub(crate) const SKILL_NAME: &str = "build-spec";
+pub(crate) const SKILL_DISPLAY: &str = "gwt-build-spec";
+pub(crate) const VERB: &str = "build";
+
+pub(super) fn run<E: CliEnv>(
+    env: &mut E,
+    action: SkillStateAction,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    skill_state_runtime::run(env, action, SKILL_NAME, SKILL_DISPLAY, VERB, out)
+}

--- a/crates/gwt/src/cli/discuss.rs
+++ b/crates/gwt/src/cli/discuss.rs
@@ -1,0 +1,70 @@
+//! `gwt discuss <resolve|park|reject|clear-next-question> --proposal <label>`
+//!
+//! Exit CLI for the `gwt-discussion` skill (SPEC-1935 FR-014p). The LLM
+//! invokes these commands to mutate `.gwt/discussion.md` so the
+//! `skill-discussion-stop-check` handler stops blocking Stop events.
+//!
+//! All commands are idempotent: calling `resolve` on an already-resolved
+//! proposal, or targeting a missing label, exits successfully with a
+//! short informational message. This matches the "LLM 忘れ漏れ耐性"
+//! design note.
+
+use gwt_github::SpecOpsError;
+
+use crate::cli::{CliEnv, DiscussAction};
+use crate::discussion_resume::{clear_proposal_next_question, set_proposal_status_by_label};
+
+pub(super) fn run<E: CliEnv>(
+    env: &mut E,
+    action: DiscussAction,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    let worktree = env.repo_path().to_path_buf();
+    match action {
+        DiscussAction::Resolve { proposal } => apply_status(&worktree, &proposal, "chosen", out),
+        DiscussAction::Park { proposal } => apply_status(&worktree, &proposal, "parked", out),
+        DiscussAction::Reject { proposal } => apply_status(&worktree, &proposal, "rejected", out),
+        DiscussAction::ClearNextQuestion { proposal } => {
+            match clear_proposal_next_question(&worktree, &proposal) {
+                Ok(true) => {
+                    out.push_str(&format!("discuss: cleared Next Question for {proposal}\n"));
+                    Ok(0)
+                }
+                Ok(false) => {
+                    out.push_str(&format!(
+                        "discuss: no active Next Question to clear for {proposal}\n"
+                    ));
+                    Ok(0)
+                }
+                Err(err) => {
+                    out.push_str(&format!("discuss: clear-next-question failed: {err}\n"));
+                    Ok(1)
+                }
+            }
+        }
+    }
+}
+
+fn apply_status(
+    worktree: &std::path::Path,
+    proposal: &str,
+    new_status: &str,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    match set_proposal_status_by_label(worktree, proposal, new_status) {
+        Ok(true) => {
+            out.push_str(&format!("discuss: {proposal} -> [{new_status}]\n"));
+            Ok(0)
+        }
+        Ok(false) => {
+            out.push_str(&format!(
+                "discuss: {proposal} is already resolved or not found (no change)\n"
+            ));
+            Ok(0)
+        }
+        Err(err) => {
+            out.push_str(&format!("discuss: {new_status} failed: {err}\n"));
+            Ok(1)
+        }
+    }
+}

--- a/crates/gwt/src/cli/env.rs
+++ b/crates/gwt/src/cli/env.rs
@@ -492,6 +492,9 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "actions" => parse_actions_args(&rest),
         "board" => parse_board_args(&rest),
         "hook" => parse_hook_args(&rest),
+        "discuss" => super::parse_discuss_args(&rest),
+        "plan" => super::parse_plan_args(&rest),
+        "build" => super::parse_build_args(&rest),
         "update" => Ok(super::CliCommand::Update {
             check_only: rest.iter().any(|a| a == "--check"),
         }),

--- a/crates/gwt/src/cli/hook/board_reminder.rs
+++ b/crates/gwt/src/cli/hook/board_reminder.rs
@@ -324,7 +324,9 @@ fn plan_event(output: &HookOutput) -> IntentBoundaryEvent {
     match output {
         HookOutput::HookSpecificAdditionalContext { event, .. } => *event,
         HookOutput::SystemMessage(_) => IntentBoundaryEvent::Stop,
-        HookOutput::PreToolUsePermission { .. } | HookOutput::Silent => {
+        HookOutput::PreToolUsePermission { .. }
+        | HookOutput::Silent
+        | HookOutput::StopBlock { .. } => {
             panic!("board reminder plans must emit intent-boundary output")
         }
     }

--- a/crates/gwt/src/cli/hook/envelope.rs
+++ b/crates/gwt/src/cli/hook/envelope.rs
@@ -43,6 +43,12 @@ pub enum HookOutput {
     },
     SystemMessage(String),
     Silent,
+    /// Stop-hook block envelope: `{"decision":"block","reason":"<reason>"}`.
+    /// Claude Code / Codex interpret this as "do not stop; continue with
+    /// <reason> as the new instruction". exit code is 0.
+    StopBlock {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -81,6 +87,12 @@ struct SystemMessagePayload<'a> {
     system_message: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+struct StopBlockPayload<'a> {
+    decision: &'static str,
+    reason: &'a str,
+}
+
 impl HookOutput {
     pub fn pre_tool_use_permission(summary: impl Into<String>, detail: impl Into<String>) -> Self {
         let summary = summary.into();
@@ -111,6 +123,12 @@ impl HookOutput {
         Self::SystemMessage(text.into())
     }
 
+    pub fn stop_block(reason: impl Into<String>) -> Self {
+        Self::StopBlock {
+            reason: reason.into(),
+        }
+    }
+
     pub fn summary(&self) -> &str {
         match self {
             Self::PreToolUsePermission { summary, .. } => summary,
@@ -135,7 +153,10 @@ impl HookOutput {
     pub fn exit_code(&self) -> i32 {
         match self {
             Self::PreToolUsePermission { .. } => 2,
-            Self::HookSpecificAdditionalContext { .. } | Self::SystemMessage(_) | Self::Silent => 0,
+            Self::HookSpecificAdditionalContext { .. }
+            | Self::SystemMessage(_)
+            | Self::Silent
+            | Self::StopBlock { .. } => 0,
         }
     }
 
@@ -182,9 +203,33 @@ impl HookOutput {
                 writer.write_all(b"\n")?;
             }
             Self::Silent => {}
+            Self::StopBlock { reason } => {
+                let payload = StopBlockPayload {
+                    decision: "block",
+                    reason,
+                };
+                serde_json::to_writer(&mut *writer, &payload)?;
+                writer.write_all(b"\n")?;
+            }
         }
         Ok(())
     }
+}
+
+/// Extract `stop_hook_active` from a Stop hook's stdin JSON payload.
+///
+/// Returns `true` only when the input JSON is a valid object containing
+/// `stop_hook_active: true`. Any parse failure, missing key, or non-boolean
+/// value resolves to `false`. Callers should treat `true` as the Claude Code
+/// built-in loop guard: do not emit `StopBlock` when this flag is set.
+pub fn stop_hook_active_from(input: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(input) else {
+        return false;
+    };
+    value
+        .get("stop_hook_active")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -263,6 +308,47 @@ mod tests {
     fn silent_emits_no_stdout() {
         let text = serialize(&HookOutput::Silent);
         assert!(text.is_empty(), "silent output must not write stdout");
+    }
+
+    #[test]
+    fn stop_block_serializes_as_decision_block_envelope() {
+        let text = serialize(&HookOutput::stop_block("discussion is active"));
+        let json: Value = serde_json::from_str(text.trim()).expect("json");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "decision": "block",
+                "reason": "discussion is active"
+            })
+        );
+        assert!(
+            json.get("hookSpecificOutput").is_none(),
+            "StopBlock envelope must not contain hookSpecificOutput"
+        );
+        assert!(
+            json.get("systemMessage").is_none(),
+            "StopBlock envelope must not contain systemMessage"
+        );
+    }
+
+    #[test]
+    fn stop_block_exit_code_is_zero() {
+        assert_eq!(HookOutput::stop_block("x").exit_code(), 0);
+    }
+
+    #[test]
+    fn stop_hook_active_from_reads_true_only_when_field_is_explicit_true() {
+        use super::stop_hook_active_from;
+        assert!(stop_hook_active_from(r#"{"stop_hook_active":true}"#));
+        assert!(!stop_hook_active_from(r#"{"stop_hook_active":false}"#));
+        assert!(!stop_hook_active_from(r#"{"stop_hook_active":"true"}"#));
+        assert!(!stop_hook_active_from(r#"{"session_id":"abc"}"#));
+        assert!(!stop_hook_active_from("{}"));
+        assert!(!stop_hook_active_from(""));
+        assert!(!stop_hook_active_from("not json"));
+        assert!(stop_hook_active_from(
+            r#"{"session_id":"abc","stop_hook_active":true}"#
+        ));
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -22,6 +22,9 @@ pub mod envelope;
 pub mod forward;
 pub mod runtime_state;
 pub mod segments;
+pub mod skill_build_spec_stop_check;
+pub mod skill_discussion_stop_check;
+pub mod skill_plan_spec_stop_check;
 pub mod workflow_policy;
 pub mod worktree;
 
@@ -43,6 +46,9 @@ pub enum HookKind {
     BlockBashPolicy,
     WorkflowPolicy,
     Forward,
+    SkillDiscussionStopCheck,
+    SkillPlanSpecStopCheck,
+    SkillBuildSpecStopCheck,
 }
 
 impl HookKind {
@@ -58,6 +64,9 @@ impl HookKind {
             "block-bash-policy" => Some(Self::BlockBashPolicy),
             "workflow-policy" => Some(Self::WorkflowPolicy),
             "forward" => Some(Self::Forward),
+            "skill-discussion-stop-check" => Some(Self::SkillDiscussionStopCheck),
+            "skill-plan-spec-stop-check" => Some(Self::SkillPlanSpecStopCheck),
+            "skill-build-spec-stop-check" => Some(Self::SkillBuildSpecStopCheck),
             _ => None,
         }
     }

--- a/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
@@ -1,0 +1,127 @@
+//! `gwt hook skill-build-spec-stop-check` — Stop-block handler for the
+//! `gwt-build-spec` skill (SPEC-1935 Phase 10, FR-014r).
+//!
+//! Mirrors the `skill_plan_spec_stop_check` structure but targets the
+//! `build-spec` state file. The shared decision body lives in
+//! [`super::skill_plan_spec_stop_check::decide`] so both handlers stay
+//! in lock-step regarding `stop_hook_active`, session isolation, and
+//! fail-open policy.
+
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+use gwt_agent::GWT_SESSION_ID_ENV;
+
+use super::{HookError, HookOutput};
+
+pub const SKILL_NAME: &str = "build-spec";
+pub const SKILL_DISPLAY: &str = "gwt-build-spec";
+
+pub fn handle() -> Result<HookOutput, HookError> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let cwd = std::env::current_dir()?;
+    let current_session = std::env::var(GWT_SESSION_ID_ENV).ok();
+    Ok(handle_with_input(&cwd, &input, current_session.as_deref()))
+}
+
+pub fn handle_with_input(
+    worktree: &Path,
+    input: &str,
+    current_session_id: Option<&str>,
+) -> HookOutput {
+    super::skill_plan_spec_stop_check::decide(
+        worktree,
+        input,
+        current_session_id,
+        SKILL_NAME,
+        SKILL_DISPLAY,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use gwt_core::skill_state::{save, SkillState};
+
+    fn active_state(session: &str, phase: &str) -> SkillState {
+        SkillState {
+            active: true,
+            owner_spec: Some(1935),
+            started_at: Utc.with_ymd_and_hms(2026, 4, 21, 9, 0, 0).unwrap(),
+            phase: Some(phase.to_string()),
+            session_id: session.to_string(),
+        }
+    }
+
+    fn assert_block_with(output: HookOutput, contains: &[&str]) {
+        match output {
+            HookOutput::StopBlock { reason } => {
+                for needle in contains {
+                    assert!(
+                        reason.contains(needle),
+                        "reason {reason:?} missing {needle:?}"
+                    );
+                }
+            }
+            other => panic!("expected StopBlock, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blocks_when_build_state_active_and_includes_phase_in_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        save(
+            dir.path(),
+            SKILL_NAME,
+            &active_state("sess-1", "red-green-refactor"),
+        )
+        .unwrap();
+        let output = handle_with_input(dir.path(), "{}", Some("sess-1"));
+        assert_block_with(
+            output,
+            &[
+                "gwt-build-spec for SPEC-1935",
+                "phase: red-green-refactor",
+                "gwt build complete",
+            ],
+        );
+    }
+
+    #[test]
+    fn silent_when_state_file_absent_even_with_active_session() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_session_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        save(
+            dir.path(),
+            SKILL_NAME,
+            &active_state("sess-other", "verify"),
+        )
+        .unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_stop_hook_active_is_true() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1", "red")).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), r#"{"stop_hook_active":true}"#, Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+}

--- a/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
@@ -1,0 +1,158 @@
+//! `gwt hook skill-discussion-stop-check` — Stop-block handler for the
+//! `gwt-discussion` skill (SPEC-1935 Phase 10, FR-014p).
+//!
+//! Reads `.gwt/discussion.md` in the current worktree and, when an
+//! `[active]` proposal with a non-empty `Next Question:` line is found,
+//! returns `HookOutput::StopBlock` so Claude Code / Codex continue the
+//! agent instead of stopping. Claude Code's built-in `stop_hook_active`
+//! flag (FR-014o) short-circuits this handler to prevent infinite loops.
+//!
+//! Fail-open policy (FR-014u): any I/O or parse failure resolves to
+//! `HookOutput::Silent` so a corrupted state file never accidentally
+//! blocks a Stop.
+
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+use super::{envelope::stop_hook_active_from, HookError, HookOutput};
+use crate::discussion_resume::load_pending_resume;
+
+pub fn handle() -> Result<HookOutput, HookError> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let cwd = std::env::current_dir()?;
+    Ok(handle_with_input(&cwd, &input))
+}
+
+/// Pure core decision. Always returns `Silent` on any parse/IO failure
+/// so the Stop hook stays fail-open.
+pub fn handle_with_input(worktree: &Path, input: &str) -> HookOutput {
+    if stop_hook_active_from(input) {
+        return HookOutput::Silent;
+    }
+    let Ok(Some(pending)) = load_pending_resume(worktree) else {
+        return HookOutput::Silent;
+    };
+    let Some(question) = pending
+        .next_question
+        .as_deref()
+        .map(str::trim)
+        .filter(|q| !q.is_empty())
+    else {
+        return HookOutput::Silent;
+    };
+
+    HookOutput::stop_block(format!(
+        "Discussion is still [active] on proposal \"{title}\".\n\
+         Next question: {question}\n\
+         Continue the gwt-discussion workflow (investigate → ask the user → update Discussion TODO), \
+         or call `gwt discuss resolve|park|reject --proposal {label}` to exit the discussion explicitly.",
+        title = pending.proposal_title,
+        question = question,
+        label = pending.proposal_label,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const ACTIVE_WITH_QUESTION: &str = "## Discussion TODO\n\n\
+### Proposal A - Hook-driven resume [active]\n\
+- Summary: Keep unfinished discussion state in the local artifact.\n\
+- Next Question: Should SessionStart or UserPromptSubmit surface the resume proposal?\n\
+";
+
+    const ACTIVE_WITHOUT_QUESTION: &str = "## Discussion TODO\n\n\
+### Proposal A - Hook-driven resume [active]\n\
+- Summary: Keep unfinished discussion state in the local artifact.\n\
+- Next Question:\n\
+";
+
+    const ALL_RESOLVED: &str = "## Discussion TODO\n\n\
+### Proposal A - Hook-driven resume [chosen]\n\
+- Summary: Done.\n\
+- Next Question: Should SessionStart surface the proposal?\n\
+";
+
+    fn write_discussion(dir: &Path, body: &str) {
+        let path = dir.join(".gwt/discussion.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, body).unwrap();
+    }
+
+    fn assert_stop_block(output: HookOutput, contains: &[&str]) {
+        match output {
+            HookOutput::StopBlock { reason } => {
+                for needle in contains {
+                    assert!(
+                        reason.contains(needle),
+                        "reason {reason:?} missing {needle:?}"
+                    );
+                }
+            }
+            other => panic!("expected StopBlock, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blocks_when_active_proposal_has_non_empty_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ACTIVE_WITH_QUESTION);
+        let output = handle_with_input(dir.path(), "{}");
+        assert_stop_block(
+            output,
+            &[
+                "Hook-driven resume",
+                "Should SessionStart or UserPromptSubmit surface the resume proposal?",
+                "gwt discuss resolve",
+                "Proposal A",
+            ],
+        );
+    }
+
+    #[test]
+    fn silent_when_stop_hook_active_flag_is_true() {
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ACTIVE_WITH_QUESTION);
+        assert_eq!(
+            handle_with_input(dir.path(), r#"{"stop_hook_active":true}"#),
+            HookOutput::Silent
+        );
+    }
+
+    #[test]
+    fn silent_when_discussion_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(handle_with_input(dir.path(), "{}"), HookOutput::Silent);
+    }
+
+    #[test]
+    fn silent_when_active_proposal_has_empty_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ACTIVE_WITHOUT_QUESTION);
+        assert_eq!(handle_with_input(dir.path(), "{}"), HookOutput::Silent);
+    }
+
+    #[test]
+    fn silent_when_no_active_proposals_remain() {
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ALL_RESOLVED);
+        assert_eq!(handle_with_input(dir.path(), "{}"), HookOutput::Silent);
+    }
+
+    #[test]
+    fn silent_when_discussion_md_is_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        // `parse_proposals` is tolerant, but this test future-proofs the
+        // fail-open contract: any unparseable input must not block Stop.
+        write_discussion(
+            dir.path(),
+            "### Proposal ??? broken header without status label\n",
+        );
+        assert_eq!(handle_with_input(dir.path(), "{}"), HookOutput::Silent);
+    }
+}

--- a/crates/gwt/src/cli/hook/skill_plan_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_plan_spec_stop_check.rs
@@ -1,0 +1,212 @@
+//! `gwt hook skill-plan-spec-stop-check` — Stop-block handler for the
+//! `gwt-plan-spec` skill (SPEC-1935 Phase 10, FR-014q).
+//!
+//! Reads `.gwt/skill-state/plan-spec.json` in the current worktree. When
+//! the state is `active: true` and the recorded `session_id` matches the
+//! current agent session, returns `HookOutput::StopBlock` so the skill
+//! keeps planning instead of stopping. `stop_hook_active: true`
+//! short-circuits to `Silent` (FR-014o).
+//!
+//! Fail-open policy (FR-014u): any I/O or JSON failure resolves to
+//! `Silent`.
+//!
+//! Session isolation (FR-014t): if `state.session_id` differs from the
+//! current `GWT_SESSION_ID` env value, the handler returns `Silent` so
+//! other agent sessions are not interrupted.
+
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+use gwt_agent::GWT_SESSION_ID_ENV;
+use gwt_core::skill_state;
+
+use super::{envelope::stop_hook_active_from, HookError, HookOutput};
+
+pub const SKILL_NAME: &str = "plan-spec";
+pub const SKILL_DISPLAY: &str = "gwt-plan-spec";
+
+pub fn handle() -> Result<HookOutput, HookError> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let cwd = std::env::current_dir()?;
+    let current_session = std::env::var(GWT_SESSION_ID_ENV).ok();
+    Ok(handle_with_input(&cwd, &input, current_session.as_deref()))
+}
+
+pub fn handle_with_input(
+    worktree: &Path,
+    input: &str,
+    current_session_id: Option<&str>,
+) -> HookOutput {
+    decide(
+        worktree,
+        input,
+        current_session_id,
+        SKILL_NAME,
+        SKILL_DISPLAY,
+    )
+}
+
+/// Shared decision logic between plan-spec and build-spec handlers.
+pub(crate) fn decide(
+    worktree: &Path,
+    input: &str,
+    current_session_id: Option<&str>,
+    skill_name: &str,
+    skill_display: &str,
+) -> HookOutput {
+    if stop_hook_active_from(input) {
+        return HookOutput::Silent;
+    }
+    let Ok(Some(state)) = skill_state::load(worktree, skill_name) else {
+        return HookOutput::Silent;
+    };
+    if !state.active {
+        return HookOutput::Silent;
+    }
+    if let Some(current) = current_session_id {
+        if current != state.session_id {
+            return HookOutput::Silent;
+        }
+    }
+
+    let phase_clause = state
+        .phase
+        .as_deref()
+        .map(|p| format!(" (phase: {p})"))
+        .unwrap_or_default();
+    let spec_clause = state
+        .owner_spec
+        .map(|n| format!("SPEC-{n}"))
+        .unwrap_or_else(|| "the current owner".to_string());
+    let short_name = short_verb_for(skill_name);
+
+    HookOutput::stop_block(format!(
+        "{skill} for {spec} is still active{phase}.\n\
+         Continue the {skill} workflow, or call `gwt {verb} complete --spec <n>` when the artifacts are ready, \
+         or `gwt {verb} abort --spec <n> --reason '<text>'` to abandon.",
+        skill = skill_display,
+        spec = spec_clause,
+        phase = phase_clause,
+        verb = short_name,
+    ))
+}
+
+fn short_verb_for(skill_name: &str) -> &'static str {
+    match skill_name {
+        "plan-spec" => "plan",
+        "build-spec" => "build",
+        _ => "<skill>",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use gwt_core::skill_state::{save, SkillState};
+
+    fn active_state(session: &str) -> SkillState {
+        SkillState {
+            active: true,
+            owner_spec: Some(1935),
+            started_at: Utc.with_ymd_and_hms(2026, 4, 21, 9, 0, 0).unwrap(),
+            phase: Some("plan-draft".to_string()),
+            session_id: session.to_string(),
+        }
+    }
+
+    fn assert_block_with(output: HookOutput, contains: &[&str]) {
+        match output {
+            HookOutput::StopBlock { reason } => {
+                for needle in contains {
+                    assert!(
+                        reason.contains(needle),
+                        "reason {reason:?} missing {needle:?}"
+                    );
+                }
+            }
+            other => panic!("expected StopBlock, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blocks_when_state_is_active_and_session_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1")).unwrap();
+        let output = handle_with_input(dir.path(), "{}", Some("sess-1"));
+        assert_block_with(
+            output,
+            &[
+                "gwt-plan-spec for SPEC-1935",
+                "phase: plan-draft",
+                "gwt plan complete",
+            ],
+        );
+    }
+
+    #[test]
+    fn silent_when_stop_hook_active_is_true() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1")).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), r#"{"stop_hook_active":true}"#, Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_state_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_state_is_inactive() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = active_state("sess-1");
+        state.active = false;
+        save(dir.path(), SKILL_NAME, &state).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_session_id_does_not_match() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-other")).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn blocks_when_current_session_is_unknown_and_state_is_active() {
+        // No GWT_SESSION_ID set: we trust that the state file was written
+        // for the current agent and still block to avoid missing work.
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1")).unwrap();
+        let output = handle_with_input(dir.path(), "{}", None);
+        assert!(matches!(output, HookOutput::StopBlock { .. }));
+    }
+
+    #[test]
+    fn silent_when_state_file_json_is_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = skill_state::state_path(dir.path(), SKILL_NAME);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{broken").unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+}

--- a/crates/gwt/src/cli/plan.rs
+++ b/crates/gwt/src/cli/plan.rs
@@ -1,0 +1,21 @@
+//! `gwt plan <start|phase|complete|abort> --spec <n> [...]`
+//!
+//! Exit CLI for the `gwt-plan-spec` skill (SPEC-1935 FR-014q). Writes
+//! `.gwt/skill-state/plan-spec.json` via [`gwt_core::skill_state`].
+
+use gwt_github::SpecOpsError;
+
+use super::skill_state_runtime;
+use crate::cli::{CliEnv, SkillStateAction};
+
+pub(crate) const SKILL_NAME: &str = "plan-spec";
+pub(crate) const SKILL_DISPLAY: &str = "gwt-plan-spec";
+pub(crate) const VERB: &str = "plan";
+
+pub(super) fn run<E: CliEnv>(
+    env: &mut E,
+    action: SkillStateAction,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    skill_state_runtime::run(env, action, SKILL_NAME, SKILL_DISPLAY, VERB, out)
+}

--- a/crates/gwt/src/cli/skill_state_runtime.rs
+++ b/crates/gwt/src/cli/skill_state_runtime.rs
@@ -1,0 +1,162 @@
+//! Shared `start|phase|complete|abort` implementation for the
+//! `gwt plan ...` and `gwt build ...` exit CLIs (SPEC-1935 FR-014q/r).
+//!
+//! Both CLIs persist a small JSON state file under
+//! `<worktree>/.gwt/skill-state/<skill>.json` via
+//! [`gwt_core::skill_state`]. The Stop-block handlers
+//! (`skill-plan-spec-stop-check` / `skill-build-spec-stop-check`) read
+//! that file to decide whether to continue the skill's turn.
+//!
+//! `start` is idempotent: calling it twice simply refreshes the
+//! `started_at` and `session_id` fields. `complete` and `abort` flip
+//! `active: false` without deleting the file so later inspection (and
+//! Codex smoke tests) can see the skill's final state.
+
+use chrono::Utc;
+use gwt_agent::GWT_SESSION_ID_ENV;
+use gwt_core::skill_state::{self, SkillState};
+use gwt_github::SpecOpsError;
+
+use super::{CliEnv, SkillStateAction};
+
+fn current_session_id() -> String {
+    std::env::var(GWT_SESSION_ID_ENV).unwrap_or_default()
+}
+
+pub(crate) fn run<E: CliEnv>(
+    env: &mut E,
+    action: SkillStateAction,
+    skill_name: &str,
+    skill_display: &str,
+    verb: &str,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    let worktree = env.repo_path().to_path_buf();
+    match action {
+        SkillStateAction::Start { spec } => {
+            let state = SkillState {
+                active: true,
+                owner_spec: Some(spec),
+                started_at: Utc::now(),
+                phase: None,
+                session_id: current_session_id(),
+            };
+            match skill_state::save(&worktree, skill_name, &state) {
+                Ok(()) => {
+                    out.push_str(&format!(
+                        "{verb}: started {skill_display} for SPEC-{spec}\n"
+                    ));
+                    Ok(0)
+                }
+                Err(err) => {
+                    out.push_str(&format!("{verb}: start failed: {err}\n"));
+                    Ok(1)
+                }
+            }
+        }
+        SkillStateAction::Phase { spec, label } => {
+            let current = match skill_state::load(&worktree, skill_name) {
+                Ok(Some(state)) => state,
+                Ok(None) => {
+                    out.push_str(&format!(
+                        "{verb}: no active {skill_display} state to update phase\n"
+                    ));
+                    return Ok(0);
+                }
+                Err(err) => {
+                    out.push_str(&format!("{verb}: load failed: {err}\n"));
+                    return Ok(1);
+                }
+            };
+            if current.owner_spec.is_some() && current.owner_spec != Some(spec) {
+                out.push_str(&format!(
+                    "{verb}: phase refused: state owns SPEC-{owner:?}, got --spec {spec}\n",
+                    owner = current.owner_spec
+                ));
+                return Ok(2);
+            }
+            let next = SkillState {
+                phase: Some(label.clone()),
+                ..current
+            };
+            match skill_state::save(&worktree, skill_name, &next) {
+                Ok(()) => {
+                    out.push_str(&format!("{verb}: {skill_display} phase -> {label}\n"));
+                    Ok(0)
+                }
+                Err(err) => {
+                    out.push_str(&format!("{verb}: phase failed: {err}\n"));
+                    Ok(1)
+                }
+            }
+        }
+        SkillStateAction::Complete { spec } => {
+            finalize(&worktree, skill_name, skill_display, verb, spec, None, out)
+        }
+        SkillStateAction::Abort { spec, reason } => finalize(
+            &worktree,
+            skill_name,
+            skill_display,
+            verb,
+            spec,
+            reason,
+            out,
+        ),
+    }
+}
+
+fn finalize(
+    worktree: &std::path::Path,
+    skill_name: &str,
+    skill_display: &str,
+    verb: &str,
+    spec: u64,
+    reason: Option<String>,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    let current = match skill_state::load(worktree, skill_name) {
+        Ok(Some(state)) => state,
+        Ok(None) => {
+            out.push_str(&format!(
+                "{verb}: no active {skill_display} state; nothing to finalize\n"
+            ));
+            return Ok(0);
+        }
+        Err(err) => {
+            out.push_str(&format!("{verb}: load failed: {err}\n"));
+            return Ok(1);
+        }
+    };
+    if current.owner_spec.is_some() && current.owner_spec != Some(spec) {
+        out.push_str(&format!(
+            "{verb}: finalize refused: state owns SPEC-{owner:?}, got --spec {spec}\n",
+            owner = current.owner_spec
+        ));
+        return Ok(2);
+    }
+    let next = SkillState {
+        active: false,
+        phase: reason
+            .as_ref()
+            .map(|r| format!("aborted: {r}"))
+            .or(current.phase.clone()),
+        ..current
+    };
+    match skill_state::save(worktree, skill_name, &next) {
+        Ok(()) => {
+            match reason {
+                Some(reason) => out.push_str(&format!(
+                    "{verb}: aborted {skill_display} for SPEC-{spec}: {reason}\n"
+                )),
+                None => out.push_str(&format!(
+                    "{verb}: completed {skill_display} for SPEC-{spec}\n"
+                )),
+            }
+            Ok(0)
+        }
+        Err(err) => {
+            out.push_str(&format!("{verb}: finalize failed: {err}\n"));
+            Ok(1)
+        }
+    }
+}

--- a/crates/gwt/src/discussion_resume.rs
+++ b/crates/gwt/src/discussion_resume.rs
@@ -56,6 +56,90 @@ pub fn park_pending_resume(worktree: &Path, pending: &PendingDiscussionResume) -
     Ok(true)
 }
 
+/// Set a proposal's status label (e.g. `[active]` → `[chosen]`) by its
+/// label (e.g. `Proposal A`). Returns `Ok(true)` when the proposal was
+/// found in an `[active]` state and rewritten; `Ok(false)` otherwise.
+///
+/// Used by the `gwt discuss resolve|park|reject` CLI to let the LLM
+/// explicitly exit the `gwt-discussion` skill so the Stop-block handler
+/// (SPEC-1935 FR-014p) stays silent.
+pub fn set_proposal_status_by_label(
+    worktree: &Path,
+    label: &str,
+    new_status: &str,
+) -> io::Result<bool> {
+    let discussion_path = worktree.join(DISCUSSION_RELATIVE_PATH);
+    if !discussion_path.exists() {
+        return Ok(false);
+    }
+    let content = std::fs::read_to_string(&discussion_path)?;
+    let proposals = parse_proposals(&content);
+    let Some(target) = proposals
+        .into_iter()
+        .find(|p| p.status == ProposalStatus::Active && p.label.eq_ignore_ascii_case(label))
+    else {
+        return Ok(false);
+    };
+
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+    if let Some(line) = lines.get_mut(target.header_line_index) {
+        *line = line.replacen("[active]", &format!("[{new_status}]"), 1);
+    }
+    let rewritten = lines.join("\n");
+    let final_content = if content.ends_with('\n') {
+        format!("{rewritten}\n")
+    } else {
+        rewritten
+    };
+    std::fs::write(discussion_path, final_content)?;
+    Ok(true)
+}
+
+/// Clear the `Next Question:` line of the named `[active]` proposal.
+/// Returns `Ok(true)` when the proposal was found and modified.
+pub fn clear_proposal_next_question(worktree: &Path, label: &str) -> io::Result<bool> {
+    let discussion_path = worktree.join(DISCUSSION_RELATIVE_PATH);
+    if !discussion_path.exists() {
+        return Ok(false);
+    }
+    let content = std::fs::read_to_string(&discussion_path)?;
+    let proposals = parse_proposals(&content);
+    let Some(target) = proposals
+        .into_iter()
+        .find(|p| p.status == ProposalStatus::Active && p.label.eq_ignore_ascii_case(label))
+    else {
+        return Ok(false);
+    };
+
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+    let start = target.header_line_index + 1;
+    let mut modified = false;
+    for line in lines.iter_mut().skip(start) {
+        if line.trim_start().starts_with("### Proposal ") {
+            break;
+        }
+        let leading_trim = line.trim_start();
+        if leading_trim.starts_with("- Next Question:") {
+            let indent_len = line.len() - leading_trim.len();
+            let indent: String = line.chars().take(indent_len).collect();
+            *line = format!("{indent}- Next Question:");
+            modified = true;
+            break;
+        }
+    }
+    if !modified {
+        return Ok(false);
+    }
+    let rewritten = lines.join("\n");
+    let final_content = if content.ends_with('\n') {
+        format!("{rewritten}\n")
+    } else {
+        rewritten
+    };
+    std::fs::write(discussion_path, final_content)?;
+    Ok(true)
+}
+
 pub fn build_resume_prompt(pending: &PendingDiscussionResume) -> String {
     let next_question = pending
         .next_question
@@ -70,7 +154,7 @@ pub fn build_resume_prompt(pending: &PendingDiscussionResume) -> String {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProposalStatus {
+pub(crate) enum ProposalStatus {
     Active,
     Parked,
     Rejected,
@@ -79,15 +163,15 @@ enum ProposalStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ParsedProposal {
-    header_line_index: usize,
-    label: String,
-    title: String,
-    status: ProposalStatus,
-    next_question: Option<String>,
+pub(crate) struct ParsedProposal {
+    pub(crate) header_line_index: usize,
+    pub(crate) label: String,
+    pub(crate) title: String,
+    pub(crate) status: ProposalStatus,
+    pub(crate) next_question: Option<String>,
 }
 
-fn parse_proposals(content: &str) -> Vec<ParsedProposal> {
+pub(crate) fn parse_proposals(content: &str) -> Vec<ParsedProposal> {
     let mut proposals: Vec<ParsedProposal> = Vec::new();
 
     for (index, raw_line) in content.lines().enumerate() {
@@ -275,6 +359,57 @@ mod tests {
             next_question: None,
         });
         assert!(!prompt_without_question.contains("Next question:"));
+    }
+
+    #[test]
+    fn set_proposal_status_updates_active_to_chosen() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(&discussion_path, sample_discussion()).unwrap();
+
+        let changed = set_proposal_status_by_label(dir.path(), "Proposal A", "chosen").unwrap();
+        assert!(changed);
+        let updated = std::fs::read_to_string(&discussion_path).unwrap();
+        assert!(updated.contains("### Proposal A - Hook-driven resume [chosen]"));
+        assert!(!updated.contains("### Proposal A - Hook-driven resume [active]"));
+        // Other proposals remain untouched
+        assert!(updated.contains("### Proposal B - Manual follow-up only [parked]"));
+    }
+
+    #[test]
+    fn set_proposal_status_returns_false_for_non_active_or_missing_label() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(&discussion_path, sample_discussion()).unwrap();
+
+        // Already parked
+        assert!(!set_proposal_status_by_label(dir.path(), "Proposal B", "chosen").unwrap());
+        // Unknown label
+        assert!(!set_proposal_status_by_label(dir.path(), "Proposal Z", "chosen").unwrap());
+    }
+
+    #[test]
+    fn set_proposal_status_returns_false_when_discussion_md_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!set_proposal_status_by_label(dir.path(), "Proposal A", "chosen").unwrap());
+    }
+
+    #[test]
+    fn clear_proposal_next_question_blanks_line_for_active_proposal() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(&discussion_path, sample_discussion()).unwrap();
+
+        let changed = clear_proposal_next_question(dir.path(), "Proposal A").unwrap();
+        assert!(changed);
+        let updated = std::fs::read_to_string(&discussion_path).unwrap();
+        assert!(updated.contains("- Next Question:\n"));
+        assert!(!updated.contains(
+            "- Next Question: Should SessionStart or UserPromptSubmit surface the resume proposal?"
+        ));
     }
 
     #[test]

--- a/crates/gwt/tests/skill_exit_cli_test.rs
+++ b/crates/gwt/tests/skill_exit_cli_test.rs
@@ -1,0 +1,220 @@
+//! Integration tests for the SPEC-1935 Phase 10 LLM-facing exit CLIs:
+//! `gwt discuss <action>`, `gwt plan <action>`, and `gwt build <action>`.
+//!
+//! These tests drive the real `dispatch` entry point over `TestEnv` so
+//! the end-to-end parse → run path stays covered. The underlying state
+//! file semantics are exhaustively tested at the unit level in
+//! `gwt_core::skill_state` and `crate::discussion_resume`.
+
+use gwt::cli::{dispatch, should_dispatch_cli, TestEnv};
+use gwt_core::skill_state::{self, SkillState};
+use tempfile::TempDir;
+
+fn argv(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|p| p.to_string()).collect()
+}
+
+fn new_env() -> (TestEnv, TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    (TestEnv::new(dir.path().to_path_buf()), dir)
+}
+
+#[test]
+fn should_dispatch_cli_recognises_the_three_new_verbs() {
+    assert!(should_dispatch_cli(&argv(&["gwt", "discuss", "resolve"])));
+    assert!(should_dispatch_cli(&argv(&["gwt", "plan", "start"])));
+    assert!(should_dispatch_cli(&argv(&["gwt", "build", "complete"])));
+}
+
+#[test]
+fn discuss_resolve_flips_active_proposal_to_chosen() {
+    let (mut env, dir) = new_env();
+    let discussion_path = dir.path().join(".gwt/discussion.md");
+    std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &discussion_path,
+        "### Proposal A - Hook-driven resume [active]\n\
+         - Next Question: Should we block on Stop?\n",
+    )
+    .unwrap();
+
+    let code = dispatch(
+        &mut env,
+        &argv(&["gwt", "discuss", "resolve", "--proposal", "Proposal A"]),
+    );
+    assert_eq!(code, 0);
+    let updated = std::fs::read_to_string(&discussion_path).unwrap();
+    assert!(updated.contains("[chosen]"));
+    assert!(!updated.contains("[active]"));
+}
+
+#[test]
+fn discuss_park_and_reject_follow_the_same_pattern() {
+    for (action, expected) in &[("park", "[parked]"), ("reject", "[rejected]")] {
+        let (mut env, dir) = new_env();
+        let path = dir.path().join(".gwt/discussion.md");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "### Proposal B - WIP [active]\n- Next Question: ???\n",
+        )
+        .unwrap();
+
+        let code = dispatch(
+            &mut env,
+            &argv(&["gwt", "discuss", action, "--proposal", "Proposal B"]),
+        );
+        assert_eq!(code, 0, "action={action} should exit 0");
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains(expected), "expected {expected} in {body}");
+    }
+}
+
+#[test]
+fn discuss_clear_next_question_empties_the_field() {
+    let (mut env, dir) = new_env();
+    let path = dir.path().join(".gwt/discussion.md");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        "### Proposal A - Hook-driven resume [active]\n\
+         - Next Question: Should SessionStart surface it?\n",
+    )
+    .unwrap();
+
+    let code = dispatch(
+        &mut env,
+        &argv(&[
+            "gwt",
+            "discuss",
+            "clear-next-question",
+            "--proposal",
+            "Proposal A",
+        ]),
+    );
+    assert_eq!(code, 0);
+    let body = std::fs::read_to_string(&path).unwrap();
+    assert!(body.contains("- Next Question:\n"));
+    assert!(!body.contains("Should SessionStart surface it?"));
+}
+
+#[test]
+fn plan_start_creates_active_state_file() {
+    let (mut env, dir) = new_env();
+    let code = dispatch(&mut env, &argv(&["gwt", "plan", "start", "--spec", "1935"]));
+    assert_eq!(code, 0);
+
+    let state = skill_state::load(dir.path(), "plan-spec")
+        .unwrap()
+        .expect("plan-spec state should exist");
+    assert!(state.active);
+    assert_eq!(state.owner_spec, Some(1935));
+}
+
+#[test]
+fn plan_complete_marks_state_inactive() {
+    let (mut env, dir) = new_env();
+    dispatch(&mut env, &argv(&["gwt", "plan", "start", "--spec", "1935"]));
+    let code = dispatch(
+        &mut env,
+        &argv(&["gwt", "plan", "complete", "--spec", "1935"]),
+    );
+    assert_eq!(code, 0);
+
+    let state: SkillState = skill_state::load(dir.path(), "plan-spec")
+        .unwrap()
+        .expect("plan-spec state should still exist");
+    assert!(!state.active);
+}
+
+#[test]
+fn plan_complete_with_mismatched_spec_is_rejected() {
+    let (mut env, dir) = new_env();
+    dispatch(&mut env, &argv(&["gwt", "plan", "start", "--spec", "1935"]));
+    let code = dispatch(
+        &mut env,
+        &argv(&["gwt", "plan", "complete", "--spec", "9999"]),
+    );
+    assert_eq!(code, 2, "mismatched SPEC must refuse to finalize");
+    let state: SkillState = skill_state::load(dir.path(), "plan-spec").unwrap().unwrap();
+    assert!(state.active, "state must remain active on rejection");
+}
+
+#[test]
+fn build_lifecycle_start_phase_complete_sequences_correctly() {
+    let (mut env, dir) = new_env();
+    assert_eq!(
+        dispatch(
+            &mut env,
+            &argv(&["gwt", "build", "start", "--spec", "1935"])
+        ),
+        0
+    );
+    assert_eq!(
+        dispatch(
+            &mut env,
+            &argv(&["gwt", "build", "phase", "--spec", "1935", "--label", "verify"])
+        ),
+        0
+    );
+    let state = skill_state::load(dir.path(), "build-spec")
+        .unwrap()
+        .unwrap();
+    assert!(state.active);
+    assert_eq!(state.phase.as_deref(), Some("verify"));
+
+    assert_eq!(
+        dispatch(
+            &mut env,
+            &argv(&["gwt", "build", "complete", "--spec", "1935"])
+        ),
+        0
+    );
+    let state = skill_state::load(dir.path(), "build-spec")
+        .unwrap()
+        .unwrap();
+    assert!(!state.active);
+}
+
+#[test]
+fn build_abort_records_reason_in_phase_field() {
+    let (mut env, dir) = new_env();
+    dispatch(
+        &mut env,
+        &argv(&["gwt", "build", "start", "--spec", "1935"]),
+    );
+    let code = dispatch(
+        &mut env,
+        &argv(&[
+            "gwt",
+            "build",
+            "abort",
+            "--spec",
+            "1935",
+            "--reason",
+            "needs clarification from product",
+        ]),
+    );
+    assert_eq!(code, 0);
+    let state = skill_state::load(dir.path(), "build-spec")
+        .unwrap()
+        .unwrap();
+    assert!(!state.active);
+    assert!(state
+        .phase
+        .as_deref()
+        .unwrap_or("")
+        .starts_with("aborted: "));
+}
+
+#[test]
+fn discuss_commands_exit_zero_when_discussion_md_absent() {
+    // Idempotent no-op: absent file is not an error; the handler just
+    // reports "no change".
+    let (mut env, _dir) = new_env();
+    let code = dispatch(
+        &mut env,
+        &argv(&["gwt", "discuss", "resolve", "--proposal", "Proposal X"]),
+    );
+    assert_eq!(code, 0);
+}


### PR DESCRIPTION
## Summary

SPEC-1935 Phase 10 (FR-014m〜FR-014u / US-6): マルチターン skill (`gwt-discussion` / `gwt-plan-spec` / `gwt-build-spec`) が未完了のまま Stop した場合に、Stop hook から `{"decision":"block","reason":"..."}` を返して LLM を自律継続させる仕組みを追加する。暴走ガードは Claude Code / Codex のビルトイン `stop_hook_active` フラグのみ。短期 skill (`gwt-register-issue` / `gwt-fix-issue` / `gwt-issue-search` / `gwt-search`) は対象外。

## 主な変更

**共通基盤**
- `HookOutput::StopBlock { reason }` envelope variant を `envelope.rs` に追加（FR-014m）
- `stop_hook_active_from(input)` util で built-in ループ防止フラグを尊重（FR-014o）
- `crates/gwt-core/src/skill_state.rs` を新設し `SkillState` / `load` / `save` / `mark_inactive` を実装（plan-spec / build-spec 共用）

**3 つの skill-*-stop-check handler（FR-014p/q/r）**
- `skill-discussion-stop-check` — 既存 `discussion_resume::load_pending_resume` を再利用し `.gwt/discussion.md` の `[active]` proposal と `Next Question` を判定
- `skill-plan-spec-stop-check` / `skill-build-spec-stop-check` — `.gwt/skill-state/<skill>.json` の `active` / `session_id` から判定。session_id mismatch で Silent（FR-014t）、parse 失敗で Silent（FR-014u）

**Managed Stop チェーン（FR-014n）**
- `crates/gwt-skills/src/settings_local.rs` の Stop チェーンに既存 `board-reminder Stop` の後段として 3 handler を追加
- ユーザー定義 Stop hook と共存（FR-012 / FR-014s）

**LLM 向け exit CLI（state 書き換え専用）**
- `gwt discuss resolve|park|reject|clear-next-question --proposal <label>`
- `gwt plan start|phase|complete|abort --spec <n>`
- `gwt build start|phase|complete|abort --spec <n>`

**SKILL.md 更新**
- `.claude/skills/gwt-{discussion,plan-spec,build-spec}/SKILL.md` / `.codex/skills/...`
- 各 skill に「Exit CLI (Stop-block contract)」セクションを追加し LLM 向け完了宣言契約を明記

## テストカバレッジ

- `envelope.rs`: 8 tests（StopBlock serialize + stop_hook_active_from）
- `gwt-core::skill_state`: 8 tests（load/save/mark_inactive ラウンドトリップ + fail-open）
- 3 skill-stop-check handler: 17 tests（ブロック条件 + fail-open + session 分離 + stop_hook_active 尊重）
- `settings_local.rs`: 3 新規 tests（Stop チェーン + 非 Stop 除外 + 短期 skill 除外）
- `discussion_resume.rs`: 4 新規 tests（label ベース status 書き換え + Next Question クリア）
- `skill_exit_cli_test.rs`: 10 integration tests（`gwt discuss|plan|build` 全アクション）

## Verification

- `cargo test -p gwt -p gwt-core`: pass
- `cargo test -p gwt-skills --lib`: 106/107 pass（1 pre-existing failure `gwt_arch_review_uses_scope_based_contract` は本 Phase 対象外、stash で検証済み）
- `cargo clippy --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: clean
- `npm run lint:skills`: 27 SKILL.md validated
- Manual smoke: `gwt hook skill-discussion-stop-check` / `skill-plan-spec-stop-check` で envelope 形状と `stop_hook_active:true` のフォールバック動作を確認

## Test plan

- [x] `cargo test -p gwt -p gwt-core` 通過
- [x] `cargo clippy -p gwt -p gwt-skills -p gwt-core --all-targets -- -D warnings` で 0 warnings
- [x] `cargo fmt --check` clean
- [x] `npm run lint:skills` 通過
- [x] Manual smoke で `{"decision":"block","reason":"..."}` envelope 確認
- [ ] E2E smoke: `/gwt:gwt-discussion` を実セッションで走らせた際の継続ループ動作（follow-up、T-245）
- [ ] Codex parity smoke: Codex ランタイムで `decision:block` が honor されるかの実機検証（follow-up、T-246）

## 関連

- Owner SPEC: #1935（US-6 / FR-014m〜FR-014u / SC-030〜SC-033 / Phase 10 T-215〜T-246 を同 SPEC に追記済）
- Pre-existing test failure (`gwt_arch_review_uses_scope_based_contract`) は本 PR の scope 外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
