### PR TITLE
feat(daemon): gwtd daemon subscribe <channel> debug CLI (SPEC-2077)

### DIFF
--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -99,6 +99,8 @@ fn format_daemon_help() -> String {
         "Subcommands:",
         "  start                                   Bootstrap and serve the runtime daemon",
         "  status                                  Report whether a daemon is registered + probe its socket",
+        "  subscribe <channel>...                  Connect to the running daemon, subscribe to channels,",
+        "                                          and stream received events as JSON to stdout",
         "",
         "Notes:",
         "  - Listens on a Unix domain socket per RuntimeScope (POSIX only today).",

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -160,6 +160,11 @@ pub enum DaemonCommand {
     Start,
     /// `gwtd daemon status` — print whether a daemon is registered for cwd scope.
     Status,
+    /// `gwtd daemon subscribe <channel>...` — connect to the running daemon,
+    /// subscribe to one or more broadcast channels, and print received events
+    /// to stdout one JSON line at a time. Useful for debugging the Phase H1+
+    /// fan-out pipeline.
+    Subscribe { channels: Vec<String> },
 }
 
 /// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).

--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -45,6 +45,13 @@ pub(super) fn parse(args: &[String]) -> Result<DaemonCommand, CliParseError> {
             ensure_no_extra_args(args.get(1..).unwrap_or(&[]))?;
             Ok(DaemonCommand::Status)
         }
+        Some("subscribe") => {
+            let channels: Vec<String> = args[1..].to_vec();
+            if channels.is_empty() {
+                return Err(CliParseError::Usage);
+            }
+            Ok(DaemonCommand::Subscribe { channels })
+        }
         Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
     }
 }
@@ -65,6 +72,7 @@ pub(super) fn run<E: CliEnv>(
     match cmd {
         DaemonCommand::Start => start_daemon(env, out),
         DaemonCommand::Status => report_status(env, out),
+        DaemonCommand::Subscribe { channels } => subscribe_command(env, channels, out),
     }
 }
 
@@ -160,6 +168,75 @@ fn probe_daemon_endpoint(
     _endpoint: &gwt_core::daemon::DaemonEndpoint,
 ) -> Result<DaemonStatus, String> {
     Err("probe not implemented on this platform".to_string())
+}
+
+#[cfg(unix)]
+fn subscribe_command<E: CliEnv>(
+    env: &mut E,
+    channels: Vec<String>,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    let scope = resolve_scope(env)?;
+    let gwt_home = gwt_core::paths::gwt_home();
+    let action = resolve_bootstrap_action(
+        &gwt_home,
+        &scope,
+        DAEMON_PROTOCOL_VERSION,
+        is_process_alive_pid,
+    )
+    .map_err(|err| config_error(err.to_string()))?;
+
+    let endpoint = match action {
+        DaemonBootstrapAction::Reuse(endpoint) => endpoint,
+        DaemonBootstrapAction::Spawn { endpoint_path } => {
+            out.push_str(&format!(
+                "gwtd daemon subscribe: no daemon registered (endpoint={})\n",
+                endpoint_path.display()
+            ));
+            return Ok(2);
+        }
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| config_error(format!("tokio runtime build failed: {err}")))?;
+    runtime.block_on(async {
+        let mut client = client::DaemonClient::connect(&endpoint)
+            .await
+            .map_err(|err| config_error(format!("daemon connect failed: {err}")))?;
+        client
+            .send_frame(&ClientFrame::Subscribe { channels })
+            .await
+            .map_err(|err| config_error(format!("subscribe send failed: {err}")))?;
+        let _ack: DaemonFrame = client
+            .read_frame()
+            .await
+            .map_err(|err| config_error(format!("subscribe ack failed: {err}")))?;
+        loop {
+            let frame: DaemonFrame = client
+                .read_frame()
+                .await
+                .map_err(|err| config_error(format!("read event failed: {err}")))?;
+            let line = serde_json::to_string(&frame)
+                .map_err(|err| config_error(format!("serialize event failed: {err}")))?;
+            writeln!(env.stdout(), "{line}")
+                .map_err(|err| config_error(format!("write stdout failed: {err}")))?;
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn subscribe_command<E: CliEnv>(
+    _env: &mut E,
+    _channels: Vec<String>,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    out.push_str(
+        "gwtd daemon subscribe: not implemented on this platform; \
+         subscribe support requires Unix domain sockets.\n",
+    );
+    Ok(2)
 }
 
 #[cfg(unix)]
@@ -267,6 +344,23 @@ mod tests {
     fn parse_recognises_status() {
         let cmd = parse(&[s("status")]).expect("parse");
         assert_eq!(cmd, DaemonCommand::Status);
+    }
+
+    #[test]
+    fn parse_recognises_subscribe_with_channels() {
+        let cmd = parse(&[s("subscribe"), s("board"), s("runtime-status")]).expect("parse");
+        assert_eq!(
+            cmd,
+            DaemonCommand::Subscribe {
+                channels: vec!["board".to_string(), "runtime-status".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_subscribe_without_channels() {
+        let err = parse(&[s("subscribe")]).unwrap_err();
+        assert!(matches!(err, CliParseError::Usage));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Phase H1+ の broadcast pipeline の動作確認と観測を容易にするため、 **daemon の broadcast channel に外部 CLI から購読して受信 event を JSON 1 行ずつ stdout に流す debug ツール** `gwtd daemon subscribe` を追加。
- 起動中の daemon を直接 tail できるので、 handler 側 (Phase H1 GREEN 以降) が `hub.publish` を呼ぶか、 broadcast pipeline が機能しているか、 を即座に確認可能。

## Usage

```bash
$ gwtd daemon subscribe board
{"type":"event","channel":"board","payload":{"entries":7}}
{"type":"event","channel":"board","payload":{"entries":8}}
^C

$ gwtd daemon subscribe board runtime-status
{"type":"event","channel":"board","payload":{...}}
{"type":"event","channel":"runtime-status","payload":{...}}
```

daemon が登録されていない (Spawn ブランチ) 場合:

```text
$ gwtd daemon subscribe board
gwtd daemon subscribe: no daemon registered (endpoint=/path/to/endpoint.json)
```

## Changes

- `crates/gwt/src/cli.rs`: `DaemonCommand` に `Subscribe { channels: Vec<String> }` variant を追加。
- `crates/gwt/src/cli/daemon/mod.rs`: `parse` で `subscribe <channel>...` を受け付け、 channels 0 個の場合は `CliParseError::Usage`。 `subscribe_command` 関数を実装し、 daemon endpoint 解決 → DaemonClient::connect → `ClientFrame::Subscribe` 送信 → ack 受信 → `DaemonFrame` 受信ループ → `serde_json::to_string` で env.stdout() へ writeln!。 cfg(not(unix)) は stub。
- `crates/gwt/src/bin/gwtd.rs`: `format_daemon_help` の Subcommands 一覧に subscribe を追加。

## Why a debug CLI?

Phase H1 GREEN handler migration を実装する際、 「daemon 経由で event が流れてきているか」 を確認する手段が無いと debug が難しい。 本 CLI で:

1. 別 terminal で `gwtd daemon subscribe board` を起動
2. gwt 本体 (or テストコード / 別 instance) で Board projection 変更を発生させる
3. subscribe terminal に Event JSON が流れてくれば pipeline は機能している

外部 CLI なので test infrastructure を変えず、 production 動作を観測できる。

## Testing

新規 unit test:

- `parse_recognises_subscribe_with_channels`: `subscribe board runtime-status` → `DaemonCommand::Subscribe { channels: [...] }`
- `parse_rejects_subscribe_without_channels`: `subscribe` (no channel) → `CliParseError::Usage`

検証:

- `cargo test -p gwt --lib cli::daemon` → 24/24 pass (新 2 + 既存 22)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし
- `cargo run -p gwt --bin gwtd -- --help daemon` → Subcommands に subscribe が表示

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2283 (BroadcastHub server wiring)、 #2287 (DaemonStatus connections counter)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] daemon 登録なし (Spawn ブランチ) では actionable error message
- [x] cfg(not(unix)) stub で Windows ビルド通過
- [x] Ctrl-C で interrupt 可能 (graceful 不要、 disconnect 自然)
