### PR TITLE
feat(daemon): typed ClientFrame / DaemonFrame schema (SPEC-2077 Phase H1 前提)

### DIFF
--- a/crates/gwt-core/src/daemon.rs
+++ b/crates/gwt-core/src/daemon.rs
@@ -168,6 +168,38 @@ pub struct IpcHandshakeResponse {
     pub rejection_reason: Option<String>,
 }
 
+/// Tagged frame envelope sent by `gwt` over the post-handshake IPC stream.
+///
+/// Wire format is newline-delimited JSON. The `type` discriminator selects
+/// the variant. Phase H1+ extends the variants for additional hot paths
+/// (subscriptions, runtime status pushes, etc.); the existing variants are
+/// stable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientFrame {
+    /// Forward a managed-hook event to the daemon for routing.
+    Hook(HookEnvelope),
+    /// Subscribe to one or more daemon broadcast channels.
+    Subscribe { channels: Vec<String> },
+}
+
+/// Tagged frame envelope returned by `gwtd`.
+///
+/// Wire format is newline-delimited JSON. `Ack` is the canonical reply for
+/// a successfully processed [`ClientFrame`]; `Event` carries a daemon
+/// broadcast payload (used once Phase H1+ runtime ownership migrations
+/// land); `Error` represents a frame that the daemon rejected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DaemonFrame {
+    /// Acknowledgment for the previous client frame.
+    Ack,
+    /// Broadcast event delivered to subscribed clients.
+    Event { channel: String, payload: Value },
+    /// The daemon rejected the frame. `message` is human-readable.
+    Error { message: String },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DaemonBootstrapAction {
     Reuse(DaemonEndpoint),

--- a/crates/gwt-core/tests/runtime_daemon_contract.rs
+++ b/crates/gwt-core/tests/runtime_daemon_contract.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use gwt_core::daemon::{
-    persist_endpoint, resolve_bootstrap_action, validate_handshake, DaemonBootstrapAction,
-    DaemonEndpoint, HookEnvelope, IpcHandshakeRequest, IpcHandshakeResponse, RuntimeScope,
-    RuntimeTarget, DAEMON_PROTOCOL_VERSION,
+    persist_endpoint, resolve_bootstrap_action, validate_handshake, ClientFrame,
+    DaemonBootstrapAction, DaemonEndpoint, DaemonFrame, HookEnvelope, IpcHandshakeRequest,
+    IpcHandshakeResponse, RuntimeScope, RuntimeTarget, DAEMON_PROTOCOL_VERSION,
 };
 use serde_json::json;
 use tempfile::tempdir;
@@ -447,6 +447,84 @@ fn persist_endpoint_round_trips_through_file_system() {
     assert_eq!(loaded.pid, 4242);
     assert_eq!(loaded.bind, "http://127.0.0.1:7777");
     assert_eq!(loaded.auth_token, "secret-token");
+}
+
+#[test]
+fn client_frame_hook_round_trips_through_json() {
+    let project_root = tempdir().unwrap();
+    let scope = RuntimeScope::new(
+        "repo-scope-1234",
+        "worktree-scope-5678",
+        project_root.path().to_path_buf(),
+        RuntimeTarget::Host,
+    )
+    .unwrap();
+    let envelope = HookEnvelope {
+        protocol_version: DAEMON_PROTOCOL_VERSION,
+        scope,
+        hook_name: "pre-command".into(),
+        session_id: Some("sess-1".into()),
+        cwd: PathBuf::from(project_root.path()),
+        payload: json!({"command": "codex"}),
+    };
+
+    let frame = ClientFrame::Hook(envelope);
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "hook");
+    assert_eq!(json_value["hook_name"], "pre-command");
+    assert_eq!(json_value["payload"]["command"], "codex");
+
+    let round_trip: ClientFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
+}
+
+#[test]
+fn client_frame_subscribe_serializes_channel_list() {
+    let frame = ClientFrame::Subscribe {
+        channels: vec!["board".to_string(), "runtime-status".to_string()],
+    };
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "subscribe");
+    assert_eq!(json_value["channels"][0], "board");
+    assert_eq!(json_value["channels"][1], "runtime-status");
+
+    let round_trip: ClientFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
+}
+
+#[test]
+fn daemon_frame_ack_serializes_to_canonical_shape() {
+    let frame = DaemonFrame::Ack;
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "ack");
+    let round_trip: DaemonFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
+}
+
+#[test]
+fn daemon_frame_event_carries_channel_and_payload() {
+    let frame = DaemonFrame::Event {
+        channel: "board".to_string(),
+        payload: json!({"entries": 3}),
+    };
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "event");
+    assert_eq!(json_value["channel"], "board");
+    assert_eq!(json_value["payload"]["entries"], 3);
+    let round_trip: DaemonFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
+}
+
+#[test]
+fn daemon_frame_error_serializes_message() {
+    let frame = DaemonFrame::Error {
+        message: "unknown frame type".to_string(),
+    };
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "error");
+    assert_eq!(json_value["message"], "unknown frame type");
+    let round_trip: DaemonFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
 }
 
 #[test]

--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -131,7 +131,10 @@ where
 mod tests {
     use std::time::Duration;
 
-    use gwt_core::daemon::{DaemonEndpoint, RuntimeScope, RuntimeTarget, DAEMON_PROTOCOL_VERSION};
+    use gwt_core::daemon::{
+        ClientFrame, DaemonEndpoint, DaemonFrame, HookEnvelope, RuntimeScope, RuntimeTarget,
+        DAEMON_PROTOCOL_VERSION,
+    };
     use tempfile::TempDir;
 
     use super::DaemonClient;
@@ -192,13 +195,26 @@ mod tests {
             .await
             .expect("client connects");
 
-        client
-            .send_frame(&serde_json::json!({ "hook": "runtime-state" }))
-            .await
-            .expect("send frame");
+        let hook_frame = ClientFrame::Hook(HookEnvelope {
+            protocol_version: DAEMON_PROTOCOL_VERSION,
+            scope: scope.clone(),
+            hook_name: "runtime-state".to_string(),
+            session_id: None,
+            cwd: temp.path().to_path_buf(),
+            payload: serde_json::json!({}),
+        });
+        client.send_frame(&hook_frame).await.expect("send frame");
 
-        let ack = client.read_ack().await.expect("read ack");
-        assert_eq!(ack, serde_json::json!({ "ack": true }));
+        let ack: DaemonFrame = client.read_frame().await.expect("read ack");
+        assert_eq!(ack, DaemonFrame::Ack);
+
+        // Send a Subscribe frame and confirm it also acks.
+        let subscribe = ClientFrame::Subscribe {
+            channels: vec!["board".to_string()],
+        };
+        client.send_frame(&subscribe).await.expect("send subscribe");
+        let ack2: DaemonFrame = client.read_frame().await.expect("read second ack");
+        assert_eq!(ack2, DaemonFrame::Ack);
 
         drop(client);
         server_handle.abort();

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -28,8 +28,8 @@ use std::{
 };
 
 use gwt_core::daemon::{
-    persist_endpoint, validate_handshake, DaemonEndpoint, IpcHandshakeRequest,
-    IpcHandshakeResponse, RuntimeScope, DAEMON_PROTOCOL_VERSION,
+    persist_endpoint, validate_handshake, ClientFrame, DaemonEndpoint, DaemonFrame,
+    IpcHandshakeRequest, IpcHandshakeResponse, RuntimeScope, DAEMON_PROTOCOL_VERSION,
 };
 use gwt_github::{client::ApiError, SpecOpsError};
 use tokio::{
@@ -196,13 +196,21 @@ async fn handle_connection(
         if trimmed.is_empty() {
             continue;
         }
-        // Phase 1: surface the frame to logs; Phase H1 will route into
-        // hook handlers / runtime-state aggregator.
-        tracing::debug!(target: "gwtd::daemon", frame = %trimmed, "received frame");
-        write_half
-            .write_all(b"{\"ack\":true}\n")
-            .await
-            .map_err(|err| format!("ack write failed: {err}"))?;
+        let response = match serde_json::from_str::<ClientFrame>(trimmed) {
+            Ok(frame) => {
+                // Phase 1: surface the frame to logs; Phase H1 will route
+                // hook envelopes / subscriptions into actual handlers.
+                tracing::debug!(target: "gwtd::daemon", ?frame, "received client frame");
+                DaemonFrame::Ack
+            }
+            Err(err) => {
+                tracing::warn!(target: "gwtd::daemon", frame = %trimmed, error = %err, "rejected unrecognized frame");
+                DaemonFrame::Error {
+                    message: format!("frame parse failed: {err}"),
+                }
+            }
+        };
+        write_json_line(&mut write_half, &response).await?;
     }
 
     Ok(())
@@ -291,7 +299,8 @@ mod tests {
     use std::{path::Path, time::Duration};
 
     use gwt_core::daemon::{
-        DaemonEndpoint, IpcHandshakeRequest, RuntimeScope, RuntimeTarget, DAEMON_PROTOCOL_VERSION,
+        ClientFrame, DaemonEndpoint, HookEnvelope, IpcHandshakeRequest, RuntimeScope,
+        RuntimeTarget, DAEMON_PROTOCOL_VERSION,
     };
     use tempfile::TempDir;
     use tokio::{
@@ -418,14 +427,43 @@ mod tests {
             .expect("read response");
         assert!(response_line.contains("\"accepted\":true"));
 
-        // Send a sample frame and expect the ack response.
+        // Send a typed `ClientFrame::Hook` and expect a `DaemonFrame::Ack`.
+        let request_scope = sample_scope(&temp);
+        let frame = ClientFrame::Hook(HookEnvelope {
+            protocol_version: DAEMON_PROTOCOL_VERSION,
+            scope: request_scope,
+            hook_name: "runtime-state".to_string(),
+            session_id: None,
+            cwd: temp.path().to_path_buf(),
+            payload: serde_json::json!({}),
+        });
+        let mut frame_bytes = serde_json::to_vec(&frame).expect("serialize frame");
+        frame_bytes.push(b'\n');
         write_half
-            .write_all(b"{\"hook\":\"runtime-state\"}\n")
+            .write_all(&frame_bytes)
             .await
             .expect("write frame");
         let mut ack = String::new();
         reader.read_line(&mut ack).await.expect("read ack");
-        assert!(ack.contains("\"ack\":true"));
+        assert!(
+            ack.contains("\"type\":\"ack\""),
+            "expected typed ack frame, got: {ack}"
+        );
+
+        // Send a malformed line and expect a typed Error frame back.
+        write_half
+            .write_all(b"not-json\n")
+            .await
+            .expect("write malformed frame");
+        let mut error_line = String::new();
+        reader
+            .read_line(&mut error_line)
+            .await
+            .expect("read error frame");
+        assert!(
+            error_line.contains("\"type\":\"error\""),
+            "expected typed error frame, got: {error_line}"
+        );
 
         // Closing the client should let the per-connection task finish.
         drop(write_half);


### PR DESCRIPTION
## Summary

- SPEC-2077 Phase H1 (handler runtime ownership migration) の前提となる **typed IPC frame schema** を `gwt_core::daemon` に追加。
- untyped JSON フレームから `#[serde(tag = "type")]` の tagged enum へ schema 化することで、 Phase H1〜H4 で hook envelope や Board projection broadcast を区別したルーティングが可能になる。
- 既存 wire format (newline-delimited JSON over Unix socket) は維持。 contract layer の追加だけで実 handler 移行はまだ走らない (Phase H1 GREEN 待ち)。

## Changes

- `crates/gwt-core/src/daemon.rs`: `ClientFrame::Hook(HookEnvelope) | Subscribe { channels: Vec<String> }`、 `DaemonFrame::Ack | Event { channel, payload } | Error { message }` の 2 enum を追加。
- `crates/gwt-core/tests/runtime_daemon_contract.rs`: 5 件の round-trip test 追加 (`client_frame_hook_round_trips_through_json` / `client_frame_subscribe_serializes_channel_list` / `daemon_frame_ack_serializes_to_canonical_shape` / `daemon_frame_event_carries_channel_and_payload` / `daemon_frame_error_serializes_message`)。
- `crates/gwt/src/cli/daemon/server.rs`: post-handshake loop を `serde_json::from_str::<ClientFrame>` で typed parse に変更。 success 時 `DaemonFrame::Ack`、 parse 失敗時 `DaemonFrame::Error { message }` を返却。 既存 round-trip test も typed envelope に更新 + malformed frame の error path test 追加。
- `crates/gwt/src/cli/daemon/client.rs`: round-trip test を `ClientFrame::Hook` / `ClientFrame::Subscribe` 経由に更新、 `DaemonFrame::Ack` を `read_frame::<DaemonFrame>` で取得する型安全な flow に変更。

## Testing

- `cargo test -p gwt-core --test runtime_daemon_contract` → 22/22 pass (5 new + 17 existing)
- `cargo test -p gwt --lib cli::daemon` → 12/12 pass (server: 4 + client: 3 + dispatch: 5)
- `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon (Phase H1〜H4 で handler migration が grafting される)
- 前 PR #2278 (server)、 #2280 (client)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] tagged enum で type 安全 + 後方互換 (新 variant の追加が容易)
- [x] wire format (newline-delimited JSON) は不変
- [x] error path の test も追加 (malformed frame → DaemonFrame::Error)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced typed message frames for daemon inter-process communication, replacing unstructured JSON payloads for improved protocol clarity and robustness.

* **Bug Fixes**
  * Enhanced error handling for malformed daemon messages with explicit error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->