### PR TITLE
chore(deps): remove 6 unused [workspace.dependencies] entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ serde_yaml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "chrono"] }
 tracing-appender = "0.2"
-tracing-chrome = "0.7"
 
 # File locking
 fs2 = "0.4"
@@ -79,16 +78,11 @@ portable-pty = "0.9"
 
 # Testing
 tempfile = "3"
-insta = { version = "1", features = ["yaml"] }
-
-# Benchmarks
-criterion = { version = "0.8", features = ["html_reports"] }
 
 # Embedded assets
 include_dir = "0.7"
 
 # Utilities
-directories = "6"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
@@ -102,8 +96,7 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 # Windows executable resources
 winresource = "0.1.31"
 
-# WebSocket
-tokio-tungstenite = "0.28"
+# WebSocket-related
 futures-util = "0.3"
 
 # Base64 encoding
@@ -123,7 +116,6 @@ dunce = "1"
 
 # System information
 sysinfo = { version = "0.38", default-features = false, features = ["system"] }
-nvml-wrapper = "0.12"
 
 # File system watcher (gwt-spec issue)
 notify = "8"


### PR DESCRIPTION
## Summary

Removes 6 unused `[workspace.dependencies]` entries from the root `Cargo.toml`. These were declared at the workspace level but referenced by zero member crates — likely leftovers from earlier feature work that was refactored out without cleaning the workspace manifest.

## Changes

`Cargo.toml`:

```diff
-tracing-chrome = "0.7"
-insta = { version = "1", features = ["yaml"] }
-criterion = { version = "0.8", features = ["html_reports"] }
-directories = "6"
-tokio-tungstenite = "0.28"
-nvml-wrapper = "0.12"
```

## Why

Verified each is unused by:

```
$ grep -l '^<dep>' crates/*/Cargo.toml          # zero crate manifests opt in
$ grep -rln "<module_path>" crates --include='*.rs'  # zero source-file uses
```

`workspace.dependencies` entries are inert until a member crate opts in via `<dep>.workspace = true`, so removing them is a no-op for build behavior. But keeping them around:

- misleads future contributors into thinking these versions are intentionally pinned for the project
- shows up in security advisory paths even when no code uses them
- bloats `cargo info` and IDE dependency views

`Cargo.lock` is unchanged because the deps were never resolved into the actual dependency graph.

This is the workspace-level analogue of PR #2322 (per-crate unused deps).

## Testing

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --lib` — all groups pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `Cargo.lock` unchanged (verified by `git diff Cargo.lock` — empty)

## Closing Issues

None — workspace manifest cleanup.

## Related Issues / Links

- PR #2322 — per-crate unused dependency removal (gwt-terminal, gwt-github)

## Checklist

- [x] No behavior change (workspace deps were inert)
- [x] All workspace lints + tests + builds clean
- [x] Verified zero member opt-ins and zero source references for each removed entry
