### PR TITLE
refactor(app_runtime): spawn_wizard_shell_window を wizard.rs に追加 (SPEC-2077 Phase F3a)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2306,53 +2306,6 @@ impl AppRuntime {
         Ok(events)
     }
 
-    pub(crate) fn spawn_wizard_shell_window(
-        &mut self,
-        tab_id: &str,
-        config: ShellLaunchConfig,
-        bounds: WindowGeometry,
-    ) -> Result<Vec<OutboundEvent>, String> {
-        let tab = self
-            .tab_mut(tab_id)
-            .ok_or_else(|| "Project tab not found".to_string())?;
-        let project_root = tab.project_root.display().to_string();
-        let title = format!(
-            "{} · {}",
-            config.display_name,
-            config.branch.as_ref().unwrap_or(&"workspace".to_string())
-        );
-        let window = tab
-            .workspace
-            .add_window_with_title(WindowPreset::Shell, title, false, bounds);
-        self.register_window(tab_id, &window.id);
-        let window_id = combined_window_id(tab_id, &window.id);
-
-        self.window_pty_statuses
-            .insert(window_id.clone(), WindowProcessStatus::Running);
-        self.window_hook_states.remove(&window_id);
-
-        let mut events = vec![self.workspace_state_broadcast()];
-        events.extend(Self::status_events(
-            window_id.clone(),
-            WindowProcessStatus::Running,
-            Some("Launching...".to_string()),
-        ));
-
-        let proxy = self.proxy.clone();
-        let profile_config_path = self.profile_config_path()?;
-        thread::spawn(move || {
-            Self::spawn_wizard_shell_window_async(
-                proxy,
-                project_root,
-                window_id,
-                config,
-                profile_config_path,
-            )
-        });
-
-        Ok(events)
-    }
-
     pub(crate) fn spawn_agent_window_async(
         proxy: AppEventProxy,
         sessions_dir: PathBuf,

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -23,11 +23,14 @@ use uuid::Uuid;
 
 use crate::UserEvent;
 
+use crate::ShellLaunchConfig;
+
 use super::{
-    branch_worktree_path, detect_wizard_docker_context_and_status, knowledge_error_event,
-    knowledge_kind_for_preset, list_branch_entries_with_active_sessions, normalize_branch_name,
-    preferred_issue_launch_branch, synthetic_branch_entry, AppRuntime, BackendEvent,
-    IssueLaunchWizardPrepared, LaunchWizardSession, OutboundEvent, WindowPreset,
+    branch_worktree_path, combined_window_id, detect_wizard_docker_context_and_status,
+    knowledge_error_event, knowledge_kind_for_preset, list_branch_entries_with_active_sessions,
+    normalize_branch_name, preferred_issue_launch_branch, synthetic_branch_entry, AppRuntime,
+    BackendEvent, IssueLaunchWizardPrepared, LaunchWizardSession, OutboundEvent, WindowPreset,
+    WindowProcessStatus,
 };
 
 impl AppRuntime {
@@ -418,6 +421,53 @@ impl AppRuntime {
                 vec![self.launch_wizard_state_outbound()]
             }
         }
+    }
+
+    pub(crate) fn spawn_wizard_shell_window(
+        &mut self,
+        tab_id: &str,
+        config: ShellLaunchConfig,
+        bounds: WindowGeometry,
+    ) -> Result<Vec<OutboundEvent>, String> {
+        let tab = self
+            .tab_mut(tab_id)
+            .ok_or_else(|| "Project tab not found".to_string())?;
+        let project_root = tab.project_root.display().to_string();
+        let title = format!(
+            "{} · {}",
+            config.display_name,
+            config.branch.as_ref().unwrap_or(&"workspace".to_string())
+        );
+        let window = tab
+            .workspace
+            .add_window_with_title(WindowPreset::Shell, title, false, bounds);
+        self.register_window(tab_id, &window.id);
+        let window_id = combined_window_id(tab_id, &window.id);
+
+        self.window_pty_statuses
+            .insert(window_id.clone(), WindowProcessStatus::Running);
+        self.window_hook_states.remove(&window_id);
+
+        let mut events = vec![self.workspace_state_broadcast()];
+        events.extend(Self::status_events(
+            window_id.clone(),
+            WindowProcessStatus::Running,
+            Some("Launching...".to_string()),
+        ));
+
+        let proxy = self.proxy.clone();
+        let profile_config_path = self.profile_config_path()?;
+        thread::spawn(move || {
+            Self::spawn_wizard_shell_window_async(
+                proxy,
+                project_root,
+                window_id,
+                config,
+                profile_config_path,
+            )
+        });
+
+        Ok(events)
     }
 
     pub(super) fn refresh_open_launch_wizard_from_cache(&mut self) {


### PR DESCRIPTION
## Summary

SPEC-2077 Phase F3a: `spawn_wizard_shell_window` (47 行) を `crates/gwt/src/app_runtime/wizard.rs` に追加。 当初 ~210 行と見積もったが実測 47 行で manageable scope。

## Changes

- 拡張: `app_runtime/wizard.rs` (449 → 503 行) に spawn_wizard_shell_window を追加
- 修正: `app_runtime/mod.rs` から該当 method 削除

## Phase F 残

- F3b (follow-up): spawn_wizard_shell_window_async ~315 行 (Tokio 非同期 + agent launch dependency)
- これで Phase F 完了 → mod.rs の wizard 関連は spawn_wizard_shell_window_async 1 件のみ

## Testing

- cargo test -p gwt-core -p gwt: 全 pass (既知 flake 1 件、 個別 pass)
- cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings: 0 warnings
- cargo fmt --check: 差分なし

## Closing Issues

None.

## Related Issues

- #2077 (SPEC-2077) - phase chain Phase F3a
- #2260 - 直前 PR (Phase F2b)、 同 wizard.rs に拡張


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization to enhance module structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->