### PR TITLE
fix(gui): restore macOS paste shortcuts

### DIFF
--- a/crates/gwt/src/native_app.rs
+++ b/crates/gwt/src/native_app.rs
@@ -28,7 +28,7 @@ pub fn macos_bundle_identifier() -> &'static str {
 }
 
 pub fn macos_native_menu_titles() -> &'static [&'static str] {
-    &[APP_NAME, "File", "View", "Window"]
+    &[APP_NAME, "File", "Edit", "View", "Window"]
 }
 
 pub fn native_launch_surface() -> NativeLaunchSurface {
@@ -83,6 +83,7 @@ impl MacosNativeMenu {
         let menu_bar = Menu::new();
         let app_menu = Submenu::new(APP_NAME, true);
         let file_menu = Submenu::new("File", true);
+        let edit_menu = Submenu::new("Edit", true);
         let view_menu = Submenu::new("View", true);
         let window_menu = Submenu::new("Window", true);
         let open_project_item = MenuItem::with_id(
@@ -98,7 +99,8 @@ impl MacosNativeMenu {
             Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyR)),
         );
 
-        let _ = menu_bar.append_items(&[&app_menu, &file_menu, &view_menu, &window_menu]);
+        let _ =
+            menu_bar.append_items(&[&app_menu, &file_menu, &edit_menu, &view_menu, &window_menu]);
         let _ = app_menu.append_items(&[
             &PredefinedMenuItem::about(
                 None,
@@ -120,6 +122,16 @@ impl MacosNativeMenu {
             &open_project_item,
             &PredefinedMenuItem::separator(),
             &PredefinedMenuItem::close_window(None),
+        ]);
+        let _ = edit_menu.append_items(&[
+            &PredefinedMenuItem::undo(None),
+            &PredefinedMenuItem::redo(None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::cut(None),
+            &PredefinedMenuItem::copy(None),
+            &PredefinedMenuItem::paste(None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::select_all(None),
         ]);
         let _ = view_menu.append_items(&[&reload_item]);
         let _ = window_menu.append_items(&[

--- a/crates/gwt/tests/native_app_test.rs
+++ b/crates/gwt/tests/native_app_test.rs
@@ -9,7 +9,7 @@ fn macos_native_shell_uses_expected_bundle_identifier_and_menu_titles() {
     assert_eq!(macos_bundle_identifier(), "io.github.akiojin.gwt");
     assert_eq!(
         macos_native_menu_titles(),
-        &["GWT", "File", "View", "Window"]
+        &["GWT", "File", "Edit", "View", "Window"]
     );
 }
 
@@ -35,7 +35,10 @@ fn native_launch_surface_keeps_gui_primary_bundle_and_menu_contract() {
     assert_eq!(surface.bundle_name, MACOS_APP_BUNDLE_NAME);
     assert_eq!(surface.front_door_binary, GUI_FRONT_DOOR_BINARY_NAME);
     assert_eq!(surface.daemon_binary, INTERNAL_DAEMON_BINARY_NAME);
-    assert_eq!(surface.menu_titles, &["GWT", "File", "View", "Window"]);
+    assert_eq!(
+        surface.menu_titles,
+        &["GWT", "File", "Edit", "View", "Window"]
+    );
     assert_eq!(
         surface.command_ids,
         &[OPEN_PROJECT_MENU_ID, RELOAD_MENU_ID],


### PR DESCRIPTION
## Summary

- Restores macOS Cmd+V paste support in the native GUI by adding the standard Edit menu.
- Keeps custom app menu routing limited to Open Project and Reload so standard edit commands stay owned by AppKit/WebView.

## Changes

- `crates/gwt/src/native_app.rs`: adds the macOS `Edit` menu with Undo, Redo, Cut, Copy, Paste, and Select All predefined menu items.
- `crates/gwt/tests/native_app_test.rs`: updates the native app menu contract to require `Edit` while preserving existing custom command IDs.

## Testing

- [x] `cargo test -p gwt --test native_app_test` — passed.
- [x] `cargo fmt --check` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.

## Closing Issues

- Closes #2226

## Related Issues / Links

- #2008
- #1926

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not needed: no README-facing usage text changed)
- [ ] Migration/backfill plan included (not needed: no schema or data migration)
- [x] CHANGELOG impact considered (patch fix via `fix:` commit)

## Context

- macOS Cmd+V paste did not work in terminal panes or normal WebView inputs such as Issue/SPEC search fields because the app menu lacked standard Edit commands.

## Screenshots

- Not captured from this agent session; the change is a native macOS menu contract update and was verified with native app tests.
