### PR TITLE
refactor(cli): issue + actions + hook helpers を family modules へ集約 (SPEC-1942)

### DIFF
--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -33,15 +33,11 @@ mod pr;
 mod skill_state_runtime;
 pub mod update;
 
-use std::{
-    fs,
-    io::{self},
-    path::PathBuf,
-};
+use std::io::{self};
 
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
-use gwt_github::{cache::write_atomic, ApiError, Cache, IssueClient, IssueNumber, SpecOpsError};
+use gwt_github::{ApiError, SpecOpsError};
 
 /// Compact linked PR summary used by `gwtd issue linked-prs`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -595,252 +591,6 @@ pub(crate) fn fake_gh_test_lock() -> &'static std::sync::Mutex<()> {
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
 }
 
-fn load_or_refresh_issue<E: CliEnv>(
-    env: &mut E,
-    number: IssueNumber,
-    refresh: bool,
-) -> Result<gwt_github::CacheEntry, SpecOpsError> {
-    let cache = Cache::new(env.cache_root());
-    if !refresh {
-        if let Some(entry) = cache.load_entry(number) {
-            return Ok(entry);
-        }
-    }
-    refresh_issue_cache(env, number)
-}
-
-fn refresh_issue_cache<E: CliEnv>(
-    env: &mut E,
-    number: IssueNumber,
-) -> Result<gwt_github::CacheEntry, SpecOpsError> {
-    let snapshot = match env.client().fetch(number, None)? {
-        gwt_github::FetchResult::Updated(snapshot) => snapshot,
-        gwt_github::FetchResult::NotModified => {
-            return Cache::new(env.cache_root())
-                .load_entry(number)
-                .ok_or_else(|| SpecOpsError::SectionNotFound(format!("issue {}", number.0)));
-        }
-    };
-    let cache = Cache::new(env.cache_root());
-    cache.write_snapshot(&snapshot)?;
-    cache
-        .load_entry(number)
-        .ok_or_else(|| SpecOpsError::SectionNotFound(format!("issue {}", number.0)))
-}
-
-fn load_or_refresh_linked_prs<E: CliEnv>(
-    env: &mut E,
-    number: IssueNumber,
-    refresh: bool,
-) -> Result<Vec<LinkedPrSummary>, SpecOpsError> {
-    let cache_root = env.cache_root();
-    if !refresh {
-        if let Some(cached) = read_linked_prs_cache(&cache_root, number)? {
-            return Ok(cached);
-        }
-    }
-    let linked_prs = env.fetch_linked_prs(number).map_err(io_as_api_error)?;
-    write_linked_prs_cache(&cache_root, number, &linked_prs)?;
-    Ok(linked_prs)
-}
-
-fn linked_prs_cache_path(cache_root: &std::path::Path, number: IssueNumber) -> PathBuf {
-    cache_root
-        .join(number.0.to_string())
-        .join("linked_prs.json")
-}
-
-fn read_linked_prs_cache(
-    cache_root: &std::path::Path,
-    number: IssueNumber,
-) -> Result<Option<Vec<LinkedPrSummary>>, SpecOpsError> {
-    let path = linked_prs_cache_path(cache_root, number);
-    match fs::read_to_string(&path) {
-        Ok(text) => {
-            let parsed = serde_json::from_str(&text)
-                .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
-            Ok(Some(parsed))
-        }
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(io_as_api_error(err)),
-    }
-}
-
-fn write_linked_prs_cache(
-    cache_root: &std::path::Path,
-    number: IssueNumber,
-    linked_prs: &[LinkedPrSummary],
-) -> Result<(), SpecOpsError> {
-    let bytes = serde_json::to_vec_pretty(linked_prs)
-        .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
-    write_atomic(&linked_prs_cache_path(cache_root, number), &bytes).map_err(io_as_api_error)
-}
-
-fn fetch_linked_prs_via_gh(
-    owner: &str,
-    repo: &str,
-    number: IssueNumber,
-) -> io::Result<Vec<LinkedPrSummary>> {
-    let query = r#"
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    issue(number: $number) {
-      timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT]) {
-        nodes {
-          __typename
-          ... on CrossReferencedEvent {
-            source {
-              __typename
-              ... on PullRequest {
-                number
-                title
-                state
-                url
-              }
-            }
-          }
-          ... on ConnectedEvent {
-            subject {
-              __typename
-              ... on PullRequest {
-                number
-                title
-                state
-                url
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-"#;
-
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
-            "api",
-            "graphql",
-            "-f",
-            &format!("query={query}"),
-            "-f",
-            &format!("owner={owner}"),
-            "-f",
-            &format!("repo={repo}"),
-            "-F",
-            &format!("number={}", number.0),
-        ])
-        .output()?;
-
-    if !output.status.success() {
-        return Err(io::Error::other(format!(
-            "gh api graphql failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
-    let nodes = value
-        .get("data")
-        .and_then(|v| v.get("repository"))
-        .and_then(|v| v.get("issue"))
-        .and_then(|v| v.get("timelineItems"))
-        .and_then(|v| v.get("nodes"))
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-
-    let mut seen = std::collections::BTreeSet::new();
-    let mut out = Vec::new();
-    for node in nodes {
-        let typename = node
-            .get("__typename")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default();
-        let pr = match typename {
-            "CrossReferencedEvent" => node.get("source"),
-            "ConnectedEvent" => node.get("subject"),
-            _ => None,
-        };
-        let Some(pr) = pr else { continue };
-        if pr.get("__typename").and_then(|v| v.as_str()) != Some("PullRequest") {
-            continue;
-        }
-        let Some(pr_number) = pr.get("number").and_then(|v| v.as_u64()) else {
-            continue;
-        };
-        if !seen.insert(pr_number) {
-            continue;
-        }
-        out.push(LinkedPrSummary {
-            number: pr_number,
-            title: pr
-                .get("title")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
-            state: pr
-                .get("state")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
-            url: pr
-                .get("url")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
-        });
-    }
-    Ok(out)
-}
-
-fn fetch_actions_run_log_via_gh(repo_path: &std::path::Path, run_id: u64) -> io::Result<String> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["run", "view", &run_id.to_string(), "--log"])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
-        return Err(io::Error::other(format!(
-            "gh run view --log: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
-fn fetch_actions_job_log_via_gh(
-    owner: &str,
-    repo: &str,
-    repo_path: &std::path::Path,
-    job_id: u64,
-) -> io::Result<String> {
-    let endpoint = format!("/repos/{owner}/{repo}/actions/jobs/{job_id}/logs");
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["api", &endpoint])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
-        return Err(io::Error::other(format!(
-            "gh api {endpoint}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-    if output.stdout.starts_with(b"PK") {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "job logs returned a zip archive; unable to parse",
-        ));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
-/// Dispatch a `gwtd hook <name> [args...]` invocation.
-///
-/// SPEC-2077 hot path tightening: `gwtd hook ...` remains the outward-facing
-/// surface, but dispatches in-process so every Claude/Codex hook event does not
-/// pay for a second `gwtd __internal daemon-hook ...` process spawn. The hidden
-/// internal command stays available as a compatibility route.
 pub fn run_hook<E: CliEnv>(env: &mut E, name: &str, rest: &[String]) -> Result<i32, SpecOpsError> {
     run_daemon_hook(env, name, rest)
 }
@@ -1449,12 +1199,14 @@ fn main() -> ExitCode {
             url: "https://github.com/akiojin/gwt/pull/9".to_string(),
         }];
 
-        assert!(read_linked_prs_cache(temp.path(), number)
-            .unwrap()
-            .is_none());
-        write_linked_prs_cache(temp.path(), number, &linked_prs).unwrap();
+        assert!(
+            crate::cli::issue::read_linked_prs_cache(temp.path(), number)
+                .unwrap()
+                .is_none()
+        );
+        crate::cli::issue::write_linked_prs_cache(temp.path(), number, &linked_prs).unwrap();
         assert_eq!(
-            read_linked_prs_cache(temp.path(), number).unwrap(),
+            crate::cli::issue::read_linked_prs_cache(temp.path(), number).unwrap(),
             Some(linked_prs)
         );
 
@@ -1715,11 +1467,13 @@ fn main() -> ExitCode {
         let snapshot = sample_issue_snapshot();
         env.client.seed(snapshot.clone());
 
-        let loaded = load_or_refresh_issue(&mut env, snapshot.number, false).expect("load issue");
+        let loaded = crate::cli::issue::load_or_refresh_issue(&mut env, snapshot.number, false)
+            .expect("load issue");
         assert_eq!(loaded.snapshot.number, snapshot.number);
         assert_eq!(env.client.call_log(), vec!["fetch:#42".to_string()]);
 
-        let cached = load_or_refresh_issue(&mut env, snapshot.number, false).expect("cached issue");
+        let cached = crate::cli::issue::load_or_refresh_issue(&mut env, snapshot.number, false)
+            .expect("cached issue");
         assert_eq!(cached.snapshot.title, snapshot.title);
         assert_eq!(env.client.call_log(), vec!["fetch:#42".to_string()]);
 
@@ -1733,27 +1487,30 @@ fn main() -> ExitCode {
             }],
         );
         let linked =
-            load_or_refresh_linked_prs(&mut env, snapshot.number, false).expect("linked prs");
+            crate::cli::issue::load_or_refresh_linked_prs(&mut env, snapshot.number, false)
+                .expect("linked prs");
         assert_eq!(linked.len(), 1);
         assert_eq!(env.linked_pr_calls(), vec![42]);
 
         env.clear_linked_pr_calls();
-        let cached_linked = load_or_refresh_linked_prs(&mut env, snapshot.number, false)
-            .expect("cached linked prs");
+        let cached_linked =
+            crate::cli::issue::load_or_refresh_linked_prs(&mut env, snapshot.number, false)
+                .expect("cached linked prs");
         assert_eq!(cached_linked.len(), 1);
         assert!(env.linked_pr_calls().is_empty());
 
-        let cache_path = linked_prs_cache_path(temp.path(), snapshot.number);
+        let cache_path = crate::cli::issue::linked_prs_cache_path(temp.path(), snapshot.number);
         std::fs::create_dir_all(cache_path.parent().expect("cache dir")).expect("create cache dir");
         std::fs::write(&cache_path, "{not-json").expect("write invalid json");
-        assert!(read_linked_prs_cache(temp.path(), snapshot.number).is_err());
+        assert!(crate::cli::issue::read_linked_prs_cache(temp.path(), snapshot.number).is_err());
     }
 
     #[test]
     fn gh_wrappers_parse_successful_responses() {
         with_fake_gh("success", |repo_path| {
             let linked =
-                fetch_linked_prs_via_gh("akiojin", "gwt", IssueNumber(42)).expect("linked");
+                crate::cli::issue::fetch_linked_prs_via_gh("akiojin", "gwt", IssueNumber(42))
+                    .expect("linked");
             assert_eq!(linked.len(), 2);
             assert_eq!(linked[0].number, 12);
             assert_eq!(linked[1].state, "MERGED");
@@ -1814,11 +1571,13 @@ fn main() -> ExitCode {
             assert_eq!(checks.checks.len(), 1);
             assert_eq!(checks.checks[0].conclusion, "SUCCESS");
 
-            let run_log = fetch_actions_run_log_via_gh(repo_path, 90).expect("run log");
+            let run_log =
+                crate::cli::actions::fetch_actions_run_log_via_gh(repo_path, 90).expect("run log");
             assert_eq!(run_log.trim(), "run log 90");
 
             let job_log =
-                fetch_actions_job_log_via_gh("akiojin", "gwt", repo_path, 91).expect("job log");
+                crate::cli::actions::fetch_actions_job_log_via_gh("akiojin", "gwt", repo_path, 91)
+                    .expect("job log");
             assert_eq!(job_log, "job log 91");
         });
     }
@@ -1853,7 +1612,8 @@ fn main() -> ExitCode {
 
         with_fake_gh("job-log-zip", |repo_path| {
             let err =
-                fetch_actions_job_log_via_gh("akiojin", "gwt", repo_path, 91).expect_err("zip");
+                crate::cli::actions::fetch_actions_job_log_via_gh("akiojin", "gwt", repo_path, 91)
+                    .expect_err("zip");
             assert_eq!(err.kind(), io::ErrorKind::InvalidData);
             assert!(err.to_string().contains("zip archive"));
         });

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -559,10 +559,10 @@ pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError>
         CliCommand::Plan(action) => plan::run(env, action, &mut out)?,
         CliCommand::Build(action) => build::run(env, action, &mut out)?,
         CliCommand::Hook(HookCommand::Run { name, rest }) => {
-            return run_hook(env, &name, &rest);
+            return hook::run_hook(env, &name, &rest);
         }
         CliCommand::Hook(HookCommand::InternalDaemon { name, rest }) => {
-            return run_daemon_hook(env, &name, &rest);
+            return hook::run_daemon_hook(env, &name, &rest);
         }
         CliCommand::Update(UpdateCommand::CheckOnly) => {
             std::process::exit(update::run(update::UpdateRunMode::CheckOnly));
@@ -589,214 +589,6 @@ fn io_as_api_error(err: io::Error) -> SpecOpsError {
 pub(crate) fn fake_gh_test_lock() -> &'static std::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
-}
-
-pub fn run_hook<E: CliEnv>(env: &mut E, name: &str, rest: &[String]) -> Result<i32, SpecOpsError> {
-    run_daemon_hook(env, name, rest)
-}
-
-#[cfg(test)]
-fn daemon_hook_argv(name: &str, rest: &[String]) -> Vec<String> {
-    let mut argv = vec![
-        "gwtd".to_string(),
-        "__internal".to_string(),
-        "daemon-hook".to_string(),
-        name.to_string(),
-    ];
-    argv.extend(rest.iter().cloned());
-    argv
-}
-
-#[cfg(test)]
-fn write_internal_command_output<E: CliEnv>(
-    env: &mut E,
-    output: crate::cli::env::InternalCommandOutput,
-) -> Result<i32, SpecOpsError> {
-    env.stdout()
-        .write_all(&output.stdout)
-        .map_err(io_as_api_error)?;
-    env.stdout().flush().map_err(io_as_api_error)?;
-    env.stderr()
-        .write_all(&output.stderr)
-        .map_err(io_as_api_error)?;
-    env.stderr().flush().map_err(io_as_api_error)?;
-    Ok(output.status)
-}
-
-pub fn prepare_daemon_front_door_for_path(project_root: &std::path::Path) -> Result<(), String> {
-    if !project_root.exists() {
-        return Ok(());
-    }
-
-    refresh_managed_assets_for_hook_front_door(project_root)?;
-
-    crate::index_worker::bootstrap_project_index_for_path(project_root)?;
-
-    let scope = gwt_core::daemon::RuntimeScope::from_project_root(
-        project_root,
-        gwt_core::daemon::RuntimeTarget::Host,
-    )
-    .map_err(|err| err.to_string())?;
-    let gwt_home = gwt_core::paths::gwt_home();
-    let action = gwt_core::daemon::resolve_bootstrap_action(
-        &gwt_home,
-        &scope,
-        gwt_core::daemon::DAEMON_PROTOCOL_VERSION,
-        |pid| pid == std::process::id(),
-    )
-    .map_err(|err| err.to_string())?;
-
-    if let gwt_core::daemon::DaemonBootstrapAction::Spawn { endpoint_path } = action {
-        let endpoint = gwt_core::daemon::DaemonEndpoint::new(
-            scope,
-            std::process::id(),
-            "internal://gwt-front-door".to_string(),
-            uuid::Uuid::new_v4().to_string(),
-            env!("CARGO_PKG_VERSION").to_string(),
-        );
-        gwt_core::daemon::persist_endpoint(&endpoint_path, &endpoint)
-            .map_err(|err| err.to_string())?;
-    }
-
-    Ok(())
-}
-
-fn refresh_managed_assets_for_hook_front_door(
-    project_root: &std::path::Path,
-) -> Result<(), String> {
-    if gwt_git::Repository::discover(project_root).is_err() {
-        return Ok(());
-    }
-    crate::managed_assets::refresh_managed_gwt_assets_for_worktree(project_root)
-        .map_err(|err| err.to_string())
-}
-
-pub fn run_daemon_hook<E: CliEnv>(
-    env: &mut E,
-    name: &str,
-    rest: &[String],
-) -> Result<i32, SpecOpsError> {
-    use crate::cli::hook::{
-        block_bash_policy, event_dispatcher, skill_build_spec_stop_check,
-        skill_discussion_stop_check, skill_plan_spec_stop_check, workflow_policy, HookKind,
-        HookOutput,
-    };
-
-    let Some(kind) = HookKind::from_name(name) else {
-        let _ = writeln!(env.stderr(), "gwtd hook: unknown hook '{name}'");
-        return Ok(2);
-    };
-    let stdin = env.read_stdin().map_err(io_as_api_error)?;
-
-    fn emit_hook_output<E: CliEnv>(env: &mut E, output: &HookOutput) -> i32 {
-        match output.serialize_to(env.stdout()) {
-            Ok(()) => output.exit_code(),
-            Err(err) => {
-                let _ = writeln!(env.stderr(), "gwtd hook: failed to serialize output: {err}");
-                1
-            }
-        }
-    }
-    fn emit_hook_error<E: CliEnv>(env: &mut E, name: &str, err: impl std::fmt::Display) -> i32 {
-        let _ = writeln!(env.stderr(), "gwtd hook {name}: {err}");
-        1
-    }
-
-    match kind {
-        HookKind::Event => {
-            let Some(event) = rest.first() else {
-                let _ = writeln!(env.stderr(), "gwtd hook event: missing <event> argument");
-                return Ok(2);
-            };
-            let cwd = env.repo_path().to_path_buf();
-            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
-            match event_dispatcher::handle_with_input(
-                event,
-                &stdin,
-                &cwd,
-                current_session.as_deref(),
-            ) {
-                Ok(output) => Ok(emit_hook_output(env, &output)),
-                Err(err) => Ok(emit_hook_error(env, name, err)),
-            }
-        }
-        HookKind::RuntimeState => {
-            let Some(event) = rest.first() else {
-                let _ = writeln!(
-                    env.stderr(),
-                    "gwtd hook runtime-state: missing <event> argument"
-                );
-                return Ok(2);
-            };
-            match crate::daemon_runtime::handle_runtime_state(event, &stdin) {
-                Ok(()) => Ok(0),
-                Err(err) => Ok(emit_hook_error(env, name, err)),
-            }
-        }
-        HookKind::CoordinationEvent => {
-            let Some(event) = rest.first() else {
-                let _ = writeln!(
-                    env.stderr(),
-                    "gwtd hook coordination-event: missing <event> argument"
-                );
-                return Ok(2);
-            };
-            match crate::daemon_runtime::handle_coordination_event(event, &stdin) {
-                Ok(()) => Ok(0),
-                Err(err) => Ok(emit_hook_error(env, name, err)),
-            }
-        }
-        HookKind::BoardReminder => {
-            let Some(event) = rest.first() else {
-                let _ = writeln!(
-                    env.stderr(),
-                    "gwtd hook board-reminder: missing <event> argument"
-                );
-                return Ok(2);
-            };
-            match crate::cli::hook::board_reminder::handle_with_input(event, &stdin) {
-                Ok(output) => Ok(emit_hook_output(env, &output)),
-                Err(err) => Ok(emit_hook_error(env, name, err)),
-            }
-        }
-        HookKind::BlockBashPolicy => match block_bash_policy::handle_with_input(&stdin) {
-            Ok(output) => Ok(emit_hook_output(env, &output)),
-            Err(err) => Ok(emit_hook_error(env, name, err)),
-        },
-        HookKind::WorkflowPolicy => match workflow_policy::handle_with_input(&stdin) {
-            Ok(output) => Ok(emit_hook_output(env, &output)),
-            Err(err) => Ok(emit_hook_error(env, name, err)),
-        },
-        HookKind::Forward => match crate::daemon_runtime::handle_forward(&stdin) {
-            Ok(()) => Ok(0),
-            Err(err) => Ok(emit_hook_error(env, name, err)),
-        },
-        HookKind::SkillDiscussionStopCheck => {
-            let cwd = env.repo_path().to_path_buf();
-            let output = skill_discussion_stop_check::handle_with_input(&cwd, &stdin);
-            Ok(emit_hook_output(env, &output))
-        }
-        HookKind::SkillPlanSpecStopCheck => {
-            let cwd = env.repo_path().to_path_buf();
-            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
-            let output = skill_plan_spec_stop_check::handle_with_input(
-                &cwd,
-                &stdin,
-                current_session.as_deref(),
-            );
-            Ok(emit_hook_output(env, &output))
-        }
-        HookKind::SkillBuildSpecStopCheck => {
-            let cwd = env.repo_path().to_path_buf();
-            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
-            let output = skill_build_spec_stop_check::handle_with_input(
-                &cwd,
-                &stdin,
-                current_session.as_deref(),
-            );
-            Ok(emit_hook_output(env, &output))
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1236,7 +1028,7 @@ fn main() -> ExitCode {
 
     #[test]
     fn daemon_hook_argv_and_internal_command_output_preserve_streams() {
-        let argv = daemon_hook_argv(
+        let argv = crate::cli::hook::daemon_hook_argv(
             "runtime-state",
             &["start".to_string(), "--json".to_string()],
         );
@@ -1254,7 +1046,7 @@ fn main() -> ExitCode {
 
         let temp = tempdir().expect("tempdir");
         let mut env = TestEnv::new(temp.path().to_path_buf());
-        let status = write_internal_command_output(
+        let status = crate::cli::hook::write_internal_command_output(
             &mut env,
             InternalCommandOutput {
                 status: 7,
@@ -1329,7 +1121,8 @@ fn main() -> ExitCode {
         )
         .expect("write stale settings");
 
-        refresh_managed_assets_for_hook_front_door(temp.path()).expect("refresh hook assets");
+        crate::cli::hook::refresh_managed_assets_for_hook_front_door(temp.path())
+            .expect("refresh hook assets");
 
         let content = fs::read_to_string(&settings_path).expect("read settings");
         let value: serde_json::Value = serde_json::from_str(&content).expect("settings json");

--- a/crates/gwt/src/cli/actions.rs
+++ b/crates/gwt/src/cli/actions.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use gwt_github::SpecOpsError;
 
 use crate::cli::{ActionsCommand, CliEnv, CliParseError};
@@ -50,6 +52,49 @@ pub(super) fn run<E: CliEnv>(
         }
     };
     Ok(code)
+}
+
+pub(super) fn fetch_actions_run_log_via_gh(
+    repo_path: &std::path::Path,
+    run_id: u64,
+) -> io::Result<String> {
+    let output = gwt_core::process::hidden_command("gh")
+        .args(["run", "view", &run_id.to_string(), "--log"])
+        .current_dir(repo_path)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "gh run view --log: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub(super) fn fetch_actions_job_log_via_gh(
+    owner: &str,
+    repo: &str,
+    repo_path: &std::path::Path,
+    job_id: u64,
+) -> io::Result<String> {
+    let endpoint = format!("/repos/{owner}/{repo}/actions/jobs/{job_id}/logs");
+    let output = gwt_core::process::hidden_command("gh")
+        .args(["api", &endpoint])
+        .current_dir(repo_path)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "gh api {endpoint}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    if output.stdout.starts_with(b"PK") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "job logs returned a zip archive; unable to parse",
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/cli/env.rs
+++ b/crates/gwt/src/cli/env.rs
@@ -372,7 +372,7 @@ impl CliEnv for DefaultCliEnv {
         fs::read_to_string(path)
     }
     fn fetch_linked_prs(&mut self, number: IssueNumber) -> io::Result<Vec<LinkedPrSummary>> {
-        super::fetch_linked_prs_via_gh(&self.owner, &self.repo, number)
+        super::issue::fetch_linked_prs_via_gh(&self.owner, &self.repo, number)
     }
     fn fetch_current_pr(&mut self) -> io::Result<Option<PrStatus>> {
         super::pr::fetch_current_pr_via_gh(&self.repo_path)
@@ -446,10 +446,15 @@ impl CliEnv for DefaultCliEnv {
         )
     }
     fn fetch_actions_run_log(&mut self, run_id: u64) -> io::Result<String> {
-        super::fetch_actions_run_log_via_gh(&self.repo_path, run_id)
+        super::actions::fetch_actions_run_log_via_gh(&self.repo_path, run_id)
     }
     fn fetch_actions_job_log(&mut self, job_id: u64) -> io::Result<String> {
-        super::fetch_actions_job_log_via_gh(&self.owner, &self.repo, &self.repo_path, job_id)
+        super::actions::fetch_actions_job_log_via_gh(
+            &self.owner,
+            &self.repo,
+            &self.repo_path,
+            job_id,
+        )
     }
     fn run_internal_command(
         &mut self,

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -127,3 +127,225 @@ pub enum HookError {
     #[error("invalid hook event: {0}")]
     InvalidEvent(String),
 }
+
+// ---------------------------------------------------------------------------
+// SPEC-1942 Phase 4: in-process hook dispatch + daemon-front-door bootstrap
+// (moved here from cli.rs as part of family helper migration). All entry
+// points stay reachable via super::hook::* from cli.rs and env.rs.
+// ---------------------------------------------------------------------------
+
+use gwt_github::{client::ApiError, SpecOpsError};
+
+use crate::cli::CliEnv;
+
+fn io_as_api_error(err: io::Error) -> SpecOpsError {
+    SpecOpsError::from(ApiError::Network(err.to_string()))
+}
+
+pub fn run_hook<E: CliEnv>(env: &mut E, name: &str, rest: &[String]) -> Result<i32, SpecOpsError> {
+    run_daemon_hook(env, name, rest)
+}
+
+#[cfg(test)]
+pub(crate) fn daemon_hook_argv(name: &str, rest: &[String]) -> Vec<String> {
+    let mut argv = vec![
+        "gwtd".to_string(),
+        "__internal".to_string(),
+        "daemon-hook".to_string(),
+        name.to_string(),
+    ];
+    argv.extend(rest.iter().cloned());
+    argv
+}
+
+#[cfg(test)]
+pub(crate) fn write_internal_command_output<E: CliEnv>(
+    env: &mut E,
+    output: crate::cli::env::InternalCommandOutput,
+) -> Result<i32, SpecOpsError> {
+    env.stdout()
+        .write_all(&output.stdout)
+        .map_err(io_as_api_error)?;
+    env.stdout().flush().map_err(io_as_api_error)?;
+    env.stderr()
+        .write_all(&output.stderr)
+        .map_err(io_as_api_error)?;
+    env.stderr().flush().map_err(io_as_api_error)?;
+    Ok(output.status)
+}
+
+pub fn prepare_daemon_front_door_for_path(project_root: &std::path::Path) -> Result<(), String> {
+    if !project_root.exists() {
+        return Ok(());
+    }
+
+    refresh_managed_assets_for_hook_front_door(project_root)?;
+
+    crate::index_worker::bootstrap_project_index_for_path(project_root)?;
+
+    let scope = gwt_core::daemon::RuntimeScope::from_project_root(
+        project_root,
+        gwt_core::daemon::RuntimeTarget::Host,
+    )
+    .map_err(|err| err.to_string())?;
+    let gwt_home = gwt_core::paths::gwt_home();
+    let action = gwt_core::daemon::resolve_bootstrap_action(
+        &gwt_home,
+        &scope,
+        gwt_core::daemon::DAEMON_PROTOCOL_VERSION,
+        |pid| pid == std::process::id(),
+    )
+    .map_err(|err| err.to_string())?;
+
+    if let gwt_core::daemon::DaemonBootstrapAction::Spawn { endpoint_path } = action {
+        let endpoint = gwt_core::daemon::DaemonEndpoint::new(
+            scope,
+            std::process::id(),
+            "internal://gwt-front-door".to_string(),
+            uuid::Uuid::new_v4().to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+        );
+        gwt_core::daemon::persist_endpoint(&endpoint_path, &endpoint)
+            .map_err(|err| err.to_string())?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn refresh_managed_assets_for_hook_front_door(
+    project_root: &std::path::Path,
+) -> Result<(), String> {
+    if gwt_git::Repository::discover(project_root).is_err() {
+        return Ok(());
+    }
+    crate::managed_assets::refresh_managed_gwt_assets_for_worktree(project_root)
+        .map_err(|err| err.to_string())
+}
+
+pub fn run_daemon_hook<E: CliEnv>(
+    env: &mut E,
+    name: &str,
+    rest: &[String],
+) -> Result<i32, SpecOpsError> {
+    use crate::cli::hook::{
+        block_bash_policy, event_dispatcher, skill_build_spec_stop_check,
+        skill_discussion_stop_check, skill_plan_spec_stop_check, workflow_policy, HookKind,
+        HookOutput,
+    };
+
+    let Some(kind) = HookKind::from_name(name) else {
+        let _ = writeln!(env.stderr(), "gwtd hook: unknown hook '{name}'");
+        return Ok(2);
+    };
+    let stdin = env.read_stdin().map_err(io_as_api_error)?;
+
+    fn emit_hook_output<E: CliEnv>(env: &mut E, output: &HookOutput) -> i32 {
+        match output.serialize_to(env.stdout()) {
+            Ok(()) => output.exit_code(),
+            Err(err) => {
+                let _ = writeln!(env.stderr(), "gwtd hook: failed to serialize output: {err}");
+                1
+            }
+        }
+    }
+    fn emit_hook_error<E: CliEnv>(env: &mut E, name: &str, err: impl std::fmt::Display) -> i32 {
+        let _ = writeln!(env.stderr(), "gwtd hook {name}: {err}");
+        1
+    }
+
+    match kind {
+        HookKind::Event => {
+            let Some(event) = rest.first() else {
+                let _ = writeln!(env.stderr(), "gwtd hook event: missing <event> argument");
+                return Ok(2);
+            };
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            match event_dispatcher::handle_with_input(
+                event,
+                &stdin,
+                &cwd,
+                current_session.as_deref(),
+            ) {
+                Ok(output) => Ok(emit_hook_output(env, &output)),
+                Err(err) => Ok(emit_hook_error(env, name, err)),
+            }
+        }
+        HookKind::RuntimeState => {
+            let Some(event) = rest.first() else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook runtime-state: missing <event> argument"
+                );
+                return Ok(2);
+            };
+            match crate::daemon_runtime::handle_runtime_state(event, &stdin) {
+                Ok(()) => Ok(0),
+                Err(err) => Ok(emit_hook_error(env, name, err)),
+            }
+        }
+        HookKind::CoordinationEvent => {
+            let Some(event) = rest.first() else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook coordination-event: missing <event> argument"
+                );
+                return Ok(2);
+            };
+            match crate::daemon_runtime::handle_coordination_event(event, &stdin) {
+                Ok(()) => Ok(0),
+                Err(err) => Ok(emit_hook_error(env, name, err)),
+            }
+        }
+        HookKind::BoardReminder => {
+            let Some(event) = rest.first() else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook board-reminder: missing <event> argument"
+                );
+                return Ok(2);
+            };
+            match crate::cli::hook::board_reminder::handle_with_input(event, &stdin) {
+                Ok(output) => Ok(emit_hook_output(env, &output)),
+                Err(err) => Ok(emit_hook_error(env, name, err)),
+            }
+        }
+        HookKind::BlockBashPolicy => match block_bash_policy::handle_with_input(&stdin) {
+            Ok(output) => Ok(emit_hook_output(env, &output)),
+            Err(err) => Ok(emit_hook_error(env, name, err)),
+        },
+        HookKind::WorkflowPolicy => match workflow_policy::handle_with_input(&stdin) {
+            Ok(output) => Ok(emit_hook_output(env, &output)),
+            Err(err) => Ok(emit_hook_error(env, name, err)),
+        },
+        HookKind::Forward => match crate::daemon_runtime::handle_forward(&stdin) {
+            Ok(()) => Ok(0),
+            Err(err) => Ok(emit_hook_error(env, name, err)),
+        },
+        HookKind::SkillDiscussionStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let output = skill_discussion_stop_check::handle_with_input(&cwd, &stdin);
+            Ok(emit_hook_output(env, &output))
+        }
+        HookKind::SkillPlanSpecStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            let output = skill_plan_spec_stop_check::handle_with_input(
+                &cwd,
+                &stdin,
+                current_session.as_deref(),
+            );
+            Ok(emit_hook_output(env, &output))
+        }
+        HookKind::SkillBuildSpecStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            let output = skill_build_spec_stop_check::handle_with_input(
+                &cwd,
+                &stdin,
+                current_session.as_deref(),
+            );
+            Ok(emit_hook_output(env, &output))
+        }
+    }
+}

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -1,6 +1,15 @@
-use gwt_github::{Cache, IssueClient, IssueNumber, IssueSnapshot, IssueState, SpecOpsError};
+use std::{fs, io, path::PathBuf};
+
+use gwt_github::{
+    cache::write_atomic, client::ApiError, Cache, IssueClient, IssueNumber, IssueSnapshot,
+    IssueState, SpecOpsError,
+};
 
 use crate::cli::{CliEnv, CliParseError, IssueCommand, LinkedPrSummary};
+
+fn io_as_api_error(err: io::Error) -> SpecOpsError {
+    SpecOpsError::from(ApiError::Network(err.to_string()))
+}
 
 pub(super) fn parse(args: &[String]) -> Result<IssueCommand, CliParseError> {
     let mut it = args.iter().peekable();
@@ -42,17 +51,17 @@ pub(super) fn run<E: CliEnv>(
 
     let code = match cmd {
         IssueCommand::View { number, refresh } => {
-            let entry = super::load_or_refresh_issue(env, IssueNumber(number), refresh)?;
+            let entry = load_or_refresh_issue(env, IssueNumber(number), refresh)?;
             render_issue(out, &entry.snapshot);
             0
         }
         IssueCommand::Comments { number, refresh } => {
-            let entry = super::load_or_refresh_issue(env, IssueNumber(number), refresh)?;
+            let entry = load_or_refresh_issue(env, IssueNumber(number), refresh)?;
             render_issue_comments(out, &entry.snapshot);
             0
         }
         IssueCommand::LinkedPrs { number, refresh } => {
-            let linked_prs = super::load_or_refresh_linked_prs(env, IssueNumber(number), refresh)?;
+            let linked_prs = load_or_refresh_linked_prs(env, IssueNumber(number), refresh)?;
             render_linked_prs(out, &linked_prs);
             0
         }
@@ -73,7 +82,7 @@ pub(super) fn run<E: CliEnv>(
         IssueCommand::Comment { number, file } => {
             let body = env.read_file(&file).map_err(super::io_as_api_error)?;
             let comment = env.client().create_comment(IssueNumber(number), &body)?;
-            let _ = super::refresh_issue_cache(env, IssueNumber(number))?;
+            let _ = refresh_issue_cache(env, IssueNumber(number))?;
             out.push_str(&format!(
                 "created comment {} on #{}\n",
                 comment.id.0, number
@@ -210,6 +219,206 @@ pub(super) fn render_linked_prs(out: &mut String, linked_prs: &[LinkedPrSummary]
             pr.number, pr.state, pr.title, pr.url
         ));
     }
+}
+
+pub(super) fn load_or_refresh_issue<E: CliEnv>(
+    env: &mut E,
+    number: IssueNumber,
+    refresh: bool,
+) -> Result<gwt_github::CacheEntry, SpecOpsError> {
+    let cache = Cache::new(env.cache_root());
+    if !refresh {
+        if let Some(entry) = cache.load_entry(number) {
+            return Ok(entry);
+        }
+    }
+    refresh_issue_cache(env, number)
+}
+
+pub(super) fn refresh_issue_cache<E: CliEnv>(
+    env: &mut E,
+    number: IssueNumber,
+) -> Result<gwt_github::CacheEntry, SpecOpsError> {
+    let snapshot = match env.client().fetch(number, None)? {
+        gwt_github::FetchResult::Updated(snapshot) => snapshot,
+        gwt_github::FetchResult::NotModified => {
+            return Cache::new(env.cache_root())
+                .load_entry(number)
+                .ok_or_else(|| SpecOpsError::SectionNotFound(format!("issue {}", number.0)));
+        }
+    };
+    let cache = Cache::new(env.cache_root());
+    cache.write_snapshot(&snapshot)?;
+    cache
+        .load_entry(number)
+        .ok_or_else(|| SpecOpsError::SectionNotFound(format!("issue {}", number.0)))
+}
+
+pub(super) fn load_or_refresh_linked_prs<E: CliEnv>(
+    env: &mut E,
+    number: IssueNumber,
+    refresh: bool,
+) -> Result<Vec<LinkedPrSummary>, SpecOpsError> {
+    let cache_root = env.cache_root();
+    if !refresh {
+        if let Some(cached) = read_linked_prs_cache(&cache_root, number)? {
+            return Ok(cached);
+        }
+    }
+    let linked_prs = env.fetch_linked_prs(number).map_err(io_as_api_error)?;
+    write_linked_prs_cache(&cache_root, number, &linked_prs)?;
+    Ok(linked_prs)
+}
+
+pub(super) fn linked_prs_cache_path(cache_root: &std::path::Path, number: IssueNumber) -> PathBuf {
+    cache_root
+        .join(number.0.to_string())
+        .join("linked_prs.json")
+}
+
+pub(super) fn read_linked_prs_cache(
+    cache_root: &std::path::Path,
+    number: IssueNumber,
+) -> Result<Option<Vec<LinkedPrSummary>>, SpecOpsError> {
+    let path = linked_prs_cache_path(cache_root, number);
+    match fs::read_to_string(&path) {
+        Ok(text) => {
+            let parsed = serde_json::from_str(&text)
+                .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
+            Ok(Some(parsed))
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(io_as_api_error(err)),
+    }
+}
+
+pub(super) fn write_linked_prs_cache(
+    cache_root: &std::path::Path,
+    number: IssueNumber,
+    linked_prs: &[LinkedPrSummary],
+) -> Result<(), SpecOpsError> {
+    let bytes = serde_json::to_vec_pretty(linked_prs)
+        .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
+    write_atomic(&linked_prs_cache_path(cache_root, number), &bytes).map_err(io_as_api_error)
+}
+
+pub(super) fn fetch_linked_prs_via_gh(
+    owner: &str,
+    repo: &str,
+    number: IssueNumber,
+) -> io::Result<Vec<LinkedPrSummary>> {
+    let query = r#"
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT]) {
+        nodes {
+          __typename
+          ... on CrossReferencedEvent {
+            source {
+              __typename
+              ... on PullRequest {
+                number
+                title
+                state
+                url
+              }
+            }
+          }
+          ... on ConnectedEvent {
+            subject {
+              __typename
+              ... on PullRequest {
+                number
+                title
+                state
+                url
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+    let output = gwt_core::process::hidden_command("gh")
+        .args([
+            "api",
+            "graphql",
+            "-f",
+            &format!("query={query}"),
+            "-f",
+            &format!("owner={owner}"),
+            "-f",
+            &format!("repo={repo}"),
+            "-F",
+            &format!("number={}", number.0),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "gh api graphql failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+    let nodes = value
+        .get("data")
+        .and_then(|v| v.get("repository"))
+        .and_then(|v| v.get("issue"))
+        .and_then(|v| v.get("timelineItems"))
+        .and_then(|v| v.get("nodes"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = Vec::new();
+    for node in nodes {
+        let typename = node
+            .get("__typename")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let pr = match typename {
+            "CrossReferencedEvent" => node.get("source"),
+            "ConnectedEvent" => node.get("subject"),
+            _ => None,
+        };
+        let Some(pr) = pr else { continue };
+        if pr.get("__typename").and_then(|v| v.as_str()) != Some("PullRequest") {
+            continue;
+        }
+        let Some(pr_number) = pr.get("number").and_then(|v| v.as_u64()) else {
+            continue;
+        };
+        if !seen.insert(pr_number) {
+            continue;
+        }
+        out.push(LinkedPrSummary {
+            number: pr_number,
+            title: pr
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            state: pr
+                .get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            url: pr
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        });
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -4351,7 +4351,7 @@ fn main() -> wry::Result<()> {
         })
         .ok();
 
-    if let Err(error) = gwt::cli::prepare_daemon_front_door_for_path(&startup_dir) {
+    if let Err(error) = gwt::cli::hook::prepare_daemon_front_door_for_path(&startup_dir) {
         eprintln!("gwt daemon bootstrap: {error}");
     }
 


### PR DESCRIPTION
## Summary

SPEC-1942 SC-025 進捗の連続 follow-up: 残 helper を 3 つの family module へ集約。 cli.rs を 1992 → 1545 行に縮小 (-447、 累計 -1156 from 2701、 god-module の 42.8%)。

## Changes

### `cli/issue.rs` へ移動 (`pub(super)`)

issue cache + linked-PR 系 7 helper:
- `load_or_refresh_issue` / `refresh_issue_cache`
- `load_or_refresh_linked_prs` / `linked_prs_cache_path`
- `read_linked_prs_cache` / `write_linked_prs_cache` / `fetch_linked_prs_via_gh`

### `cli/actions.rs` へ移動 (`pub(super)`)

GitHub Actions log 取得 helper:
- `fetch_actions_run_log_via_gh` / `fetch_actions_job_log_via_gh`

### `cli/hook/mod.rs` へ移動

hook dispatch + daemon front door helper:
- `run_hook` (`pub`、 in-process hook entry)
- `run_daemon_hook` (`pub`、 internal daemon-hook fallback)
- `daemon_hook_argv` (`pub(crate)`、 test-only argv builder)
- `write_internal_command_output` (`pub(crate)`、 test-only stream relay)
- `prepare_daemon_front_door_for_path` (`pub`、 daemon bootstrap)
- `refresh_managed_assets_for_hook_front_door` (`pub(crate)`)

### caller 更新

- `env.rs` の `super::fetch_linked_prs_via_gh` → `super::issue::fetch_linked_prs_via_gh`
- `env.rs` の `super::fetch_actions_*_via_gh` → `super::actions::fetch_actions_*_via_gh`
- `cli.rs` の `run_hook` / `run_daemon_hook` → `hook::run_hook` / `hook::run_daemon_hook`
- `main.rs` (gwt binary) の `cli::prepare_daemon_front_door_for_path` →
  `cli::hook::prepare_daemon_front_door_for_path`
- `cli.rs` 内 test refs を `crate::cli::issue::*` / `crate::cli::actions::*` /
  `crate::cli::hook::*` qualified path に更新

## Metrics

| 項目 | 前 | 後 | 差分 |
|---|---|---|---|
| `cli.rs` | 1992 行 | **1545 行** | **-447** |
| `cli/issue.rs` | 293 行 | 492 行 | +199 |
| `cli/actions.rs` | 83 行 | 128 行 | +45 |
| `cli/hook/mod.rs` | 129 行 | 351 行 | +222 |

SC-025 (`cli.rs` <1000 行) target に対する継続進捗:
- 開始時 (PR #2264 merge 後) cli.rs = 2701 行
- PR #2266 後 = 2572 (-129)
- PR #2267 後 = 1992 (-580、 -709 累計)
- **本 PR 後 = 1545 (-447、 -1156 累計、 god-module の 42.8% 縮小)**
- 残 ~545 行を test relocation (gh_wrappers_* / pr_checks_response_* / review_thread_reply_* / cache_backed_issue_* / render_helpers_* を family module の tests へ) で達成見込

## Testing

- `cargo test -p gwt --lib`: **345 passed**
- `cargo test -p gwt --tests`: 全 integration tests pass (cli_test 68件含む、 既知 flake test `app_runtime_viewport_and_geometry_updates_persist_workspace_state` は個別 run で pass)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: 差分なし

## Closing Issues

None (SPEC-1942 phase/implementation 継続)。

## Related Issues

- #1942 SPEC-1942 (gwt CLI) - SC-025 helper migration follow-up
- #2267 直前 PR (fetch_pr_*_via_gh の移行)
- #2266 render_* helpers の移行
- #2264 family-nested CliCommand split

🤖 Generated with [Claude Code](https://claude.com/claude-code)
