### PR TITLE
chore(release): v9.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [9.11.4] - 2026-04-29
+
+### Bug Fixes
+
+- **gui:** Sync Launch Wizard agent selection
+
 ## [9.11.3] - 2026-04-29
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "axum",
  "base64",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "chrono",
  "dunce",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "reqwest",
  "serde",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "dirs",
  "serde",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "fs2",
  "regex",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "chrono",
  "fs2",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.11.3"
+version = "9.11.4"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.11.3"
+version = "9.11.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1276,10 +1276,13 @@ impl LaunchWizardState {
         match self
             .detected_agents
             .iter()
-            .find(|candidate| candidate.id == agent_id)
+            .position(|candidate| candidate.id == agent_id)
         {
-            Some(candidate) if candidate.available => {
+            Some(index) if self.detected_agents[index].available => {
                 self.agent_id = agent_id.to_string();
+                if self.step == LaunchWizardStep::AgentSelect {
+                    self.selected = index;
+                }
                 self.sync_selected_agent_options();
             }
             _ => {
@@ -4010,6 +4013,32 @@ mod tests {
             state.build_launch_config().unwrap_err(),
             "Agent option is unavailable"
         );
+    }
+
+    #[test]
+    fn set_agent_keeps_launch_config_on_selected_agent_when_index_is_stale() {
+        let mut options = sample_agent_options();
+        options
+            .iter_mut()
+            .find(|option| option.id == "claude")
+            .expect("claude option")
+            .available = false;
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/current"), "feature/current"),
+            options,
+            Vec::new(),
+        );
+        state.step = LaunchWizardStep::AgentSelect;
+        state.selected = 0;
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "codex".to_string(),
+        });
+
+        assert_eq!(state.error, None);
+        assert_eq!(state.agent_id, "codex");
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::Codex);
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -995,6 +995,44 @@ mod tests {
         }]
     }
 
+    fn sample_wizard_stale_agent_options() -> Vec<AgentOption> {
+        let (command, default_args) = if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "echo".to_string(), "ok".to_string()],
+            )
+        } else {
+            ("/bin/echo".to_string(), vec!["ok".to_string()])
+        };
+        vec![
+            AgentOption {
+                id: "claude".to_string(),
+                name: "Claude Code".to_string(),
+                available: false,
+                installed_version: None,
+                versions: Vec::new(),
+                custom_agent: None,
+            },
+            AgentOption {
+                id: "echo-agent".to_string(),
+                name: "Echo Agent".to_string(),
+                available: true,
+                installed_version: Some("test".to_string()),
+                versions: Vec::new(),
+                custom_agent: Some(gwt_agent::CustomCodingAgent {
+                    id: "echo-agent".to_string(),
+                    display_name: "Echo Agent".to_string(),
+                    agent_type: gwt_agent::custom::CustomAgentType::Command,
+                    command,
+                    default_args,
+                    mode_args: None,
+                    skip_permissions_args: Vec::new(),
+                    env: HashMap::new(),
+                }),
+            },
+        ]
+    }
+
     fn sample_wizard_quick_start_entry(live_window_id: Option<&str>) -> QuickStartEntry {
         QuickStartEntry {
             session_id: "gwt-session-1".to_string(),
@@ -2330,6 +2368,83 @@ mod tests {
                 .linked_issue_number,
             Some(99)
         );
+    }
+
+    #[test]
+    fn launch_wizard_action_flow_launches_agent_when_selected_index_is_stale() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut runtime = sample_runtime(
+            temp.path(),
+            vec![sample_project_tab(
+                "tab-1",
+                "Repo",
+                repo.clone(),
+                ProjectKind::NonRepo,
+                &[WindowPreset::Issue],
+            )],
+            Some("tab-1"),
+        );
+        runtime.launch_wizard = Some(LaunchWizardSession {
+            tab_id: "tab-1".to_string(),
+            wizard_id: "wizard-stale-agent".to_string(),
+            wizard: LaunchWizardState::open_with(
+                LaunchWizardContext {
+                    selected_branch: sample_branch_entry("feature/demo"),
+                    normalized_branch_name: "feature/demo".to_string(),
+                    worktree_path: Some(repo.clone()),
+                    quick_start_root: repo.clone(),
+                    live_sessions: Vec::new(),
+                    docker_context: None,
+                    docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+                    linked_issue_number: Some(42),
+                },
+                sample_wizard_stale_agent_options(),
+                Vec::new(),
+            ),
+        });
+        {
+            let wizard = &mut runtime.launch_wizard.as_mut().unwrap().wizard;
+            wizard.step = gwt::LaunchWizardStep::AgentSelect;
+            wizard.selected = 0;
+        }
+
+        let set_agent_events = runtime.handle_launch_wizard_action(
+            LaunchWizardAction::SetAgent {
+                agent_id: "echo-agent".to_string(),
+            },
+            Some(canvas_bounds()),
+        );
+        assert_eq!(set_agent_events.len(), 1);
+        assert_eq!(
+            runtime
+                .launch_wizard
+                .as_ref()
+                .unwrap()
+                .wizard
+                .error
+                .as_deref(),
+            None
+        );
+
+        let launch_events =
+            runtime.handle_launch_wizard_action(LaunchWizardAction::Submit, Some(canvas_bounds()));
+
+        assert!(runtime.launch_wizard.is_none());
+        assert!(launch_events.iter().any(|event| {
+            matches!(
+                event.event,
+                BackendEvent::LaunchWizardState { wizard: None }
+            )
+        }));
+        let tab = runtime.tab("tab-1").expect("tab");
+        assert!(tab
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .any(|window| window.preset == WindowPreset::Agent));
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.11.3",
+  "version": "9.11.4",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,25 @@
 # Lessons Learned
 
+## 2026-04-29 — test(gui): Launch Wizard 修正は action flow と E2E まで同時に固定する
+
+### 事象
+
+Launch Wizard の agent 選択不具合で、原因調査と unit regression だけを先行し、
+ユーザーから「テストやE2Eテストを実行していないのですか？」、
+「調査と同時にテストしてください」と指摘された。
+
+### 原因
+
+状態モデル上の `agent_id` と UI の `selected` index がずれる不具合は、
+`LaunchWizardState` 単体だけでなく `handle_launch_wizard_action` 経由の
+submit path まで確認しないと、実際の GUI launch path の再発防止にならない。
+
+### 再発防止策
+
+1. Launch Wizard の選択・submit 系修正では、state unit test と runtime action flow test を同時に追加する。
+2. ユーザー操作で起きる GUI 不具合は、調査と並行して再現テストを RED にしてから実装する。
+3. 完了前に unit / integration / frontend smoke / ignored E2E の実行結果を揃えて報告する。
+
 ## 2026-04-29 — fix(shell): GUI shell terminal は login shell 初期化を読む必要がある
 
 ### 事象


### PR DESCRIPTION
## Summary
Release v9.11.4 from develop to main.

## Changes
- Fixed Launch Wizard agent selection synchronization so selecting an available agent no longer fails with "Agent option is unavailable".
- Bumped Cargo workspace, Cargo.lock package versions, and npm package metadata to 9.11.4.
- Updated CHANGELOG.md with the v9.11.4 bug fix entry.

## Version
v9.11.4

## Closing Issues
None

## Related Issues / Links
None
