### PR TITLE
feat: normalize canvas window state badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ PLANS.md
 .gwt/index.crashed-*/
 .gwt/discussion.md
 .gwt/draft/
+.gwt/skill-state/
 
 # Serena MCP tool cache directory
 .serena/

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -300,8 +300,10 @@ impl std::error::Error for CliParseError {}
 
 /// Determine whether the given argv (starting at the program name) should be
 /// handled as a CLI invocation. Returns `true` when argv[1..] begins with
-/// `issue`, `pr`, `actions`, `board`, or `hook`. The GUI launcher keeps its
-/// legacy behaviour (positional repo path) for any other shape.
+/// a supported top-level CLI verb such as `issue`, `pr`, `actions`, `board`,
+/// `hook`, `discuss`, `plan`, `build`, `update`, or `__internal`. The GUI
+/// launcher keeps its legacy behaviour (positional repo path) for any other
+/// shape.
 pub fn should_dispatch_cli(args: &[String]) -> bool {
     args.get(1)
         .map(|s| {

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -235,6 +235,102 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_window_status_chip_uses_running_waiting_stopped_error_variants() {
+        let html = index_html();
+
+        assert!(
+            html.contains(".status-chip.waiting .status-dot"),
+            "expected embedded html to define a waiting variant for window status chips",
+        );
+        assert!(
+            html.contains(".status-chip.stopped .status-dot"),
+            "expected embedded html to define a stopped variant for window status chips",
+        );
+        assert!(
+            !html.contains(".status-chip.ready .status-dot")
+                && !html.contains(".status-chip.exited .status-dot"),
+            "expected embedded html to stop styling legacy ready/exited status chip variants",
+        );
+    }
+
+    #[test]
+    fn embedded_web_window_state_visualization_normalizes_runtime_state_and_separates_geometry() {
+        let js = app_js();
+
+        assert!(
+            js.contains("function normalizeWindowRuntimeState(status, preset)"),
+            "expected embedded js to expose a runtime-state normalization helper",
+        );
+        assert!(
+            js.contains("function windowGeometryLabel(windowData)"),
+            "expected embedded js to expose a dedicated geometry label helper",
+        );
+        assert!(
+            js.contains("function windowRuntimeLabel(status)"),
+            "expected embedded js to expose a dedicated runtime label helper",
+        );
+        assert!(
+            js.contains("const geometryLabel = windowGeometryLabel(entry);")
+                && js.contains("const runtimeState = runtimeStateForWindow(entry);")
+                && js.contains("const runtimeLabel = windowRuntimeLabel(runtimeState);"),
+            "expected window list rendering to derive geometry and runtime labels through separate helpers",
+        );
+        assert!(
+            !js.contains("function windowStateLabel(windowData)"),
+            "expected embedded js to stop reusing one helper for both geometry and runtime labels",
+        );
+    }
+
+    #[test]
+    fn embedded_web_shell_windows_do_not_render_waiting_status() {
+        let js = app_js();
+
+        assert!(
+            js.contains("function presetSupportsWaitingStatus(preset)"),
+            "expected embedded js to isolate the waiting-capable preset contract",
+        );
+        assert!(
+            js.contains(
+                "if (!presetSupportsWaitingStatus(preset) && normalizedState === \"waiting\")"
+            ) && js.contains("return \"running\";"),
+            "expected embedded js to downgrade waiting to running for shell-like presets",
+        );
+    }
+
+    #[test]
+    fn embedded_web_apply_status_keeps_window_list_and_badges_in_sync() {
+        let js = app_js();
+        let apply_status = regex::Regex::new(
+            r#"(?s)function applyStatus\(windowId,\s*status,\s*detail\)\s*\{.*?const runtimeState = normalizeWindowRuntimeState\(status,\s*windowData\?\.preset\);.*?windowRuntimeStateMap\.set\(windowId,\s*runtimeState\);.*?label\.textContent = windowRuntimeLabel\(runtimeState\);.*?renderWindowList\(\);"#,
+        )
+        .expect("valid regex");
+
+        assert!(
+            js.contains("const windowRuntimeStateMap = new Map();"),
+            "expected embedded js to keep a shared runtime-state map for badges and the window list",
+        );
+        assert!(
+            apply_status.is_match(js),
+            "expected applyStatus to normalize runtime state once, update the shared map, and re-render the window list",
+        );
+    }
+
+    #[test]
+    fn embedded_web_window_list_selection_keeps_focus_center_and_restore_contract() {
+        let js = app_js();
+
+        assert!(
+            js.contains("focusWindowRemotely(entry.id, { center: true });"),
+            "expected window list selection to keep centering the chosen window",
+        );
+        assert!(
+            js.contains("if (entry.minimized) {")
+                && js.contains("send({ kind: \"restore_window\", id: entry.id });"),
+            "expected window list selection to keep restoring minimized windows after focus",
+        );
+    }
+
+    #[test]
     fn embedded_web_socket_protocol_wiring_uses_named_handlers() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -381,7 +381,7 @@ pub(crate) fn front_door_route(argv: &[String]) -> FrontDoorRoute {
         Some(top_verb) if gwt::cli::should_dispatch_cli(argv) => {
             debug_assert!(matches!(
                 top_verb,
-                "board" | "hook" | "update" | "__internal"
+                "board" | "hook" | "discuss" | "plan" | "build" | "update" | "__internal"
             ));
             FrontDoorRoute::DetachedCli
         }
@@ -492,10 +492,13 @@ mod tests {
     }
 
     #[test]
-    fn front_door_route_keeps_board_hook_update_and_internal_commands_on_cli_path() {
+    fn front_door_route_keeps_detached_helper_commands_on_cli_path() {
         for args in [
             argv(&["gwt", "board", "show", "--json"]),
             argv(&["gwt", "hook", "runtime-state", "PreToolUse"]),
+            argv(&["gwt", "discuss", "resolve", "--proposal", "Resume"]),
+            argv(&["gwt", "plan", "start", "--spec", "1935"]),
+            argv(&["gwt", "build", "complete", "--spec", "1935"]),
             argv(&["gwt", "update", "--check"]),
             argv(&["gwt", "__internal", "daemon-hook", "forward"]),
         ] {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -47,6 +47,7 @@
       const pendingOutputMap = new Map();
       const pendingSnapshotMap = new Map();
       const detailMap = new Map();
+      const windowRuntimeStateMap = new Map();
       const terminalMap = new Map();
       const windowMap = new Map();
       const fileTreeStateMap = new Map();
@@ -402,7 +403,36 @@
           .join(" ");
       }
 
-      function windowStateLabel(windowData) {
+      const WINDOW_RUNTIME_STATE_LABELS = Object.freeze({
+        running: "Running",
+        waiting: "Waiting",
+        stopped: "Stopped",
+        error: "Error",
+      });
+
+      const LEGACY_WINDOW_RUNTIME_STATE_ALIASES = Object.freeze({
+        starting: "running",
+        ready: "waiting",
+        exited: "stopped",
+      });
+
+      function presetSupportsWaitingStatus(preset) {
+        return preset === "agent" || preset === "claude" || preset === "codex";
+      }
+
+      function normalizeWindowRuntimeState(status, preset) {
+        const rawState = String(status || "running").toLowerCase();
+        const normalizedState = LEGACY_WINDOW_RUNTIME_STATE_ALIASES[rawState] || rawState;
+        if (!presetSupportsWaitingStatus(preset) && normalizedState === "waiting") {
+          return "running";
+        }
+        if (!WINDOW_RUNTIME_STATE_LABELS[normalizedState]) {
+          return "running";
+        }
+        return normalizedState;
+      }
+
+      function windowGeometryLabel(windowData) {
         if (windowData.minimized) {
           return "Minimized";
         }
@@ -410,6 +440,18 @@
           return "Maximized";
         }
         return "Normal";
+      }
+
+      function windowRuntimeLabel(status) {
+        return WINDOW_RUNTIME_STATE_LABELS[status] || WINDOW_RUNTIME_STATE_LABELS.running;
+      }
+
+      function runtimeStateForWindow(windowData) {
+        const cachedState = windowRuntimeStateMap.get(windowData.id);
+        if (cachedState) {
+          return cachedState;
+        }
+        return normalizeWindowRuntimeState(windowData.status, windowData.preset);
       }
 
       function requestWindowList() {
@@ -425,8 +467,16 @@
         if (!windowListOpen) {
           return;
         }
+        const workspaceWindows = activeWorkspace().windows || [];
+        const workspaceWindowMap = new Map(
+          workspaceWindows.map((windowData) => [windowData.id, windowData]),
+        );
         const entries =
-          windowListEntries.length > 0 ? windowListEntries : activeWorkspace().windows || [];
+          windowListEntries.length > 0
+            ? windowListEntries
+                .map((entry) => workspaceWindowMap.get(entry.id) || entry)
+                .filter((entry) => workspaceWindowMap.size === 0 || workspaceWindowMap.has(entry.id))
+            : workspaceWindows;
         windowListPanel.innerHTML = "";
         if (entries.length === 0) {
           const empty = document.createElement("div");
@@ -439,14 +489,20 @@
           const row = document.createElement("button");
           row.type = "button";
           row.className = "window-list-row";
+          const geometryLabel = windowGeometryLabel(entry);
+          const runtimeState = runtimeStateForWindow(entry);
+          const runtimeLabel = windowRuntimeLabel(runtimeState);
           row.innerHTML = `
             <div class="window-list-copy">
               <div class="window-list-title">${entry.title}</div>
-              <div class="window-list-meta">${presetLabel(entry.preset)} · ${windowStateLabel(entry)}</div>
+              <div class="window-list-meta">
+                <span class="window-list-preset">${presetLabel(entry.preset)}</span>
+                <span class="window-list-geometry">${geometryLabel}</span>
+              </div>
             </div>
-            <span class="status-chip ${entry.status}">
+            <span class="status-chip ${runtimeState}">
               <span class="status-dot"></span>
-              <span class="status-label">${windowStateLabel(entry)}</span>
+              <span class="status-label">${runtimeLabel}</span>
             </span>
           `;
           row.addEventListener("click", () => {
@@ -798,13 +854,17 @@
       }
 
       function applyStatus(windowId, status, detail) {
+        const windowData = workspaceWindowById(windowId);
+        const runtimeState = normalizeWindowRuntimeState(status, windowData?.preset);
+        windowRuntimeStateMap.set(windowId, runtimeState);
         if (detail) {
           detailMap.set(windowId, detail);
-        } else if (status === "running" || status === "waiting" || status === "ready") {
+        } else if (runtimeState === "running" || runtimeState === "waiting") {
           detailMap.delete(windowId);
         }
         const element = windowMap.get(windowId);
         if (!element) {
+          renderWindowList();
           return;
         }
         const chip = element.querySelector(".status-chip");
@@ -819,8 +879,8 @@
           "exited",
           "error",
         );
-        chip.classList.add(status);
-        label.textContent = status;
+        chip.classList.add(runtimeState);
+        label.textContent = windowRuntimeLabel(runtimeState);
         const effectiveDetail = detailMap.get(windowId);
         if (overlay) {
           const messageEl = overlay.querySelector(".overlay-message");
@@ -831,18 +891,17 @@
           }
           overlay.classList.toggle(
             "visible",
-            status === "starting" ||
-              status === "error" ||
-              status === "stopped" ||
-              status === "exited" ||
-              (status === "running" && Boolean(effectiveDetail)),
+            runtimeState === "error" ||
+              runtimeState === "stopped" ||
+              (runtimeState === "running" && Boolean(effectiveDetail)),
           );
-          if (status === "starting" || (status === "running" && Boolean(effectiveDetail))) {
+          if (runtimeState === "running" && Boolean(effectiveDetail)) {
             startSpinnerAnimation(overlay);
           } else {
             stopSpinnerAnimation(overlay);
           }
         }
+        renderWindowList();
       }
 
       function stopSpinnerAnimation(overlay) {
@@ -5149,9 +5208,9 @@
             <div class="titlebar">
               <div class="title">
                 <span class="title-text"></span>
-                <span class="status-chip starting">
+                <span class="status-chip running">
                   <span class="status-dot"></span>
-                  <span class="status-label">starting</span>
+                  <span class="status-label">Running</span>
                 </span>
               </div>
               <div class="window-actions">
@@ -5267,6 +5326,7 @@
           terminalMap.delete(windowId);
           decoderMap.delete(windowId);
           detailMap.delete(windowId);
+          windowRuntimeStateMap.delete(windowId);
           pendingOutputMap.delete(windowId);
           pendingSnapshotMap.delete(windowId);
           const profileState = profileStateMap.get(windowId);

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -252,8 +252,17 @@
 
       .window-list-meta {
         margin-top: 4px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
         font-size: 12px;
         color: #64748b;
+      }
+
+      .window-list-geometry {
+        font-weight: 600;
+        color: #475569;
       }
 
       .window-list-empty {
@@ -411,7 +420,7 @@
         background: #22c55e;
       }
 
-      .status-chip.ready .status-dot {
+      .status-chip.waiting .status-dot {
         background: #3b82f6;
       }
 
@@ -419,7 +428,7 @@
         background: #ef4444;
       }
 
-      .status-chip.exited .status-dot {
+      .status-chip.stopped .status-dot {
         background: #94a3b8;
       }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,30 @@
 # Lessons Learned
 
+## 2026-04-22 — verify: Windows GUI smoke は `browser URL` 出力だけで成功扱いしない
+
+### 事象
+
+`target/debug/gwt.exe` を起動すると `gwt browser URL: http://127.0.0.1:<port>/`
+までは出たが、その直後に index runner が
+`'cp932' codec can't decode byte 0x94 ... illegal multibyte sequence`
+で `RUNTIME_ERROR` を返し、native GUI の手動確認を最後まで進められなかった。
+
+### 原因
+
+- `browser URL` の出力は front-door server 起動成功しか保証せず、indexing/runtime の
+  後続失敗は別で起こりうる。
+- この環境では Windows ユーザープロファイル配下の Unicode path と index runner の
+  文字コード処理が衝突し、GUI 操作前に runtime error になった。
+
+### 再発防止策
+
+1. Windows GUI smoke では `browser URL` 出力後に `~/.gwt/logs/index/*.log` か
+   stderr を必ず確認し、index/runtime error がないことまで見て成功判定する。
+2. front-door HTML が `127.0.0.1` で取れても、native GUI 操作まで届かなければ
+   manual E2E 完了扱いにしない。
+3. Unicode path 由来の index runner failure が出た場合は、当該手動確認タスクを
+   block として記録し、別 issue/scope に切り出して扱う。
+
 ## 2026-04-22 — test: `HOME` / `USERPROFILE` を触る gwt-core test は crate-wide lock を共有する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Normalize canvas window runtime badges to the `Running` / `Waiting` / `Stopped` / `Error` contract so the badge row and window list stay in sync.
- Separate window geometry text from runtime state labels in the web UI so shell-like presets no longer render misleading `Waiting` copy.
- Fix the detached front-door CLI routing so `gwt build start --spec 2008` no longer panics in debug builds before the build skill lifecycle state is recorded.

## Changes

- `crates/gwt/web/app.js`: add runtime-state normalization helpers, share normalized state between window chips and the window list, and suppress `Waiting` for shell presets.
- `crates/gwt/web/index.html`: add `waiting` / `stopped` chip styling and split window list geometry metadata from runtime badge metadata.
- `crates/gwt/src/embedded_web.rs`: extend embedded web contract coverage for four-state badges, shell-specific rendering, badge/list synchronization, and window-list selection behavior.
- `crates/gwt/src/runtime_support.rs`: route `discuss`, `plan`, and `build` helper verbs through the detached CLI front door in debug builds and lock the behavior with a regression test.
- `crates/gwt/src/cli.rs`: align the `should_dispatch_cli()` contract comment with the actual supported top-level verbs.
- `.gitignore`: ignore `.gwt/skill-state/` so local build-skill state does not dirty the worktree.

## Testing

- [x] `cargo fmt -- --check` — passes.
- [x] `cargo test -p gwt-core -p gwt` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo build -p gwt` — passes.
- [x] `target/debug/gwt.exe build start --spec 2008` — prints `build: started gwt-build-spec for SPEC-2008` instead of panicking.
- [ ] `target/debug/gwt.exe` native GUI smoke — `gwt browser URL` is emitted and `Invoke-WebRequest` can fetch the front-door HTML, but the local index runner fails with `'cp932' codec can't decode byte 0x94 ... illegal multibyte sequence` before manual window interaction is possible.

## Closing Issues

- Closes #2008

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (no README change needed; behavior change is covered by SPEC/tasks and test contracts)
- [ ] Migration/backfill plan included (not needed; no schema or persisted data changed)
- [x] CHANGELOG impact considered (covered by Conventional Commits: `feat` + `fix`)

## Context

- SPEC-2008 Phase 7 updates the window-state visualization contract in the embedded web UI.
- The follow-up `fix:` commit was required because the new build lifecycle command path (`gwt build ...`) still tripped a stale debug-only assertion before the skill-state file could be written.

## Risk / Impact

- **Affected areas**: embedded web window-status rendering, front-door CLI routing for detached helper verbs, and local worktree hygiene for build skill state.
- **Rollback plan**: revert `b8667364` and `06080014` from `feature/issue-2008`.

## Notes

- SPEC-2008 manual verification tasks `T-067` and `T-054` remain unchecked because the Windows GUI smoke is blocked in this environment by the existing `cp932` index-runner runtime error.
