### PR TITLE
test(daemon): regression for v1 endpoint rejection (SPEC-2077)

### DIFF
--- a/crates/gwt-core/tests/runtime_daemon_contract.rs
+++ b/crates/gwt-core/tests/runtime_daemon_contract.rs
@@ -38,6 +38,49 @@ fn daemon_endpoint_path_is_scoped_by_repo_and_worktree() {
 }
 
 #[test]
+fn bootstrap_rejects_pre_v2_endpoint_files() {
+    // Locks in the v1 -> v2 protocol bump (PR #2299): an endpoint
+    // file persisted by a daemon speaking the older untyped frame
+    // schema (`protocol_version: 1`) must be rejected by the
+    // current bootstrap path so we force a respawn instead of
+    // inheriting an incompatible daemon. Without this regression
+    // guard a future revert of the bump would be silent.
+    let project_root = tempdir().unwrap();
+    let scope = RuntimeScope::new(
+        "repo-scope-1234",
+        "worktree-scope-5678",
+        project_root.path().to_path_buf(),
+        RuntimeTarget::Host,
+    )
+    .unwrap();
+    let gwt_home = tempdir().unwrap();
+
+    let mut legacy = DaemonEndpoint::new(
+        scope.clone(),
+        4242,
+        "http://127.0.0.1:7777".into(),
+        "secret-token".into(),
+        "0.1.0".into(),
+    );
+    legacy.protocol_version = 1;
+    persist_endpoint(&scope.endpoint_path(gwt_home.path()), &legacy).unwrap();
+
+    let action =
+        resolve_bootstrap_action(gwt_home.path(), &scope, DAEMON_PROTOCOL_VERSION, |pid| {
+            pid == 4242
+        })
+        .unwrap();
+    assert!(
+        matches!(action, DaemonBootstrapAction::Spawn { .. }),
+        "expected Spawn for v1 endpoint, got: {action:?}"
+    );
+    assert!(
+        !scope.endpoint_path(gwt_home.path()).exists(),
+        "stale v1 endpoint file should be removed"
+    );
+}
+
+#[test]
 fn bootstrap_reuses_live_endpoint_and_rejects_stale_or_mismatched_versions() {
     let project_root = tempdir().unwrap();
     let scope = RuntimeScope::new(


### PR DESCRIPTION
## Summary

PR #2299 で `DAEMON_PROTOCOL_VERSION` を `1 → 2` に bump した際、 「v1 (旧 untyped frame schema) endpoint を bootstrap path が拒否する」という **具体的な regression を lock-in する test** が無かった。 既存 `bootstrap_reuses_live_endpoint_and_rejects_stale_or_mismatched_versions` は generic な version mismatch (current+1) を cover するが、 v1 そのものへの guard は無かったため、 将来的に protocol bump を巻き戻した場合 silent に通ってしまう。

## What this PR adds

`bootstrap_rejects_pre_v2_endpoint_files` test (`crates/gwt-core/tests/runtime_daemon_contract.rs`):

- `protocol_version: 1` の `DaemonEndpoint` をディスクに persist
- `resolve_bootstrap_action(.., DAEMON_PROTOCOL_VERSION, ..)` が `Spawn` 経路を返すことを assert (`Reuse` ではない)
- 拒否された endpoint file が cleanup される (`!endpoint_path.exists()`) ことを assert

Phase H1 typed-frame schema (`ClientFrame::Hook | Subscribe | Publish | Status`) は v2 protocol に紐付くので、 この test が green である限り「旧 v1 daemon と新 client が handshake を通過してから frame parse で死ぬ」 race は起きない。

## Testing

- `cargo test -p gwt-core --test runtime_daemon_contract` → 27/27 pass (新 1 + 既存 26)
- `cargo clippy -p gwt-core --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 関連 PR #2281 (typed frame schema 導入)、 #2299 (protocol version bump)

## Checklist

- [x] commit type は `test:` (test 追加のみ、 production code 不変)
- [x] 既存 generic version-mismatch test と独立した v1 specific guard
- [x] 実装の動作変化なし (lock-in only)
