### PR TITLE
docs(daemon-publisher): correct default timeout from 2 s to 200 ms in module docstring

### DIFF
--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -17,8 +17,9 @@
 //!    `Ack`.
 //!
 //! Connect, publish, and ack are each bounded by `timeout` (default
-//! 2 s). On any error the caller should treat the publish as
-//! best-effort — the local store remains authoritative.
+//! 200 ms per stage, so the worst-case wall time is ~600 ms across
+//! the three stages). On any error the caller should treat the
+//! publish as best-effort — the local store remains authoritative.
 
 #![cfg(unix)]
 


### PR DESCRIPTION
## Summary

Fixes a real 10× documentation bug: `crates/gwt/src/daemon_publisher.rs` module docstring claimed the default timeout is "2 s" but the actual `DEFAULT_TIMEOUT` constant is `Duration::from_millis(200)` — 200 ms.

## Changes

- `crates/gwt/src/daemon_publisher.rs` (3 lines): module-level docstring now reads:

  > Connect, publish, and ack are each bounded by `timeout` (default 200 ms per stage, so the worst-case wall time is ~600 ms across the three stages). On any error the caller should treat the publish as best-effort — the local store remains authoritative.

  Previously read "default 2 s" with no worst-case computation.

## Why

The drift matters for operational reasoning. A reader debugging a stalled GUI hot-path publish (`app_runtime/board.rs::publish_board_change`) would budget ~6 s of worst-case wall time (3 stages × 2 s) when the actual ceiling is ~600 ms (3 stages × 200 ms). Same class of docstring-vs-code drift as PRs #2317-#2319; would've been caught by `tasks/lessons.md` rule 4 ("enumerate every claim, find the falsifying code path") via a grep for `DEFAULT_TIMEOUT`.

The narrower per-stage docstring on `DEFAULT_TIMEOUT` (line 38-46) already correctly says "200 ms is generous for a local Unix-socket round-trip" — only the high-level module summary had drifted.

## Testing

- [x] `cargo test -p gwt --lib daemon_publisher` — 1/1 pass
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean

## Closing Issues

None — docstring drift cleanup.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon
- PR #2313 — verify-claims-against-code lesson
- PR #2317/#2318/#2319 — sibling docstring refresh / cleanup PRs in the daemon area

## Checklist

- [x] No behavior change (docstring only)
- [x] Verified actual timeout value via grep before fixing
- [x] Worst-case wall time stated explicitly to spare future readers the recomputation
