### PR TITLE
feat(daemon): gwtd daemon subcommand + Unix-socket IPC server (SPEC-2077)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "gwt-terminal",
  "ignore",
  "image",
+ "libc",
  "muda",
  "notify",
  "notify-debouncer-mini",

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -51,6 +51,9 @@ reqwest.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 muda = "0.18"
 

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -68,6 +68,7 @@ fn print_help() {
     println!("  plan        gwt-plan-spec exit CLI (SPEC-1935)");
     println!("  build       gwt-build-spec exit CLI (SPEC-1935)");
     println!("  update      Check / apply gwt updates");
+    println!("  daemon      Long-running runtime daemon (SPEC-2077)");
 }
 
 /// SPEC-1942 T-204: render family-scoped help text. Returns `None` for
@@ -84,8 +85,28 @@ fn family_help(family: &str) -> Option<String> {
         "plan" => Some(format_plan_help()),
         "build" => Some(format_build_help()),
         "update" => Some(format_update_help()),
+        "daemon" => Some(format_daemon_help()),
         _ => None,
     }
+}
+
+fn format_daemon_help() -> String {
+    [
+        "gwtd daemon — Long-running runtime daemon (SPEC-2077).",
+        "",
+        "Usage: gwtd daemon <subcommand>",
+        "",
+        "Subcommands:",
+        "  start                                   Bootstrap and serve the runtime daemon",
+        "  status                                  Report whether a daemon is registered",
+        "",
+        "Notes:",
+        "  - Listens on a Unix domain socket per RuntimeScope (POSIX only today).",
+        "  - Endpoint metadata is persisted under ~/.gwt/projects/<repo>/runtime/daemon/.",
+        "  - SIGINT / SIGTERM trigger graceful shutdown + endpoint file removal.",
+        "",
+    ]
+    .join("\n")
 }
 
 fn format_issue_help() -> String {

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -22,6 +22,7 @@
 mod actions;
 mod board;
 mod build;
+pub mod daemon;
 mod discuss;
 mod env;
 pub mod hook;
@@ -148,6 +149,17 @@ pub enum CliCommand {
     Build(BuildCommand),
     /// `gwtd update [...]` and `gwtd __internal {apply-update,run-installer} ...`.
     Update(UpdateCommand),
+    /// `gwtd daemon ...` — long-running runtime daemon (SPEC-2077).
+    Daemon(DaemonCommand),
+}
+
+/// SPEC-2077 family enum for `gwtd daemon ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DaemonCommand {
+    /// `gwtd daemon start` — bootstrap and serve the runtime daemon.
+    Start,
+    /// `gwtd daemon status` — print whether a daemon is registered for cwd scope.
+    Status,
 }
 
 /// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).
@@ -387,6 +399,7 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
                     | "discuss"
                     | "plan"
                     | "build"
+                    | "daemon"
             )
         })
         .unwrap_or(false)
@@ -417,6 +430,11 @@ pub fn parse_board_args(args: &[String]) -> Result<CliCommand, CliParseError> {
 /// Parse an argv slice into a `gwtd index ...` [`CliCommand`].
 pub fn parse_index_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     index::parse(args).map(CliCommand::Index)
+}
+
+/// Parse an argv slice into a `gwtd daemon ...` [`CliCommand`] (SPEC-2077).
+pub fn parse_daemon_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    daemon::parse(args).map(CliCommand::Daemon)
 }
 
 fn expect_flag(arg: Option<&String>, expected: &'static str) -> Result<(), CliParseError> {
@@ -578,6 +596,7 @@ pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError>
         CliCommand::Update(UpdateCommand::InternalRunInstaller { rest }) => {
             std::process::exit(update::run_internal_run_installer(&rest));
         }
+        CliCommand::Daemon(inner) => daemon::run(env, inner, &mut out)?,
     };
     let _ = env.stdout().write_all(out.as_bytes());
     Ok(code)

--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -1,0 +1,204 @@
+//! `gwtd daemon ...` family — long-running runtime daemon (SPEC-2077).
+//!
+//! - `mod.rs` (this file): argv parsing + dispatch + status reporting.
+//! - `server.rs`: tokio-based IPC listener (Unix domain socket today;
+//!   Windows named-pipe support is a follow-up).
+//!
+//! The contract layer (`gwt_core::daemon::*`) defines the on-disk endpoint
+//! file, handshake protocol, and `DaemonBootstrapAction`. `Start` honours
+//! that contract: if a usable endpoint already exists for the cwd
+//! [`RuntimeScope`], we exit 0 with a "already running" notice; otherwise
+//! we generate a fresh `auth_token`, persist a new [`DaemonEndpoint`], and
+//! enter the listen loop.
+
+#[cfg(unix)]
+mod server;
+
+use std::path::PathBuf;
+
+use gwt_core::daemon::{
+    resolve_bootstrap_action, DaemonBootstrapAction, RuntimeScope, RuntimeTarget,
+    DAEMON_PROTOCOL_VERSION,
+};
+use gwt_github::{client::ApiError, SpecOpsError};
+
+use crate::cli::{CliEnv, CliParseError, DaemonCommand};
+
+pub(super) fn parse(args: &[String]) -> Result<DaemonCommand, CliParseError> {
+    match args.first().map(String::as_str) {
+        None | Some("start") => {
+            ensure_no_extra_args(args.get(1..).unwrap_or(&[]))?;
+            Ok(DaemonCommand::Start)
+        }
+        Some("status") => {
+            ensure_no_extra_args(args.get(1..).unwrap_or(&[]))?;
+            Ok(DaemonCommand::Status)
+        }
+        Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
+    }
+}
+
+fn ensure_no_extra_args(rest: &[String]) -> Result<(), CliParseError> {
+    if rest.is_empty() {
+        Ok(())
+    } else {
+        Err(CliParseError::Usage)
+    }
+}
+
+pub(super) fn run<E: CliEnv>(
+    env: &mut E,
+    cmd: DaemonCommand,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    match cmd {
+        DaemonCommand::Start => start_daemon(env, out),
+        DaemonCommand::Status => report_status(env, out),
+    }
+}
+
+fn config_error(message: impl Into<String>) -> SpecOpsError {
+    SpecOpsError::from(ApiError::Unexpected(message.into()))
+}
+
+fn resolve_scope(env: &impl CliEnv) -> Result<RuntimeScope, SpecOpsError> {
+    let project_root = canonical_project_root(env.repo_path().to_path_buf());
+    RuntimeScope::from_project_root(&project_root, RuntimeTarget::Host)
+        .map_err(|err| config_error(format!("daemon scope resolution failed: {err}")))
+}
+
+fn canonical_project_root(path: PathBuf) -> PathBuf {
+    dunce::canonicalize(&path).unwrap_or(path)
+}
+
+fn report_status<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOpsError> {
+    let scope = resolve_scope(env)?;
+    let gwt_home = gwt_core::paths::gwt_home();
+    let action = resolve_bootstrap_action(
+        &gwt_home,
+        &scope,
+        DAEMON_PROTOCOL_VERSION,
+        is_process_alive_pid,
+    )
+    .map_err(|err| config_error(err.to_string()))?;
+
+    match action {
+        DaemonBootstrapAction::Reuse(endpoint) => {
+            out.push_str(&format!(
+                "running pid={pid} bind={bind} version={version}\n",
+                pid = endpoint.pid,
+                bind = endpoint.bind,
+                version = endpoint.daemon_version
+            ));
+            Ok(0)
+        }
+        DaemonBootstrapAction::Spawn { endpoint_path } => {
+            out.push_str(&format!(
+                "stopped scope={repo_hash}/{worktree_hash} endpoint={path}\n",
+                repo_hash = scope.repo_hash,
+                worktree_hash = scope.worktree_hash,
+                path = endpoint_path.display()
+            ));
+            Ok(0)
+        }
+    }
+}
+
+#[cfg(unix)]
+fn start_daemon<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOpsError> {
+    let scope = resolve_scope(env)?;
+    let gwt_home = gwt_core::paths::gwt_home();
+    let action = resolve_bootstrap_action(
+        &gwt_home,
+        &scope,
+        DAEMON_PROTOCOL_VERSION,
+        is_process_alive_pid,
+    )
+    .map_err(|err| config_error(err.to_string()))?;
+
+    match action {
+        DaemonBootstrapAction::Reuse(endpoint) => {
+            out.push_str(&format!(
+                "daemon already running pid={pid} bind={bind}\n",
+                pid = endpoint.pid,
+                bind = endpoint.bind
+            ));
+            Ok(0)
+        }
+        DaemonBootstrapAction::Spawn { endpoint_path } => {
+            server::serve_blocking(scope, endpoint_path, out)
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn start_daemon<E: CliEnv>(_env: &mut E, out: &mut String) -> Result<i32, SpecOpsError> {
+    out.push_str(
+        "gwtd daemon start: long-running daemon mode is not yet implemented on this platform; \
+         use `gwt hook ...` synchronous dispatch.\n",
+    );
+    Ok(2)
+}
+
+fn is_process_alive_pid(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        // SAFETY: kill(pid, 0) returns 0 if the process exists, -1 with
+        // ESRCH if it does not. We never deliver a real signal.
+        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if rc == 0 {
+            return true;
+        }
+        let err = std::io::Error::last_os_error();
+        // EPERM means the process exists but we lack permission to signal it.
+        matches!(err.raw_os_error(), Some(libc::EPERM))
+    }
+    #[cfg(not(unix))]
+    {
+        // Conservative fallback — assume alive so we never racily clobber
+        // an in-flight daemon endpoint on an unsupported platform.
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(value: &str) -> String {
+        value.to_string()
+    }
+
+    #[test]
+    fn parse_defaults_to_start_when_no_subcommand() {
+        let cmd = parse(&[]).expect("parse");
+        assert_eq!(cmd, DaemonCommand::Start);
+    }
+
+    #[test]
+    fn parse_recognises_start_explicitly() {
+        let cmd = parse(&[s("start")]).expect("parse");
+        assert_eq!(cmd, DaemonCommand::Start);
+    }
+
+    #[test]
+    fn parse_recognises_status() {
+        let cmd = parse(&[s("status")]).expect("parse");
+        assert_eq!(cmd, DaemonCommand::Status);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_subcommand() {
+        let err = parse(&[s("foo")]).unwrap_err();
+        assert!(matches!(err, CliParseError::UnknownSubcommand(_)));
+    }
+
+    #[test]
+    fn parse_rejects_extra_args() {
+        let err = parse(&[s("start"), s("--whatever")]).unwrap_err();
+        assert!(matches!(err, CliParseError::Usage));
+    }
+}

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -1,0 +1,438 @@
+//! Tokio-based Unix-socket IPC server for the runtime daemon (SPEC-2077
+//! Phase 1 runtime layer).
+//!
+//! Foreground entry: caller blocks inside [`serve_blocking`] until the
+//! daemon receives `SIGINT` / `SIGTERM`, at which point the listener is
+//! dropped, the socket file is removed, and the persisted endpoint file
+//! is unlinked. Per-connection workers handle:
+//!
+//! 1. Read one newline-delimited [`IpcHandshakeRequest`] JSON line.
+//! 2. Validate against the in-memory endpoint with
+//!    [`validate_handshake`].
+//! 3. Write the matching [`IpcHandshakeResponse`] line.
+//! 4. While the connection stays open, accept newline-delimited JSON
+//!    payloads (today: log + ack; later phases route hook envelopes).
+//!
+//! Hook envelope routing is intentionally out of scope for this PR — the
+//! purpose here is to stand up the daemon process and make `gwt -> gwtd`
+//! IPC end-to-end provable. Phase H1〜H4 will graft handler logic onto
+//! the per-connection loop.
+
+#![cfg(unix)]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use gwt_core::daemon::{
+    persist_endpoint, validate_handshake, DaemonEndpoint, IpcHandshakeRequest,
+    IpcHandshakeResponse, RuntimeScope, DAEMON_PROTOCOL_VERSION,
+};
+use gwt_github::{client::ApiError, SpecOpsError};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::{UnixListener, UnixStream},
+    runtime::Builder,
+    signal::unix::{signal, SignalKind},
+    sync::Notify,
+};
+
+const ACCEPT_BACKOFF_MS: u64 = 50;
+
+pub(super) fn serve_blocking(
+    scope: RuntimeScope,
+    endpoint_path: PathBuf,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    let socket_path = derive_socket_path(&endpoint_path);
+    if let Err(err) = ensure_socket_parent(&socket_path) {
+        return Err(config_error(format!(
+            "failed to prepare daemon socket directory: {err}"
+        )));
+    }
+    cleanup_stale_socket(&socket_path);
+
+    let auth_token = uuid::Uuid::new_v4().to_string();
+    let endpoint = DaemonEndpoint::new(
+        scope,
+        std::process::id(),
+        socket_path.to_string_lossy().to_string(),
+        auth_token,
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
+
+    persist_endpoint(&endpoint_path, &endpoint)
+        .map_err(|err| config_error(format!("failed to persist daemon endpoint: {err}")))?;
+
+    out.push_str(&format!(
+        "gwtd daemon start: bind={socket}\n",
+        socket = socket_path.display()
+    ));
+    out.push_str(&format!(
+        "gwtd daemon start: pid={pid} version={version}\n",
+        pid = endpoint.pid,
+        version = endpoint.daemon_version
+    ));
+
+    let runtime = Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(2)
+        .build()
+        .map_err(|err| config_error(format!("tokio runtime build failed: {err}")))?;
+
+    let result = runtime.block_on(run_server(
+        endpoint,
+        socket_path.clone(),
+        endpoint_path.clone(),
+    ));
+
+    let _ = fs::remove_file(&socket_path);
+    let _ = fs::remove_file(&endpoint_path);
+
+    result
+}
+
+async fn run_server(
+    endpoint: DaemonEndpoint,
+    socket_path: PathBuf,
+    endpoint_path: PathBuf,
+) -> Result<i32, SpecOpsError> {
+    let listener = UnixListener::bind(&socket_path).map_err(|err| {
+        config_error(format!(
+            "failed to bind daemon socket {}: {err}",
+            socket_path.display()
+        ))
+    })?;
+
+    let shutdown = Arc::new(Notify::new());
+    spawn_signal_watcher(Arc::clone(&shutdown));
+
+    let endpoint = Arc::new(endpoint);
+    let _endpoint_path = endpoint_path; // retained for symmetry with future watch flows
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.notified() => {
+                tracing::info!("gwtd daemon: shutdown signal received");
+                break;
+            }
+            accept = listener.accept() => {
+                match accept {
+                    Ok((stream, _addr)) => {
+                        let endpoint = Arc::clone(&endpoint);
+                        tokio::spawn(async move {
+                            if let Err(err) = handle_connection(stream, endpoint).await {
+                                tracing::warn!("gwtd daemon: connection error: {err}");
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        tracing::warn!("gwtd daemon: accept failed: {err}");
+                        tokio::time::sleep(Duration::from_millis(ACCEPT_BACKOFF_MS)).await;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(0)
+}
+
+fn spawn_signal_watcher(shutdown: Arc<Notify>) {
+    let term = shutdown.clone();
+    tokio::spawn(async move {
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(sig) => sig,
+            Err(err) => {
+                tracing::warn!("gwtd daemon: failed to install SIGTERM handler: {err}");
+                return;
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(sig) => sig,
+            Err(err) => {
+                tracing::warn!("gwtd daemon: failed to install SIGINT handler: {err}");
+                return;
+            }
+        };
+        tokio::select! {
+            _ = sigterm.recv() => {}
+            _ = sigint.recv() => {}
+        }
+        term.notify_waiters();
+    });
+}
+
+async fn handle_connection(
+    stream: UnixStream,
+    endpoint: Arc<DaemonEndpoint>,
+) -> Result<(), String> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    let request = read_handshake(&mut reader).await?;
+    let response = build_handshake_response(&endpoint, &request);
+    write_json_line(&mut write_half, &response).await?;
+
+    let validation = validate_handshake(&endpoint, &request, &response);
+    if validation.is_err() {
+        return Ok(()); // we already told the client; drop the connection.
+    }
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader
+            .read_line(&mut line)
+            .await
+            .map_err(|err| format!("read frame failed: {err}"))?;
+        if n == 0 {
+            break; // peer closed
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Phase 1: surface the frame to logs; Phase H1 will route into
+        // hook handlers / runtime-state aggregator.
+        tracing::debug!(target: "gwtd::daemon", frame = %trimmed, "received frame");
+        write_half
+            .write_all(b"{\"ack\":true}\n")
+            .await
+            .map_err(|err| format!("ack write failed: {err}"))?;
+    }
+
+    Ok(())
+}
+
+async fn read_handshake(
+    reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>,
+) -> Result<IpcHandshakeRequest, String> {
+    let mut line = String::new();
+    let n = reader
+        .read_line(&mut line)
+        .await
+        .map_err(|err| format!("handshake read failed: {err}"))?;
+    if n == 0 {
+        return Err("client closed before handshake".to_string());
+    }
+    serde_json::from_str(line.trim_end()).map_err(|err| format!("handshake parse failed: {err}"))
+}
+
+fn build_handshake_response(
+    endpoint: &DaemonEndpoint,
+    request: &IpcHandshakeRequest,
+) -> IpcHandshakeResponse {
+    let mut response = IpcHandshakeResponse {
+        protocol_version: DAEMON_PROTOCOL_VERSION,
+        daemon_version: endpoint.daemon_version.clone(),
+        accepted: true,
+        rejection_reason: None,
+    };
+    if request.protocol_version != endpoint.protocol_version {
+        response.accepted = false;
+        response.rejection_reason = Some("protocol version mismatch".to_string());
+        return response;
+    }
+    if request.auth_token != endpoint.auth_token {
+        response.accepted = false;
+        response.rejection_reason = Some("auth token mismatch".to_string());
+        return response;
+    }
+    if request.scope != endpoint.scope {
+        response.accepted = false;
+        response.rejection_reason = Some("scope mismatch".to_string());
+        return response;
+    }
+    response
+}
+
+async fn write_json_line<T, W>(writer: &mut W, value: &T) -> Result<(), String>
+where
+    T: serde::Serialize,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut payload =
+        serde_json::to_vec(value).map_err(|err| format!("serialize failed: {err}"))?;
+    payload.push(b'\n');
+    writer
+        .write_all(&payload)
+        .await
+        .map_err(|err| format!("write failed: {err}"))?;
+    Ok(())
+}
+
+fn derive_socket_path(endpoint_path: &Path) -> PathBuf {
+    endpoint_path.with_extension("sock")
+}
+
+fn ensure_socket_parent(socket_path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = socket_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+fn cleanup_stale_socket(socket_path: &Path) {
+    if socket_path.exists() {
+        let _ = fs::remove_file(socket_path);
+    }
+}
+
+fn config_error(message: impl Into<String>) -> SpecOpsError {
+    SpecOpsError::from(ApiError::Unexpected(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, time::Duration};
+
+    use gwt_core::daemon::{
+        DaemonEndpoint, IpcHandshakeRequest, RuntimeScope, RuntimeTarget, DAEMON_PROTOCOL_VERSION,
+    };
+    use tempfile::TempDir;
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+        net::UnixStream,
+    };
+
+    use super::{build_handshake_response, run_server};
+
+    fn sample_endpoint(scope: RuntimeScope, socket_path: &Path, token: &str) -> DaemonEndpoint {
+        DaemonEndpoint::new(
+            scope,
+            std::process::id(),
+            socket_path.to_string_lossy().to_string(),
+            token.to_string(),
+            "test-daemon".to_string(),
+        )
+    }
+
+    fn sample_scope(temp: &TempDir) -> RuntimeScope {
+        RuntimeScope::new(
+            "abcdef0123456789",
+            "feedfacecafebeef",
+            temp.path().to_path_buf(),
+            RuntimeTarget::Host,
+        )
+        .expect("scope")
+    }
+
+    #[test]
+    fn build_handshake_response_rejects_protocol_version_mismatch() {
+        let temp = TempDir::new().unwrap();
+        let scope = sample_scope(&temp);
+        let endpoint = sample_endpoint(scope.clone(), &temp.path().join("daemon.sock"), "tok");
+        let request = IpcHandshakeRequest {
+            protocol_version: DAEMON_PROTOCOL_VERSION + 99,
+            auth_token: "tok".to_string(),
+            scope,
+        };
+        let response = super::build_handshake_response(&endpoint, &request);
+        assert!(!response.accepted);
+        assert_eq!(
+            response.rejection_reason.as_deref(),
+            Some("protocol version mismatch")
+        );
+    }
+
+    #[test]
+    fn build_handshake_response_rejects_auth_token_mismatch() {
+        let temp = TempDir::new().unwrap();
+        let scope = sample_scope(&temp);
+        let endpoint = sample_endpoint(scope.clone(), &temp.path().join("daemon.sock"), "tok");
+        let request = IpcHandshakeRequest {
+            protocol_version: DAEMON_PROTOCOL_VERSION,
+            auth_token: "wrong".to_string(),
+            scope,
+        };
+        let response = build_handshake_response(&endpoint, &request);
+        assert!(!response.accepted);
+        assert_eq!(
+            response.rejection_reason.as_deref(),
+            Some("auth token mismatch")
+        );
+    }
+
+    #[test]
+    fn build_handshake_response_accepts_matching_request() {
+        let temp = TempDir::new().unwrap();
+        let scope = sample_scope(&temp);
+        let endpoint = sample_endpoint(scope.clone(), &temp.path().join("daemon.sock"), "tok");
+        let request = IpcHandshakeRequest {
+            protocol_version: DAEMON_PROTOCOL_VERSION,
+            auth_token: "tok".to_string(),
+            scope,
+        };
+        let response = build_handshake_response(&endpoint, &request);
+        assert!(response.accepted);
+        assert!(response.rejection_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn run_server_accepts_handshake_and_acknowledges_frames() {
+        let temp = TempDir::new().expect("tempdir");
+        let scope = sample_scope(&temp);
+        let socket_path = temp.path().join("daemon.sock");
+        let endpoint_path = temp.path().join("endpoint.json");
+        let endpoint = sample_endpoint(scope.clone(), &socket_path, "secret");
+
+        // Pre-create the socket file by binding inside run_server. We need
+        // run_server to bind, then a client connects, exchanges handshake,
+        // and sends one frame.
+        let server_socket = socket_path.clone();
+        let server_endpoint_path = endpoint_path.clone();
+        let server_handle =
+            tokio::spawn(
+                async move { run_server(endpoint, server_socket, server_endpoint_path).await },
+            );
+
+        // wait until the socket is bound
+        let mut attempts = 0;
+        while !socket_path.exists() && attempts < 50 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            attempts += 1;
+        }
+        assert!(socket_path.exists(), "socket bound");
+
+        let stream = UnixStream::connect(&socket_path).await.expect("connect");
+        let (read_half, mut write_half) = stream.into_split();
+        let mut reader = BufReader::new(read_half);
+
+        let request = IpcHandshakeRequest {
+            protocol_version: DAEMON_PROTOCOL_VERSION,
+            auth_token: "secret".to_string(),
+            scope,
+        };
+        let payload = serde_json::to_vec(&request).expect("serialize");
+        write_half.write_all(&payload).await.expect("write request");
+        write_half.write_all(b"\n").await.expect("write newline");
+
+        let mut response_line = String::new();
+        reader
+            .read_line(&mut response_line)
+            .await
+            .expect("read response");
+        assert!(response_line.contains("\"accepted\":true"));
+
+        // Send a sample frame and expect the ack response.
+        write_half
+            .write_all(b"{\"hook\":\"runtime-state\"}\n")
+            .await
+            .expect("write frame");
+        let mut ack = String::new();
+        reader.read_line(&mut ack).await.expect("read ack");
+        assert!(ack.contains("\"ack\":true"));
+
+        // Closing the client should let the per-connection task finish.
+        drop(write_half);
+        drop(reader);
+
+        // Cancel the server (simulating SIGINT) by aborting.
+        server_handle.abort();
+        let _ = server_handle.await;
+    }
+}

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -182,6 +182,7 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "discuss" => super::parse_discuss_args(&rest),
         "plan" => super::parse_plan_args(&rest),
         "build" => super::parse_build_args(&rest),
+        "daemon" => super::parse_daemon_args(&rest),
         "update" => {
             let mode = if rest.iter().any(|a| a == "--check") {
                 super::UpdateCommand::CheckOnly


### PR DESCRIPTION
## Summary

SPEC-2077 Phase 1 runtime layer foundation: 既に整備されていた `gwt_core::daemon::*` contract (`RuntimeScope` / `DaemonEndpoint` / `HookEnvelope` / `IpcHandshakeRequest`/`Response` / `validate_handshake` / `resolve_bootstrap_action`) の上に、 実際に常駐する `gwtd daemon` process を追加。

## Changes

### 新コマンド (CliCommand::Daemon family)

| コマンド | 動作 |
|---|---|
| `gwtd daemon start` | bootstrap (Reuse / Spawn 判定) + IPC listener serve |
| `gwtd daemon status` | 現在の cwd scope に対する endpoint 登録状態を表示 |

`CliCommand::Daemon(DaemonCommand)` を 11 番目の family enum として追加。 `parse_daemon_args` / dispatch / `should_dispatch_cli` verb / `gwtd --help daemon` を全て family-nested 規約に揃える。

### 実装 (cli/daemon/)

| File | 行数 | 役割 |
|---|---|---|
| `cli/daemon/mod.rs` | 203 | subcommand parse + status report + scope resolve + `is_process_alive_pid` (`libc::kill(pid, 0)` で生存確認) |
| `cli/daemon/server.rs` | 438 (cfg(unix)) | tokio multi-thread runtime + `UnixListener` + per-connection handler。 handshake は newline-delimited JSON、 `IpcHandshakeRequest` を `validate_handshake` で検証し `IpcHandshakeResponse` を返す。 SIGINT / SIGTERM で graceful shutdown、 socket file + endpoint file を unlink |

### 設計判断

- **IPC**: tokio `UnixListener` (Unix domain socket)。 Windows は cfg(unix) 範囲外、 当面 `gwt hook ...` 同期 dispatch を継続使用 (start_daemon は exit 2 + 説明メッセージ)
- **Frame format**: newline-delimited JSON (シンプル、 既存 contract と互換)
- **Hook envelope routing**: 本 PR では **out-of-scope** (Phase 1 runtime 層の最小成立を目的とする)。 frame 受信 → log + ack のみ。 Phase H1〜H4 で hook handler / runtime-state aggregator を per-connection loop に統合

### 依存追加

- `libc` (cfg(unix) 限定、 既存 workspace 依存を re-export) — `kill(pid, 0)` で daemon process 生存確認に使用

## Testing

9 unit tests:

- `cli::daemon::tests::parse_*` (5 件):
  - parse_defaults_to_start_when_no_subcommand
  - parse_recognises_start_explicitly / parse_recognises_status
  - parse_rejects_unknown_subcommand / parse_rejects_extra_args
- `cli::daemon::server::tests::build_handshake_response_*` (3 件):
  - rejects_protocol_version_mismatch / rejects_auth_token_mismatch / accepts_matching_request
- `cli::daemon::server::tests::run_server_accepts_handshake_and_acknowledges_frames` (tokio test):
  - 実際に `UnixListener::bind` → client 接続 → handshake → frame send → ack 受領を end-to-end で検証

検証コマンド:

- `cargo test -p gwt --lib`: **354 passed** (+9 from daemon foundation)
- `cargo test -p gwt --tests`: 全 integration tests pass
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings`: 0 warnings
- `cargo fmt --check`: 差分なし
- 手動 smoke: `gwtd --help daemon` / `gwtd daemon status` が想定動作

## Closing Issues

None (SPEC-2077 phase/draft 継続)。

## Related Issues

- #2077 SPEC-2077 (Runtime Daemon)

## Follow-up scope

- Phase H1〜H4: per-connection loop に hook handler / runtime-state aggregator を統合 (現状は frame ack のみ)
- gwt → gwtd client 実装 (現存する Phase 1 hook delegation を IPC に切替)
- Windows named-pipe 実装 (cfg(windows) 別実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
