### PR TITLE
fix(deny): restore unknown-git source denial (codex P2 follow-up)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,5 +52,5 @@ ignore = [
 
 [sources]
 unknown-registry = "deny"
-unknown-git = "allow"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Follow-up to PR #2314. Codex flagged that the cargo-deny migration loosened `unknown-git` from `"deny"` to `"allow"` in `[sources]`, weakening the source policy. Reviewer was correct — I changed it without verifying we actually use any Git-sourced deps. We don't. Restoring the strict denial.

## Changes

- `deny.toml`: `unknown-git = "allow"` → `unknown-git = "deny"` (1 line).

## Why

Codex review on PR #2314:

> Setting `unknown-git` to `"allow"` weakens the source policy and lets `cargo deny check sources` pass even when a new dependency is pulled from an unapproved Git repository. This is a security regression compared to the previous config (`"deny"`), because an accidental or malicious Git-sourced crate would no longer be flagged during dependency audits.

Verified the workspace has zero Git dependencies:

```
$ grep -E "git\s*=|source\s*=" Cargo.toml crates/*/Cargo.toml
Cargo.toml:gwt-git = { path = "crates/gwt-git" }
Cargo.toml:winresource = "0.1.31"
```

(Only one match contains the substring `git`, and it's the `gwt-git` workspace-internal crate using `path =`, not `git =`.) So `unknown-git = "deny"` costs us nothing today and keeps the regression safety net: if anyone adds an accidental or malicious Git-source dep, `cargo deny check sources` will fail at PR time.

This is the same anti-pattern called out in `tasks/lessons.md` "Verify claims against actual code path" — I should have grep'd the workspace for Git deps before flipping the policy.

## Testing

- [x] `cargo deny check sources` — `sources ok`
- [x] `cargo deny check advisories` — `advisories ok`

## Closing Issues

None — addresses codex P2 finding from PR #2314 review.

## Related Issues / Links

- PR #2314 — original cargo-deny schema migration

## Checklist

- [x] One-line config change
- [x] Verified by grep that no Git deps exist in the workspace
- [x] No source code change
