### PR TITLE
fix(gui): normalize vendored xterm css spacing

### DIFF
--- a/crates/gwt/web/vendor/xterm/xterm.css
+++ b/crates/gwt/web/vendor/xterm/xterm.css
@@ -236,10 +236,8 @@
 
 .xterm .xterm-scrollable-element > .visible {
 	opacity: 1;
-
 	/* Background rule added for IE9 - to allow clicks on dom node */
 	background:rgba(0,0,0,0);
-
 	transition: opacity 100ms linear;
 	/* In front of peek view */
 	z-index: 11;


### PR DESCRIPTION
## Summary

- Normalizes the vendored xterm stylesheet spacing so the previously resolved stylelint finding is included on `develop`.

## Changes

- `crates/gwt/web/vendor/xterm/xterm.css`: removes blank lines before declarations in the `.visible` scrollbar block.

## Testing

- [x] `git diff --check origin/develop...HEAD` - passed.
- [x] `cargo test -p gwt embedded_server_exposes_health_and_authenticated_hook_live_routes -- --nocapture` - passed.
- [x] `cargo fmt --check` - passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` - passed.

## Closing Issues

- None

## Related Issues / Links

- #2185

## Checklist

- [x] Tests added/updated not needed: formatting-only CSS change covered by diff check and existing embedded asset route test.
- [x] Lint/format passed (`cargo fmt`)
- [x] Documentation updated not needed: no user-facing behavior or docs change.
- [x] Migration/backfill plan included not needed: no schema or data change.
- [x] CHANGELOG impact considered: no release-note entry needed for vendored CSS spacing only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up CSS formatting in terminal component styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->