### PR TITLE
fix(daemon,gui): board scroll element + daemon startup flush + non-unix liveness (SPEC-2077)

### DIFF
--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -307,7 +307,11 @@ fn start_daemon<E: CliEnv>(env: &mut E, out: &mut String) -> Result<i32, SpecOps
             Ok(0)
         }
         DaemonBootstrapAction::Spawn { endpoint_path } => {
-            server::serve_blocking(scope, endpoint_path, out)
+            // Pass `env.stdout()` directly so `serve_blocking` can
+            // flush its readiness lines while the serve loop is still
+            // running. Returning the buffer-only `out` here would mean
+            // those lines are visible only after shutdown.
+            server::serve_blocking(scope, endpoint_path, env.stdout())
         }
     }
 }
@@ -339,9 +343,17 @@ fn is_process_alive_pid(pid: u32) -> bool {
     }
     #[cfg(not(unix))]
     {
-        // Conservative fallback — assume alive so we never racily clobber
-        // an in-flight daemon endpoint on an unsupported platform.
-        true
+        // The long-running daemon currently only runs under cfg(unix);
+        // `start_daemon` is a stub on every other platform. Reporting
+        // every persisted endpoint as "alive" therefore surfaced
+        // permanent-stale entries in `gwtd daemon status`. Returning
+        // `false` here lets `resolve_bootstrap_action` treat the
+        // endpoint as dead on platforms where no daemon can actually
+        // be running, so the file gets cleaned up on the next status
+        // / start. When Windows named-pipe support lands, this branch
+        // should switch to a real liveness probe (e.g.
+        // `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, ...)`).
+        false
     }
 }
 

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -47,10 +47,10 @@ use super::broadcast::BroadcastHub;
 
 const ACCEPT_BACKOFF_MS: u64 = 50;
 
-pub(super) fn serve_blocking(
+pub(super) fn serve_blocking<W: std::io::Write + ?Sized>(
     scope: RuntimeScope,
     endpoint_path: PathBuf,
-    out: &mut String,
+    writer: &mut W,
 ) -> Result<i32, SpecOpsError> {
     let socket_path = derive_socket_path(&endpoint_path);
     if let Err(err) = ensure_socket_parent(&socket_path) {
@@ -72,15 +72,22 @@ pub(super) fn serve_blocking(
     persist_endpoint(&endpoint_path, &endpoint)
         .map_err(|err| config_error(format!("failed to persist daemon endpoint: {err}")))?;
 
-    out.push_str(&format!(
-        "gwtd daemon start: bind={socket}\n",
+    // Stream readiness lines to the caller's stdout *before* entering
+    // the blocking serve loop. Buffering them in a `&mut String` left
+    // supervising scripts unable to detect that the daemon was up
+    // until the process eventually exited.
+    let _ = writeln!(
+        writer,
+        "gwtd daemon start: bind={socket}",
         socket = socket_path.display()
-    ));
-    out.push_str(&format!(
-        "gwtd daemon start: pid={pid} version={version}\n",
+    );
+    let _ = writeln!(
+        writer,
+        "gwtd daemon start: pid={pid} version={version}",
         pid = endpoint.pid,
         version = endpoint.daemon_version
-    ));
+    );
+    let _ = writer.flush();
 
     let runtime = Builder::new_multi_thread()
         .enable_all()

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2990,10 +2990,18 @@
           status.classList.add("info");
         }
 
+        // The actual scroll viewport is `.board-timeline-scroll`, the
+        // parent wrapper that has `overflow: auto`. Reading scrollTop /
+        // scrollHeight off `.board-timeline` returns 0/wrong values
+        // because `.board-timeline` itself is sized to its content.
+        const scroller = timeline.parentElement;
         const stickyBottomThreshold = 64;
-        const previousScrollTop = timeline.scrollTop;
-        const previousScrollMax = timeline.scrollHeight - timeline.clientHeight;
+        const previousScrollTop = scroller ? scroller.scrollTop : 0;
+        const previousScrollMax = scroller
+          ? scroller.scrollHeight - scroller.clientHeight
+          : 0;
         const wasNearBottom =
+          !scroller ||
           previousScrollMax <= 0 ||
           previousScrollMax - previousScrollTop <= stickyBottomThreshold;
 
@@ -3033,10 +3041,12 @@
           timeline.appendChild(card);
         }
 
-        if (wasNearBottom) {
-          timeline.scrollTop = timeline.scrollHeight;
-        } else {
-          timeline.scrollTop = previousScrollTop;
+        if (scroller) {
+          if (wasNearBottom) {
+            scroller.scrollTop = scroller.scrollHeight;
+          } else {
+            scroller.scrollTop = previousScrollTop;
+          }
         }
 
         composer.innerHTML = "";


### PR DESCRIPTION
## Summary

PR #2278 / #2279 の codex review (P1×1 + P2×2) を解消。

| # | 元 PR | 重要度 | 問題 |
|---|---|---|---|
| 1 | #2279 | P1 | `renderBoard` が `.board-timeline` の scrollTop/scrollHeight を読んでいたが、 実際の overflow:auto は parent `.board-timeline-scroll` |
| 2 | #2278 | P2 | `serve_blocking` の readiness lines が `out: &mut String` に buffer され、 shutdown 後にしか visible でない |
| 3 | #2278 | P2 | 非-Unix の `is_process_alive_pid` が常に `true` で stale endpoint が永続的に「running」報告される |

## (1) Board scroll の正しい scroll container 取得 (P1)

before:

```js
const previousScrollTop = timeline.scrollTop;        // always 0
const previousScrollMax = timeline.scrollHeight - timeline.clientHeight;
// ...
timeline.scrollTop = timeline.scrollHeight;          // no-op
```

after:

```js
const scroller = timeline.parentElement;             // .board-timeline-scroll
const previousScrollTop = scroller ? scroller.scrollTop : 0;
const previousScrollMax = scroller
  ? scroller.scrollHeight - scroller.clientHeight
  : 0;
// ...
if (scroller) {
  if (wasNearBottom) {
    scroller.scrollTop = scroller.scrollHeight;
  } else {
    scroller.scrollTop = previousScrollTop;
  }
}
```

`.board-timeline` (line 4944) は `.board-timeline-scroll` (line 4943) の inner element で、 overflow は parent 側に設定されている。 そのため scroll 計測も復元も parent 側で行う必要があった。 これで PR #2279 で意図していた「Board open 時に最新エントリへ scroll」「user が上方向に scroll した状態で再描画されても position 維持」が実機で動作する。

## (2) Daemon 起動 readiness lines を即時 flush (P2)

before: `serve_blocking(scope, endpoint_path, out: &mut String)` は `out` に文字列を push するだけ。 cli::run は serve_blocking が return してから out を stdout に書く設計だが、 serve_blocking は shutdown まで return しないので readiness lines は daemon 終了時にしか見えない。

after: serve_blocking のシグネチャを `serve_blocking<W: Write + ?Sized>(.., writer: &mut W)` に変更。 readiness lines を `writeln!` + `flush()` で writer (= env.stdout()) に直接書き込む。 supervising script が daemon up を即座に検出できる。

```rust
let _ = writeln!(writer, "gwtd daemon start: bind={socket}", ...);
let _ = writeln!(writer, "gwtd daemon start: pid={pid} version={version}", ...);
let _ = writer.flush();
```

`start_daemon` の caller も `env.stdout()` を渡すように変更:

```rust
DaemonBootstrapAction::Spawn { endpoint_path } => {
    server::serve_blocking(scope, endpoint_path, env.stdout())
}
```

## (3) 非-Unix liveness check (P2)

before: `is_process_alive_pid` の `#[cfg(not(unix))]` branch が `true` を返していた。 docstring は "Conservative fallback — assume alive so we never racily clobber an in-flight daemon endpoint" だが、 実際には:

- daemon 自体が `cfg(unix)` gated
- `start_daemon` は非-Unix で "not implemented" stub を返す
- → 非-Unix では real daemon が running する path が存在しない
- → leftover endpoint file は必ず stale なのに永久に「alive」報告され、 cleanup trigger が発火しない

after: 非-Unix で `false` を返す。 stale endpoint は次の `daemon status` / `daemon start` で正しく cleanup される。 doc comment に Windows named-pipe support 追加時の方向性 (OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)) を明記。

## Testing

- `cargo build -p gwt` → clean
- `cargo test -p gwt --lib daemon` → 33/33 pass
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 修正対象: PR #2278 / #2279 の codex review threads (3 件すべて reply + resolved)

## Checklist

- [x] commit type は `fix:` (実機の不具合修正、 docs 修正含む)
- [x] Board sticky-bottom が実機で動作する scroll element に取得元修正
- [x] Daemon 起動時 readiness が supervising script から observable
- [x] 非-Unix の stale endpoint cleanup が trigger される
- [x] 3 review threads 全て reply + resolved
