### PR TITLE
fix(branch-list): cache remote names for cleanup hydration

### DIFF
--- a/crates/gwt-git/src/branch.rs
+++ b/crates/gwt-git/src/branch.rs
@@ -108,8 +108,26 @@ pub fn detect_cleanable_target(
     gone_branches: &HashSet<String>,
 ) -> Result<Option<MergeTargetRef>> {
     let remote_names = list_remote_names(repo_path).unwrap_or_default();
+    detect_cleanable_target_with_remote_names(
+        repo_path,
+        branch,
+        upstream,
+        gone_branches,
+        &remote_names,
+    )
+}
+
+/// Resolves the canonical cleanup target for `branch` using remote names
+/// already discovered for the current branch-list scan.
+pub fn detect_cleanable_target_with_remote_names(
+    repo_path: &Path,
+    branch: &str,
+    upstream: Option<&str>,
+    gone_branches: &HashSet<String>,
+    remote_names: &[String],
+) -> Result<Option<MergeTargetRef>> {
     let Some(primary_remote) =
-        upstream.and_then(|reference| split_remote_ref(reference, &remote_names).0)
+        upstream.and_then(|reference| split_remote_ref(reference, remote_names).0)
     else {
         if gone_branches.contains(branch) {
             return Ok(Some(MergeTargetRef::new(MergeTarget::Gone, "")));
@@ -384,7 +402,7 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
     Ok(branches)
 }
 
-fn list_remote_names(repo_path: &Path) -> Result<Vec<String>> {
+pub fn list_remote_names(repo_path: &Path) -> Result<Vec<String>> {
     let output = std::process::Command::new("git")
         .arg("remote")
         .current_dir(repo_path)
@@ -723,6 +741,48 @@ mod tests {
         assert_eq!(
             detect_cleanable_target(repo, "feature/d", Some("origin/feature/d"), &gone).unwrap(),
             Some(MergeTargetRef::new(MergeTarget::Develop, "origin/develop"))
+        );
+    }
+
+    #[test]
+    fn detect_cleanable_target_with_remote_names_handles_slash_remote() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_named_repo(repo);
+        run(&["checkout", "-b", "develop"], repo);
+        run(&["checkout", "-b", "feature/slash-remote"], repo);
+        make_commit(repo, "slash.txt", "slash\n", "feat: slash remote");
+        run(&["checkout", "develop"], repo);
+        run(
+            &[
+                "merge",
+                "--no-ff",
+                "-m",
+                "merge slash",
+                "feature/slash-remote",
+            ],
+            repo,
+        );
+        run(
+            &["update-ref", "refs/remotes/team/core/develop", "develop"],
+            repo,
+        );
+
+        let remote_names = vec!["team/core".to_string()];
+        let gone = HashSet::new();
+        assert_eq!(
+            detect_cleanable_target_with_remote_names(
+                repo,
+                "feature/slash-remote",
+                Some("team/core/feature/slash-remote"),
+                &gone,
+                &remote_names,
+            )
+            .unwrap(),
+            Some(MergeTargetRef::new(
+                MergeTarget::Develop,
+                "team/core/develop"
+            ))
         );
     }
 

--- a/crates/gwt-git/src/lib.rs
+++ b/crates/gwt-git/src/lib.rs
@@ -12,8 +12,9 @@ pub mod repository;
 pub mod worktree;
 
 pub use branch::{
-    delete_local_branch, detect_cleanable_target, git_divergence, is_branch_merged_into,
-    is_protected_branch, list_gone_branches, Branch, DivergenceInfo, MergeTarget, MergeTargetRef,
+    delete_local_branch, detect_cleanable_target, detect_cleanable_target_with_remote_names,
+    git_divergence, is_branch_merged_into, is_protected_branch, list_gone_branches,
+    list_remote_names, Branch, DivergenceInfo, MergeTarget, MergeTargetRef,
 };
 pub use commit::CommitEntry;
 pub use diff::{FileEntry, FileStatus};

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -116,16 +116,18 @@ fn build_cleanup_targets(
     entries: &[BranchListEntry],
     gone_branches: &HashSet<String>,
 ) -> std::io::Result<HashMap<String, Option<gwt_git::MergeTargetRef>>> {
+    let remote_names = gwt_git::list_remote_names(repo_path).unwrap_or_default();
     let mut cleanup_targets = HashMap::new();
     for branch in entries
         .iter()
         .filter(|branch| branch.scope == BranchScope::Local)
     {
-        let target = gwt_git::detect_cleanable_target(
+        let target = gwt_git::detect_cleanable_target_with_remote_names(
             repo_path,
             &branch.name,
             branch.upstream.as_deref(),
             gone_branches,
+            &remote_names,
         )
         .map_err(|error| std::io::Error::other(error.to_string()))?;
         cleanup_targets.insert(branch.name.clone(), target);


### PR DESCRIPTION
## Summary

- Cache Git remote-name discovery once per branch-list cleanup hydration pass so local branch cleanup state no longer shells out once per branch.
- Keep the existing `detect_cleanable_target` API and add a cached remote-name variant for callers that already scan branch metadata.

## Changes

- `crates/gwt-git/src/branch.rs`: added `detect_cleanable_target_with_remote_names`, exposed `list_remote_names`, and covered slash-containing remotes with cached metadata.
- `crates/gwt-git/src/lib.rs`: re-exported the cached cleanup-target API and remote-name discovery helper.
- `crates/gwt/src/branch_list.rs`: resolves remote names once before iterating local branches during cleanup target hydration.

## Testing

- [x] `cargo test -p gwt-git detect_cleanable_target -- --test-threads=1` — passed.
- [x] `cargo test -p gwt branch_list::tests::base_branch_pin -- --test-threads=1` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt-git -p gwt-core -p gwt -- --test-threads=1` — passed after the final diff.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #2196
- #2193
- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated — Not user-facing; no README/docs change required.
- [ ] Migration/backfill plan included — No schema or data migration involved.
- [x] CHANGELOG impact considered (patch fix, no breaking change)

## Context

- Follow-up for the unresolved PR #2196 review thread about O(n) `git remote` subprocess calls during branch cleanup-state hydration.

## Risk / Impact

- **Affected areas**: Branch list cleanup-state hydration and gwt-git branch cleanup target resolution.
- **Rollback plan**: Revert this single commit if cleanup hydration regresses.
