### PR TITLE
ci: install webview deps for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: develop
+      - name: Install WebView dependencies (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
       - uses: actions/setup-node@v6
         with:
           node-version: 20


### PR DESCRIPTION
## Summary

- Install Linux WebView system dependencies before running the Rust Coverage job.
- Fix the scheduled `Coverage Report` failure where `glib-sys` could not find `glib-2.0.pc` during `cargo llvm-cov`.

## Changes

- `.github/workflows/coverage.yml`: add the same `libgtk-3-dev`, `libwebkit2gtk-4.1-dev`, and `libayatana-appindicator3-dev` install step used by Build/Test/Lint before `cargo llvm-cov`.

## Testing

- [x] `gh run view 25141421560 --repo akiojin/gwt --log-failed` — confirmed the failure is `glib-sys` missing `glib-2.0` through `pkg-config`.
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/coverage.yml"); puts "coverage workflow YAML ok"'` — passed.
- [x] `git diff --check HEAD~1..HEAD` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `gh workflow run "Coverage Report" --ref bugfix/pty-creation-failed` — manual run https://github.com/akiojin/gwt/actions/runs/25143023953 passed, including `Generate filtered summary`, `Enforce coverage threshold`, and Codecov upload.
- [x] Local coverage command previously passed on macOS with 90.36% filtered line coverage; this PR fixes the Linux runner dependency setup before the same command can execute.

## Closing Issues

- None

## Related Issues / Links

- https://github.com/akiojin/gwt/actions/runs/25141421560

## Checklist

- [x] Tests added/updated not required; this is CI dependency setup.
- [x] Lint/format passed for the touched workflow (`git diff --check`, YAML parse).
- [x] Documentation updated not required; no user-facing behavior changed.
- [x] Migration/backfill plan not required because no schema or data changed.
- [x] CHANGELOG impact considered; this is a CI-only change.

## Context

- `Coverage Report` checks out `develop` but did not install the Linux WebView packages required by the `gwt` crate dependency graph. Build, Test, and Lint already install these dependencies.
