### PR TITLE
fix(board): manage board watcher lifecycle

### DIFF
--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -4563,6 +4563,16 @@ exit 0
         panic!("timed out waiting for {label}: {snapshot:?}");
     }
 
+    fn wait_for_path(label: &str, path: &Path) {
+        for _ in 0..800 {
+            if path.exists() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("timed out waiting for {label}: {}", path.display());
+    }
+
     fn sample_launch_wizard_session(tab_id: &str, project_root: &Path) -> LaunchWizardSession {
         LaunchWizardSession {
             tab_id: tab_id.to_string(),
@@ -5561,14 +5571,10 @@ exit 0
             force: false,
             list_scope: gwt::KnowledgeListScope::Open,
         });
-        thread::sleep(Duration::from_millis(250));
+        wait_for_path("stale knowledge refresh gh invocation", &marker);
         assert!(
             events.lock().expect("event log").is_empty(),
             "background refresh errors should not overwrite the current cache view"
-        );
-        assert!(
-            marker.exists(),
-            "expected fake gh to be invoked for stale cache"
         );
 
         fs::remove_file(&marker).expect("remove marker");

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -148,21 +148,68 @@ fn board_projection_watch_key(project_root: &Path) -> PathBuf {
     dunce::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf())
 }
 
-fn ensure_board_projection_watchers(
-    app: &AppRuntime,
-    watched_roots: &mut HashSet<PathBuf>,
-    proxy: EventLoopProxy<UserEvent>,
-) {
-    for tab in &app.tabs {
-        let project_root = tab.project_root.clone();
-        let key = board_projection_watch_key(&project_root);
-        if watched_roots.insert(key) {
-            spawn_board_projection_watcher(project_root, proxy.clone());
+fn frontend_event_may_change_project_tabs(event: &FrontendEvent) -> bool {
+    matches!(
+        event,
+        FrontendEvent::OpenProjectDialog
+            | FrontendEvent::ReopenRecentProject { .. }
+            | FrontendEvent::CloseProjectTab { .. }
+    )
+}
+
+enum BoardProjectionWatcherMessage {
+    Changed(Vec<PathBuf>),
+    Stop,
+}
+
+struct BoardProjectionWatcher {
+    tx: std_mpsc::Sender<BoardProjectionWatcherMessage>,
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for BoardProjectionWatcher {
+    fn drop(&mut self) {
+        let _ = self.tx.send(BoardProjectionWatcherMessage::Stop);
+        if let Some(join_handle) = self.join_handle.take() {
+            if let Err(error) = join_handle.join() {
+                tracing::warn!(?error, "board projection watcher thread join failed");
+            }
         }
     }
 }
 
-fn spawn_board_projection_watcher(project_root: PathBuf, proxy: EventLoopProxy<UserEvent>) {
+#[derive(Default)]
+struct BoardProjectionWatcherRegistry {
+    watchers: HashMap<PathBuf, BoardProjectionWatcher>,
+}
+
+impl BoardProjectionWatcherRegistry {
+    fn sync(&mut self, app: &AppRuntime, proxy: EventLoopProxy<UserEvent>) {
+        let mut active_roots = HashSet::new();
+        for tab in &app.tabs {
+            let project_root = tab.project_root.clone();
+            let key = board_projection_watch_key(&project_root);
+            active_roots.insert(key.clone());
+            if let std::collections::hash_map::Entry::Vacant(entry) = self.watchers.entry(key) {
+                if let Some(watcher) = spawn_board_projection_watcher(project_root, proxy.clone()) {
+                    entry.insert(watcher);
+                }
+            }
+        }
+
+        self.watchers
+            .retain(|project_root, _| active_roots.contains(project_root));
+    }
+
+    fn shutdown(&mut self) {
+        self.watchers.clear();
+    }
+}
+
+fn spawn_board_projection_watcher(
+    project_root: PathBuf,
+    proxy: EventLoopProxy<UserEvent>,
+) -> Option<BoardProjectionWatcher> {
     let name = format!(
         "gwt-board-watch-{}",
         project_root
@@ -170,7 +217,9 @@ fn spawn_board_projection_watcher(project_root: PathBuf, proxy: EventLoopProxy<U
             .and_then(|name| name.to_str())
             .unwrap_or("project")
     );
-    if let Err(error) = thread::Builder::new().name(name).spawn(move || {
+    let (tx, rx) = std_mpsc::channel::<BoardProjectionWatcherMessage>();
+    let stop_tx = tx.clone();
+    let join_handle = match thread::Builder::new().name(name).spawn(move || {
         if let Err(error) = gwt_core::coordination::ensure_repo_local_files(&project_root) {
             tracing::warn!(
                 project_root = %project_root.display(),
@@ -190,14 +239,13 @@ fn spawn_board_projection_watcher(project_root: PathBuf, proxy: EventLoopProxy<U
             return;
         };
 
-        let (tx, rx) = std_mpsc::channel::<Vec<PathBuf>>();
         let mut debouncer = match notify_debouncer_mini::new_debouncer(
             Duration::from_millis(250),
             move |res: notify_debouncer_mini::DebounceEventResult| {
                 if let Ok(events) = res {
                     let paths: Vec<PathBuf> = events.into_iter().map(|event| event.path).collect();
                     if !paths.is_empty() {
-                        let _ = tx.send(paths);
+                        let _ = tx.send(BoardProjectionWatcherMessage::Changed(paths));
                     }
                 }
             },
@@ -226,19 +274,32 @@ fn spawn_board_projection_watcher(project_root: PathBuf, proxy: EventLoopProxy<U
             return;
         }
 
-        while let Ok(paths) = rx.recv() {
-            if paths
-                .iter()
-                .any(|path| path.file_name() == Some(projection_file_name.as_os_str()))
-            {
-                let _ = proxy.send_event(UserEvent::BoardProjectionChanged {
-                    project_root: project_root.clone(),
-                });
+        while let Ok(message) = rx.recv() {
+            match message {
+                BoardProjectionWatcherMessage::Changed(paths) => {
+                    if paths
+                        .iter()
+                        .any(|path| path.file_name() == Some(projection_file_name.as_os_str()))
+                    {
+                        let _ = proxy.send_event(UserEvent::BoardProjectionChanged {
+                            project_root: project_root.clone(),
+                        });
+                    }
+                }
+                BoardProjectionWatcherMessage::Stop => break,
             }
         }
     }) {
-        tracing::warn!(error = %error, "board projection watcher thread failed to spawn");
-    }
+        Ok(join_handle) => join_handle,
+        Err(error) => {
+            tracing::warn!(error = %error, "board projection watcher thread failed to spawn");
+            return None;
+        }
+    };
+    Some(BoardProjectionWatcher {
+        tx: stop_tx,
+        join_handle: Some(join_handle),
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -356,6 +417,64 @@ mod tests {
             width: 1400.0,
             height: 900.0,
         }
+    }
+
+    #[test]
+    fn board_projection_watcher_sync_only_for_project_tab_changes() {
+        assert!(super::frontend_event_may_change_project_tabs(
+            &gwt::FrontendEvent::OpenProjectDialog
+        ));
+        assert!(super::frontend_event_may_change_project_tabs(
+            &gwt::FrontendEvent::ReopenRecentProject {
+                path: "/tmp/repo".to_string()
+            }
+        ));
+        assert!(super::frontend_event_may_change_project_tabs(
+            &gwt::FrontendEvent::CloseProjectTab {
+                tab_id: "tab-1".to_string()
+            }
+        ));
+
+        assert!(!super::frontend_event_may_change_project_tabs(
+            &gwt::FrontendEvent::TerminalInput {
+                id: "tab-1::shell-1".to_string(),
+                data: "x".to_string(),
+            }
+        ));
+        assert!(!super::frontend_event_may_change_project_tabs(
+            &gwt::FrontendEvent::PostBoardEntry {
+                id: "tab-1::board-1".to_string(),
+                entry_kind: gwt_core::coordination::BoardEntryKind::Status,
+                body: "done".to_string(),
+                parent_id: None,
+                topics: Vec::new(),
+                owners: Vec::new(),
+            }
+        ));
+    }
+
+    #[test]
+    fn board_projection_watcher_drop_sends_stop_to_thread() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let stopped = Arc::new(Mutex::new(false));
+        let stopped_in_thread = stopped.clone();
+        let join_handle = std::thread::spawn(move || {
+            if matches!(rx.recv(), Ok(super::BoardProjectionWatcherMessage::Stop)) {
+                *stopped_in_thread.lock().expect("stopped flag") = true;
+            }
+        });
+
+        let watcher = super::BoardProjectionWatcher {
+            tx,
+            join_handle: Some(join_handle),
+        };
+
+        drop(watcher);
+
+        assert!(
+            *stopped.lock().expect("stopped flag"),
+            "dropping a watcher must wake and join its thread"
+        );
     }
 
     fn init_git_repo(path: &Path) {
@@ -3994,8 +4113,8 @@ fn main() -> wry::Result<()> {
     )
     .expect("app runtime");
     app.bootstrap();
-    let mut board_projection_watch_roots = HashSet::new();
-    ensure_board_projection_watchers(&app, &mut board_projection_watch_roots, proxy.clone());
+    let mut board_projection_watchers = BoardProjectionWatcherRegistry::default();
+    board_projection_watchers.sync(&app, proxy.clone());
     if let Some(log_handles) = log_handles.as_mut() {
         if let Some(mut ui_rx) = log_handles.take_ui_rx() {
             let log_proxy = proxy.clone();
@@ -4071,17 +4190,17 @@ fn main() -> wry::Result<()> {
                 // Kill every PTY / agent before the event loop exits so no
                 // child process outlives the window.
                 app.stop_all_runtimes();
+                board_projection_watchers.shutdown();
                 server.shutdown();
                 *control_flow = ControlFlow::Exit;
             }
             Event::UserEvent(UserEvent::Frontend { client_id, event }) => {
                 let refresh_index_status = matches!(event, FrontendEvent::FrontendReady);
+                let sync_board_projection_watchers = frontend_event_may_change_project_tabs(&event);
                 let events = app.handle_frontend_event(client_id, event);
-                ensure_board_projection_watchers(
-                    &app,
-                    &mut board_projection_watch_roots,
-                    proxy.clone(),
-                );
+                if sync_board_projection_watchers {
+                    board_projection_watchers.sync(&app, proxy.clone());
+                }
                 clients.dispatch(events);
                 if refresh_index_status {
                     spawn_project_index_status_check(&runtime, proxy.clone());
@@ -4148,11 +4267,7 @@ fn main() -> wry::Result<()> {
                     match command {
                         NativeMenuCommand::OpenProject => {
                             let events = app.open_project_dialog_events();
-                            ensure_board_projection_watchers(
-                                &app,
-                                &mut board_projection_watch_roots,
-                                proxy.clone(),
-                            );
+                            board_projection_watchers.sync(&app, proxy.clone());
                             clients.dispatch(events);
                         }
                         NativeMenuCommand::ReloadWebView => {
@@ -4167,6 +4282,7 @@ fn main() -> wry::Result<()> {
                 // Belt-and-suspenders: if the event loop is torn down via a
                 // path other than CloseRequested, still release PTY children.
                 app.stop_all_runtimes();
+                board_projection_watchers.shutdown();
                 server.shutdown();
             }
             _ => {}

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -20,6 +20,40 @@ fn argv(strs: &[&str]) -> Vec<String> {
     strs.iter().map(|s| s.to_string()).collect()
 }
 
+fn env_test_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.as_ref() {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
 #[test]
 fn unknown_hook_name_exits_two() {
     let tmp = tempfile::tempdir().unwrap();
@@ -45,25 +79,21 @@ fn runtime_state_missing_event_argument_exits_two() {
 
 #[test]
 fn runtime_state_invalid_event_exits_one() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     // Set GWT_SESSION_RUNTIME_PATH so `handle` gets past the silent
     // no-op branch and actually calls `write_for_event`, which in turn
     // surfaces `InvalidEvent`.
     let tmp = tempfile::tempdir().unwrap();
     let runtime_path = tmp.path().join("runtime-state.json");
-    let prev = std::env::var_os("GWT_SESSION_RUNTIME_PATH");
-    std::env::set_var("GWT_SESSION_RUNTIME_PATH", &runtime_path);
+    let _runtime_path = ScopedEnvVar::set("GWT_SESSION_RUNTIME_PATH", &runtime_path);
 
     let mut env = TestEnv::new(tmp.path().to_path_buf());
     let code = dispatch(
         &mut env,
         &argv(&["gwt", "hook", "runtime-state", "BogusEventName"]),
     );
-
-    if let Some(v) = prev {
-        std::env::set_var("GWT_SESSION_RUNTIME_PATH", v);
-    } else {
-        std::env::remove_var("GWT_SESSION_RUNTIME_PATH");
-    }
 
     assert_eq!(code, 1, "InvalidEvent must map to exit code 1");
     let err = String::from_utf8(env.stderr).unwrap();
@@ -165,6 +195,10 @@ fn delegated_block_hook_preserves_block_json_contract() {
 
 #[test]
 fn event_dispatcher_preserves_pre_tool_use_block_json_contract() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _runtime_path = ScopedEnvVar::unset("GWT_SESSION_RUNTIME_PATH");
     let tmp = tempfile::tempdir().unwrap();
     let mut env = TestEnv::new(tmp.path().to_path_buf());
     env.stdin = serde_json::json!({

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,54 @@
 # Lessons Learned
 
+## 2026-04-27 — fix(board): GUI watcher は hot path で同期せず lifecycle owner を持つ
+
+### 事象
+
+Board projection watcher を `UserEvent::Frontend` ごとに同期していたため、
+terminal input など高頻度イベントのたびに project root の canonicalize と watcher
+lookup が走る設計になっていた。さらに watcher thread は stop signal / join handle を
+持たず、tab を閉じたあとも watch registration が残り得た。
+
+### 原因
+
+初回登録の重複防止を `HashSet<PathBuf>` だけで表現し、watcher の lifecycle owner を
+持たせなかった。tab set が変わるイベントと通常 frontend event を分離せず、
+「念のため同期」を hot path に置いてしまった。
+
+### 再発防止策
+
+1. GUI の filesystem watcher / background thread は registry 型で所有し、stop signal と
+   join handle を持たせる。
+2. watcher 同期は startup / open project / close tab など tab set が変わる境界だけで行い、
+   terminal input や board post など高頻度 event から filesystem work を外す。
+3. review comment が auto-merge 後に出た場合も、valid な lifecycle / hot path 指摘は
+   follow-up PR で解消する。
+
+## 2026-04-27 — test(async): background thread の完了確認に固定 sleep を使わない
+
+### 事象
+
+`cargo test -p gwt-core -p gwt` の full suite で、
+`app_runtime_background_knowledge_refresh_silent_paths_do_not_dispatch` が断続的に
+`expected fake gh to be invoked for stale cache` で失敗した。単体実行では通るため、
+full suite の負荷で background thread が 250ms 以内に fake gh marker を作れない
+タイミング依存だった。
+
+### 原因
+
+テストが background refresh の完了を `thread::sleep(Duration::from_millis(250))`
+で推測していた。実際に確認したい状態は「fake gh が呼ばれたこと」なので、
+固定時間ではなく marker file という positive signal を待つべきだった。
+
+### 再発防止策
+
+1. background thread / async dispatch のテストでは、固定 sleep だけで完了扱いにせず、
+   event log、marker file、channel など観測可能な positive signal を待つ。
+2. full suite でだけ落ちるテストは、production logic より先に test wait condition を疑い、
+   単体実行と full 実行の差を確認する。
+3. no-op / silent path のテストでも、可能な限り「処理がその分岐まで到達した」ことを
+   別 signal で固定してから副作用なしを検証する。
+
 ## 2026-04-25 — fix(board): canvas wheel routing の allowlist に新しい scroll surface を必ず登録する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Addresses post-merge review feedback from #2191 by giving Board projection watchers an explicit lifecycle owner and shutdown path.
- Limits Board watcher synchronization to project-tab lifecycle events so normal frontend traffic no longer rebuilds watcher lookup state.
- Stabilizes related async and hook tests that surfaced while merging the latest `origin/develop`.

## Changes

- `crates/gwt/src/main.rs`: replaced ad hoc watcher tracking with `BoardProjectionWatcherRegistry`, stop messages, join-on-drop shutdown, and event filtering for tab lifecycle changes.
- `crates/gwt/src/app_runtime.rs`: replaced a fixed sleep in the background knowledge refresh test with a positive file-existence wait.
- `crates/gwt/tests/hook_exit_codes_test.rs`: serialized process-env mutation and restored `GWT_SESSION_RUNTIME_PATH` with scoped guards.
- `tasks/lessons.md`: recorded lessons for GUI watcher lifecycle ownership and async test synchronization.

## Testing

- [x] `cargo test -p gwt board_projection_ -- --nocapture` — passed.
- [x] `cargo test -p gwt embedded_web_board_ -- --nocapture` — passed.
- [x] `cargo test -p gwt board_ -- --nocapture` — passed.
- [x] `cargo test -p gwt --test hook_exit_codes_test -- --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## Closing Issues

- None

## Related Issues / Links

- #2191
- #2018
- #1974

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not required: no new user-facing operation beyond #2191)
- [ ] Migration/backfill plan included (not required: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level fix; no breaking change)

## Context

- This follow-up keeps the merged Board functionality from #2191 but fixes valid post-merge review findings around watcher hot-path work and thread shutdown.

## Risk / Impact

- **Affected areas**: Board window projection updates, GUI watcher lifecycle, related tests.
- **Rollback plan**: Revert this PR; #2191 remains the user-facing Board feature baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved filesystem watcher stability through enhanced resource management and proper lifecycle handling to reduce monitoring issues

* **Tests**
  * Enhanced test isolation mechanisms to prevent race conditions and improve test reliability
  * Improved async background thread testing to eliminate flaky tests

* **Documentation**
  * Added engineering best practices documentation for filesystem watcher management and reliable async testing patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->