### PR TITLE
fix(gui): restore focus after overlay copy

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -127,6 +127,20 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_terminal_clipboard_async_path_restores_focus() {
+        let html = frontend_bundle_source();
+        let async_copy = regex::Regex::new(
+            r"await\s+navigator\.clipboard\.writeText\(text\);\s*restoreFocus\?\.\(\);\s*return\s+true;",
+        )
+        .expect("valid regex");
+
+        assert!(
+            async_copy.is_match(html),
+            "expected async clipboard success path to restore terminal focus before returning",
+        );
+    }
+
+    #[test]
     fn embedded_web_terminal_overlay_text_is_copyable() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1074,6 +1074,7 @@
         if (navigator.clipboard?.writeText) {
           try {
             await navigator.clipboard.writeText(text);
+            restoreFocus?.();
             return true;
           } catch (_error) {
             // Fall back to a temporary textarea when the async clipboard API is unavailable.


### PR DESCRIPTION
## Summary

- Restore terminal focus after overlay Copy succeeds through the async Clipboard API.
- Add a contract test so future clipboard success paths cannot skip focus restoration.

## Changes

- `crates/gwt/web/app.js`: call `restoreFocus` before returning from the async clipboard success path.
- `crates/gwt/src/embedded_web.rs`: add a frontend contract test for async clipboard focus restoration.

## Testing

- [x] `cargo test -p gwt embedded_web_terminal_clipboard_async_path_restores_focus` - passed.
- [x] `cargo test -p gwt embedded_web_terminal_` - passed.
- [x] `Get-Content -Raw -LiteralPath 'crates\gwt\web\app.js' | node --input-type=module --check` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `cargo test -p gwt-core -p gwt` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt` - passed.

## Closing Issues

- None

## Related Issues / Links

- #2202
- #1919

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated in #2202 / SPEC #1919; no additional spec delta required
- [x] Migration/backfill plan not required (no schema/data change)
- [x] CHANGELOG impact considered (patch fix)

## Context

- Follow-up for the CodeRabbit review thread on #2202: the fallback clipboard path restored terminal focus, but the async Clipboard API success path returned before invoking the same callback.
