### PR TITLE
docs(readme): scope runtime daemon description to macOS/Linux (codex P2 follow-up)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -80,15 +80,22 @@ gwtd hook workflow-policy
 gwtd daemon status            # プロジェクトごとの runtime daemon を確認
 ```
 
-managed hook と runtime 委譲は `gwtd` を使います。最初の `gwt` 実行や GUI
-起動時に、プロジェクトごとの runtime daemon が自動で立ち上がり、同じ
-リポジトリに繋がっている全 `gwt` インスタンスへイベントを fan-out
-します（例: 片方のウィンドウで Board に投稿した内容が、同じリポジトリの
+managed hook と runtime 委譲は `gwtd` を使います。macOS と Linux では、
+最初の `gwt` 実行や GUI 起動時にプロジェクトごとの runtime daemon
+（Unix ドメインソケット IPC）が自動で立ち上がり、同じリポジトリに
+繋がっている全 `gwt` インスタンスへイベントを fan-out します
+（例: 片方のウィンドウで Board に投稿した内容が、同じリポジトリの
 別インスタンスにも遅延なく届く）。GUI を閉じた後も daemon はバック
 グラウンドで動き続け、同じプロジェクトで次に `gwt` を起動した際は
 そのまま再利用されます。クラッシュ等で残った stale エントリは次回
 起動時に自動でクリーンアップされます。診断用に `gwtd daemon status`
 で現在の endpoint を確認できます。
+
+Windows では現状 long-running daemon は提供されておらず、
+`gwtd daemon start` は "not yet implemented" で終了します。managed
+hook は同期的な `gwt hook ...` dispatch にフォールバックし、複数
+インスタンス間のイベント fan-out と `gwtd daemon status` は
+Windows 対応が完了するまで利用できません。
 
 ## 基本フロー
 

--- a/README.md
+++ b/README.md
@@ -81,15 +81,22 @@ gwtd hook workflow-policy
 gwtd daemon status            # inspect the per-project runtime daemon
 ```
 
-Managed hooks and runtime delegation use `gwtd`. The first `gwt` command
-or GUI launch auto-bootstraps a per-project runtime daemon so events can
-fan out to every `gwt` instance attached to the same project (e.g. Board
-posts you make in one window appear in another instance opened on the
-same repo without a polling delay). The daemon keeps running in the
+Managed hooks and runtime delegation use `gwtd`. On macOS and Linux,
+the first `gwt` command or GUI launch auto-bootstraps a per-project
+runtime daemon (Unix-domain socket IPC) so events can fan out to every
+`gwt` instance attached to the same project — for example, Board posts
+you make in one window appear in another instance opened on the same
+repo without a polling delay. The daemon keeps running in the
 background after you close the GUI; subsequent `gwt` invocations on the
 same project reuse it, and a stale entry from a crashed daemon is
 cleaned up automatically on the next launch. `gwtd daemon status`
 prints the live endpoint for diagnostics.
+
+Windows currently has no long-running daemon: `gwtd daemon start`
+exits with "not yet implemented", and managed hooks fall back to
+synchronous `gwt hook ...` dispatch. Multi-instance fan-out and
+`gwtd daemon status` are unavailable on Windows pending follow-up
+work.
 
 ## Main Workflow
 


### PR DESCRIPTION
## Summary

Follow-up to PR #2310. Codex flagged that the daemon description in README applied unconditionally, but the daemon path is `#[cfg(unix)]` only — on Windows `gwtd daemon start` returns "not yet implemented" and managed hooks fall back to synchronous `gwt hook ...` dispatch. Adds a Windows-specific note so the README does not mislead Windows users.

## Changes

- `README.md`: qualify the daemon paragraph with "On macOS and Linux" and add a follow-up paragraph describing the Windows fallback.
- `README.ja.md`: equivalent JA update.

## Why

Codex review on PR #2310:

> This paragraph states unconditionally that `gwt` auto-bootstraps and reuses a background runtime daemon, but the daemon server path is compiled only on Unix and non-Unix `gwtd daemon start` returns "not yet implemented" (`crates/gwt/src/cli/daemon/mod.rs` lines 319-325). On Windows, readers of this README section will expect fan-out/background-daemon behavior that is unavailable, so the text should be scoped to Unix/POSIX (or note the platform limitation) to avoid incorrect operational guidance.

Verified against `crates/gwt/src/cli/daemon/mod.rs:319-325`:

```rust
#[cfg(not(unix))]
fn start_daemon<E: CliEnv>(_env: &mut E, out: &mut String) -> Result<i32, SpecOpsError> {
    out.push_str(
        "gwtd daemon start: long-running daemon mode is not yet implemented on this platform; \
         use `gwt hook ...` synchronous dispatch.\n",
    );
    Ok(2)
}
```

## Testing

- [x] `npx markdownlint-cli2 README.md README.ja.md` — 0 errors

## Closing Issues

None — addresses codex P2 finding from PR #2310 review.

## Related Issues / Links

- PR #2310 — original docs PR
- SPEC-2077 (#2077) — Runtime Daemon

## Checklist

- [x] EN and JA versions kept structurally equivalent
- [x] markdownlint clean
- [x] No source-code change
