### PR TITLE
feat(daemon): Board post 後に daemon publish (Phase H1 GREEN publish path, SPEC-2077)

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -146,13 +146,16 @@ impl AppRuntime {
             entry = entry.with_target_owners(targets);
         }
         match coordination::post_entry(&tab.project_root, entry) {
-            Ok(snapshot) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardEntries {
-                    id,
-                    entries: snapshot.board.entries,
-                },
-            )],
+            Ok(snapshot) => {
+                publish_board_change(&tab.project_root, snapshot.board.entries.len());
+                vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BoardEntries {
+                        id,
+                        entries: snapshot.board.entries,
+                    },
+                )]
+            }
             Err(error) => vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::BoardError {
@@ -162,6 +165,38 @@ impl AppRuntime {
             )],
         }
     }
+}
+
+/// Best-effort fan-out of a Board projection change to other gwt
+/// instances connected to the same daemon (SPEC-2077 Phase H1).
+///
+/// This is a side-channel notification: the local file watcher already
+/// triggers `UserEvent::BoardProjectionChanged` for the in-process GUI,
+/// and the on-disk projection remains the source of truth. The daemon
+/// publish gives **other** gwt instances on the same project a
+/// deterministic push (instead of relying on each instance's file
+/// watcher debounce). Any error is logged at debug level and ignored.
+#[cfg(unix)]
+fn publish_board_change(project_root: &std::path::Path, entries_count: usize) {
+    let result = gwt::daemon_publisher::publish_event(
+        project_root,
+        "board",
+        serde_json::json!({"entries_count": entries_count}),
+    );
+    if let Err(err) = result {
+        tracing::debug!(
+            error = %err,
+            project_root = %project_root.display(),
+            entries_count,
+            "board projection daemon publish failed (non-fatal)"
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn publish_board_change(_project_root: &std::path::Path, _entries_count: usize) {
+    // Daemon publishing is gated on Unix; the local file watcher
+    // continues to drive single-instance updates on other platforms.
 }
 
 fn sanitize_board_list(values: &[String]) -> Vec<String> {


### PR DESCRIPTION
## Summary

- SPEC-2077 Phase H1 GREEN の **publish path** を完成。 `app_runtime/board.rs::post_board_entry_events` の `coordination::post_entry` 成功後に `gwt::daemon_publisher::publish_event` を呼び、 同一 project に接続している他 gwt instance に Board projection 変更を broadcast する。
- ローカル file watcher (BoardProjectionWatcher) は引き続き動作するので、 local の挙動 (即時反映、 file ベースの source-of-truth) は不変。 daemon publish は **他 instance への push** 専用の side channel。

## Architecture (after this PR)

```text
Board post (gwt-A)
       │
       ├─ coordination::post_entry           ← writes to ~/.gwt/projects/<repo>/coordination/board.json
       │     │
       │     └─ file watcher (gwt-A)        ← detects change, fires UserEvent::BoardProjectionChanged (LOCAL UI update)
       │
       └─ daemon_publisher::publish_event   ← (NEW)
             │
             ▼
          gwtd daemon (BroadcastHub)
             │
             ▼
          subscribers on "board" channel  ← (gwt-B, gwt-C, ...)
             │
             └─ Phase H1 GREEN subscribe path (next PR) will fire
                UserEvent::BoardProjectionChanged on each subscribed instance
```

## Changes

- `crates/gwt/src/app_runtime/board.rs`: `post_board_entry_events` の `Ok(snapshot)` arm に `publish_board_change(&tab.project_root, snapshot.board.entries.len())` 呼び出しを追加。
- 同ファイル末尾に `publish_board_change` ヘルパーを追加 (cfg-gated)。
  - `#[cfg(unix)]`: `gwt::daemon_publisher::publish_event(project_root, "board", json!({"entries_count": N}))` を呼び、 daemon 不在 / connect 失敗等は debug log だけ記録 (best-effort)。
  - `#[cfg(not(unix))]`: no-op stub (Windows は file watcher のみで動作)。

## Why minimal payload?

`{"entries_count": N}` だけにした理由:

1. **Subscriber の行動は file 再読込で十分** — gwt-B 側の DaemonSubscriber が Event を受信した際、 file 経由で snapshot を再ロードすれば最新になる。 entries 全部を payload に詰める必要なし。
2. **Wire size 最小化** — Board entries は最大数百 KB になりうる。 100 instance に fan-out したら膨大。 `entries_count` だけなら数十 bytes。
3. **Daemon は relay として透過** — daemon-side に entries store を持たせるのは Phase H2-H4 以降の検討。 Phase H1 では daemon は単なる pub-sub relay。

## Testing

- `cargo test -p gwt --bin gwt app_runtime::tests` → 39/39 pass (既存全 pass)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

注: テスト環境では daemon endpoint file が存在しないので `publish_event` は `daemon not running` で即座に Err を返す (tokio runtime build 前に short-circuit)。 テスト性能への影響は無視できる範囲。

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2289 (DaemonSubscriber)、 #2290 (Publish frame)、 #2291 (daemon_publisher helper)

## Phase H1 GREEN 残スコープ

本 PR で publish path は完成。 残るのは **subscribe path**:

```rust
// main.rs (next PR sketch):
let subscriber = DaemonSubscriber::spawn(endpoint, vec!["board".into()], move |channel, _| {
    if channel == "board" {
        let _ = proxy.send_event(UserEvent::BoardProjectionChanged { project_root: project_root.clone() });
    }
});
```

これでマルチ-instance gwt の Board 同期が daemon 経由で成立する。

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] best-effort: daemon 不在は debug log のみで挙動継続
- [x] ローカル file watcher の動作不変
- [x] cfg(not(unix)) は no-op stub で Windows ビルド通過
- [x] 既存の Board test 全 pass (39/39)
