### PR TITLE
refactor(app_runtime): spawn_wizard_shell_window_async を wizard.rs に追加 (SPEC-2077 Phase F3b、 Phase F 完成)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2468,43 +2468,6 @@ impl AppRuntime {
         }
     }
 
-    pub(crate) fn spawn_wizard_shell_window_async(
-        proxy: AppEventProxy,
-        project_root: String,
-        window_id: String,
-        mut config: ShellLaunchConfig,
-        profile_config_path: PathBuf,
-    ) {
-        let result = (|| {
-            proxy.send(UserEvent::LaunchProgress {
-                window_id: window_id.clone(),
-                message: "Preparing worktree...".to_string(),
-            });
-            resolve_shell_launch_worktree(Path::new(&project_root), &mut config)?;
-            let worktree_path = config
-                .working_dir
-                .clone()
-                .unwrap_or_else(|| PathBuf::from(&project_root));
-            gwt_agent::LaunchEnvironment::from_active_profile(
-                &profile_config_path,
-                config.runtime_target,
-            )?
-            .with_project_root(&worktree_path)
-            .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
-
-            if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
-                proxy.send(UserEvent::LaunchProgress {
-                    window_id: window_id.clone(),
-                    message: "Starting Docker service...".to_string(),
-                });
-            }
-
-            build_shell_process_launch(Path::new(&project_root), &mut config)
-        })();
-
-        proxy.send(UserEvent::ShellLaunchComplete { window_id, result });
-    }
-
     pub(crate) fn mark_agent_session_stopped(&mut self, window_id: &str) {
         let Some(session) = self.active_agent_sessions.remove(window_id) else {
             return;

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -13,7 +13,10 @@
 //! handlers (Phase F2b / F3 scope) construct and mutate it; once those
 //! phases land the struct can move here too.
 
-use std::{path::Path, thread};
+use std::{
+    path::{Path, PathBuf},
+    thread,
+};
 
 use gwt::{
     KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration,
@@ -21,15 +24,14 @@ use gwt::{
 };
 use uuid::Uuid;
 
-use crate::UserEvent;
-
-use crate::ShellLaunchConfig;
+use crate::{ShellLaunchConfig, UserEvent};
 
 use super::{
-    branch_worktree_path, combined_window_id, detect_wizard_docker_context_and_status,
-    knowledge_error_event, knowledge_kind_for_preset, list_branch_entries_with_active_sessions,
-    normalize_branch_name, preferred_issue_launch_branch, synthetic_branch_entry, AppRuntime,
-    BackendEvent, IssueLaunchWizardPrepared, LaunchWizardSession, OutboundEvent, WindowPreset,
+    branch_worktree_path, build_shell_process_launch, combined_window_id,
+    detect_wizard_docker_context_and_status, knowledge_error_event, knowledge_kind_for_preset,
+    list_branch_entries_with_active_sessions, normalize_branch_name, preferred_issue_launch_branch,
+    resolve_shell_launch_worktree, synthetic_branch_entry, AppEventProxy, AppRuntime, BackendEvent,
+    IssueLaunchWizardPrepared, LaunchWizardSession, OutboundEvent, WindowPreset,
     WindowProcessStatus,
 };
 
@@ -468,6 +470,43 @@ impl AppRuntime {
         });
 
         Ok(events)
+    }
+
+    pub(crate) fn spawn_wizard_shell_window_async(
+        proxy: AppEventProxy,
+        project_root: String,
+        window_id: String,
+        mut config: ShellLaunchConfig,
+        profile_config_path: PathBuf,
+    ) {
+        let result = (|| {
+            proxy.send(UserEvent::LaunchProgress {
+                window_id: window_id.clone(),
+                message: "Preparing worktree...".to_string(),
+            });
+            resolve_shell_launch_worktree(Path::new(&project_root), &mut config)?;
+            let worktree_path = config
+                .working_dir
+                .clone()
+                .unwrap_or_else(|| PathBuf::from(&project_root));
+            gwt_agent::LaunchEnvironment::from_active_profile(
+                &profile_config_path,
+                config.runtime_target,
+            )?
+            .with_project_root(&worktree_path)
+            .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
+
+            if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
+                proxy.send(UserEvent::LaunchProgress {
+                    window_id: window_id.clone(),
+                    message: "Starting Docker service...".to_string(),
+                });
+            }
+
+            build_shell_process_launch(Path::new(&project_root), &mut config)
+        })();
+
+        proxy.send(UserEvent::ShellLaunchComplete { window_id, result });
     }
 
     pub(super) fn refresh_open_launch_wizard_from_cache(&mut self) {


### PR DESCRIPTION
## Summary

SPEC-2077 Phase F3b (Phase F 完成): `spawn_wizard_shell_window_async` (36 行) を `crates/gwt/src/app_runtime/wizard.rs` に追加。 これで Phase F (Wizard handler) の全 9 method 抽出が完了。

## Phase F 完成サマリ

| Sub-phase | PR | 抽出 method | wizard.rs 累計 |
|---|---|---|---|
| F1 | #2257 | wizard state helpers (3) | 50 行 |
| F2a-1 | #2258 | branch open helpers (3) | 162 行 |
| F2a-2 | #2259 | issue open helpers (2) | 305 行 |
| F2b | #2260 | handle_launch_wizard_action (1) | 449 行 |
| F3a | #2261 | spawn_wizard_shell_window (1) | 503 行 |
| **F3b (本 PR)** | — | spawn_wizard_shell_window_async (1) | **533 行** |

合計 9 method、 wizard 関連を wizard.rs に完全集約。 mod.rs に残る wizard 参照は static helper (`launch_wizard_action_error_stage` / `label` / `log_launch_wizard_error` / `sanitize_launch_log_error`) のみで、 これらは impl extension 経由で Self:: で呼べるため抽出不要。

## Changes

- 拡張: `app_runtime/wizard.rs` (503 → 533 行) に spawn_wizard_shell_window_async を追加
- 修正: `app_runtime/mod.rs` から該当 method 削除 (36 行)

## god module 解体累計

- Phase A-F 完了 (12 PR)
- mod.rs: 7445 → **6011 行 (-1434 行、 god module 19.3% 縮小)**
- 6 単一責務 module 抽出: `board.rs` / `memory.rs` / `migration.rs` / `window.rs` / `profile.rs` / `wizard.rs`

## Testing

- cargo test -p gwt-core -p gwt: 全 pass
- cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings: 0 warnings
- cargo fmt --check: 差分なし

## Closing Issues

None.

## Related Issues

- #2077 (SPEC-2077) - Phase F 完成
- #2261 - 直前 PR (Phase F3a)、 同 wizard.rs に拡張

## Next

- Phase G (optional): mod.rs 残部 (現 6011 行) review、 gwtd 移行候補 identify (SPEC-2077 主 scope 接続)
- SPEC-1942 family split 1 PR (CliCommand 51 variants → 10 family)
- release v9.15.0 (develop worktree) — Phase A-F + Phase 10 を一般公開
