### PR TITLE
test(managed-assets): add diagnostic context to flaky assert

### DIFF
--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -38,12 +38,38 @@ fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() 
     let codex_hooks =
         std::fs::read_to_string(dir.path().join(".codex/hooks.json")).expect("read codex");
     let cli_bin_text = cli_bin.display().to_string();
-    assert!(json_commands(&claude_settings)
-        .iter()
-        .any(|command| command.contains(&cli_bin_text)));
-    assert!(json_commands(&codex_hooks)
-        .iter()
-        .any(|command| command.contains(&cli_bin_text)));
+    // Diagnostic-rich asserts: if the test ever flakes on CI again,
+    // the failure message includes the resolved cli_bin path, the
+    // observed GWT_HOOK_BIN env value, and a redacted view of the
+    // generated commands so we can see WHICH command shape mismatched
+    // instead of just `assertion failed`.
+    let observed_env = std::env::var("GWT_HOOK_BIN").unwrap_or_else(|_| "<unset>".to_string());
+    let claude_commands = json_commands(&claude_settings);
+    assert!(
+        claude_commands
+            .iter()
+            .any(|command| command.contains(&cli_bin_text)),
+        "claude settings missing cli_bin path\n  cli_bin_text: {cli_bin_text}\n  GWT_HOOK_BIN env: {observed_env}\n  generated commands ({} entries):\n{}",
+        claude_commands.len(),
+        claude_commands
+            .iter()
+            .map(|c| format!("    - {c}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    let codex_commands = json_commands(&codex_hooks);
+    assert!(
+        codex_commands
+            .iter()
+            .any(|command| command.contains(&cli_bin_text)),
+        "codex hooks missing cli_bin path\n  cli_bin_text: {cli_bin_text}\n  GWT_HOOK_BIN env: {observed_env}\n  generated commands ({} entries):\n{}",
+        codex_commands.len(),
+        codex_commands
+            .iter()
+            .map(|c| format!("    - {c}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
 
     let exclude_path = dir.path().join(".git/info/exclude");
     let exclude = std::fs::read_to_string(&exclude_path).expect("read exclude");


### PR DESCRIPTION
## Summary

Adds diagnostic context to the two `assert!` calls in `refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes` so the next CI flake gives enough info to actually root-cause it. Pure test-message hardening — production code unchanged.

## Why

During PR #2326's CI run, this test flaked transiently on a Linux runner with this completely uninformative log:

```
thread '...' panicked at crates/gwt/tests/managed_assets_test.rs:41:5:
assertion failed: json_commands(&claude_settings).iter().any(|command|
        command.contains(&cli_bin_text))
```

The rerun passed cleanly (10/10 checks green), so the test recovered, but the next time it flakes we'd be back to "assertion failed" with no way to tell:

- whether `cli_bin_text` was what we expected
- whether `GWT_HOOK_BIN` was set when the generator ran
- whether the generated commands embedded a *different* path or *no* path

Per `tasks/lessons.md` rule "verify claims against actual code path" — diagnosing a flake requires diagnostic data; without it we're guessing. This PR captures all three signals on the failure path.

## Changes

`crates/gwt/tests/managed_assets_test.rs`: upgrade both `assert!(any-contains)` calls to message-bearing form. New failure messages now include:

- The `cli_bin_text` the test expected
- The actual `GWT_HOOK_BIN` env value at assertion time (catches a lost-env race)
- A bulleted list of every command the generator emitted, so we see exactly which command shape didn't match

The success path is unchanged — only the failure path gains weight.

## Testing

- [x] `cargo test -p gwt --test managed_assets_test` — 3/3 pass
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Closing Issues

None — flake-investigation hardening.

## Related Issues / Links

- PR #2326 — original CI flake observed during this PR's run; rerun passed
- PR #2307 — earlier flake fix (same module class, viewport persist test)

## Checklist

- [x] No behavior change (test-only assertion message upgrade)
- [x] Locally verified test still passes
- [x] Failure path captures `cli_bin_text`, `GWT_HOOK_BIN`, and observed commands
