### PR TITLE
feat(daemon): gwtd board post でも daemon publish (Phase H1 GREEN 補完、 SPEC-2077)

### DIFF
--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -81,6 +81,7 @@ pub(super) fn run<E: CliEnv>(
             }
             let snapshot =
                 post_entry(env.repo_path(), entry).map_err(gwt_error_to_spec_ops_error)?;
+            publish_board_change(env.repo_path(), snapshot.board.entries.len());
             out.push_str(&format!(
                 "board entries: {}\n",
                 snapshot.board.entries.len()
@@ -89,6 +90,35 @@ pub(super) fn run<E: CliEnv>(
         }
     };
     Ok(code)
+}
+
+/// Best-effort daemon broadcast after a CLI `gwtd board post` succeeds
+/// (SPEC-2077 Phase H1 GREEN). Mirrors the GUI handler in
+/// `app_runtime/board.rs`: notify subscribers via the daemon so other
+/// gwt instances on the same project see the new entry without
+/// waiting for their file watcher to fire. Errors are logged at debug
+/// level and ignored — local file is the source of truth.
+#[cfg(unix)]
+fn publish_board_change(project_root: &std::path::Path, entries_count: usize) {
+    let result = crate::daemon_publisher::publish_event(
+        project_root,
+        "board",
+        serde_json::json!({"entries_count": entries_count}),
+    );
+    if let Err(err) = result {
+        tracing::debug!(
+            error = %err,
+            project_root = %project_root.display(),
+            entries_count,
+            "gwtd board post: daemon publish failed (non-fatal)"
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn publish_board_change(_project_root: &std::path::Path, _entries_count: usize) {
+    // Daemon publishing is gated on Unix; CLI continues to drive the
+    // local file path on other platforms.
 }
 
 fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {


### PR DESCRIPTION
## Summary

- Phase H1 GREEN を完成させるための **CLI side coverage**。 `gwtd board post --kind <K> --body 'text'` 経由の post も GUI handler と同様に daemon broadcast を発火するようになる。
- これで CLI / GUI どちらの経路で post しても他 instance に projection 変更が即時伝搬する。

## Why this PR?

PR #2292 では GUI handler (`app_runtime/board.rs::post_board_entry_events`) に daemon publish を追加した。 しかし `gwtd board post` CLI コマンド (`cli/board.rs::run` の `BoardCommand::Post` arm) は別経路で `coordination::post_entry` を呼ぶので、 daemon publish が発火していなかった。

例えば次のシナリオで漏れが起きる:

```bash
# Window 1: gwt GUI
# Window 2: gwt GUI
# Terminal: gwtd board post --kind status --body "from CLI"
```

CLI post 後、 Window 1 と Window 2 はそれぞれ自分の file watcher が 250ms debounce 後に反応する (時間差あり)。 daemon broadcast 経由なら即座 (< 50ms) に両方が更新される。

## Changes

- `crates/gwt/src/cli/board.rs::run` の `BoardCommand::Post` arm に `publish_board_change(env.repo_path(), snapshot.board.entries.len())` 呼び出しを追加。
- 同ファイル末尾に `publish_board_change` ヘルパーを追加 (cfg-gated)。 内容は `app_runtime/board.rs` の helper と等価。
  - `#[cfg(unix)]`: `crate::daemon_publisher::publish_event(project_root, "board", json!({"entries_count": N}))` を best-effort で呼び、 失敗は debug log のみ。
  - `#[cfg(not(unix))]`: no-op stub。

注: `cli/board.rs` は lib 側のモジュールなので `crate::daemon_publisher`、 `app_runtime/board.rs` は bin 側で `gwt::daemon_publisher` という import path の違いがある。 PR #2292 で確立した pattern。

## Testing

- `cargo test -p gwt --lib cli::board` → 9/9 pass (既存全 pass、 daemon 不在時は publish_event が即 Err 返却で test 速度に影響なし)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2292 (GUI publish path)、 #2293 (subscribe path)

## Phase H1 GREEN coverage

| Caller | Daemon publish | PR |
|---|---|---|
| `app_runtime/board.rs::post_board_entry_events` (GUI) | ✅ | #2292 |
| `cli/board.rs::run BoardCommand::Post` (CLI) | ✅ | (this PR) |
| `app_runtime/mod.rs:4755` | テストコード | n/a |
| `app_runtime/mod.rs:5740` | テストコード | n/a |
| `cli/board.rs:374, 405, 433` | テストコード | n/a |

すべての production caller がカバーされた。

## Checklist

- [x] commitlint 形式 (`feat(daemon): ...`)
- [x] best-effort: daemon 不在は debug log のみ
- [x] cfg(not(unix)) で Windows ビルド通過
- [x] 既存の `cli::board` test 全 pass (9/9)
