### PR TITLE
refactor(*): centralize is_process_alive helper into crate::process

### DIFF
--- a/crates/gwt/src/cli/daemon/mod.rs
+++ b/crates/gwt/src/cli/daemon/mod.rs
@@ -325,37 +325,12 @@ fn start_daemon<E: CliEnv>(_env: &mut E, out: &mut String) -> Result<i32, SpecOp
     Ok(2)
 }
 
-fn is_process_alive_pid(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
-    }
-    #[cfg(unix)]
-    {
-        // SAFETY: kill(pid, 0) returns 0 if the process exists, -1 with
-        // ESRCH if it does not. We never deliver a real signal.
-        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
-        if rc == 0 {
-            return true;
-        }
-        let err = std::io::Error::last_os_error();
-        // EPERM means the process exists but we lack permission to signal it.
-        matches!(err.raw_os_error(), Some(libc::EPERM))
-    }
-    #[cfg(not(unix))]
-    {
-        // The long-running daemon currently only runs under cfg(unix);
-        // `start_daemon` is a stub on every other platform. Reporting
-        // every persisted endpoint as "alive" therefore surfaced
-        // permanent-stale entries in `gwtd daemon status`. Returning
-        // `false` here lets `resolve_bootstrap_action` treat the
-        // endpoint as dead on platforms where no daemon can actually
-        // be running, so the file gets cleaned up on the next status
-        // / start. When Windows named-pipe support lands, this branch
-        // should switch to a real liveness probe (e.g.
-        // `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, ...)`).
-        false
-    }
-}
+// Liveness probe lives in `crate::process::is_process_alive` so the
+// three daemon-related callers (this file, daemon_publisher, main)
+// share one definition. The narrow `|pid| pid == self.pid` predicate
+// used by `prepare_daemon_front_door_for_path` is intentionally NOT
+// the same function; see Issue #2338.
+use crate::process::is_process_alive as is_process_alive_pid;
 
 #[cfg(test)]
 mod tests {

--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -108,21 +108,9 @@ pub fn publish_event_with_timeout(
     })
 }
 
-fn is_alive(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
-    }
-    // SAFETY: kill(pid, 0) only probes the process; we never deliver a
-    // real signal. Returns 0 if alive, -1 with ESRCH otherwise.
-    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
-    if rc == 0 {
-        return true;
-    }
-    matches!(
-        std::io::Error::last_os_error().raw_os_error(),
-        Some(libc::EPERM)
-    )
-}
+// Liveness probe shared with `cli::daemon` and `main`; see
+// `crate::process::is_process_alive`.
+use crate::process::is_process_alive as is_alive;
 
 #[cfg(test)]
 mod tests {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -21,6 +21,7 @@ pub mod migration;
 pub mod native_app;
 pub mod persistence;
 pub mod preset;
+pub mod process;
 pub mod profile_dispatch;
 pub mod protocol;
 pub mod window_state;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -418,21 +418,10 @@ fn spawn_board_daemon_subscriber(
     )
 }
 
+// Liveness probe shared with `cli::daemon` and `daemon_publisher`;
+// see `gwt::process::is_process_alive`.
 #[cfg(unix)]
-fn is_subscriber_pid_alive(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
-    }
-    // SAFETY: kill(pid, 0) only probes the process; no signal is delivered.
-    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
-    if rc == 0 {
-        return true;
-    }
-    matches!(
-        std::io::Error::last_os_error().raw_os_error(),
-        Some(libc::EPERM)
-    )
-}
+use gwt::process::is_process_alive as is_subscriber_pid_alive;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct DockerBundleMounts {

--- a/crates/gwt/src/process.rs
+++ b/crates/gwt/src/process.rs
@@ -1,0 +1,77 @@
+//! Cross-platform process liveness probe shared by the daemon
+//! bootstrap callers.
+//!
+//! This module centralises the `kill(pid, 0)` probe that several
+//! daemon-related modules (`cli::daemon::mod`, `daemon_publisher`,
+//! `main`) used to duplicate. Three identical 10-line helpers had
+//! drifted slightly (`is_process_alive_pid`, `is_alive`,
+//! `is_subscriber_pid_alive`); consolidating into one definition
+//! removes that drift surface and makes the platform-conditional
+//! behaviour explicit in a single place.
+//!
+//! Note: `prepare_daemon_front_door_for_path`
+//! (`crates/gwt/src/cli/hook/mod.rs`) deliberately uses a *narrower*
+//! predicate (`|pid| pid == std::process::id()`) and is kept inline
+//! there. That difference is the subject of Issue #2338 — fixing it
+//! requires SPEC-2077 owner alignment on endpoint-slot semantics, so
+//! this module intentionally does not absorb that callsite.
+
+/// Return `true` when `pid` refers to a live process visible to the
+/// current user on a Unix host.
+///
+/// On non-Unix targets (Windows today), the daemon's `serve_blocking`
+/// is a stub, so reporting any persisted endpoint as "alive" would
+/// surface permanent stale entries in `gwtd daemon status`. Returning
+/// `false` lets `resolve_bootstrap_action` treat such endpoints as
+/// dead and clean them up on the next bootstrap call.
+pub fn is_process_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        // SAFETY: kill(pid, 0) returns 0 if the process exists, -1
+        // with ESRCH if it does not. We never deliver a real signal.
+        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if rc == 0 {
+            return true;
+        }
+        let err = std::io::Error::last_os_error();
+        // EPERM means the process exists but we lack permission to
+        // signal it — still alive from the bootstrap caller's POV.
+        matches!(err.raw_os_error(), Some(libc::EPERM))
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows named-pipe support for the daemon is a follow-up.
+        // When that lands, this branch should switch to a real
+        // liveness probe (e.g. `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+        // ...)`).
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pid_zero_is_never_alive() {
+        assert!(!is_process_alive(0));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_process_is_alive() {
+        assert!(is_process_alive(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn far_unused_pid_is_not_alive() {
+        // u32::MAX - 1 is well past any realistic OS pid_t allocation
+        // window; if this ever fails on a CI runner we'll know that
+        // pid recycling has reached extreme territory.
+        assert!(!is_process_alive(u32::MAX - 1));
+    }
+}


### PR DESCRIPTION
## Summary

Three identical 10-line `kill(pid, 0)` helpers had drifted across the `gwt` crate (`is_process_alive_pid` in `cli/daemon/mod.rs`, `is_alive` in `daemon_publisher.rs`, `is_subscriber_pid_alive` in `main.rs`). Consolidates them into one `crate::process::is_process_alive` definition with platform-conditional behaviour explicit, while keeping local aliases at each callsite so existing usages don't move.

## Changes

- **New**: `crates/gwt/src/process.rs` — single `pub fn is_process_alive(pid: u32) -> bool` covering both `cfg(unix)` (real `libc::kill(pid, 0)` probe with EPERM-for-permission-denied) and `cfg(not(unix))` (returns false until Windows named-pipe support lands). 3 unit tests: `pid_zero_is_never_alive`, `current_process_is_alive`, `far_unused_pid_is_not_alive`.
- **`crates/gwt/src/lib.rs`**: `pub mod process;` declaration.
- **`crates/gwt/src/cli/daemon/mod.rs`**: removed the local `is_process_alive_pid` (32 lines), replaced with `use crate::process::is_process_alive as is_process_alive_pid;`.
- **`crates/gwt/src/daemon_publisher.rs`**: removed the local `is_alive` (14 lines), replaced with `use crate::process::is_process_alive as is_alive;`.
- **`crates/gwt/src/main.rs`**: removed the local `is_subscriber_pid_alive` (15 lines), replaced with `#[cfg(unix)] use gwt::process::is_process_alive as is_subscriber_pid_alive;`.

Net: +90 / −60 LOC, but +1 well-tested module and −3 duplicate implementations.

## Why

Three identical helpers across modules that already work together is a drift surface. The most complete copy (`cli/daemon/mod.rs`) handled `cfg(not(unix))` correctly; the other two were silently relying on `#![cfg(unix)]` at the file level. A future Windows port (when named-pipe daemon lands) would have needed to update three places. Now it's one.

## Why **not** consolidate the front-door predicate

`prepare_daemon_front_door_for_path` in `cli/hook/mod.rs:192-198` uses `|pid| pid == std::process::id()` instead of the broad helper. That difference is the subject of **Issue #2338** (filed earlier this session) — the narrow predicate causes the front-door to clobber a running `gwtd daemon start`'s endpoint with the `internal://gwt-front-door` sentinel. Whether the front-door should adopt the broad predicate, skip-if-non-sentinel, or coexist via a separate slot needs SPEC-2077 owner input.

This refactor deliberately leaves that callsite untouched; the new module docstring explicitly documents the divergence so future readers don't assume the front-door was overlooked.

## Verification

- `cargo build -p gwt` — clean
- `cargo test --workspace --lib` — all groups pass (377 + 186 + others, including 3 new tests in `process::tests`)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Closing Issues

None — refactoring DRY cleanup. Issue #2338 stays open.

## Related Issues / Links

- Issue #2338 — front-door clobber bug; the refactor explicitly does not absorb that callsite
- PR #2339 — sibling lessons.md update from same docs-correction round

## Checklist

- [x] No behavior change (each renamed callsite uses identical logic via the alias)
- [x] All workspace lints + tests + fmt clean
- [x] New module covers `cfg(unix)` and `cfg(not(unix))` so the previously-implicit cfg gate is now explicit
- [x] Front-door callsite intentionally left as-is with documented rationale
- [x] 3 unit tests cover the new module's behaviour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate process-checking logic from multiple internal modules into a centralized shared module, reducing code duplication and improving maintainability across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->