### PR TITLE
fix(custom-agent): support windows shell selection

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -108,6 +108,10 @@ managed hook と runtime 委譲の入口も引き続き `gwt` です。利用者
 `Shell` と `Agent` は実プロセスを持つウィンドウです。`File Tree` は実装済みの
 read-only ツリーです。それ以外は現時点では mock surface です。
 
+Windows の Host 起動では、Launch Agent で Command Prompt、Windows PowerShell、
+PowerShell 7 を選択できます。選択したシェルは `Shell` と `Agent` の両方に適用され、
+Docker 起動では引き続きコンテナ内のシェルを使います。
+
 ターミナルウィンドウでは、テキストをドラッグ選択してマウスボタンを離すとコピー
 できます。Windows / Linux では `Ctrl+Shift+C` でも現在の選択をコピーできます。
 `Ctrl+C` は実行中のターミナルプロセス向けの割り込みのままです。

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Available windows include:
 tree view. The remaining windows are currently mock surfaces where production
 behavior has not been wired yet.
 
+On Windows Host launches, Launch Agent lets you choose Command Prompt, Windows
+PowerShell, or PowerShell 7. The selected shell applies to both `Shell` and
+`Agent` windows; Docker launches continue to use the container shell.
+
 In terminal windows, drag to select text and release the mouse button to copy.
 On Windows and Linux, `Ctrl+Shift+C` also copies the current terminal
 selection. `Ctrl+C` stays mapped to the running terminal process.

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -245,6 +245,7 @@ pub struct LaunchConfig {
     pub docker_service: Option<String>,
     pub docker_lifecycle_intent: DockerLifecycleIntent,
     pub linked_issue_number: Option<u64>,
+    pub windows_shell: Option<crate::WindowsShellKind>,
 }
 
 /// Permission mode for agent launch.
@@ -285,6 +286,7 @@ pub struct AgentLaunchBuilder {
     docker_service: Option<String>,
     docker_lifecycle_intent: DockerLifecycleIntent,
     linked_issue_number: Option<u64>,
+    windows_shell: Option<crate::WindowsShellKind>,
 }
 
 impl AgentLaunchBuilder {
@@ -310,6 +312,7 @@ impl AgentLaunchBuilder {
             docker_service: None,
             docker_lifecycle_intent: DockerLifecycleIntent::Connect,
             linked_issue_number: None,
+            windows_shell: None,
         }
     }
 
@@ -411,6 +414,11 @@ impl AgentLaunchBuilder {
 
     pub fn linked_issue_number(mut self, n: u64) -> Self {
         self.linked_issue_number = Some(n);
+        self
+    }
+
+    pub fn windows_shell(mut self, shell: crate::WindowsShellKind) -> Self {
+        self.windows_shell = Some(shell);
         self
     }
 
@@ -535,6 +543,7 @@ impl AgentLaunchBuilder {
             docker_service: self.docker_service,
             docker_lifecycle_intent: self.docker_lifecycle_intent,
             linked_issue_number: self.linked_issue_number,
+            windows_shell: self.windows_shell,
         }
     }
 

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -47,6 +47,6 @@ pub use store::{
 };
 pub use types::{
     resolve_agent_id, AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent,
-    LaunchRuntimeTarget, SessionMode, WorkflowBypass,
+    LaunchRuntimeTarget, SessionMode, WindowsShellKind, WorkflowBypass,
 };
 pub use version_cache::{build_version_options, VersionCache, VersionOption};

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -11,7 +11,10 @@ use uuid::Uuid;
 
 use crate::{
     launch::{normalize_launch_args, LaunchConfig},
-    types::{AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, WorkflowBypass},
+    types::{
+        AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, WindowsShellKind,
+        WorkflowBypass,
+    },
 };
 
 /// Idle duration (in seconds) after which a session is considered stopped.
@@ -62,6 +65,8 @@ pub struct Session {
     pub launch_command: String,
     #[serde(default)]
     pub launch_args: Vec<String>,
+    #[serde(default)]
+    pub windows_shell: Option<WindowsShellKind>,
     /// Schema version of this persisted session. SPEC-1921 Phase 53 / FR-066:
     /// bumped by `Session::migrate_legacy_launch_args` so migrations are
     /// idempotent. Legacy TOML files without this field deserialize as `0`.
@@ -127,6 +132,7 @@ impl Session {
             workflow_bypass: None,
             launch_command: String::new(),
             launch_args: Vec::new(),
+            windows_shell: None,
             schema_version: Self::CURRENT_SCHEMA_VERSION,
             created_at: now,
             updated_at: now,
@@ -137,9 +143,9 @@ impl Session {
 
     /// Create a persisted session snapshot from a prepared launch config.
     ///
-    /// The launch command/args are captured before any outer runtime wrapper
-    /// (for example `docker compose exec`) is applied so resume/quick-start
-    /// metadata preserves the logical agent command.
+    /// The launch command/args are captured from the prepared Host command.
+    /// Docker still persists the logical agent command before `compose exec`
+    /// is applied.
     pub fn from_launch_config(
         worktree_path: impl Into<PathBuf>,
         branch: impl Into<String>,
@@ -158,6 +164,7 @@ impl Session {
         session.linked_issue_number = config.linked_issue_number;
         session.launch_command = config.command.clone();
         session.launch_args = config.args.clone();
+        session.windows_shell = config.windows_shell;
         session.update_status(AgentStatus::Running);
         session
     }
@@ -1036,6 +1043,28 @@ mod tests {
         );
         assert_eq!(session.linked_issue_number, Some(1921));
         assert_eq!(session.status, AgentStatus::Running);
+    }
+
+    #[test]
+    fn session_from_launch_config_persists_windows_shell_choice() {
+        let mut config = crate::AgentLaunchBuilder::new(AgentId::Codex)
+            .working_dir("/tmp/worktree")
+            .branch("feature/shell")
+            .build();
+        config.command = "pwsh".to_string();
+        config.args = vec![
+            "-NoLogo".to_string(),
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+            "& 'codex'".to_string(),
+        ];
+        config.windows_shell = Some(WindowsShellKind::PowerShell7);
+
+        let session = Session::from_launch_config("/tmp/worktree", "feature/shell", &config);
+
+        assert_eq!(session.windows_shell, Some(WindowsShellKind::PowerShell7));
+        assert_eq!(session.launch_command, "pwsh");
+        assert_eq!(session.launch_args, config.args);
     }
 
     #[test]

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -177,41 +177,8 @@ pub enum LaunchRuntimeTarget {
 pub enum WindowsShellKind {
     CommandPrompt,
     WindowsPowerShell,
+    #[serde(rename = "power_shell_7", alias = "power_shell7")]
     PowerShell7,
-}
-
-impl WindowsShellKind {
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::CommandPrompt => "Command Prompt",
-            Self::WindowsPowerShell => "Windows PowerShell",
-            Self::PowerShell7 => "PowerShell 7",
-        }
-    }
-
-    pub fn description(self) -> &'static str {
-        match self {
-            Self::CommandPrompt => "Run through cmd.exe",
-            Self::WindowsPowerShell => "Run through Windows PowerShell",
-            Self::PowerShell7 => "Run through PowerShell 7",
-        }
-    }
-
-    pub fn command(self) -> &'static str {
-        match self {
-            Self::CommandPrompt => "cmd.exe",
-            Self::WindowsPowerShell => "powershell",
-            Self::PowerShell7 => "pwsh",
-        }
-    }
-
-    pub fn value(self) -> &'static str {
-        match self {
-            Self::CommandPrompt => "command_prompt",
-            Self::WindowsPowerShell => "windows_power_shell",
-            Self::PowerShell7 => "power_shell_7",
-        }
-    }
 }
 
 /// Non-persisted lifecycle intent for a Docker launch.
@@ -447,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    fn windows_shell_kind_wire_values_and_labels_are_stable() {
+    fn windows_shell_kind_wire_values_are_stable() {
         assert_eq!(
             serde_json::to_string(&WindowsShellKind::CommandPrompt).unwrap(),
             "\"command_prompt\""
@@ -456,11 +423,13 @@ mod tests {
             serde_json::from_str::<WindowsShellKind>("\"windows_power_shell\"").unwrap(),
             WindowsShellKind::WindowsPowerShell
         );
-        assert_eq!(WindowsShellKind::CommandPrompt.label(), "Command Prompt");
         assert_eq!(
-            WindowsShellKind::WindowsPowerShell.label(),
-            "Windows PowerShell"
+            serde_json::from_str::<WindowsShellKind>("\"power_shell_7\"").unwrap(),
+            WindowsShellKind::PowerShell7
         );
-        assert_eq!(WindowsShellKind::PowerShell7.command(), "pwsh");
+        assert_eq!(
+            serde_json::from_str::<WindowsShellKind>("\"power_shell7\"").unwrap(),
+            WindowsShellKind::PowerShell7
+        );
     }
 }

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -171,6 +171,49 @@ pub enum LaunchRuntimeTarget {
     Docker,
 }
 
+/// Windows Host shell used to wrap interactive launch commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowsShellKind {
+    CommandPrompt,
+    WindowsPowerShell,
+    PowerShell7,
+}
+
+impl WindowsShellKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::CommandPrompt => "Command Prompt",
+            Self::WindowsPowerShell => "Windows PowerShell",
+            Self::PowerShell7 => "PowerShell 7",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::CommandPrompt => "Run through cmd.exe",
+            Self::WindowsPowerShell => "Run through Windows PowerShell",
+            Self::PowerShell7 => "Run through PowerShell 7",
+        }
+    }
+
+    pub fn command(self) -> &'static str {
+        match self {
+            Self::CommandPrompt => "cmd.exe",
+            Self::WindowsPowerShell => "powershell",
+            Self::PowerShell7 => "pwsh",
+        }
+    }
+
+    pub fn value(self) -> &'static str {
+        match self {
+            Self::CommandPrompt => "command_prompt",
+            Self::WindowsPowerShell => "windows_power_shell",
+            Self::PowerShell7 => "power_shell_7",
+        }
+    }
+}
+
 /// Non-persisted lifecycle intent for a Docker launch.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DockerLifecycleIntent {
@@ -401,5 +444,23 @@ mod tests {
             let parsed: WorkflowBypass = serde_json::from_str(&json).unwrap();
             assert_eq!(parsed, bypass);
         }
+    }
+
+    #[test]
+    fn windows_shell_kind_wire_values_and_labels_are_stable() {
+        assert_eq!(
+            serde_json::to_string(&WindowsShellKind::CommandPrompt).unwrap(),
+            "\"command_prompt\""
+        );
+        assert_eq!(
+            serde_json::from_str::<WindowsShellKind>("\"windows_power_shell\"").unwrap(),
+            WindowsShellKind::WindowsPowerShell
+        );
+        assert_eq!(WindowsShellKind::CommandPrompt.label(), "Command Prompt");
+        assert_eq!(
+            WindowsShellKind::WindowsPowerShell.label(),
+            "Windows PowerShell"
+        );
+        assert_eq!(WindowsShellKind::PowerShell7.command(), "pwsh");
     }
 }

--- a/crates/gwt-terminal/src/pty/windows_spawn.rs
+++ b/crates/gwt-terminal/src/pty/windows_spawn.rs
@@ -12,7 +12,11 @@ struct WindowsSpawnTarget {
     args_prefix: Vec<String>,
 }
 
+const CMD_WRAPPER_EXPRESSION_ENV: &str = "GWT_WINDOWS_CMD_WRAPPER_EXPRESSION";
+
 pub(super) fn normalize_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
+    config.command = normalize_command_token(&config.command);
+
     let resolved = resolve_spawn_target(&config.command, &config.env, &config.remove_env)
         .unwrap_or_else(|| WindowsSpawnTarget {
             command: config.command.clone(),
@@ -25,9 +29,12 @@ pub(super) fn normalize_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
         &config.env,
         &config.remove_env,
     ) {
-        Some((command, args)) => {
+        Some((command, args, expression)) => {
             config.command = command;
             config.args = args;
+            config
+                .env
+                .insert(CMD_WRAPPER_EXPRESSION_ENV.to_string(), expression);
         }
         None => {
             let mut args = resolved.args_prefix;
@@ -38,6 +45,25 @@ pub(super) fn normalize_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
     }
 
     config
+}
+
+fn normalize_command_token(command: &str) -> String {
+    let trimmed = command.trim();
+    if trimmed.len() < 2 {
+        return trimmed.to_string();
+    }
+
+    let mut chars = trimmed.chars();
+    let first = chars.next();
+    let last = chars.next_back();
+    if matches!(
+        (first, last),
+        (Some('"'), Some('"')) | (Some('\''), Some('\''))
+    ) {
+        chars.as_str().to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn escape_cmd_double_quoted(value: &str) -> String {
@@ -60,6 +86,7 @@ fn quote_cmd_token_if_needed(value: &str) -> String {
 
 fn build_cmd_command_expression(command: &str, args: &[String]) -> String {
     let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push("call".to_string());
     parts.push(quote_cmd_token_if_needed(command));
     parts.extend(args.iter().map(|arg| quote_cmd_token_if_needed(arg)));
     parts.join(" ")
@@ -127,7 +154,7 @@ fn spawn_wrapper(
     forwarded_args: &[String],
     env: &HashMap<String, String>,
     remove_env: &[String],
-) -> Option<(String, Vec<String>)> {
+) -> Option<(String, Vec<String>, String)> {
     let ext = resolved
         .extension()
         .and_then(|value| value.to_str())
@@ -139,18 +166,21 @@ fn spawn_wrapper(
     let comspec =
         windows_env_value("ComSpec", env, remove_env).unwrap_or_else(|| OsString::from("cmd.exe"));
 
-    // SPEC-1921 FR-082: Do NOT pass `/s`. `/s` forces CMD to strip the
-    // quotes that surround the executable path, which breaks invocations
-    // with whitespace in the path (e.g. `C:\Program Files\nodejs\npx.cmd`).
-    // Without `/s`, CMD's default rule preserves the quotes when the
-    // command line has the typical `"<exe>" <args>` shape we emit here.
+    // SPEC-1921 FR-082: Do NOT pass `/s`. The command expression is expanded
+    // from an env var so `portable-pty` does not backslash-escape the inner
+    // quotes before CMD parses spaced `.cmd` paths.
     let expression = format!(
         "{} & exit",
         build_cmd_command_expression(&resolved.display().to_string(), forwarded_args)
     );
     Some((
         PathBuf::from(comspec).display().to_string(),
-        vec!["/d".to_string(), "/k".to_string(), expression],
+        vec![
+            "/d".to_string(),
+            "/k".to_string(),
+            format!("%{CMD_WRAPPER_EXPRESSION_ENV}%"),
+        ],
+        expression,
     ))
 }
 
@@ -327,11 +357,11 @@ fn has_executable_extension(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, path::PathBuf};
+    use std::{collections::HashMap, path::PathBuf, time::Duration};
 
     use super::*;
     use crate::pty::PtyHandle;
-    use crate::test_util::lock_pty_test;
+    use crate::test_util::{answer_cursor_position_query, lock_pty_test, read_until_contains};
 
     fn normalized_config(
         command: &str,
@@ -382,8 +412,15 @@ mod tests {
             vec![
                 "/d".to_string(),
                 "/k".to_string(),
-                format!("{} --dangerously-skip-permissions & exit", cmd.display()),
+                format!("%{CMD_WRAPPER_EXPRESSION_ENV}%"),
             ]
+        );
+        assert_eq!(
+            normalized.env.get(CMD_WRAPPER_EXPRESSION_ENV),
+            Some(&format!(
+                "call {} --dangerously-skip-permissions & exit",
+                cmd.display()
+            ))
         );
     }
 
@@ -401,7 +438,7 @@ mod tests {
 
         assert_eq!(
             expression,
-            r#""C:\Program Files\nodejs\npx.cmd" --cwd "C:\Users\Test User\repo" "a&b" "arg ""quoted"" value""#
+            r#"call "C:\Program Files\nodejs\npx.cmd" --cwd "C:\Users\Test User\repo" "a&b" "arg ""quoted"" value""#
         );
     }
 
@@ -634,16 +671,93 @@ mod tests {
             normalized.args,
         );
         let expected_expression = format!(
-            "\"{}\" --yes @anthropic-ai/claude-code@latest & exit",
+            "call \"{}\" --yes @anthropic-ai/claude-code@latest & exit",
             npx_cmd.display()
         );
         assert!(
-            normalized
-                .args
-                .iter()
-                .any(|arg| arg == &expected_expression),
+            normalized.env.get(CMD_WRAPPER_EXPRESSION_ENV) == Some(&expected_expression),
             "expected original package spec preserved inside cmd wrapper expression, got {:?}",
-            normalized.args,
+            normalized.env,
+        );
+    }
+
+    #[test]
+    fn spawn_succeeds_via_spaced_npx_cmd_path() {
+        let _pty_guard = lock_pty_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("Program Files").join("nodejs");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let cmd_path = bin_dir.join("npx.cmd");
+        std::fs::write(
+            &cmd_path,
+            "@echo off\r\necho GWT_NPX_OK %*\r\nexit /b 0\r\n",
+        )
+        .expect("npx.cmd");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), bin_dir.display().to_string());
+        env.insert("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string());
+
+        let handle = PtyHandle::spawn(SpawnConfig {
+            command: "npx".to_string(),
+            args: vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+            ],
+            cols: 80,
+            rows: 24,
+            env,
+            remove_env: Vec::new(),
+            cwd: None,
+        })
+        .expect("spawn npx.cmd");
+        answer_cursor_position_query(&handle);
+        let reader = handle.reader().expect("reader");
+
+        let output = read_until_contains(reader, Duration::from_secs(5), "GWT_NPX_OK")
+            .expect("read npx output");
+        let text = String::from_utf8_lossy(&output);
+        assert!(
+            text.contains("GWT_NPX_OK --yes @anthropic-ai/claude-code@latest"),
+            "expected fake npx.cmd to receive forwarded args, got: {text}"
+        );
+    }
+
+    #[test]
+    fn spawn_strips_outer_quotes_from_spaced_npx_cmd_path() {
+        let _pty_guard = lock_pty_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("Program Files").join("nodejs");
+        std::fs::create_dir_all(&bin_dir).expect("bin dir");
+        let cmd_path = bin_dir.join("npx.cmd");
+        std::fs::write(
+            &cmd_path,
+            "@echo off\r\necho GWT_QUOTED_NPX_OK %*\r\nexit /b 0\r\n",
+        )
+        .expect("npx.cmd");
+
+        let handle = PtyHandle::spawn(SpawnConfig {
+            command: format!("\"{}\"", cmd_path.display()),
+            args: vec![
+                "--yes".to_string(),
+                "@anthropic-ai/claude-code@latest".to_string(),
+            ],
+            cols: 80,
+            rows: 24,
+            env: HashMap::new(),
+            remove_env: Vec::new(),
+            cwd: None,
+        })
+        .expect("spawn quoted npx.cmd");
+        answer_cursor_position_query(&handle);
+        let reader = handle.reader().expect("reader");
+
+        let output = read_until_contains(reader, Duration::from_secs(5), "GWT_QUOTED_NPX_OK")
+            .expect("read quoted npx output");
+        let text = String::from_utf8_lossy(&output);
+        assert!(
+            text.contains("GWT_QUOTED_NPX_OK --yes @anthropic-ai/claude-code@latest"),
+            "expected quoted fake npx.cmd to receive forwarded args, got: {text}"
         );
     }
 
@@ -686,14 +800,14 @@ mod tests {
             wrapped.1,
         );
         let expected_expression = format!(
-            "\"{}\" --yes @anthropic-ai/claude-code@latest & exit",
+            "call \"{}\" --yes @anthropic-ai/claude-code@latest & exit",
             cmd_path.display()
         );
         assert_eq!(
-            wrapped.1.last().map(String::as_str),
-            Some(expected_expression.as_str()),
+            wrapped.2.as_str(),
+            expected_expression.as_str(),
             "wrapper should preserve quoting for spaced shim paths and append `& exit`, got {:?}",
-            wrapped.1,
+            wrapped,
         );
     }
 }

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -3010,6 +3010,7 @@ impl AppRuntime {
                 });
             }
             install_launch_gwt_bin_env(&mut config.env_vars, config.runtime_target)?;
+            apply_windows_host_shell_wrapper(&mut config)?;
 
             let branch_name = config
                 .branch
@@ -3031,6 +3032,7 @@ impl AppRuntime {
             session.linked_issue_number = config.linked_issue_number;
             session.launch_command = config.command.clone();
             session.launch_args = config.args.clone();
+            session.windows_shell = config.windows_shell;
             session.update_status(gwt_agent::AgentStatus::Running);
 
             let session_id = session.id.clone();

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -161,7 +161,7 @@ pub(crate) fn build_shell_process_launch(
     if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Docker {
         let shell = match config.windows_shell {
             Some(windows_shell) => gwt::ShellProgram {
-                command: windows_shell.command().to_string(),
+                command: windows_shell_process_command(windows_shell).to_string(),
                 args: interactive_windows_shell_args(windows_shell),
             },
             None => detect_shell_program().map_err(|error| error.to_string())?,
@@ -210,6 +210,14 @@ pub(crate) fn build_shell_process_launch(
 
 pub(crate) const WINDOWS_HOST_SHELL_EXPRESSION_ENV: &str = "GWT_WINDOWS_HOST_SHELL_EXPRESSION";
 
+pub(crate) fn windows_shell_process_command(shell: gwt_agent::WindowsShellKind) -> &'static str {
+    match shell {
+        gwt_agent::WindowsShellKind::CommandPrompt => "cmd.exe",
+        gwt_agent::WindowsShellKind::WindowsPowerShell => "powershell",
+        gwt_agent::WindowsShellKind::PowerShell7 => "pwsh",
+    }
+}
+
 fn interactive_windows_shell_args(shell: gwt_agent::WindowsShellKind) -> Vec<String> {
     match shell {
         gwt_agent::WindowsShellKind::CommandPrompt => Vec::new(),
@@ -246,7 +254,7 @@ fn wrap_windows_host_shell_command(
             let expression = format!("{} & exit", build_cmd_command_expression(command, args));
             env.insert(WINDOWS_HOST_SHELL_EXPRESSION_ENV.to_string(), expression);
             (
-                shell.command().to_string(),
+                windows_shell_process_command(shell).to_string(),
                 vec![
                     "/d".to_string(),
                     "/k".to_string(),
@@ -256,7 +264,7 @@ fn wrap_windows_host_shell_command(
         }
         gwt_agent::WindowsShellKind::WindowsPowerShell
         | gwt_agent::WindowsShellKind::PowerShell7 => (
-            shell.command().to_string(),
+            windows_shell_process_command(shell).to_string(),
             vec![
                 "-NoLogo".to_string(),
                 "-NoProfile".to_string(),

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -159,7 +159,13 @@ pub(crate) fn build_shell_process_launch(
     env.extend(config.env_vars.clone());
 
     if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Docker {
-        let shell = detect_shell_program().map_err(|error| error.to_string())?;
+        let shell = match config.windows_shell {
+            Some(windows_shell) => gwt::ShellProgram {
+                command: windows_shell.command().to_string(),
+                args: interactive_windows_shell_args(windows_shell),
+            },
+            None => detect_shell_program().map_err(|error| error.to_string())?,
+        };
         env.entry("GWT_PROJECT_ROOT".to_string())
             .or_insert_with(|| worktree.display().to_string());
         install_launch_gwt_bin_env(&mut env, gwt_agent::LaunchRuntimeTarget::Host)?;
@@ -200,6 +206,105 @@ pub(crate) fn build_shell_process_launch(
         env,
         cwd: Some(worktree),
     })
+}
+
+pub(crate) const WINDOWS_HOST_SHELL_EXPRESSION_ENV: &str = "GWT_WINDOWS_HOST_SHELL_EXPRESSION";
+
+fn interactive_windows_shell_args(shell: gwt_agent::WindowsShellKind) -> Vec<String> {
+    match shell {
+        gwt_agent::WindowsShellKind::CommandPrompt => Vec::new(),
+        gwt_agent::WindowsShellKind::WindowsPowerShell
+        | gwt_agent::WindowsShellKind::PowerShell7 => vec!["-NoLogo".to_string()],
+    }
+}
+
+pub(crate) fn apply_windows_host_shell_wrapper(
+    config: &mut gwt_agent::LaunchConfig,
+) -> Result<(), String> {
+    if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Host {
+        return Ok(());
+    }
+    let Some(shell) = config.windows_shell else {
+        return Ok(());
+    };
+
+    let (command, args) =
+        wrap_windows_host_shell_command(shell, &config.command, &config.args, &mut config.env_vars);
+    config.command = command;
+    config.args = args;
+    Ok(())
+}
+
+fn wrap_windows_host_shell_command(
+    shell: gwt_agent::WindowsShellKind,
+    command: &str,
+    args: &[String],
+    env: &mut HashMap<String, String>,
+) -> (String, Vec<String>) {
+    match shell {
+        gwt_agent::WindowsShellKind::CommandPrompt => {
+            let expression = format!("{} & exit", build_cmd_command_expression(command, args));
+            env.insert(WINDOWS_HOST_SHELL_EXPRESSION_ENV.to_string(), expression);
+            (
+                shell.command().to_string(),
+                vec![
+                    "/d".to_string(),
+                    "/k".to_string(),
+                    format!("%{WINDOWS_HOST_SHELL_EXPRESSION_ENV}%"),
+                ],
+            )
+        }
+        gwt_agent::WindowsShellKind::WindowsPowerShell
+        | gwt_agent::WindowsShellKind::PowerShell7 => (
+            shell.command().to_string(),
+            vec![
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                build_powershell_command_script(command, args),
+            ],
+        ),
+    }
+}
+
+fn escape_cmd_double_quoted(value: &str) -> String {
+    value.replace('"', "\"\"")
+}
+
+fn quote_cmd_token_if_needed(value: &str) -> String {
+    let needs_quotes = value.is_empty()
+        || value.chars().any(|c| {
+            c.is_whitespace()
+                || matches!(c, '&' | '|' | '<' | '>' | '(' | ')' | '^' | '%' | '!' | '"')
+        });
+
+    if needs_quotes {
+        format!("\"{}\"", escape_cmd_double_quoted(value))
+    } else {
+        value.to_string()
+    }
+}
+
+fn build_cmd_command_expression(command: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 2);
+    parts.push("call".to_string());
+    parts.push(quote_cmd_token_if_needed(command));
+    parts.extend(args.iter().map(|arg| quote_cmd_token_if_needed(arg)));
+    parts.join(" ")
+}
+
+fn quote_powershell_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn build_powershell_command_script(command: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(quote_powershell_literal(command));
+    parts.extend(args.iter().map(|arg| quote_powershell_literal(arg)));
+    format!(
+        "& {}; if ($null -ne $LASTEXITCODE) {{ exit $LASTEXITCODE }}; if (-not $?) {{ exit 1 }}",
+        parts.join(" ")
+    )
 }
 
 pub(crate) fn apply_host_package_runner_fallback(config: &mut gwt_agent::LaunchConfig) -> bool {

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -25,6 +25,7 @@ pub enum LaunchWizardStep {
     ModelSelect,
     ReasoningLevel,
     RuntimeTarget,
+    WindowsShell,
     DockerServiceSelect,
     DockerLifecycle,
     VersionSelect,
@@ -106,6 +107,8 @@ pub struct LaunchWizardView {
     pub selected_reasoning: String,
     pub runtime_target_options: Vec<LaunchWizardOptionView>,
     pub selected_runtime_target: String,
+    pub windows_shell_options: Vec<LaunchWizardOptionView>,
+    pub selected_windows_shell: Option<String>,
     pub docker_service_options: Vec<LaunchWizardOptionView>,
     pub selected_docker_service: Option<String>,
     pub docker_lifecycle_options: Vec<LaunchWizardOptionView>,
@@ -118,6 +121,7 @@ pub struct LaunchWizardView {
     pub show_agent_settings: bool,
     pub show_reasoning: bool,
     pub show_runtime_target: bool,
+    pub show_windows_shell: bool,
     pub show_docker_service: bool,
     pub show_docker_lifecycle: bool,
     pub show_version: bool,
@@ -165,6 +169,7 @@ pub struct ShellLaunchConfig {
     pub runtime_target: gwt_agent::LaunchRuntimeTarget,
     pub docker_service: Option<String>,
     pub docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
+    pub windows_shell: Option<gwt_agent::WindowsShellKind>,
     pub env_vars: HashMap<String, String>,
 }
 
@@ -280,6 +285,9 @@ pub enum LaunchWizardAction {
     SetRuntimeTarget {
         target: gwt_agent::LaunchRuntimeTarget,
     },
+    SetWindowsShell {
+        shell: gwt_agent::WindowsShellKind,
+    },
     SetDockerService {
         service: String,
     },
@@ -322,6 +330,7 @@ pub struct LaunchWizardState {
     pub mode: String,
     pub resume_session_id: Option<String>,
     pub runtime_target: gwt_agent::LaunchRuntimeTarget,
+    pub windows_shell: gwt_agent::WindowsShellKind,
     pub docker_service: Option<String>,
     pub docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
     pub skip_permissions: bool,
@@ -395,6 +404,7 @@ impl LaunchWizardState {
             mode: "normal".to_string(),
             resume_session_id: None,
             runtime_target,
+            windows_shell: default_windows_shell_kind(),
             docker_service,
             docker_lifecycle_intent,
             skip_permissions: false,
@@ -461,6 +471,10 @@ impl LaunchWizardState {
             selected_reasoning: self.reasoning.clone(),
             runtime_target_options: runtime_target_options_view(),
             selected_runtime_target: runtime_target_value(self.runtime_target).to_string(),
+            windows_shell_options: windows_shell_options_view(),
+            selected_windows_shell: self
+                .windows_shell_for_launch()
+                .map(|shell| shell.value().to_string()),
             docker_service_options: self.docker_service_options_view(),
             selected_docker_service: self.docker_service.clone(),
             docker_lifecycle_options: self.docker_lifecycle_options_view(),
@@ -474,6 +488,7 @@ impl LaunchWizardState {
             show_agent_settings: self.launch_target_is_agent(),
             show_reasoning: self.launch_target_is_agent() && self.agent_uses_reasoning_step(),
             show_runtime_target: self.has_docker_workflow(),
+            show_windows_shell: self.show_windows_shell_selection(),
             show_docker_service: self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker
                 && self.docker_service_prompt_required(),
             show_docker_lifecycle: self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker,
@@ -577,6 +592,9 @@ impl LaunchWizardState {
             }
             LaunchWizardAction::SetRuntimeTarget { target } => {
                 self.set_runtime_target(target);
+            }
+            LaunchWizardAction::SetWindowsShell { shell } => {
+                self.windows_shell = shell;
             }
             LaunchWizardAction::SetDockerService { service } => {
                 self.set_docker_service(&service);
@@ -693,6 +711,9 @@ impl LaunchWizardState {
         }
 
         builder = builder.runtime_target(self.runtime_target);
+        if let Some(windows_shell) = self.windows_shell_for_launch() {
+            builder = builder.windows_shell(windows_shell);
+        }
         if let Some(docker_service) = self.docker_service.as_deref() {
             builder = builder.docker_service(docker_service.to_string());
         }
@@ -749,6 +770,7 @@ impl LaunchWizardState {
             runtime_target: self.runtime_target,
             docker_service: self.docker_service.clone(),
             docker_lifecycle_intent: self.docker_lifecycle_intent,
+            windows_shell: self.windows_shell_for_launch(),
             env_vars,
         })
     }
@@ -866,6 +888,11 @@ impl LaunchWizardState {
                     self.docker_service = self.preferred_docker_service().map(str::to_string);
                 }
                 self.sync_docker_lifecycle_default();
+            }
+            LaunchWizardStep::WindowsShell => {
+                if let Some(option) = WINDOWS_SHELL_OPTIONS.get(self.selected) {
+                    self.windows_shell = option.shell;
+                }
             }
             LaunchWizardStep::DockerServiceSelect => {
                 if let Some(service) = self.docker_service_options().get(self.selected) {
@@ -1290,6 +1317,12 @@ impl LaunchWizardState {
                 "host".to_string()
             },
         });
+        if let Some(windows_shell) = self.windows_shell_for_launch() {
+            summary.push(LaunchWizardSummaryView {
+                label: "Shell".to_string(),
+                value: windows_shell.label().to_string(),
+            });
+        }
         if self.launch_target_is_agent() {
             summary.push(LaunchWizardSummaryView {
                 label: "Permissions".to_string(),
@@ -1452,6 +1485,14 @@ impl LaunchWizardState {
 
     fn has_docker_workflow(&self) -> bool {
         self.context.docker_context.is_some()
+    }
+
+    fn show_windows_shell_selection(&self) -> bool {
+        cfg!(windows) && self.windows_shell_for_launch().is_some()
+    }
+
+    fn windows_shell_for_launch(&self) -> Option<gwt_agent::WindowsShellKind> {
+        (self.runtime_target == gwt_agent::LaunchRuntimeTarget::Host).then_some(self.windows_shell)
     }
 
     fn docker_service_prompt_required(&self) -> bool {
@@ -1756,6 +1797,7 @@ impl LaunchWizardState {
                     color: None,
                 })
                 .collect(),
+            LaunchWizardStep::WindowsShell => windows_shell_options_view(),
             LaunchWizardStep::DockerServiceSelect => self
                 .docker_service_options()
                 .into_iter()
@@ -1836,6 +1878,11 @@ struct ReasoningDisplayOption {
 struct ChoiceOption {
     label: &'static str,
     description: &'static str,
+}
+
+#[derive(Clone, Copy)]
+struct WindowsShellOption {
+    shell: gwt_agent::WindowsShellKind,
 }
 
 #[derive(Clone, Copy)]
@@ -2077,6 +2124,18 @@ const RUNTIME_TARGET_OPTIONS: [ChoiceOption; 2] = [
     },
 ];
 
+const WINDOWS_SHELL_OPTIONS: [WindowsShellOption; 3] = [
+    WindowsShellOption {
+        shell: gwt_agent::WindowsShellKind::CommandPrompt,
+    },
+    WindowsShellOption {
+        shell: gwt_agent::WindowsShellKind::WindowsPowerShell,
+    },
+    WindowsShellOption {
+        shell: gwt_agent::WindowsShellKind::PowerShell7,
+    },
+];
+
 const YES_NO_OPTIONS: [ChoiceOption; 2] = [
     ChoiceOption {
         label: "Yes",
@@ -2137,6 +2196,8 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
                 Some(LaunchWizardStep::AgentSelect)
             } else if state.has_docker_workflow() {
                 Some(LaunchWizardStep::RuntimeTarget)
+            } else if state.show_windows_shell_selection() {
+                Some(LaunchWizardStep::WindowsShell)
             } else {
                 None
             }
@@ -2146,6 +2207,8 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
                 Some(LaunchWizardStep::ModelSelect)
             } else if state.has_docker_workflow() {
                 Some(LaunchWizardStep::RuntimeTarget)
+            } else if state.show_windows_shell_selection() {
+                Some(LaunchWizardStep::WindowsShell)
             } else if agent_has_npm_package(state.effective_agent_id()) {
                 Some(LaunchWizardStep::VersionSelect)
             } else {
@@ -2157,6 +2220,8 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
                 Some(LaunchWizardStep::ReasoningLevel)
             } else if state.has_docker_workflow() {
                 Some(LaunchWizardStep::RuntimeTarget)
+            } else if state.show_windows_shell_selection() {
+                Some(LaunchWizardStep::WindowsShell)
             } else if agent_has_npm_package(state.effective_agent_id()) {
                 Some(LaunchWizardStep::VersionSelect)
             } else {
@@ -2166,6 +2231,8 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
         LaunchWizardStep::ReasoningLevel => {
             if state.has_docker_workflow() {
                 Some(LaunchWizardStep::RuntimeTarget)
+            } else if state.show_windows_shell_selection() {
+                Some(LaunchWizardStep::WindowsShell)
             } else if agent_has_npm_package(state.effective_agent_id()) {
                 Some(LaunchWizardStep::VersionSelect)
             } else {
@@ -2180,6 +2247,17 @@ fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
             } else if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
                 Some(LaunchWizardStep::DockerLifecycle)
             } else if state.launch_target_is_shell() {
+                None
+            } else if state.show_windows_shell_selection() {
+                Some(LaunchWizardStep::WindowsShell)
+            } else if agent_has_npm_package(state.effective_agent_id()) {
+                Some(LaunchWizardStep::VersionSelect)
+            } else {
+                Some(LaunchWizardStep::ExecutionMode)
+            }
+        }
+        LaunchWizardStep::WindowsShell => {
+            if state.launch_target_is_shell() {
                 None
             } else if agent_has_npm_package(state.effective_agent_id()) {
                 Some(LaunchWizardStep::VersionSelect)
@@ -2244,6 +2322,19 @@ fn prev_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
                 Some(LaunchWizardStep::AgentSelect)
             }
         }
+        LaunchWizardStep::WindowsShell => {
+            if state.has_docker_workflow() {
+                Some(LaunchWizardStep::RuntimeTarget)
+            } else if state.launch_target_is_shell() {
+                Some(LaunchWizardStep::LaunchTarget)
+            } else if state.agent_uses_reasoning_step() {
+                Some(LaunchWizardStep::ReasoningLevel)
+            } else if state.agent_has_models() {
+                Some(LaunchWizardStep::ModelSelect)
+            } else {
+                Some(LaunchWizardStep::AgentSelect)
+            }
+        }
         LaunchWizardStep::DockerServiceSelect => Some(LaunchWizardStep::RuntimeTarget),
         LaunchWizardStep::DockerLifecycle => {
             if state.docker_service_prompt_required() {
@@ -2255,6 +2346,8 @@ fn prev_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
         LaunchWizardStep::VersionSelect => {
             if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
                 Some(LaunchWizardStep::DockerLifecycle)
+            } else if state.show_windows_shell_selection() {
+                Some(LaunchWizardStep::WindowsShell)
             } else if state.has_docker_workflow() {
                 Some(LaunchWizardStep::RuntimeTarget)
             } else if state.agent_uses_reasoning_step() {
@@ -2268,6 +2361,8 @@ fn prev_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<Lau
         LaunchWizardStep::ExecutionMode => {
             if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
                 Some(LaunchWizardStep::DockerLifecycle)
+            } else if state.show_windows_shell_selection() {
+                Some(LaunchWizardStep::WindowsShell)
             } else if agent_has_npm_package(state.effective_agent_id()) {
                 Some(LaunchWizardStep::VersionSelect)
             } else if state.has_docker_workflow() {
@@ -2316,6 +2411,10 @@ fn step_default_selection(step: LaunchWizardStep, state: &LaunchWizardState) -> 
         LaunchWizardStep::RuntimeTarget => {
             usize::from(state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker)
         }
+        LaunchWizardStep::WindowsShell => WINDOWS_SHELL_OPTIONS
+            .iter()
+            .position(|option| option.shell == state.windows_shell)
+            .unwrap_or(0),
         LaunchWizardStep::DockerServiceSelect => state
             .preferred_docker_service()
             .and_then(|service| {
@@ -2436,6 +2535,35 @@ fn runtime_target_options_view() -> Vec<LaunchWizardOptionView> {
             color: None,
         })
         .collect()
+}
+
+fn windows_shell_options_view() -> Vec<LaunchWizardOptionView> {
+    WINDOWS_SHELL_OPTIONS
+        .iter()
+        .map(|option| LaunchWizardOptionView {
+            value: option.shell.value().to_string(),
+            label: option.shell.label().to_string(),
+            description: Some(option.shell.description().to_string()),
+            color: None,
+        })
+        .collect()
+}
+
+fn default_windows_shell_kind() -> gwt_agent::WindowsShellKind {
+    default_windows_shell_kind_with(gwt_core::process::command_exists)
+}
+
+fn default_windows_shell_kind_with<F>(mut command_exists: F) -> gwt_agent::WindowsShellKind
+where
+    F: FnMut(&str) -> bool,
+{
+    if command_exists(gwt_agent::WindowsShellKind::PowerShell7.command()) {
+        return gwt_agent::WindowsShellKind::PowerShell7;
+    }
+    if command_exists(gwt_agent::WindowsShellKind::WindowsPowerShell.command()) {
+        return gwt_agent::WindowsShellKind::WindowsPowerShell;
+    }
+    gwt_agent::WindowsShellKind::CommandPrompt
 }
 
 fn execution_mode_options_view() -> Vec<LaunchWizardOptionView> {
@@ -3637,6 +3765,102 @@ mod tests {
     }
 
     #[test]
+    fn default_windows_shell_kind_prefers_pwsh_then_windows_powershell_then_cmd() {
+        let shell = default_windows_shell_kind_with(|command| command == "pwsh");
+        assert_eq!(shell, gwt_agent::WindowsShellKind::PowerShell7);
+
+        let shell = default_windows_shell_kind_with(|command| command == "powershell");
+        assert_eq!(shell, gwt_agent::WindowsShellKind::WindowsPowerShell);
+
+        let shell = default_windows_shell_kind_with(|_| false);
+        assert_eq!(shell, gwt_agent::WindowsShellKind::CommandPrompt);
+    }
+
+    #[test]
+    fn windows_shell_selection_flows_to_agent_and_shell_launch_requests() {
+        let mut ctx = context(branch("feature/gui"), "feature/gui");
+        ctx.worktree_path = Some(PathBuf::from("/tmp/repo-feature"));
+        let mut state = LaunchWizardState::open_with(ctx, sample_agent_options(), Vec::new());
+
+        state.apply(LaunchWizardAction::SetWindowsShell {
+            shell: gwt_agent::WindowsShellKind::PowerShell7,
+        });
+
+        let view = state.view();
+        assert_eq!(
+            view.selected_windows_shell.as_deref(),
+            Some("power_shell_7")
+        );
+        assert_eq!(view.windows_shell_options.len(), 3);
+        assert!(view
+            .windows_shell_options
+            .iter()
+            .any(|option| option.label == "PowerShell 7"));
+        assert!(view
+            .launch_summary
+            .iter()
+            .any(|item| item.label == "Shell" && item.value == "PowerShell 7"));
+
+        let config = state.build_launch_config().expect("agent config");
+        assert_eq!(
+            config.windows_shell,
+            Some(gwt_agent::WindowsShellKind::PowerShell7)
+        );
+
+        state.apply(LaunchWizardAction::SetLaunchTarget {
+            target: LaunchTargetKind::Shell,
+        });
+
+        match state.build_launch_request().expect("shell request") {
+            LaunchWizardLaunchRequest::Shell(config) => {
+                assert_eq!(
+                    config.windows_shell,
+                    Some(gwt_agent::WindowsShellKind::PowerShell7)
+                );
+            }
+            other => panic!("expected shell launch request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn docker_runtime_omits_windows_shell_from_launch_requests() {
+        let mut ctx = context(branch("feature/gui"), "feature/gui");
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string()],
+            suggested_service: Some("api".to_string()),
+        });
+        let mut state = LaunchWizardState::open_with(ctx, sample_agent_options(), Vec::new());
+
+        state.apply(LaunchWizardAction::SetWindowsShell {
+            shell: gwt_agent::WindowsShellKind::CommandPrompt,
+        });
+        state.apply(LaunchWizardAction::SetRuntimeTarget {
+            target: gwt_agent::LaunchRuntimeTarget::Docker,
+        });
+
+        let config = state.build_launch_config().expect("agent config");
+        assert_eq!(
+            config.runtime_target,
+            gwt_agent::LaunchRuntimeTarget::Docker
+        );
+        assert_eq!(config.windows_shell, None);
+
+        state.apply(LaunchWizardAction::SetLaunchTarget {
+            target: LaunchTargetKind::Shell,
+        });
+        match state.build_launch_request().expect("shell request") {
+            LaunchWizardLaunchRequest::Shell(config) => {
+                assert_eq!(
+                    config.runtime_target,
+                    gwt_agent::LaunchRuntimeTarget::Docker
+                );
+                assert_eq!(config.windows_shell, None);
+            }
+            other => panic!("expected shell launch request, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn build_launch_config_preserves_linked_issue_number() {
         let mut ctx = context(branch("feature/gui"), "feature/gui");
         ctx.linked_issue_number = Some(1234);
@@ -4394,7 +4618,15 @@ mod tests {
             Some(LaunchWizardStep::AgentSelect)
         );
         plain.launch_target = LaunchTargetKind::Shell;
-        assert_eq!(next_step(LaunchWizardStep::LaunchTarget, &plain), None);
+        let expected_shell_step = if cfg!(windows) {
+            Some(LaunchWizardStep::WindowsShell)
+        } else {
+            None
+        };
+        assert_eq!(
+            next_step(LaunchWizardStep::LaunchTarget, &plain),
+            expected_shell_step
+        );
         plain.apply(LaunchWizardAction::SetLinkedIssue { issue_number: 42 });
         assert_eq!(plain.linked_issue_number, Some(42));
         plain.apply(LaunchWizardAction::ClearLinkedIssue);

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -474,7 +474,7 @@ impl LaunchWizardState {
             windows_shell_options: windows_shell_options_view(),
             selected_windows_shell: self
                 .windows_shell_for_launch()
-                .map(|shell| shell.value().to_string()),
+                .map(|shell| windows_shell_option_value(shell).to_string()),
             docker_service_options: self.docker_service_options_view(),
             selected_docker_service: self.docker_service.clone(),
             docker_lifecycle_options: self.docker_lifecycle_options_view(),
@@ -891,7 +891,7 @@ impl LaunchWizardState {
             }
             LaunchWizardStep::WindowsShell => {
                 if let Some(option) = WINDOWS_SHELL_OPTIONS.get(self.selected) {
-                    self.windows_shell = option.shell;
+                    self.windows_shell = *option;
                 }
             }
             LaunchWizardStep::DockerServiceSelect => {
@@ -1320,7 +1320,7 @@ impl LaunchWizardState {
         if let Some(windows_shell) = self.windows_shell_for_launch() {
             summary.push(LaunchWizardSummaryView {
                 label: "Shell".to_string(),
-                value: windows_shell.label().to_string(),
+                value: windows_shell_option_label(windows_shell).to_string(),
             });
         }
         if self.launch_target_is_agent() {
@@ -1881,11 +1881,6 @@ struct ChoiceOption {
 }
 
 #[derive(Clone, Copy)]
-struct WindowsShellOption {
-    shell: gwt_agent::WindowsShellKind,
-}
-
-#[derive(Clone, Copy)]
 struct ExecutionModeOption {
     label: &'static str,
     description: &'static str,
@@ -2124,16 +2119,10 @@ const RUNTIME_TARGET_OPTIONS: [ChoiceOption; 2] = [
     },
 ];
 
-const WINDOWS_SHELL_OPTIONS: [WindowsShellOption; 3] = [
-    WindowsShellOption {
-        shell: gwt_agent::WindowsShellKind::CommandPrompt,
-    },
-    WindowsShellOption {
-        shell: gwt_agent::WindowsShellKind::WindowsPowerShell,
-    },
-    WindowsShellOption {
-        shell: gwt_agent::WindowsShellKind::PowerShell7,
-    },
+const WINDOWS_SHELL_OPTIONS: [gwt_agent::WindowsShellKind; 3] = [
+    gwt_agent::WindowsShellKind::CommandPrompt,
+    gwt_agent::WindowsShellKind::WindowsPowerShell,
+    gwt_agent::WindowsShellKind::PowerShell7,
 ];
 
 const YES_NO_OPTIONS: [ChoiceOption; 2] = [
@@ -2172,212 +2161,228 @@ fn default_docker_lifecycle_intent(
     }
 }
 
-fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<LaunchWizardStep> {
-    match current {
-        LaunchWizardStep::QuickStart => match state.selected_quick_start_action() {
-            QuickStartAction::ChooseDifferent => Some(LaunchWizardStep::BranchAction),
-            QuickStartAction::FocusExistingSession => Some(LaunchWizardStep::FocusExistingSession),
-            QuickStartAction::ReuseEntry { .. } | QuickStartAction::StartNewEntry { .. } => {
-                Some(LaunchWizardStep::SkipPermissions)
+struct LaunchWizardFlow<'a> {
+    state: &'a LaunchWizardState,
+}
+
+impl<'a> LaunchWizardFlow<'a> {
+    fn new(state: &'a LaunchWizardState) -> Self {
+        Self { state }
+    }
+
+    fn next_step(&self, current: LaunchWizardStep) -> Option<LaunchWizardStep> {
+        match current {
+            LaunchWizardStep::QuickStart => match self.state.selected_quick_start_action() {
+                QuickStartAction::ChooseDifferent => Some(LaunchWizardStep::BranchAction),
+                QuickStartAction::FocusExistingSession => {
+                    Some(LaunchWizardStep::FocusExistingSession)
+                }
+                QuickStartAction::ReuseEntry { .. } | QuickStartAction::StartNewEntry { .. } => {
+                    Some(LaunchWizardStep::SkipPermissions)
+                }
+            },
+            LaunchWizardStep::FocusExistingSession => None,
+            LaunchWizardStep::BranchAction => {
+                if self.state.selected == 0 {
+                    Some(LaunchWizardStep::LaunchTarget)
+                } else {
+                    Some(LaunchWizardStep::BranchTypeSelect)
+                }
             }
-        },
-        LaunchWizardStep::FocusExistingSession => None,
-        LaunchWizardStep::BranchAction => {
-            if state.selected == 0 {
-                Some(LaunchWizardStep::LaunchTarget)
-            } else {
-                Some(LaunchWizardStep::BranchTypeSelect)
+            LaunchWizardStep::BranchTypeSelect => Some(LaunchWizardStep::BranchNameInput),
+            LaunchWizardStep::BranchNameInput => Some(LaunchWizardStep::LaunchTarget),
+            LaunchWizardStep::LaunchTarget => self.next_after_launch_target(),
+            LaunchWizardStep::AgentSelect => {
+                if self.state.agent_has_models() {
+                    Some(LaunchWizardStep::ModelSelect)
+                } else {
+                    self.next_after_agent_configuration()
+                }
             }
+            LaunchWizardStep::ModelSelect => {
+                if self.state.agent_uses_reasoning_step() {
+                    Some(LaunchWizardStep::ReasoningLevel)
+                } else {
+                    self.next_after_agent_configuration()
+                }
+            }
+            LaunchWizardStep::ReasoningLevel => self.next_after_agent_configuration(),
+            LaunchWizardStep::RuntimeTarget => self.next_after_runtime_target(),
+            LaunchWizardStep::WindowsShell => self.next_after_windows_shell(),
+            LaunchWizardStep::DockerServiceSelect => Some(LaunchWizardStep::DockerLifecycle),
+            LaunchWizardStep::DockerLifecycle => self.next_after_docker_lifecycle(),
+            LaunchWizardStep::VersionSelect => Some(LaunchWizardStep::ExecutionMode),
+            LaunchWizardStep::ExecutionMode => Some(LaunchWizardStep::SkipPermissions),
+            LaunchWizardStep::SkipPermissions => {
+                if self.state.agent_is_codex() {
+                    Some(LaunchWizardStep::CodexFastMode)
+                } else {
+                    None
+                }
+            }
+            LaunchWizardStep::CodexFastMode => None,
         }
-        LaunchWizardStep::BranchTypeSelect => Some(LaunchWizardStep::BranchNameInput),
-        LaunchWizardStep::BranchNameInput => Some(LaunchWizardStep::LaunchTarget),
-        LaunchWizardStep::LaunchTarget => {
-            if state.launch_target_is_agent() {
-                Some(LaunchWizardStep::AgentSelect)
-            } else if state.has_docker_workflow() {
-                Some(LaunchWizardStep::RuntimeTarget)
-            } else if state.show_windows_shell_selection() {
-                Some(LaunchWizardStep::WindowsShell)
-            } else {
-                None
+    }
+
+    fn prev_step(&self, current: LaunchWizardStep) -> Option<LaunchWizardStep> {
+        match current {
+            LaunchWizardStep::QuickStart => None,
+            LaunchWizardStep::FocusExistingSession => Some(LaunchWizardStep::QuickStart),
+            LaunchWizardStep::BranchAction => {
+                if !self.state.quick_start_entries.is_empty()
+                    || !self.state.context.live_sessions.is_empty()
+                {
+                    Some(LaunchWizardStep::QuickStart)
+                } else {
+                    None
+                }
             }
-        }
-        LaunchWizardStep::AgentSelect => {
-            if state.agent_has_models() {
-                Some(LaunchWizardStep::ModelSelect)
-            } else if state.has_docker_workflow() {
-                Some(LaunchWizardStep::RuntimeTarget)
-            } else if state.show_windows_shell_selection() {
-                Some(LaunchWizardStep::WindowsShell)
-            } else if agent_has_npm_package(state.effective_agent_id()) {
-                Some(LaunchWizardStep::VersionSelect)
-            } else {
-                Some(LaunchWizardStep::ExecutionMode)
+            LaunchWizardStep::BranchTypeSelect => Some(LaunchWizardStep::BranchAction),
+            LaunchWizardStep::BranchNameInput => Some(LaunchWizardStep::BranchTypeSelect),
+            LaunchWizardStep::LaunchTarget => {
+                if self.state.is_new_branch {
+                    Some(LaunchWizardStep::BranchNameInput)
+                } else {
+                    Some(LaunchWizardStep::BranchAction)
+                }
             }
-        }
-        LaunchWizardStep::ModelSelect => {
-            if state.agent_uses_reasoning_step() {
-                Some(LaunchWizardStep::ReasoningLevel)
-            } else if state.has_docker_workflow() {
-                Some(LaunchWizardStep::RuntimeTarget)
-            } else if state.show_windows_shell_selection() {
-                Some(LaunchWizardStep::WindowsShell)
-            } else if agent_has_npm_package(state.effective_agent_id()) {
-                Some(LaunchWizardStep::VersionSelect)
-            } else {
-                Some(LaunchWizardStep::ExecutionMode)
+            LaunchWizardStep::AgentSelect => Some(LaunchWizardStep::LaunchTarget),
+            LaunchWizardStep::ModelSelect => Some(LaunchWizardStep::AgentSelect),
+            LaunchWizardStep::ReasoningLevel => Some(LaunchWizardStep::ModelSelect),
+            LaunchWizardStep::RuntimeTarget => {
+                if self.state.launch_target_is_shell() {
+                    Some(LaunchWizardStep::LaunchTarget)
+                } else {
+                    self.previous_agent_configuration_step()
+                }
             }
-        }
-        LaunchWizardStep::ReasoningLevel => {
-            if state.has_docker_workflow() {
-                Some(LaunchWizardStep::RuntimeTarget)
-            } else if state.show_windows_shell_selection() {
-                Some(LaunchWizardStep::WindowsShell)
-            } else if agent_has_npm_package(state.effective_agent_id()) {
-                Some(LaunchWizardStep::VersionSelect)
-            } else {
-                Some(LaunchWizardStep::ExecutionMode)
+            LaunchWizardStep::WindowsShell => self.previous_before_windows_shell(),
+            LaunchWizardStep::DockerServiceSelect => Some(LaunchWizardStep::RuntimeTarget),
+            LaunchWizardStep::DockerLifecycle => {
+                if self.state.docker_service_prompt_required() {
+                    Some(LaunchWizardStep::DockerServiceSelect)
+                } else {
+                    Some(LaunchWizardStep::RuntimeTarget)
+                }
             }
+            LaunchWizardStep::VersionSelect => self.previous_before_version_select(),
+            LaunchWizardStep::ExecutionMode => self.previous_before_execution_mode(),
+            LaunchWizardStep::SkipPermissions => Some(LaunchWizardStep::ExecutionMode),
+            LaunchWizardStep::CodexFastMode => Some(LaunchWizardStep::SkipPermissions),
         }
-        LaunchWizardStep::RuntimeTarget => {
-            if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker
-                && state.docker_service_prompt_required()
-            {
-                Some(LaunchWizardStep::DockerServiceSelect)
-            } else if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
-                Some(LaunchWizardStep::DockerLifecycle)
-            } else if state.launch_target_is_shell() {
-                None
-            } else if state.show_windows_shell_selection() {
-                Some(LaunchWizardStep::WindowsShell)
-            } else if agent_has_npm_package(state.effective_agent_id()) {
-                Some(LaunchWizardStep::VersionSelect)
-            } else {
-                Some(LaunchWizardStep::ExecutionMode)
-            }
+    }
+
+    fn next_after_launch_target(&self) -> Option<LaunchWizardStep> {
+        if self.state.launch_target_is_agent() {
+            Some(LaunchWizardStep::AgentSelect)
+        } else if self.state.has_docker_workflow() {
+            Some(LaunchWizardStep::RuntimeTarget)
+        } else {
+            self.next_after_host_runtime()
         }
-        LaunchWizardStep::WindowsShell => {
-            if state.launch_target_is_shell() {
-                None
-            } else if agent_has_npm_package(state.effective_agent_id()) {
-                Some(LaunchWizardStep::VersionSelect)
-            } else {
-                Some(LaunchWizardStep::ExecutionMode)
-            }
+    }
+
+    fn next_after_agent_configuration(&self) -> Option<LaunchWizardStep> {
+        if self.state.has_docker_workflow() {
+            Some(LaunchWizardStep::RuntimeTarget)
+        } else {
+            self.next_after_host_runtime()
         }
-        LaunchWizardStep::DockerServiceSelect => Some(LaunchWizardStep::DockerLifecycle),
-        LaunchWizardStep::DockerLifecycle => {
-            if state.launch_target_is_shell() {
-                None
-            } else if agent_has_npm_package(state.effective_agent_id()) {
-                Some(LaunchWizardStep::VersionSelect)
-            } else {
-                Some(LaunchWizardStep::ExecutionMode)
-            }
+    }
+
+    fn next_after_runtime_target(&self) -> Option<LaunchWizardStep> {
+        if self.state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker
+            && self.state.docker_service_prompt_required()
+        {
+            Some(LaunchWizardStep::DockerServiceSelect)
+        } else if self.state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
+            Some(LaunchWizardStep::DockerLifecycle)
+        } else {
+            self.next_after_host_runtime()
         }
-        LaunchWizardStep::VersionSelect => Some(LaunchWizardStep::ExecutionMode),
-        LaunchWizardStep::ExecutionMode => Some(LaunchWizardStep::SkipPermissions),
-        LaunchWizardStep::SkipPermissions => {
-            if state.agent_is_codex() {
-                Some(LaunchWizardStep::CodexFastMode)
-            } else {
-                None
-            }
+    }
+
+    fn next_after_host_runtime(&self) -> Option<LaunchWizardStep> {
+        if self.state.show_windows_shell_selection() {
+            Some(LaunchWizardStep::WindowsShell)
+        } else {
+            self.next_after_windows_shell()
         }
-        LaunchWizardStep::CodexFastMode => None,
+    }
+
+    fn next_after_windows_shell(&self) -> Option<LaunchWizardStep> {
+        if self.state.launch_target_is_shell() {
+            None
+        } else if agent_has_npm_package(self.state.effective_agent_id()) {
+            Some(LaunchWizardStep::VersionSelect)
+        } else {
+            Some(LaunchWizardStep::ExecutionMode)
+        }
+    }
+
+    fn next_after_docker_lifecycle(&self) -> Option<LaunchWizardStep> {
+        if self.state.launch_target_is_shell() {
+            None
+        } else if agent_has_npm_package(self.state.effective_agent_id()) {
+            Some(LaunchWizardStep::VersionSelect)
+        } else {
+            Some(LaunchWizardStep::ExecutionMode)
+        }
+    }
+
+    fn previous_agent_configuration_step(&self) -> Option<LaunchWizardStep> {
+        if self.state.agent_uses_reasoning_step() {
+            Some(LaunchWizardStep::ReasoningLevel)
+        } else if self.state.agent_has_models() {
+            Some(LaunchWizardStep::ModelSelect)
+        } else {
+            Some(LaunchWizardStep::AgentSelect)
+        }
+    }
+
+    fn previous_before_windows_shell(&self) -> Option<LaunchWizardStep> {
+        if self.state.has_docker_workflow() {
+            Some(LaunchWizardStep::RuntimeTarget)
+        } else if self.state.launch_target_is_shell() {
+            Some(LaunchWizardStep::LaunchTarget)
+        } else {
+            self.previous_agent_configuration_step()
+        }
+    }
+
+    fn previous_before_version_select(&self) -> Option<LaunchWizardStep> {
+        if self.state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
+            Some(LaunchWizardStep::DockerLifecycle)
+        } else if self.state.show_windows_shell_selection() {
+            Some(LaunchWizardStep::WindowsShell)
+        } else if self.state.has_docker_workflow() {
+            Some(LaunchWizardStep::RuntimeTarget)
+        } else {
+            self.previous_agent_configuration_step()
+        }
+    }
+
+    fn previous_before_execution_mode(&self) -> Option<LaunchWizardStep> {
+        if self.state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
+            Some(LaunchWizardStep::DockerLifecycle)
+        } else if self.state.show_windows_shell_selection() {
+            Some(LaunchWizardStep::WindowsShell)
+        } else if agent_has_npm_package(self.state.effective_agent_id()) {
+            Some(LaunchWizardStep::VersionSelect)
+        } else if self.state.has_docker_workflow() {
+            Some(LaunchWizardStep::RuntimeTarget)
+        } else {
+            self.previous_agent_configuration_step()
+        }
     }
 }
 
+fn next_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<LaunchWizardStep> {
+    LaunchWizardFlow::new(state).next_step(current)
+}
+
 fn prev_step(current: LaunchWizardStep, state: &LaunchWizardState) -> Option<LaunchWizardStep> {
-    match current {
-        LaunchWizardStep::QuickStart => None,
-        LaunchWizardStep::FocusExistingSession => Some(LaunchWizardStep::QuickStart),
-        LaunchWizardStep::BranchAction => {
-            if !state.quick_start_entries.is_empty() || !state.context.live_sessions.is_empty() {
-                Some(LaunchWizardStep::QuickStart)
-            } else {
-                None
-            }
-        }
-        LaunchWizardStep::BranchTypeSelect => Some(LaunchWizardStep::BranchAction),
-        LaunchWizardStep::BranchNameInput => Some(LaunchWizardStep::BranchTypeSelect),
-        LaunchWizardStep::LaunchTarget => {
-            if state.is_new_branch {
-                Some(LaunchWizardStep::BranchNameInput)
-            } else {
-                Some(LaunchWizardStep::BranchAction)
-            }
-        }
-        LaunchWizardStep::AgentSelect => Some(LaunchWizardStep::LaunchTarget),
-        LaunchWizardStep::ModelSelect => Some(LaunchWizardStep::AgentSelect),
-        LaunchWizardStep::ReasoningLevel => Some(LaunchWizardStep::ModelSelect),
-        LaunchWizardStep::RuntimeTarget => {
-            if state.launch_target_is_shell() {
-                Some(LaunchWizardStep::LaunchTarget)
-            } else if state.agent_uses_reasoning_step() {
-                Some(LaunchWizardStep::ReasoningLevel)
-            } else if state.agent_has_models() {
-                Some(LaunchWizardStep::ModelSelect)
-            } else {
-                Some(LaunchWizardStep::AgentSelect)
-            }
-        }
-        LaunchWizardStep::WindowsShell => {
-            if state.has_docker_workflow() {
-                Some(LaunchWizardStep::RuntimeTarget)
-            } else if state.launch_target_is_shell() {
-                Some(LaunchWizardStep::LaunchTarget)
-            } else if state.agent_uses_reasoning_step() {
-                Some(LaunchWizardStep::ReasoningLevel)
-            } else if state.agent_has_models() {
-                Some(LaunchWizardStep::ModelSelect)
-            } else {
-                Some(LaunchWizardStep::AgentSelect)
-            }
-        }
-        LaunchWizardStep::DockerServiceSelect => Some(LaunchWizardStep::RuntimeTarget),
-        LaunchWizardStep::DockerLifecycle => {
-            if state.docker_service_prompt_required() {
-                Some(LaunchWizardStep::DockerServiceSelect)
-            } else {
-                Some(LaunchWizardStep::RuntimeTarget)
-            }
-        }
-        LaunchWizardStep::VersionSelect => {
-            if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
-                Some(LaunchWizardStep::DockerLifecycle)
-            } else if state.show_windows_shell_selection() {
-                Some(LaunchWizardStep::WindowsShell)
-            } else if state.has_docker_workflow() {
-                Some(LaunchWizardStep::RuntimeTarget)
-            } else if state.agent_uses_reasoning_step() {
-                Some(LaunchWizardStep::ReasoningLevel)
-            } else if state.agent_has_models() {
-                Some(LaunchWizardStep::ModelSelect)
-            } else {
-                Some(LaunchWizardStep::AgentSelect)
-            }
-        }
-        LaunchWizardStep::ExecutionMode => {
-            if state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
-                Some(LaunchWizardStep::DockerLifecycle)
-            } else if state.show_windows_shell_selection() {
-                Some(LaunchWizardStep::WindowsShell)
-            } else if agent_has_npm_package(state.effective_agent_id()) {
-                Some(LaunchWizardStep::VersionSelect)
-            } else if state.has_docker_workflow() {
-                Some(LaunchWizardStep::RuntimeTarget)
-            } else if state.agent_uses_reasoning_step() {
-                Some(LaunchWizardStep::ReasoningLevel)
-            } else if state.agent_has_models() {
-                Some(LaunchWizardStep::ModelSelect)
-            } else {
-                Some(LaunchWizardStep::AgentSelect)
-            }
-        }
-        LaunchWizardStep::SkipPermissions => Some(LaunchWizardStep::ExecutionMode),
-        LaunchWizardStep::CodexFastMode => Some(LaunchWizardStep::SkipPermissions),
-    }
+    LaunchWizardFlow::new(state).prev_step(current)
 }
 
 fn step_default_selection(step: LaunchWizardStep, state: &LaunchWizardState) -> usize {
@@ -2413,7 +2418,7 @@ fn step_default_selection(step: LaunchWizardStep, state: &LaunchWizardState) -> 
         }
         LaunchWizardStep::WindowsShell => WINDOWS_SHELL_OPTIONS
             .iter()
-            .position(|option| option.shell == state.windows_shell)
+            .position(|option| *option == state.windows_shell)
             .unwrap_or(0),
         LaunchWizardStep::DockerServiceSelect => state
             .preferred_docker_service()
@@ -2540,13 +2545,46 @@ fn runtime_target_options_view() -> Vec<LaunchWizardOptionView> {
 fn windows_shell_options_view() -> Vec<LaunchWizardOptionView> {
     WINDOWS_SHELL_OPTIONS
         .iter()
-        .map(|option| LaunchWizardOptionView {
-            value: option.shell.value().to_string(),
-            label: option.shell.label().to_string(),
-            description: Some(option.shell.description().to_string()),
+        .copied()
+        .map(|shell| LaunchWizardOptionView {
+            value: windows_shell_option_value(shell).to_string(),
+            label: windows_shell_option_label(shell).to_string(),
+            description: Some(windows_shell_option_description(shell).to_string()),
             color: None,
         })
         .collect()
+}
+
+fn windows_shell_option_value(shell: gwt_agent::WindowsShellKind) -> &'static str {
+    match shell {
+        gwt_agent::WindowsShellKind::CommandPrompt => "command_prompt",
+        gwt_agent::WindowsShellKind::WindowsPowerShell => "windows_power_shell",
+        gwt_agent::WindowsShellKind::PowerShell7 => "power_shell_7",
+    }
+}
+
+fn windows_shell_option_label(shell: gwt_agent::WindowsShellKind) -> &'static str {
+    match shell {
+        gwt_agent::WindowsShellKind::CommandPrompt => "Command Prompt",
+        gwt_agent::WindowsShellKind::WindowsPowerShell => "Windows PowerShell",
+        gwt_agent::WindowsShellKind::PowerShell7 => "PowerShell 7",
+    }
+}
+
+fn windows_shell_option_description(shell: gwt_agent::WindowsShellKind) -> &'static str {
+    match shell {
+        gwt_agent::WindowsShellKind::CommandPrompt => "Run through cmd.exe",
+        gwt_agent::WindowsShellKind::WindowsPowerShell => "Run through Windows PowerShell",
+        gwt_agent::WindowsShellKind::PowerShell7 => "Run through PowerShell 7",
+    }
+}
+
+fn windows_shell_detection_command(shell: gwt_agent::WindowsShellKind) -> &'static str {
+    match shell {
+        gwt_agent::WindowsShellKind::CommandPrompt => "cmd.exe",
+        gwt_agent::WindowsShellKind::WindowsPowerShell => "powershell",
+        gwt_agent::WindowsShellKind::PowerShell7 => "pwsh",
+    }
 }
 
 fn default_windows_shell_kind() -> gwt_agent::WindowsShellKind {
@@ -2557,10 +2595,14 @@ fn default_windows_shell_kind_with<F>(mut command_exists: F) -> gwt_agent::Windo
 where
     F: FnMut(&str) -> bool,
 {
-    if command_exists(gwt_agent::WindowsShellKind::PowerShell7.command()) {
+    if command_exists(windows_shell_detection_command(
+        gwt_agent::WindowsShellKind::PowerShell7,
+    )) {
         return gwt_agent::WindowsShellKind::PowerShell7;
     }
-    if command_exists(gwt_agent::WindowsShellKind::WindowsPowerShell.command()) {
+    if command_exists(windows_shell_detection_command(
+        gwt_agent::WindowsShellKind::WindowsPowerShell,
+    )) {
         return gwt_agent::WindowsShellKind::WindowsPowerShell;
     }
     gwt_agent::WindowsShellKind::CommandPrompt
@@ -3774,6 +3816,53 @@ mod tests {
 
         let shell = default_windows_shell_kind_with(|_| false);
         assert_eq!(shell, gwt_agent::WindowsShellKind::CommandPrompt);
+    }
+
+    #[test]
+    fn windows_shell_option_metadata_is_owned_by_launch_wizard() {
+        assert_eq!(
+            windows_shell_option_value(gwt_agent::WindowsShellKind::CommandPrompt),
+            "command_prompt"
+        );
+        assert_eq!(
+            windows_shell_option_label(gwt_agent::WindowsShellKind::WindowsPowerShell),
+            "Windows PowerShell"
+        );
+        assert_eq!(
+            windows_shell_option_description(gwt_agent::WindowsShellKind::PowerShell7),
+            "Run through PowerShell 7"
+        );
+    }
+
+    #[test]
+    fn launch_wizard_flow_policy_centralizes_host_shell_step() {
+        let state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        let flow = LaunchWizardFlow::new(&state);
+        let expected_host_tail = if cfg!(windows) {
+            Some(LaunchWizardStep::WindowsShell)
+        } else if agent_has_npm_package(state.effective_agent_id()) {
+            Some(LaunchWizardStep::VersionSelect)
+        } else {
+            Some(LaunchWizardStep::ExecutionMode)
+        };
+
+        assert_eq!(flow.next_after_agent_configuration(), expected_host_tail);
+
+        let mut docker = state.clone();
+        docker.context.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string(), "worker".to_string()],
+            suggested_service: Some("api".to_string()),
+        });
+        docker.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+
+        assert_ne!(
+            LaunchWizardFlow::new(&docker).next_after_runtime_target(),
+            Some(LaunchWizardStep::WindowsShell)
+        );
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -64,9 +64,9 @@ pub(crate) use docker_launch::{
 use embedded_server::{broadcast_runtime_hook_event, health_handler, hook_forward_authorized};
 use embedded_server::{ClientHub, EmbeddedServer};
 pub(crate) use launch_runtime::{
-    apply_host_package_runner_fallback, build_shell_process_launch,
-    ensure_docker_launch_runtime_ready, install_launch_gwt_bin_env, resolve_launch_worktree,
-    resolve_shell_launch_worktree,
+    apply_host_package_runner_fallback, apply_windows_host_shell_wrapper,
+    build_shell_process_launch, ensure_docker_launch_runtime_ready, install_launch_gwt_bin_env,
+    resolve_launch_worktree, resolve_shell_launch_worktree,
 };
 #[cfg(test)]
 pub(crate) use launch_runtime::{
@@ -209,10 +209,10 @@ mod tests {
 
     use super::{
         app_state_view_from_parts, apply_host_package_runner_fallback_with_probe,
-        broadcast_log_entry, broadcast_runtime_hook_event, build_frontend_sync_events,
-        build_shell_process_launch, close_window_from_workspace, combined_window_id,
-        current_git_branch, docker_bundle_mounts_for_home, docker_bundle_override_content,
-        gui_front_door_launch_surface, hook_forward_authorized,
+        apply_windows_host_shell_wrapper, broadcast_log_entry, broadcast_runtime_hook_event,
+        build_frontend_sync_events, build_shell_process_launch, close_window_from_workspace,
+        combined_window_id, current_git_branch, docker_bundle_mounts_for_home,
+        docker_bundle_override_content, gui_front_door_launch_surface, hook_forward_authorized,
         install_launch_gwt_bin_env_with_lookup, knowledge_kind_for_preset, resolve_project_target,
         should_auto_close_agent_window, should_auto_start_restored_window, ActiveAgentSession,
         AppEventProxy, AppRuntime, BlockingTaskSpawner, ClientHub, DispatchTarget,
@@ -2499,6 +2499,7 @@ mod tests {
             docker_service: None,
             docker_lifecycle_intent: DockerLifecycleIntent::Connect,
             env_vars: HashMap::from([("EXTRA_FLAG".to_string(), "1".to_string())]),
+            windows_shell: None,
         };
 
         let launch = build_shell_process_launch(&worktree, &mut config).expect("shell launch");
@@ -2514,6 +2515,81 @@ mod tests {
             config.env_vars.get("GWT_PROJECT_ROOT").map(String::as_str),
             Some(worktree.display().to_string().as_str())
         );
+    }
+
+    #[test]
+    fn build_shell_process_launch_for_host_uses_selected_windows_shell() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo-feature");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let mut config = ShellLaunchConfig {
+            working_dir: Some(worktree.clone()),
+            branch: Some("feature/gui".to_string()),
+            base_branch: None,
+            display_name: "Shell".to_string(),
+            runtime_target: LaunchRuntimeTarget::Host,
+            docker_service: None,
+            docker_lifecycle_intent: DockerLifecycleIntent::Connect,
+            env_vars: HashMap::new(),
+            windows_shell: Some(gwt_agent::WindowsShellKind::WindowsPowerShell),
+        };
+
+        let launch = build_shell_process_launch(&worktree, &mut config).expect("shell launch");
+
+        assert_eq!(launch.command, "powershell");
+        assert_eq!(launch.args, vec!["-NoLogo".to_string()]);
+    }
+
+    #[test]
+    fn command_prompt_agent_wrapper_preserves_spaced_cmd_path() {
+        let mut config = sample_versioned_launch_config();
+        config.command = r"C:\Program Files\nodejs\npx.cmd".to_string();
+        config.args = vec![
+            "--yes".to_string(),
+            "@anthropic-ai/claude-code@latest".to_string(),
+            "value with space".to_string(),
+        ];
+        config.windows_shell = Some(gwt_agent::WindowsShellKind::CommandPrompt);
+
+        apply_windows_host_shell_wrapper(&mut config).expect("wrap command prompt");
+
+        assert_eq!(config.command, "cmd.exe");
+        assert_eq!(
+            config.args,
+            vec![
+                "/d".to_string(),
+                "/k".to_string(),
+                "%GWT_WINDOWS_HOST_SHELL_EXPRESSION%".to_string()
+            ]
+        );
+        assert_eq!(
+            config
+                .env_vars
+                .get("GWT_WINDOWS_HOST_SHELL_EXPRESSION")
+                .map(String::as_str),
+            Some(
+                r#"call "C:\Program Files\nodejs\npx.cmd" --yes @anthropic-ai/claude-code@latest "value with space" & exit"#
+            )
+        );
+    }
+
+    #[test]
+    fn powershell_agent_wrapper_quotes_spaced_path_and_single_quotes() {
+        let mut config = sample_versioned_launch_config();
+        config.command = r"C:\Program Files\nodejs\npx.cmd".to_string();
+        config.args = vec!["value's".to_string()];
+        config.windows_shell = Some(gwt_agent::WindowsShellKind::PowerShell7);
+
+        apply_windows_host_shell_wrapper(&mut config).expect("wrap powershell");
+
+        assert_eq!(config.command, "pwsh");
+        assert_eq!(config.args[0], "-NoLogo");
+        assert_eq!(config.args[1], "-NoProfile");
+        assert_eq!(config.args[2], "-Command");
+        let script = config.args[3].as_str();
+        assert!(script.contains(r"& 'C:\Program Files\nodejs\npx.cmd'"));
+        assert!(script.contains("'value''s'"));
+        assert!(script.contains("exit $LASTEXITCODE"));
     }
 
     #[test]
@@ -3216,6 +3292,7 @@ mod tests {
             docker_service: None,
             docker_lifecycle_intent: DockerLifecycleIntent::Connect,
             env_vars: HashMap::new(),
+            windows_shell: None,
         };
         super::resolve_shell_launch_worktree(&repo, &mut shell_config)
             .expect("shell launch wrapper");

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2541,6 +2541,28 @@ mod tests {
     }
 
     #[test]
+    fn windows_shell_process_command_mapping_is_owned_by_launch_runtime() {
+        assert_eq!(
+            super::launch_runtime::windows_shell_process_command(
+                gwt_agent::WindowsShellKind::CommandPrompt
+            ),
+            "cmd.exe"
+        );
+        assert_eq!(
+            super::launch_runtime::windows_shell_process_command(
+                gwt_agent::WindowsShellKind::WindowsPowerShell
+            ),
+            "powershell"
+        );
+        assert_eq!(
+            super::launch_runtime::windows_shell_process_command(
+                gwt_agent::WindowsShellKind::PowerShell7
+            ),
+            "pwsh"
+        );
+    }
+
+    #[test]
     fn command_prompt_agent_wrapper_preserves_spaced_cmd_path() {
         let mut config = sample_versioned_launch_config();
         config.command = r"C:\Program Files\nodejs\npx.cmd".to_string();

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3505,6 +3505,19 @@
             );
             grid.appendChild(note);
           }
+          if (launchWizard.show_windows_shell) {
+            appendSelectField(
+              grid,
+              "Shell",
+              launchWizard.windows_shell_options || [],
+              launchWizard.selected_windows_shell,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_windows_shell",
+                  shell: value,
+                }),
+            );
+          }
           section.appendChild(grid);
           panel.appendChild(section);
         }


### PR DESCRIPTION
## Summary

- Fix Windows custom-agent launches that fail when a quoted `npx.cmd` path is passed to the PTY layer.
- Add a Windows Host shell choice to Launch Agent so both `Shell` and `Agent` launches can use Command Prompt, Windows PowerShell, or PowerShell 7.
- Keep Windows shell metadata layered by moving UI labels into the launch wizard and process command mapping into launch runtime.

## Changes

- `crates/gwt-terminal/src/pty/windows_spawn.rs`: normalizes quoted `.cmd` paths and preserves spaced npm shim paths.
- `crates/gwt-agent/src/*`: persists Windows shell choice on launch/session metadata while keeping stable wire values.
- `crates/gwt/src/launch_wizard.rs`: adds the Windows shell step for Host launches and centralizes optional flow policy.
- `crates/gwt/src/launch_runtime.rs` / `crates/gwt/src/main.rs`: applies the selected Windows shell to Host `Shell` and `Agent` process launches.
- `crates/gwt/web/app.js`: sends the selected Windows shell through Launch Wizard actions.
- `README.md` / `README.ja.md`: document the Windows Host shell selection behavior.

## Testing

- [x] `cargo fmt -- --check` - passed.
- [x] `git diff --check` - passed.
- [x] `cargo test -p gwt persistence::tests::migrate_legacy_app_state_splits_session_and_project_workspaces --lib -- --nocapture` - passed.
- [x] `cargo test -p gwt-core -p gwt-terminal -p gwt-agent -p gwt` - passed after rerun.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt` - passed.
- [x] `bunx markdownlint-cli2 README.md README.ja.md` - passed with 0 errors.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.

## Closing Issues

- None

## Related Issues / Links

- #1921
- #2014
- #2062

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `markdownlint`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change): new fields are serde-defaulted and legacy PowerShell 7 wire value is accepted as an alias.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Windows users can have `npx.cmd` installed under `C:\Program Files\nodejs`; passing that quoted path through the PTY command field caused Command Prompt to treat it as an invalid literal command.
- A shell choice is needed because Custom Agent and normal shell launches can require different Windows shell semantics.
- SPEC notes for #1921 and #2014 were updated to record the launch/session metadata and Launch Wizard flow amendments.

## Risk / Impact

- **Affected areas**: Windows Host process launch, Launch Wizard navigation, persisted agent session metadata.
- **Rollback plan**: revert this PR; existing session payloads remain readable because the new Windows shell fields default when absent.

## Screenshots

- Not captured. The UI change is an additional Launch Wizard option step and is covered by wizard view/state tests.

## Notes

- The first full post-merge test run had one non-reproducible persistence migration failure; the specific test and the full suite both passed on rerun.
