### PR TITLE
ci(lint): enforce zero rustdoc warnings on every PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,14 @@ jobs:
         run: cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings
       - name: Check formatting
         run: cargo fmt --all -- --check
+      - name: Check rustdoc warnings
+        # The codebase is at 0 rustdoc warnings post-PR #2331; this
+        # gate keeps it that way by failing CI if a future PR
+        # reintroduces a broken intra-doc link, an unclosed HTML tag,
+        # or a public-doc link to a private item.
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --no-deps --document-private-items
       - name: Check frontend bundle syntax
         run: npm run --silent test:frontend-bundle
       - name: Check release flow contract

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -291,9 +291,9 @@ pub struct AgentLaunchBuilder {
     env_overrides: HashMap<String, String>,
     /// Env table from a `CustomCodingAgent`. Merged into the spawn env AFTER
     /// the SPEC-1921 Common family (TERM / GWT_*) and agent-specific env
-    /// (Claude / Codex / …), and BEFORE [`env_overrides`], so preset-seeded
-    /// custom entries win over built-in defaults but never clobber explicit
-    /// caller-provided overrides.
+    /// (Claude / Codex / …), and BEFORE the explicit `env_overrides` field
+    /// above, so preset-seeded custom entries win over built-in defaults
+    /// but never clobber explicit caller-provided overrides.
     custom_agent_env: HashMap<String, String>,
     extra_args: Vec<String>,
     runtime_target: LaunchRuntimeTarget,

--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -2,10 +2,10 @@
 //!
 //! [`BroadcastHub`] keeps a `tokio::sync::broadcast` channel per logical
 //! event channel ("board", "runtime-status", ...). When a per-connection
-//! handler observes a [`ClientFrame::Subscribe`], it asks the hub for a
-//! receiver. Daemon-side code paths (Board projection writer, runtime
-//! status aggregator, hook event router) call [`BroadcastHub::publish`]
-//! to fan a single payload out to all subscribers.
+//! handler observes a [`gwt_core::daemon::ClientFrame::Subscribe`], it asks
+//! the hub for a receiver. Daemon-side code paths (Board projection writer,
+//! runtime status aggregator, hook event router) call
+//! [`BroadcastHub::publish`] to fan a single payload out to all subscribers.
 //!
 //! The hub is intentionally small: one mutex around a `HashMap<String,
 //! broadcast::Sender<DaemonFrame>>`. Phase H1 wired the Board

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -3,8 +3,10 @@
 //! - `mod.rs` (this file): public [`CliEnv`] trait, helper types
 //!   ([`InternalCommandOutput`] / [`InternalCommandCall`] / [`ClientRef`]),
 //!   and the global [`dispatch`] entry point.
-//! - `default.rs`: production [`DefaultCliEnv`] + [`LazyIssueClient`].
-//! - `test_env.rs`: in-memory [`TestEnv`] used by `cli` family tests.
+//! - `default.rs`: production [`default::DefaultCliEnv`] +
+//!   [`default::LazyIssueClient`].
+//! - `test_env.rs`: in-memory [`test_env::TestEnv`] used by `cli` family
+//!   tests.
 //! - `tests.rs`: env integration tests (`#[cfg(test)]`).
 
 mod default;


### PR DESCRIPTION
## Summary

Locks in PR #2331's "0 rustdoc warnings" achievement by adding a `cargo doc --workspace --no-deps --document-private-items` step to the Lint workflow with `RUSTDOCFLAGS=-D warnings`. Future PRs that reintroduce broken intra-doc links, unclosed HTML tags, or public-doc links to private items will fail CI at PR time instead of accumulating silently.

## Changes

`.github/workflows/lint.yml`: new step at end of the `lint` job:

```yaml
- name: Check rustdoc warnings
  env:
    RUSTDOCFLAGS: "-D warnings"
  run: cargo doc --workspace --no-deps --document-private-items
```

The `--document-private-items` flag covers everything rustdoc renders (not just the public surface), which surfaced 3 additional warnings beyond PR #2331's scope. Fixed in this same PR:

- `crates/gwt-agent/src/launch.rs:294` — `[``env_overrides``]` referenced a struct field (rustdoc can't link those). Demoted to prose. Mirrors the fix at line 396 in PR #2331.
- `crates/gwt/src/cli/daemon/broadcast.rs:5` — `[``ClientFrame::Subscribe``]` had no scope. Qualified to `[``gwt_core::daemon::ClientFrame::Subscribe``]`.
- `crates/gwt/src/cli/env/mod.rs:6` — `[``DefaultCliEnv``]` / `[``LazyIssueClient``]` / `[``TestEnv``]` were unscoped. Qualified to their respective sub-modules (`default::DefaultCliEnv`, etc.).

## Why

Doc warnings were silently accumulating for weeks before PR #2331 cleared them. Without CI enforcement, the pattern would repeat. Same model as the `cargo clippy -- -D warnings` and `cargo deny check advisories sources` jobs already in this workflow: the codebase is at zero warnings now, so locking that in costs nothing today and prevents regressions.

The `--document-private-items` flag is significant: PR #2331 only fixed the public-doc surface (7 of 9 errors visible to `cargo doc --workspace --no-deps`). Adding `--document-private-items` would have exposed 3 more errors that this PR also clears. Locking in the stricter check prevents the next accidental link drift on internal modules from surfacing only in CI weeks later.

## Verification

- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items` — clean (was 3 errors before this PR's source-code edits)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Wall-time impact

The new step adds ~30 s to the lint job (rustdoc walks the entire crate graph). One-time per PR; offset by avoiding the manual sweep cost when warnings pile up between releases.

## Closing Issues

None — CI hardening to lock in PR #2331.

## Related Issues / Links

- PR #2331 — initial doc-warning cleanup (12 sites, 6 crates)
- PR #2316 — sibling CI hardening (cargo-deny advisories+sources)

## Checklist

- [x] CI step gated behind the same conditions as existing lint steps (PR-only)
- [x] All 3 additional `--document-private-items` errors fixed in same PR (no leaked failures)
- [x] All workspace lints + tests + fmt clean
- [x] Rustdoc check exits with 0 warnings on the new flag combination
