### PR TITLE
fix(gui): restore frontend agent color surfaces

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -282,6 +282,68 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_agent_color_styles_define_palette_and_accent_surfaces() {
+        let html = index_html();
+
+        assert!(
+            html.contains("--agent-claude")
+                && html.contains("--agent-codex")
+                && html.contains("--agent-gemini")
+                && html.contains("--agent-opencode")
+                && html.contains("--agent-copilot")
+                && html.contains("--agent-custom"),
+            "expected embedded html to define the AgentColor palette variables",
+        );
+        assert!(
+            html.contains("[data-agent-color=\"yellow\"]")
+                && html.contains("[data-agent-color=\"cyan\"]")
+                && html.contains("[data-agent-color=\"magenta\"]")
+                && html.contains("[data-agent-color=\"green\"]")
+                && html.contains("[data-agent-color=\"blue\"]")
+                && html.contains("[data-agent-color=\"gray\"]"),
+            "expected embedded html to map serialized AgentColor values to the shared CSS variable",
+        );
+        assert!(
+            html.contains(".workspace-window[data-agent-color]::before")
+                && html.contains(".window-list-row[data-agent-color]::before"),
+            "expected embedded html to expose agent-color accent bars for workspace windows and the window list",
+        );
+        assert!(
+            html.contains(".agent-dot"),
+            "expected embedded html to style the shared agent color dot surface",
+        );
+    }
+
+    #[test]
+    fn embedded_web_agent_color_is_bound_for_windows_wizard_and_board() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("if (windowData.agent_color)")
+                && html.contains("element.dataset.agentColor = windowData.agent_color"),
+            "expected embedded bundle to bind workspace window colors from windowData.agent_color",
+        );
+        assert!(
+            html.contains("row.dataset.agentColor = entry.agent_color"),
+            "expected embedded bundle to bind window list rows from entry.agent_color",
+        );
+        assert!(
+            html.contains("card.dataset.agentColor = entry.agent_color"),
+            "expected embedded bundle to bind board cards from entry.agent_color",
+        );
+        assert!(
+            html.contains("if (entry.agent_color)")
+                && html.contains("createNode(\"span\", \"agent-dot\")"),
+            "expected embedded bundle to render board entry agent dots when agent_color is present",
+        );
+        assert!(
+            html.contains("if (option.color)")
+                && html.contains("button.dataset.agentColor = option.color"),
+            "expected embedded bundle to bind launch wizard agent colors from option.color",
+        );
+    }
+
+    #[test]
     fn embedded_web_shell_windows_do_not_render_waiting_status() {
         let js = app_js();
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -489,6 +489,9 @@
           const row = document.createElement("button");
           row.type = "button";
           row.className = "window-list-row";
+          if (entry.agent_color) {
+            row.dataset.agentColor = entry.agent_color;
+          }
           const geometryLabel = windowGeometryLabel(entry);
           const runtimeState = runtimeStateForWindow(entry);
           const runtimeLabel = windowRuntimeLabel(runtimeState);
@@ -2790,17 +2793,24 @@
         }
         for (const entry of state.entries) {
           const card = createNode("article", "board-entry");
+          if (entry.agent_color) {
+            card.dataset.agentColor = entry.agent_color;
+          }
           if (state.replyParentId === entry.id) {
             card.classList.add("reply-target");
           }
 
           const header = createNode("div", "board-entry-header");
-          const meta = createNode(
-            "div",
-            "board-entry-meta",
-            `${entry.author || "Unknown"} · ${boardTimestampLabel(
-              entry.updated_at || entry.created_at,
-            )}`,
+          const meta = createNode("div", "board-entry-meta");
+          if (entry.agent_color) {
+            meta.appendChild(createNode("span", "agent-dot"));
+          }
+          meta.appendChild(
+            document.createTextNode(
+              `${entry.author || "Unknown"} · ${boardTimestampLabel(
+                entry.updated_at || entry.created_at,
+              )}`,
+            ),
           );
           const chips = createNode("div", "board-entry-chips");
           chips.appendChild(
@@ -3017,7 +3027,13 @@
         if (selected) {
           button.classList.add("selected");
         }
-        button.appendChild(createNode("span", "launch-choice-title", option.label));
+        const title = createNode("span", "launch-choice-title");
+        if (option.color) {
+          button.dataset.agentColor = option.color;
+          title.appendChild(createNode("span", "agent-dot"));
+        }
+        title.appendChild(document.createTextNode(option.label));
+        button.appendChild(title);
         if (option.description) {
           button.appendChild(
             createNode("span", "launch-choice-detail", option.description),
@@ -5285,6 +5301,11 @@
         }
 
         element.querySelector(".title-text").textContent = windowData.title;
+        if (windowData.agent_color) {
+          element.dataset.agentColor = windowData.agent_color;
+        } else {
+          delete element.dataset.agentColor;
+        }
         const wasMinimized = element.classList.contains("minimized");
         const shouldPersistTerminalGeometry = wasMinimized && !windowData.minimized;
         element.classList.toggle("minimized", Boolean(windowData.minimized));

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -14,6 +14,36 @@
         font-family:
           Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
           "Segoe UI", sans-serif;
+        --agent-claude: #f59e0b;
+        --agent-codex: #06b6d4;
+        --agent-gemini: #c026d3;
+        --agent-opencode: #16a34a;
+        --agent-copilot: #2563eb;
+        --agent-custom: #9ca3af;
+      }
+
+      [data-agent-color="yellow"] {
+        --current-agent: var(--agent-claude);
+      }
+
+      [data-agent-color="cyan"] {
+        --current-agent: var(--agent-codex);
+      }
+
+      [data-agent-color="magenta"] {
+        --current-agent: var(--agent-gemini);
+      }
+
+      [data-agent-color="green"] {
+        --current-agent: var(--agent-opencode);
+      }
+
+      [data-agent-color="blue"] {
+        --current-agent: var(--agent-copilot);
+      }
+
+      [data-agent-color="gray"] {
+        --current-agent: var(--agent-custom);
       }
 
       * {
@@ -218,6 +248,7 @@
       }
 
       .window-list-row {
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -230,6 +261,21 @@
         color: #0f172a;
         text-align: left;
         cursor: pointer;
+      }
+
+      .window-list-row[data-agent-color] {
+        padding-left: 14px;
+      }
+
+      .window-list-row[data-agent-color]::before {
+        content: "";
+        position: absolute;
+        top: 6px;
+        bottom: 6px;
+        left: 0;
+        width: 3px;
+        background: var(--current-agent);
+        border-radius: 0 2px 2px 0;
       }
 
       .window-list-row:hover {
@@ -316,6 +362,18 @@
         box-shadow:
           0 18px 42px rgba(15, 23, 42, 0.2),
           0 2px 6px rgba(15, 23, 42, 0.1);
+      }
+
+      .workspace-window[data-agent-color]::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 4px;
+        background: var(--current-agent);
+        z-index: 2;
+        pointer-events: none;
       }
 
       .workspace-window.focused {
@@ -1285,6 +1343,12 @@
         color: #475569;
       }
 
+      .board-entry-meta {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
       .board-entry-chips,
       .board-entry-links {
         display: flex;
@@ -2092,8 +2156,21 @@
       }
 
       .launch-choice-title {
+        display: inline-flex;
+        align-items: center;
         font-size: 12px;
         font-weight: 700;
+      }
+
+      .agent-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--current-agent, transparent);
+        margin-right: 6px;
+        flex-shrink: 0;
+        vertical-align: middle;
       }
 
       .launch-choice-detail {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,32 @@
 # Lessons Learned
 
+## 2026-04-23 — fix(gui): agent-color の「色が出ない」は ANSI 色ではなく frontend surface contract を先に疑う
+
+### 事象
+
+`feature/agent-color` で「Window一覧でも terminal でもエージェント毎の色が出ない」
+という報告に対し、初手で ANSI/terminal color 側の切り分けに寄ってしまった。
+実際には対象は `SPEC #2133` の agent surface color で、`origin/develop`
+取り込み後の frontend bundle (`index.html` / `app.js`) から
+`data-agent-color` / `agent-dot` 契約が落ちていたのが原因だった。
+
+### 原因
+
+- 「terminal でも色が出ない」という表現を ANSI color 問題として解釈し、
+  現在の owner SPEC と UI contract を先に突き合わせなかった。
+- `feature/agent-color` が `origin/develop` に大きく behind している事実を
+ 先に使わず、古い branch 上の実装前提で調査を始めた。
+
+### 再発防止策
+
+1. `agent-color` / `エージェント毎の色` 系の報告では、まず ANSI 色ではなく
+   `workspace window` / `window list` / `launch wizard` / `board` の
+   surface contract を確認する。
+2. feature branch が `origin/develop` に大きく behind のときは、個別修正前に
+   先に develop を取り込んでから退行点を再確認する。
+3. frontend bundle 分離後の回帰では、`embedded_web.rs` に CSS/DOM bind
+   契約テストを追加してから修正する。
+
 ## 2026-04-23 — refactor: Windows spawn splitでも interactive cmd wrapper 契約を落とさない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Restore the frontend agent-color surfaces after the `origin/develop` sync dropped the `data-agent-color` wiring from the embedded web bundle.
- Rebind per-agent color hints for workspace windows, the window list, the launch wizard, and board entries so GUI surfaces match `SPEC #2133` again.
- Add embedded web regression tests so future frontend bundle refactors keep the agent-color CSS and DOM contracts intact.

## Changes

- `crates/gwt/web/index.html`: restore the shared AgentColor palette variables, `data-agent-color` CSS mapping, window/list accent bars, and the reusable `agent-dot` style.
- `crates/gwt/web/app.js`: rebind `agent_color` / `color` into workspace window, window list, launch wizard, and board DOM surfaces.
- `crates/gwt/src/embedded_web.rs`: add regression tests that lock the frontend agent-color CSS and DOM binding contracts.
- `tasks/lessons.md`: record the regression pattern and the investigation shortcut for future agent-color fixes.

## Testing

- [x] `cargo test -p gwt embedded_web_agent_color -- --nocapture` — embedded web agent-color regression tests pass.
- [x] `cargo test -p gwt-agent -p gwt` — relevant Rust unit/integration suites pass.
- [x] `cargo fmt -- --check` — formatting check passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes with no warnings.
- [x] `cargo build -p gwt` — the GUI binary builds successfully.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` — updated markdown passes lint.

## Closing Issues

- None

## Related Issues / Links

- #2133
- https://github.com/akiojin/gwt/pull/2136

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [ ] Documentation updated (if user-facing change) — No user-facing README flow changed; this restores an existing GUI contract.
- [ ] Migration/backfill plan included (if schema/data change) — No schema or persisted data change.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- The branch was behind `origin/develop`, so the fix first synced the branch to the current GUI/runtime layout and then restored the agent-color frontend surfaces on top of the extracted embedded web bundle.
- The regression was in the frontend bundle only: backend `agent_color` helpers and wire types were still present after the sync.

## Risk / Impact

- **Affected areas**: Embedded WebView GUI surfaces for workspace windows, the window list, the launch wizard, and board entries.
- **Rollback plan**: Revert commit `4f996015` if the restored frontend bindings cause regressions.

## Screenshots

| Before | After |
|--------|-------|
| Not attached in CLI workflow; regression was verified by embedded web contract tests. | Not attached in CLI workflow; restored by CSS/DOM contract tests and build verification. |

## Notes

- The branch already contains the `origin/develop` sync needed before recreating the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual agent color theming throughout the interface with accent indicators on workspace windows and list rows.
  * Agent color dots now appear on board timeline cards and launch wizard options when associated with an agent.
  * Implemented agent color palette system for consistent styling across UI surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->