### PR TITLE
fix(skills): correct .claude/.codex path cross-references in Codex skill mirrors

### DIFF
--- a/.codex/skills/gwt-fix-issue/SKILL.md
+++ b/.codex/skills/gwt-fix-issue/SKILL.md
@@ -33,7 +33,7 @@ Do not use this for new work intake. Use `gwt-register-issue` instead.
 ## Workflow
 
 1. Verify that `gwtd issue view` and `gwtd issue comments` can access the target issue.
-2. Gather facts with `gwtd issue view`, `gwtd issue comments`, linked PR inspection, and `python3 ".claude/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
+2. Gather facts with `gwtd issue view <number>`, `gwtd issue comments <number>`, `gwtd issue linked-prs <number>`, and `python3 ".codex/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
 3. Decide direct-fix vs spec-needed. Prefer direct fix for clear corrective work; prefer `gwt-discussion` when behavior design or broader scope definition is required.
 4. If the change is a clear direct fix, continue through `gwt-build-spec` and finish verification.
 5. Post progress and closure comments through `gwtd issue comment`.

--- a/.codex/skills/gwt-manage-pr/SKILL.md
+++ b/.codex/skills/gwt-manage-pr/SKILL.md
@@ -104,7 +104,7 @@ Create mode is entered from the Preflight 2×2 matrix when `N > 0`.
 
 ### PR Body Rules
 
-- Template: `.claude/skills/gwt-manage-pr/references/pr-body-template.md`
+- Template: `.codex/skills/gwt-manage-pr/references/pr-body-template.md`
 - Required sections: Summary, Changes, Testing, Closing Issues, Related Issues, Checklist
 - Conditional sections (remove if N/A): Context, Risk/Impact, Screenshots, Deployment
 - Remove all `<!-- GUIDE: ... -->` comments from final output

--- a/.codex/skills/gwt-manage-pr/references/create-flow.md
+++ b/.codex/skills/gwt-manage-pr/references/create-flow.md
@@ -62,7 +62,7 @@
 
 ## Step 8: Build PR body from template
 
-- Template path: `.claude/skills/gwt-manage-pr/references/pr-body-template.md`
+- Template path: `.codex/skills/gwt-manage-pr/references/pr-body-template.md`
 - Fill all required placeholders.
 - If a conditional section does not apply, remove the entire section.
 - Remove any `<!-- GUIDE: ... -->` comments from the final output.
@@ -116,7 +116,7 @@
 ```bash
 head=$(git rev-parse --abbrev-ref HEAD)
 base=develop
-PR_BODY_TEMPLATE=".claude/skills/gwt-manage-pr/references/pr-body-template.md"
+PR_BODY_TEMPLATE=".codex/skills/gwt-manage-pr/references/pr-body-template.md"
 
 base_compare_has_diff() {
   git diff --quiet "origin/$base...HEAD" -- 2>/dev/null


### PR DESCRIPTION
## Summary

Three executable references in `.codex/skills/` pointed to `.claude/skills/...` paths. For any Codex-only setup (no `.claude/` on disk), these references would fail. Each `.codex/` location has its own symmetric copy of the referenced asset, so the fix is to use the matching `.codex/` path. Also restored missing `<number>` argument placeholders on a Codex `gwtd issue` example that had drifted from the Claude version.

## Changes

- `.codex/skills/gwt-fix-issue/SKILL.md` Workflow step 2:
  - Restored `<number>` placeholders on `gwtd issue view` / `comments` / `linked-prs` (Claude version had them; Codex copy had drifted to vaguer wording that even substituted "linked PR inspection" for the actual command name)
  - Changed `python3 ".claude/skills/.../inspect_issue.py"` → `.codex/skills/.../inspect_issue.py`
- `.codex/skills/gwt-manage-pr/SKILL.md` line 107: PR body template path `.claude/...` → `.codex/...`
- `.codex/skills/gwt-manage-pr/references/create-flow.md`:
  - Line 65 (markdown text): same template path fix
  - Line 119 (`PR_BODY_TEMPLATE=` shell variable): same template path fix

## Why

The `.codex/` skill mirror is meant to be self-contained for Codex setups. Cross-referencing `.claude/skills/...` from a Codex skill assumes both trees are deployed, which isn't always true. Each referenced asset (the inspect_issue.py script, the pr-body-template.md) ships in both trees as byte-identical copies, so the fix is mechanical: each tree should reference its own copy.

The argument-placeholder drift on `gwt-fix-issue` step 2 was a separate sync gap — the Claude version shows the right invocation:

```
gwtd issue view <number>, gwtd issue comments <number>, gwtd issue linked-prs <number>
```

while the Codex version had degraded to:

```
gwtd issue view, gwtd issue comments, linked PR inspection
```

— the last fragment isn't even a command. Restored both correctness and parity.

## Why one reference left untouched

`.codex/skills/gwt-discussion/references/ddd-modeling.md:26` documents:

```
| Skills | `.claude/skills/` | Agent skill definitions |
```

This is descriptive documentation about where skills live in the repo (the `.claude/` tree IS the canonical source; `.codex/` is the mirror). Same line is byte-identical in `.claude/skills/...`. Not an executable path; left as-is.

## Testing

- [x] Verified both `.claude/skills/gwt-fix-issue/scripts/inspect_issue.py` and `.codex/skills/...` exist and are byte-identical (`diff` returns empty)
- [x] Verified both `.claude/skills/gwt-manage-pr/references/pr-body-template.md` and `.codex/skills/...` exist
- [x] No build or test impact (skill markdown only)

## Closing Issues

None — skill mirror correctness fix.

## Related Issues / Links

- AGENTS.md "Skill Authoring Language" — skill mirror parity expectation
- `.claude/skills` ↔ `.codex/skills` mirror invariant

## Checklist

- [x] All three Codex skill references corrected
- [x] Argument-placeholder drift fixed alongside the path drift
- [x] Documentation-only `.claude/` reference (ddd-modeling.md) left intentionally untouched with explanation
