### PR TITLE
refactor(*): broader clippy auto-fix sweep (redundant-closure-for-method-calls + 8 others)

### DIFF
--- a/crates/gwt-agent/src/audit.rs
+++ b/crates/gwt-agent/src/audit.rs
@@ -59,7 +59,7 @@ pub fn redact_env_value_for_audit<'a>(key: &str, value: &'a str) -> std::borrow:
 /// Callers should clone the `CustomCodingAgent` first when the original must
 /// retain secrets for launch.
 pub fn redact_secrets_in_agent(agent: &mut crate::custom::CustomCodingAgent) {
-    for (key, value) in agent.env.iter_mut() {
+    for (key, value) in &mut agent.env {
         if is_secret_env_key(key) {
             *value = REDACTED_PLACEHOLDER.to_string();
         }

--- a/crates/gwt-agent/src/custom.rs
+++ b/crates/gwt-agent/src/custom.rs
@@ -98,21 +98,21 @@ mod tests {
     #[test]
     fn validate_empty_id() {
         let mut a = sample_agent();
-        a.id = "".to_string();
+        a.id = String::new();
         assert!(!a.validate());
     }
 
     #[test]
     fn validate_empty_display_name() {
         let mut a = sample_agent();
-        a.display_name = "".to_string();
+        a.display_name = String::new();
         assert!(!a.validate());
     }
 
     #[test]
     fn validate_empty_command() {
         let mut a = sample_agent();
-        a.command = "".to_string();
+        a.command = String::new();
         assert!(!a.validate());
     }
 

--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -468,7 +468,7 @@ mod tests {
         let base_env = vec![
             ("PATH".to_string(), "/usr/bin".to_string()),
             ("TERM".to_string(), "dumb".to_string()),
-            ("COLORTERM".to_string(), "".to_string()),
+            ("COLORTERM".to_string(), String::new()),
         ];
 
         let (env, _) = LaunchEnvironment::from_base_env(base_env).into_parts();

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -705,7 +705,7 @@ impl AgentLaunchBuilder {
             .get(GWT_SESSION_RUNTIME_PATH_ENV)
             .or_else(|| env_vars.get(GWT_SESSION_RUNTIME_PATH_ENV))
             .map(PathBuf::from)
-            .and_then(|runtime_path| runtime_path.parent().map(|dir| dir.to_path_buf()))
+            .and_then(|runtime_path| runtime_path.parent().map(std::path::Path::to_path_buf))
             .map(|dir| dir.to_string_lossy().into_owned())
     }
 

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -362,7 +362,7 @@ pub fn sessions_dir_from_runtime_path(runtime_path: &Path) -> Option<PathBuf> {
         .parent()?
         .parent()?
         .parent()
-        .map(|path| path.to_path_buf())
+        .map(std::path::Path::to_path_buf)
 }
 
 /// Reset the runtime namespace for the current gwt process.

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -111,7 +111,7 @@ impl AgentInfo {
         Self {
             display_name: id.display_name().to_string(),
             command: id.command().to_string(),
-            package_name: id.package_name().map(|s| s.to_string()),
+            package_name: id.package_name().map(std::string::ToString::to_string),
             color: id.default_color(),
             id,
         }

--- a/crates/gwt-agent/src/version_cache.rs
+++ b/crates/gwt-agent/src/version_cache.rs
@@ -162,7 +162,7 @@ impl VersionCache {
         });
 
         for version in versions {
-            if entry.versions.last().map(|v| v.as_str()) == Some(version.as_str()) {
+            if entry.versions.last().map(std::string::String::as_str) == Some(version.as_str()) {
                 continue;
             }
             entry.versions.push(version);

--- a/crates/gwt-config/src/settings.rs
+++ b/crates/gwt-config/src/settings.rs
@@ -125,7 +125,7 @@ impl Settings {
     {
         let _guard = UPDATE_LOCK
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let mut settings = Self::load()?;
         mutate(&mut settings)?;

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -819,7 +819,9 @@ mod tests {
 
     #[test]
     fn git_repo_without_origin_uses_project_scoped_coordination_dir() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -869,7 +871,7 @@ mod tests {
 
         let mut names: Vec<String> = std::fs::read_dir(coordination_dir(dir.path()))
             .unwrap()
-            .filter_map(|entry| entry.ok())
+            .filter_map(std::result::Result::ok)
             .map(|entry| entry.file_name().to_string_lossy().into_owned())
             .collect();
         names.sort();

--- a/crates/gwt-core/src/index/runtime.rs
+++ b/crates/gwt-core/src/index/runtime.rs
@@ -286,7 +286,7 @@ mod tests {
         ) -> std::io::Result<()> {
             self.calls
                 .lock()
-                .unwrap_or_else(|p| p.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .push(format!(
                     "{}|{}|{}",
                     repo_hash,
@@ -313,7 +313,7 @@ mod tests {
             spawner
                 .calls
                 .lock()
-                .unwrap_or_else(|p| p.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .len(),
             1
         );

--- a/crates/gwt-core/src/logging/config.rs
+++ b/crates/gwt-core/src/logging/config.rs
@@ -191,7 +191,9 @@ mod tests {
 
     #[test]
     fn initial_filter_directive_prefers_rust_log_env() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let original = std::env::var("RUST_LOG").ok();
         std::env::set_var("RUST_LOG", "gwt=trace");
         let cfg = LoggingConfig::new("/tmp".into()).with_config_file_level(Some(LogLevel::Warn));
@@ -204,7 +206,9 @@ mod tests {
 
     #[test]
     fn initial_filter_directive_falls_back_to_config_file_level() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let original = std::env::var("RUST_LOG").ok();
         std::env::remove_var("RUST_LOG");
         let cfg = LoggingConfig::new("/tmp".into()).with_config_file_level(Some(LogLevel::Debug));
@@ -216,7 +220,9 @@ mod tests {
 
     #[test]
     fn initial_filter_directive_uses_default_when_neither_set() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let original = std::env::var("RUST_LOG").ok();
         std::env::remove_var("RUST_LOG");
         let cfg = LoggingConfig::new("/tmp".into());

--- a/crates/gwt-core/src/notes.rs
+++ b/crates/gwt-core/src/notes.rs
@@ -376,7 +376,9 @@ mod tests {
 
     #[test]
     fn load_snapshot_returns_empty_when_notes_file_is_missing() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -390,7 +392,9 @@ mod tests {
 
     #[test]
     fn load_snapshot_treats_zero_byte_file_as_empty() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -406,7 +410,9 @@ mod tests {
 
     #[test]
     fn load_snapshot_supports_legacy_top_level_array_schema() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -432,7 +438,9 @@ mod tests {
 
     #[test]
     fn load_snapshot_errors_on_invalid_json() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -448,7 +456,9 @@ mod tests {
 
     #[test]
     fn create_update_delete_note_round_trips_through_repo_scoped_store() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -482,7 +492,9 @@ mod tests {
 
     #[test]
     fn load_snapshot_orders_pinned_first_then_updated_at_desc_then_id() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -492,7 +504,7 @@ mod tests {
                 MemoNote {
                     id: "z-note".to_string(),
                     title: "Older pinned".to_string(),
-                    body: "".to_string(),
+                    body: String::new(),
                     pinned: true,
                     created_at: Utc.with_ymd_and_hms(2026, 4, 20, 0, 0, 0).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2026, 4, 20, 0, 0, 0).unwrap(),
@@ -500,7 +512,7 @@ mod tests {
                 MemoNote {
                     id: "a-note".to_string(),
                     title: "Newest unpinned".to_string(),
-                    body: "".to_string(),
+                    body: String::new(),
                     pinned: false,
                     created_at: Utc.with_ymd_and_hms(2026, 4, 21, 0, 0, 0).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2026, 4, 21, 0, 0, 0).unwrap(),
@@ -508,7 +520,7 @@ mod tests {
                 MemoNote {
                     id: "b-note".to_string(),
                     title: "Newest pinned".to_string(),
-                    body: "".to_string(),
+                    body: String::new(),
                     pinned: true,
                     created_at: Utc.with_ymd_and_hms(2026, 4, 22, 0, 0, 0).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2026, 4, 22, 0, 0, 0).unwrap(),
@@ -516,7 +528,7 @@ mod tests {
                 MemoNote {
                     id: "c-note".to_string(),
                     title: "Tie breaker".to_string(),
-                    body: "".to_string(),
+                    body: String::new(),
                     pinned: false,
                     created_at: Utc.with_ymd_and_hms(2026, 4, 21, 0, 0, 0).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2026, 4, 21, 0, 0, 0).unwrap(),
@@ -541,7 +553,9 @@ mod tests {
 
     #[test]
     fn repo_scoped_notes_path_reuses_repo_identity_for_linked_worktrees() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -575,7 +589,9 @@ mod tests {
 
     #[test]
     fn create_note_waits_for_repo_scoped_lock_release() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().unwrap();
         let _home_guard = ScopedEnvVar::set("HOME", home.path());
         let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -197,7 +197,9 @@ mod tests {
 
     #[test]
     fn gwt_home_ends_with_dot_gwt() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = gwt_home();
         assert!(home.ends_with(".gwt"));
     }
@@ -251,7 +253,9 @@ mod tests {
 
     #[test]
     fn gwt_config_path_ends_with_config_toml() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_config_path();
         assert_eq!(p.file_name().unwrap(), "config.toml");
         assert!(p.ends_with(gwt_home_suffix(&["config.toml"])));
@@ -259,21 +263,27 @@ mod tests {
 
     #[test]
     fn gwt_sessions_dir_is_under_home() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_sessions_dir();
         assert!(p.ends_with(gwt_home_suffix(&["sessions"])));
     }
 
     #[test]
     fn gwt_cache_dir_is_under_home() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_cache_dir();
         assert!(p.ends_with(gwt_home_suffix(&["cache"])));
     }
 
     #[test]
     fn gwt_projects_dir_is_under_home() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_projects_dir();
         assert!(p.ends_with(gwt_home_suffix(&["projects"])));
     }
@@ -287,7 +297,9 @@ mod tests {
 
     #[test]
     fn gwt_session_state_path_is_under_home() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_session_state_path();
         assert!(p.ends_with(gwt_home_suffix(&["session.json"])));
     }
@@ -305,7 +317,9 @@ mod tests {
 
     #[test]
     fn gwt_logs_dir_is_under_home() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_logs_dir();
         assert!(p.ends_with(gwt_home_suffix(&["logs"])));
     }
@@ -353,21 +367,27 @@ mod tests {
 
     #[test]
     fn gwt_runtime_dir_is_under_home() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_runtime_dir();
         assert!(p.ends_with(gwt_home_suffix(&["runtime"])));
     }
 
     #[test]
     fn gwt_runtime_runner_path_is_under_runtime_dir() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_runtime_runner_path();
         assert!(p.ends_with(gwt_home_suffix(&["runtime", "chroma_index_runner.py"])));
     }
 
     #[test]
     fn gwt_project_index_venv_dir_is_under_runtime_dir() {
-        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let p = gwt_project_index_venv_dir();
         assert!(p.ends_with(gwt_home_suffix(&["runtime", "chroma-venv"])));
     }

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -812,9 +812,9 @@ fn parse_tag_version(tag: &str) -> Option<Version> {
 fn asset_name_from_url(url: &str) -> Option<String> {
     url.split('/')
         .next_back()
-        .map(|s| s.trim())
+        .map(str::trim)
         .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
 }
 
 fn find_installer_asset_url(platform: &Platform, assets: &[GitHubAsset]) -> Option<String> {
@@ -2132,7 +2132,7 @@ mod tests {
     fn choose_apply_plan_prefers_installer_for_windows_per_user_msi_install() {
         let _guard = ENV_MUTEX
             .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempfile::tempdir().unwrap();
         let local_app_data = temp.path().join("AppData").join("Local");
         let current_exe = local_app_data.join("Programs").join("GWT").join("gwt.exe");
@@ -2170,7 +2170,7 @@ mod tests {
     ) {
         let _guard = ENV_MUTEX
             .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempfile::tempdir().unwrap();
         let local_app_data = temp.path().join("AppData").join("Local");
         let current_exe = local_app_data.join("Programs").join("GWT").join("gwt.exe");
@@ -2252,7 +2252,7 @@ mod tests {
     fn resolve_windows_restart_executable_prefers_per_user_install_after_migration() {
         let _guard = ENV_MUTEX
             .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempfile::tempdir().unwrap();
         let local_app_data = temp.path().join("AppData").join("Local");
         let migrated_exe = local_app_data.join("Programs").join("GWT").join("gwt.exe");

--- a/crates/gwt-core/tests/issue_refresh.rs
+++ b/crates/gwt-core/tests/issue_refresh.rs
@@ -27,7 +27,7 @@ impl RunnerSpawner for RecordingSpawner {
     ) -> std::io::Result<()> {
         self.calls
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(format!(
                 "{}|{}|{}",
                 repo_hash,
@@ -66,7 +66,10 @@ async fn refresh_kicks_runner_when_ttl_expired() {
     };
     refresh_issues_if_stale(&opts, &spawner).await.unwrap();
 
-    let calls = spawner.calls.lock().unwrap_or_else(|p| p.into_inner());
+    let calls = spawner
+        .calls
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert_eq!(calls.len(), 1, "expected one runner spawn call");
 }
 
@@ -86,7 +89,10 @@ async fn refresh_skipped_within_ttl() {
     };
     refresh_issues_if_stale(&opts, &spawner).await.unwrap();
 
-    let calls = spawner.calls.lock().unwrap_or_else(|p| p.into_inner());
+    let calls = spawner
+        .calls
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert_eq!(calls.len(), 0, "must not spawn runner within TTL window");
 }
 
@@ -104,7 +110,10 @@ async fn refresh_kicks_runner_when_meta_missing() {
     };
     refresh_issues_if_stale(&opts, &spawner).await.unwrap();
 
-    let calls = spawner.calls.lock().unwrap_or_else(|p| p.into_inner());
+    let calls = spawner
+        .calls
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert_eq!(calls.len(), 1, "missing meta means stale");
 }
 

--- a/crates/gwt-core/tests/runtime_daemon_contract.rs
+++ b/crates/gwt-core/tests/runtime_daemon_contract.rs
@@ -289,7 +289,7 @@ fn daemon_endpoint_is_usable_returns_false_for_empty_auth_token() {
         scope.clone(),
         4242,
         "http://127.0.0.1:7777".into(),
-        "".into(),
+        String::new(),
         "0.1.0".into(),
     );
     assert!(!endpoint.is_usable(&scope, DAEMON_PROTOCOL_VERSION, |_| true));

--- a/crates/gwt-docker/src/compose.rs
+++ b/crates/gwt-docker/src/compose.rs
@@ -62,18 +62,18 @@ fn parse_compose_content(content: &str) -> Result<Vec<ComposeService>> {
         let image = value
             .get("image")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         let platform = value
             .get("platform")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
 
         let ports = value
             .get("ports")
             .and_then(|v| v.as_sequence())
             .map(|seq| {
                 seq.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                     .collect()
             })
             .unwrap_or_default();
@@ -82,7 +82,7 @@ fn parse_compose_content(content: &str) -> Result<Vec<ComposeService>> {
         let working_dir = value
             .get("working_dir")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         let volumes = extract_volumes(value);
 
         result.push(ComposeService {
@@ -109,11 +109,11 @@ fn extract_depends_on(service: &Value) -> Vec<String> {
     match service.get("depends_on") {
         Some(Value::Sequence(seq)) => seq
             .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
             .collect(),
         Some(Value::Mapping(map)) => map
             .keys()
-            .filter_map(|k| k.as_str().map(|s| s.to_string()))
+            .filter_map(|k| k.as_str().map(std::string::ToString::to_string))
             .collect(),
         _ => Vec::new(),
     }
@@ -144,7 +144,7 @@ fn extract_volumes(service: &Value) -> Vec<ComposeVolumeMount> {
                                 target: target.to_string(),
                                 mode: map
                                     .get(Value::String("read_only".to_string()))
-                                    .and_then(|v| v.as_bool())
+                                    .and_then(serde_yaml::Value::as_bool)
                                     .filter(|read_only| *read_only)
                                     .map(|_| "ro".to_string()),
                             })

--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -140,7 +140,7 @@ fn spawn_output_reader(
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let reader = BufReader::new(reader);
-        for line in reader.lines().map_while(|line| line.ok()) {
+        for line in reader.lines().map_while(std::result::Result::ok) {
             if tx.send(CommandOutputLine { stream, line }).is_err() {
                 break;
             }
@@ -892,7 +892,7 @@ mod tests {
     fn with_fake_docker<R>(script_body: &str, f: impl FnOnce(&PathBuf) -> R) -> R {
         let _guard = TEST_LOCK
             .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (_dir, script_path) = write_fake_docker(script_body);
         let prev = std::env::var_os("GWT_DOCKER_BIN");
         std::env::set_var("GWT_DOCKER_BIN", &script_path);

--- a/crates/gwt-git/src/branch.rs
+++ b/crates/gwt-git/src/branch.rs
@@ -481,7 +481,7 @@ fn parse_branch_line(line: &str) -> Option<Branch> {
     let upstream = parts
         .get(2)
         .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
     let track = parts.get(3).unwrap_or(&"");
     let (ahead, behind) = parse_ahead_behind(track);
     let last_commit_date = parts

--- a/crates/gwt-git/src/pr_status.rs
+++ b/crates/gwt-git/src/pr_status.rs
@@ -248,7 +248,10 @@ fn parse_rest_pr_list_json(json: &str) -> Result<Vec<PrStatus>> {
                 _ => PrState::Open,
             };
             PrStatus {
-                number: v.get("number").and_then(|n| n.as_u64()).unwrap_or(0),
+                number: v
+                    .get("number")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0),
                 title: v
                     .get("title")
                     .and_then(|t| t.as_str())

--- a/crates/gwt-github/src/body.rs
+++ b/crates/gwt-github/src/body.rs
@@ -91,7 +91,7 @@ impl SpecBody {
             .map(|s| (s.name, s.content))
             .collect();
 
-        for (name, location) in sections_index.0.iter() {
+        for (name, location) in &sections_index.0 {
             match location {
                 SectionLocation::Body => {
                     if let Some(content) = body_section_map.get(name) {

--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -145,7 +145,7 @@ impl Cache {
         match SpecBody::parse(&snapshot.body, &parsed_comments) {
             Ok(spec_body) => {
                 let mut desired_sections: HashSet<String> = HashSet::new();
-                for (name, content) in spec_body.sections.iter() {
+                for (name, content) in &spec_body.sections {
                     let filename = section_filename(name);
                     let path = sections_dir.join(&filename);
                     write_atomic(&path, content.as_bytes())?;

--- a/crates/gwt-github/src/client/fake.rs
+++ b/crates/gwt-github/src/client/fake.rs
@@ -48,7 +48,10 @@ impl FakeIssueClient {
 
     /// Preload an Issue snapshot. Used by tests to set up fixtures.
     pub fn seed(&self, snapshot: IssueSnapshot) {
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Ensure next_issue_number stays ahead of seeded numbers.
         let current_next = self.next_issue_number.load(Ordering::SeqCst);
         if snapshot.number.0 >= current_next {
@@ -69,7 +72,7 @@ impl FakeIssueClient {
     pub fn call_log(&self) -> Vec<String> {
         self.inner
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .call_log
             .clone()
     }
@@ -96,7 +99,10 @@ impl IssueClient for FakeIssueClient {
         number: IssueNumber,
         since: Option<&UpdatedAt>,
     ) -> Result<FetchResult, ApiError> {
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "fetch", &number.to_string());
         let issue = state
             .issues
@@ -115,7 +121,10 @@ impl IssueClient for FakeIssueClient {
         if new_body.len() > 65_536 {
             return Err(ApiError::BodyTooLarge);
         }
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "patch_body", &number.to_string());
         let issue = state
             .issues
@@ -127,7 +136,10 @@ impl IssueClient for FakeIssueClient {
     }
 
     fn patch_title(&self, number: IssueNumber, new_title: &str) -> Result<IssueSnapshot, ApiError> {
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "patch_title", &number.to_string());
         let issue = state
             .issues
@@ -146,11 +158,14 @@ impl IssueClient for FakeIssueClient {
         if new_body.len() > 65_536 {
             return Err(ApiError::BodyTooLarge);
         }
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "patch_comment", &comment_id.to_string());
         // Find the issue owning this comment and update it in place.
         for issue in state.issues.values_mut() {
-            for comment in issue.comments.iter_mut() {
+            for comment in &mut issue.comments {
                 if comment.id == comment_id {
                     comment.body = new_body.to_string();
                     comment.updated_at = self.tick();
@@ -167,7 +182,10 @@ impl IssueClient for FakeIssueClient {
             return Err(ApiError::BodyTooLarge);
         }
         let new_id = CommentId(self.next_comment_id.fetch_add(1, Ordering::SeqCst));
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "create_comment", &number.to_string());
         let issue = state
             .issues
@@ -193,7 +211,10 @@ impl IssueClient for FakeIssueClient {
             return Err(ApiError::BodyTooLarge);
         }
         let number = IssueNumber(self.next_issue_number.fetch_add(1, Ordering::SeqCst));
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "create_issue", &number.to_string());
         let snapshot = IssueSnapshot {
             number,
@@ -213,7 +234,10 @@ impl IssueClient for FakeIssueClient {
         number: IssueNumber,
         labels: &[String],
     ) -> Result<IssueSnapshot, ApiError> {
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "set_labels", &number.to_string());
         let issue = state
             .issues
@@ -229,7 +253,10 @@ impl IssueClient for FakeIssueClient {
         number: IssueNumber,
         new_state: IssueState,
     ) -> Result<IssueSnapshot, ApiError> {
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "set_state", &number.to_string());
         let issue = state
             .issues
@@ -241,7 +268,10 @@ impl IssueClient for FakeIssueClient {
     }
 
     fn list_spec_issues(&self, filter: &SpecListFilter) -> Result<Vec<SpecSummary>, ApiError> {
-        let mut state = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.record(&mut state, "list_spec_issues", "*");
         let mut out: Vec<SpecSummary> = state
             .issues

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -104,7 +104,7 @@ impl FakeTransport {
     pub fn enqueue(&self, response: HttpResponse) {
         self.state
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .canned
             .push_back(response);
     }
@@ -113,7 +113,7 @@ impl FakeTransport {
     pub fn recorded(&self) -> Vec<HttpRequest> {
         self.state
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .recorded
             .clone()
     }
@@ -127,7 +127,10 @@ impl Default for FakeTransport {
 
 impl HttpTransport for FakeTransport {
     fn execute(&self, request: HttpRequest) -> Result<HttpResponse, HttpError> {
-        let mut state = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.recorded.push(request);
         state
             .canned
@@ -361,7 +364,7 @@ fn parse_issue_state(s: &str) -> IssueState {
 fn parse_graphql_issue(issue: &Value) -> Result<IssueSnapshot, ApiError> {
     let number = issue
         .get("number")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ApiError::Unexpected("issue.number missing".into()))?;
     let title = issue
         .get("title")
@@ -400,7 +403,7 @@ fn parse_graphql_issue(issue: &Value) -> Result<IssueSnapshot, ApiError> {
         .map(|arr| {
             arr.iter()
                 .filter_map(|v| {
-                    let id = v.get("databaseId").and_then(|i| i.as_u64())?;
+                    let id = v.get("databaseId").and_then(serde_json::Value::as_u64)?;
                     let body = v
                         .get("body")
                         .and_then(|b| b.as_str())
@@ -434,7 +437,7 @@ fn parse_graphql_issue(issue: &Value) -> Result<IssueSnapshot, ApiError> {
 fn parse_rest_issue(json: &Value) -> Result<IssueSnapshot, ApiError> {
     let number = json
         .get("number")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ApiError::Unexpected("issue.number missing".into()))?;
     let title = json
         .get("title")
@@ -479,7 +482,7 @@ fn parse_rest_issue(json: &Value) -> Result<IssueSnapshot, ApiError> {
 fn parse_rest_comment(json: &Value) -> Result<CommentSnapshot, ApiError> {
     let id = json
         .get("id")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ApiError::Unexpected("comment.id missing".into()))?;
     let body = json
         .get("body")
@@ -663,7 +666,7 @@ impl<T: HttpTransport> IssueClient for HttpIssueClient<T> {
         let mut out: Vec<SpecSummary> = nodes
             .into_iter()
             .filter_map(|v| {
-                let number = v.get("number").and_then(|n| n.as_u64())?;
+                let number = v.get("number").and_then(serde_json::Value::as_u64)?;
                 let title = v
                     .get("title")
                     .and_then(|t| t.as_str())

--- a/crates/gwt-github/src/routing.rs
+++ b/crates/gwt-github/src/routing.rs
@@ -53,7 +53,7 @@ pub fn decide_routing(sections: &BTreeMap<SectionName, String>) -> Routing {
         let body_total: usize = map
             .iter()
             .filter_map(|(n, loc)| match loc {
-                SectionLocation::Body => sections.get(n).map(|c| c.len()),
+                SectionLocation::Body => sections.get(n).map(std::string::String::len),
                 _ => None,
             })
             .sum();
@@ -65,7 +65,7 @@ pub fn decide_routing(sections: &BTreeMap<SectionName, String>) -> Routing {
             .iter()
             .filter_map(|(n, loc)| match loc {
                 SectionLocation::Body => {
-                    let size = sections.get(n).map(|c| c.len()).unwrap_or(0);
+                    let size = sections.get(n).map(std::string::String::len).unwrap_or(0);
                     Some((n.clone(), size))
                 }
                 _ => None,

--- a/crates/gwt-github/src/spec_ops.rs
+++ b/crates/gwt-github/src/spec_ops.rs
@@ -324,7 +324,7 @@ fn strip_body_section(body: &str, name: &SectionName) -> String {
 fn rewrite_index_map(body: &str, index: &SectionsIndex) -> String {
     // Render a new index block and replace the existing one.
     let mut rendered = String::from("<!-- sections:\n");
-    for (name, location) in index.0.iter() {
+    for (name, location) in &index.0 {
         match location {
             SectionLocation::Body => {
                 rendered.push_str(&format!("{}=body\n", name.0));
@@ -365,7 +365,7 @@ fn render_body(
         meta.id, meta.version
     ));
     out.push_str("<!-- sections:\n");
-    for (name, location) in routing.0.iter() {
+    for (name, location) in &routing.0 {
         match location {
             SectionLocation::Body => {
                 out.push_str(&format!("{}=body\n", name.0));
@@ -387,7 +387,7 @@ fn render_body(
     }
     out.push_str("-->\n\n");
 
-    for (name, location) in routing.0.iter() {
+    for (name, location) in &routing.0 {
         if let SectionLocation::Body = location {
             if let Some(content) = sections.get(name) {
                 out.push_str(&format!("<!-- artifact:{} BEGIN -->\n", name.0));

--- a/crates/gwt-github/tests/body_test.rs
+++ b/crates/gwt-github/tests/body_test.rs
@@ -81,15 +81,24 @@ fn red_12_assemble_body_and_comments() {
     let comments = [mk_comment(42, "plan", "plan content\nline 2")];
     let spec_body = SpecBody::parse(&body, &comments).unwrap();
     assert_eq!(
-        spec_body.sections.get(&n("spec")).map(|s| s.as_str()),
+        spec_body
+            .sections
+            .get(&n("spec"))
+            .map(std::string::String::as_str),
         Some("spec content")
     );
     assert_eq!(
-        spec_body.sections.get(&n("tasks")).map(|s| s.as_str()),
+        spec_body
+            .sections
+            .get(&n("tasks"))
+            .map(std::string::String::as_str),
         Some("tasks content")
     );
     assert_eq!(
-        spec_body.sections.get(&n("plan")).map(|s| s.as_str()),
+        spec_body
+            .sections
+            .get(&n("plan"))
+            .map(std::string::String::as_str),
         Some("plan content\nline 2")
     );
 }
@@ -127,7 +136,10 @@ s\n\
     ];
     let spec_body = SpecBody::parse(&body, &comments).unwrap();
     assert_eq!(
-        spec_body.sections.get(&n("plan")).map(|s| s.as_str()),
+        spec_body
+            .sections
+            .get(&n("plan"))
+            .map(std::string::String::as_str),
         Some("alpha\nbeta")
     );
 }
@@ -172,7 +184,10 @@ fn red_17_splice_preserves_other_sections() {
     spec_body.splice(n("tasks"), "tasks REPLACED".to_string());
 
     assert_eq!(
-        spec_body.sections.get(&n("tasks")).map(|s| s.as_str()),
+        spec_body
+            .sections
+            .get(&n("tasks"))
+            .map(std::string::String::as_str),
         Some("tasks REPLACED")
     );
     assert_eq!(spec_body.sections.get(&n("spec")).cloned(), before_spec);
@@ -188,7 +203,10 @@ fn red_18_splice_adds_new_section() {
     assert!(!spec_body.sections.contains_key(&n("research")));
     spec_body.splice(n("research"), "research body".to_string());
     assert_eq!(
-        spec_body.sections.get(&n("research")).map(|s| s.as_str()),
+        spec_body
+            .sections
+            .get(&n("research"))
+            .map(std::string::String::as_str),
         Some("research body")
     );
 }

--- a/crates/gwt-terminal/src/manager.rs
+++ b/crates/gwt-terminal/src/manager.rs
@@ -119,7 +119,7 @@ impl PaneManager {
 
     /// List all pane IDs.
     pub fn list_panes(&self) -> Vec<&str> {
-        self.panes.keys().map(|s| s.as_str()).collect()
+        self.panes.keys().map(std::string::String::as_str).collect()
     }
 
     /// Number of active panes.

--- a/crates/gwt-terminal/src/scrollback.rs
+++ b/crates/gwt-terminal/src/scrollback.rs
@@ -96,7 +96,7 @@ impl ScrollbackStorage {
 
     /// Clear all stored lines.
     pub fn clear(&mut self) {
-        for slot in self.lines.iter_mut() {
+        for slot in &mut self.lines {
             *slot = None;
         }
         self.head = 0;

--- a/crates/gwt-terminal/src/test_util.rs
+++ b/crates/gwt-terminal/src/test_util.rs
@@ -12,7 +12,7 @@ pub fn lock_pty_test() -> MutexGuard<'static, ()> {
     PTY_TEST_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4690,7 +4690,7 @@ exit 0
         // tempdir).
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -4758,7 +4758,7 @@ exit 0
     fn app_runtime_load_board_replies_with_repo_scoped_snapshot() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -4811,7 +4811,7 @@ exit 0
     fn app_runtime_load_knowledge_bridge_replies_with_cache_backed_issue_and_spec_views() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -4996,7 +4996,7 @@ exit 0
     fn app_runtime_knowledge_search_replies_through_async_dispatch() {
         let _lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -5079,10 +5079,10 @@ exit 0
     fn app_runtime_manual_knowledge_refresh_replies_through_async_dispatch() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _gh_lock = fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -5168,10 +5168,10 @@ exit 0
     fn app_runtime_manual_knowledge_refresh_error_preserves_request_context() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _gh_lock = fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -5241,10 +5241,10 @@ exit 0
     fn app_runtime_background_knowledge_refresh_silent_paths_do_not_dispatch() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _gh_lock = fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -5412,7 +5412,7 @@ exit 0
     fn app_runtime_load_memo_replies_with_repo_scoped_snapshot() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -5610,7 +5610,7 @@ exit 0
     fn app_runtime_create_memo_note_broadcasts_repo_scoped_snapshot_to_memo_windows() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -5644,8 +5644,8 @@ exit 0
             "client-1".to_string(),
             FrontendEvent::CreateMemoNote {
                 id: current_window_id.clone(),
-                title: "".to_string(),
-                body: "".to_string(),
+                title: String::new(),
+                body: String::new(),
                 pinned: false,
             },
         );
@@ -5684,7 +5684,7 @@ exit 0
     fn app_runtime_update_memo_note_persists_repo_scoped_edits() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
@@ -5743,7 +5743,7 @@ exit 0
     fn app_runtime_post_board_entry_persists_reply_topics_and_owners() {
         let _env_lock = env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());

--- a/crates/gwt/src/app_runtime/window.rs
+++ b/crates/gwt/src/app_runtime/window.rs
@@ -115,7 +115,7 @@ impl AppRuntime {
             return Vec::new();
         }
         if let Some(tab) = self.tab(&tab_id) {
-            for window in tab.workspace.persisted().windows.iter() {
+            for window in &tab.workspace.persisted().windows {
                 self.resize_runtime_to_window(&combined_window_id(&tab_id, &window.id));
             }
         }

--- a/crates/gwt/src/cli/env/default.rs
+++ b/crates/gwt/src/cli/env/default.rs
@@ -335,8 +335,7 @@ impl CliEnv for DefaultCliEnv {
         stdin: &str,
     ) -> io::Result<InternalCommandOutput> {
         let current_exe = std::env::current_exe()?;
-        let current_exe =
-            dunce::canonicalize(&current_exe).unwrap_or_else(|_| current_exe.to_path_buf());
+        let current_exe = dunce::canonicalize(&current_exe).unwrap_or_else(|_| current_exe.clone());
         let mut child = Command::new(current_exe)
             .args(args.iter().skip(1))
             .stdin(Stdio::piped())

--- a/crates/gwt/src/cli/env/tests.rs
+++ b/crates/gwt/src/cli/env/tests.rs
@@ -140,7 +140,7 @@ match args.as_slice() {
 fn with_fake_gh<T>(test: impl FnOnce(&Path) -> T) -> T {
     let _lock = crate::cli::test_support::fake_gh_test_lock()
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let temp = tempfile::tempdir().expect("tempdir");
     compile_fake_gh(temp.path());
 

--- a/crates/gwt/src/cli/hook/block_file_ops.rs
+++ b/crates/gwt/src/cli/hook/block_file_ops.rs
@@ -68,7 +68,7 @@ fn extract_file_paths(segment: &str) -> Vec<String> {
         .split_whitespace()
         .skip(1)
         .filter(|t| !t.starts_with('-'))
-        .map(|t| t.to_string())
+        .map(std::string::ToString::to_string)
         .collect()
 }
 

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -406,7 +406,7 @@ mod tests {
     fn hook_front_door_refresh_migrates_stale_multi_hook_settings() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let status = gwt_core::process::hidden_command("git")
             .arg("init")

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -326,10 +326,10 @@ Coverage requirements.
     fn resolve_workflow_context_uses_session_cache_and_linkage_store() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _lock = crate::cli::fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -393,7 +393,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
         if pr.get("__typename").and_then(|v| v.as_str()) != Some("PullRequest") {
             continue;
         }
-        let Some(pr_number) = pr.get("number").and_then(|v| v.as_u64()) else {
+        let Some(pr_number) = pr.get("number").and_then(serde_json::Value::as_u64) else {
             continue;
         };
         if !seen.insert(pr_number) {

--- a/crates/gwt/src/cli/issue_spec/tests.rs
+++ b/crates/gwt/src/cli/issue_spec/tests.rs
@@ -127,7 +127,7 @@ Old statement.
 Keep this note.
 "#;
     let patch = StructuredSpecInput {
-        background: Some(TextBlock::Text("".to_string())),
+        background: Some(TextBlock::Text(String::new())),
         user_stories: sample_structured_input().user_stories,
         edge_cases: Some(vec!["New edge".to_string()]),
         functional_requirements: None,
@@ -206,7 +206,7 @@ Preserve me.
         None
     );
     assert_eq!(
-        render_bullet_section("Edge Cases", &["".to_string(), "- case".to_string()]),
+        render_bullet_section("Edge Cases", &[String::new(), "- case".to_string()]),
         Some("## Edge Cases\n\n- case".to_string())
     );
     assert_eq!(

--- a/crates/gwt/src/cli/pr/gh.rs
+++ b/crates/gwt/src/cli/pr/gh.rs
@@ -183,7 +183,7 @@ pub(crate) fn fetch_pr_reviews_via_gh(
         .map(|value| PrReview {
             id: value
                 .get("id")
-                .and_then(|v| v.as_i64())
+                .and_then(serde_json::Value::as_i64)
                 .map(|v| v.to_string())
                 .or_else(|| {
                     value
@@ -291,18 +291,18 @@ query($owner: String!, $repo: String!, $number: Int!) {
                 .to_string(),
             is_resolved: node
                 .get("isResolved")
-                .and_then(|v| v.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false),
             is_outdated: node
                 .get("isOutdated")
-                .and_then(|v| v.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false),
             path: node
                 .get("path")
                 .and_then(|v| v.as_str())
                 .unwrap_or_default()
                 .to_string(),
-            line: node.get("line").and_then(|v| v.as_u64()),
+            line: node.get("line").and_then(serde_json::Value::as_u64),
             comments: node
                 .get("comments")
                 .and_then(|v| v.get("nodes"))

--- a/crates/gwt/src/cli/test_support.rs
+++ b/crates/gwt/src/cli/test_support.rs
@@ -185,7 +185,7 @@ fn main() -> ExitCode {
 pub(crate) fn with_fake_gh<T>(mode: &str, test: impl FnOnce(&Path) -> T) -> T {
     let _lock = fake_gh_test_lock()
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let temp = tempdir().expect("tempdir");
     compile_fake_gh(temp.path());
 

--- a/crates/gwt/src/cli/update/tests.rs
+++ b/crates/gwt/src/cli/update/tests.rs
@@ -195,7 +195,9 @@ fn parse_flag_u32_parses_number() {
 
 #[test]
 fn run_check_only_returns_zero_in_ci() {
-    let _guard = CI_ENV_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+    let _guard = CI_ENV_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     std::env::set_var("CI", "true");
     let code = run(UpdateRunMode::CheckOnly);
     std::env::remove_var("CI");
@@ -204,7 +206,9 @@ fn run_check_only_returns_zero_in_ci() {
 
 #[test]
 fn run_apply_returns_zero_in_ci() {
-    let _guard = CI_ENV_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+    let _guard = CI_ENV_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     std::env::set_var("CI", "true");
     let code = run(UpdateRunMode::Apply);
     std::env::remove_var("CI");

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -42,7 +42,7 @@ impl ClientHub {
         let (tx, rx) = mpsc::channel(CLIENT_QUEUE_CAPACITY);
         self.clients
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(client_id, tx);
         rx
     }
@@ -50,12 +50,15 @@ impl ClientHub {
     pub(super) fn unregister(&self, client_id: &str) {
         self.clients
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(client_id);
     }
 
     pub(super) fn dispatch(&self, events: Vec<OutboundEvent>) {
-        let mut clients = self.clients.lock().unwrap_or_else(|p| p.into_inner());
+        let mut clients = self
+            .clients
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut stale_clients = Vec::new();
         for outbound in events {
             let payload = serde_json::to_string(&outbound.event).expect("backend event json");
@@ -440,7 +443,9 @@ mod tests {
             FrontendEvent::FrontendReady,
         );
 
-        let recorded = events.lock().unwrap_or_else(|p| p.into_inner());
+        let recorded = events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert!(matches!(
             recorded.as_slice(),
             [UserEvent::Frontend { client_id, event: FrontendEvent::FrontendReady }]
@@ -463,7 +468,9 @@ mod tests {
             },
         );
 
-        let recorded = events.lock().unwrap_or_else(|p| p.into_inner());
+        let recorded = events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert!(matches!(
             recorded.as_slice(),
             [UserEvent::Frontend { client_id, event: FrontendEvent::TerminalInput { id, data } }]
@@ -486,7 +493,10 @@ mod tests {
             )]);
         }
 
-        let clients = hub.clients.lock().unwrap_or_else(|p| p.into_inner());
+        let clients = hub
+            .clients
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert!(
             !clients.contains_key("slow-client"),
             "lagging websocket client should be unregistered once its queue is full"
@@ -641,7 +651,9 @@ mod tests {
             .expect("authorized hook request");
         assert_eq!(accepted.status(), HttpStatusCode::NO_CONTENT);
 
-        let recorded = events.lock().unwrap_or_else(|p| p.into_inner());
+        let recorded = events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert!(recorded.iter().any(|user_event| {
             matches!(
                 user_event,

--- a/crates/gwt/src/gui_single_instance.rs
+++ b/crates/gwt/src/gui_single_instance.rs
@@ -38,7 +38,7 @@ impl Drop for GuiInstanceLock {
         let _ = self.file.unlock();
         let mut registry = process_lock_registry()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         registry.remove(&self.path);
     }
 }
@@ -82,7 +82,7 @@ pub fn acquire_gui_instance_lock(
     {
         let mut registry = process_lock_registry()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if registry.contains(&lock_path) {
             return Err(GuiInstanceLockError::AlreadyRunning {
                 project_root: project_root.to_path_buf(),
@@ -127,7 +127,7 @@ pub fn acquire_gui_instance_lock(
 fn unregister_process_lock(path: &Path) {
     let mut registry = process_lock_registry()
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     registry.remove(path);
 }
 

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -249,10 +249,13 @@ fn parse_issue_labels(issue: &Value) -> Vec<String> {
 }
 
 fn parse_comment_id(comment: &Value) -> Option<u64> {
-    if let Some(id) = comment.get("databaseId").and_then(|value| value.as_u64()) {
+    if let Some(id) = comment
+        .get("databaseId")
+        .and_then(serde_json::Value::as_u64)
+    {
         return Some(id);
     }
-    if let Some(id) = comment.get("id").and_then(|value| value.as_u64()) {
+    if let Some(id) = comment.get("id").and_then(serde_json::Value::as_u64) {
         return Some(id);
     }
     let url = comment.get("url").and_then(|value| value.as_str())?;
@@ -264,7 +267,7 @@ fn parse_issue_snapshot(json: &str, number: IssueNumber) -> Result<IssueSnapshot
     let issue: Value = serde_json::from_str(json).map_err(|err| err.to_string())?;
     let actual_number = issue
         .get("number")
-        .and_then(|value| value.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| format!("issue #{number} missing number field", number = number.0))?;
     let title = issue
         .get("title")

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -973,10 +973,10 @@ Extra context.
     fn load_knowledge_bridge_builds_issue_and_spec_views_from_cache() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _lock = crate::cli::fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -1101,10 +1101,10 @@ Extra context.
     fn semantic_issue_search_respects_scope_filters_specs_and_scores_results() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _lock = crate::cli::fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -1171,10 +1171,10 @@ Extra context.
     fn semantic_issue_search_reads_cache_without_stale_remote_sync() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _lock = crate::cli::fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -1235,10 +1235,10 @@ Extra context.
     fn load_knowledge_bridge_reads_local_cache_without_stale_remote_sync() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _lock = crate::cli::fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
@@ -1294,10 +1294,10 @@ Extra context.
     fn semantic_spec_search_prioritizes_exact_matches_and_removes_duplicates() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _lock = crate::cli::fake_gh_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3033,7 +3033,7 @@ pub fn build_builtin_agent_options(
                 installed_version: detected.and_then(|detected| detected.version.clone()),
                 versions: cache
                     .get(&agent_id)
-                    .map(|versions| versions.to_vec())
+                    .map(<[std::string::String]>::to_vec)
                     .unwrap_or_default(),
                 custom_agent: None,
             }
@@ -4227,7 +4227,7 @@ mod tests {
 
         state.apply(LaunchWizardAction::SetBranchMode { create_new: true });
         state.apply(LaunchWizardAction::SetBranchName {
-            value: "".to_string(),
+            value: String::new(),
         });
         state.apply(LaunchWizardAction::Submit);
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -243,7 +243,9 @@ fn spawn_board_projection_watcher(
         let Some(watch_dir) = projection_path.parent().map(Path::to_path_buf) else {
             return;
         };
-        let Some(projection_file_name) = projection_path.file_name().map(|name| name.to_owned())
+        let Some(projection_file_name) = projection_path
+            .file_name()
+            .map(std::borrow::ToOwned::to_owned)
         else {
             return;
         };

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -259,7 +259,7 @@ mod tests {
     fn same_path_and_env_var_guard_preserve_previous_values() {
         let _guard = ENV_MUTEX
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempfile::tempdir().expect("tempdir");
         let nested = dir.path().join("nested");
         std::fs::create_dir_all(&nested).expect("create nested");

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -615,7 +615,7 @@ mod tests {
     fn workspace_state_path_uses_project_scoped_storage() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempdir().expect("tempdir");
         let path = workspace_state_path(dir.path());
         let hash = gwt_core::paths::project_scope_hash(dir.path());
@@ -626,7 +626,7 @@ mod tests {
     fn load_restored_workspace_state_pauses_process_windows() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempdir().expect("tempdir");
         let project_root = dir.path().join("project");
         std::fs::create_dir_all(&project_root).expect("project dir");
@@ -685,7 +685,7 @@ mod tests {
     fn migrate_legacy_app_state_splits_session_and_project_workspaces() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempdir().expect("tempdir");
         let legacy_path = dir.path().join("legacy-workspace.json");
         let session_path = dir.path().join("session.json");
@@ -755,7 +755,7 @@ mod tests {
     fn migrate_legacy_single_workspace_uses_fallback_project_target() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempdir().expect("tempdir");
         let legacy_path = dir.path().join("legacy-workspace.json");
         let session_path = dir.path().join("session.json");
@@ -793,7 +793,7 @@ mod tests {
     fn migrate_legacy_workspace_state_keeps_existing_new_workspace() {
         let _env_lock = crate::env_test_lock()
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempdir().expect("tempdir");
         let legacy_path = dir.path().join("legacy-workspace.json");
         let session_path = dir.path().join("session.json");

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -123,7 +123,7 @@ pub(crate) fn dedupe_recent_projects(
 pub(crate) fn prune_missing_recent_projects(
     entries: Vec<gwt::RecentProjectEntry>,
 ) -> Vec<gwt::RecentProjectEntry> {
-    prune_missing_recent_projects_with(entries, |path| path.exists())
+    prune_missing_recent_projects_with(entries, std::path::Path::exists)
 }
 
 pub(crate) fn prune_missing_recent_projects_with(
@@ -622,7 +622,7 @@ mod tests {
     use super::{front_door_route, FrontDoorRoute};
 
     fn argv(parts: &[&str]) -> Vec<String> {
-        parts.iter().map(|part| part.to_string()).collect()
+        parts.iter().map(std::string::ToString::to_string).collect()
     }
 
     #[test]

--- a/crates/gwt/tests/cli_test.rs
+++ b/crates/gwt/tests/cli_test.rs
@@ -18,7 +18,7 @@ fn s(v: &str) -> String {
 }
 
 fn argv(parts: &[&str]) -> Vec<String> {
-    parts.iter().map(|p| p.to_string()).collect()
+    parts.iter().map(std::string::ToString::to_string).collect()
 }
 
 // -----------------------------------------------------------------

--- a/crates/gwt/tests/daemon_runtime_hook_test.rs
+++ b/crates/gwt/tests/daemon_runtime_hook_test.rs
@@ -25,7 +25,7 @@ fn env_lock() -> std::sync::MutexGuard<'static, ()> {
     ENV_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 struct EnvGuard {

--- a/crates/gwt/tests/hook_diagnostics_test.rs
+++ b/crates/gwt/tests/hook_diagnostics_test.rs
@@ -4,7 +4,7 @@ use gwt::cli::{dispatch, TestEnv};
 use serde_json::Value;
 
 fn argv(strs: &[&str]) -> Vec<String> {
-    strs.iter().map(|s| s.to_string()).collect()
+    strs.iter().map(std::string::ToString::to_string).collect()
 }
 
 fn env_test_lock() -> &'static std::sync::Mutex<()> {
@@ -39,7 +39,7 @@ impl Drop for ScopedEnvVar {
 fn hook_event_writes_opt_in_handler_timing_without_stdout_noise() {
     let _env_lock = env_test_lock()
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let tmp = tempfile::tempdir().unwrap();
     let profile_path = tmp.path().join("hook-profile.jsonl");
     let _profile = ScopedEnvVar::set("GWT_HOOK_PROFILE_PATH", &profile_path);

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -18,7 +18,7 @@ use gwt::cli::hook::{event_dispatcher, HookOutput};
 use gwt::cli::{dispatch, TestEnv};
 
 fn argv(strs: &[&str]) -> Vec<String> {
-    strs.iter().map(|s| s.to_string()).collect()
+    strs.iter().map(std::string::ToString::to_string).collect()
 }
 
 fn env_test_lock() -> &'static std::sync::Mutex<()> {
@@ -82,7 +82,7 @@ fn runtime_state_missing_event_argument_exits_two() {
 fn runtime_state_invalid_event_exits_one() {
     let _env_lock = env_test_lock()
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     // Set GWT_SESSION_RUNTIME_PATH so `handle` gets past the silent
     // no-op branch and actually calls `write_for_event`, which in turn
     // surfaces `InvalidEvent`.
@@ -196,7 +196,7 @@ fn public_block_hook_preserves_block_json_contract_without_respawning() {
 fn event_dispatcher_preserves_pre_tool_use_block_json_contract() {
     let _env_lock = env_test_lock()
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _runtime_path = ScopedEnvVar::unset("GWT_SESSION_RUNTIME_PATH");
     let tmp = tempfile::tempdir().unwrap();
     let mut env = TestEnv::new(tmp.path().to_path_buf());
@@ -237,7 +237,7 @@ fn event_dispatcher_preserves_pre_tool_use_block_json_contract() {
 fn event_dispatcher_non_blocking_events_are_silent_without_live_runtime() {
     let _env_lock = env_test_lock()
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _runtime_path = ScopedEnvVar::unset("GWT_SESSION_RUNTIME_PATH");
     let _session_id = ScopedEnvVar::unset("GWT_SESSION_ID");
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/gwt/tests/hook_runtime_state_test.rs
+++ b/crates/gwt/tests/hook_runtime_state_test.rs
@@ -75,7 +75,7 @@ fn repeated_writes_overwrite_and_leave_no_tmp_residue() {
     // Only the canonical file should exist — no `.tmp-*` siblings.
     let mut entries: Vec<String> = fs::read_dir(dir.path())
         .unwrap()
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .map(|e| e.file_name().to_string_lossy().into_owned())
         .collect();
     entries.sort();

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -49,7 +49,9 @@ fn evaluate(event: &HookEvent, context: workflow_policy::WorkflowContext) -> Opt
 }
 
 fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
-    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let home = tempfile::tempdir().expect("temp home");
     let previous_home = std::env::var_os("HOME");
     let previous_session_id = std::env::var_os(GWT_SESSION_ID_ENV);

--- a/crates/gwt/tests/index_bootstrap_test.rs
+++ b/crates/gwt/tests/index_bootstrap_test.rs
@@ -24,7 +24,7 @@ impl RunnerSpawner for RecordingSpawner {
     ) -> std::io::Result<()> {
         self.calls
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(format!(
                 "{}|{}|{}",
                 repo_hash,
@@ -108,7 +108,10 @@ fn bootstrap_helper_reconciles_index_layout_and_kicks_issue_refresh() {
         "bootstrap should remove orphan worktree index"
     );
 
-    let calls = spawner.calls.lock().unwrap_or_else(|p| p.into_inner());
+    let calls = spawner
+        .calls
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert_eq!(
         calls.len(),
         1,

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -180,7 +180,7 @@ fn env_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 struct ScopedEnvVar {

--- a/crates/gwt/tests/skill_exit_cli_test.rs
+++ b/crates/gwt/tests/skill_exit_cli_test.rs
@@ -11,7 +11,7 @@ use gwt_core::skill_state::{self, SkillState};
 use tempfile::TempDir;
 
 fn argv(parts: &[&str]) -> Vec<String> {
-    parts.iter().map(|p| p.to_string()).collect()
+    parts.iter().map(std::string::ToString::to_string).collect()
 }
 
 fn new_env() -> (TestEnv, TempDir) {


### PR DESCRIPTION
## Summary

Wider `cargo clippy --fix` pass extending PRs #2328 / #2329 with additional auto-fixable lints. The dominant transform is `redundant_closure_for_method_calls` (e.g., `|p| p.into_inner()` → `std::sync::PoisonError::into_inner`).

## Changes

Lints applied (all auto-fixable):

- `clippy::redundant-closure-for-method-calls` (most of the diff)
- `clippy::cloned-instead-of-copied`
- `clippy::explicit-iter-loop`
- `clippy::explicit-into-iter-loop`
- `clippy::redundant-else`
- `clippy::implicit-clone`
- `clippy::unnecessary-to-owned`
- `clippy::manual-string-new`
- `clippy::or-fun-call`

60 files touched, 310 insertions / 178 deletions. Most insertions are `rustfmt` re-flowing the longer fully-qualified function names across multiple lines (e.g., `unwrap_or_else(std::sync::PoisonError::into_inner)` no longer fits on one line, so it splits).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib` — all groups pass
- `cargo test --workspace` — all integration tests pass
- `cargo fmt --check` — clean

## Closing Issues

None — clippy hygiene cleanup.

## Related Issues / Links

- PR #2328 — earlier auto-fix sweep (10 lints, 21 files)
- PR #2329 — single-char-pattern + if-not-else
- PR #2325 — uninlined format args

## Checklist

- [x] No behavior change (mechanical clippy auto-fix only)
- [x] All workspace lints + tests + fmt clean
- [x] All 60 file changes verified by cargo test --workspace
