### PR TITLE
fix(agent): prevent custom agent misclassification

### DIFF
--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -85,22 +85,14 @@ pub fn resolve_agent_id(raw: &str) -> Option<AgentId> {
         return None;
     }
     let lower = trimmed.to_ascii_lowercase();
-    if lower.contains("claude") {
-        return Some(AgentId::ClaudeCode);
+    match lower.as_str() {
+        "claude" | "claudecode" | "claude-code" | "claude code" => Some(AgentId::ClaudeCode),
+        "codex" => Some(AgentId::Codex),
+        "gemini" | "gemini cli" | "gemini-cli" => Some(AgentId::Gemini),
+        "opencode" | "open-code" => Some(AgentId::OpenCode),
+        "gh" | "copilot" | "github copilot" | "github-copilot" => Some(AgentId::Copilot),
+        _ => Some(AgentId::Custom(trimmed.to_string())),
     }
-    if lower.contains("codex") {
-        return Some(AgentId::Codex);
-    }
-    if lower.contains("gemini") {
-        return Some(AgentId::Gemini);
-    }
-    if lower.contains("opencode") || lower.contains("open-code") {
-        return Some(AgentId::OpenCode);
-    }
-    if lower == "gh" || lower.contains("copilot") {
-        return Some(AgentId::Copilot);
-    }
-    Some(AgentId::Custom(trimmed.to_string()))
 }
 
 /// Static information about an agent, combining identity with presentation.
@@ -295,6 +287,18 @@ mod tests {
             resolve_agent_id("unknown-cli"),
             Some(AgentId::Custom("unknown-cli".into()))
         );
+    }
+
+    #[test]
+    fn resolve_agent_id_does_not_infer_known_agents_from_custom_names() {
+        let custom_inputs = ["my-claude-wrapper", "codex-wrapper", "opencode-mentor"];
+        for raw in custom_inputs {
+            assert_eq!(
+                resolve_agent_id(raw),
+                Some(AgentId::Custom(raw.into())),
+                "{raw}"
+            );
+        }
     }
 
     #[test]

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -291,7 +291,14 @@ mod tests {
 
     #[test]
     fn resolve_agent_id_does_not_infer_known_agents_from_custom_names() {
-        let custom_inputs = ["my-claude-wrapper", "codex-wrapper", "opencode-mentor"];
+        let custom_inputs = [
+            "my-claude-wrapper",
+            "codex-wrapper",
+            "gemini-helper",
+            "opencode-mentor",
+            "copilot-mentor",
+            "github-copilot-wrapper",
+        ];
         for raw in custom_inputs {
             assert_eq!(
                 resolve_agent_id(raw),


### PR DESCRIPTION
## Summary

- narrow `resolve_agent_id` to an exact-match alias table so custom agent IDs are not misclassified as built-in agents
- preserve the existing built-in aliases while forcing unknown composite names like `my-claude-wrapper` to fall back to `Custom(...)`
- add a regression test for the SPEC #2133 follow-up in issue #2137

## Changes

- `crates/gwt-agent/src/types.rs`: replace substring-based inference with exact-match alias resolution and `Custom(trimmed)` fallback
- `crates/gwt-agent/src/types.rs`: add a regression test covering custom names that include built-in agent keywords

## Testing

- [x] `cargo test -p gwt-agent` — all tests pass
- [x] `cargo clippy -p gwt-agent --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatting is clean

## Closing Issues

- Closes #2137

## Related Issues / Links

- #2133

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change)
  Not needed: internal bug fix with no README or user workflow change.
- [ ] Migration/backfill plan included (if schema/data change)
  Not needed: no persisted schema or data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent identification now requires exact name matching. Previously, agent names containing recognized keywords (such as "claude" or "gemini") would automatically match known agents. Now only exact names are recognized as known agents, with all other naming patterns treated as custom agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->