### PR TITLE
test(daemon): multi-subscriber fan-out regression (SPEC-2077 Phase H2 prep)

### DIFF
--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -440,6 +440,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn publish_fans_out_to_multiple_subscribers_on_same_channel() {
+        // Locks in the multi-subscriber fan-out invariant: a single
+        // `ClientFrame::Publish` reaches every connection that has
+        // subscribed to the same channel. Phase H2-H4 will rely on
+        // this — runtime status / hook events / launch lifecycle all
+        // assume "broadcast to N gwt instances" is the default.
+        let temp = TempDir::new().expect("tempdir");
+        let scope = sample_scope(&temp);
+        let socket_path = temp.path().join("daemon.sock");
+        let endpoint_path = temp.path().join("endpoint.json");
+        let endpoint = sample_endpoint(scope.clone(), &socket_path, "fan-out-secret");
+
+        let server_endpoint = endpoint.clone();
+        let server_socket = socket_path.clone();
+        let server_endpoint_path = endpoint_path.clone();
+        let server_hub = BroadcastHub::new();
+        let server_handle = tokio::spawn(async move {
+            server::run_server(
+                server_endpoint,
+                server_socket,
+                server_endpoint_path,
+                server_hub,
+            )
+            .await
+        });
+
+        wait_for_socket(&socket_path).await;
+
+        // Three independent subscribers on the same "board" channel.
+        let mut subscribers = Vec::with_capacity(3);
+        for _ in 0..3 {
+            let mut client = DaemonClient::connect(&endpoint)
+                .await
+                .expect("subscriber connects");
+            client
+                .send_frame(&ClientFrame::Subscribe {
+                    channels: vec!["board".to_string()],
+                })
+                .await
+                .expect("subscribe send");
+            let ack: DaemonFrame = client.read_frame().await.expect("subscribe ack");
+            assert_eq!(ack, DaemonFrame::Ack);
+            subscribers.push(client);
+        }
+
+        // Single publisher, single Publish frame.
+        let mut publisher = DaemonClient::connect(&endpoint)
+            .await
+            .expect("publisher connects");
+        let payload = serde_json::json!({"entries": 11});
+        publisher
+            .send_frame(&ClientFrame::Publish {
+                channel: "board".to_string(),
+                payload: payload.clone(),
+            })
+            .await
+            .expect("publish send");
+        let pub_ack: DaemonFrame = publisher.read_frame().await.expect("publish ack");
+        assert_eq!(pub_ack, DaemonFrame::Ack);
+
+        // Every subscriber must observe the same Event payload.
+        let expected = DaemonFrame::Event {
+            channel: "board".to_string(),
+            payload,
+        };
+        for (idx, mut client) in subscribers.into_iter().enumerate() {
+            let event: DaemonFrame = tokio::time::timeout(
+                Duration::from_millis(500),
+                client.read_frame::<DaemonFrame>(),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("subscriber {idx} timeout"))
+            .unwrap_or_else(|err| panic!("subscriber {idx} read: {err}"));
+            assert_eq!(
+                event, expected,
+                "subscriber {idx} got unexpected frame: {event:?}"
+            );
+            drop(client);
+        }
+
+        drop(publisher);
+        server_handle.abort();
+        let _ = server_handle.await;
+    }
+
+    #[tokio::test]
     async fn subscribed_client_receives_published_broadcast_events() {
         let temp = TempDir::new().expect("tempdir");
         let scope = sample_scope(&temp);


### PR DESCRIPTION
## Summary

Phase H2-H4 (`handle_runtime_output` / `handle_runtime_status` / `handle_runtime_hook_event` / `handle_launch_complete` の daemon 移行) は **「単一 publish が複数 subscriber に均等に届く」 fan-out 不変条件** に依存する。 既存の `publish_frame_fans_out_to_subscriber_through_daemon` test は 1 subscriber だけ cover していたため、 multi-subscriber 配信の regression guard が無かった。

`publish_fans_out_to_multiple_subscribers_on_same_channel` を追加し、 fan-out 数の regression を 3-subscriber scenario で lock-in する。

## What this PR adds

新 test in `crates/gwt/src/cli/daemon/client.rs`:

1. 同一 daemon に **3 つの subscriber** を ack まで完了させる
2. 1 つの publisher が 1 回 `ClientFrame::Publish` を送信
3. 全 subscriber が同じ `DaemonFrame::Event { channel, payload }` を 500ms 以内に受信することを assert
4. subscriber の index 別 timeout / read error を panic message に含めて debug 容易化

```rust
let event: DaemonFrame = tokio::time::timeout(
    Duration::from_millis(500),
    client.read_frame::<DaemonFrame>(),
)
.await
.unwrap_or_else(|_| panic!("subscriber {idx} timeout"))
.unwrap_or_else(|err| panic!("subscriber {idx} read: {err}"));
assert_eq!(
    event, expected,
    "subscriber {idx} got unexpected frame: {event:?}"
);
```

## Why now?

Phase H2-H4 では同じ pattern (publish + subscribe) を別 channel ("runtime-status", "hook-event", "agent-launch" 等) で再利用する。 fan-out が壊れる regression は Phase H 系の core 不変条件を破るので、 SCAFFOLD 完了状態で lock-in しておく。

## Testing

- `cargo test -p gwt --lib daemon` → 34/34 pass (新 1 + 既存 33)
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` → warnings 0
- `cargo fmt --check` → 差分なし

## Closing Issues

None

## Related Issues / Links

- SPEC-2077 (#2056): Runtime Daemon
- 関連 PR #2290 (publish frame primitive)、 #2299 (publish ack ordering 修正)、 #2302 (v1 endpoint rejection regression)

## Checklist

- [x] commit type は `test:` (test 追加のみ、 production code 不変)
- [x] Phase H2-H4 で再利用される fan-out 不変条件を 3-subscriber scenario で lock-in
- [x] 既存 1-subscriber test と相補的、 重複なし
