### PR TITLE
fix: restore GUI host PATH for agent launches

### DIFF
--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -256,7 +256,7 @@ fn parse_macos_path_helper_output(output: &str) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
 fn push_path_value(entries: &mut Vec<PathBuf>, value: &str) {
     for path in std::env::split_paths(value) {
         push_unique_path(entries, path);

--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -2,12 +2,46 @@
 
 use std::{
     collections::{BTreeSet, HashMap},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
-use crate::types::LaunchRuntimeTarget;
+use crate::{
+    session::{
+        GWT_BIN_PATH_ENV, GWT_HOOK_FORWARD_TOKEN_ENV, GWT_HOOK_FORWARD_URL_ENV, GWT_SESSION_ID_ENV,
+        GWT_SESSION_RUNTIME_PATH_ENV,
+    },
+    types::LaunchRuntimeTarget,
+};
 
 const GWT_PROJECT_ROOT_ENV: &str = "GWT_PROJECT_ROOT";
+const GWT_REPO_HASH_ENV: &str = "GWT_REPO_HASH";
+const GWT_WORKTREE_HASH_ENV: &str = "GWT_WORKTREE_HASH";
+const INHERITED_LAUNCH_ENV_KEYS: &[&str] = &[
+    GWT_BIN_PATH_ENV,
+    GWT_HOOK_FORWARD_TOKEN_ENV,
+    GWT_HOOK_FORWARD_URL_ENV,
+    GWT_PROJECT_ROOT_ENV,
+    GWT_REPO_HASH_ENV,
+    GWT_SESSION_ID_ENV,
+    GWT_SESSION_RUNTIME_PATH_ENV,
+    GWT_WORKTREE_HASH_ENV,
+];
+
+/// Return the current host process environment with GUI-launch PATH gaps filled.
+pub fn host_process_env() -> HashMap<String, String> {
+    hydrate_host_base_env(std::env::vars().collect::<Vec<_>>())
+}
+
+/// Fill common GUI-launch PATH gaps in a host base environment.
+pub(crate) fn hydrate_host_base_env<I>(base_env: I) -> HashMap<String, String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut env: HashMap<String, String> = base_env.into_iter().collect();
+    remove_inherited_launch_env(&mut env);
+    hydrate_host_path(&mut env);
+    env
+}
 
 /// Effective environment assembled from the active profile and launch context.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,10 +86,9 @@ impl LaunchEnvironment {
         runtime_target: LaunchRuntimeTarget,
     ) -> Result<Self, String> {
         match runtime_target {
-            LaunchRuntimeTarget::Host => Self::from_active_profile_with_base(
-                config_path,
-                std::env::vars().collect::<Vec<_>>(),
-            ),
+            LaunchRuntimeTarget::Host => {
+                Self::from_active_profile_with_base(config_path, host_process_env())
+            }
             LaunchRuntimeTarget::Docker => Self::from_active_profile_with_base(
                 config_path,
                 std::iter::empty::<(String, String)>(),
@@ -103,7 +136,9 @@ impl LaunchEnvironment {
         I: IntoIterator<Item = (String, String)>,
     {
         match runtime_target {
-            LaunchRuntimeTarget::Host => Self::from_active_profile_with_base(config_path, base_env),
+            LaunchRuntimeTarget::Host => {
+                Self::from_active_profile_with_base(config_path, hydrate_host_base_env(base_env))
+            }
             LaunchRuntimeTarget::Docker => Self::from_active_profile_with_base(
                 config_path,
                 std::iter::empty::<(String, String)>(),
@@ -161,6 +196,81 @@ fn ensure_terminal_env(env: &mut HashMap<String, String>) {
         .or_insert_with(|| "xterm-256color".to_string());
     env.entry("COLORTERM".to_string())
         .or_insert_with(|| "truecolor".to_string());
+}
+
+fn remove_inherited_launch_env(env: &mut HashMap<String, String>) {
+    for key in INHERITED_LAUNCH_ENV_KEYS {
+        env.remove(*key);
+    }
+}
+
+#[cfg(windows)]
+fn hydrate_host_path(_env: &mut HashMap<String, String>) {}
+
+#[cfg(not(windows))]
+fn hydrate_host_path(env: &mut HashMap<String, String>) {
+    let mut entries = env
+        .get("PATH")
+        .map(|path| std::env::split_paths(path).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    #[cfg(target_os = "macos")]
+    if let Some(path) = macos_path_helper_path(env.get("PATH").map(String::as_str)) {
+        push_path_value(&mut entries, &path);
+    }
+
+    if let Some(home) = env.get("HOME").filter(|home| !home.trim().is_empty()) {
+        let home = PathBuf::from(home);
+        for relative in [".bun/bin", ".local/bin", ".cargo/bin"] {
+            let candidate = home.join(relative);
+            if candidate.is_dir() {
+                push_unique_path(&mut entries, candidate);
+            }
+        }
+    }
+
+    if let Ok(path) = std::env::join_paths(&entries) {
+        env.insert("PATH".to_string(), path.to_string_lossy().into_owned());
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_path_helper_path(current_path: Option<&str>) -> Option<String> {
+    let mut command = std::process::Command::new("/usr/libexec/path_helper");
+    command.arg("-s");
+    if let Some(path) = current_path {
+        command.env("PATH", path);
+    }
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_macos_path_helper_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(target_os = "macos")]
+fn parse_macos_path_helper_output(output: &str) -> Option<String> {
+    let start = output.find("PATH=\"")? + "PATH=\"".len();
+    let rest = &output[start..];
+    let end = rest.find("\";")?;
+    Some(rest[..end].to_string())
+}
+
+#[cfg(not(windows))]
+fn push_path_value(entries: &mut Vec<PathBuf>, value: &str) {
+    for path in std::env::split_paths(value) {
+        push_unique_path(entries, path);
+    }
+}
+
+#[cfg(not(windows))]
+fn push_unique_path(entries: &mut Vec<PathBuf>, path: PathBuf) {
+    if path.as_os_str().is_empty() {
+        return;
+    }
+    if !entries.iter().any(|entry| entry == &path) {
+        entries.push(path);
+    }
 }
 
 fn merged_remove_env(base: &[String], additional: &[String]) -> Vec<String> {
@@ -339,5 +449,93 @@ mod tests {
         assert_eq!(env.get("TERM").map(String::as_str), Some("xterm-256color"));
         assert_eq!(env.get("COLORTERM").map(String::as_str), Some("truecolor"));
         assert!(remove_env.is_empty());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn host_runtime_expands_minimal_gui_path_with_existing_user_bins() {
+        let home = tempfile::tempdir().unwrap();
+        for relative in [".bun/bin", ".local/bin", ".cargo/bin"] {
+            std::fs::create_dir_all(home.path().join(relative)).unwrap();
+        }
+        let (_dir, config_path) = write_profile_config(Profile::new("default"));
+        let base_env = vec![
+            (
+                "PATH".to_string(),
+                "/usr/bin:/bin:/usr/sbin:/sbin".to_string(),
+            ),
+            ("HOME".to_string(), home.path().display().to_string()),
+        ];
+
+        let (env, _) = LaunchEnvironment::from_active_profile_for_runtime_with_base(
+            &config_path,
+            LaunchRuntimeTarget::Host,
+            base_env,
+        )
+        .unwrap()
+        .into_parts();
+
+        let path = env.get("PATH").expect("PATH");
+        let entries = std::env::split_paths(path).collect::<Vec<_>>();
+        assert!(entries.contains(&home.path().join(".bun/bin")));
+        assert!(entries.contains(&home.path().join(".local/bin")));
+        assert!(entries.contains(&home.path().join(".cargo/bin")));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn docker_runtime_does_not_import_host_user_bins() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".bun/bin")).unwrap();
+        let (_dir, config_path) = write_profile_config(Profile::new("default"));
+
+        let (env, _) = LaunchEnvironment::from_active_profile_for_runtime_with_base(
+            &config_path,
+            LaunchRuntimeTarget::Docker,
+            vec![
+                (
+                    "PATH".to_string(),
+                    "/usr/bin:/bin:/usr/sbin:/sbin".to_string(),
+                ),
+                ("HOME".to_string(), home.path().display().to_string()),
+            ],
+        )
+        .unwrap()
+        .into_parts();
+
+        let entries = env
+            .get("PATH")
+            .map(|path| std::env::split_paths(path).collect::<Vec<_>>())
+            .unwrap_or_default();
+        assert!(!entries.contains(&home.path().join(".bun/bin")));
+    }
+
+    #[test]
+    fn host_base_env_drops_inherited_launch_scoped_env() {
+        let env = hydrate_host_base_env([
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            (GWT_BIN_PATH_ENV.to_string(), "/stale/gwtd".to_string()),
+            (GWT_SESSION_ID_ENV.to_string(), "parent-session".to_string()),
+            (
+                GWT_SESSION_RUNTIME_PATH_ENV.to_string(),
+                "/tmp/parent.json".to_string(),
+            ),
+            (
+                GWT_HOOK_FORWARD_TOKEN_ENV.to_string(),
+                "secret-token".to_string(),
+            ),
+            (GWT_PROJECT_ROOT_ENV.to_string(), "/old/project".to_string()),
+        ]);
+
+        let path_entries = env
+            .get("PATH")
+            .map(|path| std::env::split_paths(path).collect::<Vec<_>>())
+            .unwrap_or_default();
+        assert!(path_entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(!env.contains_key(GWT_BIN_PATH_ENV));
+        assert!(!env.contains_key(GWT_SESSION_ID_ENV));
+        assert!(!env.contains_key(GWT_SESSION_RUNTIME_PATH_ENV));
+        assert!(!env.contains_key(GWT_HOOK_FORWARD_TOKEN_ENV));
+        assert!(!env.contains_key(GWT_PROJECT_ROOT_ENV));
     }
 }

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::{
     custom::{CustomAgentType, CustomCodingAgent},
+    environment::{host_process_env, hydrate_host_base_env},
     session::GWT_SESSION_RUNTIME_PATH_ENV,
     types::{AgentColor, AgentId, DockerLifecycleIntent, LaunchRuntimeTarget, SessionMode},
 };
@@ -208,9 +209,21 @@ fn package_runner_candidates() -> &'static [(&'static str, bool)] {
 /// - bunx: no `--yes` needed
 /// - npx: `--yes` needed to suppress interactive prompt
 fn find_bunx_or_npx() -> (String, bool) {
+    let env = host_process_env();
+    find_bunx_or_npx_with_env(&env)
+}
+
+fn find_bunx_or_npx_with_env(env: &HashMap<String, String>) -> (String, bool) {
+    let env = hydrate_host_base_env(env.clone());
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let path = env.get("PATH").map(String::as_str);
     for (name, needs_yes) in package_runner_candidates() {
-        if let Ok(path) = which::which(name) {
-            let path_str = path.to_string_lossy();
+        let found = match path {
+            Some(path) => which::which_in(name, Some(path), &cwd),
+            None => which::which(name),
+        };
+        if let Ok(found) = found {
+            let path_str = found.to_string_lossy();
             if path_str.contains("node_modules") {
                 continue;
             }
@@ -1249,6 +1262,36 @@ mod tests {
 
         let needs_yes: Vec<bool> = candidates.iter().map(|(_, yes)| *yes).collect();
         assert_eq!(needs_yes, vec![false, true]);
+    }
+
+    #[cfg(all(not(windows), unix))]
+    #[test]
+    fn package_runner_detection_uses_hydrated_host_env_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir().expect("home");
+        let bin = home.path().join(".bun/bin");
+        std::fs::create_dir_all(&bin).expect("create bin");
+        let bunx = bin.join("bunx");
+        std::fs::write(&bunx, "#!/bin/sh\nexit 0\n").expect("write bunx");
+        let mut permissions = std::fs::metadata(&bunx)
+            .expect("bunx metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&bunx, permissions).expect("chmod bunx");
+
+        let env = HashMap::from([
+            (
+                "PATH".to_string(),
+                "/usr/bin:/bin:/usr/sbin:/sbin".to_string(),
+            ),
+            ("HOME".to_string(), home.path().display().to_string()),
+        ]);
+
+        let (executable, needs_yes) = find_bunx_or_npx_with_env(&env);
+
+        assert_eq!(PathBuf::from(executable), bunx);
+        assert!(!needs_yes);
     }
 
     #[test]

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -164,7 +164,13 @@ where
         .working_dir
         .clone()
         .unwrap_or_else(|| repo_path.to_path_buf());
-    LaunchEnvironment::empty()
+    let launch_env = match config.runtime_target {
+        LaunchRuntimeTarget::Host => {
+            LaunchEnvironment::from_base_env(crate::environment::host_process_env())
+        }
+        LaunchRuntimeTarget::Docker => LaunchEnvironment::empty(),
+    };
+    launch_env
         .with_project_root(&worktree_path)
         .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
     refresh_worktree_assets(&worktree_path)?;

--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -40,6 +40,12 @@ pub struct SpawnConfig {
     pub cwd: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SpawnDiagnostic {
+    path_entry_count: usize,
+    command_resolved_from_env_path: bool,
+}
+
 /// Handle to a spawned PTY process.
 ///
 /// Provides methods for I/O, resize, and process lifecycle management.
@@ -84,12 +90,30 @@ impl PtyHandle {
             cmd.env(key, value);
         }
 
-        let child =
-            pair.slave
-                .spawn_command(cmd)
-                .map_err(|e| TerminalError::PtyCreationFailed {
-                    reason: e.to_string(),
-                })?;
+        let child = match pair.slave.spawn_command(cmd) {
+            Ok(child) => child,
+            Err(error) => {
+                let diagnostic = spawn_diagnostic(&config);
+                let cwd = config
+                    .cwd
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| "none".to_string());
+                tracing::error!(
+                    target: "gwt::pty",
+                    command = %config.command,
+                    cwd = %cwd,
+                    path_entry_count = diagnostic.path_entry_count,
+                    command_resolved_from_env_path = diagnostic.command_resolved_from_env_path,
+                    env_path = %env_path_for_log(&config.env),
+                    error = %error,
+                    "PTY spawn command failed"
+                );
+                return Err(TerminalError::PtyCreationFailed {
+                    reason: error.to_string(),
+                });
+            }
+        };
 
         let writer = pair
             .master
@@ -237,6 +261,36 @@ fn normalize_spawn_config(config: SpawnConfig) -> SpawnConfig {
     }
 }
 
+fn spawn_diagnostic(config: &SpawnConfig) -> SpawnDiagnostic {
+    SpawnDiagnostic {
+        path_entry_count: env_path_value(&config.env)
+            .map(|path| std::env::split_paths(path).count())
+            .unwrap_or(0),
+        command_resolved_from_env_path: command_resolves_from_env_path(config),
+    }
+}
+
+#[cfg(not(windows))]
+fn command_resolves_from_env_path(config: &SpawnConfig) -> bool {
+    resolve_command_from_env_path(&config.command, &config.env).is_some()
+}
+
+#[cfg(windows)]
+fn command_resolves_from_env_path(_config: &SpawnConfig) -> bool {
+    false
+}
+
+fn env_path_value(env: &HashMap<String, String>) -> Option<&str> {
+    env.get("PATH")
+        .or_else(|| env.get("Path"))
+        .or_else(|| env.get("path"))
+        .map(String::as_str)
+}
+
+fn env_path_for_log(env: &HashMap<String, String>) -> &str {
+    env_path_value(env).unwrap_or("<unset>")
+}
+
 #[cfg(not(windows))]
 fn normalize_non_windows_spawn_config(mut config: SpawnConfig) -> SpawnConfig {
     if let Some(command) = resolve_command_from_env_path(&config.command, &config.env) {
@@ -357,6 +411,36 @@ mod tests {
         let normalized = normalize_spawn_config(config);
 
         assert_eq!(PathBuf::from(normalized.command), runner);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_diagnostic_reports_config_path_command_resolution() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runner = dir.path().join("gwt-test-runner");
+        std::fs::write(&runner, "#!/bin/sh\nexit 0\n").expect("write runner");
+        let mut permissions = std::fs::metadata(&runner)
+            .expect("runner metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&runner, permissions).expect("chmod runner");
+
+        let config = SpawnConfig {
+            command: "gwt-test-runner".to_string(),
+            args: Vec::new(),
+            cols: 80,
+            rows: 24,
+            env: HashMap::from([("PATH".to_string(), dir.path().display().to_string())]),
+            remove_env: Vec::new(),
+            cwd: None,
+        };
+
+        let diagnostic = spawn_diagnostic(&config);
+
+        assert_eq!(diagnostic.path_entry_count, 1);
+        assert!(diagnostic.command_resolved_from_env_path);
     }
 
     #[test]

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -158,7 +158,7 @@ pub(crate) fn build_shell_process_launch(
     let base_env = if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
         gwt_agent::LaunchEnvironment::from_base_env(std::iter::empty::<(String, String)>())
     } else {
-        gwt_agent::LaunchEnvironment::from_base_env(std::env::vars().collect::<Vec<_>>())
+        gwt_agent::LaunchEnvironment::from_base_env(gwt_agent::environment::host_process_env())
     };
     let mut env = config.env_vars.clone();
     let mut remove_env = config.remove_env.clone();

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -359,7 +359,9 @@ pub(crate) fn resolve_launch_spec_with_fallback(
 
 #[cfg(test)]
 pub(crate) fn spawn_env() -> HashMap<String, String> {
-    let (env, _) = gwt_agent::LaunchEnvironment::from_base_env(std::env::vars()).into_parts();
+    let (env, _) =
+        gwt_agent::LaunchEnvironment::from_base_env(gwt_agent::environment::host_process_env())
+            .into_parts();
     env
 }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,30 @@
 # Lessons Learned
 
+## 2026-04-30 — fix(gui): 修正済み判断の前にインストール済みアプリの最新ログで再検証する
+
+### 事象
+
+v9.11.9 適用後も `$gwt-discussion` / Codex 起動で
+`PTY creation failed: Unable to spawn npx because: No viable candidates found in PATH "/usr/bin:/bin:/usr/sbin:/sbin"`
+が再発していた。`~/.gwt/projects/8a5edab282632443/logs/gwt.log.2026-04-30`
+には 2026-04-30T11:36:32+09:00 の失敗が記録されており、アプリも
+`/Applications/GWT.app` v9.11.9 だった。
+
+### 原因
+
+前回修正は PTY spawn 時に `config.env["PATH"]` から bare command を解決するだけで、
+GUI / LaunchServices 由来の最小 `PATH` そのものを Host launch env で復元していなかった。
+また、project log はエラーを記録していたが、PTY に渡した `PATH` でコマンドが解決可能かの
+診断がなく、原因の切り分けが遅れた。
+
+### 再発防止策
+
+1. 「修正済み」と判断する前に、インストール済みアプリの version、起動中プロセス、
+   project-scoped log の最新失敗時刻を確認する。
+2. GUI Host 起動の `PATH` 問題では、runner 選択だけでなく Host base env 生成元を検査する。
+3. PTY spawn failure では、エラー本文に加えて `env_path`、path entry 数、
+   command の env PATH 解決可否を structured log に残す。
+
 ## 2026-04-30 — fix(gui): PTY creation failure は runner 名ではなく起動環境から切り分ける
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,28 @@
 # Lessons Learned
 
+## 2026-04-30 — fix(ci): ローカル lint は CI と同じ package selection でも確認する
+
+### 事象
+
+PR #2230 の `Clippy & Rustfmt` で、Linux CI の
+`cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` が
+`crates/gwt-agent/src/environment.rs` の `push_path_value` を dead code として失敗した。
+手元では先に workspace 全体の clippy を通していたが、CI と同一の package selection では
+確認していなかった。
+
+### 原因
+
+`push_path_value` は macOS の `path_helper` 経路だけで使われる helper だったが、
+`#[cfg(not(windows))]` で Linux にも compile されていた。workspace 全体の all-targets では
+test target 側の利用条件に隠れ、PR CI の lib dependency build でだけ dead code が表面化した。
+
+### 再発防止策
+
+1. PR lint を確認するときは、広い workspace clippy に加えて CI と同一の
+   `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` も実行する。
+2. OS 固有 helper は「使われる呼び出し元」と同じ `cfg` 条件まで狭め、Linux CI に不要な symbol を残さない。
+3. CI で失敗したら、ローカル成功結果より GitHub Actions の exact command と package selection を優先して再現する。
+
 ## 2026-04-30 — fix(gui): 修正済み判断の前にインストール済みアプリの最新ログで再検証する
 
 ### 事象


### PR DESCRIPTION
## Summary
- hydrate Host launch environment on macOS so GUI-launched agents can resolve bunx/npx/codex from user PATH locations
- use the same hydrated Host environment for package runner detection, runtime support spawns, and prepared agent launches
- log PTY spawn failures with structured command, cwd, PATH, resolution, and underlying error diagnostics

## Verification
- cargo fmt -- --check
- cargo test -p gwt-agent -p gwt-terminal --no-fail-fast
- cargo test -p gwt-core -p gwt --all-features --no-fail-fast
- cargo clippy --all-targets --all-features -- -D warnings
- cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json
- node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90
- cargo llvm-cov report -p gwt-core -p gwt --lcov --output-path lcov.info
- cargo test -p gwt-core --tests -- --ignored
- cargo build -p gwt
- npx --yes markdownlint-cli2 tasks/lessons.md
- bunx commitlint --from origin/develop --to HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved host environment variable and PATH handling to ensure proper runtime execution across different environments.
  * Enhanced command resolution and spawn failure diagnostics with detailed environment path information.
  * Better isolation of Docker runtime environments from host system configurations.

* **Documentation**
  * Updated guidance for diagnosing and resolving terminal spawn failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->