### PR TITLE
feat(daemon): ClientFrame::Status / DaemonStatus snapshot frame (SPEC-2077)

### DIFF
--- a/crates/gwt-core/src/daemon.rs
+++ b/crates/gwt-core/src/daemon.rs
@@ -181,6 +181,8 @@ pub enum ClientFrame {
     Hook(HookEnvelope),
     /// Subscribe to one or more daemon broadcast channels.
     Subscribe { channels: Vec<String> },
+    /// Request a snapshot of the daemon's current runtime stats.
+    Status,
 }
 
 /// Tagged frame envelope returned by `gwtd`.
@@ -198,6 +200,18 @@ pub enum DaemonFrame {
     Event { channel: String, payload: Value },
     /// The daemon rejected the frame. `message` is human-readable.
     Error { message: String },
+    /// Snapshot of daemon runtime stats, returned in response to a
+    /// [`ClientFrame::Status`] request.
+    Status(DaemonStatus),
+}
+
+/// Runtime stats snapshot returned by a [`DaemonFrame::Status`] frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonStatus {
+    pub protocol_version: u32,
+    pub daemon_version: String,
+    pub uptime_seconds: u64,
+    pub broadcast_channels: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/gwt-core/tests/runtime_daemon_contract.rs
+++ b/crates/gwt-core/tests/runtime_daemon_contract.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 
 use gwt_core::daemon::{
     persist_endpoint, resolve_bootstrap_action, validate_handshake, ClientFrame,
-    DaemonBootstrapAction, DaemonEndpoint, DaemonFrame, HookEnvelope, IpcHandshakeRequest,
-    IpcHandshakeResponse, RuntimeScope, RuntimeTarget, DAEMON_PROTOCOL_VERSION,
+    DaemonBootstrapAction, DaemonEndpoint, DaemonFrame, DaemonStatus, HookEnvelope,
+    IpcHandshakeRequest, IpcHandshakeResponse, RuntimeScope, RuntimeTarget,
+    DAEMON_PROTOCOL_VERSION,
 };
 use serde_json::json;
 use tempfile::tempdir;
@@ -523,6 +524,33 @@ fn daemon_frame_error_serializes_message() {
     let json_value = serde_json::to_value(&frame).unwrap();
     assert_eq!(json_value["type"], "error");
     assert_eq!(json_value["message"], "unknown frame type");
+    let round_trip: DaemonFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
+}
+
+#[test]
+fn client_frame_status_serializes_to_canonical_shape() {
+    let frame = ClientFrame::Status;
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "status");
+    let round_trip: ClientFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
+}
+
+#[test]
+fn daemon_frame_status_carries_uptime_and_channel_count() {
+    let frame = DaemonFrame::Status(DaemonStatus {
+        protocol_version: DAEMON_PROTOCOL_VERSION,
+        daemon_version: "9.14.0".to_string(),
+        uptime_seconds: 42,
+        broadcast_channels: 3,
+    });
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "status");
+    assert_eq!(json_value["protocol_version"], DAEMON_PROTOCOL_VERSION);
+    assert_eq!(json_value["daemon_version"], "9.14.0");
+    assert_eq!(json_value["uptime_seconds"], 42);
+    assert_eq!(json_value["broadcast_channels"], 3);
     let round_trip: DaemonFrame = serde_json::from_value(json_value).unwrap();
     assert_eq!(round_trip, frame);
 }

--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -70,10 +70,13 @@ impl BroadcastHub {
         }
     }
 
-    /// Number of distinct channels currently tracked. Test helper.
-    #[cfg(test)]
+    /// Number of distinct channels currently tracked. Used by the
+    /// daemon's status snapshot frame and by tests.
     pub(super) fn channel_count(&self) -> usize {
-        self.channels.lock().unwrap().len()
+        self.channels
+            .lock()
+            .expect("BroadcastHub mutex poisoned")
+            .len()
     }
 }
 

--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -305,6 +305,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn client_status_request_returns_daemon_snapshot() {
+        let temp = TempDir::new().expect("tempdir");
+        let scope = sample_scope(&temp);
+        let socket_path = temp.path().join("daemon.sock");
+        let endpoint_path = temp.path().join("endpoint.json");
+        let endpoint = sample_endpoint(scope.clone(), &socket_path, "status-secret");
+
+        let server_endpoint = endpoint.clone();
+        let server_socket = socket_path.clone();
+        let server_endpoint_path = endpoint_path.clone();
+        let server_hub = BroadcastHub::new();
+        // Pre-create one channel so the snapshot has a known nonzero
+        // value to assert against.
+        let _initial_rx = server_hub.subscribe("warmup");
+        let server_handle = tokio::spawn(async move {
+            server::run_server(
+                server_endpoint,
+                server_socket,
+                server_endpoint_path,
+                server_hub,
+            )
+            .await
+        });
+
+        wait_for_socket(&socket_path).await;
+
+        let mut client = DaemonClient::connect(&endpoint)
+            .await
+            .expect("client connects");
+
+        client
+            .send_frame(&ClientFrame::Status)
+            .await
+            .expect("send status");
+        let frame: DaemonFrame = client.read_frame().await.expect("read status");
+        match frame {
+            DaemonFrame::Status(status) => {
+                assert_eq!(status.protocol_version, DAEMON_PROTOCOL_VERSION);
+                assert_eq!(status.daemon_version, "test-daemon");
+                // uptime_seconds may be 0 for very fast tests; just check
+                // that the field exists in the response by reading it.
+                let _uptime = status.uptime_seconds;
+                assert!(
+                    status.broadcast_channels >= 1,
+                    "expected at least the warmup channel, got {}",
+                    status.broadcast_channels
+                );
+            }
+            other => panic!("expected Status frame, got: {other:?}"),
+        }
+
+        drop(client);
+        server_handle.abort();
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test]
     async fn subscribed_client_receives_published_broadcast_events() {
         let temp = TempDir::new().expect("tempdir");
         let scope = sample_scope(&temp);

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -24,11 +24,11 @@ use std::{
     fs,
     path::{Path, PathBuf},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use gwt_core::daemon::{
-    persist_endpoint, validate_handshake, ClientFrame, DaemonEndpoint, DaemonFrame,
+    persist_endpoint, validate_handshake, ClientFrame, DaemonEndpoint, DaemonFrame, DaemonStatus,
     IpcHandshakeRequest, IpcHandshakeResponse, RuntimeScope, DAEMON_PROTOCOL_VERSION,
 };
 use gwt_github::{client::ApiError, SpecOpsError};
@@ -116,6 +116,7 @@ pub(super) async fn run_server(
     spawn_signal_watcher(Arc::clone(&shutdown));
 
     let endpoint = Arc::new(endpoint);
+    let started_at = Instant::now();
     let _endpoint_path = endpoint_path; // retained for symmetry with future watch flows
     loop {
         tokio::select! {
@@ -130,7 +131,9 @@ pub(super) async fn run_server(
                         let endpoint = Arc::clone(&endpoint);
                         let hub = hub.clone();
                         tokio::spawn(async move {
-                            if let Err(err) = handle_connection(stream, endpoint, hub).await {
+                            if let Err(err) =
+                                handle_connection(stream, endpoint, hub, started_at).await
+                            {
                                 tracing::warn!("gwtd daemon: connection error: {err}");
                             }
                         });
@@ -176,6 +179,7 @@ async fn handle_connection(
     stream: UnixStream,
     endpoint: Arc<DaemonEndpoint>,
     hub: BroadcastHub,
+    started_at: Instant,
 ) -> Result<(), String> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -260,6 +264,17 @@ async fn handle_connection(
                     });
                 }
                 if out_tx.send(DaemonFrame::Ack).is_err() {
+                    break;
+                }
+            }
+            Ok(ClientFrame::Status) => {
+                let snapshot = DaemonStatus {
+                    protocol_version: endpoint.protocol_version,
+                    daemon_version: endpoint.daemon_version.clone(),
+                    uptime_seconds: started_at.elapsed().as_secs(),
+                    broadcast_channels: hub.channel_count(),
+                };
+                if out_tx.send(DaemonFrame::Status(snapshot)).is_err() {
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

- daemon の自己観測 (uptime, broadcast channel 数等) を IPC 経由で取得できる typed frame を追加。
- 新 `ClientFrame::Status` (引数なし、 snapshot リクエスト) → `DaemonFrame::Status(DaemonStatus { protocol_version, daemon_version, uptime_seconds, broadcast_channels })` の round-trip。
- Phase H1 以降で multi-instance gwt が daemon の health を確認したり、 `gwtd daemon status` が endpoint 由来 (固定値) ではなく daemon 由来の live snapshot を表示する経路を整備。

## Why DaemonStatus and not just probe?

PR #2284 の `gwtd daemon status` probe は **「socket が応答するか」** を確認する。 本 PR の `DaemonFrame::Status` は **「daemon の自己申告 state」** を取り出す。 違いは:

| 観点 | probe (#2284) | Status frame (本 PR) |
|---|---|---|
| 検出 | socket が応答するか | daemon の生 state |
| 出典 | endpoint file (固定値) | daemon プロセス (live) |
| Phase H1 用途 | 健全性確認 | hub の subscriber 数等を取得して GUI 側で可視化 |

両方が揃うことで `gwtd daemon status` が `responding=ok uptime=42s channels=3` のような richer な情報を出力する経路が整う (本 PR には未含、 follow-up)。

## Changes

- `crates/gwt-core/src/daemon.rs`: `ClientFrame::Status` variant、 `DaemonFrame::Status(DaemonStatus)` variant、 `DaemonStatus` struct を追加。
- `crates/gwt-core/tests/runtime_daemon_contract.rs`: 2 件の round-trip test 追加 (`client_frame_status_serializes_to_canonical_shape` / `daemon_frame_status_carries_uptime_and_channel_count`)。
- `crates/gwt/src/cli/daemon/server.rs`: `run_server` で `Instant::now()` を捕捉して `handle_connection` に 4 番目の引数として渡す。 `ClientFrame::Status` arm を追加し、 endpoint.{protocol_version, daemon_version} + `started_at.elapsed()` + `hub.channel_count()` から DaemonStatus を構築。
- `crates/gwt/src/cli/daemon/broadcast.rs`: `channel_count` を `pub(super)` に昇格 (server から呼び出し可能に、 test-only attribute を解除)。
- `crates/gwt/src/cli/daemon/client.rs`: end-to-end test `client_status_request_returns_daemon_snapshot` 追加 (warmup チャネル登録 → Status 送信 → snapshot validation)。

## Testing

- `cargo test -p gwt-core --test runtime_daemon_contract` → 24/24 pass (新 2 件 + 既存 22)
- `cargo test -p gwt --lib cli::daemon` → 22/22 pass (新 1 件 + 既存 21)
- `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2281 (typed frame schema)、 #2283 (BroadcastHub server wiring)、 #2284 (status probe)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] frame schema を typed enum で安全に拡張
- [x] daemon の自己観測 state (uptime / channel 数) を typed で公開
- [x] PR #2284 (probe) と orthogonal、 両方を将来 status コマンドで合成可能
