### PR TITLE
refactor(*): add Eq derive where PartialEq exists with no float fields

### DIFF
--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Status of a pane's child process.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PaneStatus {
     Running,
     Completed(i32),

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -102,7 +102,7 @@ pub struct RecentProjectEntry {
     pub kind: ProjectKind,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PersistedSessionTabState {
     pub id: String,
     pub title: String,
@@ -110,7 +110,7 @@ pub struct PersistedSessionTabState {
     pub kind: ProjectKind,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PersistedSessionState {
     #[serde(default)]
     pub tabs: Vec<PersistedSessionTabState>,


### PR DESCRIPTION
## Summary

`cargo clippy --fix` flagged two types where `PartialEq` was derived but `Eq` was missing despite all fields being `Eq`-compatible. Adding `Eq` lets these types appear in `HashMap` / `BTreeSet` keys without callers needing wrapper types.

## Changes

- `crates/gwt-terminal/src/pane.rs::PaneStatus` — variants (`Running`, `Completed(i32)`, `Failed(String)`, etc.) all have `Eq`-compatible payloads.
- `crates/gwt/src/persistence.rs::PersistedSessionTabState` — fields are `String / String / PathBuf / ProjectKind`, all `Eq`.

Net: 2 files, +3 / −3 (just adding `Eq` to the derive lists).

## Verification

- `cargo test --workspace --lib` — all groups pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Closing Issues

None — clippy hygiene cleanup.

## Related Issues / Links

- PR #2342 — sibling clippy auto-fix sweep (unnested-or-patterns)
- PR #2325-#2330, #2340 — earlier mechanical lint passes

## Checklist

- [x] No behavior change (just new trait bound, types still satisfy via existing field types)
- [x] All workspace lints + tests + fmt clean
