### PR TITLE
refactor(*): additional clippy auto-fixes (single-char-pattern + if-not-else)

### DIFF
--- a/crates/gwt-voice/src/lib.rs
+++ b/crates/gwt-voice/src/lib.rs
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn silence_detected_error_carries_duration() {
         let err = VoiceError::SilenceDetected(3);
-        assert!(err.to_string().contains("3"));
+        assert!(err.to_string().contains('3'));
         assert!(matches!(err, VoiceError::SilenceDetected(3)));
     }
 

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -946,10 +946,10 @@ impl LaunchWizardState {
             return Err("Launch options are still loading".to_string());
         }
 
-        let working_dir = if !self.is_new_branch {
-            self.context.worktree_path.clone()
-        } else {
+        let working_dir = if self.is_new_branch {
             None
+        } else {
+            self.context.worktree_path.clone()
         };
         let branch = (!self.branch_name.is_empty()).then(|| self.branch_name.clone());
         let base_branch = self.is_new_branch.then(|| {


### PR DESCRIPTION
## Summary

Two more small clippy auto-fixes from a wider lint sweep beyond what PR #2328 covered:

1. `crates/gwt-voice/src/lib.rs:148` — `err.to_string().contains("3")` → `contains('3')` (`single-char-pattern` lint)
2. `crates/gwt/src/launch_wizard.rs:949` — inverted `if !is_new_branch { worktree } else { None }` to `if is_new_branch { None } else { worktree }` (`if-not-else` lint)

Both mechanical, verified safe.

## Why

- `contains('c')` skips substring-search machinery for a single ASCII char, marginally faster and one byte shorter in the compiled binary.
- `if cond { ... } else { ... }` reads more naturally than `if !cond { ... } else { ... }` for boolean checks.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib` — all groups pass
- `cargo fmt --check` — clean

## Closing Issues

None — clippy hygiene cleanup.

## Related Issues / Links

- PR #2328 — the broader auto-fix sweep (10 lints, 21 files)
- PR #2325 — earlier auto-fix sweep (uninlined format args)

## Checklist

- [x] No behavior change (mechanical clippy auto-fix)
- [x] All workspace lints + tests + fmt clean
