### PR TITLE
fix(runtime): force UTF-8 in chroma_index_runner to prevent cp932 decode errors on Japanese Windows

### DIFF
--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -109,7 +109,7 @@ def load_gitignore_patterns(project_root: Path) -> List[str]:
     gitignore = project_root / ".gitignore"
     patterns: List[str] = list(DEFAULT_IGNORE_PATTERNS)
     if gitignore.is_file():
-        for line in gitignore.read_text(errors="replace").splitlines():
+        for line in gitignore.read_text(encoding="utf-8", errors="replace").splitlines():
             line = line.strip()
             if line and not line.startswith("#"):
                 patterns.append(line)
@@ -221,7 +221,7 @@ def extract_description(file_path: Path) -> str:
     name = file_path.name.lower()
 
     try:
-        content = file_path.read_text(errors="replace")
+        content = file_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return file_path.name
 
@@ -832,7 +832,7 @@ def action_index_specs(project_root: str, db_path: str) -> dict:
             continue
 
         try:
-            meta = json.loads(metadata_file.read_text(errors="replace"))
+            meta = json.loads(metadata_file.read_text(encoding="utf-8", errors="replace"))
         except (json.JSONDecodeError, ValueError, OSError):
             continue
 
@@ -846,7 +846,7 @@ def action_index_specs(project_root: str, db_path: str) -> dict:
         spec_md = spec_path / "spec.md"
         if spec_md.is_file():
             try:
-                spec_content = spec_md.read_text(errors="replace")[:500]
+                spec_content = spec_md.read_text(encoding="utf-8", errors="replace")[:500]
             except OSError:
                 pass
 
@@ -1049,7 +1049,7 @@ def acquire_lock(db_path: Path, exclusive: bool = True) -> Iterator[None]:
     if os.name == "nt":
         import msvcrt  # type: ignore
 
-        fh = open(lock_path, "a+")
+        fh = open(lock_path, "a+b")
         try:
             mode = msvcrt.LK_LOCK  # always blocking; Windows lacks shared locks here
             msvcrt.locking(fh.fileno(), mode, 1)
@@ -1067,7 +1067,7 @@ def acquire_lock(db_path: Path, exclusive: bool = True) -> Iterator[None]:
 
     import fcntl  # type: ignore
 
-    fh = open(lock_path, "a+")
+    fh = open(lock_path, "a+b")
     try:
         fcntl.flock(fh, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
         try:
@@ -1243,7 +1243,7 @@ def read_manifest(worktree_dir: Path, scope: str) -> List[Dict[str, Any]]:
     if not path.is_file():
         return []
     try:
-        payload = json.loads(path.read_text())
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return []
     if isinstance(payload, dict) and isinstance(payload.get("entries"), list):
@@ -1261,7 +1261,7 @@ def write_manifest(worktree_dir: Path, scope: str, entries: List[Dict[str, Any]]
         "scope": scope,
         "entries": entries,
     }
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def compute_manifest_diff(
@@ -1361,7 +1361,7 @@ def embed_documents_for_paths(
             continue
         desc = extract_description(fpath)
         try:
-            text = fpath.read_text(errors="replace")[:2000]
+            text = fpath.read_text(encoding="utf-8", errors="replace")[:2000]
         except OSError:
             text = ""
         ids.append(rel)
@@ -1679,14 +1679,16 @@ def _read_issue_meta(db_path: Path) -> Optional[Dict[str, Any]]:
     if not meta_file.is_file():
         return None
     try:
-        return json.loads(meta_file.read_text())
+        return json.loads(meta_file.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 
 
 def _write_issue_meta(db_path: Path, payload: Dict[str, Any]) -> None:
     db_path.mkdir(parents=True, exist_ok=True)
-    (db_path / META_FILENAME).write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    (db_path / META_FILENAME).write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
 
 def _now_utc() -> datetime.datetime:
@@ -1757,12 +1759,14 @@ def _load_cached_issue_documents(repo_hash: str) -> List[Dict[str, Any]]:
         if not meta_path.is_file():
             continue
         try:
-            meta = json.loads(meta_path.read_text())
-        except (json.JSONDecodeError, OSError, ValueError):
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, ValueError, UnicodeDecodeError):
             continue
         try:
-            body = body_path.read_text() if body_path.is_file() else ""
-        except OSError:
+            body = (
+                body_path.read_text(encoding="utf-8") if body_path.is_file() else ""
+            )
+        except (OSError, UnicodeDecodeError):
             body = ""
         labels = meta.get("labels", [])
         if isinstance(labels, str):
@@ -1799,8 +1803,8 @@ def _load_cached_spec_documents(
         if not meta_path.is_file():
             continue
         try:
-            meta = json.loads(meta_path.read_text())
-        except (json.JSONDecodeError, OSError, ValueError):
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, ValueError, UnicodeDecodeError):
             continue
 
         labels = _normalize_labels(meta.get("labels", []))
@@ -1811,8 +1815,12 @@ def _load_cached_spec_documents(
         body_path = entry / "body.md"
         source_path = spec_path if spec_path.is_file() else body_path
         try:
-            content = source_path.read_text() if source_path.is_file() else ""
-        except OSError:
+            content = (
+                source_path.read_text(encoding="utf-8")
+                if source_path.is_file()
+                else ""
+            )
+        except (OSError, UnicodeDecodeError):
             content = ""
 
         manifest_entry = _build_cache_manifest_entry(
@@ -1921,8 +1929,8 @@ def _read_scope_meta_blob(
     if not meta_path.is_file():
         return {"schema_version": INDEX_SCHEMA_VERSION, "scopes": {}}
     try:
-        payload = json.loads(meta_path.read_text())
-    except (json.JSONDecodeError, OSError, ValueError):
+        payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError, UnicodeDecodeError):
         return {"schema_version": INDEX_SCHEMA_VERSION, "scopes": {}}
     if not isinstance(payload, dict):
         return {"schema_version": INDEX_SCHEMA_VERSION, "scopes": {}}
@@ -1963,7 +1971,9 @@ def _write_scope_meta(
         scope_payload.update(updates)
     scopes[scope] = scope_payload
     meta_path.parent.mkdir(parents=True, exist_ok=True)
-    meta_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    meta_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
 
 def _scope_collection_name(scope: str) -> str:

--- a/crates/gwt-core/runtime/tests/test_cp932_safety.py
+++ b/crates/gwt-core/runtime/tests/test_cp932_safety.py
@@ -1,0 +1,155 @@
+"""Regression tests for cp932 decode failures on Japanese Windows.
+
+The runtime previously used Path.read_text() / Path.write_text() without
+specifying an encoding. On Japanese Windows, locale.getpreferredencoding
+returns "cp932", so UTF-8 content written by gwt (issue cache meta.json,
+body.md, spec.md etc.) fails to decode when read back.
+
+These tests pin the expected behavior: production code must force UTF-8 so
+that file I/O is independent of the system locale.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import chroma_index_runner as runner
+
+
+_REAL_OPEN = io.open
+
+
+def _cp932_default_open(
+    file,
+    mode="r",
+    buffering=-1,
+    encoding=None,
+    errors=None,
+    newline=None,
+    *args,
+    **kwargs,
+):
+    """Simulate Windows Japanese locale: when the caller does not pass an
+    encoding and opens the file in text mode, default to cp932 instead of
+    the host's actual locale encoding (usually UTF-8 on CI).
+
+    pathlib's Path.open forwards positional arguments to io.open as
+    (file, mode, buffering, encoding, errors, newline), so we must accept
+    them positionally to catch the bug before bytes reach the decoder."""
+    if "b" not in mode and encoding is None:
+        encoding = "cp932"
+    return _REAL_OPEN(
+        file, mode, buffering, encoding, errors, newline, *args, **kwargs
+    )
+
+
+class Cp932SafetyTests(unittest.TestCase):
+    def _write_utf8_cache(self, cache_root: Path, number: int) -> None:
+        issue = cache_root / str(number)
+        issue.mkdir(parents=True, exist_ok=True)
+        meta = {
+            "number": number,
+            "title": "秦泉寺の章夫テスト",
+            "labels": ["bug"],
+            "state": "open",
+            "updated_at": "2026-04-23T00:00:00Z",
+            "comment_ids": [],
+        }
+        # Explicit UTF-8 write so we test the read path, not the write path.
+        (issue / "meta.json").write_text(
+            json.dumps(meta, ensure_ascii=False), encoding="utf-8"
+        )
+        (issue / "body.md").write_text(
+            "本文には日本語文字列 (秦泉寺章夫) が含まれる。\n"
+            "position 172 以降に 0x94 を踏むような文字列テスト。\n"
+            "端末エンコーディング依存のバグを防ぐ。",
+            encoding="utf-8",
+        )
+
+    def test_load_cached_issue_documents_under_cp932_locale(self):
+        """_load_cached_issue_documents must decode UTF-8 cache even when the
+        default locale is cp932 (Japanese Windows)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_hash = "abc1234567890def"
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / repo_hash
+            self._write_utf8_cache(cache_root, 42)
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                with mock.patch("io.open", side_effect=_cp932_default_open):
+                    issues = runner._load_cached_issue_documents(repo_hash)
+
+            self.assertEqual(len(issues), 1, issues)
+            self.assertEqual(issues[0]["number"], 42)
+            self.assertEqual(issues[0]["title"], "秦泉寺の章夫テスト")
+            self.assertIn("秦泉寺章夫", issues[0]["body"])
+
+    def test_read_issue_meta_under_cp932_locale(self):
+        """_read_issue_meta reads the db-level meta.json which records
+        last_full_refresh and TTL. If this file is written in UTF-8 (the
+        common case when gwt runs on macOS/Linux and the cache is then
+        synced to Windows, or after this fix), reading it under a cp932
+        default locale must still succeed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "issues"
+            db_path.mkdir(parents=True)
+            payload = {
+                "schema_version": 1,
+                "last_full_refresh": "2026-04-23T00:00:00+00:00",
+                "ttl_minutes": 15,
+                "note": "日本語コメントを含む",
+            }
+            (db_path / runner.META_FILENAME).write_text(
+                json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+            )
+
+            with mock.patch("io.open", side_effect=_cp932_default_open):
+                meta = runner._read_issue_meta(db_path)
+
+            self.assertIsNotNone(meta)
+            self.assertEqual(meta["last_full_refresh"], payload["last_full_refresh"])
+            self.assertEqual(meta["note"], "日本語コメントを含む")
+
+    def test_load_cached_spec_documents_under_cp932_locale(self):
+        """_load_cached_spec_documents reads gwt-spec labelled issues with
+        their sections/spec.md content. Japanese spec text must round-trip
+        cleanly under a cp932 default locale."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_hash = "abc1234567890def"
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / repo_hash
+            issue = cache_root / "1930"
+            (issue / "sections").mkdir(parents=True, exist_ok=True)
+            (issue / "meta.json").write_text(
+                json.dumps(
+                    {
+                        "number": 1930,
+                        "title": "SPEC-1930: 秦泉寺仕様",
+                        "labels": ["gwt-spec"],
+                        "state": "open",
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            (issue / "sections" / "spec.md").write_text(
+                "# 仕様\n\n秦泉寺章夫がオーナーの SPEC。\n",
+                encoding="utf-8",
+            )
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                with mock.patch("io.open", side_effect=_cp932_default_open):
+                    specs, _ = runner._load_cached_spec_documents(repo_hash)
+
+            self.assertEqual(len(specs), 1, specs)
+            self.assertEqual(specs[0]["spec_id"], "1930")
+            self.assertIn("秦泉寺章夫", specs[0]["content"])
+            self.assertEqual(specs[0]["title"], "SPEC-1930: 秦泉寺仕様")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,40 @@
 # Lessons Learned
 
+## 2026-04-23 — fix: Python の file I/O は `encoding="utf-8"` を必ず明示する
+
+### 事象
+
+`bunx @akiojin/gwt@latest` を日本語Windows (`C:\Users\AkioJinsenji秦泉寺章夫`)
+で実行すると、indexing フェーズで `chroma_index_runner.py` が
+`'cp932' codec can't decode byte 0x94 in position 172: illegal multibyte sequence`
+で `RUNTIME_ERROR` を返し、`SessionStart` / `UserPromptSubmit` フックも同じ
+エラーで落ちていた。2026-04-22 の lessons にも同症状の記録あり。
+
+### 原因
+
+`chroma_index_runner.py` の production 側 `Path.read_text()` /
+`Path.write_text()` / `open()` が `encoding` 未指定だった。Python 3 は
+`locale.getpreferredencoding(False)` をデフォルトに使うため、日本語Windows
+では `cp932` として UTF-8 の `~/.gwt/cache/issues/<n>/meta.json` 等を読もう
+として失敗していた。`_load_cached_issue_documents` の except で
+`UnicodeDecodeError` (実体は `ValueError` subclass) を飲み込んでいたため、
+静かに空リストを返していた経路もあった。
+
+### 再発防止策
+
+1. Python で `Path.read_text()` / `Path.write_text()` / `open()` を **テキスト
+   モード**で使うときは、必ず `encoding="utf-8"` を明示する。ロケール依存の
+   暗黙デフォルトは許容しない。
+2. Lock file や binary-safe なファイルを開く場合は `open(path, "a+b")` など
+   binary モードを使い、暗黙デコードを発生させない。
+3. JSON / YAML の読み込みには `(UnicodeDecodeError, ValueError,
+   json.JSONDecodeError, OSError)` を except で受け、旧キャッシュの混入
+   エンコードでサイレントに進まないようにする。意図を明確化するために
+   `UnicodeDecodeError` を明示する。
+4. 回帰テストでは `locale.getpreferredencoding` に頼らず、`io.open` を
+   monkey-patch して `encoding is None` 時に cp932 を注入するパターンで
+   Windows 日本語ロケールを再現する (`tests/test_cp932_safety.py` 参照)。
+
 ## 2026-04-23 — refactor: Windows spawn splitでも interactive cmd wrapper 契約を落とさない
 
 ### 事象


### PR DESCRIPTION
## Summary

- 日本語Windows (`C:\Users\...日本語...`) で `bunx @akiojin/gwt@latest` を実行すると、indexing フェーズおよび SessionStart / UserPromptSubmit フックで `'cp932' codec can't decode byte 0x94 in position 172: illegal multibyte sequence` が発生して `RUNTIME_ERROR` を返していた。
- 原因は `crates/gwt-core/runtime/chroma_index_runner.py` のテキスト I/O (`Path.read_text()` / `Path.write_text()` / `open()`) が `encoding` 未指定で、Python 3 の `locale.getpreferredencoding(False)` が cp932 を返すため UTF-8 キャッシュを cp932 としてデコードしていたこと。
- production 側の全テキスト I/O に `encoding=\"utf-8\"` を明示、lock file は binary モード (`\"a+b\"`) に変更、cache-read の except 節に `UnicodeDecodeError` を明示追加。
- `tests/test_cp932_safety.py` で `io.open` を monkey-patch して cp932 デフォルトロケールを再現し、`_load_cached_issue_documents` / `_read_issue_meta` / `_load_cached_spec_documents` の3経路を RED→GREEN で固定。

## Root cause trace

```
bunx @akiojin/gwt@latest
  └── gwt.exe spawns chroma_index_runner.py --action index-issues
        └── action_index_issues_v2
              └── _load_cached_issue_documents(repo_hash)
                    └── meta_path.read_text()  # encoding=None → cp932 on Japanese Windows
                          └── UnicodeDecodeError("'cp932' codec ... byte 0x94 ... position 172")
                                └── caught by outer `_dispatch_v2` except → emit RUNTIME_ERROR
```

## Changes

- `crates/gwt-core/runtime/chroma_index_runner.py`:
  - `read_text()` 9箇所に `encoding=\"utf-8\"` 追加 (`errors=\"replace\"` は維持)
  - `write_text()` 3箇所に `encoding=\"utf-8\"` 追加
  - lock file `open(lock_path, \"a+\")` → `open(lock_path, \"a+b\")` (2箇所)
  - cache-read except 節に `UnicodeDecodeError` を明示追加 (4箇所)
- `crates/gwt-core/runtime/tests/test_cp932_safety.py` (新規): cp932 ロケール下での UTF-8 キャッシュ読み取りを回帰テスト化
- `tasks/lessons.md`: 再発防止策を追記

## Test plan

- [x] Python regression: `python -m unittest tests.test_cp932_safety -v` → 3/3 PASS (RED→GREEN)
- [x] Python 既存: `GWT_INDEX_FAKE_EMBEDDING=1 python -m unittest discover` → 修正前と同じ 2 errors のみ (Windows tempdir cleanup の事前既存の PermissionError、本修正と無関係)
- [x] Rust: `cargo test -p gwt-core -p gwt` → 全 suite PASS
- [x] Lint: `cargo clippy --all-targets --all-features -- -D warnings` → 警告なし
- [x] Format: `cargo fmt --check` → clean
- [x] commitlint: `bunx commitlint --from HEAD~1 --to HEAD` → PASS
- [ ] 実環境での `bunx @akiojin/gwt@latest` 手動確認は本 PR が merge され次回リリースに乗ってから (bunx がキャッシュされた v9.8.x バンドルを使うため、リリース前は旧 gwt.exe のまま)。

## Notes

- 旧バージョン gwt が日本語Windows上で cp932 として書いていた可能性のある `~/.gwt/cache/issues/*/meta.json` は、UTF-8 read で `UnicodeDecodeError` → except で skip → 次回 `gh issue list` で再生成、という既存の graceful 経路を利用する。専用 migration は不要。
- 関連 lessons: `tasks/lessons.md` 2026-04-22 エントリ (`Windows GUI smoke は browser URL 出力だけで成功扱いしない`) で同症状が記録されていた。今回の PR で根本対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)