### PR TITLE
feat(daemon): daemon_publisher sync helper (Phase H1 GREEN 直前、 SPEC-2077)

### DIFF
--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -1,0 +1,172 @@
+//! Best-effort synchronous daemon publisher for SPEC-2077 Phase H1+.
+//!
+//! `publish_event` is the sync convenience wrapper that gwt-side
+//! domain handlers (Board projection writer, runtime status emitter,
+//! launch lifecycle hooks) call after a state change to fan the change
+//! out across other gwt instances connected to the same daemon.
+//!
+//! The function:
+//!
+//! 1. Resolves the [`RuntimeScope`] for `project_root` and reads the
+//!    persisted [`DaemonEndpoint`].
+//! 2. If no live daemon is registered, returns
+//!    `Err("daemon not running")` so the caller can continue with the
+//!    local file path as the source of truth.
+//! 3. Otherwise opens a single-shot [`DaemonClient`] connection,
+//!    sends one [`ClientFrame::Publish`], and waits for the daemon's
+//!    `Ack`.
+//!
+//! Connect, publish, and ack are each bounded by `timeout` (default
+//! 2 s). On any error the caller should treat the publish as
+//! best-effort — the local store remains authoritative.
+
+#![cfg(unix)]
+
+use std::{path::Path, time::Duration};
+
+use gwt_core::{
+    daemon::{
+        resolve_bootstrap_action, ClientFrame, DaemonBootstrapAction, DaemonFrame, RuntimeScope,
+        RuntimeTarget, DAEMON_PROTOCOL_VERSION,
+    },
+    paths,
+};
+use serde_json::Value;
+
+use crate::cli::daemon::client::DaemonClient;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Publish `payload` to `channel` on the daemon for `project_root`.
+///
+/// Default timeout (2 s) bounds the whole connect + send + ack
+/// sequence. See [`publish_event_with_timeout`] when callers need a
+/// custom budget.
+pub fn publish_event(project_root: &Path, channel: &str, payload: Value) -> Result<(), String> {
+    publish_event_with_timeout(project_root, channel, payload, DEFAULT_TIMEOUT)
+}
+
+/// Same as [`publish_event`] but lets the caller override the
+/// connect / read / ack timeout budget. Each individual stage is
+/// bounded by `timeout` so a stuck daemon cannot pin the calling
+/// thread for longer than `2 * timeout` in the worst case.
+pub fn publish_event_with_timeout(
+    project_root: &Path,
+    channel: &str,
+    payload: Value,
+    timeout: Duration,
+) -> Result<(), String> {
+    let scope = RuntimeScope::from_project_root(project_root, RuntimeTarget::Host)
+        .map_err(|err| format!("scope resolution failed: {err}"))?;
+    let gwt_home = paths::gwt_home();
+    let action = resolve_bootstrap_action(&gwt_home, &scope, DAEMON_PROTOCOL_VERSION, is_alive)
+        .map_err(|err| format!("bootstrap resolve failed: {err}"))?;
+    let endpoint = match action {
+        DaemonBootstrapAction::Reuse(ep) => ep,
+        DaemonBootstrapAction::Spawn { .. } => return Err("daemon not running".to_string()),
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| format!("tokio runtime build failed: {err}"))?;
+    runtime.block_on(async move {
+        let mut client = tokio::time::timeout(timeout, DaemonClient::connect(&endpoint))
+            .await
+            .map_err(|_| format!("connect timeout after {}ms", timeout.as_millis()))??;
+        client
+            .send_frame(&ClientFrame::Publish {
+                channel: channel.to_string(),
+                payload,
+            })
+            .await
+            .map_err(|err| format!("publish send failed: {err}"))?;
+        let ack: DaemonFrame = tokio::time::timeout(timeout, client.read_frame())
+            .await
+            .map_err(|_| format!("publish ack timeout after {}ms", timeout.as_millis()))??;
+        match ack {
+            DaemonFrame::Ack => Ok(()),
+            DaemonFrame::Error { message } => Err(format!("daemon rejected publish: {message}")),
+            other => Err(format!("expected Ack, got: {other:?}")),
+        }
+    })
+}
+
+fn is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: kill(pid, 0) only probes the process; we never deliver a
+    // real signal. Returns 0 if alive, -1 with ESRCH otherwise.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    matches!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::EPERM)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::publish_event_with_timeout;
+
+    #[test]
+    fn publish_returns_error_when_no_daemon_registered() {
+        // Use a tempdir for the project root and a tempdir for $HOME so
+        // the resolver looks for the endpoint inside an empty
+        // `~/.gwt/projects/.../runtime/daemon/` tree and finds nothing.
+        let project = TempDir::new().expect("project tempdir");
+        let home = TempDir::new().expect("home tempdir");
+        std::fs::create_dir_all(project.path()).expect("project dir");
+
+        let _home_guard = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
+
+        let err = publish_event_with_timeout(
+            project.path(),
+            "board",
+            json!({"entries": 1}),
+            Duration::from_millis(200),
+        )
+        .expect_err("expected error when no daemon is running");
+        assert!(
+            err.contains("daemon not running"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    /// Minimal scoped env-var helper used by tests in this module to
+    /// avoid pulling in the workspace-wide test_support graph.
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: impl AsRef<std::path::Path>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value.as_ref());
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+}

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -3,6 +3,8 @@ pub mod branch_list;
 pub mod cli;
 pub mod custom_agents_dispatch;
 pub mod custom_agents_service;
+#[cfg(unix)]
+pub mod daemon_publisher;
 pub mod daemon_runtime;
 #[cfg(unix)]
 pub mod daemon_subscriber;


### PR DESCRIPTION
## Summary

- `crates/gwt/src/daemon_publisher.rs` に sync convenience wrapper `publish_event(project_root, channel, payload)` を追加。
- gwt-side domain handler (Board projection writer 等) が post_entry 成功後に **1 行で呼べる** best-effort daemon publish helper。
- Phase H1 GREEN handler integration の最後の primitive。 これで app_runtime/board.rs での actual wiring が:

```rust
let _ = gwt::daemon_publisher::publish_event(
    &project_root,
    "board",
    serde_json::json!({"entries": entries.len()}),
);
```

の form で成立する (best-effort、 daemon 不在時は黙ってローカル file path に fallback)。

## API

```rust
pub fn publish_event(
    project_root: &Path,
    channel: &str,
    payload: Value,
) -> Result<(), String>;

pub fn publish_event_with_timeout(
    project_root: &Path,
    channel: &str,
    payload: Value,
    timeout: Duration,  // 各段階の budget
) -> Result<(), String>;
```

## Implementation

1. `RuntimeScope::from_project_root` + `paths::gwt_home()` で endpoint 解決
2. `resolve_bootstrap_action(..., is_alive)` で `Reuse(endpoint)` / `Spawn { .. }` を判定。 Spawn なら `daemon not running` Err
3. 短命 current-thread tokio runtime を構築
4. `DaemonClient::connect` → `ClientFrame::Publish { channel, payload }` 送信 → `DaemonFrame::Ack` 受信、 各段階を `tokio::time::timeout(timeout)` で bound (default 2s)
5. 戻り値 `Result<(), String>`、 callable はログ記録のみで OK (ローカル file がソース・オブ・トゥルース)

## Why sync?

app_runtime の `handle_*` family は tao event loop 上の sync function (`Vec<OutboundEvent>` を返却)。 async 化すると整合性のために大規模 refactor が必要。 daemon publish は post_entry に比べると稀かつ小さい I/O (local Unix socket、 1 round-trip) なので、 短命 tokio runtime のオーバーヘッド (~ms 単位) は許容範囲。

将来的に persistent connection を持つ DaemonPublisher (long-lived background thread + mpsc queue) に格上げできるが、 Phase H1 GREEN の規模では sync 1-shot で十分。

## Testing

unit test:

- `publish_returns_error_when_no_daemon_registered`: 空 home + 空 project 状態で `publish_event_with_timeout(200ms)` を呼び、 `daemon not running` を含む Err が返ることを確認 (ScopedEnvVar で `HOME` / `USERPROFILE` を tempdir に差し替え)。

検証:

- `cargo test -p gwt --lib daemon_publisher` → 1/1 pass
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2280 (DaemonClient)、 #2289 (DaemonSubscriber)、 #2290 (Publish frame)

## Phase H1 GREEN への接続

これで Phase H1 GREEN が以下の 2 line で完結する:

1. **Publish path** (本 PR で primitive 完成):

```rust
// app_runtime/board.rs::run_post の post_entry success 後:
let _ = daemon_publisher::publish_event(
    &project_root,
    "board",
    json!({"entries": snapshot.board.entries.len()}),
);
```

2. **Subscribe path** (PR #2289 の DaemonSubscriber を main.rs で起動):

```rust
let subscriber = DaemonSubscriber::spawn(
    endpoint,
    vec!["board".into()],
    move |channel, _payload| {
        if channel == "board" {
            let _ = proxy.send_event(UserEvent::BoardProjectionChanged { project_root: project_root.clone() });
        }
    },
);
```

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] best-effort: daemon 不在は黙って Err、 caller がログのみで処理
- [x] 各段階 (connect / send / ack) を独立 timeout で bound
- [x] cfg(unix) gating で Windows ビルド通過
