### PR TITLE
ci(lint): add cargo deny advisories + sources job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,18 @@ on:
     branches: [develop, main]
 
 jobs:
+  audit:
+    name: Cargo Deny (advisories + sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.19.4
+      - name: Run cargo deny (advisories + sources)
+        run: cargo deny check advisories sources
   lint:
     name: Clippy & Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds `cargo deny check advisories sources` to the Lint workflow. After PRs #2314 / #2315 fixed `deny.toml` to parse on cargo-deny 0.19+, local `cargo deny check` exits clean — wiring it into CI catches new RUSTSEC advisories (or unapproved Git-sourced deps) at PR time instead of waiting for Dependabot's post-merge scan.

## Changes

- `.github/workflows/lint.yml`: prepended a new `audit` job (12 lines) that:
  1. Checks out the repo
  2. Installs Rust stable
  3. Installs `cargo-deny@0.19.4` via `taiki-e/install-action` (prebuilt binary, ~5 s vs ~45 s for `cargo install`)
  4. Runs `cargo deny check advisories sources`

## Why

The 12 currently-detected advisories (11 × gtk-rs ecosystem unmaintained + RUSTSEC-2024-0429 glib unsoundness) are explicitly allowlisted in `deny.toml`'s `[advisories].ignore` with documented exit paths (wry/tao bumping to gtk-rs 0.20+). Today this CI step is green and will stay green until:

- A new RUSTSEC advisory hits a dependency we use → CI fails at PR time, forcing a conscious decision (update, ignore with reason, or revert the dep change).
- A new Git-sourced dep is introduced → `unknown-git = "deny"` blocks it.

This closes the gap between Dependabot (post-merge, slower feedback) and the developer's local environment (which now has a working `cargo deny`).

## Why scope-limited

The job runs `advisories sources` only. `licenses` and `bans` are intentionally unconfigured in `deny.toml` because:

- License allowlist needs explicit enumeration of every license the dependency graph actually contains. The historical config was missing `bzip2-1.0.6`, `CDLA-Permissive-2.0`, `Unicode-3.0`, `MPL-2.0`, etc.
- The bans table flagged every `dep.workspace = true` reference as a wildcard due to a known cargo-deny resolution issue with workspace deps.

Both can land in follow-ups after owner review (see `deny.toml` header comment for context).

## Why a separate job

Rather than a step inside `lint`, the new `audit` job:

- Lets failures attribute cleanly (no need to scroll past 30 lines of clippy output to see why audit failed)
- Runs in parallel with the existing lint job, so total wall time doesn't grow
- Keeps the lint job's current 4-5 minute budget intact

## Testing

- [x] `cargo deny check advisories sources` locally — exits clean
- [x] Workflow YAML parses (verified by GitHub Actions on push)
- [ ] First green run on this PR (visible in CI checks)

## Closing Issues

None — CI hardening.

## Related Issues / Links

- PR #2314 — deny.toml schema migration (made this possible)
- PR #2315 — restored `unknown-git = "deny"` (codex P2 follow-up)
- PR #2309 — rand 0.9.4 security update

## Checklist

- [x] Pinned cargo-deny version for deterministic parsing
- [x] Single-job addition; no change to existing lint behavior
- [x] No source code change; workflow-only
