### PR TITLE
docs(readme): describe per-project runtime daemon and gwtd daemon status

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -77,10 +77,18 @@ gwtd issue spec 1784 --section plan
 gwtd pr current
 gwtd board show
 gwtd hook workflow-policy
+gwtd daemon status            # プロジェクトごとの runtime daemon を確認
 ```
 
-managed hook と runtime 委譲は `gwtd` を使います。利用者が別の daemon
-プロセスを手動起動する必要はありません。
+managed hook と runtime 委譲は `gwtd` を使います。最初の `gwt` 実行や GUI
+起動時に、プロジェクトごとの runtime daemon が自動で立ち上がり、同じ
+リポジトリに繋がっている全 `gwt` インスタンスへイベントを fan-out
+します（例: 片方のウィンドウで Board に投稿した内容が、同じリポジトリの
+別インスタンスにも遅延なく届く）。GUI を閉じた後も daemon はバック
+グラウンドで動き続け、同じプロジェクトで次に `gwt` を起動した際は
+そのまま再利用されます。クラッシュ等で残った stale エントリは次回
+起動時に自動でクリーンアップされます。診断用に `gwtd daemon status`
+で現在の endpoint を確認できます。
 
 ## 基本フロー
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,18 @@ gwtd issue spec 1784 --section plan
 gwtd pr current
 gwtd board show
 gwtd hook workflow-policy
+gwtd daemon status            # inspect the per-project runtime daemon
 ```
 
-Managed hooks and runtime delegation use `gwtd`. There is no separate daemon
-process to start by hand.
+Managed hooks and runtime delegation use `gwtd`. The first `gwt` command
+or GUI launch auto-bootstraps a per-project runtime daemon so events can
+fan out to every `gwt` instance attached to the same project (e.g. Board
+posts you make in one window appear in another instance opened on the
+same repo without a polling delay). The daemon keeps running in the
+background after you close the GUI; subsequent `gwt` invocations on the
+same project reuse it, and a stale entry from a crashed daemon is
+cleaned up automatically on the next launch. `gwtd daemon status`
+prints the live endpoint for diagnostics.
 
 ## Main Workflow
 


### PR DESCRIPTION
## Summary

Updates README.md and README.ja.md to accurately describe the per-project runtime daemon shipped by SPEC-2077 Phase H1. The previous wording ("no separate daemon process to start by hand") was correct before H1 but now incomplete — there *is* a daemon, users just don't start it manually.

## Changes

- `README.md`: 6-line replacement plus add `gwtd daemon status` to the CLI subcommand example.
- `README.ja.md`: equivalent JA update mirroring the EN structure.

## Why

Phase H1 (SPEC-2077, PRs #2278–#2300) introduced:

1. A per-project `gwtd daemon` that auto-bootstraps on first `gwt` invocation
2. Unix-socket IPC with handshake + typed frame schema
3. Multi-instance broadcast on the `board` channel (Board projection changes flow to all `gwt` instances on the same repo)
4. `gwtd daemon status` for diagnostics

None of that was visible in the README. Users running multiple `gwt` instances on the same project now see Board posts propagate without polling, and they may notice a `gwtd` process in their process list — the README should explain it.

The wording was verified against the actual code paths:

- `crates/gwt-core/src/daemon.rs::resolve_bootstrap_action` — Reuse if the persisted endpoint's PID is alive, else clean up the stale file and Spawn fresh.
- `crates/gwt/src/cli/daemon/server.rs::run_server` — runs until SIGTERM/SIGINT; does not auto-shutdown when connections drop to zero. README accordingly says "keeps running in the background after you close the GUI" rather than "shuts down when no instance is using it" (the second draft I wrote and rejected after re-reading the code).

## Testing

- [x] `npx markdownlint-cli2 README.md README.ja.md` — 0 errors
- [x] `cargo test -p gwt -p gwt-core` — unaffected (docs-only change)

## Closing Issues

None — docs.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- Phase H1 PRs #2278–#2300 (board projection daemon broadcast)

## Checklist

- [x] EN and JA versions kept structurally equivalent
- [x] Wording verified against actual code (no false claims about auto-shutdown)
- [x] markdownlint clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced daemon documentation with detailed operational procedures, including automatic per-project daemon startup and bootstrapping, background operation with reuse across invocations, automatic stale entry cleanup, and live endpoint status monitoring via `gwtd daemon status`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->