### PR TITLE
refactor(app_runtime): wizard state helpers を wizard.rs に抽出 (SPEC-2077 Phase F1)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -147,6 +147,7 @@ mod memory;
 mod migration;
 mod profile;
 mod window;
+mod wizard;
 pub(crate) use board::BoardPostRequest;
 use profile::ProfileSaveRequest;
 
@@ -3219,24 +3220,6 @@ impl AppRuntime {
         })
     }
 
-    pub(crate) fn launch_wizard_state_outbound(&self) -> OutboundEvent {
-        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
-            wizard: self
-                .launch_wizard
-                .as_ref()
-                .map(|wizard| Box::new(wizard.wizard.view())),
-        })
-    }
-
-    pub(crate) fn launch_wizard_state_broadcast(
-        &self,
-        wizard: Option<gwt::LaunchWizardView>,
-    ) -> OutboundEvent {
-        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
-            wizard: wizard.map(Box::new),
-        })
-    }
-
     pub(crate) fn window_status(&self, window_id: &str) -> Option<WindowProcessStatus> {
         let pty_state = self
             .window_pty_statuses
@@ -3328,10 +3311,6 @@ impl AppRuntime {
             self.launch_wizard = None;
         }
         wizard_closed
-    }
-
-    pub(crate) fn clear_launch_wizard(&mut self) -> Option<LaunchWizardSession> {
-        self.launch_wizard.take()
     }
 
     pub(crate) fn rebuild_window_lookup(&mut self) {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -1,0 +1,47 @@
+//! Launch wizard handler split out of `app_runtime/mod.rs` for SPEC-2077
+//! Phase F1 (arch-review handoff, 2026-05-01).
+//!
+//! Phase F1 scope is intentionally narrow: only the wizard state broadcast
+//! / clear helpers move here so that the larger `handle_launch_wizard_action`
+//! (~600 lines) and `spawn_wizard_shell_window*` (~525 lines) helpers can be
+//! split in follow-up phases (F2 / F3) without merge conflicts.
+//!
+//! Owns:
+//! - [`AppRuntime::launch_wizard_state_outbound`] — broadcast the current
+//!   wizard view (or `None`) to all clients
+//! - [`AppRuntime::launch_wizard_state_broadcast`] — broadcast a caller-
+//!   provided view (used after the action handler mutates state)
+//! - [`AppRuntime::clear_launch_wizard`] — drop the in-memory session state
+//!   and return the previous session for any cleanup the caller needs
+//!
+//! [`LaunchWizardSession`] still lives in `mod.rs` because the larger wizard
+//! handlers (Phase F2 / F3 scope) construct and mutate it; once those
+//! phases land the struct can move here too.
+
+use gwt::LaunchWizardView;
+
+use super::{AppRuntime, BackendEvent, LaunchWizardSession, OutboundEvent};
+
+impl AppRuntime {
+    pub(crate) fn launch_wizard_state_outbound(&self) -> OutboundEvent {
+        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
+            wizard: self
+                .launch_wizard
+                .as_ref()
+                .map(|wizard| Box::new(wizard.wizard.view())),
+        })
+    }
+
+    pub(crate) fn launch_wizard_state_broadcast(
+        &self,
+        wizard: Option<LaunchWizardView>,
+    ) -> OutboundEvent {
+        OutboundEvent::broadcast(BackendEvent::LaunchWizardState {
+            wizard: wizard.map(Box::new),
+        })
+    }
+
+    pub(crate) fn clear_launch_wizard(&mut self) -> Option<LaunchWizardSession> {
+        self.launch_wizard.take()
+    }
+}


### PR DESCRIPTION
## Summary

SPEC-2077 Phase F1 (wizard state helpers): 3 small wizard state handler を `crates/gwt/src/app_runtime/wizard.rs` に抽出。 Phase F (Wizard) を blast radius 順で 3 分割した最初の phase。

## Changes

- 新規: `app_runtime/wizard.rs` (50 行) - 3 wizard state handler を impl AppRuntime extension で集約
  - `launch_wizard_state_outbound` (current state broadcast)
  - `launch_wizard_state_broadcast(view)` (caller-provided view broadcast)
  - `clear_launch_wizard` (drop in-memory session、 return previous)
- 修正: `app_runtime/mod.rs` から該当 3 handler 削除 + `mod wizard;` 宣言追加
- mod.rs: 6505 → 6486 行 (Phase F1 で -19 行、 累計 **-959 行**)

## Phase F の 3 分割計画

- **F1 (本 PR)**: state 関連 small (3 handler、 19 行) — scope 小、 dependency 軽い
- **F2 (別 PR)**: action handler 大 (`handle_launch_wizard_action` 単独 ~600 行 + 関連 open handler ~245 行)
- **F3 (別 PR)**: spawn handler 大 (`spawn_wizard_shell_window` ~210 行 + `spawn_wizard_shell_window_async` ~315 行)

`LaunchWizardSession` struct は他の wizard handler (F2/F3) で使われるため mod.rs に残し、 wizard.rs から `super::LaunchWizardSession` で参照。 F2/F3 で全 wizard handler 統合後に struct も wizard.rs へ move 予定。

## Testing

- cargo test -p gwt-core -p gwt: 全 pass
- cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings: 0 warnings
- cargo fmt --check: 差分なし

## Closing Issues

None.

## Related Issues

- #2077 (SPEC-2077) - phase chain Phase F1
- #2256 - 直前 PR (Phase E Profile)、 同 pattern を reuse

## Checklist

- [x] Tests pass
- [x] Lint passes
- [x] Format passes
- [x] dispatch 経路 0 変更 (FR-016 blast radius 最小)
- [x] impl AppRuntime extension 形式 (FR-017)
- [x] LaunchWizardSession struct は F2/F3 まで mod.rs に維持
