### PR TITLE
feat(launch): restore previous agent profile

### DIFF
--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use crate::{
     launch::{normalize_launch_args, LaunchConfig},
     types::{
-        AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, WindowsShellKind,
-        WorkflowBypass,
+        AgentId, AgentStatus, DockerLifecycleIntent, LaunchRuntimeTarget, SessionMode,
+        WindowsShellKind, WorkflowBypass,
     },
 };
 
@@ -47,6 +47,8 @@ pub struct Session {
     pub model: Option<String>,
     #[serde(default)]
     pub reasoning_level: Option<String>,
+    #[serde(default)]
+    pub session_mode: SessionMode,
     #[serde(default)]
     pub skip_permissions: bool,
     #[serde(default)]
@@ -123,6 +125,7 @@ impl Session {
             tool_version: None,
             model: None,
             reasoning_level: None,
+            session_mode: SessionMode::Normal,
             skip_permissions: false,
             codex_fast_mode: false,
             runtime_target: LaunchRuntimeTarget::Host,
@@ -156,6 +159,7 @@ impl Session {
         session.tool_version = config.tool_version.clone();
         session.model = config.model.clone();
         session.reasoning_level = config.reasoning_level.clone();
+        session.session_mode = config.session_mode;
         session.skip_permissions = config.skip_permissions;
         session.codex_fast_mode = config.codex_fast_mode;
         session.runtime_target = config.runtime_target;
@@ -1017,6 +1021,7 @@ mod tests {
         config.docker_service = Some("app".to_string());
         config.docker_lifecycle_intent = DockerLifecycleIntent::Restart;
         config.linked_issue_number = Some(1921);
+        config.session_mode = crate::SessionMode::Continue;
 
         let session = Session::from_launch_config("/tmp/worktree", "feature/demo", &config);
 
@@ -1042,6 +1047,7 @@ mod tests {
             DockerLifecycleIntent::Restart
         );
         assert_eq!(session.linked_issue_number, Some(1921));
+        assert_eq!(session.session_mode, crate::SessionMode::Continue);
         assert_eq!(session.status, AgentStatus::Running);
     }
 

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -2393,7 +2393,10 @@ impl AppRuntime {
                 &active_session_branches,
                 &sessions_dir,
             );
-            proxy.send(UserEvent::LaunchWizardHydrated { wizard_id, result });
+            proxy.send(UserEvent::LaunchWizardHydrated {
+                wizard_id,
+                result: Box::new(result),
+            });
         });
 
         Ok(())
@@ -3160,6 +3163,7 @@ impl AppRuntime {
             session.tool_version = config.tool_version.clone();
             session.model = config.model.clone();
             session.reasoning_level = config.reasoning_level.clone();
+            session.session_mode = config.session_mode;
             session.skip_permissions = config.skip_permissions;
             session.codex_fast_mode = config.codex_fast_mode;
             session.runtime_target = config.runtime_target;

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -161,6 +161,21 @@ pub struct QuickStartEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchWizardPreviousProfile {
+    pub agent_id: String,
+    pub model: Option<String>,
+    pub reasoning: Option<String>,
+    pub version: Option<String>,
+    pub session_mode: gwt_agent::SessionMode,
+    pub skip_permissions: bool,
+    pub codex_fast_mode: bool,
+    pub runtime_target: gwt_agent::LaunchRuntimeTarget,
+    pub docker_service: Option<String>,
+    pub docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
+    pub windows_shell: Option<gwt_agent::WindowsShellKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShellLaunchConfig {
     pub working_dir: Option<PathBuf>,
     pub branch: Option<String>,
@@ -200,6 +215,73 @@ impl QuickStartEntry {
     }
 }
 
+pub fn load_previous_launch_profile(
+    repo_path: &Path,
+    sessions_dir: &Path,
+) -> Option<LaunchWizardPreviousProfile> {
+    let entries = std::fs::read_dir(sessions_dir).ok()?;
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
+        })
+        .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
+        .filter(|session| same_launch_profile_repo(repo_path, &session.worktree_path))
+        .max_by(|left, right| {
+            left.updated_at
+                .cmp(&right.updated_at)
+                .then_with(|| left.created_at.cmp(&right.created_at))
+        })
+        .map(previous_profile_from_session)
+}
+
+fn previous_profile_from_session(session: gwt_agent::Session) -> LaunchWizardPreviousProfile {
+    LaunchWizardPreviousProfile {
+        agent_id: session.agent_id.command().to_string(),
+        model: session.model,
+        reasoning: session.reasoning_level,
+        version: session.tool_version.or_else(|| {
+            session
+                .agent_id
+                .package_name()
+                .map(|_| "installed".to_string())
+        }),
+        session_mode: session.session_mode,
+        skip_permissions: session.skip_permissions,
+        codex_fast_mode: session.codex_fast_mode,
+        runtime_target: session.runtime_target,
+        docker_service: session.docker_service,
+        docker_lifecycle_intent: session.docker_lifecycle_intent,
+        windows_shell: session.windows_shell,
+    }
+}
+
+fn same_launch_profile_repo(repo_path: &Path, session_worktree_path: &Path) -> bool {
+    if same_path_or_exact(repo_path, session_worktree_path) {
+        return true;
+    }
+
+    let Ok(repo_root) = gwt_git::worktree::main_worktree_root(repo_path) else {
+        return false;
+    };
+    let Ok(session_root) = gwt_git::worktree::main_worktree_root(session_worktree_path) else {
+        return false;
+    };
+    same_path_or_exact(&repo_root, &session_root)
+}
+
+fn same_path_or_exact(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DockerWizardContext {
     pub services: Vec<String>,
@@ -228,6 +310,7 @@ pub struct LaunchWizardHydration {
     pub docker_service_status: gwt_docker::ComposeServiceStatus,
     pub agent_options: Vec<AgentOption>,
     pub quick_start_entries: Vec<QuickStartEntry>,
+    pub previous_profile: Option<LaunchWizardPreviousProfile>,
 }
 
 #[derive(Debug, Clone)]
@@ -367,6 +450,7 @@ impl LaunchWizardState {
         context: LaunchWizardContext,
         agent_options: Vec<AgentOption>,
         mut quick_start_entries: Vec<QuickStartEntry>,
+        previous_profile: Option<LaunchWizardPreviousProfile>,
         is_hydrating: bool,
     ) -> Self {
         Self::hydrate_live_window_ids(&context, &mut quick_start_entries);
@@ -418,6 +502,9 @@ impl LaunchWizardState {
         };
         state.branch_name = state.context.normalized_branch_name.clone();
         state.sync_selected_agent_options();
+        if let Some(previous_profile) = previous_profile {
+            state.apply_previous_profile(previous_profile);
+        }
         state.selected = step_default_selection(state.step, &state);
         state
     }
@@ -427,11 +514,26 @@ impl LaunchWizardState {
         agent_options: Vec<AgentOption>,
         quick_start_entries: Vec<QuickStartEntry>,
     ) -> Self {
-        Self::new_with(context, agent_options, quick_start_entries, false)
+        Self::new_with(context, agent_options, quick_start_entries, None, false)
+    }
+
+    pub fn open_with_previous_profile(
+        context: LaunchWizardContext,
+        agent_options: Vec<AgentOption>,
+        quick_start_entries: Vec<QuickStartEntry>,
+        previous_profile: Option<LaunchWizardPreviousProfile>,
+    ) -> Self {
+        Self::new_with(
+            context,
+            agent_options,
+            quick_start_entries,
+            previous_profile,
+            false,
+        )
     }
 
     pub fn open_loading(context: LaunchWizardContext, agent_options: Vec<AgentOption>) -> Self {
-        Self::new_with(context, agent_options, Vec::new(), true)
+        Self::new_with(context, agent_options, Vec::new(), None, true)
     }
 
     pub fn open(context: LaunchWizardContext, sessions_dir: &Path, cache_path: &Path) -> Self {
@@ -441,7 +543,14 @@ impl LaunchWizardState {
             sessions_dir,
             &context.normalized_branch_name,
         );
-        Self::open_with(context, agent_options, quick_start_entries)
+        let previous_profile =
+            load_previous_launch_profile(&context.quick_start_root, sessions_dir);
+        Self::open_with_previous_profile(
+            context,
+            agent_options,
+            quick_start_entries,
+            previous_profile,
+        )
     }
 
     pub fn view(&self) -> LaunchWizardView {
@@ -513,6 +622,7 @@ impl LaunchWizardState {
             docker_service_status,
             agent_options,
             mut quick_start_entries,
+            previous_profile,
         } = hydration;
         if let Some(selected_branch) = selected_branch {
             self.context.selected_branch = selected_branch;
@@ -542,7 +652,11 @@ impl LaunchWizardState {
             self.docker_service = None;
         }
         self.sync_selected_agent_options();
-        self.sync_docker_lifecycle_default();
+        if let Some(previous_profile) = previous_profile {
+            self.apply_previous_profile(previous_profile);
+        } else {
+            self.sync_docker_lifecycle_default();
+        }
         self.selected = self
             .selected
             .min(self.current_options().len().saturating_sub(1));
@@ -996,6 +1110,81 @@ impl LaunchWizardState {
                 }
             }
         }
+    }
+
+    fn apply_previous_profile(&mut self, profile: LaunchWizardPreviousProfile) {
+        let Some(agent) = self
+            .detected_agents
+            .iter()
+            .find(|candidate| candidate.id == profile.agent_id && candidate.available)
+        else {
+            return;
+        };
+
+        self.launch_target = LaunchTargetKind::Agent;
+        self.agent_id = agent.id.clone();
+        self.sync_selected_agent_options();
+        self.apply_saved_model(profile.model.as_deref());
+        if let Some(reasoning) = profile.reasoning.as_deref() {
+            if self
+                .current_reasoning_options()
+                .iter()
+                .any(|option| option.stored_value == reasoning)
+            {
+                self.reasoning = reasoning.to_string();
+            }
+        }
+        self.sync_reasoning_state();
+        if let Some(version) = profile.version.as_deref() {
+            if self
+                .current_version_options()
+                .iter()
+                .any(|option| option.value == version)
+            {
+                self.version = version.to_string();
+            }
+        }
+        self.mode = execution_mode_value_from_session_mode(profile.session_mode).to_string();
+        self.resume_session_id = None;
+        self.skip_permissions = profile.skip_permissions;
+        self.codex_fast_mode = profile.codex_fast_mode && self.agent_is_codex();
+        self.apply_previous_runtime_profile(
+            profile.runtime_target,
+            profile.docker_service.as_deref(),
+            profile.docker_lifecycle_intent,
+        );
+        if let Some(windows_shell) = profile.windows_shell {
+            self.windows_shell = windows_shell;
+        }
+    }
+
+    fn apply_previous_runtime_profile(
+        &mut self,
+        runtime_target: gwt_agent::LaunchRuntimeTarget,
+        docker_service: Option<&str>,
+        docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
+    ) {
+        if runtime_target != gwt_agent::LaunchRuntimeTarget::Docker || !self.has_docker_workflow() {
+            self.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
+            self.docker_service = None;
+            self.sync_docker_lifecycle_default();
+            return;
+        }
+
+        self.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+        let services = self.docker_service_options();
+        self.docker_service = docker_service
+            .filter(|service| services.iter().any(|candidate| candidate == service))
+            .map(str::to_string)
+            .or_else(|| {
+                self.context
+                    .docker_context
+                    .as_ref()
+                    .and_then(|ctx| ctx.suggested_service.clone())
+            })
+            .or_else(|| services.first().cloned());
+        self.docker_lifecycle_intent = docker_lifecycle_intent;
+        self.sync_docker_lifecycle_default();
     }
 
     fn focus_existing_session(&mut self, index: usize) {
@@ -2621,6 +2810,13 @@ fn execution_mode_options_view() -> Vec<LaunchWizardOptionView> {
         .collect()
 }
 
+fn execution_mode_value_from_session_mode(mode: gwt_agent::SessionMode) -> &'static str {
+    match mode {
+        gwt_agent::SessionMode::Normal => "normal",
+        gwt_agent::SessionMode::Continue | gwt_agent::SessionMode::Resume => "continue",
+    }
+}
+
 fn launch_target_value(target: LaunchTargetKind) -> &'static str {
     match target {
         LaunchTargetKind::Agent => "agent",
@@ -3271,6 +3467,52 @@ mod tests {
     }
 
     #[test]
+    fn load_previous_launch_profile_uses_latest_session_for_repo_without_reusing_branch() {
+        let dir = tempdir().expect("tempdir");
+        let worktree = dir.path().join("repo");
+        std::fs::create_dir_all(&worktree).expect("repo dir");
+        let mut older = sample_session_record(
+            "feature/old",
+            &worktree,
+            gwt_agent::AgentId::ClaudeCode,
+            Utc.with_ymd_and_hms(2026, 4, 14, 9, 0, 0).unwrap(),
+            None,
+        );
+        older.session_mode = gwt_agent::SessionMode::Normal;
+        older.save(dir.path()).expect("save older session");
+
+        let mut newer = sample_session_record(
+            "feature/previous",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
+            Some("resume-ignored"),
+        );
+        newer.tool_version = Some("0.110.0".to_string());
+        newer.model = Some("gpt-5.5".to_string());
+        newer.reasoning_level = Some("high".to_string());
+        newer.session_mode = gwt_agent::SessionMode::Continue;
+        newer.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+        newer.docker_service = Some("gwt".to_string());
+        newer.docker_lifecycle_intent = gwt_agent::DockerLifecycleIntent::Restart;
+        newer.save(dir.path()).expect("save newer session");
+
+        let profile =
+            load_previous_launch_profile(&worktree, dir.path()).expect("previous profile");
+
+        assert_eq!(profile.agent_id, "codex");
+        assert_eq!(profile.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(profile.reasoning.as_deref(), Some("high"));
+        assert_eq!(profile.version.as_deref(), Some("0.110.0"));
+        assert_eq!(profile.session_mode, gwt_agent::SessionMode::Continue);
+        assert_eq!(
+            profile.runtime_target,
+            gwt_agent::LaunchRuntimeTarget::Docker
+        );
+        assert_eq!(profile.docker_service.as_deref(), Some("gwt"));
+    }
+
+    #[test]
     fn branch_action_create_new_from_selected_sets_base_branch() {
         let mut state = LaunchWizardState::open_with(
             context(branch("feature/gui"), "feature/gui"),
@@ -3522,6 +3764,112 @@ mod tests {
 
         let view = state.view();
         assert!(view.quick_start_entries[0].reuse_action_label.is_none());
+    }
+
+    #[test]
+    fn open_with_previous_profile_restores_full_profile_without_reusing_branch() {
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string(), "gwt".to_string()],
+            suggested_service: Some("api".to_string()),
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Running;
+        let state = LaunchWizardState::open_with_previous_profile(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                session_mode: gwt_agent::SessionMode::Continue,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Docker,
+                docker_service: Some("gwt".to_string()),
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Restart,
+                windows_shell: None,
+            }),
+        );
+
+        let view = state.view();
+        assert_eq!(view.branch_name, "feature/current");
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.5");
+        assert_eq!(view.selected_reasoning, "high");
+        assert_eq!(view.selected_version, "0.110.0");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("gwt"));
+        assert_eq!(view.selected_docker_lifecycle, "restart");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.branch.as_deref(), Some("feature/current"));
+        assert_eq!(config.session_mode, gwt_agent::SessionMode::Continue);
+        assert!(config.resume_session_id.is_none());
+        assert_eq!(config.linked_issue_number, None);
+    }
+
+    #[test]
+    fn previous_profile_docker_service_falls_back_to_current_suggestion() {
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string(), "worker".to_string()],
+            suggested_service: Some("worker".to_string()),
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Running;
+        let state = LaunchWizardState::open_with_previous_profile(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                session_mode: gwt_agent::SessionMode::Normal,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Docker,
+                docker_service: Some("missing".to_string()),
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Restart,
+                windows_shell: None,
+            }),
+        );
+
+        let view = state.view();
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("worker"));
+    }
+
+    #[test]
+    fn previous_profile_docker_runtime_falls_back_to_host_without_context() {
+        let state = LaunchWizardState::open_with_previous_profile(
+            context(branch("feature/current"), "feature/current"),
+            sample_agent_options(),
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                session_mode: gwt_agent::SessionMode::Normal,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Docker,
+                docker_service: Some("gwt".to_string()),
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Restart,
+                windows_shell: None,
+            }),
+        );
+
+        let view = state.view();
+        assert_eq!(view.selected_runtime_target, "host");
+        assert!(view.selected_docker_service.is_none());
+        assert!(!view.show_docker_lifecycle);
     }
 
     #[test]
@@ -4374,6 +4722,7 @@ mod tests {
                 docker_service: None,
                 docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
             }],
+            previous_profile: None,
         });
 
         let view = state.view();

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -107,7 +107,10 @@ impl AppRuntime {
                 &active_session_branches,
                 &sessions_dir,
             );
-            proxy.send(UserEvent::LaunchWizardHydrated { wizard_id, result });
+            proxy.send(UserEvent::LaunchWizardHydrated {
+                wizard_id,
+                result: Box::new(result),
+            });
         });
 
         Ok(())
@@ -402,6 +405,8 @@ fn resolve_launch_wizard_hydration(
         sessions_dir,
         &normalized_branch_name,
     );
+    let previous_profile =
+        gwt::launch_wizard::load_previous_launch_profile(&quick_start_root, sessions_dir);
     let (docker_context, docker_service_status) =
         detect_wizard_docker_context_and_status(&quick_start_root);
 
@@ -414,5 +419,6 @@ fn resolve_launch_wizard_hydration(
         docker_service_status,
         agent_options,
         quick_start_entries,
+        previous_profile,
     })
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -44,9 +44,9 @@ pub use launch_wizard::{
     build_agent_options, build_builtin_agent_options, default_wizard_version_cache_path,
     load_agent_options, AgentOption, DockerWizardContext, LaunchTargetKind, LaunchWizardAction,
     LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest,
-    LaunchWizardLiveSessionView, LaunchWizardOptionView, LaunchWizardQuickStartView,
-    LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView, LaunchWizardView,
-    LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode, ShellLaunchConfig,
+    LaunchWizardLiveSessionView, LaunchWizardOptionView, LaunchWizardPreviousProfile,
+    LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView,
+    LaunchWizardView, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode, ShellLaunchConfig,
 };
 pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
 #[cfg(target_os = "macos")]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -196,7 +196,7 @@ enum UserEvent {
     },
     LaunchWizardHydrated {
         wizard_id: String,
-        result: Result<LaunchWizardHydration, String>,
+        result: Box<Result<LaunchWizardHydration, String>>,
     },
     IssueLaunchWizardPrepared(IssueLaunchWizardPrepared),
     Dispatch(Vec<OutboundEvent>),
@@ -1983,6 +1983,7 @@ mod tests {
                 docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                 agent_options: sample_wizard_agent_options(),
                 quick_start_entries: vec![sample_wizard_quick_start_entry(None)],
+                previous_profile: None,
             }),
         );
         assert_eq!(hydration_ok.len(), 1);
@@ -4006,7 +4007,7 @@ fn main() -> wry::Result<()> {
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::LaunchWizardHydrated { wizard_id, result }) => {
-                let events = app.handle_launch_wizard_hydrated(wizard_id, result);
+                let events = app.handle_launch_wizard_hydrated(wizard_id, *result);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::IssueLaunchWizardPrepared(prepared)) => {

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -208,6 +208,8 @@ pub(crate) fn resolve_launch_wizard_hydration(
         sessions_dir,
         &normalized_branch_name,
     );
+    let previous_profile =
+        gwt::launch_wizard::load_previous_launch_profile(&quick_start_root, sessions_dir);
     let (docker_context, docker_service_status) =
         detect_wizard_docker_context_and_status(&quick_start_root);
 
@@ -220,6 +222,7 @@ pub(crate) fn resolve_launch_wizard_hydration(
         docker_service_status,
         agent_options,
         quick_start_entries,
+        previous_profile,
     })
 }
 


### PR DESCRIPTION
## Summary

- Restores the previous Launch Agent profile into the normal Launch Wizard form so users do not need to reselect agent, model, execution mode, or Host/Docker settings every launch.
- Keeps the current selected branch, linked issue, resume id, and live-window reuse out of the restored profile so previous-session state cannot override the user's current launch context.
- Syncs the feature branch with `origin/develop` before opening the PR.

## Changes

- `crates/gwt-agent/src/session.rs`: persists `session_mode` in session metadata and carries it from `LaunchConfig`.
- `crates/gwt/src/launch_wizard.rs`: loads the latest repo-local previous profile, applies it to wizard defaults, and normalizes unavailable Docker settings to the current context.
- `crates/gwt/src/runtime_support.rs` / `crates/gwt/src/launch_wizard_runtime.rs`: include previous-profile hydration when opening the Launch Wizard.
- `crates/gwt/src/app_runtime.rs`: persists launch session mode and boxes the large wizard hydration event payload.
- `crates/gwt/src/main.rs` / `crates/gwt/src/lib.rs`: expose the new profile type and keep event dispatch efficient.

## Testing

- [x] `cargo test -p gwt previous_profile --lib -- --nocapture` - previous-profile restoration scenarios passed.
- [x] `cargo test -p gwt load_previous_launch_profile_uses_latest_session_for_repo_without_reusing_branch --lib -- --nocapture` - repo-local latest profile loading passed.
- [x] `cargo test -p gwt launch_wizard::tests:: --lib -- --nocapture` - Launch Wizard unit suite passed.
- [x] `cargo test -p gwt-agent` - gwt-agent session metadata tests passed.
- [x] `cargo test -p gwt-core -p gwt` - workspace regression suite passed after syncing `origin/develop`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - lint passed after syncing `origin/develop`.
- [x] `cargo fmt -- --check` - formatting passed.
- [x] `cargo build -p gwt` - gwt build passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` - branch commits passed commitlint.

## Closing Issues

- Closes #2014

## Related Issues / Links

- #1784
- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #2014 updated; README is not changed because the feature is already covered by the Launch Wizard user flow)
- [x] Migration/backfill plan included (backward-compatible `session_mode` default covers existing session metadata)
- [x] CHANGELOG impact considered (feature commit uses `feat:`; no breaking change)

## Context

- SPEC #2014 owns the Launch Wizard GUI flow. This PR extends the existing session metadata reuse so the regular Launch Agent form gets the same low-friction defaults as Quick Start without automatically reusing branch or resume state.

## Risk / Impact

- **Affected areas**: Launch Wizard defaults, session metadata serialization, and GUI launch hydration.
- **Rollback plan**: Revert this PR; existing sessions remain readable because the new `session_mode` field has a serde default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch wizard now remembers and restores previous launch configurations from sessions, including agent selection, model choice, reasoning settings, tool version, execution mode, runtime target, docker configuration, and shell preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->