### PR TITLE
fix(release): sign gwtd before gwt in macOS app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,9 +348,9 @@ jobs:
         run: |
           set -euo pipefail
           codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
-            dist/GWT.app/Contents/MacOS/gwt
-          codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
             dist/GWT.app/Contents/MacOS/gwtd
+          codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
+            dist/GWT.app/Contents/MacOS/gwt
           codesign --force --options runtime --timestamp --sign "$GWT_CODESIGN_IDENTITY" \
             dist/GWT.app
           codesign --verify --deep --strict --verbose=4 dist/GWT.app

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-23 — release: macOS `.app` 内の CFBundleExecutable を他バイナリより先に codesign しない
+
+### 事象
+
+`release.yml` の `Build DMG installer (macOS)` で `Sign app bundle` ステップが
+`dist/GWT.app/Contents/MacOS/gwt: code object is not signed at all`
+`In subcomponent: .../MacOS/gwtd` と出して exit 1。結果として v9.8.0 の DMG ビルドが
+失敗し、`upload-release` / `publish-npm` まで連鎖失敗してドラフトリリースが公開されなかった。
+
+### 原因
+
+`GWT.app/Contents/MacOS/` に CFBundleExecutable (`gwt`) と helper (`gwtd`) が
+並んで置かれているとき、CFBundleExecutable を先に `codesign --sign` すると
+codesign はバンドルの他の subcomponent (この場合 `gwtd`) が既に署名済みで
+あることを要求し、未署名だと "code object is not signed at all" で失敗する。
+
+### 再発防止策
+
+1. `.app` バンドル内を個別に署名する場合、helper バイナリ → CFBundleExecutable → バンドル
+   の順で `codesign --sign` を呼ぶ。順序を逆にしない。
+2. もしくは `codesign --force --deep --sign` を `.app` 1 回だけ呼ぶ。
+3. 新しい helper バイナリを `.app/Contents/MacOS/` に追加するときは、`release.yml` の
+   署名順を必ず見直す。
+
 ## 2026-04-22 — verify: Windows GUI smoke は `browser URL` 出力だけで成功扱いしない
 
 ### 事象


### PR DESCRIPTION
## Summary

v9.8.0 Release workflow の `Build DMG installer (macOS)` ジョブが codesign の順序誤りで exit 1 となり、DMG ビルド失敗 → `upload-release` / `publish-npm` が連鎖失敗してドラフトリリースが publish されなかった。本 PR は `Sign app bundle` ステップで `gwtd` を `gwt` より先に署名するよう順序を入れ替える hotfix。

- 根本原因: `GWT.app/Contents/MacOS/` の CFBundleExecutable (`gwt`) を helper (`gwtd`) より先に `codesign --sign` すると、codesign はバンドルの他 subcomponent が署名済みであることを要求し失敗する
- 修正: `.github/workflows/release.yml` の codesign 順序を swap
- 再発防止: `tasks/lessons.md` に順序ルールを記録

## Changes

- `.github/workflows/release.yml`: `Sign app bundle` ステップで `gwtd` → `gwt` → `GWT.app` の順に codesign する
- `tasks/lessons.md`: macOS `.app` 内 CFBundleExecutable の署名順についての学びを追加

## Version

バージョンは変更しない (v9.8.0 のまま再リリース)。`Create Tag and Release` は既存タグ `v9.8.0` を検出して `create and push tag` / `Create GitHub Release` をスキップし、既存のドラフトを流用する想定。

## Closing Issues

Closes #2145

## Related Issues / Links

- Failed workflow run: <https://github.com/akiojin/gwt/actions/runs/24813816226/job/72623938601>
- Release PR that produced v9.8.0: #2144


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS app release failures caused by incorrect code signing execution order during the build process.

* **Documentation**
  * Added comprehensive macOS release troubleshooting documentation covering code signing requirements, common issues, and remediation steps to prevent similar failures when building and signing app bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->