### PR TITLE
fix(logging): enforce project-scoped structured logs

### DIFF
--- a/crates/gwt-agent/src/audit.rs
+++ b/crates/gwt-agent/src/audit.rs
@@ -1,9 +1,10 @@
 //! Secret-name classifier for the agent launch audit log (FR-047, FR-063).
 //!
-//! The launch audit log writes a JSONL line per agent launch that includes the
-//! resolved command, args, cwd, and environment. To prevent plaintext API keys
-//! from ending up in `~/.gwt/logs/agent-launch.jsonl`, env entries whose keys
-//! match a known secret pattern are masked before the line is written.
+//! Agent launch diagnostics are emitted through the canonical structured
+//! logging pipeline with resolved command, args, cwd, and environment. To
+//! prevent plaintext API keys from ending up in the project-scoped
+//! `gwt.log.YYYY-MM-DD`, env entries whose keys match a known secret pattern
+//! are masked before the event is emitted.
 
 /// Placeholder string that replaces a secret value in the audit record.
 pub const REDACTED_PLACEHOLDER: &str = "***REDACTED***";

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -128,6 +128,16 @@ pub fn gwt_project_logs_dir_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
     detect_repo_hash(repo_path).map(|repo_hash| gwt_project_logs_dir(&repo_hash))
 }
 
+/// Return the canonical structured-log directory for a project path.
+///
+/// Git repositories are scoped by normalized `origin` URL. Non-repository
+/// paths fall back to a stable path hash, matching project-scoped workspace
+/// storage.
+pub fn gwt_project_logs_dir_for_project_path(project_path: &Path) -> PathBuf {
+    let project_hash = project_scope_hash(project_path);
+    gwt_project_logs_dir(&project_hash)
+}
+
 /// Return the update check cache path (`~/.gwt/cache/update-check.json`).
 pub fn gwt_update_cache_path() -> PathBuf {
     gwt_cache_dir().join("update-check.json")
@@ -308,6 +318,29 @@ mod tests {
     }
 
     #[test]
+    fn gwt_project_logs_dir_for_project_path_uses_origin_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        init_git_repo(&repo);
+        add_origin(&repo, "https://github.com/example/project.git");
+
+        let p = gwt_project_logs_dir_for_project_path(&repo);
+        let repo_hash = compute_repo_hash("https://github.com/example/project.git");
+
+        assert!(p.ends_with(gwt_home_suffix(&["projects", repo_hash.as_str(), "logs"])));
+    }
+
+    #[test]
+    fn gwt_project_logs_dir_for_project_path_uses_path_hash_without_origin() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let p = gwt_project_logs_dir_for_project_path(dir.path());
+        let path_hash = compute_path_hash(dir.path());
+
+        assert!(p.ends_with(gwt_home_suffix(&["projects", path_hash.as_str(), "logs"])));
+    }
+
+    #[test]
     fn gwt_coordination_dir_scopes_by_repo_hash() {
         let repo_hash = compute_repo_hash("https://github.com/example/project.git");
         let p = gwt_coordination_dir(&repo_hash);
@@ -359,5 +392,30 @@ mod tests {
     fn ensure_dir_succeeds_for_existing_directory() {
         let tmp = std::env::temp_dir();
         ensure_dir(&tmp).unwrap();
+    }
+
+    fn init_git_repo(path: &Path) {
+        let output = std::process::Command::new("git")
+            .args(["init", path.to_str().unwrap()])
+            .output()
+            .expect("git init");
+        assert!(
+            output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn add_origin(path: &Path, url: &str) {
+        let output = std::process::Command::new("git")
+            .args(["remote", "add", "origin", url])
+            .current_dir(path)
+            .output()
+            .expect("git remote add origin");
+        assert!(
+            output.status.success(),
+            "git remote add origin failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -301,8 +301,8 @@ impl AppRuntime {
         blocking_tasks: BlockingTaskSpawner,
     ) -> std::io::Result<Self> {
         let session_state_path = gwt_core::paths::gwt_session_state_path();
-        let log_dir = gwt_core::paths::gwt_logs_dir();
         let launch_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let log_dir = gwt_core::paths::gwt_project_logs_dir_for_project_path(&launch_dir);
         let legacy_target = resolve_project_target(&launch_dir)
             .unwrap_or_else(|_| fallback_project_target(launch_dir.clone()));
         migrate_legacy_workspace_state(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -112,6 +112,10 @@ fn gui_front_door_launch_surface(server_url: &str) -> GuiFrontDoorLaunchSurface<
     }
 }
 
+fn logging_dir_for_startup_path(startup_path: &Path) -> PathBuf {
+    gwt_core::paths::gwt_project_logs_dir_for_project_path(startup_path)
+}
+
 fn broadcast_log_entry(clients: &ClientHub, entry: gwt_core::logging::LogEvent) {
     clients.dispatch(vec![OutboundEvent::broadcast(
         BackendEvent::LogEntryAppended { entry },
@@ -213,11 +217,11 @@ mod tests {
         build_shell_process_launch, close_window_from_workspace, combined_window_id,
         current_git_branch, docker_bundle_mounts_for_home, docker_bundle_override_content,
         gui_front_door_launch_surface, hook_forward_authorized,
-        install_launch_gwt_bin_env_with_lookup, knowledge_kind_for_preset, resolve_project_target,
-        should_auto_close_agent_window, should_auto_start_restored_window, ActiveAgentSession,
-        AppEventProxy, AppRuntime, BlockingTaskSpawner, ClientHub, DispatchTarget,
-        LaunchWizardSession, OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent,
-        WindowAddress,
+        install_launch_gwt_bin_env_with_lookup, knowledge_kind_for_preset,
+        logging_dir_for_startup_path, resolve_project_target, should_auto_close_agent_window,
+        should_auto_start_restored_window, ActiveAgentSession, AppEventProxy, AppRuntime,
+        BlockingTaskSpawner, ClientHub, DispatchTarget, LaunchWizardSession, OutboundEvent,
+        ProcessLaunch, ProjectTabRuntime, UserEvent, WindowAddress,
     };
 
     fn canvas_bounds() -> WindowGeometry {
@@ -387,6 +391,43 @@ mod tests {
         assert!(native_payload.contains("\"kind\":\"log_entry_appended\""));
         assert!(native_payload.contains("\"severity\":\"Warn\""));
         assert!(native_payload.contains("\"message\":\"reader stalled\""));
+    }
+
+    #[test]
+    fn logging_dir_for_startup_path_uses_project_scoped_fallback() {
+        let temp = tempdir().expect("tempdir");
+        let log_dir = logging_dir_for_startup_path(temp.path());
+        let project_hash = gwt_core::repo_hash::compute_path_hash(temp.path());
+
+        assert!(log_dir.ends_with(
+            Path::new("projects")
+                .join(project_hash.as_str())
+                .join("logs")
+        ));
+    }
+
+    #[test]
+    fn logging_initialization_sources_do_not_use_legacy_log_dir() {
+        let legacy_helper = ["gwt_core::paths::", "gwt_logs_dir", "()"].concat();
+        let forbidden_init = [
+            "LoggingConfig::new(",
+            "gwt_core::paths::",
+            "gwt_logs_dir",
+            "()",
+        ]
+        .concat();
+
+        let main_source = include_str!("main.rs");
+        let runtime_source = include_str!("app_runtime.rs");
+
+        assert!(
+            !main_source.contains(&forbidden_init),
+            "main logging initialization must use the project-scoped canonical resolver"
+        );
+        assert!(
+            !runtime_source.contains(&legacy_helper),
+            "AppRuntime log snapshots must use the project-scoped canonical resolver"
+        );
     }
 
     #[test]
@@ -3639,25 +3680,25 @@ fn main() -> wry::Result<()> {
         }
     }
 
+    let startup_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let log_dir = logging_dir_for_startup_path(&startup_dir);
+
     // Install the tracing subscriber so that `tracing::debug!/info!` lands in
-    // `~/.gwt/logs/gwt.log`. The returned guard must outlive the event loop;
-    // we bind it to `log_handles` and keep it until `main` returns.
+    // the startup project's canonical `gwt.log.YYYY-MM-DD`. The returned guard
+    // must outlive the event loop; we bind it to `log_handles` and keep it
+    // until `main` returns.
     //
     // Diagnostic trace for intermittent key-input drop (bugfix/input-key) is
     // emitted at `debug` level under `target: "gwt_input_trace"`. Enable with
     // `RUST_LOG=gwt_input_trace=debug`.
-    let mut log_handles = gwt_core::logging::init(gwt_core::logging::LoggingConfig::new(
-        gwt_core::paths::gwt_logs_dir(),
-    ))
-    .map_err(|error| {
-        eprintln!("gwt logging init failed: {error}");
-    })
-    .ok();
+    let mut log_handles = gwt_core::logging::init(gwt_core::logging::LoggingConfig::new(log_dir))
+        .map_err(|error| {
+            eprintln!("gwt logging init failed: {error}");
+        })
+        .ok();
 
-    if let Ok(project_root) = std::env::current_dir() {
-        if let Err(error) = gwt::cli::prepare_daemon_front_door_for_path(&project_root) {
-            eprintln!("gwt daemon bootstrap: {error}");
-        }
+    if let Err(error) = gwt::cli::prepare_daemon_front_door_for_path(&startup_dir) {
+        eprintln!("gwt daemon bootstrap: {error}");
     }
 
     let runtime = Runtime::new().expect("tokio runtime");

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,4 +37,4 @@ gwt は単一の Rust バイナリで GUI と CLI を提供します。
 - Issue / SPEC キャッシュ:
   - `~/.gwt/cache/issues/<repo-hash>/`
 - ログ:
-  - `~/.gwt/logs/`
+  - `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@
 
 1. ログを確認します。
 
-- `~/.gwt/logs/`
+- `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD`
 - `stderr` に出力される `http://127.0.0.1:<port>/` の URL を通常のブラウザで開き、WebView 固有の問題かどうかを切り分けます。
 
 1. 開発環境では GUI を直接起動して確認します。
@@ -38,4 +38,4 @@ cargo run -p gwt
 2. 起動を実行し、失敗ケースを再現します（旧バージョンからのマイグレーション済みプロジェクトを含む）。
 3. 失敗時に terminal タブへ `PTY stream error` を含むメッセージと `Press Enter to close this tab.` が表示されることを確認します。
 4. terminal タブをアクティブにして `Enter` を押し、タブが閉じることを確認します。
-5. 表示されない / 閉じられない場合は `~/.gwt/logs/` の該当時刻ログを採取し、起動条件（branch / profile / runtime）とあわせて記録します。
+5. 表示されない / 閉じられない場合は `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD` の該当時刻ログを採取し、起動条件（branch / profile / runtime）とあわせて記録します。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,36 @@
 # Lessons Learned
 
+## 2026-04-24 — fix(logging): structured runtime log は project-scoped canonical file 以外へ出さない
+
+### 事象
+
+ログ機能の仕様追加を重ねる中で、#1924 の古い `~/.gwt/logs/` 契約、#2021 の
+`~/.gwt/projects/<repo-hash>/logs/` 契約、実装上の `gwt_logs_dir()` 使用が混在し、
+新しい診断機能が別ログファイルや legacy path へ出力される余地が残っていた。
+
+### 原因
+
+- `gwt_core::logging::init` 自体は単一入口だったが、呼び出し側が任意の
+  `log_dir` を渡せるため、entrypoint ごとに path 解決が割れた。
+- README と #2021 は project-scoped path を示していた一方、#1924 の Phase 5
+  説明と一部コードコメントに legacy path が残っていた。
+- 新規診断機能追加時に「Logs window と同じ canonical file に出ること」を
+  テストや acceptance で固定していなかった。
+
+### 再発防止策
+
+1. structured runtime log の保存先は
+   `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD` のみとする。Git origin
+   がない場合は `project_scope_hash(path)` の path hash fallback を使う。
+2. logging 初期化では `gwt_logs_dir()` を直接使わず、必ず project-scoped
+   canonical resolver を通す。
+3. 新しい診断機能は独自の `.log` / `.jsonl` writer を追加せず、`tracing`
+   target / fields / spans として canonical structured log に流す。
+4. logging 変更では writer / watcher / housekeeping / SPEC / README / docs を同時に確認し、
+   legacy path が残っていないか `rg "~/.gwt/logs|gwt_logs_dir\\(\\)"` で確認する。
+5. regression test で `LoggingConfig::new(gwt_logs_dir())` や `crates/gwt` の
+   logging setup における direct legacy path 使用を失敗させる。
+
 ## 2026-04-23 — fix: Python の file I/O は `encoding="utf-8"` を必ず明示する
 
 ### 事象


### PR DESCRIPTION
## Summary
- プロジェクトごとの構造化ログ出力先を `~/.gwt/projects/<hash>/logs/gwt.log` に統一しました。
- CLI/GUI runtime log snapshot の既定ログ参照も同じ resolver に接続しました。
- SPEC #1924 Phase 7 とドキュメント、再発防止レッスンを更新しました。

## Changes
- `gwt_core::paths::gwt_project_logs_dir_for_project_path` を追加し、Git origin hash と path hash fallback でプロジェクトスコープのログディレクトリを解決します。
- `crates/gwt` の startup/runtime ログ初期化から legacy global `gwt_logs_dir()` 依存を除去しました。
- 直接 legacy ログ helper を再導入しない source guard test を追加しました。
- `docs/architecture.md` と `docs/troubleshooting.md` に canonical log path と調査導線を反映しました。

## Testing
- `cargo test -p gwt-core -p gwt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `bunx markdownlint-cli2 docs/architecture.md docs/troubleshooting.md tasks/lessons.md`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Closing Issues
None

## Related Issues
- #1924
- #2021
- #2019

## Checklist
- [x] SPEC #1924 updated
- [x] Tests, clippy, format, markdownlint passed
- [x] Commitlint passed
- [x] Branch pushed to `origin/feature/logging`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated log file locations to `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD` in architecture and troubleshooting guides.

* **Chores**
  * Restructured logging to organize logs by project with date-stamped files.
  * Added logging best practices documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->