### PR TITLE
refactor(cli): CliCommand を family-nested 10 variant 構造へ分割 (SPEC-1942)

### DIFF
--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -39,7 +39,6 @@ use std::{
     path::PathBuf,
 };
 
-pub(crate) use board::parse as parse_board_args;
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
 use gwt_git::PrStatus;
@@ -47,7 +46,6 @@ use gwt_github::{
     cache::write_atomic, ApiError, Cache, IssueClient, IssueNumber, IssueSnapshot, IssueState,
     SpecOpsError,
 };
-pub(crate) use index::parse as parse_index_args;
 
 /// Compact linked PR summary used by `gwtd issue linked-prs`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -131,9 +129,36 @@ pub struct PrEditCall {
     pub add_labels: Vec<String>,
 }
 
-/// Top-level argv parse result for the CLI.
+/// Top-level argv parse result for the CLI. SPEC-1942 FR-088〜092: each top
+/// verb maps to one family-typed inner enum, so the parent enum stays at 10
+/// variants and dispatch becomes a nested match.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CliCommand {
+    /// `gwtd issue ...` — issue + spec management.
+    Issue(IssueCommand),
+    /// `gwtd pr ...` — pull request management.
+    Pr(PrCommand),
+    /// `gwtd actions ...` — GitHub Actions log access.
+    Actions(ActionsCommand),
+    /// `gwtd board ...` — coordination Board read/post.
+    Board(BoardCommand),
+    /// `gwtd hook ...` and `gwtd __internal daemon-hook ...`.
+    Hook(HookCommand),
+    /// `gwtd index ...` — local search index.
+    Index(IndexCommand),
+    /// `gwtd discuss ...` — gwt-discussion exit CLI.
+    Discuss(DiscussCommand),
+    /// `gwtd plan ...` — gwt-plan-spec exit CLI.
+    Plan(PlanCommand),
+    /// `gwtd build ...` — gwt-build-spec exit CLI.
+    Build(BuildCommand),
+    /// `gwtd update [...]` and `gwtd __internal {apply-update,run-installer} ...`.
+    Update(UpdateCommand),
+}
+
+/// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IssueCommand {
     /// `gwtd issue spec <n>` — print all sections.
     SpecReadAll { number: u64 },
     /// `gwtd issue spec <n> --section <name>` — print a single section.
@@ -177,23 +202,28 @@ pub enum CliCommand {
     /// `gwtd issue spec <n> --rename <title>` — update the Issue title.
     SpecRename { number: u64, title: String },
     /// `gwtd issue view <n> [--refresh]` — print a plain issue from cache/live.
-    IssueView { number: u64, refresh: bool },
+    View { number: u64, refresh: bool },
     /// `gwtd issue comments <n> [--refresh]` — print issue comments.
-    IssueComments { number: u64, refresh: bool },
+    Comments { number: u64, refresh: bool },
     /// `gwtd issue linked-prs <n> [--refresh]` — print linked PR summaries.
-    IssueLinkedPrs { number: u64, refresh: bool },
+    LinkedPrs { number: u64, refresh: bool },
     /// `gwtd issue create --title <t> -f <body_file> [--label <l>]*`.
-    IssueCreate {
+    Create {
         title: String,
         file: String,
         labels: Vec<String>,
     },
     /// `gwtd issue comment <n> -f <body_file>` — create a plain issue comment.
-    IssueComment { number: u64, file: String },
-    /// `gwtd pr current` — print the PR associated with the current branch.
-    PrCurrent,
+    Comment { number: u64, file: String },
+}
+
+/// SPEC-1942 family enum for `gwtd pr ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrCommand {
+    /// `gwtd pr current`.
+    Current,
     /// `gwtd pr create --base <branch> [--head <branch>] --title <t> -f <body_file>`.
-    PrCreate {
+    Create {
         base: String,
         head: Option<String>,
         title: String,
@@ -202,32 +232,42 @@ pub enum CliCommand {
         draft: bool,
     },
     /// `gwtd pr edit <n> [--title <t>] [-f <body_file>] [--add-label <label>]*`.
-    PrEdit {
+    Edit {
         number: u64,
         title: Option<String>,
         file: Option<String>,
         add_labels: Vec<String>,
     },
-    /// `gwtd pr view <n>` — print a PR by number.
-    PrView { number: u64 },
-    /// `gwtd pr comment <n> -f <body_file>` — create a PR issue comment.
-    PrComment { number: u64, file: String },
-    /// `gwtd pr reviews <n>` — print PR review summaries.
-    PrReviews { number: u64 },
-    /// `gwtd pr review-threads <n>` — print review thread snapshots.
-    PrReviewThreads { number: u64 },
+    /// `gwtd pr view <n>`.
+    View { number: u64 },
+    /// `gwtd pr comment <n> -f <body_file>`.
+    Comment { number: u64, file: String },
+    /// `gwtd pr reviews <n>`.
+    Reviews { number: u64 },
+    /// `gwtd pr review-threads <n>`.
+    ReviewThreads { number: u64 },
     /// `gwtd pr review-threads reply-and-resolve <n> -f <body_file>`.
-    PrReviewThreadsReplyAndResolve { number: u64, file: String },
-    /// `gwtd pr checks <n>` — print PR checks and summary.
-    PrChecks { number: u64 },
-    /// `gwtd actions logs --run <id>` — print raw GitHub Actions run logs.
-    ActionsLogs { run_id: u64 },
-    /// `gwtd actions job-logs --job <id>` — print raw GitHub Actions job logs.
-    ActionsJobLogs { job_id: u64 },
+    ReviewThreadsReplyAndResolve { number: u64, file: String },
+    /// `gwtd pr checks <n>`.
+    Checks { number: u64 },
+}
+
+/// SPEC-1942 family enum for `gwtd actions ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionsCommand {
+    /// `gwtd actions logs --run <id>`.
+    Logs { run_id: u64 },
+    /// `gwtd actions job-logs --job <id>`.
+    JobLogs { job_id: u64 },
+}
+
+/// SPEC-1942 family enum for `gwtd board ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardCommand {
     /// `gwtd board show [--json]`.
-    BoardShow { json: bool },
+    Show { json: bool },
     /// `gwtd board post --kind <kind> (--body <text> | -f <file>) [--target <id>]`.
-    BoardPost {
+    Post {
         kind: String,
         body: Option<String>,
         file: Option<String>,
@@ -236,30 +276,48 @@ pub enum CliCommand {
         owners: Vec<String>,
         targets: Vec<String>,
     },
-    /// `gwtd index status`.
-    IndexStatus,
-    /// `gwtd index rebuild [--scope <scope>]`.
-    IndexRebuild { scope: IndexScope },
-    /// `gwtd hook <name> [args...]` — dispatch to an in-binary hook handler.
-    ///
-    /// See SPEC #1942 (CORE-CLI) — replaces retired external hook scripts
-    /// and inline shell hooks in `.claude/settings.local.json`.
-    Hook { name: String, rest: Vec<String> },
-    /// `gwtd update [--check]` — check for a new gwt release and optionally apply it.
-    Update { check_only: bool },
-    /// `gwtd __internal apply-update ...` — internal helper: replace the binary then restart.
-    InternalApplyUpdate { rest: Vec<String> },
-    /// `gwtd __internal run-installer ...` — internal helper: run DMG/MSI installer then restart.
-    InternalRunInstaller { rest: Vec<String> },
-    /// `gwtd __internal daemon-hook <name> [args...]` — hidden compatibility helper.
-    InternalDaemonHook { name: String, rest: Vec<String> },
-    /// `gwtd discuss <resolve|park|reject|clear-next-question> --proposal <label>`.
-    Discuss(DiscussAction),
-    /// `gwtd plan <start|phase|complete|abort> --spec <n> [...]`.
-    Plan(SkillStateAction),
-    /// `gwtd build <start|phase|complete|abort> --spec <n> [...]`.
-    Build(SkillStateAction),
 }
+
+/// SPEC-1942 family enum for `gwtd index ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexCommand {
+    /// `gwtd index status`.
+    Status,
+    /// `gwtd index rebuild [--scope <scope>]`.
+    Rebuild { scope: IndexScope },
+}
+
+/// SPEC-1942 family enum for `gwtd hook ...` and `gwtd __internal daemon-hook ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookCommand {
+    /// `gwtd hook <name> [args...]` — visible managed hook entry.
+    Run { name: String, rest: Vec<String> },
+    /// `gwtd __internal daemon-hook <name> [args...]` — hidden helper.
+    InternalDaemon { name: String, rest: Vec<String> },
+}
+
+/// SPEC-1942 family enum for `gwtd update ...` and `gwtd __internal apply-update`/`run-installer`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateCommand {
+    /// `gwtd update --check` — only check and report.
+    CheckOnly,
+    /// `gwtd update` — check and, with approval, download and apply.
+    Apply,
+    /// `gwtd __internal apply-update ...`.
+    InternalApply { rest: Vec<String> },
+    /// `gwtd __internal run-installer ...`.
+    InternalRunInstaller { rest: Vec<String> },
+}
+
+/// SPEC-1942 family enum for `gwtd discuss ...`. Backed by the legacy
+/// [`DiscussAction`] alias to keep call-sites stable.
+pub type DiscussCommand = DiscussAction;
+
+/// SPEC-1942 family enum for `gwtd plan ...`. Backed by [`SkillStateAction`].
+pub type PlanCommand = SkillStateAction;
+
+/// SPEC-1942 family enum for `gwtd build ...`. Backed by [`SkillStateAction`].
+pub type BuildCommand = SkillStateAction;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndexScope {
@@ -344,17 +402,27 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
 /// the first post-subcommand argument — i.e. if the caller received
 /// `["gwt", "issue", "spec", "2001"]`, they pass `["spec", "2001"]`.
 pub fn parse_issue_args(args: &[String]) -> Result<CliCommand, CliParseError> {
-    issue::parse(args)
+    issue::parse(args).map(CliCommand::Issue)
 }
 
 /// Parse an argv slice into a `gwtd pr ...` [`CliCommand`].
 pub fn parse_pr_args(args: &[String]) -> Result<CliCommand, CliParseError> {
-    pr::parse(args)
+    pr::parse(args).map(CliCommand::Pr)
 }
 
 /// Parse an argv slice into a `gwtd actions ...` [`CliCommand`].
 pub fn parse_actions_args(args: &[String]) -> Result<CliCommand, CliParseError> {
-    actions::parse(args)
+    actions::parse(args).map(CliCommand::Actions)
+}
+
+/// Parse an argv slice into a `gwtd board ...` [`CliCommand`].
+pub fn parse_board_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    board::parse(args).map(CliCommand::Board)
+}
+
+/// Parse an argv slice into a `gwtd index ...` [`CliCommand`].
+pub fn parse_index_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    index::parse(args).map(CliCommand::Index)
 }
 
 fn expect_flag(arg: Option<&String>, expected: &'static str) -> Result<(), CliParseError> {
@@ -381,7 +449,8 @@ fn ensure_no_remaining_args<'a>(
     Ok(())
 }
 
-/// Parse the tail of a `gwtd hook ...` argv slice into a [`CliCommand::Hook`].
+/// Parse the tail of a `gwtd hook ...` argv slice into a
+/// [`CliCommand::Hook`] holding [`HookCommand::Run`].
 ///
 /// SPEC #1942 (CORE-CLI): `gwtd hook <name> [args...]` is the single entry
 /// point for every in-binary hook handler. The known hook names are:
@@ -395,10 +464,10 @@ fn ensure_no_remaining_args<'a>(
 /// [`run_hook`].
 pub fn parse_hook_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
-    Ok(CliCommand::Hook {
+    Ok(CliCommand::Hook(HookCommand::Run {
         name: head.clone(),
         rest: rest.to_vec(),
-    })
+    }))
 }
 
 /// Parse `gwtd discuss <action> --proposal <label>` (SPEC-1935 FR-014p).
@@ -480,67 +549,39 @@ fn parse_named_u64(args: &[String], flag: &'static str) -> Result<u64, CliParseE
 
 /// Dispatch a parsed [`CliCommand`] against the given [`CliEnv`].
 ///
-/// We collect output into a String buffer first so the [`SpecOps`] borrow of
+/// SPEC-1942 family-nested form: each parent variant carries the family enum
+/// and we delegate to the matching family module's `run`.
+///
+/// We collect output into a String buffer first so the family run's borrow of
 /// `env.client()` does not conflict with the mutable borrow required by
 /// `env.stdout()` at write time.
 pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError> {
     let mut out = String::new();
     let code = match cmd {
-        cmd @ (CliCommand::SpecReadAll { .. }
-        | CliCommand::SpecReadSection { .. }
-        | CliCommand::SpecEditSection { .. }
-        | CliCommand::SpecEditSectionJson { .. }
-        | CliCommand::SpecList { .. }
-        | CliCommand::SpecCreate { .. }
-        | CliCommand::SpecCreateJson { .. }
-        | CliCommand::SpecCreateHelp
-        | CliCommand::SpecPull { .. }
-        | CliCommand::SpecRepair { .. }
-        | CliCommand::SpecRename { .. }
-        | CliCommand::IssueView { .. }
-        | CliCommand::IssueComments { .. }
-        | CliCommand::IssueLinkedPrs { .. }
-        | CliCommand::IssueCreate { .. }
-        | CliCommand::IssueComment { .. }) => issue::run(env, cmd, &mut out)?,
-        cmd @ (CliCommand::PrCurrent
-        | CliCommand::PrCreate { .. }
-        | CliCommand::PrEdit { .. }
-        | CliCommand::PrView { .. }
-        | CliCommand::PrComment { .. }
-        | CliCommand::PrReviews { .. }
-        | CliCommand::PrReviewThreads { .. }
-        | CliCommand::PrReviewThreadsReplyAndResolve { .. }
-        | CliCommand::PrChecks { .. }) => pr::run(env, cmd, &mut out)?,
-        cmd @ (CliCommand::ActionsLogs { .. } | CliCommand::ActionsJobLogs { .. }) => {
-            actions::run(env, cmd, &mut out)?
-        }
-        cmd @ (CliCommand::BoardShow { .. } | CliCommand::BoardPost { .. }) => {
-            board::run(env, cmd, &mut out)?
-        }
-        cmd @ (CliCommand::IndexStatus | CliCommand::IndexRebuild { .. }) => {
-            index::run(env, cmd, &mut out)?
-        }
+        CliCommand::Issue(inner) => issue::run(env, inner, &mut out)?,
+        CliCommand::Pr(inner) => pr::run(env, inner, &mut out)?,
+        CliCommand::Actions(inner) => actions::run(env, inner, &mut out)?,
+        CliCommand::Board(inner) => board::run(env, inner, &mut out)?,
+        CliCommand::Index(inner) => index::run(env, inner, &mut out)?,
         CliCommand::Discuss(action) => discuss::run(env, action, &mut out)?,
         CliCommand::Plan(action) => plan::run(env, action, &mut out)?,
         CliCommand::Build(action) => build::run(env, action, &mut out)?,
-        CliCommand::Hook { name, rest } => {
+        CliCommand::Hook(HookCommand::Run { name, rest }) => {
             return run_hook(env, &name, &rest);
         }
-        CliCommand::InternalDaemonHook { name, rest } => {
+        CliCommand::Hook(HookCommand::InternalDaemon { name, rest }) => {
             return run_daemon_hook(env, &name, &rest);
         }
-        CliCommand::Update { check_only } => {
-            let cmd = if check_only {
-                update::UpdateCommand::CheckOnly
-            } else {
-                update::UpdateCommand::Apply
-            };
-            std::process::exit(update::run(cmd));
+        CliCommand::Update(UpdateCommand::CheckOnly) => {
+            std::process::exit(update::run(update::UpdateRunMode::CheckOnly));
         }
-        CliCommand::InternalApplyUpdate { rest } => {
+        CliCommand::Update(UpdateCommand::Apply) => {
+            std::process::exit(update::run(update::UpdateRunMode::Apply));
+        }
+        CliCommand::Update(UpdateCommand::InternalApply { rest }) => {
             std::process::exit(update::run_internal_apply_update(&rest));
         }
-        CliCommand::InternalRunInstaller { rest } => {
+        CliCommand::Update(UpdateCommand::InternalRunInstaller { rest }) => {
             std::process::exit(update::run_internal_run_installer(&rest));
         }
     };
@@ -2536,5 +2577,125 @@ fn main() -> ExitCode {
                 .expect("resolved after retry");
             assert_eq!(resolved, 2);
         });
+    }
+
+    /// SPEC-1942 family split (FR-088〜092 / SC-025〜027): the parent
+    /// [`CliCommand`] is a 10-variant nested enum and each top-level verb
+    /// parses into the matching family-typed inner enum. This RED test
+    /// pins the contract before the refactor lands and stays green
+    /// afterwards as the round-trip guard for the family split.
+    #[test]
+    fn cli_command_family_split_round_trip_parses() {
+        use crate::cli::{
+            ActionsCommand, BoardCommand, CliCommand, DiscussCommand, HookCommand, IndexCommand,
+            IssueCommand, PrCommand, UpdateCommand,
+        };
+
+        fn s(value: &str) -> String {
+            value.to_string()
+        }
+
+        // gwtd issue spec list
+        let cmd = parse_issue_args(&[s("spec"), s("list")]).expect("parse issue spec list");
+        assert!(matches!(
+            cmd,
+            CliCommand::Issue(IssueCommand::SpecList {
+                phase: None,
+                state: None
+            })
+        ));
+
+        // gwtd issue view 42 --refresh
+        let cmd =
+            parse_issue_args(&[s("view"), s("42"), s("--refresh")]).expect("parse issue view");
+        assert_eq!(
+            cmd,
+            CliCommand::Issue(IssueCommand::View {
+                number: 42,
+                refresh: true,
+            })
+        );
+
+        // gwtd pr current
+        let cmd = parse_pr_args(&[s("current")]).expect("parse pr current");
+        assert_eq!(cmd, CliCommand::Pr(PrCommand::Current));
+
+        // gwtd pr checks 12
+        let cmd = parse_pr_args(&[s("checks"), s("12")]).expect("parse pr checks");
+        assert_eq!(cmd, CliCommand::Pr(PrCommand::Checks { number: 12 }));
+
+        // gwtd actions logs --run 42
+        let cmd =
+            parse_actions_args(&[s("logs"), s("--run"), s("42")]).expect("parse actions logs");
+        assert_eq!(
+            cmd,
+            CliCommand::Actions(ActionsCommand::Logs { run_id: 42 })
+        );
+
+        // gwtd board show --json
+        let cmd = parse_board_args(&[s("show"), s("--json")]).expect("parse board show");
+        assert_eq!(cmd, CliCommand::Board(BoardCommand::Show { json: true }));
+
+        // gwtd board post --kind status --body x
+        let cmd = parse_board_args(&[s("post"), s("--kind"), s("status"), s("--body"), s("x")])
+            .expect("parse board post");
+        assert!(matches!(
+            cmd,
+            CliCommand::Board(BoardCommand::Post {
+                kind,
+                body: Some(body),
+                file: None,
+                ..
+            }) if kind == "status" && body == "x"
+        ));
+
+        // gwtd index status / rebuild
+        let cmd = parse_index_args(&[s("status")]).expect("parse index status");
+        assert_eq!(cmd, CliCommand::Index(IndexCommand::Status));
+        let cmd = parse_index_args(&[s("rebuild")]).expect("parse index rebuild");
+        assert!(matches!(
+            cmd,
+            CliCommand::Index(IndexCommand::Rebuild {
+                scope: IndexScope::All
+            })
+        ));
+
+        // gwtd hook runtime-state PreToolUse
+        let cmd =
+            parse_hook_args(&[s("runtime-state"), s("PreToolUse")]).expect("parse hook command");
+        assert!(matches!(
+            cmd,
+            CliCommand::Hook(HookCommand::Run { ref name, ref rest })
+                if name == "runtime-state" && rest == &[s("PreToolUse")]
+        ));
+
+        // gwtd discuss park --proposal "Proposal A"
+        let cmd = parse_discuss_args(&[s("park"), s("--proposal"), s("Proposal A")])
+            .expect("parse discuss park");
+        assert!(matches!(
+            cmd,
+            CliCommand::Discuss(DiscussCommand::Park { ref proposal })
+                if proposal == "Proposal A"
+        ));
+
+        // gwtd plan start --spec 1942
+        let cmd = parse_plan_args(&[s("start"), s("--spec"), s("1942")]).expect("parse plan start");
+        assert!(matches!(
+            cmd,
+            CliCommand::Plan(SkillStateAction::Start { spec: 1942 })
+        ));
+
+        // gwtd build start --spec 1942
+        let cmd =
+            parse_build_args(&[s("start"), s("--spec"), s("1942")]).expect("parse build start");
+        assert!(matches!(
+            cmd,
+            CliCommand::Build(SkillStateAction::Start { spec: 1942 })
+        ));
+
+        // `update --check` is parsed inline by `dispatch`. Round-trip it via
+        // the public CliCommand builder to keep the family contract pinned.
+        let cmd = CliCommand::Update(UpdateCommand::CheckOnly);
+        assert!(matches!(cmd, CliCommand::Update(UpdateCommand::CheckOnly)));
     }
 }

--- a/crates/gwt/src/cli/actions.rs
+++ b/crates/gwt/src/cli/actions.rs
@@ -1,21 +1,21 @@
 use gwt_github::SpecOpsError;
 
-use crate::cli::{CliCommand, CliEnv, CliParseError};
+use crate::cli::{ActionsCommand, CliEnv, CliParseError};
 
-pub(super) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
+pub(super) fn parse(args: &[String]) -> Result<ActionsCommand, CliParseError> {
     let mut it = args.iter().peekable();
     match it.next().map(String::as_str) {
         Some("logs") => {
             super::expect_flag(it.next(), "--run")?;
             let run_id = super::parse_required_number(it.next())?;
             super::ensure_no_remaining_args(it)?;
-            Ok(CliCommand::ActionsLogs { run_id })
+            Ok(ActionsCommand::Logs { run_id })
         }
         Some("job-logs") => {
             super::expect_flag(it.next(), "--job")?;
             let job_id = super::parse_required_number(it.next())?;
             super::ensure_no_remaining_args(it)?;
-            Ok(CliCommand::ActionsJobLogs { job_id })
+            Ok(ActionsCommand::JobLogs { job_id })
         }
         Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
         None => Err(CliParseError::Usage),
@@ -24,11 +24,11 @@ pub(super) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
-    cmd: CliCommand,
+    cmd: ActionsCommand,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     let code = match cmd {
-        CliCommand::ActionsLogs { run_id } => {
+        ActionsCommand::Logs { run_id } => {
             let log = env
                 .fetch_actions_run_log(run_id)
                 .map_err(super::io_as_api_error)?;
@@ -38,7 +38,7 @@ pub(super) fn run<E: CliEnv>(
             }
             0
         }
-        CliCommand::ActionsJobLogs { job_id } => {
+        ActionsCommand::JobLogs { job_id } => {
             let log = env
                 .fetch_actions_job_log(job_id)
                 .map_err(super::io_as_api_error)?;
@@ -48,7 +48,6 @@ pub(super) fn run<E: CliEnv>(
             }
             0
         }
-        _ => unreachable!("actions::run called with non-actions command"),
     };
     Ok(code)
 }
@@ -64,7 +63,7 @@ mod tests {
     #[test]
     fn actions_family_parse_directly_handles_logs() {
         let cmd = parse(&[s("logs"), s("--run"), s("101")]).expect("parse actions family command");
-        assert_eq!(cmd, CliCommand::ActionsLogs { run_id: 101 });
+        assert_eq!(cmd, ActionsCommand::Logs { run_id: 101 });
     }
 
     #[test]
@@ -74,7 +73,7 @@ mod tests {
         env.seed_run_log(101, "hello from actions log");
 
         let mut out = String::new();
-        let code = run(&mut env, CliCommand::ActionsLogs { run_id: 101 }, &mut out)
+        let code = run(&mut env, ActionsCommand::Logs { run_id: 101 }, &mut out)
             .expect("run actions family");
 
         assert_eq!(code, 0);

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -7,9 +7,9 @@ use gwt_core::{
 };
 use gwt_github::SpecOpsError;
 
-use crate::cli::{CliCommand, CliEnv, CliParseError};
+use crate::cli::{BoardCommand, CliEnv, CliParseError};
 
-pub(crate) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
+pub(crate) fn parse(args: &[String]) -> Result<BoardCommand, CliParseError> {
     let mut it = args.iter().peekable();
     match it.next().map(String::as_str) {
         Some("show") => {
@@ -20,7 +20,7 @@ pub(crate) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
                     other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
                 }
             }
-            Ok(CliCommand::BoardShow { json })
+            Ok(BoardCommand::Show { json })
         }
         Some("post") => parse_post_args(it.collect::<Vec<_>>().as_slice()),
         Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
@@ -30,11 +30,11 @@ pub(crate) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
-    cmd: CliCommand,
+    cmd: BoardCommand,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     let code = match cmd {
-        CliCommand::BoardShow { json } => {
+        BoardCommand::Show { json } => {
             let snapshot = load_snapshot(env.repo_path()).map_err(gwt_error_to_spec_ops_error)?;
             if json {
                 let rendered = serde_json::to_string_pretty(&snapshot)
@@ -46,7 +46,7 @@ pub(super) fn run<E: CliEnv>(
             }
             0
         }
-        CliCommand::BoardPost {
+        BoardCommand::Post {
             kind,
             body,
             file,
@@ -87,12 +87,11 @@ pub(super) fn run<E: CliEnv>(
             ));
             0
         }
-        _ => unreachable!("board::run called with non-board command"),
     };
     Ok(code)
 }
 
-fn parse_post_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
+fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
     let mut kind: Option<String> = None;
     let mut body: Option<String> = None;
     let mut file: Option<String> = None;
@@ -158,7 +157,7 @@ fn parse_post_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
         i += 1;
     }
 
-    Ok(CliCommand::BoardPost {
+    Ok(BoardCommand::Post {
         kind: kind.ok_or(CliParseError::MissingFlag("--kind"))?,
         body,
         file,
@@ -247,7 +246,7 @@ mod tests {
     #[test]
     fn board_family_parse_show_json() {
         let cmd = parse(&[s("show"), s("--json")]).unwrap();
-        assert_eq!(cmd, CliCommand::BoardShow { json: true });
+        assert_eq!(cmd, BoardCommand::Show { json: true });
     }
 
     #[test]
@@ -264,7 +263,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             cmd,
-            CliCommand::BoardPost {
+            BoardCommand::Post {
                 kind: "request".into(),
                 body: Some("hello".into()),
                 file: None,
@@ -292,7 +291,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             cmd,
-            CliCommand::BoardPost {
+            BoardCommand::Post {
                 kind: "claim".into(),
                 body: Some("I claim feature/foo".into()),
                 file: None,
@@ -312,7 +311,7 @@ mod tests {
         let mut out = String::new();
         let code = run(
             &mut env,
-            CliCommand::BoardPost {
+            BoardCommand::Post {
                 kind: "claim".into(),
                 body: Some("taking the migration".into()),
                 file: None,
@@ -348,7 +347,7 @@ mod tests {
         let mut out = String::new();
         let code = run(
             &mut env,
-            CliCommand::BoardPost {
+            BoardCommand::Post {
                 kind: "request".into(),
                 body: Some("Need a board".into()),
                 file: None,
@@ -390,7 +389,7 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, CliCommand::BoardShow { json: false }, &mut out).unwrap();
+        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
 
         assert_eq!(code, 0);
         assert!(
@@ -419,7 +418,7 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, CliCommand::BoardShow { json: false }, &mut out).unwrap();
+        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("user: legacy entry"));
@@ -447,7 +446,7 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, CliCommand::BoardShow { json: false }, &mut out).unwrap();
+        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("== Chat =="));

--- a/crates/gwt/src/cli/env.rs
+++ b/crates/gwt/src/cli/env.rs
@@ -498,21 +498,30 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "discuss" => super::parse_discuss_args(&rest),
         "plan" => super::parse_plan_args(&rest),
         "build" => super::parse_build_args(&rest),
-        "update" => Ok(super::CliCommand::Update {
-            check_only: rest.iter().any(|a| a == "--check"),
-        }),
+        "update" => {
+            let mode = if rest.iter().any(|a| a == "--check") {
+                super::UpdateCommand::CheckOnly
+            } else {
+                super::UpdateCommand::Apply
+            };
+            Ok(super::CliCommand::Update(mode))
+        }
         "__internal" => match rest.first().map(String::as_str) {
-            Some("apply-update") => Ok(super::CliCommand::InternalApplyUpdate {
-                rest: rest[1..].to_vec(),
-            }),
-            Some("run-installer") => Ok(super::CliCommand::InternalRunInstaller {
-                rest: rest[1..].to_vec(),
-            }),
+            Some("apply-update") => Ok(super::CliCommand::Update(
+                super::UpdateCommand::InternalApply {
+                    rest: rest[1..].to_vec(),
+                },
+            )),
+            Some("run-installer") => Ok(super::CliCommand::Update(
+                super::UpdateCommand::InternalRunInstaller {
+                    rest: rest[1..].to_vec(),
+                },
+            )),
             Some("daemon-hook") => parse_hook_args(&rest[1..]).map(|cmd| match cmd {
-                super::CliCommand::Hook { name, rest } => {
-                    super::CliCommand::InternalDaemonHook { name, rest }
+                super::CliCommand::Hook(super::HookCommand::Run { name, rest }) => {
+                    super::CliCommand::Hook(super::HookCommand::InternalDaemon { name, rest })
                 }
-                _ => unreachable!("parse_hook_args must return CliCommand::Hook"),
+                _ => unreachable!("parse_hook_args must return CliCommand::Hook(Run {{..}})"),
             }),
             other => Err(CliParseError::UnknownSubcommand(format!(
                 "__internal {}",

--- a/crates/gwt/src/cli/index.rs
+++ b/crates/gwt/src/cli/index.rs
@@ -9,18 +9,18 @@ use gwt_core::{repo_hash::RepoHash, worktree_hash::compute_worktree_hash};
 use gwt_github::{client::ApiError, SpecOpsError};
 use serde_json::{json, Map, Value};
 
-use super::{CliCommand, CliEnv, CliParseError, IndexScope};
+use super::{CliEnv, CliParseError, IndexCommand, IndexScope};
 
-pub fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
+pub fn parse(args: &[String]) -> Result<IndexCommand, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     match head.as_str() {
         "status" => {
             if !rest.is_empty() {
                 return Err(CliParseError::Usage);
             }
-            Ok(CliCommand::IndexStatus)
+            Ok(IndexCommand::Status)
         }
-        "rebuild" => Ok(CliCommand::IndexRebuild {
+        "rebuild" => Ok(IndexCommand::Rebuild {
             scope: parse_rebuild_scope(rest)?,
         }),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
@@ -44,11 +44,14 @@ fn parse_rebuild_scope(args: &[String]) -> Result<IndexScope, CliParseError> {
     }
 }
 
-pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand, out: &mut String) -> Result<i32, SpecOpsError> {
+pub fn run<E: CliEnv>(
+    env: &mut E,
+    cmd: IndexCommand,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
     match cmd {
-        CliCommand::IndexStatus => run_status(env, out),
-        CliCommand::IndexRebuild { scope } => run_rebuild(env, scope, out),
-        _ => unreachable!("index::run only accepts index commands"),
+        IndexCommand::Status => run_status(env, out),
+        IndexCommand::Rebuild { scope } => run_rebuild(env, scope, out),
     }
 }
 
@@ -534,16 +537,16 @@ mod tests {
 
     #[test]
     fn parses_index_status_and_rebuild_scope() {
-        assert_eq!(parse(&s(&["status"])).unwrap(), CliCommand::IndexStatus);
+        assert_eq!(parse(&s(&["status"])).unwrap(), IndexCommand::Status);
         assert_eq!(
             parse(&s(&["rebuild", "--scope", "files-docs"])).unwrap(),
-            CliCommand::IndexRebuild {
+            IndexCommand::Rebuild {
                 scope: IndexScope::FilesDocs
             }
         );
         assert_eq!(
             parse(&s(&["rebuild"])).unwrap(),
-            CliCommand::IndexRebuild {
+            IndexCommand::Rebuild {
                 scope: IndexScope::All
             }
         );

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -1,8 +1,8 @@
 use gwt_github::{Cache, IssueClient, IssueNumber, SpecOpsError};
 
-use crate::cli::{CliCommand, CliEnv, CliParseError};
+use crate::cli::{CliEnv, CliParseError, IssueCommand};
 
-pub(super) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
+pub(super) fn parse(args: &[String]) -> Result<IssueCommand, CliParseError> {
     let mut it = args.iter().peekable();
     match it.next().map(String::as_str) {
         Some("spec") => super::issue_spec::parse(it.collect::<Vec<_>>().as_slice()),
@@ -20,43 +20,43 @@ pub(super) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
-    cmd: CliCommand,
+    cmd: IssueCommand,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     if matches!(
         cmd,
-        CliCommand::SpecReadAll { .. }
-            | CliCommand::SpecReadSection { .. }
-            | CliCommand::SpecEditSection { .. }
-            | CliCommand::SpecEditSectionJson { .. }
-            | CliCommand::SpecList { .. }
-            | CliCommand::SpecCreate { .. }
-            | CliCommand::SpecCreateJson { .. }
-            | CliCommand::SpecCreateHelp
-            | CliCommand::SpecPull { .. }
-            | CliCommand::SpecRepair { .. }
-            | CliCommand::SpecRename { .. }
+        IssueCommand::SpecReadAll { .. }
+            | IssueCommand::SpecReadSection { .. }
+            | IssueCommand::SpecEditSection { .. }
+            | IssueCommand::SpecEditSectionJson { .. }
+            | IssueCommand::SpecList { .. }
+            | IssueCommand::SpecCreate { .. }
+            | IssueCommand::SpecCreateJson { .. }
+            | IssueCommand::SpecCreateHelp
+            | IssueCommand::SpecPull { .. }
+            | IssueCommand::SpecRepair { .. }
+            | IssueCommand::SpecRename { .. }
     ) {
         return super::issue_spec::run(env, cmd, out);
     }
 
     let code = match cmd {
-        CliCommand::IssueView { number, refresh } => {
+        IssueCommand::View { number, refresh } => {
             let entry = super::load_or_refresh_issue(env, IssueNumber(number), refresh)?;
             super::render_issue(out, &entry.snapshot);
             0
         }
-        CliCommand::IssueComments { number, refresh } => {
+        IssueCommand::Comments { number, refresh } => {
             let entry = super::load_or_refresh_issue(env, IssueNumber(number), refresh)?;
             super::render_issue_comments(out, &entry.snapshot);
             0
         }
-        CliCommand::IssueLinkedPrs { number, refresh } => {
+        IssueCommand::LinkedPrs { number, refresh } => {
             let linked_prs = super::load_or_refresh_linked_prs(env, IssueNumber(number), refresh)?;
             super::render_linked_prs(out, &linked_prs);
             0
         }
-        CliCommand::IssueCreate {
+        IssueCommand::Create {
             title,
             file,
             labels,
@@ -70,7 +70,7 @@ pub(super) fn run<E: CliEnv>(
             ));
             0
         }
-        CliCommand::IssueComment { number, file } => {
+        IssueCommand::Comment { number, file } => {
             let body = env.read_file(&file).map_err(super::io_as_api_error)?;
             let comment = env.client().create_comment(IssueNumber(number), &body)?;
             let _ = super::refresh_issue_cache(env, IssueNumber(number))?;
@@ -85,7 +85,7 @@ pub(super) fn run<E: CliEnv>(
     Ok(code)
 }
 
-fn parse_issue_read_args(args: &[&String], mode: &str) -> Result<CliCommand, CliParseError> {
+fn parse_issue_read_args(args: &[&String], mode: &str) -> Result<IssueCommand, CliParseError> {
     let Some(number_arg) = args.first() else {
         return Err(CliParseError::Usage);
     };
@@ -100,14 +100,14 @@ fn parse_issue_read_args(args: &[&String], mode: &str) -> Result<CliCommand, Cli
         }
     }
     Ok(match mode {
-        "view" => CliCommand::IssueView { number, refresh },
-        "comments" => CliCommand::IssueComments { number, refresh },
-        "linked-prs" => CliCommand::IssueLinkedPrs { number, refresh },
+        "view" => IssueCommand::View { number, refresh },
+        "comments" => IssueCommand::Comments { number, refresh },
+        "linked-prs" => IssueCommand::LinkedPrs { number, refresh },
         _ => return Err(CliParseError::Usage),
     })
 }
 
-fn parse_issue_create_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
+fn parse_issue_create_args(args: &[&String]) -> Result<IssueCommand, CliParseError> {
     let mut title: Option<String> = None;
     let mut file: Option<String> = None;
     let mut labels: Vec<String> = Vec::new();
@@ -139,14 +139,14 @@ fn parse_issue_create_args(args: &[&String]) -> Result<CliCommand, CliParseError
         }
         i += 1;
     }
-    Ok(CliCommand::IssueCreate {
+    Ok(IssueCommand::Create {
         title: title.ok_or(CliParseError::MissingFlag("--title"))?,
         file: file.ok_or(CliParseError::MissingFlag("-f"))?,
         labels,
     })
 }
 
-fn parse_issue_comment_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
+fn parse_issue_comment_args(args: &[&String]) -> Result<IssueCommand, CliParseError> {
     if args.len() != 3 {
         return Err(CliParseError::Usage);
     }
@@ -154,7 +154,7 @@ fn parse_issue_comment_args(args: &[&String]) -> Result<CliCommand, CliParseErro
         .parse()
         .map_err(|_| CliParseError::InvalidNumber(args[0].clone()))?;
     match args[1].as_str() {
-        "-f" | "--file" => Ok(CliCommand::IssueComment {
+        "-f" | "--file" => Ok(IssueCommand::Comment {
             number,
             file: args[2].clone(),
         }),
@@ -178,7 +178,7 @@ mod tests {
         let cmd = parse(&[s("view"), s("42")]).expect("parse issue family command");
         assert_eq!(
             cmd,
-            CliCommand::IssueView {
+            IssueCommand::View {
                 number: 42,
                 refresh: false,
             }
@@ -192,7 +192,7 @@ mod tests {
         let cmd = crate::cli::issue_spec::parse(&refs).expect("parse spec family command");
         assert_eq!(
             cmd,
-            CliCommand::SpecList {
+            IssueCommand::SpecList {
                 phase: Some("phase/implementation".to_string()),
                 state: None,
             }
@@ -219,7 +219,7 @@ mod tests {
         let mut out = String::new();
         let code = run(
             &mut env,
-            CliCommand::IssueView {
+            IssueCommand::View {
                 number: 42,
                 refresh: false,
             },

--- a/crates/gwt/src/cli/issue_spec.rs
+++ b/crates/gwt/src/cli/issue_spec.rs
@@ -6,7 +6,7 @@ use gwt_github::{
 };
 use serde::Deserialize;
 
-use crate::cli::{CliCommand, CliEnv, CliParseError, ClientRef};
+use crate::cli::{CliEnv, CliParseError, ClientRef, IssueCommand};
 
 const SPEC_SECTION_NAME: &str = "spec";
 const CANONICAL_SECTION_HEADINGS: [&str; 6] = [
@@ -101,7 +101,7 @@ struct StructuredUserStory {
     acceptance_scenarios: Vec<String>,
 }
 
-pub(super) fn parse(args: &[&String]) -> Result<CliCommand, CliParseError> {
+pub(super) fn parse(args: &[&String]) -> Result<IssueCommand, CliParseError> {
     if args.is_empty() {
         return Err(CliParseError::Usage);
     }
@@ -130,7 +130,7 @@ pub(super) fn parse(args: &[&String]) -> Result<CliCommand, CliParseError> {
             }
             i += 1;
         }
-        return Ok(CliCommand::SpecList { phase, state });
+        return Ok(IssueCommand::SpecList { phase, state });
     }
     if head == "create" {
         let mut title: Option<String> = None;
@@ -169,16 +169,16 @@ pub(super) fn parse(args: &[&String]) -> Result<CliCommand, CliParseError> {
             i += 1;
         }
         if help {
-            return Ok(CliCommand::SpecCreateHelp);
+            return Ok(IssueCommand::SpecCreateHelp);
         }
         if json {
-            return Ok(CliCommand::SpecCreateJson {
+            return Ok(IssueCommand::SpecCreateJson {
                 title: title.ok_or(CliParseError::MissingFlag("--title"))?,
                 file,
                 labels,
             });
         }
-        return Ok(CliCommand::SpecCreate {
+        return Ok(IssueCommand::SpecCreate {
             title: title.ok_or(CliParseError::MissingFlag("--title"))?,
             file: file.ok_or(CliParseError::MissingFlag("-f"))?,
             labels,
@@ -200,7 +200,7 @@ pub(super) fn parse(args: &[&String]) -> Result<CliCommand, CliParseError> {
             }
             i += 1;
         }
-        return Ok(CliCommand::SpecPull { all, numbers });
+        return Ok(IssueCommand::SpecPull { all, numbers });
     }
     if head == "repair" {
         if args.len() < 2 {
@@ -209,7 +209,7 @@ pub(super) fn parse(args: &[&String]) -> Result<CliCommand, CliParseError> {
         let number = args[1]
             .parse()
             .map_err(|_| CliParseError::InvalidNumber(args[1].clone()))?;
-        return Ok(CliCommand::SpecRepair { number });
+        return Ok(IssueCommand::SpecRepair { number });
     }
 
     let number = head
@@ -262,18 +262,18 @@ pub(super) fn parse(args: &[&String]) -> Result<CliCommand, CliParseError> {
         return Err(CliParseError::Usage);
     }
     if let Some(title) = rename_title {
-        return Ok(CliCommand::SpecRename { number, title });
+        return Ok(IssueCommand::SpecRename { number, title });
     }
     if let Some(section) = edit_section {
         if json {
-            return Ok(CliCommand::SpecEditSectionJson {
+            return Ok(IssueCommand::SpecEditSectionJson {
                 number,
                 section,
                 file,
                 replace,
             });
         }
-        return Ok(CliCommand::SpecEditSection {
+        return Ok(IssueCommand::SpecEditSection {
             number,
             section,
             file: file.ok_or(CliParseError::MissingFlag("-f"))?,
@@ -283,18 +283,18 @@ pub(super) fn parse(args: &[&String]) -> Result<CliCommand, CliParseError> {
         return Err(CliParseError::Usage);
     }
     if let Some(section) = section {
-        return Ok(CliCommand::SpecReadSection { number, section });
+        return Ok(IssueCommand::SpecReadSection { number, section });
     }
-    Ok(CliCommand::SpecReadAll { number })
+    Ok(IssueCommand::SpecReadAll { number })
 }
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
-    cmd: CliCommand,
+    cmd: IssueCommand,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     let code = match cmd {
-        CliCommand::SpecReadAll { number } => {
+        IssueCommand::SpecReadAll { number } => {
             let cache = Cache::new(env.cache_root());
             let ops = SpecOps::new(
                 ClientRef {
@@ -320,7 +320,7 @@ pub(super) fn run<E: CliEnv>(
             }
             0
         }
-        CliCommand::SpecReadSection { number, section } => {
+        IssueCommand::SpecReadSection { number, section } => {
             let cache = Cache::new(env.cache_root());
             let ops = SpecOps::new(
                 ClientRef {
@@ -332,7 +332,7 @@ pub(super) fn run<E: CliEnv>(
             out.push_str(&format!("{content}\n"));
             0
         }
-        CliCommand::SpecEditSection {
+        IssueCommand::SpecEditSection {
             number,
             section,
             file,
@@ -352,7 +352,7 @@ pub(super) fn run<E: CliEnv>(
             ));
             0
         }
-        CliCommand::SpecEditSectionJson {
+        IssueCommand::SpecEditSectionJson {
             number,
             section,
             file,
@@ -391,7 +391,7 @@ pub(super) fn run<E: CliEnv>(
             ));
             0
         }
-        CliCommand::SpecList { phase, state } => {
+        IssueCommand::SpecList { phase, state } => {
             let filter = SpecListFilter {
                 phase,
                 state: state.as_deref().and_then(|value| match value {
@@ -419,7 +419,7 @@ pub(super) fn run<E: CliEnv>(
             }
             0
         }
-        CliCommand::SpecCreate {
+        IssueCommand::SpecCreate {
             title,
             file,
             labels,
@@ -447,7 +447,7 @@ pub(super) fn run<E: CliEnv>(
             ));
             0
         }
-        CliCommand::SpecCreateJson {
+        IssueCommand::SpecCreateJson {
             title,
             file,
             labels,
@@ -471,14 +471,14 @@ pub(super) fn run<E: CliEnv>(
             ));
             0
         }
-        CliCommand::SpecCreateHelp => {
+        IssueCommand::SpecCreateHelp => {
             out.push_str(SPEC_CREATE_HELP);
             if !SPEC_CREATE_HELP.ends_with('\n') {
                 out.push('\n');
             }
             0
         }
-        CliCommand::SpecPull { all, numbers } => {
+        IssueCommand::SpecPull { all, numbers } => {
             let cache = Cache::new(env.cache_root());
             let ops = SpecOps::new(
                 ClientRef {
@@ -505,7 +505,7 @@ pub(super) fn run<E: CliEnv>(
             }
             0
         }
-        CliCommand::SpecRepair { number } => {
+        IssueCommand::SpecRepair { number } => {
             let cache = Cache::new(env.cache_root());
             let ops = SpecOps::new(
                 ClientRef {
@@ -517,7 +517,7 @@ pub(super) fn run<E: CliEnv>(
             out.push_str(&format!("repaired cache for #{number}\n"));
             0
         }
-        CliCommand::SpecRename { number, title } => {
+        IssueCommand::SpecRename { number, title } => {
             let snapshot = env.client().patch_title(IssueNumber(number), &title)?;
             Cache::new(env.cache_root()).write_snapshot(&snapshot)?;
             out.push_str(&format!(
@@ -1176,7 +1176,7 @@ Preserve me.
         let refs = args.iter().collect::<Vec<_>>();
         assert!(matches!(
             parse(&refs),
-            Ok(CliCommand::SpecList { phase, state })
+            Ok(IssueCommand::SpecList { phase, state })
                 if phase.as_deref() == Some("review") && state.as_deref() == Some("closed")
         ));
 
@@ -1193,7 +1193,7 @@ Preserve me.
         let refs = args.iter().collect::<Vec<_>>();
         assert!(matches!(
             parse(&refs),
-            Ok(CliCommand::SpecCreateJson { title, file, labels })
+            Ok(IssueCommand::SpecCreateJson { title, file, labels })
                 if title == "SPEC: Launch"
                     && file.as_deref() == Some("spec.json")
                     && labels == vec!["phase/review".to_string()]
@@ -1201,7 +1201,7 @@ Preserve me.
 
         let args = ["create".to_string(), "--help".to_string()];
         let refs = args.iter().collect::<Vec<_>>();
-        assert!(matches!(parse(&refs), Ok(CliCommand::SpecCreateHelp)));
+        assert!(matches!(parse(&refs), Ok(IssueCommand::SpecCreateHelp)));
 
         let args = [
             "1942".to_string(),
@@ -1215,7 +1215,7 @@ Preserve me.
         let refs = args.iter().collect::<Vec<_>>();
         assert!(matches!(
             parse(&refs),
-            Ok(CliCommand::SpecEditSectionJson {
+            Ok(IssueCommand::SpecEditSectionJson {
                 number,
                 section,
                 file,
@@ -1231,14 +1231,14 @@ Preserve me.
         let refs = args.iter().collect::<Vec<_>>();
         assert!(matches!(
             parse(&refs),
-            Ok(CliCommand::SpecPull { all, numbers }) if all && numbers == vec![77]
+            Ok(IssueCommand::SpecPull { all, numbers }) if all && numbers == vec![77]
         ));
 
         let args = ["repair".to_string(), "77".to_string()];
         let refs = args.iter().collect::<Vec<_>>();
         assert!(matches!(
             parse(&refs),
-            Ok(CliCommand::SpecRepair { number }) if number == 77
+            Ok(IssueCommand::SpecRepair { number }) if number == 77
         ));
 
         let args = [
@@ -1249,7 +1249,7 @@ Preserve me.
         let refs = args.iter().collect::<Vec<_>>();
         assert!(matches!(
             parse(&refs),
-            Ok(CliCommand::SpecRename { number, title })
+            Ok(IssueCommand::SpecRename { number, title })
                 if number == 77 && title == "SPEC: Renamed"
         ));
 
@@ -1292,7 +1292,7 @@ Preserve me.
 
         let mut out = String::new();
         assert_eq!(
-            run(&mut env, CliCommand::SpecReadAll { number: 42 }, &mut out).unwrap(),
+            run(&mut env, IssueCommand::SpecReadAll { number: 42 }, &mut out).unwrap(),
             0
         );
         assert!(out.contains("=== spec ===\nspec body"));
@@ -1302,7 +1302,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecReadSection {
+                IssueCommand::SpecReadSection {
                     number: 42,
                     section: "tasks".to_string(),
                 },
@@ -1317,7 +1317,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecList {
+                IssueCommand::SpecList {
                     phase: Some("review".to_string()),
                     state: Some("open".to_string()),
                 },
@@ -1336,7 +1336,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecCreate {
+                IssueCommand::SpecCreate {
                     title: "SPEC: Created from markdown".to_string(),
                     file: "legacy.md".to_string(),
                     labels: vec!["gwt-spec".to_string()],
@@ -1357,7 +1357,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecCreateJson {
+                IssueCommand::SpecCreateJson {
                     title: "SPEC: Created from json".to_string(),
                     file: None,
                     labels: vec!["gwt-spec".to_string()],
@@ -1371,7 +1371,7 @@ Preserve me.
 
         out.clear();
         assert_eq!(
-            run(&mut env, CliCommand::SpecCreateHelp, &mut out).unwrap(),
+            run(&mut env, IssueCommand::SpecCreateHelp, &mut out).unwrap(),
             0
         );
         assert!(out.contains("Input JSON schema:"));
@@ -1380,7 +1380,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecPull {
+                IssueCommand::SpecPull {
                     all: true,
                     numbers: Vec::new(),
                 },
@@ -1395,7 +1395,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecPull {
+                IssueCommand::SpecPull {
                     all: false,
                     numbers: vec![42],
                 },
@@ -1408,7 +1408,7 @@ Preserve me.
 
         let err = run(
             &mut env,
-            CliCommand::SpecPull {
+            IssueCommand::SpecPull {
                 all: false,
                 numbers: Vec::new(),
             },
@@ -1419,7 +1419,7 @@ Preserve me.
 
         out.clear();
         assert_eq!(
-            run(&mut env, CliCommand::SpecRepair { number: 42 }, &mut out).unwrap(),
+            run(&mut env, IssueCommand::SpecRepair { number: 42 }, &mut out).unwrap(),
             0
         );
         assert_eq!(out, "repaired cache for #42\n");
@@ -1428,7 +1428,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecRename {
+                IssueCommand::SpecRename {
                     number: 42,
                     title: "SPEC: Renamed".to_string(),
                 },
@@ -1464,7 +1464,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecEditSection {
+                IssueCommand::SpecEditSection {
                     number: 7,
                     section: "tasks".to_string(),
                     file: "tasks.md".to_string(),
@@ -1485,7 +1485,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecEditSectionJson {
+                IssueCommand::SpecEditSectionJson {
                     number: 7,
                     section: "spec".to_string(),
                     file: None,
@@ -1513,7 +1513,7 @@ Preserve me.
         assert_eq!(
             run(
                 &mut env,
-                CliCommand::SpecEditSectionJson {
+                IssueCommand::SpecEditSectionJson {
                     number: 7,
                     section: "spec".to_string(),
                     file: Some("replace.json".to_string()),
@@ -1536,7 +1536,7 @@ Preserve me.
 
         let err = run(
             &mut env,
-            CliCommand::SpecEditSectionJson {
+            IssueCommand::SpecEditSectionJson {
                 number: 7,
                 section: "tasks".to_string(),
                 file: None,

--- a/crates/gwt/src/cli/pr.rs
+++ b/crates/gwt/src/cli/pr.rs
@@ -1,32 +1,32 @@
 use gwt_github::SpecOpsError;
 
-use crate::cli::{CliCommand, CliEnv, CliParseError};
+use crate::cli::{CliEnv, CliParseError, PrCommand};
 
-pub(super) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
+pub(super) fn parse(args: &[String]) -> Result<PrCommand, CliParseError> {
     let mut it = args.iter().peekable();
     match it.next().map(String::as_str) {
         Some("current") => {
             super::ensure_no_remaining_args(it)?;
-            Ok(CliCommand::PrCurrent)
+            Ok(PrCommand::Current)
         }
         Some("create") => parse_pr_create_args(it.collect::<Vec<_>>().as_slice()),
         Some("edit") => parse_pr_edit_args(it.collect::<Vec<_>>().as_slice()),
         Some("view") => {
             let number = super::parse_required_number(it.next())?;
             super::ensure_no_remaining_args(it)?;
-            Ok(CliCommand::PrView { number })
+            Ok(PrCommand::View { number })
         }
         Some("comment") => {
             let number = super::parse_required_number(it.next())?;
             super::expect_flag(it.next(), "-f")?;
             let file = it.next().ok_or(CliParseError::MissingFlag("-f"))?.clone();
             super::ensure_no_remaining_args(it)?;
-            Ok(CliCommand::PrComment { number, file })
+            Ok(PrCommand::Comment { number, file })
         }
         Some("reviews") => {
             let number = super::parse_required_number(it.next())?;
             super::ensure_no_remaining_args(it)?;
-            Ok(CliCommand::PrReviews { number })
+            Ok(PrCommand::Reviews { number })
         }
         Some("review-threads") => match it.next().map(String::as_str) {
             Some("reply-and-resolve") => {
@@ -34,21 +34,21 @@ pub(super) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
                 super::expect_flag(it.next(), "-f")?;
                 let file = it.next().ok_or(CliParseError::MissingFlag("-f"))?.clone();
                 super::ensure_no_remaining_args(it)?;
-                Ok(CliCommand::PrReviewThreadsReplyAndResolve { number, file })
+                Ok(PrCommand::ReviewThreadsReplyAndResolve { number, file })
             }
             Some(number_arg) => {
                 let number = number_arg
                     .parse()
                     .map_err(|_| CliParseError::InvalidNumber(number_arg.to_string()))?;
                 super::ensure_no_remaining_args(it)?;
-                Ok(CliCommand::PrReviewThreads { number })
+                Ok(PrCommand::ReviewThreads { number })
             }
             None => Err(CliParseError::Usage),
         },
         Some("checks") => {
             let number = super::parse_required_number(it.next())?;
             super::ensure_no_remaining_args(it)?;
-            Ok(CliCommand::PrChecks { number })
+            Ok(PrCommand::Checks { number })
         }
         Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
         None => Err(CliParseError::Usage),
@@ -57,18 +57,18 @@ pub(super) fn parse(args: &[String]) -> Result<CliCommand, CliParseError> {
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
-    cmd: CliCommand,
+    cmd: PrCommand,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     let code = match cmd {
-        CliCommand::PrCurrent => {
+        PrCommand::Current => {
             match env.fetch_current_pr().map_err(super::io_as_api_error)? {
                 Some(pr) => super::render_pr(out, &pr),
                 None => out.push_str("no current pull request\n"),
             }
             0
         }
-        CliCommand::PrCreate {
+        PrCommand::Create {
             base,
             head,
             title,
@@ -84,7 +84,7 @@ pub(super) fn run<E: CliEnv>(
             super::render_pr(out, &pr);
             0
         }
-        CliCommand::PrEdit {
+        PrCommand::Edit {
             number,
             title,
             file,
@@ -101,33 +101,33 @@ pub(super) fn run<E: CliEnv>(
             super::render_pr(out, &pr);
             0
         }
-        CliCommand::PrView { number } => {
+        PrCommand::View { number } => {
             let pr = env.fetch_pr(number).map_err(super::io_as_api_error)?;
             super::render_pr(out, &pr);
             0
         }
-        CliCommand::PrComment { number, file } => {
+        PrCommand::Comment { number, file } => {
             let body = env.read_file(&file).map_err(super::io_as_api_error)?;
             env.comment_on_pr(number, &body)
                 .map_err(super::io_as_api_error)?;
             out.push_str(&format!("created comment on PR #{number}\n"));
             0
         }
-        CliCommand::PrReviews { number } => {
+        PrCommand::Reviews { number } => {
             let reviews = env
                 .fetch_pr_reviews(number)
                 .map_err(super::io_as_api_error)?;
             super::render_pr_reviews(out, &reviews);
             0
         }
-        CliCommand::PrReviewThreads { number } => {
+        PrCommand::ReviewThreads { number } => {
             let threads = env
                 .fetch_pr_review_threads(number)
                 .map_err(super::io_as_api_error)?;
             super::render_pr_review_threads(out, &threads);
             0
         }
-        CliCommand::PrReviewThreadsReplyAndResolve { number, file } => {
+        PrCommand::ReviewThreadsReplyAndResolve { number, file } => {
             let body = env.read_file(&file).map_err(super::io_as_api_error)?;
             let resolved = env
                 .reply_and_resolve_pr_review_threads(number, &body)
@@ -137,19 +137,18 @@ pub(super) fn run<E: CliEnv>(
             ));
             0
         }
-        CliCommand::PrChecks { number } => {
+        PrCommand::Checks { number } => {
             let report = env
                 .fetch_pr_checks(number)
                 .map_err(super::io_as_api_error)?;
             super::render_pr_checks(out, &report);
             0
         }
-        _ => unreachable!("pr::run called with non-pr command"),
     };
     Ok(code)
 }
 
-fn parse_pr_create_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
+fn parse_pr_create_args(args: &[&String]) -> Result<PrCommand, CliParseError> {
     let mut base: Option<String> = None;
     let mut head: Option<String> = None;
     let mut title: Option<String> = None;
@@ -199,7 +198,7 @@ fn parse_pr_create_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
         }
         i += 1;
     }
-    Ok(CliCommand::PrCreate {
+    Ok(PrCommand::Create {
         base: base.ok_or(CliParseError::MissingFlag("--base"))?,
         head,
         title: title.ok_or(CliParseError::MissingFlag("--title"))?,
@@ -209,7 +208,7 @@ fn parse_pr_create_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
     })
 }
 
-fn parse_pr_edit_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
+fn parse_pr_edit_args(args: &[&String]) -> Result<PrCommand, CliParseError> {
     let Some(number_arg) = args.first() else {
         return Err(CliParseError::Usage);
     };
@@ -250,7 +249,7 @@ fn parse_pr_edit_args(args: &[&String]) -> Result<CliCommand, CliParseError> {
     if title.is_none() && file.is_none() && add_labels.is_empty() {
         return Err(CliParseError::Usage);
     }
-    Ok(CliCommand::PrEdit {
+    Ok(PrCommand::Edit {
         number,
         title,
         file,
@@ -282,7 +281,7 @@ mod tests {
     #[test]
     fn pr_family_parse_directly_handles_current() {
         let cmd = parse(&[s("current")]).expect("parse pr family command");
-        assert_eq!(cmd, CliCommand::PrCurrent);
+        assert_eq!(cmd, PrCommand::Current);
     }
 
     #[test]
@@ -292,7 +291,7 @@ mod tests {
         env.seed_current_pr(Some(seeded_pr()));
 
         let mut out = String::new();
-        let code = run(&mut env, CliCommand::PrCurrent, &mut out).expect("run pr family");
+        let code = run(&mut env, PrCommand::Current, &mut out).expect("run pr family");
 
         assert_eq!(code, 0);
         assert!(out.contains("#7 [OPEN] CLI family split"));

--- a/crates/gwt/src/cli/update.rs
+++ b/crates/gwt/src/cli/update.rs
@@ -9,7 +9,7 @@ use gwt_core::update::{is_ci, InstallerKind, PreparedPayload, UpdateManager, Upd
 
 /// Parsed form of `gwtd update` arguments.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum UpdateCommand {
+pub enum UpdateRunMode {
     /// Only check and report; do not download or apply.
     CheckOnly,
     /// Check and, with user approval, download and apply.
@@ -142,15 +142,15 @@ impl UpdateCliOps for RealUpdateCliOps {
 }
 
 /// Parse `gwtd update [--check]` arguments.
-pub fn parse_args(args: &[String]) -> UpdateCommand {
+pub fn parse_args(args: &[String]) -> UpdateRunMode {
     if args.iter().any(|a| a == "--check") {
-        UpdateCommand::CheckOnly
+        UpdateRunMode::CheckOnly
     } else {
-        UpdateCommand::Apply
+        UpdateRunMode::Apply
     }
 }
 
-fn run_with(ops: &mut impl UpdateCliOps, cmd: UpdateCommand) -> RunOutcome {
+fn run_with(ops: &mut impl UpdateCliOps, cmd: UpdateRunMode) -> RunOutcome {
     if ops.is_ci() {
         ops.write_stdout("Update check skipped in CI environment.\n");
         return RunOutcome::Code(0);
@@ -177,7 +177,7 @@ fn run_with(ops: &mut impl UpdateCliOps, cmd: UpdateCommand) -> RunOutcome {
         } => {
             ops.write_stdout(&format!("Update available: v{current} → v{latest}\n"));
 
-            if cmd == UpdateCommand::CheckOnly {
+            if cmd == UpdateRunMode::CheckOnly {
                 return RunOutcome::Code(0);
             }
 
@@ -281,7 +281,7 @@ fn run_with(ops: &mut impl UpdateCliOps, cmd: UpdateCommand) -> RunOutcome {
 /// Run the update command.
 ///
 /// Returns the process exit code (0 = success, non-zero = error).
-pub fn run(cmd: UpdateCommand) -> i32 {
+pub fn run(cmd: UpdateRunMode) -> i32 {
     let mut ops = RealUpdateCliOps::default();
     match run_with(&mut ops, cmd) {
         RunOutcome::Code(code) => code,
@@ -540,13 +540,13 @@ mod tests {
     #[test]
     fn parse_args_defaults_to_apply() {
         let args: Vec<String> = vec![];
-        assert_eq!(parse_args(&args), UpdateCommand::Apply);
+        assert_eq!(parse_args(&args), UpdateRunMode::Apply);
     }
 
     #[test]
     fn parse_args_check_flag() {
         let args = vec!["--check".to_string()];
-        assert_eq!(parse_args(&args), UpdateCommand::CheckOnly);
+        assert_eq!(parse_args(&args), UpdateRunMode::CheckOnly);
     }
 
     #[test]
@@ -565,7 +565,7 @@ mod tests {
     fn run_check_only_returns_zero_in_ci() {
         let _guard = CI_ENV_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
         std::env::set_var("CI", "true");
-        let code = run(UpdateCommand::CheckOnly);
+        let code = run(UpdateRunMode::CheckOnly);
         std::env::remove_var("CI");
         assert_eq!(code, 0);
     }
@@ -574,7 +574,7 @@ mod tests {
     fn run_apply_returns_zero_in_ci() {
         let _guard = CI_ENV_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
         std::env::set_var("CI", "true");
-        let code = run(UpdateCommand::Apply);
+        let code = run(UpdateRunMode::Apply);
         std::env::remove_var("CI");
         assert_eq!(code, 0);
     }
@@ -627,7 +627,7 @@ mod tests {
         let mut ci = FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         ci.is_ci = true;
         assert!(matches!(
-            run_with(&mut ci, UpdateCommand::Apply),
+            run_with(&mut ci, UpdateRunMode::Apply),
             RunOutcome::Code(0)
         ));
         assert!(ci.stdout.contains("skipped in CI"));
@@ -637,7 +637,7 @@ mod tests {
             checked_at: Some(chrono::Utc::now()),
         };
         assert!(matches!(
-            run_with(&mut up_to_date, UpdateCommand::Apply),
+            run_with(&mut up_to_date, UpdateRunMode::Apply),
             RunOutcome::Code(0)
         ));
         assert!(up_to_date.stdout.contains("up to date"));
@@ -648,7 +648,7 @@ mod tests {
             failed_at: chrono::Utc::now(),
         };
         assert!(matches!(
-            run_with(&mut failed, UpdateCommand::Apply),
+            run_with(&mut failed, UpdateRunMode::Apply),
             RunOutcome::Code(1)
         ));
         assert!(failed.stderr.contains("network down"));
@@ -658,7 +658,7 @@ mod tests {
     fn run_with_covers_check_only_cancel_and_missing_asset_paths() {
         let mut check_only = FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         assert!(matches!(
-            run_with(&mut check_only, UpdateCommand::CheckOnly),
+            run_with(&mut check_only, UpdateRunMode::CheckOnly),
             RunOutcome::Code(0)
         ));
         assert!(check_only.stdout.contains("Update available"));
@@ -667,14 +667,14 @@ mod tests {
         let mut cancelled = FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         cancelled.input_line = Ok("n\n".to_string());
         assert!(matches!(
-            run_with(&mut cancelled, UpdateCommand::Apply),
+            run_with(&mut cancelled, UpdateRunMode::Apply),
             RunOutcome::Code(0)
         ));
         assert!(cancelled.stdout.contains("Update cancelled"));
 
         let mut missing_asset = FakeUpdateCliOps::available(None);
         assert!(matches!(
-            run_with(&mut missing_asset, UpdateCommand::Apply),
+            run_with(&mut missing_asset, UpdateRunMode::Apply),
             RunOutcome::Code(1)
         ));
         assert!(missing_asset
@@ -687,7 +687,7 @@ mod tests {
         let mut prepare_error = FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         prepare_error.prepare_update_result = Err("download broke".to_string());
         assert!(matches!(
-            run_with(&mut prepare_error, UpdateCommand::Apply),
+            run_with(&mut prepare_error, UpdateRunMode::Apply),
             RunOutcome::Code(1)
         ));
         assert!(prepare_error.stderr.contains("Download failed"));
@@ -696,7 +696,7 @@ mod tests {
             FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         current_exe_error.current_exe = Err(io::Error::new(io::ErrorKind::NotFound, "missing"));
         assert!(matches!(
-            run_with(&mut current_exe_error, UpdateCommand::Apply),
+            run_with(&mut current_exe_error, UpdateRunMode::Apply),
             RunOutcome::Code(1)
         ));
         assert!(current_exe_error
@@ -706,7 +706,7 @@ mod tests {
         let mut restart_error = FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         restart_error.write_restart_args_result = Err("disk full".to_string());
         assert!(matches!(
-            run_with(&mut restart_error, UpdateCommand::Apply),
+            run_with(&mut restart_error, UpdateRunMode::Apply),
             RunOutcome::Code(1)
         ));
         assert!(restart_error
@@ -723,7 +723,7 @@ mod tests {
     fn run_with_covers_helper_copy_and_spawn_paths() {
         let mut apply = FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         assert!(matches!(
-            run_with(&mut apply, UpdateCommand::Apply),
+            run_with(&mut apply, UpdateRunMode::Apply),
             RunOutcome::ExitSuccess
         ));
         if cfg!(windows) {
@@ -737,7 +737,7 @@ mod tests {
         let mut apply_error = FakeUpdateCliOps::available(Some("https://example.test/gwt.zip"));
         apply_error.spawn_apply_result = Err("spawn failed".to_string());
         assert!(matches!(
-            run_with(&mut apply_error, UpdateCommand::Apply),
+            run_with(&mut apply_error, UpdateRunMode::Apply),
             RunOutcome::Code(1)
         ));
         assert!(apply_error.stderr.contains("Failed to apply update"));
@@ -746,7 +746,7 @@ mod tests {
         helper_error.make_helper_copy_result = Err("copy failed".to_string());
         if cfg!(windows) {
             assert!(matches!(
-                run_with(&mut helper_error, UpdateCommand::Apply),
+                run_with(&mut helper_error, UpdateRunMode::Apply),
                 RunOutcome::Code(1)
             ));
             assert!(helper_error
@@ -754,7 +754,7 @@ mod tests {
                 .contains("Failed to create update helper"));
         } else {
             assert!(matches!(
-                run_with(&mut helper_error, UpdateCommand::Apply),
+                run_with(&mut helper_error, UpdateRunMode::Apply),
                 RunOutcome::ExitSuccess
             ));
             assert!(helper_error.helper_copy_calls.is_empty());
@@ -766,7 +766,7 @@ mod tests {
             kind: InstallerKind::WindowsMsi,
         });
         assert!(matches!(
-            run_with(&mut installer, UpdateCommand::Apply),
+            run_with(&mut installer, UpdateRunMode::Apply),
             RunOutcome::ExitSuccess
         ));
         assert_eq!(installer.installer_calls.len(), 1);
@@ -778,7 +778,7 @@ mod tests {
         });
         installer_error.spawn_installer_result = Err("installer failed".to_string());
         assert!(matches!(
-            run_with(&mut installer_error, UpdateCommand::Apply),
+            run_with(&mut installer_error, UpdateRunMode::Apply),
             RunOutcome::Code(1)
         ));
         assert!(installer_error.stderr.contains("Failed to apply update"));

--- a/crates/gwt/tests/cli_test.rs
+++ b/crates/gwt/tests/cli_test.rs
@@ -1,9 +1,10 @@
 //! Integration tests for the `gwtd issue spec` CLI dispatch (SPEC-12 Phase 6).
 
 use gwt::cli::{
-    dispatch, parse_actions_args, parse_issue_args, parse_pr_args, should_dispatch_cli, CliCommand,
-    CliParseError, LinkedPrSummary, PrCheckItem, PrChecksSummary, PrCreateCall, PrEditCall,
-    PrReview, PrReviewThread, PrReviewThreadComment, TestEnv,
+    dispatch, parse_actions_args, parse_issue_args, parse_pr_args, should_dispatch_cli,
+    ActionsCommand, CliCommand, CliParseError, HookCommand, IssueCommand, LinkedPrSummary,
+    PrCheckItem, PrChecksSummary, PrCommand, PrCreateCall, PrEditCall, PrReview, PrReviewThread,
+    PrReviewThreadComment, TestEnv,
 };
 use gwt_git::PrStatus;
 use gwt_github::{
@@ -76,10 +77,10 @@ fn red_90_parse_hook_runtime_state() {
     let cmd = parse_hook_args(&[s("runtime-state"), s("PreToolUse")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::Hook {
+        CliCommand::Hook(HookCommand::Run {
             name: "runtime-state".to_string(),
             rest: vec!["PreToolUse".to_string()],
-        }
+        })
     );
 }
 
@@ -89,10 +90,10 @@ fn red_91_parse_hook_block_without_args() {
     let cmd = parse_hook_args(&[s("block-bash-policy")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::Hook {
+        CliCommand::Hook(HookCommand::Run {
             name: "block-bash-policy".to_string(),
             rest: vec![],
-        }
+        })
     );
 }
 
@@ -102,10 +103,10 @@ fn red_92_parse_hook_workflow_policy_without_args() {
     let cmd = parse_hook_args(&[s("workflow-policy")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::Hook {
+        CliCommand::Hook(HookCommand::Run {
             name: "workflow-policy".to_string(),
             rest: vec![],
-        }
+        })
     );
 }
 
@@ -115,10 +116,10 @@ fn red_92a_parse_hook_coordination_event() {
     let cmd = parse_hook_args(&[s("coordination-event"), s("SessionStart")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::Hook {
+        CliCommand::Hook(HookCommand::Run {
             name: "coordination-event".to_string(),
             rest: vec!["SessionStart".to_string()],
-        }
+        })
     );
 }
 
@@ -128,10 +129,10 @@ fn red_92b_parse_hook_event_dispatcher() {
     let cmd = parse_hook_args(&[s("event"), s("PreToolUse")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::Hook {
+        CliCommand::Hook(HookCommand::Run {
             name: "event".to_string(),
             rest: vec!["PreToolUse".to_string()],
-        }
+        })
     );
 }
 
@@ -253,7 +254,10 @@ fn dispatch_internal_daemon_hook_runs_as_cli_helper() {
 #[test]
 fn red_71_parse_spec_read_all() {
     let cmd = parse_issue_args(&[s("spec"), s("42")]).unwrap();
-    assert_eq!(cmd, CliCommand::SpecReadAll { number: 42 });
+    assert_eq!(
+        cmd,
+        CliCommand::Issue(IssueCommand::SpecReadAll { number: 42 })
+    );
 }
 
 #[test]
@@ -261,10 +265,10 @@ fn red_72_parse_spec_read_section() {
     let cmd = parse_issue_args(&[s("spec"), s("42"), s("--section"), s("tasks")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::SpecReadSection {
+        CliCommand::Issue(IssueCommand::SpecReadSection {
             number: 42,
             section: "tasks".into()
-        }
+        })
     );
 }
 
@@ -281,11 +285,11 @@ fn red_73_parse_spec_edit_section() {
     .unwrap();
     assert_eq!(
         cmd,
-        CliCommand::SpecEditSection {
+        CliCommand::Issue(IssueCommand::SpecEditSection {
             number: 42,
             section: "tasks".into(),
             file: "/tmp/new.md".into()
-        }
+        })
     );
 }
 
@@ -294,10 +298,10 @@ fn red_74_parse_spec_list_with_phase() {
     let cmd = parse_issue_args(&[s("spec"), s("list"), s("--phase"), s("implementation")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::SpecList {
+        CliCommand::Issue(IssueCommand::SpecList {
             phase: Some("implementation".into()),
             state: None
-        }
+        })
     );
 }
 
@@ -306,10 +310,10 @@ fn red_75_parse_spec_list_with_state() {
     let cmd = parse_issue_args(&[s("spec"), s("list"), s("--state"), s("closed")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::SpecList {
+        CliCommand::Issue(IssueCommand::SpecList {
             phase: None,
             state: Some("closed".into())
-        }
+        })
     );
 }
 
@@ -336,10 +340,10 @@ fn red_94_parse_issue_view() {
     let cmd = parse_issue_args(&[s("view"), s("42")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::IssueView {
+        CliCommand::Issue(IssueCommand::View {
             number: 42,
             refresh: false,
-        }
+        })
     );
 }
 
@@ -348,10 +352,10 @@ fn red_94_parse_issue_comments_with_refresh() {
     let cmd = parse_issue_args(&[s("comments"), s("42"), s("--refresh")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::IssueComments {
+        CliCommand::Issue(IssueCommand::Comments {
             number: 42,
             refresh: true,
-        }
+        })
     );
 }
 
@@ -369,11 +373,11 @@ fn red_95_parse_issue_create() {
     .unwrap();
     assert_eq!(
         cmd,
-        CliCommand::IssueCreate {
+        CliCommand::Issue(IssueCommand::Create {
             title: "Plain issue".into(),
             file: "/tmp/body.md".into(),
             labels: vec!["bug".into()],
-        }
+        })
     );
 }
 
@@ -382,10 +386,10 @@ fn red_96_parse_issue_comment() {
     let cmd = parse_issue_args(&[s("comment"), s("42"), s("-f"), s("/tmp/comment.md")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::IssueComment {
+        CliCommand::Issue(IssueCommand::Comment {
             number: 42,
             file: "/tmp/comment.md".into(),
-        }
+        })
     );
 }
 
@@ -405,13 +409,13 @@ fn red_96a_parse_issue_comment_rejects_trailing_args() {
 #[test]
 fn red_103_parse_pr_current() {
     let cmd = parse_pr_args(&[s("current")]).unwrap();
-    assert_eq!(cmd, CliCommand::PrCurrent);
+    assert_eq!(cmd, CliCommand::Pr(PrCommand::Current));
 }
 
 #[test]
 fn red_104_parse_pr_view() {
     let cmd = parse_pr_args(&[s("view"), s("42")]).unwrap();
-    assert_eq!(cmd, CliCommand::PrView { number: 42 });
+    assert_eq!(cmd, CliCommand::Pr(PrCommand::View { number: 42 }));
 }
 
 #[test]
@@ -433,14 +437,14 @@ fn red_104a_parse_pr_create() {
     .unwrap();
     assert_eq!(
         cmd,
-        CliCommand::PrCreate {
+        CliCommand::Pr(PrCommand::Create {
             base: "develop".into(),
             head: Some("feature/hooks".into()),
             title: "feat(hooks): canonical gwtd pr create".into(),
             file: "/tmp/pr-body.md".into(),
             labels: vec!["release".into()],
             draft: true,
-        }
+        })
     );
 }
 
@@ -459,19 +463,19 @@ fn red_104b_parse_pr_edit() {
     .unwrap();
     assert_eq!(
         cmd,
-        CliCommand::PrEdit {
+        CliCommand::Pr(PrCommand::Edit {
             number: 42,
             title: Some("feat(hooks): updated title".into()),
             file: Some("/tmp/pr-body.md".into()),
             add_labels: vec!["release".into()],
-        }
+        })
     );
 }
 
 #[test]
 fn red_105_parse_pr_checks() {
     let cmd = parse_pr_args(&[s("checks"), s("42")]).unwrap();
-    assert_eq!(cmd, CliCommand::PrChecks { number: 42 });
+    assert_eq!(cmd, CliCommand::Pr(PrCommand::Checks { number: 42 }));
 }
 
 #[test]
@@ -479,23 +483,23 @@ fn red_105a_parse_pr_comment() {
     let cmd = parse_pr_args(&[s("comment"), s("42"), s("-f"), s("/tmp/reply.md")]).unwrap();
     assert_eq!(
         cmd,
-        CliCommand::PrComment {
+        CliCommand::Pr(PrCommand::Comment {
             number: 42,
             file: "/tmp/reply.md".into(),
-        }
+        })
     );
 }
 
 #[test]
 fn red_105b_parse_pr_reviews() {
     let cmd = parse_pr_args(&[s("reviews"), s("42")]).unwrap();
-    assert_eq!(cmd, CliCommand::PrReviews { number: 42 });
+    assert_eq!(cmd, CliCommand::Pr(PrCommand::Reviews { number: 42 }));
 }
 
 #[test]
 fn red_105c_parse_pr_review_threads() {
     let cmd = parse_pr_args(&[s("review-threads"), s("42")]).unwrap();
-    assert_eq!(cmd, CliCommand::PrReviewThreads { number: 42 });
+    assert_eq!(cmd, CliCommand::Pr(PrCommand::ReviewThreads { number: 42 }));
 }
 
 #[test]
@@ -510,10 +514,10 @@ fn red_105d_parse_pr_reply_and_resolve() {
     .unwrap();
     assert_eq!(
         cmd,
-        CliCommand::PrReviewThreadsReplyAndResolve {
+        CliCommand::Pr(PrCommand::ReviewThreadsReplyAndResolve {
             number: 42,
             file: "/tmp/reply.md".into(),
-        }
+        })
     );
 }
 
@@ -556,13 +560,19 @@ fn red_105e_parse_pr_fixed_arity_subcommands_reject_trailing_args() {
 #[test]
 fn red_106_parse_actions_logs() {
     let cmd = parse_actions_args(&[s("logs"), s("--run"), s("101")]).unwrap();
-    assert_eq!(cmd, CliCommand::ActionsLogs { run_id: 101 });
+    assert_eq!(
+        cmd,
+        CliCommand::Actions(ActionsCommand::Logs { run_id: 101 })
+    );
 }
 
 #[test]
 fn red_107_parse_actions_job_logs() {
     let cmd = parse_actions_args(&[s("job-logs"), s("--job"), s("202")]).unwrap();
-    assert_eq!(cmd, CliCommand::ActionsJobLogs { job_id: 202 });
+    assert_eq!(
+        cmd,
+        CliCommand::Actions(ActionsCommand::JobLogs { job_id: 202 })
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

SPEC-1942 family split (FR-088〜092 / SC-025〜027): `crates/gwt/src/cli.rs` の god-enum `CliCommand` 36 variants を、 family 別 nested enum 10 variant 構造に再構成しました。 各 family module は own enum を受け取り、 親 dispatch は nested match に集約。 外部 CLI 契約 (argv / stdout / exit code / settings_local 経路) は完全に不変です。

## Changes

### Family enums

`CliCommand` を以下の 10 variant nested enum に再構成:

```rust
pub enum CliCommand {
    Issue(IssueCommand),
    Pr(PrCommand),
    Actions(ActionsCommand),
    Board(BoardCommand),
    Hook(HookCommand),
    Index(IndexCommand),
    Discuss(DiscussCommand),
    Plan(PlanCommand),
    Build(BuildCommand),
    Update(UpdateCommand),
}
```

family enum 配置:

| Family | Variant 数 | 主な命令 |
|---|---|---|
| `IssueCommand` | 16 | spec read/edit/list/create/pull/repair/rename + view/comments/linked-prs/create/comment |
| `PrCommand` | 9 | current/create/edit/view/comment/reviews/review-threads/review-threads reply-and-resolve/checks |
| `ActionsCommand` | 2 | logs/job-logs |
| `BoardCommand` | 2 | show/post |
| `HookCommand` | 2 | Run / InternalDaemon (`__internal daemon-hook`) |
| `IndexCommand` | 2 | status/rebuild |
| `UpdateCommand` | 4 | CheckOnly/Apply/InternalApply/InternalRunInstaller |
| `DiscussCommand` | 4 | resolve/park/reject/clear-next-question (alias of `DiscussAction`) |
| `PlanCommand` | 4 | start/phase/complete/abort (alias of `SkillStateAction`) |
| `BuildCommand` | 4 | start/phase/complete/abort (alias of `SkillStateAction`) |

### dispatch

`run<E: CliEnv>(env, cmd)` は parent variant 1 段の nested match に縮小:

```rust
match cmd {
    CliCommand::Issue(inner) => issue::run(env, inner, &mut out)?,
    CliCommand::Pr(inner) => pr::run(env, inner, &mut out)?,
    CliCommand::Actions(inner) => actions::run(env, inner, &mut out)?,
    // ...
}
```

### Internal command rename

`update::UpdateCommand` (内部 CLI 動作モード列挙) は `update::UpdateRunMode` に rename。 親の family enum 名と衝突しないよう改名 (transport-only、 外部 caller なし)。

### Round-trip RED test

`cli::tests::cli_command_family_split_round_trip_parses` を追加。 代表的な argv (`gwt issue spec list` / `gwt pr current` / `gwt board post --kind status --body x` / `gwt actions logs --run 42` / `gwt index status` / `gwt hook runtime-state ...` / `gwt discuss park --proposal ...` / `gwt plan start --spec 1942` / `gwt build start --spec 1942` / `update --check`) が family-nested CliCommand に正しく parse されることを assert。 family split の契約 pin として永続化。

## Testing

- `cargo test -p gwt --lib`: **345 passed** (RED test 含む family round-trip も pass)
- `cargo test -p gwt --tests`: **全 integration tests pass** (cli_test.rs 68件、 hook_runtime_state_test、 daemon_runtime_hook_test 等を含む)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: 差分なし
- `cargo build -p gwt --bin gwt --bin gwtd`: 通過
- 手動 smoke test: `gwtd --version` / `gwtd --help` / `gwtd issue spec list` / `gwtd board show --json` で stdout / exit code が family split 前と完全一致

## Closing Issues

None (SPEC-1942 は phase/implementation 継続)。

## Related Issues

- #1942 SPEC-1942 (gwt CLI) - family split 計画 (FR-088〜092)
- #2247 arch-review (PR #2247 で H3 finding として検出)

## Follow-up scope (本 PR 対象外)

- **SC-025 (cli.rs <1000 行)**: 本 PR では cli.rs = 2701 行 (family enum 定義追加で +180 行)。 SC-025 達成には render_/fetch_/load_ helper を family module へ移行する必要あり。 別 PR で順次:
  - `render_pr*` / `fetch_*_via_gh` / `parse_pr_checks_*` 系 helper を `cli/pr.rs` へ
  - `render_issue*` / `load_or_refresh_issue` / `fetch_linked_prs_via_gh` 系 helper を `cli/issue.rs` へ
  - `fetch_actions_*_via_gh` を `cli/actions.rs` へ
  - `run_hook` / `run_daemon_hook` / `prepare_daemon_front_door_for_path` を `cli/hook/mod.rs` へ
- **T-204** (`gwtd --help` の 2 段階 family 階層出力) も follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
