### PR TITLE
chore(release): v9.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [9.11.6] - 2026-04-29
+
+### Bug Fixes
+
+- Make launch agent wizard runtime-first
+
 ## [9.11.5] - 2026-04-29
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "axum",
  "base64",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "chrono",
  "dunce",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "reqwest",
  "serde",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "dirs",
  "serde",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "fs2",
  "regex",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "chrono",
  "fs2",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.11.5"
+version = "9.11.6"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.11.5"
+version = "9.11.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -951,7 +951,8 @@ fn normalize_docker_launch_action(
         | DockerLifecycleIntent::Restart
         | DockerLifecycleIntent::CreateAndStart => match status {
             ComposeServiceStatus::Running => DockerLaunchServiceAction::Connect,
-            ComposeServiceStatus::Stopped
+            ComposeServiceStatus::Unknown
+            | ComposeServiceStatus::Stopped
             | ComposeServiceStatus::Exited
             | ComposeServiceStatus::NotFound => DockerLaunchServiceAction::Start,
         },

--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -68,6 +68,7 @@ pub enum CommandOutputStream {
 /// Status of a Docker Compose service.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ComposeServiceStatus {
+    Unknown,
     Running,
     Stopped,
     Exited,

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -2811,9 +2811,19 @@ impl AppRuntime {
         };
         let action_stage = Self::launch_wizard_action_error_stage(&action);
         let action_label = Self::launch_wizard_action_label(&action);
+        let requested_agent_id = match &action {
+            gwt::LaunchWizardAction::SetAgent { agent_id } => Some(agent_id.clone()),
+            _ => None,
+        };
         session.wizard.apply(action);
         if let Some(error) = session.wizard.error.as_deref() {
-            Self::log_launch_wizard_error(&session, action_stage, action_label, error);
+            Self::log_launch_wizard_error(
+                &session,
+                action_stage,
+                action_label,
+                requested_agent_id.as_deref(),
+                error,
+            );
         }
 
         match session.wizard.completion.take() {
@@ -2823,21 +2833,39 @@ impl AppRuntime {
             Some(LaunchWizardCompletion::FocusWindow { window_id }) => {
                 let Some(address) = self.window_lookup.get(&window_id).cloned() else {
                     let error = "The selected session window is no longer available".to_string();
-                    Self::log_launch_wizard_error(&session, "focus_window", action_label, &error);
+                    Self::log_launch_wizard_error(
+                        &session,
+                        "focus_window",
+                        action_label,
+                        requested_agent_id.as_deref(),
+                        &error,
+                    );
                     session.wizard.error = Some(error);
                     self.launch_wizard = Some(session);
                     return vec![self.launch_wizard_state_outbound()];
                 };
                 let Some(tab) = self.tab_mut(&address.tab_id) else {
                     let error = "Project tab not found".to_string();
-                    Self::log_launch_wizard_error(&session, "focus_window", action_label, &error);
+                    Self::log_launch_wizard_error(
+                        &session,
+                        "focus_window",
+                        action_label,
+                        requested_agent_id.as_deref(),
+                        &error,
+                    );
                     session.wizard.error = Some(error);
                     self.launch_wizard = Some(session);
                     return vec![self.launch_wizard_state_outbound()];
                 };
                 if !tab.workspace.focus_window(&address.raw_id, None) {
                     let error = "The selected session window is no longer available".to_string();
-                    Self::log_launch_wizard_error(&session, "focus_window", action_label, &error);
+                    Self::log_launch_wizard_error(
+                        &session,
+                        "focus_window",
+                        action_label,
+                        requested_agent_id.as_deref(),
+                        &error,
+                    );
                     session.wizard.error = Some(error);
                     self.launch_wizard = Some(session);
                     return vec![self.launch_wizard_state_outbound()];
@@ -2852,7 +2880,13 @@ impl AppRuntime {
             Some(LaunchWizardCompletion::Launch(config)) => {
                 let Some(bounds) = bounds else {
                     let error = "Viewport bounds are required to launch a window".to_string();
-                    Self::log_launch_wizard_error(&session, "launch_bounds", action_label, &error);
+                    Self::log_launch_wizard_error(
+                        &session,
+                        "launch_bounds",
+                        action_label,
+                        requested_agent_id.as_deref(),
+                        &error,
+                    );
                     session.wizard.error = Some(error);
                     self.launch_wizard = Some(session);
                     return vec![self.launch_wizard_state_outbound()];
@@ -2869,6 +2903,7 @@ impl AppRuntime {
                                     &session,
                                     "spawn_agent_window",
                                     action_label,
+                                    requested_agent_id.as_deref(),
                                     &error,
                                 );
                                 session.wizard.error = Some(error);
@@ -2888,6 +2923,7 @@ impl AppRuntime {
                                     &session,
                                     "spawn_shell_window",
                                     action_label,
+                                    requested_agent_id.as_deref(),
                                     &error,
                                 );
                                 session.wizard.error = Some(error);
@@ -4055,6 +4091,7 @@ impl AppRuntime {
         session: &LaunchWizardSession,
         stage: &'static str,
         action: &'static str,
+        requested_agent_id: Option<&str>,
         error: &str,
     ) {
         let view = session.wizard.view();
@@ -4063,15 +4100,20 @@ impl AppRuntime {
             .linked_issue_number
             .map(|issue_number| issue_number.to_string())
             .unwrap_or_else(|| "none".to_string());
+        let requested_agent_id = requested_agent_id.unwrap_or("none");
+        let selected_docker_service = view.selected_docker_service.as_deref().unwrap_or("none");
         tracing::error!(
             target: "gwt::agent_launch",
             stage = %stage,
             action = %action,
             wizard_id = %session.wizard_id,
             tab_id = %session.tab_id,
+            requested_agent_id = %requested_agent_id,
             selected_agent_id = %view.selected_agent_id,
             selected_launch_target = %view.selected_launch_target,
             selected_runtime_target = %view.selected_runtime_target,
+            selected_tool_version = %view.selected_version,
+            selected_docker_service = %selected_docker_service,
             linked_issue_number = %linked_issue_number,
             error = %sanitized_error,
             "launch wizard action failed"
@@ -4317,10 +4359,10 @@ mod tests {
 
     use base64::Engine;
     use gwt::{
-        empty_workspace_state, load_restored_workspace_state, load_session_state, AgentOption,
-        BackendEvent, BranchCleanupInfo, BranchListEntry, BranchScope, FrontendEvent,
-        LaunchWizardAction, LaunchWizardContext, LaunchWizardState, ProfileEnvEntryView,
-        ProjectKind, WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState,
+        empty_workspace_state, load_restored_workspace_state, load_session_state, BackendEvent,
+        BranchCleanupInfo, BranchListEntry, BranchScope, FrontendEvent, LaunchWizardAction,
+        LaunchWizardContext, LaunchWizardState, ProfileEnvEntryView, ProjectKind, WindowGeometry,
+        WindowPreset, WindowProcessStatus, WorkspaceState,
     };
     use gwt_config::{Profile, Settings};
     use gwt_core::{
@@ -4853,7 +4895,7 @@ exit 0
         }
     }
 
-    fn sample_unavailable_agent_launch_wizard_session(
+    fn sample_no_agent_launch_wizard_session(
         tab_id: &str,
         project_root: &Path,
     ) -> LaunchWizardSession {
@@ -4881,14 +4923,7 @@ exit 0
                     docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                     linked_issue_number: Some(42),
                 },
-                vec![AgentOption {
-                    id: "codex".to_string(),
-                    name: "Codex".to_string(),
-                    available: false,
-                    installed_version: None,
-                    versions: Vec::new(),
-                    custom_agent: None,
-                }],
+                Vec::new(),
                 Vec::new(),
             ),
         }
@@ -5103,9 +5138,7 @@ exit 0
             &[WindowPreset::Branches],
         );
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
-        runtime.launch_wizard = Some(sample_unavailable_agent_launch_wizard_session(
-            "tab-1", &repo,
-        ));
+        runtime.launch_wizard = Some(sample_no_agent_launch_wizard_session("tab-1", &repo));
 
         let events = capture_tracing_events(|| {
             let _ = runtime
@@ -5130,7 +5163,11 @@ exit 0
         );
         assert_eq!(
             event.fields.get("selected_agent_id").map(String::as_str),
-            Some("codex")
+            Some("")
+        );
+        assert_eq!(
+            event.fields.get("requested_agent_id").map(String::as_str),
+            Some("none")
         );
         assert_eq!(
             event
@@ -5142,6 +5179,58 @@ exit 0
         assert_eq!(
             event.fields.get("error").map(String::as_str),
             Some("Agent option is unavailable")
+        );
+    }
+
+    #[test]
+    fn app_runtime_launch_wizard_set_agent_failure_logs_requested_agent() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::NonRepo,
+            &[WindowPreset::Branches],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.launch_wizard = Some(sample_no_agent_launch_wizard_session("tab-1", &repo));
+
+        let events = capture_tracing_events(|| {
+            let _ = runtime.handle_launch_wizard_action(
+                LaunchWizardAction::SetAgent {
+                    agent_id: "codex".to_string(),
+                },
+                Some(canvas_bounds()),
+            );
+        });
+
+        let event = events
+            .iter()
+            .find(|event| {
+                event.level == Level::ERROR
+                    && event.target == "gwt::agent_launch"
+                    && event.fields.get("stage").map(String::as_str) == Some("agent_select")
+            })
+            .expect("set agent failure log");
+        assert_eq!(
+            event.fields.get("requested_agent_id").map(String::as_str),
+            Some("codex")
+        );
+        assert_eq!(
+            event
+                .fields
+                .get("selected_runtime_target")
+                .map(String::as_str),
+            Some("host")
+        );
+        assert_eq!(
+            event
+                .fields
+                .get("selected_tool_version")
+                .map(String::as_str),
+            Some("")
         );
     }
 

--- a/crates/gwt/src/docker_launch.rs
+++ b/crates/gwt/src/docker_launch.rs
@@ -24,20 +24,12 @@ pub(crate) fn detect_wizard_docker_context_and_status(
     let suggested_service = docker_devcontainer_defaults(project_root, &files)
         .and_then(|defaults| defaults.service)
         .or_else(|| services.first().map(|service| service.name.clone()));
-    let status = suggested_service
-        .as_deref()
-        .map(|service| {
-            gwt_docker::compose_service_status_with_files(&compose_files, service)
-                .unwrap_or(gwt_docker::ComposeServiceStatus::NotFound)
-        })
-        .unwrap_or(gwt_docker::ComposeServiceStatus::NotFound);
-
     (
         Some(DockerWizardContext {
             services: services.into_iter().map(|service| service.name).collect(),
             suggested_service,
         }),
-        status,
+        gwt_docker::ComposeServiceStatus::Unknown,
     )
 }
 
@@ -467,7 +459,8 @@ pub(crate) fn normalize_docker_launch_action(
         | DockerLifecycleIntent::Restart
         | DockerLifecycleIntent::CreateAndStart => match status {
             ComposeServiceStatus::Running => DockerLaunchServiceAction::Connect,
-            ComposeServiceStatus::Stopped
+            ComposeServiceStatus::Unknown
+            | ComposeServiceStatus::Stopped
             | ComposeServiceStatus::Exited
             | ComposeServiceStatus::NotFound => DockerLaunchServiceAction::Start,
         },

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -800,9 +800,6 @@ impl LaunchWizardState {
             .selected_agent()
             .cloned()
             .ok_or_else(|| "Agent option is unavailable".to_string())?;
-        if !selected_agent.available {
-            return Err("Agent option is unavailable".to_string());
-        }
 
         let agent_id = agent_id_from_key(&selected_agent.id);
         let mut builder = gwt_agent::AgentLaunchBuilder::new(agent_id.clone());
@@ -993,10 +990,6 @@ impl LaunchWizardState {
             }
             LaunchWizardStep::AgentSelect => {
                 if let Some(agent) = self.detected_agents.get(self.selected) {
-                    if !agent.available {
-                        self.error = Some("Agent option is unavailable".to_string());
-                        return;
-                    }
                     self.agent_id = agent.id.clone();
                 }
                 self.sync_selected_agent_options();
@@ -1141,14 +1134,7 @@ impl LaunchWizardState {
             .detected_agents
             .iter()
             .find(|candidate| candidate.id == profile.agent_id);
-        let Some(agent) = (match saved_agent {
-            Some(agent) if agent.available => Some(agent),
-            Some(_) => self
-                .detected_agents
-                .iter()
-                .find(|candidate| candidate.available),
-            None => None,
-        }) else {
+        let Some(agent) = saved_agent.or_else(|| self.detected_agents.first()) else {
             return false;
         };
 
@@ -1278,7 +1264,7 @@ impl LaunchWizardState {
             .iter()
             .position(|candidate| candidate.id == agent_id)
         {
-            Some(index) if self.detected_agents[index].available => {
+            Some(index) => {
                 self.agent_id = agent_id.to_string();
                 if self.step == LaunchWizardStep::AgentSelect {
                     self.selected = index;
@@ -1681,10 +1667,7 @@ impl LaunchWizardState {
             return self.detected_agents.get(self.selected);
         }
         if self.agent_id.is_empty() {
-            self.detected_agents
-                .iter()
-                .find(|agent| agent.available)
-                .or_else(|| self.detected_agents.first())
+            self.detected_agents.first()
         } else {
             self.detected_agents
                 .iter()
@@ -1756,6 +1739,11 @@ impl LaunchWizardState {
 
     fn docker_lifecycle_options(&self) -> &'static [DockerLifecycleOption] {
         match self.context.docker_service_status {
+            gwt_docker::ComposeServiceStatus::Unknown => &[DockerLifecycleOption {
+                label: "Connect or start then launch",
+                description: "Resolve the Docker service state at launch time",
+                intent: gwt_agent::DockerLifecycleIntent::Start,
+            }],
             gwt_docker::ComposeServiceStatus::Running => &[
                 DockerLifecycleOption {
                     label: "Connect only",
@@ -2376,6 +2364,7 @@ fn default_docker_lifecycle_intent(
     status: gwt_docker::ComposeServiceStatus,
 ) -> gwt_agent::DockerLifecycleIntent {
     match status {
+        gwt_docker::ComposeServiceStatus::Unknown => gwt_agent::DockerLifecycleIntent::Start,
         gwt_docker::ComposeServiceStatus::Running => gwt_agent::DockerLifecycleIntent::Connect,
         gwt_docker::ComposeServiceStatus::Stopped | gwt_docker::ComposeServiceStatus::Exited => {
             gwt_agent::DockerLifecycleIntent::Start
@@ -2909,14 +2898,10 @@ fn agent_id_from_key(agent_id: &str) -> gwt_agent::AgentId {
 }
 
 fn agent_description(agent: &AgentOption) -> String {
-    let availability = if agent.available {
-        "Installed"
-    } else {
-        "Unavailable"
-    };
     match agent.installed_version.as_deref() {
-        Some(version) => format!("{availability} · {version}"),
-        None => availability.to_string(),
+        Some(version) => format!("Detected · {version}"),
+        None if agent.custom_agent.is_some() => "Configured".to_string(),
+        None => "Built-in".to_string(),
     }
 }
 
@@ -2926,52 +2911,6 @@ fn load_global_custom_agents() -> Vec<gwt_agent::CustomCodingAgent> {
     }
 
     gwt_agent::load_custom_agents_from_path(&gwt_core::paths::gwt_config_path()).unwrap_or_default()
-}
-
-#[cfg(windows)]
-fn package_runner_candidates() -> &'static [&'static str] {
-    &["bunx.cmd", "bunx", "npx.cmd", "npx"]
-}
-
-#[cfg(not(windows))]
-fn package_runner_candidates() -> &'static [&'static str] {
-    &["bunx", "npx"]
-}
-
-fn package_runner_available() -> bool {
-    package_runner_candidates().iter().any(|candidate| {
-        which::which(candidate)
-            .ok()
-            .is_some_and(|path| !path.to_string_lossy().contains("node_modules"))
-    })
-}
-
-fn command_version(command: &str) -> Option<String> {
-    let output = std::process::Command::new(command)
-        .arg("--version")
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!raw.is_empty()).then_some(raw)
-}
-
-fn custom_agent_availability(agent: &gwt_agent::CustomCodingAgent) -> (bool, Option<String>) {
-    match agent.agent_type {
-        gwt_agent::custom::CustomAgentType::Command => {
-            gwt_agent::AgentDetector::detect_by_command(&agent.command)
-                .map(|detected| (true, detected.version))
-                .unwrap_or((false, None))
-        }
-        gwt_agent::custom::CustomAgentType::Path => {
-            let path = Path::new(&agent.command);
-            (path.is_file(), command_version(&agent.command))
-        }
-        gwt_agent::custom::CustomAgentType::Bunx => (package_runner_available(), None),
-    }
 }
 
 /// Map the raw agent option id (command name or custom agent id) to the
@@ -2991,26 +2930,19 @@ pub fn build_agent_options(
     custom_agents: Vec<gwt_agent::CustomCodingAgent>,
 ) -> Vec<AgentOption> {
     let mut options = build_builtin_agent_options(detected_agents, cache);
-    options.extend(custom_agents.into_iter().map(|agent| {
-        let (available, installed_version) = custom_agent_availability(&agent);
-        AgentOption {
-            id: agent.id.clone(),
-            name: agent.display_name.clone(),
-            available,
-            installed_version,
-            versions: Vec::new(),
-            custom_agent: Some(agent),
-        }
+    options.extend(custom_agents.into_iter().map(|agent| AgentOption {
+        id: agent.id.clone(),
+        name: agent.display_name.clone(),
+        available: true,
+        installed_version: None,
+        versions: Vec::new(),
+        custom_agent: Some(agent),
     }));
     options
 }
 
 pub fn load_agent_options(cache: &gwt_agent::VersionCache) -> Vec<AgentOption> {
-    build_agent_options(
-        gwt_agent::AgentDetector::detect_all(),
-        cache,
-        load_global_custom_agents(),
-    )
+    build_agent_options(Vec::new(), cache, load_global_custom_agents())
 }
 
 pub fn build_builtin_agent_options(
@@ -3033,7 +2965,7 @@ pub fn build_builtin_agent_options(
             AgentOption {
                 id: agent_id.command().to_string(),
                 name: agent_id.display_name().to_string(),
-                available: detected.is_some(),
+                available: true,
                 installed_version: detected.and_then(|detected| detected.version.clone()),
                 versions: cache
                     .get(&agent_id)
@@ -3166,7 +3098,10 @@ mod tests {
         assert!(missing > proxy, "custom agents should keep append order");
         assert_eq!(options[proxy].name, "Claude Proxy");
         assert!(options[proxy].available);
-        assert!(!options[missing].available);
+        assert!(
+            options[missing].available,
+            "configured custom agents must stay selectable; runtime preparation validates execution"
+        );
     }
 
     fn branch(name: &str) -> BranchListEntry {
@@ -3953,7 +3888,7 @@ mod tests {
     }
 
     #[test]
-    fn previous_profile_falls_back_when_saved_agent_is_unavailable() {
+    fn previous_profile_keeps_saved_builtin_agent_without_host_detection() {
         let mut options = sample_agent_options();
         options
             .iter_mut()
@@ -3979,13 +3914,13 @@ mod tests {
             }),
         );
 
-        assert_eq!(state.view().selected_agent_id, "claude");
+        assert_eq!(state.view().selected_agent_id, "codex");
         let config = state.build_launch_config().expect("launch config");
-        assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
+        assert_eq!(config.agent_id, gwt_agent::AgentId::Codex);
     }
 
     #[test]
-    fn previous_profile_still_blocks_when_no_agent_is_available() {
+    fn previous_profile_uses_builtin_agent_even_when_none_are_host_detected() {
         let mut options = sample_agent_options();
         for option in &mut options {
             option.available = false;
@@ -4009,10 +3944,9 @@ mod tests {
             }),
         );
 
-        assert_eq!(
-            state.build_launch_config().unwrap_err(),
-            "Agent option is unavailable"
-        );
+        assert_eq!(state.view().selected_agent_id, "codex");
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::Codex);
     }
 
     #[test]
@@ -4608,7 +4542,7 @@ mod tests {
     }
 
     #[test]
-    fn build_launch_config_rejects_unavailable_custom_agent() {
+    fn build_launch_config_allows_configured_custom_agent_without_host_detection() {
         let missing_path = PathBuf::from("/tmp/nonexistent-custom-agent");
         let mut state = LaunchWizardState::open_with(
             context(branch("feature/gui"), "feature/gui"),
@@ -4626,10 +4560,11 @@ mod tests {
         );
         state.set_agent_id("missing-agent");
 
-        let error = state
+        let config = state
             .build_launch_config()
-            .expect_err("unavailable custom agent must not launch");
-        assert_eq!(error, "Agent option is unavailable");
+            .expect("configured custom agent should reach runtime preparation");
+        assert_eq!(config.command, missing_path.display().to_string());
+        assert_eq!(config.display_name, "Missing Agent");
     }
 
     #[test]
@@ -4749,7 +4684,7 @@ mod tests {
         );
         assert_eq!(
             agent_description(&sample_agent_options()[0]),
-            "Installed · 1.0.0".to_string()
+            "Detected · 1.0.0".to_string()
         );
     }
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3806,7 +3806,7 @@ mod tests {
         let context = context.expect("docker context");
         assert!(context.services.contains(&"app".to_string()));
         assert_eq!(context.suggested_service.as_deref(), Some("app"));
-        assert_eq!(status, gwt_docker::ComposeServiceStatus::NotFound);
+        assert_eq!(status, gwt_docker::ComposeServiceStatus::Unknown);
 
         let multi = temp.path().join("multi");
         fs::create_dir_all(&multi).expect("create multi project");
@@ -3900,6 +3900,54 @@ mod tests {
             Some(value) => std::env::set_var("GWT_DOCKER_BIN", value),
             None => std::env::remove_var("GWT_DOCKER_BIN"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wizard_docker_context_detection_does_not_spawn_docker_cli() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        fs::write(
+            project.join("docker-compose.yml"),
+            "services:\n  app:\n    image: alpine:3.19\n",
+        )
+        .expect("write compose");
+
+        let marker = temp.path().join("docker-called");
+        let fake_docker = temp.path().join("docker");
+        fs::write(
+            &fake_docker,
+            format!(
+                "#!/bin/sh\nprintf called > '{}'\nexit 0\n",
+                marker.display()
+            ),
+        )
+        .expect("write fake docker");
+        let mut perms = fs::metadata(&fake_docker)
+            .expect("fake docker metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake_docker, perms).expect("chmod fake docker");
+
+        let old_docker_bin = std::env::var_os("GWT_DOCKER_BIN");
+        std::env::set_var("GWT_DOCKER_BIN", &fake_docker);
+        let (context, status) = super::detect_wizard_docker_context_and_status(&project);
+        match old_docker_bin {
+            Some(value) => std::env::set_var("GWT_DOCKER_BIN", value),
+            None => std::env::remove_var("GWT_DOCKER_BIN"),
+        }
+
+        let context = context.expect("docker context");
+        assert_eq!(context.services, vec!["app".to_string()]);
+        assert_eq!(context.suggested_service.as_deref(), Some("app"));
+        assert_eq!(status, gwt_docker::ComposeServiceStatus::Unknown);
+        assert!(
+            !marker.exists(),
+            "wizard context detection must not block on docker CLI status probes"
+        );
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.11.5",
+  "version": "9.11.6",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,32 @@
 # Lessons Learned
 
+## 2026-04-29 — fix(launch): Launch Wizard は runtime 検出と実行可否検証を混ぜない
+
+### 事象
+
+Launch Agent の初期表示が Docker status probe に引きずられて遅延し、Codex などの
+agent 選択でも Host 側の検出結果により `Agent option is unavailable` が出た。
+ユーザーから、Docker での起動が存在するのに Host PATH / Docker status を
+Wizard の選択可否へ使っている点を再度指摘された。
+
+### 原因
+
+Wizard hydration が Docker file/config detection と `docker compose ps` による
+runtime status detection を混同していた。さらに agent option の `available` を
+Host 上の agent 検出結果として扱い、その値で built-in / custom agent の選択と
+launch config build をブロックしていた。
+
+### 再発防止策
+
+1. Wizard は候補提示と設定収集だけを行い、Host/Docker/将来 runtime の実行可否は
+   Launch preparation で選択 runtime に対して検証する。
+2. Docker/DevContainer 検出は Wizard 初期表示ではファイル存在確認と設定ファイル
+   読み取りに限定し、Docker CLI / daemon / `docker compose ps` は呼ばない。
+3. built-in agent と configured custom agent は Host 検出結果で無効化しない。
+   command/package runner 不在は session/tab 作成前の preparation error として扱う。
+4. 同種の修正では、Docker CLI を呼ばない regression test と、Host 未検出 agent が
+   選択できる regression test を先に RED にする。
+
 ## 2026-04-29 — fix(gui): Agent 起動失敗は UI エラーだけでなく構造化ログに残す
 
 ### 事象


### PR DESCRIPTION
## Summary

Prepare release v9.11.6 from develop to main.

## Changes

- Make the Launch Agent wizard runtime-first so agent selection does not depend on host detection.
- Avoid Docker CLI/daemon checks during Launch Wizard display.
- Update Cargo workspace, package metadata, lockfile, and changelog for v9.11.6.

## Version

v9.11.6

## Closing Issues

None

## Related Issues / Links

None
