### PR TITLE
fix(gui): serve migration modal module in WebView

### DIFF
--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -116,6 +116,10 @@ impl EmbeddedServer {
                 get(embedded_web::branch_cleanup_modal_js_handler),
             )
             .route(
+                "/migration-modal.js",
+                get(embedded_web::migration_modal_js_handler),
+            )
+            .route(
                 "/assets/xterm/xterm.mjs",
                 get(embedded_web::xterm_js_handler),
             )

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -15,6 +15,10 @@ pub(crate) fn branch_cleanup_modal_js() -> &'static str {
     include_str!("../web/branch-cleanup-modal.js")
 }
 
+pub(crate) fn migration_modal_js() -> &'static str {
+    include_str!("../web/migration-modal.js")
+}
+
 pub(crate) fn xterm_js() -> &'static str {
     include_str!("../web/vendor/xterm/xterm.mjs")
 }
@@ -42,6 +46,13 @@ pub(crate) async fn branch_cleanup_modal_js_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
         branch_cleanup_modal_js(),
+    )
+}
+
+pub(crate) async fn migration_modal_js_handler() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
+        migration_modal_js(),
     )
 }
 
@@ -694,6 +705,37 @@ mod tests {
             !html.contains("BRANCH_CLEANUP_TIMEOUT_MS"),
             "expected branch cleanup to avoid a hard-coded frontend failure timeout"
         );
+    }
+
+    #[test]
+    fn embedded_web_serves_every_root_module_import() {
+        let js = app_js();
+        let embedded_web_source = include_str!("embedded_web.rs");
+        let embedded_server_source = include_str!("embedded_server.rs");
+
+        for module_path in ["/branch-cleanup-modal.js", "/migration-modal.js"] {
+            assert!(
+                js.contains(module_path),
+                "expected app.js to import {module_path}",
+            );
+            assert!(
+                embedded_server_source.contains(&format!("\"{module_path}\"")),
+                "expected embedded server to route {module_path}",
+            );
+
+            let source_name = module_path
+                .trim_start_matches('/')
+                .trim_end_matches(".js")
+                .replace('-', "_");
+            assert!(
+                embedded_web_source.contains(&format!("fn {source_name}_js()")),
+                "expected embedded web module source function for {module_path}",
+            );
+            assert!(
+                embedded_web_source.contains(&format!("fn {source_name}_js_handler()")),
+                "expected embedded web module handler for {module_path}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Serves the migration modal ES module from the embedded WebView server so `app.js` can finish initialization on Windows.
- Adds a frontend asset contract test so root module imports cannot be added without matching embedded routes.

## Changes

- `crates/gwt/src/embedded_web.rs`: added the `migration-modal.js` embedded source function, JavaScript handler, and route/import contract test.
- `crates/gwt/src/embedded_server.rs`: added the `GET /migration-modal.js` route used by `app.js`.

## Testing

- [x] `cargo test -p gwt embedded_web_serves_every_root_module_import` — passed after first confirming RED on the missing `/migration-modal.js` route.
- [x] `npm run --silent test:frontend-bundle` — passed.
- [x] `cargo test -p gwt` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo fmt --check` — passed.
- [x] `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## Closing Issues

- Closes #2244

## Related Issues / Links

- SPEC-1934
- SPEC-2008
- SPEC-2012

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not required: no user-facing docs behavior changed)
- [x] Migration/backfill plan included (not required: no schema/data migration)
- [x] CHANGELOG impact considered (patch fix via `fix(gui)` commit)

## Context

- Windows v9.13.0 users reported that Open Project and other WebView buttons did not respond.
- `app.js` imports `/migration-modal.js`, but the embedded server did not serve that module, which can stop top-level module evaluation and leave click handlers unregistered.

## Risk / Impact

- **Affected areas**: Embedded WebView frontend asset serving for the migration modal.
- **Rollback plan**: Revert this PR; the only runtime change is one additional static JavaScript route.

