### PR TITLE
chore(release): v9.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [9.11.2] - 2026-04-29
+
+### Bug Fixes
+
+- **gui:** Launch Agentの利用不能な前回Agentからフォールバックする
+
 ## [9.11.1] - 2026-04-28
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "axum",
  "base64",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "chrono",
  "dunce",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "dirs",
  "serde",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "fs2",
  "regex",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.11.1"
+version = "9.11.2"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.11.1"
+version = "9.11.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1137,11 +1137,18 @@ impl LaunchWizardState {
     }
 
     fn apply_previous_profile(&mut self, profile: LaunchWizardPreviousProfile) -> bool {
-        let Some(agent) = self
+        let saved_agent = self
             .detected_agents
             .iter()
-            .find(|candidate| candidate.id == profile.agent_id)
-        else {
+            .find(|candidate| candidate.id == profile.agent_id);
+        let Some(agent) = (match saved_agent {
+            Some(agent) if agent.available => Some(agent),
+            Some(_) => self
+                .detected_agents
+                .iter()
+                .find(|candidate| candidate.available),
+            None => None,
+        }) else {
             return false;
         };
 
@@ -3943,7 +3950,7 @@ mod tests {
     }
 
     #[test]
-    fn previous_profile_restores_unavailable_agent_and_blocks_launch() {
+    fn previous_profile_falls_back_when_saved_agent_is_unavailable() {
         let mut options = sample_agent_options();
         options
             .iter_mut()
@@ -3969,7 +3976,36 @@ mod tests {
             }),
         );
 
-        assert_eq!(state.view().selected_agent_id, "codex");
+        assert_eq!(state.view().selected_agent_id, "claude");
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
+    }
+
+    #[test]
+    fn previous_profile_still_blocks_when_no_agent_is_available() {
+        let mut options = sample_agent_options();
+        for option in &mut options {
+            option.available = false;
+        }
+        let state = LaunchWizardState::open_with_previous_profile(
+            context(branch("feature/current"), "feature/current"),
+            options,
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                session_mode: gwt_agent::SessionMode::Normal,
+                skip_permissions: true,
+                codex_fast_mode: true,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+                windows_shell: None,
+            }),
+        );
+
         assert_eq!(
             state.build_launch_config().unwrap_err(),
             "Agent option is unavailable"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.11.1",
+  "version": "9.11.2",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Prepare the v9.11.2 patch release.

## Changes

- Bump the Rust workspace and npm package versions to 9.11.2.
- Update Cargo.lock workspace package versions.
- Add the v9.11.2 CHANGELOG entry for the Launch Agent fallback fix.

## Version

v9.11.2

## Closing Issues

None

## Related Issues / Links

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a GUI issue where launch would fail when the previously configured Agent was unavailable; the application now automatically falls back to the first available Agent instead of blocking the launch process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->