### PR TITLE
feat(agent): enable Codex goal command on launch

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -668,6 +668,9 @@ impl AgentLaunchBuilder {
             args.push("--yolo".to_string());
         }
 
+        args.push("--enable".to_string());
+        args.push("goals".to_string());
+
         // Web search args
         if let Some(ref ver) = parsed_version {
             if *ver >= semver::Version::new(0, 90, 0) {
@@ -1050,6 +1053,72 @@ mod tests {
             .args
             .windows(2)
             .any(|pair| pair[0] == "--enable" && pair[1] == "codex_hooks"));
+    }
+
+    #[test]
+    fn build_codex_enables_goal_feature_by_default() {
+        let config = AgentLaunchBuilder::new(AgentId::Codex).build();
+
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+    }
+
+    #[test]
+    fn build_codex_resume_and_continue_keep_goal_feature_enabled() {
+        let resume = AgentLaunchBuilder::new(AgentId::Codex)
+            .session_mode(SessionMode::Resume)
+            .resume_session_id("sess-123")
+            .build();
+        let continue_last = AgentLaunchBuilder::new(AgentId::Codex)
+            .session_mode(SessionMode::Continue)
+            .build();
+
+        assert!(resume
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+        assert!(resume
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "resume" && pair[1] == "sess-123"));
+        assert!(continue_last
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+        assert!(continue_last
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "resume" && pair[1] == "--last"));
+    }
+
+    #[test]
+    fn build_non_codex_agents_do_not_enable_goal_feature() {
+        for agent in [
+            AgentId::ClaudeCode,
+            AgentId::Gemini,
+            AgentId::OpenCode,
+            AgentId::Copilot,
+            AgentId::Custom("custom".into()),
+        ] {
+            let config = AgentLaunchBuilder::new(agent).build();
+
+            assert!(!config
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+        }
+    }
+
+    #[test]
+    fn canonical_codex_args_do_not_include_goal_feature_flag() {
+        let args = canonical_launch_args(&AgentId::Codex);
+
+        assert_eq!(args, vec!["--no-alt-screen".to_string()]);
+        assert!(!args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Codex launches now enable the upstream `goals` feature flag so the `/goal` command is available inside GWT-started Codex sessions.
- The flag is injected only by the Codex launch builder, keeping canonical launch args stable for session metadata and preset equality.

## Changes

- `crates/gwt-agent/src/launch.rs`: adds `--enable goals` to Codex normal, resume, and continue launches.
- `crates/gwt-agent/src/launch.rs`: adds regression coverage for Codex goal flag injection, non-Codex exclusion, and canonical args stability.

## Testing

- [x] `cargo test -p gwt-agent --lib goal_feature -- --nocapture` - failed before implementation, passed after implementation.
- [x] `cargo test -p gwt-agent --lib launch::` - 56 passed.
- [x] `cargo test -p gwt-agent -p gwt` - passed.
- [x] `cargo test -p gwt-core -p gwt` - passed.
- [x] `cargo build -p gwt` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.

## Closing Issues

None

## Related Issues / Links

- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not required: this changes launch argv behavior; SPEC-1921 sections were updated)
- [ ] Migration/backfill plan included (not required: no schema or data migration)
- [x] CHANGELOG impact considered (covered by `feat(agent): enable Codex goal command on launch`)
