### PR TITLE
fix(board): repair board window interaction

### DIFF
--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -970,11 +970,12 @@ fn choose_apply_plan(
     if platform.os == "windows" {
         if let (Some(current_exe), Some(url)) = (current_exe, installer_url) {
             if windows_should_prefer_installer(current_exe) {
-                let kind = installer_kind_for_url(platform, url)?;
-                return Some(ApplyPlan::Installer {
-                    url: url.to_string(),
-                    kind,
-                });
+                if let Some(kind) = installer_kind_for_url(platform, url) {
+                    return Some(ApplyPlan::Installer {
+                        url: url.to_string(),
+                        kind,
+                    });
+                }
             }
         }
     }
@@ -1006,11 +1007,12 @@ fn choose_apply_plan_with_writable(
     if platform.os == "macos" {
         if running_from_app_bundle {
             if let Some(url) = installer_url {
-                let kind = installer_kind_for_url(platform, url)?;
-                return Some(ApplyPlan::Installer {
-                    url: url.to_string(),
-                    kind,
-                });
+                if let Some(kind) = installer_kind_for_url(platform, url) {
+                    return Some(ApplyPlan::Installer {
+                        url: url.to_string(),
+                        kind,
+                    });
+                }
             }
         } else if writable {
             if let Some(url) = portable_url {
@@ -1024,11 +1026,12 @@ fn choose_apply_plan_with_writable(
     // If we cannot replace in-place, prefer installer when available.
     if !writable {
         if let Some(url) = installer_url {
-            let kind = installer_kind_for_url(platform, url)?;
-            return Some(ApplyPlan::Installer {
-                url: url.to_string(),
-                kind,
-            });
+            if let Some(kind) = installer_kind_for_url(platform, url) {
+                return Some(ApplyPlan::Installer {
+                    url: url.to_string(),
+                    kind,
+                });
+            }
         }
         return None;
     }
@@ -1040,11 +1043,12 @@ fn choose_apply_plan_with_writable(
     }
 
     if let Some(url) = installer_url {
-        let kind = installer_kind_for_url(platform, url)?;
-        return Some(ApplyPlan::Installer {
-            url: url.to_string(),
-            kind,
-        });
+        if let Some(kind) = installer_kind_for_url(platform, url) {
+            return Some(ApplyPlan::Installer {
+                url: url.to_string(),
+                kind,
+            });
+        }
     }
 
     None
@@ -2084,6 +2088,8 @@ mod tests {
 
     #[test]
     fn choose_apply_plan_prefers_portable_for_macos_cli_install() {
+        let temp = tempfile::tempdir().unwrap();
+        let current_exe = temp.path().join("gwt");
         let platform = Platform {
             os: "macos".to_string(),
             arch: "aarch64".to_string(),
@@ -2091,7 +2097,7 @@ mod tests {
 
         let plan = choose_apply_plan(
             &platform,
-            Some(Path::new("/usr/local/bin/gwt")),
+            Some(&current_exe),
             Some("https://example.com/gwt-macos-arm64.tar.gz"),
             Some("https://example.com/gwt_7.1.0_aarch64.dmg"),
         );

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -701,6 +701,62 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_board_surface_owns_plain_wheel_routing() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains(".board-scroll-surface"),
+            "expected Board scroll containers to be registered as native wheel surfaces",
+        );
+        assert!(
+            html.contains(
+                "return element.closest(\".branch-scroll, .file-tree-scroll, .board-scroll-surface\");",
+            ),
+            "expected Board wheel input to stay inside the window instead of falling through to canvas pan",
+        );
+    }
+
+    #[test]
+    fn embedded_web_board_surface_uses_chat_first_layout() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("board-chat-shell")
+                && html.contains("board-timeline-scroll")
+                && html.contains("board-composer-bar"),
+            "expected Board scaffold to be a chat timeline with a bottom-fixed composer",
+        );
+        assert!(
+            html.contains("board-message user")
+                && html.contains("board-message agent")
+                && html.contains("board-message system"),
+            "expected Board entries to render through user/agent/system chat message classes",
+        );
+        assert!(
+            !html.contains("board-side-pane"),
+            "expected Board v1 GUI to avoid the old dashboard sidebar",
+        );
+    }
+
+    #[test]
+    fn embedded_web_board_composer_is_body_first_and_resets_after_post() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("Share a Board update")
+                && html.contains("state.composerBody = \"\";")
+                && html.contains("state.replyParentId = null;"),
+            "expected Board post success to clear body-first draft state",
+        );
+        assert!(
+            !html.contains("Post update")
+                && !html.contains("Topics</span>")
+                && !html.contains("Owners</span>"),
+            "expected Board composer to keep kind/topics/owners out of the primary posting path",
+        );
+    }
+
+    #[test]
     fn embedded_web_memo_surface_uses_repo_scoped_notes_contract() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -967,7 +967,10 @@ mod tests {
         assert!(existing);
         assert_eq!(new_active, "tab-1");
         assert!(runtime.launch_wizard.is_none());
-        assert_eq!(runtime.recent_projects[0].path, repo);
+        assert!(super::same_worktree_path(
+            &runtime.recent_projects[0].path,
+            &repo
+        ));
 
         let added = runtime
             .open_project_path(scratch.clone())
@@ -975,7 +978,10 @@ mod tests {
 
         assert!(!added);
         assert_eq!(runtime.tabs.len(), 3);
-        assert_eq!(runtime.recent_projects[0].path, scratch);
+        assert!(super::same_worktree_path(
+            &runtime.recent_projects[0].path,
+            &scratch
+        ));
         assert!(runtime
             .active_tab_id
             .as_deref()
@@ -3002,7 +3008,11 @@ mod tests {
                 .expect("compose file from defaults"),
             &compose_file,
         ));
-        assert_eq!(defaults.compose_files, vec![compose_file.clone()]);
+        assert_eq!(defaults.compose_files.len(), 1);
+        assert!(super::same_worktree_path(
+            &defaults.compose_files[0],
+            &compose_file
+        ));
         assert!(super::same_worktree_path(
             super::docker_compose_file_for_launch(&project_root, &files)
                 .unwrap()
@@ -3063,11 +3073,13 @@ mod tests {
         .expect("write devcontainer");
 
         let plan = super::resolve_docker_launch_plan(&project, None).expect("launch plan");
-        assert_eq!(
-            plan.compose_files,
-            vec![base.clone(), override_file.clone()]
-        );
-        assert_eq!(plan.compose_file, base);
+        assert_eq!(plan.compose_files.len(), 2);
+        assert!(super::same_worktree_path(&plan.compose_files[0], &base));
+        assert!(super::same_worktree_path(
+            &plan.compose_files[1],
+            &override_file
+        ));
+        assert!(super::same_worktree_path(&plan.compose_file, &base));
         assert_eq!(plan.container_cwd, "/workspace/override");
     }
 
@@ -3280,7 +3292,9 @@ mod tests {
             &mut existing_env,
         )
         .expect("existing worktree");
-        assert_eq!(existing_dir.as_deref(), Some(existing_worktree.as_path()));
+        assert!(existing_dir
+            .as_deref()
+            .is_some_and(|value| super::same_worktree_path(value, &existing_worktree)));
         assert!(existing_env
             .get("GWT_PROJECT_ROOT")
             .is_some_and(|value| super::same_worktree_path(Path::new(value), &existing_worktree)));
@@ -3369,10 +3383,10 @@ mod tests {
         launch_config.working_dir = None;
         launch_config.env_vars = HashMap::new();
         super::resolve_launch_worktree(&repo, &mut launch_config).expect("agent launch wrapper");
-        assert_eq!(
-            launch_config.working_dir.as_deref(),
-            Some(existing_worktree.as_path())
-        );
+        assert!(launch_config
+            .working_dir
+            .as_deref()
+            .is_some_and(|value| super::same_worktree_path(value, &existing_worktree)));
 
         let mut shell_config = ShellLaunchConfig {
             working_dir: None,
@@ -3387,10 +3401,10 @@ mod tests {
         };
         super::resolve_shell_launch_worktree(&repo, &mut shell_config)
             .expect("shell launch wrapper");
-        assert_eq!(
-            shell_config.working_dir.as_deref(),
-            Some(existing_worktree.as_path())
-        );
+        assert!(shell_config
+            .working_dir
+            .as_deref()
+            .is_some_and(|value| super::same_worktree_path(value, &existing_worktree)));
     }
 
     #[test]

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1491,8 +1491,6 @@
             replyParentId: null,
             composerKind: "status",
             composerBody: "",
-            topicsDraft: "",
-            ownersDraft: "",
           });
         }
         return boardStateMap.get(windowId);
@@ -1663,43 +1661,6 @@
           node.textContent = textContent;
         }
         return node;
-      }
-
-      function sanitizeBoardDraftList(value) {
-        const items = [];
-        for (const raw of String(value || "").split(",")) {
-          const trimmed = raw.trim();
-          if (!trimmed || items.includes(trimmed)) {
-            continue;
-          }
-          items.push(trimmed);
-        }
-        return items;
-      }
-
-      function boardKindLabel(kind) {
-        switch (kind) {
-          case "request":
-            return "Request";
-          case "status":
-            return "Status";
-          case "next":
-            return "Next";
-          case "claim":
-            return "Claim";
-          case "impact":
-            return "Impact";
-          case "question":
-            return "Question";
-          case "blocked":
-            return "Blocked";
-          case "handoff":
-            return "Handoff";
-          case "decision":
-            return "Decision";
-          default:
-            return "Entry";
-        }
       }
 
       function memoTitleLabel(note) {
@@ -1924,26 +1885,6 @@
             ),
           );
         }
-      }
-
-      function boardAgentKey(entry) {
-        return (
-          entry.origin_agent_id ||
-          entry.origin_session_id ||
-          (entry.author_kind === "agent" ? entry.author : "")
-        );
-      }
-
-      function boardAgentSummaries(entries) {
-        const latestByAgent = new Map();
-        for (const entry of entries) {
-          const key = boardAgentKey(entry);
-          if (!key) {
-            continue;
-          }
-          latestByAgent.set(key, entry);
-        }
-        return Array.from(latestByAgent.values());
       }
 
       function memoSelectedNote(state) {
@@ -2759,8 +2700,8 @@
           entry_kind: state.composerKind,
           body,
           parent_id: state.replyParentId,
-          topics: sanitizeBoardDraftList(state.topicsDraft),
-          owners: sanitizeBoardDraftList(state.ownersDraft),
+          topics: [],
+          owners: [],
         });
         renderBoard(windowId);
       }
@@ -2801,9 +2742,8 @@
         const state = ensureBoardState(windowId);
         const status = body.querySelector(".board-status");
         const timeline = body.querySelector(".board-timeline");
-        const agents = body.querySelector(".board-agent-pane");
         const composer = body.querySelector(".board-composer-pane");
-        if (!status || !timeline || !agents || !composer) {
+        if (!status || !timeline || !composer) {
           return;
         }
 
@@ -2828,16 +2768,20 @@
           );
         }
         for (const entry of state.entries) {
-          const card = createNode("article", "board-entry");
+          const authorKind = String(entry.author_kind || "").toLowerCase();
+          let card;
+          if (authorKind === "user") {
+            card = createNode("article", "board-message user");
+          } else if (authorKind === "system") {
+            card = createNode("article", "board-message system");
+          } else {
+            card = createNode("article", "board-message agent");
+          }
           if (entry.agent_color) {
             card.dataset.agentColor = entry.agent_color;
           }
-          if (state.replyParentId === entry.id) {
-            card.classList.add("reply-target");
-          }
 
-          const header = createNode("div", "board-entry-header");
-          const meta = createNode("div", "board-entry-meta");
+          const meta = createNode("div", "board-message-meta");
           if (entry.agent_color) {
             meta.appendChild(createNode("span", "agent-dot"));
           }
@@ -2848,144 +2792,14 @@
               )}`,
             ),
           );
-          const chips = createNode("div", "board-entry-chips");
-          chips.appendChild(
-            createNode("span", "board-chip", boardKindLabel(entry.kind)),
-          );
-          if (entry.state) {
-            chips.appendChild(createNode("span", "board-chip state", entry.state));
-          }
-          header.appendChild(meta);
-          header.appendChild(chips);
-          card.appendChild(header);
-          card.appendChild(createNode("div", "board-entry-body", entry.body));
-
-          if (
-            (entry.related_topics && entry.related_topics.length > 0) ||
-            (entry.related_owners && entry.related_owners.length > 0)
-          ) {
-            const links = createNode("div", "board-entry-links");
-            if (entry.related_topics && entry.related_topics.length > 0) {
-              links.appendChild(
-                createNode(
-                  "span",
-                  "board-entry-link",
-                  `Topics · ${entry.related_topics.join(", ")}`,
-                ),
-              );
-            }
-            if (entry.related_owners && entry.related_owners.length > 0) {
-              links.appendChild(
-                createNode(
-                  "span",
-                  "board-entry-link",
-                  `Owners · ${entry.related_owners.join(", ")}`,
-                ),
-              );
-            }
-            card.appendChild(links);
-          }
-
-          const footer = createNode("div", "board-entry-footer");
-          const replyButton = createNode("button", "text-button", "Reply");
-          replyButton.type = "button";
-          replyButton.addEventListener("click", (event) => {
-            event.stopPropagation();
-            state.replyParentId = entry.id;
-            renderBoard(windowId);
-          });
-          footer.appendChild(replyButton);
-          card.appendChild(footer);
+          card.appendChild(meta);
+          card.appendChild(createNode("div", "board-message-body", entry.body));
           timeline.appendChild(card);
         }
 
-        agents.innerHTML = "";
-        agents.appendChild(createNode("div", "mock-label", "Agent activity"));
-        const summaries = boardAgentSummaries(state.entries);
-        if (summaries.length === 0) {
-          agents.appendChild(
-            createNode("div", "board-empty", "No active agent status yet."),
-          );
-        } else {
-          for (const entry of summaries) {
-            const section = createNode("div", "mock-section");
-            section.appendChild(
-              createNode("div", "mock-label", entry.author || "Agent"),
-            );
-            section.appendChild(
-              createNode(
-                "div",
-                "board-agent-status",
-                entry.state || boardKindLabel(entry.kind),
-              ),
-            );
-            section.appendChild(createNode("div", "board-agent-copy", entry.body));
-            if (entry.origin_branch) {
-              section.appendChild(
-                createNode(
-                  "div",
-                  "board-agent-copy",
-                  `Branch · ${entry.origin_branch}`,
-                ),
-              );
-            }
-            agents.appendChild(section);
-          }
-        }
-
         composer.innerHTML = "";
-        composer.appendChild(createNode("div", "mock-label", "Post update"));
-        if (state.replyParentId) {
-          const replyEntry = state.entries.find((entry) => entry.id === state.replyParentId);
-          const replyBox = createNode("div", "board-reply-box");
-          replyBox.appendChild(
-            createNode(
-              "div",
-              "board-reply-copy",
-              replyEntry
-                ? `Replying to ${replyEntry.author || "entry"}`
-                : "Reply target selected",
-            ),
-          );
-          const clearReply = createNode("button", "text-button", "Clear reply");
-          clearReply.type = "button";
-          clearReply.addEventListener("click", () => {
-            state.replyParentId = null;
-            renderBoard(windowId);
-          });
-          replyBox.appendChild(clearReply);
-          composer.appendChild(replyBox);
-        }
-
-        const kindField = createNode("label", "board-field");
-        kindField.appendChild(createNode("span", "mock-label", "Kind"));
-        const kindSelect = document.createElement("select");
-        kindSelect.className = "launch-select";
-        for (const kind of [
-          "status",
-          "next",
-          "request",
-          "question",
-          "blocked",
-          "handoff",
-          "decision",
-          "claim",
-          "impact",
-        ]) {
-          const option = document.createElement("option");
-          option.value = kind;
-          option.textContent = boardKindLabel(kind);
-          kindSelect.appendChild(option);
-        }
-        kindSelect.value = state.composerKind;
-        kindSelect.addEventListener("change", () => {
-          state.composerKind = kindSelect.value;
-        });
-        kindField.appendChild(kindSelect);
-        composer.appendChild(kindField);
-
-        const bodyField = createNode("label", "board-field");
-        bodyField.appendChild(createNode("span", "mock-label", "Message"));
+        const bodyField = createNode("label", "board-composer-field");
+        bodyField.appendChild(createNode("span", "mock-label", "Share a Board update"));
         const bodyInput = document.createElement("textarea");
         bodyInput.className = "board-textarea";
         bodyInput.value = state.composerBody;
@@ -2995,32 +2809,6 @@
         });
         bodyField.appendChild(bodyInput);
         composer.appendChild(bodyField);
-
-        const topicsField = createNode("label", "board-field");
-        topicsField.appendChild(createNode("span", "mock-label", "Topics"));
-        const topicsInput = document.createElement("input");
-        topicsInput.className = "launch-input";
-        topicsInput.type = "text";
-        topicsInput.value = state.topicsDraft;
-        topicsInput.placeholder = "coordination, release";
-        topicsInput.addEventListener("input", () => {
-          state.topicsDraft = topicsInput.value;
-        });
-        topicsField.appendChild(topicsInput);
-        composer.appendChild(topicsField);
-
-        const ownersField = createNode("label", "board-field");
-        ownersField.appendChild(createNode("span", "mock-label", "Owners"));
-        const ownersInput = document.createElement("input");
-        ownersInput.className = "launch-input";
-        ownersInput.type = "text";
-        ownersInput.value = state.ownersDraft;
-        ownersInput.placeholder = "2018, 1784";
-        ownersInput.addEventListener("input", () => {
-          state.ownersDraft = ownersInput.value;
-        });
-        ownersField.appendChild(ownersInput);
-        composer.appendChild(ownersField);
 
         const actions = createNode("div", "board-composer-actions");
         const submit = createNode(
@@ -4867,19 +4655,18 @@
             <div class="board-root">
               <div class="knowledge-toolbar">
                 <div class="knowledge-toolbar-main">
-                  <div class="knowledge-heading">Coordination timeline</div>
+                  <div class="knowledge-heading">Board chat</div>
                   <div class="board-status"></div>
                 </div>
                 <div class="knowledge-toolbar-actions">
                   <button class="icon-button" data-action="refresh-board" aria-label="Refresh board">↻</button>
                 </div>
               </div>
-              <div class="board-layout">
-                <div class="board-timeline-pane">
+              <div class="board-chat-shell">
+                <div class="board-timeline-scroll board-scroll-surface">
                   <div class="board-timeline"></div>
                 </div>
-                <div class="board-side-pane">
-                  <div class="board-agent-pane"></div>
+                <div class="board-composer-bar">
                   <div class="board-composer-pane"></div>
                 </div>
               </div>
@@ -5724,6 +5511,10 @@
             ) {
               state.replyParentId = null;
             }
+            if (state.submitting) {
+              state.composerBody = "";
+              state.replyParentId = null;
+            }
             state.loading = false;
             state.submitting = false;
             state.error = "";
@@ -6086,7 +5877,7 @@
         if (!element) {
           return null;
         }
-        return element.closest(".branch-scroll, .file-tree-scroll");
+        return element.closest(".branch-scroll, .file-tree-scroll, .board-scroll-surface");
       }
 
       function handleCanvasWheelEvent(event) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1301,39 +1301,34 @@
         overflow-wrap: anywhere;
       }
 
-      .board-layout {
+      .board-chat-shell {
         flex: 1;
         min-height: 0;
-        display: grid;
-        grid-template-columns: minmax(0, 1.7fr) minmax(240px, 0.9fr);
+        display: flex;
+        flex-direction: column;
+        background:
+          radial-gradient(circle at top left, rgba(59, 130, 246, 0.08), transparent 34%),
+          linear-gradient(180deg, #f8fafc 0%, #ffffff 42%);
       }
 
-      .board-timeline-pane,
-      .board-side-pane {
-        min-width: 0;
-        min-height: 0;
-      }
-
-      .board-timeline-pane {
-        border-right: 1px solid rgba(148, 163, 184, 0.18);
-        overflow: auto;
-      }
-
-      .board-side-pane {
-        display: grid;
-        grid-template-rows: minmax(0, 0.9fr) minmax(0, 1.1fr);
-      }
-
-      .board-timeline,
-      .board-agent-pane,
-      .board-composer-pane {
+      .board-timeline-scroll {
+        flex: 1;
         min-height: 0;
         overflow: auto;
+        padding: 16px;
+      }
+
+      .board-timeline {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .board-composer-bar {
+        border-top: 1px solid rgba(148, 163, 184, 0.22);
+        background: rgba(255, 255, 255, 0.94);
         padding: 12px;
-      }
-
-      .board-agent-pane {
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 -18px 40px rgba(15, 23, 42, 0.08);
       }
 
       .board-status {
@@ -1349,61 +1344,44 @@
         color: #b91c1c;
       }
 
-      .board-entry {
+      .board-message {
         display: grid;
-        gap: 8px;
-        padding: 12px;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        gap: 7px;
+        width: min(78%, 560px);
+        padding: 12px 14px;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.94);
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
       }
 
-      .board-entry.reply-target {
-        background: rgba(59, 130, 246, 0.08);
+      .board-message.user {
+        align-self: flex-start;
+        border-bottom-left-radius: 5px;
       }
 
-      .board-entry-header,
-      .board-entry-footer {
-        display: flex;
+      .board-message.agent {
+        align-self: flex-end;
+        border-bottom-right-radius: 5px;
+        background: #eff6ff;
+      }
+
+      .board-message.system {
+        align-self: center;
+        width: min(86%, 620px);
+        text-align: center;
+        background: #f8fafc;
+      }
+
+      .board-message-meta {
+        display: inline-flex;
         align-items: center;
-        justify-content: space-between;
-        gap: 8px;
-      }
-
-      .board-entry-meta,
-      .board-entry-link,
-      .board-agent-copy,
-      .board-reply-copy {
+        gap: 6px;
         font-size: 12px;
         color: #475569;
       }
 
-      .board-entry-meta {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-      }
-
-      .board-entry-chips,
-      .board-entry-links {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        flex-wrap: wrap;
-      }
-
-      .board-chip {
-        padding: 4px 8px;
-        border-radius: 999px;
-        background: rgba(59, 130, 246, 0.1);
-        color: #1d4ed8;
-        font-size: 11px;
-      }
-
-      .board-chip.state {
-        background: rgba(16, 185, 129, 0.12);
-        color: #047857;
-      }
-
-      .board-entry-body {
+      .board-message-body {
         font-size: 13px;
         line-height: 1.5;
         color: #0f172a;
@@ -1411,35 +1389,24 @@
         overflow-wrap: anywhere;
       }
 
-      .board-agent-status {
-        font-size: 12px;
-        font-weight: 700;
-        color: #0f172a;
-      }
-
-      .board-field {
-        display: grid;
-        gap: 6px;
-        margin-bottom: 10px;
-      }
-
       .board-textarea {
-        min-height: 110px;
-        resize: vertical;
-        padding: 10px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
+        min-height: 76px;
+        width: 100%;
+        resize: none;
+        padding: 11px 12px;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.38);
         font: inherit;
         color: #0f172a;
+        background: #ffffff;
       }
 
-      .board-reply-box,
       .board-composer-actions {
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-end;
         gap: 8px;
-        margin-bottom: 10px;
+        margin-top: 8px;
       }
 
       .logs-filter-bar {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,50 @@
 # Lessons Learned
 
+## 2026-04-25 — fix(board): canvas wheel routing の allowlist に新しい scroll surface を必ず登録する
+
+### 事象
+
+GUI Board を chat timeline に寄せても、Board 上の trackpad / wheel scroll が
+canvas pan に奪われると、ユーザーからは「Board がスクロールできない」ように見える。
+
+### 原因
+
+canvas は capture-phase の wheel handler で terminal / repo browser など一部 surface
+だけを native scroll として早期 return していた。Board の scroll container は
+allowlist に入っておらず、plain wheel が canvas pan として処理されていた。
+
+### 再発防止策
+
+1. 新しい window 内 scroll surface を追加したら、DOM/CSS だけでなく
+   `findNativeWheelScrollSurface` の allowlist を同時に更新する。
+2. window 内 scroll は、scroll 端でも canvas pan へフォールバックしない方針を
+   surface ごとに明示し、embedded frontend contract test で固定する。
+3. 「UI が分かりにくい」と「操作不能」が同時に出た場合、まず wheel ownership と
+   primary layout model を分けて原因を確認する。
+
+## 2026-04-25 — fix(update): installer URL は platform kind 判定後にのみ installer 扱いする
+
+### 事象
+
+`cargo test -p gwt-core -p gwt` で update tests が macOS 上だけ失敗した。
+cache に Windows MSI のような current platform 非対応 installer URL が残っていると、
+portable asset があるのに `choose_apply_plan` が installer path で `None` に落ちた。
+
+### 原因
+
+`installer_kind_for_url(platform, url)?` を使っていたため、platform 非対応 installer URL が
+「installer なし」ではなく「apply plan 全体なし」として扱われた。さらに macOS CLI install
+test は `/usr/local/bin` の実 filesystem writable 状態に依存していた。
+
+### 再発防止策
+
+1. installer URL は `installer_kind_for_url` が `Some` を返したときだけ installer plan にする。
+   platform 非対応 URL は portable fallback を妨げない。
+2. writable / non-writable 分岐をテストする場合、実環境の `/usr/local/bin` などに依存せず
+   temp dir または explicit writable helper を使う。
+3. update cache の fallback asset test では、portable と installer の両方があるケースで
+   current platform 非対応 installer が portable を潰さないことを固定する。
+
 ## 2026-04-24 — fix(index): chunked index の health check は下限不変条件を残す
 
 ### 事象


### PR DESCRIPTION
## Summary

- Repair the shared Board window so it behaves as a readable chat timeline instead of an unfinished dashboard.
- Make plain wheel and trackpad scrolling stay inside the Board surface so the canvas does not steal scroll gestures.
- Keep Board storage and wire contracts stable while simplifying the GUI composer to body-first posting.

## Changes

- `crates/gwt/web/app.js`: replaces the Board dashboard/sidebar rendering with chat-first cards, routes Board wheel events through the native scroll-surface allowlist, and clears the composer after post success.
- `crates/gwt/web/index.html`: replaces the old Board dashboard styles with timeline, message, and bottom composer styles.
- `crates/gwt/src/embedded_web.rs`: adds embedded frontend contract tests for Board wheel ownership, chat-first layout, and composer reset behavior.
- `crates/gwt-core/src/update.rs`: fixes an unrelated verification blocker where unsupported installer fallback URLs prevented portable update fallback selection.
- `crates/gwt/src/main.rs`: hardens macOS path-dependent tests against `/private/var` versus `/var` canonicalization.
- `tasks/lessons.md`: records recurrence-prevention notes for Board scroll-surface routing and update fallback classification.

## Testing

- [x] `cargo test -p gwt-core -p gwt` — passed; all gwt/gwt-core unit, integration, and doc tests completed with 0 failures.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed with no warnings.
- [x] `cargo fmt -- --check` — passed with no formatting diffs.
- [x] `cargo build -p gwt` — passed.
- [x] `git diff --check` — passed with no whitespace errors.
- [x] `bunx commitlint --from HEAD~3 --to HEAD` — passed for all commits in this branch.

## Closing Issues

- Closes #1974

## Related Issues / Links

- #2018

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated: SPEC-1974/SPEC-2018 and local lessons were updated; README is not changed because this is a bugfix to existing GUI behavior.
- [x] Migration/backfill plan included: not required because storage and wire schema are unchanged.
- [x] CHANGELOG impact considered: patch-level `fix` commits only; no breaking change.

## Context

- SPEC-1974 reported that the shared Board window was difficult to understand, trackpad scrolling did not work, and user posting felt unfinished.
- SPEC-2018 owns the GUI Board presentation contract, so the implementation keeps domain storage stable and changes only the frontend presentation and interaction contract.

## Risk / Impact

- **Affected areas**: GUI Board rendering, canvas wheel routing allowlist, Board embedded frontend contract tests, update apply-plan fallback test path.
- **Rollback plan**: revert this PR; no data migration or compatibility cleanup is required.

## Screenshots

| Before | After |
|--------|-------|
| Not captured in this CLI-only session. | Not captured in this CLI-only session. |

## Notes

- The native WebView was not manually screenshot-tested from this environment; the user-facing GUI behavior is covered by embedded bundle contract tests plus the full Cargo verification suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned Board surface with chat-first layout replacing multi-pane design
  * Simplified composer UI to single textarea with automatic state clearing
  * Improved wheel event routing for native scroll surface handling

* **Bug Fixes**
  * Enhanced installer URL platform matching to prevent fallback interference

* **Tests**
  * Added regression tests for Board UI layout, wheel routing, and composer behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->