### PR TITLE
fix(branch-list): handle slash remotes in base pinning

### DIFF
--- a/crates/gwt-git/src/branch.rs
+++ b/crates/gwt-git/src/branch.rs
@@ -107,7 +107,10 @@ pub fn detect_cleanable_target(
     upstream: Option<&str>,
     gone_branches: &HashSet<String>,
 ) -> Result<Option<MergeTargetRef>> {
-    let Some(primary_remote) = upstream.and_then(remote_name_from_tracking_ref) else {
+    let remote_names = list_remote_names(repo_path).unwrap_or_default();
+    let Some(primary_remote) =
+        upstream.and_then(|reference| split_remote_ref(reference, &remote_names).0)
+    else {
         if gone_branches.contains(branch) {
             return Ok(Some(MergeTargetRef::new(MergeTarget::Gone, "")));
         }
@@ -115,7 +118,7 @@ pub fn detect_cleanable_target(
     };
 
     let (primary_has_bases, primary_target) =
-        detect_cleanable_target_for_remote(repo_path, branch, primary_remote)?;
+        detect_cleanable_target_for_remote(repo_path, branch, &primary_remote)?;
     if let Some(target) = primary_target {
         return Ok(Some(target));
     }
@@ -149,10 +152,6 @@ fn detect_cleanable_target_for_remote(
         }
     }
     Ok((has_canonical_base, None))
-}
-
-fn remote_name_from_tracking_ref(reference: &str) -> Option<&str> {
-    reference.split_once('/').map(|(remote, _)| remote)
 }
 
 /// Returns the set of local branch names whose upstream tracking ref is
@@ -297,6 +296,12 @@ fn parse_divergence_output(output: &str) -> Result<DivergenceInfo> {
 pub struct Branch {
     /// Branch name (e.g. "main", "origin/main").
     pub name: String,
+    /// Remote name for remote-tracking branches (e.g. "origin").
+    #[serde(default)]
+    pub remote_name: Option<String>,
+    /// Branch name without the remote prefix for remote-tracking branches.
+    #[serde(default)]
+    pub remote_branch_name: Option<String>,
     /// Whether this is a local branch.
     pub is_local: bool,
     /// Whether this is a remote-tracking branch.
@@ -335,6 +340,8 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
         }
     }
 
+    let remote_names = list_remote_names(repo_path).unwrap_or_default();
+
     // Also list remote branches
     let remote_output = std::process::Command::new("git")
         .args([
@@ -358,8 +365,11 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
                 continue;
             }
             let date = parts.get(1).map(|s| s.trim().to_string());
+            let (remote_name, remote_branch_name) = split_remote_ref(&name, &remote_names);
             branches.push(Branch {
                 name,
+                remote_name,
+                remote_branch_name,
                 is_local: false,
                 is_remote: true,
                 is_head: false,
@@ -372,6 +382,45 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
     }
 
     Ok(branches)
+}
+
+fn list_remote_names(repo_path: &Path) -> Result<Vec<String>> {
+    let output = std::process::Command::new("git")
+        .arg("remote")
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| GwtError::Git(format!("remote: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(GwtError::Git(format!("remote: {stderr}")));
+    }
+
+    let mut names: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    names.sort_by_key(|name| std::cmp::Reverse(name.len()));
+    Ok(names)
+}
+
+fn split_remote_ref(name: &str, remote_names: &[String]) -> (Option<String>, Option<String>) {
+    for remote_name in remote_names {
+        let Some(branch_name) = name.strip_prefix(remote_name) else {
+            continue;
+        };
+        let Some(branch_name) = branch_name.strip_prefix('/') else {
+            continue;
+        };
+        return (Some(remote_name.clone()), Some(branch_name.to_string()));
+    }
+
+    name.split_once('/')
+        .map_or((None, None), |(remote, branch)| {
+            (Some(remote.to_string()), Some(branch.to_string()))
+        })
 }
 
 /// Parse ahead/behind from the tracking info string like "[ahead 3, behind 2]".
@@ -424,6 +473,8 @@ fn parse_branch_line(line: &str) -> Option<Branch> {
 
     Some(Branch {
         name,
+        remote_name: None,
+        remote_branch_name: None,
         is_local: true,
         is_remote: false,
         is_head,
@@ -456,6 +507,24 @@ mod tests {
     #[test]
     fn parse_ahead_behind_empty() {
         assert_eq!(parse_ahead_behind(""), (0, 0));
+    }
+
+    #[test]
+    fn split_remote_ref_prefers_longest_known_remote_name() {
+        let remote_names = vec!["team/core".to_string(), "team".to_string()];
+
+        let (remote_name, branch_name) = split_remote_ref("team/core/main", &remote_names);
+
+        assert_eq!(remote_name.as_deref(), Some("team/core"));
+        assert_eq!(branch_name.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn split_remote_ref_falls_back_to_first_path_segment() {
+        let (remote_name, branch_name) = split_remote_ref("origin/feature/main", &[]);
+
+        assert_eq!(remote_name.as_deref(), Some("origin"));
+        assert_eq!(branch_name.as_deref(), Some("feature/main"));
     }
 
     #[test]
@@ -636,14 +705,24 @@ mod tests {
         run(&["checkout", "develop"], repo);
         run(&["merge", "--no-ff", "-m", "merge d", "feature/d"], repo);
 
-        let bases = [
-            ("main", MergeTarget::Main),
-            ("develop", MergeTarget::Develop),
-        ];
+        run(
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://example.invalid/repo.git",
+            ],
+            repo,
+        );
+        run(
+            &["update-ref", "refs/remotes/origin/develop", "develop"],
+            repo,
+        );
+
         let gone = HashSet::new();
         assert_eq!(
-            detect_cleanable_target(repo, "feature/d", &bases, &gone).unwrap(),
-            Some(MergeTargetRef::new(MergeTarget::Develop, "develop"))
+            detect_cleanable_target(repo, "feature/d", Some("origin/feature/d"), &gone).unwrap(),
+            Some(MergeTargetRef::new(MergeTarget::Develop, "origin/develop"))
         );
     }
 
@@ -655,10 +734,21 @@ mod tests {
         run(&["checkout", "-b", "feature/free"], repo);
         make_commit(repo, "f.txt", "f", "feat: f");
 
-        let bases = [("main", MergeTarget::Main)];
+        run(
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://example.invalid/repo.git",
+            ],
+            repo,
+        );
+        run(&["update-ref", "refs/remotes/origin/main", "main"], repo);
+
         let gone = HashSet::new();
         assert_eq!(
-            detect_cleanable_target(repo, "feature/free", &bases, &gone).unwrap(),
+            detect_cleanable_target(repo, "feature/free", Some("origin/feature/free"), &gone)
+                .unwrap(),
             None
         );
     }
@@ -671,11 +761,10 @@ mod tests {
         run(&["checkout", "-b", "feature/abandoned"], repo);
         make_commit(repo, "a.txt", "a", "feat: a");
 
-        let bases = [("main", MergeTarget::Main)];
         let mut gone = HashSet::new();
         gone.insert("feature/abandoned".to_string());
         assert_eq!(
-            detect_cleanable_target(repo, "feature/abandoned", &bases, &gone).unwrap(),
+            detect_cleanable_target(repo, "feature/abandoned", None, &gone).unwrap(),
             Some(MergeTargetRef::new(MergeTarget::Gone, ""))
         );
     }

--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -466,6 +466,12 @@ fn matches_annotation(line: &str, key: &str) -> bool {
 mod tests {
     use super::*;
 
+    fn comparable_path(path: &Path) -> String {
+        path.to_string_lossy()
+            .trim_start_matches(r"\\?\")
+            .replace('\\', "/")
+    }
+
     fn init_git_repo(path: &Path) {
         let output = std::process::Command::new("git")
             .args(["init", path.to_str().unwrap()])
@@ -651,8 +657,8 @@ prunable gitdir file points to non-existent location
         );
 
         assert_eq!(
-            main_worktree_root(&linked_worktree).unwrap(),
-            std::fs::canonicalize(&repo_path).unwrap()
+            comparable_path(&main_worktree_root(&linked_worktree).unwrap()),
+            comparable_path(&std::fs::canonicalize(&repo_path).unwrap())
         );
     }
 
@@ -698,11 +704,14 @@ prunable gitdir file points to non-existent location
         );
 
         let layout_root = main_worktree_root(&linked_worktree).unwrap();
-        assert_eq!(layout_root, std::fs::canonicalize(&bare_repo_path).unwrap());
+        assert_eq!(
+            comparable_path(&layout_root),
+            comparable_path(&std::fs::canonicalize(&bare_repo_path).unwrap())
+        );
         let expected_parent = std::fs::canonicalize(tmp.path()).unwrap();
         assert_eq!(
-            sibling_worktree_path(&layout_root, "feature/banner"),
-            expected_parent.join("feature").join("banner")
+            comparable_path(&sibling_worktree_path(&layout_root, "feature/banner")),
+            comparable_path(&expected_parent.join("feature").join("banner"))
         );
     }
 

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -4860,6 +4860,7 @@ exit 0
             .expect("pane"),
         ));
         if cfg!(windows) {
+            // Windows ConPTY may wait for this CPR response before exposing exit state.
             if let Ok(pane) = pane.lock() {
                 let _ = pane.pty().write_input(b"\x1b[1;1R");
             }

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -7,6 +7,8 @@ use std::{
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
 
+type RemoteBaseBranchRanks = HashMap<String, u8>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BranchCleanupAvailability {
@@ -132,6 +134,7 @@ fn build_cleanup_targets(
 }
 
 fn adapt_branch_inventory(branches: Vec<gwt_git::Branch>) -> Vec<BranchListEntry> {
+    let remote_base_branch_ranks = remote_base_branch_ranks(&branches);
     let mut entries: Vec<BranchListEntry> = branches
         .into_iter()
         .map(|branch| BranchListEntry {
@@ -151,7 +154,7 @@ fn adapt_branch_inventory(branches: Vec<gwt_git::Branch>) -> Vec<BranchListEntry
         })
         .collect();
 
-    entries.sort_by(compare_branch_entries);
+    entries.sort_by(|left, right| compare_branch_entries(left, right, &remote_base_branch_ranks));
     entries
 }
 
@@ -174,7 +177,7 @@ fn hydrate_branch_entries(
         .filter(|branch| branch.scope == BranchScope::Local)
         .map(|branch| (branch.name.clone(), (branch.ahead, branch.behind)))
         .collect();
-    let mut entries: Vec<BranchListEntry> = entries
+    let entries: Vec<BranchListEntry> = entries
         .into_iter()
         .map(|mut branch| {
             branch.cleanup = build_cleanup_info(
@@ -190,7 +193,6 @@ fn hydrate_branch_entries(
         })
         .collect();
 
-    entries.sort_by(compare_branch_entries);
     entries
 }
 
@@ -307,16 +309,36 @@ fn local_branch_for_remote_ref(name: &str) -> Option<&str> {
     name.split_once('/').map(|(_, branch_name)| branch_name)
 }
 
-fn base_branch_sort_rank(entry: &BranchListEntry) -> Option<(u8, u8)> {
-    let branch_name = match entry.scope {
-        BranchScope::Local => entry.name.as_str(),
-        BranchScope::Remote => local_branch_for_remote_ref(&entry.name)?,
-    };
-    let base_rank = match branch_name {
+fn remote_base_branch_ranks(branches: &[gwt_git::Branch]) -> RemoteBaseBranchRanks {
+    branches
+        .iter()
+        .filter(|branch| branch.is_remote)
+        .filter_map(|branch| {
+            let branch_name = branch
+                .remote_branch_name
+                .as_deref()
+                .or_else(|| local_branch_for_remote_ref(&branch.name))?;
+            Some((branch.name.clone(), base_branch_rank(branch_name)?))
+        })
+        .collect()
+}
+
+fn base_branch_rank(branch_name: &str) -> Option<u8> {
+    Some(match branch_name {
         "main" => 0,
         "master" => 1,
         "develop" => 2,
         _ => return None,
+    })
+}
+
+fn base_branch_sort_rank(
+    entry: &BranchListEntry,
+    remote_base_branch_ranks: &RemoteBaseBranchRanks,
+) -> Option<(u8, u8)> {
+    let base_rank = match entry.scope {
+        BranchScope::Local => base_branch_rank(&entry.name)?,
+        BranchScope::Remote => *remote_base_branch_ranks.get(&entry.name)?,
     };
     let scope_rank = match entry.scope {
         BranchScope::Local => 0,
@@ -325,8 +347,15 @@ fn base_branch_sort_rank(entry: &BranchListEntry) -> Option<(u8, u8)> {
     Some((base_rank, scope_rank))
 }
 
-fn compare_branch_entries(left: &BranchListEntry, right: &BranchListEntry) -> Ordering {
-    match (base_branch_sort_rank(left), base_branch_sort_rank(right)) {
+fn compare_branch_entries(
+    left: &BranchListEntry,
+    right: &BranchListEntry,
+    remote_base_branch_ranks: &RemoteBaseBranchRanks,
+) -> Ordering {
+    match (
+        base_branch_sort_rank(left, remote_base_branch_ranks),
+        base_branch_sort_rank(right, remote_base_branch_ranks),
+    ) {
         (Some(left_rank), Some(right_rank)) => {
             return left_rank
                 .cmp(&right_rank)
@@ -348,8 +377,9 @@ fn compare_branch_entries(left: &BranchListEntry, right: &BranchListEntry) -> Or
 }
 
 fn compare_branch_names(left: &str, right: &str) -> Ordering {
-    left.to_ascii_lowercase()
-        .cmp(&right.to_ascii_lowercase())
+    left.bytes()
+        .map(|byte| byte.to_ascii_lowercase())
+        .cmp(right.bytes().map(|byte| byte.to_ascii_lowercase()))
         .then_with(|| left.cmp(right))
 }
 
@@ -381,8 +411,18 @@ mod tests {
         is_head: bool,
         last_commit_date: Option<&str>,
     ) -> gwt_git::Branch {
+        let (remote_name, remote_branch_name) = if is_local {
+            (None, None)
+        } else {
+            name.split_once('/')
+                .map_or((None, None), |(remote, branch)| {
+                    (Some(remote.to_string()), Some(branch.to_string()))
+                })
+        };
         gwt_git::Branch {
             name: name.to_string(),
+            remote_name,
+            remote_branch_name,
             is_local,
             is_remote: !is_local,
             is_head,
@@ -393,49 +433,44 @@ mod tests {
         }
     }
 
+    fn make_remote_branch(
+        name: &str,
+        remote_name: &str,
+        remote_branch_name: &str,
+        last_commit_date: Option<&str>,
+    ) -> gwt_git::Branch {
+        gwt_git::Branch {
+            remote_name: Some(remote_name.to_string()),
+            remote_branch_name: Some(remote_branch_name.to_string()),
+            ..make_branch(name, false, false, last_commit_date)
+        }
+    }
+
     #[test]
     fn adapt_branches_sorts_base_first_then_newest_head_local() {
         let branches = vec![
+            make_branch(
+                "origin/main",
+                false,
+                false,
+                Some("2026-04-19 12:00:00 +0000"),
+            ),
+            make_branch(
+                "feature/zeta",
+                true,
+                false,
+                Some("2026-04-20 08:30:00 +0000"),
+            ),
             gwt_git::Branch {
-                name: "origin/main".to_string(),
-                is_local: false,
-                is_remote: true,
-                is_head: false,
-                upstream: None,
-                ahead: 0,
-                behind: 0,
-                last_commit_date: Some("2026-04-19 12:00:00 +0000".to_string()),
-            },
-            gwt_git::Branch {
-                name: "feature/zeta".to_string(),
-                is_local: true,
-                is_remote: false,
-                is_head: false,
-                upstream: None,
-                ahead: 0,
-                behind: 0,
-                last_commit_date: Some("2026-04-20 08:30:00 +0000".to_string()),
-            },
-            gwt_git::Branch {
-                name: "main".to_string(),
-                is_local: true,
-                is_remote: false,
-                is_head: true,
                 upstream: Some("origin/main".to_string()),
-                ahead: 0,
-                behind: 0,
-                last_commit_date: Some("2026-04-20 08:30:00 +0000".to_string()),
+                ..make_branch("main", true, true, Some("2026-04-20 08:30:00 +0000"))
             },
-            gwt_git::Branch {
-                name: "feature/alpha".to_string(),
-                is_local: true,
-                is_remote: false,
-                is_head: false,
-                upstream: None,
-                ahead: 0,
-                behind: 0,
-                last_commit_date: Some("2026-04-18 09:00:00 +0000".to_string()),
-            },
+            make_branch(
+                "feature/alpha",
+                true,
+                false,
+                Some("2026-04-18 09:00:00 +0000"),
+            ),
         ];
 
         let entries = adapt_branch_inventory(branches);
@@ -532,6 +567,38 @@ mod tests {
         let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
 
         assert_eq!(names, vec!["origin/develop", "feature/y", "feature/x"]);
+    }
+
+    #[test]
+    fn base_branch_pin_uses_remote_metadata_for_slash_remotes() {
+        let branches = vec![
+            make_branch(
+                "feature/current",
+                true,
+                true,
+                Some("2026-04-21 10:00:00 +0000"),
+            ),
+            make_remote_branch(
+                "origin/feature/main",
+                "origin",
+                "feature/main",
+                Some("2026-04-20 10:00:00 +0000"),
+            ),
+            make_remote_branch(
+                "team/core/main",
+                "team/core",
+                "main",
+                Some("2026-04-01 10:00:00 +0000"),
+            ),
+        ];
+
+        let entries = adapt_branch_inventory(branches);
+        let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
+
+        assert_eq!(
+            names,
+            vec!["team/core/main", "feature/current", "origin/feature/main"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix remote base-branch pinning for remotes whose names contain path separators.
- Avoid misclassifying branch names such as `origin/feature/main` as protected base branches.
- Address post-merge review feedback from PR #2193 with additional regression coverage.

## Changes

- `crates/gwt-git/src/branch.rs`: Added remote metadata for listed remote-tracking branches by splitting refs against the configured remote names with longest-prefix matching.
- `crates/gwt/src/branch_list.rs`: Uses remote branch metadata when ranking remote base branches and avoids allocations in case-insensitive branch name comparisons.
- `crates/gwt/src/app_runtime.rs`: Added a short comment documenting the Windows ConPTY CPR test workaround.
- `crates/gwt-git/src/worktree.rs`: Normalizes Windows extended-path prefixes in path assertion tests.

## Testing

- [x] `cargo fmt -- --check` - completed successfully.
- [x] `cargo test -p gwt-git -p gwt-core -p gwt -- --test-threads=1` - completed successfully.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - completed successfully.
- [x] `cargo build -p gwt` - completed successfully.
- [x] `bunx commitlint --from origin/develop --to HEAD` - completed successfully.

## Closing Issues

- None

## Related Issues / Links

- #2193
- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not applicable: internal branch parsing and test maintenance only)
- [ ] Migration/backfill plan included (not applicable: no schema or persisted data change)
- [x] CHANGELOG impact considered (patch-level `fix` commit included)

## Context

- PR #2193 was merged automatically before a reviewer thread pointed out that remote names containing `/` were not handled by the base branch pinning logic.

## Risk / Impact

- **Affected areas**: Branch inventory parsing and branch-list ordering for remote-tracking refs.
- **Rollback plan**: Revert the follow-up fix commit if branch ordering or remote cleanup target detection regresses.
