### PR TITLE
feat(ui): color agent surfaces by AgentColor (#2133)

### DIFF
--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -46,7 +46,7 @@ pub use store::{
     save_stored_custom_agents_to_path, StoredCustomAgent, DISABLE_GLOBAL_CUSTOM_AGENTS_ENV,
 };
 pub use types::{
-    AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget,
-    SessionMode, WorkflowBypass,
+    resolve_agent_id, AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent,
+    LaunchRuntimeTarget, SessionMode, WorkflowBypass,
 };
 pub use version_cache::{build_version_options, VersionCache, VersionOption};

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -70,6 +70,39 @@ impl std::fmt::Display for AgentId {
     }
 }
 
+/// Normalize a raw agent identifier string (command name, display name, or
+/// persisted `agent_id`) back into an [`AgentId`].
+///
+/// 既知のエージェントは表記揺れを吸収して確定する (`"claude"`,
+/// `"ClaudeCode"`, `"claude-code"` → `ClaudeCode`)。空文字または
+/// 空白のみの入力は `None`。それ以外の未知文字列は `Custom(trimmed)`。
+///
+/// SPEC #2133 FR-012 / gwt-core::BoardEntry::origin_agent_id の
+/// 正規化で使用される。
+pub fn resolve_agent_id(raw: &str) -> Option<AgentId> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.contains("claude") {
+        return Some(AgentId::ClaudeCode);
+    }
+    if lower.contains("codex") {
+        return Some(AgentId::Codex);
+    }
+    if lower.contains("gemini") {
+        return Some(AgentId::Gemini);
+    }
+    if lower.contains("opencode") || lower.contains("open-code") {
+        return Some(AgentId::OpenCode);
+    }
+    if lower == "gh" || lower.contains("copilot") {
+        return Some(AgentId::Copilot);
+    }
+    Some(AgentId::Custom(trimmed.to_string()))
+}
+
 /// Static information about an agent, combining identity with presentation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentInfo {
@@ -94,7 +127,13 @@ impl AgentInfo {
 }
 
 /// UI color for agent display.
+///
+/// Wire 表現は snake_case 小文字固定 (`"yellow"` / `"cyan"` など)。
+/// フロント側の CSS 変数名 (`--agent-*`) と 1 対 1 対応させ、色値の
+/// ハードコードを `crates/gwt/web/index.html` に持ち込まないための
+/// 制約。See SPEC #2133 FR-001 / FR-002.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AgentColor {
     Green,
     Blue,
@@ -217,6 +256,67 @@ mod tests {
     }
 
     #[test]
+    fn resolve_agent_id_maps_known_identifiers() {
+        let claude_inputs = ["claude", "ClaudeCode", "Claude Code", "claude-code"];
+        for raw in claude_inputs {
+            assert_eq!(resolve_agent_id(raw), Some(AgentId::ClaudeCode), "{raw}");
+        }
+        assert_eq!(resolve_agent_id("codex"), Some(AgentId::Codex));
+        assert_eq!(resolve_agent_id("Codex"), Some(AgentId::Codex));
+        assert_eq!(resolve_agent_id("gemini"), Some(AgentId::Gemini));
+        assert_eq!(resolve_agent_id("Gemini CLI"), Some(AgentId::Gemini));
+        assert_eq!(resolve_agent_id("opencode"), Some(AgentId::OpenCode));
+        assert_eq!(resolve_agent_id("OpenCode"), Some(AgentId::OpenCode));
+        assert_eq!(resolve_agent_id("open-code"), Some(AgentId::OpenCode));
+        assert_eq!(resolve_agent_id("gh"), Some(AgentId::Copilot));
+        assert_eq!(resolve_agent_id("copilot"), Some(AgentId::Copilot));
+        assert_eq!(resolve_agent_id("GitHub Copilot"), Some(AgentId::Copilot));
+    }
+
+    #[test]
+    fn resolve_agent_id_returns_none_for_empty() {
+        assert_eq!(resolve_agent_id(""), None);
+        assert_eq!(resolve_agent_id("   "), None);
+        assert_eq!(resolve_agent_id("\t\n"), None);
+    }
+
+    #[test]
+    fn resolve_agent_id_falls_back_to_custom() {
+        assert_eq!(
+            resolve_agent_id("my-aider"),
+            Some(AgentId::Custom("my-aider".into()))
+        );
+        assert_eq!(
+            resolve_agent_id("  aider  "),
+            Some(AgentId::Custom("aider".into())),
+            "trims whitespace"
+        );
+        assert_eq!(
+            resolve_agent_id("unknown-cli"),
+            Some(AgentId::Custom("unknown-cli".into()))
+        );
+    }
+
+    #[test]
+    fn resolve_agent_id_feeds_default_color() {
+        // FR-012 → resolve_agent_id → default_color 連携の確認
+        let cases = [
+            ("claude", AgentColor::Yellow),
+            ("codex", AgentColor::Cyan),
+            ("gemini", AgentColor::Magenta),
+            ("opencode", AgentColor::Green),
+            ("gh", AgentColor::Blue),
+            ("my-custom", AgentColor::Gray),
+        ];
+        for (raw, expected) in cases {
+            let color = resolve_agent_id(raw)
+                .map(|id| id.default_color())
+                .expect("non-empty input");
+            assert_eq!(color, expected, "{raw}");
+        }
+    }
+
+    #[test]
     fn agent_id_serde_roundtrip() {
         let ids = vec![
             AgentId::ClaudeCode,
@@ -236,6 +336,26 @@ mod tests {
         let json = serde_json::to_string(&color).unwrap();
         let parsed: AgentColor = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, color);
+    }
+
+    #[test]
+    fn agent_color_serializes_as_snake_case() {
+        // CSS variable names (--agent-claude など) と 1 対 1 対応させるため、
+        // wire 表現は snake_case 小文字固定。
+        let pairs = [
+            (AgentColor::Yellow, "\"yellow\""),
+            (AgentColor::Cyan, "\"cyan\""),
+            (AgentColor::Magenta, "\"magenta\""),
+            (AgentColor::Green, "\"green\""),
+            (AgentColor::Blue, "\"blue\""),
+            (AgentColor::Gray, "\"gray\""),
+        ];
+        for (color, expected) in pairs {
+            let json = serde_json::to_string(&color).unwrap();
+            assert_eq!(json, expected, "serialize form for {color:?}");
+            let parsed: AgentColor = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, color);
+        }
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -38,6 +38,12 @@ pub struct LaunchWizardOptionView {
     pub value: String,
     pub label: String,
     pub description: Option<String>,
+    /// Agent-specific color hint used by the frontend for candidate rows.
+    /// `agent_options` から派生した option のみが `Some` を持ち、branch
+    /// type や model など agent 非関連の他選択肢は常に `None`。
+    /// SPEC #2133 FR-009.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<gwt_agent::AgentColor>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -1142,6 +1148,7 @@ impl LaunchWizardState {
                 value: agent.id.clone(),
                 label: agent.name.clone(),
                 description: Some(agent_description(agent)),
+                color: agent_option_color(&agent.id),
             })
             .collect()
     }
@@ -1153,6 +1160,7 @@ impl LaunchWizardState {
                 value: option.label.to_string(),
                 label: option.label.to_string(),
                 description: Some(option.description.to_string()),
+                color: None,
             })
             .collect()
     }
@@ -1164,6 +1172,7 @@ impl LaunchWizardState {
                 value: option.stored_value.to_string(),
                 label: option.label.to_string(),
                 description: Some(option.description.to_string()),
+                color: None,
             })
             .collect()
     }
@@ -1175,6 +1184,7 @@ impl LaunchWizardState {
                 value: service.clone(),
                 label: service,
                 description: Some("Docker Compose service".to_string()),
+                color: None,
             })
             .collect()
     }
@@ -1186,6 +1196,7 @@ impl LaunchWizardState {
                 value: docker_lifecycle_value(option.intent).to_string(),
                 label: option.label.to_string(),
                 description: Some(option.description.to_string()),
+                color: None,
             })
             .collect()
     }
@@ -1197,6 +1208,7 @@ impl LaunchWizardState {
                 value: option.value,
                 label: option.label,
                 description: Some("Tool version".to_string()),
+                color: None,
             })
             .collect()
     }
@@ -1621,12 +1633,14 @@ impl LaunchWizardState {
                             value: format!("reuse:{index}"),
                             label: format!("{reuse_action_label} {}", entry.tool_label),
                             description: Some(summary.clone()),
+                            color: None,
                         });
                     }
                     options.push(LaunchWizardOptionView {
                         value: format!("start_new:{index}"),
                         label: format!("Start new with {}", entry.tool_label),
                         description: Some(summary),
+                        color: None,
                     });
                 }
                 if !self.context.live_sessions.is_empty() {
@@ -1634,12 +1648,14 @@ impl LaunchWizardState {
                         value: "focus_existing".to_string(),
                         label: "Focus existing session".to_string(),
                         description: Some("Jump to a running window on this branch".to_string()),
+                        color: None,
                     });
                 }
                 options.push(LaunchWizardOptionView {
                     value: "choose_different".to_string(),
                     label: "Choose different".to_string(),
                     description: Some("Open the full launch wizard".to_string()),
+                    color: None,
                 });
                 options
             }
@@ -1651,6 +1667,7 @@ impl LaunchWizardState {
                     value: entry.window_id.clone(),
                     label: entry.name.clone(),
                     description: entry.detail.clone(),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::BranchAction => vec![
@@ -1658,6 +1675,7 @@ impl LaunchWizardState {
                     value: "use_selected".to_string(),
                     label: "Use selected branch".to_string(),
                     description: Some("Launch on the selected branch".to_string()),
+                    color: None,
                 },
                 LaunchWizardOptionView {
                     value: "create_new".to_string(),
@@ -1665,6 +1683,7 @@ impl LaunchWizardState {
                     description: Some(
                         "Create a new branch based on the selected branch".to_string(),
                     ),
+                    color: None,
                 },
             ],
             LaunchWizardStep::BranchTypeSelect => BRANCH_TYPE_PREFIXES
@@ -1676,6 +1695,7 @@ impl LaunchWizardState {
                         "Use {} as the branch prefix",
                         prefix.trim_end_matches('/')
                     )),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::LaunchTarget => launch_target_options_view(),
@@ -1686,6 +1706,7 @@ impl LaunchWizardState {
                     value: agent.id.clone(),
                     label: agent.name.clone(),
                     description: Some(agent_description(agent)),
+                    color: agent_option_color(&agent.id),
                 })
                 .collect(),
             LaunchWizardStep::ModelSelect => model_display_options(self.effective_agent_id())
@@ -1694,6 +1715,7 @@ impl LaunchWizardState {
                     value: option.label.to_string(),
                     label: option.label.to_string(),
                     description: Some(option.description.to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::ReasoningLevel => self
@@ -1703,6 +1725,7 @@ impl LaunchWizardState {
                     value: option.stored_value.to_string(),
                     label: option.label.to_string(),
                     description: Some(option.description.to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::RuntimeTarget => RUNTIME_TARGET_OPTIONS
@@ -1711,6 +1734,7 @@ impl LaunchWizardState {
                     value: option.label.to_ascii_lowercase(),
                     label: option.label.to_string(),
                     description: Some(option.description.to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::DockerServiceSelect => self
@@ -1720,6 +1744,7 @@ impl LaunchWizardState {
                     value: service.clone(),
                     label: service,
                     description: Some("Docker Compose service".to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::DockerLifecycle => self
@@ -1729,6 +1754,7 @@ impl LaunchWizardState {
                     value: docker_lifecycle_value(option.intent).to_string(),
                     label: option.label.to_string(),
                     description: Some(option.description.to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::VersionSelect => self
@@ -1738,6 +1764,7 @@ impl LaunchWizardState {
                     value: option.value,
                     label: option.label,
                     description: Some("Tool version".to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::ExecutionMode => EXECUTION_MODE_OPTIONS
@@ -1746,6 +1773,7 @@ impl LaunchWizardState {
                     value: option.value.to_string(),
                     label: option.label.to_string(),
                     description: Some(option.description.to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::SkipPermissions => YES_NO_OPTIONS
@@ -1754,6 +1782,7 @@ impl LaunchWizardState {
                     value: option.label.to_ascii_lowercase(),
                     label: option.label.to_string(),
                     description: Some(option.description.to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::CodexFastMode => FAST_MODE_OPTIONS
@@ -1762,6 +1791,7 @@ impl LaunchWizardState {
                     value: option.label.to_ascii_lowercase(),
                     label: option.label.to_string(),
                     description: Some(option.description.to_string()),
+                    color: None,
                 })
                 .collect(),
             LaunchWizardStep::BranchNameInput => Vec::new(),
@@ -2355,6 +2385,7 @@ fn branch_type_options_view() -> Vec<LaunchWizardOptionView> {
                 "Use {} as the branch prefix",
                 prefix.trim_end_matches('/')
             )),
+            color: None,
         })
         .collect()
 }
@@ -2365,11 +2396,13 @@ fn launch_target_options_view() -> Vec<LaunchWizardOptionView> {
             value: "agent".to_string(),
             label: "Agent".to_string(),
             description: Some("Launch a coding agent terminal".to_string()),
+            color: None,
         },
         LaunchWizardOptionView {
             value: "shell".to_string(),
             label: "Shell".to_string(),
             description: Some("Open a plain shell terminal".to_string()),
+            color: None,
         },
     ]
 }
@@ -2381,6 +2414,7 @@ fn runtime_target_options_view() -> Vec<LaunchWizardOptionView> {
             value: option.label.to_ascii_lowercase(),
             label: option.label.to_string(),
             description: Some(option.description.to_string()),
+            color: None,
         })
         .collect()
 }
@@ -2392,6 +2426,7 @@ fn execution_mode_options_view() -> Vec<LaunchWizardOptionView> {
             value: option.value.to_string(),
             label: option.label.to_string(),
             description: Some(option.description.to_string()),
+            color: None,
         })
         .collect()
 }
@@ -2464,6 +2499,13 @@ fn agent_description(agent: &AgentOption) -> String {
     }
 }
 
+/// Map the raw agent option id (command name or custom agent id) to the
+/// AgentColor rendered on the Launch Wizard candidate row.
+/// SPEC #2133 FR-009 / シナリオ 2.
+fn agent_option_color(agent_id: &str) -> Option<gwt_agent::AgentColor> {
+    gwt_agent::resolve_agent_id(agent_id).map(|id| id.default_color())
+}
+
 pub fn default_wizard_version_cache_path() -> PathBuf {
     gwt_core::paths::gwt_cache_dir().join("agent-versions.json")
 }
@@ -2523,6 +2565,32 @@ mod tests {
                 versions: vec!["0.109.0".to_string(), "0.110.0".to_string()],
             },
         ]
+    }
+
+    #[test]
+    fn agent_option_color_maps_known_ids_and_falls_back_to_gray() {
+        assert_eq!(
+            agent_option_color("claude"),
+            Some(gwt_agent::AgentColor::Yellow)
+        );
+        assert_eq!(
+            agent_option_color("codex"),
+            Some(gwt_agent::AgentColor::Cyan)
+        );
+        assert_eq!(
+            agent_option_color("gemini"),
+            Some(gwt_agent::AgentColor::Magenta)
+        );
+        assert_eq!(
+            agent_option_color("opencode"),
+            Some(gwt_agent::AgentColor::Green)
+        );
+        assert_eq!(agent_option_color("gh"), Some(gwt_agent::AgentColor::Blue));
+        assert_eq!(
+            agent_option_color("my-custom"),
+            Some(gwt_agent::AgentColor::Gray)
+        );
+        assert_eq!(agent_option_color(""), None);
     }
 
     fn branch(name: &str) -> BranchListEntry {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -74,8 +74,8 @@ pub use profiles_service::{
     ProfileView,
 };
 pub use protocol::{
-    AppStateView, ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode,
-    FocusCycleDirection, FrontendEvent, ProfileErrorCode, ProjectTabView, RecentProjectView,
-    WorkspaceView,
+    AppStateView, ArrangeMode, BackendEvent, BoardEntryView, BranchEntriesPhase,
+    CustomAgentErrorCode, FocusCycleDirection, FrontendEvent, ProfileErrorCode, ProjectTabView,
+    RecentProjectView, WorkspaceView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -551,6 +551,7 @@ impl AppRuntime {
                 )]
             }
             FrontendEvent::LoadBranches { id } => self.load_branches_events(&client_id, &id),
+            FrontendEvent::LoadBoard { id } => self.load_board_events(&client_id, &id),
             FrontendEvent::LoadKnowledgeBridge {
                 id,
                 knowledge_kind,
@@ -1219,6 +1220,55 @@ impl AppRuntime {
         Vec::new()
     }
 
+    /// SPEC #2133 FR-006 / シナリオ 3: Board preset の window から
+    /// ロード要求を受けたら `BoardEntry` 一覧をまとめてフロントへ送る。
+    /// 進行中 Board UI 本格実装は別 SPEC。ここでは最低限のスナップ
+    /// ショットだけ送信する。
+    fn load_board_events(&self, client_id: &str, id: &str) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        match gwt_core::coordination::load_snapshot(&tab.project_root) {
+            Ok(snapshot) => {
+                let entries = snapshot
+                    .board
+                    .entries
+                    .iter()
+                    .map(board_entry_view_from)
+                    .collect();
+                vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BoardSnapshot {
+                        id: id.to_string(),
+                        entries,
+                    },
+                )]
+            }
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: error.to_string(),
+                },
+            )],
+        }
+    }
+
     fn load_knowledge_bridge_events(
         &self,
         client_id: &str,
@@ -1549,6 +1599,13 @@ impl AppRuntime {
                     })];
                 };
                 let geometry = window.geometry.clone();
+                // SPEC #2133: launch 成功時に agent_id を persistence に書き込み、
+                // 以降のスナップショットで agent_color が正しく解決されるようにする。
+                if let Some(tab_mut) = self.tab_mut(&address.tab_id) {
+                    tab_mut
+                        .workspace
+                        .set_agent_id(&address.raw_id, agent_id.command().to_string());
+                }
 
                 match self.spawn_process_window(&window_id, geometry, process_launch) {
                     Ok(event) => {
@@ -2391,9 +2448,48 @@ fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
             .cloned()
             .map(|mut window| {
                 window.id = combined_window_id(&tab.id, &window.id);
+                window.agent_color = resolve_window_agent_color(&window);
                 window
             })
             .collect(),
+    }
+}
+
+/// Compute the wire-only `agent_color` for a window snapshot.
+///
+/// SPEC #2133: agent_id が明示的に設定されていればそれを優先
+/// (resolve_agent_id → default_color)。未設定なら preset の固定
+/// マッピングにフォールバック。どちらでも None なら色無し。
+fn resolve_window_agent_color(window: &gwt::PersistedWindowState) -> Option<gwt_agent::AgentColor> {
+    let by_agent_id = window
+        .agent_id
+        .as_deref()
+        .and_then(gwt_agent::resolve_agent_id);
+    let agent_id = by_agent_id.or_else(|| window.preset.resolved_agent_id());
+    agent_id.map(|id| id.default_color())
+}
+
+/// Project a [`gwt_core::coordination::BoardEntry`] into the wire
+/// [`gwt::BoardEntryView`]. `origin_agent_id` を `gwt_agent::resolve_agent_id`
+/// で正規化し、`default_color()` で `agent_color` を補完する
+/// (SPEC #2133 FR-006 / FR-012)。
+fn board_entry_view_from(entry: &gwt_core::coordination::BoardEntry) -> gwt::BoardEntryView {
+    let agent_color = entry
+        .origin_agent_id
+        .as_deref()
+        .and_then(gwt_agent::resolve_agent_id)
+        .map(|id| id.default_color());
+    gwt::BoardEntryView {
+        id: entry.id.clone(),
+        author_kind: entry.author_kind.clone(),
+        author: entry.author.clone(),
+        kind: entry.kind.clone(),
+        body: entry.body.clone(),
+        created_at: entry.created_at,
+        updated_at: entry.updated_at,
+        origin_branch: entry.origin_branch.clone(),
+        origin_agent_id: entry.origin_agent_id.clone(),
+        agent_color,
     }
 }
 
@@ -2457,14 +2553,14 @@ mod tests {
 
     use super::{
         app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
-        broadcast_runtime_hook_event, build_frontend_sync_events, build_shell_process_launch,
-        close_window_from_workspace, combined_window_id, current_git_branch,
-        hook_forward_authorized, knowledge_kind_for_preset,
+        board_entry_view_from, broadcast_runtime_hook_event, build_frontend_sync_events,
+        build_shell_process_launch, close_window_from_workspace, combined_window_id,
+        current_git_branch, hook_forward_authorized, knowledge_kind_for_preset,
         record_issue_branch_link_with_cache_dir, resolve_project_target,
-        should_auto_close_agent_window, should_auto_start_restored_window, ActiveAgentSession,
-        AgentLaunchReady, AppEventProxy, AppRuntime, BlockingTaskSpawner, ClientHub,
-        DispatchTarget, LaunchWizardSession, OutboundEvent, ProcessLaunch, ProjectTabRuntime,
-        UserEvent, WindowAddress,
+        resolve_window_agent_color, should_auto_close_agent_window,
+        should_auto_start_restored_window, ActiveAgentSession, AgentLaunchReady, AppEventProxy,
+        AppRuntime, BlockingTaskSpawner, ClientHub, DispatchTarget, LaunchWizardSession,
+        OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent, WindowAddress,
     };
 
     fn canvas_bounds() -> WindowGeometry {
@@ -2583,6 +2679,8 @@ mod tests {
             maximized: false,
             pre_maximize_geometry: None,
             persist: true,
+            agent_id: None,
+            agent_color: None,
         }
     }
 
@@ -2752,6 +2850,84 @@ mod tests {
             WindowPreset::Branches,
             WindowProcessStatus::Ready,
         )));
+    }
+
+    #[test]
+    fn resolve_window_agent_color_prefers_explicit_agent_id() {
+        let mut window = sample_window(WindowPreset::Agent, WindowProcessStatus::Running);
+        window.agent_id = Some("gemini".into());
+        assert_eq!(
+            resolve_window_agent_color(&window),
+            Some(gwt_agent::AgentColor::Magenta),
+        );
+    }
+
+    #[test]
+    fn resolve_window_agent_color_falls_back_to_preset() {
+        let mut window = sample_window(WindowPreset::Claude, WindowProcessStatus::Running);
+        window.agent_id = None;
+        assert_eq!(
+            resolve_window_agent_color(&window),
+            Some(gwt_agent::AgentColor::Yellow),
+        );
+        let codex = sample_window(WindowPreset::Codex, WindowProcessStatus::Running);
+        assert_eq!(
+            resolve_window_agent_color(&codex),
+            Some(gwt_agent::AgentColor::Cyan),
+        );
+    }
+
+    #[test]
+    fn resolve_window_agent_color_returns_none_for_agent_preset_without_id() {
+        let window = sample_window(WindowPreset::Agent, WindowProcessStatus::Running);
+        assert_eq!(resolve_window_agent_color(&window), None);
+    }
+
+    #[test]
+    fn resolve_window_agent_color_handles_custom_agent_as_gray() {
+        let mut window = sample_window(WindowPreset::Agent, WindowProcessStatus::Running);
+        window.agent_id = Some("my-custom-agent".into());
+        assert_eq!(
+            resolve_window_agent_color(&window),
+            Some(gwt_agent::AgentColor::Gray),
+        );
+    }
+
+    #[test]
+    fn board_entry_view_resolves_origin_agent_id_to_color() {
+        use gwt_core::coordination::{AuthorKind, BoardEntry, BoardEntryKind};
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "Started task",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_origin_agent_id("codex");
+        let view = board_entry_view_from(&entry);
+        assert_eq!(view.agent_color, Some(gwt_agent::AgentColor::Cyan));
+        assert_eq!(view.origin_agent_id.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn board_entry_view_returns_none_color_for_missing_origin_agent_id() {
+        use gwt_core::coordination::{AuthorKind, BoardEntry, BoardEntryKind};
+        let entry = BoardEntry::new(
+            AuthorKind::User,
+            "akio",
+            BoardEntryKind::Request,
+            "Please look into X",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        let view = board_entry_view_from(&entry);
+        assert_eq!(view.agent_color, None);
+        assert_eq!(view.origin_agent_id, None);
     }
 
     fn sample_project_tab_with_window(

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use gwt_agent::AgentColor;
 use serde::{Deserialize, Serialize};
 
 use crate::preset::WindowPreset;
@@ -53,6 +54,17 @@ pub struct PersistedWindowState {
     pub pre_maximize_geometry: Option<WindowGeometry>,
     #[serde(default = "default_persist_window")]
     pub persist: bool,
+    /// Identifier of the agent occupying this window. Persisted across
+    /// restarts so SPEC #2133 の色付けが復元される。`preset.Agent` の
+    /// window では launch wizard 起動時に設定される。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// Wire-only color hint sent to the WebView. 送信直前に backend が
+    /// [`agent_id`] (または `preset` のフォールバック) から計算する。
+    /// disk には書かない (`skip_deserializing` + skip_serializing_if で
+    /// 読み書き両方向に漏らさない)。SPEC #2133 FR-008.
+    #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
+    pub agent_color: Option<AgentColor>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -141,6 +153,8 @@ pub fn default_workspace_state() -> PersistedWorkspaceState {
                 maximized: false,
                 pre_maximize_geometry: None,
                 persist: true,
+                agent_id: None,
+                agent_color: None,
             },
             PersistedWindowState {
                 id: "codex-1".to_string(),
@@ -158,6 +172,8 @@ pub fn default_workspace_state() -> PersistedWorkspaceState {
                 maximized: false,
                 pre_maximize_geometry: None,
                 persist: true,
+                agent_id: None,
+                agent_color: None,
             },
         ],
         next_z_index: 3,
@@ -446,6 +462,8 @@ mod tests {
                         height: 480.0,
                     }),
                     persist: true,
+                    agent_id: None,
+                    agent_color: None,
                 },
                 PersistedWindowState {
                     id: "branches-1".to_string(),
@@ -463,6 +481,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    agent_id: None,
+                    agent_color: None,
                 },
             ],
             next_z_index: 6,
@@ -502,6 +522,81 @@ mod tests {
         assert!(!loaded.windows[0].minimized);
         assert!(!loaded.windows[0].maximized);
         assert!(loaded.windows[0].pre_maximize_geometry.is_none());
+        // SPEC #2133: legacy window payloads predate agent_id / agent_color.
+        // serde `default` は無い値を None に初期化する。
+        assert!(loaded.windows[0].agent_id.is_none());
+        assert!(loaded.windows[0].agent_color.is_none());
+    }
+
+    #[test]
+    fn persisted_window_state_accepts_new_agent_id_field() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("workspace.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "windows": [
+    {
+      "id": "claude-1",
+      "title": "Claude",
+      "preset": "claude",
+      "geometry": { "x": 0.0, "y": 0.0, "width": 640.0, "height": 420.0 },
+      "z_index": 1,
+      "status": "ready",
+      "persist": true,
+      "agent_id": "claude"
+    }
+  ],
+  "next_z_index": 2
+}"#,
+        )
+        .expect("write new-format workspace");
+
+        let loaded = load_workspace_state(&path).expect("load");
+        assert_eq!(loaded.windows[0].agent_id.as_deref(), Some("claude"));
+        // agent_color は wire 専用なので disk 読み込みでは常に None
+        assert!(loaded.windows[0].agent_color.is_none());
+    }
+
+    #[test]
+    fn persisted_window_state_serializes_agent_color_without_persisting() {
+        // wire serialize では agent_color を含むが、deserialize は無視する。
+        // disk 読み書きの round-trip では agent_color 情報が落ちることを確認。
+        let original = PersistedWindowState {
+            id: "w-1".into(),
+            title: "Claude".into(),
+            preset: WindowPreset::Claude,
+            geometry: WindowGeometry {
+                x: 0.0,
+                y: 0.0,
+                width: 320.0,
+                height: 200.0,
+            },
+            z_index: 1,
+            status: WindowProcessStatus::Running,
+            minimized: false,
+            maximized: false,
+            pre_maximize_geometry: None,
+            persist: true,
+            agent_id: Some("claude".into()),
+            agent_color: Some(AgentColor::Yellow),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        assert!(
+            json.contains("\"agent_id\":\"claude\""),
+            "agent_id should be serialized: {json}"
+        );
+        assert!(
+            json.contains("\"agent_color\":\"yellow\""),
+            "agent_color should be serialized as snake_case: {json}"
+        );
+
+        let parsed: PersistedWindowState = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed.agent_id.as_deref(), Some("claude"));
+        assert!(
+            parsed.agent_color.is_none(),
+            "agent_color must be wire-only: skip_deserializing drops it"
+        );
     }
 
     #[test]
@@ -536,6 +631,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    agent_id: None,
+                    agent_color: None,
                 },
                 PersistedWindowState {
                     id: "file-tree-1".to_string(),
@@ -553,6 +650,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    agent_id: None,
+                    agent_color: None,
                 },
             ],
             next_z_index: 3,
@@ -746,6 +845,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    agent_id: None,
+                    agent_color: None,
                 },
                 PersistedWindowState {
                     id: "branches-1".to_string(),
@@ -763,6 +864,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    agent_id: None,
+                    agent_color: None,
                 },
             ],
             next_z_index: 3,

--- a/crates/gwt/src/preset.rs
+++ b/crates/gwt/src/preset.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use gwt_agent::AgentId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -141,6 +142,31 @@ impl WindowPreset {
             Self::Codex => Some("codex"),
             Self::Agent => None,
             Self::FileTree
+            | Self::Branches
+            | Self::Settings
+            | Self::Memo
+            | Self::Profile
+            | Self::Logs
+            | Self::Issue
+            | Self::Spec
+            | Self::Board
+            | Self::Pr => None,
+        }
+    }
+
+    /// Fixed mapping from preset to [`AgentId`] for presets that always
+    /// represent a specific agent. `Claude` / `Codex` are固定; `Agent`
+    /// is wizard-driven and has no deterministic mapping (返り値は None)。
+    ///
+    /// SPEC #2133 FR-011: `agent_id` 未設定の window でも
+    /// preset から色のフォールバックを得るため使用する。
+    pub fn resolved_agent_id(self) -> Option<AgentId> {
+        match self {
+            Self::Claude => Some(AgentId::ClaudeCode),
+            Self::Codex => Some(AgentId::Codex),
+            Self::Shell
+            | Self::Agent
+            | Self::FileTree
             | Self::Branches
             | Self::Settings
             | Self::Memo
@@ -309,6 +335,39 @@ mod tests {
     fn settings_preset_is_mock_surface() {
         assert_eq!(WindowPreset::Settings.surface(), WindowSurface::Mock);
         assert!(!WindowPreset::Settings.requires_process());
+    }
+
+    #[test]
+    fn resolved_agent_id_is_fixed_for_claude_and_codex_only() {
+        assert_eq!(
+            WindowPreset::Claude.resolved_agent_id(),
+            Some(AgentId::ClaudeCode)
+        );
+        assert_eq!(
+            WindowPreset::Codex.resolved_agent_id(),
+            Some(AgentId::Codex)
+        );
+        // 他 preset はすべて None
+        for preset in [
+            WindowPreset::Shell,
+            WindowPreset::Agent,
+            WindowPreset::FileTree,
+            WindowPreset::Branches,
+            WindowPreset::Settings,
+            WindowPreset::Memo,
+            WindowPreset::Profile,
+            WindowPreset::Logs,
+            WindowPreset::Issue,
+            WindowPreset::Spec,
+            WindowPreset::Board,
+            WindowPreset::Pr,
+        ] {
+            assert_eq!(
+                preset.resolved_agent_id(),
+                None,
+                "{preset:?} should not resolve to an AgentId"
+            );
+        }
     }
 
     #[test]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1,4 +1,6 @@
-use gwt_agent::{CustomCodingAgent, PresetDefinition, PresetId};
+use chrono::{DateTime, Utc};
+use gwt_agent::{AgentColor, CustomCodingAgent, PresetDefinition, PresetId};
+use gwt_core::coordination::{AuthorKind, BoardEntryKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -99,6 +101,9 @@ pub enum FrontendEvent {
         path: Option<String>,
     },
     LoadBranches {
+        id: String,
+    },
+    LoadBoard {
         id: String,
     },
     LoadKnowledgeBridge {
@@ -229,6 +234,28 @@ pub struct WorkspaceView {
     pub windows: Vec<PersistedWindowState>,
 }
 
+/// Frontend-facing projection of a [`gwt_core::coordination::BoardEntry`].
+///
+/// 付加した `agent_color` は wire-only。`origin_agent_id` を既知の
+/// [`gwt_agent::AgentId`] に正規化し、`default_color()` をここで
+/// 計算してフロントに渡す (SPEC #2133 FR-006 / FR-012)。
+#[derive(Debug, Clone, Serialize)]
+pub struct BoardEntryView {
+    pub id: String,
+    pub author_kind: AuthorKind,
+    pub author: String,
+    pub kind: BoardEntryKind,
+    pub body: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin_agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_color: Option<AgentColor>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectTabView {
     pub id: String,
@@ -308,6 +335,14 @@ pub enum BackendEvent {
         results: Vec<BranchCleanupResultEntry>,
     },
     BranchError {
+        id: String,
+        message: String,
+    },
+    BoardSnapshot {
+        id: String,
+        entries: Vec<BoardEntryView>,
+    },
+    BoardError {
         id: String,
         message: String,
     },

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -52,6 +52,21 @@ impl WorkspaceState {
         true
     }
 
+    /// Record the AgentId command name on the given window so later snapshots
+    /// can populate `agent_color` correctly. SPEC #2133 FR-007 / シナリオ 1.
+    pub fn set_agent_id(&mut self, id: &str, agent_id: impl Into<String>) -> bool {
+        let Some(window) = self
+            .persisted
+            .windows
+            .iter_mut()
+            .find(|window| window.id == id)
+        else {
+            return false;
+        };
+        window.agent_id = Some(agent_id.into());
+        true
+    }
+
     pub fn update_viewport(&mut self, viewport: CanvasViewport) {
         self.persisted.viewport = viewport;
     }
@@ -167,6 +182,8 @@ impl WorkspaceState {
             maximized: false,
             pre_maximize_geometry: None,
             persist,
+            agent_id: None,
+            agent_color: None,
         };
         self.persisted.next_z_index += 1;
         self.persisted.windows.push(window.clone());
@@ -449,6 +466,8 @@ mod tests {
                 maximized: false,
                 pre_maximize_geometry: None,
                 persist: false,
+                agent_id: None,
+                agent_color: None,
             }],
             next_z_index: 2,
         });

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -14,6 +14,110 @@
         font-family:
           Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
           "Segoe UI", sans-serif;
+
+        /* SPEC #2133 FR-002: per-agent color palette.
+           色値の正本は Rust (crates/gwt-agent/src/types.rs の AgentColor /
+           AgentId::default_color) で、ここはフロント側の表示チャネル。 */
+        --agent-claude: #f59e0b;   /* ClaudeCode → Yellow */
+        --agent-codex: #06b6d4;    /* Codex → Cyan */
+        --agent-gemini: #c026d3;   /* Gemini → Magenta */
+        --agent-opencode: #16a34a; /* OpenCode → Green */
+        --agent-copilot: #2563eb;  /* Copilot → Blue */
+        --agent-custom: #9ca3af;   /* Custom → Gray */
+      }
+
+      /* Wire `agent_color` 値 (snake_case 小文字の AgentColor) を agent
+         slot に紐付け、`--current-agent` を解決する。該当する
+         data-agent-color を持つ要素とその子孫でドット / アクセント
+         バーが表示される。 */
+      [data-agent-color="yellow"]  { --current-agent: var(--agent-claude); }
+      [data-agent-color="cyan"]    { --current-agent: var(--agent-codex); }
+      [data-agent-color="magenta"] { --current-agent: var(--agent-gemini); }
+      [data-agent-color="green"]   { --current-agent: var(--agent-opencode); }
+      [data-agent-color="blue"]    { --current-agent: var(--agent-copilot); }
+      [data-agent-color="gray"]    { --current-agent: var(--agent-custom); }
+
+      /* FR-003: Workspace window titlebar の左端アクセントバー。
+         data-agent-color が無い window には ::before が出ない。 */
+      .workspace-window[data-agent-color]::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 4px;
+        background: var(--current-agent);
+        z-index: 2;
+        pointer-events: none;
+      }
+
+      /* FR-004: Window List Panel 行左端 */
+      .window-list-row[data-agent-color]::before {
+        content: "";
+        position: absolute;
+        top: 6px;
+        bottom: 6px;
+        left: 0;
+        width: 3px;
+        background: var(--current-agent);
+        border-radius: 0 2px 2px 0;
+      }
+
+      /* FR-005 / FR-006: Launch Wizard + Board 行先頭ドット */
+      .agent-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--current-agent, transparent);
+        margin-right: 6px;
+        flex-shrink: 0;
+        vertical-align: middle;
+      }
+
+      /* Board 最小レンダリング */
+      .board-entries {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 12px;
+        overflow-y: auto;
+        font-size: 13px;
+        color: #1f2937;
+      }
+
+      .board-entry {
+        display: flex;
+        align-items: flex-start;
+        gap: 6px;
+        padding: 6px 8px;
+        border-radius: 4px;
+        background: rgba(241, 245, 249, 0.6);
+      }
+
+      .board-entry-head {
+        font-weight: 600;
+        color: #0f172a;
+      }
+
+      .board-entry-body {
+        display: block;
+        margin-top: 2px;
+        white-space: pre-wrap;
+        word-break: break-word;
+        color: #334155;
+      }
+
+      .board-entry-meta {
+        font-size: 11px;
+        color: #64748b;
+        margin-left: 8px;
+      }
+
+      .board-empty {
+        color: #64748b;
+        font-style: italic;
+        padding: 12px;
       }
 
       * {
@@ -218,6 +322,7 @@
       }
 
       .window-list-row {
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -230,6 +335,10 @@
         color: #0f172a;
         text-align: left;
         cursor: pointer;
+      }
+
+      .window-list-row[data-agent-color] {
+        padding-left: 14px;
       }
 
       .window-list-row:hover {
@@ -2217,6 +2326,9 @@
       const knowledgeBridgeStateMap = new Map();
       const profileWindowStateMap = new Map();
       const profileWindowBodies = new Map();
+      // SPEC #2133: Board preset の minimum rendering 用状態。
+      const boardWindowStateMap = new Map();
+      const boardWindowBodies = new Map();
       const pendingMessages = [];
 
       // Diagnostic counter for intermittent key-input drops (bugfix/input-key).
@@ -2471,6 +2583,9 @@
           const row = document.createElement("button");
           row.type = "button";
           row.className = "window-list-row";
+          if (entry.agent_color) {
+            row.dataset.agentColor = entry.agent_color;
+          }
           row.innerHTML = `
             <div class="window-list-copy">
               <div class="window-list-title">${entry.title}</div>
@@ -3597,7 +3712,15 @@
         if (selected) {
           button.classList.add("selected");
         }
-        button.appendChild(createNode("span", "launch-choice-title", option.label));
+        const title = createNode("span", "launch-choice-title");
+        // SPEC #2133 FR-005: Launch Wizard 候補行の先頭ドット。
+        // option.color (AgentColor wire 値) が有るときだけ表示する。
+        if (option.color) {
+          button.dataset.agentColor = option.color;
+          title.appendChild(createNode("span", "agent-dot"));
+        }
+        title.appendChild(document.createTextNode(option.label));
+        button.appendChild(title);
         if (option.description) {
           button.appendChild(
             createNode("span", "launch-choice-detail", option.description),
@@ -5295,6 +5418,11 @@
           return;
         }
 
+        if (windowData.preset === "board") {
+          renderBoardWindow(body, windowData);
+          return;
+        }
+
         const mock = mockContentForPreset(windowData.preset);
         body.innerHTML = `
           <div class="mock-root">
@@ -5793,6 +5921,120 @@
         }
       }
 
+      // SPEC #2133 FR-006: Board preset window の最小レンダリング。
+      // BackendEvent::BoardSnapshot を受けると entries が更新され、
+      // 各行の左先頭に agent_color のドットが出る。
+      function ensureBoardWindowState(windowId) {
+        if (!boardWindowStateMap.has(windowId)) {
+          boardWindowStateMap.set(windowId, {
+            entries: [],
+            loading: true,
+            error: "",
+          });
+        }
+        return boardWindowStateMap.get(windowId);
+      }
+
+      function renderBoardWindow(body, windowData) {
+        while (body.firstChild) body.removeChild(body.firstChild);
+        const state = ensureBoardWindowState(windowData.id);
+        boardWindowBodies.set(windowData.id, body);
+
+        const root = createDiv("mock-root");
+        const toolbar = createDiv("mock-toolbar");
+        const heading = createDiv("mock-heading");
+        heading.textContent = "Board";
+        const chip = document.createElement("span");
+        chip.className = "mock-chip";
+        chip.textContent = windowData.title || "Board";
+        toolbar.appendChild(heading);
+        toolbar.appendChild(chip);
+
+        const actions = createDiv("profile-toolbar-actions");
+        const refresh = document.createElement("button");
+        refresh.className = "icon-button";
+        refresh.type = "button";
+        refresh.setAttribute("aria-label", "Refresh board");
+        refresh.textContent = "↻";
+        refresh.addEventListener("click", (event) => {
+          event.stopPropagation();
+          const s = ensureBoardWindowState(windowData.id);
+          s.loading = true;
+          s.error = "";
+          renderBoardEntries(windowData.id);
+          send({ kind: "load_board", id: windowData.id });
+        });
+        actions.appendChild(refresh);
+        toolbar.appendChild(actions);
+        root.appendChild(toolbar);
+
+        const list = createDiv("board-entries");
+        list.dataset.role = "board-entries";
+        root.appendChild(list);
+        body.appendChild(root);
+
+        body.addEventListener("mousedown", () => {
+          focusWindowLocally(windowData.id);
+          send({ kind: "focus_window", id: windowData.id });
+        });
+
+        renderBoardEntries(windowData.id);
+        send({ kind: "load_board", id: windowData.id });
+      }
+
+      function renderBoardEntries(windowId) {
+        const body = boardWindowBodies.get(windowId);
+        if (!body || !body.isConnected) {
+          return;
+        }
+        const list = body.querySelector("[data-role='board-entries']");
+        if (!list) {
+          return;
+        }
+        while (list.firstChild) list.removeChild(list.firstChild);
+        const state = ensureBoardWindowState(windowId);
+        if (state.error) {
+          const err = createDiv("board-empty");
+          err.textContent = `Failed to load: ${state.error}`;
+          list.appendChild(err);
+          return;
+        }
+        if (state.loading) {
+          const loading = createDiv("board-empty");
+          loading.textContent = "Loading board entries...";
+          list.appendChild(loading);
+          return;
+        }
+        if (!state.entries || state.entries.length === 0) {
+          const empty = createDiv("board-empty");
+          empty.textContent = "No board entries yet.";
+          list.appendChild(empty);
+          return;
+        }
+        for (const entry of state.entries) {
+          const row = createDiv("board-entry");
+          if (entry.agent_color) {
+            row.dataset.agentColor = entry.agent_color;
+          }
+          const dot = createDiv("agent-dot");
+          row.appendChild(dot);
+          const content = createDiv();
+          const head = createDiv("board-entry-head");
+          const kind = (entry.kind || "").toString();
+          head.textContent = `${entry.author} · ${kind}`;
+          const meta = document.createElement("span");
+          meta.className = "board-entry-meta";
+          meta.textContent = entry.created_at || "";
+          head.appendChild(meta);
+          content.appendChild(head);
+          const bodyText = createDiv("board-entry-body");
+          bodyText.textContent = entry.body || "";
+          content.appendChild(bodyText);
+          row.appendChild(content);
+          list.appendChild(row);
+        }
+      }
+
       function renderSettingsWindow(body, windowData) {
         // Sweep detached bodies up-front so repeated open/close cycles do
         // not accumulate references.
@@ -6145,6 +6387,13 @@
         element.querySelector(".title-text").textContent = windowData.title;
         element.classList.toggle("minimized", Boolean(windowData.minimized));
         element.classList.toggle("maximized", Boolean(windowData.maximized));
+        // SPEC #2133: propagate agent_color so the titlebar accent bar
+        // (.workspace-window[data-agent-color]::before) picks the right color.
+        if (windowData.agent_color) {
+          element.dataset.agentColor = windowData.agent_color;
+        } else {
+          delete element.dataset.agentColor;
+        }
         element.style.left = `${windowData.geometry.x}px`;
         element.style.top = `${windowData.geometry.y}px`;
         element.style.width = `${windowData.geometry.width}px`;
@@ -6279,6 +6528,21 @@
             state.loading = false;
             state.error = "";
             renderKnowledgeBridge(event.id);
+            break;
+          }
+          case "board_snapshot": {
+            const state = ensureBoardWindowState(event.id);
+            state.entries = event.entries || [];
+            state.loading = false;
+            state.error = "";
+            renderBoardEntries(event.id);
+            break;
+          }
+          case "board_error": {
+            const state = ensureBoardWindowState(event.id);
+            state.loading = false;
+            state.error = event.message || "Unknown error";
+            renderBoardEntries(event.id);
             break;
           }
           case "knowledge_detail": {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,40 @@
 # Lessons Learned
 
+## 2026-04-21 — `gwt issue spec --edit <section> -f <file>` に artifact marker を入れると body が復旧不能になる
+
+### 事象
+
+SPEC #2133 に `gwt issue spec 2133 --edit plan -f tasks/plan-agent-color.md`
+を実行。ファイル先頭末尾に `<!-- artifact:plan BEGIN/END -->` マーカーを
+自分で入れていたところ、CLI は「セクション content をマーカーで包んで
+comment に投稿」する処理を行うため、出力された comment 本文に
+`<!-- artifact:plan BEGIN -->` が 2 行連続する nested 状態が発生した。
+以降 `gwt issue view 2133` / `gwt issue spec 2133` / `gwt issue comment
+2133` すべてが `body parse error: malformed marker: nested BEGIN for
+'plan' inside 'plan'` で失敗し、CLI からの復旧が一切効かなくなった。
+
+### 原因
+
+- lessons.md 2026-04-15 の教訓「`spec create` はマーカー必要、`--edit
+  spec` はマーカー不要」を `--edit plan` / `--edit tasks` にも展開して
+  適用すべきだったが、本番前に `--edit` 全体のマーカー扱いを確認せず
+  に投入した。
+- `gwt issue spec create -f` と `gwt issue spec --edit -f` で必要な
+  ファイル形式が逆転しているという非対称は直感に反する。`--help` 等で
+  見える形になっていないため、毎回再確認が必要。
+
+### 再発防止策
+
+1. `gwt issue spec --edit <section> -f <file>` に渡すファイルに
+   `<!-- artifact:<section> BEGIN/END -->` マーカーを入れない。CLI 側で
+   wrap される前提。
+2. `gwt issue spec create --title … -f <file>` に渡すファイルはマーカー
+   付きにする (既存教訓)。
+3. section を初めて書き込む前に必ず小さいテストファイルで 1 回試す
+   (1 セクション分の数行だけ)。フル本文を一発で投げない。
+4. 壊れた comment は gwt CLI で復旧できないので、GitHub Web / workflow-
+   policy で許容された API を通じて手動修復が必要。未然防止がすべて。
+
 ## 2026-04-21 — fix(review): text contract は success status だけでなく semantic validity を確認する
 
 ### 事象


### PR DESCRIPTION
## Summary

SPEC #2133 の実装。エージェント種別 (Claude / Codex / Gemini / OpenCode /
Copilot / Custom) を 4 つの UI サーフェスで視覚的に区別する。色パレット
の正本は既存 `crates/gwt-agent/src/types.rs` の `AgentColor` /
`AgentId::default_color()` を再利用 (旧 PR #1021 と同対応)。

## 適用サーフェス

| サーフェス | スタイル |
| --- | --- |
| Workspace window titlebar | 左端 4px アクセントバー (`::before`) |
| Window List Panel 行 | 左端 3px アクセントバー |
| Launch Wizard 候補行 | 先頭の丸ドット |
| Board エントリ行 | 先頭の丸ドット + Board UI 最小レンダリング |

## 色対応

- ClaudeCode → Yellow
- Codex → Cyan
- Gemini → Magenta
- OpenCode → Green
- Copilot → Blue
- Custom(_) → Gray

フロントは `--agent-*` CSS 変数を data-attr セレクタ経由で参照し、色値の
ハードコードを持たない。wire は `AgentColor` snake_case (`"yellow"` 等)。

## 主な変更

- `AgentColor` に `#[serde(rename_all = "snake_case")]` 追加 (CSS 変数名と
  1 対 1 対応)
- `resolve_agent_id(raw: &str) -> Option<AgentId>` helper (gwt-agent)
- `PersistedWindowState.agent_id: Option<String>` + wire-only
  `agent_color: Option<AgentColor>` (skip_deserializing)
- `WindowPreset::resolved_agent_id()` で Claude/Codex 固定マッピング
- Launch 成功時に `workspace.set_agent_id()` で window へ書き込み
- `LaunchWizardOptionView.color` を populate
- `BoardEntryView` + `LoadBoard` / `BoardSnapshot` / `BoardError` の
  protocol 追加、Board surface の最小レンダリング

## 後方互換

- 既存 `~/.gwt/sessions/` の agent_id 欠落 JSON は serde default で None
  にデシリアライズされる (回帰テスト追加)
- preset.Claude / preset.Codex の legacy window は
  `resolved_agent_id()` でフォールバック色が出る

## Test plan

- [x] `cargo test -p gwt-agent -p gwt-core -p gwt` (800+ tests passing)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (警告ゼロ)
- [x] `cargo fmt`
- [ ] **Manual WebView verification required** (CI では実施困難):
  - [ ] 6 AgentId × 4 surface の色が正しく出る
  - [ ] Blue (Copilot) と Cyan (Codex) を隣接で開き区別できる
  - [ ] agent_id 欠落した旧永続化から起動して panic しない
  - [ ] Board に各 AgentId から post して色ドット確認

## 関連

- Closes #2133 (SPEC)
- Prior art: PR #1021 (旧 Svelte gwt-gui、#928 で撤去済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-colored UI accents and visual indicators reflect the selected agent throughout windows and launch options
  * Board window preset displays project board entries with real-time loading and updates

* **Documentation**
  * Added lessons on artifact marker handling in specification workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->