### PR TITLE
feat(daemon): ClientFrame::Publish + daemon-side fan-out (SPEC-2077 Phase H1)

### DIFF
--- a/crates/gwt-core/src/daemon.rs
+++ b/crates/gwt-core/src/daemon.rs
@@ -181,6 +181,12 @@ pub enum ClientFrame {
     Hook(HookEnvelope),
     /// Subscribe to one or more daemon broadcast channels.
     Subscribe { channels: Vec<String> },
+    /// Publish a payload to a daemon broadcast channel. Subscribers of
+    /// `channel` receive a [`DaemonFrame::Event`] with the same payload.
+    /// This is the gwt → gwtd companion to `Subscribe`; it is what
+    /// Phase H1 GREEN domain handlers use to fan a state change out
+    /// across all gwt instances on the same project scope.
+    Publish { channel: String, payload: Value },
     /// Request a snapshot of the daemon's current runtime stats.
     Status,
 }

--- a/crates/gwt-core/tests/runtime_daemon_contract.rs
+++ b/crates/gwt-core/tests/runtime_daemon_contract.rs
@@ -494,6 +494,22 @@ fn client_frame_subscribe_serializes_channel_list() {
 }
 
 #[test]
+fn client_frame_publish_round_trips_payload() {
+    let frame = ClientFrame::Publish {
+        channel: "board".to_string(),
+        payload: json!({"entries": 7, "last_seq": 42}),
+    };
+    let json_value = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json_value["type"], "publish");
+    assert_eq!(json_value["channel"], "board");
+    assert_eq!(json_value["payload"]["entries"], 7);
+    assert_eq!(json_value["payload"]["last_seq"], 42);
+
+    let round_trip: ClientFrame = serde_json::from_value(json_value).unwrap();
+    assert_eq!(round_trip, frame);
+}
+
+#[test]
 fn daemon_frame_ack_serializes_to_canonical_shape() {
     let frame = DaemonFrame::Ack;
     let json_value = serde_json::to_value(&frame).unwrap();

--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -370,6 +370,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn publish_frame_fans_out_to_subscriber_through_daemon() {
+        let temp = TempDir::new().expect("tempdir");
+        let scope = sample_scope(&temp);
+        let socket_path = temp.path().join("daemon.sock");
+        let endpoint_path = temp.path().join("endpoint.json");
+        let endpoint = sample_endpoint(scope.clone(), &socket_path, "publish-secret");
+
+        let server_endpoint = endpoint.clone();
+        let server_socket = socket_path.clone();
+        let server_endpoint_path = endpoint_path.clone();
+        let server_hub = BroadcastHub::new();
+        let server_handle = tokio::spawn(async move {
+            server::run_server(
+                server_endpoint,
+                server_socket,
+                server_endpoint_path,
+                server_hub,
+            )
+            .await
+        });
+
+        wait_for_socket(&socket_path).await;
+
+        // Client A: subscribes to "board" and waits for events.
+        let mut subscriber = DaemonClient::connect(&endpoint).await.expect("subscriber");
+        subscriber
+            .send_frame(&ClientFrame::Subscribe {
+                channels: vec!["board".to_string()],
+            })
+            .await
+            .expect("subscribe send");
+        let sub_ack: DaemonFrame = subscriber.read_frame().await.expect("subscribe ack");
+        assert_eq!(sub_ack, DaemonFrame::Ack);
+
+        // Client B: publishes a payload via ClientFrame::Publish.
+        let mut publisher = DaemonClient::connect(&endpoint).await.expect("publisher");
+        let payload = serde_json::json!({"entries": 9});
+        publisher
+            .send_frame(&ClientFrame::Publish {
+                channel: "board".to_string(),
+                payload: payload.clone(),
+            })
+            .await
+            .expect("publish send");
+        let pub_ack: DaemonFrame = publisher.read_frame().await.expect("publish ack");
+        assert_eq!(pub_ack, DaemonFrame::Ack);
+
+        // Subscriber must observe the matching Event frame.
+        let event: DaemonFrame = tokio::time::timeout(
+            Duration::from_millis(500),
+            subscriber.read_frame::<DaemonFrame>(),
+        )
+        .await
+        .expect("subscriber read timeout")
+        .expect("subscriber read");
+        assert_eq!(
+            event,
+            DaemonFrame::Event {
+                channel: "board".to_string(),
+                payload,
+            }
+        );
+
+        drop(subscriber);
+        drop(publisher);
+        server_handle.abort();
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test]
     async fn subscribed_client_receives_published_broadcast_events() {
         let temp = TempDir::new().expect("tempdir");
         let scope = sample_scope(&temp);

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -310,6 +310,29 @@ async fn handle_connection(
                     break;
                 }
             }
+            Ok(ClientFrame::Publish { channel, payload }) => {
+                // Fan the payload out to every subscriber of the
+                // channel. `publish` returns the number of receivers
+                // the daemon's broadcast::Sender queued to; we only log
+                // it, the publisher does not need delivery confirmation
+                // beyond the immediate Ack.
+                let queued = hub.publish(
+                    &channel,
+                    DaemonFrame::Event {
+                        channel: channel.clone(),
+                        payload,
+                    },
+                );
+                tracing::debug!(
+                    target: "gwtd::daemon",
+                    %channel,
+                    queued,
+                    "publish frame fanned out"
+                );
+                if out_tx.send(DaemonFrame::Ack).is_err() {
+                    break;
+                }
+            }
             Err(err) => {
                 tracing::warn!(target: "gwtd::daemon", frame = %trimmed, error = %err, "rejected unrecognized frame");
                 if out_tx


### PR DESCRIPTION
## Summary

- `ClientFrame::Publish { channel, payload }` variant を追加し、 client が daemon broadcast channel に直接 publish できる経路を成立。
- これで Phase H1 GREEN handler migration が以下の form で実装可能:

```rust
let mut client = DaemonClient::connect(&endpoint).await?;
client.send_frame(&ClientFrame::Publish {
    channel: "board".into(),
    payload: serde_json::json!({"entries": entries.len()}),
}).await?;
let _ack: DaemonFrame = client.read_frame().await?;
```

post_entry 成功後の app_runtime/board.rs handler が上記を呼べば、 他の gwt instance が `DaemonSubscriber` (PR #2289) 経由で受信して `UserEvent::BoardProjectionChanged` を再発火する経路が完成する。

## Wire flow

```text
gwt-A                    gwtd                     gwt-B (subscribed)
  │                        │                        │
  │ Publish { channel, p } │                        │
  │ ─────────────────────► │                        │
  │                        │ hub.publish(channel,   │
  │                        │  Event { channel, p }) │
  │                        │ ─────────────────────► │
  │                        │                        │ DaemonSubscriber
  │                        │                        │  → callback(channel, p)
  │ Ack                    │                        │
  │ ◄───────────────────── │                        │
```

## Changes

- `crates/gwt-core/src/daemon.rs`: `ClientFrame::Publish { channel: String, payload: Value }` variant 追加。
- `crates/gwt-core/tests/runtime_daemon_contract.rs`: round-trip test `client_frame_publish_round_trips_payload`。
- `crates/gwt/src/cli/daemon/server.rs`: `handle_connection` の reader loop に Publish arm を追加。 `hub.publish(&channel, DaemonFrame::Event { channel, payload })` で該当 channel の全 subscriber に fan-out、 完了後 `DaemonFrame::Ack` を返却 (publisher 側は ack のみ確認)。
- `crates/gwt/src/cli/daemon/client.rs`: end-to-end test `publish_frame_fans_out_to_subscriber_through_daemon` — 2 つの DaemonClient (subscriber + publisher) を起動して publish-subscribe pattern を完全に証明。

## Why a separate Publish variant?

既存 `ClientFrame::Hook(HookEnvelope)` でも payload を流せるが、 Hook は **「daemon が hook handler に routing する」** semantic。 Publish は **「daemon は単なる relay」** semantic。 役割を typed enum で分離することで:

- Phase H1 GREEN は Publish のみで OK (handler routing は将来)
- Hook envelope の追加 metadata (session_id, cwd 等) を Publish では強制しない
- Phase H2-H4 で hook 系 handler が daemon-owned になった時に Hook の semantics を変えても Publish は影響なし

## Testing

- `cargo test -p gwt-core --test runtime_daemon_contract` → 26/26 pass (新 1 + 既存 25)
- `cargo test -p gwt --lib daemon` → 31/31 pass (新 1 + 既存 30)
- `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2281 (typed frame schema)、 #2283 (BroadcastHub server wiring)、 #2289 (DaemonSubscriber primitive)

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] tagged enum で Publish と Hook の semantic 区別
- [x] daemon は単なる relay (publish payload を Event に wrap して broadcast)
- [x] end-to-end test で multi-client publish-subscribe を証明
