### PR TITLE
fix(gui): open launch wizard without hydration loading

### DIFF
--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -163,6 +163,87 @@ pub(crate) struct ActiveAgentSession {
     pub(crate) tab_id: String,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct LaunchWizardMemoryCache {
+    sessions: Vec<gwt_agent::Session>,
+    agent_options: Vec<gwt::AgentOption>,
+}
+
+impl LaunchWizardMemoryCache {
+    pub(crate) fn load(sessions_dir: &Path) -> Self {
+        Self {
+            sessions: Self::load_sessions(sessions_dir),
+            agent_options: Self::load_agent_options(),
+        }
+    }
+
+    fn load_sessions(sessions_dir: &Path) -> Vec<gwt_agent::Session> {
+        let Ok(entries) = std::fs::read_dir(sessions_dir) else {
+            return Vec::new();
+        };
+        entries
+            .flatten()
+            .filter_map(|entry| {
+                let path = entry.path();
+                (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
+            })
+            .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
+            .collect()
+    }
+
+    fn load_agent_options() -> Vec<gwt::AgentOption> {
+        gwt::load_agent_options(&gwt_agent::VersionCache::load(
+            &gwt::default_wizard_version_cache_path(),
+        ))
+    }
+
+    fn refresh_agent_options(&mut self) {
+        self.agent_options = Self::load_agent_options();
+    }
+
+    fn agent_options(&self) -> Vec<gwt::AgentOption> {
+        self.agent_options.clone()
+    }
+
+    fn quick_start_entries(
+        &self,
+        repo_path: &Path,
+        branch_name: &str,
+    ) -> Vec<gwt::QuickStartEntry> {
+        gwt::launch_wizard::quick_start_entries_from_sessions(
+            repo_path,
+            branch_name,
+            &self.sessions,
+        )
+    }
+
+    fn previous_profile(&self, repo_path: &Path) -> Option<gwt::LaunchWizardPreviousProfile> {
+        gwt::launch_wizard::previous_launch_profile_from_sessions(repo_path, &self.sessions)
+    }
+
+    fn record_session(&mut self, session: gwt_agent::Session) {
+        if let Some(existing) = self
+            .sessions
+            .iter_mut()
+            .find(|existing| existing.id == session.id)
+        {
+            *existing = session;
+        } else {
+            self.sessions.push(session);
+        }
+    }
+
+    fn mark_stopped(&mut self, session_id: &str) {
+        if let Some(session) = self
+            .sessions
+            .iter_mut()
+            .find(|session| session.id == session_id)
+        {
+            session.update_status(gwt_agent::AgentStatus::Stopped);
+        }
+    }
+}
+
 #[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
 struct IssueBranchLinkStore {
     #[serde(default)]
@@ -365,6 +446,7 @@ pub(crate) struct AppRuntime {
     pub(crate) proxy: AppEventProxy,
     pub(crate) blocking_tasks: BlockingTaskSpawner,
     pub(crate) sessions_dir: PathBuf,
+    pub(crate) launch_wizard_cache: LaunchWizardMemoryCache,
     pub(crate) launch_wizard: Option<LaunchWizardSession>,
     pub(crate) active_agent_sessions: HashMap<String, ActiveAgentSession>,
     pub(crate) window_pty_statuses: HashMap<String, WindowProcessStatus>,
@@ -421,6 +503,7 @@ impl AppRuntime {
         let active_tab_id = normalize_active_tab_id(&tabs, persisted.active_tab_id);
         let sessions_dir = gwt_core::paths::gwt_sessions_dir();
         let _ = gwt_agent::reset_runtime_state_dir(&sessions_dir);
+        let launch_wizard_cache = LaunchWizardMemoryCache::load(&sessions_dir);
 
         let mut app = Self {
             tabs,
@@ -436,6 +519,7 @@ impl AppRuntime {
             proxy: AppEventProxy::new(proxy),
             blocking_tasks,
             sessions_dir,
+            launch_wizard_cache,
             launch_wizard: None,
             active_agent_sessions: HashMap::new(),
             window_pty_statuses: HashMap::new(),
@@ -675,27 +759,41 @@ impl AppRuntime {
                 client_id,
                 gwt::custom_agents_dispatch::list_presets_event(),
             )],
-            FrontendEvent::AddCustomAgentFromPreset { input } => vec![OutboundEvent::reply(
-                client_id,
-                gwt::custom_agents_dispatch::add_from_preset_event(
+            FrontendEvent::AddCustomAgentFromPreset { input } => {
+                let event = gwt::custom_agents_dispatch::add_from_preset_event(
                     gwt::PresetId::ClaudeCodeOpenaiCompat,
                     serde_json::to_value(input)
                         .expect("custom agent preset payload should serialize"),
-                ),
-            )],
-            FrontendEvent::UpdateCustomAgent { agent } => vec![OutboundEvent::reply(
-                client_id,
-                gwt::custom_agents_dispatch::update_event(*agent),
-            )],
-            FrontendEvent::DeleteCustomAgent { agent_id } => vec![OutboundEvent::reply(
-                client_id,
-                gwt::custom_agents_dispatch::delete_event(agent_id),
-            )],
+                );
+                self.custom_agent_reply_with_cache_refresh(client_id, event)
+            }
+            FrontendEvent::UpdateCustomAgent { agent } => {
+                let event = gwt::custom_agents_dispatch::update_event(*agent);
+                self.custom_agent_reply_with_cache_refresh(client_id, event)
+            }
+            FrontendEvent::DeleteCustomAgent { agent_id } => {
+                let event = gwt::custom_agents_dispatch::delete_event(agent_id);
+                self.custom_agent_reply_with_cache_refresh(client_id, event)
+            }
             FrontendEvent::TestBackendConnection { base_url, api_key } => {
                 self.spawn_backend_connection_probe(client_id, base_url, api_key);
                 Vec::new()
             }
         }
+    }
+
+    fn custom_agent_reply_with_cache_refresh(
+        &mut self,
+        client_id: ClientId,
+        event: BackendEvent,
+    ) -> Vec<OutboundEvent> {
+        if matches!(
+            &event,
+            BackendEvent::CustomAgentSaved { .. } | BackendEvent::CustomAgentDeleted { .. }
+        ) {
+            self.launch_wizard_cache.refresh_agent_options();
+        }
+        vec![OutboundEvent::reply(client_id, event)]
     }
 
     pub(crate) fn spawn_backend_connection_probe(
@@ -2615,41 +2713,32 @@ impl AppRuntime {
     ) -> Result<(), String> {
         let normalized_branch_name = normalize_branch_name(branch_name);
         let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
+        let quick_start_entries = self
+            .launch_wizard_cache
+            .quick_start_entries(project_root, &normalized_branch_name);
+        let previous_profile = self.launch_wizard_cache.previous_profile(project_root);
+        let agent_options = self.launch_wizard_cache.agent_options();
+        let (docker_context, docker_service_status) =
+            detect_wizard_docker_context_and_status(project_root);
         let wizard_id = Uuid::new_v4().to_string();
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
-            wizard_id: wizard_id.clone(),
-            wizard: LaunchWizardState::open_loading(
+            wizard_id,
+            wizard: LaunchWizardState::open_with_previous_profile(
                 LaunchWizardContext {
                     selected_branch: synthetic_branch_entry(branch_name),
                     normalized_branch_name,
                     worktree_path: None,
                     quick_start_root: project_root.to_path_buf(),
                     live_sessions,
-                    docker_context: None,
-                    docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+                    docker_context,
+                    docker_service_status,
                     linked_issue_number,
                 },
-                Vec::new(),
+                agent_options,
+                quick_start_entries,
+                previous_profile,
             ),
-        });
-
-        let proxy = self.proxy.clone();
-        let sessions_dir = self.sessions_dir.clone();
-        let project_root = project_root.to_path_buf();
-        let branch_name = branch_name.to_string();
-        let active_session_branches = self.active_session_branches_for_tab(tab_id);
-        thread::spawn(move || {
-            let result = resolve_launch_wizard_hydration(
-                &project_root,
-                &branch_name,
-                &active_session_branches,
-                &sessions_dir,
-            );
-            proxy.send(UserEvent::LaunchWizardHydrated {
-                wizard_id,
-                result: Box::new(result),
-            });
         });
 
         Ok(())
@@ -2741,26 +2830,6 @@ impl AppRuntime {
             ));
         });
         Vec::new()
-    }
-
-    pub(crate) fn handle_launch_wizard_hydrated(
-        &mut self,
-        wizard_id: String,
-        result: Result<LaunchWizardHydration, String>,
-    ) -> Vec<OutboundEvent> {
-        let Some(session) = self.launch_wizard.as_mut() else {
-            return Vec::new();
-        };
-        if session.wizard_id != wizard_id {
-            return Vec::new();
-        }
-
-        match result {
-            Ok(hydration) => session.wizard.apply_hydration(hydration),
-            Err(error) => session.wizard.set_hydration_error(error),
-        }
-
-        vec![self.launch_wizard_state_outbound()]
     }
 
     pub(crate) fn handle_issue_launch_wizard_prepared(
@@ -3136,6 +3205,7 @@ impl AppRuntime {
                         tab_id: address.tab_id,
                     },
                 );
+                self.refresh_launch_wizard_session_cache(&window_id);
 
                 match self.spawn_process_window(&window_id, geometry, process_launch) {
                     Ok(()) => {
@@ -3647,6 +3717,24 @@ impl AppRuntime {
             &session.session_id,
             gwt_agent::AgentStatus::Stopped,
         );
+        self.launch_wizard_cache.mark_stopped(&session.session_id);
+    }
+
+    fn refresh_launch_wizard_session_cache(&mut self, window_id: &str) {
+        let Some(session) = self.active_agent_sessions.get(window_id) else {
+            return;
+        };
+        let path = self
+            .sessions_dir
+            .join(format!("{}.toml", session.session_id));
+        match gwt_agent::Session::load_and_migrate(&path) {
+            Ok(session) => self.launch_wizard_cache.record_session(session),
+            Err(error) => tracing::warn!(
+                path = %path.display(),
+                error = %error,
+                "failed to refresh Launch Wizard session cache"
+            ),
+        }
     }
 
     pub(crate) fn register_pty_writer(&self, id: &str, pane: &Arc<Mutex<Pane>>) {
@@ -4435,8 +4523,9 @@ mod tests {
 
     use super::{
         ActiveAgentSession, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
-        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest, LaunchWizardSession,
-        OutboundEvent, ProjectTabRuntime, UserEvent, WindowRuntime,
+        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest,
+        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProjectTabRuntime, UserEvent,
+        WindowRuntime,
     };
     use crate::{combined_window_id, PtyWriterRegistry};
 
@@ -4860,6 +4949,7 @@ exit 0
         let log_dir = temp_root.join("logs");
         fs::create_dir_all(&sessions_dir).expect("create sessions dir");
         fs::create_dir_all(&log_dir).expect("create log dir");
+        let launch_wizard_cache = LaunchWizardMemoryCache::load(&sessions_dir);
         let pty_writers: PtyWriterRegistry = Arc::new(RwLock::new(HashMap::new()));
         let mut runtime = AppRuntime {
             tabs,
@@ -4875,6 +4965,7 @@ exit 0
             proxy,
             blocking_tasks: BlockingTaskSpawner::thread(),
             sessions_dir,
+            launch_wizard_cache,
             launch_wizard: None,
             active_agent_sessions: HashMap::<String, ActiveAgentSession>::new(),
             window_pty_statuses: HashMap::new(),
@@ -5175,6 +5266,52 @@ exit 0
                     && *status == WindowProcessStatus::Error
                     && detail.as_deref() == Some("boom")
         ));
+    }
+
+    #[test]
+    fn app_runtime_open_launch_wizard_uses_cached_previous_profile_without_hydrating() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let sessions_dir = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+
+        let mut session = gwt_agent::Session::new(&repo, "feature/demo", gwt_agent::AgentId::Codex);
+        session.model = Some("gpt-5.4".to_string());
+        session.reasoning_level = Some("high".to_string());
+        session.tool_version = Some("latest".to_string());
+        session.session_mode = gwt_agent::SessionMode::Continue;
+        session.skip_permissions = true;
+        session.codex_fast_mode = true;
+        session.save(&sessions_dir).expect("save session");
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_launch_wizard_for_branch("tab-1", &repo, "feature/demo", None)
+            .expect("open launch wizard");
+
+        let view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("launch wizard")
+            .wizard
+            .view();
+        assert!(!view.is_hydrating);
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_reasoning, "high");
+        assert_eq!(view.selected_version, "latest");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -221,20 +221,49 @@ pub fn load_previous_launch_profile(
     sessions_dir: &Path,
 ) -> Option<LaunchWizardPreviousProfile> {
     let entries = std::fs::read_dir(sessions_dir).ok()?;
-    entries
+    let sessions = entries
         .flatten()
         .filter_map(|entry| {
             let path = entry.path();
             (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
         })
         .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
+        .collect::<Vec<_>>();
+    previous_launch_profile_from_sessions(repo_path, &sessions)
+}
+
+pub fn previous_launch_profile_from_sessions(
+    repo_path: &Path,
+    sessions: &[gwt_agent::Session],
+) -> Option<LaunchWizardPreviousProfile> {
+    sessions
+        .iter()
         .filter(|session| same_launch_profile_repo(repo_path, session))
         .max_by(|left, right| {
             left.updated_at
                 .cmp(&right.updated_at)
                 .then_with(|| left.created_at.cmp(&right.created_at))
         })
+        .cloned()
         .map(previous_profile_from_session)
+}
+
+pub fn quick_start_entries_from_sessions(
+    repo_path: &Path,
+    branch_name: &str,
+    sessions: &[gwt_agent::Session],
+) -> Vec<QuickStartEntry> {
+    let sessions = sessions
+        .iter()
+        .filter(|session| session.branch == branch_name)
+        .filter(|session| same_launch_profile_repo(repo_path, session))
+        .cloned()
+        .map(|mut session| {
+            session.worktree_path = repo_path.to_path_buf();
+            session
+        })
+        .collect::<Vec<_>>();
+    quick_start::collect_quick_start_entries_from_sessions(repo_path, branch_name, sessions)
 }
 
 fn previous_profile_from_session(session: gwt_agent::Session) -> LaunchWizardPreviousProfile {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -13,13 +13,12 @@ use std::{
 use crate::repo_browser::{preferred_issue_launch_branch, spawn_branch_load_async};
 use base64::Engine;
 use gwt::{
-    cleanup_selected_branches, default_wizard_version_cache_path, detect_shell_program,
-    list_branch_entries_with_active_sessions, list_directory_entries, load_agent_options,
-    load_knowledge_bridge, load_restored_workspace_state, load_session_state,
-    migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree, resolve_launch_spec,
-    save_session_state, save_workspace_state, workspace_state_path, BackendEvent,
-    BranchEntriesPhase, BranchListEntry, DockerWizardContext, FrontendEvent, HookForwardTarget,
-    KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration,
+    cleanup_selected_branches, detect_shell_program, list_branch_entries_with_active_sessions,
+    list_directory_entries, load_knowledge_bridge, load_restored_workspace_state,
+    load_session_state, migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree,
+    resolve_launch_spec, save_session_state, save_workspace_state, workspace_state_path,
+    BackendEvent, BranchEntriesPhase, BranchListEntry, DockerWizardContext, FrontendEvent,
+    HookForwardTarget, KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext,
     LaunchWizardLaunchRequest, LaunchWizardState, LiveSessionEntry, ShellLaunchConfig,
     WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
 };
@@ -42,6 +41,8 @@ mod repo_browser;
 mod runtime_support;
 mod update_front_door;
 
+#[cfg(test)]
+pub(crate) use app_runtime::LaunchWizardMemoryCache;
 #[cfg(test)]
 pub(crate) use app_runtime::{
     build_frontend_sync_events, KnowledgeLoadRequest, LaunchWizardSession,
@@ -83,14 +84,13 @@ pub(crate) use runtime_support::{
     combined_window_id, current_git_branch, dedupe_recent_projects, fallback_project_target,
     first_available_worktree_path, front_door_route, geometry_to_pty_size,
     knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
-    origin_remote_ref, resolve_launch_spec_with_fallback, resolve_launch_wizard_hydration,
-    resolve_project_target, run_cli, same_worktree_path, should_auto_close_agent_window,
-    should_auto_start_restored_window, synthetic_branch_entry, workspace_view_for_tab,
+    origin_remote_ref, resolve_launch_spec_with_fallback, resolve_project_target, run_cli,
+    same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
+    synthetic_branch_entry, workspace_view_for_tab,
 };
 #[cfg(test)]
 pub(crate) use runtime_support::{
-    branch_worktree_path, parse_github_remote_url, spawn_env, suffixed_worktree_path,
-    worktree_path_is_occupied,
+    parse_github_remote_url, spawn_env, suffixed_worktree_path, worktree_path_is_occupied,
 };
 pub(crate) use update_front_door::{apply_update_and_exit, spawn_startup_update_check};
 #[cfg(test)]
@@ -359,10 +359,6 @@ enum UserEvent {
         window_id: String,
         result: Result<ProcessLaunch, String>,
     },
-    LaunchWizardHydrated {
-        wizard_id: String,
-        result: Box<Result<LaunchWizardHydration, String>>,
-    },
     IssueLaunchWizardPrepared(IssueLaunchWizardPrepared),
     Dispatch(Vec<OutboundEvent>),
     UpdateAvailable(gwt_core::update::UpdateState),
@@ -409,8 +405,9 @@ mod tests {
         install_launch_gwt_bin_env_with_lookup, knowledge_kind_for_preset,
         logging_dir_for_startup_path, resolve_project_target, should_auto_close_agent_window,
         should_auto_start_restored_window, ActiveAgentSession, AppEventProxy, AppRuntime,
-        BlockingTaskSpawner, ClientHub, DispatchTarget, KnowledgeLoadRequest, LaunchWizardSession,
-        OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent, WindowAddress,
+        BlockingTaskSpawner, ClientHub, DispatchTarget, KnowledgeLoadRequest,
+        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProcessLaunch,
+        ProjectTabRuntime, UserEvent, WindowAddress,
     };
 
     fn canvas_bounds() -> WindowGeometry {
@@ -913,6 +910,7 @@ mod tests {
         let log_dir = temp_root.join("logs");
         fs::create_dir_all(&sessions_dir).expect("create sessions dir");
         fs::create_dir_all(&log_dir).expect("create log dir");
+        let launch_wizard_cache = LaunchWizardMemoryCache::load(&sessions_dir);
         let mut runtime = AppRuntime {
             tabs,
             active_tab_id: active_tab_id.map(str::to_owned),
@@ -927,6 +925,7 @@ mod tests {
             proxy,
             blocking_tasks: BlockingTaskSpawner::thread(),
             sessions_dir,
+            launch_wizard_cache,
             launch_wizard: None,
             active_agent_sessions: HashMap::new(),
             window_pty_statuses: HashMap::new(),
@@ -1823,11 +1822,14 @@ mod tests {
             wizard_events[0].event,
             BackendEvent::LaunchWizardState { wizard: Some(_) }
         ));
-        wait_for_recorded_event("launch wizard hydration", &events, |events| {
-            events
-                .iter()
-                .any(|event| matches!(event, UserEvent::LaunchWizardHydrated { .. }))
-        });
+        assert!(
+            !runtime
+                .launch_wizard
+                .as_ref()
+                .expect("launch wizard")
+                .wizard
+                .is_hydrating
+        );
 
         let issue_events = runtime.open_issue_launch_wizard_events("client-1", &issue_id, 42);
         assert!(issue_events.is_empty());
@@ -2135,11 +2137,14 @@ mod tests {
             },
         );
         assert_eq!(wizard_events.len(), 1);
-        wait_for_recorded_event("launch wizard hydration", &events, |events| {
-            events
-                .iter()
-                .any(|event| matches!(event, UserEvent::LaunchWizardHydrated { .. }))
-        });
+        assert!(
+            !runtime
+                .launch_wizard
+                .as_ref()
+                .expect("launch wizard")
+                .wizard
+                .is_hydrating
+        );
 
         let issue_events = runtime.handle_frontend_event(
             "client-1".to_string(),
@@ -2202,11 +2207,11 @@ mod tests {
     }
 
     #[test]
-    fn wizard_handler_helpers_cover_hydration_preparation_focus_and_error_paths() {
+    fn wizard_handler_helpers_cover_preparation_focus_and_error_paths() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo");
-        let (mut runtime, events) = sample_runtime_with_events(
+        let (mut runtime, _events) = sample_runtime_with_events(
             temp.path(),
             vec![sample_project_tab(
                 "tab-1",
@@ -2218,48 +2223,6 @@ mod tests {
             Some("tab-1"),
         );
         let claude_id = window_id_for_preset(&runtime, "tab-1", WindowPreset::Claude, 0);
-
-        assert!(runtime
-            .handle_launch_wizard_hydrated("wizard-1".to_string(), Err("missing".to_string()))
-            .is_empty());
-
-        runtime.launch_wizard = Some(sample_launch_wizard_session("tab-1", &repo));
-        assert!(runtime
-            .handle_launch_wizard_hydrated("other".to_string(), Err("skip".to_string()))
-            .is_empty());
-
-        let hydration_error = runtime.handle_launch_wizard_hydrated(
-            "wizard-1".to_string(),
-            Err("hydrate failed".to_string()),
-        );
-        assert_eq!(hydration_error.len(), 1);
-        assert_eq!(
-            runtime
-                .launch_wizard
-                .as_ref()
-                .unwrap()
-                .wizard
-                .hydration_error
-                .as_deref(),
-            Some("hydrate failed")
-        );
-
-        let hydration_ok = runtime.handle_launch_wizard_hydrated(
-            "wizard-1".to_string(),
-            Ok(gwt::LaunchWizardHydration {
-                selected_branch: Some(sample_branch_entry("feature/demo")),
-                normalized_branch_name: "feature/demo".to_string(),
-                worktree_path: Some(repo.clone()),
-                quick_start_root: repo.clone(),
-                docker_context: None,
-                docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
-                agent_options: sample_wizard_agent_options(),
-                quick_start_entries: vec![sample_wizard_quick_start_entry(None)],
-                previous_profile: None,
-            }),
-        );
-        assert_eq!(hydration_ok.len(), 1);
-        assert!(!runtime.launch_wizard.as_ref().unwrap().wizard.is_hydrating);
 
         let missing_tab =
             runtime.handle_issue_launch_wizard_prepared(super::IssueLaunchWizardPrepared {
@@ -2308,11 +2271,14 @@ mod tests {
             prepared_ok[0].event,
             BackendEvent::LaunchWizardState { wizard: Some(_) }
         ));
-        wait_for_recorded_event("prepared launch hydration", &events, |events| {
-            events
-                .iter()
-                .any(|event| matches!(event, UserEvent::LaunchWizardHydrated { .. }))
-        });
+        assert!(
+            !runtime
+                .launch_wizard
+                .as_ref()
+                .expect("launch wizard")
+                .wizard
+                .is_hydrating
+        );
 
         runtime.launch_wizard = None;
         assert!(runtime
@@ -3508,10 +3474,6 @@ mod tests {
             .expect("git branch");
         assert!(branch.success(), "git branch failed");
 
-        assert_eq!(
-            super::branch_worktree_path(&repo, "develop"),
-            Some(repo.clone())
-        );
         assert!(super::local_branch_exists(&repo, "feature/demo").unwrap());
         assert!(!super::local_branch_exists(&repo, "feature/missing").unwrap());
 
@@ -4488,10 +4450,6 @@ fn main() -> wry::Result<()> {
             }
             Event::UserEvent(UserEvent::ShellLaunchComplete { window_id, result }) => {
                 let events = app.handle_shell_launch_complete(window_id, result);
-                clients.dispatch(events);
-            }
-            Event::UserEvent(UserEvent::LaunchWizardHydrated { wizard_id, result }) => {
-                let events = app.handle_launch_wizard_hydrated(wizard_id, *result);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::IssueLaunchWizardPrepared(prepared)) => {

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -183,49 +183,6 @@ pub(crate) fn synthetic_branch_entry(branch_name: &str) -> BranchListEntry {
     }
 }
 
-pub(crate) fn resolve_launch_wizard_hydration(
-    project_root: &Path,
-    branch_name: &str,
-    active_session_branches: &std::collections::HashSet<String>,
-    sessions_dir: &Path,
-) -> Result<LaunchWizardHydration, String> {
-    let agent_options = load_agent_options(&gwt_agent::VersionCache::load(
-        &default_wizard_version_cache_path(),
-    ));
-    let entries = list_branch_entries_with_active_sessions(project_root, active_session_branches)
-        .map_err(|error| error.to_string())?;
-    let selected_branch = entries
-        .into_iter()
-        .find(|entry| entry.name == branch_name)
-        .ok_or_else(|| format!("Branch not found: {branch_name}"))?;
-    let normalized_branch_name = normalize_branch_name(&selected_branch.name);
-    let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
-    let quick_start_root = worktree_path
-        .clone()
-        .unwrap_or_else(|| project_root.to_path_buf());
-    let quick_start_entries = gwt::launch_wizard::load_quick_start_entries(
-        &quick_start_root,
-        sessions_dir,
-        &normalized_branch_name,
-    );
-    let previous_profile =
-        gwt::launch_wizard::load_previous_launch_profile(&quick_start_root, sessions_dir);
-    let (docker_context, docker_service_status) =
-        detect_wizard_docker_context_and_status(&quick_start_root);
-
-    Ok(LaunchWizardHydration {
-        selected_branch: Some(selected_branch),
-        normalized_branch_name,
-        worktree_path,
-        quick_start_root,
-        docker_context,
-        docker_service_status,
-        agent_options,
-        quick_start_entries,
-        previous_profile,
-    })
-}
-
 pub(crate) fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> {
     match preset {
         WindowPreset::Issue => Some(KnowledgeKind::Issue),
@@ -233,24 +190,6 @@ pub(crate) fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<Knowledg
         WindowPreset::Pr => Some(KnowledgeKind::Pr),
         _ => None,
     }
-}
-
-pub(crate) fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
-    if current_git_branch(repo_path)
-        .as_ref()
-        .is_ok_and(|current| current == branch_name)
-    {
-        return Some(repo_path.to_path_buf());
-    }
-
-    let main_repo_path = gwt_git::worktree::main_worktree_root(repo_path).ok()?;
-    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
-    manager
-        .list()
-        .ok()?
-        .into_iter()
-        .find(|worktree| worktree.branch.as_deref() == Some(branch_name))
-        .map(|worktree| worktree.path)
 }
 
 pub(crate) fn first_available_worktree_path(


### PR DESCRIPTION
## Summary

- Open Launch Agent without the intermediate hydration loading state so users can select options and launch immediately.
- Cache Launch Wizard session metadata and agent options in `AppRuntime` to avoid rescanning persisted sessions on every wizard open.
- Keep the cache fresh after launches, stopped sessions, and custom-agent changes.

## Changes

- `crates/gwt/src/app_runtime.rs`: added `LaunchWizardMemoryCache`, switched `open_launch_wizard_for_branch` to build a non-hydrating wizard state from cached previous profile, QuickStart entries, and agent options, and refreshes cache on launch/stop/custom-agent updates.
- `crates/gwt/src/launch_wizard.rs`: exposed session-slice helpers for previous-profile and QuickStart construction so runtime cache can reuse existing wizard policies.
- `crates/gwt/src/main.rs`: removed the `LaunchWizardHydrated` event path and updated integration tests to assert immediate non-hydrating wizard state.
- `crates/gwt/src/runtime_support.rs`: removed the per-open Launch Wizard hydration resolver that scanned sessions during each open.

## Testing

- [x] `cargo test -p gwt app_runtime_open_launch_wizard_uses_cached_previous_profile_without_hydrating -- --nocapture` — passes; regression test failed before the cache implementation because the wizard opened in hydrating state.
- [x] `cargo test -p gwt wizard_handler_helpers_cover_preparation_focus_and_error_paths -- --nocapture` — passes.
- [x] `cargo test -p gwt frontend_event_dispatch_routes -- --nocapture` — passes.
- [x] `cargo test -p gwt worktree_git_and_misc_helpers_cover_repo_paths_and_defaults -- --nocapture` — passes.
- [x] `cargo test -p gwt-core -p gwt` — passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo build -p gwt` — passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passes.

## Closing Issues

- Closes #2014

## Related Issues / Links

- #1784
- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (not applicable: no schema or persisted-data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- Launch Agent previously showed a disabled Loading state while the app scanned persisted sessions and resolved wizard hydration on each open.
- SPEC-2014 now records the memory-cache contract as US-8 / FR-015 / FR-016 / T13-T15.

## Risk / Impact

- **Affected areas**: Launch Wizard open path, previous-profile restoration, QuickStart entries, custom-agent option cache.
- **Rollback plan**: Revert this PR to restore the prior hydration event path.

## Screenshots

- Not included: this changes the wizard initialization behavior and removes transient Loading; no visual styling changed. Behavior is covered by the AppRuntime regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved launch wizard performance by introducing in-memory caching of session data, eliminating asynchronous hydration delays.
  * Enhanced session lifecycle handling with automatic cache updates when sessions are created, updated, or deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->