### PR TITLE
chore(deps): update rand 0.9.2 → 0.9.4 to fix RUSTSEC-2026-0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,9 +2948,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -3663,7 +3663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",


### PR DESCRIPTION
## Summary

Updates `rand` from 0.9.2 to 0.9.4 to clear Dependabot alert #54 (RUSTSEC-2026-0097, GHSA-cq8v-f236-94qc, low severity).

## Changes

- `Cargo.lock`: `rand 0.9.2 → 0.9.4`. Cargo also bumped `tempfile`'s transitive `getrandom` from 0.3.4 to 0.4.2 to satisfy resolver constraints; both versions still coexist for crates that don't need 0.4.x.

No source-code changes — `rand` is a transitive dep via `axum → tokio-tungstenite → tungstenite`.

## Why

GHSA-cq8v-f236-94qc reports unsoundness in `rand 0.9.0 .. 0.9.3` when ALL of:

- the `log` and `thread_rng` features are enabled
- a custom logger is installed
- the custom logger calls `rand::rng()` and uses `TryRng` methods on `ThreadRng`
- `ThreadRng` reseeds while called from inside the custom logger

We don't trigger that path — no custom logger calls `rand::rng()` from inside log emission — but the patch is in-range, the upgrade is mechanical, and clearing the alert keeps the GitHub security tab clean.

Vulnerable range: `>= 0.9.0, < 0.9.3`. Fixed in 0.9.3. We're going to 0.9.4 because that's the latest 0.9.x cargo could resolve.

## What about alert #29 (glib)?

GHSA on `glib::VariantStrIter` (medium, unsound `Iterator` / `DoubleEndedIterator` impls), vulnerable range `>= 0.15.0, < 0.20.0`. We pull `glib 0.18.5` transitively via `gtk → wry / tao / webkit2gtk` (Linux GUI stack). Resolution requires the upstream gtk-rs ecosystem to bump to `glib 0.20+`, which our wry 0.55 / tao 0.35 (both already at the latest tag) don't yet support. We don't use `VariantStrIter` directly, so the unsoundness is not reachable from our code paths. Will reassess when wry/tao update their `glib` constraint.

## Testing

- [x] `cargo test -p gwt -p gwt-core` — all groups pass (377 + 186 + others)
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build -p gwt` — clean

## Closing Issues

None — addresses Dependabot alert #54.

## Related Issues / Links

- RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc (rand unsoundness)
- Dependabot alert: https://github.com/akiojin/gwt/security/dependabot/54

## Checklist

- [x] Lockfile-only change (no source code touched)
- [x] Test suite passes
- [x] Clippy + fmt clean
- [x] Documented why the parallel glib alert is not actionable
