### PR TITLE
fix(codex): 保存済み旧モデルIDをAutoへ戻す

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -927,9 +927,7 @@ impl LaunchWizardState {
         self.launch_target = LaunchTargetKind::Agent;
         self.agent_id = entry.agent_id.clone();
         self.sync_selected_agent_options();
-        if let Some(model) = entry.model {
-            self.model = model;
-        }
+        self.apply_saved_model(entry.model.as_deref());
         if let Some(reasoning) = entry.reasoning {
             self.reasoning = reasoning;
         }
@@ -1358,6 +1356,18 @@ impl LaunchWizardState {
         self.sync_reasoning_state();
     }
 
+    fn apply_saved_model(&mut self, model: Option<&str>) {
+        let Some(model) = model else {
+            return;
+        };
+        if current_model_options(self.effective_agent_id())
+            .iter()
+            .any(|candidate| candidate == &model)
+        {
+            self.model = model.to_string();
+        }
+    }
+
     fn sync_reasoning_state(&mut self) {
         let options = self.current_reasoning_options();
         if options.is_empty() {
@@ -1593,9 +1603,7 @@ impl LaunchWizardState {
         }
         self.sync_selected_agent_options();
 
-        if let Some(model) = entry.model {
-            self.model = model;
-        }
+        self.apply_saved_model(entry.model.as_deref());
         if let Some(reasoning) = entry.reasoning {
             self.reasoning = reasoning;
         }
@@ -3174,6 +3182,45 @@ mod tests {
         assert_eq!(state.docker_service.as_deref(), Some("gwt"));
         assert!(state.skip_permissions);
         assert!(state.codex_fast_mode);
+    }
+
+    #[test]
+    fn quick_start_with_removed_codex_model_falls_back_to_auto() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            vec![QuickStartEntry {
+                session_id: "gwt-session-1".to_string(),
+                agent_id: "codex".to_string(),
+                tool_label: "Codex".to_string(),
+                model: Some("gpt-5.2-codex".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                resume_session_id: Some("resume-1".to_string()),
+                live_window_id: None,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+            }],
+        );
+
+        state.apply(LaunchWizardAction::ApplyQuickStart {
+            index: 0,
+            mode: QuickStartLaunchMode::Resume,
+        });
+
+        assert_eq!(state.model, "Default (Auto)");
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::Launch(config)) => match config.as_ref() {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    assert!(config.model.is_none());
+                }
+                other => panic!("expected agent launch request, got {other:?}"),
+            },
+            other => panic!("expected launch completion, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3529,3 +3529,22 @@ Project index の manual quickstart で、Python runner は `HOME` 注入先の 
 1. Python と Rust の両方が同じ on-disk layout を読む場合、`HOME` / `USERPROFILE` / fallback の優先順を一致させる。
 2. runtime helper を manual verification する場合、fresh `HOME` では managed venv 作成に入るため、既存 runtime を使う通常 HOME と temp index subtree の cleanup も確認する。
 3. index root を注入する unit test だけでなく、public path resolver の環境変数 contract も regression test で固定する。
+
+## 2026-04-24 — process: 実装前に関連 SPEC を必ず gwt-search で確認する
+
+### 事象
+
+Codex 対応モデル一覧の更新で、関連 SPEC が存在するにもかかわらず初動で SPEC
+確認を省略し、ユーザーから「関連SPECがないですか？あるはずです。」と指摘された。
+
+### 原因
+
+- 変更が小さく見えたため、`feat` 相当の実装前ワークフローを軽視した。
+- `gwt-search` による SPEC / Issue / project file の横断検索を、実装前の必須ゲートとして扱わなかった。
+- SPEC owner が見つかる前に実装計画を進めようとしたため、受け入れ条件と実装対象の同期が遅れた。
+
+### 再発防止策
+
+1. `feat` / `fix` / `refactor` の実装前は、変更規模に関わらず `gwt-search` で関連 SPEC / Issue を先に確認する。
+2. ユーザーが「SPEC があるはず」と示唆した場合は、実装を止めて SPEC owner を特定し、SPEC / plan / tasks を更新してから再開する。
+3. 完了報告前に、対象 SPEC が今回の変更と受け入れ条件を反映していることをセルフチェックする。


### PR DESCRIPTION
## Summary

- Saved QuickStart/session metadata now ignores removed Codex model IDs so launches fall back to the agent default instead of forwarding unsupported `--model` values.
- Added regression coverage for legacy `gpt-5.2-codex` metadata and recorded the SPEC-search process lesson from this task.

## Changes

- `crates/gwt/src/launch_wizard.rs`: restore saved models only when they still exist in the active agent model catalog.
- `crates/gwt/src/launch_wizard.rs`: add a regression test proving removed Codex model IDs fall back to `Default (Auto)` and produce `model: None` in the launch request.
- `tasks/lessons.md`: document the missed SPEC-search preflight and prevention rule.

## Testing

- [x] `cargo test -p gwt launch_wizard::tests:: --lib` — 38 tests passed.
- [x] `cargo test -p gwt-core -p gwt` — full gwt/gwt-core test suite passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` — 0 errors.
- [x] `bunx commitlint --from HEAD~2 --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #2014
- #2155

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #2014 and `tasks/lessons.md`)
- [x] Migration/backfill plan included (legacy saved model IDs fall back to default at launch)
- [x] CHANGELOG impact considered (patch-level fix commit)

## Context

- PR #2155 updated the Codex model catalog and merged, then review identified that existing saved metadata could still contain removed Codex model IDs.
- SPEC #2014 was updated with the compatibility edge case before this follow-up implementation.
