### PR TITLE
fix(gui): keep launch wizard footer below content

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1614,6 +1614,46 @@ mod tests {
         );
     }
 
+    /// Launch Wizard hydration can add QuickStart, Docker, and Advanced form
+    /// content after the initial loading state. The footer must stay outside
+    /// that scrollable form body so the Launch button never overlaps hydrated
+    /// content.
+    #[test]
+    fn embedded_web_launch_wizard_scrolls_body_without_footer_overlap() {
+        let html = index_html();
+
+        let css_body = |selector: &str| {
+            let start = html
+                .find(selector)
+                .unwrap_or_else(|| panic!("expected `{selector}` CSS rule to exist"));
+            let block = &html[start..];
+            let end = block
+                .find('}')
+                .unwrap_or_else(|| panic!("expected `{selector}` CSS rule to close"));
+            &block[..end]
+        };
+
+        let wizard_shell = css_body(".modal-shell.is-wizard {");
+        assert!(
+            wizard_shell.contains("overflow: hidden"),
+            "expected Launch Wizard shell to hide shell-level overflow so only the form body scrolls, got: {wizard_shell}",
+        );
+
+        let wizard_body = css_body("#wizard-body {");
+        for prop in ["overflow: auto", "min-height: 0"] {
+            assert!(
+                wizard_body.contains(prop),
+                "expected #wizard-body to declare `{prop}` as the scroll container, got: {wizard_body}",
+            );
+        }
+
+        let wizard_footer = css_body(".wizard-footer {");
+        assert!(
+            wizard_footer.contains("flex: 0 0 auto"),
+            "expected wizard footer to keep a stable non-overlapping height, got: {wizard_footer}",
+        );
+    }
+
     /// SPEC-2008 FR-035 (JS-side guard): the legacy `.modal` shell class is
     /// retired in HTML, so any `querySelector(".modal")` left in `app.js`
     /// resolves to `null` and silently breaks the modal it backs (this

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1978,6 +1978,7 @@
         width: min(980px, calc(100vw - 32px));
         padding: 18px;
         gap: 12px;
+        overflow: hidden;
         z-index: 2000;
         box-shadow: 0 22px 56px rgba(15, 23, 42, 0.22);
       }
@@ -2084,6 +2085,11 @@
 
       .wizard-summary:empty {
         display: none;
+      }
+
+      #wizard-body {
+        min-height: 0;
+        overflow: auto;
       }
 
       .wizard-summary-item {
@@ -2333,6 +2339,7 @@
       }
 
       .wizard-footer {
+        flex: 0 0 auto;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -2365,7 +2372,7 @@
       }
 
       @media (max-width: 720px) {
-        .wizard-modal {
+        .modal-shell.is-wizard {
           width: calc(100vw - 16px);
           max-height: calc(100vh - 16px);
           padding: 14px;


### PR DESCRIPTION
## Summary

- Keep the Launch Wizard footer separate from hydrated form content so Launch and Cancel remain reachable after loading.
- Lock the footer/body scroll contract with an embedded web regression test so future modal CSS changes catch overlap regressions.

## Changes

- `crates/gwt/web/index.html`: makes `.modal-shell.is-wizard` hide shell-level overflow, gives `#wizard-body` the scroll responsibility, keeps `.wizard-footer` at a stable height, and updates the narrow viewport selector from the retired `.wizard-modal` class.
- `crates/gwt/src/embedded_web.rs`: adds a Launch Wizard layout contract test covering shell overflow, body scrolling, and footer sizing.

## Testing

- [x] `cargo test -p gwt embedded_web_launch_wizard_scrolls_body_without_footer_overlap -- --nocapture` — failed before the CSS fix and passed after it.
- [x] `cargo test -p gwt embedded_web_ -- --nocapture` — passed 57 embedded web contract tests.
- [x] `npm run test:frontend-bundle` — passed JavaScript syntax checks.
- [x] `npm run test:frontend-smoke` — passed 5 frontend smoke tests after installing dev dependencies with `pnpm install --frozen-lockfile`.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] Pre-push CI-equivalent checks — passed with filtered line coverage 90.40%.

## Closing Issues

None

## Related Issues / Links

- #2014
- #1936

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #2014 updated; README/user docs not needed for this internal layout fix)
- [x] Migration/backfill plan included (N/A: CSS-only WebView layout fix)
- [x] CHANGELOG impact considered (patch-level `fix:` commit, no breaking change)

## Context

- The Launch Wizard initially displayed the Launch button at the bottom while loading, then after hydration the larger form content could visually overlap the button area.
- The fix keeps header, summary, and footer outside the hydrated form scroll area instead of changing Docker detection or launch state.

## Risk / Impact

- **Affected areas**: Launch Wizard modal layout only.
- **Rollback plan**: Revert commit `694c6b95` if the modal layout regresses.

## Screenshots

No screenshots captured in this non-interactive agent session. The visual behavior is covered by the new CSS contract test and existing frontend smoke checks.
