### PR TITLE
fix(daemon): board post の daemon publish を fire-and-forget + 短 timeout 化 (SPEC-2077)

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -178,19 +178,29 @@ impl AppRuntime {
 /// watcher debounce). Any error is logged at debug level and ignored.
 #[cfg(unix)]
 fn publish_board_change(project_root: &std::path::Path, entries_count: usize) {
-    let result = gwt::daemon_publisher::publish_event(
-        project_root,
-        "board",
-        serde_json::json!({"entries_count": entries_count}),
-    );
-    if let Err(err) = result {
-        tracing::debug!(
-            error = %err,
-            project_root = %project_root.display(),
-            entries_count,
-            "board projection daemon publish failed (non-fatal)"
-        );
-    }
+    // Fire-and-forget: spawn a detached thread so the GUI handler's
+    // `Vec<OutboundEvent>` return is never delayed by the daemon
+    // round-trip. The publish itself is bounded by the
+    // `daemon_publisher::publish_event` per-stage timeout (~200 ms),
+    // so the spawned thread can never linger long.
+    let project_root_owned = project_root.to_path_buf();
+    let _ = std::thread::Builder::new()
+        .name("gwt-board-daemon-publish".to_string())
+        .spawn(move || {
+            let result = gwt::daemon_publisher::publish_event(
+                &project_root_owned,
+                "board",
+                serde_json::json!({"entries_count": entries_count}),
+            );
+            if let Err(err) = result {
+                tracing::debug!(
+                    error = %err,
+                    project_root = %project_root_owned.display(),
+                    entries_count,
+                    "board projection daemon publish failed (non-fatal)"
+                );
+            }
+        });
 }
 
 #[cfg(not(unix))]

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -100,19 +100,28 @@ pub(super) fn run<E: CliEnv>(
 /// level and ignored — local file is the source of truth.
 #[cfg(unix)]
 fn publish_board_change(project_root: &std::path::Path, entries_count: usize) {
-    let result = crate::daemon_publisher::publish_event(
-        project_root,
-        "board",
-        serde_json::json!({"entries_count": entries_count}),
-    );
-    if let Err(err) = result {
-        tracing::debug!(
-            error = %err,
-            project_root = %project_root.display(),
-            entries_count,
-            "gwtd board post: daemon publish failed (non-fatal)"
-        );
-    }
+    // Fire-and-forget on a detached thread so `gwtd board post`
+    // returns immediately even if the daemon socket is briefly slow.
+    // The publish itself is bounded by the `daemon_publisher::
+    // publish_event` per-stage timeout (~200 ms).
+    let project_root_owned = project_root.to_path_buf();
+    let _ = std::thread::Builder::new()
+        .name("gwtd-board-daemon-publish".to_string())
+        .spawn(move || {
+            let result = crate::daemon_publisher::publish_event(
+                &project_root_owned,
+                "board",
+                serde_json::json!({"entries_count": entries_count}),
+            );
+            if let Err(err) = result {
+                tracing::debug!(
+                    error = %err,
+                    project_root = %project_root_owned.display(),
+                    entries_count,
+                    "gwtd board post: daemon publish failed (non-fatal)"
+                );
+            }
+        });
 }
 
 #[cfg(not(unix))]

--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -35,13 +35,21 @@ use serde_json::Value;
 
 use crate::cli::daemon::client::DaemonClient;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+/// Default per-stage timeout for the GUI / CLI hot path. 200 ms is
+/// generous for a local Unix-socket round-trip (typical is < 5 ms) but
+/// short enough that a hung daemon cannot freeze the UI for more than
+/// 400 ms total (connect + ack). Phase H1 GREEN handler integration
+/// trades the small worst-case stall for code-path simplicity.
+/// Callers needing a different budget should use
+/// [`publish_event_with_timeout`].
+const DEFAULT_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Publish `payload` to `channel` on the daemon for `project_root`.
 ///
-/// Default timeout (2 s) bounds the whole connect + send + ack
-/// sequence. See [`publish_event_with_timeout`] when callers need a
-/// custom budget.
+/// Default per-stage timeout (200 ms) bounds connect and ack
+/// independently, so total wall time is at most 400 ms even when the
+/// daemon is hung. See [`publish_event_with_timeout`] when callers
+/// need a custom budget.
 pub fn publish_event(project_root: &Path, channel: &str, payload: Value) -> Result<(), String> {
     publish_event_with_timeout(project_root, channel, payload, DEFAULT_TIMEOUT)
 }


### PR DESCRIPTION
## Summary

- Phase H1 GREEN の publish path で GUI / CLI handler が daemon round-trip を待つ問題を修正。
- `publish_board_change` を **fire-and-forget detached thread** に変更し、 daemon の応答に関わらず handler が即座に return するように。
- 併せて `daemon_publisher::DEFAULT_TIMEOUT` を 2s → 200ms に短縮 (local Unix socket round-trip には十分な余裕、 daemon 異常時の最大 stall を 4s → 400ms に圧縮)。

## Why

before:
- `publish_board_change` は同期で `publish_event` を呼ぶ
- `publish_event` は default 2s × 2 stages = 最大 4s ブロック
- daemon 応答が遅い場合、 GUI / CLI handler が freeze、 ユーザー体験が劣化

after:
- `publish_board_change` は `std::thread::Builder::spawn` で detached thread を起動
- caller (GUI handler / CLI handler) は thread spawn (~1ms) のみで完了
- spawned thread の最悪ケース: connect 200ms + ack 200ms = 約 400ms (thread 寿命のみ、 caller には影響なし)

## Output behaviour

- daemon 健全: GUI post → 即時 reply、 別 instance には ~50ms 後 broadcast 到達
- daemon 不在: caller 即時 reply、 detached thread は `daemon not running` Err で短時間終了
- daemon 異常 (応答遅延): caller 即時 reply、 detached thread は最大 400ms 後 timeout

## Changes

- `crates/gwt/src/daemon_publisher.rs`: `DEFAULT_TIMEOUT` を 2s → 200ms に短縮 + doc 更新。 worst-case wall time = `2 * DEFAULT_TIMEOUT` = 400ms。
- `crates/gwt/src/app_runtime/board.rs::publish_board_change`: thread spawn 化 (`gwt-board-daemon-publish` スレッド名で診断容易化)。
- `crates/gwt/src/cli/board.rs::publish_board_change`: thread spawn 化 (`gwtd-board-daemon-publish` スレッド名)。

## Why std::thread (not tokio::spawn)?

`publish_board_change` は GUI 同期 handler / CLI sync command から呼ばれる。 tokio runtime はこの context にない (tokio は WebSocket server / IPC 内部のみ)。 OS thread spawn が最も simple で、 spawn 自体は ~1ms で済む。

将来的に長寿命 daemon publisher actor (mpsc queue + 1 dedicated thread) に格上げできるが、 Phase H1 GREEN の負荷では不要と判断。 board post は user-initiated で rare、 OS thread spawn cost は許容範囲。

## Testing

- `cargo test -p gwt --bin gwt app_runtime::tests::app_runtime_post_board` → 1/1 pass
- `cargo test -p gwt --lib cli::board` → 9/9 pass
- `cargo test -p gwt --lib daemon_publisher` → 1/1 pass
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 前 PR #2291 (publish_event helper)、 #2292 (GUI publish path)、 #2293 (subscribe path)、 #2294 (CLI publish path)

## Checklist

- [x] commit type は `fix:` (UX issue の修正)
- [x] caller の latency が daemon 応答に依存しない
- [x] daemon 異常時の最大 stall を 4s → 400ms に圧縮
- [x] thread name で診断容易 (`gwt-board-daemon-publish` / `gwtd-board-daemon-publish`)
- [x] cfg(not(unix)) は引き続き no-op stub
