### PR TITLE
fix(terminal): restore Windows interactive shim wrapper

### DIFF
--- a/crates/gwt-terminal/src/pty/windows_spawn.rs
+++ b/crates/gwt-terminal/src/pty/windows_spawn.rs
@@ -21,11 +21,11 @@ pub(super) fn normalize_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
 
     match spawn_wrapper(
         Path::new(&resolved.command),
+        &config.args,
         &config.env,
         &config.remove_env,
     ) {
-        Some((command, mut args)) => {
-            args.extend(config.args);
+        Some((command, args)) => {
             config.command = command;
             config.args = args;
         }
@@ -38,6 +38,31 @@ pub(super) fn normalize_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
     }
 
     config
+}
+
+fn escape_cmd_double_quoted(value: &str) -> String {
+    value.replace('"', "\"\"")
+}
+
+fn quote_cmd_token_if_needed(value: &str) -> String {
+    let needs_quotes = value.is_empty()
+        || value.chars().any(|c| {
+            c.is_whitespace()
+                || matches!(c, '&' | '|' | '<' | '>' | '(' | ')' | '^' | '%' | '!' | '"')
+        });
+
+    if needs_quotes {
+        format!("\"{}\"", escape_cmd_double_quoted(value))
+    } else {
+        value.to_string()
+    }
+}
+
+fn build_cmd_command_expression(command: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(quote_cmd_token_if_needed(command));
+    parts.extend(args.iter().map(|arg| quote_cmd_token_if_needed(arg)));
+    parts.join(" ")
 }
 
 fn resolve_spawn_target(
@@ -99,6 +124,7 @@ fn resolve_path_candidate(
 
 fn spawn_wrapper(
     resolved: &Path,
+    forwarded_args: &[String],
     env: &HashMap<String, String>,
     remove_env: &[String],
 ) -> Option<(String, Vec<String>)> {
@@ -118,13 +144,13 @@ fn spawn_wrapper(
     // with whitespace in the path (e.g. `C:\Program Files\nodejs\npx.cmd`).
     // Without `/s`, CMD's default rule preserves the quotes when the
     // command line has the typical `"<exe>" <args>` shape we emit here.
+    let expression = format!(
+        "{} & exit",
+        build_cmd_command_expression(&resolved.display().to_string(), forwarded_args)
+    );
     Some((
         PathBuf::from(comspec).display().to_string(),
-        vec![
-            "/d".to_string(),
-            "/c".to_string(),
-            resolved.display().to_string(),
-        ],
+        vec!["/d".to_string(), "/k".to_string(), expression],
     ))
 }
 
@@ -355,10 +381,27 @@ mod tests {
             normalized.args,
             vec![
                 "/d".to_string(),
-                "/c".to_string(),
-                cmd.display().to_string(),
-                "--dangerously-skip-permissions".to_string(),
+                "/k".to_string(),
+                format!("{} --dangerously-skip-permissions & exit", cmd.display()),
             ]
+        );
+    }
+
+    #[test]
+    fn build_cmd_command_expression_quotes_paths_and_metacharacters() {
+        let expression = build_cmd_command_expression(
+            r"C:\Program Files\nodejs\npx.cmd",
+            &[
+                "--cwd".to_string(),
+                r"C:\Users\Test User\repo".to_string(),
+                "a&b".to_string(),
+                r#"arg "quoted" value"#.to_string(),
+            ],
+        );
+
+        assert_eq!(
+            expression,
+            r#""C:\Program Files\nodejs\npx.cmd" --cwd "C:\Users\Test User\repo" "a&b" "arg ""quoted"" value""#
         );
     }
 
@@ -586,16 +629,20 @@ mod tests {
             normalized.args,
         );
         assert!(
+            normalized.args.iter().any(|a| a.eq_ignore_ascii_case("/k")),
+            "interactive batch shim should stay on /k wrapper, got {:?}",
+            normalized.args,
+        );
+        let expected_expression = format!(
+            "\"{}\" --yes @anthropic-ai/claude-code@latest & exit",
+            npx_cmd.display()
+        );
+        assert!(
             normalized
                 .args
                 .iter()
-                .any(|a| a == "@anthropic-ai/claude-code@latest"),
-            "expected original package spec preserved in argv, got {:?}",
-            normalized.args,
-        );
-        assert!(
-            normalized.args.iter().any(|a| a == "--yes"),
-            "expected --yes preserved in argv, got {:?}",
+                .any(|arg| arg == &expected_expression),
+            "expected original package spec preserved inside cmd wrapper expression, got {:?}",
             normalized.args,
         );
     }
@@ -612,7 +659,16 @@ mod tests {
         std::fs::write(&cmd_path, "@echo off\n").expect("cmd");
 
         let env: HashMap<String, String> = HashMap::new();
-        let wrapped = spawn_wrapper(&cmd_path, &env, &[]).expect("wrapper");
+        let wrapped = spawn_wrapper(
+            &cmd_path,
+            &[
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+            ],
+            &env,
+            &[],
+        )
+        .expect("wrapper");
 
         assert!(
             !wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/s")),
@@ -625,8 +681,18 @@ mod tests {
             wrapped.1,
         );
         assert!(
-            wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/c")),
-            "wrapper should still include /c, got {:?}",
+            wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/k")),
+            "interactive wrapper should use /k so ConPTY input forwarding stays intact, got {:?}",
+            wrapped.1,
+        );
+        let expected_expression = format!(
+            "\"{}\" --yes @anthropic-ai/claude-code@latest & exit",
+            cmd_path.display()
+        );
+        assert_eq!(
+            wrapped.1.last().map(String::as_str),
+            Some(expected_expression.as_str()),
+            "wrapper should preserve quoting for spaced shim paths and append `& exit`, got {:?}",
             wrapped.1,
         );
     }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-23 — refactor: Windows spawn splitでも interactive cmd wrapper 契約を落とさない
+
+### 事象
+
+Windows の Codex pane で通常対話中にもキー入力が断続的に欠落した。`terminal_input`
+fast-path は残っていたが、Codex のような shim 起動エージェントでだけ再発していた。
+
+### 原因
+
+`b330d7e8` で Windows spawn 解決を `crates/gwt-terminal/src/pty/windows_spawn.rs`
+へ分離した際、`#1604/#1608` で確立していた interactive batch wrapper 契約
+(`cmd.exe /D /K <expression> & exit`) が脱落し、`.cmd` / `.bat` shim が再び
+`/C` で包まれていた。Codex は `codex.cmd` / `npx.cmd` などの shim 経由で起動
+しやすく、ConPTY の入力転送が最初に壊れた。
+
+### 再発防止策
+
+1. Windows の `.cmd` / `.bat` shim 解決を触るときは、path 解決だけでなく
+   interactive wrapper 契約 (`/D /K <expression> & exit`) まで引き継ぐ。
+2. 回帰テストには、spaced shim path、metachar を含む引数、`/S` omission、
+   Node.js 配布の `npx.cmd` shim を必ず含める。
+3. Codex の入力欠落を調査するときは、frontend や WebSocket より先に
+   Windows launch wrapper の `/K` / `/C` 契約を確認する。
+
 ## 2026-04-23 — release: macOS `.app` 内の CFBundleExecutable を他バイナリより先に codesign しない
 
 ### 事象


### PR DESCRIPTION
## Summary
- Restore the Windows interactive `.cmd` / `.bat` shim wrapper contract so Codex keeps reliable ConPTY input forwarding
- Preserve spaced shim-path quoting and forwarded args while keeping `/S` omitted

## Context
- Issue #2149 tracks intermittent key-input drops in Windows Codex panes even after the earlier input fast-path fix
- Root cause was a regression in `crates/gwt-terminal/src/pty/windows_spawn.rs`: the Windows spawn split dropped the old interactive `cmd.exe /D /K <expression> & exit` contract and wrapped shim launches with `/C` again

## Changes
- Reworked `windows_spawn.rs` so shim wrappers build a quoted command expression and launch via `cmd.exe /D /K ... & exit`
- Added focused regression coverage for spaced shim paths, metachar-containing args, and Node.js distribution `npx.cmd` shims
- Recorded the failure mode and prevention rule in `tasks/lessons.md`

## Testing
- `cargo test -p gwt-terminal windows_spawn -- --nocapture`
- `cargo test -p gwt-terminal test_write_input -- --nocapture`
- `cargo test -p gwt-terminal`
- `cargo test -p gwt-core -p gwt`
- `cargo clippy -p gwt-terminal --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `bunx markdownlint-cli tasks/lessons.md`

## Risk / Impact
- Touched area is limited to Windows shim-based PTY spawn normalization in `gwt-terminal`
- Main regression risk is Windows batch-wrapper quoting; coverage now locks the expected `/K ... & exit` behavior for both local shims and `npx.cmd`

## Deployment
- none

## Screenshots
- none

## Related Issues / Links
- #2149
- SPEC-1919
- #1604
- #1608

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [ ] Docs updated
- [ ] Migration/backfill plan included (if needed)
- [ ] Monitoring/alerts updated (if needed)

## Notes
- This is distinct from #2091 / #2096, which were Plan-mode wheel / scrollback regressions.
