### PR TITLE
test(daemon): regression for auth_token rotation between sessions (SPEC-2077)

### DIFF
--- a/crates/gwt/src/daemon_subscriber.rs
+++ b/crates/gwt/src/daemon_subscriber.rs
@@ -509,4 +509,122 @@ mod tests {
         server_handle.abort();
         let _ = server_handle.await;
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn subscriber_resolver_picks_up_new_token_between_sessions() {
+        // Production scenario: `gwtd daemon start` is killed and
+        // respawned. The new daemon picks a fresh `auth_token`, so a
+        // subscriber that cached the old endpoint at spawn time would
+        // loop forever on handshake rejection. `spawn_with_resolver`
+        // re-reads the persisted endpoint between sessions; this
+        // regression test exercises the contract that the auth_token
+        // is read FRESH per session, not cached at spawn.
+        //
+        // Locks in the Codex P1 fix from PR #2298.
+        //
+        // Test strategy: stand up exactly one daemon configured with
+        // the "live" token, but seed the resolver with a stale token
+        // first. The first connect attempt hits the daemon's
+        // handshake check and is rejected. After we swap the
+        // resolver's state to the live token, the next session
+        // (driven by run_loop's reconnect-on-error path) succeeds and
+        // events flow through.
+        let temp = TempDir::new().expect("tempdir");
+        let scope = sample_scope(&temp);
+        let socket_path = temp.path().join("daemon.sock");
+        let endpoint_path = temp.path().join("endpoint.json");
+
+        // The daemon expects "live-token". The resolver initially
+        // returns "stale-token", which mirrors a subscriber holding a
+        // pre-restart cache.
+        let live_endpoint = sample_endpoint(scope.clone(), &socket_path, "live-token");
+        let stale_endpoint = sample_endpoint(scope.clone(), &socket_path, "stale-token");
+
+        // Start the daemon with the live token.
+        let hub = BroadcastHub::new();
+        let publisher = hub.clone();
+        let server_endpoint = live_endpoint.clone();
+        let server_socket = socket_path.clone();
+        let server_endpoint_path = endpoint_path.clone();
+        let server_handle = tokio::spawn(async move {
+            server::run_server(server_endpoint, server_socket, server_endpoint_path, hub).await
+        });
+        wait_for_socket(&socket_path).await;
+
+        // Resolver state holds the currently-believed endpoint. We
+        // mutate it during the test to simulate
+        // `paths::gwt_home()` -> `endpoint.json` being rewritten by a
+        // restarted daemon.
+        let resolver_state = Arc::new(Mutex::new(stale_endpoint.clone()));
+        let resolver_state_for_resolver = Arc::clone(&resolver_state);
+        let resolver = move || -> Result<DaemonEndpoint, String> {
+            Ok(resolver_state_for_resolver.lock().unwrap().clone())
+        };
+
+        let received: Arc<Mutex<Vec<(String, serde_json::Value)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let received_for_cb = Arc::clone(&received);
+        let subscriber = DaemonSubscriber::spawn_with_resolver(
+            resolver,
+            vec!["board".to_string()],
+            move |channel, payload| {
+                received_for_cb.lock().unwrap().push((channel, payload));
+            },
+        );
+
+        // Give the subscriber time to attempt at least one stale
+        // connect. The handshake will be rejected because the token
+        // doesn't match.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        // Sanity check: nothing has been received yet — the session
+        // never reached a Subscribe Ack because the handshake failed.
+        assert!(
+            received.lock().unwrap().is_empty(),
+            "stale token must not deliver events"
+        );
+
+        // Simulate the daemon-restart endpoint refresh: rewrite the
+        // resolver's cache to the live token. The next reconnect
+        // attempt should now succeed.
+        *resolver_state.lock().unwrap() = live_endpoint.clone();
+
+        // Publish a marker event. The publish loop spins until the
+        // subscriber's Subscribe is processed and a forwarder is
+        // attached on the daemon side.
+        let event = DaemonFrame::Event {
+            channel: "board".to_string(),
+            payload: json!({"phase": "post-restart"}),
+        };
+        for _ in 0..400 {
+            if publisher.publish("board", event.clone()) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Wait up to 8 s for the callback to record the event. The
+        // reconnect path can backoff up to 5 s between sessions, so
+        // allow generous slack.
+        let mut delivered = false;
+        for _ in 0..800 {
+            if received
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, payload)| payload == &json!({"phase": "post-restart"}))
+            {
+                delivered = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            delivered,
+            "expected subscriber to reconnect with rotated auth_token and receive event"
+        );
+
+        subscriber.stop();
+        server_handle.abort();
+        let _ = server_handle.await;
+    }
 }


### PR DESCRIPTION
## Summary

Adds a regression test for the `spawn_with_resolver` auth_token rotation contract introduced in PR #2298. The test verifies that a subscriber re-reads its `DaemonEndpoint` between sessions and successfully reconnects when the daemon's auth_token rotates (e.g., after `gwtd daemon start` kills+respawns).

## Changes

- `crates/gwt/src/daemon_subscriber.rs`: new `subscriber_resolver_picks_up_new_token_between_sessions` test (118 LOC, including comments).

## Why

PR #2298 fixed a Codex P1 finding: a subscriber spawned before the daemon's first `gwtd daemon start` would cache a stale endpoint and loop forever on handshake rejection. The fix added `spawn_with_resolver` so each connect attempt re-reads the persisted endpoint. Behavior was verified by review only — no test asserted that a token change between sessions actually flows through.

This test:

1. Mounts a single daemon configured with `live-token`
2. Seeds the resolver with `stale-token` first
3. Asserts the stale token's handshake fails (no events delivered)
4. Flips the resolver to `live-token`
5. Asserts the next reconnect succeeds and events flow through

An earlier draft attempted to simulate a true daemon restart by aborting the server task, but `tokio::JoinHandle::abort()` does not cancel already-spawned `handle_connection` tasks, so the existing client connection persisted and the run_loop never re-resolved. Driving the rotation through resolver-pre-handshake state is the reliable path.

## Testing

- [x] `cargo test -p gwt --lib daemon_subscriber` — 4 / 4 pass
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Closing Issues

None — locks in the existing `spawn_with_resolver` contract for SPEC-2077.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- PR #2298 — original Codex P1 fix that introduced `spawn_with_resolver`

## Checklist

- [x] Tests added for new behavior
- [x] Clippy clean
- [x] fmt clean
- [x] No production code change (test-only)
