### PR TITLE
feat(cli): gwtd --help を 2 段階 family 階層出力に拡張 (SPEC-1942 T-204)

### DIFF
--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -8,10 +8,27 @@ fn main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
         Some("-h" | "--help") | None => {
+            // SPEC-1942 T-204: `gwtd --help <family>` shows family-scoped help.
+            if let Some(family) = argv.get(2).map(String::as_str) {
+                if let Some(help_text) = family_help(family) {
+                    print!("{help_text}");
+                    return ExitCode::SUCCESS;
+                }
+            }
             print_help();
             return ExitCode::SUCCESS;
         }
         _ => {}
+    }
+
+    // SPEC-1942 T-204: `gwtd <family> --help` mirrors `gwtd --help <family>`.
+    if matches!(argv.get(2).map(String::as_str), Some("-h" | "--help")) {
+        if let Some(family) = argv.get(1).map(String::as_str) {
+            if let Some(help_text) = family_help(family) {
+                print!("{help_text}");
+                return ExitCode::SUCCESS;
+            }
+        }
     }
 
     if !gwt::cli::should_dispatch_cli(&argv) {
@@ -38,8 +55,226 @@ fn print_help() {
     println!("Headless CLI for gwt agent, hook, and workflow automation.");
     println!();
     println!("Usage: gwtd <command> [args]");
+    println!("       gwtd --help <command>   Show subcommands for a family");
     println!();
-    println!("Commands: issue, pr, actions, board, hook, discuss, plan, build, index, update");
+    println!("Commands:");
+    println!("  issue       Manage GitHub Issues and SPEC sections");
+    println!("  pr          Manage pull requests, reviews, checks, threads");
+    println!("  actions     Fetch GitHub Actions run/job logs");
+    println!("  board       Read/write the coordination Board (SPEC-1974)");
+    println!("  hook        Dispatch Claude Code / Codex hook events");
+    println!("  index       Manage the local search index");
+    println!("  discuss     gwt-discussion exit CLI (SPEC-1935)");
+    println!("  plan        gwt-plan-spec exit CLI (SPEC-1935)");
+    println!("  build       gwt-build-spec exit CLI (SPEC-1935)");
+    println!("  update      Check / apply gwt updates");
+}
+
+/// SPEC-1942 T-204: render family-scoped help text. Returns `None` for
+/// unknown families so the caller can fall back to the global help.
+fn family_help(family: &str) -> Option<String> {
+    match family {
+        "issue" => Some(format_issue_help()),
+        "pr" => Some(format_pr_help()),
+        "actions" => Some(format_actions_help()),
+        "board" => Some(format_board_help()),
+        "hook" => Some(format_hook_help()),
+        "index" => Some(format_index_help()),
+        "discuss" => Some(format_discuss_help()),
+        "plan" => Some(format_plan_help()),
+        "build" => Some(format_build_help()),
+        "update" => Some(format_update_help()),
+        _ => None,
+    }
+}
+
+fn format_issue_help() -> String {
+    [
+        "gwtd issue — Manage GitHub Issues and SPEC sections.",
+        "",
+        "Usage: gwtd issue <subcommand> [args]",
+        "",
+        "Subcommands:",
+        "  spec <n>                              Print every section for an issue",
+        "  spec <n> --section <name>             Print one section only",
+        "  spec <n> --edit <name> -f <file>      Replace one section from file (- = stdin)",
+        "  spec <n> --edit spec --json [-f <f>] [--replace]",
+        "                                         Structured JSON update for the spec section",
+        "  spec <n> --rename <title>             Update the issue title",
+        "  spec list [--phase <p>] [--state open|closed]",
+        "                                         List SPEC-labeled issues",
+        "  spec create --title <t> -f <body> [--label <l>]*",
+        "                                         Create a SPEC issue",
+        "  spec create --json --title <t> [-f <f>] [--label <l>]*",
+        "                                         Create a SPEC from structured JSON",
+        "  spec pull [--all | <n>...]            Refresh cache from server",
+        "  spec repair <n>                        Clear cache and re-fetch from server",
+        "  view <n> [--refresh]                  Print a plain issue from cache or live",
+        "  comments <n> [--refresh]              Print issue comments",
+        "  linked-prs <n> [--refresh]            Print linked PR summaries",
+        "  create --title <t> -f <body> [--label <l>]*",
+        "                                         Create a plain issue",
+        "  comment <n> -f <body>                 Create a plain issue comment",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_pr_help() -> String {
+    [
+        "gwtd pr — Manage pull requests, reviews, checks, and threads.",
+        "",
+        "Usage: gwtd pr <subcommand> [args]",
+        "",
+        "Subcommands:",
+        "  current                                Print the PR for the current branch",
+        "  create --base <b> [--head <h>] --title <t> -f <body> [--label <l>]* [--draft]",
+        "                                          Create a pull request",
+        "  edit <n> [--title <t>] [-f <body>] [--add-label <l>]*",
+        "                                          Update a pull request",
+        "  view <n>                               Print a PR by number",
+        "  comment <n> -f <body>                  Add a PR issue comment",
+        "  reviews <n>                            Print PR review summaries",
+        "  review-threads <n>                     Print review thread snapshots",
+        "  review-threads reply-and-resolve <n> -f <body>",
+        "                                          Reply to + resolve unresolved threads",
+        "  checks <n>                             Print PR checks summary",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_actions_help() -> String {
+    [
+        "gwtd actions — Fetch GitHub Actions run/job logs.",
+        "",
+        "Usage: gwtd actions <subcommand> [args]",
+        "",
+        "Subcommands:",
+        "  logs --run <id>                        Print raw run logs",
+        "  job-logs --job <id>                    Print raw job logs",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_board_help() -> String {
+    [
+        "gwtd board — Read/write the coordination Board (SPEC-1974).",
+        "",
+        "Usage: gwtd board <subcommand> [args]",
+        "",
+        "Subcommands:",
+        "  show [--json]                           Print the Board snapshot",
+        "  post --kind <kind> (--body <text> | -f <file>)",
+        "       [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]*",
+        "                                          Append a Board entry",
+        "",
+        "Kinds: request, status, next, claim, impact, question, blocked, handoff, decision",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_hook_help() -> String {
+    [
+        "gwtd hook — Dispatch Claude Code / Codex hook events (SPEC-1935).",
+        "",
+        "Usage: gwtd hook <name> [args]",
+        "",
+        "Hook names:",
+        "  event <PreToolUse|...>                  Generic event dispatcher",
+        "  runtime-state <event>                   Runtime state telemetry",
+        "  coordination-event <event>              Coordination Board event",
+        "  board-reminder                          Board reminder injection",
+        "  workflow-policy                         PreToolUse workflow guard",
+        "  block-bash-policy                       PreToolUse Bash policy guard",
+        "  forward                                 Bridge to live event stream",
+        "  skill-discussion-stop-check             Stop-check for gwt-discussion",
+        "  skill-plan-spec-stop-check              Stop-check for gwt-plan-spec",
+        "  skill-build-spec-stop-check             Stop-check for gwt-build-spec",
+        "",
+        "Stdin: hooks read JSON from stdin per the Claude Code hook contract.",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_index_help() -> String {
+    [
+        "gwtd index — Manage the local search index.",
+        "",
+        "Usage: gwtd index <subcommand> [args]",
+        "",
+        "Subcommands:",
+        "  status                                  Show index runtime + asset status",
+        "  rebuild [--scope all|issues|specs|files|files-docs]",
+        "                                          Rebuild a specific scope",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_discuss_help() -> String {
+    [
+        "gwtd discuss — gwt-discussion exit CLI (SPEC-1935).",
+        "",
+        "Usage: gwtd discuss <action> --proposal <label>",
+        "",
+        "Actions:",
+        "  resolve --proposal <label>              Mark a proposal chosen",
+        "  park --proposal <label>                 Mark a proposal parked",
+        "  reject --proposal <label>               Mark a proposal rejected",
+        "  clear-next-question --proposal <label>  Clear the open question (Stop unblock)",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_plan_help() -> String {
+    [
+        "gwtd plan — gwt-plan-spec exit CLI (SPEC-1935).",
+        "",
+        "Usage: gwtd plan <action> --spec <n> [...]",
+        "",
+        "Actions:",
+        "  start --spec <n>                       Mark plan-spec started",
+        "  phase --spec <n> --label <stage>       Mark a phase milestone",
+        "  complete --spec <n>                    Mark plan-spec complete",
+        "  abort --spec <n> [--reason <text>]     Abort plan-spec",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_build_help() -> String {
+    [
+        "gwtd build — gwt-build-spec exit CLI (SPEC-1935).",
+        "",
+        "Usage: gwtd build <action> --spec <n> [...]",
+        "",
+        "Actions:",
+        "  start --spec <n>                       Mark build-spec started",
+        "  phase --spec <n> --label <stage>       Mark a phase milestone (red/green/...)",
+        "  complete --spec <n>                    Mark build-spec complete",
+        "  abort --spec <n> [--reason <text>]     Abort build-spec",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_update_help() -> String {
+    [
+        "gwtd update — Check / apply gwt updates.",
+        "",
+        "Usage: gwtd update [--check]",
+        "",
+        "Flags:",
+        "  --check                                 Only check, do not download/apply",
+        "  (no flag)                               Check and prompt to apply",
+        "",
+    ]
+    .join("\n")
 }
 
 fn run_repo_backed_cli(argv: &[String]) -> i32 {


### PR DESCRIPTION
## Summary

SPEC-1942 **T-204 完了**: `gwtd --help` を family 階層 → subcommand 階層の 2 段表示に拡張。 family 一覧と各 family の詳細 subcommand 一覧を独立に呼び出せる UX に。

## Changes

### 新しい help 形式

| コマンド | 出力 |
|---|---|
| `gwtd --help` | family 一覧 + 各 family の 1 行説明 |
| `gwtd --help <family>` | 指定 family の subcommand 一覧 |
| `gwtd <family> --help` | 同上 (代替形式) |
| `gwtd --help <unknown>` | global help にフォールバック |

### Family help 対応 (10 family)

`issue` / `pr` / `actions` / `board` / `hook` / `index` / `discuss` / `plan` / `build` / `update` 各 family の subcommand / フラグ / オプションをまとめた help テキストを `format_<family>_help()` で生成。

### Implementation

`gwtd/src/bin/gwtd.rs` に:
- `family_help(family: &str) -> Option<String>` ルーティング関数を追加
- `--help` の前段 intercept を強化 (既存 dispatch 経路は不変)
- `gwtd <family> --help` 形式も `--help <family>` と同一出力にマップ

外部 CLI 契約 (subcommand 列・stdout / exit code) は変更なし。

## Sample output

`gwtd --help`:
```
gwtd 9.14.0
Headless CLI for gwt agent, hook, and workflow automation.

Usage: gwtd <command> [args]
       gwtd --help <command>   Show subcommands for a family

Commands:
  issue       Manage GitHub Issues and SPEC sections
  pr          Manage pull requests, reviews, checks, threads
  actions     Fetch GitHub Actions run/job logs
  board       Read/write the coordination Board (SPEC-1974)
  hook        Dispatch Claude Code / Codex hook events
  ...
```

`gwtd --help board`:
```
gwtd board — Read/write the coordination Board (SPEC-1974).

Usage: gwtd board <subcommand> [args]

Subcommands:
  show [--json]                           Print the Board snapshot
  post --kind <kind> (--body <text> | -f <file>)
       [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]*
                                          Append a Board entry

Kinds: request, status, next, claim, impact, question, blocked, handoff, decision
```

## Testing

- `cargo build -p gwt --bin gwtd`: 通過
- `cargo test -p gwt --lib`: **345 passed**
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: 差分なし
- 手動 smoke test:
  - `gwtd --help` / `--help <family>` / `<family> --help` (10 family 全て)
  - `--help unknown` → global help fallback
  - 既存 dispatch (`issue spec list` / `board show --json`) 動作不変

## Closing Issues

None (SPEC-1942 phase/implementation 継続)。

## Related Issues

- #1942 SPEC-1942 (gwt CLI) - T-204 完了
- #2269 直前 PR (family tests relocate + SC-025 達成)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
