### PR TITLE
feat(codex): gpt-5.5モデル一覧に更新

### DIFF
--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -1002,7 +1002,7 @@ mod tests {
             "@openai/codex@0.122.0".to_string(),
             "--no-alt-screen".to_string(),
         ];
-        config.model = Some("gpt-5.4".to_string());
+        config.model = Some("gpt-5.5".to_string());
         config.reasoning_level = Some("high".to_string());
         config.skip_permissions = true;
         config.codex_fast_mode = true;
@@ -1024,7 +1024,7 @@ mod tests {
                 "--no-alt-screen".to_string(),
             ]
         );
-        assert_eq!(session.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(session.model.as_deref(), Some("gpt-5.5"));
         assert_eq!(session.reasoning_level.as_deref(), Some("high"));
         assert!(session.skip_permissions);
         assert!(session.codex_fast_mode);

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1889,42 +1889,34 @@ const CLAUDE_MODEL_OPTIONS: [ModelDisplayOption; 4] = [
     },
 ];
 
-const CODEX_MODEL_OPTIONS: [ModelDisplayOption; 9] = [
+const CODEX_MODEL_OPTIONS: [ModelDisplayOption; 7] = [
     ModelDisplayOption {
         label: "Default (Auto)",
-        description: "Use Codex default model",
+        description: "Use Codex default model (gpt-5.5)",
+    },
+    ModelDisplayOption {
+        label: "gpt-5.5",
+        description: "Frontier model for complex coding, research, and real-world work",
     },
     ModelDisplayOption {
         label: "gpt-5.4",
-        description: "Latest frontier agentic coding model",
+        description: "Strong model for everyday coding",
     },
     ModelDisplayOption {
         label: "gpt-5.4-mini",
-        description: "Smaller frontier agentic coding model",
+        description: "Small, fast, and cost-efficient model for simpler coding tasks",
     },
     ModelDisplayOption {
         label: "gpt-5.3-codex",
-        description: "Frontier Codex-optimized coding model",
+        description: "Coding-optimized model",
     },
     ModelDisplayOption {
         label: "gpt-5.3-codex-spark",
         description: "Ultra-fast coding model",
     },
     ModelDisplayOption {
-        label: "gpt-5.2-codex",
-        description: "Frontier agentic coding model",
-    },
-    ModelDisplayOption {
         label: "gpt-5.2",
-        description: "Optimized for professional work",
-    },
-    ModelDisplayOption {
-        label: "gpt-5.1-codex-max",
-        description: "Deep and fast reasoning",
-    },
-    ModelDisplayOption {
-        label: "gpt-5.1-codex-mini",
-        description: "Cheaper and faster codex option",
+        description: "Optimized for professional work and long-running agents",
     },
 ];
 
@@ -2824,7 +2816,7 @@ mod tests {
         session.display_name = session.agent_id.display_name().to_string();
         session.agent_session_id = resume_id.map(str::to_string);
         session.tool_version = Some("installed".to_string());
-        session.model = Some("gpt-5.4".to_string());
+        session.model = Some("gpt-5.5".to_string());
         session.reasoning_level = Some("high".to_string());
         session.skip_permissions = true;
         session.codex_fast_mode = true;
@@ -2848,7 +2840,7 @@ mod tests {
         session.display_name = session.agent_id.display_name().to_string();
         session.agent_session_id = resume_id.map(str::to_string);
         session.tool_version = Some("installed".to_string());
-        session.model = Some("gpt-5.4".to_string());
+        session.model = Some("gpt-5.5".to_string());
         session.reasoning_level = Some("high".to_string());
         session.skip_permissions = true;
         session.codex_fast_mode = true;
@@ -2879,7 +2871,7 @@ mod tests {
             ),
             "codex" => (
                 "Codex",
-                Some("gpt-5.4"),
+                Some("gpt-5.5"),
                 Some("high"),
                 Some("0.110.0"),
                 true,
@@ -2925,7 +2917,7 @@ mod tests {
                 session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
-                model: Some("gpt-5.4".to_string()),
+                model: Some("gpt-5.5".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: Some("resume-1".to_string()),
@@ -3052,7 +3044,7 @@ mod tests {
             Some("resume-older"),
         );
         older.tool_version = Some("0.110.0".to_string());
-        older.model = Some("gpt-5.4".to_string());
+        older.model = Some("gpt-5.5".to_string());
         older.reasoning_level = Some("high".to_string());
         older.skip_permissions = true;
         older.codex_fast_mode = true;
@@ -3087,7 +3079,7 @@ mod tests {
             entries[0].resume_session_id.as_deref(),
             Some("resume-older")
         );
-        assert_eq!(entries[0].model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(entries[0].model.as_deref(), Some("gpt-5.5"));
         assert_eq!(entries[0].reasoning.as_deref(), Some("high"));
         assert_eq!(entries[0].version.as_deref(), Some("0.110.0"));
         assert_eq!(
@@ -3122,7 +3114,7 @@ mod tests {
             Vec::new(),
         );
         state.agent_id = "codex".to_string();
-        state.model = "gpt-5.4".to_string();
+        state.model = "gpt-5.5".to_string();
         state.reasoning = "high".to_string();
         state.version = "0.110.0".to_string();
         state.mode = "resume".to_string();
@@ -3154,7 +3146,7 @@ mod tests {
                 session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
-                model: Some("gpt-5.4".to_string()),
+                model: Some("gpt-5.5".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: Some("resume-1".to_string()),
@@ -3173,7 +3165,7 @@ mod tests {
         });
 
         assert_eq!(state.agent_id, "codex");
-        assert_eq!(state.model, "gpt-5.4");
+        assert_eq!(state.model, "gpt-5.5");
         assert_eq!(state.reasoning, "high");
         assert_eq!(state.version, "0.110.0");
         assert_eq!(state.mode, "resume");
@@ -3204,7 +3196,7 @@ mod tests {
                 session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
-                model: Some("gpt-5.4".to_string()),
+                model: Some("gpt-5.5".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: Some("resume-1".to_string()),
@@ -3256,7 +3248,7 @@ mod tests {
                 session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
-                model: Some("gpt-5.4".to_string()),
+                model: Some("gpt-5.5".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: Some("resume-1".to_string()),
@@ -3297,7 +3289,7 @@ mod tests {
                 session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
-                model: Some("gpt-5.4".to_string()),
+                model: Some("gpt-5.5".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: None,
@@ -3343,7 +3335,7 @@ mod tests {
             agent_id: "codex".to_string(),
         });
         state.apply(LaunchWizardAction::SetModel {
-            model: "gpt-5.4".to_string(),
+            model: "gpt-5.5".to_string(),
         });
         state.apply(LaunchWizardAction::SetReasoning {
             reasoning: "high".to_string(),
@@ -3361,7 +3353,7 @@ mod tests {
 
         assert_eq!(view.branch_mode, "use_selected");
         assert_eq!(view.selected_agent_id, "codex");
-        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_model, "gpt-5.5");
         assert_eq!(view.selected_reasoning, "high");
         assert_eq!(view.selected_runtime_target, "host");
         assert_eq!(view.selected_version, "0.110.0");
@@ -3415,8 +3407,8 @@ mod tests {
         state.set_agent_id("missing");
         assert_eq!(state.error.as_deref(), Some("Agent option is unavailable"));
 
-        state.set_model("gpt-5.4");
-        assert_eq!(state.model, "gpt-5.4");
+        state.set_model("gpt-5.5");
+        assert_eq!(state.model, "gpt-5.5");
         state.set_model("bad-model");
         assert_eq!(state.error.as_deref(), Some("Model option is unavailable"));
 
@@ -3533,7 +3525,7 @@ mod tests {
         state.step = LaunchWizardStep::ModelSelect;
         state.selected = 1;
         state.apply_selection();
-        assert_eq!(state.model, "gpt-5.4");
+        assert_eq!(state.model, "gpt-5.5");
 
         state.step = LaunchWizardStep::ReasoningLevel;
         state.selected = 1;
@@ -3817,7 +3809,7 @@ mod tests {
             "fix/coverage"
         );
         assert_eq!(apply_branch_prefix("  ", "chore/"), "chore/");
-        assert!(is_explicit_model_selection("gpt-5.4"));
+        assert!(is_explicit_model_selection("gpt-5.5"));
         assert!(!is_explicit_model_selection("Default (Installed)"));
         assert!(agent_has_npm_package("codex"));
         assert!(!agent_has_npm_package("custom"));
@@ -3859,7 +3851,18 @@ mod tests {
             .any(|option| option.value == "resume"));
 
         assert!(current_model_options("claude").contains(&"sonnet"));
-        assert!(current_model_options("codex").contains(&"gpt-5.4"));
+        assert_eq!(
+            current_model_options("codex"),
+            vec![
+                "Default (Auto)",
+                "gpt-5.5",
+                "gpt-5.4",
+                "gpt-5.4-mini",
+                "gpt-5.3-codex",
+                "gpt-5.3-codex-spark",
+                "gpt-5.2",
+            ]
+        );
         assert!(current_model_options("gemini").contains(&"gemini-2.5-pro"));
         assert!(current_model_options("custom").is_empty());
         assert!(model_display_options("custom").is_empty());
@@ -3872,7 +3875,7 @@ mod tests {
             session_id: "gwt-session-1".to_string(),
             agent_id: "codex".to_string(),
             tool_label: "Codex".to_string(),
-            model: Some("gpt-5.4".to_string()),
+            model: Some("gpt-5.5".to_string()),
             reasoning: Some("high".to_string()),
             version: Some("0.110.0".to_string()),
             resume_session_id: Some("resume-1".to_string()),
@@ -3884,7 +3887,7 @@ mod tests {
             docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Restart,
         });
 
-        assert_eq!(summary, "Codex · gpt-5.4 · high · 0.110.0 · docker:gwt");
+        assert_eq!(summary, "Codex · gpt-5.5 · high · 0.110.0 · docker:gwt");
     }
 
     #[test]
@@ -3926,7 +3929,7 @@ mod tests {
 
         state.launch_target = LaunchTargetKind::Agent;
         state.agent_id = "codex".to_string();
-        state.model = "gpt-5.4".to_string();
+        state.model = "gpt-5.5".to_string();
         state.reasoning = "high".to_string();
         state.version = "0.110.0".to_string();
         state.mode = "resume".to_string();
@@ -3945,7 +3948,7 @@ mod tests {
             step_default_selection(LaunchWizardStep::ModelSelect, &state),
             current_model_options("codex")
                 .iter()
-                .position(|model| model == &"gpt-5.4")
+                .position(|model| model == &"gpt-5.5")
                 .unwrap()
         );
         assert_eq!(
@@ -3987,7 +3990,7 @@ mod tests {
                 session_id: "gwt-session-1".to_string(),
                 agent_id: "codex".to_string(),
                 tool_label: "Codex".to_string(),
-                model: Some("gpt-5.4".to_string()),
+                model: Some("gpt-5.5".to_string()),
                 reasoning: Some("high".to_string()),
                 version: Some("0.110.0".to_string()),
                 resume_session_id: Some("resume-1".to_string()),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -713,7 +713,7 @@ mod tests {
             session_id: "gwt-session-1".to_string(),
             agent_id: "codex".to_string(),
             tool_label: "Codex".to_string(),
-            model: Some("gpt-5.4".to_string()),
+            model: Some("gpt-5.5".to_string()),
             reasoning: Some("high".to_string()),
             version: Some("0.110.0".to_string()),
             resume_session_id: Some("resume-1".to_string()),


### PR DESCRIPTION
## Summary

- Update the Codex launch wizard model catalog to match the current Codex CLI options.
- Make `gpt-5.5` the explicit current Codex model in launch wizard fixtures and session metadata tests.
- Refresh the related SPEC records so model management and Launch Wizard contracts point at the same catalog.

## Changes

- `crates/gwt/src/launch_wizard.rs`: Replaced the Codex picker catalog with `Default (Auto)`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, and `gpt-5.2`; updated descriptions and model catalog tests.
- `crates/gwt/src/main.rs`: Updated Codex quick-start test fixtures to use `gpt-5.5`.
- `crates/gwt-agent/src/session.rs`: Updated Codex launch metadata capture test expectations to use `gpt-5.5`.
- SPECs: Updated #2014 `spec` section and added #1489 follow-up comment `4310709581`.

## Testing

- [x] `cargo test -p gwt launch_wizard::tests:: --lib` - passed.
- [x] `cargo test -p gwt-agent` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `cargo test -p gwt-core -p gwt` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt` - passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.

## Closing Issues

- None

## Related Issues / Links

- #1489
- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (SPEC #2014 and #1489)
- [x] Migration/backfill plan included (not required: no schema or data migration)
- [x] CHANGELOG impact considered (feature-level model catalog update, no breaking change)

## Context

- Codex CLI now lists `gpt-5.5` as the default model and no longer presents `gpt-5.2-codex`, `gpt-5.1-codex-max`, or `gpt-5.1-codex-mini` in the current model picker.
- SPEC #1489 owns AI agent model management, while SPEC #2014 owns the Launch Wizard surface that renders the model picker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gpt-5.5 to the model catalog as the new default option.

* **Bug Fixes**
  * Removed obsolete model versions (gpt-5.2-codex, gpt-5.1-codex variants) from available selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->