### PR TITLE
docs(architecture): refresh post-Tauri-migration + add SPEC-2077 daemon overview

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,16 +1,25 @@
 # Architecture
 
-gwt は単一の Rust バイナリで GUI と CLI を提供します。
+gwt は二つの Rust バイナリ — `gwt` (GUI フロントドア) と `gwtd`
+(CLI / 常駐ランタイム) — として配布されます。両者は同じワークスペース
+からビルドされ、`gwtd daemon` が macOS / Linux 上ではバックグラウンドで
+プロジェクト単位の runtime daemon としても動作します (SPEC-2077)。
 
 ## Components
 
 - `crates/gwt/`
-  - Wry + Tao ベースのネイティブ GUI
-  - ローカル HTTP/WebSocket サーバー
-  - WebView / ブラウザ共通のキャンバス UI
-  - `gwt issue ...` / `gwt pr ...` / `gwt hook ...` の CLI 入口
+  - **`gwt`**: Wry + Tao ベースのネイティブ GUI、ローカル
+    HTTP/WebSocket サーバー、WebView / ブラウザ共通のキャンバス UI、
+    フックの outward-facing 入口 (`gwt hook ...`)
+  - **`gwtd`**: 同じクレート内で生成される CLI バイナリ
+    (`gwtd issue ...` / `gwtd pr ...` / `gwtd board ...` /
+    `gwtd actions ...` / `gwtd daemon ...`)。`gwtd daemon start` は
+    Unix ドメインソケット経由でプロジェクト単位の runtime daemon を
+    bootstrap する (SPEC-2077 Phase H1)
 - `crates/gwt-core/`
-  - Git / worktree / 設定 / ログ / coordination / index ランタイム
+  - Git / worktree / 設定 / ログ / coordination / index ランタイム、
+    daemon 契約 (`DaemonEndpoint` / `ClientFrame` / `DaemonFrame` の
+    ワイヤスキーマ)
 - `crates/gwt-github/`
   - SPEC Issue の取得・更新・ローカルキャッシュ
 - `crates/gwt-agent/`
@@ -20,11 +29,24 @@ gwt は単一の Rust バイナリで GUI と CLI を提供します。
 
 ## Data Flow
 
-1. `gwt` を GUI モードで起動すると、ネイティブウィンドウとローカル HTTP/WebSocket サーバーが立ち上がる
-2. WebView は同じサーバーへ接続し、キャンバス上のウィンドウ状態を同期する
+1. `gwt` を GUI モードで起動すると、ネイティブウィンドウとローカル
+   HTTP/WebSocket サーバーが立ち上がる。 同時に macOS / Linux では
+   プロジェクトに紐づく `gwtd daemon` が auto-bootstrap し、
+   Unix ドメインソケットで待ち受ける
+2. WebView は同じサーバーへ接続し、キャンバス上のウィンドウ状態を
+   同期する
 3. `Shell` / `Agent` ウィンドウは PTY を通してプロセスを実行する
-4. `Branches` / `File Tree` / `Issue` などのウィンドウは Rust 側でデータを集約し、フロントエンドへ送る
-5. `gwt issue ...` などの CLI サブコマンドは GUI を起動せず、同じバイナリ内で完結する
+4. `Branches` / `File Tree` / `Issue` などのウィンドウは Rust 側で
+   データを集約し、フロントエンドへ送る
+5. Board に投稿が起きると、 GUI ハンドラが local の workspace-state を
+   更新したあと daemon に `ClientFrame::Publish { channel: "board", .. }`
+   を発火する。 同じプロジェクトの全 `gwt` インスタンスが
+   `DaemonFrame::Event` を購読していれば、 polling 遅延なく UI に
+   反映される (SPEC-2077 Phase H1)
+6. `gwtd issue ...` などの CLI サブコマンドは GUI を起動せず、
+   同じバイナリ内で完結する。 Windows では daemon は未実装のため
+   multi-instance fan-out は行われず、 `gwtd daemon status` は
+   常に `stopped` を返す
 
 ## Persistence
 
@@ -38,3 +60,7 @@ gwt は単一の Rust バイナリで GUI と CLI を提供します。
   - `~/.gwt/cache/issues/<repo-hash>/`
 - ログ:
   - `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD`
+- Runtime daemon endpoint (macOS / Linux):
+  - `~/.gwt/projects/<repo-hash>/runtime/daemon/endpoint.json`
+  - クラッシュした daemon の stale エントリは次回の `gwtd daemon
+    start` / GUI 起動時に自動でクリーンアップされる


### PR DESCRIPTION
## Summary

Refreshes `docs/architecture.md` on three axes that had drifted: (1) two-binary distribution (`gwt` + `gwtd`) instead of "single binary," (2) SPEC-2077 Phase H1 runtime daemon overview (missing entirely), and (3) Windows fallback noted explicitly.

## Changes

`docs/architecture.md`:

1. **Opening paragraph + `crates/gwt/` bullet**: documented the two-binary distribution. CLI examples now use `gwtd issue ... / pr ... / board ... / actions ... / daemon ...` (the canonical surface) instead of the old `gwt issue ...` form.

2. **`crates/gwt-core/` bullet**: explicit mention of the daemon contract layer (`DaemonEndpoint` / `ClientFrame` / `DaemonFrame`).

3. **Data Flow section**: added two steps —
   - Step 1 augmented with "macOS / Linux では gwtd daemon が auto-bootstrap" note.
   - New step 5 describing the Board publish path through the daemon (`ClientFrame::Publish { channel: "board", ... }` → `DaemonFrame::Event` → other instances) for multi-instance fan-out.
   - Windows fallback note ("daemon は未実装のため multi-instance fan-out は行われず").

4. **Persistence section**: added the daemon endpoint file path (`~/.gwt/projects/<repo-hash>/runtime/daemon/endpoint.json`) and the auto-cleanup-on-stale behavior.

## Why

`docs/spec-catalog-audit.md:185` and `:211` already flagged this file as "still in GUI/Tauri era" but the audit's specific complaints were two months stale (the file no longer mentioned Tauri/Svelte; the bigger gap was the two-binary split and the entire daemon layer being absent). New contributors reading `docs/architecture.md` would conclude there's no daemon, no `gwtd`, and the CLI lives behind `gwt`-prefixed commands — none of which is true.

## Why not also touch `docs/spec-catalog-audit.md`

Audit-doc lines 185/211 are now obsolete, but `docs/spec-catalog-audit.md` is a dated snapshot artifact (the file has progress sections marked "2026-04-02 P0 進捗"). Mutating its body would falsify a historical record. Future audit waves can supersede those callouts naturally.

## Verification

- `markdownlint-cli2 docs/architecture.md` — 0 errors
- All daemon claims in the new Data Flow and Persistence sections verified against `crates/gwt-core/src/daemon.rs` (frame variants, endpoint structure) and `crates/gwt/src/cli/daemon/mod.rs` (Windows non-unix fallback)

## Closing Issues

None — documentation accuracy refresh.

## Related Issues / Links

- SPEC-2077 (#2077) — Runtime Daemon (the layer being documented)
- PR #2334 — sibling cleanup of stale gwt-gui / Tauri references in CONTRIBUTING.md / codecov.yml / Codex skill
- PR #2310-#2312 — earlier README refreshes for the same migration

## Checklist

- [x] No code change (docs only)
- [x] All claims verified against actual code paths
- [x] markdownlint clean
- [x] Stale audit-doc callouts intentionally left alone (preserved as historical snapshot)
