### PR TITLE
fix + docs: persist recent_projects pruning + sync .codex skills (#1678/#1679)

### DIFF
--- a/.codex/skills/gwt-build-spec/SKILL.md
+++ b/.codex/skills/gwt-build-spec/SKILL.md
@@ -57,19 +57,18 @@ continuation; a genuinely stuck turn still terminates normally.
 Determine the mode at entry:
 
 - **SPEC mode** if a SPEC ID is provided or discoverable from the current branch/context, AND
-  `specs/SPEC-{id}/tasks.md` exists
+  `gwtd issue spec <N> --section tasks` で tasks セクションが取得できる
 - **Standalone mode** otherwise
 
 ## Phase 1: Context Load
 
 ### SPEC mode
 
-1. Load the SPEC directory: `spec.md`, `plan.md`, `tasks.md`, `progress.md` (if present).
-2. Load supporting artifacts: `research.md`, `data-model.md`, `quickstart.md`, `contracts/*`, `checklists/*`.
-3. Identify the next incomplete task slice in dependency order:
+1. `gwtd issue spec <N>` で SPEC の全セクション（spec, plan, tasks）を読み込む。
+2. Identify the next incomplete task slice in dependency order:
    - Setup before Foundational work
    - Foundational before story-specific work
-4. Use `.claude/scripts/spec_artifact.py` for artifact read/update operations.
+3. SPEC セクションの読み書きは `gwtd issue spec <N> --section <name>` / `gwtd issue spec <N> --edit <name> -f <file>` を使用する。
 
 ### Standalone mode
 
@@ -123,10 +122,10 @@ All other changes require the TDD loop.
 
 Run the smallest meaningful validation set first, then broaden:
 
-1. **Tests**: `cargo test -p gwt-core -p gwt-tui` (or narrower scope first)
+1. **Tests**: `cargo test -p gwt-core -p gwt` (or narrower scope first)
 2. **Lint**: `cargo clippy --all-targets --all-features -- -D warnings`
 3. **Format**: `cargo fmt -- --check`
-4. **Build**: `cargo build -p gwt-tui`
+4. **Build**: `cargo build -p gwt`
 
 In SPEC mode, also verify:
 
@@ -153,16 +152,15 @@ Reconcile implemented behavior against all SPEC artifacts. See `references/compl
 Required checks:
 
 - Every completed task in `tasks.md` matches the implementation
-- `checklists/acceptance.md` reflects actual accepted behavior
-- `checklists/tdd.md` reflects actual verification evidence
-- `progress.md` entries do not claim completion unsupported by code
+- tasks セクションの受け入れチェックボックスが実際の受け入れ済み動作を反映している
+- tasks セクションの TDD チェックボックスが実際の検証エビデンスを反映している
+- tasks セクションの完了マーカーがコードで裏付けられていない完了を主張していない
 - If artifacts disagree, return to `gwt-discussion` — do not proceed to PR
 
 Update execution tracking:
 
 - Mark completed tasks in `tasks.md`
-- Append progress to `specs/SPEC-{id}/progress.md` using the Progress / Done / Next template
-- Use `.claude/scripts/spec_artifact.py` for artifact updates
+- tasks セクションのチェックボックスを `gwtd issue spec <N> --edit tasks -f <file>` で更新する
 
 ### Standalone mode
 

--- a/.codex/skills/gwt-build-spec/references/completion-gate.md
+++ b/.codex/skills/gwt-build-spec/references/completion-gate.md
@@ -19,30 +19,30 @@ In SPEC mode, it reconciles all artifacts. In standalone mode, it verifies user 
 
 ### 3. Checklist verification
 
-#### checklists/acceptance.md
+#### Acceptance verification (tasks section)
 
 - Each acceptance criterion reflects actual tested behavior.
 - No criterion is marked "accepted" without a corresponding passing test.
 
-#### checklists/tdd.md
+#### TDD verification (tasks section)
 
 - Each entry reflects actual verification evidence (test names, command output).
 - No entry claims coverage that does not exist.
 
-### 4. progress.md consistency
+### 4. tasks section consistency
 
-- Progress entries do not claim completion that artifacts or code do not support.
-- The final progress entry summarizes the overall implementation state accurately.
+- tasks セクションのチェックボックスがアーティファクトやコードで裏付けられていない完了を主張していない。
+- 最終的な tasks セクションの状態が全体の実装状況を正確に要約している。
 
 ### 5. Code verification
 
 Run all verification commands and confirm success:
 
 ```bash
-cargo test -p gwt-core -p gwt-tui
+cargo test -p gwt-core -p gwt
 cargo clippy --all-targets --all-features -- -D warnings
 cargo fmt -- --check
-cargo build -p gwt-tui
+cargo build -p gwt
 ```
 
 ## Standalone mode checks

--- a/.codex/skills/gwt-build-spec/references/progress-tracking.md
+++ b/.codex/skills/gwt-build-spec/references/progress-tracking.md
@@ -16,37 +16,18 @@ Rules:
 - Update tasks.md after each task slice is verified, not before.
 - Do not mark tasks complete until the implementation passes verification.
 - Do not batch-mark multiple tasks; update incrementally.
-- Use `.claude/scripts/spec_artifact.py` for artifact operations.
+- アーティファクト操作には `gwtd issue spec <N> --edit tasks -f <file>` を使用する。
 
-## progress.md template
+## 進捗追跡
 
-Append entries to `specs/SPEC-{id}/progress.md` after each verified task slice.
+tasks セクションのチェックボックスを `gwtd issue spec <N> --edit tasks -f <file>` で更新する。
 
-### Entry format
+### ルール
 
-```markdown
-## YYYY-MM-DD HH:MM — <brief summary>
-
-**Progress:**
-- <what was accomplished in this slice>
-- <specific files changed>
-
-**Done:**
-- <verification results: test pass/fail, lint, build>
-- <task IDs completed>
-
-**Next:**
-- <next task to execute>
-- <any blockers or decisions needed>
-```
-
-### Rules
-
-- Keep entries factual and incremental.
-- Do not claim completion that the code does not support.
-- Include verification command output (pass/fail counts).
-- Reference specific task IDs from `tasks.md`.
-- Append new entries; do not overwrite previous entries.
+- 事実に基づき、インクリメンタルに更新する。
+- コードで裏付けられていない完了を主張しない。
+- 検証コマンドの出力（pass/fail カウント）を含める。
+- `tasks.md` の具体的なタスク ID を参照する。
 
 ## Completion markers
 
@@ -73,8 +54,8 @@ Do not mark the SPEC complete during progress tracking; that is the gate's respo
 Watch for these signals that indicate premature completion claims:
 
 - Tasks marked `[x]` but related tests are not in the codebase
-- `progress.md` claims "all tests pass" but `cargo test` output shows failures
-- `checklists/acceptance.md` says "accepted" but the behavior is not implemented
+- tasks セクションが "all tests pass" と主張しているが `cargo test` の出力が失敗を示している
+- tasks セクションの受け入れチェックが "accepted" だが動作が未実装
 - Task marked complete but the file listed in the task was not modified
 
 If any of these are detected, revert the completion marker and return to implementation.

--- a/.codex/skills/gwt-build-spec/references/tdd-workflow.md
+++ b/.codex/skills/gwt-build-spec/references/tdd-workflow.md
@@ -97,4 +97,4 @@ When in doubt, write the test. A skipped test is a potential regression.
 
 - Narrow scope first: `cargo test -p gwt-core -- test_name`
 - Module scope: `cargo test -p gwt-core`
-- Full suite: `cargo test -p gwt-core -p gwt-tui`
+- Full suite: `cargo test -p gwt-core -p gwt`

--- a/.codex/skills/gwt-discussion/references/clarification.md
+++ b/.codex/skills/gwt-discussion/references/clarification.md
@@ -12,28 +12,26 @@ scenarios.
 
 This phase works on:
 
-```text
-specs/SPEC-{id}/spec.md
-```
+GitHub Issue #<Issue番号> の spec セクション。`gwtd issue spec <Issue番号> --section spec` で取得する。
 
-The file must contain these sections:
+spec セクションは以下の構造を含む:
 
-- Background
-- Ubiquitous Language (added in Phase 2/3)
-- User Stories
-- Acceptance Scenarios
-- Edge Cases
-- Functional Requirements
-- Non-Functional Requirements
-- Success Criteria
+- 状態
+- 背景
+- ユビキタス言語 (Phase 2/3 で追加)
+- ユーザーストーリー
+- 受け入れシナリオ
+- エッジケース
+- 機能要件
+- 非機能要件
+- 成功基準
 
 ## Workflow
 
 ### Step 1: Read current spec.md
 
 ```bash
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." --spec "<id>" --get --artifact "doc:spec.md"
+gwtd issue spec <Issue番号> --section spec
 ```
 
 If spec.md does not exist, return to Phase 3 (registration) first.
@@ -85,9 +83,7 @@ After receiving answers:
 Upload:
 
 ```bash
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." --spec "<id>" --upsert \
-  --artifact "doc:spec.md" --body-file /tmp/spec.md
+gwtd issue spec <Issue番号> --edit spec -f /tmp/spec.md
 ```
 
 ### Step 6: Decide next step

--- a/.codex/skills/gwt-discussion/references/ddd-modeling.md
+++ b/.codex/skills/gwt-discussion/references/ddd-modeling.md
@@ -21,8 +21,8 @@ map to crate boundaries and major subsystems.
 | BC | Crate / Location | Responsibility |
 |---|---|---|
 | Core | `gwt-core` | Git operations, PTY management, configuration, data model |
-| TUI | `gwt-tui` | Terminal UI rendering, input handling, screen management |
-| Specs | `specs/` | Feature specification artifacts |
+| TUI | `gwt` | Terminal UI rendering, input handling, screen management |
+| Specs | GitHub Issue (`gwt-spec` label) | Feature specification artifacts |
 | Skills | `.claude/skills/` | Agent skill definitions |
 
 ### Identification process
@@ -93,7 +93,7 @@ and conversation. Prevents confusion from synonyms or overloaded terms.
 1. Extract domain terms from the intake memo and interview answers.
 2. Check each term against existing codebase usage:
    - Search with `gwt-project-search` for existing definitions.
-   - Check struct/enum/function names in `gwt-core` and `gwt-tui`.
+   - Check struct/enum/function names in `gwt-core` and `gwt`.
 3. For each term, write a one-sentence definition.
 4. Flag conflicts:
    - Term used differently in different parts of the codebase.

--- a/.codex/skills/gwt-discussion/references/deepening.md
+++ b/.codex/skills/gwt-discussion/references/deepening.md
@@ -24,8 +24,7 @@ break down coarse tasks through a two-phase interactive workshop.
 ### Read all SPEC artifacts
 
 ```bash
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." --spec "<id>" --list
+gwtd issue spec <Issue番号>
 ```
 
 Read spec.md, plan.md, and tasks.md (whichever exist).
@@ -118,17 +117,13 @@ Show the diff or new section text.
 Update the artifact:
 
 ```bash
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." --spec "<id>" --upsert \
-  --artifact "doc:spec.md" --body-file /tmp/spec.md
+gwtd issue spec <Issue番号> --edit spec -f /tmp/spec.md
 ```
 
 Or for tasks.md:
 
 ```bash
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." --spec "<id>" --upsert \
-  --artifact "doc:tasks.md" --body-file /tmp/tasks.md
+gwtd issue spec <Issue番号> --edit tasks -f /tmp/tasks.md
 ```
 
 ### Step 6: Move to next point

--- a/.codex/skills/gwt-discussion/references/intake.md
+++ b/.codex/skills/gwt-discussion/references/intake.md
@@ -16,7 +16,7 @@ Run these before any creation or routing decision:
 3. **Local SPEC listing** if ownership is still unclear:
 
 ```bash
-python3 ".claude/scripts/spec_artifact.py" --repo "." --list-all
+gwtd issue spec list
 ```
 
 ### Search evaluation

--- a/.codex/skills/gwt-discussion/references/registration.md
+++ b/.codex/skills/gwt-discussion/references/registration.md
@@ -7,145 +7,65 @@ Detailed logic for the SPEC creation/update phase of gwt-discussion.
 Phase 3 runs only when Phase 1 routing produced `NEW-SPEC` and Phase 2 domain
 discovery confirmed the scope is right for a SPEC.
 
-## SPEC ID allocation
+## SPEC creation
 
-SPEC IDs are sequential integers. Determine the next ID by listing existing SPECs:
+SPEC の作成・更新は `gwtd issue spec` CLI で行う。
+すべての要約・タイトル・更新説明は current user's language で記述する。
 
-```bash
-python3 ".claude/scripts/spec_artifact.py" --repo "." --list-all
-```
-
-Pick the next available number.
-
-## Title convention
-
-All SPECs must use the `gwt-spec:` prefix:
-
-```text
-gwt-spec: <concise description in the current user's language>
-```
-
-- Always use `gwt-spec:` (not other prefixes).
-- Description should be a short action-oriented summary in the current user's
-  language.
-
-## Directory creation
+### コマンド
 
 ```bash
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." --create --title "gwt-spec: <description in the current user's language>"
+# SPEC 一覧
+gwtd issue spec list
+
+# SPEC 作成（構造化 JSON 推奨）
+gwtd issue spec create --help
+gwtd issue spec create --json --title "SPEC: <説明> — <サブタイトル>" \
+  -f <spec.json>
+
+# SPEC 作成（既存 Markdown 断片から直接作る互換パス）
+gwtd issue spec create --title "SPEC: <説明> — <サブタイトル>" \
+  -f <spec.md>
+
+# SPEC セクション読み取り
+gwtd issue spec <Issue番号>
+gwtd issue spec <Issue番号> --section spec
+
+# SPEC セクション更新
+gwtd issue spec <Issue番号> --edit spec -f <file>
 ```
 
-This creates:
+注意:
+
+- `gwtd issue spec create --help` をフォーマット、JSON スキーマ、入力例の唯一の正とする。
+- `spec create -f` はファイル内に `<!-- artifact:spec BEGIN/END -->` マーカーを期待する。
+- マーカーなしの場合は `spec create` でタイトルだけ作成し、`--edit spec -f` または
+  `--edit spec --json` で内容を投入する。
+
+### Title convention
 
 ```text
-specs/SPEC-{id}/
-  metadata.json
+SPEC-<Issue#>: <現在のユーザー言語での簡潔な説明> — <サブタイトル>
 ```
 
-### metadata.json structure
+`SPEC-<Issue#>:` プレフィックスは Issue 作成後に確定する。
 
-```json
-{
-  "id": "SPEC-{id}",
-  "title": "gwt-spec: <description in the current user's language>",
-  "status": "open",
-  "phase": "Specify",
-  "created_at": "2024-01-01T00:00:00Z",
-  "updated_at": "2024-01-01T00:00:00Z"
-}
-```
-
-## Seeding spec.md
-
-After directory creation, write spec.md populated from the intake memo and
-domain model summary.
-
-### Template
-
-Use the current user's language for the actual artifact text. The headings below
-show structure, not a required output language.
-
-```markdown
-# Feature Specification: <title>
-
-## Background
-
-<from intake memo: Request + Why now>
-
-## Ubiquitous Language
-
-<from domain model: term definitions>
-
-| Term | Definition |
-|---|---|
-| <term> | <definition> |
-
-## User Stories
-
-### User Story 1 - <title> (Priority: P1)
-
-As a <actor>, I want to <goal>, so that <benefit>.
-
-## Acceptance Scenarios
-
-1. Given <precondition>, when <action>, then <expected result>.
-
-## Edge Cases
-
-- <edge case description>
-
-## Functional Requirements
-
-- FR-001: <requirement>
-
-## Non-Functional Requirements
-
-- NFR-001: <requirement>
-
-## Success Criteria
-
-- SC-001: <measurable criterion>
-```
-
-### Rules for seeding
+### Seeding rules
 
 - Populate from the intake memo and domain model. Do not invent requirements.
 - Use `[NEEDS CLARIFICATION: <question>]` for unknowns instead of guessing.
-- Include the Ubiquitous Language section from Phase 2.
+- Include ユビキタス言語 from Phase 2.
 - Map user stories to the entities and BCs identified in Phase 2.
-- Do not create plan.md or tasks.md at this phase.
-
-### Upload
-
-```bash
-cat <<'SPEC_EOF' > /tmp/spec.md
-<spec content>
-SPEC_EOF
-
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." --spec "<id>" --upsert \
-  --artifact "doc:spec.md" --body-file /tmp/spec.md
-```
+- Do not create plan or tasks at this phase.
 
 ## Post-registration
 
-After creating the SPEC and seeding spec.md, proceed directly to Phase 4
-(Clarification). Do not stop unless the user explicitly requested register-only.
+After creating the SPEC, proceed directly to Phase 4 (Clarification). Do not
+stop unless the user explicitly requested register-only.
 
-## Full SPEC directory structure (for reference)
+## SPEC storage
 
-Later phases will add these files:
+SPEC は GitHub Issue の body 内に `<!-- artifact:NAME BEGIN/END -->` マーカーで
+格納される。大きなセクションは Issue comment に分割される。
 
-```text
-specs/SPEC-{id}/
-  metadata.json      # created in Phase 3
-  spec.md            # created in Phase 3
-  plan.md            # created by gwt-spec-plan
-  tasks.md           # created by gwt-spec-plan/gwt-tasks
-  research.md        # created by gwt-spec-plan
-  data-model.md      # created by gwt-spec-plan
-  quickstart.md      # created by gwt-spec-plan
-  contracts/         # created by gwt-spec-plan
-  checklists/        # created by gwt-spec-plan
-```
+ローカルキャッシュ: `~/.gwt/cache/issues/<Issue番号>/`

--- a/.codex/skills/gwt-plan-spec/SKILL.md
+++ b/.codex/skills/gwt-plan-spec/SKILL.md
@@ -59,7 +59,7 @@ skipped.
 
 ## Required outputs
 
-All artifacts are written to the SPEC directory (`specs/SPEC-<id>/`):
+All artifacts are written to the SPEC's GitHub Issue sections:
 
 - `plan.md` — architecture, phases, constitution check
 - `research.md` — unknowns, tradeoff decisions, external findings
@@ -215,52 +215,18 @@ When invoked without a SPEC:
 
 ## Operations
 
-Use `.claude/scripts/spec_artifact.py` for artifact persistence:
+Use `gwtd issue spec` CLI for artifact persistence:
 
 ```bash
-# Write plan.md
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." \
-  --spec "<id>" \
-  --upsert \
-  --artifact "doc:plan.md" \
-  --body-file /tmp/plan.md
+# Read spec section
+gwtd issue spec <Issue番号> --section spec
 
-# Write research.md
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." \
-  --spec "<id>" \
-  --upsert \
-  --artifact "doc:research.md" \
-  --body-file /tmp/research.md
+# Write plan section
+gwtd issue spec <Issue番号> --edit plan -f /tmp/plan.md
 
-# Write data-model.md
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." \
-  --spec "<id>" \
-  --upsert \
-  --artifact "doc:data-model.md" \
-  --body-file /tmp/data-model.md
+# Write tasks section
+gwtd issue spec <Issue番号> --edit tasks -f /tmp/tasks.md
 
-# Write quickstart.md
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." \
-  --spec "<id>" \
-  --upsert \
-  --artifact "doc:quickstart.md" \
-  --body-file /tmp/quickstart.md
-
-# Write tasks.md
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." \
-  --spec "<id>" \
-  --upsert \
-  --artifact "doc:tasks.md" \
-  --body-file /tmp/tasks.md
-
-# List artifacts
-python3 ".claude/scripts/spec_artifact.py" \
-  --repo "." \
-  --spec "<id>" \
-  --list
+# List all SPEC Issues
+gwtd issue spec list
 ```

--- a/.codex/skills/gwt-plan-spec/references/sdd-design.md
+++ b/.codex/skills/gwt-plan-spec/references/sdd-design.md
@@ -30,7 +30,7 @@ For each new or significantly modified component:
 - Prefer modifying existing components over introducing new ones
 - A component that cannot be described in one sentence is too large — split it
 - Record the reason in `Complexity Tracking` when adding a new abstraction layer
-- Follow the project's existing module hierarchy (`gwt-core`, `gwt-tui`)
+- Follow the project's existing module hierarchy (`gwt-core`, `gwt`)
 
 ## Interface Contracts
 
@@ -38,7 +38,7 @@ For each new or significantly modified component:
 
 Write a contract file in `contracts/` when:
 
-- An interface crosses crate boundaries (e.g., `gwt-core` to `gwt-tui`)
+- An interface crosses crate boundaries (e.g., `gwt-core` to `gwt`)
 - A public API will be consumed by multiple callers
 - A message format or protocol needs stability guarantees
 - An external system boundary is involved

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -596,7 +596,9 @@ impl AppRuntime {
         let mut app = Self {
             tabs,
             active_tab_id,
-            recent_projects: dedupe_recent_projects(persisted.recent_projects),
+            recent_projects: prune_missing_recent_projects(dedupe_recent_projects(
+                persisted.recent_projects,
+            )),
             profile_selections: HashMap::new(),
             profile_config_path: None,
             runtimes: HashMap::new(),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -84,9 +84,9 @@ pub(crate) use runtime_support::{
     close_window_from_workspace, combined_window_id, current_git_branch, dedupe_recent_projects,
     fallback_project_target, first_available_worktree_path, front_door_route, geometry_to_pty_size,
     knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
-    origin_remote_ref, resolve_launch_spec_with_fallback, resolve_project_target, run_cli,
-    same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
-    synthetic_branch_entry, workspace_view_for_tab,
+    origin_remote_ref, prune_missing_recent_projects, resolve_launch_spec_with_fallback,
+    resolve_project_target, run_cli, same_worktree_path, should_auto_close_agent_window,
+    should_auto_start_restored_window, synthetic_branch_entry, workspace_view_for_tab,
 };
 #[cfg(test)]
 pub(crate) use runtime_support::{

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -116,6 +116,26 @@ pub(crate) fn dedupe_recent_projects(
     deduped
 }
 
+/// Issue #1678: drop recent project entries whose paths no longer exist on
+/// disk. Called once at load time so subsequent `persist()` writes a clean
+/// list back. A separate function (rather than baked into `dedupe_*`) so
+/// tests and callers can exercise the path predicate without filesystem.
+pub(crate) fn prune_missing_recent_projects(
+    entries: Vec<gwt::RecentProjectEntry>,
+) -> Vec<gwt::RecentProjectEntry> {
+    prune_missing_recent_projects_with(entries, |path| path.exists())
+}
+
+pub(crate) fn prune_missing_recent_projects_with(
+    entries: Vec<gwt::RecentProjectEntry>,
+    exists: impl Fn(&Path) -> bool,
+) -> Vec<gwt::RecentProjectEntry> {
+    entries
+        .into_iter()
+        .filter(|entry| exists(&entry.path))
+        .collect()
+}
+
 pub(crate) fn fallback_project_target(path: PathBuf) -> ProjectOpenTarget {
     ProjectOpenTarget {
         title: gwt::project_title_from_path(&path),
@@ -597,6 +617,8 @@ pub(crate) fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::{front_door_route, FrontDoorRoute};
 
     fn argv(parts: &[&str]) -> Vec<String> {
@@ -775,6 +797,53 @@ mod tests {
             &super::RepoEnvOverrides::default(),
         );
         assert_eq!(coords, None);
+    }
+
+    #[test]
+    fn prune_missing_recent_projects_drops_entries_whose_paths_are_gone() {
+        // Issue #1678: stale entries must be removed before the next persist
+        // round-trip so disk state stops referring to deleted projects.
+        let exists_paths: std::collections::HashSet<String> = ["/tmp/exists-a", "/tmp/exists-b"]
+            .iter()
+            .map(|p| (*p).to_string())
+            .collect();
+        let entries = vec![
+            gwt::RecentProjectEntry {
+                path: PathBuf::from("/tmp/exists-a"),
+                title: "alive a".to_string(),
+                kind: gwt::ProjectKind::Git,
+            },
+            gwt::RecentProjectEntry {
+                path: PathBuf::from("/tmp/missing-x"),
+                title: "deleted x".to_string(),
+                kind: gwt::ProjectKind::Git,
+            },
+            gwt::RecentProjectEntry {
+                path: PathBuf::from("/tmp/exists-b"),
+                title: "alive b".to_string(),
+                kind: gwt::ProjectKind::Bare,
+            },
+        ];
+
+        let pruned = super::prune_missing_recent_projects_with(entries, |path| {
+            exists_paths.contains(&path.to_string_lossy().to_string())
+        });
+
+        assert_eq!(pruned.len(), 2);
+        assert_eq!(pruned[0].title, "alive a");
+        assert_eq!(pruned[1].title, "alive b");
+    }
+
+    #[test]
+    fn prune_missing_recent_projects_returns_input_when_all_paths_exist() {
+        let entries = vec![gwt::RecentProjectEntry {
+            path: PathBuf::from("/tmp/here"),
+            title: "alive".to_string(),
+            kind: gwt::ProjectKind::Git,
+        }];
+        let pruned = super::prune_missing_recent_projects_with(entries.clone(), |_| true);
+        assert_eq!(pruned.len(), 1);
+        assert_eq!(pruned[0].path, entries[0].path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

2 件の積み残し issue を一括対応。 v8.7.0 era 由来の bug fix #1678 と docs cleanup #1679 を解消。

## Closing Issues

Closes #1678
Closes #1679

## Changes

### `fix(app_runtime): persist recent_projects stale entry pruning at load (#1678)`

`AppRuntime::new()` で `recent_projects` のロード時に **存在しないパスを除外** する `prune_missing_recent_projects` を追加 (dedupe 後に適用)。 `bootstrap()` が直後に `persist()` を呼ぶため、 clean 化された list は次回起動時には disk に反映済となる。

実装:
- `runtime_support::prune_missing_recent_projects(entries)` — `Path::exists` で filter
- `runtime_support::prune_missing_recent_projects_with(entries, predicate)` — testable な内部関数
- `AppRuntime::new()` で `dedupe → prune` の順に適用

Tests: 2 件 (drops missing / keeps existing)。

### `docs(skills): sync .codex/skills with .claude/skills (#1679)`

`.codex/skills/` 配下の SKILL.md / references が v8.7.0 era の旧 SPEC 管理形式 (`specs/SPEC-{id}/<file>.md` / `.claude/scripts/spec_artifact.py` / `gwt-tui`) への参照を残していた問題を、 canonical な `.claude/skills/` 版に置き換えて解消。

更新ファイル (11 件):
- `gwt-build-spec/SKILL.md` + references 3 件 (completion-gate / progress-tracking / tdd-workflow)
- `gwt-plan-spec/SKILL.md` + `references/sdd-design.md`
- `gwt-discussion/references` 5 件 (clarification / ddd-modeling / deepening / intake / registration)

旧形式の `specs/SPEC-{id}/` ディレクトリ参照と `spec_artifact.py` 直接呼び出しは、 現 GitHub Issue (gwt-spec label) を SOT とする `gwtd issue spec` ワークフロー (SPEC-12) に移行済。

## Testing

- `cargo test -p gwt --lib`: **345 passed**
- `cargo test -p gwt --bin gwt`: **186 passed** (+2 new for `prune_missing_recent_projects_with`)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: 差分なし

## Related Issues

- #1678 (closed)
- #1679 (closed)
- #1677 (#1677 は現アーキテクチャでは該当ロジックが存在せず obsolete、 別途 close 予定)
- #1680 / #1681 (現アーキテクチャで対応 file 自体が消滅、 obsolete として close 予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
