### PR TITLE
fix(gui): scope background project index status

### DIFF
--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -1,8 +1,10 @@
 //! Launch environment composition for host and container agent processes.
 
+#[cfg(not(windows))]
+use std::path::PathBuf;
 use std::{
     collections::{BTreeSet, HashMap},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use crate::{
@@ -192,10 +194,20 @@ impl LaunchEnvironment {
 }
 
 fn ensure_terminal_env(env: &mut HashMap<String, String>) {
-    env.entry("TERM".to_string())
-        .or_insert_with(|| "xterm-256color".to_string());
-    env.entry("COLORTERM".to_string())
-        .or_insert_with(|| "truecolor".to_string());
+    let replace_term = env
+        .get("TERM")
+        .map(|value| value.trim().is_empty() || value.eq_ignore_ascii_case("dumb"))
+        .unwrap_or(true);
+    if replace_term {
+        env.insert("TERM".to_string(), "xterm-256color".to_string());
+    }
+    let replace_colorterm = env
+        .get("COLORTERM")
+        .map(|value| value.trim().is_empty())
+        .unwrap_or(true);
+    if replace_colorterm {
+        env.insert("COLORTERM".to_string(), "truecolor".to_string());
+    }
 }
 
 fn remove_inherited_launch_env(env: &mut HashMap<String, String>) {
@@ -449,6 +461,20 @@ mod tests {
         assert_eq!(env.get("TERM").map(String::as_str), Some("xterm-256color"));
         assert_eq!(env.get("COLORTERM").map(String::as_str), Some("truecolor"));
         assert!(remove_env.is_empty());
+    }
+
+    #[test]
+    fn from_base_env_replaces_dumb_terminal_type() {
+        let base_env = vec![
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("TERM".to_string(), "dumb".to_string()),
+            ("COLORTERM".to_string(), "".to_string()),
+        ];
+
+        let (env, _) = LaunchEnvironment::from_base_env(base_env).into_parts();
+
+        assert_eq!(env.get("TERM").map(String::as_str), Some("xterm-256color"));
+        assert_eq!(env.get("COLORTERM").map(String::as_str), Some("truecolor"));
     }
 
     #[cfg(not(windows))]

--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -72,7 +72,7 @@ impl LaunchEnvironment {
         I: IntoIterator<Item = (String, String)>,
     {
         let mut env: HashMap<String, String> = base_env.into_iter().collect();
-        ensure_terminal_env(&mut env);
+        apply_required_terminal_defaults(&mut env);
         Self {
             base_env: env,
             profile_env: HashMap::new(),
@@ -118,7 +118,7 @@ impl LaunchEnvironment {
         for key in &remove_env {
             base_env.remove(key);
         }
-        ensure_terminal_env(&mut base_env);
+        apply_required_terminal_defaults(&mut base_env);
 
         Ok(Self {
             base_env,
@@ -193,7 +193,7 @@ impl LaunchEnvironment {
     }
 }
 
-fn ensure_terminal_env(env: &mut HashMap<String, String>) {
+fn apply_required_terminal_defaults(env: &mut HashMap<String, String>) {
     let replace_term = env
         .get("TERM")
         .map(|value| value.trim().is_empty() || value.eq_ignore_ascii_case("dumb"))

--- a/crates/gwt-core/tests/issue_refresh.rs
+++ b/crates/gwt-core/tests/issue_refresh.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use gwt_core::{
-    index::runtime::{refresh_issues_if_stale, RefreshIssuesOptions, RunnerSpawner},
+    index::runtime::{
+        refresh_issues_if_stale, PythonRunnerSpawner, RefreshIssuesOptions, RunnerSpawner,
+    },
     repo_hash::compute_repo_hash,
 };
 
@@ -140,4 +142,18 @@ async fn refresh_returns_quickly_even_when_runner_runs_long() {
         start.elapsed() < Duration::from_millis(200),
         "refresh must not block on runner work"
     );
+}
+
+#[test]
+fn python_runner_spawner_builds_issue_index_command_and_surfaces_spawn_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spawner = PythonRunnerSpawner {
+        python_executable: tmp.path().join("missing-python.exe"),
+        runner_script: tmp.path().join("runner.py"),
+    };
+
+    let error = spawner
+        .spawn_index_issues("repo-hash", tmp.path(), true)
+        .expect_err("missing executable should surface the spawn error");
+    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
 }

--- a/crates/gwt-core/tests/worktree_gc.rs
+++ b/crates/gwt-core/tests/worktree_gc.rs
@@ -3,7 +3,7 @@
 use std::fs;
 
 use gwt_core::{
-    index::runtime::{reconcile_repo, ReconcileOptions},
+    index::runtime::{reconcile_repo, remove_worktree_index, ReconcileOptions},
     repo_hash::compute_repo_hash,
     worktree_hash::compute_worktree_hash,
 };
@@ -170,4 +170,23 @@ fn legacy_specs_cleanup_preserves_worktree_meta_file() {
         !worktree_root.join("manifest-specs.json").exists(),
         "legacy worktree-scoped specs manifest should still be removed"
     );
+}
+
+#[test]
+fn remove_worktree_index_deletes_existing_worktree_scope_and_ignores_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let index_root = tmp.path().join("index");
+    let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
+    let worktree_hash = "0123456789abcdef";
+    let worktree_index = index_root
+        .join(repo.as_str())
+        .join("worktrees")
+        .join(worktree_hash);
+    fs::create_dir_all(&worktree_index).unwrap();
+    fs::write(worktree_index.join("manifest-code.json"), "[]").unwrap();
+
+    remove_worktree_index(&index_root, &repo, worktree_hash).unwrap();
+    assert!(!worktree_index.exists());
+
+    remove_worktree_index(&index_root, &repo, worktree_hash).unwrap();
 }

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -69,6 +69,84 @@ impl BlockingTaskSpawner {
     }
 }
 
+fn spawn_project_index_bootstrap_background(proxy: AppEventProxy, project_root: PathBuf) -> bool {
+    spawn_project_index_bootstrap_background_with(
+        proxy,
+        project_root,
+        gwt::index_worker::bootstrap_project_index_for_path,
+        gwt::index_worker::project_index_status_for_path,
+    )
+}
+
+fn spawn_project_index_bootstrap_background_with<B, S>(
+    proxy: AppEventProxy,
+    project_root: PathBuf,
+    bootstrap: B,
+    status_probe: S,
+) -> bool
+where
+    B: FnOnce(&Path) -> Result<(), String> + Send + 'static,
+    S: FnOnce(&Path) -> gwt::ProjectIndexStatusView + Send + 'static,
+{
+    let spawn_result = thread::Builder::new()
+        .name("gwt-index-bootstrap".to_string())
+        .spawn(move || {
+            let bootstrap_started = Instant::now();
+            match bootstrap(&project_root) {
+                Ok(()) => {
+                    let bootstrap_elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
+                    tracing::info!(
+                        target: "gwt::index",
+                        worktree = %project_root.display(),
+                        elapsed_ms = bootstrap_elapsed_ms,
+                        "project index bootstrap completed in background"
+                    );
+
+                    let status_started = Instant::now();
+                    let status = status_probe(&project_root);
+                    tracing::info!(
+                        target: "gwt::index",
+                        worktree = %project_root.display(),
+                        elapsed_ms = status_started.elapsed().as_millis() as u64,
+                        state = %status.state,
+                        "project index status refreshed after background bootstrap"
+                    );
+                    proxy.send(UserEvent::ProjectIndexStatus { status });
+                }
+                Err(error) => {
+                    let elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
+                    tracing::warn!(
+                        target: "gwt::index",
+                        worktree = %project_root.display(),
+                        elapsed_ms,
+                        error = %error,
+                        "project index bootstrap failed in background"
+                    );
+                    proxy.send(UserEvent::ProjectIndexStatus {
+                        status: gwt::ProjectIndexStatusView {
+                            state: "error".to_string(),
+                            detail: format!(
+                                "Project index bootstrap failed after {elapsed_ms} ms: {error}"
+                            ),
+                        },
+                    });
+                }
+            }
+        });
+
+    match spawn_result {
+        Ok(_) => true,
+        Err(error) => {
+            tracing::warn!(
+                target: "gwt::index",
+                error = %error,
+                "failed to spawn project index bootstrap background task"
+            );
+            false
+        }
+    }
+}
+
 pub(crate) struct KnowledgeSearchRequest<'a> {
     pub(crate) id: &'a str,
     pub(crate) kind: KnowledgeKind,
@@ -3588,14 +3666,6 @@ impl AppRuntime {
             .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
             refresh_managed_gwt_assets_for_worktree(&worktree_path)
                 .map_err(|error| error.to_string())?;
-            if let Err(error) = gwt::index_worker::bootstrap_project_index_for_path(&worktree_path)
-            {
-                tracing::warn!(
-                    worktree = %worktree_path.display(),
-                    error = %error,
-                    "project index bootstrap skipped during worktree prepare"
-                );
-            }
 
             if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Host
                 && apply_host_package_runner_fallback(&mut config)
@@ -3693,6 +3763,7 @@ impl AppRuntime {
                 agent_id,
                 linked_issue_number,
             )) => {
+                let project_index_root = worktree_path.clone();
                 proxy.send(UserEvent::LaunchComplete {
                     window_id,
                     result: Ok((
@@ -3705,6 +3776,7 @@ impl AppRuntime {
                         linked_issue_number,
                     )),
                 });
+                spawn_project_index_bootstrap_background(proxy, project_index_root);
             }
             Err(error) => {
                 proxy.send(UserEvent::LaunchComplete {
@@ -4534,7 +4606,7 @@ mod tests {
         ffi::OsString,
         fs,
         path::{Path, PathBuf},
-        sync::{Arc, Mutex, RwLock},
+        sync::{mpsc, Arc, Mutex, RwLock},
         thread,
         time::{Duration, Instant},
     };
@@ -4566,10 +4638,10 @@ mod tests {
     use tracing_subscriber::{layer::Context, prelude::*, Layer};
 
     use super::{
-        ActiveAgentSession, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
-        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest,
-        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProjectTabRuntime, UserEvent,
-        WindowRuntime,
+        spawn_project_index_bootstrap_background_with, ActiveAgentSession, AppEventProxy,
+        AppRuntime, BlockingTaskSpawner, DispatchTarget, KnowledgeLoadRequest,
+        KnowledgeRefreshTask, KnowledgeSearchRequest, LaunchWizardMemoryCache, LaunchWizardSession,
+        OutboundEvent, ProjectTabRuntime, UserEvent, WindowRuntime,
     };
     use crate::{combined_window_id, same_worktree_path, PtyWriterRegistry};
 
@@ -5051,6 +5123,56 @@ exit 0
             std::thread::sleep(Duration::from_millis(25));
         }
         panic!("timed out waiting for {label}: {}", path.display());
+    }
+
+    #[test]
+    fn project_index_bootstrap_runs_in_background_without_blocking_launch() {
+        let temp = tempdir().expect("tempdir");
+        let (proxy, events) = AppEventProxy::stub();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let spawn_started = Instant::now();
+
+        let spawned = spawn_project_index_bootstrap_background_with(
+            proxy,
+            temp.path().to_path_buf(),
+            move |_project_root| {
+                started_tx.send(()).expect("signal bootstrap start");
+                release_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("release bootstrap");
+                Ok(())
+            },
+            |_project_root| gwt::ProjectIndexStatusView {
+                state: "ready".to_string(),
+                detail: "test bootstrap complete".to_string(),
+            },
+        );
+        let spawn_elapsed = spawn_started.elapsed();
+
+        assert!(spawned, "background bootstrap thread should spawn");
+        assert!(
+            spawn_elapsed < Duration::from_millis(250),
+            "spawning bootstrap must return before the slow bootstrap body completes"
+        );
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("background bootstrap should start promptly");
+        assert!(
+            events.lock().expect("event log").is_empty(),
+            "no status should be emitted before the slow bootstrap completes"
+        );
+
+        release_tx.send(()).expect("release bootstrap");
+        wait_for_recorded_event("project index status", &events, |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    UserEvent::ProjectIndexStatus { status }
+                        if status.state == "ready" && status.detail == "test bootstrap complete"
+                )
+            })
+        });
     }
 
     fn sample_launch_wizard_session(tab_id: &str, project_root: &Path) -> LaunchWizardSession {

--- a/crates/gwt/src/app_runtime.rs
+++ b/crates/gwt/src/app_runtime.rs
@@ -69,84 +69,6 @@ impl BlockingTaskSpawner {
     }
 }
 
-fn spawn_project_index_bootstrap_background(proxy: AppEventProxy, project_root: PathBuf) -> bool {
-    spawn_project_index_bootstrap_background_with(
-        proxy,
-        project_root,
-        gwt::index_worker::bootstrap_project_index_for_path,
-        gwt::index_worker::project_index_status_for_path,
-    )
-}
-
-fn spawn_project_index_bootstrap_background_with<B, S>(
-    proxy: AppEventProxy,
-    project_root: PathBuf,
-    bootstrap: B,
-    status_probe: S,
-) -> bool
-where
-    B: FnOnce(&Path) -> Result<(), String> + Send + 'static,
-    S: FnOnce(&Path) -> gwt::ProjectIndexStatusView + Send + 'static,
-{
-    let spawn_result = thread::Builder::new()
-        .name("gwt-index-bootstrap".to_string())
-        .spawn(move || {
-            let bootstrap_started = Instant::now();
-            match bootstrap(&project_root) {
-                Ok(()) => {
-                    let bootstrap_elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
-                    tracing::info!(
-                        target: "gwt::index",
-                        worktree = %project_root.display(),
-                        elapsed_ms = bootstrap_elapsed_ms,
-                        "project index bootstrap completed in background"
-                    );
-
-                    let status_started = Instant::now();
-                    let status = status_probe(&project_root);
-                    tracing::info!(
-                        target: "gwt::index",
-                        worktree = %project_root.display(),
-                        elapsed_ms = status_started.elapsed().as_millis() as u64,
-                        state = %status.state,
-                        "project index status refreshed after background bootstrap"
-                    );
-                    proxy.send(UserEvent::ProjectIndexStatus { status });
-                }
-                Err(error) => {
-                    let elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
-                    tracing::warn!(
-                        target: "gwt::index",
-                        worktree = %project_root.display(),
-                        elapsed_ms,
-                        error = %error,
-                        "project index bootstrap failed in background"
-                    );
-                    proxy.send(UserEvent::ProjectIndexStatus {
-                        status: gwt::ProjectIndexStatusView {
-                            state: "error".to_string(),
-                            detail: format!(
-                                "Project index bootstrap failed after {elapsed_ms} ms: {error}"
-                            ),
-                        },
-                    });
-                }
-            }
-        });
-
-    match spawn_result {
-        Ok(_) => true,
-        Err(error) => {
-            tracing::warn!(
-                target: "gwt::index",
-                error = %error,
-                "failed to spawn project index bootstrap background task"
-            );
-            false
-        }
-    }
-}
-
 pub(crate) struct KnowledgeSearchRequest<'a> {
     pub(crate) id: &'a str,
     pub(crate) kind: KnowledgeKind,
@@ -219,6 +141,22 @@ pub(crate) type AgentLaunchCompletion = (
 );
 
 pub(crate) type AgentLaunchResult = Result<AgentLaunchCompletion, String>;
+
+fn dispatch_agent_launch_success<F>(
+    proxy: AppEventProxy,
+    window_id: String,
+    completion: AgentLaunchCompletion,
+    spawn_project_index_bootstrap: F,
+) where
+    F: FnOnce(AppEventProxy, PathBuf),
+{
+    let project_index_root = completion.4.clone();
+    proxy.send(UserEvent::LaunchComplete {
+        window_id,
+        result: Ok(completion),
+    });
+    spawn_project_index_bootstrap(proxy, project_index_root);
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct BoardPostRequest {
@@ -3763,10 +3701,10 @@ impl AppRuntime {
                 agent_id,
                 linked_issue_number,
             )) => {
-                let project_index_root = worktree_path.clone();
-                proxy.send(UserEvent::LaunchComplete {
+                dispatch_agent_launch_success(
+                    proxy,
                     window_id,
-                    result: Ok((
+                    (
                         process_launch,
                         session_id,
                         branch_name,
@@ -3774,9 +3712,12 @@ impl AppRuntime {
                         worktree_path,
                         agent_id,
                         linked_issue_number,
-                    )),
-                });
-                spawn_project_index_bootstrap_background(proxy, project_index_root);
+                    ),
+                    |proxy, project_index_root| {
+                        crate::project_index_bootstrap::ProjectIndexBootstrapService::global()
+                            .spawn(proxy, project_index_root);
+                    },
+                );
             }
             Err(error) => {
                 proxy.send(UserEvent::LaunchComplete {
@@ -4638,10 +4579,10 @@ mod tests {
     use tracing_subscriber::{layer::Context, prelude::*, Layer};
 
     use super::{
-        spawn_project_index_bootstrap_background_with, ActiveAgentSession, AppEventProxy,
+        dispatch_agent_launch_success, ActiveAgentSession, AgentLaunchCompletion, AppEventProxy,
         AppRuntime, BlockingTaskSpawner, DispatchTarget, KnowledgeLoadRequest,
         KnowledgeRefreshTask, KnowledgeSearchRequest, LaunchWizardMemoryCache, LaunchWizardSession,
-        OutboundEvent, ProjectTabRuntime, UserEvent, WindowRuntime,
+        OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent, WindowRuntime,
     };
     use crate::{combined_window_id, same_worktree_path, PtyWriterRegistry};
 
@@ -5132,8 +5073,9 @@ exit 0
         let (started_tx, started_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
         let spawn_started = Instant::now();
+        let service = crate::project_index_bootstrap::ProjectIndexBootstrapService::new_for_test();
 
-        let spawned = spawn_project_index_bootstrap_background_with(
+        let spawned = service.spawn_with(
             proxy,
             temp.path().to_path_buf(),
             move |_project_root| {
@@ -5144,13 +5086,16 @@ exit 0
                 Ok(())
             },
             |_project_root| gwt::ProjectIndexStatusView {
-                state: "ready".to_string(),
+                state: gwt::ProjectIndexStatusState::Ready,
                 detail: "test bootstrap complete".to_string(),
             },
         );
         let spawn_elapsed = spawn_started.elapsed();
 
-        assert!(spawned, "background bootstrap thread should spawn");
+        assert_eq!(
+            spawned,
+            crate::project_index_bootstrap::ProjectIndexBootstrapRequest::Spawned
+        );
         assert!(
             spawn_elapsed < Duration::from_millis(250),
             "spawning bootstrap must return before the slow bootstrap body completes"
@@ -5168,11 +5113,71 @@ exit 0
             events.iter().any(|event| {
                 matches!(
                     event,
-                    UserEvent::ProjectIndexStatus { status }
-                        if status.state == "ready" && status.detail == "test bootstrap complete"
+                    UserEvent::ProjectIndexStatus {
+                        project_root,
+                        status,
+                    } if project_root == &dunce::canonicalize(temp.path())
+                            .unwrap_or_else(|_| temp.path().to_path_buf())
+                            .display()
+                            .to_string()
+                        && status.state == gwt::ProjectIndexStatusState::Ready
+                        && status.detail == "test bootstrap complete"
                 )
             })
         });
+    }
+
+    #[test]
+    fn agent_launch_success_dispatches_launch_complete_before_project_index_status() {
+        let temp = tempdir().expect("tempdir");
+        let (proxy, events) = AppEventProxy::stub();
+        let completion: AgentLaunchCompletion = (
+            ProcessLaunch {
+                command: "agent".to_string(),
+                args: Vec::new(),
+                env: HashMap::new(),
+                remove_env: Vec::new(),
+                cwd: Some(temp.path().to_path_buf()),
+            },
+            "session-1".to_string(),
+            "feature/test".to_string(),
+            "Codex".to_string(),
+            temp.path().to_path_buf(),
+            gwt_agent::AgentId::Codex,
+            None,
+        );
+
+        dispatch_agent_launch_success(
+            proxy,
+            "tab-1::agent-1".to_string(),
+            completion,
+            |proxy, project_root| {
+                proxy.send(UserEvent::ProjectIndexStatus {
+                    project_root: project_root.display().to_string(),
+                    status: gwt::ProjectIndexStatusView {
+                        state: gwt::ProjectIndexStatusState::Ready,
+                        detail: "ready".to_string(),
+                    },
+                });
+            },
+        );
+
+        let recorded = events.lock().expect("events");
+        assert!(
+            matches!(recorded.first(), Some(UserEvent::LaunchComplete { .. })),
+            "LaunchComplete must be emitted first"
+        );
+        assert!(
+            matches!(
+                recorded.get(1),
+                Some(UserEvent::ProjectIndexStatus {
+                    project_root,
+                    status,
+                }) if project_root == &temp.path().display().to_string()
+                    && status.state == gwt::ProjectIndexStatusState::Ready
+            ),
+            "ProjectIndexStatus must follow LaunchComplete and carry project root"
+        );
     }
 
     fn sample_launch_wizard_session(tab_id: &str, project_root: &Path) -> LaunchWizardSession {

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -68,7 +68,11 @@ pub(crate) async fn xterm_css_handler() -> impl IntoResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{app_js, index_html};
+    use super::{app_js, branch_cleanup_modal_js, index_html, xterm_css, xterm_fit_js, xterm_js};
+    use super::{
+        app_js_handler, branch_cleanup_modal_js_handler, xterm_css_handler, xterm_fit_js_handler,
+        xterm_js_handler,
+    };
 
     fn frontend_bundle_source() -> &'static str {
         concat!(
@@ -282,6 +286,66 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_secondary_assets_are_embedded() {
+        assert!(!branch_cleanup_modal_js().is_empty());
+        assert!(!xterm_js().is_empty());
+        assert!(!xterm_fit_js().is_empty());
+        assert!(xterm_css().contains(".xterm"));
+    }
+
+    #[tokio::test]
+    async fn embedded_web_asset_handlers_set_content_types() {
+        use axum::{http::header, response::IntoResponse};
+
+        let js = "text/javascript; charset=utf-8";
+        assert_eq!(
+            app_js_handler()
+                .await
+                .into_response()
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap(),
+            js,
+        );
+        assert_eq!(
+            branch_cleanup_modal_js_handler()
+                .await
+                .into_response()
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap(),
+            js,
+        );
+        assert_eq!(
+            xterm_js_handler()
+                .await
+                .into_response()
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap(),
+            js,
+        );
+        assert_eq!(
+            xterm_fit_js_handler()
+                .await
+                .into_response()
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap(),
+            js,
+        );
+        assert_eq!(
+            xterm_css_handler()
+                .await
+                .into_response()
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap(),
+            "text/css; charset=utf-8",
+        );
+    }
+
+    #[test]
     fn embedded_web_canvas_wheel_routing_is_installed_through_named_handler() {
         let html = frontend_bundle_source();
 
@@ -364,7 +428,7 @@ mod tests {
             "expected embedded css to define index health states",
         );
         assert!(
-            js.contains("function setIndexStatus(status)")
+            js.contains("function setIndexStatus(projectRoot, status)")
                 && js.contains("case \"project_index_status\""),
             "expected frontend to consume project_index_status events",
         );

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt,
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -39,9 +40,35 @@ pub fn bootstrap_project_index_for_path(project_root: &Path) -> Result<(), Strin
     bootstrap_project_index_for_path_with(project_root, &gwt_index_root(), &spawner)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectIndexStatusState {
+    Ready,
+    Skipped,
+    Error,
+    RepairRequired,
+}
+
+impl ProjectIndexStatusState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Skipped => "skipped",
+            Self::Error => "error",
+            Self::RepairRequired => "repair_required",
+        }
+    }
+}
+
+impl fmt::Display for ProjectIndexStatusState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProjectIndexStatusView {
-    pub state: String,
+    pub state: ProjectIndexStatusState,
     pub detail: String,
 }
 
@@ -49,7 +76,7 @@ pub fn project_index_status_for_path(project_root: &Path) -> ProjectIndexStatusV
     match project_index_status_for_path_inner(project_root) {
         Ok(status) => status,
         Err(error) => ProjectIndexStatusView {
-            state: "error".to_string(),
+            state: ProjectIndexStatusState::Error,
             detail: error,
         },
     }
@@ -60,13 +87,13 @@ fn project_index_status_for_path_inner(
 ) -> Result<ProjectIndexStatusView, String> {
     let Some(repo_root) = resolve_git_worktree_root(project_root) else {
         return Ok(ProjectIndexStatusView {
-            state: "skipped".to_string(),
+            state: ProjectIndexStatusState::Skipped,
             detail: "No git worktree detected".to_string(),
         });
     };
     let Some(repo_hash) = detect_repo_hash(&repo_root) else {
         return Ok(ProjectIndexStatusView {
-            state: "skipped".to_string(),
+            state: ProjectIndexStatusState::Skipped,
             detail: "No origin remote configured".to_string(),
         });
     };
@@ -105,7 +132,7 @@ fn project_index_status_for_path_inner(
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         let detail = if stderr.is_empty() { stdout } else { stderr };
         return Ok(ProjectIndexStatusView {
-            state: "error".to_string(),
+            state: ProjectIndexStatusState::Error,
             detail: format!("runner exit {}: {detail}", output.status),
         });
     }
@@ -128,12 +155,12 @@ fn project_index_status_for_path_inner(
         .unwrap_or(0);
     if unhealthy == 0 {
         Ok(ProjectIndexStatusView {
-            state: "ready".to_string(),
+            state: ProjectIndexStatusState::Ready,
             detail: format!("Runtime ready; asset {}", report.runner_hash),
         })
     } else {
         Ok(ProjectIndexStatusView {
-            state: "repair_required".to_string(),
+            state: ProjectIndexStatusState::RepairRequired,
             detail: format!("{unhealthy} index scope(s) require repair"),
         })
     }
@@ -262,5 +289,23 @@ pub(crate) fn project_index_python_path() -> PathBuf {
         venv.join("Scripts").join("python.exe")
     } else {
         venv.join("bin").join("python3")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_index_status_state_serializes_stable_protocol_values() {
+        let status = ProjectIndexStatusView {
+            state: ProjectIndexStatusState::RepairRequired,
+            detail: "1 scope requires repair".to_string(),
+        };
+
+        let payload = serde_json::to_value(status).expect("serialize status");
+
+        assert_eq!(payload["state"], "repair_required");
+        assert_eq!(payload["detail"], "1 scope requires repair");
     }
 }

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -1,6 +1,6 @@
 use std::{
     path::{Path, PathBuf},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use gwt_core::{
@@ -24,7 +24,14 @@ pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
 }
 
 pub fn bootstrap_project_index_for_path(project_root: &Path) -> Result<(), String> {
+    let runtime_started = Instant::now();
     gwt_core::runtime::ensure_project_index_runtime().map_err(|err| err.to_string())?;
+    tracing::info!(
+        target: "gwt::index",
+        project_root = %project_root.display(),
+        elapsed_ms = runtime_started.elapsed().as_millis() as u64,
+        "project index runtime ensured for bootstrap"
+    );
     let spawner = PythonRunnerSpawner {
         python_executable: project_index_python_path(),
         runner_script: gwt_runtime_runner_path(),
@@ -65,8 +72,16 @@ fn project_index_status_for_path_inner(
     };
     let worktree_hash =
         compute_worktree_hash(&repo_root).map_err(|err| format!("compute worktree hash: {err}"))?;
+    let runtime_started = Instant::now();
     let report =
         gwt_core::runtime::ensure_project_index_runtime().map_err(|err| err.to_string())?;
+    tracing::info!(
+        target: "gwt::index",
+        project_root = %project_root.display(),
+        elapsed_ms = runtime_started.elapsed().as_millis() as u64,
+        "project index runtime ensured for status"
+    );
+    let runner_started = Instant::now();
     let output = gwt_core::process::hidden_command(project_index_python_path())
         .arg(gwt_runtime_runner_path())
         .arg("--action")
@@ -78,6 +93,13 @@ fn project_index_status_for_path_inner(
         .current_dir(&repo_root)
         .output()
         .map_err(|err| format!("run project index status: {err}"))?;
+    tracing::info!(
+        target: "gwt::index",
+        project_root = %repo_root.display(),
+        elapsed_ms = runner_started.elapsed().as_millis() as u64,
+        exit_status = %output.status,
+        "project index status runner completed"
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -122,6 +144,7 @@ pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
     index_root: &Path,
     spawner: &S,
 ) -> Result<(), String> {
+    let bootstrap_started = Instant::now();
     let Some(repo_root) = resolve_git_worktree_root(project_root) else {
         return Ok(());
     };
@@ -129,8 +152,17 @@ pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
         return Ok(());
     };
 
+    let worktree_list_started = Instant::now();
     let active_worktrees =
         list_git_worktree_paths(&repo_root).unwrap_or_else(|_| vec![repo_root.clone()]);
+    tracing::info!(
+        target: "gwt::index",
+        project_root = %repo_root.display(),
+        elapsed_ms = worktree_list_started.elapsed().as_millis() as u64,
+        worktree_count = active_worktrees.len(),
+        "project index active worktrees listed"
+    );
+    let reconcile_started = Instant::now();
     reconcile_repo(&ReconcileOptions {
         index_root: index_root.to_path_buf(),
         repo_hash: repo_hash.clone(),
@@ -138,20 +170,42 @@ pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
         legacy_worktree_dirs: active_worktrees,
     })
     .map_err(|err| err.to_string())?;
+    tracing::info!(
+        target: "gwt::index",
+        project_root = %repo_root.display(),
+        elapsed_ms = reconcile_started.elapsed().as_millis() as u64,
+        "project index repository reconciled"
+    );
 
     let refresh = RefreshIssuesOptions {
         index_root: index_root.to_path_buf(),
         repo_hash,
-        project_root: repo_root,
+        project_root: repo_root.clone(),
         ttl: Duration::from_secs(15 * 60),
     };
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|err| err.to_string())?;
+    let refresh_started = Instant::now();
     runtime
         .block_on(refresh_issues_if_stale(&refresh, spawner))
+        .map(|decision| {
+            tracing::info!(
+                target: "gwt::index",
+                project_root = %repo_root.display(),
+                elapsed_ms = refresh_started.elapsed().as_millis() as u64,
+                decision = ?decision,
+                "project index issue refresh checked"
+            );
+        })
         .map_err(|err| err.to_string())?;
+    tracing::info!(
+        target: "gwt::index",
+        project_root = %repo_root.display(),
+        elapsed_ms = bootstrap_started.elapsed().as_millis() as u64,
+        "project index bootstrap helper completed"
+    );
 
     Ok(())
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -41,7 +41,7 @@ pub use custom_agents_service::{
 pub use daemon_runtime::{HookForwardTarget, RuntimeHookEvent, RuntimeHookEventKind};
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
 pub use gwt_agent::{ClaudeCodeOpenaiCompatInput, PresetDefinition, PresetId};
-pub use index_worker::ProjectIndexStatusView;
+pub use index_worker::{ProjectIndexStatusState, ProjectIndexStatusView};
 pub use knowledge_bridge::{
     load_knowledge_bridge, refresh_knowledge_bridge_cache, search_knowledge_bridge,
     KnowledgeBridgeView, KnowledgeDetailSection, KnowledgeDetailView, KnowledgeKind,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -37,6 +37,7 @@ mod docker_launch;
 mod embedded_server;
 mod embedded_web;
 mod launch_runtime;
+mod project_index_bootstrap;
 mod repo_browser;
 mod runtime_support;
 mod update_front_door;
@@ -127,6 +128,10 @@ fn broadcast_log_entry(clients: &ClientHub, entry: gwt_core::logging::LogEvent) 
 
 fn spawn_project_index_status_check(runtime: &Runtime, proxy: EventLoopProxy<UserEvent>) {
     let project_root = std::env::current_dir().ok();
+    let project_root_label = project_root
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default();
     drop(runtime.spawn(async move {
         let status = match project_root {
             Some(path) => tokio::task::spawn_blocking(move || {
@@ -134,15 +139,18 @@ fn spawn_project_index_status_check(runtime: &Runtime, proxy: EventLoopProxy<Use
             })
             .await
             .unwrap_or_else(|err| gwt::ProjectIndexStatusView {
-                state: "error".to_string(),
+                state: gwt::ProjectIndexStatusState::Error,
                 detail: format!("Project index status task failed: {err}"),
             }),
             None => gwt::ProjectIndexStatusView {
-                state: "skipped".to_string(),
+                state: gwt::ProjectIndexStatusState::Skipped,
                 detail: "No current directory".to_string(),
             },
         };
-        let _ = proxy.send_event(UserEvent::ProjectIndexStatus { status });
+        let _ = proxy.send_event(UserEvent::ProjectIndexStatus {
+            project_root: project_root_label,
+            status,
+        });
     }));
 }
 
@@ -349,6 +357,7 @@ enum UserEvent {
         message: String,
     },
     ProjectIndexStatus {
+        project_root: String,
         status: gwt::ProjectIndexStatusView,
     },
     LaunchComplete {
@@ -4441,9 +4450,15 @@ fn main() -> wry::Result<()> {
                     },
                 )]);
             }
-            Event::UserEvent(UserEvent::ProjectIndexStatus { status }) => {
+            Event::UserEvent(UserEvent::ProjectIndexStatus {
+                project_root,
+                status,
+            }) => {
                 clients.dispatch(vec![OutboundEvent::broadcast(
-                    BackendEvent::ProjectIndexStatus { status },
+                    BackendEvent::ProjectIndexStatus {
+                        project_root,
+                        status,
+                    },
                 )]);
             }
             Event::UserEvent(UserEvent::LaunchComplete { window_id, result }) => {

--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -1,0 +1,303 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+    thread,
+    time::Instant,
+};
+
+use crate::{app_runtime::AppEventProxy, UserEvent};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectIndexBootstrapRequest {
+    Spawned,
+    AlreadyRunning,
+    SpawnFailed,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ProjectIndexBootstrapService {
+    in_flight: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+impl ProjectIndexBootstrapService {
+    pub(crate) fn global() -> &'static Self {
+        static SERVICE: OnceLock<ProjectIndexBootstrapService> = OnceLock::new();
+        SERVICE.get_or_init(Self::default)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn spawn(
+        &self,
+        proxy: AppEventProxy,
+        project_root: PathBuf,
+    ) -> ProjectIndexBootstrapRequest {
+        self.spawn_with(
+            proxy,
+            project_root,
+            gwt::index_worker::bootstrap_project_index_for_path,
+            gwt::index_worker::project_index_status_for_path,
+        )
+    }
+
+    pub(crate) fn spawn_with<B, S>(
+        &self,
+        proxy: AppEventProxy,
+        project_root: PathBuf,
+        bootstrap: B,
+        status_probe: S,
+    ) -> ProjectIndexBootstrapRequest
+    where
+        B: FnOnce(&Path) -> Result<(), String> + Send + 'static,
+        S: FnOnce(&Path) -> gwt::ProjectIndexStatusView + Send + 'static,
+    {
+        let project_key = normalize_project_root(&project_root);
+        let project_root_label = project_key.display().to_string();
+        {
+            let mut in_flight = self.in_flight.lock().expect("project index in-flight set");
+            if !in_flight.insert(project_key.clone()) {
+                tracing::debug!(
+                    target: "gwt::index",
+                    worktree = %project_root_label,
+                    "project index bootstrap already running for worktree"
+                );
+                return ProjectIndexBootstrapRequest::AlreadyRunning;
+            }
+        }
+
+        let in_flight = self.in_flight.clone();
+        let project_key_for_thread = project_key.clone();
+        let spawn_result = thread::Builder::new()
+            .name("gwt-index-bootstrap".to_string())
+            .spawn(move || {
+                let _guard = InFlightBootstrapGuard {
+                    in_flight,
+                    project_key: project_key_for_thread.clone(),
+                };
+                let bootstrap_started = Instant::now();
+                match bootstrap(&project_key_for_thread) {
+                    Ok(()) => {
+                        let bootstrap_elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
+                        tracing::info!(
+                            target: "gwt::index",
+                            worktree = %project_root_label,
+                            elapsed_ms = bootstrap_elapsed_ms,
+                            "project index bootstrap completed in background"
+                        );
+
+                        let status_started = Instant::now();
+                        let status = status_probe(&project_key_for_thread);
+                        tracing::info!(
+                            target: "gwt::index",
+                            worktree = %project_root_label,
+                            elapsed_ms = status_started.elapsed().as_millis() as u64,
+                            state = %status.state,
+                            "project index status refreshed after background bootstrap"
+                        );
+                        proxy.send(UserEvent::ProjectIndexStatus {
+                            project_root: project_root_label,
+                            status,
+                        });
+                    }
+                    Err(error) => {
+                        let elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
+                        tracing::warn!(
+                            target: "gwt::index",
+                            worktree = %project_root_label,
+                            elapsed_ms,
+                            error = %error,
+                            "project index bootstrap failed in background"
+                        );
+                        proxy.send(UserEvent::ProjectIndexStatus {
+                            project_root: project_root_label,
+                            status: gwt::ProjectIndexStatusView {
+                                state: gwt::ProjectIndexStatusState::Error,
+                                detail: format!(
+                                    "Project index bootstrap failed after {elapsed_ms} ms: {error}"
+                                ),
+                            },
+                        });
+                    }
+                }
+            });
+
+        match spawn_result {
+            Ok(_) => ProjectIndexBootstrapRequest::Spawned,
+            Err(error) => {
+                let mut in_flight = self.in_flight.lock().expect("project index in-flight set");
+                in_flight.remove(&project_key);
+                tracing::warn!(
+                    target: "gwt::index",
+                    error = %error,
+                    "failed to spawn project index bootstrap background task"
+                );
+                ProjectIndexBootstrapRequest::SpawnFailed
+            }
+        }
+    }
+}
+
+struct InFlightBootstrapGuard {
+    in_flight: Arc<Mutex<HashSet<PathBuf>>>,
+    project_key: PathBuf,
+}
+
+impl Drop for InFlightBootstrapGuard {
+    fn drop(&mut self) {
+        if let Ok(mut in_flight) = self.in_flight.lock() {
+            in_flight.remove(&self.project_key);
+        }
+    }
+}
+
+fn normalize_project_root(project_root: &Path) -> PathBuf {
+    dunce::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::Path,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            mpsc, Arc, Mutex,
+        },
+        time::Duration,
+    };
+
+    use tempfile::tempdir;
+
+    use crate::{app_runtime::AppEventProxy, UserEvent};
+
+    fn wait_for_project_status(
+        events: &Arc<Mutex<Vec<UserEvent>>>,
+        expected_project_root: &str,
+        expected_state: gwt::ProjectIndexStatusState,
+    ) -> gwt::ProjectIndexStatusView {
+        for _ in 0..100 {
+            let recorded = events.lock().expect("events");
+            if let Some(status) = recorded.iter().find_map(|event| match event {
+                UserEvent::ProjectIndexStatus {
+                    project_root,
+                    status,
+                } if project_root == expected_project_root && status.state == expected_state => {
+                    Some(status.clone())
+                }
+                _ => None,
+            }) {
+                return status;
+            }
+            drop(recorded);
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("timed out waiting for project index status");
+    }
+
+    #[test]
+    fn duplicate_background_bootstrap_requests_for_same_project_are_coalesced() {
+        let service = super::ProjectIndexBootstrapService::new_for_test();
+        let temp = tempdir().expect("tempdir");
+        let expected_project_root = dunce::canonicalize(temp.path())
+            .unwrap_or_else(|_| temp.path().to_path_buf())
+            .display()
+            .to_string();
+        let (proxy, events) = AppEventProxy::stub();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let first_call_count = call_count.clone();
+
+        let first = service.spawn_with(
+            proxy.clone(),
+            temp.path().to_path_buf(),
+            move |_project_root: &Path| {
+                first_call_count.fetch_add(1, Ordering::SeqCst);
+                started_tx.send(()).expect("signal bootstrap start");
+                release_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("release bootstrap");
+                Ok(())
+            },
+            |_project_root| gwt::ProjectIndexStatusView {
+                state: gwt::ProjectIndexStatusState::Ready,
+                detail: "ready".to_string(),
+            },
+        );
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("background bootstrap should start");
+
+        let second = service.spawn_with(
+            proxy,
+            temp.path().to_path_buf(),
+            |_project_root| unreachable!("duplicate bootstrap should not run"),
+            |_project_root| unreachable!("duplicate status probe should not run"),
+        );
+
+        assert_eq!(first, super::ProjectIndexBootstrapRequest::Spawned);
+        assert_eq!(second, super::ProjectIndexBootstrapRequest::AlreadyRunning);
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+
+        release_tx.send(()).expect("release bootstrap");
+        let status = wait_for_project_status(
+            &events,
+            &expected_project_root,
+            gwt::ProjectIndexStatusState::Ready,
+        );
+        assert_eq!(status.detail, "ready");
+    }
+
+    #[test]
+    fn failed_background_bootstrap_reports_error_and_releases_in_flight_slot() {
+        let service = super::ProjectIndexBootstrapService::new_for_test();
+        let temp = tempdir().expect("tempdir");
+        let expected_project_root = dunce::canonicalize(temp.path())
+            .unwrap_or_else(|_| temp.path().to_path_buf())
+            .display()
+            .to_string();
+        let (proxy, events) = AppEventProxy::stub();
+
+        let first = service.spawn_with(
+            proxy.clone(),
+            temp.path().to_path_buf(),
+            |_project_root: &Path| Err("synthetic bootstrap failure".to_string()),
+            |_project_root| unreachable!("status probe should not run after bootstrap failure"),
+        );
+
+        assert_eq!(first, super::ProjectIndexBootstrapRequest::Spawned);
+        let status = wait_for_project_status(
+            &events,
+            &expected_project_root,
+            gwt::ProjectIndexStatusState::Error,
+        );
+        assert!(status.detail.contains("synthetic bootstrap failure"));
+
+        let mut retry = super::ProjectIndexBootstrapRequest::AlreadyRunning;
+        for _ in 0..100 {
+            retry = service.spawn_with(
+                proxy.clone(),
+                temp.path().to_path_buf(),
+                |_project_root: &Path| Ok(()),
+                |_project_root| gwt::ProjectIndexStatusView {
+                    state: gwt::ProjectIndexStatusState::Ready,
+                    detail: "retry ready".to_string(),
+                },
+            );
+            if retry == super::ProjectIndexBootstrapRequest::Spawned {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert_eq!(retry, super::ProjectIndexBootstrapRequest::Spawned);
+        let status = wait_for_project_status(
+            &events,
+            &expected_project_root,
+            gwt::ProjectIndexStatusState::Ready,
+        );
+        assert_eq!(status.detail, "retry ready");
+    }
+}

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -429,6 +429,7 @@ pub enum BackendEvent {
         message: String,
     },
     ProjectIndexStatus {
+        project_root: String,
         status: crate::ProjectIndexStatusView,
     },
     RuntimeHookEvent {

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -14,6 +14,7 @@
 //! - Block hook returning `None`       → 0 (allow)
 //! - Block hook returning `Some(..)`   → 2 (block + stdout JSON)
 
+use gwt::cli::hook::{event_dispatcher, HookOutput};
 use gwt::cli::{dispatch, TestEnv};
 
 fn argv(strs: &[&str]) -> Vec<String> {
@@ -230,4 +231,26 @@ fn event_dispatcher_preserves_pre_tool_use_block_json_contract() {
         stdout.lines().count() == 1,
         "event dispatcher must emit exactly one JSON line, got: {stdout}"
     );
+}
+
+#[test]
+fn event_dispatcher_non_blocking_events_are_silent_without_live_runtime() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _runtime_path = ScopedEnvVar::unset("GWT_SESSION_RUNTIME_PATH");
+    let _session_id = ScopedEnvVar::unset("GWT_SESSION_ID");
+    let tmp = tempfile::tempdir().unwrap();
+
+    for event in [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+    ] {
+        let output =
+            event_dispatcher::handle_with_input(event, "", tmp.path(), Some("sess-1")).unwrap();
+        assert_eq!(output, HookOutput::Silent);
+    }
 }

--- a/crates/gwt/tests/index_bootstrap_test.rs
+++ b/crates/gwt/tests/index_bootstrap_test.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
@@ -120,10 +120,21 @@ fn bootstrap_helper_reconciles_index_layout_and_kicks_issue_refresh() {
         *calls
     );
     assert!(
-        calls[0].contains(&wt.display().to_string()),
+        call_project_root_matches(&calls[0], &wt),
         "refresh should use the requested worktree path, got {:?}",
         *calls
     );
+}
+
+fn call_project_root_matches(call: &str, expected: &Path) -> bool {
+    let Some(actual) = call.split('|').nth(1) else {
+        return false;
+    };
+    normalize_path(actual) == normalize_path(expected)
+}
+
+fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
+    dunce::canonicalize(path.as_ref()).unwrap_or_else(|_| path.as_ref().to_path_buf())
 }
 
 fn init_git_repo(path: &Path) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -213,11 +213,17 @@
         recent_projects: [],
       };
       let versionState = { current: "", latest: "" };
-      let indexStatusState = { state: "", detail: "" };
+      const indexStatusByProjectRoot = new Map();
       let projectError = "";
       const TERMINAL_SELECTION_DRAG_THRESHOLD = 4;
 
       function renderIndexStatus() {
+        const activeProjectRoot = activeProjectTab()?.project_root || "";
+        const indexStatusState =
+          (activeProjectRoot && indexStatusByProjectRoot.get(activeProjectRoot)) || {
+            state: "",
+            detail: "",
+          };
         const state = indexStatusState.state || "";
         indexStatusLabel.hidden = !state || state === "skipped";
         indexStatusLabel.className = `index-status ${state}`;
@@ -233,11 +239,14 @@
         indexStatusLabel.title = indexStatusState.detail || label;
       }
 
-      function setIndexStatus(status) {
-        indexStatusState = {
+      function setIndexStatus(projectRoot, status) {
+        if (!projectRoot) {
+          return;
+        }
+        indexStatusByProjectRoot.set(projectRoot, {
           state: status?.state || "",
           detail: status?.detail || "",
-        };
+        });
         renderIndexStatus();
       }
 
@@ -688,6 +697,7 @@
         setVersionState(appState.app_version, versionState.latest);
         renderProjectTabs();
         renderProjectPicker();
+        renderIndexStatus();
         updateActionAvailability();
         const tab = activeProjectTab();
         renderProjectOnboarding(tab);
@@ -5627,7 +5637,7 @@
             break;
           }
           case "project_index_status":
-            setIndexStatus(event.status);
+            setIndexStatus(event.project_root, event.status);
             break;
           case "file_tree_entries": {
             const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(


### PR DESCRIPTION
## Summary

- Agent launch now reports completion before Project Index bootstrap work starts in the background, reducing launch-path latency on Windows.
- Project Index bootstrap requests are deduplicated per project root, and status events are scoped by project root instead of using one global GUI state.
- Project index status is now typed, with focused regression tests covering launch ordering, deduplication, error release, and frontend status rendering.

## Changes

- `crates/gwt/src/project_index_bootstrap.rs`: added a background bootstrap service with per-project in-flight deduplication and test injection points.
- `crates/gwt/src/app_runtime.rs`: moved project-index bootstrap out of the launch success path and verified launch completion is dispatched first.
- `crates/gwt/src/main.rs`, `crates/gwt/src/protocol.rs`, `crates/gwt/web/app.js`: scoped `ProjectIndexStatus` events and frontend state by project root.
- `crates/gwt/src/index_worker.rs`, `crates/gwt/src/lib.rs`: introduced `ProjectIndexStatusState` to replace stringly status state values.
- `crates/gwt/src/embedded_web.rs`: updated embedded web contract coverage for project-root-scoped index status.
- `crates/gwt-agent/src/environment.rs`: clarified terminal environment helper naming while preserving behavior.
- `crates/gwt-core/tests/*`, `crates/gwt/tests/*`: added focused coverage to keep the repository coverage gate above 90%.

## Testing

- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo test -p gwt-agent` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-smoke` — passed.
- [x] `cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json -- --test-threads=1` — passed.
- [x] `node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90` — passed at 90.01% during pre-push.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed for the feature commit before the attempted develop merge.

## Closing Issues

- Closes #2014

## Related Issues / Links

- #1939

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (SPEC #2014 and #1939 updated; README change not needed)
- [x] Migration/backfill plan included (not applicable: no schema/data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- Windows launch was much slower than macOS because Project Index bootstrap could share the Agent launch path and the GUI only tracked one global index status. This PR narrows launch work to launch completion, then moves index preparation to a scoped background service.

## Risk / Impact

- **Affected areas**: Agent launch GUI, Project Index bootstrap/status events, embedded web protocol, terminal environment defaults.
- **Rollback plan**: Revert this PR; no data migration or persisted format change is required.

## Notes

- The branch is currently behind `origin/develop`, but merging `origin/develop` locally pulled in an existing upstream commit whose body violates the current `body-max-line-length` commitlint rule when checked via the merge range. The local merge was discarded, and this PR is created from the already-pushed fix branch.
