### PR TITLE
fix(daemon): protocol bump + forwarder leak + hub mutex hold + CLI ack race (SPEC-2077)

### DIFF
--- a/crates/gwt-core/src/daemon.rs
+++ b/crates/gwt-core/src/daemon.rs
@@ -15,7 +15,20 @@ use crate::{
 };
 
 /// Protocol version spoken by `gwt` and `gwtd`.
-pub const DAEMON_PROTOCOL_VERSION: u32 = 1;
+///
+/// Daemon endpoint reuse is keyed by this version, so a bump forces
+/// the bootstrap path to discard endpoints persisted by older daemons
+/// instead of accepting a connection that would later fail at the
+/// frame layer.
+///
+/// History:
+/// - `1`: initial untyped post-handshake frames (`{"ack":true}` etc).
+/// - `2`: typed `ClientFrame` / `DaemonFrame` post-handshake schema
+///   plus per-channel broadcast fan-out (SPEC-2077 Phase H1
+///   primitives + GREEN integration). Older clients/daemons will
+///   reject the handshake and force a respawn instead of attempting
+///   to exchange frames they cannot parse.
+pub const DAEMON_PROTOCOL_VERSION: u32 = 2;
 
 /// Runtime backend target for daemon-managed execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -61,10 +61,20 @@ impl BroadcastHub {
     /// projection writer, runtime status aggregator). Until then the
     /// only callers live in tests, so the lib-only dead-code lint is
     /// suppressed.
+    ///
+    /// Critically, the global `channels` mutex is released *before*
+    /// `sender.send` runs. `tokio::sync::broadcast::Sender::send`
+    /// clones the payload for every subscriber, so retaining the lock
+    /// across that call would block unrelated subscribe / publish
+    /// activity on other channels for the duration of a (potentially
+    /// large) fan-out.
     #[allow(dead_code)]
     pub(crate) fn publish(&self, channel: &str, frame: DaemonFrame) -> usize {
-        let guard = self.channels.lock().expect("BroadcastHub mutex poisoned");
-        match guard.get(channel) {
+        let sender = {
+            let guard = self.channels.lock().expect("BroadcastHub mutex poisoned");
+            guard.get(channel).cloned()
+        };
+        match sender {
             Some(sender) => sender.send(frame).unwrap_or(0),
             None => 0,
         }

--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -209,10 +209,35 @@ fn subscribe_command<E: CliEnv>(
             .send_frame(&ClientFrame::Subscribe { channels })
             .await
             .map_err(|err| config_error(format!("subscribe send failed: {err}")))?;
-        let _ack: DaemonFrame = client
-            .read_frame()
-            .await
-            .map_err(|err| config_error(format!("subscribe ack failed: {err}")))?;
+
+        // Drain frames until we observe the daemon's Subscribe ack.
+        // Frames received before the Ack can be real `Event` payloads
+        // because the per-channel forwarder is spawned before the
+        // server enqueues the Ack — silently dropping the first frame
+        // would cost the user the earliest event in the stream they
+        // are watching.
+        let writer = env.stdout();
+        loop {
+            let frame: DaemonFrame = client
+                .read_frame()
+                .await
+                .map_err(|err| config_error(format!("subscribe ack failed: {err}")))?;
+            match frame {
+                DaemonFrame::Ack => break,
+                DaemonFrame::Error { message } => {
+                    return Err(config_error(format!(
+                        "daemon rejected subscribe: {message}"
+                    )));
+                }
+                other => {
+                    let line = serde_json::to_string(&other)
+                        .map_err(|err| config_error(format!("serialize event failed: {err}")))?;
+                    writeln!(writer, "{line}")
+                        .map_err(|err| config_error(format!("write stdout failed: {err}")))?;
+                }
+            }
+        }
+
         loop {
             let frame: DaemonFrame = client
                 .read_frame()
@@ -220,7 +245,7 @@ fn subscribe_command<E: CliEnv>(
                 .map_err(|err| config_error(format!("read event failed: {err}")))?;
             let line = serde_json::to_string(&frame)
                 .map_err(|err| config_error(format!("serialize event failed: {err}")))?;
-            writeln!(env.stdout(), "{line}")
+            writeln!(writer, "{line}")
                 .map_err(|err| config_error(format!("write stdout failed: {err}")))?;
         }
     })

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -24,7 +24,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::{Duration, Instant},
@@ -228,6 +228,22 @@ async fn handle_connection(
     // and any broadcast forwarders can send concurrently without sharing
     // `write_half` directly.
     let (out_tx, mut out_rx) = mpsc::unbounded_channel::<DaemonFrame>();
+    // Cancellation primitive fired when the reader exits (peer
+    // closed, EOF, or read error). Each per-channel forwarder spawns
+    // with a clone of `out_tx`, so without this signal the forwarders
+    // would stay parked on `rx.recv()` forever, keeping the writer
+    // task alive (out_rx still has senders) and leaking both the
+    // connection task and its `ConnectionGuard` — the connection
+    // counter in `DaemonStatus` would be permanently inflated.
+    //
+    // We use a `(AtomicBool, Notify)` pair instead of `Notify` alone
+    // because `notify_waiters` is fire-and-forget: a forwarder that
+    // is between `rx.recv()` and `out_tx.send()` when the cancel
+    // fires would miss the notification and re-enter `select!` on a
+    // fresh `notified()` future that never resolves. The atomic flag
+    // is checked at the top of each iteration to close that race.
+    let forwarder_cancel = Arc::new(AtomicBool::new(false));
+    let forwarder_notify = Arc::new(Notify::new());
     let writer = tokio::spawn(async move {
         while let Some(frame) = out_rx.recv().await {
             if let Err(err) = write_json_line(&mut write_half, &frame).await {
@@ -273,22 +289,39 @@ async fn handle_connection(
                     let mut rx = hub.subscribe(&channel);
                     let out_tx = out_tx.clone();
                     let channel_for_log = channel.clone();
+                    let cancel = Arc::clone(&forwarder_cancel);
+                    let notify = Arc::clone(&forwarder_notify);
                     tokio::spawn(async move {
                         loop {
-                            match rx.recv().await {
-                                Ok(frame) => {
-                                    if out_tx.send(frame).is_err() {
-                                        break;
+                            // Atomic flag check protects against the
+                            // race where `notify_waiters` fires while
+                            // we're in the match arm below; a fresh
+                            // `notified()` future created the next
+                            // iteration would otherwise miss the
+                            // notification and park forever.
+                            if cancel.load(Ordering::SeqCst) {
+                                break;
+                            }
+                            tokio::select! {
+                                biased;
+                                _ = notify.notified() => break,
+                                result = rx.recv() => {
+                                    match result {
+                                        Ok(frame) => {
+                                            if out_tx.send(frame).is_err() {
+                                                break;
+                                            }
+                                        }
+                                        Err(err) => {
+                                            tracing::debug!(
+                                                target: "gwtd::daemon",
+                                                channel = %channel_for_log,
+                                                error = %err,
+                                                "broadcast receiver closed"
+                                            );
+                                            break;
+                                        }
                                     }
-                                }
-                                Err(err) => {
-                                    tracing::debug!(
-                                        target: "gwtd::daemon",
-                                        channel = %channel_for_log,
-                                        error = %err,
-                                        "broadcast receiver closed"
-                                    );
-                                    break;
                                 }
                             }
                         }
@@ -352,6 +385,13 @@ async fn handle_connection(
         }
     }
 
+    // Reader exited (peer closed, EOF, or read error). Wake every
+    // active forwarder so they drop their `out_tx` clones; once all
+    // senders are dropped the writer task's `out_rx.recv()` returns
+    // `None` and the task ends, allowing this connection task (and
+    // its `ConnectionGuard`) to be released.
+    forwarder_cancel.store(true, Ordering::SeqCst);
+    forwarder_notify.notify_waiters();
     drop(out_tx);
     let _ = writer.await;
     Ok(())


### PR DESCRIPTION
## Summary

PR #2281 / #2282 / #2283 / #2287 / #2288 で codex review が指摘した 5 件 (P1×2 + P2×3) を一括解消。 Phase H1 SCAFFOLD の robustness を本番品質に押し上げる修正。

| # | 元 PR | 重要度 | 問題 |
|---|---|---|---|
| 1 | #2281 | P1 | `DAEMON_PROTOCOL_VERSION` 未 bump で旧 daemon と新 client が handshake 後に schema mismatch |
| 2 | #2283 | P1 | Subscribe 後の forwarder task が peer close 後も park、 connection / writer / `ConnectionGuard` が leak |
| 3 | #2287 | P2 | (#2283 派生) `DaemonStatus.connections` が leak した connection 分だけ inflate して live count を反映しない |
| 4 | #2282 | P2 | `BroadcastHub::publish` が channels mutex を hold しながら `Sender::send` を呼び、 別 channel の subscribe / publish が head-of-line block される |
| 5 | #2288 | P2 | `gwtd daemon subscribe` CLI が ack 待ちで最初の Event を `_ack` に吸収して stdout に届かない |

## (1) Protocol bump (P1)

```rust
- pub const DAEMON_PROTOCOL_VERSION: u32 = 1;
+ pub const DAEMON_PROTOCOL_VERSION: u32 = 2;
```

doc に history を記載。 endpoint reuse は version key に紐付くので、 旧 v1 endpoint file は `resolve_bootstrap_action` で reject され強制 respawn。 schema mismatch race が消える。

## (2)+(3) Forwarder cancellation (P1+P2)

`handle_connection` に `Arc<AtomicBool>` + `Arc<Notify>` の cancel pair を追加。 reader loop 終了時に flag を set して `notify_waiters()` 発火。

各 forwarder:

```rust
loop {
    if cancel.load(Ordering::SeqCst) { break; }  // notify_waiters race cover
    tokio::select! {
        biased;
        _ = notify.notified() => break,
        result = rx.recv() => { ... }
    }
}
```

reader 終了 → 全 forwarder break → out_tx 全 drop → writer 終了 → handle_connection return → ConnectionGuard drop → counter 減算 の順で正しく終了。

## (4) Hub mutex hold (P2)

```rust
- let guard = self.channels.lock()...;
- match guard.get(channel) {
-     Some(sender) => sender.send(frame).unwrap_or(0),
-     None => 0,
- }
+ let sender = {
+     let guard = self.channels.lock()...;
+     guard.get(channel).cloned()
+ };
+ match sender {
+     Some(sender) => sender.send(frame).unwrap_or(0),
+     None => 0,
+ }
```

`Sender::clone` は cheap (Arc-style refcount)、 `send` は subscriber 数だけ payload clone する重い処理。 lock を `HashMap::get + Sender::clone` のみで release することで cross-channel head-of-line block を排除。

## (5) CLI subscribe ack race (P2)

```rust
- let _ack: DaemonFrame = client.read_frame().await?;
+ loop {
+     let frame: DaemonFrame = client.read_frame().await?;
+     match frame {
+         DaemonFrame::Ack => break,
+         DaemonFrame::Error { message } => return Err(...),
+         other => {
+             let line = serde_json::to_string(&other)?;
+             writeln!(writer, "{line}")?;
+         }
+     }
+ }
```

PR #2289 / #2297 と同じ pattern を CLI subscribe にも適用。 ack 前 Event は stdout に書き出される。

## Testing

- `cargo build -p gwt` → clean
- `cargo test -p gwt --lib daemon` → 33/33 pass
- `cargo test -p gwt-core --test runtime_daemon_contract` → 26/26 pass
- `cargo clippy -p gwt -p gwt-core --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 修正対象: PR #2281 / #2282 / #2283 / #2287 / #2288 の codex review threads (5 件すべて reply + resolved)

## Checklist

- [x] commit type は `fix:` (race / leak / hold の修正)
- [x] protocol version bump で schema mismatch race 解消
- [x] forwarder cancel で connection / writer leak 解消
- [x] DaemonStatus.connections が live count を反映するように
- [x] hub mutex の hold 範囲を最小化
- [x] CLI subscribe の earliest event を保全
- [x] 5 review threads 全て reply + resolved
