### PR TITLE
refactor(app_runtime): Board handler を board.rs に抽出 (SPEC-2077 Phase A)

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -1,0 +1,177 @@
+//! Board post handler split out of `app_runtime/mod.rs` for SPEC-2077 Phase A
+//! (arch-review handoff, 2026-05-01).
+//!
+//! Owns:
+//! - [`BoardPostRequest`] payload coming from the frontend
+//! - [`AppRuntime::post_board_entry_events`] impl extension (validates the
+//!   target window, sanitizes lists, and persists the entry through
+//!   `gwt_core::coordination::post_entry`)
+//! - [`sanitize_board_list`] helper that trims and de-duplicates string
+//!   payloads
+//!
+//! SPEC-1974 Phase 9 / Phase 10 contracts (`target_owners`, `>>` marker,
+//! reminder coordination axes) flow through here unchanged — the handler
+//! still uses `BoardEntry::with_target_owners` from `gwt-core` and emits
+//! the same `BackendEvent::BoardEntries` / `BackendEvent::BoardError`
+//! responses.
+
+use gwt_core::coordination::{self, BoardEntryKind};
+
+use super::{AppRuntime, BackendEvent, OutboundEvent, WindowPreset};
+
+#[derive(Debug, Clone)]
+pub(crate) struct BoardPostRequest {
+    pub(crate) id: String,
+    pub(crate) entry_kind: BoardEntryKind,
+    pub(crate) body: String,
+    pub(crate) parent_id: Option<String>,
+    pub(crate) topics: Vec<String>,
+    pub(crate) owners: Vec<String>,
+    pub(crate) targets: Vec<String>,
+}
+
+impl AppRuntime {
+    pub(crate) fn post_board_entry_events(
+        &self,
+        client_id: &str,
+        request: BoardPostRequest,
+    ) -> Vec<OutboundEvent> {
+        let BoardPostRequest {
+            id,
+            entry_kind,
+            body,
+            parent_id,
+            topics,
+            owners,
+            targets,
+        } = request;
+
+        let Some(address) = self.window_lookup.get(&id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id,
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id,
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        if window.preset != WindowPreset::Board {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id,
+                    message: "Window is not a Board surface".to_string(),
+                },
+            )];
+        }
+
+        let trimmed_body = body.trim();
+        if trimmed_body.is_empty() {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id,
+                    message: "Board entry body is required".to_string(),
+                },
+            )];
+        }
+
+        let parent_id = parent_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let topics = sanitize_board_list(&topics);
+        let owners = sanitize_board_list(&owners);
+        let targets = sanitize_board_list(&targets);
+
+        let snapshot = match coordination::load_snapshot(&tab.project_root) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BoardError {
+                        id,
+                        message: error.to_string(),
+                    },
+                )];
+            }
+        };
+        if let Some(parent_id) = parent_id.as_deref() {
+            if !snapshot
+                .board
+                .entries
+                .iter()
+                .any(|entry| entry.id == parent_id)
+            {
+                return vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BoardError {
+                        id,
+                        message: "Reply target was not found".to_string(),
+                    },
+                )];
+            }
+        }
+
+        let mut entry = coordination::BoardEntry::new(
+            coordination::AuthorKind::User,
+            "You",
+            entry_kind,
+            trimmed_body,
+            None,
+            parent_id,
+            topics,
+            owners,
+        );
+        if !targets.is_empty() {
+            entry = entry.with_target_owners(targets);
+        }
+        match coordination::post_entry(&tab.project_root, entry) {
+            Ok(snapshot) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardEntries {
+                    id,
+                    entries: snapshot.board.entries,
+                },
+            )],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id,
+                    message: error.to_string(),
+                },
+            )],
+        }
+    }
+}
+
+fn sanitize_board_list(values: &[String]) -> Vec<String> {
+    let mut sanitized = Vec::new();
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() || sanitized.iter().any(|item| item == trimmed) {
+            continue;
+        }
+        sanitized.push(trimmed.to_string());
+    }
+    sanitized
+}

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -142,16 +142,8 @@ pub(crate) type AgentLaunchCompletion = (
 
 pub(crate) type AgentLaunchResult = Result<AgentLaunchCompletion, String>;
 
-#[derive(Debug, Clone)]
-pub(crate) struct BoardPostRequest {
-    pub(crate) id: String,
-    pub(crate) entry_kind: gwt_core::coordination::BoardEntryKind,
-    pub(crate) body: String,
-    pub(crate) parent_id: Option<String>,
-    pub(crate) topics: Vec<String>,
-    pub(crate) owners: Vec<String>,
-    pub(crate) targets: Vec<String>,
-}
+mod board;
+pub(crate) use board::BoardPostRequest;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ActiveAgentSession {
@@ -2297,138 +2289,6 @@ impl AppRuntime {
             .collect()
     }
 
-    pub(crate) fn post_board_entry_events(
-        &self,
-        client_id: &str,
-        request: BoardPostRequest,
-    ) -> Vec<OutboundEvent> {
-        let BoardPostRequest {
-            id,
-            entry_kind,
-            body,
-            parent_id,
-            topics,
-            owners,
-            targets,
-        } = request;
-
-        let Some(address) = self.window_lookup.get(&id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id,
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        let Some(tab) = self.tab(&address.tab_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id,
-                    message: "Project tab not found".to_string(),
-                },
-            )];
-        };
-        let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id,
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        if window.preset != WindowPreset::Board {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id,
-                    message: "Window is not a Board surface".to_string(),
-                },
-            )];
-        }
-
-        let trimmed_body = body.trim();
-        if trimmed_body.is_empty() {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id,
-                    message: "Board entry body is required".to_string(),
-                },
-            )];
-        }
-
-        let parent_id = parent_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string);
-        let topics = sanitize_board_list(&topics);
-        let owners = sanitize_board_list(&owners);
-        let targets = sanitize_board_list(&targets);
-
-        let snapshot = match gwt_core::coordination::load_snapshot(&tab.project_root) {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                return vec![OutboundEvent::reply(
-                    client_id,
-                    BackendEvent::BoardError {
-                        id,
-                        message: error.to_string(),
-                    },
-                )];
-            }
-        };
-        if let Some(parent_id) = parent_id.as_deref() {
-            if !snapshot
-                .board
-                .entries
-                .iter()
-                .any(|entry| entry.id == parent_id)
-            {
-                return vec![OutboundEvent::reply(
-                    client_id,
-                    BackendEvent::BoardError {
-                        id,
-                        message: "Reply target was not found".to_string(),
-                    },
-                )];
-            }
-        }
-
-        let mut entry = gwt_core::coordination::BoardEntry::new(
-            gwt_core::coordination::AuthorKind::User,
-            "You",
-            entry_kind,
-            trimmed_body,
-            None,
-            parent_id,
-            topics,
-            owners,
-        );
-        if !targets.is_empty() {
-            entry = entry.with_target_owners(targets);
-        }
-        match gwt_core::coordination::post_entry(&tab.project_root, entry) {
-            Ok(snapshot) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardEntries {
-                    id,
-                    entries: snapshot.board.entries,
-                },
-            )],
-            Err(error) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id,
-                    message: error.to_string(),
-                },
-            )],
-        }
-    }
-
     pub(crate) fn handle_board_projection_changed_events(
         &self,
         project_root: &Path,
@@ -2801,18 +2661,6 @@ impl AppRuntime {
         );
         Vec::new()
     }
-}
-
-fn sanitize_board_list(values: &[String]) -> Vec<String> {
-    let mut sanitized = Vec::new();
-    for value in values {
-        let trimmed = value.trim();
-        if trimmed.is_empty() || sanitized.iter().any(|item| item == trimmed) {
-            continue;
-        }
-        sanitized.push(trimmed.to_string());
-    }
-    sanitized
 }
 
 fn load_log_entries_from_dir(log_dir: &Path) -> Result<Vec<gwt_core::logging::LogEvent>, String> {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -685,7 +685,7 @@ mod tests {
         .concat();
 
         let main_source = include_str!("main.rs");
-        let runtime_source = include_str!("app_runtime.rs");
+        let runtime_source = include_str!("app_runtime/mod.rs");
 
         assert!(
             !main_source.contains(&forbidden_init),


### PR DESCRIPTION
## Summary

SPEC-2077 (Runtime Daemon) Phase A の実装。 arch-review (PR #2247 / Phase 9 changed files scan) で H2 finding として検出された `crates/gwt/src/app_runtime.rs` (7445 行・103 pub(crate) fn の god module) を handler 種別ごとに段階分割する phase chain の最初の phase。

本 PR では Board entry / projection 関連 handler を `crates/gwt/src/app_runtime/board.rs` に抽出し、 god module 解体 pattern を確立する。 1 module 抽出 + dispatch 経路 1 箇所のみ変更で blast radius 最小。

経緯: gwt-discussion で Mixed phasing (SPEC-1942 は 1 PR、 SPEC-2077 は phase chain) が確定し、 Phase A は SPEC-1974 Phase 9 / Phase 10 で最近触ったコード経路と連携性が高いため最初に着手。

## Changes

### app_runtime ディレクトリ化

- **`crates/gwt/src/app_runtime.rs` を `crates/gwt/src/app_runtime/mod.rs` にリネーム** (git mv)
- 既存内容はそのまま mod.rs として継続、 Board 関連 4 箇所のみ新 module へ移動

### `app_runtime/board.rs` 新規作成 (177 行)

抽出した内容:

- **`BoardPostRequest` struct**: 元 `app_runtime.rs:145-154` (10 行)
- **`AppRuntime::post_board_entry_events` impl extension**: 元 `app_runtime.rs:2300-2422` (~123 行)。 `impl AppRuntime { ... }` 形式で AppRuntime に method を追加 (Rust の impl block 分散機能を使用)
- **`sanitize_board_list` helper**: 元 `app_runtime.rs:2806-2816` (~11 行)、 board.rs に private fn として配置

### `app_runtime/mod.rs` 修正

- `mod board;` 宣言を追加
- `pub(crate) use board::BoardPostRequest;` で re-export し、 既存 caller (`FrontendEvent::PostBoardEntry` dispatch arm 等) のコード変更を最小化
- BoardPostRequest struct / post_board_entry_events impl / sanitize_board_list helper を削除

### `crates/gwt/src/main.rs` 修正

- `include_str!("app_runtime.rs")` を `include_str!("app_runtime/mod.rs")` に更新 (logging assertion test 用、 file rename に追従)

## Testing

- `cargo test -p gwt-core -p gwt` — 全 pass。 SPEC-1974 Phase 9 (`board_family_run_post_persists_target_owners` / `board_entry_target_owners_*` 等) と SPEC-1974 Phase 10 (`format_entry_line_uses_for_you_marker_constant_*` 等) の Board 関連 test が新 `board.rs` 経由で全件 pass することを確認 (FR-018 / SC-009 達成)
- `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` — 0 warnings
- `cargo fmt --check` — 差分なし
- 物理確認: `find crates/gwt/src/app_runtime -name '*.rs' -type f` で `mod.rs` + `board.rs` の 2 ファイル存在
- 行数測定:
  - `mod.rs`: 7445 → 7293 行 (152 行減、 god module 解体の最初の一歩)
  - `board.rs`: 新規 177 行 (Board handler の単一責務 module、 適正サイズ)

## Closing Issues

None.

## Related Issues

- #2077 (SPEC-2077) — domain owner、 phase chain の Phase A を実装
- #1974 (SPEC-1974) — Phase 9 (target_owners) / Phase 10 (`>>` marker) で導入された Board contract が新 `board.rs` で動作 (FR-018 / SC-009)
- #2247 / #2250 — 直前 PR (SPEC-1974 Phase 9 / Phase 10)、 本 PR は arch-review feedback の handoff

## Next Phase (別 PR)

- **Phase B**: Memory handler 抽出 (`app_runtime/memory.rs`)
- **Phase C**: Window handler 抽出 (`app_runtime/window.rs`、 SPEC-2008 連携)
- **Phase D**: Migration handler 抽出 (`app_runtime/migration.rs`、 SPEC-1934 連携)
- **Phase E**: Agent handler 抽出 (`app_runtime/agent.rs`、 SPEC-1921 連携)
- **Phase F**: Wizard handler 抽出 (`app_runtime/wizard.rs`)
- **Phase G** (optional): mod.rs 残部 review、 gwtd 移行候補 identify

各 phase で 1 module 抽出 + dispatch 経路 1 箇所のみ変更を維持し、 phase chain 完了で SC-007 (mod.rs 4000 行未満) を達成する。

## Checklist

- [x] Tests pass (`cargo test -p gwt-core -p gwt`)
- [x] Lint passes (`cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings`)
- [x] Format passes (`cargo fmt --check`)
- [x] SPEC-1974 Board test 群 (Phase 9 / Phase 10) が新 module 経由で全 pass (FR-018 / SC-009)
- [x] 1 module 抽出 + dispatch 経路 1 箇所のみ変更 (FR-016 blast radius 最小)
- [x] `impl AppRuntime` extension 形式で entry point を維持 (FR-017)
- [ ] mod.rs 残部 review (Phase G、 別 PR)
- [ ] SPEC-2077 主 scope (gwt → gwtd 移行) との接続 (Phase G で identify、 別 phase chain で実施)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of board entry handling code structure.

* **Tests**
  * Updated unit tests for logging initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->