### PR TITLE
test(process): use i32::MAX-as-u32 in far-unused-pid test (codex P2)

### DIFF
--- a/crates/gwt/src/process.rs
+++ b/crates/gwt/src/process.rs
@@ -69,9 +69,17 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn far_unused_pid_is_not_alive() {
-        // u32::MAX - 1 is well past any realistic OS pid_t allocation
-        // window; if this ever fails on a CI runner we'll know that
-        // pid recycling has reached extreme territory.
-        assert!(!is_process_alive(u32::MAX - 1));
+        // Use `i32::MAX as u32` so the value stays positive after the
+        // `pid as libc::pid_t` cast inside `is_process_alive`. Going
+        // higher (e.g. `u32::MAX - 1`) wraps to a negative `pid_t` and
+        // `kill(-N, 0)` probes process *group* `N` instead of a far
+        // PID, which is a different semantic and can flake on
+        // runners where group 2 exists.
+        //
+        // `i32::MAX` (~2.1 billion) is far past any realistic OS
+        // pid_t allocation window today; if this ever flakes on a CI
+        // runner we'll have learned that pid recycling has reached
+        // extreme territory.
+        assert!(!is_process_alive(i32::MAX as u32));
     }
 }


### PR DESCRIPTION
## Summary

Fixes a real flake-prone test introduced in PR #2340. Codex caught it before any CI flake materialized.

## Codex P2

> On Unix this assertion does not test a "far unused PID" as intended: `u32::MAX - 1` is cast to `pid_t` inside `is_process_alive`, which wraps to `-2`, and `kill(-2, 0)` probes process group 2 rather than a high PID. If process group 2 exists (or returns `EPERM`), this test can fail nondeterministically across environments even though liveness logic is unchanged.

Verified — `man 2 kill` confirms negative `pid_t` operates on a process *group*, not a single PID. So `u32::MAX - 1` cast to `i32` wraps to `-2`, making `kill(-2, 0)` probe process group 2 instead of probing whether PID 4294967294 is alive. The test could pass or fail depending on whether group 2 exists / is signalable on the runner.

## Changes

`crates/gwt/src/process.rs` — single test edit:

```diff
-        assert!(!is_process_alive(u32::MAX - 1));
+        assert!(!is_process_alive(i32::MAX as u32));
```

`i32::MAX` (≈ 2.1 billion) stays positive after the `pid as libc::pid_t` cast, so `kill(2147483647, 0)` exercises the intended ESRCH-on-unallocated-high-PID path. Comment updated to explain why this specific value, with a note that future PID-allocation extremes would be the only way it'd flake.

## Verification

- `cargo test -p gwt --lib process::tests::far_unused_pid_is_not_alive` — 1/1 pass
- `cargo test --workspace --lib` — all groups pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Closing Issues

None — addresses codex P2 finding on PR #2340.

## Related Issues / Links

- PR #2340 — original consolidation that introduced the test
- `tasks/lessons.md` rule 4 — "verify claims against actual code path"; the wrap behaviour was hiding inside the cast and would have been caught by re-reading `kill`'s pid_t semantics

## Checklist

- [x] No production code change (test-only fix)
- [x] All workspace lints + tests clean
- [x] Updated comment explains why `i32::MAX as u32` specifically, including the future-PID-recycling caveat
