### PR TITLE
docs(daemon-contract): refresh DaemonFrame::Event comment post Phase H1 ship

### DIFF
--- a/crates/gwt-core/src/daemon.rs
+++ b/crates/gwt-core/src/daemon.rs
@@ -208,8 +208,10 @@ pub enum ClientFrame {
 ///
 /// Wire format is newline-delimited JSON. `Ack` is the canonical reply for
 /// a successfully processed [`ClientFrame`]; `Event` carries a daemon
-/// broadcast payload (used once Phase H1+ runtime ownership migrations
-/// land); `Error` represents a frame that the daemon rejected.
+/// broadcast payload (Phase H1 ships board projection events; H2-H4
+/// will add runtime status / hook events / launch lifecycle on the
+/// same variant); `Error` represents a frame that the daemon rejected;
+/// `Status` returns the snapshot requested via [`ClientFrame::Status`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum DaemonFrame {


### PR DESCRIPTION
## Summary

Tiny docstring refresh: `DaemonFrame::Event`'s doc comment in `crates/gwt-core/src/daemon.rs:211` said the variant is "used once Phase H1+ runtime ownership migrations land" — past-tense now that Phase H1 has shipped board projection broadcasts. Updated to describe the actual current usage and frame H2-H4 as additive.

## Changes

- `crates/gwt-core/src/daemon.rs`: 4 line replacement in the `DaemonFrame` enum docstring (line 207-213). Now reads:
  > `Event` carries a daemon broadcast payload (Phase H1 ships board projection events; H2-H4 will add runtime status / hook events / launch lifecycle on the same variant); ... `Status` returns the snapshot requested via `ClientFrame::Status`.

## Why

Same docstring drift pattern as PR #2317 / #2318 — the comment was written when Phase H1 was still TODO and wasn't refreshed when H1 shipped. The previous wording would mislead a reader into thinking `DaemonFrame::Event` is unused dead code, when it's actively delivering board events to subscribers via `BroadcastHub`. Future contributors reading the contract layer to understand the wire schema deserve an accurate description of what each variant carries today.

The new wording also adds a sentence about `DaemonFrame::Status`, which the original comment didn't cover at all (Status was added at the same time as Event but the docstring only mentioned three of the four variants).

## Testing

- [x] `cargo test -p gwt-core` — 178 lib + 8 integration pass
- [x] `cargo clippy -p gwt-core --all-targets -- -D warnings` — clean

## Closing Issues

None — docstring drift cleanup.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- PR #2317 — sibling docstring refresh in server.rs / broadcast.rs
- PR #2318 — sibling cleanup in client.rs

## Checklist

- [x] No behavior change (4-line docstring tweak)
- [x] Verified the new wording matches the actual variant usage
- [x] gwt-core tests still green
