### PR TITLE
chore(release): v9.14.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,20 @@
 - ログ（`~/.gwt/logs/` 等）はこの環境から直接参照できる前提で対応すること
 - ログ参照の指示があれば、この環境から直接読み取って調査すること
 
+### Board 運用 (SPEC-1974)
+
+Board は Coordination ドメインの shared chat。`gwtd board post --kind <X> --body '<text>'` で投稿、`gwtd board show` で読み取り。詳細な reminder 文言は SessionStart / UserPromptSubmit / Stop hook で `board_reminder.rs` から **動的注入** される（重複ドリフトを避けるため静的ドキュメントには複製しない）。
+
+主要 kind の使い分け:
+
+- **推論可視化軸**: `status`（フェーズ遷移・思考・懸念）、`decision`（確定した判断）
+- **協調軸**: `claim`（担当宣言で衝突回避）、`next`（協調 next を broadcast）、`blocked`（ブロッカー可視化・unblock 要請）、`handoff`（具体的な引き継ぎ）
+- **その他**: `request`、`impact`、`question`
+
+`--target <session-id|branch|agent-id>` を複数指定すると、受信側 Agent の reminder injection で `[for-you]` ハイライトされる（FR-041）。指定なしは broadcast。`--owner` は SPEC/Issue 番号、`--topic` は分類タグ、`--parent` は thread reply。
+
+ツール単位の報告（"running gcc"等）は **post 禁止**。reasoning milestone (phase / choice / concern) または coordination boundary (claim / next / blocked / handoff / decision) でのみ post する。
+
 ## ドキュメント管理
 
 - ドキュメントはREADME.md/README.ja.mdに集約する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.14.0] - 2026-05-01
+
+### Features
+
+- **coordination:** Board に coordination 投稿軸と target_owners を追加 (SPEC-1974 Phase 9)
+- **agent:** Enable Codex goal command on launch
+
 ## [9.13.2] - 2026-05-01
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "axum",
  "base64",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "fs2",
  "gwt-core",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.13.2"
+version = "9.14.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.13.2"
+version = "9.14.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -668,6 +668,9 @@ impl AgentLaunchBuilder {
             args.push("--yolo".to_string());
         }
 
+        args.push("--enable".to_string());
+        args.push("goals".to_string());
+
         // Web search args
         if let Some(ref ver) = parsed_version {
             if *ver >= semver::Version::new(0, 90, 0) {
@@ -1050,6 +1053,72 @@ mod tests {
             .args
             .windows(2)
             .any(|pair| pair[0] == "--enable" && pair[1] == "codex_hooks"));
+    }
+
+    #[test]
+    fn build_codex_enables_goal_feature_by_default() {
+        let config = AgentLaunchBuilder::new(AgentId::Codex).build();
+
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+    }
+
+    #[test]
+    fn build_codex_resume_and_continue_keep_goal_feature_enabled() {
+        let resume = AgentLaunchBuilder::new(AgentId::Codex)
+            .session_mode(SessionMode::Resume)
+            .resume_session_id("sess-123")
+            .build();
+        let continue_last = AgentLaunchBuilder::new(AgentId::Codex)
+            .session_mode(SessionMode::Continue)
+            .build();
+
+        assert!(resume
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+        assert!(resume
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "resume" && pair[1] == "sess-123"));
+        assert!(continue_last
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+        assert!(continue_last
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "resume" && pair[1] == "--last"));
+    }
+
+    #[test]
+    fn build_non_codex_agents_do_not_enable_goal_feature() {
+        for agent in [
+            AgentId::ClaudeCode,
+            AgentId::Gemini,
+            AgentId::OpenCode,
+            AgentId::Copilot,
+            AgentId::Custom("custom".into()),
+        ] {
+            let config = AgentLaunchBuilder::new(agent).build();
+
+            assert!(!config
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
+        }
+    }
+
+    #[test]
+    fn canonical_codex_args_do_not_include_goal_feature_flag() {
+        let args = canonical_launch_args(&AgentId::Codex);
+
+        assert_eq!(args, vec!["--no-alt-screen".to_string()]);
+        assert!(!args
+            .windows(2)
+            .any(|pair| pair[0] == "--enable" && pair[1] == "goals"));
     }
 
     #[test]

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -101,6 +101,8 @@ pub struct BoardEntry {
     pub origin_session_id: Option<String>,
     #[serde(default)]
     pub origin_agent_id: Option<String>,
+    #[serde(default)]
+    pub target_owners: Vec<String>,
 }
 
 impl BoardEntry {
@@ -116,6 +118,11 @@ impl BoardEntry {
 
     pub fn with_origin_agent_id(mut self, value: impl Into<String>) -> Self {
         self.origin_agent_id = Some(value.into());
+        self
+    }
+
+    pub fn with_target_owners(mut self, values: Vec<String>) -> Self {
+        self.target_owners = values;
         self
     }
 
@@ -146,6 +153,7 @@ impl BoardEntry {
             origin_branch: None,
             origin_session_id: None,
             origin_agent_id: None,
+            target_owners: Vec::new(),
         }
     }
 }
@@ -1119,6 +1127,60 @@ mod tests {
         assert_eq!(entry.origin_branch.as_deref(), Some("feature/update-board"));
         assert_eq!(entry.origin_session_id.as_deref(), Some("sess-a3f2"));
         assert_eq!(entry.origin_agent_id.as_deref(), Some("agent-codex-001"));
+    }
+
+    #[test]
+    fn board_entry_target_owners_default_empty() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "no targets",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+
+        assert!(entry.target_owners.is_empty());
+    }
+
+    #[test]
+    fn board_entry_round_trips_target_owners_with_values() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Claim,
+            "I claim feature/foo",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_target_owners(vec!["sess-a3f2".into(), "feature/foo".into()]);
+
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: BoardEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed.target_owners,
+            vec!["sess-a3f2".to_string(), "feature/foo".to_string()]
+        );
+    }
+
+    #[test]
+    fn board_entry_deserializes_legacy_without_target_owners() {
+        let legacy_json = r#"{
+            "id": "00000000-0000-0000-0000-000000000002",
+            "author_kind": "agent",
+            "author": "Codex",
+            "kind": "claim",
+            "body": "legacy claim",
+            "created_at": "2026-04-14T00:00:00Z",
+            "updated_at": "2026-04-14T00:00:00Z"
+        }"#;
+
+        let entry: BoardEntry = serde_json::from_str(legacy_json).unwrap();
+        assert!(entry.target_owners.is_empty());
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -150,6 +150,7 @@ pub(crate) struct BoardPostRequest {
     pub(crate) parent_id: Option<String>,
     pub(crate) topics: Vec<String>,
     pub(crate) owners: Vec<String>,
+    pub(crate) targets: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -760,6 +761,7 @@ impl AppRuntime {
                 parent_id,
                 topics,
                 owners,
+                targets,
             } => self.post_board_entry_events(
                 &client_id,
                 BoardPostRequest {
@@ -769,6 +771,7 @@ impl AppRuntime {
                     parent_id,
                     topics,
                     owners,
+                    targets,
                 },
             ),
             FrontendEvent::CreateMemoNote {
@@ -2306,6 +2309,7 @@ impl AppRuntime {
             parent_id,
             topics,
             owners,
+            targets,
         } = request;
 
         let Some(address) = self.window_lookup.get(&id) else {
@@ -2363,6 +2367,7 @@ impl AppRuntime {
             .map(str::to_string);
         let topics = sanitize_board_list(&topics);
         let owners = sanitize_board_list(&owners);
+        let targets = sanitize_board_list(&targets);
 
         let snapshot = match gwt_core::coordination::load_snapshot(&tab.project_root) {
             Ok(snapshot) => snapshot,
@@ -2393,7 +2398,7 @@ impl AppRuntime {
             }
         }
 
-        let entry = gwt_core::coordination::BoardEntry::new(
+        let mut entry = gwt_core::coordination::BoardEntry::new(
             gwt_core::coordination::AuthorKind::User,
             "You",
             entry_kind,
@@ -2403,6 +2408,9 @@ impl AppRuntime {
             topics,
             owners,
         );
+        if !targets.is_empty() {
+            entry = entry.with_target_owners(targets);
+        }
         match gwt_core::coordination::post_entry(&tab.project_root, entry) {
             Ok(snapshot) => vec![OutboundEvent::reply(
                 client_id,
@@ -7197,6 +7205,7 @@ exit 0
                 parent_id: Some(parent.id.clone()),
                 topics: vec!["coordination".to_string(), "phase-1b".to_string()],
                 owners: vec!["2018".to_string()],
+                targets: Vec::new(),
             },
         );
 

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -226,7 +226,7 @@ pub enum CliCommand {
     ActionsJobLogs { job_id: u64 },
     /// `gwtd board show [--json]`.
     BoardShow { json: bool },
-    /// `gwtd board post --kind <kind> (--body <text> | -f <file>)`.
+    /// `gwtd board post --kind <kind> (--body <text> | -f <file>) [--target <id>]`.
     BoardPost {
         kind: String,
         body: Option<String>,
@@ -234,6 +234,7 @@ pub enum CliCommand {
         parent: Option<String>,
         topics: Vec<String>,
         owners: Vec<String>,
+        targets: Vec<String>,
     },
     /// `gwtd index status`.
     IndexStatus,

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -53,6 +53,7 @@ pub(super) fn run<E: CliEnv>(
             parent,
             topics,
             owners,
+            targets,
         } => {
             let body = match (body, file) {
                 (Some(body), None) => body,
@@ -65,7 +66,7 @@ pub(super) fn run<E: CliEnv>(
             };
             let (author_kind, author) =
                 current_author_from_env().unwrap_or((AuthorKind::User, "user".to_string()));
-            let entry = BoardEntry::new(
+            let mut entry = BoardEntry::new(
                 author_kind,
                 author,
                 kind.parse().map_err(gwt_error_to_spec_ops_error)?,
@@ -75,6 +76,9 @@ pub(super) fn run<E: CliEnv>(
                 topics,
                 owners,
             );
+            if !targets.is_empty() {
+                entry = entry.with_target_owners(targets);
+            }
             let snapshot =
                 post_entry(env.repo_path(), entry).map_err(gwt_error_to_spec_ops_error)?;
             out.push_str(&format!(
@@ -95,6 +99,7 @@ fn parse_post_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
     let mut parent: Option<String> = None;
     let mut topics = Vec::new();
     let mut owners = Vec::new();
+    let mut targets = Vec::new();
     let mut i = 0;
 
     while i < args.len() {
@@ -141,6 +146,13 @@ fn parse_post_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
                 }
                 owners.push(args[i].clone());
             }
+            "--target" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err(CliParseError::MissingFlag("--target"));
+                }
+                targets.push(args[i].clone());
+            }
             other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
         }
         i += 1;
@@ -153,6 +165,7 @@ fn parse_post_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
         parent,
         topics,
         owners,
+        targets,
     })
 }
 
@@ -258,7 +271,66 @@ mod tests {
                 parent: None,
                 topics: vec!["coordination".into()],
                 owners: vec![],
+                targets: vec![],
             }
+        );
+    }
+
+    #[test]
+    fn board_family_parse_post_collects_target_flags() {
+        let cmd = parse(&[
+            s("post"),
+            s("--kind"),
+            s("claim"),
+            s("--body"),
+            s("I claim feature/foo"),
+            s("--target"),
+            s("sess-a3f2"),
+            s("--target"),
+            s("feature/foo"),
+        ])
+        .unwrap();
+        assert_eq!(
+            cmd,
+            CliCommand::BoardPost {
+                kind: "claim".into(),
+                body: Some("I claim feature/foo".into()),
+                file: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec!["sess-a3f2".into(), "feature/foo".into()],
+            }
+        );
+    }
+
+    #[test]
+    fn board_family_run_post_persists_target_owners() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = crate::cli::TestEnv::new(tmp.path().to_path_buf());
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            CliCommand::BoardPost {
+                kind: "claim".into(),
+                body: Some("taking the migration".into()),
+                file: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec!["sess-a3f2".into(), "feature/x".into()],
+            },
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(code, 0);
+        let snapshot = load_snapshot(tmp.path()).unwrap();
+        assert_eq!(snapshot.board.entries.len(), 1);
+        assert_eq!(
+            snapshot.board.entries[0].target_owners,
+            vec!["sess-a3f2".to_string(), "feature/x".to_string()]
         );
     }
 
@@ -283,6 +355,7 @@ mod tests {
                 parent: None,
                 topics: vec!["coordination".into()],
                 owners: vec!["1974".into()],
+                targets: vec![],
             },
             &mut out,
         )

--- a/crates/gwt/src/cli/hook/board_reminder.rs
+++ b/crates/gwt/src/cli/hook/board_reminder.rs
@@ -55,20 +55,37 @@ fn redundancy_window() -> Duration {
 
 const USER_PROMPT_REMINDER: &str = "# Board Post Reminder\n\
 \n\
-Post to the shared Board when you cross a reasoning milestone:\n\
-- Work phase transitions (e.g., implementation -> build check -> PR handoff).\n\
-- Choices between alternatives with the reasoning behind them (e.g., \"A vs B, chose B because ...\").\n\
-- Concerns or hypotheses you are verifying (e.g., \"Hypothesis: failure stems from Y, verifying ...\").\n\
+Post to the shared Board when you cross a reasoning milestone OR a coordination boundary, \
+so other agents and the user can collaborate without collision.\n\
+\n\
+**Reasoning axes** (the *why* behind your work):\n\
+- Work phase transitions (e.g., implementation -> build check -> PR handoff). Use `--kind status`.\n\
+- Choices between alternatives with the reasoning behind them (e.g., \"A vs B, chose B because ...\"). Use `--kind decision` or `--kind status`.\n\
+- Concerns or hypotheses you are verifying (e.g., \"Hypothesis: failure stems from Y, verifying ...\"). Use `--kind status`.\n\
+\n\
+**Coordination axes** (so others know what you own and what is next):\n\
+- claim — declare ownership of a scope (e.g., \"I claim feature/X migration; others take other ranges\"). Use `--kind claim`.\n\
+- next — coordinate the next step without picking a recipient (e.g., \"phase 1 done, please pick up phase 2\"). Use `--kind next`.\n\
+- blocked — surface a blocker that needs unblocking (e.g., \"waiting on Y, requesting unblock\"). Use `--kind blocked`.\n\
+- handoff — pass concrete work to another agent or the user (e.g., \"completed Y, handing off the PR\"). Use `--kind handoff`.\n\
+- decision — broadcast a confirmed decision (e.g., \"adopting X for the migration\"). Use `--kind decision`.\n\
+\n\
+Add `--target <session-id|branch|agent-id>` (repeatable) when the post is meant for specific agents. \
+Targeted posts are highlighted as `[for-you]` in the recipient's reminder injection. Omit `--target` for broadcast.\n\
 \n\
 Do NOT post tool-level reports (e.g., \"running gcc\", \"opening file X\", \"ran test Y\"). \
 Anything already visible in the diff or log does not need a Board entry.\n\
 \n\
-Use: gwtd board post --kind status --body '<your reasoning>'\n";
+Examples:\n\
+  gwtd board post --kind status --body '<your reasoning>'\n\
+  gwtd board post --kind claim --target feature/foo --body 'taking the migration on feature/foo'\n\
+  gwtd board post --kind handoff --body 'phase 1 done, please pick up phase 2'\n";
 
 const USER_PROMPT_REMINDER_SHORT: &str = "# Board Post Reminder\n\
 \n\
 You posted to the Board recently. Post again only if a new reasoning milestone \
-(phase change, alternative chosen, concern raised) has emerged.\n";
+(phase change, alternative chosen, concern raised) or a coordination boundary \
+(claim, next, handoff, blocked, decision) has emerged.\n";
 
 // Stop reminders are emitted as `systemMessage` (user-facing) because
 // Claude Code's Stop hook schema does not accept `hookSpecificOutput`.
@@ -97,6 +114,11 @@ pub struct ReminderInputs {
     pub now: DateTime<Utc>,
     pub self_session_id: String,
     pub display_name: String,
+    /// Identifiers used to detect self-targeted entries (SPEC-1974 FR-041).
+    /// Typically the session id, the active branch, and the agent display
+    /// name; an entry whose `target_owners` contains any of these values is
+    /// rendered with a `[for-you]` marker. Empty disables highlighting.
+    pub self_match_keys: Vec<String>,
     /// Board entries preloaded for the event's window:
     /// - `SessionStart`: entries whose `updated_at` is within the last 24h.
     /// - `UserPromptSubmit`: entries whose `updated_at > last_injected_at`.
@@ -131,7 +153,7 @@ fn plan_session_start(inputs: ReminderInputs) -> ReminderPlan {
         &inputs.self_session_id,
         SESSION_START_CAP,
     );
-    let text = session_start_text(&entries);
+    let text = session_start_text(&entries, &inputs.self_match_keys);
     let mut next = inputs.reminders;
     next.last_injected_at = Some(inputs.now);
     ReminderPlan {
@@ -159,7 +181,11 @@ fn plan_user_prompt_submit(inputs: ReminderInputs) -> ReminderPlan {
     let context = if entries.is_empty() {
         reminder.to_string()
     } else {
-        format!("{}\n\n{}", injection_text(&entries), reminder)
+        format!(
+            "{}\n\n{}",
+            injection_text(&entries, &inputs.self_match_keys),
+            reminder
+        )
     };
 
     let mut next = inputs.reminders;
@@ -261,11 +287,23 @@ pub fn compute_plan(
         redundancy_window(),
     )?;
 
+    let mut self_match_keys = Vec::with_capacity(3);
+    if !session.id.trim().is_empty() {
+        self_match_keys.push(session.id.clone());
+    }
+    if !session.branch.trim().is_empty() {
+        self_match_keys.push(session.branch.clone());
+    }
+    if !session.display_name.trim().is_empty() {
+        self_match_keys.push(session.display_name.clone());
+    }
+
     Ok(Some(plan_reminder(ReminderInputs {
         event: intent_event,
         now,
         self_session_id: session.id.clone(),
         display_name: session.display_name.clone(),
+        self_match_keys,
         recent_entries,
         reminders,
         has_recent_own_status,
@@ -285,21 +323,21 @@ fn filter_and_cap_latest(
     entries
 }
 
-fn injection_text(entries: &[BoardEntry]) -> String {
+fn injection_text(entries: &[BoardEntry], match_keys: &[String]) -> String {
     let mut out = String::from(INJECTION_HEADER);
     for entry in entries {
-        out.push_str(&format_entry_line(entry));
+        out.push_str(&format_entry_line(entry, match_keys));
     }
     out
 }
 
-fn session_start_text(entries: &[BoardEntry]) -> String {
+fn session_start_text(entries: &[BoardEntry], match_keys: &[String]) -> String {
     let mut out = String::from(SESSION_START_HEADER);
     if entries.is_empty() {
         out.push_str("- (no recent posts from other Agents)\n");
     } else {
         for entry in entries {
-            out.push_str(&format_entry_line(entry));
+            out.push_str(&format_entry_line(entry, match_keys));
         }
     }
     out.push('\n');
@@ -307,11 +345,25 @@ fn session_start_text(entries: &[BoardEntry]) -> String {
     out
 }
 
-fn format_entry_line(entry: &BoardEntry) -> String {
+fn entry_targets_self(entry: &BoardEntry, match_keys: &[String]) -> bool {
+    !entry.target_owners.is_empty()
+        && entry
+            .target_owners
+            .iter()
+            .any(|t| match_keys.iter().any(|k| k == t))
+}
+
+fn format_entry_line(entry: &BoardEntry, match_keys: &[String]) -> String {
     let branch = entry.origin_branch.as_deref().unwrap_or("-");
     let session_id = entry.origin_session_id.as_deref().unwrap_or("-");
+    let prefix = if entry_targets_self(entry, match_keys) {
+        "[for-you] "
+    } else {
+        ""
+    };
     format!(
-        "- [{author} @ {branch} / {session}] ({kind}) {body}\n",
+        "- {prefix}[{author} @ {branch} / {session}] ({kind}) {body}\n",
+        prefix = prefix,
         author = entry.author,
         branch = branch,
         session = session_id,
@@ -418,6 +470,7 @@ mod tests {
             now: Utc::now(),
             self_session_id: "sess-1".into(),
             display_name: "Codex".into(),
+            self_match_keys: vec![],
             recent_entries: vec![],
             reminders: RemindersState::default(),
             has_recent_own_status: false,
@@ -437,6 +490,7 @@ mod tests {
             now: Utc::now(),
             self_session_id: "sess-1".into(),
             display_name: "Codex".into(),
+            self_match_keys: vec![],
             recent_entries: vec![],
             reminders: RemindersState::default(),
             has_recent_own_status: false,
@@ -456,12 +510,167 @@ mod tests {
     }
 
     #[test]
+    fn plan_user_prompt_submit_includes_coordination_axes() {
+        let plan = plan_reminder(ReminderInputs {
+            event: IntentBoundaryEvent::UserPromptSubmit,
+            now: Utc::now(),
+            self_session_id: "sess-1".into(),
+            display_name: "Codex".into(),
+            self_match_keys: vec![],
+            recent_entries: vec![],
+            reminders: RemindersState::default(),
+            has_recent_own_status: false,
+        });
+        let text = additional_context(&plan.output);
+
+        for axis in ["claim", "next", "blocked", "handoff", "decision"] {
+            assert!(
+                text.contains(axis),
+                "USER_PROMPT_REMINDER should promote coordination axis '{axis}', got:\n{text}"
+            );
+        }
+        assert!(
+            text.contains("--kind claim"),
+            "reminder should show --kind claim example, got:\n{text}"
+        );
+        assert!(
+            text.contains("--kind handoff"),
+            "reminder should show --kind handoff example, got:\n{text}"
+        );
+        assert!(
+            text.contains("--target"),
+            "reminder should mention --target flag for targeted posts, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn plan_user_prompt_submit_short_reminder_mentions_coordination() {
+        let plan = plan_reminder(ReminderInputs {
+            event: IntentBoundaryEvent::UserPromptSubmit,
+            now: Utc::now(),
+            self_session_id: "sess-1".into(),
+            display_name: "Codex".into(),
+            self_match_keys: vec![],
+            recent_entries: vec![],
+            reminders: RemindersState::default(),
+            has_recent_own_status: true,
+        });
+        let text = additional_context(&plan.output);
+        assert!(
+            text.contains("coordination"),
+            "short reminder should still surface coordination boundary, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn plan_session_start_marks_for_you_when_target_matches_session_id() {
+        let now = Utc::now();
+        let other = entry(
+            "OtherAgent",
+            BoardEntryKind::Claim,
+            "claim feature/foo migration",
+            "feature/other",
+            "sess-other",
+            now,
+        )
+        .with_target_owners(vec!["sess-1".into()]);
+
+        let plan = plan_reminder(ReminderInputs {
+            event: IntentBoundaryEvent::SessionStart,
+            now,
+            self_session_id: "sess-1".into(),
+            display_name: "Codex".into(),
+            self_match_keys: vec!["sess-1".into(), "feature/me".into(), "Codex".into()],
+            recent_entries: vec![other],
+            reminders: RemindersState::default(),
+            has_recent_own_status: false,
+        });
+        let text = additional_context(&plan.output);
+        let entry_line = text
+            .lines()
+            .find(|line| line.contains("claim feature/foo migration"))
+            .expect("entry line missing");
+        assert!(
+            entry_line.contains("[for-you]"),
+            "for-you marker missing on entry targeted at self session id: {entry_line}"
+        );
+    }
+
+    #[test]
+    fn plan_session_start_marks_for_you_when_target_matches_branch() {
+        let now = Utc::now();
+        let other = entry(
+            "OtherAgent",
+            BoardEntryKind::Handoff,
+            "handing off to feature/me",
+            "feature/other",
+            "sess-other",
+            now,
+        )
+        .with_target_owners(vec!["feature/me".into()]);
+
+        let plan = plan_reminder(ReminderInputs {
+            event: IntentBoundaryEvent::SessionStart,
+            now,
+            self_session_id: "sess-1".into(),
+            display_name: "Codex".into(),
+            self_match_keys: vec!["sess-1".into(), "feature/me".into(), "Codex".into()],
+            recent_entries: vec![other],
+            reminders: RemindersState::default(),
+            has_recent_own_status: false,
+        });
+        let text = additional_context(&plan.output);
+        let entry_line = text
+            .lines()
+            .find(|line| line.contains("handing off to feature/me"))
+            .expect("entry line missing");
+        assert!(
+            entry_line.contains("[for-you]"),
+            "for-you marker missing on entry targeted at self branch: {entry_line}"
+        );
+    }
+
+    #[test]
+    fn plan_session_start_no_for_you_marker_when_target_owners_empty() {
+        let now = Utc::now();
+        let other = entry(
+            "OtherAgent",
+            BoardEntryKind::Status,
+            "broadcast status",
+            "feature/other",
+            "sess-other",
+            now,
+        );
+
+        let plan = plan_reminder(ReminderInputs {
+            event: IntentBoundaryEvent::SessionStart,
+            now,
+            self_session_id: "sess-1".into(),
+            display_name: "Codex".into(),
+            self_match_keys: vec!["sess-1".into(), "feature/me".into(), "Codex".into()],
+            recent_entries: vec![other],
+            reminders: RemindersState::default(),
+            has_recent_own_status: false,
+        });
+        let text = additional_context(&plan.output);
+        let entry_line = text
+            .lines()
+            .find(|line| line.contains("broadcast status"))
+            .expect("entry line missing");
+        assert!(
+            !entry_line.contains("[for-you]"),
+            "broadcast entry must not be highlighted: {entry_line}"
+        );
+    }
+
+    #[test]
     fn plan_user_prompt_submit_short_reminder_when_redundant() {
         let plan = plan_reminder(ReminderInputs {
             event: IntentBoundaryEvent::UserPromptSubmit,
             now: Utc::now(),
             self_session_id: "sess-1".into(),
             display_name: "Codex".into(),
+            self_match_keys: vec![],
             recent_entries: vec![],
             reminders: RemindersState::default(),
             has_recent_own_status: true,
@@ -495,6 +704,7 @@ mod tests {
             now,
             self_session_id: "sess-1".into(),
             display_name: "Claude".into(),
+            self_match_keys: vec![],
             recent_entries: entries,
             reminders: RemindersState::default(),
             has_recent_own_status: false,
@@ -514,6 +724,7 @@ mod tests {
             now: Utc::now(),
             self_session_id: "sess-1".into(),
             display_name: "Codex".into(),
+            self_match_keys: vec![],
             recent_entries: vec![],
             reminders: RemindersState::default(),
             has_recent_own_status: false,
@@ -536,6 +747,7 @@ mod tests {
             now,
             self_session_id: "sess-1".into(),
             display_name: "Codex".into(),
+            self_match_keys: vec![],
             recent_entries: vec![],
             reminders,
             has_recent_own_status: false,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -471,6 +471,7 @@ mod tests {
                 parent_id: None,
                 topics: Vec::new(),
                 owners: Vec::new(),
+                targets: Vec::new(),
             }
         ));
     }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -153,6 +153,8 @@ pub enum FrontendEvent {
         parent_id: Option<String>,
         topics: Vec<String>,
         owners: Vec<String>,
+        #[serde(default)]
+        targets: Vec<String>,
     },
     CreateMemoNote {
         id: String,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.13.2",
+  "version": "9.14.0",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v9.14.0 brings the SPEC-1974 Phase 9 coordination posting expansion to Board (target_owners + 5 coordination axes + `[for-you]` highlights) and enables the Codex `/goal` slash command at agent launch (SPEC-1921).

## Changes

### Features
- **coordination (SPEC-1974 Phase 9):** Board に target_owners を導入し、`gwtd board post --target <owner>` で対象エージェントを明示できる。`status` / `decision` 軸に加え `claim` / `next` / `blocked` / `handoff` の coordination 軸を Reminder で促す設計に拡張し、自分宛投稿は `[for-you]` でハイライトされる。AGENTS.md にも Board 運用セクションを追加。
- **agent (SPEC-1921):** Codex 0.128+ の `/goal` slash command を有効化するため、Codex launch builder に `--enable goals` を追加。`canonical_launch_args` は `--no-alt-screen` のみ維持。

## Version

- **Previous:** v9.13.2
- **This release:** v9.14.0
- **Bump type:** minor (2× feat, no breaking changes)

## Closing Issues

None

## Related Issues / Links

- #1921 (SPEC-1921: Codex agent `/goal` enablement — referenced via PR #2248, not auto-closing)

> Note: Reference-only issues are intentionally not auto-closed. #1921 (SPEC-1921) remains the long-running owner SPEC for the Codex agent launch experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
