### PR TITLE
fix(daemon): CLI publish 同期化 + DaemonSubscriber endpoint resolver 化 (SPEC-2077)

### DIFF
--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -100,28 +100,26 @@ pub(super) fn run<E: CliEnv>(
 /// level and ignored — local file is the source of truth.
 #[cfg(unix)]
 fn publish_board_change(project_root: &std::path::Path, entries_count: usize) {
-    // Fire-and-forget on a detached thread so `gwtd board post`
-    // returns immediately even if the daemon socket is briefly slow.
-    // The publish itself is bounded by the `daemon_publisher::
-    // publish_event` per-stage timeout (~200 ms).
-    let project_root_owned = project_root.to_path_buf();
-    let _ = std::thread::Builder::new()
-        .name("gwtd-board-daemon-publish".to_string())
-        .spawn(move || {
-            let result = crate::daemon_publisher::publish_event(
-                &project_root_owned,
-                "board",
-                serde_json::json!({"entries_count": entries_count}),
-            );
-            if let Err(err) = result {
-                tracing::debug!(
-                    error = %err,
-                    project_root = %project_root_owned.display(),
-                    entries_count,
-                    "gwtd board post: daemon publish failed (non-fatal)"
-                );
-            }
-        });
+    // CLI path runs in a short-lived process: `gwtd board post`
+    // returns to the shell immediately, so a detached publish thread
+    // would be killed before it finishes the connect/publish/ack
+    // round-trip (the daemon would then never see the broadcast).
+    // The publish is bounded by `daemon_publisher::publish_event`'s
+    // per-stage timeout (~200 ms, ~400 ms worst case), which is an
+    // acceptable amount of synchronous wall time for a CLI command.
+    let result = crate::daemon_publisher::publish_event(
+        project_root,
+        "board",
+        serde_json::json!({"entries_count": entries_count}),
+    );
+    if let Err(err) = result {
+        tracing::debug!(
+            error = %err,
+            project_root = %project_root.display(),
+            entries_count,
+            "gwtd board post: daemon publish failed (non-fatal)"
+        );
+    }
 }
 
 #[cfg(not(unix))]

--- a/crates/gwt/src/daemon_subscriber.rs
+++ b/crates/gwt/src/daemon_subscriber.rs
@@ -35,6 +35,14 @@ use crate::cli::daemon::client::DaemonClient;
 const RETRY_BACKOFF_MIN: Duration = Duration::from_millis(100);
 const RETRY_BACKOFF_MAX: Duration = Duration::from_secs(5);
 
+/// Closure that produces the *current* daemon endpoint for each
+/// connect attempt. Returning `Err` puts the subscriber into
+/// retry-with-backoff mode (e.g. when no daemon is registered yet),
+/// while a successful resolve provides a fresh `DaemonEndpoint` —
+/// crucially, picking up any new `auth_token` / `bind` after a daemon
+/// restart.
+pub type EndpointResolver = dyn Fn() -> Result<DaemonEndpoint, String> + Send + Sync + 'static;
+
 /// Owns the subscriber thread. Drop or call [`Self::stop`] to wind it
 /// down cleanly.
 pub struct DaemonSubscriber {
@@ -44,13 +52,34 @@ pub struct DaemonSubscriber {
 }
 
 impl DaemonSubscriber {
-    /// Spawn a subscriber thread for `endpoint`'s daemon. Each received
-    /// `DaemonFrame::Event { channel, payload }` invokes `on_event(channel,
-    /// payload)`. The callback runs on the subscriber thread; keep it
-    /// short and forward to your own queue (e.g. via a `Sender` clone)
-    /// if more work is needed.
+    /// Spawn a subscriber thread for a fixed `endpoint`. Convenience
+    /// shorthand for [`Self::spawn_with_resolver`] when the caller
+    /// guarantees the endpoint never changes (mostly tests with an
+    /// in-process daemon).
     pub fn spawn<F>(endpoint: DaemonEndpoint, channels: Vec<String>, on_event: F) -> Self
     where
+        F: Fn(String, serde_json::Value) + Send + Sync + 'static,
+    {
+        Self::spawn_with_resolver(move || Ok(endpoint.clone()), channels, on_event)
+    }
+
+    /// Spawn a subscriber thread that re-resolves its `DaemonEndpoint`
+    /// on every connect attempt. Each received
+    /// `DaemonFrame::Event { channel, payload }` invokes
+    /// `on_event(channel, payload)`. The callback runs on the
+    /// subscriber thread; keep it short and forward to your own queue
+    /// (e.g. via a `Sender` clone) if more work is needed.
+    ///
+    /// Re-resolving is what keeps subscribers healthy across daemon
+    /// restarts. When `gwtd daemon start` is killed and respawned, the
+    /// new daemon picks a fresh `auth_token`, so a subscriber that
+    /// caches the old endpoint would loop forever on handshake
+    /// rejection. Calling `resolver()` per session gives the caller a
+    /// chance to re-read the persisted endpoint file before each
+    /// reconnect.
+    pub fn spawn_with_resolver<R, F>(resolver: R, channels: Vec<String>, on_event: F) -> Self
+    where
+        R: Fn() -> Result<DaemonEndpoint, String> + Send + Sync + 'static,
         F: Fn(String, serde_json::Value) + Send + Sync + 'static,
     {
         let stop_flag = Arc::new(AtomicBool::new(false));
@@ -58,11 +87,12 @@ impl DaemonSubscriber {
         let stop_flag_inner = Arc::clone(&stop_flag);
         let shutdown_inner = Arc::clone(&shutdown);
         let callback = Arc::new(on_event);
+        let resolver: Arc<EndpointResolver> = Arc::new(resolver);
         let join_handle = thread::Builder::new()
             .name("gwt-daemon-subscriber".to_string())
             .spawn(move || {
                 run_loop(
-                    endpoint,
+                    resolver,
                     channels,
                     callback,
                     stop_flag_inner,
@@ -101,7 +131,7 @@ impl Drop for DaemonSubscriber {
 }
 
 fn run_loop(
-    endpoint: DaemonEndpoint,
+    resolver: Arc<EndpointResolver>,
     channels: Vec<String>,
     on_event: Arc<dyn Fn(String, serde_json::Value) + Send + Sync>,
     stop_flag: Arc<AtomicBool>,
@@ -120,14 +150,22 @@ fn run_loop(
 
     let mut backoff = RETRY_BACKOFF_MIN;
     while !stop_flag.load(Ordering::SeqCst) {
-        let endpoint_for_session = endpoint.clone();
+        let endpoint = match resolver() {
+            Ok(ep) => ep,
+            Err(err) => {
+                tracing::debug!(error = %err, "daemon subscriber: endpoint resolve failed, retrying");
+                sleep_with_stop(&stop_flag, &shutdown, backoff);
+                backoff = (backoff * 2).min(RETRY_BACKOFF_MAX);
+                continue;
+            }
+        };
         let channels_for_session = channels.clone();
         let callback_for_session = Arc::clone(&on_event);
         let shutdown_for_session = Arc::clone(&shutdown);
         let stop_flag_for_session = Arc::clone(&stop_flag);
         let session = runtime.block_on(async move {
             run_session(
-                endpoint_for_session,
+                endpoint,
                 channels_for_session,
                 callback_for_session,
                 shutdown_for_session,
@@ -355,6 +393,96 @@ mod tests {
         // Drop without sending any events; stop() must complete promptly.
         subscriber.stop();
 
+        server_handle.abort();
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn subscriber_with_resolver_picks_up_endpoint_after_initial_failure() {
+        // Reflects the production race: a project tab opens before
+        // `gwtd daemon start` is invoked, so the first resolver call
+        // returns Err. Once the daemon comes up the resolver returns
+        // the live endpoint and the subscriber starts receiving
+        // events without needing a re-spawn.
+
+        let temp = TempDir::new().expect("tempdir");
+        let scope = sample_scope(&temp);
+        let socket_path = temp.path().join("daemon.sock");
+        let endpoint_path = temp.path().join("endpoint.json");
+        let endpoint = sample_endpoint(scope.clone(), &socket_path, "resolver-secret");
+
+        // The resolver returns Err the first 3 times, then Ok. This
+        // simulates the daemon coming up after the subscriber is
+        // already retrying.
+        let calls = Arc::new(Mutex::new(0usize));
+        let endpoint_for_resolver = endpoint.clone();
+        let calls_for_resolver = Arc::clone(&calls);
+        let resolver = move || -> Result<DaemonEndpoint, String> {
+            let mut guard = calls_for_resolver.lock().unwrap();
+            *guard += 1;
+            if *guard <= 3 {
+                Err("daemon not running".to_string())
+            } else {
+                Ok(endpoint_for_resolver.clone())
+            }
+        };
+
+        let received: Arc<Mutex<Vec<(String, serde_json::Value)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let received_for_cb = Arc::clone(&received);
+        let subscriber = DaemonSubscriber::spawn_with_resolver(
+            resolver,
+            vec!["board".to_string()],
+            move |channel, payload| {
+                received_for_cb.lock().unwrap().push((channel, payload));
+            },
+        );
+
+        // Now bring the daemon up. The resolver is on a backoff loop;
+        // wait long enough for it to call past the threshold and then
+        // start the server before the next backoff window.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        let server_endpoint = endpoint.clone();
+        let server_socket = socket_path.clone();
+        let server_endpoint_path = endpoint_path.clone();
+        let hub = BroadcastHub::new();
+        let publisher = hub.clone();
+        let server_handle = tokio::spawn(async move {
+            server::run_server(server_endpoint, server_socket, server_endpoint_path, hub).await
+        });
+
+        // Wait for the daemon socket and then publish.
+        wait_for_socket(&socket_path).await;
+        let event = DaemonFrame::Event {
+            channel: "board".to_string(),
+            payload: json!({"entries": 11}),
+        };
+        for _ in 0..200 {
+            if publisher.publish("board", event.clone()) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Wait up to 5 s for the callback to record the event.
+        let mut delivered = false;
+        for _ in 0..500 {
+            if !received.lock().unwrap().is_empty() {
+                delivered = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            delivered,
+            "expected resolver-based subscriber to receive event after daemon came up"
+        );
+        assert!(
+            *calls.lock().unwrap() >= 4,
+            "expected resolver to retry at least 3 times before succeeding"
+        );
+
+        subscriber.stop();
         server_handle.abort();
         let _ = server_handle.await;
     }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -363,58 +363,57 @@ fn spawn_board_daemon_subscriber(
         DAEMON_PROTOCOL_VERSION,
     };
 
-    let scope = match RuntimeScope::from_project_root(&project_root, RuntimeTarget::Host) {
-        Ok(s) => s,
-        Err(err) => {
-            tracing::debug!(
-                project_root = %project_root.display(),
-                error = %err,
-                "daemon subscriber: scope resolution failed"
-            );
-            return None;
-        }
-    };
-    let gwt_home = gwt_core::paths::gwt_home();
-    let action = match resolve_bootstrap_action(
-        &gwt_home,
-        &scope,
-        DAEMON_PROTOCOL_VERSION,
-        is_subscriber_pid_alive,
-    ) {
-        Ok(a) => a,
-        Err(err) => {
-            tracing::debug!(
-                project_root = %project_root.display(),
-                error = %err,
-                "daemon subscriber: bootstrap resolve failed"
-            );
-            return None;
-        }
-    };
-    let endpoint = match action {
-        DaemonBootstrapAction::Reuse(ep) => ep,
-        DaemonBootstrapAction::Spawn { .. } => {
-            tracing::debug!(
-                project_root = %project_root.display(),
-                "daemon subscriber: no daemon registered (will retry on next sync)"
-            );
-            return None;
+    // Validate that we *can* construct a `RuntimeScope` for this
+    // project before spawning the thread. Failures here are
+    // permanent (invalid path, etc) so there's no point retrying on
+    // every reconnect attempt.
+    if let Err(err) = RuntimeScope::from_project_root(&project_root, RuntimeTarget::Host) {
+        tracing::debug!(
+            project_root = %project_root.display(),
+            error = %err,
+            "daemon subscriber: scope resolution failed (subscriber not spawned)"
+        );
+        return None;
+    }
+
+    // Re-resolve the daemon endpoint on every connect attempt. This
+    // is essential because (a) a daemon that wasn't running when the
+    // tab opened may come up later, and (b) `gwtd daemon start` mints
+    // a fresh `auth_token` on every restart — caching the original
+    // endpoint would loop forever on handshake rejection.
+    let resolver_project_root = project_root.clone();
+    let resolver = move || -> Result<gwt_core::daemon::DaemonEndpoint, String> {
+        let scope = RuntimeScope::from_project_root(&resolver_project_root, RuntimeTarget::Host)
+            .map_err(|err| format!("scope: {err}"))?;
+        let gwt_home = gwt_core::paths::gwt_home();
+        let action = resolve_bootstrap_action(
+            &gwt_home,
+            &scope,
+            DAEMON_PROTOCOL_VERSION,
+            is_subscriber_pid_alive,
+        )
+        .map_err(|err| format!("bootstrap: {err}"))?;
+        match action {
+            DaemonBootstrapAction::Reuse(ep) => Ok(ep),
+            DaemonBootstrapAction::Spawn { .. } => Err("daemon not running".to_string()),
         }
     };
 
     let proxy_for_callback = proxy;
-    let project_root_for_callback = project_root.clone();
-    Some(gwt::daemon_subscriber::DaemonSubscriber::spawn(
-        endpoint,
-        vec!["board".to_string()],
-        move |channel, _payload| {
-            if channel == "board" {
-                let _ = proxy_for_callback.send_event(UserEvent::BoardProjectionChanged {
-                    project_root: project_root_for_callback.clone(),
-                });
-            }
-        },
-    ))
+    let project_root_for_callback = project_root;
+    Some(
+        gwt::daemon_subscriber::DaemonSubscriber::spawn_with_resolver(
+            resolver,
+            vec!["board".to_string()],
+            move |channel, _payload| {
+                if channel == "board" {
+                    let _ = proxy_for_callback.send_event(UserEvent::BoardProjectionChanged {
+                        project_root: project_root_for_callback.clone(),
+                    });
+                }
+            },
+        ),
+    )
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

PR #2295 / #2293 の codex review (P1) で指摘された 2 件を解消。

1. **`gwtd board post` の publish が detached thread で消える** — CLI は短命プロセスなので detached thread は process exit 直前に kill され、 publish が間欠的 / 完全に失われる。 → CLI 経路は同期 publish に戻す。
2. **`DaemonSubscriber` が daemon restart 後の新 auth_token を pickup しない** — restart のたびに `gwtd daemon start` が UUID で fresh token を生成するが、 subscriber は spawn 時の endpoint を握り続けるため永遠に handshake rejection。 → `spawn_with_resolver` 経由で connect 毎に endpoint を re-resolve するように変更。

## Why

| 問題 | 影響 | 修正 |
|---|---|---|
| CLI publish detached thread | `gwtd board post` 後 process exit が publish より先で broadcast 消失 | 同期 publish (200-400ms wall time、 CLI command として許容) |
| Subscriber stale endpoint | daemon restart 後 既存 tab で broadcast 受信不能、 process restart でしか復旧しない | `spawn_with_resolver` で connect 毎 re-resolve |

## Changes

- `crates/gwt/src/cli/board.rs::publish_board_change`: thread spawn 削除、 `daemon_publisher::publish_event` を直接 sync 呼び出し。 GUI 経路 (`app_runtime/board.rs`) は引き続き detached thread で OK (GUI process は長寿命)。
- `crates/gwt/src/daemon_subscriber.rs`:
  - 新 type alias `EndpointResolver = dyn Fn() -> Result<DaemonEndpoint, String> + Send + Sync + 'static`
  - 新 constructor `DaemonSubscriber::spawn_with_resolver(resolver, channels, on_event)`
  - 既存 `spawn(endpoint, ...)` は内部で `move || Ok(endpoint.clone())` resolver にラップして互換維持
  - `run_loop` が各 iteration で `resolver()` を呼び、 Err なら backoff + retry、 Ok なら接続
- `crates/gwt/src/main.rs::spawn_board_daemon_subscriber`: resolver 経由に変更。 `RuntimeScope` validation は spawn 時のみ (path 関連の永続 failure はリトライ不要)、 endpoint 解決は resolver 内で `resolve_bootstrap_action` を毎回呼ぶ。

## Wire-level behaviour after fix

- gwt-A が daemon に接続済 → daemon 再起動 → gwt-A 側 subscriber session error → run_loop が backoff → resolver 再呼び出し → 新 auth_token / bind を取得 → 再接続成功 → broadcast 受信再開
- gwt-A 起動時に daemon 不在 → resolver 連続 Err → backoff → daemon 起動 → resolver Ok → 接続成功 (テストで証明)

## Testing

新 unit test:

- `subscriber_with_resolver_picks_up_endpoint_after_initial_failure`: resolver が最初の 3 回 Err、 4 回目以降 Ok を返す scenario で、 daemon を遅れて起動しても event を正しく受信することを assert。

検証:

- `cargo test -p gwt --lib daemon_subscriber` → 3/3 pass (新 1 + 既存 2)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 修正対象: PR #2293 / #2295 の codex review thread (両方とも reply + resolved 済)

## Checklist

- [x] commit type は `fix:` (review 指摘の修正)
- [x] CLI 経路の publish lost を解消 (短命プロセスでも broadcast が届く)
- [x] daemon restart 後も subscriber が自動復旧 (handshake rejection ループから脱出)
- [x] 既存 `spawn(endpoint, ...)` API は backwards-compat (内部で resolver にラップ)
- [x] review threads は reply + resolved 済
