### PR TITLE
refactor(docker): remove unused DevContainerLaunchDefaults::compose_file field

### DIFF
--- a/crates/gwt/src/docker_launch.rs
+++ b/crates/gwt/src/docker_launch.rs
@@ -65,8 +65,6 @@ pub(crate) struct DevContainerLaunchDefaults {
     pub(crate) service: Option<String>,
     pub(crate) workspace_folder: Option<String>,
     pub(crate) compose_files: Vec<PathBuf>,
-    #[allow(dead_code)]
-    pub(crate) compose_file: Option<PathBuf>,
 }
 
 impl DockerLaunchPlan {
@@ -676,7 +674,6 @@ pub(crate) fn docker_devcontainer_defaults(
     Some(DevContainerLaunchDefaults {
         service: config.service,
         workspace_folder: config.workspace_folder,
-        compose_file: compose_files.first().cloned(),
         compose_files,
     })
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3527,13 +3527,6 @@ mod tests {
             defaults.workspace_folder.as_deref(),
             Some("/workspaces/repo")
         );
-        assert!(super::same_worktree_path(
-            defaults
-                .compose_file
-                .as_deref()
-                .expect("compose file from defaults"),
-            &compose_file,
-        ));
         assert_eq!(defaults.compose_files.len(), 1);
         assert!(super::same_worktree_path(
             &defaults.compose_files[0],


### PR DESCRIPTION
## Summary

Removes the unused `DevContainerLaunchDefaults::compose_file: Option<PathBuf>` field. Declared `pub(crate)` with `#[allow(dead_code)]` and only ever written, never read in production. The only reader was a tautological test assertion (`defaults.compose_file == defaults.compose_files.first()` by construction).

## Changes

- `crates/gwt/src/docker_launch.rs`:
  - Removed `compose_file: Option<PathBuf>` field from `DevContainerLaunchDefaults` (3 lines)
  - Removed corresponding `compose_file: compose_files.first().cloned(),` initializer (1 line)
- `crates/gwt/src/main.rs`:
  - Removed the redundant test assertion that checked the now-removed convenience field against `compose_files.first()` (7 lines)

## Why

The field was added as a convenience but never consumed. Production callers of `docker_devcontainer_defaults` only access `.service` (line 24) and `.compose_files` (line 621). The lone test that touched `.compose_file` was checking that the convenience field matched the canonical list, which is true by construction (`compose_file: compose_files.first().cloned()`) — a tautology that would pass even if the field were always `None`.

Removing eliminates a `#[allow(dead_code)]` suppression and shrinks the struct's API surface.

Note that the similar-looking `gwt_docker::DockerFiles::compose_file` (referenced in `docker_launch.rs:624` via `files.compose_file.clone()`) is on a **different upstream struct** in the `gwt_docker` crate — that field is actively consumed and is not affected by this PR.

The other two `#[allow(dead_code)]` annotations in the codebase remain intentionally:

- `docker_compose_file_for_launch` (`docker_launch.rs:629`): only used in `#[cfg(test)]` blocks of `main.rs`. Marking it `#[cfg(test)]` would require a larger restructure since it's `pub(crate)`.
- `_layout_anchor` (`gwt-core/src/index/runtime.rs:261`): documented sentinel that "keeps this path in scope so tests can verify the layout matches" — intentionally retained.

## Testing

- [x] `cargo build -p gwt` — clean
- [x] `cargo test -p gwt --bin gwt` — 186/186 pass
- [x] `cargo test -p gwt --lib` — 377/377 pass
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Closing Issues

None — dead code cleanup.

## Related Issues / Links

- PR #2318 — sibling cleanup (removed unused `read_ack` from daemon client)
- PR #2313 — `tasks/lessons.md` "verify-claims-against-code" rule

## Checklist

- [x] No behavior change
- [x] All workspace lints clean
- [x] Verified no other callers via `grep -rn DevContainerLaunchDefaults` and `grep -rn '\.compose_file\b'`
- [x] Tautological test assertion removed alongside the field
