### PR TITLE
fix(daemon): keep broadcast subscription alive after RecvError::Lagged (SPEC-2077)

### DIFF
--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -94,9 +94,9 @@ mod tests {
 
     use gwt_core::daemon::DaemonFrame;
     use serde_json::json;
-    use tokio::sync::broadcast::error::TryRecvError;
+    use tokio::sync::broadcast::error::{RecvError, TryRecvError};
 
-    use super::BroadcastHub;
+    use super::{BroadcastHub, DEFAULT_CHANNEL_CAPACITY};
 
     #[test]
     fn subscribe_creates_channel_lazily() {
@@ -185,5 +185,64 @@ mod tests {
 
         let received = rx.recv().await.expect("recv");
         assert_eq!(received, frame);
+    }
+
+    #[tokio::test]
+    async fn slow_subscriber_recovers_after_lag() {
+        // A subscriber that does not drain fast enough loses old
+        // frames once the publisher pushes more than
+        // `DEFAULT_CHANNEL_CAPACITY` items. The first post-lag
+        // `recv()` returns `RecvError::Lagged(skipped)`, but the
+        // subscription is NOT closed — the next `recv()` returns the
+        // newest still-buffered frame.
+        //
+        // The daemon's per-channel forwarder relies on this contract:
+        // it must distinguish `Lagged` (recoverable, log + continue)
+        // from `Closed` (terminal, break loop). A naive `match
+        // result { Err(_) => break }` would silently kill a slow
+        // subscriber's entire subscription on the very first lag,
+        // not just the dropped frames. This test pins the recovery
+        // semantic so the forwarder's `Lagged` branch stays correct.
+        let hub = BroadcastHub::new();
+        let mut rx = hub.subscribe("board");
+
+        // Push capacity + a few extras with no draining, forcing the
+        // broadcast channel to overwrite the oldest slots.
+        let overflow = DEFAULT_CHANNEL_CAPACITY + 4;
+        for i in 0..overflow {
+            hub.publish(
+                "board",
+                DaemonFrame::Event {
+                    channel: "board".into(),
+                    payload: json!({"seq": i}),
+                },
+            );
+        }
+
+        // First receive after overflow must surface the lag signal,
+        // not silently swallow or fail the subscription.
+        match rx.recv().await {
+            Err(RecvError::Lagged(skipped)) => {
+                assert!(
+                    skipped > 0,
+                    "expected a positive skipped count from RecvError::Lagged"
+                );
+            }
+            other => panic!("expected RecvError::Lagged, got {other:?}"),
+        }
+
+        // The subscription is still alive: the next recv returns a
+        // real frame. Confirms the forwarder's "log + continue"
+        // strategy will keep delivering the newest events.
+        match rx.recv().await {
+            Ok(DaemonFrame::Event { payload, .. }) => {
+                let seq = payload["seq"].as_u64().expect("seq u64");
+                assert!(
+                    seq < overflow as u64,
+                    "post-lag frame should still be from the recent burst"
+                );
+            }
+            other => panic!("expected event frame after lag recovery, got {other:?}"),
+        }
     }
 }

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -40,7 +40,7 @@ use tokio::{
     net::{UnixListener, UnixStream},
     runtime::Builder,
     signal::unix::{signal, SignalKind},
-    sync::{mpsc, Notify},
+    sync::{broadcast::error::RecvError, mpsc, Notify},
 };
 
 use super::broadcast::BroadcastHub;
@@ -319,11 +319,32 @@ async fn handle_connection(
                                                 break;
                                             }
                                         }
-                                        Err(err) => {
+                                        // `Lagged` is the broadcast
+                                        // channel's "you're behind by
+                                        // N frames" signal: capacity
+                                        // is `DEFAULT_CHANNEL_CAPACITY`
+                                        // (64) and a slow subscriber
+                                        // can drop frames if a publish
+                                        // burst overruns the
+                                        // forwarder's drain. The
+                                        // subscription itself is still
+                                        // healthy — keep reading the
+                                        // newer frames so the slow
+                                        // client recovers instead of
+                                        // silently losing the channel
+                                        // forever.
+                                        Err(RecvError::Lagged(skipped)) => {
+                                            tracing::warn!(
+                                                target: "gwtd::daemon",
+                                                channel = %channel_for_log,
+                                                skipped,
+                                                "broadcast receiver lagged; resuming with newer frames"
+                                            );
+                                        }
+                                        Err(RecvError::Closed) => {
                                             tracing::debug!(
                                                 target: "gwtd::daemon",
                                                 channel = %channel_for_log,
-                                                error = %err,
                                                 "broadcast receiver closed"
                                             );
                                             break;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,68 @@
 # Lessons Learned
 
+## 2026-05-04 — fix(daemon): broadcast forwarder treated RecvError::Lagged as fatal
+
+### 事象
+
+SPEC-2077 Phase H1 の per-channel broadcast forwarder
+(`crates/gwt/src/cli/daemon/server.rs`) が `broadcast::Receiver::recv()`
+の `Err(_)` をすべて fatal 扱いして loop break していたため、 slow
+subscriber が DEFAULT_CHANNEL_CAPACITY (64) を超えて lag した瞬間に
+購読が無音で終了する。 client 側は出口 EOF だけを観測し、 reconnect
+からのフル resubscribe が必要だった。
+
+### 原因
+
+`tokio::sync::broadcast::error::RecvError` には 2 variant あり、
+意味が完全に異なる:
+
+- `Lagged(u64)`: 「N frames を捨てたよ」という回復可能な warning
+  signal。 channel そのものは健全で、 次の `recv()` は新しい frame
+  を返す。
+- `Closed`: 全 Sender が drop された terminal 状態。 これ以降 frame
+  は来ない。
+
+両者を `Err(_)` でまとめて break すると、 lag burst で副次的に
+subscription 全体が落ちる。 capacity 64 は通常運用では十分だが、
+forwarder task が runtime 上の他タスクで一瞬 starve した間に publish
+バーストが来ると現実的に発生する。
+
+同じ落とし穴は他の async primitive にも潜む:
+
+- `mpsc::error::TryRecvError::Empty` (一時的に空) vs `Disconnected`
+  (terminal) を `Err(_)` でまとめると spurious wakeup を terminate
+  扱いしてしまう
+- `std::io::ErrorKind::WouldBlock` / `Interrupted` を `Err(_)` で
+  まとめると nonblocking IO で正常な再試行を諦める
+- `tokio::time::error::Elapsed` (timeout、 retry 可能) と underlying
+  IO error (terminal) を区別せず break する
+
+### 再発防止策
+
+並列 / 非同期 primitive の `Result::Err` を match するときは、
+**variant ごとに recoverable / terminal を明示分類する**:
+
+1. `RecvError`, `TryRecvError`, `io::ErrorKind`, `Elapsed` などの
+   error 型を `Err(_)` でまとめて catch しない。 必ず variant を
+   pattern match して各 variant の意味を確認する。
+2. recoverable variant (Lagged / WouldBlock / Interrupted /
+   Empty / Elapsed) は **continue + 観測のための warn log**、
+   terminal variant (Closed / Disconnected / 真の IO error) は
+   **break / 上位エラー化** に分岐する。
+3. forwarder のような producer-consumer pattern では、
+   recoverable error 経路を必ず unit test で pin する。 underlying
+   primitive (broadcast::Receiver, mpsc::Receiver) に対してオーバー
+   フロー / drain 試験を書き、 「subscription は alive のまま、
+   次の recv() で newer frame が返る」契約を assertion で固定する。
+4. defensive code は code comment で **どの variant が来うるか** /
+   **どう振り分けたか** を明記する。 単に `match err` だけだと
+   reviewer は「全 Err が同じ意味」と読みがち。
+
+これは Phase H2-H4 で `handle_runtime_output` / `handle_runtime_hook_event`
+を daemon 経由化するときも同じパターンが再出現する。 broadcast
+channel に乗せる別 channel を増やすたびに、 forwarder の error
+handling を見直すこと。
+
 ## 2026-05-03 — fix(daemon): SPEC-2077 Phase H1 GREEN review-driven hardening
 
 ### 事象


### PR DESCRIPTION
## Summary

Fixes a real defect in the daemon's per-channel broadcast forwarder: any error from `broadcast::Receiver::recv()` was treated as fatal, including the recoverable `RecvError::Lagged(n)` signal. A slow subscriber that fell behind the 64-frame channel capacity would silently lose its entire subscription and have to reconnect to recover.

## Changes

- `crates/gwt/src/cli/daemon/server.rs`: split the forwarder's error arm into `Lagged` (log warn + continue) and `Closed` (terminal break). Imports `tokio::sync::broadcast::error::RecvError`.
- `crates/gwt/src/cli/daemon/broadcast.rs`: new `slow_subscriber_recovers_after_lag` test that pins the underlying `broadcast::Receiver` lag-and-recover contract the forwarder now relies on.

## Why

The forwarder previously had:

```rust
Err(err) => {
    tracing::debug!(channel = %ch, error = %err, "broadcast receiver closed");
    break;
}
```

`tokio::sync::broadcast::error::RecvError` has two variants: `Lagged(u64)` (skipped N frames, keep going) and `Closed` (sender dropped, no more frames coming). Treating both the same kills the subscription on the very first lag.

In production this means: a publish burst overruns a slow subscriber's drain → `Lagged` → forwarder breaks → daemon-side handle_connection sees the writer task draining the empty channel → eventual EOF → subscriber sees socket close. The client has no idea why its subscription died.

After the fix: `Lagged` is logged at `warn!` with the skipped count, and the forwarder keeps delivering. Only `Closed` (which never fires today since the hub never removes channels) terminates the loop.

## Testing

- [x] `cargo test -p gwt --lib daemon` — 36 / 36 pass (35 previous + 1 new)
- [x] `cargo test -p gwt --lib` — 378 / 378 pass
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

The new test publishes `DEFAULT_CHANNEL_CAPACITY + 4` frames without draining, asserts the next `recv()` returns `RecvError::Lagged(skipped)` with `skipped > 0`, and asserts a subsequent `recv()` still returns a real `Event` frame from the buffered tail.

## Closing Issues

None — defensive correctness fix in SPEC-2077 daemon code.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- PR #2283 — original forwarder wiring that introduced the broken error arm

## Checklist

- [x] Bug fix in production code with regression test
- [x] Code comment explains the Lagged vs Closed distinction
- [x] Clippy clean
- [x] fmt clean
