### PR TITLE
fix(windows): suppress GUI subprocess windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ name = "gwt-github"
 version = "9.11.11"
 dependencies = [
  "fs2",
+ "gwt-core",
  "regex",
  "reqwest",
  "serde",

--- a/crates/gwt-agent/src/detect.rs
+++ b/crates/gwt-agent/src/detect.rs
@@ -110,7 +110,7 @@ impl AgentDetector {
     }
 
     fn fetch_version(command: &str, version_flag: &str, prefix_args: &[&str]) -> Option<String> {
-        let mut cmd = std::process::Command::new(command);
+        let mut cmd = gwt_core::process::hidden_command(command);
         for arg in prefix_args {
             cmd.arg(arg);
         }

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Resolve the gwt repo hash for the directory by shelling out to
 /// `git remote get-url origin`. Returns `None` when no origin is configured.
 fn detect_repo_hash_for_dir(dir: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .arg("remote")
         .arg("get-url")
         .arg("origin")

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::Stdio,
 };
 
 use crate::{
@@ -585,7 +585,7 @@ fn probe_host_package_runner(
     remove_env: &[String],
     cwd: Option<PathBuf>,
 ) -> bool {
-    let mut process = Command::new(command);
+    let mut process = gwt_core::process::hidden_command(command);
     process
         .args(args)
         .stdin(Stdio::null())
@@ -1218,7 +1218,7 @@ fn origin_remote_ref(branch_name: &str) -> String {
 }
 
 fn current_git_branch(repo_path: &Path) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["branch", "--show-current"])
         .current_dir(repo_path)
         .output()
@@ -1237,7 +1237,7 @@ fn current_git_branch(repo_path: &Path) -> Result<String, String> {
 }
 
 fn local_branch_exists(repo_path: &Path, branch_name: &str) -> Result<bool, String> {
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["show-ref", "--verify", "--quiet"])
         .arg(format!("refs/heads/{branch_name}"))
         .current_dir(repo_path)
@@ -1297,7 +1297,6 @@ mod tests {
     use crate::{AgentLaunchBuilder, SessionMode};
     use std::{
         fs,
-        process::Command,
         sync::atomic::{AtomicUsize, Ordering},
     };
     use tempfile::tempdir;
@@ -1684,38 +1683,38 @@ mod tests {
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo dir");
 
-        let init = Command::new("git")
+        let init = gwt_core::process::hidden_command("git")
             .args(["init", "-q", "-b", "develop"])
             .current_dir(&repo)
             .status()
             .expect("git init");
         assert!(init.success(), "git init failed");
-        let config_name = Command::new("git")
+        let config_name = gwt_core::process::hidden_command("git")
             .args(["config", "user.name", "Codex"])
             .current_dir(&repo)
             .status()
             .expect("git config user.name");
         assert!(config_name.success(), "git config user.name failed");
-        let config_email = Command::new("git")
+        let config_email = gwt_core::process::hidden_command("git")
             .args(["config", "user.email", "codex@example.com"])
             .current_dir(&repo)
             .status()
             .expect("git config user.email");
         assert!(config_email.success(), "git config user.email failed");
         fs::write(repo.join("README.md"), "repo\n").expect("write readme");
-        let add = Command::new("git")
+        let add = gwt_core::process::hidden_command("git")
             .args(["add", "README.md"])
             .current_dir(&repo)
             .status()
             .expect("git add");
         assert!(add.success(), "git add failed");
-        let commit = Command::new("git")
+        let commit = gwt_core::process::hidden_command("git")
             .args(["commit", "-qm", "init"])
             .current_dir(&repo)
             .status()
             .expect("git commit");
         assert!(commit.success(), "git commit failed");
-        let detach = Command::new("git")
+        let detach = gwt_core::process::hidden_command("git")
             .args(["checkout", "--detach"])
             .current_dir(&repo)
             .status()

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -339,7 +339,7 @@ fn coordination_project_dir(worktree_root: &Path) -> Option<PathBuf> {
 }
 
 fn coordination_repo_root(worktree_root: &Path) -> Option<PathBuf> {
-    let mut cmd = std::process::Command::new("git");
+    let mut cmd = crate::process::hidden_command("git");
     cmd.args(["rev-parse", "--show-toplevel"])
         .current_dir(worktree_root);
     crate::process::scrub_git_env(&mut cmd);
@@ -361,7 +361,7 @@ fn coordination_migration_marker_path(project_dir: &Path) -> PathBuf {
 }
 
 fn discover_legacy_coordination_dirs(worktree_root: &Path) -> Vec<PathBuf> {
-    let mut cmd = std::process::Command::new("git");
+    let mut cmd = crate::process::hidden_command("git");
     cmd.args(["worktree", "list", "--porcelain"])
         .current_dir(worktree_root);
     crate::process::scrub_git_env(&mut cmd);
@@ -813,7 +813,7 @@ mod tests {
 
         let repo = home.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
-        let mut init_cmd = std::process::Command::new("git");
+        let mut init_cmd = crate::process::hidden_command("git");
         init_cmd.args(["init", "--quiet"]).current_dir(&repo);
         crate::process::scrub_git_env(&mut init_cmd);
         let output = init_cmd.output().unwrap();

--- a/crates/gwt-core/src/index/runtime.rs
+++ b/crates/gwt-core/src/index/runtime.rs
@@ -239,7 +239,7 @@ impl RunnerSpawner for PythonRunnerSpawner {
         project_root: &Path,
         respect_ttl: bool,
     ) -> std::io::Result<()> {
-        let mut cmd = std::process::Command::new(&self.python_executable);
+        let mut cmd = crate::process::hidden_command(&self.python_executable);
         cmd.arg(&self.runner_script)
             .arg("--action")
             .arg("index-issues")

--- a/crates/gwt-core/src/notes.rs
+++ b/crates/gwt-core/src/notes.rs
@@ -320,13 +320,13 @@ mod tests {
     }
 
     fn init_git_repo(path: &Path) {
-        let mut init_cmd = std::process::Command::new("git");
+        let mut init_cmd = crate::process::hidden_command("git");
         init_cmd.args(["init", path.to_str().unwrap()]);
         crate::process::scrub_git_env(&mut init_cmd);
         let output = init_cmd.output().expect("git init");
         assert!(output.status.success(), "git init failed");
 
-        let mut email_cmd = std::process::Command::new("git");
+        let mut email_cmd = crate::process::hidden_command("git");
         email_cmd
             .args(["config", "user.email", "test@example.com"])
             .current_dir(path);
@@ -334,7 +334,7 @@ mod tests {
         let email = email_cmd.output().expect("git config user.email");
         assert!(email.status.success(), "git config user.email failed");
 
-        let mut name_cmd = std::process::Command::new("git");
+        let mut name_cmd = crate::process::hidden_command("git");
         name_cmd
             .args(["config", "user.name", "Test User"])
             .current_dir(path);
@@ -344,7 +344,7 @@ mod tests {
     }
 
     fn add_origin(path: &Path, url: &str) {
-        let mut cmd = std::process::Command::new("git");
+        let mut cmd = crate::process::hidden_command("git");
         cmd.args(["remote", "add", "origin", url]).current_dir(path);
         crate::process::scrub_git_env(&mut cmd);
         let output = cmd.output().expect("git remote add origin");
@@ -357,13 +357,13 @@ mod tests {
 
     fn commit_file(path: &Path, name: &str, body: &str) {
         std::fs::write(path.join(name), body).unwrap();
-        let mut add_cmd = std::process::Command::new("git");
+        let mut add_cmd = crate::process::hidden_command("git");
         add_cmd.args(["add", name]).current_dir(path);
         crate::process::scrub_git_env(&mut add_cmd);
         let add = add_cmd.output().expect("git add");
         assert!(add.status.success(), "git add failed");
 
-        let mut commit_cmd = std::process::Command::new("git");
+        let mut commit_cmd = crate::process::hidden_command("git");
         commit_cmd.args(["commit", "-m", "init"]).current_dir(path);
         crate::process::scrub_git_env(&mut commit_cmd);
         let commit = commit_cmd.output().expect("git commit");
@@ -552,7 +552,7 @@ mod tests {
         add_origin(&repo, "https://github.com/example/project.git");
         commit_file(&repo, "README.md", "# repo\n");
 
-        let mut wt_cmd = std::process::Command::new("git");
+        let mut wt_cmd = crate::process::hidden_command("git");
         wt_cmd
             .args([
                 "worktree",

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -395,7 +395,7 @@ mod tests {
     }
 
     fn init_git_repo(path: &Path) {
-        let mut cmd = std::process::Command::new("git");
+        let mut cmd = crate::process::hidden_command("git");
         cmd.args(["init", path.to_str().unwrap()]);
         crate::process::scrub_git_env(&mut cmd);
         let output = cmd.output().expect("git init");
@@ -407,7 +407,7 @@ mod tests {
     }
 
     fn add_origin(path: &Path, url: &str) {
-        let mut cmd = std::process::Command::new("git");
+        let mut cmd = crate::process::hidden_command("git");
         cmd.args(["remote", "add", "origin", url]).current_dir(path);
         crate::process::scrub_git_env(&mut cmd);
         let output = cmd.output().expect("git remote add origin");

--- a/crates/gwt-core/src/process.rs
+++ b/crates/gwt-core/src/process.rs
@@ -1,6 +1,9 @@
 //! Process execution helpers.
 
-use std::process::{Command, Output};
+use std::{
+    ffi::OsStr,
+    process::{Command, Output},
+};
 
 use crate::error::{GwtError, Result};
 
@@ -22,7 +25,7 @@ fn capture_output(cmd: &str, output: Output) -> Result<String> {
 /// Returns an error if the command fails to start or exits with a non-zero
 /// status.
 pub fn run_command(cmd: &str, args: &[&str]) -> Result<String> {
-    let output = Command::new(cmd)
+    let output = hidden_command(cmd)
         .args(args)
         .output()
         .map_err(GwtError::Io)?;
@@ -31,7 +34,7 @@ pub fn run_command(cmd: &str, args: &[&str]) -> Result<String> {
 
 /// Run a command with additional environment variables and capture its stdout.
 pub fn run_command_with_env(cmd: &str, args: &[&str], env: &[(String, String)]) -> Result<String> {
-    let mut command = Command::new(cmd);
+    let mut command = hidden_command(cmd);
     command.args(args);
     for (key, value) in env {
         command.env(key, value);
@@ -43,6 +46,40 @@ pub fn run_command_with_env(cmd: &str, args: &[&str], env: &[(String, String)]) 
 /// Check whether a command exists on `$PATH`.
 pub fn command_exists(cmd: &str) -> bool {
     which::which(cmd).is_ok()
+}
+
+/// Create a non-interactive command that does not create an extra console
+/// window when spawned from the Windows GUI front door.
+pub fn hidden_command<S: AsRef<OsStr>>(program: S) -> Command {
+    let mut command = Command::new(program);
+    configure_hidden_command(&mut command);
+    command
+}
+
+/// Apply platform-specific non-interactive process flags.
+pub fn configure_hidden_command(command: &mut Command) -> &mut Command {
+    let flags = hidden_creation_flags();
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        command.creation_flags(flags);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = flags;
+    }
+    command
+}
+
+#[cfg(windows)]
+fn hidden_creation_flags() -> u32 {
+    0x08000000
+}
+
+#[cfg(not(windows))]
+fn hidden_creation_flags() -> u32 {
+    0
 }
 
 /// Drop `GIT_*` env vars from `cmd` that override path-specific lookup.
@@ -178,5 +215,29 @@ mod tests {
         // `git --version` is universally available in dev environments
         let version = get_command_version("git").unwrap();
         assert!(version.contains("git version"));
+    }
+
+    #[test]
+    fn hidden_creation_flags_match_platform() {
+        if cfg!(windows) {
+            assert_eq!(hidden_creation_flags(), 0x08000000);
+        } else {
+            assert_eq!(hidden_creation_flags(), 0);
+        }
+    }
+
+    #[test]
+    fn hidden_command_captures_stdout() {
+        let (cmd, args) = echo_command("hidden hello");
+        let output = hidden_command(&cmd)
+            .args(args)
+            .output()
+            .expect("run hidden command");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "hidden hello"
+        );
     }
 }

--- a/crates/gwt-core/src/repo_hash.rs
+++ b/crates/gwt-core/src/repo_hash.rs
@@ -111,7 +111,7 @@ pub fn compute_path_hash(path: &Path) -> RepoHash {
 
 /// Detect a `RepoHash` from the `origin` remote configured for `repo_root`.
 pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
-    let mut cmd = std::process::Command::new("git");
+    let mut cmd = crate::process::hidden_command("git");
     cmd.args(["remote", "get-url", "origin"])
         .current_dir(repo_root);
     scrub_git_env(&mut cmd);
@@ -197,7 +197,7 @@ mod tests {
         add_origin(&repo, "https://github.com/example/project.git");
         commit_file(&repo, "README.md", "# repo\n");
 
-        let mut wt_cmd = std::process::Command::new("git");
+        let mut wt_cmd = crate::process::hidden_command("git");
         wt_cmd
             .args([
                 "worktree",
@@ -229,13 +229,13 @@ mod tests {
     }
 
     fn init_git_repo(path: &Path) {
-        let mut init_cmd = std::process::Command::new("git");
+        let mut init_cmd = crate::process::hidden_command("git");
         init_cmd.args(["init", path.to_str().unwrap()]);
         scrub_git_env(&mut init_cmd);
         let output = init_cmd.output().expect("git init");
         assert!(output.status.success(), "git init failed");
 
-        let mut email_cmd = std::process::Command::new("git");
+        let mut email_cmd = crate::process::hidden_command("git");
         email_cmd
             .args(["config", "user.email", "test@example.com"])
             .current_dir(path);
@@ -243,7 +243,7 @@ mod tests {
         let email = email_cmd.output().expect("git config user.email");
         assert!(email.status.success(), "git config user.email failed");
 
-        let mut name_cmd = std::process::Command::new("git");
+        let mut name_cmd = crate::process::hidden_command("git");
         name_cmd
             .args(["config", "user.name", "Test User"])
             .current_dir(path);
@@ -253,7 +253,7 @@ mod tests {
     }
 
     fn add_origin(path: &Path, url: &str) {
-        let mut cmd = std::process::Command::new("git");
+        let mut cmd = crate::process::hidden_command("git");
         cmd.args(["remote", "add", "origin", url]).current_dir(path);
         scrub_git_env(&mut cmd);
         let output = cmd.output().expect("git remote add origin");
@@ -266,13 +266,13 @@ mod tests {
 
     fn commit_file(path: &Path, name: &str, body: &str) {
         std::fs::write(path.join(name), body).unwrap();
-        let mut add_cmd = std::process::Command::new("git");
+        let mut add_cmd = crate::process::hidden_command("git");
         add_cmd.args(["add", name]).current_dir(path);
         scrub_git_env(&mut add_cmd);
         let add = add_cmd.output().expect("git add");
         assert!(add.status.success(), "git add failed");
 
-        let mut commit_cmd = std::process::Command::new("git");
+        let mut commit_cmd = crate::process::hidden_command("git");
         commit_cmd.args(["commit", "-m", "init"]).current_dir(path);
         scrub_git_env(&mut commit_cmd);
         let commit = commit_cmd.output().expect("git commit");

--- a/crates/gwt-core/src/runtime.rs
+++ b/crates/gwt-core/src/runtime.rs
@@ -71,7 +71,7 @@ impl RuntimeProvisioner for RealProvisioner {
     }
 
     fn create_venv(&self, python: &BootstrapPython, venv_dir: &Path) -> Result<()> {
-        let mut command = Command::new(&python.program);
+        let mut command = crate::process::hidden_command(&python.program);
         command
             .args(python.prefix_args)
             .arg("-m")
@@ -82,7 +82,7 @@ impl RuntimeProvisioner for RealProvisioner {
 
     fn install_requirements(&self, venv_python: &Path, requirements: &Path) -> Result<()> {
         run_checked(
-            Command::new(venv_python)
+            crate::process::hidden_command(venv_python)
                 .arg("-m")
                 .arg("pip")
                 .arg("install")
@@ -95,14 +95,16 @@ impl RuntimeProvisioner for RealProvisioner {
 
     fn probe_chromadb(&self, venv_python: &Path) -> Result<()> {
         run_checked(
-            Command::new(venv_python).arg("-c").arg("import chromadb"),
+            crate::process::hidden_command(venv_python)
+                .arg("-c")
+                .arg("import chromadb"),
             "python -c import chromadb",
         )
     }
 
     fn probe_runner(&self, venv_python: &Path, runner_script: &Path) -> Result<()> {
         run_checked(
-            Command::new(venv_python)
+            crate::process::hidden_command(venv_python)
                 .arg(runner_script)
                 .arg("--action")
                 .arg("probe"),
@@ -389,7 +391,7 @@ fn python_version(
     path: &Path,
     prefix_args: &[&str],
 ) -> std::result::Result<(u32, u32, String), String> {
-    let output = Command::new(path)
+    let output = crate::process::hidden_command(path)
         .args(prefix_args)
         .arg("-c")
         .arg(PYTHON_VERSION_SNIPPET)

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -1204,7 +1204,7 @@ fn is_process_running(pid: u32) -> bool {
         let script = format!(
             "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}"
         );
-        std::process::Command::new("powershell")
+        crate::process::hidden_command("powershell")
             .args(["-NoProfile", "-Command", &script])
             .status()
             .map(|s: std::process::ExitStatus| s.success())

--- a/crates/gwt-git/src/branch.rs
+++ b/crates/gwt-git/src/branch.rs
@@ -76,7 +76,7 @@ pub fn is_branch_merged_into(repo_path: &Path, branch: &str, base: &str) -> Resu
         return Ok(false);
     }
 
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["cherry", base, branch])
         .current_dir(repo_path)
         .output()
@@ -176,7 +176,7 @@ fn detect_cleanable_target_for_remote(
 /// `[gone]` (FR-018a). Used to flag branches whose remote was deleted but
 /// which still exist locally.
 pub fn list_gone_branches(repo_path: &Path) -> Result<HashSet<String>> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args([
             "for-each-ref",
             "--format=%(refname:short)\t%(upstream:track)",
@@ -218,7 +218,7 @@ pub fn delete_local_branch(repo_path: &Path, name: &str, force: bool) -> Result<
     }
 
     let flag = if force { "-D" } else { "-d" };
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["branch", flag, name])
         .current_dir(repo_path)
         .output()
@@ -233,7 +233,7 @@ pub fn delete_local_branch(repo_path: &Path, name: &str, force: bool) -> Result<
 
 /// Returns true when `git rev-parse --verify <ref>` succeeds.
 fn ref_exists(repo_path: &Path, refname: &str) -> Result<bool> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["rev-parse", "--verify", "--quiet", refname])
         .current_dir(repo_path)
         .output()
@@ -268,7 +268,7 @@ pub struct DivergenceInfo {
 /// Returns `DivergenceInfo { ahead, behind }`. If either ref is missing the
 /// command will fail and an error is returned.
 pub fn git_divergence(repo_path: &Path, branch: &str, upstream: &str) -> Result<DivergenceInfo> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args([
             "-C",
             &repo_path.to_string_lossy(),
@@ -340,7 +340,7 @@ pub struct Branch {
 pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
     let format =
         "%(refname:short)\t%(HEAD)\t%(upstream:short)\t%(upstream:track)\t%(creatordate:iso8601)";
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["for-each-ref", &format!("--format={format}"), "refs/heads/"])
         .current_dir(repo_path)
         .output()
@@ -361,7 +361,7 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
     let remote_names = list_remote_names(repo_path).unwrap_or_default();
 
     // Also list remote branches
-    let remote_output = std::process::Command::new("git")
+    let remote_output = gwt_core::process::hidden_command("git")
         .args([
             "for-each-ref",
             "--format=%(refname:short)\t%(creatordate:iso8601)",
@@ -403,7 +403,7 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
 }
 
 pub fn list_remote_names(repo_path: &Path) -> Result<Vec<String>> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .arg("remote")
         .current_dir(repo_path)
         .output()
@@ -620,7 +620,7 @@ mod tests {
     // ---------- Branch Cleanup helpers (FR-018) ----------
 
     fn run(args: &[&str], cwd: &Path) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(args)
             .current_dir(cwd)
             .output()
@@ -883,11 +883,11 @@ mod tests {
     fn list_branches_in_test_repo() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(path)
             .output()

--- a/crates/gwt-git/src/commit.rs
+++ b/crates/gwt-git/src/commit.rs
@@ -23,7 +23,7 @@ pub struct CommitEntry {
 /// Returns up to `count` commits from HEAD.
 pub fn recent_commits(repo_path: &Path, count: usize) -> Result<Vec<CommitEntry>> {
     let format = "%h\t%s\t%an\t%aI";
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args([
             "log",
             &format!("--max-count={count}"),
@@ -108,16 +108,16 @@ mod tests {
     fn recent_commits_in_test_repo() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "first commit"])
             .current_dir(path)
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "second commit"])
             .current_dir(path)
             .output()
@@ -133,12 +133,12 @@ mod tests {
     fn recent_commits_respects_count() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
         for i in 0..5 {
-            std::process::Command::new("git")
+            gwt_core::process::hidden_command("git")
                 .args(["commit", "--allow-empty", "-m", &format!("commit {i}")])
                 .current_dir(path)
                 .output()
@@ -153,7 +153,7 @@ mod tests {
     fn recent_commits_empty_repo() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();

--- a/crates/gwt-git/src/diff.rs
+++ b/crates/gwt-git/src/diff.rs
@@ -40,7 +40,7 @@ impl FileEntry {
     pub fn diff_content(&self, repo_path: &Path) -> Result<String> {
         match self.status {
             FileStatus::Staged => {
-                let output = std::process::Command::new("git")
+                let output = gwt_core::process::hidden_command("git")
                     .args(["diff", "--cached", "--", self.path.to_str().unwrap_or("")])
                     .current_dir(repo_path)
                     .output()
@@ -48,7 +48,7 @@ impl FileEntry {
                 Ok(String::from_utf8_lossy(&output.stdout).to_string())
             }
             FileStatus::Unstaged => {
-                let output = std::process::Command::new("git")
+                let output = gwt_core::process::hidden_command("git")
                     .args(["diff", "--", self.path.to_str().unwrap_or("")])
                     .current_dir(repo_path)
                     .output()
@@ -65,7 +65,7 @@ impl FileEntry {
 
 /// Get the working tree status as a list of `FileEntry`.
 pub fn get_status(repo_path: &Path) -> Result<Vec<FileEntry>> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["status", "--porcelain=v1"])
         .current_dir(repo_path)
         .output()
@@ -198,11 +198,11 @@ mod tests {
     fn get_status_in_clean_repo() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(path)
             .output()
@@ -216,11 +216,11 @@ mod tests {
     fn get_status_with_untracked_file() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(path)
             .output()

--- a/crates/gwt-git/src/issue.rs
+++ b/crates/gwt-git/src/issue.rs
@@ -96,7 +96,7 @@ fn cache_filename(owner: &str, repo: &str) -> String {
 /// Fetch open issues from GitHub via `gh issue list --json`.
 pub fn fetch_issues(owner: &str, repo: &str) -> Result<Vec<Issue>> {
     let repo_slug = format!("{owner}/{repo}");
-    let output = std::process::Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args([
             "issue",
             "list",

--- a/crates/gwt-git/src/pr_status.rs
+++ b/crates/gwt-git/src/pr_status.rs
@@ -55,7 +55,7 @@ impl PrStatus {
 ///
 /// The `repo_slug` should be in "owner/repo" format.
 pub fn fetch_pr_status(repo_slug: &str, number: u64) -> Result<PrStatus> {
-    let output = std::process::Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args([
             "pr",
             "view",
@@ -222,7 +222,7 @@ where
 }
 
 fn run_gh_command(repo_path: &Path, args: &[&str]) -> Result<GhCliOutput> {
-    let output = std::process::Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args(args)
         .current_dir(repo_path)
         .output()
@@ -314,7 +314,7 @@ pub struct PrCheckReport {
 /// Runs `gh pr view` to gather CI, merge, and review states. Falls back
 /// to `Unknown` states when `gh` is unavailable or the repo has no open PR.
 pub fn pr_check_report(repo_path: &Path) -> Result<PrCheckReport> {
-    let output = std::process::Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args([
             "pr",
             "view",

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -3,7 +3,6 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use gwt_core::{GwtError, Result};
@@ -107,7 +106,7 @@ pub fn clone_repo(url: &str, target_dir: &Path) -> Result<PathBuf> {
         .ok_or_else(|| GwtError::Git(format!("Invalid target path: {}", target_dir.display())))?;
 
     // Try with -b develop first
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["clone", "--depth=1", "-b", "develop", url, target])
         .output()
         .map_err(|e| GwtError::Git(format!("git clone: {e}")))?;
@@ -117,7 +116,7 @@ pub fn clone_repo(url: &str, target_dir: &Path) -> Result<PathBuf> {
     }
 
     // Fallback: clone without -b develop (uses default branch)
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["clone", "--depth=1", url, target])
         .output()
         .map_err(|e| GwtError::Git(format!("git clone: {e}")))?;
@@ -298,7 +297,7 @@ impl Repository {
     ///
     /// Returns `None` for detached HEAD.
     pub fn current_branch(&self) -> Result<Option<String>> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["symbolic-ref", "--short", "HEAD"])
             .current_dir(&self.path)
             .output()
@@ -315,7 +314,7 @@ impl Repository {
 
     /// List local and remote branch names.
     pub fn branches(&self) -> Result<Vec<String>> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["branch", "-a", "--format=%(refname:short)"])
             .current_dir(&self.path)
             .output()
@@ -337,7 +336,7 @@ impl Repository {
 
     /// Check if this repository is bare.
     pub fn is_bare(&self) -> bool {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["rev-parse", "--is-bare-repository"])
             .current_dir(&self.path)
             .output();
@@ -350,7 +349,7 @@ impl Repository {
 
     /// Check if the current directory is inside a worktree.
     pub fn is_worktree(&self) -> bool {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["rev-parse", "--is-inside-work-tree"])
             .current_dir(&self.path)
             .output();
@@ -377,7 +376,7 @@ mod tests {
     #[test]
     fn detect_repo_type_returns_normal_for_git_repo() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -387,7 +386,7 @@ mod tests {
     #[test]
     fn detect_repo_type_returns_bare_for_bare_repo() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", "--bare", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -400,7 +399,7 @@ mod tests {
     #[test]
     fn detect_repo_type_walks_parents_to_find_normal() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -413,7 +412,7 @@ mod tests {
     fn detect_repo_type_finds_bare_in_child_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let bare_dir = tmp.path().join("repo.git");
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", "--bare", bare_dir.to_str().unwrap()])
             .output()
             .unwrap();
@@ -429,7 +428,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let repo_dir = tmp.path().join("my-project");
         std::fs::create_dir_all(&repo_dir).unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", repo_dir.to_str().unwrap()])
             .output()
             .unwrap();
@@ -452,7 +451,7 @@ mod tests {
     #[test]
     fn install_develop_protection_creates_hook() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -479,7 +478,7 @@ mod tests {
     #[test]
     fn install_develop_protection_preserves_existing_hook() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -498,7 +497,7 @@ mod tests {
     #[test]
     fn install_develop_protection_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -515,7 +514,7 @@ mod tests {
     #[test]
     fn install_develop_protection_blocks_main_but_not_develop() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -533,7 +532,7 @@ mod tests {
     #[test]
     fn install_develop_protection_rewrites_legacy_managed_block() {
         let tmp = tempfile::tempdir().unwrap();
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -560,7 +559,7 @@ mod tests {
     fn initialize_workspace_creates_specs_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let gwt_home = tmp.path().join(".gwt-home");
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -573,7 +572,7 @@ mod tests {
     fn initialize_workspace_creates_config_in_supplied_gwt_home() {
         let tmp = tempfile::tempdir().unwrap();
         let gwt_home = tmp.path().join(".gwt-home");
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -592,7 +591,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let gwt_home = tmp.path().join(".gwt-home");
         let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -621,7 +620,7 @@ mod tests {
     #[test]
     fn open_valid_git_repo() {
         let tmp = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -633,7 +632,7 @@ mod tests {
     #[test]
     fn discover_walks_up_to_repo() {
         let tmp = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -656,12 +655,12 @@ mod tests {
     fn current_branch_returns_name() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
         // Create an initial commit so HEAD exists
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(path)
             .output()
@@ -676,11 +675,11 @@ mod tests {
     fn branches_lists_at_least_one() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(path)
             .output()
@@ -694,7 +693,7 @@ mod tests {
     #[test]
     fn is_bare_false_for_normal_repo() {
         let tmp = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
@@ -706,7 +705,7 @@ mod tests {
     #[test]
     fn is_worktree_true_for_normal_repo() {
         let tmp = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();

--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -49,7 +49,7 @@ impl WorktreeManager {
 
     /// List all worktrees for this repository.
     pub fn list(&self) -> Result<Vec<WorktreeInfo>> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["worktree", "list", "--porcelain"])
             .current_dir(&self.repo_path)
             .output()
@@ -66,7 +66,7 @@ impl WorktreeManager {
 
     /// Fetch latest refs from `origin`.
     pub fn fetch_origin(&self) -> Result<()> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["fetch", "origin", "--prune"])
             .current_dir(&self.repo_path)
             .output()
@@ -87,7 +87,7 @@ impl WorktreeManager {
         let tracking_ref = to_tracking_ref(remote_ref)
             .ok_or_else(|| GwtError::Git(format!("invalid remote ref: {remote_ref}")))?;
 
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["show-ref", "--verify", "--quiet", &tracking_ref])
             .current_dir(&self.repo_path)
             .output()
@@ -105,7 +105,7 @@ impl WorktreeManager {
 
     /// Create a new worktree at `path` for `branch`.
     pub fn create(&self, branch: &str, path: &Path) -> Result<()> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["worktree", "add", path.to_str().unwrap_or(""), branch])
             .current_dir(&self.repo_path)
             .output()
@@ -128,7 +128,7 @@ impl WorktreeManager {
             )));
         }
 
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args([
                 "worktree",
                 "add",
@@ -159,7 +159,7 @@ impl WorktreeManager {
     ) -> Result<()> {
         let base_ref = normalize_remote_ref(base_remote_ref);
         let push_refspec = format!("{base_ref}:refs/heads/{new_branch}");
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["push", "origin", &push_refspec])
             .current_dir(&self.repo_path)
             .output()
@@ -197,7 +197,7 @@ impl WorktreeManager {
             .split_once('/')
             .ok_or_else(|| GwtError::Git(format!("invalid remote ref: {normalized}")))?;
 
-        let mut command = std::process::Command::new("git");
+        let mut command = gwt_core::process::hidden_command("git");
         command
             .args(["push", remote, "--delete", branch])
             .current_dir(&self.repo_path);
@@ -222,7 +222,7 @@ impl WorktreeManager {
         path: &Path,
     ) -> Result<()> {
         let remote_ref = normalize_remote_ref(remote_ref);
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args([
                 "worktree",
                 "add",
@@ -240,7 +240,7 @@ impl WorktreeManager {
             return Err(GwtError::Git(stderr));
         }
 
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["branch", "--set-upstream-to", &remote_ref, local_branch])
             .current_dir(path)
             .output()
@@ -255,7 +255,7 @@ impl WorktreeManager {
 
     /// Remove the worktree at `path`.
     pub fn remove(&self, path: &Path) -> Result<()> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["worktree", "remove", path.to_str().unwrap_or("")])
             .current_dir(&self.repo_path)
             .output()
@@ -273,7 +273,7 @@ impl WorktreeManager {
     /// `git worktree remove --force` so worktrees with uncommitted or
     /// untracked files can also be deleted by Branch Cleanup.
     pub fn remove_force(&self, path: &Path) -> Result<()> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["worktree", "remove", "--force", path.to_str().unwrap_or("")])
             .current_dir(&self.repo_path)
             .output()
@@ -294,7 +294,7 @@ impl WorktreeManager {
     /// branch delete that follows inside [`Self::cleanup_branch`]. `--expire
     /// now` disables that grace period.
     pub fn prune(&self) -> Result<()> {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["worktree", "prune", "--expire", "now"])
             .current_dir(&self.repo_path)
             .output()
@@ -423,7 +423,7 @@ fn terminate_child_tree_platform(pid: u32) {
 
 #[cfg(windows)]
 fn terminate_child_tree_platform(pid: u32) {
-    let _ = Command::new("taskkill")
+    let _ = gwt_core::process::hidden_command("taskkill")
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -486,7 +486,7 @@ fn to_tracking_ref(remote_ref: &str) -> Option<String> {
 
 /// Resolve the main worktree root for a repository or linked worktree path.
 pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
         .current_dir(repo_path)
         .output()
@@ -600,20 +600,20 @@ mod tests {
     }
 
     fn init_git_repo(path: &Path) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .expect("git init");
         assert!(output.status.success(), "git init failed");
 
-        let email = std::process::Command::new("git")
+        let email = gwt_core::process::hidden_command("git")
             .args(["config", "user.email", "test@example.com"])
             .current_dir(path)
             .output()
             .expect("git config user.email");
         assert!(email.status.success(), "git config user.email failed");
 
-        let name = std::process::Command::new("git")
+        let name = gwt_core::process::hidden_command("git")
             .args(["config", "user.name", "Test User"])
             .current_dir(path)
             .output()
@@ -622,7 +622,7 @@ mod tests {
     }
 
     fn init_bare_git_repo(path: &Path) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["init", "--bare", path.to_str().unwrap()])
             .output()
             .expect("git init --bare");
@@ -631,7 +631,7 @@ mod tests {
 
     fn slow_command() -> std::process::Command {
         if cfg!(windows) {
-            let mut command = std::process::Command::new("powershell");
+            let mut command = gwt_core::process::hidden_command("powershell");
             command.args(["-NoProfile", "-Command", "Start-Sleep -Milliseconds 250"]);
             command
         } else {
@@ -643,7 +643,7 @@ mod tests {
 
     fn verbose_command() -> std::process::Command {
         if cfg!(windows) {
-            let mut command = std::process::Command::new("powershell");
+            let mut command = gwt_core::process::hidden_command("powershell");
             command.args([
                 "-NoProfile",
                 "-Command",
@@ -659,7 +659,7 @@ mod tests {
 
     fn lingering_pipe_command() -> std::process::Command {
         if cfg!(windows) {
-            let mut command = std::process::Command::new("powershell");
+            let mut command = gwt_core::process::hidden_command("powershell");
             command.args([
                 "-NoProfile",
                 "-Command",
@@ -674,7 +674,7 @@ mod tests {
     }
 
     fn git_clone_repo(src: &Path, dst: &Path) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["clone", src.to_str().unwrap(), dst.to_str().unwrap()])
             .output()
             .expect("git clone");
@@ -686,7 +686,7 @@ mod tests {
     }
 
     fn git_push_branch(path: &Path, branch: &str) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["push", "-u", "origin", branch])
             .current_dir(path)
             .output()
@@ -699,7 +699,7 @@ mod tests {
     }
 
     fn git_commit_allow_empty(path: &Path, message: &str) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", message])
             .current_dir(path)
             .output()
@@ -712,7 +712,7 @@ mod tests {
     }
 
     fn git_checkout_new_branch(path: &Path, branch: &str) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["checkout", "-b", branch])
             .current_dir(path)
             .output()
@@ -810,7 +810,7 @@ prunable gitdir file points to non-existent location
         git_commit_allow_empty(&repo_path, "initial commit");
 
         let linked_worktree = tmp.path().join("develop");
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args([
                 "worktree",
                 "add",
@@ -841,13 +841,13 @@ prunable gitdir file points to non-existent location
 
         let bootstrap_path = tmp.path().join("bootstrap");
         git_clone_repo(&bare_repo_path, &bootstrap_path);
-        let email = std::process::Command::new("git")
+        let email = gwt_core::process::hidden_command("git")
             .args(["config", "user.email", "test@example.com"])
             .current_dir(&bootstrap_path)
             .output()
             .expect("git config user.email");
         assert!(email.status.success(), "git config user.email failed");
-        let name = std::process::Command::new("git")
+        let name = gwt_core::process::hidden_command("git")
             .args(["config", "user.name", "Test User"])
             .current_dir(&bootstrap_path)
             .output()
@@ -858,7 +858,7 @@ prunable gitdir file points to non-existent location
         git_push_branch(&bootstrap_path, "develop");
 
         let linked_worktree = tmp.path().join("develop");
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args([
                 "worktree",
                 "add",
@@ -903,7 +903,7 @@ prunable gitdir file points to non-existent location
             .unwrap();
 
         assert!(worktree_path.exists());
-        let branch_output = std::process::Command::new("git")
+        let branch_output = gwt_core::process::hidden_command("git")
             .args(["branch", "--show-current"])
             .current_dir(&worktree_path)
             .output()
@@ -936,7 +936,7 @@ prunable gitdir file points to non-existent location
         // Dirty the worktree (uncommitted + untracked).
         std::fs::write(worktree_path.join("dirty.txt"), "dirty\n").unwrap();
         std::fs::write(worktree_path.join("staged.txt"), "staged\n").unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["add", "staged.txt"])
             .current_dir(&worktree_path)
             .output()
@@ -1036,7 +1036,7 @@ prunable gitdir file points to non-existent location
         git_commit_allow_empty(&repo_path, "initial commit");
 
         // Create a branch but no worktree.
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["branch", "feature/no-worktree"])
             .current_dir(&repo_path)
             .output()
@@ -1209,7 +1209,7 @@ prunable gitdir file points to non-existent location
             .unwrap();
         assert!(worktree_path.exists());
 
-        let branch_output = std::process::Command::new("git")
+        let branch_output = gwt_core::process::hidden_command("git")
             .args(["branch", "--show-current"])
             .current_dir(&worktree_path)
             .output()
@@ -1220,7 +1220,7 @@ prunable gitdir file points to non-existent location
             "feature/materialized"
         );
 
-        let upstream_output = std::process::Command::new("git")
+        let upstream_output = gwt_core::process::hidden_command("git")
             .args([
                 "rev-parse",
                 "--abbrev-ref",
@@ -1241,11 +1241,11 @@ prunable gitdir file points to non-existent location
     fn list_worktrees_in_test_repo() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", path.to_str().unwrap()])
             .output()
             .unwrap();
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["commit", "--allow-empty", "-m", "init"])
             .current_dir(path)
             .output()
@@ -1258,7 +1258,7 @@ prunable gitdir file points to non-existent location
     }
 
     fn git_add_remote(path: &Path, name: &str, remote: &Path) {
-        let output = std::process::Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["remote", "add", name, remote.to_str().unwrap()])
             .current_dir(path)
             .output()

--- a/crates/gwt-github/Cargo.toml
+++ b/crates/gwt-github/Cargo.toml
@@ -12,6 +12,7 @@ regex = { workspace = true }
 sha2 = { workspace = true }
 fs2 = { workspace = true }
 reqwest = { workspace = true }
+gwt-core = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -16,8 +16,9 @@
 //! so one network round-trip covers "issue body + every comment"; mutations
 //! go through the REST endpoints.
 
-use std::{process::Command, sync::Mutex};
+use std::sync::Mutex;
 
+use gwt_core::process::hidden_command;
 use serde_json::{json, Value};
 
 use crate::client::{
@@ -336,7 +337,7 @@ fn check_status(resp: &HttpResponse) -> Result<(), ApiError> {
 }
 
 fn resolve_gh_token() -> Result<String, ApiError> {
-    let output = Command::new("gh")
+    let output = hidden_command("gh")
         .args(["auth", "token"])
         .output()
         .map_err(|e| ApiError::Network(format!("gh auth token: {e}")))?;

--- a/crates/gwt-skills/src/distribute.rs
+++ b/crates/gwt-skills/src/distribute.rs
@@ -4,9 +4,9 @@ use std::{
     collections::HashSet,
     fs, io,
     path::{Path, PathBuf},
-    process::Command,
 };
 
+use gwt_core::process::hidden_command;
 use include_dir::Dir;
 
 use crate::assets::{CLAUDE_COMMANDS, CLAUDE_SKILLS};
@@ -286,7 +286,7 @@ fn should_skip_tracked_path(
 }
 
 fn tracked_gwt_asset_paths(worktree: &Path) -> HashSet<PathBuf> {
-    match Command::new("git")
+    match hidden_command("git")
         .arg("-C")
         .arg(worktree)
         .arg("ls-files")
@@ -310,7 +310,7 @@ fn tracked_gwt_asset_paths(worktree: &Path) -> HashSet<PathBuf> {
 }
 
 fn is_git_worktree(worktree: &Path) -> bool {
-    match Command::new("git")
+    match hidden_command("git")
         .arg("-C")
         .arg(worktree)
         .arg("rev-parse")

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -3,8 +3,9 @@
 use std::{
     fs, io,
     path::{Path, PathBuf},
-    process::Command,
 };
+
+use gwt_core::process::hidden_command;
 
 const BEGIN_MARKER: &str = "# gwt-managed-begin";
 const END_MARKER: &str = "# gwt-managed-end";
@@ -52,7 +53,7 @@ pub fn update_git_exclude(worktree: &Path) -> io::Result<()> {
 }
 
 fn resolve_git_exclude_path(worktree: &Path) -> io::Result<PathBuf> {
-    let output = Command::new("git")
+    let output = hidden_command("git")
         .arg("-C")
         .arg(worktree)
         .args(["rev-parse", "--git-path", "info/exclude"])

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -4583,7 +4583,7 @@ mod tests {
             ["init", "-q"].as_slice(),
             ["remote", "add", "origin", remote.as_str()].as_slice(),
         ] {
-            let output = std::process::Command::new("git")
+            let output = gwt_core::process::hidden_command("git")
                 .args(args)
                 .current_dir(repo_path)
                 .output()

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -56,7 +56,7 @@ fn run_repo_backed_cli(argv: &[String]) -> i32 {
 }
 
 fn resolve_repo_coordinates() -> Option<(String, String)> {
-    let output = std::process::Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["remote", "get-url", "origin"])
         .output()
         .ok()?;

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -37,7 +37,6 @@ use std::{
     fs,
     io::{self},
     path::PathBuf,
-    process::Command,
 };
 
 pub(crate) use board::parse as parse_board_args;
@@ -809,7 +808,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }
 "#;
 
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args([
             "api",
             "graphql",
@@ -888,7 +887,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }
 
 fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option<PrStatus>> {
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args([
             "pr",
             "view",
@@ -944,7 +943,7 @@ fn create_pr_via_gh(
         args.push("--draft".to_string());
     }
 
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args(&args)
         .current_dir(repo_path)
         .output()?;
@@ -987,7 +986,7 @@ fn edit_pr_via_gh(
         args.push(label.clone());
     }
 
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args(&args)
         .current_dir(repo_path)
         .output()?;
@@ -1014,7 +1013,7 @@ fn parse_pr_number_from_url(url: &str) -> Option<u64> {
 }
 
 fn comment_on_pr_via_gh(repo_path: &std::path::Path, number: u64, body: &str) -> io::Result<()> {
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args(["pr", "comment", &number.to_string(), "--body", body])
         .current_dir(repo_path)
         .output()?;
@@ -1029,7 +1028,9 @@ fn comment_on_pr_via_gh(repo_path: &std::path::Path, number: u64, body: &str) ->
 
 fn fetch_pr_reviews_via_gh(owner: &str, repo: &str, number: u64) -> io::Result<Vec<PrReview>> {
     let endpoint = format!("repos/{owner}/{repo}/pulls/{number}/reviews");
-    let output = Command::new("gh").args(["api", &endpoint]).output()?;
+    let output = gwt_core::process::hidden_command("gh")
+        .args(["api", &endpoint])
+        .output()?;
     if !output.status.success() {
         return Err(io::Error::other(format!(
             "gh api {endpoint}: {}",
@@ -1109,7 +1110,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
   }
 }
 "#;
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args([
             "api",
             "graphql",
@@ -1237,7 +1238,7 @@ mutation($threadId: ID!, $body: String!) {
 }
 "#;
         if should_reply_to_review_thread(&current_thread, body) {
-            let reply = Command::new("gh")
+            let reply = gwt_core::process::hidden_command("gh")
                 .args([
                     "api",
                     "graphql",
@@ -1264,7 +1265,7 @@ mutation($threadId: ID!) {
   }
 }
 "#;
-        let resolve = Command::new("gh")
+        let resolve = gwt_core::process::hidden_command("gh")
             .args([
                 "api",
                 "graphql",
@@ -1310,7 +1311,7 @@ fn fetch_pr_checks_via_gh(
         "startedAt",
         "completedAt",
     ];
-    let mut output = Command::new("gh")
+    let mut output = gwt_core::process::hidden_command("gh")
         .args([
             "pr",
             "checks",
@@ -1340,7 +1341,7 @@ fn fetch_pr_checks_via_gh(
                 .filter(|field| available.iter().any(|candidate| candidate == field))
                 .collect();
             if !selected.is_empty() {
-                output = Command::new("gh")
+                output = gwt_core::process::hidden_command("gh")
                     .args([
                         "pr",
                         "checks",
@@ -1475,7 +1476,7 @@ fn parse_available_fields(message: &str) -> Vec<String> {
 }
 
 fn fetch_actions_run_log_via_gh(repo_path: &std::path::Path, run_id: u64) -> io::Result<String> {
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args(["run", "view", &run_id.to_string(), "--log"])
         .current_dir(repo_path)
         .output()?;
@@ -1495,7 +1496,7 @@ fn fetch_actions_job_log_via_gh(
     job_id: u64,
 ) -> io::Result<String> {
     let endpoint = format!("/repos/{owner}/{repo}/actions/jobs/{job_id}/logs");
-    let output = Command::new("gh")
+    let output = gwt_core::process::hidden_command("gh")
         .args(["api", &endpoint])
         .current_dir(repo_path)
         .output()?;
@@ -2204,7 +2205,7 @@ fn main() -> ExitCode {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let temp = tempdir().expect("tempdir");
-        let status = std::process::Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .arg("init")
             .arg("-q")
             .current_dir(temp.path())

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -231,13 +231,13 @@ mod tests {
 
     fn init_repo(repo: &Path) {
         fs::create_dir_all(repo).expect("create repo");
-        let mut init_cmd = std::process::Command::new("git");
+        let mut init_cmd = gwt_core::process::hidden_command("git");
         init_cmd.args(["init", "--quiet"]).current_dir(repo);
         gwt_core::process::scrub_git_env(&mut init_cmd);
         let init = init_cmd.output().expect("git init");
         assert!(init.status.success(), "git init failed");
 
-        let mut remote_cmd = std::process::Command::new("git");
+        let mut remote_cmd = gwt_core::process::hidden_command("git");
         remote_cmd
             .args([
                 "remote",
@@ -250,7 +250,7 @@ mod tests {
         let remote = remote_cmd.output().expect("git remote add");
         assert!(remote.status.success(), "git remote add failed");
 
-        let mut branch_cmd = std::process::Command::new("git");
+        let mut branch_cmd = gwt_core::process::hidden_command("git");
         branch_cmd
             .args(["checkout", "-b", "feature/coverage"])
             .current_dir(repo);

--- a/crates/gwt/src/cli/hook/worktree.rs
+++ b/crates/gwt/src/cli/hook/worktree.rs
@@ -2,13 +2,13 @@
 //! `block-file-ops`. Shells out to `git rev-parse --show-toplevel`
 //! exactly like the Node helpers did.
 
-use std::{path::PathBuf, process::Command};
+use std::path::PathBuf;
 
 /// Return the worktree root as reported by `git rev-parse
 /// --show-toplevel`. Falls back to the current process cwd if git is
 /// unavailable or the command fails.
 pub fn detect_worktree_root() -> PathBuf {
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["rev-parse", "--show-toplevel"])
         .output();
     match output {

--- a/crates/gwt/src/cli/index.rs
+++ b/crates/gwt/src/cli/index.rs
@@ -3,7 +3,6 @@ use std::{
     io,
     io::Write,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use gwt_core::{repo_hash::RepoHash, worktree_hash::compute_worktree_hash};
@@ -153,7 +152,7 @@ fn project_index_python_path() -> PathBuf {
 }
 
 fn run_runner_status(context: &IndexContext) -> Result<std::process::Output, SpecOpsError> {
-    Command::new(&context.python)
+    gwt_core::process::hidden_command(&context.python)
         .arg(&context.runner)
         .arg("--action")
         .arg("status")
@@ -217,7 +216,7 @@ fn run_runner_rebuild(
     context: &IndexContext,
     action: RebuildAction,
 ) -> Result<std::process::Output, SpecOpsError> {
-    let mut command = Command::new(&context.python);
+    let mut command = gwt_core::process::hidden_command(&context.python);
     command
         .arg(&context.runner)
         .arg("--action")

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -1,6 +1,5 @@
 use std::{
     path::{Path, PathBuf},
-    process::Command,
     time::Duration,
 };
 
@@ -68,7 +67,7 @@ fn project_index_status_for_path_inner(
         compute_worktree_hash(&repo_root).map_err(|err| format!("compute worktree hash: {err}"))?;
     let report =
         gwt_core::runtime::ensure_project_index_runtime().map_err(|err| err.to_string())?;
-    let output = Command::new(project_index_python_path())
+    let output = gwt_core::process::hidden_command(project_index_python_path())
         .arg(gwt_runtime_runner_path())
         .arg("--action")
         .arg("status")
@@ -161,7 +160,7 @@ fn resolve_git_worktree_root(path: &Path) -> Option<PathBuf> {
     if !path.exists() {
         return None;
     }
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(path)
         .output()
@@ -177,7 +176,7 @@ fn resolve_git_worktree_root(path: &Path) -> Option<PathBuf> {
 }
 
 fn list_git_worktree_paths(project_root: &Path) -> Result<Vec<PathBuf>, String> {
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(project_root)
         .output()

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -3,7 +3,6 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::Command,
     time::Duration,
 };
 
@@ -177,7 +176,7 @@ fn issue_cache_refresh_is_stale(cache_root: &Path, ttl: Duration) -> bool {
 }
 
 fn fetch_issue_list_snapshots(repo_path: &Path) -> Result<Vec<IssueSnapshot>, String> {
-    let output = Command::new(gh_executable())
+    let output = gwt_core::process::hidden_command(gh_executable())
         .args([
             "issue",
             "list",
@@ -202,7 +201,7 @@ fn fetch_issue_list_snapshots(repo_path: &Path) -> Result<Vec<IssueSnapshot>, St
 }
 
 fn fetch_issue_snapshot(repo_path: &Path, number: IssueNumber) -> Result<IssueSnapshot, String> {
-    let output = Command::new(gh_executable())
+    let output = gwt_core::process::hidden_command(gh_executable())
         .args([
             "issue",
             "view",
@@ -476,7 +475,7 @@ echo [{\"number\":7,\"title\":\"Cached issue\",\"body\":\"Body\",\"labels\":[{\"
 exit /b 0\r\n",
         )
         .expect("write fake gh");
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", "-b", "main"])
             .current_dir(&repo_path)
             .status()
@@ -545,7 +544,7 @@ if /I \"%1 %2\"==\"issue view\" (\r\n\
 exit /b 1\r\n",
         )
         .expect("write fake gh");
-        std::process::Command::new("git")
+        gwt_core::process::hidden_command("git")
             .args(["init", "-b", "main"])
             .current_dir(&repo_path)
             .status()

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
-    process::Command,
 };
 
 use gwt_core::paths::gwt_cache_dir;
@@ -105,21 +104,22 @@ impl SemanticSearchClient for RunnerSemanticSearchClient {
         let repo_hash = crate::index_worker::detect_repo_hash(repo_path)
             .ok_or_else(|| "semantic search requires a git origin remote".to_string())?;
         gwt_core::runtime::ensure_project_index_runtime().map_err(|error| error.to_string())?;
-        let output = Command::new(crate::index_worker::project_index_python_path())
-            .arg(gwt_core::paths::gwt_runtime_runner_path())
-            .arg("--action")
-            .arg(action)
-            .arg("--repo-hash")
-            .arg(repo_hash.as_str())
-            .arg("--project-root")
-            .arg(repo_path)
-            .arg("--query")
-            .arg(query)
-            .arg("--n-results")
-            .arg(limit.to_string())
-            .current_dir(repo_path)
-            .output()
-            .map_err(|error| format!("run semantic search: {error}"))?;
+        let output =
+            gwt_core::process::hidden_command(crate::index_worker::project_index_python_path())
+                .arg(gwt_core::paths::gwt_runtime_runner_path())
+                .arg("--action")
+                .arg(action)
+                .arg("--repo-hash")
+                .arg(repo_hash.as_str())
+                .arg("--project-root")
+                .arg(repo_path)
+                .arg("--query")
+                .arg(query)
+                .arg("--n-results")
+                .arg(limit.to_string())
+                .current_dir(repo_path)
+                .output()
+                .map_err(|error| format!("run semantic search: {error}"))?;
         if !output.status.success() {
             return Err(format_runner_failure(&output));
         }
@@ -846,13 +846,13 @@ mod tests {
 
     fn init_repo(repo: &Path) {
         fs::create_dir_all(repo).expect("create repo");
-        let mut init_cmd = std::process::Command::new("git");
+        let mut init_cmd = gwt_core::process::hidden_command("git");
         init_cmd.args(["init", "--quiet"]).current_dir(repo);
         gwt_core::process::scrub_git_env(&mut init_cmd);
         let init = init_cmd.output().expect("git init");
         assert!(init.status.success(), "git init failed");
 
-        let mut remote_cmd = std::process::Command::new("git");
+        let mut remote_cmd = gwt_core::process::hidden_command("git");
         remote_cmd
             .args([
                 "remote",

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -437,7 +437,7 @@ pub(crate) fn probe_host_package_runner_with_timeout(
     timeout: Duration,
     poll_interval: Duration,
 ) -> bool {
-    let mut process = Command::new(command);
+    let mut process = gwt_core::process::hidden_command(command);
     process
         .args(args)
         .stdin(Stdio::null())

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2981,7 +2981,7 @@ pub fn build_builtin_agent_options(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, process::Command};
+    use std::collections::HashMap;
 
     use chrono::{TimeZone, Utc};
     use tempfile::tempdir;
@@ -3202,13 +3202,13 @@ mod tests {
 
     fn init_repo_with_origin(path: &Path, origin: &str) {
         std::fs::create_dir_all(path).expect("repo dir");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["init"])
             .current_dir(path)
             .status()
             .expect("git init");
         assert!(status.success(), "git init failed");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["remote", "add", "origin", origin])
             .current_dir(path)
             .status()

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     io::{self, Read},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::Stdio,
     sync::{mpsc as std_mpsc, Arc, Mutex, RwLock},
     thread::{self, JoinHandle},
     time::{Duration, Instant},
@@ -377,7 +377,6 @@ mod tests {
         collections::HashMap,
         fs,
         path::{Path, PathBuf},
-        process::Command,
         sync::{Arc, Mutex, RwLock},
         time::{Duration, Instant},
     };
@@ -482,7 +481,7 @@ mod tests {
 
     fn init_git_repo(path: &Path) {
         fs::create_dir_all(path).expect("create repo dir");
-        let init = Command::new("git")
+        let init = gwt_core::process::hidden_command("git")
             .args(["init", "-q"])
             .arg(path)
             .status()
@@ -495,7 +494,7 @@ mod tests {
             vec!["commit", "--allow-empty", "-qm", "init"],
             vec!["branch", "feature/demo"],
         ] {
-            let status = Command::new("git")
+            let status = gwt_core::process::hidden_command("git")
                 .args(&args)
                 .current_dir(path)
                 .status()
@@ -510,7 +509,7 @@ mod tests {
         let origin = root.join("origin.git");
 
         fs::create_dir_all(&seed).expect("create seed dir");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["init", "-q", "-b", "develop"])
             .arg(&seed)
             .status()
@@ -521,7 +520,7 @@ mod tests {
             vec!["config", "user.name", "Codex Test"],
             vec!["config", "user.email", "codex@example.com"],
         ] {
-            let status = Command::new("git")
+            let status = gwt_core::process::hidden_command("git")
                 .args(&args)
                 .current_dir(&seed)
                 .status()
@@ -531,7 +530,7 @@ mod tests {
 
         fs::write(seed.join("README.md"), "seed\n").expect("write seed readme");
         for args in [vec!["add", "README.md"], vec!["commit", "-qm", "init"]] {
-            let status = Command::new("git")
+            let status = gwt_core::process::hidden_command("git")
                 .args(&args)
                 .current_dir(&seed)
                 .status()
@@ -539,7 +538,7 @@ mod tests {
             assert!(status.success(), "git {:?} failed", args);
         }
 
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["clone", "--bare"])
             .arg(&seed)
             .arg(&origin)
@@ -547,7 +546,7 @@ mod tests {
             .expect("git clone --bare");
         assert!(status.success(), "git clone --bare failed");
 
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["clone"])
             .arg(&origin)
             .arg(path)
@@ -559,7 +558,7 @@ mod tests {
             vec!["config", "user.name", "Codex Test"],
             vec!["config", "user.email", "codex@example.com"],
         ] {
-            let status = Command::new("git")
+            let status = gwt_core::process::hidden_command("git")
                 .args(&args)
                 .current_dir(path)
                 .status()
@@ -1770,13 +1769,13 @@ mod tests {
         let repo = temp.path().join("repo");
         init_git_repo(&repo);
         let default_branch = current_git_branch(&repo).expect("current branch");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["checkout", "-qb", "feature/prune-me"])
             .current_dir(&repo)
             .status()
             .expect("create branch");
         assert!(status.success(), "create branch failed");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["checkout", default_branch.as_str()])
             .current_dir(&repo)
             .status()
@@ -2611,7 +2610,7 @@ mod tests {
         assert!(missing_err.contains("failed to open project"));
 
         let bare = temp.path().join("bare.git");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["init", "--bare"])
             .arg(&bare)
             .status()
@@ -2720,7 +2719,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("demo-repo");
         fs::create_dir_all(repo.join("apps/frontend")).expect("create repo dirs");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["init", "-q"])
             .current_dir(temp.path())
             .arg(&repo)
@@ -3470,38 +3469,38 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("repo dir");
-        let init = Command::new("git")
+        let init = gwt_core::process::hidden_command("git")
             .args(["init", "-q", "-b", "develop"])
             .current_dir(&repo)
             .status()
             .expect("git init");
         assert!(init.success(), "git init failed");
-        let config_name = Command::new("git")
+        let config_name = gwt_core::process::hidden_command("git")
             .args(["config", "user.name", "Codex"])
             .current_dir(&repo)
             .status()
             .expect("git config user.name");
         assert!(config_name.success(), "git config user.name failed");
-        let config_email = Command::new("git")
+        let config_email = gwt_core::process::hidden_command("git")
             .args(["config", "user.email", "codex@example.com"])
             .current_dir(&repo)
             .status()
             .expect("git config user.email");
         assert!(config_email.success(), "git config user.email failed");
         fs::write(repo.join("README.md"), "repo\n").expect("write readme");
-        let add = Command::new("git")
+        let add = gwt_core::process::hidden_command("git")
             .args(["add", "README.md"])
             .current_dir(&repo)
             .status()
             .expect("git add");
         assert!(add.success(), "git add failed");
-        let commit = Command::new("git")
+        let commit = gwt_core::process::hidden_command("git")
             .args(["commit", "-qm", "init"])
             .current_dir(&repo)
             .status()
             .expect("git commit");
         assert!(commit.success(), "git commit failed");
-        let branch = Command::new("git")
+        let branch = gwt_core::process::hidden_command("git")
             .args(["branch", "feature/demo"])
             .current_dir(&repo)
             .status()
@@ -3599,7 +3598,7 @@ mod tests {
         .expect("non repo short circuit");
         assert!(working_dir.is_none());
 
-        let detach = Command::new("git")
+        let detach = gwt_core::process::hidden_command("git")
             .args(["checkout", "--detach", "HEAD"])
             .current_dir(&repo)
             .status()
@@ -3616,7 +3615,7 @@ mod tests {
         .expect_err("repo branch resolution failure should not silently skip");
         assert!(err.contains("git branch --show-current"));
 
-        let attach = Command::new("git")
+        let attach = gwt_core::process::hidden_command("git")
             .args(["checkout", "develop"])
             .current_dir(&repo)
             .status()
@@ -3652,14 +3651,14 @@ mod tests {
         assert_eq!(preset_dir.as_deref(), Some(preset.as_path()));
         assert!(preset_env.is_empty());
 
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["branch", "feature/existing"])
             .current_dir(&repo)
             .status()
             .expect("create feature branch");
         assert!(status.success(), "create feature branch failed");
         let existing_worktree = temp.path().join("feature-existing");
-        let status = Command::new("git")
+        let status = gwt_core::process::hidden_command("git")
             .args(["worktree", "add"])
             .arg(&existing_worktree)
             .arg("feature/existing")
@@ -3711,7 +3710,7 @@ mod tests {
             .get("GWT_PROJECT_ROOT")
             .is_some_and(|value| super::same_worktree_path(Path::new(value), &created_dir)));
 
-        let output = Command::new("git")
+        let output = gwt_core::process::hidden_command("git")
             .args(["branch", "--show-current"])
             .current_dir(&created_dir)
             .output()
@@ -3722,7 +3721,7 @@ mod tests {
             "feature/created"
         );
 
-        let local_only_branch = Command::new("git")
+        let local_only_branch = gwt_core::process::hidden_command("git")
             .args(["branch", "feature/local-only"])
             .current_dir(&repo)
             .status()
@@ -3743,7 +3742,7 @@ mod tests {
         )
         .expect("local-only worktree");
         let local_only_dir = local_only_dir.expect("local-only worktree dir");
-        let local_remote = Command::new("git")
+        let local_remote = gwt_core::process::hidden_command("git")
             .args([
                 "show-ref",
                 "--verify",
@@ -4223,13 +4222,13 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo");
-        let init = Command::new("git")
+        let init = gwt_core::process::hidden_command("git")
             .args(["init", "--quiet"])
             .current_dir(&repo)
             .output()
             .expect("git init");
         assert!(init.status.success(), "git init failed");
-        let remote = Command::new("git")
+        let remote = gwt_core::process::hidden_command("git")
             .args([
                 "remote",
                 "add",
@@ -4240,19 +4239,19 @@ mod tests {
             .output()
             .expect("git remote");
         assert!(remote.status.success(), "git remote add failed");
-        let branch = Command::new("git")
+        let branch = gwt_core::process::hidden_command("git")
             .args(["checkout", "-b", "feature/coverage"])
             .current_dir(&repo)
             .output()
             .expect("git checkout");
         assert!(branch.status.success(), "git checkout failed");
-        let config_name = Command::new("git")
+        let config_name = gwt_core::process::hidden_command("git")
             .args(["config", "user.name", "Test User"])
             .current_dir(&repo)
             .output()
             .expect("git config user.name");
         assert!(config_name.status.success(), "git config user.name failed");
-        let config_email = Command::new("git")
+        let config_email = gwt_core::process::hidden_command("git")
             .args(["config", "user.email", "test@example.com"])
             .current_dir(&repo)
             .output()
@@ -4262,13 +4261,13 @@ mod tests {
             "git config user.email failed"
         );
         fs::write(repo.join("README.md"), "hello\n").expect("write README");
-        let add = Command::new("git")
+        let add = gwt_core::process::hidden_command("git")
             .args(["add", "README.md"])
             .current_dir(&repo)
             .output()
             .expect("git add");
         assert!(add.status.success(), "git add failed");
-        let commit = Command::new("git")
+        let commit = gwt_core::process::hidden_command("git")
             .args(["commit", "-m", "init"])
             .current_dir(&repo)
             .output()

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -306,7 +306,7 @@ pub(crate) fn origin_remote_ref(branch_name: &str) -> String {
 }
 
 pub(crate) fn current_git_branch(repo_path: &Path) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["branch", "--show-current"])
         .current_dir(repo_path)
         .output()
@@ -327,7 +327,7 @@ pub(crate) fn current_git_branch(repo_path: &Path) -> Result<String, String> {
 }
 
 pub(crate) fn local_branch_exists(repo_path: &Path, branch_name: &str) -> Result<bool, String> {
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args([
             "show-ref",
             "--verify",
@@ -500,7 +500,7 @@ mod windows_console {
 }
 
 pub(crate) fn resolve_repo_coordinates() -> Option<(String, String)> {
-    let output = Command::new("git")
+    let output = gwt_core::process::hidden_command("git")
         .args(["remote", "get-url", "origin"])
         .output()
         .ok()?;


### PR DESCRIPTION
## Summary

- Suppresses extra Windows console windows for non-interactive subprocesses launched from the GUI front door.
- Keeps PTY, ConPTY, and installer UAC flows interactive while hiding background `git`, `gh`, `powershell`, and index runner probes.
- Adds process helper coverage so stdout, stderr, and exit status behavior stays unchanged outside the Windows GUI windowing fix.

## Changes

- `crates/gwt-core/src/process.rs`: adds `hidden_command` and `configure_hidden_command`, using `CREATE_NO_WINDOW` on Windows and a no-op on other platforms.
- `crates/gwt-git`, `crates/gwt-agent`, and `crates/gwt`: route non-interactive background command creation through the hidden process helper.
- `crates/gwt-github` and `crates/gwt-skills`: route production `gh` and `git` helper calls through the hidden process helper.
- `crates/gwt-core/src/update.rs`: hides the non-interactive process-running PowerShell probe while keeping the MSI UAC prompt user-visible.

## Testing

- [x] `cargo fmt -- --check` -- passed.
- [x] `cargo check -p gwt-core -p gwt-git -p gwt-agent -p gwt -p gwt-github -p gwt-skills` -- passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- passed.
- [x] `cargo test -p gwt-core -p gwt-git -p gwt-agent -p gwt -p gwt-github -p gwt-skills` -- passed.
- [x] `cargo build -p gwt` -- passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` -- passed.

## Closing Issues

- Closes #1942

## Related Issues / Links

- #1942

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation not required: no user-facing setup or usage instructions changed.
- [x] Migration/backfill not required: no schema or data migration changed.
- [x] CHANGELOG impact considered: patch-level bug fix via `fix:` commit.

## Context

- Windows GUI launches were spawning visible subprocess console windows for background helper commands, which made the main gwt window unusable and surfaced raw `git.exe` errors outside the app.
- SPEC-1942 was updated with the Windows GUI subprocess suppression follow-up requirements and tasks T-147 through T-151.

## Risk / Impact

- **Affected areas**: Windows GUI background subprocess launch paths for repository discovery, issue/cache refresh, PR metadata, skill asset maintenance, and agent preparation.
- **Rollback plan**: Revert this PR to restore the previous direct `Command::new` behavior.

## Notes

- Windows Start Menu and Explorer manual validation was not run in this macOS environment; the Windows-specific behavior is covered by platform-gated process flags and regression tests.
