### PR TITLE
chore(daemon): drop stale dead_code allow on BroadcastHub::publish

### DIFF
--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -57,10 +57,9 @@ impl BroadcastHub {
     /// `channel`. Returns the number of receivers the frame was queued
     /// for (zero is a successful no-op when nobody is listening).
     ///
-    /// Phase H1 GREEN will call this from real domain handlers (Board
-    /// projection writer, runtime status aggregator). Until then the
-    /// only callers live in tests, so the lib-only dead-code lint is
-    /// suppressed.
+    /// Called from `server::handle_connection` when a
+    /// `ClientFrame::Publish` arrives, so the daemon fans the payload
+    /// out to every subscribed connection on `channel`.
     ///
     /// Critically, the global `channels` mutex is released *before*
     /// `sender.send` runs. `tokio::sync::broadcast::Sender::send`
@@ -68,7 +67,6 @@ impl BroadcastHub {
     /// across that call would block unrelated subscribe / publish
     /// activity on other channels for the duration of a (potentially
     /// large) fan-out.
-    #[allow(dead_code)]
     pub(crate) fn publish(&self, channel: &str, frame: DaemonFrame) -> usize {
         let sender = {
             let guard = self.channels.lock().expect("BroadcastHub mutex poisoned");


### PR DESCRIPTION
## Summary

`BroadcastHub::publish` の `#[allow(dead_code)]` が stale だったので削除。

Phase H1 SCAFFOLD で primitive を land した直後 (PR #2282) は publish の caller が test のみだったため lint suppress が必要だった。 その後 Phase H1 GREEN (PR #2283) で `server::handle_connection` の `Subscribe` 経由 forwarder が、 さらに PR #2299 で `ClientFrame::Publish` arm が `hub.publish` を呼ぶようになり production caller が成立。 attribute は今や lint を誤って suppress するだけで、 Phase H1 の完了状態を反映できていなかった。

## Changes

- `crates/gwt/src/cli/daemon/broadcast.rs::BroadcastHub::publish`: `#[allow(dead_code)]` 削除、 doc を「caller は `server::handle_connection`」と明示するよう書き換え。

実装変化なし、 動作不変。

## Testing

- `cargo build -p gwt` → clean
- `cargo test -p gwt --lib daemon` → 33/33 pass
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 関連 PR #2282 (BroadcastHub primitive 導入時に allow(dead_code) 追加)、 #2299 (Phase H1 GREEN で production caller 成立)

## Checklist

- [x] commit type は `chore:` (lint attribute 削除のみ、 production code 不変)
- [x] doc が現在の caller (`server::handle_connection`) を反映
- [x] 動作変化なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal documentation clarity and removed unnecessary code annotations for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->