### PR TITLE
fix(knowledge): harden semantic search

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -709,6 +709,24 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_knowledge_bridge_cancels_pending_semantic_search_on_window_teardown() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("function clearKnowledgeBridgeState(windowId)"),
+            "expected knowledge bridge teardown to clear pending timers before deleting state",
+        );
+        assert!(
+            html.contains("clearKnowledgeBridgeState(windowId);"),
+            "expected workspace window removal to use knowledge bridge cleanup",
+        );
+        assert!(
+            html.contains("if (!workspaceWindowById(windowId))"),
+            "expected debounced semantic search to verify the window still exists before sending",
+        );
+    }
+
+    #[test]
     fn embedded_web_board_surface_uses_cache_backed_contract() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -240,7 +240,7 @@ pub(crate) fn search_knowledge_bridge_with_client<C: SemanticSearchClient + ?Siz
         return Ok(non_repo_view(kind));
     }
 
-    let mut entries = load_cache_entries_for_repo(repo_path, false)?
+    let mut entries = load_local_cache_entries_for_repo(repo_path)?
         .into_iter()
         .filter(|entry| candidate_matches_kind_and_scope(entry, kind, list_scope))
         .collect::<Vec<_>>();
@@ -315,6 +315,12 @@ fn load_cache_entries_for_repo(repo_path: &Path, refresh: bool) -> Result<Vec<Ca
         }
     }
 
+    let cache = Cache::new(cache_root);
+    load_cache_entries(&cache)
+}
+
+fn load_local_cache_entries_for_repo(repo_path: &Path) -> Result<Vec<CacheEntry>, String> {
+    let cache_root = issue_cache_root_for_repo_path_or_detached(repo_path);
     let cache = Cache::new(cache_root);
     load_cache_entries(&cache)
 }
@@ -1154,6 +1160,67 @@ Extra context.
         assert_eq!(view.entries[0].number, 11);
         assert_eq!(view.entries[0].match_score, Some(80));
         assert_eq!(view.selected_number, Some(11));
+    }
+
+    #[test]
+    fn semantic_issue_search_reads_cache_without_stale_remote_sync() {
+        let _lock = crate::cli::fake_gh_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        init_repo(&repo);
+
+        let cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path(&repo).expect("repo cache root");
+        let cache = Cache::new(cache_root);
+        cache
+            .write_snapshot(&issue_snapshot(
+                11,
+                "Open semantic issue",
+                "Need semantic search.",
+                &["bug"],
+                IssueState::Open,
+            ))
+            .expect("write issue");
+
+        let marker = home.path().join("gh-was-called");
+        let fake_gh = home.path().join("fake-gh");
+        fs::write(
+            &fake_gh,
+            format!("#!/bin/sh\ntouch '{}'\nexit 1\n", marker.display()),
+        )
+        .expect("write fake gh");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&fake_gh, fs::Permissions::from_mode(0o755))
+                .expect("chmod fake gh");
+        }
+        let _gh = ScopedEnvVar::set("GWT_TEST_GH", &fake_gh);
+
+        let view = search_knowledge_bridge_with_client(
+            &repo,
+            KnowledgeKind::Issue,
+            "semantic search",
+            None,
+            KnowledgeListScope::Open,
+            &FakeSemanticSearchClient {
+                hits: vec![SemanticSearchHit {
+                    number: 11,
+                    distance: Some(0.1),
+                }],
+            },
+        )
+        .expect("search view");
+
+        assert_eq!(view.entries.len(), 1);
+        assert!(
+            !marker.exists(),
+            "interactive semantic search must not invoke stale remote cache sync"
+        );
     }
 
     #[test]

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1471,6 +1471,15 @@
         return state;
       }
 
+      function clearKnowledgeBridgeState(windowId) {
+        const state = knowledgeBridgeStateMap.get(windowId);
+        if (state?.pendingSearchTimer) {
+          clearTimeout(state.pendingSearchTimer);
+          state.pendingSearchTimer = null;
+        }
+        knowledgeBridgeStateMap.delete(windowId);
+      }
+
       function ensureLogState(windowId) {
         if (!logStateMap.has(windowId)) {
           logStateMap.set(windowId, {
@@ -1665,6 +1674,9 @@
         state.emptyMessage = "";
         state.pendingSearchTimer = setTimeout(() => {
           state.pendingSearchTimer = null;
+          if (!workspaceWindowById(windowId)) {
+            return;
+          }
           send({
             kind: "search_knowledge_bridge",
             id: windowId,
@@ -5334,7 +5346,7 @@
           profileStateMap.delete(windowId);
           boardStateMap.delete(windowId);
           logStateMap.delete(windowId);
-          knowledgeBridgeStateMap.delete(windowId);
+          clearKnowledgeBridgeState(windowId);
           if (branchCleanupWindowId === windowId) {
             branchCleanupWindowId = null;
             renderBranchCleanupModal();


### PR DESCRIPTION
## Summary

Follow-up to #2166 that addresses review feedback on the Knowledge Bridge semantic search path.

## Changes

- Keep interactive semantic search on local cache reads so per-keystroke searches do not retry stale remote cache sync.
- Cancel pending semantic search debounce timers when Knowledge Bridge windows are removed.
- Guard debounced semantic search sends when the target window no longer exists.
- Add regression coverage for both cases.

## Testing

- `cargo test -p gwt semantic_issue_search_reads_cache_without_stale_remote_sync -- --nocapture`
- `cargo test -p gwt embedded_web_knowledge_bridge_cancels_pending_semantic_search_on_window_teardown -- --nocapture`
- `cargo test -p gwt-core -p gwt`
- `node --check crates/gwt/web/app.js`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `cargo build -p gwt`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Closing Issues

None

## Related Issues

- Related to #2017
- Follow-up to #2166

## Checklist

- [x] Tests added or updated
- [x] Local verification passed
- [x] Commit message validated with commitlint
