### PR TITLE
fix(cleanup): avoid timeout hang on inherited pipes

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -377,8 +377,10 @@ fn run_command_with_timeout(
             Ok(None) if started.elapsed() >= timeout => {
                 let _ = child.kill();
                 let _ = child.wait();
-                join_pipe_reader_lossy(stdout.take());
-                join_pipe_reader_lossy(stderr.take());
+                // Descendant processes can inherit these pipe handles. Joining here would
+                // let them extend the timeout/error path beyond the requested deadline.
+                drop(stdout.take());
+                drop(stderr.take());
                 return Err(GwtError::Git(format!(
                     "{action} timed out after {}ms",
                     timeout.as_millis()
@@ -388,8 +390,8 @@ fn run_command_with_timeout(
             Err(error) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                join_pipe_reader_lossy(stdout.take());
-                join_pipe_reader_lossy(stderr.take());
+                drop(stdout.take());
+                drop(stderr.take());
                 return Err(GwtError::Git(format!("{action}: {error}")));
             }
         }
@@ -420,12 +422,6 @@ fn join_pipe_reader(
         Err(_) => Err(GwtError::Git(format!(
             "{action} read {stream}: reader thread panicked"
         ))),
-    }
-}
-
-fn join_pipe_reader_lossy(reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>) {
-    if let Some(reader) = reader {
-        let _ = reader.join();
     }
 }
 
@@ -616,6 +612,22 @@ mod tests {
         } else {
             let mut command = std::process::Command::new("sh");
             command.args(["-c", "yes x | head -c 200000"]);
+            command
+        }
+    }
+
+    fn lingering_pipe_command() -> std::process::Command {
+        if cfg!(windows) {
+            let mut command = std::process::Command::new("powershell");
+            command.args([
+                "-NoProfile",
+                "-Command",
+                "$psi = [Diagnostics.ProcessStartInfo]::new('powershell'); $psi.Arguments = '-NoProfile -Command Start-Sleep -Milliseconds 3000'; $psi.UseShellExecute = $false; [Diagnostics.Process]::Start($psi) | Out-Null; Start-Sleep -Milliseconds 3000",
+            ]);
+            command
+        } else {
+            let mut command = std::process::Command::new("sh");
+            command.args(["-c", "(sleep 3) & sleep 3"]);
             command
         }
     }
@@ -1098,6 +1110,28 @@ prunable gitdir file points to non-existent location
             output.stdout.len() >= 200_000,
             "expected captured stdout, got {} bytes",
             output.stdout.len()
+        );
+    }
+
+    #[test]
+    fn run_command_with_timeout_does_not_wait_for_lingering_descendant_pipes() {
+        let mut command = lingering_pipe_command();
+        let started = Instant::now();
+        let err = run_command_with_timeout(
+            &mut command,
+            "lingering descendant",
+            Duration::from_millis(500),
+        )
+        .unwrap_err();
+        let elapsed = started.elapsed();
+
+        assert!(
+            err.to_string().contains("lingering descendant timed out"),
+            "unexpected timeout error: {err}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(1500),
+            "timeout path waited for descendant pipe handles for {elapsed:?}"
         );
     }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,25 @@
 # Lessons Learned
 
+## 2026-04-27 — fix(process): timeout path で pipe reader を blocking join しない
+
+### 事象
+
+timeout 付き subprocess helper で stdout/stderr を drain thread に移したあと、
+timeout/error path でも reader thread を `join()` していたため、子孫 process が
+pipe handle を継承して生存している場合に EOF が届かず、timeout 後の return が
+さらに待たされる可能性があった。
+
+### 原因
+
+正常終了時の output capture と timeout/error 時の deadline 保証を同じ join 処理で扱い、
+timeout 後は output capture よりも caller へ戻ることを優先する必要がある点を分離していなかった。
+
+### 再発防止策
+
+1. timeout/error path では、終了を保証できない reader thread を blocking join しない。
+2. pipe drain thread は正常終了時だけ join して output を回収し、timeout/error 時は detach する。
+3. 子孫 process が pipe handle を保持する command で、timeout 後に短時間で戻ることをテストする。
+
 ## 2026-04-27 — fix(process): timeout 付き process は pipe を実行中に drain する
 
 ### 事象


### PR DESCRIPTION
## Summary

- Avoids blocking joins on stdout/stderr drain threads after command timeout or process polling errors.
- Preserves the timeout contract when descendant processes inherit pipe handles and remain alive after the direct child is killed.
- Adds a regression test for lingering descendant pipe handles and records the lesson.

## Changes

- `crates/gwt-git/src/worktree.rs`: detach drain threads on timeout/error paths instead of joining readers that may wait indefinitely for EOF.
- `crates/gwt-git/src/worktree.rs`: add `run_command_with_timeout_does_not_wait_for_lingering_descendant_pipes` to cover descendants that inherit stdout/stderr handles.
- `tasks/lessons.md`: document the timeout-path rule for subprocess pipe reader threads.

## Testing

- [x] `cargo test -p gwt-git run_command_with_timeout -- --nocapture` - targeted timeout tests pass, including verbose output and lingering descendant pipe coverage.
- [x] `cargo test -p gwt-git -p gwt-core -p gwt` - workspace package tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - clippy passes with warnings denied.
- [x] `cargo fmt -- --check` - formatting check passes.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` - lesson markdown passes lint.
- [x] `git diff --check` - whitespace check passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - commit message passes commitlint.

## Closing Issues

None

## Related Issues / Links

- #2207
- #2206
- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (internal lesson recorded; no user-facing docs change needed)
- [ ] Migration/backfill plan included (not applicable: no schema or data change)
- [x] CHANGELOG impact considered (patch-level bug fix)

## Context

- Follow-up to the post-merge Codex review on #2207. The review correctly noted that timeout/error paths must not block on drain thread joins when descendants keep inherited pipe handles open.

## Risk / Impact

- **Affected areas**: branch cleanup remote delete command timeout handling in `gwt-git`.
- **Rollback plan**: revert this commit if detached drain threads cause unexpected process-resource behavior.
