### PR TITLE
chore(release): v9.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.8.2] - 2026-04-23
+
+### Bug Fixes
+
+- Custom Claude bunx launchでnpx fallbackを使う
+- **terminal:** Restore Windows interactive shim wrapper (#2149)
+- **gui:** エージェント色のfrontend配線を復元
+
 ## [9.8.1] - 2026-04-23
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "axum",
  "base64",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "chrono",
  "dunce",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "dirs",
  "serde",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "fs2",
  "regex",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.8.1"
+version = "9.8.2"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.8.1"
+version = "9.8.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -507,7 +507,7 @@ fn resolve_host_package_runner_with_probe<F>(
 where
     F: FnMut(&str, Vec<String>, &HashMap<String, String>, Option<PathBuf>) -> bool,
 {
-    let version_spec = package_runner_version_spec(config)?;
+    let version_spec = host_package_runner_version_spec(config)?;
     if !command_matches_runner(&config.command, "bunx") {
         return None;
     }
@@ -525,6 +525,26 @@ where
         executable: fallback_executable,
         args,
     })
+}
+
+fn host_package_runner_version_spec(config: &LaunchConfig) -> Option<String> {
+    package_runner_version_spec(config)
+        .or_else(|| infer_package_runner_version_spec(&config.command, &config.args))
+}
+
+fn infer_package_runner_version_spec(command: &str, args: &[String]) -> Option<String> {
+    if !(command_matches_runner(command, "bunx") || command_matches_runner(command, "npx")) {
+        return None;
+    }
+
+    let version_spec = match args.first().map(String::as_str) {
+        Some("--yes") | Some("-y") => args.get(1)?,
+        _ => args.first()?,
+    };
+    if version_spec.is_empty() || version_spec.starts_with('-') {
+        return None;
+    }
+    Some(version_spec.clone())
 }
 
 fn probe_host_package_runner(
@@ -1253,6 +1273,36 @@ mod tests {
         config
     }
 
+    fn sample_custom_bunx_launch_config(worktree: &Path) -> LaunchConfig {
+        let mut config = AgentLaunchBuilder::new(AgentId::Custom("claude-code-openai".to_string()))
+            .working_dir(worktree)
+            .branch("feature/demo")
+            .session_mode(SessionMode::Normal)
+            .build();
+        config.command = "bunx".to_string();
+        config.args = vec![
+            "@anthropic-ai/claude-code@latest".to_string(),
+            "--print".to_string(),
+        ];
+        config.env_vars = HashMap::from([("TERM".to_string(), "xterm-256color".to_string())]);
+        config.working_dir = Some(worktree.to_path_buf());
+        config.runtime_target = LaunchRuntimeTarget::Host;
+        config.docker_lifecycle_intent = DockerLifecycleIntent::Connect;
+        config
+    }
+
+    #[test]
+    fn host_package_runner_version_spec_uses_runner_args_for_custom_bunx_launch() {
+        let temp = tempdir().expect("tempdir");
+        let config = sample_custom_bunx_launch_config(temp.path());
+
+        assert_eq!(super::package_runner_version_spec(&config), None);
+        assert_eq!(
+            super::host_package_runner_version_spec(&config),
+            Some("@anthropic-ai/claude-code@latest".to_string())
+        );
+    }
+
     #[test]
     fn prepare_agent_launch_persists_session_and_builds_process_launch() {
         let temp = tempdir().expect("tempdir");
@@ -1328,6 +1378,60 @@ mod tests {
             .exists());
         assert_eq!(prepared.session.launch_command, "npx");
         assert_eq!(prepared.session.branch, "feature/demo");
+    }
+
+    #[test]
+    fn prepare_agent_launch_uses_npx_fallback_for_custom_bunx_launch() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo-feature");
+        let sessions_dir = temp.path().join(".gwt").join("sessions");
+        fs::create_dir_all(&worktree).expect("create worktree");
+
+        let mut probe_host_runner =
+            |_command: &str,
+             _args: Vec<String>,
+             _env: &HashMap<String, String>,
+             _cwd: Option<PathBuf>| false;
+        let lookup_gwt_bin =
+            |_command: &str| Some(PathBuf::from(r"C:\Users\Example\.bun\bin\gwt.exe"));
+        let prepared = prepare_agent_launch_with(
+            &worktree,
+            &sessions_dir,
+            sample_custom_bunx_launch_config(&worktree),
+            None,
+            |path| {
+                assert_eq!(path, worktree.as_path());
+                Ok(())
+            },
+            PrepareLaunchDeps {
+                current_exe: Path::new(
+                    r"C:\Users\Example\AppData\Local\Temp\bunx-1234567890-@akiojin\gwt@latest\node_modules\@akiojin\gwt\bin\gwt.exe",
+                ),
+                probe_host_runner: &mut probe_host_runner,
+                lookup_gwt_bin: &lookup_gwt_bin,
+            },
+        )
+        .expect("prepare launch");
+
+        assert!(prepared.used_host_package_runner_fallback);
+        assert_eq!(prepared.process_launch.command, "npx");
+        assert_eq!(
+            prepared.process_launch.args,
+            vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+                "--print".to_string(),
+            ]
+        );
+        assert_eq!(prepared.session.launch_command, "npx");
+        assert_eq!(
+            prepared.session.launch_args,
+            vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+                "--print".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/gwt-terminal/src/pty/windows_spawn.rs
+++ b/crates/gwt-terminal/src/pty/windows_spawn.rs
@@ -21,11 +21,11 @@ pub(super) fn normalize_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
 
     match spawn_wrapper(
         Path::new(&resolved.command),
+        &config.args,
         &config.env,
         &config.remove_env,
     ) {
-        Some((command, mut args)) => {
-            args.extend(config.args);
+        Some((command, args)) => {
             config.command = command;
             config.args = args;
         }
@@ -38,6 +38,31 @@ pub(super) fn normalize_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
     }
 
     config
+}
+
+fn escape_cmd_double_quoted(value: &str) -> String {
+    value.replace('"', "\"\"")
+}
+
+fn quote_cmd_token_if_needed(value: &str) -> String {
+    let needs_quotes = value.is_empty()
+        || value.chars().any(|c| {
+            c.is_whitespace()
+                || matches!(c, '&' | '|' | '<' | '>' | '(' | ')' | '^' | '%' | '!' | '"')
+        });
+
+    if needs_quotes {
+        format!("\"{}\"", escape_cmd_double_quoted(value))
+    } else {
+        value.to_string()
+    }
+}
+
+fn build_cmd_command_expression(command: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(quote_cmd_token_if_needed(command));
+    parts.extend(args.iter().map(|arg| quote_cmd_token_if_needed(arg)));
+    parts.join(" ")
 }
 
 fn resolve_spawn_target(
@@ -99,6 +124,7 @@ fn resolve_path_candidate(
 
 fn spawn_wrapper(
     resolved: &Path,
+    forwarded_args: &[String],
     env: &HashMap<String, String>,
     remove_env: &[String],
 ) -> Option<(String, Vec<String>)> {
@@ -118,13 +144,13 @@ fn spawn_wrapper(
     // with whitespace in the path (e.g. `C:\Program Files\nodejs\npx.cmd`).
     // Without `/s`, CMD's default rule preserves the quotes when the
     // command line has the typical `"<exe>" <args>` shape we emit here.
+    let expression = format!(
+        "{} & exit",
+        build_cmd_command_expression(&resolved.display().to_string(), forwarded_args)
+    );
     Some((
         PathBuf::from(comspec).display().to_string(),
-        vec![
-            "/d".to_string(),
-            "/c".to_string(),
-            resolved.display().to_string(),
-        ],
+        vec!["/d".to_string(), "/k".to_string(), expression],
     ))
 }
 
@@ -355,10 +381,27 @@ mod tests {
             normalized.args,
             vec![
                 "/d".to_string(),
-                "/c".to_string(),
-                cmd.display().to_string(),
-                "--dangerously-skip-permissions".to_string(),
+                "/k".to_string(),
+                format!("{} --dangerously-skip-permissions & exit", cmd.display()),
             ]
+        );
+    }
+
+    #[test]
+    fn build_cmd_command_expression_quotes_paths_and_metacharacters() {
+        let expression = build_cmd_command_expression(
+            r"C:\Program Files\nodejs\npx.cmd",
+            &[
+                "--cwd".to_string(),
+                r"C:\Users\Test User\repo".to_string(),
+                "a&b".to_string(),
+                r#"arg "quoted" value"#.to_string(),
+            ],
+        );
+
+        assert_eq!(
+            expression,
+            r#""C:\Program Files\nodejs\npx.cmd" --cwd "C:\Users\Test User\repo" "a&b" "arg ""quoted"" value""#
         );
     }
 
@@ -586,16 +629,20 @@ mod tests {
             normalized.args,
         );
         assert!(
+            normalized.args.iter().any(|a| a.eq_ignore_ascii_case("/k")),
+            "interactive batch shim should stay on /k wrapper, got {:?}",
+            normalized.args,
+        );
+        let expected_expression = format!(
+            "\"{}\" --yes @anthropic-ai/claude-code@latest & exit",
+            npx_cmd.display()
+        );
+        assert!(
             normalized
                 .args
                 .iter()
-                .any(|a| a == "@anthropic-ai/claude-code@latest"),
-            "expected original package spec preserved in argv, got {:?}",
-            normalized.args,
-        );
-        assert!(
-            normalized.args.iter().any(|a| a == "--yes"),
-            "expected --yes preserved in argv, got {:?}",
+                .any(|arg| arg == &expected_expression),
+            "expected original package spec preserved inside cmd wrapper expression, got {:?}",
             normalized.args,
         );
     }
@@ -612,7 +659,16 @@ mod tests {
         std::fs::write(&cmd_path, "@echo off\n").expect("cmd");
 
         let env: HashMap<String, String> = HashMap::new();
-        let wrapped = spawn_wrapper(&cmd_path, &env, &[]).expect("wrapper");
+        let wrapped = spawn_wrapper(
+            &cmd_path,
+            &[
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+            ],
+            &env,
+            &[],
+        )
+        .expect("wrapper");
 
         assert!(
             !wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/s")),
@@ -625,8 +681,18 @@ mod tests {
             wrapped.1,
         );
         assert!(
-            wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/c")),
-            "wrapper should still include /c, got {:?}",
+            wrapped.1.iter().any(|a| a.eq_ignore_ascii_case("/k")),
+            "interactive wrapper should use /k so ConPTY input forwarding stays intact, got {:?}",
+            wrapped.1,
+        );
+        let expected_expression = format!(
+            "\"{}\" --yes @anthropic-ai/claude-code@latest & exit",
+            cmd_path.display()
+        );
+        assert_eq!(
+            wrapped.1.last().map(String::as_str),
+            Some(expected_expression.as_str()),
+            "wrapper should preserve quoting for spaced shim paths and append `& exit`, got {:?}",
             wrapped.1,
         );
     }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -282,6 +282,68 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_agent_color_styles_define_palette_and_accent_surfaces() {
+        let html = index_html();
+
+        assert!(
+            html.contains("--agent-claude")
+                && html.contains("--agent-codex")
+                && html.contains("--agent-gemini")
+                && html.contains("--agent-opencode")
+                && html.contains("--agent-copilot")
+                && html.contains("--agent-custom"),
+            "expected embedded html to define the AgentColor palette variables",
+        );
+        assert!(
+            html.contains("[data-agent-color=\"yellow\"]")
+                && html.contains("[data-agent-color=\"cyan\"]")
+                && html.contains("[data-agent-color=\"magenta\"]")
+                && html.contains("[data-agent-color=\"green\"]")
+                && html.contains("[data-agent-color=\"blue\"]")
+                && html.contains("[data-agent-color=\"gray\"]"),
+            "expected embedded html to map serialized AgentColor values to the shared CSS variable",
+        );
+        assert!(
+            html.contains(".workspace-window[data-agent-color]::before")
+                && html.contains(".window-list-row[data-agent-color]::before"),
+            "expected embedded html to expose agent-color accent bars for workspace windows and the window list",
+        );
+        assert!(
+            html.contains(".agent-dot"),
+            "expected embedded html to style the shared agent color dot surface",
+        );
+    }
+
+    #[test]
+    fn embedded_web_agent_color_is_bound_for_windows_wizard_and_board() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("if (windowData.agent_color)")
+                && html.contains("element.dataset.agentColor = windowData.agent_color"),
+            "expected embedded bundle to bind workspace window colors from windowData.agent_color",
+        );
+        assert!(
+            html.contains("row.dataset.agentColor = entry.agent_color"),
+            "expected embedded bundle to bind window list rows from entry.agent_color",
+        );
+        assert!(
+            html.contains("card.dataset.agentColor = entry.agent_color"),
+            "expected embedded bundle to bind board cards from entry.agent_color",
+        );
+        assert!(
+            html.contains("if (entry.agent_color)")
+                && html.contains("createNode(\"span\", \"agent-dot\")"),
+            "expected embedded bundle to render board entry agent dots when agent_color is present",
+        );
+        assert!(
+            html.contains("if (option.color)")
+                && html.contains("button.dataset.agentColor = option.color"),
+            "expected embedded bundle to bind launch wizard agent colors from option.color",
+        );
+    }
+
+    #[test]
     fn embedded_web_shell_windows_do_not_render_waiting_status() {
         let js = app_js();
 

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -236,7 +236,7 @@ fn resolve_host_package_runner_with_probe<F>(
 where
     F: FnMut(&str, Vec<String>, &HashMap<String, String>, Option<PathBuf>) -> bool,
 {
-    let version_spec = package_runner_version_spec(config)?;
+    let version_spec = host_package_runner_version_spec(config)?;
     if !command_matches_runner(&config.command, "bunx") {
         return None;
     }
@@ -254,6 +254,26 @@ where
         executable: fallback_executable,
         args,
     })
+}
+
+fn host_package_runner_version_spec(config: &gwt_agent::LaunchConfig) -> Option<String> {
+    package_runner_version_spec(config)
+        .or_else(|| infer_package_runner_version_spec(&config.command, &config.args))
+}
+
+fn infer_package_runner_version_spec(command: &str, args: &[String]) -> Option<String> {
+    if !(command_matches_runner(command, "bunx") || command_matches_runner(command, "npx")) {
+        return None;
+    }
+
+    let version_spec = match args.first().map(String::as_str) {
+        Some("--yes") | Some("-y") => args.get(1)?,
+        _ => args.first()?,
+    };
+    if version_spec.is_empty() || version_spec.starts_with('-') {
+        return None;
+    }
+    Some(version_spec.clone())
 }
 
 fn probe_host_package_runner(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2337,6 +2337,22 @@ mod tests {
         config
     }
 
+    fn sample_custom_bunx_launch_config() -> gwt_agent::LaunchConfig {
+        let mut config = AgentLaunchBuilder::new(AgentId::Custom("claude-code-openai".to_string()))
+            .working_dir("E:/gwt/develop")
+            .build();
+        config.command = "bunx".to_string();
+        config.args = vec![
+            "@anthropic-ai/claude-code@latest".to_string(),
+            "--print".to_string(),
+        ];
+        config.env_vars = HashMap::from([("TERM".to_string(), "xterm-256color".to_string())]);
+        config.working_dir = Some(PathBuf::from("E:/gwt/develop"));
+        config.runtime_target = LaunchRuntimeTarget::Host;
+        config.docker_lifecycle_intent = DockerLifecycleIntent::Connect;
+        config
+    }
+
     #[test]
     fn host_package_runner_fallback_switches_bunx_to_npx_when_probe_fails() {
         let mut config = sample_versioned_launch_config();
@@ -2385,6 +2401,39 @@ mod tests {
         assert!(!changed, "successful bunx probe should keep bunx");
         assert_eq!(config.command, original_command);
         assert_eq!(config.args, original_args);
+    }
+
+    #[test]
+    fn host_package_runner_fallback_switches_custom_bunx_to_npx_when_probe_fails() {
+        let mut config = sample_custom_bunx_launch_config();
+
+        let changed = apply_host_package_runner_fallback_with_probe(
+            &mut config,
+            "npx".to_string(),
+            |command, args, _env, cwd| {
+                assert_eq!(command, "bunx");
+                assert_eq!(
+                    args,
+                    vec![
+                        "@anthropic-ai/claude-code@latest".to_string(),
+                        "--version".to_string(),
+                    ]
+                );
+                assert_eq!(cwd, Some(PathBuf::from("E:/gwt/develop")));
+                false
+            },
+        );
+
+        assert!(changed, "expected custom bunx failure to switch to npx");
+        assert_eq!(config.command, "npx");
+        assert_eq!(
+            config.args,
+            vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+                "--print".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -489,6 +489,9 @@
           const row = document.createElement("button");
           row.type = "button";
           row.className = "window-list-row";
+          if (entry.agent_color) {
+            row.dataset.agentColor = entry.agent_color;
+          }
           const geometryLabel = windowGeometryLabel(entry);
           const runtimeState = runtimeStateForWindow(entry);
           const runtimeLabel = windowRuntimeLabel(runtimeState);
@@ -2790,17 +2793,24 @@
         }
         for (const entry of state.entries) {
           const card = createNode("article", "board-entry");
+          if (entry.agent_color) {
+            card.dataset.agentColor = entry.agent_color;
+          }
           if (state.replyParentId === entry.id) {
             card.classList.add("reply-target");
           }
 
           const header = createNode("div", "board-entry-header");
-          const meta = createNode(
-            "div",
-            "board-entry-meta",
-            `${entry.author || "Unknown"} · ${boardTimestampLabel(
-              entry.updated_at || entry.created_at,
-            )}`,
+          const meta = createNode("div", "board-entry-meta");
+          if (entry.agent_color) {
+            meta.appendChild(createNode("span", "agent-dot"));
+          }
+          meta.appendChild(
+            document.createTextNode(
+              `${entry.author || "Unknown"} · ${boardTimestampLabel(
+                entry.updated_at || entry.created_at,
+              )}`,
+            ),
           );
           const chips = createNode("div", "board-entry-chips");
           chips.appendChild(
@@ -3017,7 +3027,13 @@
         if (selected) {
           button.classList.add("selected");
         }
-        button.appendChild(createNode("span", "launch-choice-title", option.label));
+        const title = createNode("span", "launch-choice-title");
+        if (option.color) {
+          button.dataset.agentColor = option.color;
+          title.appendChild(createNode("span", "agent-dot"));
+        }
+        title.appendChild(document.createTextNode(option.label));
+        button.appendChild(title);
         if (option.description) {
           button.appendChild(
             createNode("span", "launch-choice-detail", option.description),
@@ -5285,6 +5301,11 @@
         }
 
         element.querySelector(".title-text").textContent = windowData.title;
+        if (windowData.agent_color) {
+          element.dataset.agentColor = windowData.agent_color;
+        } else {
+          delete element.dataset.agentColor;
+        }
         const wasMinimized = element.classList.contains("minimized");
         const shouldPersistTerminalGeometry = wasMinimized && !windowData.minimized;
         element.classList.toggle("minimized", Boolean(windowData.minimized));

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -14,6 +14,36 @@
         font-family:
           Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
           "Segoe UI", sans-serif;
+        --agent-claude: #f59e0b;
+        --agent-codex: #06b6d4;
+        --agent-gemini: #c026d3;
+        --agent-opencode: #16a34a;
+        --agent-copilot: #2563eb;
+        --agent-custom: #9ca3af;
+      }
+
+      [data-agent-color="yellow"] {
+        --current-agent: var(--agent-claude);
+      }
+
+      [data-agent-color="cyan"] {
+        --current-agent: var(--agent-codex);
+      }
+
+      [data-agent-color="magenta"] {
+        --current-agent: var(--agent-gemini);
+      }
+
+      [data-agent-color="green"] {
+        --current-agent: var(--agent-opencode);
+      }
+
+      [data-agent-color="blue"] {
+        --current-agent: var(--agent-copilot);
+      }
+
+      [data-agent-color="gray"] {
+        --current-agent: var(--agent-custom);
       }
 
       * {
@@ -218,6 +248,7 @@
       }
 
       .window-list-row {
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -230,6 +261,21 @@
         color: #0f172a;
         text-align: left;
         cursor: pointer;
+      }
+
+      .window-list-row[data-agent-color] {
+        padding-left: 14px;
+      }
+
+      .window-list-row[data-agent-color]::before {
+        content: "";
+        position: absolute;
+        top: 6px;
+        bottom: 6px;
+        left: 0;
+        width: 3px;
+        background: var(--current-agent);
+        border-radius: 0 2px 2px 0;
       }
 
       .window-list-row:hover {
@@ -316,6 +362,18 @@
         box-shadow:
           0 18px 42px rgba(15, 23, 42, 0.2),
           0 2px 6px rgba(15, 23, 42, 0.1);
+      }
+
+      .workspace-window[data-agent-color]::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 4px;
+        background: var(--current-agent);
+        z-index: 2;
+        pointer-events: none;
       }
 
       .workspace-window.focused {
@@ -1285,6 +1343,12 @@
         color: #475569;
       }
 
+      .board-entry-meta {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
       .board-entry-chips,
       .board-entry-links {
         display: flex;
@@ -2092,8 +2156,21 @@
       }
 
       .launch-choice-title {
+        display: inline-flex;
+        align-items: center;
         font-size: 12px;
         font-weight: 700;
+      }
+
+      .agent-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--current-agent, transparent);
+        margin-right: 6px;
+        flex-shrink: 0;
+        vertical-align: middle;
       }
 
       .launch-choice-detail {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.8.1",
+  "version": "9.8.2",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-23 — refactor: Windows spawn splitでも interactive cmd wrapper 契約を落とさない
+
+### 事象
+
+Windows の Codex pane で通常対話中にもキー入力が断続的に欠落した。`terminal_input`
+fast-path は残っていたが、Codex のような shim 起動エージェントでだけ再発していた。
+
+### 原因
+
+`b330d7e8` で Windows spawn 解決を `crates/gwt-terminal/src/pty/windows_spawn.rs`
+へ分離した際、`#1604/#1608` で確立していた interactive batch wrapper 契約
+(`cmd.exe /D /K <expression> & exit`) が脱落し、`.cmd` / `.bat` shim が再び
+`/C` で包まれていた。Codex は `codex.cmd` / `npx.cmd` などの shim 経由で起動
+しやすく、ConPTY の入力転送が最初に壊れた。
+
+### 再発防止策
+
+1. Windows の `.cmd` / `.bat` shim 解決を触るときは、path 解決だけでなく
+   interactive wrapper 契約 (`/D /K <expression> & exit`) まで引き継ぐ。
+2. 回帰テストには、spaced shim path、metachar を含む引数、`/S` omission、
+   Node.js 配布の `npx.cmd` shim を必ず含める。
+3. Codex の入力欠落を調査するときは、frontend や WebSocket より先に
+   Windows launch wrapper の `/K` / `/C` 契約を確認する。
+
 ## 2026-04-23 — release: macOS `.app` 内の CFBundleExecutable を他バイナリより先に codesign しない
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,32 @@
 # Lessons Learned
 
+## 2026-04-23 — fix(gui): agent-color の「色が出ない」は ANSI 色ではなく frontend surface contract を先に疑う
+
+### 事象
+
+`feature/agent-color` で「Window一覧でも terminal でもエージェント毎の色が出ない」
+という報告に対し、初手で ANSI/terminal color 側の切り分けに寄ってしまった。
+実際には対象は `SPEC #2133` の agent surface color で、`origin/develop`
+取り込み後の frontend bundle (`index.html` / `app.js`) から
+`data-agent-color` / `agent-dot` 契約が落ちていたのが原因だった。
+
+### 原因
+
+- 「terminal でも色が出ない」という表現を ANSI color 問題として解釈し、
+  現在の owner SPEC と UI contract を先に突き合わせなかった。
+- `feature/agent-color` が `origin/develop` に大きく behind している事実を
+ 先に使わず、古い branch 上の実装前提で調査を始めた。
+
+### 再発防止策
+
+1. `agent-color` / `エージェント毎の色` 系の報告では、まず ANSI 色ではなく
+   `workspace window` / `window list` / `launch wizard` / `board` の
+   surface contract を確認する。
+2. feature branch が `origin/develop` に大きく behind のときは、個別修正前に
+   先に develop を取り込んでから退行点を再確認する。
+3. frontend bundle 分離後の回帰では、`embedded_web.rs` に CSS/DOM bind
+   契約テストを追加してから修正する。
+
 ## 2026-04-23 — refactor: Windows spawn splitでも interactive cmd wrapper 契約を落とさない
 
 ### 事象


### PR DESCRIPTION
## Summary

v9.8.2 パッチリリース。custom Claude の bunx/npx フォールバック、GUI エージェント色の配線復元、Windows インタラクティブシムラッパーの復元を含む3件のバグフィックスを反映する。

## Changes

### Bug Fixes

- Custom Claude bunx launch で npx fallback を使うように修正 (4df01039)
- **terminal:** Windows インタラクティブシムラッパーを復元 (39026e2a, #2149)
- **gui:** エージェント色の frontend 配線を復元 (4f996015)

## Version

`v9.8.2` (前回: `v9.8.1`)

## Closing Issues

Closes #2149

## Related Issues / Links

- #1604
- #1608
- #1921
- #2133

## Notes

- Related Issues (#1604 / #1608 / #1921 / #2133) は本 PR では auto-close されない。クローズさせたい場合は Closing Issues へ移す必要がある。
