### PR TITLE
refactor(*): clippy auto-fix sweep (unnested-or-patterns + 5 others)

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -569,7 +569,7 @@ fn infer_package_runner_version_spec(command: &str, args: &[String]) -> Option<S
     }
 
     let version_spec = match args.first().map(String::as_str) {
-        Some("--yes") | Some("-y") => args.get(1)?,
+        Some("--yes" | "-y") => args.get(1)?,
         _ => args.first()?,
     };
     if version_spec.is_empty() || version_spec.starts_with('-') {

--- a/crates/gwt-github/src/spec_ops.rs
+++ b/crates/gwt-github/src/spec_ops.rs
@@ -118,8 +118,7 @@ impl<C: IssueClient> SpecOps<C> {
 
         match (&prev_location, &new_location) {
             // Stay in body: rewrite the section between the markers, then patch.
-            (Some(SectionLocation::Body), SectionLocation::Body)
-            | (None, SectionLocation::Body) => {
+            (Some(SectionLocation::Body) | None, SectionLocation::Body) => {
                 issue_body = rewrite_body_section(&issue_body, name, content);
                 new_sections_index
                     .0
@@ -129,8 +128,7 @@ impl<C: IssueClient> SpecOps<C> {
             }
             // Body -> Comment promotion: create a new comment, drop the
             // body-inline markers, then patch the body with the new index map.
-            (Some(SectionLocation::Body), SectionLocation::Comments(_))
-            | (None, SectionLocation::Comments(_)) => {
+            (Some(SectionLocation::Body) | None, SectionLocation::Comments(_)) => {
                 let comment_body = wrap_comment_body(name, content);
                 let comment: CommentSnapshot = self.client.create_comment(number, &comment_body)?;
                 new_sections_index

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2302,7 +2302,7 @@ impl AppRuntime {
                 config,
                 profile_config_path,
                 hook_forward_target,
-            )
+            );
         });
 
         Ok(events)

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -481,7 +481,7 @@ impl AppRuntime {
                 window_id,
                 config,
                 profile_config_path,
-            )
+            );
         });
 
         Ok(events)

--- a/crates/gwt/src/cli/hook/segments.rs
+++ b/crates/gwt/src/cli/hook/segments.rs
@@ -77,7 +77,7 @@ fn split_unquoted_control_operators(command: &str) -> Vec<&str> {
                     start = i;
                     continue;
                 }
-                b'|' if matches!(bytes.get(i + 1), Some(b'|') | Some(b'&')) => {
+                b'|' if matches!(bytes.get(i + 1), Some(b'|' | b'&')) => {
                     segments.push(&command[start..i]);
                     i += 2;
                     start = i;

--- a/crates/gwt/src/daemon_subscriber.rs
+++ b/crates/gwt/src/daemon_subscriber.rs
@@ -97,7 +97,7 @@ impl DaemonSubscriber {
                     callback,
                     stop_flag_inner,
                     shutdown_inner,
-                )
+                );
             })
             .expect("daemon subscriber thread spawn");
         Self {

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -225,7 +225,7 @@ fn fetch_issue_snapshot(repo_path: &Path, number: IssueNumber) -> Result<IssueSn
 
 fn parse_issue_state(value: Option<&str>) -> IssueState {
     match value {
-        Some("CLOSED") | Some("closed") => IssueState::Closed,
+        Some("CLOSED" | "closed") => IssueState::Closed,
         _ => IssueState::Open,
     }
 }

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -401,7 +401,7 @@ fn infer_package_runner_version_spec(command: &str, args: &[String]) -> Option<S
     }
 
     let version_spec = match args.first().map(String::as_str) {
-        Some("--yes") | Some("-y") => args.get(1)?,
+        Some("--yes" | "-y") => args.get(1)?,
         _ => args.first()?,
     };
     if version_spec.is_empty() || version_spec.starts_with('-') {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3403,8 +3403,8 @@ mod tests {
         )]);
         assert!(matches!(
             client_one.try_recv(),
-            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
-                | Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected
+                | tokio::sync::mpsc::error::TryRecvError::Empty)
         ));
         assert!(client_two
             .try_recv()

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -269,7 +269,7 @@ fn t100_e2e_progress_callback_walks_phases() {
 
     let mut seen: Vec<MigrationPhase> = Vec::new();
     execute_migration(project.path(), MigrationOptions::default(), |phase, _| {
-        seen.push(phase)
+        seen.push(phase);
     })
     .expect("execute_migration");
 


### PR DESCRIPTION
## Summary

Another wave of mechanical `cargo clippy --fix` covering 6 additional auto-fixable lints. 10 files touched, net −2 LOC, no behaviour change.

## Changes

Lints applied:

- `clippy::semicolon-if-nothing-returned`
- `clippy::unnested-or-patterns` — dominant transform on this pass: `Err(A) | Err(B)` → `Err(A | B)` flattening
- `clippy::explicit-deref-methods`
- `clippy::redundant-pattern-matching`
- `clippy::needless-return`
- `clippy::needless-bool`

Plus `cargo fmt --all` because rustfmt re-flowed the collapsed `Err(A | B)` pattern at `crates/gwt/src/main.rs:3403`.

## Verification

- `cargo test --workspace --lib` — all groups pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Closing Issues

None — clippy hygiene cleanup.

## Related Issues / Links

- PR #2325-#2330 — earlier clippy auto-fix sweeps
- PR #2340-#2341 — sibling cleanup (consolidate is_process_alive)

## Checklist

- [x] No behavior change (mechanical clippy auto-fix only)
- [x] All workspace lints + tests + fmt clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected daemon subscriber initialization to properly transmit callbacks and shutdown signals.

* **Refactor**
  * Code consistency improvements and syntax enhancements across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->