### PR TITLE
fix(pty): add defensive platform guard in build_shell_process_launch

### DIFF
--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -159,7 +159,12 @@ pub(crate) fn build_shell_process_launch(
     env.extend(config.env_vars.clone());
 
     if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Docker {
-        let shell = match config.windows_shell {
+        let windows_shell = if cfg!(windows) {
+            config.windows_shell
+        } else {
+            None
+        };
+        let shell = match windows_shell {
             Some(windows_shell) => gwt::ShellProgram {
                 command: windows_shell_process_command(windows_shell).to_string(),
                 args: interactive_windows_shell_args(windows_shell),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2610,8 +2610,15 @@ mod tests {
 
         let launch = build_shell_process_launch(&worktree, &mut config).expect("shell launch");
 
-        assert_eq!(launch.command, "powershell");
-        assert_eq!(launch.args, vec!["-NoLogo".to_string()]);
+        if cfg!(windows) {
+            assert_eq!(launch.command, "powershell");
+            assert_eq!(launch.args, vec!["-NoLogo".to_string()]);
+        } else {
+            // On non-Windows, the defensive platform guard ignores windows_shell
+            // and falls back to detect_shell_program().
+            assert_ne!(launch.command, "powershell");
+            assert_ne!(launch.command, "cmd.exe");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add belt-and-suspenders `cfg!(windows)` guard at the consumption site in `build_shell_process_launch` to prevent `cmd.exe` spawn on macOS even if `windows_shell` is set through a non-wizard code path

## Changes

- `crates/gwt/src/launch_runtime.rs`: Add defensive platform guard that forces `windows_shell` to `None` on non-Windows before the shell selection match
- `crates/gwt/src/main.rs`: Update `build_shell_process_launch_for_host_uses_selected_windows_shell` test to expect platform-appropriate behavior

## Testing

- [x] `cargo test -p gwt-core -p gwt` -- all tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- no warnings
- [x] `cargo fmt --check` -- formatting clean
- [x] Coverage threshold met (90.13%)

## Closing Issues

None

## Related Issues / Links

- #2171

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) -- Not applicable: internal defensive guard
- [ ] Migration/backfill plan included (if schema/data change) -- Not applicable
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Follow-up to PR #2171 which fixed the primary bug via `windows_shell_for_launch()`. This PR adds a second defense layer at the consumption site so that any future code path constructing `ShellLaunchConfig` directly (bypassing the wizard) is also protected.
