### PR TITLE
docs(daemon): refresh module docstrings to reflect Phase H1 ship

### DIFF
--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -8,10 +8,12 @@
 //! to fan a single payload out to all subscribers.
 //!
 //! The hub is intentionally small: one mutex around a `HashMap<String,
-//! broadcast::Sender<DaemonFrame>>`. Phase H1 will graft the actual
-//! handler-to-publish wiring; this module ships the storage primitive
-//! plus tests so future PRs can layer real ownership migrations on top
-//! without re-deriving the synchronization boundary.
+//! broadcast::Sender<DaemonFrame>>`. Phase H1 wired the Board
+//! projection writer through `daemon_publisher::publish_event` to
+//! `BroadcastHub::publish("board", ...)`. Phase H2-H4 will layer
+//! `runtime-output` / `runtime-status` / `runtime-hook` /
+//! `launch-complete` channels onto the same primitive without
+//! re-deriving the synchronization boundary.
 
 #![cfg(unix)]
 

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -11,12 +11,16 @@
 //!    [`validate_handshake`].
 //! 3. Write the matching [`IpcHandshakeResponse`] line.
 //! 4. While the connection stays open, accept newline-delimited JSON
-//!    payloads (today: log + ack; later phases route hook envelopes).
+//!    payloads (today: hook envelopes log + ack, board publish/subscribe
+//!    fans out via the broadcast hub, status returns daemon snapshot).
 //!
-//! Hook envelope routing is intentionally out of scope for this PR — the
-//! purpose here is to stand up the daemon process and make `gwt -> gwtd`
-//! IPC end-to-end provable. Phase H1〜H4 will graft handler logic onto
-//! the per-connection loop.
+//! Phase H1 (board projection daemon broadcast) is shipped. Hook
+//! envelope routing into real GUI-side handlers is still on the
+//! per-connection loop's TODO — Phase H2/H3/H4 will graft
+//! `handle_runtime_output` / `handle_runtime_status` /
+//! `handle_runtime_hook_event` / `handle_launch_complete` /
+//! `handle_shell_launch_complete` ownership across the IPC boundary
+//! (see SPEC-2077 plan.md Phase H1-H4).
 
 #![cfg(unix)]
 
@@ -279,9 +283,12 @@ async fn handle_connection(
         }
         match serde_json::from_str::<ClientFrame>(trimmed) {
             Ok(ClientFrame::Hook(envelope)) => {
-                // Phase H1〜H4 will route hook envelopes into real handlers;
-                // for now we just ack so the client side knows the daemon
-                // received the frame.
+                // Hook envelope routing into real GUI-side handlers is
+                // gated on Phase H3 (handle_runtime_hook_event daemon
+                // migration). Until then we ack so the client side knows
+                // the daemon received the frame, and the existing
+                // synchronous `gwt hook ...` dispatch path remains the
+                // outward-facing fallback.
                 tracing::debug!(
                     target: "gwtd::daemon",
                     hook = %envelope.hook_name,


### PR DESCRIPTION
## Summary

Refreshes the daemon module docstrings to reflect Phase H1's actual shipped state. The previous comments described handler routing as future work, but Phase H1 (board projection daemon broadcast) shipped via PRs #2278–#2300 + this session's hardening. Pure docstring change — no behavior change.

## Changes

- `crates/gwt/src/cli/daemon/server.rs`:
  - Module docstring (line 14–19) — previously said the per-connection loop did "log + ack" with hook routing "out of scope for this PR". Updated to describe the actual current behavior: hook envelopes log + ack, board publish/subscribe fans out via BroadcastHub, status returns daemon snapshot. Phase H1 marked shipped; H2/H3/H4 named explicitly with the remaining handlers (`handle_runtime_output` / `handle_runtime_status` / `handle_runtime_hook_event` / `handle_launch_complete` / `handle_shell_launch_complete`).
  - Hook arm comment (line 282) — changed "Phase H1〜H4 will route" (over-broad) to "Phase H3 will route" (hook handler is specifically H3's scope per SPEC-2077 plan.md; H2 and H4 don't touch this arm).
- `crates/gwt/src/cli/daemon/broadcast.rs`:
  - Module docstring (line 11–14) — changed "Phase H1 will graft the actual handler-to-publish wiring" (now past-tense) to describe H1 as completed and H2-H4 as future channel additions on the same `BroadcastHub` primitive.

## Why

The codex feedback pattern from earlier this session (PR #2310 / #2311 / #2312 / #2315 — "verify claim against actual code path") applies to docstrings just as much as user-facing docs. Future contributors reading these comments would be misled into thinking H1 is still TODO, which would frame their reading of the code in stale terms. Refreshing now keeps `tasks/lessons.md` rule #4 (pre-review self-check) honest for the next reader.

## Testing

- [x] `cargo test -p gwt --lib daemon` — 36/36 pass
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Closing Issues

None — docstring drift cleanup.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- Phase H1 PRs #2278–#2300 (board projection daemon broadcast)
- This session's hardening: #2305–#2316

## Checklist

- [x] No behavior change (docstring only)
- [x] Daemon test suite still green
