### PR TITLE
chore(release): v9.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.13.2] - 2026-05-01
+
+### Bug Fixes
+
+- **gui:** Serve migration modal module in WebView
+
 ## [9.13.1] - 2026-05-01
 
 ### Testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "axum",
  "base64",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "chrono",
  "dunce",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "dirs",
  "serde",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "fs2",
  "gwt-core",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.13.1"
+version = "9.13.2"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.13.1"
+version = "9.13.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -116,6 +116,10 @@ impl EmbeddedServer {
                 get(embedded_web::branch_cleanup_modal_js_handler),
             )
             .route(
+                "/migration-modal.js",
+                get(embedded_web::migration_modal_js_handler),
+            )
+            .route(
                 "/assets/xterm/xterm.mjs",
                 get(embedded_web::xterm_js_handler),
             )

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -15,6 +15,10 @@ pub(crate) fn branch_cleanup_modal_js() -> &'static str {
     include_str!("../web/branch-cleanup-modal.js")
 }
 
+pub(crate) fn migration_modal_js() -> &'static str {
+    include_str!("../web/migration-modal.js")
+}
+
 pub(crate) fn xterm_js() -> &'static str {
     include_str!("../web/vendor/xterm/xterm.mjs")
 }
@@ -42,6 +46,13 @@ pub(crate) async fn branch_cleanup_modal_js_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
         branch_cleanup_modal_js(),
+    )
+}
+
+pub(crate) async fn migration_modal_js_handler() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
+        migration_modal_js(),
     )
 }
 
@@ -694,6 +705,37 @@ mod tests {
             !html.contains("BRANCH_CLEANUP_TIMEOUT_MS"),
             "expected branch cleanup to avoid a hard-coded frontend failure timeout"
         );
+    }
+
+    #[test]
+    fn embedded_web_serves_every_root_module_import() {
+        let js = app_js();
+        let embedded_web_source = include_str!("embedded_web.rs");
+        let embedded_server_source = include_str!("embedded_server.rs");
+
+        for module_path in ["/branch-cleanup-modal.js", "/migration-modal.js"] {
+            assert!(
+                js.contains(module_path),
+                "expected app.js to import {module_path}",
+            );
+            assert!(
+                embedded_server_source.contains(&format!("\"{module_path}\"")),
+                "expected embedded server to route {module_path}",
+            );
+
+            let source_name = module_path
+                .trim_start_matches('/')
+                .trim_end_matches(".js")
+                .replace('-', "_");
+            assert!(
+                embedded_web_source.contains(&format!("fn {source_name}_js()")),
+                "expected embedded web module source function for {module_path}",
+            );
+            assert!(
+                embedded_web_source.contains(&format!("fn {source_name}_js_handler()")),
+                "expected embedded web module handler for {module_path}",
+            );
+        }
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.13.1",
+  "version": "9.13.2",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Prepare v9.13.2 patch release for the Windows WebView button hotfix.
- Includes the embedded `/migration-modal.js` route fix so `app.js` can initialize click handlers in packaged WebView builds.

## Changes

- Bump workspace and npm package version to `9.13.2`.
- Update `Cargo.lock` package versions to `9.13.2`.
- Prepend `CHANGELOG.md` entry for the `fix(gui)` change.

## Version

v9.13.2

## Closing Issues

Closes #2244

## Related Issues / Links

None

