### PR TITLE
feat(daemon): wire BroadcastHub into server fan-out (SPEC-2077 Phase H1)

### DIFF
--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -14,12 +14,6 @@
 //! without re-deriving the synchronization boundary.
 
 #![cfg(unix)]
-// Phase H1 will graft this hub onto the server's per-connection task; the
-// scaffolding lands now so the data structure has a stable contract +
-// tests before any handler migration touches it. The `dead_code` allow is
-// scoped to this module and removed once `server::handle_connection`
-// starts referencing the hub.
-#![allow(dead_code)]
 
 use std::{
     collections::HashMap,
@@ -62,6 +56,12 @@ impl BroadcastHub {
     /// Publish `frame` to every subscriber currently registered on
     /// `channel`. Returns the number of receivers the frame was queued
     /// for (zero is a successful no-op when nobody is listening).
+    ///
+    /// Phase H1 GREEN will call this from real domain handlers (Board
+    /// projection writer, runtime status aggregator). Until then the
+    /// only callers live in tests, so the lib-only dead-code lint is
+    /// suppressed.
+    #[allow(dead_code)]
     pub(super) fn publish(&self, channel: &str, frame: DaemonFrame) -> usize {
         let guard = self.channels.lock().expect("BroadcastHub mutex poisoned");
         match guard.get(channel) {

--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -138,7 +138,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::DaemonClient;
-    use crate::cli::daemon::server;
+    use crate::cli::daemon::{broadcast::BroadcastHub, server};
 
     fn sample_scope(temp: &TempDir) -> RuntimeScope {
         RuntimeScope::new(
@@ -185,8 +185,15 @@ mod tests {
         let server_endpoint = endpoint.clone();
         let server_socket = socket_path.clone();
         let server_endpoint_path = endpoint_path.clone();
+        let server_hub = BroadcastHub::new();
         let server_handle = tokio::spawn(async move {
-            server::run_server(server_endpoint, server_socket, server_endpoint_path).await
+            server::run_server(
+                server_endpoint,
+                server_socket,
+                server_endpoint_path,
+                server_hub,
+            )
+            .await
         });
 
         wait_for_socket(&socket_path).await;
@@ -232,8 +239,15 @@ mod tests {
         let server_endpoint_clone = server_endpoint.clone();
         let server_socket = socket_path.clone();
         let server_endpoint_path = endpoint_path.clone();
+        let server_hub = BroadcastHub::new();
         let server_handle = tokio::spawn(async move {
-            server::run_server(server_endpoint_clone, server_socket, server_endpoint_path).await
+            server::run_server(
+                server_endpoint_clone,
+                server_socket,
+                server_endpoint_path,
+                server_hub,
+            )
+            .await
         });
 
         wait_for_socket(&socket_path).await;
@@ -267,8 +281,15 @@ mod tests {
         let server_endpoint_clone = server_endpoint.clone();
         let server_socket = socket_path.clone();
         let server_endpoint_path = endpoint_path.clone();
+        let server_hub = BroadcastHub::new();
         let server_handle = tokio::spawn(async move {
-            server::run_server(server_endpoint_clone, server_socket, server_endpoint_path).await
+            server::run_server(
+                server_endpoint_clone,
+                server_socket,
+                server_endpoint_path,
+                server_hub,
+            )
+            .await
         });
 
         wait_for_socket(&socket_path).await;
@@ -279,6 +300,81 @@ mod tests {
         let result = DaemonClient::connect(&bad_endpoint).await;
         assert!(result.is_err(), "client connect should fail");
 
+        server_handle.abort();
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test]
+    async fn subscribed_client_receives_published_broadcast_events() {
+        let temp = TempDir::new().expect("tempdir");
+        let scope = sample_scope(&temp);
+        let socket_path = temp.path().join("daemon.sock");
+        let endpoint_path = temp.path().join("endpoint.json");
+        let endpoint = sample_endpoint(scope.clone(), &socket_path, "broadcast-secret");
+
+        let server_endpoint = endpoint.clone();
+        let server_socket = socket_path.clone();
+        let server_endpoint_path = endpoint_path.clone();
+        // Pass a hub clone the test keeps so we can publish into it.
+        let server_hub = BroadcastHub::new();
+        let publisher = server_hub.clone();
+        let server_handle = tokio::spawn(async move {
+            server::run_server(
+                server_endpoint,
+                server_socket,
+                server_endpoint_path,
+                server_hub,
+            )
+            .await
+        });
+
+        wait_for_socket(&socket_path).await;
+
+        let mut client = DaemonClient::connect(&endpoint)
+            .await
+            .expect("client connects");
+
+        // Subscribe to the "board" channel and wait for the ack so we
+        // know the per-channel forwarder has been spawned before we
+        // publish.
+        let subscribe = ClientFrame::Subscribe {
+            channels: vec!["board".to_string()],
+        };
+        client.send_frame(&subscribe).await.expect("send subscribe");
+        let subscribe_ack: DaemonFrame = client.read_frame().await.expect("subscribe ack");
+        assert_eq!(subscribe_ack, DaemonFrame::Ack);
+
+        // Publish a board event into the hub from outside the daemon
+        // (Phase H1 GREEN will make a real handler call this).
+        let event = DaemonFrame::Event {
+            channel: "board".to_string(),
+            payload: serde_json::json!({"entries": 7}),
+        };
+        // Retry briefly: the per-channel forwarder may need a moment to
+        // register on the broadcast::Sender after the Subscribe ack.
+        let mut delivered = 0;
+        for _ in 0..20 {
+            delivered = publisher.publish("board", event.clone());
+            if delivered > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            delivered > 0,
+            "expected hub to have at least one subscriber"
+        );
+
+        let received: DaemonFrame = tokio::time::timeout(
+            Duration::from_millis(500),
+            client.read_frame::<DaemonFrame>(),
+        )
+        .await
+        .expect("event timeout")
+        .expect("read event");
+        assert_eq!(received, event);
+
+        drop(client);
         server_handle.abort();
         let _ = server_handle.await;
     }

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -37,8 +37,10 @@ use tokio::{
     net::{UnixListener, UnixStream},
     runtime::Builder,
     signal::unix::{signal, SignalKind},
-    sync::Notify,
+    sync::{mpsc, Notify},
 };
+
+use super::broadcast::BroadcastHub;
 
 const ACCEPT_BACKOFF_MS: u64 = 50;
 
@@ -83,10 +85,12 @@ pub(super) fn serve_blocking(
         .build()
         .map_err(|err| config_error(format!("tokio runtime build failed: {err}")))?;
 
+    let hub = BroadcastHub::new();
     let result = runtime.block_on(run_server(
         endpoint,
         socket_path.clone(),
         endpoint_path.clone(),
+        hub,
     ));
 
     let _ = fs::remove_file(&socket_path);
@@ -99,6 +103,7 @@ pub(super) async fn run_server(
     endpoint: DaemonEndpoint,
     socket_path: PathBuf,
     endpoint_path: PathBuf,
+    hub: BroadcastHub,
 ) -> Result<i32, SpecOpsError> {
     let listener = UnixListener::bind(&socket_path).map_err(|err| {
         config_error(format!(
@@ -123,8 +128,9 @@ pub(super) async fn run_server(
                 match accept {
                     Ok((stream, _addr)) => {
                         let endpoint = Arc::clone(&endpoint);
+                        let hub = hub.clone();
                         tokio::spawn(async move {
-                            if let Err(err) = handle_connection(stream, endpoint).await {
+                            if let Err(err) = handle_connection(stream, endpoint, hub).await {
                                 tracing::warn!("gwtd daemon: connection error: {err}");
                             }
                         });
@@ -169,6 +175,7 @@ fn spawn_signal_watcher(shutdown: Arc<Notify>) {
 async fn handle_connection(
     stream: UnixStream,
     endpoint: Arc<DaemonEndpoint>,
+    hub: BroadcastHub,
 ) -> Result<(), String> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -182,13 +189,29 @@ async fn handle_connection(
         return Ok(()); // we already told the client; drop the connection.
     }
 
+    // After handshake, all writes flow through `out_tx` so the reader loop
+    // and any broadcast forwarders can send concurrently without sharing
+    // `write_half` directly.
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<DaemonFrame>();
+    let writer = tokio::spawn(async move {
+        while let Some(frame) = out_rx.recv().await {
+            if let Err(err) = write_json_line(&mut write_half, &frame).await {
+                tracing::warn!(target: "gwtd::daemon", error = %err, "writer task failed");
+                break;
+            }
+        }
+    });
+
     let mut line = String::new();
     loop {
         line.clear();
-        let n = reader
-            .read_line(&mut line)
-            .await
-            .map_err(|err| format!("read frame failed: {err}"))?;
+        let n = match reader.read_line(&mut line).await {
+            Ok(n) => n,
+            Err(err) => {
+                tracing::warn!(target: "gwtd::daemon", error = %err, "read frame failed");
+                break;
+            }
+        };
         if n == 0 {
             break; // peer closed
         }
@@ -196,23 +219,66 @@ async fn handle_connection(
         if trimmed.is_empty() {
             continue;
         }
-        let response = match serde_json::from_str::<ClientFrame>(trimmed) {
-            Ok(frame) => {
-                // Phase 1: surface the frame to logs; Phase H1 will route
-                // hook envelopes / subscriptions into actual handlers.
-                tracing::debug!(target: "gwtd::daemon", ?frame, "received client frame");
-                DaemonFrame::Ack
+        match serde_json::from_str::<ClientFrame>(trimmed) {
+            Ok(ClientFrame::Hook(envelope)) => {
+                // Phase H1〜H4 will route hook envelopes into real handlers;
+                // for now we just ack so the client side knows the daemon
+                // received the frame.
+                tracing::debug!(
+                    target: "gwtd::daemon",
+                    hook = %envelope.hook_name,
+                    "received hook envelope"
+                );
+                if out_tx.send(DaemonFrame::Ack).is_err() {
+                    break;
+                }
+            }
+            Ok(ClientFrame::Subscribe { channels }) => {
+                for channel in channels {
+                    let mut rx = hub.subscribe(&channel);
+                    let out_tx = out_tx.clone();
+                    let channel_for_log = channel.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            match rx.recv().await {
+                                Ok(frame) => {
+                                    if out_tx.send(frame).is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(err) => {
+                                    tracing::debug!(
+                                        target: "gwtd::daemon",
+                                        channel = %channel_for_log,
+                                        error = %err,
+                                        "broadcast receiver closed"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    });
+                }
+                if out_tx.send(DaemonFrame::Ack).is_err() {
+                    break;
+                }
             }
             Err(err) => {
                 tracing::warn!(target: "gwtd::daemon", frame = %trimmed, error = %err, "rejected unrecognized frame");
-                DaemonFrame::Error {
-                    message: format!("frame parse failed: {err}"),
+                if out_tx
+                    .send(DaemonFrame::Error {
+                        message: format!("frame parse failed: {err}"),
+                    })
+                    .is_err()
+                {
+                    break;
                 }
             }
-        };
-        write_json_line(&mut write_half, &response).await?;
+        }
     }
 
+    drop(out_tx);
+    let _ = writer.await;
     Ok(())
 }
 
@@ -308,7 +374,7 @@ mod tests {
         net::UnixStream,
     };
 
-    use super::{build_handshake_response, run_server};
+    use super::{build_handshake_response, run_server, BroadcastHub};
 
     fn sample_endpoint(scope: RuntimeScope, socket_path: &Path, token: &str) -> DaemonEndpoint {
         DaemonEndpoint::new(
@@ -394,10 +460,10 @@ mod tests {
         // and sends one frame.
         let server_socket = socket_path.clone();
         let server_endpoint_path = endpoint_path.clone();
-        let server_handle =
-            tokio::spawn(
-                async move { run_server(endpoint, server_socket, server_endpoint_path).await },
-            );
+        let server_hub = BroadcastHub::new();
+        let server_handle = tokio::spawn(async move {
+            run_server(endpoint, server_socket, server_endpoint_path, server_hub).await
+        });
 
         // wait until the socket is bound
         let mut attempts = 0;


### PR DESCRIPTION
## Summary

- PR #2282 で着地した `BroadcastHub` を `server::handle_connection` に wiring。
- `ClientFrame::Subscribe { channels }` を受信した時点で per-channel forwarder task が `hub.subscribe(channel)` の broadcast::Receiver から読んで socket へ転送する経路を成立。
- daemon-side のドメインハンドラが `hub.publish("board", DaemonFrame::Event { ... })` を呼ぶだけで購読中の全 client に自動 fan-out できる構造になり、 SPEC-2077 Phase H1 (handle_board_projection_changed_events daemon 移行) の handler 移行が次の単独 PR で可能になる。

## Architecture

`handle_connection` を **read/write 二相** に分離:

```text
                   ┌────────────────────────┐
client read_half ──│ reader loop            │── ClientFrame::Hook → Ack 送信
                   │  (read_line + parse)   │── ClientFrame::Subscribe → forwarder spawn + Ack
                   │                        │── parse error → DaemonFrame::Error 送信
                   └──────────┬─────────────┘
                              │ out_tx: mpsc::unbounded_channel<DaemonFrame>
                              ▼
                   ┌────────────────────────┐
client write_half ←│ writer task            │
                   │  (recv + write_json)   │
                   └────────────────────────┘
                              ▲
                              │
              ┌───────────────┴────────────────┐
              │ per-channel forwarder task     │
              │ hub.subscribe(channel).recv()  │
              │  → out_tx.send(frame)          │
              └────────────────────────────────┘
```

- writer task が socket への書き込みを単一所有 (race なし)
- ack/error と broadcast event が同じ mpsc を経由するので順序は writer の到着順
- reader 終了 (peer close / EOF) → out_tx drop → writer task break → forwarder task も `out_tx.send` failure で break

## Changes

- `crates/gwt/src/cli/daemon/server.rs`: `serve_blocking` で `BroadcastHub::new()` を構築 + `run_server` 経由で渡す。 `handle_connection` を read/write 二相 + per-channel forwarder spawn 構造に refactor。
- `crates/gwt/src/cli/daemon/broadcast.rs`: `publish` の `#[allow(dead_code)]` を Phase H1 GREEN まで残す旨の doc コメント追加 (`subscribe` は server から呼ばれて使用済み)。
- `crates/gwt/src/cli/daemon/client.rs`: 既存テストが `run_server` の新しいシグネチャに追従。 新規 `subscribed_client_receives_published_broadcast_events` テストで Subscribe → publish → Event 受信 の end-to-end 経路を assert。

## Testing

新規テスト: `subscribed_client_receives_published_broadcast_events`

- client connect → `ClientFrame::Subscribe { channels: ["board"] }` 送信
- ack を受信して forwarder の登録完了を確認
- test 側 hub clone から `publish("board", DaemonFrame::Event { ... })`
- client 側で `read_frame::<DaemonFrame>` が Event を受信することを assert
- forwarder の登録ラグを吸収するため `delivered > 0` まで 10 ms x 20 リトライ

検証:

- `cargo test -p gwt --lib cli::daemon` → 18/18 pass (broadcast: 5 + server: 4 + client: 4 + dispatch: 5)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon Phase H1 wiring step
- 前 PR #2281 (typed frame schema)、 #2282 (BroadcastHub primitive)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] Phase H1 で domain handler が `hub.publish` を呼ぶだけで fan-out できる
- [x] read/write 二相分離で write の単一所有を確保 (race なし)
- [x] reader 終了時に writer + forwarder が cascading break する drop semantics
