### PR TITLE
docs(*): clear all rustdoc broken-link and HTML warnings (12 sites, 6 crates)

### DIFF
--- a/crates/gwt-agent/src/audit.rs
+++ b/crates/gwt-agent/src/audit.rs
@@ -28,7 +28,7 @@ const SECRET_SUFFIXES: &[&str] = &["_API_KEY", "_TOKEN", "_SECRET"];
 ///
 /// Matching is case-insensitive. The following keys are considered secret:
 ///
-/// - Exact match against [`EXACT_SECRET_NAMES`].
+/// - Exact match against the module-level `EXACT_SECRET_NAMES` list.
 /// - Any key that ends with `_API_KEY`, `_TOKEN`, or `_SECRET`.
 ///
 /// Non-secret keys such as `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`,

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -53,7 +53,7 @@ fn compute_worktree_hash_for_dir(dir: &Path) -> Option<String> {
 pub struct ResolvedRunner {
     /// Executable to invoke (e.g., "claude", "bunx", "npx").
     pub executable: String,
-    /// Base args inserted before agent-specific args (e.g., ["@anthropic-ai/claude-code@1.2.3"]).
+    /// Base args inserted before agent-specific args (e.g., `["@anthropic-ai/claude-code@1.2.3"]`).
     pub base_args: Vec<String>,
 }
 
@@ -393,9 +393,9 @@ impl AgentLaunchBuilder {
 
     /// Supply a `CustomCodingAgent.env` table that should flow into the
     /// spawn env. Intended for SPEC-1921 FR-063: preset-seeded env tables
-    /// merge AFTER Common and agent-specific env, BEFORE [`env_overrides`],
-    /// so preset entries win over built-in defaults but never clobber
-    /// explicit caller overrides.
+    /// merge AFTER Common and agent-specific env, BEFORE the explicit
+    /// `env_overrides` field, so preset entries win over built-in
+    /// defaults but never clobber explicit caller overrides.
     pub fn custom_agent_env(mut self, env: HashMap<String, String>) -> Self {
         self.custom_agent_env = env;
         self

--- a/crates/gwt-ai/src/client.rs
+++ b/crates/gwt-ai/src/client.rs
@@ -102,7 +102,7 @@ impl AIClient {
     /// Send chat messages via the Responses API and return the assistant's text.
     ///
     /// Retries transient failures (429, 5xx) with exponential back-off up to
-    /// [`MAX_RETRIES`] times.
+    /// 3 times (see the `MAX_RETRIES` constant in this module).
     pub fn create_response(&self, messages: Vec<ChatMessage>) -> Result<String, AIError> {
         if messages.is_empty() {
             return Err(AIError::ConfigError("No input messages".into()));

--- a/crates/gwt-core/src/repo_hash.rs
+++ b/crates/gwt-core/src/repo_hash.rs
@@ -1,6 +1,7 @@
 //! Repository identification via normalized origin URL hashing.
 //!
-//! `RepoHash` is the SHA256[:16] of a canonicalized origin URL. The same
+//! `RepoHash` is the first 16 hex digits of the SHA256 of a canonicalized
+//! origin URL (i.e., `SHA256(...)[..16]` in slice notation). The same
 //! upstream repository (HTTPS clone, SSH clone, second worktree) always
 //! resolves to the same `RepoHash`.
 

--- a/crates/gwt-github/src/client.rs
+++ b/crates/gwt-github/src/client.rs
@@ -13,9 +13,9 @@
 //!   GraphQL query in the HTTPS backend.
 //!
 //! This module defines the trait, its input/output types, and an in-memory
-//! [`FakeIssueClient`] used by contract tests. A real HTTPS backend backed
-//! by `reqwest` is implemented in [`crate::client::http`] (coming in the next
-//! TDD cycle).
+//! [`fake::FakeIssueClient`] used by contract tests. A real HTTPS backend
+//! backed by `reqwest` is implemented in [`crate::client::http`] (coming in
+//! the next TDD cycle).
 
 pub mod fake;
 pub mod http;

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -478,7 +478,7 @@ fn ensure_no_remaining_args<'a>(
 ///
 /// Unknown names still parse (we don't maintain an allowlist here) so that
 /// newly added hooks don't need parser changes. Validation happens in
-/// [`run_hook`].
+/// [`crate::cli::hook::run_hook`].
 pub fn parse_hook_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     Ok(CliCommand::Hook(HookCommand::Run {

--- a/crates/gwt/src/cli/daemon/client.rs
+++ b/crates/gwt/src/cli/daemon/client.rs
@@ -4,7 +4,7 @@
 //! hook dispatcher to talk to a running `gwtd` daemon over the local
 //! Unix domain socket.
 //!
-//! Wire format mirrors [`super::server::handle_connection`]:
+//! Wire format mirrors `super::server::handle_connection`:
 //!
 //! 1. Send one newline-delimited [`IpcHandshakeRequest`] line.
 //! 2. Read one newline-delimited [`IpcHandshakeResponse`] line.

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -31,7 +31,8 @@ use super::{
 };
 
 /// High-level runtime environment for the CLI. Kept as a trait so tests can
-/// inject a [`FakeIssueClient`] instead of spinning up real HTTP.
+/// inject a fake `IssueClient` (see `gwt-github`'s
+/// `client::fake::FakeIssueClient`) instead of spinning up real HTTP.
 pub trait CliEnv {
     type Client: IssueClient;
     fn client(&self) -> &Self::Client;

--- a/crates/gwt/src/cli/hook/envelope.rs
+++ b/crates/gwt/src/cli/hook/envelope.rs
@@ -45,7 +45,7 @@ pub enum HookOutput {
     Silent,
     /// Stop-hook block envelope: `{"decision":"block","reason":"<reason>"}`.
     /// Claude Code / Codex interpret this as "do not stop; continue with
-    /// <reason> as the new instruction". exit code is 0.
+    /// `<reason>` as the new instruction". exit code is 0.
     StopBlock {
         reason: String,
     },

--- a/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
@@ -2,10 +2,10 @@
 //! `gwt-build-spec` skill (SPEC-1935 Phase 10, FR-014r).
 //!
 //! Mirrors the `skill_plan_spec_stop_check` structure but targets the
-//! `build-spec` state file. The shared decision body lives in
-//! [`super::skill_plan_spec_stop_check::decide`] so both handlers stay
-//! in lock-step regarding `stop_hook_active`, session isolation, and
-//! fail-open policy.
+//! `build-spec` state file. The shared decision body lives in the
+//! sibling `skill_plan_spec_stop_check::decide` (private) so both
+//! handlers stay in lock-step regarding `stop_hook_active`, session
+//! isolation, and fail-open policy.
 
 use std::{
     io::{self, Read},

--- a/crates/gwt/src/cli/update/mod.rs
+++ b/crates/gwt/src/cli/update/mod.rs
@@ -3,7 +3,8 @@
 //! SPEC-1942 SC-027 split: `mod.rs` keeps the public CLI entry points
 //! (`UpdateRunMode`, `parse_args`, `run`, `run_internal_apply_update`,
 //! `run_internal_run_installer`). The `UpdateCliOps` trait and its production
-//! `RealUpdateCliOps` impl live in [`ops`]. Tests live in [`tests`].
+//! `RealUpdateCliOps` impl live in the private sibling `ops` module; tests
+//! live in the `#[cfg(test)] mod tests` sibling.
 
 mod ops;
 #[cfg(test)]

--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -8,7 +8,7 @@
 //! The function:
 //!
 //! 1. Resolves the [`RuntimeScope`] for `project_root` and reads the
-//!    persisted [`DaemonEndpoint`].
+//!    persisted [`gwt_core::daemon::DaemonEndpoint`].
 //! 2. If no live daemon is registered, returns
 //!    `Err("daemon not running")` so the caller can continue with the
 //!    local file path as the source of truth.

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -72,7 +72,7 @@ pub struct PersistedWindowState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
     /// Wire-only color hint sent to the WebView. 送信直前に backend が
-    /// [`agent_id`] (または `preset` のフォールバック) から計算する。
+    /// `agent_id` フィールド (または `preset` のフォールバック) から計算する。
     /// disk には書かない (`skip_deserializing` + skip_serializing_if で
     /// 読み書き両方向に漏らさない)。SPEC #2133 FR-008.
     #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

Clears all 12 `cargo doc --workspace --no-deps` warnings across 6 crates. Each warning is a broken intra-doc link or HTML escape that renders as a red error / dead anchor in the published docs.

## Changes

13 files touched, 24 ins / 21 del.

**Broken intra-doc links (private item or no-scope):**

- `gwt-ai/src/client.rs:105` — `[``MAX_RETRIES``]` was a public doc linking to a private constant. Inlined the actual value (3).
- `gwt-github/src/client.rs:16` — `[``FakeIssueClient``]` qualified to `[``fake::FakeIssueClient``]`.
- `gwt-agent/src/audit.rs:31` — public doc linked private `EXACT_SECRET_NAMES`. Demoted to descriptive prose.
- `gwt-agent/src/launch.rs:396` — `[``env_overrides``]` referenced a struct field (rustdoc can't link to fields). Rewrote as prose.
- `gwt/src/cli.rs:481` — `[``run_hook``]` qualified to `[``crate::cli::hook::run_hook``]`.
- `gwt/src/cli/daemon/client.rs:7` — `[``super::server::handle_connection``]` pointed to private item. Demoted to plain code span.
- `gwt/src/cli/env/mod.rs:34` — `[``FakeIssueClient``]` (no scope). Rewrote as descriptive prose.
- `gwt/src/cli/hook/skill_build_spec_stop_check.rs:6` — public doc linked private `super::skill_plan_spec_stop_check::decide`. Demoted to prose.
- `gwt/src/cli/update/mod.rs:6` — `[``ops``]` and `[``tests``]` linked to private modules. Demoted to prose.
- `gwt/src/daemon_publisher.rs:11` — `[``DaemonEndpoint``]` qualified to `[``gwt_core::daemon::DaemonEndpoint``]`.
- `gwt/src/persistence.rs:75` — `[``agent_id``]` referenced a struct field. Rewrote as prose.

**Markdown / HTML parsing:**

- `gwt-core/src/repo_hash.rs:3` — `SHA256[:16]` parsed as a markdown link target. Rewrote to "first 16 hex digits of the SHA256" with slice notation in a code span.
- `gwt-agent/src/launch.rs:56` — array literal `["@anthropic-ai/..."]` parsed as a link with disambiguator `"`. Wrapped in code span.
- `gwt/src/cli/hook/envelope.rs:48` — `<reason>` parsed as an unclosed HTML tag. Wrapped in code span.

## Why

These warnings have been silently accumulating. They don't break the build, but they:

- Render as visible errors / dead anchors in `target/doc/.../index.html` when contributors browse the docs locally
- Will eventually surface as CI failures if/when `RUSTDOCFLAGS=-D warnings` is added
- Mislead readers into thinking a linked item exists when it doesn't, or causes rustdoc to silently swallow the surrounding markdown structure (the unclosed HTML tag case)

## Verification

- `cargo doc --workspace --no-deps` — **0 warnings** (was 12)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --workspace --lib` — all groups pass

## Closing Issues

None — docstring accuracy cleanup.

## Related Issues / Links

- PR #2317-#2320 — sibling daemon docstring refreshes
- `tasks/lessons.md` rule "verify claims against actual code path" — same rationale applied to broken intra-doc links

## Checklist

- [x] No behavior change (docstring only)
- [x] All 12 warnings traced to a specific cause (private item, missing scope, markdown parsing)
- [x] All workspace lints + tests + fmt clean
- [x] `cargo doc` exits with 0 warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and clarified documentation comments across multiple modules, including better path references, formatting consistency, and explanation clarity for retry behavior, hashing notation, and configuration merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->