### PR TITLE
fix(cleanup): drain remote delete command output

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -1,8 +1,10 @@
 //! Git worktree management
 
 use std::{
+    io::Read,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
@@ -356,18 +358,27 @@ fn run_command_with_timeout(
     let mut child = command
         .spawn()
         .map_err(|error| GwtError::Git(format!("{action}: {error}")))?;
+    let mut stdout = child.stdout.take().map(spawn_pipe_reader);
+    let mut stderr = child.stderr.take().map(spawn_pipe_reader);
     let started = Instant::now();
 
     loop {
         match child.try_wait() {
             Ok(Some(_)) => {
-                return child
-                    .wait_with_output()
-                    .map_err(|error| GwtError::Git(format!("{action}: {error}")));
+                let status = child
+                    .wait()
+                    .map_err(|error| GwtError::Git(format!("{action}: {error}")))?;
+                return Ok(Output {
+                    status,
+                    stdout: join_pipe_reader(stdout.take(), action, "stdout")?,
+                    stderr: join_pipe_reader(stderr.take(), action, "stderr")?,
+                });
             }
             Ok(None) if started.elapsed() >= timeout => {
                 let _ = child.kill();
                 let _ = child.wait();
+                join_pipe_reader_lossy(stdout.take());
+                join_pipe_reader_lossy(stderr.take());
                 return Err(GwtError::Git(format!(
                     "{action} timed out after {}ms",
                     timeout.as_millis()
@@ -377,9 +388,44 @@ fn run_command_with_timeout(
             Err(error) => {
                 let _ = child.kill();
                 let _ = child.wait();
+                join_pipe_reader_lossy(stdout.take());
+                join_pipe_reader_lossy(stderr.take());
                 return Err(GwtError::Git(format!("{action}: {error}")));
             }
         }
+    }
+}
+
+fn spawn_pipe_reader<T>(mut pipe: T) -> JoinHandle<std::io::Result<Vec<u8>>>
+where
+    T: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        pipe.read_to_end(&mut bytes).map(|_| bytes)
+    })
+}
+
+fn join_pipe_reader(
+    reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    action: &str,
+    stream: &str,
+) -> Result<Vec<u8>> {
+    let Some(reader) = reader else {
+        return Ok(Vec::new());
+    };
+    match reader.join() {
+        Ok(Ok(bytes)) => Ok(bytes),
+        Ok(Err(error)) => Err(GwtError::Git(format!("{action} read {stream}: {error}"))),
+        Err(_) => Err(GwtError::Git(format!(
+            "{action} read {stream}: reader thread panicked"
+        ))),
+    }
+}
+
+fn join_pipe_reader_lossy(reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>) {
+    if let Some(reader) = reader {
+        let _ = reader.join();
     }
 }
 
@@ -554,6 +600,22 @@ mod tests {
         } else {
             let mut command = std::process::Command::new("sh");
             command.args(["-c", "sleep 0.25"]);
+            command
+        }
+    }
+
+    fn verbose_command() -> std::process::Command {
+        if cfg!(windows) {
+            let mut command = std::process::Command::new("powershell");
+            command.args([
+                "-NoProfile",
+                "-Command",
+                "[Console]::Out.Write(('x' * 200000))",
+            ]);
+            command
+        } else {
+            let mut command = std::process::Command::new("sh");
+            command.args(["-c", "yes x | head -c 200000"]);
             command
         }
     }
@@ -1021,6 +1083,21 @@ prunable gitdir file points to non-existent location
             err.to_string()
                 .contains("git push origin --delete feature/slow timed out"),
             "unexpected timeout error: {err}"
+        );
+    }
+
+    #[test]
+    fn run_command_with_timeout_drains_verbose_child_output() {
+        let mut command = verbose_command();
+        let output =
+            run_command_with_timeout(&mut command, "verbose child", Duration::from_secs(5))
+                .expect("verbose child should exit without filling pipe buffers");
+
+        assert!(output.status.success());
+        assert!(
+            output.stdout.len() >= 200_000,
+            "expected captured stdout, got {} bytes",
+            output.stdout.len()
         );
     }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,27 @@
 # Lessons Learned
 
+## 2026-04-27 — fix(process): timeout 付き process は pipe を実行中に drain する
+
+### 事象
+
+Branch Cleanup の remote delete timeout 対応で `git push --delete` の stdout/stderr を
+pipe したが、child 終了後にだけ `wait_with_output()` 相当の回収を行っていたため、
+remote hook などの出力が多い場合に pipe buffer が詰まり、child が終了前に block して
+false timeout になる可能性があった。
+
+### 原因
+
+`Command::output()` は実行中に pipe を drain するが、timeout polling のために
+`spawn()` + `try_wait()` へ置き換えた際、その drain 責務を移植していなかった。
+
+### 再発防止策
+
+1. timeout 付き subprocess helper で stdout/stderr を pipe する場合、child 実行中に別 thread
+   または async task で drain する。
+2. `Command::output()` から `spawn()` polling へ置き換える変更では、exit status だけでなく
+   stdout/stderr capture の同等性を回帰テストで固定する。
+3. verbose child のテストを追加し、pipe buffer 詰まりによる false timeout を検知する。
+
 ## 2026-04-27 — fix(cleanup): frontend timer で backend 実行結果を推測しない
 
 ### 事象


### PR DESCRIPTION
## Summary

- Drains stdout and stderr while enforcing the remote branch delete timeout, preventing verbose child processes from blocking on full pipe buffers.
- Adds a verbose child regression test so cleanup command timeouts keep the same output-capture behavior as Command::output().
- Records the process-timeout lesson to avoid reintroducing false timeout paths.

## Changes

- `crates/gwt-git/src/worktree.rs`: spawn reader threads for piped stdout/stderr during timeout polling and join captured output after process exit.
- `crates/gwt-git/src/worktree.rs`: add a verbose child regression test that would fail if pipe buffers are not drained while the child runs.
- `tasks/lessons.md`: document the pipe-drain requirement for timeout subprocess helpers.

## Testing

- [x] `cargo test -p gwt-git run_command_with_timeout -- --nocapture` - targeted timeout tests pass, including the verbose child regression.
- [x] `cargo test -p gwt-git -p gwt-core -p gwt` - workspace package tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - clippy passes with warnings denied.
- [x] `cargo fmt -- --check` - formatting check passes.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` - lesson markdown passes lint.
- [x] `git diff --check` - whitespace check passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - commit message passes commitlint.

## Closing Issues

None

## Related Issues / Links

- #2206
- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (internal lesson recorded; no user-facing docs change needed)
- [ ] Migration/backfill plan included (not applicable: no schema or data change)
- [x] CHANGELOG impact considered (patch-level bug fix)

## Context

- Follow-up to the post-merge Codex review on #2206. The review correctly noted that replacing `Command::output()` with `spawn()` + `try_wait()` must also preserve active stdout/stderr draining.

## Risk / Impact

- **Affected areas**: branch cleanup remote delete command execution and shared timeout helper behavior in `gwt-git` worktree cleanup.
- **Rollback plan**: revert this commit if the reader-thread implementation causes unexpected process handling issues.
