### PR TITLE
fix(index): use project scoped audit log

### DIFF
--- a/crates/gwt/src/cli/index.rs
+++ b/crates/gwt/src/cli/index.rs
@@ -60,8 +60,9 @@ fn run_status<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOpsEr
     if !output.status.success() {
         out.push_str("runtime: error\n");
         out.push_str(&format_runner_failure(&output));
+        let log_dir = audit_log_dir(&context);
         let _ = audit_status_failure(
-            &gwt_core::paths::gwt_logs_dir(),
+            &log_dir,
             &context,
             &format_runner_failure(&output),
             output.status.code().unwrap_or(1),
@@ -71,13 +72,8 @@ fn run_status<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOpsEr
 
     let payload = parse_runner_json(&output.stdout)?;
     render_index_status(out, &report, &payload);
-    let _ = audit_status(
-        &gwt_core::paths::gwt_logs_dir(),
-        &context,
-        &report,
-        &payload,
-        0,
-    );
+    let log_dir = audit_log_dir(&context);
+    let _ = audit_status(&log_dir, &context, &report, &payload, 0);
     Ok(0)
 }
 
@@ -99,8 +95,8 @@ fn run_rebuild<E: CliEnv>(
     ));
 
     let mut ok = true;
+    let log_dir = audit_log_dir(&context);
     for action in rebuild_actions(scope) {
-        let log_dir = gwt_core::paths::gwt_logs_dir();
         let _ = audit_rebuild_start(&log_dir, &context, action.label);
         let output = run_runner_rebuild(&context, action)?;
         let _ = audit_runner_progress(&log_dir, &context, action.label, &output.stderr);
@@ -321,6 +317,10 @@ fn format_runner_failure(output: &std::process::Output) -> String {
         (false, false) => format!("{stderr}; stdout={stdout}"),
     };
     format!("runner exit={} detail={detail}\n", output.status)
+}
+
+fn audit_log_dir(context: &IndexContext) -> PathBuf {
+    gwt_core::paths::gwt_project_logs_dir_for_project_path(&context.project_root)
 }
 
 fn audit_status(
@@ -548,6 +548,32 @@ mod tests {
                 scope: IndexScope::All
             }
         );
+    }
+
+    #[test]
+    fn audit_log_dir_uses_project_scoped_gwt_log_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path().join("repo");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let project_hash = gwt_core::repo_hash::compute_path_hash(&project_root);
+        let context = IndexContext {
+            project_root,
+            repo_hash: gwt_core::repo_hash::compute_repo_hash(
+                "https://github.com/example/project.git",
+            ),
+            worktree_hash: "feedfacecafebeef".to_string(),
+            python: PathBuf::from("python"),
+            runner: PathBuf::from("runner.py"),
+        };
+
+        let log_dir = audit_log_dir(&context);
+
+        assert!(log_dir.ends_with(
+            PathBuf::from("projects")
+                .join(project_hash.as_str())
+                .join("logs")
+        ));
+        assert!(!log_dir.ends_with(PathBuf::from(".gwt").join("logs")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Route detached `gwt index status` / `gwt index rebuild` audit events to the project-scoped canonical log file.
- Keep unified index audit logging in the same `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD` file used by the main runtime logging surface.
- Update SPEC #1939 to name the project-scoped canonical log path.

## Context / Risk
- Related: #1939, #2158, #2159
- Risk area: manual index diagnostics and log discoverability.
- Rollback: revert this PR; no data migration is required.

## Testing
- `CARGO_TARGET_DIR=target/codex-check cargo test -p gwt cli::index::tests -- --nocapture` passed.
- `CARGO_TARGET_DIR=target/codex-check cargo test -p gwt-core -p gwt -- --test-threads=1` passed.
- `CARGO_TARGET_DIR=target/codex-check cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo fmt -- --check` passed.
- `CARGO_TARGET_DIR=target/codex-check cargo build -p gwt` passed.
- `target\codex-check\debug\gwt.exe index status` passed with all scopes ready.
- Manual log delta check: project-scoped `~/.gwt/projects/99a8660247f5bc49/logs/gwt.log.2026-04-24` grew by 1515 bytes; legacy `~/.gwt/logs/gwt.log.2026-04-24` grew by 0 bytes.
- `bunx commitlint --from HEAD~1 --to HEAD` passed.
