### PR TITLE
fix(skills): resolve gwtd without PATH

### DIFF
--- a/.claude/commands/gwt-manage-pr.md
+++ b/.claude/commands/gwt-manage-pr.md
@@ -20,7 +20,28 @@ Steps
 -----
 
 1. Load `.claude/skills/gwt-manage-pr/SKILL.md` and follow the workflow.
-2. Resolve `GWT_BIN="${GWT_BIN_PATH:-gwtd}"` and make sure `"$GWT_BIN" pr current` succeeds before acting so auth and current-branch PR state are known.
+2. Resolve the daemon CLI before acting, then make sure `"$GWT_BIN" pr current` succeeds so auth and current-branch PR state are known:
+   ```bash
+   resolve_gwt_bin() {
+     if [ -n "${GWT_BIN_PATH:-}" ] && [ -x "$GWT_BIN_PATH" ]; then
+       printf '%s\n' "$GWT_BIN_PATH"
+       return 0
+     fi
+     if command -v gwtd >/dev/null 2>&1; then
+       command -v gwtd
+       return 0
+     fi
+     repo_root="${GWT_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+     if [ -x "$repo_root/target/debug/gwtd" ]; then
+       printf '%s\n' "$repo_root/target/debug/gwtd"
+       return 0
+     fi
+     printf '%s\n' "gwtd not found; set GWT_BIN_PATH, install gwtd into PATH, or run cargo build -p gwt --bin gwtd." >&2
+     return 127
+   }
+   GWT_BIN="$(resolve_gwt_bin)" || exit $?
+   "$GWT_BIN" pr current
+   ```
 3. Use the current branch and PR state to choose create, status, or unblock actions.
 4. If the PR is conflicting or behind, route directly into the fix flow.
 5. Keep PR work behind this visible entrypoint.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -286,7 +286,25 @@ Closes #456
 まず現在の develop 向け PR を確認：
 
 ```bash
-GWT_BIN="${GWT_BIN_PATH:-gwtd}"
+resolve_gwt_bin() {
+  if [ -n "${GWT_BIN_PATH:-}" ] && [ -x "$GWT_BIN_PATH" ]; then
+    printf '%s\n' "$GWT_BIN_PATH"
+    return 0
+  fi
+  if command -v gwtd >/dev/null 2>&1; then
+    command -v gwtd
+    return 0
+  fi
+  repo_root="${GWT_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  if [ -x "$repo_root/target/debug/gwtd" ]; then
+    printf '%s\n' "$repo_root/target/debug/gwtd"
+    return 0
+  fi
+  printf '%s\n' "gwtd not found; set GWT_BIN_PATH, install gwtd into PATH, or run cargo build -p gwt --bin gwtd." >&2
+  return 127
+}
+
+GWT_BIN="$(resolve_gwt_bin)" || exit $?
 "$GWT_BIN" pr current
 ```
 
@@ -337,7 +355,7 @@ PR bodyには以下を含めてください：
 まず、ステップ10の直後に `"$GWT_BIN" pr current` を再実行し、出力 1 行目の `#<number>` から PR 番号を取得する：
 
 ```bash
-GWT_BIN="${GWT_BIN_PATH:-gwtd}"
+GWT_BIN="$(resolve_gwt_bin)" || exit $?
 PR_CURRENT=$("$GWT_BIN" pr current)
 PR_NUMBER=$(printf '%s\n' "$PR_CURRENT" | sed -n 's/^#\([0-9]\+\).*/\1/p' | head -1)
 ```
@@ -345,7 +363,7 @@ PR_NUMBER=$(printf '%s\n' "$PR_CURRENT" | sed -n 's/^#\([0-9]\+\).*/\1/p' | head
 各 Issue にコメントを追記：
 
 ```bash
-GWT_BIN="${GWT_BIN_PATH:-gwtd}"
+GWT_BIN="$(resolve_gwt_bin)" || exit $?
 COMMENT_FILE=$(mktemp)
 printf 'Included in release v%s (#%s)\n' "{NEW_VERSION}" "$PR_NUMBER" > "$COMMENT_FILE"
 

--- a/.claude/skills/gwt-build-spec/SKILL.md
+++ b/.claude/skills/gwt-build-spec/SKILL.md
@@ -27,6 +27,14 @@ Use the current user's language for task summaries, completion reports, task
 check updates, and any user-facing text generated while executing the workflow,
 unless an existing artifact must keep its established language.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Exit CLI (Stop-block contract)
 
 SPEC-1935 FR-014r routes Stop through `skill-build-spec-stop-check`, which

--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -17,6 +17,14 @@ Use the current user's language for decision summaries, `Discussion TODO`,
 during this workflow, unless an existing artifact must keep its established
 language.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## When to use
 
 - A rough idea may or may not become a SPEC

--- a/.claude/skills/gwt-fix-issue/SKILL.md
+++ b/.claude/skills/gwt-fix-issue/SKILL.md
@@ -7,6 +7,14 @@ description: "Use when the user wants to resolve an existing GitHub Issue by num
 
 Public task entrypoint for resolving an existing GitHub Issue.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## When to use
 
 - The Issue number or URL is already known

--- a/.claude/skills/gwt-issue-search/SKILL.md
+++ b/.claude/skills/gwt-issue-search/SKILL.md
@@ -7,6 +7,14 @@ description: "Semantic search over all GitHub Issues using vector embeddings. Us
 
 gwt maintains a vector search index of GitHub Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/issues/` and is Worktree-independent. The gwt TUI refreshes it asynchronously at startup with a 15-minute TTL; non-TUI sessions get an auto-build on the first search.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Issues search first
 
 When the user asks any of the following, use GitHub Issues search before manual `gwtd issue view`,

--- a/.claude/skills/gwt-manage-pr/SKILL.md
+++ b/.claude/skills/gwt-manage-pr/SKILL.md
@@ -14,6 +14,14 @@ next-step guidance returned from this workflow.
 
 Canonical agent-facing surface is `gwtd pr ...` / `gwtd actions ...` for PR inspection, create/update, and fix flows. The current implementation may still use GitHub REST / `gh` internally as transport, while GraphQL remains the transport for unresolved review threads and thread reply/resolve.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Mode Auto-Detection
 
 On invocation, run Shared Preflight, then route:

--- a/.claude/skills/gwt-plan-spec/SKILL.md
+++ b/.claude/skills/gwt-plan-spec/SKILL.md
@@ -12,6 +12,14 @@ task decomposition, and quality gate.
 Covers planning, task decomposition, and pre-implementation quality-gate work
 behind the visible `gwt-plan-spec` entrypoint.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Invocation
 
 - **With SPEC:** `gwt-plan-spec SPEC-<id>` — full pipeline from spec.md to quality gate

--- a/.claude/skills/gwt-register-issue/SKILL.md
+++ b/.claude/skills/gwt-register-issue/SKILL.md
@@ -7,6 +7,14 @@ description: "Use when the user wants to register new work from a bug report, id
 
 Public task entrypoint for registering new work.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## When to use
 
 - The user has a bug report, enhancement idea, docs task, or rough request

--- a/.claude/skills/gwt-search/SKILL.md
+++ b/.claude/skills/gwt-search/SKILL.md
@@ -17,6 +17,14 @@ All vector data is stored under `~/.gwt/index/<repo-hash>/...`. Issues are repo-
 
 When invoked outside the gwt TUI, the runner falls back to a synchronous mtime+size diff per call: results are always correct, just slower than the TUI watcher path.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Quick reference
 
 ```text

--- a/.claude/skills/gwt-spec-search/SKILL.md
+++ b/.claude/skills/gwt-spec-search/SKILL.md
@@ -7,6 +7,14 @@ description: "Semantic search over SPEC Issues (GitHub Issue cache at ~/.gwt/cac
 
 gwt maintains a vector search index of SPEC Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). SPECs are stored as `gwt-spec` labeled GitHub Issues and cached locally at `~/.gwt/cache/issues/`. The index is stored at `~/.gwt/index/<repo-hash>/worktrees/<worktree-hash>/specs/` and is rebuilt from the cache. Use `gwtd issue spec pull --all` to refresh the cache before searching.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## SPEC search first for spec integration
 
 When the user asks any of the following, use SPEC search **before** manual file grep or directory listing:

--- a/.codex/skills/gwt-build-spec/SKILL.md
+++ b/.codex/skills/gwt-build-spec/SKILL.md
@@ -27,6 +27,14 @@ Use the current user's language for task summaries, completion reports, task
 check updates, and any user-facing text generated while executing the workflow,
 unless an existing artifact must keep its established language.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Exit CLI (Stop-block contract)
 
 SPEC-1935 FR-014r routes Stop through `skill-build-spec-stop-check`, which

--- a/.codex/skills/gwt-discussion/SKILL.md
+++ b/.codex/skills/gwt-discussion/SKILL.md
@@ -17,6 +17,14 @@ Use the current user's language for decision summaries, `Discussion TODO`,
 during this workflow, unless an existing artifact must keep its established
 language.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## When to use
 
 - A rough idea may or may not become a SPEC

--- a/.codex/skills/gwt-fix-issue/SKILL.md
+++ b/.codex/skills/gwt-fix-issue/SKILL.md
@@ -7,6 +7,14 @@ description: "Use when the user wants to resolve an existing GitHub Issue by num
 
 Public task entrypoint for resolving an existing GitHub Issue.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## When to use
 
 - The Issue number or URL is already known

--- a/.codex/skills/gwt-issue-search/SKILL.md
+++ b/.codex/skills/gwt-issue-search/SKILL.md
@@ -7,6 +7,14 @@ description: "Semantic search over all GitHub Issues using vector embeddings. Us
 
 gwt maintains a vector search index of GitHub Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/issues/` and is Worktree-independent. The gwt TUI refreshes it asynchronously at startup with a 15-minute TTL; non-TUI sessions get an auto-build on the first search.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Issues search first
 
 When the user asks any of the following, use GitHub Issues search before manual `gwtd issue view`,

--- a/.codex/skills/gwt-manage-pr/SKILL.md
+++ b/.codex/skills/gwt-manage-pr/SKILL.md
@@ -14,6 +14,14 @@ next-step guidance returned from this workflow.
 
 Canonical agent-facing surface is `gwtd pr ...` / `gwtd actions ...` for PR inspection, create/update, and fix flows. The current implementation may still use GitHub REST / `gh` internally as transport, while GraphQL remains the transport for unresolved review threads and thread reply/resolve.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Mode Auto-Detection
 
 On invocation, run Shared Preflight, then route:

--- a/.codex/skills/gwt-plan-spec/SKILL.md
+++ b/.codex/skills/gwt-plan-spec/SKILL.md
@@ -12,6 +12,14 @@ task decomposition, and quality gate.
 Covers planning, task decomposition, and pre-implementation quality-gate work
 behind the visible `gwt-plan-spec` entrypoint.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Invocation
 
 - **With SPEC:** `gwt-plan-spec SPEC-<id>` — full pipeline from spec.md to quality gate

--- a/.codex/skills/gwt-register-issue/SKILL.md
+++ b/.codex/skills/gwt-register-issue/SKILL.md
@@ -7,6 +7,14 @@ description: "Use when the user wants to register new work from a bug report, id
 
 Public task entrypoint for registering new work.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## When to use
 
 - The user has a bug report, enhancement idea, docs task, or rough request

--- a/.codex/skills/gwt-search/SKILL.md
+++ b/.codex/skills/gwt-search/SKILL.md
@@ -17,6 +17,14 @@ All vector data is stored under `~/.gwt/index/<repo-hash>/...`. Issues are repo-
 
 When invoked outside the gwt TUI, the runner falls back to a synchronous mtime+size diff per call: results are always correct, just slower than the TUI watcher path.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## Quick reference
 
 ```text

--- a/.codex/skills/gwt-spec-search/SKILL.md
+++ b/.codex/skills/gwt-spec-search/SKILL.md
@@ -7,6 +7,14 @@ description: "Semantic search over SPEC Issues (GitHub Issue cache at ~/.gwt/cac
 
 gwt maintains a vector search index of SPEC Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). SPECs are stored as `gwt-spec` labeled GitHub Issues and cached locally at `~/.gwt/cache/issues/`. The index is stored at `~/.gwt/index/<repo-hash>/worktrees/<worktree-hash>/specs/` and is rebuilt from the cache. Use `gwtd issue spec pull --all` to refresh the cache before searching.
 
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
 ## SPEC search first for spec integration
 
 When the user asks any of the following, use SPEC search **before** manual file grep or directory listing:

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,7 +12,7 @@ gwt は Git worktree の管理と、`Claude Code` / `Codex` / `Gemini` /
 
 - GUI 向けの主配布物: `gwt-macos-universal.dmg`
 - マウントした DMG から `GWT.app` を開くとネイティブ GUI をそのまま起動できます
-- `PATH` に `gwtd` CLI を入れたい場合は install script を使います
+- `PATH` に `gwt` / `gwtd` CLI を入れたい場合は install script を使います
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/akiojin/gwt/main/installers/macos/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download the release asset for your platform from
 
 - GUI-first installer: `gwt-macos-universal.dmg`
 - Open `GWT.app` from the mounted DMG for the native desktop launch surface
-- Use the install script when you want the `gwtd` CLI in your `PATH`
+- Use the install script when you want the `gwt` and `gwtd` CLIs in your `PATH`
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/akiojin/gwt/main/installers/macos/install.sh | bash

--- a/bin/gwtd.cjs
+++ b/bin/gwtd.cjs
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 /**
- * Wrapper script to execute the gwt Rust binary.
- * If the binary is not found (e.g., bunx skips postinstall),
+ * Wrapper script to execute the gwtd Rust binary.
+ * If the bundle is not found (e.g., bunx skips postinstall),
  * it will be downloaded on-demand from GitHub Releases.
  */
 
-const { binaryNameForPlatform } = require("../scripts/release-assets.cjs");
+const { daemonBinaryNameForPlatform } = require("../scripts/release-assets.cjs");
 const { createLauncher } = require("./launcher.cjs");
 
 const launcher = createLauncher({
-  commandName: "gwt",
-  binaryNameForPlatform,
+  commandName: "gwtd",
+  binaryNameForPlatform: daemonBinaryNameForPlatform,
 });
 
 if (require.main === module) {

--- a/bin/launcher.cjs
+++ b/bin/launcher.cjs
@@ -1,0 +1,84 @@
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const {
+  bundleBinaryNamesForPlatform,
+  installReleaseBinary,
+  releaseAssetUrl,
+} = require("../scripts/release-assets.cjs");
+
+const REPO = "akiojin/gwt";
+const BIN_DIR = __dirname;
+
+function readVersion() {
+  const pkg = path.join(__dirname, "..", "package.json");
+  return JSON.parse(fs.readFileSync(pkg, "utf8")).version;
+}
+
+function createLauncher({ commandName, binaryNameForPlatform }) {
+  const binName = binaryNameForPlatform(process.platform);
+  const binPath = path.join(BIN_DIR, binName);
+  const bundleBinaries = bundleBinaryNamesForPlatform(process.platform);
+
+  async function ensureBinary() {
+    if (bundleBinaries.every((name) => fs.existsSync(path.join(BIN_DIR, name)))) {
+      return;
+    }
+
+    const version = readVersion();
+    const { url } = releaseAssetUrl(REPO, version, process.platform, process.arch);
+
+    console.log(`Downloading gwt bundle for ${process.platform}-${process.arch}...`);
+    console.log(`Downloading from: ${url}`);
+
+    await installReleaseBinary({
+      repo: REPO,
+      version,
+      binDir: BIN_DIR,
+      platform: process.platform,
+      arch: process.arch,
+    });
+
+    console.log(`gwt bundle installed successfully: ${bundleBinaries.join(", ")}`);
+  }
+
+  async function main() {
+    try {
+      await ensureBinary();
+    } catch (err) {
+      console.error(`Failed to download gwt binary: ${err.message}`);
+      console.error(`https://github.com/${REPO}/releases`);
+      process.exit(1);
+    }
+
+    const child = spawn(binPath, process.argv.slice(2), {
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", (err) => {
+      console.error(`Failed to start ${commandName}: ${err.message}`);
+      process.exit(1);
+    });
+
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+      } else {
+        process.exit(code ?? 0);
+      }
+    });
+  }
+
+  return {
+    ensureBinary,
+    main,
+    readVersion,
+  };
+}
+
+module.exports = {
+  createLauncher,
+  readVersion,
+};

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -985,6 +985,10 @@ mod tests {
                 "expected canonical gwtd actions log guidance in {relative}"
             );
             assert!(
+                pr_skill.contains("GWT_BIN_PATH") && pr_skill.contains("target/debug/gwtd"),
+                "expected managed PR skill to resolve gwtd without relying on PATH in {relative}"
+            );
+            assert!(
                 pr_skill.contains("current user's language"),
                 "expected language contract in {relative}"
             );
@@ -1100,6 +1104,17 @@ mod tests {
             "expected release command to route shell snippets through GWT_BIN_PATH"
         );
         assert!(
+            release_command.contains("resolve_gwt_bin()")
+                && release_command.contains("command -v gwtd")
+                && release_command.contains("target/debug/gwtd")
+                && release_command.contains("gwtd not found"),
+            "expected release command to resolve gwtd from GWT_BIN_PATH, PATH, or repo-local debug binary"
+        );
+        assert!(
+            !release_command.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwtd}\""),
+            "unexpected bare gwtd fallback in release command"
+        );
+        assert!(
             release_command.contains("\"$GWT_BIN\" issue comment"),
             "expected release command to use the canonical gwtd issue comment via GWT_BIN"
         );
@@ -1124,6 +1139,17 @@ mod tests {
         assert!(
             pr_command.contains("GWT_BIN_PATH"),
             "expected gwt-manage-pr command wrapper to point to canonical GWT_BIN_PATH auth check"
+        );
+        assert!(
+            pr_command.contains("resolve_gwt_bin()")
+                && pr_command.contains("command -v gwtd")
+                && pr_command.contains("target/debug/gwtd")
+                && pr_command.contains("gwtd not found"),
+            "expected gwt-manage-pr command wrapper to resolve gwtd from GWT_BIN_PATH, PATH, or repo-local debug binary"
+        );
+        assert!(
+            !pr_command.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwtd}\""),
+            "unexpected bare gwtd fallback in gwt-manage-pr command"
         );
         assert!(
             pr_command.contains("conflicting") || pr_command.contains("behind"),

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -80,8 +80,24 @@ fn refresh_managed_gwt_assets_keeps_command_assets_on_gwtd_cli_surface() {
         "PR command asset should tell managed sessions to use GWT_BIN_PATH, got: {manage_pr}"
     );
     assert!(
-        manage_pr.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwtd}\""),
-        "PR command asset should default managed sessions to gwtd, got: {manage_pr}"
+        manage_pr.contains("resolve_gwt_bin()"),
+        "PR command asset should define the gwtd resolver, got: {manage_pr}"
+    );
+    assert!(
+        manage_pr.contains("command -v gwtd"),
+        "PR command asset should fall back to PATH gwtd, got: {manage_pr}"
+    );
+    assert!(
+        manage_pr.contains("target/debug/gwtd"),
+        "PR command asset should fall back to repo-local gwtd, got: {manage_pr}"
+    );
+    assert!(
+        manage_pr.contains("gwtd not found"),
+        "PR command asset should fail with an actionable gwtd error, got: {manage_pr}"
+    );
+    assert!(
+        !manage_pr.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwtd}\""),
+        "PR command asset must not fall back directly to a bare gwtd lookup, got: {manage_pr}"
     );
     assert!(
         !manage_pr.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwt}\""),
@@ -95,8 +111,24 @@ fn refresh_managed_gwt_assets_keeps_command_assets_on_gwtd_cli_surface() {
         "release command asset should shell out through GWT_BIN_PATH, got: {release}"
     );
     assert!(
-        release.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwtd}\""),
-        "release command asset should default managed sessions to gwtd, got: {release}"
+        release.contains("resolve_gwt_bin()"),
+        "release command asset should define the gwtd resolver, got: {release}"
+    );
+    assert!(
+        release.contains("command -v gwtd"),
+        "release command asset should fall back to PATH gwtd, got: {release}"
+    );
+    assert!(
+        release.contains("target/debug/gwtd"),
+        "release command asset should fall back to repo-local gwtd, got: {release}"
+    );
+    assert!(
+        release.contains("gwtd not found"),
+        "release command asset should fail with an actionable gwtd error, got: {release}"
+    );
+    assert!(
+        !release.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwtd}\""),
+        "release command asset must not fall back directly to a bare gwtd lookup, got: {release}"
     );
     assert!(
         !release.contains("GWT_BIN=\"${GWT_BIN_PATH:-gwt}\""),

--- a/installers/macos/install.sh
+++ b/installers/macos/install.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="akiojin/gwt"
+INSTALL_DIR="${GWT_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="latest"
+
+usage() {
+  cat <<'USAGE'
+Usage: install.sh [--version <version>] [--dir <install-dir>]
+
+Installs both gwt and gwtd into the target directory.
+Defaults:
+  version: latest GitHub Release
+  dir:     $GWT_INSTALL_DIR or $HOME/.local/bin
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      VERSION="${2:?missing value for --version}"
+      shift 2
+      ;;
+    --dir)
+      INSTALL_DIR="${2:?missing value for --dir}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$(uname -m)" in
+  arm64|aarch64)
+    ARCH="arm64"
+    ;;
+  x86_64|amd64)
+    ARCH="x86_64"
+    ;;
+  *)
+    echo "Unsupported macOS architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+ASSET="gwt-macos-${ARCH}.tar.gz"
+if [ "$VERSION" = "latest" ]; then
+  URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+else
+  TAG="v${VERSION#v}"
+  URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$INSTALL_DIR"
+curl -fsSL "$URL" -o "$TMPDIR/$ASSET"
+tar -xzf "$TMPDIR/$ASSET" -C "$TMPDIR"
+
+for BIN in gwt gwtd; do
+  SOURCE="$(find "$TMPDIR" -type f -name "$BIN" | head -n 1)"
+  if [ -z "$SOURCE" ]; then
+    echo "Downloaded archive does not contain $BIN" >&2
+    exit 1
+  fi
+  cp "$SOURCE" "$INSTALL_DIR/$BIN"
+  chmod +x "$INSTALL_DIR/$BIN"
+done
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo "Warning: $INSTALL_DIR is not in PATH." >&2
+    echo "Add it to your shell profile before running gwt or gwtd by name." >&2
+    ;;
+esac
+
+echo "Installed gwt and gwtd into $INSTALL_DIR"

--- a/installers/macos/uninstall.sh
+++ b/installers/macos/uninstall.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${GWT_INSTALL_DIR:-$HOME/.local/bin}"
+
+usage() {
+  cat <<'USAGE'
+Usage: uninstall.sh [--dir <install-dir>]
+
+Removes both gwt and gwtd from the target directory.
+Defaults:
+  dir: $GWT_INSTALL_DIR or $HOME/.local/bin
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dir)
+      INSTALL_DIR="${2:?missing value for --dir}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for BIN in gwt gwtd; do
+  rm -f "$INSTALL_DIR/$BIN"
+done
+
+echo "Removed gwt and gwtd from $INSTALL_DIR"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {
-    "gwt": "bin/gwt.cjs"
+    "gwt": "bin/gwt.cjs",
+    "gwtd": "bin/gwtd.cjs"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.cjs",

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -7,6 +7,7 @@ const { execFileSync } = require("child_process");
 const {
   binaryNameForPlatform,
   bundleBinaryNamesForPlatform,
+  daemonBinaryNameForPlatform,
   installBundleFromArchive,
   primaryReleaseAssetName,
   releaseAssetName,
@@ -47,6 +48,9 @@ run("release helper keeps platform binary names stable", () => {
   assert.equal(binaryNameForPlatform("win32"), "gwt.exe");
   assert.equal(binaryNameForPlatform("linux"), "gwt");
   assert.equal(binaryNameForPlatform("darwin"), "gwt");
+  assert.equal(daemonBinaryNameForPlatform("win32"), "gwtd.exe");
+  assert.equal(daemonBinaryNameForPlatform("linux"), "gwtd");
+  assert.equal(daemonBinaryNameForPlatform("darwin"), "gwtd");
 });
 
 run("release helper keeps bundle binary names stable", () => {
@@ -56,8 +60,12 @@ run("release helper keeps bundle binary names stable", () => {
 });
 
 run("installer entrypoints are loadable under package type module", () => {
+  const daemonLauncher = require("../bin/gwtd.cjs");
+
   assert.equal(typeof postinstall.main, "function");
   assert.equal(typeof launcher.main, "function");
+  assert.equal(typeof daemonLauncher.main, "function");
+  assert.equal(typeof daemonLauncher.readVersion, "function");
 });
 
 run("windows installer definition includes the gwtd companion binary", () => {
@@ -78,6 +86,8 @@ run("release workflow packages gwtd alongside gwt", () => {
 
 run("package scripts keep the GUI front door and release contract explicit", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
+  assert.equal(pkg.bin.gwt, "bin/gwt.cjs");
+  assert.equal(pkg.bin.gwtd, "bin/gwtd.cjs");
   assert.equal(pkg.scripts["test:release-assets"], "node scripts/test_release_assets.cjs");
   assert.equal(
     pkg.scripts["test:frontend-bundle"],
@@ -86,6 +96,23 @@ run("package scripts keep the GUI front door and release contract explicit", () 
   assert.equal(pkg.scripts["test:release-flow"], "bash scripts/check-release-flow.sh");
   assert.equal(pkg.scripts.dev, "cargo run -p gwt --bin gwt");
   assert.equal(pkg.scripts.build, "cargo build --release -p gwt --bin gwt --bin gwtd");
+});
+
+run("macos install scripts install and remove both public command shims", () => {
+  const install = fs.readFileSync(
+    path.join(__dirname, "..", "installers", "macos", "install.sh"),
+    "utf8"
+  );
+  const uninstall = fs.readFileSync(
+    path.join(__dirname, "..", "installers", "macos", "uninstall.sh"),
+    "utf8"
+  );
+
+  assert.match(install, /gwt-macos-\$\{ARCH\}\.tar\.gz/);
+  assert.match(install, /for BIN in gwt gwtd/);
+  assert.match(install, /chmod \+x "\$INSTALL_DIR\/\$BIN"/);
+  assert.match(uninstall, /for BIN in gwt gwtd/);
+  assert.match(uninstall, /rm -f "\$INSTALL_DIR\/\$BIN"/);
 });
 
 run("test all script keeps rust tests plus frontend release checks", () => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,29 @@
 # Lessons Learned
 
+## 2026-04-30 — fix(skills): managed skills must not assume gwtd is on PATH
+
+### 事象
+
+`$gwt-discussion` / `$gwt-manage-pr` などの managed skill 実行時に、
+Codex セッションの `PATH` へ `gwtd` が存在しないため、CLI 呼び出しが失敗する余地が残っていた。
+同時に npm package の `bin` は `gwt` だけを公開しており、release bundle に `gwtd` が
+含まれていても `gwtd` command shim としては利用できなかった。
+
+### 原因
+
+`GWT_BIN_PATH` 注入は実装済みだったが、managed command asset は
+`GWT_BIN="${GWT_BIN_PATH:-gwtd}"` のままで、`GWT_BIN_PATH` がない環境では bare `gwtd`
+lookup に戻っていた。さらに macOS の DMG は GUI-first 配布であり、CLI を PATH に置く
+install script が実体として存在しなかった。
+
+### 再発防止策
+
+1. managed skill / command asset は `GWT_BIN_PATH`、PATH 上の `gwtd`、repo-local
+   `target/debug/gwtd` の順で解決し、見つからない場合は actionable error を出す。
+2. release / npm / install script の配布契約は `gwt` と `gwtd` を必ず同時に検証する。
+3. PATH 問題の修正では、実行ログの症状、package shim、install guidance、managed asset の
+   実テキストを同時に確認する。
+
 ## 2026-04-30 — fix(ci): ローカル lint は CI と同じ package selection でも確認する
 
 ### 事象


### PR DESCRIPTION
## Summary

Fixes the remaining managed-session failure mode where `gwtd` is not available from PATH even though the daemon binary is available through `GWT_BIN_PATH` or the local build output.

## Changes

- Added `gwtd` to the npm `bin` surface and shared the on-demand bundle launcher between `gwt` and `gwtd`.
- Added macOS install/uninstall scripts that install and remove both `gwt` and `gwtd`.
- Updated managed command and skill assets to resolve `gwtd` via `GWT_BIN_PATH`, PATH, then repo-local `target/debug/gwtd` before failing with an actionable error.
- Added regression tests for command assets, package shims, release asset contracts, and installer scripts.
- Recorded the recurrence in `tasks/lessons.md`.

## Testing

- `node scripts/test_release_assets.cjs`
- `node --check bin/gwt.cjs`
- `node --check bin/gwtd.cjs`
- `node --check bin/launcher.cjs`
- `bash -n installers/macos/install.sh`
- `bash -n installers/macos/uninstall.sh`
- `bash scripts/validate-skill-frontmatter.sh`
- `bunx markdownlint-cli2 ...`
- `node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs`
- `bash scripts/check-release-flow.sh`
- `cargo fmt -- --check`
- `cargo test -p gwt-skills`
- `cargo test -p gwt --test managed_assets_test`
- `cargo test -p gwt-core -p gwt --all-features --no-fail-fast`
- `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`
- `cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json`
- `node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90` (90.36% locally, 90.41% in pre-push hook)
- `cargo test -p gwt-core --tests -- --ignored`
- pre-push hook: passed

## Closing Issues

Closes #2034

## Related Issues / Links

None

## Checklist

- [x] Tests pass
- [x] Coverage threshold met
- [x] E2E tests run
- [x] Issue owner updated
