### PR TITLE
chore(release): v9.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.10.1] - 2026-04-26
+
+### Bug Fixes
+
+- Add platform guard to prevent cmd.exe spawn on macOS by @akiojin
+- Use runtime cfg! checks in windows shell tests for coverage by @akiojin
+- Add defensive platform guard in build_shell_process_launch by @akiojin
+
+### Miscellaneous Tasks
+
+- Exclude launch_runtime.rs from coverage threshold by @akiojin
+
+### Testing
+
+- Add unit tests for windows shell command mapping functions by @akiojin
+
 ## [9.10.0] - 2026-04-26
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "axum",
  "base64",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "chrono",
  "dunce",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "dirs",
  "serde",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "fs2",
  "regex",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.10.0"
+version = "9.10.1"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.10.0"
+version = "9.10.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.10.0",
+  "version": "9.10.1",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v9.10.1 — Patch release fixing PTY creation failure on macOS where the application attempted to spawn `cmd.exe` instead of the platform-appropriate shell.

## Changes

### Bug Fixes
- Add `cfg!(windows)` platform guard to `windows_shell_for_launch()` to prevent cmd.exe spawn on macOS
- Add defensive platform guard in `build_shell_process_launch` as belt-and-suspenders protection
- Use runtime `cfg!()` checks in windows shell tests for cross-platform coverage

### Testing
- Add unit tests for `windows_shell_process_command` and `interactive_windows_shell_args`

### Chore
- Exclude `launch_runtime.rs` from coverage threshold (runtime orchestration with platform-specific dead code)

## Version

v9.10.1

## Closing Issues

None

## Related Issues / Links

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v9.10.1

* **Bug Fixes**
  * Fixed platform detection to prevent incorrect shell spawning behavior on macOS
  * Enhanced shell command handling with additional platform checks for Windows environments
  * Added defensive platform guard improvements to shell process launching

* **Tests**
  * Added unit tests for Windows shell command mapping functionality
  * Enhanced test coverage with runtime platform checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->