### PR TITLE
fix(cleanup): avoid frontend branch cleanup timeout

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -1,9 +1,16 @@
 //! Git worktree management
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Output, Stdio},
+    time::{Duration, Instant},
+};
 
 use gwt_core::{GwtError, Result};
 use serde::{Deserialize, Serialize};
+
+const REMOTE_DELETE_TIMEOUT: Duration = Duration::from_secs(120);
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 /// Information about a single worktree.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,11 +195,12 @@ impl WorktreeManager {
             .split_once('/')
             .ok_or_else(|| GwtError::Git(format!("invalid remote ref: {normalized}")))?;
 
-        let output = std::process::Command::new("git")
+        let mut command = std::process::Command::new("git");
+        command
             .args(["push", remote, "--delete", branch])
-            .current_dir(&self.repo_path)
-            .output()
-            .map_err(|e| GwtError::Git(format!("push {remote} --delete {branch}: {e}")))?;
+            .current_dir(&self.repo_path);
+        let action = format!("git push {remote} --delete {branch}");
+        let output = run_command_with_timeout(&mut command, &action, REMOTE_DELETE_TIMEOUT)?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -337,6 +345,42 @@ fn is_missing_worktree_error(err: &GwtError) -> bool {
         || message.contains("not a work tree")
         || message.contains("no such file or directory")
         || message.contains("does not exist")
+}
+
+fn run_command_with_timeout(
+    command: &mut Command,
+    action: &str,
+    timeout: Duration,
+) -> Result<Output> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| GwtError::Git(format!("{action}: {error}")))?;
+    let started = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child
+                    .wait_with_output()
+                    .map_err(|error| GwtError::Git(format!("{action}: {error}")));
+            }
+            Ok(None) if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(GwtError::Git(format!(
+                    "{action} timed out after {}ms",
+                    timeout.as_millis()
+                )));
+            }
+            Ok(None) => std::thread::sleep(PROCESS_POLL_INTERVAL),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(GwtError::Git(format!("{action}: {error}")));
+            }
+        }
+    }
 }
 
 fn normalize_remote_ref(remote_ref: &str) -> String {
@@ -500,6 +544,18 @@ mod tests {
             .output()
             .expect("git init --bare");
         assert!(output.status.success(), "git init --bare failed");
+    }
+
+    fn slow_command() -> std::process::Command {
+        if cfg!(windows) {
+            let mut command = std::process::Command::new("powershell");
+            command.args(["-NoProfile", "-Command", "Start-Sleep -Milliseconds 250"]);
+            command
+        } else {
+            let mut command = std::process::Command::new("sh");
+            command.args(["-c", "sleep 0.25"]);
+            command
+        }
     }
 
     fn git_clone_repo(src: &Path, dst: &Path) {
@@ -948,6 +1004,23 @@ prunable gitdir file points to non-existent location
                 .delete_remote_branch("feature/missing", None)
                 .unwrap(),
             RemoteDeleteOutcome::SkippedMissing
+        );
+    }
+
+    #[test]
+    fn run_command_with_timeout_reports_timeout() {
+        let mut command = slow_command();
+        let err = run_command_with_timeout(
+            &mut command,
+            "git push origin --delete feature/slow",
+            std::time::Duration::from_millis(10),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("git push origin --delete feature/slow timed out"),
+            "unexpected timeout error: {err}"
         );
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -675,6 +675,14 @@ mod tests {
             !html.contains("merged to main") && !html.contains("merged to develop"),
             "expected cleanup copy to stop collapsing merge targets into abstract labels",
         );
+        assert!(
+            !html.contains("Branch cleanup timed out"),
+            "expected cleanup result handling to be driven by backend events, not a frontend timer"
+        );
+        assert!(
+            !html.contains("BRANCH_CLEANUP_TIMEOUT_MS"),
+            "expected branch cleanup to avoid a hard-coded frontend failure timeout"
+        );
     }
 
     #[test]

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -214,7 +214,6 @@
       let versionState = { current: "", latest: "" };
       let indexStatusState = { state: "", detail: "" };
       let projectError = "";
-      const BRANCH_CLEANUP_TIMEOUT_MS = 30000;
       const TERMINAL_SELECTION_DRAG_THRESHOLD = 4;
 
       function renderIndexStatus() {
@@ -1451,7 +1450,6 @@
               stage: "confirm",
               deleteRemote: false,
               results: [],
-              timeoutId: null,
             },
           });
         }
@@ -4248,13 +4246,6 @@
           .filter((entry) => Boolean(entry?.cleanup_ready));
       }
 
-      function clearBranchCleanupTimeout(state) {
-        if (state.cleanupModal.timeoutId !== null) {
-          clearTimeout(state.cleanupModal.timeoutId);
-          state.cleanupModal.timeoutId = null;
-        }
-      }
-
       function branchCleanupFailureResults(state, message) {
         const selectedBranches = Array.from(state.cleanupSelected);
         if (selectedBranches.length === 0) {
@@ -4280,7 +4271,6 @@
         if (state.cleanupModal.stage !== "running") {
           return false;
         }
-        clearBranchCleanupTimeout(state);
         state.cleanupModal.open = true;
         state.cleanupModal.stage = "result";
         state.cleanupModal.results = branchCleanupFailureResults(state, message);
@@ -4435,7 +4425,6 @@
         state.cleanupModal.stage = "confirm";
         state.cleanupModal.deleteRemote = false;
         state.cleanupModal.results = [];
-        clearBranchCleanupTimeout(state);
         branchCleanupWindowId = windowId;
         renderBranches(windowId);
       }
@@ -4450,7 +4439,6 @@
         if (state.cleanupModal.stage === "running") {
           return;
         }
-        clearBranchCleanupTimeout(state);
         state.cleanupModal.open = false;
         state.cleanupModal.stage = "confirm";
         state.cleanupModal.deleteRemote = false;
@@ -4472,17 +4460,6 @@
         state.notice = "";
         state.cleanupModal.stage = "running";
         state.cleanupModal.results = [];
-        clearBranchCleanupTimeout(state);
-        state.cleanupModal.timeoutId = window.setTimeout(() => {
-          if (
-            failRunningBranchCleanup(
-              windowId,
-              "Branch cleanup timed out. Check the branch list and try again.",
-            )
-          ) {
-            renderBranches(windowId);
-          }
-        }, BRANCH_CLEANUP_TIMEOUT_MS);
         renderBranchCleanupModal();
         send({
           kind: "run_branch_cleanup",
@@ -5939,7 +5916,6 @@
             const state = frontendUnits.branchesFileTreeSurface.ensureBranchListState(
               event.id,
             );
-            clearBranchCleanupTimeout(state);
             state.cleanupSelected.clear();
             state.cleanupModal.open = true;
             state.cleanupModal.stage = "result";

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,28 @@
 # Lessons Learned
 
+## 2026-04-27 — fix(cleanup): frontend timer で backend 実行結果を推測しない
+
+### 事象
+
+Branch Cleanup で remote branch delete を有効にすると、backend の cleanup thread と
+`git push --delete` がまだ実行中でも、frontend の固定 30 秒 timer が先に
+`Branch cleanup timed out` を表示できる状態だった。
+
+### 原因
+
+結果確定の source of truth が backend の `branch_cleanup_result` ではなく、
+frontend の推測 timer にも分散していた。remote delete はネットワーク・認証・複数 branch
+処理で 30 秒を超え得るため、UI だけが failure に進む race があった。
+
+### 再発防止策
+
+1. 長時間 backend operation の UI は frontend timer で failure 確定せず、backend result
+   event または connection loss を結果確定 signal にする。
+2. remote / network を含む Git 操作の timeout は backend 側で明示的に扱い、per-branch
+   result として success / partial / failed に落とす。
+3. frontend contract test では user-facing timeout copy だけでなく、固定 timeout 定数が
+   残っていないことも確認する。
+
 ## 2026-04-27 — fix(board): GUI watcher は hot path で同期せず lifecycle owner を持つ
 
 ### 事象


### PR DESCRIPTION
## Summary

- Removed the frontend-only Branch Cleanup failure timeout so long-running cleanup waits for backend result events instead of showing a false timeout.
- Added a backend timeout around remote branch deletion so slow `git push --delete` operations return per-branch failure data.
- Updated the cleanup contract and regression notes to keep backend events as the result source of truth.

## Changes

- `crates/gwt/web/app.js`: removes the hard-coded Branch Cleanup timeout timer and keeps result transitions driven by backend events or connection loss.
- `crates/gwt-git/src/worktree.rs`: runs remote branch deletion with a 120-second backend timeout while preserving stdout/stderr capture.
- `crates/gwt/src/embedded_web.rs`: adds a frontend contract test that rejects the old timeout copy and constant.
- `tasks/lessons.md`: records the recurrence-prevention lesson for frontend timer/backend result races.

## Testing

- [x] `cargo test -p gwt-git -p gwt-core -p gwt` — all tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — lint passes.
- [x] `cargo fmt -- --check` — format check passes.
- [x] `node --check crates/gwt/web/app.js` — frontend JavaScript syntax check passes.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` — markdown lint passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — commit message lint passes.

## Closing Issues

None

## Related Issues / Links

- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (not applicable: no schema or data change)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- Branch Cleanup could show `Branch cleanup timed out` after 30 seconds even when backend cleanup was still running, especially when remote branch deletion was enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented backend-controlled timeout handling for branch cleanup operations with improved error management.

* **Bug Fixes**
  * Eliminated client-side timeout timer that could incorrectly display timeout messages while backend operations were still processing.

* **Tests**
  * Added comprehensive timeout behavior validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->