### PR TITLE
feat(knowledge): add semantic search

### DIFF
--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -69,6 +69,15 @@ impl BlockingTaskSpawner {
     }
 }
 
+pub(crate) struct KnowledgeSearchRequest<'a> {
+    pub(crate) id: &'a str,
+    pub(crate) kind: KnowledgeKind,
+    pub(crate) query: &'a str,
+    pub(crate) request_id: u64,
+    pub(crate) selected_number: Option<u64>,
+    pub(crate) list_scope: gwt::KnowledgeListScope,
+}
+
 pub(crate) struct WindowRuntime {
     pane: Arc<Mutex<Pane>>,
     /// Handle to the background reader thread that forwards PTY output.
@@ -445,6 +454,24 @@ impl AppRuntime {
                 selected_number,
                 refresh,
                 list_scope.unwrap_or(gwt::KnowledgeListScope::Open),
+            ),
+            FrontendEvent::SearchKnowledgeBridge {
+                id,
+                knowledge_kind,
+                query,
+                request_id,
+                selected_number,
+                list_scope,
+            } => self.search_knowledge_bridge_events(
+                &client_id,
+                KnowledgeSearchRequest {
+                    id: &id,
+                    kind: knowledge_kind,
+                    query: &query,
+                    request_id,
+                    selected_number,
+                    list_scope: list_scope.unwrap_or(gwt::KnowledgeListScope::Open),
+                },
             ),
             FrontendEvent::SelectKnowledgeBridgeEntry {
                 id,
@@ -2017,6 +2044,85 @@ impl AppRuntime {
                     },
                 ),
             ],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: error,
+                },
+            )],
+        }
+    }
+
+    pub(crate) fn search_knowledge_bridge_events(
+        &self,
+        client_id: &str,
+        request: KnowledgeSearchRequest<'_>,
+    ) -> Vec<OutboundEvent> {
+        let id = request.id;
+        let kind = request.kind;
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        if knowledge_kind_for_preset(window.preset) != Some(kind) {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeError {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    message: "Window is not a knowledge bridge".to_string(),
+                },
+            )];
+        }
+
+        match gwt::search_knowledge_bridge(
+            &tab.project_root,
+            kind,
+            request.query,
+            request.selected_number,
+            request.list_scope,
+        ) {
+            Ok(view) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::KnowledgeSearchResults {
+                    id: id.to_string(),
+                    knowledge_kind: kind,
+                    query: request.query.to_string(),
+                    request_id: request.request_id,
+                    entries: view.entries,
+                    selected_number: view.selected_number,
+                    empty_message: view.empty_message,
+                    refresh_enabled: view.refresh_enabled,
+                },
+            )],
             Err(error) => vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::KnowledgeError {
@@ -3741,7 +3847,8 @@ mod tests {
 
     use super::{
         ActiveAgentSession, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
-        LaunchWizardSession, OutboundEvent, ProjectTabRuntime, WindowRuntime,
+        KnowledgeSearchRequest, LaunchWizardSession, OutboundEvent, ProjectTabRuntime,
+        WindowRuntime,
     };
     use crate::{combined_window_id, PtyWriterRegistry};
 
@@ -4454,6 +4561,49 @@ mod tests {
             BackendEvent::KnowledgeDetail { detail, .. }
                 if detail.sections.iter().any(|section| section.title == "spec"
                     && section.body.contains("Cache-backed issue view"))
+        ));
+    }
+
+    #[test]
+    fn app_runtime_knowledge_search_errors_for_wrong_surface() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_repo(&repo);
+
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "shell-1",
+            repo,
+            WindowPreset::Shell,
+            WindowProcessStatus::Ready,
+        );
+        let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "shell-1");
+        let events = runtime.search_knowledge_bridge_events(
+            "client-1",
+            KnowledgeSearchRequest {
+                id: &window_id,
+                kind: gwt::KnowledgeKind::Issue,
+                query: "semantic query",
+                request_id: 9,
+                selected_number: None,
+                list_scope: gwt::KnowledgeListScope::Open,
+            },
+        );
+
+        assert!(matches!(
+            &events[..],
+            [OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::KnowledgeError {
+                    knowledge_kind,
+                    message,
+                    ..
+                },
+            }] if client_id == "client-1"
+                && *knowledge_kind == gwt::KnowledgeKind::Issue
+                && message == "Window is not a knowledge bridge"
         ));
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -679,6 +679,36 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_knowledge_bridge_surface_uses_semantic_search_contract() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("search_knowledge_bridge"),
+            "expected knowledge bridge search input to call the semantic search backend",
+        );
+        assert!(
+            html.contains("knowledge_search_results"),
+            "expected frontend to handle semantic search result events",
+        );
+        assert!(
+            html.contains("request_id"),
+            "expected semantic search requests to carry request ids for stale-response guards",
+        );
+        assert!(
+            html.contains("Searching semantic index"),
+            "expected semantic search to expose an in-progress state",
+        );
+        assert!(
+            html.contains("% match"),
+            "expected semantic search result rows to show percentage similarity",
+        );
+        assert!(
+            !html.contains("No matching cached items"),
+            "expected semantic search to stop presenting substring-filter empty copy",
+        );
+    }
+
+    #[test]
     fn embedded_web_board_surface_uses_cache_backed_contract() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -203,7 +203,7 @@ fn canonicalize_path(path: PathBuf) -> PathBuf {
     dunce::canonicalize(&path).unwrap_or(path)
 }
 
-fn project_index_python_path() -> PathBuf {
+pub(crate) fn project_index_python_path() -> PathBuf {
     let venv = gwt_project_index_venv_dir();
     if cfg!(windows) {
         venv.join("Scripts").join("python.exe")

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1,8 +1,13 @@
-use std::{collections::HashMap, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    process::Command,
+};
 
 use gwt_core::paths::gwt_cache_dir;
 use gwt_github::{Cache, CacheEntry, IssueState, SectionName};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::issue_cache::{
     issue_cache_has_entries, issue_cache_root_for_repo_path,
@@ -11,6 +16,7 @@ use crate::issue_cache::{
 };
 
 const SPEC_LABEL: &str = "gwt-spec";
+const KNOWLEDGE_SEARCH_RESULT_LIMIT: usize = 50;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -35,6 +41,7 @@ pub struct KnowledgeListItem {
     pub meta: String,
     pub labels: Vec<String>,
     pub linked_branch_count: usize,
+    pub match_score: Option<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -64,6 +71,100 @@ pub struct KnowledgeBridgeView {
     pub detail: KnowledgeDetailView,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemanticSearchHit {
+    pub number: u64,
+    pub distance: Option<f64>,
+}
+
+pub trait SemanticSearchClient {
+    fn search(
+        &self,
+        repo_path: &Path,
+        kind: KnowledgeKind,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SemanticSearchHit>, String>;
+}
+
+#[derive(Debug, Default)]
+struct RunnerSemanticSearchClient;
+
+impl SemanticSearchClient for RunnerSemanticSearchClient {
+    fn search(
+        &self,
+        repo_path: &Path,
+        kind: KnowledgeKind,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SemanticSearchHit>, String> {
+        let action = match kind {
+            KnowledgeKind::Issue => "search-issues",
+            KnowledgeKind::Spec => "search-specs",
+            KnowledgeKind::Pr => return Ok(Vec::new()),
+        };
+        let repo_hash = crate::index_worker::detect_repo_hash(repo_path)
+            .ok_or_else(|| "semantic search requires a git origin remote".to_string())?;
+        gwt_core::runtime::ensure_project_index_runtime().map_err(|error| error.to_string())?;
+        let output = Command::new(crate::index_worker::project_index_python_path())
+            .arg(gwt_core::paths::gwt_runtime_runner_path())
+            .arg("--action")
+            .arg(action)
+            .arg("--repo-hash")
+            .arg(repo_hash.as_str())
+            .arg("--project-root")
+            .arg(repo_path)
+            .arg("--query")
+            .arg(query)
+            .arg("--n-results")
+            .arg(limit.to_string())
+            .current_dir(repo_path)
+            .output()
+            .map_err(|error| format!("run semantic search: {error}"))?;
+        if !output.status.success() {
+            return Err(format_runner_failure(&output));
+        }
+        let payload: Value = serde_json::from_slice(&output.stdout)
+            .map_err(|error| format!("parse semantic search result: {error}"))?;
+        if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            return Err(payload_error(&payload));
+        }
+        Ok(match kind {
+            KnowledgeKind::Issue => payload
+                .get("issueResults")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| {
+                            Some(SemanticSearchHit {
+                                number: value_u64(item.get("number")?)?,
+                                distance: item.get("distance").and_then(Value::as_f64),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            KnowledgeKind::Spec => payload
+                .get("specResults")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| {
+                            Some(SemanticSearchHit {
+                                number: value_u64(item.get("spec_id")?)?,
+                                distance: item.get("distance").and_then(Value::as_f64),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            KnowledgeKind::Pr => Vec::new(),
+        })
+    }
+}
+
 pub fn load_knowledge_bridge(
     repo_path: &Path,
     kind: KnowledgeKind,
@@ -86,6 +187,123 @@ pub fn load_knowledge_bridge(
         return Ok(non_repo_view(kind));
     }
 
+    let entries = load_cache_entries_for_repo(repo_path, refresh)?;
+    let linked_branches = load_linked_branches(repo_path);
+    Ok(match kind {
+        KnowledgeKind::Issue => {
+            build_issue_view(entries, linked_branches, selected_number, list_scope)
+        }
+        KnowledgeKind::Spec => build_spec_view(entries, linked_branches, selected_number),
+        KnowledgeKind::Pr => disabled_pr_view(),
+    })
+}
+
+pub fn search_knowledge_bridge(
+    repo_path: &Path,
+    kind: KnowledgeKind,
+    query: &str,
+    selected_number: Option<u64>,
+    list_scope: KnowledgeListScope,
+) -> Result<KnowledgeBridgeView, String> {
+    search_knowledge_bridge_with_client(
+        repo_path,
+        kind,
+        query,
+        selected_number,
+        list_scope,
+        &RunnerSemanticSearchClient,
+    )
+}
+
+pub(crate) fn search_knowledge_bridge_with_client<C: SemanticSearchClient + ?Sized>(
+    repo_path: &Path,
+    kind: KnowledgeKind,
+    query: &str,
+    selected_number: Option<u64>,
+    list_scope: KnowledgeListScope,
+    client: &C,
+) -> Result<KnowledgeBridgeView, String> {
+    let query = query.trim();
+    if query.is_empty() {
+        return load_knowledge_bridge(repo_path, kind, selected_number, false, list_scope);
+    }
+    if !repo_path.is_dir() {
+        return Err(format!(
+            "project root is not available: {}",
+            repo_path.display()
+        ));
+    }
+    if matches!(kind, KnowledgeKind::Pr) {
+        return Ok(disabled_pr_view());
+    }
+    if issue_cache_root_for_repo_path(repo_path).is_none() {
+        return Ok(non_repo_view(kind));
+    }
+
+    let mut entries = load_cache_entries_for_repo(repo_path, false)?
+        .into_iter()
+        .filter(|entry| candidate_matches_kind_and_scope(entry, kind, list_scope))
+        .collect::<Vec<_>>();
+    entries.sort_by(issue_entry_sort);
+    let linked_branches = load_linked_branches(repo_path);
+    let hits = client.search(repo_path, kind, query, KNOWLEDGE_SEARCH_RESULT_LIMIT)?;
+
+    let mut seen = HashSet::new();
+    let mut list_items = Vec::new();
+    for entry in entries
+        .iter()
+        .filter(|entry| is_exact_search_match(entry, query))
+    {
+        if seen.insert(entry.snapshot.number.0) {
+            list_items.push(list_item_for_kind(kind, entry, &linked_branches, Some(100)));
+        }
+    }
+
+    let entries_by_number = entries
+        .iter()
+        .map(|entry| (entry.snapshot.number.0, entry))
+        .collect::<HashMap<_, _>>();
+    for hit in hits {
+        if !seen.insert(hit.number) {
+            continue;
+        }
+        let Some(entry) = entries_by_number.get(&hit.number) else {
+            continue;
+        };
+        list_items.push(list_item_for_kind(
+            kind,
+            entry,
+            &linked_branches,
+            hit.distance.map(distance_to_match_score),
+        ));
+        if list_items.len() >= KNOWLEDGE_SEARCH_RESULT_LIMIT {
+            break;
+        }
+    }
+
+    let selected_number = selected_number
+        .filter(|selected| list_items.iter().any(|entry| entry.number == *selected))
+        .or_else(|| list_items.first().map(|entry| entry.number));
+    let detail = selected_number
+        .and_then(|selected| entries_by_number.get(&selected).copied())
+        .map(|entry| detail_for_kind(kind, entry, &linked_branches))
+        .unwrap_or_else(|| empty_detail(search_empty_title(kind), "No semantic matches found."));
+
+    Ok(KnowledgeBridgeView {
+        kind,
+        entries: list_items,
+        selected_number,
+        empty_message: if selected_number.is_none() {
+            Some("No semantic matches found.".to_string())
+        } else {
+            None
+        },
+        refresh_enabled: true,
+        detail,
+    })
+}
+
+fn load_cache_entries_for_repo(repo_path: &Path, refresh: bool) -> Result<Vec<CacheEntry>, String> {
     let cache_root = issue_cache_root_for_repo_path_or_detached(repo_path);
     if refresh {
         sync_issue_cache_from_remote(repo_path, &cache_root)?;
@@ -98,15 +316,7 @@ pub fn load_knowledge_bridge(
     }
 
     let cache = Cache::new(cache_root);
-    let entries = load_cache_entries(&cache)?;
-    let linked_branches = load_linked_branches(repo_path);
-    Ok(match kind {
-        KnowledgeKind::Issue => {
-            build_issue_view(entries, linked_branches, selected_number, list_scope)
-        }
-        KnowledgeKind::Spec => build_spec_view(entries, linked_branches, selected_number),
-        KnowledgeKind::Pr => disabled_pr_view(),
-    })
+    load_cache_entries(&cache)
 }
 
 fn load_cache_entries(cache: &Cache) -> Result<Vec<CacheEntry>, String> {
@@ -134,17 +344,7 @@ fn build_issue_view(
 
     let list_items = entries
         .iter()
-        .map(|entry| KnowledgeListItem {
-            number: entry.snapshot.number.0,
-            title: entry.snapshot.title.clone(),
-            state: issue_state_label(entry.snapshot.state),
-            meta: format!("Updated {}", short_updated_at(&entry.snapshot.updated_at.0)),
-            labels: entry.snapshot.labels.clone(),
-            linked_branch_count: linked_branches
-                .get(&entry.snapshot.number.0)
-                .map(Vec::len)
-                .unwrap_or_default(),
-        })
+        .map(|entry| issue_list_item(entry, &linked_branches, None))
         .collect::<Vec<_>>();
     let selected_number = resolve_selected_number(&entries, selected_number);
     let detail = entries
@@ -177,17 +377,7 @@ fn build_spec_view(
 
     let list_items = entries
         .iter()
-        .map(|entry| KnowledgeListItem {
-            number: entry.snapshot.number.0,
-            title: entry.snapshot.title.clone(),
-            state: issue_state_label(entry.snapshot.state),
-            meta: spec_list_meta(entry),
-            labels: entry.snapshot.labels.clone(),
-            linked_branch_count: linked_branches
-                .get(&entry.snapshot.number.0)
-                .map(Vec::len)
-                .unwrap_or_default(),
-        })
+        .map(|entry| spec_list_item(entry, &linked_branches, None))
         .collect::<Vec<_>>();
     let selected_number = resolve_selected_number(&entries, selected_number);
     let detail = entries
@@ -267,6 +457,121 @@ fn empty_detail(title: &str, body: &str) -> KnowledgeDetailView {
             body: body.to_string(),
         }],
         launch_issue_number: None,
+    }
+}
+
+fn candidate_matches_kind_and_scope(
+    entry: &CacheEntry,
+    kind: KnowledgeKind,
+    list_scope: KnowledgeListScope,
+) -> bool {
+    match kind {
+        KnowledgeKind::Issue => {
+            !is_spec_entry(entry)
+                && match list_scope {
+                    KnowledgeListScope::Open => entry.snapshot.state == IssueState::Open,
+                    KnowledgeListScope::Closed => entry.snapshot.state == IssueState::Closed,
+                }
+        }
+        KnowledgeKind::Spec => is_spec_entry(entry),
+        KnowledgeKind::Pr => false,
+    }
+}
+
+fn list_item_for_kind(
+    kind: KnowledgeKind,
+    entry: &CacheEntry,
+    linked_branches: &HashMap<u64, Vec<String>>,
+    match_score: Option<u8>,
+) -> KnowledgeListItem {
+    match kind {
+        KnowledgeKind::Issue => issue_list_item(entry, linked_branches, match_score),
+        KnowledgeKind::Spec => spec_list_item(entry, linked_branches, match_score),
+        KnowledgeKind::Pr => unreachable!("PR bridge has no list items"),
+    }
+}
+
+fn issue_list_item(
+    entry: &CacheEntry,
+    linked_branches: &HashMap<u64, Vec<String>>,
+    match_score: Option<u8>,
+) -> KnowledgeListItem {
+    KnowledgeListItem {
+        number: entry.snapshot.number.0,
+        title: entry.snapshot.title.clone(),
+        state: issue_state_label(entry.snapshot.state),
+        meta: format!("Updated {}", short_updated_at(&entry.snapshot.updated_at.0)),
+        labels: entry.snapshot.labels.clone(),
+        linked_branch_count: linked_branches
+            .get(&entry.snapshot.number.0)
+            .map(Vec::len)
+            .unwrap_or_default(),
+        match_score,
+    }
+}
+
+fn spec_list_item(
+    entry: &CacheEntry,
+    linked_branches: &HashMap<u64, Vec<String>>,
+    match_score: Option<u8>,
+) -> KnowledgeListItem {
+    KnowledgeListItem {
+        number: entry.snapshot.number.0,
+        title: entry.snapshot.title.clone(),
+        state: issue_state_label(entry.snapshot.state),
+        meta: spec_list_meta(entry),
+        labels: entry.snapshot.labels.clone(),
+        linked_branch_count: linked_branches
+            .get(&entry.snapshot.number.0)
+            .map(Vec::len)
+            .unwrap_or_default(),
+        match_score,
+    }
+}
+
+fn detail_for_kind(
+    kind: KnowledgeKind,
+    entry: &CacheEntry,
+    linked_branches: &HashMap<u64, Vec<String>>,
+) -> KnowledgeDetailView {
+    match kind {
+        KnowledgeKind::Issue => {
+            issue_detail_view(entry, linked_branches.get(&entry.snapshot.number.0))
+        }
+        KnowledgeKind::Spec => spec_detail_view(entry),
+        KnowledgeKind::Pr => disabled_pr_view().detail,
+    }
+}
+
+fn is_exact_search_match(entry: &CacheEntry, query: &str) -> bool {
+    let query = query.trim();
+    if query.is_empty() {
+        return false;
+    }
+    let query_lower = query.to_lowercase();
+    let number = entry.snapshot.number.0.to_string();
+    if query_lower.strip_prefix('#') == Some(number.as_str()) || query_lower == number {
+        return true;
+    }
+    if entry.snapshot.title.to_lowercase() == query_lower {
+        return true;
+    }
+    entry
+        .snapshot
+        .labels
+        .iter()
+        .any(|label| label.to_lowercase() == query_lower)
+}
+
+fn distance_to_match_score(distance: f64) -> u8 {
+    ((1.0 - distance) * 100.0).round().clamp(0.0, 100.0) as u8
+}
+
+fn search_empty_title(kind: KnowledgeKind) -> &'static str {
+    match kind {
+        KnowledgeKind::Issue => "Issue Search",
+        KnowledgeKind::Spec => "SPEC Search",
+        KnowledgeKind::Pr => "PR Bridge",
     }
 }
 
@@ -438,6 +743,36 @@ fn is_spec_entry(entry: &CacheEntry) -> bool {
         .labels
         .iter()
         .any(|label| label == SPEC_LABEL)
+}
+
+fn value_u64(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_i64().and_then(|number| u64::try_from(number).ok()))
+        .or_else(|| value.as_str().and_then(|text| text.parse::<u64>().ok()))
+}
+
+fn payload_error(payload: &Value) -> String {
+    payload
+        .get("error")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("error_code").and_then(Value::as_str))
+        .unwrap_or("semantic search failed")
+        .to_string()
+}
+
+fn format_runner_failure(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    if detail.is_empty() {
+        format!("semantic search runner exited with {}", output.status)
+    } else {
+        format!(
+            "semantic search runner exited with {}: {detail}",
+            output.status
+        )
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -735,5 +1070,147 @@ Extra context.
             .sections
             .iter()
             .any(|section| section.title == "notes"));
+    }
+
+    #[derive(Debug, Default)]
+    struct FakeSemanticSearchClient {
+        hits: Vec<SemanticSearchHit>,
+    }
+
+    impl SemanticSearchClient for FakeSemanticSearchClient {
+        fn search(
+            &self,
+            _repo_path: &Path,
+            _kind: KnowledgeKind,
+            _query: &str,
+            _limit: usize,
+        ) -> Result<Vec<SemanticSearchHit>, String> {
+            Ok(self.hits.clone())
+        }
+    }
+
+    #[test]
+    fn semantic_issue_search_respects_scope_filters_specs_and_scores_results() {
+        let _lock = crate::cli::fake_gh_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        init_repo(&repo);
+
+        let cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path(&repo).expect("repo cache root");
+        let cache = Cache::new(cache_root);
+        cache
+            .write_snapshot(&issue_snapshot(
+                11,
+                "Open semantic issue",
+                "Need semantic search.",
+                &["bug"],
+                IssueState::Open,
+            ))
+            .expect("write open issue");
+        cache
+            .write_snapshot(&issue_snapshot(
+                12,
+                "Closed semantic issue",
+                "Already fixed.",
+                &["bug"],
+                IssueState::Closed,
+            ))
+            .expect("write closed issue");
+        cache
+            .write_snapshot(&spec_snapshot(22))
+            .expect("write spec snapshot");
+
+        let view = search_knowledge_bridge_with_client(
+            &repo,
+            KnowledgeKind::Issue,
+            "semantic search",
+            None,
+            KnowledgeListScope::Open,
+            &FakeSemanticSearchClient {
+                hits: vec![
+                    SemanticSearchHit {
+                        number: 22,
+                        distance: Some(0.01),
+                    },
+                    SemanticSearchHit {
+                        number: 12,
+                        distance: Some(0.02),
+                    },
+                    SemanticSearchHit {
+                        number: 11,
+                        distance: Some(0.2),
+                    },
+                ],
+            },
+        )
+        .expect("search view");
+
+        assert_eq!(view.entries.len(), 1);
+        assert_eq!(view.entries[0].number, 11);
+        assert_eq!(view.entries[0].match_score, Some(80));
+        assert_eq!(view.selected_number, Some(11));
+    }
+
+    #[test]
+    fn semantic_spec_search_prioritizes_exact_matches_and_removes_duplicates() {
+        let _lock = crate::cli::fake_gh_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        init_repo(&repo);
+
+        let cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path(&repo).expect("repo cache root");
+        let cache = Cache::new(cache_root);
+        cache
+            .write_snapshot(&issue_snapshot(
+                11,
+                "Plain issue",
+                "Not a spec.",
+                &["bug"],
+                IssueState::Open,
+            ))
+            .expect("write issue");
+        cache
+            .write_snapshot(&spec_snapshot(22))
+            .expect("write spec");
+
+        let view = search_knowledge_bridge_with_client(
+            &repo,
+            KnowledgeKind::Spec,
+            "#22",
+            None,
+            KnowledgeListScope::Open,
+            &FakeSemanticSearchClient {
+                hits: vec![
+                    SemanticSearchHit {
+                        number: 11,
+                        distance: Some(0.01),
+                    },
+                    SemanticSearchHit {
+                        number: 22,
+                        distance: Some(0.18),
+                    },
+                    SemanticSearchHit {
+                        number: 22,
+                        distance: Some(0.2),
+                    },
+                ],
+            },
+        )
+        .expect("search view");
+
+        assert_eq!(view.entries.len(), 1);
+        assert_eq!(view.entries[0].number, 22);
+        assert_eq!(view.entries[0].match_score, Some(100));
+        assert_eq!(view.selected_number, Some(22));
     }
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -36,8 +36,8 @@ pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
 pub use gwt_agent::{ClaudeCodeOpenaiCompatInput, PresetDefinition, PresetId};
 pub use index_worker::ProjectIndexStatusView;
 pub use knowledge_bridge::{
-    load_knowledge_bridge, KnowledgeBridgeView, KnowledgeDetailSection, KnowledgeDetailView,
-    KnowledgeKind, KnowledgeListItem, KnowledgeListScope,
+    load_knowledge_bridge, search_knowledge_bridge, KnowledgeBridgeView, KnowledgeDetailSection,
+    KnowledgeDetailView, KnowledgeKind, KnowledgeListItem, KnowledgeListScope,
 };
 pub use launch_wizard::{
     build_agent_options, build_builtin_agent_options, default_wizard_version_cache_path,

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -123,6 +123,14 @@ pub enum FrontendEvent {
         refresh: bool,
         list_scope: Option<KnowledgeListScope>,
     },
+    SearchKnowledgeBridge {
+        id: String,
+        knowledge_kind: KnowledgeKind,
+        query: String,
+        request_id: u64,
+        selected_number: Option<u64>,
+        list_scope: Option<KnowledgeListScope>,
+    },
     SelectKnowledgeBridgeEntry {
         id: String,
         knowledge_kind: KnowledgeKind,
@@ -349,6 +357,16 @@ pub enum BackendEvent {
     KnowledgeEntries {
         id: String,
         knowledge_kind: KnowledgeKind,
+        entries: Vec<KnowledgeListItem>,
+        selected_number: Option<u64>,
+        empty_message: Option<String>,
+        refresh_enabled: bool,
+    },
+    KnowledgeSearchResults {
+        id: String,
+        knowledge_kind: KnowledgeKind,
+        query: String,
+        request_id: u64,
         entries: Vec<KnowledgeListItem>,
         selected_number: Option<u64>,
         empty_message: Option<String>,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -58,6 +58,7 @@
       const boardStateMap = new Map();
       const logStateMap = new Map();
       const knowledgeBridgeStateMap = new Map();
+      let nextKnowledgeSearchRequestId = 1;
       const pendingMessages = [];
       // Phase 1B extraction map: each entry names the surface that owns the
       // backing state today. New helpers should mutate state through the owning
@@ -1447,13 +1448,18 @@
             kind: knowledgeKind,
             listScope: "open",
             entries: [],
+            baseEntries: [],
             selectedNumber: null,
             detail: null,
             query: "",
             loading: false,
+            searching: false,
             detailLoading: false,
+            pendingSearchTimer: null,
+            searchRequestId: 0,
             error: "",
             emptyMessage: "",
+            baseEmptyMessage: "",
             refreshEnabled: true,
           });
         }
@@ -1605,7 +1611,12 @@
         if (state.loading) {
           return;
         }
+        if (state.pendingSearchTimer) {
+          clearTimeout(state.pendingSearchTimer);
+          state.pendingSearchTimer = null;
+        }
         state.loading = true;
+        state.searching = false;
         state.error = "";
         const effectiveKind = knowledgeKind || state.kind;
         send({
@@ -1617,6 +1628,57 @@
           list_scope:
             effectiveKind === "issue" ? state.listScope || "open" : null,
         });
+      }
+
+      function restoreKnowledgeBaseEntries(state) {
+        state.entries = Array.isArray(state.baseEntries)
+          ? state.baseEntries.slice()
+          : [];
+        state.emptyMessage = state.baseEmptyMessage || "";
+        if (
+          state.selectedNumber &&
+          !state.entries.some((entry) => entry.number === state.selectedNumber)
+        ) {
+          state.selectedNumber =
+            state.entries.length > 0 ? state.entries[0].number : null;
+        }
+      }
+
+      function scheduleKnowledgeSearch(windowId, knowledgeKind) {
+        const state = ensureKnowledgeBridgeState(windowId, knowledgeKind);
+        if (state.pendingSearchTimer) {
+          clearTimeout(state.pendingSearchTimer);
+          state.pendingSearchTimer = null;
+        }
+        const query = state.query.trim();
+        const requestId = nextKnowledgeSearchRequestId++;
+        state.searchRequestId = requestId;
+        state.error = "";
+        if (!query) {
+          state.searching = false;
+          restoreKnowledgeBaseEntries(state);
+          renderKnowledgeBridge(windowId);
+          return;
+        }
+        state.searching = true;
+        state.entries = [];
+        state.emptyMessage = "";
+        state.pendingSearchTimer = setTimeout(() => {
+          state.pendingSearchTimer = null;
+          send({
+            kind: "search_knowledge_bridge",
+            id: windowId,
+            knowledge_kind: knowledgeKind || state.kind,
+            query,
+            request_id: requestId,
+            selected_number: state.selectedNumber ?? null,
+            list_scope:
+              (knowledgeKind || state.kind) === "issue"
+                ? state.listScope || "open"
+                : null,
+          });
+        }, 250);
+        renderKnowledgeBridge(windowId);
       }
 
       function requestKnowledgeDetail(windowId, knowledgeKind, number) {
@@ -3767,10 +3829,10 @@
         switch (kind) {
           case "issue":
             return listScope === "closed"
-              ? "Search cached closed issues"
-              : "Search cached open issues";
+              ? "Semantic search closed issues"
+              : "Semantic search open issues";
           case "spec":
-            return "Search cached SPECs";
+            return "Semantic search cached SPECs";
           case "pr":
             return "Search unavailable";
           default:
@@ -3804,11 +3866,19 @@
         if (state.kind !== "issue" || state.listScope === nextScope || state.loading) {
           return;
         }
+        if (state.pendingSearchTimer) {
+          clearTimeout(state.pendingSearchTimer);
+          state.pendingSearchTimer = null;
+        }
         state.listScope = nextScope;
         state.entries = [];
+        state.baseEntries = [];
         state.selectedNumber = null;
         state.detail = null;
         state.detailLoading = false;
+        state.query = "";
+        state.searching = false;
+        state.searchRequestId += 1;
         requestKnowledgeBridge(windowId, state.kind, false);
         renderKnowledgeBridge(windowId);
       }
@@ -3848,6 +3918,9 @@
         if (state.error) {
           status.classList.add("visible", "error");
           status.textContent = state.error;
+        } else if (state.searching) {
+          status.classList.add("visible", "info");
+          status.textContent = "Searching semantic index";
         } else if (state.loading && state.entries.length === 0) {
           status.classList.add("visible", "info");
           status.textContent = "Loading cache-backed data";
@@ -3857,13 +3930,17 @@
         }
 
         list.innerHTML = "";
-        const visibleEntries = filteredKnowledgeEntries(state);
+        const visibleEntries = state.query.trim()
+          ? state.entries
+          : filteredKnowledgeEntries(state);
         if (visibleEntries.length === 0) {
           const empty = createNode("div", "knowledge-empty");
-          if (state.entries.length === 0) {
+          if (state.searching) {
+            empty.textContent = "Searching semantic index";
+          } else if (state.entries.length === 0) {
             empty.textContent = state.emptyMessage || "No cached items";
           } else {
-            empty.textContent = "No matching cached items";
+            empty.textContent = "No semantic matches";
           }
           list.appendChild(empty);
         } else {
@@ -3892,6 +3969,15 @@
 
             const meta = createNode("div", "knowledge-row-meta");
             meta.appendChild(createNode("span", "knowledge-meta-copy", entry.meta));
+            if (Number.isFinite(entry.match_score)) {
+              meta.appendChild(
+                createNode(
+                  "span",
+                  "knowledge-chip knowledge-match-score",
+                  `${entry.match_score}% match`,
+                ),
+              );
+            }
             if ((entry.linked_branch_count || 0) > 0) {
               meta.appendChild(
                 createNode(
@@ -4814,8 +4900,9 @@
           search.value = state.query;
           search.addEventListener("input", () => {
             state.query = search.value;
-            frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(
+            frontendUnits.knowledgeSettingsSurface.scheduleKnowledgeSearch(
               windowData.id,
+              knowledgeKind,
             );
           });
           for (const button of body.querySelectorAll("[data-knowledge-scope]")) {
@@ -5377,6 +5464,7 @@
       const knowledgeSettingsSurface = Object.freeze({
         ensureKnowledgeBridgeState,
         requestKnowledgeBridge,
+        scheduleKnowledgeSearch,
         requestKnowledgeDetail,
         switchKnowledgeListScope,
         renderKnowledgeBridge,
@@ -5563,12 +5651,48 @@
               event.id,
               event.knowledge_kind,
             );
+            state.baseEntries = event.entries || [];
+            state.baseEmptyMessage = event.empty_message || "";
+            if (!state.query.trim()) {
+              state.entries = state.baseEntries.slice();
+              state.emptyMessage = state.baseEmptyMessage;
+              state.searching = false;
+            }
+            state.selectedNumber = event.selected_number ?? null;
+            state.refreshEnabled = Boolean(event.refresh_enabled);
+            state.loading = false;
+            state.error = "";
+            frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(event.id);
+            break;
+          }
+          case "knowledge_search_results": {
+            const state = frontendUnits.knowledgeSettingsSurface.ensureKnowledgeBridgeState(
+              event.id,
+              event.knowledge_kind,
+            );
+            if (
+              event.request_id !== state.searchRequestId ||
+              event.query !== state.query.trim()
+            ) {
+              break;
+            }
             state.entries = event.entries || [];
             state.selectedNumber = event.selected_number ?? null;
             state.emptyMessage = event.empty_message || "";
             state.refreshEnabled = Boolean(event.refresh_enabled);
+            state.searching = false;
             state.loading = false;
             state.error = "";
+            if (state.selectedNumber) {
+              state.detailLoading = true;
+              frontendUnits.knowledgeSettingsSurface.requestKnowledgeDetail(
+                event.id,
+                event.knowledge_kind,
+                state.selectedNumber,
+              );
+            } else {
+              state.detail = null;
+            }
             frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(event.id);
             break;
           }
@@ -5654,6 +5778,7 @@
               event.knowledge_kind,
             );
             state.loading = false;
+            state.searching = false;
             state.detailLoading = false;
             state.error = event.message;
             frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(event.id);


### PR DESCRIPTION
## Summary

- Adds semantic search to the Issue and SPEC knowledge bridge windows so the existing search boxes use the #1939 ChromaDB/e5 index.
- Keeps Issue Open/Closed scope and SPEC-only filtering intact while showing percentage match scores in result rows.

## Changes

- `crates/gwt/src/knowledge_bridge.rs`: adds semantic search execution, exact-match prioritization, cache reconciliation, scope filtering, and distance-to-percent score conversion.
- `crates/gwt/src/protocol.rs` and `crates/gwt/src/app_runtime.rs`: adds search request/result wire events and routes them through the knowledge bridge runtime.
- `crates/gwt/web/app.js`: adds debounced semantic search, stale-response guards, search status, and `% match` display.
- `crates/gwt/src/embedded_web.rs`: adds frontend contract coverage for semantic search behavior.

## Testing

- [x] `cargo test -p gwt-core -p gwt` — all tests passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `node --check crates/gwt/web/app.js` — passed.

## Closing Issues

None

## Related Issues / Links

- #2017
- #1939

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- #2017 owns the GUI knowledge bridge window behavior; #1939 owns the semantic index runtime used by this PR.

## Risk / Impact

- **Affected areas**: Issue and SPEC knowledge bridge window search, knowledge bridge protocol events, and search result rendering.
- **Rollback plan**: Revert this PR; cache-backed list/detail loading remains isolated from the new search event path.
