### PR TITLE
fix(gui): refresh terminal viewport after scroll

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -187,6 +187,33 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_terminal_scrolls_refresh_viewport_after_xterm_scroll() {
+        let html = frontend_bundle_source();
+        let scroll_listener = regex::Regex::new(
+            r"const\s+viewportScrollDisposable\s*=\s*terminal\.onScroll\(\(\)\s*=>\s*\{\s*scheduleTerminalViewportRefresh\(windowId\);\s*\}\s*\);",
+        )
+        .expect("valid regex");
+
+        assert!(
+            html.contains("function installTerminalViewportRefreshHandlers(windowId, terminal)"),
+            "expected terminal viewport refresh event wiring to live in a named helper",
+        );
+        assert!(
+            scroll_listener.is_match(html),
+            "expected terminal scrollback movement to refresh the visible viewport",
+        );
+        assert!(
+            html.contains("const viewportRefreshCleanup = installTerminalViewportRefreshHandlers(windowId, terminal);")
+                && html.contains("viewportRefreshCleanup();"),
+            "expected terminal runtime cleanup to dispose viewport refresh listeners",
+        );
+        assert!(
+            html.contains("viewportScrollDisposable.dispose();"),
+            "expected xterm scroll listener disposable to be released during cleanup",
+        );
+    }
+
+    #[test]
     fn embedded_web_terminal_assets_are_local_and_pinned() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1199,6 +1199,16 @@
         };
       }
 
+      function installTerminalViewportRefreshHandlers(windowId, terminal) {
+        const viewportScrollDisposable = terminal.onScroll(() => {
+          scheduleTerminalViewportRefresh(windowId);
+        });
+
+        return () => {
+          viewportScrollDisposable.dispose();
+        };
+      }
+
       function createTerminalRuntime(windowId, terminalContainer) {
         if (terminalMap.has(windowId)) {
           return terminalMap.get(windowId);
@@ -1236,7 +1246,12 @@
         const fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
         terminal.open(terminalContainer);
-        const cleanup = installTerminalCopyHandlers(windowId, terminalContainer, terminal);
+        const copyCleanup = installTerminalCopyHandlers(windowId, terminalContainer, terminal);
+        const viewportRefreshCleanup = installTerminalViewportRefreshHandlers(windowId, terminal);
+        const cleanup = () => {
+          copyCleanup();
+          viewportRefreshCleanup();
+        };
         terminal.onData((data) => {
           inputTraceSeq += 1;
           const wsState = socket ? socket.readyState : -1;


### PR DESCRIPTION
## Summary

- Terminal scrollback movement now schedules the same debounced viewport refresh used after xterm writes, so blank cells are repainted after scrolling.
- The terminal runtime now disposes the xterm scroll listener during window cleanup to avoid stale listeners.

## Changes

- `crates/gwt/web/app.js`: added `installTerminalViewportRefreshHandlers` and wired `terminal.onScroll` to `scheduleTerminalViewportRefresh(windowId)`.
- `crates/gwt/src/embedded_web.rs`: added an embedded frontend contract test for scroll-triggered viewport refresh and listener cleanup.

## Testing

- [x] `cargo test -p gwt embedded_web_terminal` — passed after merging `origin/develop`.
- [x] `cargo fmt -- --check` — passed after merging `origin/develop`.
- [x] `cargo test -p gwt-core -p gwt` — passed before PR branch sync.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed before PR branch sync.
- [x] `cargo build -p gwt` — passed before PR branch sync.
- [x] `bunx commitlint --from origin/bugfix/redraw-window --to HEAD` — passed before push.

## Closing Issues

- None

## Related Issues / Links

- SPEC #1919
- SPEC #2008

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated — not required; no documented command or workflow changed.
- [ ] Migration/backfill plan included — not required; no schema or persisted data changed.
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Risk / Impact

- **Affected areas**: GUI terminal windows using xterm.js scrollback.
- **Rollback plan**: revert this PR; no data migration or persisted-state rollback is required.

## Screenshots

- Not included; the issue is a transient terminal canvas repaint artifact during scroll, covered by embedded frontend contract tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test for terminal scroll behavior validation in the embedded frontend bundle, covering event listener registration and cleanup procedures.

* **Bug Fixes**
  * Enhanced terminal scroll handling to trigger viewport refresh during scrollback movement, improving scrolling responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->