### PR TITLE
fix(gui): make terminal overlay errors copyable

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -127,6 +127,28 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_terminal_overlay_text_is_copyable() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("className = \"overlay-copy-button\"")
+                && html.contains("Copy")
+                && html.contains("copyTerminalOverlayMessage"),
+            "expected terminal overlay to expose an explicit copy button wired to the overlay message",
+        );
+        assert!(
+            html.contains(".terminal-overlay.visible")
+                && html.contains("user-select: text")
+                && html.contains("pointer-events: auto"),
+            "expected visible terminal overlays to allow normal text selection",
+        );
+        assert!(
+            html.contains("writeClipboardText(messageEl.textContent"),
+            "expected overlay copy to reuse the shared clipboard writer",
+        );
+    }
+
+    #[test]
     fn embedded_web_terminal_writes_refresh_viewport_after_xterm_parse() {
         let html = frontend_bundle_source();
         let streaming_write = regex::Regex::new(

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -928,6 +928,7 @@
           } else {
             overlay.textContent = effectiveDetail || "";
           }
+          updateTerminalOverlayCopyState(overlay);
           overlay.classList.toggle(
             "visible",
             runtimeState === "error" ||
@@ -1110,6 +1111,28 @@
           return false;
         }
         return writeClipboardText(selection, () => runtime.terminal.focus());
+      }
+
+      async function copyTerminalOverlayMessage(windowId) {
+        const element = windowMap.get(windowId);
+        const messageEl = element?.querySelector(".terminal-overlay .overlay-message");
+        if (!messageEl) {
+          return false;
+        }
+        return writeClipboardText(messageEl.textContent, () => {
+          terminalMap.get(windowId)?.terminal.focus();
+        });
+      }
+
+      function updateTerminalOverlayCopyState(overlay) {
+        const button = overlay?.querySelector(".overlay-copy-button");
+        const messageEl = overlay?.querySelector(".overlay-message");
+        if (!button || !messageEl) {
+          return;
+        }
+        const hasMessage = Boolean(messageEl.textContent);
+        button.hidden = !hasMessage;
+        button.disabled = !hasMessage;
       }
 
       function installTerminalCopyHandlers(windowId, terminalRoot, terminal) {
@@ -4635,8 +4658,23 @@
           const message = document.createElement("div");
           message.className = "overlay-message";
           message.textContent = "Launching...";
+          const copyButton = document.createElement("button");
+          copyButton.type = "button";
+          copyButton.className = "overlay-copy-button";
+          copyButton.textContent = "Copy";
+          copyButton.addEventListener("click", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void copyTerminalOverlayMessage(windowData.id);
+          });
+          overlay.addEventListener("mousedown", () => {
+            focusWindowLocally(windowData.id);
+            socketTransport.send({ kind: "focus_window", id: windowData.id });
+          });
           overlay.appendChild(spinner);
           overlay.appendChild(message);
+          overlay.appendChild(copyButton);
+          updateTerminalOverlayCopyState(overlay);
           terminalRoot.addEventListener("mousedown", () => {
             focusWindowLocally(windowData.id);
             socketTransport.send({ kind: "focus_window", id: windowData.id });
@@ -5633,6 +5671,7 @@
               const messageEl = element.querySelector(".terminal-overlay .overlay-message");
               if (messageEl) {
                 messageEl.textContent = event.message;
+                updateTerminalOverlayCopyState(messageEl.closest(".terminal-overlay"));
               }
             }
             break;

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -601,6 +601,7 @@
         font-size: 12px;
         border: 1px solid rgba(59, 130, 246, 0.18);
         pointer-events: none;
+        user-select: none;
         display: none;
       }
 
@@ -611,6 +612,8 @@
         justify-content: center;
         gap: 12px;
         background: rgba(15, 23, 42, 0.95);
+        pointer-events: auto;
+        user-select: text;
       }
 
       .overlay-spinner {
@@ -623,6 +626,37 @@
       .overlay-message {
         font-size: 13px;
         color: #bfdbfe;
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        white-space: pre-wrap;
+        user-select: text;
+      }
+
+      .overlay-copy-button {
+        align-self: flex-end;
+        min-width: 56px;
+        height: 26px;
+        border: 1px solid rgba(147, 197, 253, 0.32);
+        border-radius: 4px;
+        background: rgba(59, 130, 246, 0.18);
+        color: #dbeafe;
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 700;
+        user-select: none;
+      }
+
+      .overlay-copy-button:hover:not(:disabled) {
+        background: rgba(59, 130, 246, 0.28);
+      }
+
+      .overlay-copy-button:disabled {
+        cursor: default;
+        opacity: 0.5;
+      }
+
+      .overlay-copy-button[hidden] {
+        display: none;
       }
 
       @keyframes spin-text {


### PR DESCRIPTION
## Summary

- Make terminal overlay error/detail text copyable so agent launch failures can be shared without retyping.
- Add both normal text selection and an explicit Copy control for visible terminal overlays.

## Changes

- `crates/gwt/web/app.js`: add overlay message copy helpers, a Copy button, and focus handling for terminal overlays.
- `crates/gwt/web/index.html`: allow visible overlay text selection and style the overlay Copy control.
- `crates/gwt/src/embedded_web.rs`: add a frontend contract test for selectable/copyable terminal overlay text.

## Testing

- [x] `cargo test -p gwt embedded_web_terminal_overlay_text_is_copyable` - passed.
- [x] `cargo test -p gwt embedded_web_terminal_` - passed.
- [x] `Get-Content -Raw -LiteralPath 'crates\gwt\web\app.js' | node --input-type=module --check` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `cargo test -p gwt-core -p gwt` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt` - passed.

## Closing Issues

- None

## Related Issues / Links

- #1919
- #2008

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #1919)
- [x] Migration/backfill plan not required (no schema/data change)
- [x] CHANGELOG impact considered (patch fix)

## Context

- The existing xterm selection copy path did not cover the separate terminal overlay used for launch progress, stopped, and error details.

## Screenshots

- Not captured in this headless run; the visible behavior is covered by the embedded frontend contract test added in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy button to terminal overlay for easy clipboard messaging

* **Style**
  * Improved terminal overlay text wrapping and readability
  * Enhanced copy button visuals with hover and disabled states
  * Terminal overlay text now selectable and interactive when visible

<!-- end of auto-generated comment: release notes by coderabbit.ai -->