### PR TITLE
refactor(cli): render_* helpers を family modules へ移行 (SPEC-1942)

### DIFF
--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -42,10 +42,7 @@ use std::{
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
 use gwt_git::PrStatus;
-use gwt_github::{
-    cache::write_atomic, ApiError, Cache, IssueClient, IssueNumber, IssueSnapshot, IssueState,
-    SpecOpsError,
-};
+use gwt_github::{cache::write_atomic, ApiError, Cache, IssueClient, IssueNumber, SpecOpsError};
 
 /// Compact linked PR summary used by `gwtd issue linked-prs`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -597,135 +594,6 @@ fn io_as_api_error(err: io::Error) -> SpecOpsError {
 pub(crate) fn fake_gh_test_lock() -> &'static std::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
-}
-
-fn issue_state_label(state: IssueState) -> &'static str {
-    match state {
-        IssueState::Open => "OPEN",
-        IssueState::Closed => "CLOSED",
-    }
-}
-
-fn render_issue(out: &mut String, snapshot: &IssueSnapshot) {
-    out.push_str(&format!(
-        "#{} [{}] {}\n",
-        snapshot.number.0,
-        issue_state_label(snapshot.state),
-        snapshot.title
-    ));
-    if !snapshot.labels.is_empty() {
-        out.push_str(&format!("labels: {}\n", snapshot.labels.join(", ")));
-    }
-    out.push_str(&format!("updated_at: {}\n\n", snapshot.updated_at.0));
-    if !snapshot.body.is_empty() {
-        out.push_str(snapshot.body.trim_end_matches('\n'));
-        out.push('\n');
-    }
-}
-
-fn render_issue_comments(out: &mut String, snapshot: &IssueSnapshot) {
-    if snapshot.comments.is_empty() {
-        out.push_str("no comments\n");
-        return;
-    }
-    for comment in &snapshot.comments {
-        out.push_str(&format!(
-            "=== comment:{} ({}) ===\n{}\n",
-            comment.id.0, comment.updated_at.0, comment.body
-        ));
-    }
-}
-
-fn render_linked_prs(out: &mut String, linked_prs: &[LinkedPrSummary]) {
-    if linked_prs.is_empty() {
-        out.push_str("no linked pull requests\n");
-        return;
-    }
-    for pr in linked_prs {
-        out.push_str(&format!(
-            "#{} [{}] {}\n{}\n",
-            pr.number, pr.state, pr.title, pr.url
-        ));
-    }
-}
-
-fn render_pr(out: &mut String, pr: &PrStatus) {
-    out.push_str(&format!("#{} [{}] {}\n", pr.number, pr.state, pr.title));
-    out.push_str(&format!("url: {}\n", pr.url));
-    out.push_str(&format!("ci: {}\n", pr.ci_status));
-    out.push_str(&format!("mergeable: {}\n", pr.effective_merge_status()));
-    out.push_str(&format!("merge_state: {}\n", pr.merge_state_status));
-    out.push_str(&format!("review: {}\n", pr.review_status));
-}
-
-fn render_pr_checks(out: &mut String, summary: &PrChecksSummary) {
-    out.push_str(&format!("summary: {}\n", summary.summary));
-    out.push_str(&format!("ci: {}\n", summary.ci_status));
-    out.push_str(&format!("merge: {}\n", summary.merge_status));
-    out.push_str(&format!("review: {}\n", summary.review_status));
-    if summary.checks.is_empty() {
-        out.push_str("no checks\n");
-        return;
-    }
-    for check in &summary.checks {
-        out.push_str(&format!(
-            "- {} [{} / {}]\n",
-            check.name, check.state, check.conclusion
-        ));
-        if !check.workflow.is_empty() {
-            out.push_str(&format!("  workflow: {}\n", check.workflow));
-        }
-        if !check.url.is_empty() {
-            out.push_str(&format!("  url: {}\n", check.url));
-        }
-    }
-}
-
-fn render_pr_reviews(out: &mut String, reviews: &[PrReview]) {
-    if reviews.is_empty() {
-        out.push_str("no reviews\n");
-        return;
-    }
-    for review in reviews {
-        out.push_str(&format!(
-            "=== review:{} [{}] by {} at {} ===\n",
-            review.id, review.state, review.author, review.submitted_at
-        ));
-        if !review.body.is_empty() {
-            out.push_str(&review.body);
-            out.push('\n');
-        }
-    }
-}
-
-fn render_pr_review_threads(out: &mut String, threads: &[PrReviewThread]) {
-    if threads.is_empty() {
-        out.push_str("no review threads\n");
-        return;
-    }
-    for thread in threads {
-        out.push_str(&format!(
-            "=== thread:{} resolved={} outdated={} path={} line={} ===\n",
-            thread.id,
-            thread.is_resolved,
-            thread.is_outdated,
-            if thread.path.is_empty() {
-                "-"
-            } else {
-                thread.path.as_str()
-            },
-            thread
-                .line
-                .map(|line| line.to_string())
-                .unwrap_or_else(|| "-".to_string())
-        ));
-        for comment in &thread.comments {
-            out.push_str(&format!(
-                "--- comment:{} by {} ({}) ---\n{}\n",
-                comment.id, comment.author, comment.updated_at, comment.body
-            ));
-        }
-    }
 }
 
 fn load_or_refresh_issue<E: CliEnv>(
@@ -2097,9 +1965,9 @@ fn main() -> ExitCode {
         let issue = sample_issue_snapshot();
         let pr = sample_pr_status();
 
-        render_issue(&mut out, &issue);
-        render_issue_comments(&mut out, &issue);
-        render_linked_prs(
+        crate::cli::issue::render_issue(&mut out, &issue);
+        crate::cli::issue::render_issue_comments(&mut out, &issue);
+        crate::cli::issue::render_linked_prs(
             &mut out,
             &[LinkedPrSummary {
                 number: 128,
@@ -2108,8 +1976,8 @@ fn main() -> ExitCode {
                 url: pr.url.clone(),
             }],
         );
-        render_pr(&mut out, &pr);
-        render_pr_checks(
+        crate::cli::pr::render_pr(&mut out, &pr);
+        crate::cli::pr::render_pr_checks(
             &mut out,
             &PrChecksSummary {
                 summary: "All checks passed".to_string(),
@@ -2127,7 +1995,7 @@ fn main() -> ExitCode {
                 }],
             },
         );
-        render_pr_reviews(
+        crate::cli::pr::render_pr_reviews(
             &mut out,
             &[PrReview {
                 id: "review-1".to_string(),
@@ -2137,7 +2005,7 @@ fn main() -> ExitCode {
                 body: "Looks good.".to_string(),
             }],
         );
-        render_pr_review_threads(
+        crate::cli::pr::render_pr_review_threads(
             &mut out,
             &[PrReviewThread {
                 comments: vec![PrReviewThreadComment {
@@ -2344,7 +2212,10 @@ fn main() -> ExitCode {
         assert!(ensure_no_remaining_args([check].iter()).is_err());
 
         assert!(matches!(parse_hook_args(&[]), Err(CliParseError::Usage)));
-        assert_eq!(issue_state_label(IssueState::Closed), "CLOSED");
+        assert_eq!(
+            crate::cli::issue::issue_state_label(IssueState::Closed),
+            "CLOSED"
+        );
         assert!(io_as_api_error(io::Error::other("boom"))
             .to_string()
             .contains("boom"));
@@ -2393,9 +2264,9 @@ fn main() -> ExitCode {
         };
         let mut out = String::new();
 
-        render_issue_comments(&mut out, &issue);
-        render_linked_prs(&mut out, &[]);
-        render_pr_checks(
+        crate::cli::issue::render_issue_comments(&mut out, &issue);
+        crate::cli::issue::render_linked_prs(&mut out, &[]);
+        crate::cli::pr::render_pr_checks(
             &mut out,
             &PrChecksSummary {
                 summary: "pending".to_string(),
@@ -2405,8 +2276,8 @@ fn main() -> ExitCode {
                 checks: Vec::new(),
             },
         );
-        render_pr_reviews(&mut out, &[]);
-        render_pr_review_threads(&mut out, &[]);
+        crate::cli::pr::render_pr_reviews(&mut out, &[]);
+        crate::cli::pr::render_pr_review_threads(&mut out, &[]);
 
         assert!(out.contains("no comments"));
         assert!(out.contains("no linked pull requests"));

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -1,6 +1,6 @@
-use gwt_github::{Cache, IssueClient, IssueNumber, SpecOpsError};
+use gwt_github::{Cache, IssueClient, IssueNumber, IssueSnapshot, IssueState, SpecOpsError};
 
-use crate::cli::{CliEnv, CliParseError, IssueCommand};
+use crate::cli::{CliEnv, CliParseError, IssueCommand, LinkedPrSummary};
 
 pub(super) fn parse(args: &[String]) -> Result<IssueCommand, CliParseError> {
     let mut it = args.iter().peekable();
@@ -43,17 +43,17 @@ pub(super) fn run<E: CliEnv>(
     let code = match cmd {
         IssueCommand::View { number, refresh } => {
             let entry = super::load_or_refresh_issue(env, IssueNumber(number), refresh)?;
-            super::render_issue(out, &entry.snapshot);
+            render_issue(out, &entry.snapshot);
             0
         }
         IssueCommand::Comments { number, refresh } => {
             let entry = super::load_or_refresh_issue(env, IssueNumber(number), refresh)?;
-            super::render_issue_comments(out, &entry.snapshot);
+            render_issue_comments(out, &entry.snapshot);
             0
         }
         IssueCommand::LinkedPrs { number, refresh } => {
             let linked_prs = super::load_or_refresh_linked_prs(env, IssueNumber(number), refresh)?;
-            super::render_linked_prs(out, &linked_prs);
+            render_linked_prs(out, &linked_prs);
             0
         }
         IssueCommand::Create {
@@ -159,6 +159,56 @@ fn parse_issue_comment_args(args: &[&String]) -> Result<IssueCommand, CliParseEr
             file: args[2].clone(),
         }),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
+    }
+}
+
+pub(super) fn issue_state_label(state: IssueState) -> &'static str {
+    match state {
+        IssueState::Open => "OPEN",
+        IssueState::Closed => "CLOSED",
+    }
+}
+
+pub(super) fn render_issue(out: &mut String, snapshot: &IssueSnapshot) {
+    out.push_str(&format!(
+        "#{} [{}] {}\n",
+        snapshot.number.0,
+        issue_state_label(snapshot.state),
+        snapshot.title
+    ));
+    if !snapshot.labels.is_empty() {
+        out.push_str(&format!("labels: {}\n", snapshot.labels.join(", ")));
+    }
+    out.push_str(&format!("updated_at: {}\n\n", snapshot.updated_at.0));
+    if !snapshot.body.is_empty() {
+        out.push_str(snapshot.body.trim_end_matches('\n'));
+        out.push('\n');
+    }
+}
+
+pub(super) fn render_issue_comments(out: &mut String, snapshot: &IssueSnapshot) {
+    if snapshot.comments.is_empty() {
+        out.push_str("no comments\n");
+        return;
+    }
+    for comment in &snapshot.comments {
+        out.push_str(&format!(
+            "=== comment:{} ({}) ===\n{}\n",
+            comment.id.0, comment.updated_at.0, comment.body
+        ));
+    }
+}
+
+pub(super) fn render_linked_prs(out: &mut String, linked_prs: &[LinkedPrSummary]) {
+    if linked_prs.is_empty() {
+        out.push_str("no linked pull requests\n");
+        return;
+    }
+    for pr in linked_prs {
+        out.push_str(&format!(
+            "#{} [{}] {}\n{}\n",
+            pr.number, pr.state, pr.title, pr.url
+        ));
     }
 }
 

--- a/crates/gwt/src/cli/pr.rs
+++ b/crates/gwt/src/cli/pr.rs
@@ -1,6 +1,7 @@
+use gwt_git::PrStatus;
 use gwt_github::SpecOpsError;
 
-use crate::cli::{CliEnv, CliParseError, PrCommand};
+use crate::cli::{CliEnv, CliParseError, PrChecksSummary, PrCommand, PrReview, PrReviewThread};
 
 pub(super) fn parse(args: &[String]) -> Result<PrCommand, CliParseError> {
     let mut it = args.iter().peekable();
@@ -63,7 +64,7 @@ pub(super) fn run<E: CliEnv>(
     let code = match cmd {
         PrCommand::Current => {
             match env.fetch_current_pr().map_err(super::io_as_api_error)? {
-                Some(pr) => super::render_pr(out, &pr),
+                Some(pr) => render_pr(out, &pr),
                 None => out.push_str("no current pull request\n"),
             }
             0
@@ -81,7 +82,7 @@ pub(super) fn run<E: CliEnv>(
                 .create_pr(&base, head.as_deref(), &title, &body, &labels, draft)
                 .map_err(super::io_as_api_error)?;
             out.push_str("created pull request\n");
-            super::render_pr(out, &pr);
+            render_pr(out, &pr);
             0
         }
         PrCommand::Edit {
@@ -98,12 +99,12 @@ pub(super) fn run<E: CliEnv>(
                 .edit_pr(number, title.as_deref(), body.as_deref(), &add_labels)
                 .map_err(super::io_as_api_error)?;
             out.push_str("updated pull request\n");
-            super::render_pr(out, &pr);
+            render_pr(out, &pr);
             0
         }
         PrCommand::View { number } => {
             let pr = env.fetch_pr(number).map_err(super::io_as_api_error)?;
-            super::render_pr(out, &pr);
+            render_pr(out, &pr);
             0
         }
         PrCommand::Comment { number, file } => {
@@ -117,14 +118,14 @@ pub(super) fn run<E: CliEnv>(
             let reviews = env
                 .fetch_pr_reviews(number)
                 .map_err(super::io_as_api_error)?;
-            super::render_pr_reviews(out, &reviews);
+            render_pr_reviews(out, &reviews);
             0
         }
         PrCommand::ReviewThreads { number } => {
             let threads = env
                 .fetch_pr_review_threads(number)
                 .map_err(super::io_as_api_error)?;
-            super::render_pr_review_threads(out, &threads);
+            render_pr_review_threads(out, &threads);
             0
         }
         PrCommand::ReviewThreadsReplyAndResolve { number, file } => {
@@ -141,7 +142,7 @@ pub(super) fn run<E: CliEnv>(
             let report = env
                 .fetch_pr_checks(number)
                 .map_err(super::io_as_api_error)?;
-            super::render_pr_checks(out, &report);
+            render_pr_checks(out, &report);
             0
         }
     };
@@ -255,6 +256,85 @@ fn parse_pr_edit_args(args: &[&String]) -> Result<PrCommand, CliParseError> {
         file,
         add_labels,
     })
+}
+
+pub(super) fn render_pr(out: &mut String, pr: &PrStatus) {
+    out.push_str(&format!("#{} [{}] {}\n", pr.number, pr.state, pr.title));
+    out.push_str(&format!("url: {}\n", pr.url));
+    out.push_str(&format!("ci: {}\n", pr.ci_status));
+    out.push_str(&format!("mergeable: {}\n", pr.effective_merge_status()));
+    out.push_str(&format!("merge_state: {}\n", pr.merge_state_status));
+    out.push_str(&format!("review: {}\n", pr.review_status));
+}
+
+pub(super) fn render_pr_checks(out: &mut String, summary: &PrChecksSummary) {
+    out.push_str(&format!("summary: {}\n", summary.summary));
+    out.push_str(&format!("ci: {}\n", summary.ci_status));
+    out.push_str(&format!("merge: {}\n", summary.merge_status));
+    out.push_str(&format!("review: {}\n", summary.review_status));
+    if summary.checks.is_empty() {
+        out.push_str("no checks\n");
+        return;
+    }
+    for check in &summary.checks {
+        out.push_str(&format!(
+            "- {} [{} / {}]\n",
+            check.name, check.state, check.conclusion
+        ));
+        if !check.workflow.is_empty() {
+            out.push_str(&format!("  workflow: {}\n", check.workflow));
+        }
+        if !check.url.is_empty() {
+            out.push_str(&format!("  url: {}\n", check.url));
+        }
+    }
+}
+
+pub(super) fn render_pr_reviews(out: &mut String, reviews: &[PrReview]) {
+    if reviews.is_empty() {
+        out.push_str("no reviews\n");
+        return;
+    }
+    for review in reviews {
+        out.push_str(&format!(
+            "=== review:{} [{}] by {} at {} ===\n",
+            review.id, review.state, review.author, review.submitted_at
+        ));
+        if !review.body.is_empty() {
+            out.push_str(&review.body);
+            out.push('\n');
+        }
+    }
+}
+
+pub(super) fn render_pr_review_threads(out: &mut String, threads: &[PrReviewThread]) {
+    if threads.is_empty() {
+        out.push_str("no review threads\n");
+        return;
+    }
+    for thread in threads {
+        out.push_str(&format!(
+            "=== thread:{} resolved={} outdated={} path={} line={} ===\n",
+            thread.id,
+            thread.is_resolved,
+            thread.is_outdated,
+            if thread.path.is_empty() {
+                "-"
+            } else {
+                thread.path.as_str()
+            },
+            thread
+                .line
+                .map(|line| line.to_string())
+                .unwrap_or_else(|| "-".to_string())
+        ));
+        for comment in &thread.comments {
+            out.push_str(&format!(
+                "--- comment:{} by {} ({}) ---\n{}\n",
+                comment.id, comment.author, comment.updated_at, comment.body
+            ));
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

SPEC-1942 SC-025 進捗の follow-up: pure `render_*` helpers を `cli/<family>.rs` に移動して family module の自己完結性を強化。 機能変更なし、 結果不変。

## Changes

- `cli.rs` から以下を削除し、 各 family module の `pub(super)` helper として移動:
  - `cli/pr.rs`: `render_pr` / `render_pr_checks` / `render_pr_reviews` / `render_pr_review_threads` (~80 行)
  - `cli/issue.rs`: `render_issue` / `render_issue_comments` / `render_linked_prs` / `issue_state_label` (~70 行)
- family module 内 caller は `super::render_*` → 直接呼び出し に簡略化
- cli.rs 内 test の参照を `crate::cli::pr::render_pr` / `crate::cli::issue::render_issue` 等の qualified path に更新

## Metrics

| 項目 | 前 | 後 | 差分 |
|---|---|---|---|
| `cli.rs` | 2701 行 | 2572 行 | **-129** |
| `cli/pr.rs` | 301 行 | 397 行 | +96 |
| `cli/issue.rs` | 233 行 | 293 行 | +60 |

SC-025 (`cli.rs` <1000 行) target に対する継続進捗。 残 helper (`fetch_*_via_gh` / `load_or_refresh_*` / `parse_pr_checks_*` / `run_hook` / `run_daemon_hook` / `prepare_daemon_front_door_for_path`) は別 PR で順次移行予定。

## Testing

- `cargo test -p gwt --lib`: **345 passed**
- `cargo test -p gwt --tests`: 全 integration tests pass (cli_test 68件含む)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: 差分なし

## Closing Issues

None (SPEC-1942 phase/implementation 継続)。

## Related Issues

- #1942 SPEC-1942 (gwt CLI) - SC-025 helper migration follow-up
- #2264 直前 PR (family-nested CliCommand split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to CLI rendering logic for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->