### PR TITLE
fix(launch-wizard): enable custom agent selection

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use crate::{
+    custom::{CustomAgentType, CustomCodingAgent},
     session::GWT_SESSION_RUNTIME_PATH_ENV,
     types::{AgentColor, AgentId, DockerLifecycleIntent, LaunchRuntimeTarget, SessionMode},
 };
@@ -157,6 +158,27 @@ pub fn resolve_runner(agent_id: &AgentId, version: &str) -> ResolvedRunner {
     }
 }
 
+fn resolve_custom_runner(agent: &CustomCodingAgent) -> ResolvedRunner {
+    match agent.agent_type {
+        CustomAgentType::Command | CustomAgentType::Path => ResolvedRunner {
+            executable: agent.command.clone(),
+            base_args: Vec::new(),
+        },
+        CustomAgentType::Bunx => {
+            let (executable, needs_yes) = find_bunx_or_npx();
+            let mut base_args = Vec::new();
+            if needs_yes {
+                base_args.push("--yes".to_string());
+            }
+            base_args.push(agent.command.clone());
+            ResolvedRunner {
+                executable,
+                base_args,
+            }
+        }
+    }
+}
+
 /// Platform-specific priority list of package-runner executables to probe via
 /// `which::which`. Each entry is `(name, needs_yes)`.
 ///
@@ -239,6 +261,7 @@ pub enum PermissionMode {
 #[derive(Debug, Clone)]
 pub struct AgentLaunchBuilder {
     agent_id: AgentId,
+    custom_agent: Option<CustomCodingAgent>,
     working_dir: Option<PathBuf>,
     branch: Option<String>,
     base_branch: Option<String>,
@@ -268,6 +291,7 @@ impl AgentLaunchBuilder {
     pub fn new(agent_id: AgentId) -> Self {
         Self {
             agent_id,
+            custom_agent: None,
             working_dir: None,
             branch: None,
             base_branch: None,
@@ -287,6 +311,11 @@ impl AgentLaunchBuilder {
             docker_lifecycle_intent: DockerLifecycleIntent::Connect,
             linked_issue_number: None,
         }
+    }
+
+    pub fn custom_agent(mut self, agent: CustomCodingAgent) -> Self {
+        self.custom_agent = Some(agent);
+        self
     }
 
     pub fn working_dir(mut self, dir: impl Into<PathBuf>) -> Self {
@@ -388,6 +417,11 @@ impl AgentLaunchBuilder {
     /// Build the final `LaunchConfig`.
     pub fn build(self) -> LaunchConfig {
         let mut env_vars = HashMap::new();
+        let skip_permissions = self.skip_permissions
+            || matches!(
+                self.permission_mode,
+                Some(PermissionMode::BypassPermissions)
+            );
 
         // Common env vars
         env_vars.insert("TERM".to_string(), "xterm-256color".to_string());
@@ -406,12 +440,24 @@ impl AgentLaunchBuilder {
         }
 
         // Resolve runner (installed binary vs bunx/npx)
-        let runner = resolve_runner(
-            &self.agent_id,
-            self.version.as_deref().unwrap_or("installed"),
-        );
+        let runner = self
+            .custom_agent
+            .as_ref()
+            .map(resolve_custom_runner)
+            .unwrap_or_else(|| {
+                resolve_runner(
+                    &self.agent_id,
+                    self.version.as_deref().unwrap_or("installed"),
+                )
+            });
 
         let mut args = runner.base_args;
+        if let Some(custom_agent) = self.custom_agent.as_ref() {
+            args.extend(custom_agent.build_args(self.session_mode));
+            if skip_permissions {
+                args.extend(custom_agent.skip_permissions_args.clone());
+            }
+        }
 
         // Agent-specific configuration
         match &self.agent_id {
@@ -443,13 +489,20 @@ impl AgentLaunchBuilder {
         // SPEC-1921 FR-063: merge CustomCodingAgent.env AFTER Common and
         // agent-specific env so preset entries win over built-in defaults
         // but BEFORE env_overrides (explicit caller overrides still win).
+        if let Some(custom_agent) = self.custom_agent.as_ref() {
+            env_vars.extend(custom_agent.env.clone());
+        }
         env_vars.extend(self.custom_agent_env);
 
         // Apply env overrides last (user wins)
         env_vars.extend(self.env_overrides);
 
         let agent_id = self.agent_id.clone();
-        let display_name = self.agent_id.display_name().to_string();
+        let display_name = self
+            .custom_agent
+            .as_ref()
+            .map(|agent| agent.display_name.clone())
+            .unwrap_or_else(|| self.agent_id.display_name().to_string());
         let color = self.agent_id.default_color();
         let model = self.model.clone();
         let tool_version = self
@@ -459,11 +512,6 @@ impl AgentLaunchBuilder {
         let reasoning_level = self.reasoning_level.clone();
         let session_mode = self.session_mode;
         let resume_session_id = self.resume_session_id.clone();
-        let skip_permissions = self.skip_permissions
-            || matches!(
-                self.permission_mode,
-                Some(PermissionMode::BypassPermissions)
-            );
         let codex_fast_mode = matches!(self.agent_id, AgentId::Codex) && self.fast_mode;
 
         LaunchConfig {
@@ -660,6 +708,8 @@ impl AgentLaunchBuilder {
 
 #[cfg(test)]
 mod tests {
+    use crate::custom::{CustomAgentType, CustomCodingAgent, ModeArgs};
+
     use super::*;
 
     // SPEC-1921 Phase 53 / Issue #2091: canonical_launch_args is the single
@@ -1227,6 +1277,60 @@ mod tests {
         assert_eq!(config.display_name, "aider");
         assert_eq!(config.color, AgentColor::Gray);
         assert!(config.args.contains(&"--no-git".to_string()));
+    }
+
+    #[test]
+    fn custom_agent_definition_overrides_display_name_runner_args_and_env() {
+        let agent = CustomCodingAgent {
+            id: "proxy-agent".to_string(),
+            display_name: "Claude Proxy".to_string(),
+            agent_type: CustomAgentType::Bunx,
+            command: "@anthropic-ai/claude-code@latest".to_string(),
+            default_args: vec!["--print".to_string()],
+            mode_args: Some(ModeArgs {
+                normal: Vec::new(),
+                continue_mode: vec!["--continue".to_string()],
+                resume: vec!["--resume".to_string()],
+            }),
+            skip_permissions_args: vec!["--dangerously-skip-permissions".to_string()],
+            env: HashMap::from([(
+                "ANTHROPIC_BASE_URL".to_string(),
+                "http://proxy.local:32768".to_string(),
+            )]),
+        };
+
+        let config = AgentLaunchBuilder::new(AgentId::Custom("proxy-agent".into()))
+            .custom_agent(agent)
+            .session_mode(SessionMode::Continue)
+            .skip_permissions(true)
+            .build();
+
+        assert_eq!(config.display_name, "Claude Proxy");
+        assert!(
+            config.command.contains("bunx") || config.command.contains("npx"),
+            "custom bunx agent should resolve through a package runner: {}",
+            config.command
+        );
+        assert!(
+            config
+                .args
+                .iter()
+                .any(|arg| arg.contains("@anthropic-ai/claude-code@latest")),
+            "custom bunx agent must include the package spec: {:?}",
+            config.args
+        );
+        assert!(config.args.contains(&"--print".to_string()));
+        assert!(config.args.contains(&"--continue".to_string()));
+        assert!(config
+            .args
+            .contains(&"--dangerously-skip-permissions".to_string()));
+        assert_eq!(
+            config
+                .env_vars
+                .get("ANTHROPIC_BASE_URL")
+                .map(String::as_str),
+            Some("http://proxy.local:32768")
+        );
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -4088,7 +4088,7 @@ mod tests {
 
         let mut ctx = context(branch("origin/feature/gui"), "feature/gui");
         ctx.quick_start_root = worktree;
-        let mut state = LaunchWizardState::open(ctx, dir.path(), &dir.path().join("versions.json"));
+        let state = LaunchWizardState::open(ctx, dir.path(), &dir.path().join("versions.json"));
 
         assert_eq!(state.step, LaunchWizardStep::QuickStart);
         assert_eq!(state.quick_start_entries.len(), 1);
@@ -4130,12 +4130,17 @@ mod tests {
         assert!(!loading.is_hydrating);
         assert_eq!(loading.hydration_error.as_deref(), Some("network failed"));
 
-        state.apply(LaunchWizardAction::ApplyQuickStart {
+        let mut resumable = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            state.quick_start_entries.clone(),
+        );
+        resumable.apply(LaunchWizardAction::ApplyQuickStart {
             index: 0,
             mode: QuickStartLaunchMode::Resume,
         });
         assert!(matches!(
-            state.completion.as_ref(),
+            resumable.completion.as_ref(),
             Some(LaunchWizardCompletion::Launch(config))
                 if matches!(
                     config.as_ref(),

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -129,13 +129,14 @@ pub struct LaunchWizardView {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct AgentOption {
     pub id: String,
     pub name: String,
     pub available: bool,
     pub installed_version: Option<String>,
     pub versions: Vec<String>,
+    pub custom_agent: Option<gwt_agent::CustomCodingAgent>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -424,10 +425,7 @@ impl LaunchWizardState {
     }
 
     pub fn open(context: LaunchWizardContext, sessions_dir: &Path, cache_path: &Path) -> Self {
-        let agent_options = build_builtin_agent_options(
-            gwt_agent::AgentDetector::detect_all(),
-            &gwt_agent::VersionCache::load(cache_path),
-        );
+        let agent_options = load_agent_options(&gwt_agent::VersionCache::load(cache_path));
         let quick_start_entries = load_quick_start_entries(
             &context.quick_start_root,
             sessions_dir,
@@ -628,7 +626,7 @@ impl LaunchWizardState {
                 let max_index = self.current_options().len().saturating_sub(1);
                 self.selected = index.min(max_index);
                 self.apply_selection();
-                if self.completion.is_none() {
+                if self.completion.is_none() && self.error.is_none() {
                     self.advance_after_current_step();
                 }
             }
@@ -642,8 +640,19 @@ impl LaunchWizardState {
         if !self.launch_target_is_agent() {
             return Err("Agent launch target is not selected".to_string());
         }
-        let agent_id = agent_id_from_key(&self.agent_id);
+        let selected_agent = self
+            .selected_agent()
+            .cloned()
+            .ok_or_else(|| "Agent option is unavailable".to_string())?;
+        if !selected_agent.available {
+            return Err("Agent option is unavailable".to_string());
+        }
+
+        let agent_id = agent_id_from_key(&selected_agent.id);
         let mut builder = gwt_agent::AgentLaunchBuilder::new(agent_id.clone());
+        if let Some(custom_agent) = selected_agent.custom_agent.clone() {
+            builder = builder.custom_agent(custom_agent);
+        }
 
         if !self.is_new_branch {
             if let Some(worktree_path) = &self.context.worktree_path {
@@ -824,6 +833,10 @@ impl LaunchWizardState {
             }
             LaunchWizardStep::AgentSelect => {
                 if let Some(agent) = self.detected_agents.get(self.selected) {
+                    if !agent.available {
+                        self.error = Some("Agent option is unavailable".to_string());
+                        return;
+                    }
                     self.agent_id = agent.id.clone();
                 }
                 self.sync_selected_agent_options();
@@ -1014,15 +1027,18 @@ impl LaunchWizardState {
     }
 
     fn set_agent_id(&mut self, agent_id: &str) {
-        if self
+        match self
             .detected_agents
             .iter()
-            .any(|candidate| candidate.id == agent_id)
+            .find(|candidate| candidate.id == agent_id)
         {
-            self.agent_id = agent_id.to_string();
-            self.sync_selected_agent_options();
-        } else {
-            self.error = Some("Agent option is unavailable".to_string());
+            Some(candidate) if candidate.available => {
+                self.agent_id = agent_id.to_string();
+                self.sync_selected_agent_options();
+            }
+            _ => {
+                self.error = Some("Agent option is unavailable".to_string());
+            }
         }
     }
 
@@ -1398,7 +1414,10 @@ impl LaunchWizardState {
             return self.detected_agents.get(self.selected);
         }
         if self.agent_id.is_empty() {
-            self.detected_agents.first()
+            self.detected_agents
+                .iter()
+                .find(|agent| agent.available)
+                .or_else(|| self.detected_agents.first())
         } else {
             self.detected_agents
                 .iter()
@@ -2491,11 +2510,65 @@ fn agent_description(agent: &AgentOption) -> String {
     let availability = if agent.available {
         "Installed"
     } else {
-        "Not installed"
+        "Unavailable"
     };
     match agent.installed_version.as_deref() {
         Some(version) => format!("{availability} · {version}"),
         None => availability.to_string(),
+    }
+}
+
+fn load_global_custom_agents() -> Vec<gwt_agent::CustomCodingAgent> {
+    if std::env::var_os(gwt_agent::DISABLE_GLOBAL_CUSTOM_AGENTS_ENV).is_some() {
+        return Vec::new();
+    }
+
+    gwt_agent::load_custom_agents_from_path(&gwt_core::paths::gwt_config_path()).unwrap_or_default()
+}
+
+#[cfg(windows)]
+fn package_runner_candidates() -> &'static [&'static str] {
+    &["bunx.cmd", "bunx", "npx.cmd", "npx"]
+}
+
+#[cfg(not(windows))]
+fn package_runner_candidates() -> &'static [&'static str] {
+    &["bunx", "npx"]
+}
+
+fn package_runner_available() -> bool {
+    package_runner_candidates().iter().any(|candidate| {
+        which::which(candidate)
+            .ok()
+            .is_some_and(|path| !path.to_string_lossy().contains("node_modules"))
+    })
+}
+
+fn command_version(command: &str) -> Option<String> {
+    let output = std::process::Command::new(command)
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!raw.is_empty()).then_some(raw)
+}
+
+fn custom_agent_availability(agent: &gwt_agent::CustomCodingAgent) -> (bool, Option<String>) {
+    match agent.agent_type {
+        gwt_agent::custom::CustomAgentType::Command => {
+            gwt_agent::AgentDetector::detect_by_command(&agent.command)
+                .map(|detected| (true, detected.version))
+                .unwrap_or((false, None))
+        }
+        gwt_agent::custom::CustomAgentType::Path => {
+            let path = Path::new(&agent.command);
+            (path.is_file(), command_version(&agent.command))
+        }
+        gwt_agent::custom::CustomAgentType::Bunx => (package_runner_available(), None),
     }
 }
 
@@ -2508,6 +2581,34 @@ fn agent_option_color(agent_id: &str) -> Option<gwt_agent::AgentColor> {
 
 pub fn default_wizard_version_cache_path() -> PathBuf {
     gwt_core::paths::gwt_cache_dir().join("agent-versions.json")
+}
+
+pub fn build_agent_options(
+    detected_agents: Vec<gwt_agent::DetectedAgent>,
+    cache: &gwt_agent::VersionCache,
+    custom_agents: Vec<gwt_agent::CustomCodingAgent>,
+) -> Vec<AgentOption> {
+    let mut options = build_builtin_agent_options(detected_agents, cache);
+    options.extend(custom_agents.into_iter().map(|agent| {
+        let (available, installed_version) = custom_agent_availability(&agent);
+        AgentOption {
+            id: agent.id.clone(),
+            name: agent.display_name.clone(),
+            available,
+            installed_version,
+            versions: Vec::new(),
+            custom_agent: Some(agent),
+        }
+    }));
+    options
+}
+
+pub fn load_agent_options(cache: &gwt_agent::VersionCache) -> Vec<AgentOption> {
+    build_agent_options(
+        gwt_agent::AgentDetector::detect_all(),
+        cache,
+        load_global_custom_agents(),
+    )
 }
 
 pub fn build_builtin_agent_options(
@@ -2536,6 +2637,7 @@ pub fn build_builtin_agent_options(
                     .get(&agent_id)
                     .map(|versions| versions.to_vec())
                     .unwrap_or_default(),
+                custom_agent: None,
             }
         })
         .collect()
@@ -2543,6 +2645,8 @@ pub fn build_builtin_agent_options(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use chrono::{TimeZone, Utc};
     use tempfile::tempdir;
 
@@ -2556,6 +2660,7 @@ mod tests {
                 available: true,
                 installed_version: Some("1.0.0".to_string()),
                 versions: vec!["0.9.0".to_string(), "1.0.0".to_string()],
+                custom_agent: None,
             },
             AgentOption {
                 id: "codex".to_string(),
@@ -2563,8 +2668,31 @@ mod tests {
                 available: true,
                 installed_version: Some("0.110.0".to_string()),
                 versions: vec!["0.109.0".to_string(), "0.110.0".to_string()],
+                custom_agent: None,
             },
         ]
+    }
+
+    fn sample_custom_agent(
+        id: &str,
+        display_name: &str,
+        agent_type: gwt_agent::custom::CustomAgentType,
+        command: impl Into<String>,
+    ) -> gwt_agent::CustomCodingAgent {
+        gwt_agent::CustomCodingAgent {
+            id: id.to_string(),
+            display_name: display_name.to_string(),
+            agent_type,
+            command: command.into(),
+            default_args: vec!["--serve".to_string()],
+            mode_args: Some(gwt_agent::custom::ModeArgs {
+                normal: Vec::new(),
+                continue_mode: vec!["--continue".to_string()],
+                resume: vec!["--resume".to_string()],
+            }),
+            skip_permissions_args: vec!["--unsafe".to_string()],
+            env: HashMap::from([("API_KEY".to_string(), "secret".to_string())]),
+        }
     }
 
     #[test]
@@ -2591,6 +2719,52 @@ mod tests {
             Some(gwt_agent::AgentColor::Gray)
         );
         assert_eq!(agent_option_color(""), None);
+    }
+
+    #[test]
+    fn build_agent_options_appends_config_backed_custom_agents_after_builtins() {
+        let dir = tempdir().expect("tempdir");
+        let available_path = dir.path().join("custom-agent");
+        std::fs::write(&available_path, "echo custom").expect("write custom agent stub");
+        let missing_path = dir.path().join("missing-agent");
+
+        let options = build_agent_options(
+            vec![gwt_agent::DetectedAgent {
+                agent_id: gwt_agent::AgentId::ClaudeCode,
+                version: Some("1.2.3".to_string()),
+                path: PathBuf::from("/tmp/claude"),
+            }],
+            &gwt_agent::VersionCache::new(),
+            vec![
+                sample_custom_agent(
+                    "proxy-agent",
+                    "Claude Proxy",
+                    gwt_agent::custom::CustomAgentType::Path,
+                    available_path.display().to_string(),
+                ),
+                sample_custom_agent(
+                    "missing-agent",
+                    "Missing Agent",
+                    gwt_agent::custom::CustomAgentType::Path,
+                    missing_path.display().to_string(),
+                ),
+            ],
+        );
+
+        let proxy = options
+            .iter()
+            .position(|option| option.id == "proxy-agent")
+            .expect("custom agent appended");
+        let missing = options
+            .iter()
+            .position(|option| option.id == "missing-agent")
+            .expect("missing custom agent appended");
+
+        assert!(proxy > 0, "custom agents must appear after builtin options");
+        assert!(missing > proxy, "custom agents should keep append order");
+        assert_eq!(options[proxy].name, "Claude Proxy");
+        assert!(options[proxy].available);
+        assert!(!options[missing].available);
     }
 
     fn branch(name: &str) -> BranchListEntry {
@@ -3472,6 +3646,123 @@ mod tests {
         let config = state.build_launch_config().expect("config");
 
         assert_eq!(config.linked_issue_number, Some(1234));
+    }
+
+    #[test]
+    fn build_launch_config_for_custom_agent_uses_stored_definition() {
+        let dir = tempdir().expect("tempdir");
+        let custom_path = dir.path().join("custom-agent");
+        std::fs::write(&custom_path, "echo custom").expect("write custom agent stub");
+
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            build_agent_options(
+                Vec::new(),
+                &gwt_agent::VersionCache::new(),
+                vec![sample_custom_agent(
+                    "proxy-agent",
+                    "Claude Proxy",
+                    gwt_agent::custom::CustomAgentType::Path,
+                    custom_path.display().to_string(),
+                )],
+            ),
+            Vec::new(),
+        );
+        state.set_agent_id("proxy-agent");
+        state.set_execution_mode("resume");
+        state.resume_session_id = Some("resume-1".to_string());
+        state.skip_permissions = true;
+
+        let config = state.build_launch_config().expect("custom launch config");
+
+        assert_eq!(config.command, custom_path.display().to_string());
+        assert_eq!(config.display_name, "Claude Proxy");
+        assert!(config.args.contains(&"--serve".to_string()));
+        assert!(config.args.contains(&"--resume".to_string()));
+        assert!(config.args.contains(&"--unsafe".to_string()));
+        assert_eq!(
+            config.env_vars.get("API_KEY").map(String::as_str),
+            Some("secret")
+        );
+    }
+
+    #[test]
+    fn build_launch_config_rejects_unavailable_custom_agent() {
+        let missing_path = PathBuf::from("/tmp/nonexistent-custom-agent");
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            build_agent_options(
+                Vec::new(),
+                &gwt_agent::VersionCache::new(),
+                vec![sample_custom_agent(
+                    "missing-agent",
+                    "Missing Agent",
+                    gwt_agent::custom::CustomAgentType::Path,
+                    missing_path.display().to_string(),
+                )],
+            ),
+            Vec::new(),
+        );
+        state.set_agent_id("missing-agent");
+
+        let error = state
+            .build_launch_config()
+            .expect_err("unavailable custom agent must not launch");
+        assert_eq!(error, "Agent option is unavailable");
+    }
+
+    #[test]
+    fn quick_start_resume_for_custom_agent_uses_config_backed_definition() {
+        let dir = tempdir().expect("tempdir");
+        let custom_path = dir.path().join("custom-agent");
+        std::fs::write(&custom_path, "echo custom").expect("write custom agent stub");
+
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            build_agent_options(
+                Vec::new(),
+                &gwt_agent::VersionCache::new(),
+                vec![sample_custom_agent(
+                    "proxy-agent",
+                    "Claude Proxy",
+                    gwt_agent::custom::CustomAgentType::Path,
+                    custom_path.display().to_string(),
+                )],
+            ),
+            vec![QuickStartEntry {
+                session_id: "gwt-session-1".to_string(),
+                agent_id: "proxy-agent".to_string(),
+                tool_label: "Claude Proxy".to_string(),
+                model: None,
+                reasoning: None,
+                version: None,
+                resume_session_id: Some("resume-1".to_string()),
+                live_window_id: None,
+                skip_permissions: true,
+                codex_fast_mode: false,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+            }],
+        );
+
+        state.apply(LaunchWizardAction::ApplyQuickStart {
+            index: 0,
+            mode: QuickStartLaunchMode::Resume,
+        });
+
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::Launch(config)) => match config.as_ref() {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    assert_eq!(config.command, custom_path.display().to_string());
+                    assert_eq!(config.display_name, "Claude Proxy");
+                    assert!(config.args.contains(&"--resume".to_string()));
+                    assert!(config.args.contains(&"--unsafe".to_string()));
+                }
+                other => panic!("expected agent launch request, got {other:?}"),
+            },
+            other => panic!("expected quick start launch completion, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -383,10 +383,9 @@ fn resolve_launch_wizard_hydration(
     active_session_branches: &std::collections::HashSet<String>,
     sessions_dir: &Path,
 ) -> Result<LaunchWizardHydration, String> {
-    let agent_options = build_builtin_agent_options(
-        gwt_agent::AgentDetector::detect_all(),
-        &gwt_agent::VersionCache::load(&default_wizard_version_cache_path()),
-    );
+    let agent_options = load_agent_options(&gwt_agent::VersionCache::load(
+        &default_wizard_version_cache_path(),
+    ));
     let entries = list_branch_entries_with_active_sessions(project_root, active_session_branches)
         .map_err(|error| error.to_string())?;
     let selected_branch = entries

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -39,9 +39,9 @@ pub use knowledge_bridge::{
     KnowledgeKind, KnowledgeListItem,
 };
 pub use launch_wizard::{
-    build_builtin_agent_options, default_wizard_version_cache_path, AgentOption,
-    DockerWizardContext, LaunchTargetKind, LaunchWizardAction, LaunchWizardCompletion,
-    LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest,
+    build_agent_options, build_builtin_agent_options, default_wizard_version_cache_path,
+    load_agent_options, AgentOption, DockerWizardContext, LaunchTargetKind, LaunchWizardAction,
+    LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest,
     LaunchWizardLiveSessionView, LaunchWizardOptionView, LaunchWizardQuickStartView,
     LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView, LaunchWizardView,
     LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode, ShellLaunchConfig,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -11,8 +11,8 @@ use std::{
 use crate::repo_browser::{preferred_issue_launch_branch, spawn_branch_load_async};
 use base64::Engine;
 use gwt::{
-    build_builtin_agent_options, cleanup_selected_branches, default_wizard_version_cache_path,
-    detect_shell_program, list_branch_entries_with_active_sessions, list_directory_entries,
+    cleanup_selected_branches, default_wizard_version_cache_path, detect_shell_program,
+    list_branch_entries_with_active_sessions, list_directory_entries, load_agent_options,
     load_knowledge_bridge, load_restored_workspace_state, load_session_state,
     migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
     save_session_state, save_workspace_state, workspace_state_path, BackendEvent,
@@ -704,6 +704,7 @@ mod tests {
             available: true,
             installed_version: Some("0.110.0".to_string()),
             versions: vec!["0.110.0".to_string()],
+            custom_agent: None,
         }]
     }
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -189,10 +189,9 @@ pub(crate) fn resolve_launch_wizard_hydration(
     active_session_branches: &std::collections::HashSet<String>,
     sessions_dir: &Path,
 ) -> Result<LaunchWizardHydration, String> {
-    let agent_options = build_builtin_agent_options(
-        gwt_agent::AgentDetector::detect_all(),
-        &gwt_agent::VersionCache::load(&default_wizard_version_cache_path()),
-    );
+    let agent_options = load_agent_options(&gwt_agent::VersionCache::load(
+        &default_wizard_version_cache_path(),
+    ));
     let entries = list_branch_entries_with_active_sessions(project_root, active_session_branches)
         .map_err(|error| error.to_string())?;
     let selected_branch = entries


### PR DESCRIPTION
## Summary

- Append config-backed custom agents after built-in agents in GUI launch entrypoints so Settings-saved agents can actually be selected.
- Re-resolve `AgentId::Custom(...)` into the current stored `CustomCodingAgent` definition when building launch config so runner, args, env, and display name match the latest config.
- Keep unavailable custom agents visible but blocked with explicit `Unavailable` handling, and add focused plus broad regression coverage for wizard and relaunch flows.

## Changes

- `crates/gwt/src/launch_wizard.rs`: load builtin + custom agent options together, surface unavailable custom agents, and rebuild launch config / Quick Start relaunch from stored custom definitions.
- `crates/gwt/src/launch_wizard_runtime.rs`, `crates/gwt/src/runtime_support.rs`, `crates/gwt/src/lib.rs`, `crates/gwt/src/main.rs`: route wizard hydration and shared exports through the new custom-aware agent option loader.
- `crates/gwt-agent/src/launch.rs`: accept a full `CustomCodingAgent` in `AgentLaunchBuilder` and resolve `command` / `path` / `bunx` runner, args, env, and display name from that stored definition.

## Testing

- [x] `cargo test -p gwt-agent custom_agent_definition_overrides_display_name_runner_args_and_env` — passes and proves custom launch builder state comes from the stored definition.
- [x] `cargo test -p gwt build_launch_config_for_custom_agent_uses_stored_definition` — passes and proves wizard launch config reconstruction uses the config-backed custom agent.
- [x] `cargo test -p gwt build_launch_config_rejects_unavailable_custom_agent` — passes and proves unavailable custom agents stay blocked.
- [x] `cargo test -p gwt build_agent_options_appends_config_backed_custom_agents_after_builtins` — passes and proves custom agents append after built-ins.
- [x] `cargo test -p gwt quick_start_resume_for_custom_agent_uses_config_backed_definition` — passes and proves Quick Start relaunch preserves the custom agent id and resolves the current config.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo test -p gwt-core -p gwt -p gwt-agent` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo build -p gwt` — passes.

## Closing Issues

- None

## Related Issues / Links

- #1921
- #2014
- #2133

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — No README copy change was needed; owner SPEC artifacts #1921 / #2014 / #2133 were updated instead.
- [ ] Migration/backfill plan included (if schema/data change) — No schema or persisted-data migration was required for this fix.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Settings-side Custom Agent CRUD already persisted valid `command` / `path` / `bunx` agents, but Launch Wizard hydration still used a built-in-only option source, so custom agents were saved yet unselectable.

## Risk / Impact

- **Affected areas**: Launch Wizard agent selection, Quick Start / persisted-session relaunch, custom agent PTY spawn resolution.
- **Rollback plan**: Revert commit `02b2d149` if custom-agent hydration causes regressions in launch entrypoints.

## Notes

- Unavailable custom agents intentionally remain visible with gray custom-agent color and `Unavailable` status instead of being silently filtered out.
