### PR TITLE
feat(daemon): gwtd daemon status の probe で uptime/channel 数も併記 (SPEC-2077)

### DIFF
--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -104,8 +104,9 @@ fn format_daemon_help() -> String {
         "  - Listens on a Unix domain socket per RuntimeScope (POSIX only today).",
         "  - Endpoint metadata is persisted under ~/.gwt/projects/<repo>/runtime/daemon/.",
         "  - SIGINT / SIGTERM trigger graceful shutdown + endpoint file removal.",
-        "  - `status` reports `probe=ok` when the daemon's socket accepts a handshake within 1s,",
-        "    or `probe=failed:<reason>` when the endpoint file is stale or unreachable.",
+        "  - `status` reports `probe=ok uptime=<s>s channels=<n>` when the daemon answers a",
+        "    `ClientFrame::Status` request within 1s, or `probe=failed:<reason>` when the",
+        "    endpoint file is stale or unreachable.",
         "",
     ]
     .join("\n")

--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -22,12 +22,12 @@ use std::path::PathBuf;
 #[cfg(unix)]
 use std::time::Duration;
 
-#[cfg(unix)]
-use gwt_core::daemon::DaemonEndpoint;
 use gwt_core::daemon::{
-    resolve_bootstrap_action, DaemonBootstrapAction, RuntimeScope, RuntimeTarget,
+    resolve_bootstrap_action, DaemonBootstrapAction, DaemonStatus, RuntimeScope, RuntimeTarget,
     DAEMON_PROTOCOL_VERSION,
 };
+#[cfg(unix)]
+use gwt_core::daemon::{ClientFrame, DaemonEndpoint, DaemonFrame};
 use gwt_github::{client::ApiError, SpecOpsError};
 
 use crate::cli::{CliEnv, CliParseError, DaemonCommand};
@@ -118,36 +118,66 @@ fn report_status<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOp
 }
 
 #[cfg(unix)]
-fn probe_daemon_endpoint(endpoint: &DaemonEndpoint) -> Result<(), String> {
+fn probe_daemon_endpoint(endpoint: &DaemonEndpoint) -> Result<DaemonStatus, String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|err| format!("tokio runtime build failed: {err}"))?;
     runtime.block_on(async {
-        match tokio::time::timeout(
+        let connect = tokio::time::timeout(
             STATUS_PROBE_TIMEOUT,
             client::DaemonClient::connect(endpoint),
         )
         .await
-        {
-            Ok(Ok(_client)) => Ok(()),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(format!(
+        .map_err(|_| {
+            format!(
                 "probe timeout after {ms}ms",
                 ms = STATUS_PROBE_TIMEOUT.as_millis()
-            )),
+            )
+        })??;
+        let mut client = connect;
+        client
+            .send_frame(&ClientFrame::Status)
+            .await
+            .map_err(|err| format!("status send failed: {err}"))?;
+        let frame: DaemonFrame = tokio::time::timeout(STATUS_PROBE_TIMEOUT, client.read_frame())
+            .await
+            .map_err(|_| {
+                format!(
+                    "status read timeout after {ms}ms",
+                    ms = STATUS_PROBE_TIMEOUT.as_millis()
+                )
+            })??;
+        match frame {
+            DaemonFrame::Status(status) => Ok(status),
+            other => Err(format!("expected Status frame, got: {other:?}")),
         }
     })
 }
 
 #[cfg(not(unix))]
-fn probe_daemon_endpoint(_endpoint: &gwt_core::daemon::DaemonEndpoint) -> Result<(), String> {
+fn probe_daemon_endpoint(
+    _endpoint: &gwt_core::daemon::DaemonEndpoint,
+) -> Result<DaemonStatus, String> {
     Err("probe not implemented on this platform".to_string())
 }
 
-fn format_probe_result(result: &Result<(), String>) -> String {
+#[cfg(unix)]
+fn format_probe_result(result: &Result<DaemonStatus, String>) -> String {
     match result {
-        Ok(()) => "ok".to_string(),
+        Ok(status) => format!(
+            "ok uptime={uptime}s channels={channels}",
+            uptime = status.uptime_seconds,
+            channels = status.broadcast_channels
+        ),
+        Err(err) => format!("failed:{err}"),
+    }
+}
+
+#[cfg(not(unix))]
+fn format_probe_result(result: &Result<DaemonStatus, String>) -> String {
+    match result {
+        Ok(_) => "ok".to_string(),
         Err(err) => format!("failed:{err}"),
     }
 }
@@ -251,13 +281,8 @@ mod tests {
     }
 
     #[test]
-    fn format_probe_result_ok_renders_ok() {
-        assert_eq!(format_probe_result(&Ok(())), "ok");
-    }
-
-    #[test]
     fn format_probe_result_err_includes_message() {
-        let result: Result<(), String> = Err("connection refused".to_string());
+        let result: Result<DaemonStatus, String> = Err("connection refused".to_string());
         assert_eq!(format_probe_result(&result), "failed:connection refused");
     }
 
@@ -285,5 +310,20 @@ mod tests {
         );
         let result = probe_daemon_endpoint(&endpoint);
         assert!(result.is_err(), "expected probe to fail for missing socket");
+    }
+
+    #[test]
+    fn format_probe_result_ok_includes_uptime_and_channels() {
+        let status = DaemonStatus {
+            protocol_version: DAEMON_PROTOCOL_VERSION,
+            daemon_version: "9.14.0".to_string(),
+            uptime_seconds: 12,
+            broadcast_channels: 2,
+        };
+        let formatted = format_probe_result(&Ok(status));
+        #[cfg(unix)]
+        assert_eq!(formatted, "ok uptime=12s channels=2");
+        #[cfg(not(unix))]
+        assert_eq!(formatted, "ok");
     }
 }


### PR DESCRIPTION
## Summary

- PR #2284 で導入した socket probe を、 PR #2285 の `ClientFrame::Status` / `DaemonFrame::Status(DaemonStatus)` を活用するよう拡張。
- `gwtd daemon status` の probe 出力が daemon 自己申告の **live snapshot (uptime / broadcast channel 数)** を含むようになる。 endpoint file 由来の固定値ではなく、 daemon プロセスの実際の状態が見える。

## Output format

before (PR #2284):
```text
running pid=12345 bind=/path.sock version=9.14.0 probe=ok
```

after:
```text
running pid=12345 bind=/path.sock version=9.14.0 probe=ok uptime=42s channels=3
running pid=12345 bind=/path.sock version=9.14.0 probe=failed:status read timeout after 1000ms
running pid=12345 bind=/path.sock version=9.14.0 probe=failed:expected Status frame, got: Error { ... }
```

## Changes

- `crates/gwt/src/cli/daemon/mod.rs`: `probe_daemon_endpoint` の戻り型を `Result<(), String>` から `Result<DaemonStatus, String>` に変更。 handshake 成功後に `ClientFrame::Status` を送信し、 `DaemonFrame::Status(DaemonStatus)` を 1 秒 timeout で読み取って返却する統合 probe にした。 想定外の DaemonFrame variant が来た場合は明示的に error 化。
- `format_probe_result` が `Ok(status)` で `uptime / channels` を rendering、 `not(unix)` は backstop で `"ok"` のみ。
- 関連 unit test を更新 (`format_probe_result_ok_includes_uptime_and_channels` 追加、 既存 `format_probe_result_err_includes_message` を新シグネチャに追従)。
- `crates/gwt/src/bin/gwtd.rs`: `format_daemon_help` の Notes を新 probe 出力 format に追従して更新。

## Testing

- `cargo test -p gwt --lib cli::daemon` → 22/22 pass
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし
- `cargo run -p gwt --bin gwtd -- --help daemon` → Notes に新 format が表示

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2284 (status probe initial)、 #2285 (DaemonStatus snapshot frame)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] probe が `ClientFrame::Status` 経由で daemon の live snapshot を取得
- [x] handshake と Status read の両方に 1s timeout
- [x] 想定外 DaemonFrame variant は明示 error 化
- [x] gwtd --help daemon の Notes も追従
