### PR TITLE
chore(release): v9.11.9

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: develop
+      - name: Install WebView dependencies (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.11.9] - 2026-04-30
+
+### Bug Fixes
+
+- **gui:** Restore macOS paste shortcuts
+
+### Ci
+
+- Install WebView deps for coverage workflow
+
 ## [9.11.8] - 2026-04-30
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "axum",
  "base64",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "chrono",
  "dunce",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "reqwest",
  "serde",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "dirs",
  "serde",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "fs2",
  "regex",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "chrono",
  "fs2",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.11.8"
+version = "9.11.9"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.11.8"
+version = "9.11.9"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/native_app.rs
+++ b/crates/gwt/src/native_app.rs
@@ -28,7 +28,7 @@ pub fn macos_bundle_identifier() -> &'static str {
 }
 
 pub fn macos_native_menu_titles() -> &'static [&'static str] {
-    &[APP_NAME, "File", "View", "Window"]
+    &[APP_NAME, "File", "Edit", "View", "Window"]
 }
 
 pub fn native_launch_surface() -> NativeLaunchSurface {
@@ -83,6 +83,7 @@ impl MacosNativeMenu {
         let menu_bar = Menu::new();
         let app_menu = Submenu::new(APP_NAME, true);
         let file_menu = Submenu::new("File", true);
+        let edit_menu = Submenu::new("Edit", true);
         let view_menu = Submenu::new("View", true);
         let window_menu = Submenu::new("Window", true);
         let open_project_item = MenuItem::with_id(
@@ -98,7 +99,8 @@ impl MacosNativeMenu {
             Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyR)),
         );
 
-        let _ = menu_bar.append_items(&[&app_menu, &file_menu, &view_menu, &window_menu]);
+        let _ =
+            menu_bar.append_items(&[&app_menu, &file_menu, &edit_menu, &view_menu, &window_menu]);
         let _ = app_menu.append_items(&[
             &PredefinedMenuItem::about(
                 None,
@@ -120,6 +122,16 @@ impl MacosNativeMenu {
             &open_project_item,
             &PredefinedMenuItem::separator(),
             &PredefinedMenuItem::close_window(None),
+        ]);
+        let _ = edit_menu.append_items(&[
+            &PredefinedMenuItem::undo(None),
+            &PredefinedMenuItem::redo(None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::cut(None),
+            &PredefinedMenuItem::copy(None),
+            &PredefinedMenuItem::paste(None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::select_all(None),
         ]);
         let _ = view_menu.append_items(&[&reload_item]);
         let _ = window_menu.append_items(&[

--- a/crates/gwt/tests/native_app_test.rs
+++ b/crates/gwt/tests/native_app_test.rs
@@ -9,7 +9,7 @@ fn macos_native_shell_uses_expected_bundle_identifier_and_menu_titles() {
     assert_eq!(macos_bundle_identifier(), "io.github.akiojin.gwt");
     assert_eq!(
         macos_native_menu_titles(),
-        &["GWT", "File", "View", "Window"]
+        &["GWT", "File", "Edit", "View", "Window"]
     );
 }
 
@@ -35,7 +35,10 @@ fn native_launch_surface_keeps_gui_primary_bundle_and_menu_contract() {
     assert_eq!(surface.bundle_name, MACOS_APP_BUNDLE_NAME);
     assert_eq!(surface.front_door_binary, GUI_FRONT_DOOR_BINARY_NAME);
     assert_eq!(surface.daemon_binary, INTERNAL_DAEMON_BINARY_NAME);
-    assert_eq!(surface.menu_titles, &["GWT", "File", "View", "Window"]);
+    assert_eq!(
+        surface.menu_titles,
+        &["GWT", "File", "Edit", "View", "Window"]
+    );
     assert_eq!(
         surface.command_ids,
         &[OPEN_PROJECT_MENU_ID, RELOAD_MENU_ID],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.11.8",
+  "version": "9.11.9",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Prepare the v9.11.9 patch release from develop to main.

## Changes

- Bump workspace, package, and lockfile versions to v9.11.9.
- Update CHANGELOG.md with the macOS paste shortcut fix and coverage workflow CI update.
- Include the fix for restoring macOS paste shortcuts.

## Version

v9.11.9

## Closing Issues

Closes #2226

## Related Issues / Links

#1926
#2008
