### PR TITLE
fix(custom-agent): fallback claude bunx launches to npx

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -507,7 +507,7 @@ fn resolve_host_package_runner_with_probe<F>(
 where
     F: FnMut(&str, Vec<String>, &HashMap<String, String>, Option<PathBuf>) -> bool,
 {
-    let version_spec = package_runner_version_spec(config)?;
+    let version_spec = host_package_runner_version_spec(config)?;
     if !command_matches_runner(&config.command, "bunx") {
         return None;
     }
@@ -525,6 +525,26 @@ where
         executable: fallback_executable,
         args,
     })
+}
+
+fn host_package_runner_version_spec(config: &LaunchConfig) -> Option<String> {
+    package_runner_version_spec(config)
+        .or_else(|| infer_package_runner_version_spec(&config.command, &config.args))
+}
+
+fn infer_package_runner_version_spec(command: &str, args: &[String]) -> Option<String> {
+    if !(command_matches_runner(command, "bunx") || command_matches_runner(command, "npx")) {
+        return None;
+    }
+
+    let version_spec = match args.first().map(String::as_str) {
+        Some("--yes") | Some("-y") => args.get(1)?,
+        _ => args.first()?,
+    };
+    if version_spec.is_empty() || version_spec.starts_with('-') {
+        return None;
+    }
+    Some(version_spec.clone())
 }
 
 fn probe_host_package_runner(
@@ -1253,6 +1273,36 @@ mod tests {
         config
     }
 
+    fn sample_custom_bunx_launch_config(worktree: &Path) -> LaunchConfig {
+        let mut config = AgentLaunchBuilder::new(AgentId::Custom("claude-code-openai".to_string()))
+            .working_dir(worktree)
+            .branch("feature/demo")
+            .session_mode(SessionMode::Normal)
+            .build();
+        config.command = "bunx".to_string();
+        config.args = vec![
+            "@anthropic-ai/claude-code@latest".to_string(),
+            "--print".to_string(),
+        ];
+        config.env_vars = HashMap::from([("TERM".to_string(), "xterm-256color".to_string())]);
+        config.working_dir = Some(worktree.to_path_buf());
+        config.runtime_target = LaunchRuntimeTarget::Host;
+        config.docker_lifecycle_intent = DockerLifecycleIntent::Connect;
+        config
+    }
+
+    #[test]
+    fn host_package_runner_version_spec_uses_runner_args_for_custom_bunx_launch() {
+        let temp = tempdir().expect("tempdir");
+        let config = sample_custom_bunx_launch_config(temp.path());
+
+        assert_eq!(super::package_runner_version_spec(&config), None);
+        assert_eq!(
+            super::host_package_runner_version_spec(&config),
+            Some("@anthropic-ai/claude-code@latest".to_string())
+        );
+    }
+
     #[test]
     fn prepare_agent_launch_persists_session_and_builds_process_launch() {
         let temp = tempdir().expect("tempdir");
@@ -1328,6 +1378,60 @@ mod tests {
             .exists());
         assert_eq!(prepared.session.launch_command, "npx");
         assert_eq!(prepared.session.branch, "feature/demo");
+    }
+
+    #[test]
+    fn prepare_agent_launch_uses_npx_fallback_for_custom_bunx_launch() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo-feature");
+        let sessions_dir = temp.path().join(".gwt").join("sessions");
+        fs::create_dir_all(&worktree).expect("create worktree");
+
+        let mut probe_host_runner =
+            |_command: &str,
+             _args: Vec<String>,
+             _env: &HashMap<String, String>,
+             _cwd: Option<PathBuf>| false;
+        let lookup_gwt_bin =
+            |_command: &str| Some(PathBuf::from(r"C:\Users\Example\.bun\bin\gwt.exe"));
+        let prepared = prepare_agent_launch_with(
+            &worktree,
+            &sessions_dir,
+            sample_custom_bunx_launch_config(&worktree),
+            None,
+            |path| {
+                assert_eq!(path, worktree.as_path());
+                Ok(())
+            },
+            PrepareLaunchDeps {
+                current_exe: Path::new(
+                    r"C:\Users\Example\AppData\Local\Temp\bunx-1234567890-@akiojin\gwt@latest\node_modules\@akiojin\gwt\bin\gwt.exe",
+                ),
+                probe_host_runner: &mut probe_host_runner,
+                lookup_gwt_bin: &lookup_gwt_bin,
+            },
+        )
+        .expect("prepare launch");
+
+        assert!(prepared.used_host_package_runner_fallback);
+        assert_eq!(prepared.process_launch.command, "npx");
+        assert_eq!(
+            prepared.process_launch.args,
+            vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+                "--print".to_string(),
+            ]
+        );
+        assert_eq!(prepared.session.launch_command, "npx");
+        assert_eq!(
+            prepared.session.launch_args,
+            vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+                "--print".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -236,7 +236,7 @@ fn resolve_host_package_runner_with_probe<F>(
 where
     F: FnMut(&str, Vec<String>, &HashMap<String, String>, Option<PathBuf>) -> bool,
 {
-    let version_spec = package_runner_version_spec(config)?;
+    let version_spec = host_package_runner_version_spec(config)?;
     if !command_matches_runner(&config.command, "bunx") {
         return None;
     }
@@ -254,6 +254,26 @@ where
         executable: fallback_executable,
         args,
     })
+}
+
+fn host_package_runner_version_spec(config: &gwt_agent::LaunchConfig) -> Option<String> {
+    package_runner_version_spec(config)
+        .or_else(|| infer_package_runner_version_spec(&config.command, &config.args))
+}
+
+fn infer_package_runner_version_spec(command: &str, args: &[String]) -> Option<String> {
+    if !(command_matches_runner(command, "bunx") || command_matches_runner(command, "npx")) {
+        return None;
+    }
+
+    let version_spec = match args.first().map(String::as_str) {
+        Some("--yes") | Some("-y") => args.get(1)?,
+        _ => args.first()?,
+    };
+    if version_spec.is_empty() || version_spec.starts_with('-') {
+        return None;
+    }
+    Some(version_spec.clone())
 }
 
 fn probe_host_package_runner(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2337,6 +2337,22 @@ mod tests {
         config
     }
 
+    fn sample_custom_bunx_launch_config() -> gwt_agent::LaunchConfig {
+        let mut config = AgentLaunchBuilder::new(AgentId::Custom("claude-code-openai".to_string()))
+            .working_dir("E:/gwt/develop")
+            .build();
+        config.command = "bunx".to_string();
+        config.args = vec![
+            "@anthropic-ai/claude-code@latest".to_string(),
+            "--print".to_string(),
+        ];
+        config.env_vars = HashMap::from([("TERM".to_string(), "xterm-256color".to_string())]);
+        config.working_dir = Some(PathBuf::from("E:/gwt/develop"));
+        config.runtime_target = LaunchRuntimeTarget::Host;
+        config.docker_lifecycle_intent = DockerLifecycleIntent::Connect;
+        config
+    }
+
     #[test]
     fn host_package_runner_fallback_switches_bunx_to_npx_when_probe_fails() {
         let mut config = sample_versioned_launch_config();
@@ -2385,6 +2401,39 @@ mod tests {
         assert!(!changed, "successful bunx probe should keep bunx");
         assert_eq!(config.command, original_command);
         assert_eq!(config.args, original_args);
+    }
+
+    #[test]
+    fn host_package_runner_fallback_switches_custom_bunx_to_npx_when_probe_fails() {
+        let mut config = sample_custom_bunx_launch_config();
+
+        let changed = apply_host_package_runner_fallback_with_probe(
+            &mut config,
+            "npx".to_string(),
+            |command, args, _env, cwd| {
+                assert_eq!(command, "bunx");
+                assert_eq!(
+                    args,
+                    vec![
+                        "@anthropic-ai/claude-code@latest".to_string(),
+                        "--version".to_string(),
+                    ]
+                );
+                assert_eq!(cwd, Some(PathBuf::from("E:/gwt/develop")));
+                false
+            },
+        );
+
+        assert!(changed, "expected custom bunx failure to switch to npx");
+        assert_eq!(config.command, "npx");
+        assert_eq!(
+            config.args,
+            vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+                "--print".to_string(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extend Host package-runner fallback so the Claude Code OpenAI-compat custom agent can recover from broken `bunx` installs by switching to `npx --yes`.
- Persist the actual fallback runner and argv into prepared session metadata so relaunch and inspection surfaces reflect the command that really executed.
- Add focused regression coverage at both the GUI/runtime and gwt-agent prepare layers for custom `bunx @anthropic-ai/claude-code@latest` launches.

## Changes

- `crates/gwt/src/launch_runtime.rs`: derive the package spec from finalized `bunx`/`npx` argv for Host fallback instead of relying only on built-in `AgentId` package metadata.
- `crates/gwt-agent/src/prepare.rs`: reuse the same package-spec inference during launch preparation and verify that fallback session metadata records `npx --yes ...`.
- `crates/gwt/src/main.rs`: add a focused regression test proving custom Claude bunx launches switch to `npx` when the bunx probe fails.

## Testing

- [x] `cargo test -p gwt host_package_runner_fallback_switches_custom_bunx_to_npx_when_probe_fails` — passes.
- [x] `cargo test -p gwt-agent host_package_runner_version_spec_uses_runner_args_for_custom_bunx_launch` — passes.
- [x] `cargo test -p gwt-agent prepare_agent_launch_uses_npx_fallback_for_custom_bunx_launch` — passes.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo test -p gwt-core -p gwt -p gwt-agent` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo build -p gwt` — passes.

## Closing Issues

- None

## Related Issues / Links

- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (SPEC-1921 artifacts refreshed)
- [ ] Migration/backfill plan included (if schema/data change) — no schema or data migration is required.
- [x] CHANGELOG impact considered (patch-level fix, no breaking change)

## Context

- The saved `Claude Code (OpenAI-compat backend)` preset launches as `bunx @anthropic-ai/claude-code@latest`, but on this Windows environment `bunx ... --version` failed with Bun's corrupted `node_modules` remap error while `npx --yes @anthropic-ai/claude-code@latest --version` still succeeded.
- Existing Host fallback logic only handled built-in agents because it derived package specs from `AgentId::package_name()`, which returns `None` for `AgentId::Custom(_)`.
- This PR keeps Docker behavior unchanged and fixes only the Host fallback path used by the Claude local-LLM custom-agent flow owned by SPEC-1921.

## Risk / Impact

- **Affected areas**: Host agent launch fallback, prepared session metadata, custom Claude preset relaunch behavior.
- **Rollback plan**: Revert this PR to restore the previous built-in-only Host fallback behavior.

## Notes

- `SPEC-1921` `spec`, `plan`, `tasks`, and `progress` were updated through `gwt issue spec ... --edit ...` to document the new Host fallback contract.
