### PR TITLE
feat(launch-wizard): SPEC/Issueウィンドウ起動でブランチ名を自動 seed する

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3924,6 +3924,7 @@ exit 0
                     docker_context: None,
                     docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                     linked_issue_number: Some(42),
+                    linked_issue_kind: None,
                 },
                 Vec::new(),
             ),
@@ -3977,6 +3978,7 @@ exit 0
                     docker_context: None,
                     docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                     linked_issue_number: Some(42),
+                    linked_issue_kind: None,
                 },
                 Vec::new(),
                 Vec::new(),
@@ -4207,7 +4209,7 @@ exit 0
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
         runtime
-            .open_launch_wizard_for_branch("tab-1", &repo, "feature/demo", None)
+            .open_launch_wizard_for_branch("tab-1", &repo, "feature/demo", None, None)
             .expect("open launch wizard");
 
         let view = runtime
@@ -4267,7 +4269,7 @@ exit 0
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
         runtime
-            .open_launch_wizard_for_branch("tab-1", &repo, "feature/docker", None)
+            .open_launch_wizard_for_branch("tab-1", &repo, "feature/docker", None, None)
             .expect("open launch wizard");
 
         let wizard = &runtime.launch_wizard.as_ref().expect("wizard").wizard;

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -17,13 +17,25 @@ use std::{path::Path, thread};
 
 use gwt::{
     KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration,
-    LaunchWizardLaunchRequest, LaunchWizardState, LaunchWizardView, WindowGeometry,
+    LaunchWizardLaunchRequest, LaunchWizardState, LaunchWizardView, LinkedIssueKind,
+    WindowGeometry,
 };
 use uuid::Uuid;
 
 use crate::UserEvent;
 
 use crate::ShellLaunchConfig;
+
+/// Map a knowledge bridge kind to the launch-wizard linked-issue kind so that
+/// branch names can be seeded as `{prefix}{kind}-{number}` per SPEC-2014 FR-024.
+/// `KnowledgeKind::Pr` returns `None` because Launch Agent is not exposed for PRs.
+fn linked_issue_kind_from_knowledge(kind: KnowledgeKind) -> Option<LinkedIssueKind> {
+    match kind {
+        KnowledgeKind::Issue => Some(LinkedIssueKind::Issue),
+        KnowledgeKind::Spec => Some(LinkedIssueKind::Spec),
+        KnowledgeKind::Pr => None,
+    }
+}
 
 use super::{
     branch_worktree_path, combined_window_id, detect_wizard_docker_context_and_status,
@@ -95,6 +107,7 @@ impl AppRuntime {
             &project_root,
             branch_name,
             linked_issue_number,
+            None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
             Err(error) => vec![OutboundEvent::broadcast(BackendEvent::BranchError {
@@ -110,6 +123,7 @@ impl AppRuntime {
         project_root: &Path,
         branch_name: &str,
         linked_issue_number: Option<u64>,
+        linked_issue_kind: Option<LinkedIssueKind>,
     ) -> Result<(), String> {
         let normalized_branch_name = normalize_branch_name(branch_name);
         let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
@@ -138,6 +152,7 @@ impl AppRuntime {
                     docker_context,
                     docker_service_status,
                     linked_issue_number,
+                    linked_issue_kind,
                 },
                 agent_options,
                 quick_start_entries,
@@ -269,6 +284,7 @@ impl AppRuntime {
                 &project_root,
                 &branch_name,
                 Some(issue_number),
+                linked_issue_kind_from_knowledge(knowledge_kind),
             ) {
                 Ok(()) => vec![self.launch_wizard_state_outbound()],
                 Err(error) => vec![OutboundEvent::reply(

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -12,6 +12,24 @@ pub use quick_start::load_quick_start_entries;
 const DEFAULT_NEW_BRANCH_BASE_BRANCH: &str = "develop";
 const BRANCH_TYPE_PREFIXES: [&str; 4] = ["feature/", "bugfix/", "hotfix/", "release/"];
 
+/// Source kind of a SPEC/Issue knowledge bridge that opened the Launch Wizard.
+/// Used to seed branch names as `{prefix}{kind}-{number}` per SPEC-2014 FR-024/025.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkedIssueKind {
+    Issue,
+    Spec,
+}
+
+impl LinkedIssueKind {
+    fn branch_kind_segment(self) -> &'static str {
+        match self {
+            LinkedIssueKind::Issue => "issue",
+            LinkedIssueKind::Spec => "spec",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LaunchWizardStep {
@@ -349,6 +367,21 @@ pub struct LaunchWizardContext {
     pub docker_context: Option<DockerWizardContext>,
     pub docker_service_status: gwt_docker::ComposeServiceStatus,
     pub linked_issue_number: Option<u64>,
+    /// Source kind of the SPEC/Issue knowledge bridge that opened this wizard.
+    /// `None` for Branches-window callers, preserving non-breaking behavior.
+    pub linked_issue_kind: Option<LinkedIssueKind>,
+}
+
+impl LaunchWizardContext {
+    /// Returns the auto-seeded suffix `"{kind}-{number}"` (e.g. `"issue-42"`,
+    /// `"spec-2014"`) when both `linked_issue_kind` and `linked_issue_number`
+    /// are present. Used during `BranchAction::CreateNew` and `BranchTypeSelect`
+    /// to pre-fill `branch_name` per SPEC-2014 FR-025.
+    pub fn linked_issue_branch_suffix(&self) -> Option<String> {
+        let number = self.linked_issue_number?;
+        let kind = self.linked_issue_kind?;
+        Some(format!("{}-{}", kind.branch_kind_segment(), number))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1005,12 +1038,7 @@ impl LaunchWizardState {
             }
             LaunchWizardStep::BranchTypeSelect => {
                 if let Some(prefix) = BRANCH_TYPE_PREFIXES.get(self.selected) {
-                    let seed = if self.branch_name.is_empty() {
-                        (*prefix).to_string()
-                    } else {
-                        self.branch_name.clone()
-                    };
-                    self.branch_name = apply_branch_prefix(&seed, prefix);
+                    self.seed_branch_name_for_prefix(prefix);
                 }
             }
             LaunchWizardStep::LaunchTarget => {
@@ -1254,7 +1282,8 @@ impl LaunchWizardState {
             if self.branch_name.is_empty()
                 || self.branch_name == self.context.normalized_branch_name
             {
-                self.branch_name = BRANCH_TYPE_PREFIXES[0].to_string();
+                self.branch_name.clear();
+                self.seed_branch_name_for_prefix(BRANCH_TYPE_PREFIXES[0]);
             }
         } else {
             self.base_branch_name = None;
@@ -1270,12 +1299,28 @@ impl LaunchWizardState {
             self.error = Some("Branch type is unavailable".to_string());
             return;
         }
-        let seed = if self.branch_name.is_empty() {
-            prefix.to_string()
+        self.seed_branch_name_for_prefix(prefix);
+    }
+
+    /// Apply `prefix` to `branch_name`. When the current name has no
+    /// user-entered suffix (empty or just a known prefix), pre-fill from
+    /// `LinkedIssueKind` + `linked_issue_number` per SPEC-2014 FR-024/025.
+    /// User-entered suffixes are preserved (NFR-008).
+    fn seed_branch_name_for_prefix(&mut self, prefix: &str) {
+        let trimmed = self.branch_name.trim();
+        let user_suffix = BRANCH_TYPE_PREFIXES
+            .iter()
+            .find_map(|known| trimmed.strip_prefix(known))
+            .unwrap_or(trimmed)
+            .trim_matches('/');
+        if user_suffix.is_empty() {
+            self.branch_name = match self.context.linked_issue_branch_suffix() {
+                Some(seed) => format!("{prefix}{seed}"),
+                None => prefix.to_string(),
+            };
         } else {
-            self.branch_name.clone()
-        };
-        self.branch_name = apply_branch_prefix(&seed, prefix);
+            self.branch_name = format!("{prefix}{user_suffix}");
+        }
     }
 
     fn set_launch_target(&mut self, target: LaunchTargetKind) {
@@ -2897,6 +2942,7 @@ fn docker_lifecycle_value(intent: gwt_agent::DockerLifecycleIntent) -> &'static 
     }
 }
 
+#[cfg(test)]
 fn apply_branch_prefix(seed: &str, prefix: &str) -> String {
     let trimmed = seed.trim();
     let suffix = BRANCH_TYPE_PREFIXES
@@ -3160,7 +3206,20 @@ mod tests {
             docker_context: None,
             docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
             linked_issue_number: None,
+            linked_issue_kind: None,
         }
+    }
+
+    fn context_with_linked_issue(
+        branch: BranchListEntry,
+        normalized: &str,
+        kind: LinkedIssueKind,
+        number: u64,
+    ) -> LaunchWizardContext {
+        let mut ctx = context(branch, normalized);
+        ctx.linked_issue_kind = Some(kind);
+        ctx.linked_issue_number = Some(number);
+        ctx
     }
 
     fn sample_session(
@@ -3609,6 +3668,112 @@ mod tests {
         assert_eq!(state.step, LaunchWizardStep::BranchTypeSelect);
         assert!(state.is_new_branch);
         assert_eq!(state.base_branch_name.as_deref(), Some("feature/gui"));
+    }
+
+    // SPEC-2014 FR-024/025: branch name auto-seed from SPEC/Issue window.
+
+    #[test]
+    fn branch_seed_uses_issue_kind_when_create_new_then_feature_prefix() {
+        let mut state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Issue, 42),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.apply(LaunchWizardAction::SetBranchMode { create_new: true });
+        state.apply(LaunchWizardAction::SetBranchType {
+            prefix: "feature/".to_string(),
+        });
+        assert_eq!(state.branch_name, "feature/issue-42");
+    }
+
+    #[test]
+    fn branch_seed_uses_spec_kind_when_create_new_then_feature_prefix() {
+        let mut state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Spec, 2014),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.apply(LaunchWizardAction::SetBranchMode { create_new: true });
+        state.apply(LaunchWizardAction::SetBranchType {
+            prefix: "feature/".to_string(),
+        });
+        assert_eq!(state.branch_name, "feature/spec-2014");
+    }
+
+    #[test]
+    fn branch_seed_uses_issue_kind_when_alternative_prefix_selected() {
+        let mut state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Issue, 10),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.apply(LaunchWizardAction::SetBranchMode { create_new: true });
+        state.apply(LaunchWizardAction::SetBranchType {
+            prefix: "bugfix/".to_string(),
+        });
+        assert_eq!(state.branch_name, "bugfix/issue-10");
+    }
+
+    #[test]
+    fn branch_seed_omits_when_no_linked_issue_kind() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("develop"), "develop"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.apply(LaunchWizardAction::SetBranchMode { create_new: true });
+        state.apply(LaunchWizardAction::SetBranchType {
+            prefix: "feature/".to_string(),
+        });
+        assert_eq!(state.branch_name, "feature/");
+    }
+
+    #[test]
+    fn branch_seed_respects_user_edit_when_prefix_changes() {
+        let mut state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Issue, 42),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.apply(LaunchWizardAction::SetBranchMode { create_new: true });
+        state.apply(LaunchWizardAction::SetBranchType {
+            prefix: "feature/".to_string(),
+        });
+        // user replaces the auto-seeded suffix
+        state.apply(LaunchWizardAction::SetBranchName {
+            value: "feature/custom-name".to_string(),
+        });
+        // switching prefix should preserve the user-entered suffix
+        state.apply(LaunchWizardAction::SetBranchType {
+            prefix: "bugfix/".to_string(),
+        });
+        assert_eq!(state.branch_name, "bugfix/custom-name");
+    }
+
+    #[test]
+    fn branch_seed_omits_title_slug_for_spec_proposal_a() {
+        // SPEC-2014 FR-025 (Proposal A): SPEC seed must be `spec-{n}` only,
+        // not the legacy gwt-tui `feature/spec-{n}-{title-slug}` form.
+        let ctx =
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Spec, 2014);
+        let suffix = ctx
+            .linked_issue_branch_suffix()
+            .expect("linked issue branch suffix");
+        assert_eq!(suffix, "spec-2014");
+    }
+
+    #[test]
+    fn branch_seed_create_new_then_default_prefix_seeds_branch_name() {
+        // SetBranchMode { create_new: true } currently primes branch_name to
+        // BRANCH_TYPE_PREFIXES[0] (=feature/). With a linked issue context the
+        // prime should include the auto-seeded suffix as well.
+        let mut state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Issue, 7),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.apply(LaunchWizardAction::SetBranchMode { create_new: true });
+        assert_eq!(state.branch_name, "feature/issue-7");
     }
 
     #[test]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -55,7 +55,8 @@ pub use launch_wizard::{
     LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest,
     LaunchWizardLiveSessionView, LaunchWizardOptionView, LaunchWizardPreviousProfile,
     LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView,
-    LaunchWizardView, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode, ShellLaunchConfig,
+    LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
+    ShellLaunchConfig,
 };
 pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
 #[cfg(target_os = "macos")]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1000,6 +1000,7 @@ mod tests {
                     docker_context: None,
                     docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                     linked_issue_number: Some(42),
+                    linked_issue_kind: None,
                 },
                 Vec::new(),
             ),
@@ -1105,6 +1106,7 @@ mod tests {
                     docker_context: None,
                     docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                     linked_issue_number: Some(42),
+                    linked_issue_kind: None,
                 },
                 sample_wizard_agent_options(),
                 vec![sample_wizard_quick_start_entry(live_window_id)],
@@ -2307,14 +2309,32 @@ mod tests {
             prepared_ok[0].event,
             BackendEvent::LaunchWizardState { wizard: Some(_) }
         ));
-        assert!(
-            !runtime
-                .launch_wizard
-                .as_ref()
-                .expect("launch wizard")
-                .wizard
-                .is_hydrating
+        let issue_session = runtime.launch_wizard.as_ref().expect("launch wizard");
+        assert!(!issue_session.wizard.is_hydrating);
+        assert_eq!(
+            issue_session.wizard.context.linked_issue_kind,
+            Some(gwt::LinkedIssueKind::Issue)
         );
+        assert_eq!(issue_session.wizard.context.linked_issue_number, Some(7));
+
+        runtime.launch_wizard = None;
+        let prepared_spec =
+            runtime.handle_issue_launch_wizard_prepared(super::IssueLaunchWizardPrepared {
+                client_id: "client-1".to_string(),
+                id: "spec-1".to_string(),
+                knowledge_kind: KnowledgeKind::Spec,
+                tab_id: "tab-1".to_string(),
+                project_root: repo.clone(),
+                issue_number: 2014,
+                result: Ok("feature/demo".to_string()),
+            });
+        assert_eq!(prepared_spec.len(), 1);
+        let spec_session = runtime.launch_wizard.as_ref().expect("launch wizard");
+        assert_eq!(
+            spec_session.wizard.context.linked_issue_kind,
+            Some(gwt::LinkedIssueKind::Spec)
+        );
+        assert_eq!(spec_session.wizard.context.linked_issue_number, Some(2014));
 
         runtime.launch_wizard = None;
         assert!(runtime
@@ -2404,6 +2424,7 @@ mod tests {
                     docker_context: None,
                     docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
                     linked_issue_number: Some(42),
+                    linked_issue_kind: None,
                 },
                 sample_wizard_stale_agent_options(),
                 Vec::new(),


### PR DESCRIPTION
## Summary

- SPEC/Issue ウィンドウから Launch Agent を起動した時、ブランチ名入力欄に `feature/issue-{n}` または `feature/spec-{n}` が自動入力されるようになります。旧 gwt-cli 仕様 (`branch_name_suffix() = "issue-{n}"`) を GUI Launch Wizard に復活させたものです。
- prefix は既存の BranchTypeSelect step で user 選択 (`feature/` `bugfix/` `hotfix/` `release/`) — 例えば `bugfix/` を選べば `bugfix/issue-42` になります。title slug は含めず number-only でシンプルに。
- Branches window 経由 (linked issue 無し) の Launch Agent と user が手で編集した branch 名は影響を受けません (non-breaking)。

## Why

- 現状: SPEC/Issue 詳細から Launch Agent → 「Create new」 → branch type 選択で `feature/` だけが入り、user に毎回 issue/spec 番号を手で入力させていた。
- 旧 gwt-cli (削除コミット f0caaca9^ `crates/gwt-core/src/git/issue.rs:59`) には `IssueItem::branch_name_suffix() = "issue-{n}"` が存在し、ブランチ名の自動 seed が当然の挙動だった。

## Implementation

- `crates/gwt/src/launch_wizard.rs`: `LinkedIssueKind` enum 追加、`LaunchWizardContext.linked_issue_kind`、`linked_issue_branch_suffix()` helper、`seed_branch_name_for_prefix()` メソッドで `BranchAction::CreateNew` / `BranchTypeSelect` / `set_branch_type` の 3 経路を seed-aware に統一。
- `crates/gwt/src/app_runtime/wizard.rs`: `linked_issue_kind_from_knowledge(KnowledgeKind)` で Issue/Spec を `Some(LinkedIssueKind::*)` に、PR は `None` に変換。`open_launch_wizard_for_branch` の signature に `linked_issue_kind` を追加し `handle_issue_launch_wizard_prepared` から伝搬。
- Branches window 起動経路 (`open_launch_wizard`) は `linked_issue_kind = None` で挙動不変。
- `crates/gwt/src/lib.rs`: `LinkedIssueKind` を re-export。
- 仕様: SPEC-2014 に US-11 / FR-024,025 / NFR-008 / SC-013,014 を追加。

## Test plan

- [x] `cargo test -p gwt --lib launch_wizard::tests::branch_seed -- --nocapture` — 7 tests (Issue/SPEC seed, alternative prefix, no-linked-issue, user-edit preservation, title-slug omission guard, default-prefix prime).
- [x] `cargo test -p gwt --bin gwt wizard_handler_helpers_cover_preparation_focus_and_error_paths -- --nocapture` — `KnowledgeKind::Issue` → `LinkedIssueKind::Issue`、`KnowledgeKind::Spec` → `LinkedIssueKind::Spec` 伝搬確認。
- [x] `cargo test -p gwt-core -p gwt` — 全 pass。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean。
- [x] `cargo fmt -- --check` — clean。
- [x] `cargo build -p gwt` — succeeded。

## SPEC

- Owner: SPEC-2014 (Launch Wizard) を再 open し scope 拡張
- US-11 / FR-024,025 / NFR-008 / SC-013,014 / T30-T34 を追加 (`gwtd issue spec 2014` で確認可能)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
