### PR TITLE
fix(workspace): center launched windows on viewport with cascade

### DIFF
--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -2838,34 +2838,42 @@ impl AppRuntime {
                     self.launch_wizard_state_broadcast(None),
                 ]
             }
-            Some(LaunchWizardCompletion::Launch(config)) => match *config {
-                LaunchWizardLaunchRequest::Agent(config) => {
-                    match self.spawn_agent_window(&session.tab_id, *config, bounds) {
-                        Ok(mut events) => {
-                            events.push(self.launch_wizard_state_broadcast(None));
-                            events
+            Some(LaunchWizardCompletion::Launch(config)) => {
+                let Some(bounds) = bounds else {
+                    session.wizard.error =
+                        Some("Viewport bounds are required to launch a window".to_string());
+                    self.launch_wizard = Some(session);
+                    return vec![self.launch_wizard_state_outbound()];
+                };
+                match *config {
+                    LaunchWizardLaunchRequest::Agent(config) => {
+                        match self.spawn_agent_window(&session.tab_id, *config, bounds) {
+                            Ok(mut events) => {
+                                events.push(self.launch_wizard_state_broadcast(None));
+                                events
+                            }
+                            Err(error) => {
+                                session.wizard.error = Some(error);
+                                self.launch_wizard = Some(session);
+                                vec![self.launch_wizard_state_outbound()]
+                            }
                         }
-                        Err(error) => {
-                            session.wizard.error = Some(error);
-                            self.launch_wizard = Some(session);
-                            vec![self.launch_wizard_state_outbound()]
+                    }
+                    LaunchWizardLaunchRequest::Shell(config) => {
+                        match self.spawn_wizard_shell_window(&session.tab_id, *config, bounds) {
+                            Ok(mut events) => {
+                                events.push(self.launch_wizard_state_broadcast(None));
+                                events
+                            }
+                            Err(error) => {
+                                session.wizard.error = Some(error);
+                                self.launch_wizard = Some(session);
+                                vec![self.launch_wizard_state_outbound()]
+                            }
                         }
                     }
                 }
-                LaunchWizardLaunchRequest::Shell(config) => {
-                    match self.spawn_wizard_shell_window(&session.tab_id, *config, bounds) {
-                        Ok(mut events) => {
-                            events.push(self.launch_wizard_state_broadcast(None));
-                            events
-                        }
-                        Err(error) => {
-                            session.wizard.error = Some(error);
-                            self.launch_wizard = Some(session);
-                            vec![self.launch_wizard_state_outbound()]
-                        }
-                    }
-                }
-            },
+            }
             None => {
                 self.launch_wizard = Some(session);
                 vec![self.launch_wizard_state_outbound()]
@@ -3249,7 +3257,7 @@ impl AppRuntime {
         &mut self,
         tab_id: &str,
         config: gwt_agent::LaunchConfig,
-        bounds: Option<WindowGeometry>,
+        bounds: WindowGeometry,
     ) -> Result<Vec<OutboundEvent>, String> {
         let tab = self
             .tab_mut(tab_id)
@@ -3260,18 +3268,9 @@ impl AppRuntime {
             config.display_name,
             config.branch.as_ref().unwrap_or(&"workspace".to_string())
         );
-        let default_bounds = WindowGeometry {
-            x: 100.0,
-            y: 40.0,
-            width: 1000.0,
-            height: 760.0,
-        };
-        let window = tab.workspace.add_window_with_title(
-            WindowPreset::Agent,
-            title.clone(),
-            false,
-            bounds.unwrap_or(default_bounds),
-        );
+        let window =
+            tab.workspace
+                .add_window_with_title(WindowPreset::Agent, title.clone(), false, bounds);
         self.register_window(tab_id, &window.id);
         let window_id = combined_window_id(tab_id, &window.id);
 
@@ -3308,7 +3307,7 @@ impl AppRuntime {
         &mut self,
         tab_id: &str,
         config: ShellLaunchConfig,
-        bounds: Option<WindowGeometry>,
+        bounds: WindowGeometry,
     ) -> Result<Vec<OutboundEvent>, String> {
         let tab = self
             .tab_mut(tab_id)
@@ -3319,18 +3318,9 @@ impl AppRuntime {
             config.display_name,
             config.branch.as_ref().unwrap_or(&"workspace".to_string())
         );
-        let default_bounds = WindowGeometry {
-            x: 100.0,
-            y: 40.0,
-            width: 1000.0,
-            height: 760.0,
-        };
-        let window = tab.workspace.add_window_with_title(
-            WindowPreset::Shell,
-            title,
-            false,
-            bounds.unwrap_or(default_bounds),
-        );
+        let window = tab
+            .workspace
+            .add_window_with_title(WindowPreset::Shell, title, false, bounds);
         self.register_window(tab_id, &window.id);
         let window_id = combined_window_id(tab_id, &window.id);
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1026,7 +1026,7 @@ mod tests {
     fn embedded_web_launch_wizard_actions_flow_through_named_transport() {
         let html = frontend_bundle_source();
         let submit_bounds = regex::Regex::new(
-            r#"function sendWizardAction\(action\)\s*\{\s*const payload = \{\s*kind:\s*"launch_wizard_action",\s*action,\s*\};\s*if\s*\(\s*action\.kind === "submit"\s*\)\s*\{\s*payload\.bounds = visibleBounds\(\);\s*\}\s*send\(payload\);\s*\}"#,
+            r#"function sendWizardAction\(action\)\s*\{\s*send\(\{\s*kind:\s*"launch_wizard_action",\s*action,\s*bounds:\s*visibleBounds\(\),\s*\}\);\s*\}"#,
         )
         .expect("valid regex");
         let close_controls = regex::Regex::new(
@@ -1049,7 +1049,7 @@ mod tests {
         );
         assert!(
             submit_bounds.is_match(html),
-            "expected wizard actions to be normalized through launch_wizard_action and attach visible bounds on submit",
+            "expected wizard actions to be normalized through launch_wizard_action and always attach visible bounds",
         );
         assert!(
             close_controls.is_match(html),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2288,7 +2288,7 @@ mod tests {
                 index: 0,
                 mode: QuickStartLaunchMode::Resume,
             },
-            None,
+            Some(canvas_bounds()),
         );
         assert!(!missing_focus.is_empty());
 
@@ -2302,7 +2302,7 @@ mod tests {
                 index: 0,
                 mode: QuickStartLaunchMode::Resume,
             },
-            None,
+            Some(canvas_bounds()),
         );
         assert!(focus_events.len() >= 2);
         assert!(runtime.launch_wizard.is_none());

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -13,6 +13,9 @@ const STACK_OFFSET_Y: f64 = 24.0;
 const STACK_START_INSET: f64 = 48.0;
 const MIN_WINDOW_WIDTH: f64 = 360.0;
 const MIN_WINDOW_HEIGHT: f64 = 260.0;
+/// Limit cascade depth so an N-th launch (N >= CASCADE_RING_LIMIT) wraps back to
+/// the viewport center instead of marching off-screen indefinitely.
+const CASCADE_RING_LIMIT: usize = 8;
 
 #[derive(Debug, Clone)]
 pub struct WorkspaceState {
@@ -162,13 +165,36 @@ impl WorkspaceState {
         bounds: WindowGeometry,
     ) -> PersistedWindowState {
         let (width, height) = preset.default_size();
+        let center_x = bounds.x + (bounds.width - width) / 2.0;
+        let center_y = bounds.y + (bounds.height - height) / 2.0;
+
+        // Walk the cascade slots starting at the viewport center and pick the
+        // first one that no visible window already occupies. Hitting the ring
+        // limit wraps back to center so the window never marches off screen.
+        let mut step = 0usize;
+        while step < CASCADE_RING_LIMIT {
+            let candidate_x = center_x + (step as f64) * STACK_OFFSET_X;
+            let candidate_y = center_y + (step as f64) * STACK_OFFSET_Y;
+            let occupied = self.persisted.windows.iter().any(|w| {
+                !w.minimized
+                    && !w.maximized
+                    && (w.geometry.x - candidate_x).abs() < 1.0
+                    && (w.geometry.y - candidate_y).abs() < 1.0
+            });
+            if !occupied {
+                break;
+            }
+            step += 1;
+        }
+        let step = (step % CASCADE_RING_LIMIT) as f64;
+
         let window = PersistedWindowState {
             id: self.next_window_id(preset),
             title: title.into(),
             preset,
             geometry: WindowGeometry {
-                x: bounds.x + (bounds.width - width) / 2.0,
-                y: bounds.y + (bounds.height - height) / 2.0,
+                x: center_x + step * STACK_OFFSET_X,
+                y: center_y + step * STACK_OFFSET_Y,
                 width,
                 height,
             },
@@ -385,7 +411,10 @@ impl WorkspaceState {
 mod tests {
     use super::*;
     use crate::{
-        persistence::{default_canvas_viewport, default_workspace_state, WindowProcessStatus},
+        persistence::{
+            default_canvas_viewport, default_workspace_state, empty_workspace_state,
+            WindowProcessStatus,
+        },
         protocol::FocusCycleDirection,
     };
 
@@ -440,6 +469,82 @@ mod tests {
         assert_eq!(window.title, "Branches");
         assert_eq!(window.preset, WindowPreset::Branches);
         assert_eq!(window.status, WindowProcessStatus::Running);
+    }
+
+    #[test]
+    fn adding_window_centers_in_bounds() {
+        let mut workspace = WorkspaceState::from_persisted(empty_workspace_state());
+        let bounds = WindowGeometry {
+            x: 0.0,
+            y: 0.0,
+            width: 1440.0,
+            height: 920.0,
+        };
+
+        let window = workspace.add_window(WindowPreset::Shell, bounds.clone());
+
+        // Shell preset is 720x420 so the geometry must center inside bounds.
+        assert_eq!(window.geometry.x, 360.0);
+        assert_eq!(window.geometry.y, 250.0);
+    }
+
+    #[test]
+    fn adding_multiple_windows_cascades_from_center() {
+        let mut workspace = WorkspaceState::from_persisted(empty_workspace_state());
+        let bounds = WindowGeometry {
+            x: 0.0,
+            y: 0.0,
+            width: 1440.0,
+            height: 920.0,
+        };
+
+        let first = workspace.add_window(WindowPreset::Shell, bounds.clone());
+        let second = workspace.add_window(WindowPreset::Shell, bounds.clone());
+        let third = workspace.add_window(WindowPreset::Shell, bounds.clone());
+
+        assert_eq!((first.geometry.x, first.geometry.y), (360.0, 250.0));
+        assert_eq!((second.geometry.x, second.geometry.y), (388.0, 274.0));
+        assert_eq!((third.geometry.x, third.geometry.y), (416.0, 298.0));
+    }
+
+    #[test]
+    fn adding_window_resets_after_cascade_ring_limit() {
+        let mut workspace = WorkspaceState::from_persisted(empty_workspace_state());
+        let bounds = WindowGeometry {
+            x: 0.0,
+            y: 0.0,
+            width: 1440.0,
+            height: 920.0,
+        };
+
+        // Fill the entire cascade ring (8 windows occupy steps 0..7).
+        for _ in 0..8 {
+            workspace.add_window(WindowPreset::Shell, bounds.clone());
+        }
+        // The 9th launch must wrap back to the viewport center so windows do
+        // not march off screen indefinitely.
+        let ninth = workspace.add_window(WindowPreset::Shell, bounds.clone());
+
+        assert_eq!((ninth.geometry.x, ninth.geometry.y), (360.0, 250.0));
+    }
+
+    #[test]
+    fn adding_window_skips_minimized_collisions() {
+        let mut workspace = WorkspaceState::from_persisted(empty_workspace_state());
+        let bounds = WindowGeometry {
+            x: 0.0,
+            y: 0.0,
+            width: 1440.0,
+            height: 920.0,
+        };
+
+        let first = workspace.add_window(WindowPreset::Shell, bounds.clone());
+        assert!(workspace.minimize_window(&first.id));
+
+        // A minimized window must not block the cascade slot it was created in,
+        // so the next launch lands back at the viewport center.
+        let next = workspace.add_window(WindowPreset::Shell, bounds.clone());
+        assert_eq!((next.geometry.x, next.geometry.y), (360.0, 250.0));
     }
 
     #[test]

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1798,14 +1798,11 @@
       }
 
       function sendWizardAction(action) {
-        const payload = {
+        send({
           kind: "launch_wizard_action",
           action,
-        };
-        if (action.kind === "submit") {
-          payload.bounds = visibleBounds();
-        }
-        send(payload);
+          bounds: visibleBounds(),
+        });
       }
 
       function createNode(tagName, className, textContent) {


### PR DESCRIPTION
## Summary

- Launch Wizard の quick-start カードから起動した window が viewport 中心ではなく workspace 原点 (100, 40) 付近に配置される問題を修正し、すべての起動経路（quick-start / Submit / `+` モーダル / Issue 起点）で常に現在表示中の viewport 中心に出るようにした。
- 連続起動時は中央を起点に `STACK_OFFSET_X/Y` 刻みでカスケードオフセットし、`CASCADE_RING_LIMIT` で 9 枚目に中央へリングするようにして、重なりで「最後の 1 枚しか見えない」状態を解消。
- `bounds` 引数のサイレント fallback (`default_bounds (100,40,1000,760)`) を撤廃し、未送信時はエラーを wizard に積んで再表示する。

## Changes

- `crates/gwt/web/app.js`: `sendWizardAction` の条件分岐を撤廃し、すべての wizard action で `bounds: visibleBounds()` を同梱するよう変更。
- `crates/gwt/src/app_runtime.rs`: `spawn_agent_window` / `spawn_wizard_shell_window` の `bounds: Option<WindowGeometry>` を `WindowGeometry` に必須化、ハードコードされた `default_bounds` を削除。`handle_launch_wizard_action` は Launch 完了時に `bounds=None` ならエラーを wizard に積む。
- `crates/gwt/src/workspace.rs`: `add_window_with_title` を中央起点カスケード配置に変更（衝突スロットを順次走査し空きへ配置、`CASCADE_RING_LIMIT=8` で 9 枚目に中央へ戻る）。`adding_window_centers_in_bounds` / `adding_multiple_windows_cascades_from_center` / `adding_window_resets_after_cascade_ring_limit` / `adding_window_skips_minimized_collisions` の 4 ユニットテストを追加。
- `crates/gwt/src/embedded_web.rs`: `sendWizardAction` の正規表現スナップショットを「常時 bounds 同梱」の新形に更新。
- `crates/gwt/src/main.rs`: 既存テスト `wizard_handler_helpers_cover_hydration_preparation_focus_and_error_paths` がサイレント fallback に依存していたため、明示的に `Some(canvas_bounds())` を渡すよう更新。

## Testing

- [x] `cargo fmt --check` — 差分なし。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — エラー・警告ともゼロ。
- [x] `cargo test -p gwt-core -p gwt` — 全 172 件パス（新規 4 件含む）。
- [ ] 手動 GUI 検証（Windows）— `cargo run -p gwt` で起動し、Launch Wizard の quick-start "Start new" / Submit / `+` モーダルからそれぞれ window を起動し、現在 viewport 中央に出ること、連続起動でカスケードして重ならないこと、`origin/develop` ベースで既存 window のドラッグ／最小化／最大化に回帰がないことを確認する。レビュア環境で実施予定。

## Closing Issues

- None

## Related Issues / Links

- SPEC-2008 (#2008) — Canvas ワークスペース・ビューポート・フローティングウィンドウの仕様。本修正は同 SPEC が定義する「ビューポート相対の window 配置」に整合するための実装欠陥修正。
- 過去対応: `e6148ab9` / `43942b5f` — CreateWindow / FocusWindow / Submit 経由の bounds 配線を整備したが quick-start パスとカスケードを扱っておらず本 PR で完結させる。

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — UI 表示文言の追加なし、内部挙動変更のみのため README 更新不要
- [x] Migration/backfill plan included (if schema/data change) — 既存 `PersistedWindowState.geometry` フォーマットは不変、追加マイグレーション不要
- [x] CHANGELOG impact considered (breaking change flagged in commit) — 破壊的変更なし、`fix:` で patch リリースに合流


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wizard window launch now enforces required viewport bounds validation, preventing launch failures.

* **Improvements**
  * Multiple wizard windows now cascade into distinct positions instead of overlapping at the center, improving visibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->