### PR TITLE
fix(branch-list): pin base branches to top

### DIFF
--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -4630,7 +4630,12 @@ exit 0
         let (command, args) = if cfg!(windows) {
             (
                 "cmd".to_string(),
-                vec!["/C".to_string(), "exit 0".to_string()],
+                vec![
+                    "/d".to_string(),
+                    "/s".to_string(),
+                    "/c".to_string(),
+                    "exit /b 0".to_string(),
+                ],
             )
         } else {
             (
@@ -4828,9 +4833,14 @@ exit 0
             )
             .expect("pane"),
         ));
+        if cfg!(windows) {
+            if let Ok(pane) = pane.lock() {
+                let _ = pane.pty().write_input(b"\x1b[1;1R");
+            }
+        }
         let status_thread = runtime.spawn_status_thread(window_id.clone(), pane.clone());
 
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + Duration::from_secs(5);
         let mut observed_status = None;
         while Instant::now() < deadline {
             if let Ok(events) = captured_events.lock() {
@@ -5540,6 +5550,10 @@ exit 0
             events.lock().expect("event log").is_empty(),
             "background refresh errors should not overwrite the current cache view"
         );
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !marker.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+        }
         assert!(
             marker.exists(),
             "expected fake gh to be invoked for stale cache"

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -307,7 +307,36 @@ fn local_branch_for_remote_ref(name: &str) -> Option<&str> {
     name.split_once('/').map(|(_, branch_name)| branch_name)
 }
 
+fn base_branch_sort_rank(entry: &BranchListEntry) -> Option<(u8, u8)> {
+    let branch_name = match entry.scope {
+        BranchScope::Local => entry.name.as_str(),
+        BranchScope::Remote => local_branch_for_remote_ref(&entry.name)?,
+    };
+    let base_rank = match branch_name {
+        "main" => 0,
+        "master" => 1,
+        "develop" => 2,
+        _ => return None,
+    };
+    let scope_rank = match entry.scope {
+        BranchScope::Local => 0,
+        BranchScope::Remote => 1,
+    };
+    Some((base_rank, scope_rank))
+}
+
 fn compare_branch_entries(left: &BranchListEntry, right: &BranchListEntry) -> Ordering {
+    match (base_branch_sort_rank(left), base_branch_sort_rank(right)) {
+        (Some(left_rank), Some(right_rank)) => {
+            return left_rank
+                .cmp(&right_rank)
+                .then_with(|| compare_branch_names(&left.name, &right.name));
+        }
+        (Some(_), None) => return Ordering::Less,
+        (None, Some(_)) => return Ordering::Greater,
+        (None, None) => {}
+    }
+
     compare_branch_commit_dates(&left.last_commit_date, &right.last_commit_date)
         .then_with(|| right.is_head.cmp(&left.is_head))
         .then_with(|| match (left.scope, right.scope) {
@@ -315,12 +344,13 @@ fn compare_branch_entries(left: &BranchListEntry, right: &BranchListEntry) -> Or
             (BranchScope::Remote, BranchScope::Local) => Ordering::Greater,
             _ => Ordering::Equal,
         })
-        .then_with(|| {
-            left.name
-                .to_ascii_lowercase()
-                .cmp(&right.name.to_ascii_lowercase())
-        })
-        .then_with(|| left.name.cmp(&right.name))
+        .then_with(|| compare_branch_names(&left.name, &right.name))
+}
+
+fn compare_branch_names(left: &str, right: &str) -> Ordering {
+    left.to_ascii_lowercase()
+        .cmp(&right.to_ascii_lowercase())
+        .then_with(|| left.cmp(right))
 }
 
 fn compare_branch_commit_dates(left: &Option<String>, right: &Option<String>) -> Ordering {
@@ -345,8 +375,26 @@ fn parse_branch_commit_date(value: &str) -> Option<DateTime<FixedOffset>> {
 mod tests {
     use super::*;
 
+    fn make_branch(
+        name: &str,
+        is_local: bool,
+        is_head: bool,
+        last_commit_date: Option<&str>,
+    ) -> gwt_git::Branch {
+        gwt_git::Branch {
+            name: name.to_string(),
+            is_local,
+            is_remote: !is_local,
+            is_head,
+            upstream: None,
+            ahead: 0,
+            behind: 0,
+            last_commit_date: last_commit_date.map(ToString::to_string),
+        }
+    }
+
     #[test]
-    fn adapt_branches_sorts_newest_first_then_head_local_then_remote() {
+    fn adapt_branches_sorts_base_first_then_newest_head_local() {
         let branches = vec![
             gwt_git::Branch {
                 name: "origin/main".to_string(),
@@ -394,11 +442,96 @@ mod tests {
         let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
         assert_eq!(
             names,
-            vec!["main", "feature/zeta", "origin/main", "feature/alpha"]
+            vec!["main", "origin/main", "feature/zeta", "feature/alpha"]
         );
         assert_eq!(entries[0].scope, BranchScope::Local);
         assert!(entries[0].is_head);
-        assert_eq!(entries[2].scope, BranchScope::Remote);
+        assert_eq!(entries[1].scope, BranchScope::Remote);
+    }
+
+    #[test]
+    fn base_branches_pin_to_top_for_local_and_remote_refs() {
+        let branches = vec![
+            make_branch(
+                "feature/current",
+                true,
+                true,
+                Some("2026-04-21 10:00:00 +0000"),
+            ),
+            make_branch(
+                "origin/develop",
+                false,
+                false,
+                Some("2026-04-02 09:00:00 +0000"),
+            ),
+            make_branch("develop", true, false, Some("2026-04-01 09:00:00 +0000")),
+            make_branch(
+                "upstream/main",
+                false,
+                false,
+                Some("2026-04-18 09:00:00 +0000"),
+            ),
+            make_branch(
+                "origin/main",
+                false,
+                false,
+                Some("2026-04-20 09:00:00 +0000"),
+            ),
+            make_branch(
+                "origin/master",
+                false,
+                false,
+                Some("2026-04-07 09:00:00 +0000"),
+            ),
+            make_branch("master", true, false, Some("2026-04-05 09:00:00 +0000")),
+            make_branch("main", true, false, Some("2026-04-15 09:00:00 +0000")),
+            make_branch(
+                "feature/legacy",
+                true,
+                false,
+                Some("2026-03-01 09:00:00 +0000"),
+            ),
+        ];
+
+        let entries = adapt_branch_inventory(branches);
+        let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
+
+        assert_eq!(
+            &names[..7],
+            &[
+                "main",
+                "origin/main",
+                "upstream/main",
+                "master",
+                "origin/master",
+                "develop",
+                "origin/develop",
+            ]
+        );
+        assert!(
+            names.iter().position(|name| *name == "feature/current")
+                > names.iter().position(|name| *name == "origin/develop"),
+            "HEAD on a non-base branch must not override base branch pinning"
+        );
+    }
+
+    #[test]
+    fn base_branch_pin_handles_partial_base_set() {
+        let branches = vec![
+            make_branch("feature/x", true, false, Some("2026-04-20 08:30:00 +0000")),
+            make_branch(
+                "origin/develop",
+                false,
+                false,
+                Some("2026-04-01 08:30:00 +0000"),
+            ),
+            make_branch("feature/y", true, true, Some("2026-04-21 08:30:00 +0000")),
+        ];
+
+        let entries = adapt_branch_inventory(branches);
+        let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
+
+        assert_eq!(names, vec!["origin/develop", "feature/y", "feature/x"]);
     }
 
     #[test]

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -133,7 +133,6 @@ pub(crate) fn issue_cache_has_entries(cache_root: &Path) -> bool {
 }
 
 fn gh_executable() -> std::ffi::OsString {
-    #[cfg(test)]
     if let Some(path) = std::env::var_os("GWT_TEST_GH") {
         return path;
     }


### PR DESCRIPTION
## Summary

- Pin `main`, `master`, and `develop` branch rows above normal branch sorting so base branches remain visible first.
- Apply the base-branch priority consistently to local and remote refs while keeping existing newest-first ordering for non-base branches.
- Stabilize async app runtime test fixtures that blocked full verification on Windows.

## Changes

- `crates/gwt/src/branch_list.rs`: Added base branch sort ranks for local and remote branch entries and reused the existing name ordering as a deterministic tie-breaker.
- `crates/gwt/src/branch_list.rs`: Added regression tests for local/remote base branch pinning, partial base branch sets, and non-base HEAD ordering.
- `crates/gwt/src/app_runtime.rs`: Stabilized Windows PTY status and async marker waits used by app runtime tests.
- `crates/gwt/src/issue_cache.rs`: Allowed `GWT_TEST_GH` to be honored by bin-level tests that depend on the `gwt` library crate.

## Testing

- [x] `cargo fmt -- --check` - completed successfully.
- [x] `cargo test -p gwt branch_list::tests::base -- --nocapture --test-threads=1` - completed successfully.
- [x] `cargo test -p gwt-core -p gwt -- --test-threads=1` - completed successfully.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - completed successfully.
- [x] `cargo build -p gwt` - completed successfully.
- [x] `bunx commitlint --from origin/develop --to HEAD` - completed successfully.

## Closing Issues

- Closes #2009

## Related Issues / Links

- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not applicable: this is a behavior fix covered by SPEC #2009, with no README-facing workflow change)
- [ ] Migration/backfill plan included (not applicable: no schema or persisted data change)
- [x] CHANGELOG impact considered (patch-level `fix` commit included)

## Context

- SPEC #2009 requires base branches to remain at the top of the branch list even when newer feature branches or HEAD would otherwise sort before them.

## Risk / Impact

- **Affected areas**: Branch list ordering in the GUI branch surface, plus app runtime test fixtures only.
- **Rollback plan**: Revert the branch sort commit and the test fixture stabilization commit if ordering regressions appear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Base branches (main, master, develop) are now automatically prioritized and appear at the top of branch listings.
  * Enhanced reliability of status monitoring with improved Windows command handling and extended observation timeouts.
  * Environment variable configuration for GitHub CLI executable is now consistently honored across all build modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->