### PR TITLE
fix(daemon): subscribe ack race + publish ack ordering + send timeout (SPEC-2077)

### DIFF
--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -311,11 +311,19 @@ async fn handle_connection(
                 }
             }
             Ok(ClientFrame::Publish { channel, payload }) => {
-                // Fan the payload out to every subscriber of the
-                // channel. `publish` returns the number of receivers
-                // the daemon's broadcast::Sender queued to; we only log
-                // it, the publisher does not need delivery confirmation
-                // beyond the immediate Ack.
+                // Enqueue the Ack into our `out_tx` *before* the
+                // broadcast fan-out so a client that is both
+                // subscribed and publishing on the same connection
+                // never observes its own broadcast Event arrive
+                // before the Ack for the Publish that triggered it.
+                // Without this ordering the spawned per-channel
+                // forwarder task can race the Publish reader and
+                // push `DaemonFrame::Event` into `out_tx` first,
+                // desynchronizing any caller doing a simple
+                // `send_frame(Publish) -> read_frame::<Ack>` flow.
+                if out_tx.send(DaemonFrame::Ack).is_err() {
+                    break;
+                }
                 let queued = hub.publish(
                     &channel,
                     DaemonFrame::Event {
@@ -329,9 +337,6 @@ async fn handle_connection(
                     queued,
                     "publish frame fanned out"
                 );
-                if out_tx.send(DaemonFrame::Ack).is_err() {
-                    break;
-                }
             }
             Err(err) => {
                 tracing::warn!(target: "gwtd::daemon", frame = %trimmed, error = %err, "rejected unrecognized frame");

--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -82,12 +82,18 @@ pub fn publish_event_with_timeout(
         let mut client = tokio::time::timeout(timeout, DaemonClient::connect(&endpoint))
             .await
             .map_err(|_| format!("connect timeout after {}ms", timeout.as_millis()))??;
-        client
-            .send_frame(&ClientFrame::Publish {
-                channel: channel.to_string(),
-                payload,
-            })
+        // Bound the send half too: a daemon that has accepted the
+        // connection but stopped reading (or a payload large enough
+        // to fill the socket buffer) can otherwise block the writer
+        // forever, freezing the synchronous caller despite the
+        // documented per-stage `timeout`.
+        let publish_frame = ClientFrame::Publish {
+            channel: channel.to_string(),
+            payload,
+        };
+        tokio::time::timeout(timeout, client.send_frame(&publish_frame))
             .await
+            .map_err(|_| format!("publish send timeout after {}ms", timeout.as_millis()))?
             .map_err(|err| format!("publish send failed: {err}"))?;
         let ack: DaemonFrame = tokio::time::timeout(timeout, client.read_frame())
             .await

--- a/crates/gwt/src/daemon_subscriber.rs
+++ b/crates/gwt/src/daemon_subscriber.rs
@@ -201,12 +201,35 @@ async fn run_session(
         .send_frame(&ClientFrame::Subscribe { channels })
         .await
         .map_err(|err| format!("subscribe send failed: {err}"))?;
-    // The first frame after Subscribe is the daemon's Ack; drain it so
-    // the subsequent loop only sees Event frames.
-    let _ack: DaemonFrame = client
-        .read_frame()
-        .await
-        .map_err(|err| format!("subscribe ack failed: {err}"))?;
+    // Drain the daemon's Subscribe ack. There is a race where another
+    // client publishes to the same channel between our Subscribe
+    // frame and the daemon's Ack: the per-channel forwarder is
+    // already running (spawned before the Ack send), so the first
+    // post-subscribe frame can be an `Event` rather than the `Ack`.
+    // To avoid silently dropping the earliest event, route any
+    // `Event` we observe pre-Ack through the callback and keep
+    // reading until we see the actual `Ack` frame.
+    loop {
+        let frame: DaemonFrame = client
+            .read_frame()
+            .await
+            .map_err(|err| format!("subscribe ack failed: {err}"))?;
+        match frame {
+            DaemonFrame::Ack => break,
+            DaemonFrame::Event { channel, payload } => {
+                on_event(channel, payload);
+            }
+            DaemonFrame::Error { message } => {
+                return Err(format!("subscribe rejected: {message}"));
+            }
+            DaemonFrame::Status(_) => {
+                // The daemon does not currently emit Status before
+                // an Ack, but if it ever does we want to ignore it
+                // and keep waiting for the canonical Ack.
+                continue;
+            }
+        }
+    }
 
     loop {
         // Re-check the flag at the top of each iteration so a


### PR DESCRIPTION
## Summary

PR #2289 / #2290 / #2291 の codex review (P1 各 1 件) で指摘された 3 件の race / 不完全 timeout を解消。

| # | 元 PR | 問題 | 修正 |
|---|---|---|---|
| 1 | #2289 daemon_subscriber.rs:170 | Subscribe ack 前に来た Event が `_ack` に吸収されて消失 | ack を Loop 待ちにし、 間に来た Event は callback dispatch |
| 2 | #2290 server.rs:323 | Publish の Ack が forwarder の broadcast Event より遅れる | `out_tx.send(Ack)` を `hub.publish()` よりも先に行う |
| 3 | #2291 daemon_publisher.rs:83 | `send_frame` が timeout 外で freeze 可能 | `tokio::time::timeout(timeout, send_frame)` で wrap |

## (1) Subscribe ack race

### Before

```rust
client.send_frame(&ClientFrame::Subscribe { channels }).await?;
let _ack: DaemonFrame = client.read_frame().await?;  // unconditionally consumed
loop { ... }
```

別 client が同 channel に publish していた場合、 daemon の per-channel forwarder は Ack 送信より前に spawn 済 → forwarder が先に `out_tx.send(Event)` → publisher の `_ack` が Event を吸収して loop に入った時点で初回 Event を喪失。

### After

```rust
client.send_frame(&ClientFrame::Subscribe { channels }).await?;
loop {
    let frame: DaemonFrame = client.read_frame().await?;
    match frame {
        DaemonFrame::Ack => break,
        DaemonFrame::Event { channel, payload } => on_event(channel, payload),
        DaemonFrame::Error { message } => return Err(...),
        DaemonFrame::Status(_) => continue,
    }
}
```

Ack を受信するまで loop し、 間に来た Event は callback に正しく dispatch する。

## (2) Publish ack ordering

### Before

```rust
Ok(ClientFrame::Publish { channel, payload }) => {
    hub.publish(&channel, DaemonFrame::Event { ... });
    out_tx.send(DaemonFrame::Ack);
}
```

同一 connection が subscriber でもある場合、 spawned per-channel forwarder が `rx.recv()` で event を取得して `out_tx.send(Event)` を呼ぶタイミングが reader の `out_tx.send(Ack)` より早いことがあり、 client 側 `read_frame::<Ack>()` が Event を最初に受信して FSM が壊れる。

### After

```rust
Ok(ClientFrame::Publish { channel, payload }) => {
    out_tx.send(DaemonFrame::Ack);  // first
    hub.publish(&channel, DaemonFrame::Event { ... });
}
```

mpsc は FIFO なので、 同一 reader が publish より前に Ack を queue すれば writer は Ack を必ず先に書き出す。 forwarder の Event はその後 queue され、 順序が決定的になる。

## (3) Send timeout missing

### Before

```rust
let mut client = tokio::time::timeout(timeout, DaemonClient::connect(&endpoint)).await??;
client.send_frame(&ClientFrame::Publish { ... }).await?;  // unbounded
let ack: DaemonFrame = tokio::time::timeout(timeout, client.read_frame()).await??;
```

`send_frame` が `timeout` で wrap されていない。 daemon が connect を accept したが read を停止 / payload で socket buffer 満杯の場合、 writer が無限 block。 sync caller (CLI / GUI thread) が freeze する。

### After

```rust
let publish_frame = ClientFrame::Publish { channel: channel.to_string(), payload };
tokio::time::timeout(timeout, client.send_frame(&publish_frame))
    .await
    .map_err(|_| format!("publish send timeout after {}ms", timeout.as_millis()))?
    .map_err(|err| format!("publish send failed: {err}"))?;
```

connect / send / ack の各 stage が独立 timeout で bound される。

## Testing

- `cargo test -p gwt --lib daemon` → 33/33 pass (既存全 pass + 既存 resolver test も pass)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

注: 既存 round-trip test (`publish_frame_fans_out_to_subscriber_through_daemon`) は subscribe ack の race を内包する scenario なので、 修正が正しく動作することの間接的な証明にもなる。

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 修正対象: PR #2289 / #2290 / #2291 の codex review thread (本 PR merge 後に各 thread を resolve する)

## Checklist

- [x] commit type は `fix:` (race / timeout の修正)
- [x] subscribe ack 前 Event を on_event に dispatch (取りこぼし防止)
- [x] publish Ack を先送 (FSM 順序保証)
- [x] send_frame timeout 化 (sync caller freeze 防止)
- [x] 既存 test 全 pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a race condition where publishers could observe their own broadcast events before receiving acknowledgment
  * Added timeout protection for publish operations to prevent indefinite hangs
  * Fixed event loss where early events arriving during subscription setup were being dropped

<!-- end of auto-generated comment: release notes by coderabbit.ai -->