### PR TITLE
feat(daemon): gwtd daemon status が socket probe 結果を併記 (SPEC-2077)

### DIFF
--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -98,12 +98,14 @@ fn format_daemon_help() -> String {
         "",
         "Subcommands:",
         "  start                                   Bootstrap and serve the runtime daemon",
-        "  status                                  Report whether a daemon is registered",
+        "  status                                  Report whether a daemon is registered + probe its socket",
         "",
         "Notes:",
         "  - Listens on a Unix domain socket per RuntimeScope (POSIX only today).",
         "  - Endpoint metadata is persisted under ~/.gwt/projects/<repo>/runtime/daemon/.",
         "  - SIGINT / SIGTERM trigger graceful shutdown + endpoint file removal.",
+        "  - `status` reports `probe=ok` when the daemon's socket accepts a handshake within 1s,",
+        "    or `probe=failed:<reason>` when the endpoint file is stale or unreachable.",
         "",
     ]
     .join("\n")

--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -19,7 +19,11 @@ pub mod client;
 pub(super) mod server;
 
 use std::path::PathBuf;
+#[cfg(unix)]
+use std::time::Duration;
 
+#[cfg(unix)]
+use gwt_core::daemon::DaemonEndpoint;
 use gwt_core::daemon::{
     resolve_bootstrap_action, DaemonBootstrapAction, RuntimeScope, RuntimeTarget,
     DAEMON_PROTOCOL_VERSION,
@@ -27,6 +31,9 @@ use gwt_core::daemon::{
 use gwt_github::{client::ApiError, SpecOpsError};
 
 use crate::cli::{CliEnv, CliParseError, DaemonCommand};
+
+#[cfg(unix)]
+const STATUS_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub(super) fn parse(args: &[String]) -> Result<DaemonCommand, CliParseError> {
     match args.first().map(String::as_str) {
@@ -88,11 +95,13 @@ fn report_status<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOp
 
     match action {
         DaemonBootstrapAction::Reuse(endpoint) => {
+            let probe = probe_daemon_endpoint(&endpoint);
             out.push_str(&format!(
-                "running pid={pid} bind={bind} version={version}\n",
+                "running pid={pid} bind={bind} version={version} probe={probe}\n",
                 pid = endpoint.pid,
                 bind = endpoint.bind,
-                version = endpoint.daemon_version
+                version = endpoint.daemon_version,
+                probe = format_probe_result(&probe)
             ));
             Ok(0)
         }
@@ -105,6 +114,41 @@ fn report_status<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOp
             ));
             Ok(0)
         }
+    }
+}
+
+#[cfg(unix)]
+fn probe_daemon_endpoint(endpoint: &DaemonEndpoint) -> Result<(), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| format!("tokio runtime build failed: {err}"))?;
+    runtime.block_on(async {
+        match tokio::time::timeout(
+            STATUS_PROBE_TIMEOUT,
+            client::DaemonClient::connect(endpoint),
+        )
+        .await
+        {
+            Ok(Ok(_client)) => Ok(()),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(format!(
+                "probe timeout after {ms}ms",
+                ms = STATUS_PROBE_TIMEOUT.as_millis()
+            )),
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn probe_daemon_endpoint(_endpoint: &gwt_core::daemon::DaemonEndpoint) -> Result<(), String> {
+    Err("probe not implemented on this platform".to_string())
+}
+
+fn format_probe_result(result: &Result<(), String>) -> String {
+    match result {
+        Ok(()) => "ok".to_string(),
+        Err(err) => format!("failed:{err}"),
     }
 }
 
@@ -204,5 +248,42 @@ mod tests {
     fn parse_rejects_extra_args() {
         let err = parse(&[s("start"), s("--whatever")]).unwrap_err();
         assert!(matches!(err, CliParseError::Usage));
+    }
+
+    #[test]
+    fn format_probe_result_ok_renders_ok() {
+        assert_eq!(format_probe_result(&Ok(())), "ok");
+    }
+
+    #[test]
+    fn format_probe_result_err_includes_message() {
+        let result: Result<(), String> = Err("connection refused".to_string());
+        assert_eq!(format_probe_result(&result), "failed:connection refused");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_daemon_endpoint_fails_for_unreachable_bind() {
+        use gwt_core::daemon::{DaemonEndpoint, RuntimeScope, RuntimeTarget};
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().expect("tempdir");
+        let scope = RuntimeScope::new(
+            "abcdef0123456789",
+            "feedfacecafebeef",
+            temp.path().to_path_buf(),
+            RuntimeTarget::Host,
+        )
+        .expect("scope");
+        let bogus_socket = temp.path().join("does-not-exist.sock");
+        let endpoint = DaemonEndpoint::new(
+            scope,
+            std::process::id(),
+            bogus_socket.to_string_lossy().to_string(),
+            "tok".to_string(),
+            "test-daemon".to_string(),
+        );
+        let result = probe_daemon_endpoint(&endpoint);
+        assert!(result.is_err(), "expected probe to fail for missing socket");
     }
 }


### PR DESCRIPTION
## Summary

- `gwtd daemon status` が endpoint file の存在 + PID liveness だけでなく、 実際の Unix socket に handshake を試行して probe 結果を併記するようになった。
- stale endpoint (PID は alive だが socket が壊れている) や protocol mismatch の旧 daemon が残っている等を `gwtd daemon status` だけで検出可能。
- timeout は 1 秒固定で、 hang する PR を防ぐ。 daemon 不在時の `Spawn` ブランチには影響なし (probe は `Reuse` でのみ実行)。

## Output format

before:
```text
running pid=12345 bind=/path.sock version=9.14.0
```

after:
```text
running pid=12345 bind=/path.sock version=9.14.0 probe=ok
running pid=12345 bind=/path.sock version=9.14.0 probe=failed:probe timeout after 1000ms
running pid=12345 bind=/path.sock version=9.14.0 probe=failed:daemon handshake validation failed: ...
```

## Changes

- `crates/gwt/src/cli/daemon/mod.rs`: `probe_daemon_endpoint` を追加 (短命の current-thread tokio runtime を作って `DaemonClient::connect` を `tokio::time::timeout(STATUS_PROBE_TIMEOUT)` で wrap)、 `format_probe_result` で結果を `ok` / `failed:<reason>` に整形、 `report_status` の `Reuse` ブランチで併記。 cfg(not(unix)) は "probe not implemented" stub。
- `crates/gwt/src/bin/gwtd.rs`: `format_daemon_help` の Notes に probe 出力 format を追記。

## Testing

新規 unit tests:

- `format_probe_result_ok_renders_ok` (Ok → "ok")
- `format_probe_result_err_includes_message` (Err → "failed:<msg>")
- `probe_daemon_endpoint_fails_for_unreachable_bind` (存在しない socket path で Err 確認)

検証:

- `cargo test -p gwt --lib cli::daemon` → 21/21 pass (新 3 件 + 既存 18)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし
- `cargo run -p gwt --bin gwtd -- --help daemon` → Notes に probe 説明が表示

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2280 (DaemonClient)、 #2283 (BroadcastHub server wiring)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] 1s timeout で hang を防ぐ
- [x] `Spawn` ブランチには影響なし (probe は `Reuse` でのみ)
- [x] cfg(not(unix)) stub で Windows ビルドが通る
