### PR TITLE
fix(cli): multi-remote / env override 対応で gwt pr remote 解決を堅牢化 (#2054)

### DIFF
--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -291,14 +291,62 @@ fn run_repo_backed_cli(argv: &[String]) -> i32 {
 }
 
 fn resolve_repo_coordinates() -> Option<(String, String)> {
-    let output = gwt_core::process::hidden_command("git")
-        .args(["remote", "get-url", "origin"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+    // Issue #2054: scan every remote (not just `origin`) and honour
+    // `GWT_GITHUB_REPO` / `GWT_REMOTE` overrides so multi-remote repos
+    // (local mirror + GitHub under a non-origin name) can still resolve.
+    if let Some(slug) = std::env::var("GWT_GITHUB_REPO")
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        if let Some(parsed) = parse_owner_repo(slug.trim_end_matches(".git")) {
+            return Some(parsed);
+        }
     }
-    parse_github_remote_url(String::from_utf8_lossy(&output.stdout).trim())
+
+    let remotes = load_remote_pairs();
+
+    if let Some(name) = std::env::var("GWT_REMOTE").ok().filter(|v| !v.is_empty()) {
+        if let Some((_, url)) = remotes.iter().find(|(remote_name, _)| remote_name == &name) {
+            if let Some(parsed) = parse_github_remote_url(url) {
+                return Some(parsed);
+            }
+        }
+    }
+
+    if let Some((_, url)) = remotes.iter().find(|(name, _)| name == "origin") {
+        if let Some(parsed) = parse_github_remote_url(url) {
+            return Some(parsed);
+        }
+    }
+
+    remotes
+        .iter()
+        .find_map(|(_, url)| parse_github_remote_url(url))
+}
+
+fn load_remote_pairs() -> Vec<(String, String)> {
+    let Ok(output) = gwt_core::process::hidden_command("git")
+        .args(["remote", "-v"])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(name) = parts.next() else { continue };
+        let Some(url) = parts.next() else { continue };
+        if !seen.insert(name.to_string()) {
+            continue;
+        }
+        out.push((name.to_string(), url.to_string()));
+    }
+    out
 }
 
 fn parse_github_remote_url(url: &str) -> Option<(String, String)> {

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -464,15 +464,109 @@ mod windows_console {
 }
 
 pub(crate) fn resolve_repo_coordinates() -> Option<(String, String)> {
+    // Issue #2054: support multi-remote git repos where `origin` points at a
+    // local mirror and the GitHub URL lives under a different remote name.
+    // Resolution order:
+    //   1. `GWT_GITHUB_REPO=owner/name` direct override
+    //   2. `GWT_REMOTE=<name>` selects the remote to read
+    //   3. `origin` remote URL (legacy default)
+    //   4. Scan all remotes and pick the first GitHub URL we find
+    select_repo_coordinates(&load_remote_urls(), &repo_env_overrides())
+}
+
+/// Pure resolver kept independent of git invocation so it can be unit-tested
+/// against synthetic remote fixtures.
+pub(crate) fn select_repo_coordinates(
+    remotes: &[(String, String)],
+    overrides: &RepoEnvOverrides,
+) -> Option<(String, String)> {
+    if let Some(direct) = overrides
+        .github_repo
+        .as_deref()
+        .and_then(parse_owner_repo_pair)
+    {
+        return Some(direct);
+    }
+
+    if let Some(name) = overrides.remote.as_deref() {
+        if let Some((_, url)) = remotes
+            .iter()
+            .find(|(remote_name, _)| remote_name.as_str() == name)
+        {
+            if let Some(parsed) = parse_github_remote_url(url) {
+                return Some(parsed);
+            }
+        }
+    }
+
+    if let Some((_, url)) = remotes.iter().find(|(name, _)| name.as_str() == "origin") {
+        if let Some(parsed) = parse_github_remote_url(url) {
+            return Some(parsed);
+        }
+    }
+
+    remotes
+        .iter()
+        .find_map(|(_, url)| parse_github_remote_url(url))
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RepoEnvOverrides {
+    pub github_repo: Option<String>,
+    pub remote: Option<String>,
+}
+
+fn repo_env_overrides() -> RepoEnvOverrides {
+    RepoEnvOverrides {
+        github_repo: std::env::var("GWT_GITHUB_REPO")
+            .ok()
+            .filter(|v| !v.is_empty()),
+        remote: std::env::var("GWT_REMOTE").ok().filter(|v| !v.is_empty()),
+    }
+}
+
+fn load_remote_urls() -> Vec<(String, String)> {
     let output = gwt_core::process::hidden_command("git")
-        .args(["remote", "get-url", "origin"])
-        .output()
-        .ok()?;
+        .args(["remote", "-v"])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
     if !output.status.success() {
+        return Vec::new();
+    }
+    parse_git_remote_v(&String::from_utf8_lossy(&output.stdout))
+}
+
+pub(crate) fn parse_git_remote_v(text: &str) -> Vec<(String, String)> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(name) = parts.next() else { continue };
+        let Some(url) = parts.next() else { continue };
+        // The third token is "(fetch)" / "(push)". `git remote -v` lists each
+        // remote twice; dedupe so callers see a single entry per name.
+        if !seen.insert(name.to_string()) {
+            continue;
+        }
+        out.push((name.to_string(), url.to_string()));
+    }
+    out
+}
+
+fn parse_owner_repo_pair(value: &str) -> Option<(String, String)> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
         return None;
     }
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    parse_github_remote_url(&url)
+    let mut parts = trimmed.splitn(2, '/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim().trim_end_matches(".git");
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
 }
 
 pub(crate) fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
@@ -597,6 +691,107 @@ mod tests {
         assert!(
             !target.needs_migration,
             "Bare layout must not request migration"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Issue #2054: gwt pr remote resolution must tolerate non-GitHub
+    // `origin` and explicit env overrides.
+    // -------------------------------------------------------------------
+
+    fn s(value: &str) -> String {
+        value.to_string()
+    }
+
+    fn remotes(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs.iter().map(|(name, url)| (s(name), s(url))).collect()
+    }
+
+    #[test]
+    fn select_repo_coordinates_prefers_origin_when_it_is_github() {
+        let coords = super::select_repo_coordinates(
+            &remotes(&[
+                ("origin", "https://github.com/akiojin/gwt"),
+                ("upstream", "https://github.com/anthropics/example"),
+            ]),
+            &super::RepoEnvOverrides::default(),
+        );
+        assert_eq!(coords, Some((s("akiojin"), s("gwt"))));
+    }
+
+    #[test]
+    fn select_repo_coordinates_falls_back_to_other_remote_when_origin_is_local_mirror() {
+        // The exact scenario from issue #2054: origin points at a local bare
+        // mirror, and the actual GitHub URL is registered under a different
+        // remote name (here `github`).
+        let coords = super::select_repo_coordinates(
+            &remotes(&[
+                ("origin", "E:/llmlb/llmlb.git"),
+                ("github", "https://github.com/akiojin/llmlb"),
+            ]),
+            &super::RepoEnvOverrides::default(),
+        );
+        assert_eq!(coords, Some((s("akiojin"), s("llmlb"))));
+    }
+
+    #[test]
+    fn select_repo_coordinates_honours_remote_env_override() {
+        // GWT_REMOTE=upstream should redirect resolution even if origin is a
+        // perfectly valid GitHub URL.
+        let coords = super::select_repo_coordinates(
+            &remotes(&[
+                ("origin", "https://github.com/akiojin/gwt"),
+                ("upstream", "git@github.com:anthropics/example.git"),
+            ]),
+            &super::RepoEnvOverrides {
+                github_repo: None,
+                remote: Some(s("upstream")),
+            },
+        );
+        assert_eq!(coords, Some((s("anthropics"), s("example"))));
+    }
+
+    #[test]
+    fn select_repo_coordinates_honours_github_repo_env_override() {
+        // GWT_GITHUB_REPO trumps every remote; useful when no GitHub remote
+        // is registered locally but the user knows the slug.
+        let coords = super::select_repo_coordinates(
+            &remotes(&[("origin", "E:/llmlb/llmlb.git")]),
+            &super::RepoEnvOverrides {
+                github_repo: Some(s("akiojin/llmlb")),
+                remote: None,
+            },
+        );
+        assert_eq!(coords, Some((s("akiojin"), s("llmlb"))));
+    }
+
+    #[test]
+    fn select_repo_coordinates_returns_none_when_no_github_remote_or_override() {
+        let coords = super::select_repo_coordinates(
+            &remotes(&[
+                ("origin", "E:/llmlb/llmlb.git"),
+                ("backup", "/srv/git/llmlb.git"),
+            ]),
+            &super::RepoEnvOverrides::default(),
+        );
+        assert_eq!(coords, None);
+    }
+
+    #[test]
+    fn parse_git_remote_v_dedupes_fetch_and_push_lines() {
+        let stdout = "\
+origin\thttps://github.com/akiojin/gwt (fetch)
+origin\thttps://github.com/akiojin/gwt (push)
+upstream\tgit@github.com:anthropics/example.git (fetch)
+upstream\tgit@github.com:anthropics/example.git (push)
+";
+        let parsed = super::parse_git_remote_v(stdout);
+        assert_eq!(
+            parsed,
+            vec![
+                (s("origin"), s("https://github.com/akiojin/gwt")),
+                (s("upstream"), s("git@github.com:anthropics/example.git")),
+            ]
         );
     }
 }


### PR DESCRIPTION
## Summary

`gwt pr` / `gwtd pr` が常に `origin` だけを見て GitHub URL を解決していたため、 `origin` がローカルベアミラーで GitHub が別 remote 名 (例: `github`) で登録された構成で `--help` 表示すらできず即死していた。 multi-remote 対応 + env 環境変数 override で堅牢化。

## Closing Issues

Closes #2054

## Resolution order (新仕様)

1. `GWT_GITHUB_REPO=owner/name` 環境変数 override (remote 探索を skip)
2. `GWT_REMOTE=<name>` 環境変数で参照 remote を指定
3. `origin` remote の URL (legacy default、 後方互換)
4. 全 remote を走査して最初に見つかる GitHub URL を採用

## Changes

### `crates/gwt/src/runtime_support.rs` (gwt binary)

- `resolve_repo_coordinates()` を multi-remote 対応に書き換え
- 純粋関数 `select_repo_coordinates(remotes, overrides)` を抽出 (unit test 可能)
- `parse_git_remote_v` で `git remote -v` 出力を `(name, url)` 配列に変換 (fetch/push 重複 dedup)
- `RepoEnvOverrides` struct で env 環境変数を集約

### `crates/gwt/src/bin/gwtd.rs` (gwtd binary)

- 同等のロジックを実装 (gwtd は独立バイナリで gwt::* に依存しないため重複)
- `load_remote_pairs` で `git remote -v` を解析

### Tests

`crates/gwt/src/runtime_support.rs::tests` に 5 件追加:

- `select_repo_coordinates_prefers_origin_when_it_is_github` (legacy default)
- `select_repo_coordinates_falls_back_to_other_remote_when_origin_is_local_mirror` (#2054 のシナリオ)
- `select_repo_coordinates_honours_remote_env_override` (GWT_REMOTE)
- `select_repo_coordinates_honours_github_repo_env_override` (GWT_GITHUB_REPO)
- `select_repo_coordinates_returns_none_when_no_github_remote_or_override` (negative case)

加えて `parse_git_remote_v_dedupes_fetch_and_push_lines` で git output parser を pin。

## Smoke Verification

scratch repo (`origin = .local-mirror.git` / `github = https://github.com/akiojin/gwt`) で:

```
$ gwtd pr current
no current pull request                    # 従来: could not resolve GitHub owner/repo

$ GWT_REMOTE=github gwtd pr current
no current pull request                    # 同上

$ GWT_GITHUB_REPO=akiojin/gwt gwtd pr current
no current pull request                    # 同上
```

全て従来は起動時即死していたケースが正常動作。

## Testing

- `cargo test -p gwt --lib`: **345 passed**
- `cargo test -p gwt --bin gwt`: **184 passed** (+5 new)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: 差分なし
- 手動 smoke (上記 3 ケース)

## Related Issues

- #2054 (本 PR で closes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository resolution now scans all Git remotes instead of only `origin`.
  * Environment variable overrides available for custom repository configuration.
  * Enhanced fallback mechanism to automatically detect GitHub repository details across available remotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->