### PR TITLE
docs(*): refresh stale references to retired gwt-gui / Tauri components

### DIFF
--- a/.codex/skills/tui-design/SKILL.md
+++ b/.codex/skills/tui-design/SKILL.md
@@ -10,8 +10,8 @@ Create distinctive, production-grade terminal user interfaces with high design q
 
 ## gwt Technology Context
 
-- **Primary TUI framework:** Rust ratatui (gwt-core TUI migration target)
-- **Terminal emulation:** xterm.js v6 (gwt-gui, rendered in Tauri WebView)
+- **Primary TUI framework:** Rust ratatui (gwt-core terminal rendering)
+- **Terminal emulation:** xterm.js v6 (gwt GUI, rendered in WebView)
 - **Design principle:** シンプルさの極限を追求しつつ、ユーザビリティと開発者体験の品質は妥協しない (CLAUDE.md)
 - **Scope:** TUI/CLI/terminal rendering — Web UI components use `frontend-design` skill instead
 
@@ -143,8 +143,8 @@ NEVER use generic terminal aesthetics like:
 
 | Framework | Language | Notes |
 |-----------|----------|-------|
-| **ratatui** | **Rust** | **gwt primary TUI framework** |
-| xterm.js v6 | TypeScript | gwt-gui terminal emulation (Tauri WebView) |
+| **ratatui** | **Rust** | **gwt terminal rendering** |
+| xterm.js v6 | TypeScript | gwt GUI terminal emulation (WebView) |
 | Rich, Textual | Python | General purpose |
 | Bubbletea, Lipgloss | Go | General purpose |
 | Ink, Blessed | Node.js | General purpose |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,17 +47,24 @@ bunx .
 
 ```
 gwt/
-├── crates/               # Rust workspace
-├── gwt-gui/              # フロントエンド
-├── plugins/              # gwt agent assets
-├── tests/                # テストコード
-│   ├── unit/             # ユニットテスト
-│   ├── integration/      # 統合テスト
-│   ├── e2e/              # E2Eテスト
-│   ├── fixtures/         # テストフィクスチャ
-│   └── helpers/          # テストヘルパー
-└── docs/                 # ドキュメント
+├── crates/                       # Rust workspace
+│   ├── gwt/                      # メインバイナリ (gwt GUI + gwtd CLI)
+│   │   ├── src/                  # Rust ソース
+│   │   ├── tests/                # 統合テスト (#[test] in tests/*.rs)
+│   │   └── web/                  # WebView フロントエンド (HTML/JS, xterm.js)
+│   ├── gwt-core/                 # Git/PTY/設定/Issue キャッシュなどのコア
+│   ├── gwt-agent/                # エージェント起動・セッション管理
+│   ├── gwt-skills/               # 組込スキル / 管理対象アセット配布
+│   ├── gwt-github/               # GitHub Issue SOT (gwt-spec ラベル管理)
+│   └── ...                       # その他のドメインクレート (ai/git/docker/...)
+├── tests/voice_eval/             # 音声評価アセット (gwt-voice 用、ローカル実行)
+├── docs/                         # 設計ドキュメント
+└── scripts/                      # リリース/CI 補助スクリプト
 ```
+
+各ドメインクレートのソース／単体テストはそのクレート内 (`crates/<name>/src/`、
+`crates/<name>/src/**/tests.rs`) に存在し、統合テストは
+`crates/<name>/tests/` に配置されています。
 
 ## Development Workflow
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,5 +12,8 @@ coverage:
       paths: [crates/]
       carryforward: true
     frontend:
-      paths: [gwt-gui/src/]
+      # The Svelte frontend (gwt-gui/) was retired during the wry+tao+axum
+      # architecture migration. The current frontend is plain HTML/JS at
+      # crates/gwt/web/, which has no separate coverage target today.
+      paths: [crates/gwt/web/]
       carryforward: true


### PR DESCRIPTION
## Summary

Three documentation surfaces still pointed at directories or stacks removed in the wry + tao + axum architecture migration. Each is a real defect — readers following these docs would chase non-existent paths.

## Changes

**`CONTRIBUTING.md` "Project Structure" diagram (lines 46-60)**: listed `gwt-gui/`, `plugins/`, and 5 non-existent `tests/` subdirectories. Replaced with the actual structure: domain crates under `crates/<name>/`, `crates/gwt/web/` for the WebView frontend, integration tests at `crates/<name>/tests/`, and the voice-eval artifact dir.

**`codecov.yml` `frontend` flag (lines 14-16)**: `paths: [gwt-gui/src/]` referenced the removed Svelte frontend. Re-pointed to `crates/gwt/web/` (current HTML/JS frontend) plus an explanatory comment about the migration.

**`.codex/skills/tui-design/SKILL.md` (lines 13-14, 146-147)**: said "ratatui (gwt-core TUI migration target)" and "xterm.js v6 (gwt-gui, rendered in Tauri WebView)". The `.claude/skills/tui-design/SKILL.md` mirror already had the corrected wording; synced the Codex copy.

## Why

Same architecture-migration drift class as PRs #2310-#2312 (README), #2317-#2320 (daemon docstrings), and #2333 (.gitignore). A new contributor reading CONTRIBUTING.md today would expect to find a Svelte frontend at `gwt-gui/`, scoped tests at `tests/{unit,integration,e2e}`, and a `plugins/` directory — none of which exist. The `codecov.yml` `frontend` flag silently points at no source tree, so any frontend coverage data is dropped on the floor.

## Verification

- `npx markdownlint-cli2 CONTRIBUTING.md` — 0 errors
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `diff .claude/skills/tui-design/SKILL.md .codex/skills/tui-design/SKILL.md` — empty (mirrors in sync)
- `grep -rn "gwt-tauri\|gwt-mcp-bridge"` (excluding CHANGELOG) — 0 matches
- Only remaining `gwt-gui` reference outside CHANGELOG is the explanatory comment I added in `codecov.yml`

## Closing Issues

None — documentation accuracy cleanup.

## Related Issues / Links

- PR #2333 — sibling cleanup (`.gitignore` stale entries from same migration)
- PR #2310-#2312 — README scope corrections
- Closure comment on stale Issue #1782 — the architecture migration that retired these components

## Checklist

- [x] No code change (docs / config only)
- [x] All workspace lints clean
- [x] CONTRIBUTING.md project structure verified by `ls` against the repo
- [x] codecov.yml frontend path now points at the actual current frontend
- [x] Codex skill mirror brought back in sync with Claude copy
