### PR TITLE
fix(index): detect partial specs corruption

### DIFF
--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -2089,6 +2089,10 @@ def _scope_status_v2(
         reason = "empty_collection"
         healthy = False
         repair_required = True
+    elif scope == "specs" and document_count < manifest_count:
+        reason = "count_mismatch"
+        healthy = False
+        repair_required = True
     elif scope != "specs" and document_count != manifest_count:
         reason = "empty_collection" if document_count == 0 and manifest_count > 0 else "count_mismatch"
         healthy = False

--- a/crates/gwt-core/runtime/tests/test_status_health.py
+++ b/crates/gwt-core/runtime/tests/test_status_health.py
@@ -208,6 +208,41 @@ class StatusHealthTests(unittest.TestCase):
             self.assertEqual(specs["reason"], "ready")
             self.assertEqual(specs["document_count"], 5)
 
+    def test_status_reports_undersized_specs_index_as_unhealthy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_root = Path(tmp) / "index_root"
+            db_path = runner.resolve_db_path(
+                self.REPO_HASH,
+                None,
+                "specs",
+                db_root=db_root,
+            )
+            db_path.mkdir(parents=True)
+            (db_path / "chroma.sqlite3").write_text("placeholder")
+            runner.write_manifest(
+                db_path,
+                scope="specs",
+                entries=[
+                    {"path": "1939", "mtime": 1, "size": 2},
+                    {"path": "1940", "mtime": 1, "size": 2},
+                ],
+            )
+
+            with mock.patch.object(
+                runner, "_scope_document_count", return_value=(True, 1)
+            ):
+                specs = runner._scope_status_v2(
+                    self.REPO_HASH,
+                    None,
+                    "specs",
+                    db_root=db_root,
+                )
+
+            self.assertFalse(specs["healthy"], specs)
+            self.assertTrue(specs["repair_required"], specs)
+            self.assertEqual(specs["reason"], "count_mismatch")
+            self.assertEqual(specs["document_count"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crates/gwt/src/cli/index.rs
+++ b/crates/gwt/src/cli/index.rs
@@ -331,7 +331,15 @@ fn audit_status(
     exit_code: i32,
 ) -> io::Result<()> {
     let mut fields = base_audit_fields(context, "project_index_status", "index status");
-    fields.insert("status".to_string(), json!("ready"));
+    let health = audit_health(payload);
+    fields.insert("status".to_string(), json!(health.status));
+    fields.insert("repair_required".to_string(), json!(health.repair_required));
+    if !health.unhealthy_scopes.is_empty() {
+        fields.insert(
+            "unhealthy_scopes".to_string(),
+            json!(health.unhealthy_scopes),
+        );
+    }
     fields.insert("exit_code".to_string(), json!(exit_code));
     fields.insert(
         "runtime_repaired".to_string(),
@@ -355,6 +363,50 @@ fn audit_status(
         fields.insert("scopes".to_string(), status.clone());
     }
     append_index_audit_event(log_dir, Value::Object(fields))
+}
+
+struct AuditHealth {
+    status: &'static str,
+    repair_required: bool,
+    unhealthy_scopes: Vec<String>,
+}
+
+fn audit_health(payload: &Value) -> AuditHealth {
+    let Some(status) = payload.get("status").and_then(Value::as_object) else {
+        return AuditHealth {
+            status: "unknown",
+            repair_required: false,
+            unhealthy_scopes: Vec::new(),
+        };
+    };
+
+    let mut unhealthy_scopes = Vec::new();
+    for scope in ["issues", "specs", "files", "files-docs"] {
+        let Some(scope_status) = status.get(scope) else {
+            continue;
+        };
+        let healthy = scope_status
+            .get("healthy")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let repair_required = scope_status
+            .get("repair_required")
+            .and_then(Value::as_bool)
+            .unwrap_or(!healthy);
+        if !healthy || repair_required {
+            unhealthy_scopes.push(scope.to_string());
+        }
+    }
+
+    AuditHealth {
+        status: if unhealthy_scopes.is_empty() {
+            "ready"
+        } else {
+            "repair_required"
+        },
+        repair_required: !unhealthy_scopes.is_empty(),
+        unhealthy_scopes,
+    }
 }
 
 fn audit_status_failure(
@@ -574,10 +626,67 @@ mod tests {
             content.contains("\"message\":\"project_index_status\""),
             "{content}"
         );
+        assert!(content.contains("\"status\":\"ready\""), "{content}");
+        assert!(content.contains("\"repair_required\":false"), "{content}");
         assert!(content.contains("\"runner\":true"), "{content}");
         assert!(content.contains("\"files-docs\""), "{content}");
         assert!(
             content.contains("\"last_repair_at\":\"2026-04-24T06:15:20Z\""),
+            "{content}"
+        );
+        assert!(!dir.path().join("index.log").exists());
+    }
+
+    #[test]
+    fn audit_status_marks_unhealthy_scope_as_repair_required() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = IndexContext {
+            project_root: dir.path().join("repo"),
+            repo_hash: gwt_core::repo_hash::compute_repo_hash(
+                "https://github.com/example/project.git",
+            ),
+            worktree_hash: "feedfacecafebeef".to_string(),
+            python: PathBuf::from("python"),
+            runner: PathBuf::from("runner.py"),
+        };
+        let report = gwt_core::runtime::ProjectIndexRuntimeReport {
+            runner_hash: "aaaaaaaaaaaaaaaa".to_string(),
+            requirements_hash: "bbbbbbbbbbbbbbbb".to_string(),
+            runner_smoke_tested: true,
+            ..Default::default()
+        };
+        let payload = serde_json::json!({
+            "status": {
+                "specs": {
+                    "healthy": false,
+                    "repair_required": true,
+                    "reason": "count_mismatch",
+                    "document_count": 1
+                },
+                "files": {
+                    "healthy": true,
+                    "repair_required": false,
+                    "reason": "ready",
+                    "document_count": 310
+                }
+            }
+        });
+
+        audit_status(dir.path(), &context, &report, &payload, 0).unwrap();
+
+        let log_path = gwt_core::logging::current_log_file(dir.path());
+        let content = std::fs::read_to_string(log_path).unwrap();
+        assert!(
+            content.contains("\"status\":\"repair_required\""),
+            "{content}"
+        );
+        assert!(content.contains("\"repair_required\":true"), "{content}");
+        assert!(
+            content.contains("\"unhealthy_scopes\":[\"specs\"]"),
+            "{content}"
+        );
+        assert!(
+            content.contains("\"reason\":\"count_mismatch\""),
             "{content}"
         );
         assert!(!dir.path().join("index.log").exists());

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,30 @@
 # Lessons Learned
 
+## 2026-04-24 — fix(index): chunked index の health check は下限不変条件を残す
+
+### 事象
+
+Project index hardening の PR で、SPEC は 1 Issue から複数 Chroma record を生成できるため
+`document_count != manifest_count` を一律に許容した。その結果、manifest には複数 SPEC が
+あるのに Chroma collection が一部 record しか持たない部分破損でも `healthy=true` と
+報告される余地ができた。
+
+### 原因
+
+- chunking による「manifest より多い record」は正常だが、「manifest より少ない record」は
+  破損という片側条件を明文化していなかった。
+- Review 後に auto-merge が先に完了し、未解決 review thread の確認が完了報告前の
+  gate として固定されていなかった。
+
+### 再発防止策
+
+1. chunked collection の health check は `document_count >= manifest_count` のような
+   one-sided invariant として書き、等価比較を丸ごと無効化しない。
+2. `gwt pr checks` が全通過しても、完了報告前に `gwt pr review-threads <n>` を再確認し、
+   auto-merge 後に出た valid comment は follow-up PR で解消する。
+3. health status と audit log の両方を追加する変更では、UI 表示だけでなく structured
+   log の top-level status が同じ truth を示す回帰テストを追加する。
+
 ## 2026-04-24 — fix(logging): structured runtime log は project-scoped canonical file 以外へ出さない
 
 ### 事象


### PR DESCRIPTION
## Summary
- Address the post-merge Codex Review feedback from #2158.
- Keep chunked SPEC indexes valid when `document_count >= manifest_count`, but flag undersized SPEC collections as `count_mismatch` / `repair_required=true`.
- Make `project_index_status` audit logs truthful when any reported scope is unhealthy by writing top-level `status="repair_required"` and `unhealthy_scopes`.

## Context / Risk
- Related: #1939, #2158
- Risk area: project index status health and unified index audit logs.
- Rollback: revert this PR; no schema or data migration is required.

## Testing
- `PYTHONPATH=crates/gwt-core/runtime GWT_INDEX_FAKE_EMBEDDING=1 python -m unittest crates.gwt-core.runtime.tests.test_status_health` passed.
- `CARGO_TARGET_DIR=target/codex-check cargo test -p gwt cli::index::tests -- --nocapture` passed.
- `CARGO_TARGET_DIR=target/codex-check cargo test -p gwt-core -p gwt -- --test-threads=1` passed.
- `CARGO_TARGET_DIR=target/codex-check cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo fmt -- --check` passed.
- `CARGO_TARGET_DIR=target/codex-check cargo build -p gwt` passed.
- `target\codex-check\debug\gwt.exe index status` passed with issues/specs/files/files-docs all ready.
- `bunx commitlint --from HEAD~1 --to HEAD` passed.

## Notes
- A default-thread local `cargo test -p gwt-core -p gwt` run exposed an existing HOME-dependent test race in `persistence::tests::migrate_legacy_workspace_state_keeps_existing_new_workspace`; the test passes alone and the full suite passes with `--test-threads=1`.
- SPEC #1939 was updated with the follow-up scenario, FR-046, SC-030, plan, and tasks.
