### PR TITLE
refactor(*): convert 4 manual match blocks to let...else

### DIFF
--- a/crates/gwt-core/build.rs
+++ b/crates/gwt-core/build.rs
@@ -65,9 +65,8 @@ fn tracked_skill_markdowns(
 }
 
 fn scanned_skill_markdowns(skills_dir: &std::path::Path) -> Vec<PathBuf> {
-    let entries = match fs::read_dir(skills_dir) {
-        Ok(e) => e,
-        Err(_) => return Vec::new(),
+    let Ok(entries) = fs::read_dir(skills_dir) else {
+        return Vec::new();
     };
 
     entries

--- a/crates/gwt-core/src/logging/housekeep.rs
+++ b/crates/gwt-core/src/logging/housekeep.rs
@@ -54,9 +54,8 @@ pub fn housekeep_at(log_dir: &Path, retention_days: u32, today: NaiveDate) -> Ho
 
     for entry in entries.flatten() {
         let path = entry.path();
-        let file_name = match path.file_name().and_then(|s| s.to_str()) {
-            Some(name) => name,
-            None => continue,
+        let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
         };
         report.inspected += 1;
 

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -294,17 +294,14 @@ impl UpdateManager {
 
         match self.fetch_latest_release() {
             Ok(release) => {
-                let latest_ver = match parse_tag_version(&release.tag_name) {
-                    Some(v) => v,
-                    None => {
-                        return UpdateState::Failed {
-                            message: format!(
-                                "Failed to parse release tag as version: {}",
-                                release.tag_name
-                            ),
-                            failed_at: now,
-                        };
-                    }
+                let Some(latest_ver) = parse_tag_version(&release.tag_name) else {
+                    return UpdateState::Failed {
+                        message: format!(
+                            "Failed to parse release tag as version: {}",
+                            release.tag_name
+                        ),
+                        failed_at: now,
+                    };
                 };
 
                 let platform = Platform::detect();
@@ -1128,12 +1125,9 @@ fn find_extracted_binary(extract_dir: &Path, binary_name: &str) -> Result<Option
     // Fallback: deep search.
     let mut stack = vec![extract_dir.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let entries = match fs::read_dir(&dir) {
-            Ok(entries) => entries,
-            Err(_) => {
-                // Ignore unreadable directories and continue searching other paths.
-                continue;
-            }
+        // Ignore unreadable directories and continue searching other paths.
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
         };
 
         for entry in entries.flatten() {


### PR DESCRIPTION
## Summary

Converts 4 manual `match expr { Ok(x)/Some(x) => x, _ => ... }` blocks to the post-Rust-1.65 `let Ok(x)/Some(x) = expr else { ... };` idiom. Surfaced by `cargo clippy --workspace --lib -- -W clippy::manual-let-else` and applied by hand because the lint is suggestion-only (no auto-fix).

## Changes

- `crates/gwt-core/build.rs:68` — `fs::read_dir → Vec::new()` on Err
- `crates/gwt-core/src/logging/housekeep.rs:57` — `file_name` lookup, `continue` on None
- `crates/gwt-core/src/update.rs:297` — `parse_tag_version` on tag, `return UpdateState::Failed` on None
- `crates/gwt-core/src/update.rs:1131` — `fs::read_dir` on dir, `continue` on Err

Net −9 LOC.

## Why

The codebase already uses `let...else` for the same pattern — for example, `housekeep.rs:69` literally has the let-else shape immediately after one of the rewritten sites. Cleaning up the four stragglers brings them in line with the surrounding code and shortens the noise around early-return branches.

Identical control flow before/after:

```rust
// before
let entries = match fs::read_dir(&dir) {
    Ok(entries) => entries,
    Err(_) => continue,
};

// after
let Ok(entries) = fs::read_dir(&dir) else {
    continue;
};
```

## Testing

- [x] `cargo clippy --workspace --lib -- -W clippy::manual-let-else` — 0 remaining warnings
- [x] `cargo test --workspace --lib` — all groups pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Closing Issues

None — stylistic consistency cleanup.

## Related Issues / Links

- PR #2325 — sibling cleanup (inline format args)

## Checklist

- [x] No behavior change (control flow byte-identical)
- [x] All workspace lints + tests + fmt clean
- [x] Verified zero remaining warnings in the targeted lint
