### PR TITLE
chore(gitignore): drop 3 stale entries pointing at retired components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,16 +17,10 @@ PLANS.md
 /target/
 **/*.rs.bk
 
-# Generated (Tauri build)
-/crates/gwt-tauri/gen/schemas/
-
 # npm wrapper (for bunx distribution)
 node_modules/
 bun.lock
 .pnpm-store/
-
-# Legacy npm lockfile (gwt-gui migrated to pnpm)
-gwt-gui/package-lock.json
 
 # Downloaded native binaries (postinstall downloads these)
 bin/gwt
@@ -73,9 +67,6 @@ temp/
 .tmp_pkg_extract/
 .worktrees/
 .tools/
-
-# MCP bridge lockfile (generated, not shared)
-gwt-mcp-bridge/pnpm-lock.yaml
 
 # Voice evaluation local assets
 tests/voice_eval/manifest.json


### PR DESCRIPTION
## Summary

Removes 3 `.gitignore` entries that reference directories no longer present in the repository. Pure documentation cleanup — no functional change.

## Changes

`.gitignore`: drop 9 lines (3 stanzas):

- `# Generated (Tauri build)` / `/crates/gwt-tauri/gen/schemas/` — retired in the wry+tao+axum architecture migration (`crates/gwt-tauri` no longer exists; same migration that triggered closure of stale Issue #1782 earlier this session)
- `# Legacy npm lockfile (gwt-gui migrated to pnpm)` / `gwt-gui/package-lock.json` — `gwt-gui/` (the Svelte frontend) was deleted in the same migration; project is workspace-wide pnpm now
- `# MCP bridge lockfile (generated, not shared)` / `gwt-mcp-bridge/pnpm-lock.yaml` — `gwt-mcp-bridge/` is not present in the tree

## Why

`.gitignore` patterns silently document the project's expected layout. A pattern like `crates/gwt-tauri/gen/schemas/` implies that gwt-tauri is intended to exist; a contributor adding a new crate might think they're respecting some project convention by mirroring that pattern. Removing the dead patterns keeps the file aligned with reality.

Verified each path is absent:

```
$ ls crates/gwt-tauri 2>&1 | head -1
ls: crates/gwt-tauri: No such file or directory
$ ls gwt-gui 2>&1 | head -1
ls: gwt-gui: No such file or directory
$ ls gwt-mcp-bridge 2>&1 | head -1
ls: gwt-mcp-bridge: No such file or directory
```

No in-tree path matches the removed globs, so this has no functional effect on what git tracks today.

## Closing Issues

None — gitignore cleanup.

## Related Issues / Links

- Closure comment on stale Issue #1782 (Tauri WKWebView) earlier this session — same architecture migration that left these patterns dead

## Checklist

- [x] No functional change (verified zero in-tree matches before removal)
- [x] Each removed entry traced to a retired component
- [x] No build / test impact
