### PR TITLE
feat(gui): Board ウィンドウを open 時に最新エントリ (下端) へ自動 scroll

### DIFF
--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2990,6 +2990,13 @@
           status.classList.add("info");
         }
 
+        const stickyBottomThreshold = 64;
+        const previousScrollTop = timeline.scrollTop;
+        const previousScrollMax = timeline.scrollHeight - timeline.clientHeight;
+        const wasNearBottom =
+          previousScrollMax <= 0 ||
+          previousScrollMax - previousScrollTop <= stickyBottomThreshold;
+
         timeline.innerHTML = "";
         if (!state.loading && state.entries.length === 0) {
           timeline.appendChild(
@@ -3024,6 +3031,12 @@
           card.appendChild(meta);
           card.appendChild(createNode("div", "board-message-body", entry.body));
           timeline.appendChild(card);
+        }
+
+        if (wasNearBottom) {
+          timeline.scrollTop = timeline.scrollHeight;
+        } else {
+          timeline.scrollTop = previousScrollTop;
         }
 
         composer.innerHTML = "";


### PR DESCRIPTION
## Summary

- Board ウィンドウを開いたとき、最新エントリ (下端) が必ず見える状態で表示するよう挙動を変更。
- `renderBoard` で timeline 描画前に scrollTop / scrollHeight を捕捉し、64px しきい値内の near-bottom 状態なら再描画後に下端へ scroll、上方向に履歴を読みに行っている場合はその位置を維持する chat-style な sticky bottom を実装。

## Changes

- `crates/gwt/web/app.js` — `renderBoard` の前後に scroll capture + restore のロジックを追加 (+13 行、純粋追加)。

## Testing

- 手動確認: Board ウィンドウを開いたとき、最新エントリが視野に入る状態で表示されることを目視確認 (Manual UI verification on macOS WebView)。
- ユーザーが timeline を上方向にスクロールして履歴を読んでいる状態で再描画 (新規 entry 到着) が起きても、ユーザーの scroll 位置が維持されることを確認。
- Rust 単体テスト・lint には影響なし (JS のみ変更)。

## Closing Issues

None

## Related Issues / Links

- ユーザー Board post: "ボードを開くときは最新の一番下に行くようにしてほしい"

## Checklist

- [x] commitlint 形式 (`feat(gui): ...`)
- [x] 既存 functionality を破壊しない (純粋追加で chat-style behavior を実装)
- [x] timeline 以外の DOM 要素に影響なし
- [ ] 自動テストなし (理由: 既存リポジトリに JS unit test 基盤なし、UI behavior のため目視確認で代替)
