### PR TITLE
feat(daemon): DaemonStatus に live connection 数を追加 (SPEC-2077)

### DIFF
--- a/crates/gwt-core/src/daemon.rs
+++ b/crates/gwt-core/src/daemon.rs
@@ -212,6 +212,10 @@ pub struct DaemonStatus {
     pub daemon_version: String,
     pub uptime_seconds: u64,
     pub broadcast_channels: usize,
+    /// Number of currently-connected IPC clients, including the one
+    /// asking for the status snapshot.
+    #[serde(default)]
+    pub connections: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/gwt-core/tests/runtime_daemon_contract.rs
+++ b/crates/gwt-core/tests/runtime_daemon_contract.rs
@@ -544,6 +544,7 @@ fn daemon_frame_status_carries_uptime_and_channel_count() {
         daemon_version: "9.14.0".to_string(),
         uptime_seconds: 42,
         broadcast_channels: 3,
+        connections: 2,
     });
     let json_value = serde_json::to_value(&frame).unwrap();
     assert_eq!(json_value["type"], "status");
@@ -551,8 +552,31 @@ fn daemon_frame_status_carries_uptime_and_channel_count() {
     assert_eq!(json_value["daemon_version"], "9.14.0");
     assert_eq!(json_value["uptime_seconds"], 42);
     assert_eq!(json_value["broadcast_channels"], 3);
+    assert_eq!(json_value["connections"], 2);
     let round_trip: DaemonFrame = serde_json::from_value(json_value).unwrap();
     assert_eq!(round_trip, frame);
+}
+
+#[test]
+fn daemon_status_connections_field_defaults_to_zero_when_missing() {
+    // Older daemons may not include `connections` in their wire form;
+    // serde must treat the missing field as 0 to keep forward-compat
+    // working for clients reading from a daemon that predates the
+    // counter.
+    let json_value = json!({
+        "type": "status",
+        "protocol_version": DAEMON_PROTOCOL_VERSION,
+        "daemon_version": "old",
+        "uptime_seconds": 1,
+        "broadcast_channels": 0,
+    });
+    let frame: DaemonFrame = serde_json::from_value(json_value).unwrap();
+    match frame {
+        DaemonFrame::Status(status) => {
+            assert_eq!(status.connections, 0);
+        }
+        other => panic!("expected Status frame, got: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -104,9 +104,9 @@ fn format_daemon_help() -> String {
         "  - Listens on a Unix domain socket per RuntimeScope (POSIX only today).",
         "  - Endpoint metadata is persisted under ~/.gwt/projects/<repo>/runtime/daemon/.",
         "  - SIGINT / SIGTERM trigger graceful shutdown + endpoint file removal.",
-        "  - `status` reports `probe=ok uptime=<s>s channels=<n>` when the daemon answers a",
-        "    `ClientFrame::Status` request within 1s, or `probe=failed:<reason>` when the",
-        "    endpoint file is stale or unreachable.",
+        "  - `status` reports `probe=ok uptime=<s>s channels=<n> connections=<n>` when the",
+        "    daemon answers a `ClientFrame::Status` request within 1s, or `probe=failed:<reason>`",
+        "    when the endpoint file is stale or unreachable.",
         "",
     ]
     .join("\n")

--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -352,6 +352,14 @@ mod tests {
                     "expected at least the warmup channel, got {}",
                     status.broadcast_channels
                 );
+                // The asking client itself counts as one connection;
+                // the daemon should always report >= 1 from inside the
+                // ClientFrame::Status arm.
+                assert!(
+                    status.connections >= 1,
+                    "expected at least one tracked connection, got {}",
+                    status.connections
+                );
             }
             other => panic!("expected Status frame, got: {other:?}"),
         }

--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -166,9 +166,10 @@ fn probe_daemon_endpoint(
 fn format_probe_result(result: &Result<DaemonStatus, String>) -> String {
     match result {
         Ok(status) => format!(
-            "ok uptime={uptime}s channels={channels}",
+            "ok uptime={uptime}s channels={channels} connections={connections}",
             uptime = status.uptime_seconds,
-            channels = status.broadcast_channels
+            channels = status.broadcast_channels,
+            connections = status.connections
         ),
         Err(err) => format!("failed:{err}"),
     }
@@ -319,10 +320,11 @@ mod tests {
             daemon_version: "9.14.0".to_string(),
             uptime_seconds: 12,
             broadcast_channels: 2,
+            connections: 1,
         };
         let formatted = format_probe_result(&Ok(status));
         #[cfg(unix)]
-        assert_eq!(formatted, "ok uptime=12s channels=2");
+        assert_eq!(formatted, "ok uptime=12s channels=2 connections=1");
         #[cfg(not(unix))]
         assert_eq!(formatted, "ok");
     }

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -23,7 +23,10 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -117,6 +120,7 @@ pub(super) async fn run_server(
 
     let endpoint = Arc::new(endpoint);
     let started_at = Instant::now();
+    let connections = Arc::new(AtomicUsize::new(0));
     let _endpoint_path = endpoint_path; // retained for symmetry with future watch flows
     loop {
         tokio::select! {
@@ -130,9 +134,11 @@ pub(super) async fn run_server(
                     Ok((stream, _addr)) => {
                         let endpoint = Arc::clone(&endpoint);
                         let hub = hub.clone();
+                        let connections = Arc::clone(&connections);
                         tokio::spawn(async move {
+                            let guard = ConnectionGuard::new(connections);
                             if let Err(err) =
-                                handle_connection(stream, endpoint, hub, started_at).await
+                                handle_connection(stream, endpoint, hub, started_at, &guard).await
                             {
                                 tracing::warn!("gwtd daemon: connection error: {err}");
                             }
@@ -148,6 +154,30 @@ pub(super) async fn run_server(
     }
 
     Ok(0)
+}
+
+/// RAII counter for live IPC connections. The constructor increments
+/// the shared counter; `Drop` decrements it. This guarantees the
+/// counter stays accurate even on panic or abnormal task abort.
+struct ConnectionGuard {
+    counter: Arc<AtomicUsize>,
+}
+
+impl ConnectionGuard {
+    fn new(counter: Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self { counter }
+    }
+
+    fn snapshot(&self) -> usize {
+        self.counter.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 fn spawn_signal_watcher(shutdown: Arc<Notify>) {
@@ -180,6 +210,7 @@ async fn handle_connection(
     endpoint: Arc<DaemonEndpoint>,
     hub: BroadcastHub,
     started_at: Instant,
+    connection_guard: &ConnectionGuard,
 ) -> Result<(), String> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -273,6 +304,7 @@ async fn handle_connection(
                     daemon_version: endpoint.daemon_version.clone(),
                     uptime_seconds: started_at.elapsed().as_secs(),
                     broadcast_channels: hub.channel_count(),
+                    connections: connection_guard.snapshot(),
                 };
                 if out_tx.send(DaemonFrame::Status(snapshot)).is_err() {
                     break;


### PR DESCRIPTION
## Summary

- `DaemonStatus` に `connections: usize` を追加。 daemon が現在 hold している IPC connection 数を `gwtd daemon status` の probe で可視化。
- `connection_count` カウンタは `Arc<AtomicUsize>` + `ConnectionGuard` RAII pattern で管理し、 panic / abnormal abort でも常に正確。
- backwards compat: `#[serde(default)]` で旧 daemon の wire JSON (フィールドなし) も `connections=0` で deserialize 可能。

## Output format

before:
```text
running pid=12345 bind=/path.sock version=9.14.0 probe=ok uptime=42s channels=3
```

after:
```text
running pid=12345 bind=/path.sock version=9.14.0 probe=ok uptime=42s channels=3 connections=2
```

## Changes

- `crates/gwt-core/src/daemon.rs`: `DaemonStatus.connections` フィールドを追加 (`#[serde(default)]`)。
- `crates/gwt-core/tests/runtime_daemon_contract.rs`: 既存 status round-trip test に `connections=2` の検証を追加 + 新 `daemon_status_connections_field_defaults_to_zero_when_missing` で旧 daemon との互換を確認。
- `crates/gwt/src/cli/daemon/server.rs`: `Arc<AtomicUsize>` 共有 counter + `ConnectionGuard` RAII (`fetch_add` on new, `fetch_sub` on Drop) を追加。 `handle_connection` シグネチャに `&ConnectionGuard` を追加して `ClientFrame::Status` arm で snapshot を読む。
- `crates/gwt/src/cli/daemon/client.rs`: `client_status_request_returns_daemon_snapshot` に `connections >= 1` assertion (自分自身の connection が count されることを確認)。
- `crates/gwt/src/cli/daemon/mod.rs`: `format_probe_result` に `connections={n}` を追加、 関連 test を更新。
- `crates/gwt/src/bin/gwtd.rs`: help 文の Notes も新 format に追従。

## Why RAII guard?

`ConnectionGuard::Drop` が `fetch_sub` を呼ぶので、 connection task が:
- 正常終了
- 早期 return (handshake 失敗等)
- panic / abort

いずれの経路でも counter が正確に減る。 手動で increment/decrement を呼ぶより安全。

## Testing

- `cargo test -p gwt-core --test runtime_daemon_contract` → 25/25 pass (新 1 + 既存 24)
- `cargo test -p gwt --lib cli::daemon` → 22/22 pass
- `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし
- `cargo run -p gwt --bin gwtd -- --help daemon` → Notes に新 format 表示

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2285 (DaemonStatus snapshot frame)、 #2286 (probe uses Status)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] RAII で connection count の正確性を保証 (panic-safe)
- [x] `#[serde(default)]` で旧 daemon との backwards compat
- [x] 自分自身の connection も count される (>= 1 必ず)
