### PR TITLE
fix(knowledge): wait for cache before semantic search

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -727,6 +727,22 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_knowledge_bridge_waits_for_initial_cache_load_before_semantic_search() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("state.loading && state.baseEntries.length === 0"),
+            "expected semantic search scheduling to wait for initial cache load before sending",
+        );
+        assert!(
+            html.contains("const queuedQuery = state.query.trim();")
+                && html.contains("if (queuedQuery)")
+                && html.contains("frontendUnits.knowledgeSettingsSurface.scheduleKnowledgeSearch("),
+            "expected knowledge entries response to resume queued semantic search after cache load",
+        );
+    }
+
+    #[test]
     fn embedded_web_board_surface_uses_cache_backed_contract() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1669,6 +1669,13 @@
           renderKnowledgeBridge(windowId);
           return;
         }
+        if (state.loading && state.baseEntries.length === 0) {
+          state.searching = true;
+          state.entries = [];
+          state.emptyMessage = "";
+          renderKnowledgeBridge(windowId);
+          return;
+        }
         state.searching = true;
         state.entries = [];
         state.emptyMessage = "";
@@ -5663,9 +5670,10 @@
               event.id,
               event.knowledge_kind,
             );
+            const queuedQuery = state.query.trim();
             state.baseEntries = event.entries || [];
             state.baseEmptyMessage = event.empty_message || "";
-            if (!state.query.trim()) {
+            if (!queuedQuery) {
               state.entries = state.baseEntries.slice();
               state.emptyMessage = state.baseEmptyMessage;
               state.searching = false;
@@ -5674,6 +5682,13 @@
             state.refreshEnabled = Boolean(event.refresh_enabled);
             state.loading = false;
             state.error = "";
+            if (queuedQuery) {
+              frontendUnits.knowledgeSettingsSurface.scheduleKnowledgeSearch(
+                event.id,
+                event.knowledge_kind,
+              );
+              break;
+            }
             frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(event.id);
             break;
           }


### PR DESCRIPTION
## Summary

Follow-up to #2167 that prevents first-use semantic search false negatives while keeping the per-keystroke path local-cache only.

## Changes

- Defer semantic search while the initial Knowledge Bridge cache load is still in progress.
- Resume the queued semantic query after `knowledge_entries` populates the base cache list.
- Add a frontend contract test for the load-before-search behavior.

## Testing

- `cargo test -p gwt embedded_web_knowledge_bridge_waits_for_initial_cache_load_before_semantic_search -- --nocapture`
- `cargo test -p gwt-core -p gwt`
- `node --check crates/gwt/web/app.js`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `cargo build -p gwt`
- `bunx commitlint --from HEAD~1 --to HEAD`

## Closing Issues

None

## Related Issues

- Related to #2017
- Follow-up to #2167

## Checklist

- [x] Tests added or updated
- [x] Local verification passed
- [x] Commit message validated with commitlint
