### PR TITLE
docs(daemon): publish_event 最大 stall を 400ms→600ms に修正 (SPEC-2077)

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -181,8 +181,9 @@ fn publish_board_change(project_root: &std::path::Path, entries_count: usize) {
     // Fire-and-forget: spawn a detached thread so the GUI handler's
     // `Vec<OutboundEvent>` return is never delayed by the daemon
     // round-trip. The publish itself is bounded by the
-    // `daemon_publisher::publish_event` per-stage timeout (~200 ms),
-    // so the spawned thread can never linger long.
+    // `daemon_publisher::publish_event` per-stage timeout (~200 ms
+    // each across connect / send / ack, ~600 ms worst case), so the
+    // spawned thread can never linger long.
     let project_root_owned = project_root.to_path_buf();
     let _ = std::thread::Builder::new()
         .name("gwt-board-daemon-publish".to_string())

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -105,8 +105,9 @@ fn publish_board_change(project_root: &std::path::Path, entries_count: usize) {
     // would be killed before it finishes the connect/publish/ack
     // round-trip (the daemon would then never see the broadcast).
     // The publish is bounded by `daemon_publisher::publish_event`'s
-    // per-stage timeout (~200 ms, ~400 ms worst case), which is an
-    // acceptable amount of synchronous wall time for a CLI command.
+    // per-stage timeout (~200 ms each across connect / send / ack,
+    // ~600 ms worst case), which is an acceptable amount of
+    // synchronous wall time for a CLI command.
     let result = crate::daemon_publisher::publish_event(
         project_root,
         "board",

--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -37,17 +37,18 @@ use crate::cli::daemon::client::DaemonClient;
 
 /// Default per-stage timeout for the GUI / CLI hot path. 200 ms is
 /// generous for a local Unix-socket round-trip (typical is < 5 ms) but
-/// short enough that a hung daemon cannot freeze the UI for more than
-/// 400 ms total (connect + ack). Phase H1 GREEN handler integration
-/// trades the small worst-case stall for code-path simplicity.
-/// Callers needing a different budget should use
+/// short enough that a hung daemon cannot freeze the caller for more
+/// than 600 ms total (connect + send + ack — three independent
+/// stages, see [`publish_event_with_timeout`]). Phase H1 GREEN handler
+/// integration trades the small worst-case stall for code-path
+/// simplicity. Callers needing a different budget should use
 /// [`publish_event_with_timeout`].
 const DEFAULT_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Publish `payload` to `channel` on the daemon for `project_root`.
 ///
-/// Default per-stage timeout (200 ms) bounds connect and ack
-/// independently, so total wall time is at most 400 ms even when the
+/// Default per-stage timeout (200 ms) bounds connect, send, and ack
+/// independently, so total wall time is at most 600 ms even when the
 /// daemon is hung. See [`publish_event_with_timeout`] when callers
 /// need a custom budget.
 pub fn publish_event(project_root: &Path, channel: &str, payload: Value) -> Result<(), String> {


### PR DESCRIPTION
## Summary

PR #2297 で `send_frame` stage に独立 timeout を導入したことにより、 `daemon_publisher::publish_event` の worst-case stall は 2 段階 (connect + ack) から 3 段階 (connect + send + ack) に拡張された。 docs / 関連コメントが古い `400 ms` のままだったので、 実際の worst case `600 ms` に揃える。

実装は不変、 docs / コメントのみの修正。

## Changes

- `crates/gwt/src/daemon_publisher.rs::DEFAULT_TIMEOUT` の doc と `publish_event` の doc: `400 ms (connect + ack)` → `600 ms (connect + send + ack)`
- `crates/gwt/src/app_runtime/board.rs::publish_board_change` のコメント: 同じ修正
- `crates/gwt/src/cli/board.rs::publish_board_change` のコメント: 同じ修正

## Closing Issues

None

## Related Issues / Links

- 修正対象: PR #2297 の coderabbitai review thread (line 97)
- SPEC-2077 (#2056): Runtime Daemon

## Checklist

- [x] commit type は `docs:` (実装は不変)
- [x] 全 3 箇所の comment / doc が新 worst case (600ms) に揃った
- [x] review thread は reply + resolved 済
