### PR TITLE
test(daemon): gate auth_token rotation flip on resolver call counter (codex P2 follow-up)

### DIFF
--- a/crates/gwt/src/daemon_subscriber.rs
+++ b/crates/gwt/src/daemon_subscriber.rs
@@ -283,7 +283,10 @@ fn sleep_with_stop(stop_flag: &AtomicBool, _shutdown: &Notify, total: Duration) 
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::{Arc, Mutex},
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
         time::Duration,
     };
 
@@ -555,10 +558,24 @@ mod tests {
         // mutate it during the test to simulate
         // `paths::gwt_home()` -> `endpoint.json` being rewritten by a
         // restarted daemon.
+        //
+        // Wrap each call in a counter so the test can wait on the
+        // subscriber actually consuming the stale endpoint at least
+        // once before we flip the resolver state. A wall-clock sleep
+        // is unsafe here: on a slow CI runner the subscriber thread
+        // may not reach `resolver()` until *after* a fixed sleep
+        // window, in which case it would never observe the stale
+        // token and the regression path (handshake rejected → run_loop
+        // reconnects → second resolver call sees rotated token) would
+        // not run.
         let resolver_state = Arc::new(Mutex::new(stale_endpoint.clone()));
+        let resolver_calls = Arc::new(AtomicUsize::new(0));
         let resolver_state_for_resolver = Arc::clone(&resolver_state);
+        let resolver_calls_for_resolver = Arc::clone(&resolver_calls);
         let resolver = move || -> Result<DaemonEndpoint, String> {
-            Ok(resolver_state_for_resolver.lock().unwrap().clone())
+            let snapshot = resolver_state_for_resolver.lock().unwrap().clone();
+            resolver_calls_for_resolver.fetch_add(1, Ordering::SeqCst);
+            Ok(snapshot)
         };
 
         let received: Arc<Mutex<Vec<(String, serde_json::Value)>>> =
@@ -572,20 +589,41 @@ mod tests {
             },
         );
 
-        // Give the subscriber time to attempt at least one stale
-        // connect. The handshake will be rejected because the token
-        // doesn't match.
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        // Sanity check: nothing has been received yet — the session
-        // never reached a Subscribe Ack because the handshake failed.
+        // Wait for the subscriber thread to call the resolver at least
+        // twice while the stale token is still installed. Two calls
+        // proves the regression path actually fired:
+        //
+        // 1. First call: subscriber reads stale endpoint, attempts
+        //    connect, handshake is rejected by the daemon.
+        // 2. run_session returns Err, run_loop sleeps with backoff,
+        //    then enters the next iteration which calls resolver
+        //    again — the second call confirms the reconnect path was
+        //    actually exercised, not just the initial spawn.
+        //
+        // Up to 5 s slack covers slow CI runners; the steady-state
+        // first-connect attempt typically lands within a few ms after
+        // `wait_for_socket` returns.
+        let mut stale_sessions_observed = false;
+        for _ in 0..500 {
+            if resolver_calls.load(Ordering::SeqCst) >= 2 {
+                stale_sessions_observed = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            stale_sessions_observed,
+            "subscriber never attempted a stale-token session — regression path not exercised"
+        );
         assert!(
             received.lock().unwrap().is_empty(),
             "stale token must not deliver events"
         );
 
         // Simulate the daemon-restart endpoint refresh: rewrite the
-        // resolver's cache to the live token. The next reconnect
-        // attempt should now succeed.
+        // resolver's cache to the live token. The next resolver call
+        // (driven by run_loop's reconnect-on-error path) should now
+        // observe the rotated value and succeed.
         *resolver_state.lock().unwrap() = live_endpoint.clone();
 
         // Publish a marker event. The publish loop spins until the


### PR DESCRIPTION
## Summary

Strengthens the `subscriber_resolver_picks_up_new_token_between_sessions` regression test from PR #2305 to address a codex P2 finding. The test now waits for an observable resolver-call counter signal instead of a fixed wall-clock sleep before flipping the resolver state, guaranteeing the regression path (stale-token rejection → reconnect → rotated-token success) actually fires on every CI run.

## Changes

- `crates/gwt/src/daemon_subscriber.rs`: instrument the test resolver with `AtomicUsize` call counter; replace `sleep(300ms)` with a poll loop that waits until `resolver_calls >= 2` before mutating `resolver_state` to the live token.

## Why

Codex flagged on PR #2305:

> This test rotates `resolver_state` after a fixed 300 ms delay, but it never verifies that the subscriber actually attempted (and failed) a stale-token session first. On a slow or contended CI runner, the subscriber thread can start late enough that its first resolver read happens *after* the token flip, which lets the test pass without exercising the regression path it is meant to lock in.

The original test had this race:

| Timeline | Sequence |
|---|---|
| Fast runner | spawn → resolver() reads stale → connect → handshake rejected → run_session Err → backoff → resolver() reads live → connect succeeds |
| Slow runner | spawn → ⏸ thread not scheduled yet → 300ms wall-clock elapses → flip → resolver() reads live (skipping stale path) → connect succeeds |

Both end with the assertion passing, but only the first actually exercises the regression-fix code path. Codex's recommendation: "gate the flip on an observable stale-attempt signal."

The new gate requires `resolver_calls >= 2` before flipping. Two calls proves:

1. Subscriber read the stale endpoint and the daemon rejected its handshake (run_session returned Err).
2. run_loop's reconnect-on-error path fired (resolver was called again for the next session).

This eliminates the timing race and locks in the actual SPEC-2077 spawn_with_resolver contract Codex P1 fix from PR #2298.

## Testing

- [x] `cargo test -p gwt --lib subscriber_resolver_picks_up_new_token_between_sessions` — 3 sequential runs all pass
- [x] `cargo test -p gwt --lib daemon` — 36/36 pass
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Closing Issues

None — addresses codex P2 finding from PR #2305 review.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- PR #2305 — original regression test (merged)
- Codex review thread on #2305 (unresolved when this PR opens)

## Checklist

- [x] Test-only change addressing reviewer P2 feedback
- [x] No production code change
- [x] Stress-tested 3 sequential runs
