### PR TITLE
test(app_runtime): fix flaky viewport/geometry persist test by locking HOME

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4681,7 +4681,19 @@ exit 0
 
     #[test]
     fn app_runtime_viewport_and_geometry_updates_persist_workspace_state() {
+        // Persistence flows through `workspace_state_path()` which is
+        // HOME-based, so we must serialize against other HOME-touching
+        // tests and pin HOME to this test's tempdir for the duration.
+        // Without this guard, parallel tests that mutate HOME race
+        // with our persist + load pair and the workspace file ends up
+        // missing (or pointing at another test's already-cleaned
+        // tempdir).
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo");
         let tab = sample_project_tab_with_window_at(


### PR DESCRIPTION
## Summary

Fixes a flaky test: `app_runtime_viewport_and_geometry_updates_persist_workspace_state` was missing the env_test_lock + HOME pin pattern that every neighboring HOME-touching test uses, so it raced against parallel tests mutating HOME.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: prepend `env_test_lock()` + `ScopedEnvVar::set("HOME", temp.path())` + `ScopedEnvVar::set("USERPROFILE", temp.path())` to the test, matching the surrounding tests' setup.

## Why

The test exercises persistence:

1. `update_viewport_events()` → `persist()` → writes via `persistence::workspace_state_path(repo)` which expands to `gwt_home().join("projects").join(repo_hash).join("workspace.json")`.
2. `update_window_geometry_events()` → same persist path.
3. `load_restored_workspace_state(&repo)` → reads from the same HOME-based path.

If a parallel test holds `_home = ScopedEnvVar::set("HOME", other_tempdir)` and then drops on exit, this test's persist+load pair runs with whichever HOME happens to be current at each step. Common failure mode: persist writes under another test's tempdir, that tempdir is removed when the other test ends, our load returns NotFound/default, and the `workspace.viewport.x == 12.0` assertion blows up.

Fix mirrors the convention used by every other HOME-touching test in the module:

```rust
let _env_lock = env_test_lock()
    .lock()
    .unwrap_or_else(|poisoned| poisoned.into_inner());
let temp = tempdir().expect("tempdir");
let _home = ScopedEnvVar::set("HOME", temp.path());
let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
```

This serializes the test against any other HOME-touching test and pins HOME to a tempdir whose lifetime is bounded by this test's stack.

## Reproduction

```
$ cargo test -p gwt --bin gwt
# ~1/5 runs hit:
test app_runtime::tests::app_runtime_viewport_and_geometry_updates_persist_workspace_state ... FAILED
```

After fix:

```
$ for i in 1 2 3 4 5; do cargo test -p gwt --bin gwt 2>&1 | tail -1; done
test result: ok. 186 passed; 0 failed; ...
test result: ok. 186 passed; 0 failed; ...
test result: ok. 186 passed; 0 failed; ...
test result: ok. 186 passed; 0 failed; ...
test result: ok. 186 passed; 0 failed; ...
```

## Testing

- [x] `cargo test -p gwt --bin gwt` — 186/186 pass over 5 sequential runs (was ~1/5 fail before)
- [x] `cargo clippy -p gwt --bin gwt -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Closing Issues

None — test stability fix.

## Related Issues / Links

- SPEC-2008 (#2008) — Canvas workspace (origin of viewport persistence)
- SPEC-2020 (#2020) — workspace persistence schema

## Checklist

- [x] Test stability fix (no production code change)
- [x] Mirrors existing convention in the same module
