### PR TITLE
fix(hooks): skill-discussion-stop-block の [active] 置換と label クォートを修正

### DIFF
--- a/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
@@ -48,7 +48,7 @@ pub fn handle_with_input(worktree: &Path, input: &str) -> HookOutput {
         "Discussion is still [active] on proposal \"{title}\".\n\
          Next question: {question}\n\
          Continue the gwt-discussion workflow (investigate → ask the user → update Discussion TODO), \
-         or call `gwt discuss resolve|park|reject --proposal {label}` to exit the discussion explicitly.",
+         or call `gwt discuss resolve|park|reject --proposal \"{label}\"` to exit the discussion explicitly.",
         title = pending.proposal_title,
         question = question,
         label = pending.proposal_label,
@@ -112,6 +112,28 @@ mod tests {
                 "Proposal A",
             ],
         );
+    }
+
+    #[test]
+    fn block_reason_quotes_proposal_label_for_shell_safety() {
+        // Regression: default labels like `Proposal A` contain spaces.
+        // The remediation command must quote the label so the LLM's
+        // tool call does not split on whitespace.
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ACTIVE_WITH_QUESTION);
+        match handle_with_input(dir.path(), "{}") {
+            HookOutput::StopBlock { reason } => {
+                assert!(
+                    reason.contains("--proposal \"Proposal A\""),
+                    "proposal label must be double-quoted in reason; got: {reason}"
+                );
+                assert!(
+                    !reason.contains("--proposal Proposal A"),
+                    "unquoted form would shell-split; got: {reason}"
+                );
+            }
+            other => panic!("expected StopBlock, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/gwt/src/discussion_resume.rs
+++ b/crates/gwt/src/discussion_resume.rs
@@ -83,7 +83,9 @@ pub fn set_proposal_status_by_label(
 
     let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
     if let Some(line) = lines.get_mut(target.header_line_index) {
-        *line = line.replacen("[active]", &format!("[{new_status}]"), 1);
+        if let Some(rewritten) = replace_trailing_status_tag(line, new_status) {
+            *line = rewritten;
+        }
     }
     let rewritten = lines.join("\n");
     let final_content = if content.ends_with('\n') {
@@ -93,6 +95,25 @@ pub fn set_proposal_status_by_label(
     };
     std::fs::write(discussion_path, final_content)?;
     Ok(true)
+}
+
+/// Rewrite only the terminal `[status]` tag on a `### Proposal ...` header
+/// line. Mirrors the `rsplit_once('[')` parse contract used by
+/// [`parse_proposals`] so titles that happen to contain a literal
+/// `"[active]"` substring do not fool the replacement.
+fn replace_trailing_status_tag(line: &str, new_status: &str) -> Option<String> {
+    // Find the rightmost `[` and its matching `]` on the same line,
+    // ignoring anything that appears before them (including a proposal
+    // title that spuriously contains `[active]`).
+    let trimmed_end = line.trim_end();
+    if !trimmed_end.ends_with(']') {
+        return None;
+    }
+    let last_open = trimmed_end.rfind('[')?;
+    let trailing_whitespace_len = line.len() - trimmed_end.len();
+    let prefix = &line[..last_open];
+    let trailing = &line[line.len() - trailing_whitespace_len..];
+    Some(format!("{prefix}[{new_status}]{trailing}"))
 }
 
 /// Clear the `Next Question:` line of the named `[active]` proposal.
@@ -375,6 +396,36 @@ mod tests {
         assert!(!updated.contains("### Proposal A - Hook-driven resume [active]"));
         // Other proposals remain untouched
         assert!(updated.contains("### Proposal B - Manual follow-up only [parked]"));
+    }
+
+    #[test]
+    fn set_proposal_status_rewrites_only_trailing_status_tag_even_with_active_in_title() {
+        // Regression: a proposal title that literally contains "[active]"
+        // must NOT trick the setter into replacing the substring inside
+        // the title. Only the terminal `[status]` tag should change.
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "### Proposal A - Toggle [active] state review [active]\n\
+             - Next Question: is this safe?\n",
+        )
+        .unwrap();
+
+        let changed = set_proposal_status_by_label(dir.path(), "Proposal A", "chosen").unwrap();
+        assert!(changed);
+        let updated = std::fs::read_to_string(&discussion_path).unwrap();
+        // Trailing tag flipped to [chosen]; the title substring untouched.
+        assert!(
+            updated.contains("### Proposal A - Toggle [active] state review [chosen]"),
+            "trailing tag must be rewritten, title substring preserved; got: {updated}"
+        );
+        // And no stray "[active] state review [active]" remains.
+        assert!(
+            !updated.contains("[active] state review [active]"),
+            "trailing [active] must be replaced: {updated}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #2134 (SPEC-1935 Phase 10) の post-merge review で Codex から指摘された 2 件の P2 バグを修正する follow-up。

## 修正内容

**1. `set_proposal_status_by_label` が行頭 `[active]` 部分文字列を置換する不具合**

- 場所: `crates/gwt/src/discussion_resume.rs`
- 従来: `line.replacen("[active]", ...)` が最初に見つかった `[active]` を置換するため、proposal title 内に `[active]` という literal 文字列が含まれると末尾の status tag が書き換わらず、 Stop-block が永久に発火する。
- 修正: `parse_proposals` が使う `rsplit_once('[')` と同じ契約に揃えて末尾 `[...]` タグだけを置換する `replace_trailing_status_tag` helper を導入。
- Regression test: `set_proposal_status_rewrites_only_trailing_status_tag_even_with_active_in_title` — タイトルに `[active]` を含む proposal で trailing tag のみが更新されることを assert。

**2. StopBlock reason の remediation command に proposal label のクォート漏れ**

- 場所: `crates/gwt/src/cli/hook/skill_discussion_stop_check.rs`
- 従来: `gwt discuss ... --proposal {label}` とクォートなしで提示していたため、デフォルトラベル `Proposal A` のように空白を含む label が LLM の tool call で分割されて `gwt discuss ... --proposal Proposal A` のうち `Proposal` のみが渡り silent no-op になる。
- 修正: format string を `--proposal "{label}"` に変更。
- Regression test: `block_reason_quotes_proposal_label_for_shell_safety` — reason に `--proposal "Proposal A"` が含まれ、unquoted 形式が含まれないことを assert。

## Verification

- `cargo test -p gwt -p gwt-core --tests`: 全 pass（新規 regression test 2 件含む）
- `cargo clippy -p gwt -p gwt-core --all-targets -- -D warnings`: 0 warnings
- `cargo fmt --check`: clean

## Test plan

- [x] 新しい regression test 2 件が pass
- [x] 既存 hook / envelope / skill_state テストが壊れない
- [x] `cargo clippy -D warnings` / `cargo fmt --check` clean

## 関連

- 原因となった変更: #2134 (SPEC-1935 Phase 10)
- Review threads: `PRRT_kwDOPLof2M58c_UR` (B1) / `PRRT_kwDOPLof2M58c_UU` (B2) — 本 PR マージ後に reply-and-resolve する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
