### PR TITLE
refactor(daemon): remove unused read_ack and refresh client.rs module docstring

### DIFF
--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -10,12 +10,18 @@
 //! 2. Read one newline-delimited [`IpcHandshakeResponse`] line.
 //! 3. Validate using [`validate_handshake`]; bail if the daemon
 //!    rejected the handshake or reported a protocol mismatch.
-//! 4. After handshake, [`DaemonClient::send_frame`] writes a JSON line
-//!    and [`DaemonClient::read_ack`] reads the daemon's ack line.
+//! 4. After handshake, [`DaemonClient::send_frame`] writes a typed
+//!    `ClientFrame` JSON line and [`DaemonClient::read_frame`]
+//!    deserializes the daemon's response (`DaemonFrame::Ack` /
+//!    `Event` / `Error` / `Status`).
 //!
-//! Phase H1〜H4 will graft hook-envelope routing onto the post-handshake
-//! frame loop. For Phase 2 the client only needs to *prove* end-to-end
-//! IPC works so future phases can route real payloads through it.
+//! Phase H1 (board projection daemon broadcast) uses this client
+//! through [`crate::daemon_publisher::publish_event`] and
+//! [`crate::daemon_subscriber::DaemonSubscriber`]. Phase H2-H4 will
+//! reuse the same primitives for runtime status / hook events /
+//! launch lifecycle without changing this module's surface — the
+//! typed frame schema is already extensible via new
+//! `ClientFrame` / `DaemonFrame` variants.
 
 #![cfg(unix)]
 
@@ -74,16 +80,9 @@ impl DaemonClient {
         write_json_line(&mut self.writer, value).await
     }
 
-    /// Read the daemon's ack frame as a generic JSON value. Phase H
-    /// callers will replace this with typed responses keyed off
-    /// [`gwt_core::daemon::HookEnvelope`] result types.
-    pub async fn read_ack(&mut self) -> Result<serde_json::Value, String> {
-        read_json_line(&mut self.reader)
-            .await?
-            .ok_or_else(|| "daemon closed connection while awaiting ack".to_string())
-    }
-
-    /// Convenience: read a typed JSON frame from the daemon.
+    /// Read a typed JSON frame from the daemon. The caller picks the
+    /// concrete `T` (typically `DaemonFrame`) so the deserializer
+    /// validates the wire shape against the protocol enum.
     pub async fn read_frame<T: serde::de::DeserializeOwned>(&mut self) -> Result<T, String> {
         read_json_line(&mut self.reader)
             .await?


### PR DESCRIPTION
## Summary

Two-pronged Phase H1 cleanup in `crates/gwt/src/cli/daemon/client.rs`: refresh the module docstring (shipped state) and remove `read_ack`, an unused legacy method that the typed `read_frame::<DaemonFrame>()` superseded. Pure refactor — no behavior change for any current caller.

## Changes

- Module docstring (line 16-18) — previously said "Phase H1〜H4 will graft hook-envelope routing onto the post-handshake frame loop" and that the client "only needs to prove end-to-end IPC works so future phases can route real payloads." Both predicates are stale post-Phase H1 (board projection ships through `daemon_publisher::publish_event` / `daemon_subscriber::DaemonSubscriber` today). Updated to describe the actual primitives in use and frame H2-H4 as additive (new `ClientFrame` / `DaemonFrame` variants, no surface reshape).

- `pub async fn read_ack(&mut self) -> Result<serde_json::Value, String>` (line 86) — the original untyped ack reader. Its own docstring said "Phase H callers will replace this with typed responses keyed off `HookEnvelope` result types" — that replacement happened, and `grep -rn "read_ack" crates` workspace-wide shows zero call sites. The typed `read_frame::<T>()` on the same impl is what every caller uses (`DaemonClient::read_frame::<DaemonFrame>()`). Removed.

## Why

Same anti-pattern lesson from PR #2313 / `tasks/lessons.md` rule 4: "Pre-review self-check: enumerate every claim, find the falsifying code path." The docstring promised future replacement of `read_ack`, that replacement happened, and the dead method became confusing scaffolding. Future readers tracing daemon IPC would see two ways to read a response and waste cycles deciding which is canonical.

## Testing

- [x] `cargo build -p gwt` — clean
- [x] `cargo test -p gwt --lib` — 377/377 pass across 3 consecutive runs (no flake)
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `grep -rn "read_ack" crates` — confirmed no call sites before removal

## Closing Issues

None — refactor / docstring drift cleanup.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- PR #2317 — sibling docstring refresh in server.rs / broadcast.rs
- PR #2313 — verify-claims-against-code lesson

## Checklist

- [x] No behavior change (legacy unused method removal + docstring)
- [x] All workspace lints clean
- [x] Verified read_ack has zero call sites before removal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated daemon communication documentation to describe typed message frame handling.

* **Refactor**
  * Replaced generic JSON message responses in daemon client with strongly-typed protocol variants, enabling clearer error handling and more reliable detection of daemon responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->