### PR TITLE
feat(migration): SPEC-1934 US-6 normal-to-bare migration core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/README.ja.md
+++ b/README.ja.md
@@ -116,6 +116,29 @@ Docker 起動では引き続きコンテナ内のシェルを使います。
 できます。Windows / Linux では `Ctrl+Shift+C` でも現在の選択をコピーできます。
 `Ctrl+C` は実行中のターミナルプロセス向けの割り込みのままです。
 
+## ワークスペース構成
+
+gwt は各プロジェクトをワークスペースディレクトリ配下の **Nested Bare + Worktree**
+構成として管理します。
+
+```
+<workspace>/<project>/
+├── <project>.git/          # bare リポジトリ
+├── develop/                # develop ワークツリー（既定の作業ディレクトリ）
+├── feature/<name>/         # ブランチごとの追加ワークツリー
+└── .gwt/project.toml       # gwt が管理するプロジェクトメタデータ
+```
+
+Initialization ウィザード経由で clone した場合は自動でこの構成になります。
+既存の Normal Git リポジトリ（プロジェクト直下に `.git/` がある通常レイアウト）
+は検出され、要望に応じて Nested Bare + Worktree 構成へマイグレーションできます。
+マイグレーションは `.gwt-migration-backup/` にフルバックアップを取ってから
+bare リポジトリを作り直し、各 worktree を新レイアウトに再配置します。
+任意のフェーズで失敗した場合は自動的に元のレイアウトへロールバックされます。
+進行状況は
+[GitHub Issue #1934 (SPEC-1934)](https://github.com/akiojin/gwt/issues/1934)
+で管理しています。
+
 ## キャンバス操作
 
 - 画面上の zoom ボタンでキャンバスを拡大・縮小

--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ In terminal windows, drag to select text and release the mouse button to copy.
 On Windows and Linux, `Ctrl+Shift+C` also copies the current terminal
 selection. `Ctrl+C` stays mapped to the running terminal process.
 
+## Workspace Layout
+
+gwt manages each project as a **Nested Bare + Worktree** layout under your
+workspace directory:
+
+```
+<workspace>/<project>/
+├── <project>.git/          # bare repository
+├── develop/                # develop worktree (default working directory)
+├── feature/<name>/         # additional worktrees by branch
+└── .gwt/project.toml       # gwt-managed project metadata
+```
+
+`gwt` auto-creates this layout when you clone through the Initialization
+wizard. Existing Normal Git repositories (`.git/` directly under the project
+directory) are recognised so a migration to the Nested Bare + Worktree layout
+can be run on demand. The migration safely backs up the original tree to
+`.gwt-migration-backup/`, rebuilds the bare repo, recreates each worktree,
+and rolls back automatically if any phase fails. Tracking work is captured in
+[GitHub Issue #1934 (SPEC-1934)](https://github.com/akiojin/gwt/issues/1934).
+
 ## Canvas Operations
 
 - Zoom the canvas with the on-screen zoom buttons

--- a/crates/gwt-core/Cargo.toml
+++ b/crates/gwt-core/Cargo.toml
@@ -18,6 +18,7 @@ semver = { workspace = true }
 fs2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
 notify = { workspace = true }

--- a/crates/gwt-core/src/config/bare_project.rs
+++ b/crates/gwt-core/src/config/bare_project.rs
@@ -1,0 +1,60 @@
+//! Schema and serialization helpers for `<project_root>/.gwt/project.toml`.
+//!
+//! Written by the Cleanup phase of a successful migration so subsequent gwt
+//! launches can recognise the Nested Bare+Worktree layout without re-running
+//! detection heuristics.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{GwtError, Result};
+
+/// On-disk representation of a Nested Bare+Worktree project configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BareProjectConfig {
+    /// Directory name of the bare repository (e.g. `gwt.git`).
+    pub bare_repo_name: String,
+    /// Origin URL captured at migration time, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_url: Option<String>,
+    /// RFC3339 timestamp of when the configuration was written.
+    pub created_at: String,
+    /// `"normal"` when produced by US-6 migration, `None` for fresh clones.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migrated_from: Option<String>,
+}
+
+impl BareProjectConfig {
+    /// Path of the on-disk config file relative to a project root.
+    pub fn config_path(project_root: &Path) -> PathBuf {
+        project_root.join(".gwt").join("project.toml")
+    }
+
+    /// Read the config file, returning `Ok(None)` when it is absent.
+    pub fn load(project_root: &Path) -> Result<Option<Self>> {
+        let path = Self::config_path(project_root);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let body = fs::read_to_string(&path).map_err(GwtError::Io)?;
+        let parsed: Self = toml::from_str(&body)
+            .map_err(|e| GwtError::Config(format!("parse {}: {e}", path.display())))?;
+        Ok(Some(parsed))
+    }
+
+    /// Write the config file, creating the `.gwt/` directory if needed.
+    pub fn save(&self, project_root: &Path) -> Result<()> {
+        let path = Self::config_path(project_root);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(GwtError::Io)?;
+        }
+        let body = toml::to_string_pretty(self)
+            .map_err(|e| GwtError::Config(format!("serialize project.toml: {e}")))?;
+        fs::write(&path, body).map_err(GwtError::Io)?;
+        Ok(())
+    }
+}

--- a/crates/gwt-core/src/config/mod.rs
+++ b/crates/gwt-core/src/config/mod.rs
@@ -1,0 +1,5 @@
+//! Project-scoped configuration files (e.g. `<project>/.gwt/project.toml`).
+
+pub mod bare_project;
+
+pub use bare_project::BareProjectConfig;

--- a/crates/gwt-core/src/lib.rs
+++ b/crates/gwt-core/src/lib.rs
@@ -4,11 +4,13 @@
 //! execution helpers. No business logic lives here — domain crates
 //! (gwt-git, gwt-agent, etc.) build on top of these primitives.
 
+pub mod config;
 pub mod coordination;
 pub mod daemon;
 pub mod error;
 pub mod index;
 pub mod logging;
+pub mod migration;
 pub mod notes;
 pub mod paths;
 pub mod process;

--- a/crates/gwt-core/src/migration/backup.rs
+++ b/crates/gwt-core/src/migration/backup.rs
@@ -1,0 +1,50 @@
+//! Full-tree backup and restore for the migration's `.gwt-migration-backup/`
+//! directory (Phase 4 of the build plan).
+
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub enum BackupError {
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for BackupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "backup io error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for BackupError {}
+
+impl From<std::io::Error> for BackupError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+/// The directory name reserved for migration backups under `<project_root>`.
+pub const BACKUP_DIR_NAME: &str = ".gwt-migration-backup";
+
+/// Snapshot returned by [`create`]; used by rollback to find the source.
+#[derive(Debug, Clone)]
+pub struct BackupSnapshot {
+    pub project_root: PathBuf,
+    pub backup_dir: PathBuf,
+}
+
+pub fn create(_project_root: &Path) -> Result<BackupSnapshot, BackupError> {
+    // Filled in by Phase 4 tasks (T-031, T-033).
+    unimplemented!("backup::create — see SPEC-1934 tasks T-031/T-033")
+}
+
+pub fn restore(_snapshot: &BackupSnapshot) -> Result<(), BackupError> {
+    // Filled in by Phase 4 tasks (T-035).
+    unimplemented!("backup::restore — see SPEC-1934 task T-035")
+}
+
+pub fn discard(_snapshot: BackupSnapshot) -> Result<(), BackupError> {
+    // Filled in by Phase 8 tasks (T-074/T-075).
+    unimplemented!("backup::discard — see SPEC-1934 task T-074/T-075")
+}

--- a/crates/gwt-core/src/migration/backup.rs
+++ b/crates/gwt-core/src/migration/backup.rs
@@ -1,11 +1,16 @@
 //! Full-tree backup and restore for the migration's `.gwt-migration-backup/`
 //! directory (Phase 4 of the build plan).
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use chrono::Utc;
 
 #[derive(Debug)]
 pub enum BackupError {
-    Io(std::io::Error),
+    Io(io::Error),
 }
 
 impl std::fmt::Display for BackupError {
@@ -18,8 +23,8 @@ impl std::fmt::Display for BackupError {
 
 impl std::error::Error for BackupError {}
 
-impl From<std::io::Error> for BackupError {
-    fn from(value: std::io::Error) -> Self {
+impl From<io::Error> for BackupError {
+    fn from(value: io::Error) -> Self {
         Self::Io(value)
     }
 }
@@ -34,17 +39,120 @@ pub struct BackupSnapshot {
     pub backup_dir: PathBuf,
 }
 
-pub fn create(_project_root: &Path) -> Result<BackupSnapshot, BackupError> {
-    // Filled in by Phase 4 tasks (T-031, T-033).
-    unimplemented!("backup::create — see SPEC-1934 tasks T-031/T-033")
+/// Create a full snapshot of `project_root` into
+/// `<project_root>/.gwt-migration-backup/`. Any pre-existing backup directory
+/// is renamed with a UTC timestamp suffix so the previous attempt is not
+/// silently overwritten.
+pub fn create(project_root: &Path) -> Result<BackupSnapshot, BackupError> {
+    let backup_dir = project_root.join(BACKUP_DIR_NAME);
+
+    if backup_dir.exists() {
+        let stamped = project_root.join(format!(
+            "{BACKUP_DIR_NAME}-{}",
+            Utc::now().format("%Y%m%dT%H%M%S")
+        ));
+        fs::rename(&backup_dir, &stamped)?;
+    }
+
+    fs::create_dir_all(&backup_dir)?;
+    copy_dir_contents(project_root, &backup_dir, &[BACKUP_DIR_NAME])?;
+
+    Ok(BackupSnapshot {
+        project_root: project_root.to_path_buf(),
+        backup_dir,
+    })
 }
 
-pub fn restore(_snapshot: &BackupSnapshot) -> Result<(), BackupError> {
-    // Filled in by Phase 4 tasks (T-035).
-    unimplemented!("backup::restore — see SPEC-1934 task T-035")
+/// Replay a snapshot back into `snapshot.project_root`. Files added since the
+/// snapshot are removed (excluding the backup directory itself) and the
+/// backup contents are copied back into place.
+pub fn restore(snapshot: &BackupSnapshot) -> Result<(), BackupError> {
+    let project_root = &snapshot.project_root;
+    let backup_dir = &snapshot.backup_dir;
+    let backup_name = backup_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(BACKUP_DIR_NAME)
+        .to_string();
+
+    // Step 1: remove every entry in project_root except the backup directory.
+    if let Ok(entries) = fs::read_dir(project_root) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy() == backup_name {
+                continue;
+            }
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.file_type().is_symlink() || metadata.is_file() {
+                fs::remove_file(&path)?;
+            } else if metadata.is_dir() {
+                fs::remove_dir_all(&path)?;
+            }
+        }
+    }
+
+    // Step 2: copy backup contents back to project root.
+    copy_dir_contents(backup_dir, project_root, &[])?;
+
+    Ok(())
 }
 
-pub fn discard(_snapshot: BackupSnapshot) -> Result<(), BackupError> {
-    // Filled in by Phase 8 tasks (T-074/T-075).
-    unimplemented!("backup::discard — see SPEC-1934 task T-074/T-075")
+/// Delete a backup snapshot (called from the Cleanup phase on success).
+pub fn discard(snapshot: BackupSnapshot) -> Result<(), BackupError> {
+    if snapshot.backup_dir.exists() {
+        fs::remove_dir_all(&snapshot.backup_dir)?;
+    }
+    Ok(())
+}
+
+/// Recursively copy the contents of `src` into `dst`, skipping any top-level
+/// entry whose file name matches `excluded`.
+fn copy_dir_contents(src: &Path, dst: &Path, excluded: &[&str]) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if excluded.iter().any(|e| **e == *name_str) {
+            continue;
+        }
+        let from = entry.path();
+        let to = dst.join(&name);
+        let metadata = fs::symlink_metadata(&from)?;
+        let file_type = metadata.file_type();
+
+        if file_type.is_symlink() {
+            // Skip symlinks for now: backup semantics for symlinks are
+            // undefined in the spec and copying targets is potentially
+            // dangerous on a Normal Git repo (e.g. `.git` worktree markers).
+            continue;
+        }
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&from)?;
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
 }

--- a/crates/gwt-core/src/migration/executor.rs
+++ b/crates/gwt-core/src/migration/executor.rs
@@ -1,0 +1,28 @@
+//! Orchestrates the migration phases (Validate → Backup → Bareify →
+//! Worktrees → Submodules → Tracking → Cleanup).
+//!
+//! The implementation is filled in by Phase 5+ tasks in
+//! `tasks.md`; the skeleton here only exposes the public entry point so
+//! downstream modules and tests can compile.
+
+use std::path::Path;
+
+use super::types::{
+    MigrationError, MigrationOptions, MigrationOutcome, MigrationPhase, RecoveryState,
+};
+
+/// Public entry point. Drives the full Normal→Bare+Worktree migration.
+///
+/// `progress` receives `(phase, percent_complete_within_phase)` updates so a
+/// caller can stream progress to the WebSocket UI.
+pub fn execute_migration(
+    _project_root: &Path,
+    _options: MigrationOptions,
+    _progress: impl FnMut(MigrationPhase, u8),
+) -> Result<MigrationOutcome, MigrationError> {
+    Err(MigrationError {
+        phase: MigrationPhase::Confirm,
+        message: "execute_migration is not implemented yet (SPEC-1934 US-6)".to_string(),
+        recovery: RecoveryState::Untouched,
+    })
+}

--- a/crates/gwt-core/src/migration/mod.rs
+++ b/crates/gwt-core/src/migration/mod.rs
@@ -1,0 +1,15 @@
+//! Migration of legacy Normal Git repositories into the Nested Bare+Worktree
+//! layout used by gwt (`<workspace>/<repo>.git/` + `<workspace>/<branch>/`).
+//!
+//! Entry point: [`executor::execute_migration`].
+
+pub mod backup;
+pub mod executor;
+pub mod rollback;
+pub mod types;
+pub mod validator;
+
+pub use types::{
+    MigrationError, MigrationOptions, MigrationOutcome, MigrationPhase, MigrationPlan,
+    RecoveryState, WorktreeMigration,
+};

--- a/crates/gwt-core/src/migration/rollback.rs
+++ b/crates/gwt-core/src/migration/rollback.rs
@@ -1,0 +1,33 @@
+//! Failure-recovery routine triggered when any phase after `Backup` fails.
+//!
+//! Removes any partially-created bare or worktree directories, then restores
+//! the original Normal Git layout from the backup snapshot.
+
+use super::backup::{self, BackupError, BackupSnapshot};
+
+#[derive(Debug)]
+pub enum RollbackError {
+    Backup(BackupError),
+}
+
+impl std::fmt::Display for RollbackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Backup(e) => write!(f, "rollback failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for RollbackError {}
+
+impl From<BackupError> for RollbackError {
+    fn from(value: BackupError) -> Self {
+        Self::Backup(value)
+    }
+}
+
+pub fn rollback_migration(_snapshot: &BackupSnapshot) -> Result<(), RollbackError> {
+    // Filled in by Phase 9 tasks (T-081, T-083, T-085).
+    backup::restore(_snapshot)?;
+    Ok(())
+}

--- a/crates/gwt-core/src/migration/types.rs
+++ b/crates/gwt-core/src/migration/types.rs
@@ -1,0 +1,115 @@
+//! Domain types for the Normal-to-Bare+Worktree migration workflow.
+
+use std::path::PathBuf;
+
+/// Caller-tunable options for a migration run.
+#[derive(Debug, Clone, Default)]
+pub struct MigrationOptions {
+    /// When true, validate and report what would happen but do not mutate state.
+    pub dry_run: bool,
+    /// When true, keep the migration backup directory after a successful run.
+    pub keep_backup_on_success: bool,
+    /// Override the branch name used for the main worktree directory.
+    pub branch_override: Option<String>,
+}
+
+/// One worktree slated for migration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeMigration {
+    pub path: PathBuf,
+    pub branch: String,
+    pub is_main_repo: bool,
+    pub is_dirty: bool,
+    pub is_locked: bool,
+}
+
+/// Plan computed before execution: the set of worktrees to move and the
+/// resulting layout root.
+#[derive(Debug, Clone)]
+pub struct MigrationPlan {
+    pub project_root: PathBuf,
+    pub bare_repo_name: String,
+    pub remote_url: Option<String>,
+    pub worktrees: Vec<WorktreeMigration>,
+}
+
+/// Phase markers used for state-machine progress reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MigrationPhase {
+    Confirm,
+    Validate,
+    Backup,
+    Bareify,
+    Worktrees,
+    Submodules,
+    Tracking,
+    Cleanup,
+    Done,
+    Error,
+    RolledBack,
+}
+
+impl MigrationPhase {
+    /// Stable, lower-case, dash-free identifier used in WebSocket events.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Confirm => "confirm",
+            Self::Validate => "validate",
+            Self::Backup => "backup",
+            Self::Bareify => "bareify",
+            Self::Worktrees => "worktrees",
+            Self::Submodules => "submodules",
+            Self::Tracking => "tracking",
+            Self::Cleanup => "cleanup",
+            Self::Done => "done",
+            Self::Error => "error",
+            Self::RolledBack => "rolled_back",
+        }
+    }
+}
+
+impl std::fmt::Display for MigrationPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Successful outcome reported back to the caller.
+#[derive(Debug, Clone)]
+pub struct MigrationOutcome {
+    pub branch_worktree_path: PathBuf,
+    pub bare_repo_path: PathBuf,
+    pub migrated_worktrees: Vec<PathBuf>,
+}
+
+/// Recovery state attached to a [`MigrationError`] so the UI can decide
+/// what to offer the user (Retry / Restore / Quit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryState {
+    /// Nothing was changed on disk yet; safe to retry.
+    Untouched,
+    /// A partial mutation was made and successfully rolled back.
+    RolledBack,
+    /// Rollback could not fully restore the original layout.
+    Partial,
+}
+
+/// Failure shape returned by [`super::executor::execute_migration`].
+#[derive(Debug)]
+pub struct MigrationError {
+    pub phase: MigrationPhase,
+    pub message: String,
+    pub recovery: RecoveryState,
+}
+
+impl std::fmt::Display for MigrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "migration failed at phase {} (recovery: {:?}): {}",
+            self.phase, self.recovery, self.message
+        )
+    }
+}
+
+impl std::error::Error for MigrationError {}

--- a/crates/gwt-core/src/migration/validator.rs
+++ b/crates/gwt-core/src/migration/validator.rs
@@ -1,0 +1,42 @@
+//! Pre-flight checks before a migration starts (Phase 3 of the build plan).
+//!
+//! - disk space (project size × 2 must be available)
+//! - locked worktrees
+//! - write permission on the project root
+//!
+//! Implementations are filled in by Phase 3 tasks; only signatures live here
+//! to let dependent modules compile.
+
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub enum ValidationError {
+    InsufficientDiskSpace { required: u64, available: u64 },
+    LockedWorktrees(Vec<PathBuf>),
+    WritePermissionDenied(PathBuf),
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsufficientDiskSpace {
+                required,
+                available,
+            } => write!(
+                f,
+                "insufficient disk space: required {required} bytes, available {available} bytes"
+            ),
+            Self::LockedWorktrees(paths) => write!(f, "locked worktrees: {paths:?}"),
+            Self::WritePermissionDenied(path) => {
+                write!(f, "write permission denied: {}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+pub fn validate(_project_root: &Path) -> Result<(), ValidationError> {
+    // Filled in by Phase 3 tasks (T-026).
+    Ok(())
+}

--- a/crates/gwt-core/src/migration/validator.rs
+++ b/crates/gwt-core/src/migration/validator.rs
@@ -3,17 +3,22 @@
 //! - disk space (project size × 2 must be available)
 //! - locked worktrees
 //! - write permission on the project root
-//!
-//! Implementations are filled in by Phase 3 tasks; only signatures live here
-//! to let dependent modules compile.
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use fs2::available_space;
+
+use crate::process::hidden_command;
 
 #[derive(Debug)]
 pub enum ValidationError {
     InsufficientDiskSpace { required: u64, available: u64 },
     LockedWorktrees(Vec<PathBuf>),
     WritePermissionDenied(PathBuf),
+    Io(std::io::Error),
 }
 
 impl std::fmt::Display for ValidationError {
@@ -30,13 +35,129 @@ impl std::fmt::Display for ValidationError {
             Self::WritePermissionDenied(path) => {
                 write!(f, "write permission denied: {}", path.display())
             }
+            Self::Io(e) => write!(f, "validator io error: {e}"),
         }
     }
 }
 
 impl std::error::Error for ValidationError {}
 
-pub fn validate(_project_root: &Path) -> Result<(), ValidationError> {
-    // Filled in by Phase 3 tasks (T-026).
+impl From<std::io::Error> for ValidationError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+/// Pure decision rule used by [`check_disk_space`]: succeed when at least
+/// `required` bytes are available.
+pub fn evaluate_disk_space(required: u64, available: u64) -> Result<(), ValidationError> {
+    if available >= required {
+        Ok(())
+    } else {
+        Err(ValidationError::InsufficientDiskSpace {
+            required,
+            available,
+        })
+    }
+}
+
+/// Run an IO-backed disk-space check for the given `project_root`. The
+/// migration writes a full backup before mutating the layout, so we require
+/// `directory_size × 2` bytes of headroom.
+pub fn check_disk_space(project_root: &Path) -> Result<(), ValidationError> {
+    let used = directory_size(project_root)?;
+    let required = used.saturating_mul(2);
+    let available = available_space(project_root).map_err(ValidationError::Io)?;
+    evaluate_disk_space(required, available)
+}
+
+/// Compute the total bytes consumed by `path`, walking subdirectories.
+/// Symlinks are not followed.
+fn directory_size(path: &Path) -> Result<u64, ValidationError> {
+    let mut total: u64 = 0;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let metadata = fs::symlink_metadata(&current)?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            for entry in fs::read_dir(&current)? {
+                let entry = entry?;
+                stack.push(entry.path());
+            }
+        } else if metadata.is_file() {
+            total = total.saturating_add(metadata.len());
+        }
+    }
+    Ok(total)
+}
+
+/// Detect any worktrees marked as locked under the given project. Locked
+/// worktrees prevent migration because we cannot move their on-disk path.
+pub fn check_locked_worktrees(project_root: &Path) -> Result<(), ValidationError> {
+    let output = hidden_command("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(project_root)
+        .output()
+        .map_err(ValidationError::Io)?;
+
+    if !output.status.success() {
+        // Not a git repository or `git` failed: treat as no locked worktrees.
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut locked = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            current_path = Some(PathBuf::from(rest.trim()));
+        } else if line.starts_with("locked") {
+            if let Some(p) = current_path.clone() {
+                locked.push(p);
+            }
+        } else if line.is_empty() {
+            current_path = None;
+        }
+    }
+
+    if locked.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationError::LockedWorktrees(locked))
+    }
+}
+
+/// Confirm the migration can write into `project_root` by creating a probe
+/// file. The probe is removed before returning.
+pub fn check_write_permission(project_root: &Path) -> Result<(), ValidationError> {
+    let probe = project_root.join(".gwt-migration-probe");
+    match fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&probe)
+    {
+        Ok(_) => {
+            // Best-effort cleanup; ignore unlink errors so a transient probe is
+            // never the reason a migration fails.
+            let _ = fs::remove_file(&probe);
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Err(
+            ValidationError::WritePermissionDenied(project_root.to_path_buf()),
+        ),
+        Err(e) => Err(ValidationError::Io(e)),
+    }
+}
+
+/// Run all pre-flight checks against `project_root`. Short-circuits on the
+/// first failure.
+pub fn validate(project_root: &Path) -> Result<(), ValidationError> {
+    check_write_permission(project_root)?;
+    check_disk_space(project_root)?;
+    check_locked_worktrees(project_root)?;
     Ok(())
 }

--- a/crates/gwt-core/tests/migration_workflow_test.rs
+++ b/crates/gwt-core/tests/migration_workflow_test.rs
@@ -1,6 +1,10 @@
 //! Workflow-level tests for the SPEC-1934 US-6 migration support.
 
 use gwt_core::config::BareProjectConfig;
+use gwt_core::migration::validator::{
+    self, check_disk_space, check_locked_worktrees, check_write_permission, evaluate_disk_space,
+    ValidationError,
+};
 use gwt_core::migration::MigrationPhase;
 
 #[test]
@@ -44,6 +48,152 @@ fn t013_bare_project_config_save_creates_dot_gwt_directory() {
     cfg.save(tmp.path()).expect("save project.toml");
     assert!(tmp.path().join(".gwt").is_dir());
     assert!(tmp.path().join(".gwt/project.toml").is_file());
+}
+
+#[test]
+fn t020_evaluate_disk_space_rejects_when_required_exceeds_available() {
+    // FR-020 / Edge Case: マイグレーションは backup を作成するので空き容量が
+    // 元 repo の倍以上必要。required > available で
+    // ValidationError::InsufficientDiskSpace が返らなければならない。
+    let result = evaluate_disk_space(10_000, 5_000);
+    match result {
+        Err(ValidationError::InsufficientDiskSpace {
+            required,
+            available,
+        }) => {
+            assert_eq!(required, 10_000);
+            assert_eq!(available, 5_000);
+        }
+        other => panic!("expected InsufficientDiskSpace, got {other:?}"),
+    }
+}
+
+#[test]
+fn t020_evaluate_disk_space_accepts_when_available_meets_required() {
+    assert!(matches!(evaluate_disk_space(1_000, 1_000), Ok(())));
+    assert!(matches!(evaluate_disk_space(1_000, 1_500), Ok(())));
+    assert!(matches!(evaluate_disk_space(0, 0), Ok(())));
+}
+
+#[test]
+fn t020_check_disk_space_passes_for_small_tempdir() {
+    // Live filesystem check. Tempdirs created by this test fixture are kilobyte
+    // sized so unless the test host is full this must succeed.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("hello.txt"), "world").unwrap();
+    check_disk_space(tmp.path()).expect("clean tempdir must pass disk check");
+}
+
+#[test]
+fn t022_check_locked_worktrees_returns_ok_when_no_worktrees_locked() {
+    let tmp = tempfile::tempdir().unwrap();
+    gwt_core::process::hidden_command("git")
+        .args(["init", tmp.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    gwt_core::process::hidden_command("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    check_locked_worktrees(tmp.path()).expect("unlocked repo must pass");
+}
+
+#[test]
+fn t022_check_locked_worktrees_detects_locked_worktree() {
+    let tmp = tempfile::tempdir().unwrap();
+    gwt_core::process::hidden_command("git")
+        .args(["init", tmp.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    gwt_core::process::hidden_command("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let wt_path = tmp.path().join("wt-feature");
+    gwt_core::process::hidden_command("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "feature/x",
+            wt_path.to_str().unwrap(),
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    gwt_core::process::hidden_command("git")
+        .args(["worktree", "lock", wt_path.to_str().unwrap()])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let err =
+        check_locked_worktrees(tmp.path()).expect_err("locked worktree must surface as error");
+    match err {
+        ValidationError::LockedWorktrees(paths) => {
+            assert!(
+                paths.iter().any(|p| {
+                    std::fs::canonicalize(p)
+                        .map(|c| c == std::fs::canonicalize(&wt_path).unwrap())
+                        .unwrap_or(false)
+                }),
+                "locked worktree path must be reported, got {paths:?}"
+            );
+        }
+        other => panic!("expected LockedWorktrees, got {other:?}"),
+    }
+}
+
+#[test]
+fn t024_check_write_permission_passes_for_writable_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    check_write_permission(tmp.path()).expect("writable dir must pass");
+}
+
+#[cfg(unix)]
+#[test]
+fn t024_check_write_permission_fails_for_readonly_dir() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let mut perms = std::fs::metadata(tmp.path()).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(tmp.path(), perms).unwrap();
+
+    let result = check_write_permission(tmp.path());
+
+    // 後始末: パーミッションを書き戻して tempdir が削除できるようにする。
+    let mut restore = std::fs::metadata(tmp.path()).unwrap().permissions();
+    restore.set_mode(0o755);
+    std::fs::set_permissions(tmp.path(), restore).unwrap();
+
+    match result {
+        Err(ValidationError::WritePermissionDenied(path)) => {
+            assert_eq!(
+                std::fs::canonicalize(&path).unwrap(),
+                std::fs::canonicalize(tmp.path()).unwrap()
+            );
+        }
+        other => panic!("expected WritePermissionDenied, got {other:?}"),
+    }
+}
+
+#[test]
+fn t026_validate_aggregates_all_checks_for_clean_normal_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    gwt_core::process::hidden_command("git")
+        .args(["init", tmp.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    gwt_core::process::hidden_command("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    validator::validate(tmp.path()).expect("clean Normal Git must pass aggregate validate()");
 }
 
 #[test]

--- a/crates/gwt-core/tests/migration_workflow_test.rs
+++ b/crates/gwt-core/tests/migration_workflow_test.rs
@@ -1,0 +1,70 @@
+//! Workflow-level tests for the SPEC-1934 US-6 migration support.
+
+use gwt_core::config::BareProjectConfig;
+use gwt_core::migration::MigrationPhase;
+
+#[test]
+fn t013_bare_project_config_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let original = BareProjectConfig {
+        bare_repo_name: "llmlb.git".into(),
+        remote_url: Some("https://github.com/akiojin/llmlb".into()),
+        created_at: "2026-04-30T12:34:56Z".into(),
+        migrated_from: Some("normal".into()),
+    };
+
+    original.save(tmp.path()).expect("save project.toml");
+
+    let path = BareProjectConfig::config_path(tmp.path());
+    assert!(path.exists(), "project.toml must exist after save");
+
+    let loaded = BareProjectConfig::load(tmp.path())
+        .expect("load project.toml")
+        .expect("project.toml exists");
+    assert_eq!(loaded, original);
+}
+
+#[test]
+fn t013_bare_project_config_load_returns_none_when_absent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let result = BareProjectConfig::load(tmp.path()).expect("load absent project.toml");
+    assert!(result.is_none(), "absent config must yield None");
+}
+
+#[test]
+fn t013_bare_project_config_save_creates_dot_gwt_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = BareProjectConfig {
+        bare_repo_name: "x.git".into(),
+        remote_url: None,
+        created_at: "2026-04-30T00:00:00Z".into(),
+        migrated_from: None,
+    };
+    cfg.save(tmp.path()).expect("save project.toml");
+    assert!(tmp.path().join(".gwt").is_dir());
+    assert!(tmp.path().join(".gwt/project.toml").is_file());
+}
+
+#[test]
+fn t015_migration_phase_has_stable_string_keys() {
+    // FR-019/FR-029 expose phases over the WebSocket API. Their string
+    // representation must stay stable so the WebView can dispatch on it.
+    let cases = [
+        (MigrationPhase::Confirm, "confirm"),
+        (MigrationPhase::Validate, "validate"),
+        (MigrationPhase::Backup, "backup"),
+        (MigrationPhase::Bareify, "bareify"),
+        (MigrationPhase::Worktrees, "worktrees"),
+        (MigrationPhase::Submodules, "submodules"),
+        (MigrationPhase::Tracking, "tracking"),
+        (MigrationPhase::Cleanup, "cleanup"),
+        (MigrationPhase::Done, "done"),
+        (MigrationPhase::Error, "error"),
+        (MigrationPhase::RolledBack, "rolled_back"),
+    ];
+    for (phase, expected) in cases {
+        assert_eq!(phase.as_str(), expected, "as_str for {phase:?}");
+        assert_eq!(format!("{phase}"), expected, "Display for {phase:?}");
+    }
+}

--- a/crates/gwt-core/tests/migration_workflow_test.rs
+++ b/crates/gwt-core/tests/migration_workflow_test.rs
@@ -1,6 +1,8 @@
 //! Workflow-level tests for the SPEC-1934 US-6 migration support.
 
 use gwt_core::config::BareProjectConfig;
+use gwt_core::migration::backup::{self, BACKUP_DIR_NAME};
+use gwt_core::migration::rollback;
 use gwt_core::migration::validator::{
     self, check_disk_space, check_locked_worktrees, check_write_permission, evaluate_disk_space,
     ValidationError,
@@ -194,6 +196,127 @@ fn t026_validate_aggregates_all_checks_for_clean_normal_repo() {
         .unwrap();
 
     validator::validate(tmp.path()).expect("clean Normal Git must pass aggregate validate()");
+}
+
+#[test]
+fn t030_backup_create_copies_tree_into_backup_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "alpha").unwrap();
+    std::fs::create_dir_all(tmp.path().join("nested")).unwrap();
+    std::fs::write(tmp.path().join("nested").join("b.txt"), "beta").unwrap();
+
+    let snapshot = backup::create(tmp.path()).expect("backup::create");
+    assert_eq!(snapshot.project_root, tmp.path());
+
+    let backup_dir = tmp.path().join(BACKUP_DIR_NAME);
+    assert!(backup_dir.is_dir(), "backup dir must exist");
+    assert_eq!(snapshot.backup_dir, backup_dir);
+
+    assert!(backup_dir.join("a.txt").is_file());
+    assert!(backup_dir.join("nested").join("b.txt").is_file());
+    assert_eq!(
+        std::fs::read_to_string(backup_dir.join("a.txt")).unwrap(),
+        "alpha"
+    );
+}
+
+#[test]
+fn t030_backup_create_excludes_self() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("real.txt"), "x").unwrap();
+
+    let snapshot = backup::create(tmp.path()).expect("backup::create");
+
+    // The backup directory must not contain a recursive copy of itself.
+    assert!(!snapshot.backup_dir.join(BACKUP_DIR_NAME).exists());
+    assert!(snapshot.backup_dir.join("real.txt").is_file());
+}
+
+#[test]
+fn t032_backup_create_renames_existing_backup() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("seed.txt"), "fresh").unwrap();
+    let backup_dir = tmp.path().join(BACKUP_DIR_NAME);
+    std::fs::create_dir_all(&backup_dir).unwrap();
+    std::fs::write(backup_dir.join("stale.txt"), "stale").unwrap();
+
+    let snapshot = backup::create(tmp.path()).expect("backup::create");
+
+    assert!(snapshot.backup_dir.join("seed.txt").is_file());
+
+    // The legacy backup must be renamed (any sibling starting with the backup
+    // dir name + "-" is acceptable; we just ensure stale content exists somewhere).
+    let mut found_legacy = false;
+    for entry in std::fs::read_dir(tmp.path()).unwrap().flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&format!("{BACKUP_DIR_NAME}-")) {
+            let stale = entry.path().join("stale.txt");
+            if stale.is_file() && std::fs::read_to_string(&stale).unwrap_or_default() == "stale" {
+                found_legacy = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        found_legacy,
+        "legacy backup must be preserved with timestamp suffix"
+    );
+}
+
+#[test]
+fn t034_backup_restore_returns_files_to_project_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("keep.txt"), "v1").unwrap();
+    std::fs::create_dir_all(tmp.path().join("dir")).unwrap();
+    std::fs::write(tmp.path().join("dir").join("nested.txt"), "n1").unwrap();
+
+    let snapshot = backup::create(tmp.path()).expect("backup::create");
+
+    // Mutate the live tree to simulate a partial migration before restore.
+    std::fs::remove_file(tmp.path().join("keep.txt")).unwrap();
+    std::fs::write(tmp.path().join("dir").join("nested.txt"), "tampered").unwrap();
+    std::fs::write(tmp.path().join("new.txt"), "added during migration").unwrap();
+
+    backup::restore(&snapshot).expect("backup::restore");
+
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("keep.txt")).unwrap(),
+        "v1",
+        "removed file must be brought back"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("dir").join("nested.txt")).unwrap(),
+        "n1",
+        "tampered file must be reverted"
+    );
+    assert!(
+        !tmp.path().join("new.txt").exists(),
+        "files added after backup must be cleared on restore"
+    );
+}
+
+#[test]
+fn t036_rollback_uses_backup_to_restore_partial_changes() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("a"), "1").unwrap();
+    let snapshot = backup::create(tmp.path()).expect("backup::create");
+
+    // Pretend a phase failed and left junk.
+    std::fs::write(tmp.path().join("partial.bin"), "garbage").unwrap();
+    std::fs::remove_file(tmp.path().join("a")).unwrap();
+
+    rollback::rollback_migration(&snapshot).expect("rollback");
+
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a")).unwrap(),
+        "1",
+        "rollback must restore deleted files"
+    );
+    assert!(
+        !tmp.path().join("partial.bin").exists(),
+        "rollback must clear partial files"
+    );
 }
 
 #[test]

--- a/crates/gwt-git/src/lib.rs
+++ b/crates/gwt-git/src/lib.rs
@@ -7,6 +7,7 @@ pub mod branch;
 pub mod commit;
 pub mod diff;
 pub mod issue;
+pub mod migration;
 pub mod pr_status;
 pub mod repository;
 pub mod worktree;

--- a/crates/gwt-git/src/migration.rs
+++ b/crates/gwt-git/src/migration.rs
@@ -6,24 +6,120 @@
 //! Each function is intentionally narrow so tests in
 //! `crates/gwt-git/tests/migration_test.rs` can target them in isolation.
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
-use gwt_core::{GwtError, Result};
+use gwt_core::{process::hidden_command, GwtError, Result};
 
-/// Clone a Normal repository's `origin` URL into `<target>` as a bare repo.
-pub fn clone_bare_from_normal(_origin_url: &str, _target: &Path) -> Result<PathBuf> {
-    // Filled in by T-040/T-041.
-    Err(GwtError::Git(
-        "migration::clone_bare_from_normal — not implemented (SPEC-1934 T-040)".to_string(),
-    ))
+/// Clone a Normal repository's `origin` URL into `<target>` as a bare repo
+/// (FR-021). The full history is preserved so subsequent worktree adds resolve
+/// every branch the original repository knew.
+pub fn clone_bare_from_normal(origin_url: &str, target: &Path) -> Result<PathBuf> {
+    if let Some(parent) = target.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(GwtError::Io)?;
+        }
+    }
+    let target_str = target
+        .to_str()
+        .ok_or_else(|| GwtError::Git(format!("invalid bare target path: {}", target.display())))?;
+
+    let output = hidden_command("git")
+        .args(["clone", "--bare", origin_url, target_str])
+        .output()
+        .map_err(|e| GwtError::Git(format!("git clone --bare: {e}")))?;
+
+    if output.status.success() {
+        Ok(target.to_path_buf())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        Err(GwtError::Git(format!("git clone --bare failed: {stderr}")))
+    }
 }
 
 /// Bare-ify a project's local `.git/` directory in place when no usable
-/// `origin` URL is available (Edge Case in spec, T-042/T-043).
-pub fn bareify_local(_project_root: &Path, _target: &Path) -> Result<PathBuf> {
-    Err(GwtError::Git(
-        "migration::bareify_local — not implemented (SPEC-1934 T-042)".to_string(),
-    ))
+/// `origin` URL is available. The contents of `.git/` are copied into
+/// `<target>` and `core.bare` is flipped to true (FR-021 fallback path).
+pub fn bareify_local(project_root: &Path, target: &Path) -> Result<PathBuf> {
+    let dot_git = project_root.join(".git");
+    if !dot_git.is_dir() {
+        return Err(GwtError::Git(format!(
+            "bareify_local: {} is not a normal Git repository (no .git/ directory)",
+            project_root.display()
+        )));
+    }
+
+    if target.exists() {
+        return Err(GwtError::Git(format!(
+            "bareify_local: target {} already exists",
+            target.display()
+        )));
+    }
+
+    if let Some(parent) = target.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(GwtError::Io)?;
+        }
+    }
+
+    copy_dir_recursive(&dot_git, target).map_err(GwtError::Io)?;
+
+    let target_str = target.to_str().ok_or_else(|| {
+        GwtError::Git(format!(
+            "bareify_local: invalid target path: {}",
+            target.display()
+        ))
+    })?;
+
+    let output = hidden_command("git")
+        .args(["config", "--bool", "core.bare", "true"])
+        .current_dir(target_str)
+        .output()
+        .map_err(|e| GwtError::Git(format!("git config core.bare: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(GwtError::Git(format!(
+            "bareify_local: git config core.bare failed: {stderr}"
+        )));
+    }
+
+    Ok(target.to_path_buf())
+}
+
+/// Copy the contents of `<source_dot_git>/hooks/` into `<bare>/hooks/`,
+/// preserving file mode on Unix. `git clone --bare` does not bring user hooks
+/// across, so the migration must do it explicitly (FR-022).
+pub fn copy_hooks_to_bare(source_dot_git: &Path, bare: &Path) -> Result<()> {
+    let src_hooks = source_dot_git.join("hooks");
+    if !src_hooks.is_dir() {
+        return Ok(());
+    }
+    let dst_hooks = bare.join("hooks");
+    fs::create_dir_all(&dst_hooks).map_err(GwtError::Io)?;
+
+    for entry in fs::read_dir(&src_hooks).map_err(GwtError::Io)? {
+        let entry = entry.map_err(GwtError::Io)?;
+        let from = entry.path();
+        let to = dst_hooks.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&from).map_err(GwtError::Io)?;
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_file() {
+            fs::copy(&from, &to).map_err(GwtError::Io)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = metadata.permissions().mode();
+                let perms = std::fs::Permissions::from_mode(mode);
+                fs::set_permissions(&to, perms).map_err(GwtError::Io)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Add a clean worktree at `<target>` for `<branch>` from the bare repo.
@@ -69,4 +165,27 @@ pub fn set_upstream(_worktree: &Path, _branch: &str) -> Result<()> {
     Err(GwtError::Git(
         "migration::set_upstream — not implemented (SPEC-1934 T-063)".to_string(),
     ))
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&from)?;
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            // Symlinks inside `.git/` (e.g. submodule worktree pointers) are
+            // intentionally skipped: bare layout does not preserve worktree
+            // markers and re-creating links can foot-gun across hosts.
+            continue;
+        }
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
 }

--- a/crates/gwt-git/src/migration.rs
+++ b/crates/gwt-git/src/migration.rs
@@ -122,49 +122,137 @@ pub fn copy_hooks_to_bare(source_dot_git: &Path, bare: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Add a clean worktree at `<target>` for `<branch>` from the bare repo.
-pub fn add_worktree_clean(_bare: &Path, _target: &Path, _branch: &str) -> Result<()> {
-    Err(GwtError::Git(
-        "migration::add_worktree_clean — not implemented (SPEC-1934 T-050)".to_string(),
-    ))
+/// File-system entries that must never be moved by the dirty-file
+/// evacuation / restore pipeline. `.git` is the working tree's pointer (or the
+/// bare repo itself) and the migration backup is the rollback safety net.
+const EVACUATION_EXCLUSIONS: &[&str] = &[".git", ".gwt-migration-backup"];
+
+/// Add a clean worktree at `<target>` for `<branch>` from the bare repo
+/// (FR-024).
+pub fn add_worktree_clean(bare: &Path, target: &Path, branch: &str) -> Result<()> {
+    run_worktree_add(bare, target, branch, false)
 }
 
 /// Add a worktree without checkout, so callers can restore evacuated files
-/// before running `git reset` (FR-023, T-052).
-pub fn add_worktree_no_checkout(_bare: &Path, _target: &Path, _branch: &str) -> Result<()> {
-    Err(GwtError::Git(
-        "migration::add_worktree_no_checkout — not implemented (SPEC-1934 T-053)".to_string(),
-    ))
+/// before running `git reset` (FR-023).
+pub fn add_worktree_no_checkout(bare: &Path, target: &Path, branch: &str) -> Result<()> {
+    run_worktree_add(bare, target, branch, true)
 }
 
-/// Move all files except `.git/` and the migration backup to a temporary
-/// evacuation directory; returns the evacuation root for later restore.
-pub fn evacuate_dirty_files(_worktree: &Path, _evacuation_root: &Path) -> Result<PathBuf> {
-    Err(GwtError::Git(
-        "migration::evacuate_dirty_files — not implemented (SPEC-1934 T-053)".to_string(),
-    ))
+fn run_worktree_add(bare: &Path, target: &Path, branch: &str, no_checkout: bool) -> Result<()> {
+    if let Some(parent) = target.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(GwtError::Io)?;
+        }
+    }
+    let target_str = target.to_str().ok_or_else(|| {
+        GwtError::Git(format!(
+            "invalid worktree target path: {}",
+            target.display()
+        ))
+    })?;
+
+    let mut args: Vec<&str> = vec!["worktree", "add"];
+    if no_checkout {
+        args.push("--no-checkout");
+    }
+    args.push(target_str);
+    args.push(branch);
+
+    let output = hidden_command("git")
+        .args(&args)
+        .current_dir(bare)
+        .output()
+        .map_err(|e| GwtError::Git(format!("git worktree add: {e}")))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(GwtError::Git(format!(
+            "git worktree add {} failed: {stderr}",
+            target.display()
+        )))
+    }
 }
 
-/// Restore previously-evacuated files into the new worktree.
-pub fn restore_evacuated_files(_evacuation_root: &Path, _new_worktree: &Path) -> Result<()> {
-    Err(GwtError::Git(
-        "migration::restore_evacuated_files — not implemented (SPEC-1934 T-053)".to_string(),
-    ))
+/// Move every top-level entry under `worktree` to `evacuation_root` (creating
+/// it as needed). `.git` and the migration backup directory are kept in
+/// place. Returns the evacuation root so callers can pass it back into
+/// [`restore_evacuated_files`].
+pub fn evacuate_dirty_files(worktree: &Path, evacuation_root: &Path) -> Result<PathBuf> {
+    fs::create_dir_all(evacuation_root).map_err(GwtError::Io)?;
+    for entry in fs::read_dir(worktree).map_err(GwtError::Io)? {
+        let entry = entry.map_err(GwtError::Io)?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if EVACUATION_EXCLUSIONS.iter().any(|e| **e == *name_str) {
+            continue;
+        }
+        let from = entry.path();
+        let to = evacuation_root.join(&name);
+        fs::rename(&from, &to).map_err(GwtError::Io)?;
+    }
+    Ok(evacuation_root.to_path_buf())
 }
 
-/// Run `git submodule update --init --recursive` in the new worktree
-/// (best effort; failure logs a warning).
-pub fn init_submodules(_worktree: &Path) -> Result<()> {
-    Err(GwtError::Git(
-        "migration::init_submodules — not implemented (SPEC-1934 T-061)".to_string(),
-    ))
+/// Restore previously-evacuated files into `new_worktree`. Existing entries
+/// in the destination (e.g. a `.git` marker created by
+/// `git worktree add --no-checkout`) are preserved.
+pub fn restore_evacuated_files(evacuation_root: &Path, new_worktree: &Path) -> Result<()> {
+    fs::create_dir_all(new_worktree).map_err(GwtError::Io)?;
+    for entry in fs::read_dir(evacuation_root).map_err(GwtError::Io)? {
+        let entry = entry.map_err(GwtError::Io)?;
+        let name = entry.file_name();
+        let from = entry.path();
+        let to = new_worktree.join(&name);
+        if to.exists() {
+            // Don't clobber Git's bookkeeping (`.git`, `.gitignore` written by
+            // worktree add) — caller can decide whether to replace instead.
+            continue;
+        }
+        fs::rename(&from, &to).map_err(GwtError::Io)?;
+    }
+    Ok(())
 }
 
-/// Set upstream tracking for `<branch>` to `origin/<branch>`, if it exists.
-pub fn set_upstream(_worktree: &Path, _branch: &str) -> Result<()> {
-    Err(GwtError::Git(
-        "migration::set_upstream — not implemented (SPEC-1934 T-063)".to_string(),
-    ))
+/// Run `git submodule update --init --recursive` in `worktree`. Per FR-025
+/// the call is best-effort: a repo without submodules exits cleanly, and any
+/// real submodule failure is propagated as an error so the executor can log
+/// a warning without aborting the migration.
+pub fn init_submodules(worktree: &Path) -> Result<()> {
+    let output = hidden_command("git")
+        .args(["submodule", "update", "--init", "--recursive"])
+        .current_dir(worktree)
+        .output()
+        .map_err(|e| GwtError::Git(format!("git submodule update: {e}")))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        Err(GwtError::Git(format!(
+            "git submodule update failed: {stderr}"
+        )))
+    }
+}
+
+/// Set upstream tracking for `<branch>` to `origin/<branch>` in `worktree`.
+/// FR-026 requires this to succeed silently when `origin/<branch>` is missing
+/// (e.g. local-only branches), so we treat any non-zero git exit as a no-op.
+pub fn set_upstream(worktree: &Path, branch: &str) -> Result<()> {
+    let upstream = format!("origin/{branch}");
+    let output = hidden_command("git")
+        .args(["branch", "--set-upstream-to", &upstream, branch])
+        .current_dir(worktree)
+        .output()
+        .map_err(|e| GwtError::Git(format!("git branch --set-upstream-to: {e}")))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        // Missing upstream is expected for fresh / local-only branches.
+        // Non-zero exits are absorbed here so the migration does not abort.
+        Ok(())
+    }
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {

--- a/crates/gwt-git/src/migration.rs
+++ b/crates/gwt-git/src/migration.rs
@@ -1,0 +1,72 @@
+//! Pure Git operations used by the SPEC-1934 US-6 migration: bare-ifying a
+//! Normal Git repository, adding worktrees (clean / dirty), evacuating
+//! uncommitted files for the dirty path, and restoring upstream + submodule
+//! state after the move.
+//!
+//! Each function is intentionally narrow so tests in
+//! `crates/gwt-git/tests/migration_test.rs` can target them in isolation.
+
+use std::path::{Path, PathBuf};
+
+use gwt_core::{GwtError, Result};
+
+/// Clone a Normal repository's `origin` URL into `<target>` as a bare repo.
+pub fn clone_bare_from_normal(_origin_url: &str, _target: &Path) -> Result<PathBuf> {
+    // Filled in by T-040/T-041.
+    Err(GwtError::Git(
+        "migration::clone_bare_from_normal — not implemented (SPEC-1934 T-040)".to_string(),
+    ))
+}
+
+/// Bare-ify a project's local `.git/` directory in place when no usable
+/// `origin` URL is available (Edge Case in spec, T-042/T-043).
+pub fn bareify_local(_project_root: &Path, _target: &Path) -> Result<PathBuf> {
+    Err(GwtError::Git(
+        "migration::bareify_local — not implemented (SPEC-1934 T-042)".to_string(),
+    ))
+}
+
+/// Add a clean worktree at `<target>` for `<branch>` from the bare repo.
+pub fn add_worktree_clean(_bare: &Path, _target: &Path, _branch: &str) -> Result<()> {
+    Err(GwtError::Git(
+        "migration::add_worktree_clean — not implemented (SPEC-1934 T-050)".to_string(),
+    ))
+}
+
+/// Add a worktree without checkout, so callers can restore evacuated files
+/// before running `git reset` (FR-023, T-052).
+pub fn add_worktree_no_checkout(_bare: &Path, _target: &Path, _branch: &str) -> Result<()> {
+    Err(GwtError::Git(
+        "migration::add_worktree_no_checkout — not implemented (SPEC-1934 T-053)".to_string(),
+    ))
+}
+
+/// Move all files except `.git/` and the migration backup to a temporary
+/// evacuation directory; returns the evacuation root for later restore.
+pub fn evacuate_dirty_files(_worktree: &Path, _evacuation_root: &Path) -> Result<PathBuf> {
+    Err(GwtError::Git(
+        "migration::evacuate_dirty_files — not implemented (SPEC-1934 T-053)".to_string(),
+    ))
+}
+
+/// Restore previously-evacuated files into the new worktree.
+pub fn restore_evacuated_files(_evacuation_root: &Path, _new_worktree: &Path) -> Result<()> {
+    Err(GwtError::Git(
+        "migration::restore_evacuated_files — not implemented (SPEC-1934 T-053)".to_string(),
+    ))
+}
+
+/// Run `git submodule update --init --recursive` in the new worktree
+/// (best effort; failure logs a warning).
+pub fn init_submodules(_worktree: &Path) -> Result<()> {
+    Err(GwtError::Git(
+        "migration::init_submodules — not implemented (SPEC-1934 T-061)".to_string(),
+    ))
+}
+
+/// Set upstream tracking for `<branch>` to `origin/<branch>`, if it exists.
+pub fn set_upstream(_worktree: &Path, _branch: &str) -> Result<()> {
+    Err(GwtError::Git(
+        "migration::set_upstream — not implemented (SPEC-1934 T-063)".to_string(),
+    ))
+}

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -10,8 +10,15 @@ use gwt_core::{GwtError, Result};
 /// The type of repository detected at a given path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RepoType {
-    /// A normal (non-bare) git repository. Contains the resolved repo root path.
-    Normal(PathBuf),
+    /// A normal (non-bare) git repository.
+    ///
+    /// `needs_migration` indicates that gwt would prefer to migrate this
+    /// layout to the Nested Bare+Worktree convention before opening
+    /// (SPEC-1934 US-6, FR-019). Currently every Normal layout is flagged.
+    Normal {
+        path: PathBuf,
+        needs_migration: bool,
+    },
     /// A bare git repository with an optional develop worktree path.
     Bare { develop_worktree: Option<PathBuf> },
     /// Not inside any git repository.
@@ -25,7 +32,10 @@ pub enum RepoType {
 pub fn detect_repo_type(path: &Path) -> RepoType {
     // Check if path itself has .git (normal repo or worktree)
     if path.join(".git").exists() {
-        return RepoType::Normal(path.to_path_buf());
+        return RepoType::Normal {
+            path: path.to_path_buf(),
+            needs_migration: true,
+        };
     }
     // Check if path itself is a bare repo (has HEAD + objects + refs)
     if path.join("HEAD").exists() && path.join("objects").exists() && path.join("refs").exists() {
@@ -52,7 +62,10 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
                 found_bare = true;
             }
             if child.join(".git").is_dir() {
-                return RepoType::Normal(child);
+                return RepoType::Normal {
+                    path: child,
+                    needs_migration: true,
+                };
             }
         }
         if found_bare {
@@ -69,7 +82,10 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
             break;
         }
         if parent.join(".git").exists() {
-            return RepoType::Normal(parent.to_path_buf());
+            return RepoType::Normal {
+                path: parent.to_path_buf(),
+                needs_migration: true,
+            };
         }
         if parent.join("HEAD").exists()
             && parent.join("objects").exists()
@@ -380,7 +396,10 @@ mod tests {
             .args(["init", tmp.path().to_str().unwrap()])
             .output()
             .unwrap();
-        assert!(matches!(detect_repo_type(tmp.path()), RepoType::Normal(_)));
+        assert!(matches!(
+            detect_repo_type(tmp.path()),
+            RepoType::Normal { .. }
+        ));
     }
 
     #[test]
@@ -405,7 +424,7 @@ mod tests {
             .unwrap();
         let subdir = tmp.path().join("a").join("b");
         std::fs::create_dir_all(&subdir).unwrap();
-        assert!(matches!(detect_repo_type(&subdir), RepoType::Normal(_)));
+        assert!(matches!(detect_repo_type(&subdir), RepoType::Normal { .. }));
     }
 
     #[test]
@@ -433,7 +452,10 @@ mod tests {
             .output()
             .unwrap();
         // Parent directory should detect Normal via child scan
-        assert!(matches!(detect_repo_type(tmp.path()), RepoType::Normal(_)));
+        assert!(matches!(
+            detect_repo_type(tmp.path()),
+            RepoType::Normal { .. }
+        ));
     }
 
     // ---- clone_repo tests ----

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -197,11 +197,19 @@ fn upsert_managed_hook_block(existing: &str) -> String {
 
 /// Install a pre-commit hook that blocks direct commits on main.
 ///
+/// Accepts both Normal Git layouts (`<repo>/.git/hooks/...`) and Bare layouts
+/// (`<repo>.git/hooks/...` produced by Nested Bare+Worktree migration).
+///
 /// If a pre-commit hook already exists, the gwt block is appended (preserving
 /// existing content). If the gwt block is already present, it is rewritten in
 /// place so legacy develop protection is removed.
 pub fn install_develop_protection(repo_path: &Path) -> Result<()> {
-    let hooks_dir = repo_path.join(".git").join("hooks");
+    let hooks_dir = if repo_path.join(".git").is_dir() {
+        repo_path.join(".git").join("hooks")
+    } else {
+        // Bare layout: hooks live directly under the repo path.
+        repo_path.join("hooks")
+    };
     fs::create_dir_all(&hooks_dir).map_err(GwtError::Io)?;
 
     let hook_path = hooks_dir.join("pre-commit");

--- a/crates/gwt-git/tests/migration_test.rs
+++ b/crates/gwt-git/tests/migration_test.rs
@@ -1,0 +1,56 @@
+//! Integration tests for the SPEC-1934 US-6 migration entry points.
+//!
+//! These tests target the public API of `gwt_git::repository::RepoType` and
+//! `gwt_git::migration::*`. Each test corresponds to a task in the
+//! SPEC-1934 `tasks` section.
+
+use gwt_git::repository::{detect_repo_type, RepoType};
+
+fn init_normal_repo(path: &std::path::Path) {
+    gwt_core::process::hidden_command("git")
+        .args(["init", path.to_str().unwrap()])
+        .output()
+        .expect("git init");
+}
+
+#[test]
+fn t010_normal_repo_reports_needs_migration_true() {
+    // SPEC-1934 US-6 / FR-019: a Normal Git repo must be flagged so the
+    // launcher can show the Migration confirmation modal.
+    let tmp = tempfile::tempdir().unwrap();
+    init_normal_repo(tmp.path());
+
+    match detect_repo_type(tmp.path()) {
+        RepoType::Normal {
+            needs_migration, ..
+        } => {
+            assert!(
+                needs_migration,
+                "every Normal Git layout must be flagged for migration"
+            );
+        }
+        other => panic!("expected RepoType::Normal {{..}}, got {other:?}"),
+    }
+}
+
+#[test]
+fn t010_normal_repo_path_matches_input() {
+    // The `Normal` variant must still expose the resolved repository path so
+    // downstream layers (workspace, runtime_support) can locate the working
+    // tree.
+    let tmp = tempfile::tempdir().unwrap();
+    init_normal_repo(tmp.path());
+
+    let resolved = match detect_repo_type(tmp.path()) {
+        RepoType::Normal { path, .. } => path,
+        other => panic!("expected RepoType::Normal {{..}}, got {other:?}"),
+    };
+
+    // Both paths point at the same directory; canonicalise to defeat
+    // /private/var ↔ /var symlinks on macOS without forcing the rest of the
+    // codebase to canonicalise everything.
+    let resolved_canonical =
+        std::fs::canonicalize(&resolved).expect("canonicalise resolved repo path");
+    let tmp_canonical = std::fs::canonicalize(tmp.path()).expect("canonicalise tmp path");
+    assert_eq!(resolved_canonical, tmp_canonical);
+}

--- a/crates/gwt-git/tests/migration_test.rs
+++ b/crates/gwt-git/tests/migration_test.rs
@@ -4,13 +4,31 @@
 //! `gwt_git::migration::*`. Each test corresponds to a task in the
 //! SPEC-1934 `tasks` section.
 
-use gwt_git::repository::{detect_repo_type, RepoType};
+use gwt_git::migration::{bareify_local, clone_bare_from_normal, copy_hooks_to_bare};
+use gwt_git::repository::{detect_repo_type, install_develop_protection, RepoType};
 
 fn init_normal_repo(path: &std::path::Path) {
     gwt_core::process::hidden_command("git")
         .args(["init", path.to_str().unwrap()])
         .output()
         .expect("git init");
+}
+
+fn commit_initial(path: &std::path::Path) {
+    gwt_core::process::hidden_command("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(path)
+        .output()
+        .expect("git commit");
+}
+
+fn is_bare_repo(path: &std::path::Path) -> bool {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["rev-parse", "--is-bare-repository"])
+        .current_dir(path)
+        .output()
+        .expect("rev-parse");
+    output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
 }
 
 #[test]
@@ -53,4 +71,103 @@ fn t010_normal_repo_path_matches_input() {
         std::fs::canonicalize(&resolved).expect("canonicalise resolved repo path");
     let tmp_canonical = std::fs::canonicalize(tmp.path()).expect("canonicalise tmp path");
     assert_eq!(resolved_canonical, tmp_canonical);
+}
+
+#[test]
+fn t040_clone_bare_from_normal_creates_bare_repository() {
+    // FR-021: when the Normal repo has a usable origin URL we clone it as
+    // bare into the target path.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let workspace = tempfile::tempdir().unwrap();
+    let target = workspace.path().join("repo.git");
+    let url = upstream.path().to_str().unwrap();
+
+    let resolved = clone_bare_from_normal(url, &target).expect("clone_bare_from_normal");
+    assert_eq!(resolved, target);
+    assert!(target.exists(), "bare repo dir must exist");
+    assert!(is_bare_repo(&target), "target must be a bare repository");
+}
+
+#[test]
+fn t046_copy_hooks_to_bare_copies_existing_hooks_into_bare_layout() {
+    // FR-022: After cloning bare from origin, the original `.git/hooks/`
+    // contents must be brought across — `git clone --bare` does not preserve
+    // them.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    // Pretend the user added a custom hook before the migration.
+    let src_hooks = upstream.path().join(".git").join("hooks");
+    std::fs::write(
+        src_hooks.join("pre-push"),
+        "#!/bin/sh\necho 'custom pre-push'\n",
+    )
+    .unwrap();
+
+    let workspace = tempfile::tempdir().unwrap();
+    let bare = workspace.path().join("repo.git");
+    clone_bare_from_normal(upstream.path().to_str().unwrap(), &bare).unwrap();
+
+    copy_hooks_to_bare(&upstream.path().join(".git"), &bare).expect("copy_hooks_to_bare");
+
+    let copied = bare.join("hooks").join("pre-push");
+    assert!(
+        copied.is_file(),
+        "user hook must be copied into bare layout"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&copied).unwrap(),
+        "#!/bin/sh\necho 'custom pre-push'\n"
+    );
+}
+
+#[test]
+fn t047_install_develop_protection_works_against_bare_repo() {
+    // FR-007/008: install_develop_protection must work when given a bare
+    // repository path (Nested layout uses `<repo>.git/hooks/pre-commit`,
+    // not `.git/hooks/...`).
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let workspace = tempfile::tempdir().unwrap();
+    let bare = workspace.path().join("repo.git");
+    clone_bare_from_normal(upstream.path().to_str().unwrap(), &bare).unwrap();
+
+    install_develop_protection(&bare).expect("install hook on bare repo");
+
+    let hook = bare.join("hooks").join("pre-commit");
+    assert!(hook.is_file(), "pre-commit hook must exist in bare layout");
+    let content = std::fs::read_to_string(&hook).unwrap();
+    assert!(content.contains("gwt-managed"));
+    assert!(content.contains("\"$branch\" = \"main\""));
+}
+
+#[test]
+fn t042_bareify_local_converts_local_dot_git_when_origin_missing() {
+    // Edge case: when the origin URL cannot be cloned (auth required, network
+    // off, etc.), we copy the local `.git/` into a bare directory in place.
+    let normal = tempfile::tempdir().unwrap();
+    init_normal_repo(normal.path());
+    commit_initial(normal.path());
+
+    let target = normal.path().join("repo.git");
+    let resolved = bareify_local(normal.path(), &target).expect("bareify_local");
+    assert_eq!(resolved, target);
+    assert!(is_bare_repo(&target), "bareify_local target must be bare");
+
+    // Sanity: the bare clone must still know about the original branch.
+    let output = gwt_core::process::hidden_command("git")
+        .args(["branch", "--list"])
+        .current_dir(&target)
+        .output()
+        .unwrap();
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).is_empty(),
+        "bareified repo must list at least one branch"
+    );
 }

--- a/crates/gwt-git/tests/migration_test.rs
+++ b/crates/gwt-git/tests/migration_test.rs
@@ -4,7 +4,11 @@
 //! `gwt_git::migration::*`. Each test corresponds to a task in the
 //! SPEC-1934 `tasks` section.
 
-use gwt_git::migration::{bareify_local, clone_bare_from_normal, copy_hooks_to_bare};
+use gwt_git::migration::{
+    add_worktree_clean, add_worktree_no_checkout, bareify_local, clone_bare_from_normal,
+    copy_hooks_to_bare, evacuate_dirty_files, init_submodules, restore_evacuated_files,
+    set_upstream,
+};
 use gwt_git::repository::{detect_repo_type, install_develop_protection, RepoType};
 
 fn init_normal_repo(path: &std::path::Path) {
@@ -145,6 +149,154 @@ fn t047_install_develop_protection_works_against_bare_repo() {
     let content = std::fs::read_to_string(&hook).unwrap();
     assert!(content.contains("gwt-managed"));
     assert!(content.contains("\"$branch\" = \"main\""));
+}
+
+#[test]
+fn t050_add_worktree_clean_checks_out_branch_into_target() {
+    // FR-024: clean worktree migration uses plain `git worktree add` so the
+    // branch contents land in `<target>` immediately.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let workspace = tempfile::tempdir().unwrap();
+    let bare = workspace.path().join("repo.git");
+    clone_bare_from_normal(upstream.path().to_str().unwrap(), &bare).unwrap();
+
+    // Find the default branch name (init.defaultBranch may differ across hosts).
+    let head_output = gwt_core::process::hidden_command("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(&bare)
+        .output()
+        .unwrap();
+    let branch = String::from_utf8_lossy(&head_output.stdout)
+        .trim()
+        .to_string();
+
+    let target = workspace.path().join(&branch);
+    add_worktree_clean(&bare, &target, &branch).expect("add_worktree_clean");
+
+    assert!(target.is_dir(), "worktree dir must exist");
+    assert!(
+        target.join(".git").exists(),
+        "worktree must contain a .git marker"
+    );
+}
+
+#[test]
+fn t052_dirty_worktree_evacuate_no_checkout_restore_round_trip() {
+    // FR-023: dirty file changes must survive the migration.
+    // Workflow: evacuate → add_worktree_no_checkout → restore → git reset.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let workspace = tempfile::tempdir().unwrap();
+    let bare = workspace.path().join("repo.git");
+    clone_bare_from_normal(upstream.path().to_str().unwrap(), &bare).unwrap();
+
+    // Build a "dirty Normal worktree" simulation: a directory holding both
+    // pre-existing tracked content (clean files committed elsewhere are not
+    // available in this isolated fixture, so we limit ourselves to untracked
+    // files which round-trip the same way).
+    let dirty_root = workspace.path().join("dirty-source");
+    std::fs::create_dir_all(&dirty_root).unwrap();
+    std::fs::write(dirty_root.join("untracked.txt"), "kept").unwrap();
+    std::fs::create_dir_all(dirty_root.join("nested")).unwrap();
+    std::fs::write(dirty_root.join("nested").join("note.md"), "still here").unwrap();
+
+    // Step 1: evacuate dirty files away.
+    let evacuation = workspace.path().join("evacuation");
+    let evacuated = evacuate_dirty_files(&dirty_root, &evacuation).expect("evacuate");
+    assert!(
+        evacuated.join("untracked.txt").is_file(),
+        "untracked file must move into evacuation dir"
+    );
+    assert!(
+        !dirty_root.join("untracked.txt").exists(),
+        "original location must be empty after evacuation"
+    );
+
+    // Step 2: create the new worktree without checkout.
+    let head_output = gwt_core::process::hidden_command("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(&bare)
+        .output()
+        .unwrap();
+    let branch = String::from_utf8_lossy(&head_output.stdout)
+        .trim()
+        .to_string();
+    let new_worktree = workspace.path().join(&branch);
+    add_worktree_no_checkout(&bare, &new_worktree, &branch).expect("add_worktree_no_checkout");
+    assert!(new_worktree.is_dir());
+
+    // Step 3: restore the evacuated tree into the new worktree.
+    restore_evacuated_files(&evacuated, &new_worktree).expect("restore_evacuated_files");
+
+    assert_eq!(
+        std::fs::read_to_string(new_worktree.join("untracked.txt")).unwrap(),
+        "kept",
+        "evacuated file must be present in the new worktree"
+    );
+    assert_eq!(
+        std::fs::read_to_string(new_worktree.join("nested").join("note.md")).unwrap(),
+        "still here"
+    );
+}
+
+#[test]
+fn t060_init_submodules_succeeds_on_repo_without_submodules() {
+    // FR-025: submodule init must be best-effort. A repo without `.gitmodules`
+    // should not fail validation here (`git submodule update` exits 0).
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let workspace = tempfile::tempdir().unwrap();
+    let bare = workspace.path().join("repo.git");
+    clone_bare_from_normal(upstream.path().to_str().unwrap(), &bare).unwrap();
+
+    let head_output = gwt_core::process::hidden_command("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(&bare)
+        .output()
+        .unwrap();
+    let branch = String::from_utf8_lossy(&head_output.stdout)
+        .trim()
+        .to_string();
+    let target = workspace.path().join(&branch);
+    add_worktree_clean(&bare, &target, &branch).unwrap();
+
+    init_submodules(&target).expect("init_submodules must be best-effort Ok");
+}
+
+#[test]
+fn t062_set_upstream_skips_when_origin_branch_is_absent() {
+    // FR-026: When `origin/<branch>` is missing, set_upstream silently
+    // succeeds rather than aborting the migration.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let workspace = tempfile::tempdir().unwrap();
+    let bare = workspace.path().join("repo.git");
+    clone_bare_from_normal(upstream.path().to_str().unwrap(), &bare).unwrap();
+
+    let head_output = gwt_core::process::hidden_command("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(&bare)
+        .output()
+        .unwrap();
+    let branch = String::from_utf8_lossy(&head_output.stdout)
+        .trim()
+        .to_string();
+    let target = workspace.path().join(&branch);
+    add_worktree_clean(&bare, &target, &branch).unwrap();
+
+    // The bare clone has no `origin` configured (it was cloned from a local
+    // path inside this test), so `origin/<branch>` does not exist. The call
+    // must succeed without error.
+    set_upstream(&target, &branch).expect("set_upstream must skip missing upstream gracefully");
 }
 
 #[test]

--- a/crates/gwt/assets/migration-modal.css
+++ b/crates/gwt/assets/migration-modal.css
@@ -1,0 +1,99 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #161616;
+  color: #e6e6e6;
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+}
+
+.migration-modal {
+  background: #1f1f1f;
+  border: 1px solid #2c2c2c;
+  border-radius: 12px;
+  padding: 28px 32px;
+  width: min(560px, calc(100vw - 32px));
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.45);
+}
+
+.migration-modal__header h1 {
+  margin: 0 0 4px;
+  font-size: 1.35rem;
+}
+
+.migration-modal__subtitle {
+  margin: 0 0 16px;
+  color: #9c9c9c;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.migration-modal__body p {
+  line-height: 1.55;
+}
+
+.migration-modal__details {
+  list-style: disc;
+  padding-left: 20px;
+  margin: 12px 0;
+  color: #cfcfcf;
+}
+
+.migration-modal__warning {
+  background: #2a2118;
+  border-left: 3px solid #f4b942;
+  padding: 10px 14px;
+  border-radius: 4px;
+  font-size: 0.95rem;
+}
+
+.migration-modal__progress {
+  margin-top: 18px;
+}
+
+.migration-modal__progress progress {
+  width: 100%;
+  height: 8px;
+}
+
+.migration-modal__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.migration-modal__btn {
+  appearance: none;
+  border: 1px solid #3a3a3a;
+  background: #262626;
+  color: #e6e6e6;
+  padding: 8px 18px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.migration-modal__btn:hover {
+  background: #303030;
+}
+
+.migration-modal__btn--primary {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.migration-modal__btn--primary:hover {
+  background: #1d4ed8;
+}
+
+.migration-modal__btn--danger {
+  border-color: #5b2424;
+  color: #f3a3a3;
+}

--- a/crates/gwt/assets/migration-modal.html
+++ b/crates/gwt/assets/migration-modal.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Migrate Repository</title>
+  <link rel="stylesheet" href="migration-modal.css" />
+</head>
+<body>
+  <main class="migration-modal" role="dialog" aria-labelledby="migration-title" aria-modal="true">
+    <header class="migration-modal__header">
+      <h1 id="migration-title">Migrate to Bare + Worktree layout</h1>
+      <p class="migration-modal__subtitle" data-slot="repo-path"></p>
+    </header>
+
+    <section class="migration-modal__body">
+      <p>
+        gwt manages repositories in a Nested layout
+        (<code>&lt;project&gt;.git/</code> + <code>&lt;branch&gt;/</code>).
+        This repository is currently a Normal Git checkout. Migrate to keep it consistent
+        with other gwt-managed projects in your workspace.
+      </p>
+      <ul class="migration-modal__details" data-slot="details">
+        <!-- Filled by migration-modal.ts on `migration:detected` -->
+      </ul>
+      <p class="migration-modal__warning">
+        A full snapshot will be saved to <code>.gwt-migration-backup/</code> first.
+        On any failure, the repository is restored to its original state.
+      </p>
+    </section>
+
+    <section class="migration-modal__progress" data-slot="progress" hidden>
+      <p data-slot="phase-label">Preparing…</p>
+      <progress max="100" value="0" data-slot="phase-progress"></progress>
+    </section>
+
+    <footer class="migration-modal__actions">
+      <button type="button" data-action="migrate" class="migration-modal__btn migration-modal__btn--primary">Migrate</button>
+      <button type="button" data-action="skip" class="migration-modal__btn">Skip</button>
+      <button type="button" data-action="quit" class="migration-modal__btn migration-modal__btn--danger">Quit</button>
+    </footer>
+  </main>
+  <script type="module" src="migration-modal.js"></script>
+</body>
+</html>

--- a/crates/gwt/src/handlers/migration.rs
+++ b/crates/gwt/src/handlers/migration.rs
@@ -1,0 +1,13 @@
+//! WebSocket bridge between the migration modal (WebView) and the
+//! `gwt_core::migration::executor` orchestrator (SPEC-1934 US-6).
+//!
+//! Filled in by Phase 10 tasks (T-097/T-098).
+
+use std::path::Path;
+
+/// Placeholder entry point. Phase 10 tasks will wire this up to the embedded
+/// axum server and emit `migration:detected | start | skip | quit | phase |
+/// done | error` events.
+pub fn handle_migration_request(_project_root: &Path) {
+    // intentionally empty until T-097
+}

--- a/crates/gwt/src/handlers/mod.rs
+++ b/crates/gwt/src/handlers/mod.rs
@@ -1,0 +1,3 @@
+//! WebSocket-side handlers for GUI events.
+
+pub mod migration;

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -7,6 +7,7 @@ pub mod daemon_runtime;
 mod discussion_resume;
 pub mod file_tree;
 pub mod gui_single_instance;
+pub mod handlers;
 pub mod index_worker;
 mod issue_cache;
 pub mod knowledge_bridge;

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -13,6 +13,7 @@ mod issue_cache;
 pub mod knowledge_bridge;
 pub mod launch_wizard;
 pub mod managed_assets;
+pub mod migration;
 pub mod native_app;
 pub mod persistence;
 pub mod preset;

--- a/crates/gwt/src/migration/executor.rs
+++ b/crates/gwt/src/migration/executor.rs
@@ -1,0 +1,277 @@
+//! Drives the full Normal → Nested Bare+Worktree migration sequence
+//! (SPEC-1934 US-6).
+//!
+//! Composes `gwt_core::migration::*` (pure logic) with `gwt_git::migration::*`
+//! (Git side-effects). Failures roll back via `gwt_core::migration::rollback`
+//! and propagate `MigrationError` with the originating phase.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use chrono::Utc;
+use gwt_core::config::BareProjectConfig;
+use gwt_core::migration::backup::{self, BackupSnapshot};
+use gwt_core::migration::rollback;
+use gwt_core::migration::types::{
+    MigrationError, MigrationOptions, MigrationOutcome, MigrationPhase, RecoveryState,
+};
+use gwt_core::migration::validator;
+use gwt_git::migration as git_migration;
+
+/// Execute every migration phase end-to-end. Calls `progress(phase, 0..=100)`
+/// at phase boundaries so the caller (WebSocket bridge) can stream updates.
+pub fn execute_migration(
+    project_root: &Path,
+    options: MigrationOptions,
+    mut progress: impl FnMut(MigrationPhase, u8),
+) -> Result<MigrationOutcome, MigrationError> {
+    progress(MigrationPhase::Validate, 0);
+    validator::validate(project_root).map_err(|e| MigrationError {
+        phase: MigrationPhase::Validate,
+        message: e.to_string(),
+        recovery: RecoveryState::Untouched,
+    })?;
+
+    progress(MigrationPhase::Backup, 0);
+    let snapshot = backup::create(project_root).map_err(|e| MigrationError {
+        phase: MigrationPhase::Backup,
+        message: e.to_string(),
+        recovery: RecoveryState::Untouched,
+    })?;
+
+    let outcome = run_post_backup(project_root, &options, &snapshot, &mut progress);
+
+    match outcome {
+        Ok(out) => {
+            if !options.keep_backup_on_success {
+                let _ = backup::discard(snapshot);
+            }
+            progress(MigrationPhase::Done, 100);
+            Ok(out)
+        }
+        Err(err) => {
+            // Attempt to roll back. The recovery state on the returned error
+            // reflects whether the rollback succeeded.
+            let recovered = rollback::rollback_migration(&snapshot).is_ok();
+            let recovery = if recovered {
+                RecoveryState::RolledBack
+            } else {
+                RecoveryState::Partial
+            };
+            Err(MigrationError {
+                phase: err.phase,
+                message: err.message,
+                recovery,
+            })
+        }
+    }
+}
+
+fn run_post_backup(
+    project_root: &Path,
+    options: &MigrationOptions,
+    snapshot: &BackupSnapshot,
+    progress: &mut impl FnMut(MigrationPhase, u8),
+) -> Result<MigrationOutcome, MigrationError> {
+    progress(MigrationPhase::Bareify, 0);
+
+    let bare_repo_name = derive_bare_repo_name(project_root);
+    let bare_target = project_root.join(&bare_repo_name);
+    let dot_git = project_root.join(".git");
+
+    let origin_url = read_origin_url(&dot_git);
+
+    let bare_repo_path = match origin_url.as_deref() {
+        Some(url) => match git_migration::clone_bare_from_normal(url, &bare_target) {
+            Ok(p) => p,
+            Err(_) => bareify_local_or_fail(project_root, &bare_target)?,
+        },
+        None => bareify_local_or_fail(project_root, &bare_target)?,
+    };
+
+    git_migration::copy_hooks_to_bare(&dot_git, &bare_repo_path).map_err(|e| MigrationError {
+        phase: MigrationPhase::Bareify,
+        message: e.to_string(),
+        recovery: RecoveryState::Partial,
+    })?;
+    gwt_git::install_develop_protection(&bare_repo_path).map_err(|e| MigrationError {
+        phase: MigrationPhase::Bareify,
+        message: e.to_string(),
+        recovery: RecoveryState::Partial,
+    })?;
+
+    progress(MigrationPhase::Worktrees, 0);
+    let branch = current_branch(&dot_git, project_root)
+        .or_else(|| current_branch(&bare_repo_path, &bare_repo_path))
+        .or_else(|| options.branch_override.clone())
+        .unwrap_or_else(|| "develop".to_string());
+    let branch_worktree = project_root.join(&branch);
+
+    // Step 1: evacuate everything except `.git`, the bare repo, and the
+    // backup. The evacuation root lives inside the backup dir so it is
+    // automatically excluded from the walk (`.gwt-migration-backup` is in
+    // EVACUATION_EXCLUSIONS).
+    let evacuation_root = snapshot.backup_dir.join("evacuation");
+    if let Err(e) = fs::create_dir_all(&evacuation_root) {
+        return Err(MigrationError {
+            phase: MigrationPhase::Worktrees,
+            message: format!("create evacuation dir: {e}"),
+            recovery: RecoveryState::Partial,
+        });
+    }
+    let bare_basename = bare_target
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string());
+    move_top_level_into(project_root, &evacuation_root, bare_basename.as_deref()).map_err(|e| {
+        MigrationError {
+            phase: MigrationPhase::Worktrees,
+            message: e.to_string(),
+            recovery: RecoveryState::Partial,
+        }
+    })?;
+
+    // Step 2: create the new worktree, importing whatever the bare repo has at HEAD.
+    git_migration::add_worktree_no_checkout(&bare_repo_path, &branch_worktree, &branch).map_err(
+        |e| MigrationError {
+            phase: MigrationPhase::Worktrees,
+            message: e.to_string(),
+            recovery: RecoveryState::Partial,
+        },
+    )?;
+
+    // Step 3: bring evacuated files into the new worktree.
+    git_migration::restore_evacuated_files(&evacuation_root, &branch_worktree).map_err(|e| {
+        MigrationError {
+            phase: MigrationPhase::Worktrees,
+            message: e.to_string(),
+            recovery: RecoveryState::Partial,
+        }
+    })?;
+
+    // Step 4: re-sync the index so the working tree reports the same status as
+    // before the migration. Best-effort: if the worktree had no checkout we
+    // still want to clear `git status` of the synthetic deletions added by
+    // `--no-checkout`.
+    let _ = gwt_core::process::hidden_command("git")
+        .args(["reset"])
+        .current_dir(&branch_worktree)
+        .output();
+
+    // Cleanup the evacuation scratch dir.
+    let _ = fs::remove_dir_all(&evacuation_root);
+
+    progress(MigrationPhase::Submodules, 0);
+    let _ = git_migration::init_submodules(&branch_worktree);
+
+    progress(MigrationPhase::Tracking, 0);
+    let _ = git_migration::set_upstream(&branch_worktree, &branch);
+
+    progress(MigrationPhase::Cleanup, 0);
+    if dot_git.exists() {
+        fs::remove_dir_all(&dot_git).map_err(|e| MigrationError {
+            phase: MigrationPhase::Cleanup,
+            message: format!("remove old .git: {e}"),
+            recovery: RecoveryState::Partial,
+        })?;
+    }
+
+    let cfg = BareProjectConfig {
+        bare_repo_name: bare_repo_name.clone(),
+        remote_url: origin_url,
+        created_at: Utc::now().to_rfc3339(),
+        migrated_from: Some("normal".to_string()),
+    };
+    cfg.save(project_root).map_err(|e| MigrationError {
+        phase: MigrationPhase::Cleanup,
+        message: e.to_string(),
+        recovery: RecoveryState::Partial,
+    })?;
+
+    Ok(MigrationOutcome {
+        branch_worktree_path: branch_worktree,
+        bare_repo_path,
+        migrated_worktrees: vec![project_root.join(&branch)],
+    })
+}
+
+fn bareify_local_or_fail(
+    project_root: &Path,
+    bare_target: &Path,
+) -> Result<PathBuf, MigrationError> {
+    git_migration::bareify_local(project_root, bare_target).map_err(|e| MigrationError {
+        phase: MigrationPhase::Bareify,
+        message: e.to_string(),
+        recovery: RecoveryState::Partial,
+    })
+}
+
+fn derive_bare_repo_name(project_root: &Path) -> String {
+    let stem = project_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo");
+    format!("{stem}.git")
+}
+
+fn read_origin_url(dot_git: &Path) -> Option<String> {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .env("GIT_DIR", dot_git.to_str().unwrap_or_default())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if url.is_empty() {
+        None
+    } else {
+        Some(url)
+    }
+}
+
+/// Move every entry of `src` into `dst`, except `.git`, the migration
+/// backup, and an optional named directory (the bare repo we just created).
+fn move_top_level_into(
+    src: &Path,
+    dst: &Path,
+    extra_exclusion: Option<&str>,
+) -> std::io::Result<()> {
+    const ALWAYS_EXCLUDED: &[&str] = &[".git", ".gwt-migration-backup"];
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if ALWAYS_EXCLUDED.iter().any(|e| **e == *name_str) {
+            continue;
+        }
+        if extra_exclusion == Some(&name_str) {
+            continue;
+        }
+        let from = entry.path();
+        let to = dst.join(&name);
+        fs::rename(&from, &to)?;
+    }
+    Ok(())
+}
+
+fn current_branch(git_dir: &Path, work_dir: &Path) -> Option<String> {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(work_dir)
+        .env("GIT_DIR", git_dir.to_str().unwrap_or_default())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch)
+    }
+}

--- a/crates/gwt/src/migration/mod.rs
+++ b/crates/gwt/src/migration/mod.rs
@@ -1,0 +1,9 @@
+//! Migration orchestrator (SPEC-1934 US-6).
+//!
+//! Lives in the `gwt` crate (not `gwt-core`) so it can depend on both
+//! `gwt-core` (validator/backup/rollback/types) and `gwt-git` (pure Git
+//! operations) without introducing a cycle.
+
+pub mod executor;
+
+pub use executor::execute_migration;

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -136,7 +136,7 @@ pub(crate) fn resolve_project_target(path: &Path) -> Result<ProjectOpenTarget, S
     let title = gwt::project_title_from_path(&canonical);
 
     let (project_root, kind) = match gwt_git::detect_repo_type(&canonical) {
-        gwt_git::RepoType::Normal(root) => (
+        gwt_git::RepoType::Normal { path: root, .. } => (
             dunce::canonicalize(root).unwrap_or_else(|_| canonical.clone()),
             gwt::ProjectKind::Git,
         ),

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -1,0 +1,123 @@
+//! End-to-end tests for the SPEC-1934 US-6 migration orchestrator.
+
+use std::path::Path;
+
+use gwt::migration::execute_migration;
+use gwt_core::config::BareProjectConfig;
+use gwt_core::migration::{MigrationOptions, MigrationPhase};
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let output = gwt_core::process::hidden_command("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_repo_with_commit(path: &Path) {
+    run_git(path, &["init", "."]);
+    // Configure a deterministic identity so commits succeed in CI sandboxes.
+    run_git(path, &["config", "user.email", "test@example.com"]);
+    run_git(path, &["config", "user.name", "Test"]);
+    std::fs::write(path.join("README.md"), "# sample\n").unwrap();
+    run_git(path, &["add", "README.md"]);
+    run_git(path, &["commit", "-m", "init"]);
+}
+
+fn current_branch(path: &Path) -> String {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(path)
+        .output()
+        .expect("symbolic-ref");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn t100_e2e_normal_to_nested_bare_worktree_layout() {
+    let project = tempfile::tempdir().unwrap();
+    init_repo_with_commit(project.path());
+    let branch = current_branch(project.path());
+    let project_dir_name = project
+        .path()
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo")
+        .to_string();
+
+    let outcome = execute_migration(
+        project.path(),
+        MigrationOptions::default(),
+        |_phase, _pct| {},
+    )
+    .expect("execute_migration");
+
+    let bare = project.path().join(format!("{project_dir_name}.git"));
+    let worktree = project.path().join(&branch);
+
+    assert!(bare.is_dir(), "bare repo must exist at {}", bare.display());
+    assert!(
+        worktree.is_dir(),
+        "branch worktree must exist at {}",
+        worktree.display()
+    );
+    assert!(
+        worktree.join(".git").exists(),
+        "worktree must carry a .git marker"
+    );
+    assert!(
+        worktree.join("README.md").is_file(),
+        "tracked content must land in the worktree"
+    );
+
+    // Old `.git` directory is gone, replaced by the bare repo.
+    assert!(
+        !project.path().join(".git").exists(),
+        "old .git directory must be removed"
+    );
+
+    // .gwt/project.toml is written.
+    let cfg = BareProjectConfig::load(project.path())
+        .expect("load project.toml")
+        .expect("project.toml exists");
+    assert_eq!(cfg.bare_repo_name, format!("{project_dir_name}.git"));
+    assert_eq!(cfg.migrated_from.as_deref(), Some("normal"));
+
+    // Outcome reflects the layout.
+    assert_eq!(outcome.bare_repo_path, bare);
+    assert_eq!(outcome.branch_worktree_path, worktree);
+}
+
+#[test]
+fn t100_e2e_progress_callback_walks_phases() {
+    let project = tempfile::tempdir().unwrap();
+    init_repo_with_commit(project.path());
+
+    let mut seen: Vec<MigrationPhase> = Vec::new();
+    execute_migration(project.path(), MigrationOptions::default(), |phase, _| {
+        seen.push(phase)
+    })
+    .expect("execute_migration");
+
+    // The orchestrator must advertise at minimum these milestones.
+    for required in [
+        MigrationPhase::Validate,
+        MigrationPhase::Backup,
+        MigrationPhase::Bareify,
+        MigrationPhase::Worktrees,
+        MigrationPhase::Submodules,
+        MigrationPhase::Tracking,
+        MigrationPhase::Cleanup,
+        MigrationPhase::Done,
+    ] {
+        assert!(
+            seen.contains(&required),
+            "progress callback missing phase {required:?}, saw {seen:?}"
+        );
+    }
+}

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use gwt::migration::execute_migration;
 use gwt_core::config::BareProjectConfig;
-use gwt_core::migration::{MigrationOptions, MigrationPhase};
+use gwt_core::migration::{MigrationOptions, MigrationPhase, RecoveryState};
 
 fn run_git(dir: &Path, args: &[&str]) {
     let output = gwt_core::process::hidden_command("git")
@@ -91,6 +91,110 @@ fn t100_e2e_normal_to_nested_bare_worktree_layout() {
     // Outcome reflects the layout.
     assert_eq!(outcome.bare_repo_path, bare);
     assert_eq!(outcome.branch_worktree_path, worktree);
+}
+
+#[test]
+fn t101_dirty_normal_repo_preserves_uncommitted_changes_after_migration() {
+    // SPEC-1934 US-6.3: ファイルが modified / untracked の状態で migration し
+    // ても、worktree の中身は同じファイル内容で残っている。
+    let project = tempfile::tempdir().unwrap();
+    init_repo_with_commit(project.path());
+    let branch = current_branch(project.path());
+
+    // Modify a tracked file and add an untracked one before the migration.
+    std::fs::write(project.path().join("README.md"), "# sample (dirty)\n").unwrap();
+    std::fs::write(project.path().join("scratch.txt"), "untracked").unwrap();
+
+    execute_migration(
+        project.path(),
+        MigrationOptions::default(),
+        |_phase, _pct| {},
+    )
+    .expect("execute_migration");
+
+    let worktree = project.path().join(&branch);
+    assert!(worktree.is_dir());
+    assert_eq!(
+        std::fs::read_to_string(worktree.join("README.md")).unwrap(),
+        "# sample (dirty)\n",
+        "modified content must survive the migration"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree.join("scratch.txt")).unwrap(),
+        "untracked",
+        "untracked file must be preserved"
+    );
+}
+
+#[test]
+fn t103_e2e_locked_worktree_blocks_migration_with_no_changes() {
+    // SPEC-1934 US-6.5: locked worktree が見つかったらマイグレーションを中止
+    // し、リポジトリレイアウトは未変更で残らなければならない。
+    let project = tempfile::tempdir().unwrap();
+    init_repo_with_commit(project.path());
+
+    let wt_path = project.path().join("locked-wt");
+    run_git(
+        project.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/locked",
+            wt_path.to_str().unwrap(),
+        ],
+    );
+    run_git(
+        project.path(),
+        &["worktree", "lock", wt_path.to_str().unwrap()],
+    );
+
+    let result = execute_migration(
+        project.path(),
+        MigrationOptions::default(),
+        |_phase, _pct| {},
+    );
+
+    let err = result.expect_err("locked worktree must abort migration");
+    assert_eq!(err.phase, MigrationPhase::Validate);
+    assert_eq!(err.recovery, RecoveryState::Untouched);
+
+    // Project layout must be untouched: no bare repo, no .gwt config, .git
+    // directory still present.
+    assert!(
+        project.path().join(".git").is_dir(),
+        "original .git must remain"
+    );
+    assert!(
+        !project.path().join(".gwt").exists(),
+        ".gwt config must not be written when validation aborts"
+    );
+}
+
+#[test]
+fn t107_repo_hash_remains_stable_across_migration() {
+    // SPEC-2021 / SC-019: project_scope_hash is computed from the origin URL
+    // (or the path when no origin exists). Migration must not move the
+    // project root, so the hash a downstream caller would compute remains
+    // identical before and after.
+    let project = tempfile::tempdir().unwrap();
+    init_repo_with_commit(project.path());
+
+    let before = gwt_core::paths::project_scope_hash(project.path());
+
+    execute_migration(
+        project.path(),
+        MigrationOptions::default(),
+        |_phase, _pct| {},
+    )
+    .expect("execute_migration");
+
+    let after = gwt_core::paths::project_scope_hash(project.path());
+    assert_eq!(
+        before.as_str(),
+        after.as_str(),
+        "project_scope_hash must remain stable across migration"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- SPEC-1934 US-6 (既存 Normal Git → Nested Bare+Worktree 自動マイグレーション) の core orchestrator と pure Git 操作レイヤーを実装し、`gwt::migration::execute_migration` が一時 repo で end-to-end に動作する状態に到達
- 32 件 RED→GREEN テスト (gwt-core 17 + gwt-git 10 + gwt e2e 5) で受け入れシナリオ US-6.2 / US-6.3 / US-6.5 / SC-019 を実機 git で検証
- GUI モーダル統合 (Phase 10) と段階的 rollback の細部 (Phase 9 詳細) は未着手のため **draft PR**

## Changes

- `crates/gwt-core/src/migration/{mod,types,validator,backup,rollback}.rs`: pure logic (state machine, disk/locked/permission validation, full-tree backup + restore, rollback orchestrator)
- `crates/gwt-core/src/config/{mod,bare_project}.rs`: `<project>/.gwt/project.toml` schema (`BareProjectConfig`)
- `crates/gwt-git/src/migration.rs`: pure Git 操作 (`clone_bare_from_normal`, `bareify_local`, `copy_hooks_to_bare`, `add_worktree_clean/no_checkout`, `evacuate_dirty_files`, `restore_evacuated_files`, `init_submodules`, `set_upstream`)
- `crates/gwt-git/src/repository.rs`: `RepoType::Normal` を `Normal { path, needs_migration }` に拡張、`install_develop_protection` を bare レイアウトに対応
- `crates/gwt/src/migration/{mod,executor}.rs`: orchestrator (`execute_migration`)。validate → backup → bareify → worktrees → submodules → tracking → cleanup を実行し、失敗時は rollback で完全復元
- `crates/gwt/src/handlers/migration.rs` + `crates/gwt/assets/migration-modal.{html,css}`: GUI 統合用の skeleton (Phase 10 で接続予定)
- `crates/gwt-core/Cargo.toml`: `toml = { workspace = true }` を追加
- `README.md` / `README.ja.md`: Workspace Layout セクションを追加し Nested Bare+Worktree 構成と migration 機能を案内
- SPEC-1934 (Issue #1934) の `spec` / `plan` / `tasks` セクションを更新 (US-6 / FR-019〜FR-029 / SC-013〜SC-019 と進捗トレーサビリティを反映)

## Testing

- [x] `cargo test -p gwt-core --test migration_workflow_test` — 17 件 GREEN (validator/backup/rollback/bare_project/migration_phase)
- [x] `cargo test -p gwt-git --test migration_test` — 10 件 GREEN (RepoType, clone_bare, bareify_local, hooks, worktrees, submodules, tracking)
- [x] `cargo test -p gwt --test migration_e2e_test` — 5 件 GREEN (完全レイアウト変換 / 進捗 callback / dirty preservation / locked block / repo_hash 安定性)
- [x] `cargo test -p gwt-core -p gwt-git -p gwt` — 既存テストも regression なし
- [x] `cargo clippy -p gwt-core -p gwt-git -p gwt --all-targets -- -D warnings` — 警告なし
- [x] `cargo fmt -- --check` — 通過
- [x] `bunx commitlint --from origin/develop --to HEAD` — 全 8 コミット通過

## Closing Issues

- None

## Related Issues / Links

- SPEC-1934: <https://github.com/akiojin/gwt/issues/1934>
- 設計参照 (削除済み旧実装): commit `5db1f3ec^` の `crates/gwt-core/src/migration/{executor,validator,rollback}.rs`、`config/bare_project.rs`

## Checklist

- [x] Tests added/updated (32 件 RED→GREEN)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (README Workspace Layout セクション、SPEC-1934 sections)
- [x] Migration/backfill plan included (`<project>/.gwt-migration-backup/` フルバックアップ + ロールバック)
- [x] CHANGELOG impact considered (`feat(migration):` minor バージョン up — リリース時に CHANGELOG が自動生成)

## Context

- ユーザーの認識「Workbench 配下の各リポジトリは専用のディレクトリ構成 (Nested Bare+Worktree) になる」と現状実装の差分を埋めるため SPEC-1934 を reopen して US-6 + FR-019〜FR-029 + SC-013〜SC-019 を追加した
- 過去 (`5db1f3ec^`) には類似実装が存在したが SPEC-1787 で削除されていた。今回は SPEC-2021 (`~/.gwt/projects/<repo-hash>/` 集約) との整合 (project_scope_hash が migration 前後で一致) も明示的に E2E でカバー

## Risk / Impact

- **Affected areas**: `gwt-core::migration`, `gwt-core::config`, `gwt-git::migration`, `gwt-git::repository::RepoType`, `gwt::migration`, `gwt::handlers`, `crates/gwt/assets/`
- **Rollback plan**: 本 PR を revert するだけで全変更を取り消せる。実 migration を走らせていなければユーザーデータには影響しない (executor は GUI から自動呼び出ししない skeleton 状態)。万一 migration 中にプロセスが落ちた場合は `<project>/.gwt-migration-backup/` を手動復元
- **Behavioural surface**: `RepoType::Normal(PathBuf)` → `Normal { path, needs_migration }` という構造体ライク variant への変更が公開 API。downstream caller は `gwt::runtime_support` のみで、すでに更新済み

## Notes

- **Draft の理由**: Phase 10 (GUI 統合: `ActiveLayer::Migration` / WebSocket protocol / migration-modal の axum 接続 / 起動シーケンス分岐) が未着手のため、エンドユーザーから `execute_migration` を呼び出す導線がまだ無い。後続 PR で GUI 統合 + 段階的 rollback (Phase 9 詳細) + 残り E2E (multi-worktree / 失敗 rollback / Skip / Quit) を完成させる
- **設計判断**: executor は `gwt-core` ではなく `gwt` クレートに配置 (gwt-core は gwt-git に依存しないため、git 操作を伴う orchestrator を gwt-core に置くと循環依存になる)
- **トレーサビリティ**: SPEC-1934 tasks セクションに US/FR/SC ↔ Task の matrix と完了状態を記載。本 PR でカバーされる: T-001〜T-053, T-060〜T-075, T-100/T-101/T-103/T-107, T-110〜T-115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for migrating existing repositories to a new Nested Bare + Worktree directory layout with automatic backup, validation, and rollback-on-failure capabilities.
  * Auto-creates the new structure during initialization; existing repositories can opt-in to migration with full data protection.

* **Documentation**
  * Updated README with workspace directory organization and migration workflow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->