### PR TITLE
refactor(*): drop redundant pub(crate) qualifiers from bin-private modules

### DIFF
--- a/crates/gwt-core/src/test_support.rs
+++ b/crates/gwt-core/src/test_support.rs
@@ -3,12 +3,12 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-pub(crate) fn env_lock() -> &'static Mutex<()> {
+pub fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-pub(crate) struct ScopedEnvVar {
+pub struct ScopedEnvVar {
     key: &'static str,
     previous: Option<OsString>,
 }

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -20,7 +20,7 @@ use gwt_core::coordination::{self, BoardEntryKind};
 use super::{AppRuntime, BackendEvent, OutboundEvent, WindowPreset};
 
 #[derive(Debug, Clone)]
-pub(crate) struct BoardPostRequest {
+pub struct BoardPostRequest {
     pub(crate) id: String,
     pub(crate) entry_kind: BoardEntryKind,
     pub(crate) body: String,

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[derive(Clone)]
-pub(crate) enum AppEventProxy {
+pub enum AppEventProxy {
     Real(EventLoopProxy<UserEvent>),
     #[cfg(test)]
     Stub(Arc<Mutex<Vec<UserEvent>>>),
@@ -34,7 +34,7 @@ impl AppEventProxy {
 }
 
 #[derive(Clone)]
-pub(crate) enum BlockingTaskSpawner {
+pub enum BlockingTaskSpawner {
     Tokio(tokio::runtime::Handle),
     #[cfg(test)]
     Thread,
@@ -69,7 +69,7 @@ impl BlockingTaskSpawner {
     }
 }
 
-pub(crate) struct KnowledgeSearchRequest<'a> {
+pub struct KnowledgeSearchRequest<'a> {
     pub(crate) id: &'a str,
     pub(crate) kind: KnowledgeKind,
     pub(crate) query: &'a str,
@@ -78,7 +78,7 @@ pub(crate) struct KnowledgeSearchRequest<'a> {
     pub(crate) list_scope: gwt::KnowledgeListScope,
 }
 
-pub(crate) struct KnowledgeLoadRequest<'a> {
+pub struct KnowledgeLoadRequest<'a> {
     pub(crate) id: &'a str,
     pub(crate) kind: KnowledgeKind,
     pub(crate) request_id: Option<u64>,
@@ -109,7 +109,7 @@ struct KnowledgeSearchTask {
     list_scope: gwt::KnowledgeListScope,
 }
 
-pub(crate) struct WindowRuntime {
+pub struct WindowRuntime {
     pane: Arc<Mutex<Pane>>,
     /// Handle to the background reader thread that forwards PTY output.
     /// Taken and joined during `stop_window_runtime` so the reader releases
@@ -122,7 +122,7 @@ pub(crate) struct WindowRuntime {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ProcessLaunch {
+pub struct ProcessLaunch {
     pub(crate) command: String,
     pub(crate) args: Vec<String>,
     pub(crate) env: HashMap<String, String>,
@@ -130,7 +130,7 @@ pub(crate) struct ProcessLaunch {
     pub(crate) cwd: Option<PathBuf>,
 }
 
-pub(crate) type AgentLaunchCompletion = (
+pub type AgentLaunchCompletion = (
     ProcessLaunch,
     String,
     String,
@@ -140,7 +140,7 @@ pub(crate) type AgentLaunchCompletion = (
     Option<u64>,
 );
 
-pub(crate) type AgentLaunchResult = Result<AgentLaunchCompletion, String>;
+pub type AgentLaunchResult = Result<AgentLaunchCompletion, String>;
 
 mod board;
 mod memory;
@@ -148,7 +148,7 @@ mod migration;
 mod profile;
 mod window;
 mod wizard;
-pub(crate) use board::BoardPostRequest;
+pub use board::BoardPostRequest;
 use profile::ProfileSaveRequest;
 
 fn dispatch_agent_launch_success<F>(
@@ -168,7 +168,7 @@ fn dispatch_agent_launch_success<F>(
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ActiveAgentSession {
+pub struct ActiveAgentSession {
     pub(crate) window_id: String,
     pub(crate) session_id: String,
     pub(crate) agent_id: String,
@@ -179,7 +179,7 @@ pub(crate) struct ActiveAgentSession {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct LaunchWizardMemoryCache {
+pub struct LaunchWizardMemoryCache {
     sessions: Vec<gwt_agent::Session>,
     agent_options: Vec<gwt::AgentOption>,
 }
@@ -277,13 +277,13 @@ struct IssueBranchLinkStore {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum DispatchTarget {
+pub enum DispatchTarget {
     Broadcast,
     Client(ClientId),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct OutboundEvent {
+pub struct OutboundEvent {
     pub(crate) target: DispatchTarget,
     pub(crate) event: BackendEvent,
 }
@@ -357,7 +357,7 @@ fn knowledge_view_events(
     ]
 }
 
-pub(crate) fn build_frontend_sync_events(
+pub fn build_frontend_sync_events(
     client_id: &str,
     workspace: gwt::AppStateView,
     terminal_statuses: Vec<(String, WindowProcessStatus, String)>,
@@ -411,7 +411,7 @@ pub(crate) fn build_frontend_sync_events(
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ProjectTabRuntime {
+pub struct ProjectTabRuntime {
     pub(crate) id: String,
     pub(crate) title: String,
     pub(crate) project_root: PathBuf,
@@ -484,20 +484,20 @@ fn detect_locked_worktrees(project_root: &Path) -> bool {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct WindowAddress {
+pub struct WindowAddress {
     pub(crate) tab_id: String,
     pub(crate) raw_id: String,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct LaunchWizardSession {
+pub struct LaunchWizardSession {
     pub(crate) tab_id: String,
     pub(crate) wizard_id: String,
     pub(crate) wizard: LaunchWizardState,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct IssueLaunchWizardPrepared {
+pub struct IssueLaunchWizardPrepared {
     pub(crate) client_id: ClientId,
     pub(crate) id: String,
     pub(crate) knowledge_kind: KnowledgeKind,
@@ -508,7 +508,7 @@ pub(crate) struct IssueLaunchWizardPrepared {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ProjectOpenTarget {
+pub struct ProjectOpenTarget {
     pub(crate) project_root: PathBuf,
     pub(crate) title: String,
     pub(crate) kind: gwt::ProjectKind,
@@ -517,7 +517,7 @@ pub(crate) struct ProjectOpenTarget {
     pub(crate) needs_migration: bool,
 }
 
-pub(crate) struct AppRuntime {
+pub struct AppRuntime {
     pub(crate) tabs: Vec<ProjectTabRuntime>,
     pub(crate) active_tab_id: Option<String>,
     pub(crate) recent_projects: Vec<gwt::RecentProjectEntry>,

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -9,7 +9,7 @@ use gwt_github::SpecOpsError;
 
 use crate::cli::{BoardCommand, CliEnv, CliParseError};
 
-pub(crate) fn parse(args: &[String]) -> Result<BoardCommand, CliParseError> {
+pub fn parse(args: &[String]) -> Result<BoardCommand, CliParseError> {
     let mut it = args.iter().peekable();
     match it.next().map(String::as_str) {
         Some("show") => {

--- a/crates/gwt/src/cli/build.rs
+++ b/crates/gwt/src/cli/build.rs
@@ -8,9 +8,9 @@ use gwt_github::SpecOpsError;
 use super::skill_state_runtime;
 use crate::cli::{CliEnv, SkillStateAction};
 
-pub(crate) const SKILL_NAME: &str = "build-spec";
-pub(crate) const SKILL_DISPLAY: &str = "gwt-build-spec";
-pub(crate) const VERB: &str = "build";
+pub const SKILL_NAME: &str = "build-spec";
+pub const SKILL_DISPLAY: &str = "gwt-build-spec";
+pub const VERB: &str = "build";
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,

--- a/crates/gwt/src/cli/daemon/broadcast.rs
+++ b/crates/gwt/src/cli/daemon/broadcast.rs
@@ -36,7 +36,7 @@ pub(super) const DEFAULT_CHANNEL_CAPACITY: usize = 64;
 /// single short-lived [`Mutex`]. Channels are created on-demand the
 /// first time `subscribe` or `publish` references them.
 #[derive(Clone, Default)]
-pub(crate) struct BroadcastHub {
+pub struct BroadcastHub {
     channels: Arc<Mutex<HashMap<String, broadcast::Sender<DaemonFrame>>>>,
 }
 

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -113,7 +113,7 @@ pub(super) fn serve_blocking<W: std::io::Write + ?Sized>(
     result
 }
 
-pub(crate) async fn run_server(
+pub async fn run_server(
     endpoint: DaemonEndpoint,
     socket_path: PathBuf,
     endpoint_path: PathBuf,

--- a/crates/gwt/src/cli/env/default.rs
+++ b/crates/gwt/src/cli/env/default.rs
@@ -21,7 +21,7 @@ use super::{CliEnv, InternalCommandOutput};
 
 use crate::cli::{LinkedPrSummary, PrChecksSummary, PrCreateCall, PrReview, PrReviewThread};
 
-pub(crate) type IssueClientFactory =
+pub type IssueClientFactory =
     dyn Fn(&str, &str) -> Result<HttpIssueClient, gwt_github::client::ApiError> + Send + Sync;
 
 pub struct LazyIssueClient {

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -16,7 +16,7 @@ mod tests;
 
 pub use default::DefaultCliEnv;
 #[cfg(test)]
-pub(crate) use default::{IssueClientFactory, LazyIssueClient};
+pub use default::{IssueClientFactory, LazyIssueClient};
 pub use test_env::TestEnv;
 
 use std::{
@@ -95,7 +95,7 @@ pub struct InternalCommandCall {
 // ClientRef: a borrow wrapper that still implements IssueClient
 // ---------------------------------------------------------------------------
 
-pub(crate) struct ClientRef<'a, C: IssueClient> {
+pub struct ClientRef<'a, C: IssueClient> {
     pub(crate) inner: &'a C,
 }
 

--- a/crates/gwt/src/cli/index/mod.rs
+++ b/crates/gwt/src/cli/index/mod.rs
@@ -10,7 +10,7 @@
 //!   `index rebuild`.
 
 mod audit;
-pub(crate) mod runtime;
+pub mod runtime;
 
 use gwt_github::{client::ApiError, SpecOpsError};
 

--- a/crates/gwt/src/cli/index/runtime.rs
+++ b/crates/gwt/src/cli/index/runtime.rs
@@ -149,7 +149,7 @@ pub(super) fn parse_runner_json(stdout: &[u8]) -> Result<Value, SpecOpsError> {
     })
 }
 
-pub(crate) fn render_index_status(
+pub fn render_index_status(
     out: &mut String,
     report: &gwt_core::runtime::ProjectIndexRuntimeReport,
     payload: &Value,

--- a/crates/gwt/src/cli/plan.rs
+++ b/crates/gwt/src/cli/plan.rs
@@ -8,9 +8,9 @@ use gwt_github::SpecOpsError;
 use super::skill_state_runtime;
 use crate::cli::{CliEnv, SkillStateAction};
 
-pub(crate) const SKILL_NAME: &str = "plan-spec";
-pub(crate) const SKILL_DISPLAY: &str = "gwt-plan-spec";
-pub(crate) const VERB: &str = "plan";
+pub const SKILL_NAME: &str = "plan-spec";
+pub const SKILL_DISPLAY: &str = "gwt-plan-spec";
+pub const VERB: &str = "plan";
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,

--- a/crates/gwt/src/cli/pr/gh.rs
+++ b/crates/gwt/src/cli/pr/gh.rs
@@ -16,7 +16,7 @@ use crate::cli::{
     PrCheckItem, PrChecksSummary, PrCreateCall, PrReview, PrReviewThread, PrReviewThreadComment,
 };
 
-pub(crate) fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option<PrStatus>> {
+pub fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option<PrStatus>> {
     let output = gwt_core::process::hidden_command("gh")
         .args([
             "pr",
@@ -46,7 +46,7 @@ pub(crate) fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result
     Ok(Some(pr))
 }
 
-pub(crate) fn create_pr_via_gh(
+pub fn create_pr_via_gh(
     repo_slug: &str,
     repo_path: &std::path::Path,
     request: &PrCreateCall,
@@ -94,7 +94,7 @@ pub(crate) fn create_pr_via_gh(
         .map_err(|err| io::Error::other(err.to_string()))
 }
 
-pub(crate) fn edit_pr_via_gh(
+pub fn edit_pr_via_gh(
     repo_slug: &str,
     repo_path: &std::path::Path,
     number: u64,
@@ -130,7 +130,7 @@ pub(crate) fn edit_pr_via_gh(
         .map_err(|err| io::Error::other(err.to_string()))
 }
 
-pub(crate) fn extract_pr_url(stdout: &str) -> Option<String> {
+pub fn extract_pr_url(stdout: &str) -> Option<String> {
     stdout
         .lines()
         .map(str::trim)
@@ -138,11 +138,11 @@ pub(crate) fn extract_pr_url(stdout: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-pub(crate) fn parse_pr_number_from_url(url: &str) -> Option<u64> {
+pub fn parse_pr_number_from_url(url: &str) -> Option<u64> {
     url.trim_end_matches('/').rsplit('/').next()?.parse().ok()
 }
 
-pub(crate) fn comment_on_pr_via_gh(
+pub fn comment_on_pr_via_gh(
     repo_path: &std::path::Path,
     number: u64,
     body: &str,
@@ -160,11 +160,7 @@ pub(crate) fn comment_on_pr_via_gh(
     Ok(())
 }
 
-pub(crate) fn fetch_pr_reviews_via_gh(
-    owner: &str,
-    repo: &str,
-    number: u64,
-) -> io::Result<Vec<PrReview>> {
+pub fn fetch_pr_reviews_via_gh(owner: &str, repo: &str, number: u64) -> io::Result<Vec<PrReview>> {
     let endpoint = format!("repos/{owner}/{repo}/pulls/{number}/reviews");
     let output = gwt_core::process::hidden_command("gh")
         .args(["api", &endpoint])
@@ -217,7 +213,7 @@ pub(crate) fn fetch_pr_reviews_via_gh(
         .collect())
 }
 
-pub(crate) fn fetch_pr_review_threads_via_gh(
+pub fn fetch_pr_review_threads_via_gh(
     owner: &str,
     repo: &str,
     number: u64,
@@ -343,7 +339,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
         .collect())
 }
 
-pub(crate) fn reply_and_resolve_pr_review_threads_via_gh(
+pub fn reply_and_resolve_pr_review_threads_via_gh(
     owner: &str,
     repo: &str,
     number: u64,
@@ -433,7 +429,7 @@ mutation($threadId: ID!) {
     Ok(resolved_count)
 }
 
-pub(crate) fn fetch_pr_checks_via_gh(
+pub fn fetch_pr_checks_via_gh(
     repo_slug: &str,
     repo_path: &std::path::Path,
     number: u64,
@@ -510,7 +506,7 @@ pub(crate) fn fetch_pr_checks_via_gh(
     })
 }
 
-pub(crate) fn fetch_pr_review_thread_state_via_gh(
+pub fn fetch_pr_review_thread_state_via_gh(
     owner: &str,
     repo: &str,
     number: u64,
@@ -521,21 +517,19 @@ pub(crate) fn fetch_pr_review_thread_state_via_gh(
         .find(|thread| thread.id == thread_id))
 }
 
-pub(crate) fn review_thread_has_comment_body(thread: &PrReviewThread, body: &str) -> bool {
+pub fn review_thread_has_comment_body(thread: &PrReviewThread, body: &str) -> bool {
     thread.comments.iter().any(|comment| comment.body == body)
 }
 
-pub(crate) fn should_reply_to_review_thread(thread: &PrReviewThread, body: &str) -> bool {
+pub fn should_reply_to_review_thread(thread: &PrReviewThread, body: &str) -> bool {
     should_resolve_review_thread(thread) && !review_thread_has_comment_body(thread, body)
 }
 
-pub(crate) fn should_resolve_review_thread(thread: &PrReviewThread) -> bool {
+pub fn should_resolve_review_thread(thread: &PrReviewThread) -> bool {
     !thread.is_resolved && !thread.is_outdated
 }
 
-pub(crate) fn parse_pr_checks_items_json(
-    json: &str,
-) -> Result<Vec<PrCheckItem>, serde_json::Error> {
+pub fn parse_pr_checks_items_json(json: &str) -> Result<Vec<PrCheckItem>, serde_json::Error> {
     let values: Vec<serde_json::Value> = serde_json::from_str(json)?;
     Ok(values
         .into_iter()
@@ -582,7 +576,7 @@ pub(crate) fn parse_pr_checks_items_json(
         .collect())
 }
 
-pub(crate) fn parse_pr_checks_items_response(
+pub fn parse_pr_checks_items_response(
     stdout: &str,
     stderr: &str,
     success: bool,
@@ -595,7 +589,7 @@ pub(crate) fn parse_pr_checks_items_response(
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))
 }
 
-pub(crate) fn parse_available_fields(message: &str) -> Vec<String> {
+pub fn parse_available_fields(message: &str) -> Vec<String> {
     let mut fields = Vec::new();
     let mut collecting = false;
     for line in message.lines() {
@@ -615,7 +609,7 @@ pub(crate) fn parse_available_fields(message: &str) -> Vec<String> {
     fields
 }
 
-pub(crate) fn edit_or_create_repo_guard(owner: &str, repo: &str) -> io::Result<()> {
+pub fn edit_or_create_repo_guard(owner: &str, repo: &str) -> io::Result<()> {
     if owner.is_empty() || repo.is_empty() {
         return Err(io::Error::other(
             "missing repository context for PR create/edit operation",

--- a/crates/gwt/src/cli/skill_state_runtime.rs
+++ b/crates/gwt/src/cli/skill_state_runtime.rs
@@ -23,7 +23,7 @@ fn current_session_id() -> String {
     std::env::var(GWT_SESSION_ID_ENV).unwrap_or_default()
 }
 
-pub(crate) fn run<E: CliEnv>(
+pub fn run<E: CliEnv>(
     env: &mut E,
     action: SkillStateAction,
     skill_name: &str,

--- a/crates/gwt/src/cli/test_support.rs
+++ b/crates/gwt/src/cli/test_support.rs
@@ -17,12 +17,12 @@ use tempfile::tempdir;
 
 use super::PrReviewThread;
 
-pub(crate) fn fake_gh_test_lock() -> &'static std::sync::Mutex<()> {
+pub fn fake_gh_test_lock() -> &'static std::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
 }
 
-pub(crate) fn compile_fake_gh(bin_dir: &Path) {
+pub fn compile_fake_gh(bin_dir: &Path) {
     let source = r###"
 use std::{env, fs, process::ExitCode};
 
@@ -182,7 +182,7 @@ fn main() -> ExitCode {
     assert!(status.success(), "fake gh compilation failed");
 }
 
-pub(crate) fn with_fake_gh<T>(mode: &str, test: impl FnOnce(&Path) -> T) -> T {
+pub fn with_fake_gh<T>(mode: &str, test: impl FnOnce(&Path) -> T) -> T {
     let _lock = fake_gh_test_lock()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -223,7 +223,7 @@ pub(crate) fn with_fake_gh<T>(mode: &str, test: impl FnOnce(&Path) -> T) -> T {
     result
 }
 
-pub(crate) fn sample_thread() -> PrReviewThread {
+pub fn sample_thread() -> PrReviewThread {
     PrReviewThread {
         id: "thread-1".to_string(),
         is_resolved: false,
@@ -234,7 +234,7 @@ pub(crate) fn sample_thread() -> PrReviewThread {
     }
 }
 
-pub(crate) fn sample_issue_snapshot() -> IssueSnapshot {
+pub fn sample_issue_snapshot() -> IssueSnapshot {
     IssueSnapshot {
         number: IssueNumber(42),
         title: "Coverage gate".to_string(),
@@ -250,7 +250,7 @@ pub(crate) fn sample_issue_snapshot() -> IssueSnapshot {
     }
 }
 
-pub(crate) fn sample_pr_status() -> gwt_git::PrStatus {
+pub fn sample_pr_status() -> gwt_git::PrStatus {
     gwt_git::PrStatus {
         number: 128,
         title: "Enforce coverage".to_string(),
@@ -263,7 +263,7 @@ pub(crate) fn sample_pr_status() -> gwt_git::PrStatus {
     }
 }
 
-pub(crate) struct ScopedEnvVar {
+pub struct ScopedEnvVar {
     key: &'static str,
     previous: Option<std::ffi::OsString>,
 }
@@ -286,7 +286,7 @@ impl Drop for ScopedEnvVar {
     }
 }
 
-pub(crate) fn commands_for_event<'a>(value: &'a serde_json::Value, event: &str) -> Vec<&'a str> {
+pub fn commands_for_event<'a>(value: &'a serde_json::Value, event: &str) -> Vec<&'a str> {
     value["hooks"][event]
         .as_array()
         .unwrap_or_else(|| panic!("hooks missing for event {event}"))

--- a/crates/gwt/src/discussion_resume.rs
+++ b/crates/gwt/src/discussion_resume.rs
@@ -175,7 +175,7 @@ pub fn build_resume_prompt(pending: &PendingDiscussionResume) -> String {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProposalStatus {
+pub enum ProposalStatus {
     Active,
     Parked,
     Rejected,
@@ -184,7 +184,7 @@ pub(crate) enum ProposalStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ParsedProposal {
+pub struct ParsedProposal {
     pub(crate) header_line_index: usize,
     pub(crate) label: String,
     pub(crate) title: String,
@@ -192,7 +192,7 @@ pub(crate) struct ParsedProposal {
     pub(crate) next_question: Option<String>,
 }
 
-pub(crate) fn parse_proposals(content: &str) -> Vec<ParsedProposal> {
+pub fn parse_proposals(content: &str) -> Vec<ParsedProposal> {
     let mut proposals: Vec<ParsedProposal> = Vec::new();
 
     for (index, raw_line) in content.lines().enumerate() {

--- a/crates/gwt/src/docker_launch.rs
+++ b/crates/gwt/src/docker_launch.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn detect_wizard_docker_context_and_status(
+pub fn detect_wizard_docker_context_and_status(
     project_root: &Path,
 ) -> (
     Option<DockerWizardContext>,
@@ -34,7 +34,7 @@ pub(crate) fn detect_wizard_docker_context_and_status(
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct DockerLaunchPlan {
+pub struct DockerLaunchPlan {
     pub(crate) compose_files: Vec<PathBuf>,
     pub(crate) compose_file: PathBuf,
     pub(crate) override_file: PathBuf,
@@ -55,13 +55,13 @@ struct DockerPackageRunnerCandidate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PackageRunnerProgram {
+pub struct PackageRunnerProgram {
     pub(crate) executable: String,
     pub(crate) args: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct DevContainerLaunchDefaults {
+pub struct DevContainerLaunchDefaults {
     pub(crate) service: Option<String>,
     pub(crate) workspace_folder: Option<String>,
     pub(crate) compose_files: Vec<PathBuf>,
@@ -77,7 +77,7 @@ impl DockerLaunchPlan {
     }
 }
 
-pub(crate) fn apply_docker_runtime_to_launch_config(
+pub fn apply_docker_runtime_to_launch_config(
     repo_path: &Path,
     config: &mut gwt_agent::LaunchConfig,
 ) -> Result<(), String> {
@@ -105,7 +105,7 @@ pub(crate) fn apply_docker_runtime_to_launch_config(
     Ok(())
 }
 
-pub(crate) fn finalize_docker_agent_launch_config(
+pub fn finalize_docker_agent_launch_config(
     repo_path: &Path,
     config: &mut gwt_agent::LaunchConfig,
 ) -> Result<(), String> {
@@ -150,7 +150,7 @@ fn resolve_user_home_dir() -> Result<PathBuf, String> {
     Ok(home)
 }
 
-pub(crate) fn docker_bundle_mounts_for_home(home: &Path) -> DockerBundleMounts {
+pub fn docker_bundle_mounts_for_home(home: &Path) -> DockerBundleMounts {
     let gwt_bin_dir = home.join(".gwt").join("bin");
     DockerBundleMounts {
         host_gwt: gwt_bin_dir.join(DOCKER_HOST_GWT_BIN_NAME),
@@ -162,7 +162,7 @@ fn docker_compose_mount_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
-pub(crate) fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) -> String {
+pub fn docker_bundle_override_content(service: &str, bundle: &DockerBundleMounts) -> String {
     let host_gwtd = docker_compose_mount_path(&bundle.host_gwtd);
     format!(
         concat!(
@@ -179,7 +179,7 @@ pub(crate) fn docker_bundle_override_content(service: &str, bundle: &DockerBundl
     )
 }
 
-pub(crate) fn ensure_docker_gwt_binary_setup(launch: &DockerLaunchPlan) -> Result<(), String> {
+pub fn ensure_docker_gwt_binary_setup(launch: &DockerLaunchPlan) -> Result<(), String> {
     use std::fs;
 
     let home = resolve_user_home_dir()?;
@@ -249,7 +249,7 @@ fn maybe_inject_docker_sandbox_env(
     Ok(())
 }
 
-pub(crate) fn docker_compose_exec_env_args(env_vars: &HashMap<String, String>) -> Vec<String> {
+pub fn docker_compose_exec_env_args(env_vars: &HashMap<String, String>) -> Vec<String> {
     let mut keys = env_vars.keys().collect::<Vec<_>>();
     keys.sort();
 
@@ -266,7 +266,7 @@ pub(crate) fn docker_compose_exec_env_args(env_vars: &HashMap<String, String>) -
     args
 }
 
-pub(crate) fn is_valid_docker_env_key(key: &str) -> bool {
+pub fn is_valid_docker_env_key(key: &str) -> bool {
     let mut chars = key.chars();
     let Some(first) = chars.next() else {
         return false;
@@ -289,7 +289,7 @@ fn resolve_docker_exec_program(
     resolve_docker_package_runner(launch, config, &version_spec)
 }
 
-pub(crate) fn package_runner_version_spec(config: &gwt_agent::LaunchConfig) -> Option<String> {
+pub fn package_runner_version_spec(config: &gwt_agent::LaunchConfig) -> Option<String> {
     let package = config.agent_id.package_name()?;
     let version = config.tool_version.as_deref()?;
     if version == "installed" || version.is_empty() {
@@ -338,7 +338,7 @@ fn resolve_docker_package_runner(
     ))
 }
 
-pub(crate) fn strip_package_runner_args(args: &[String], version_spec: &str) -> Vec<String> {
+pub fn strip_package_runner_args(args: &[String], version_spec: &str) -> Vec<String> {
     if args.first().is_some_and(|first| first == "--yes")
         && args.get(1).is_some_and(|arg| arg == version_spec)
     {
@@ -350,7 +350,7 @@ pub(crate) fn strip_package_runner_args(args: &[String], version_spec: &str) -> 
     args.to_vec()
 }
 
-pub(crate) fn resolve_docker_shell_command(launch: &DockerLaunchPlan) -> Result<String, String> {
+pub fn resolve_docker_shell_command(launch: &DockerLaunchPlan) -> Result<String, String> {
     for candidate in ["bash", "sh"] {
         let available = gwt_docker::compose_service_has_command_with_files(
             &launch.compose_files_for_runtime(),
@@ -407,7 +407,7 @@ impl DockerPackageRunnerCandidate {
     }
 }
 
-pub(crate) fn ensure_docker_launch_service_ready(
+pub fn ensure_docker_launch_service_ready(
     launch: &DockerLaunchPlan,
     intent: gwt_agent::DockerLifecycleIntent,
 ) -> Result<(), String> {
@@ -433,14 +433,14 @@ pub(crate) fn ensure_docker_launch_service_ready(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DockerLaunchServiceAction {
+pub enum DockerLaunchServiceAction {
     Connect,
     Start,
     Restart,
     Recreate,
 }
 
-pub(crate) fn normalize_docker_launch_action(
+pub fn normalize_docker_launch_action(
     intent: gwt_agent::DockerLifecycleIntent,
     status: gwt_docker::ComposeServiceStatus,
 ) -> DockerLaunchServiceAction {
@@ -546,7 +546,7 @@ fn looks_like_relative_bind_mount(source: &str) -> bool {
         || source.starts_with("..\\")
 }
 
-pub(crate) fn resolve_docker_launch_plan(
+pub fn resolve_docker_launch_plan(
     worktree: &Path,
     selected_service: Option<&str>,
 ) -> Result<DockerLaunchPlan, String> {
@@ -608,11 +608,11 @@ pub(crate) fn resolve_docker_launch_plan(
     })
 }
 
-pub(crate) fn docker_binary_for_launch() -> String {
+pub fn docker_binary_for_launch() -> String {
     std::env::var("GWT_DOCKER_BIN").unwrap_or_else(|_| "docker".to_string())
 }
 
-pub(crate) fn docker_compose_files_for_launch(
+pub fn docker_compose_files_for_launch(
     project_root: &Path,
     files: &gwt_docker::DockerFiles,
 ) -> Result<Vec<PathBuf>, String> {
@@ -625,7 +625,7 @@ pub(crate) fn docker_compose_files_for_launch(
 }
 
 #[allow(dead_code)]
-pub(crate) fn docker_compose_file_for_launch(
+pub fn docker_compose_file_for_launch(
     project_root: &Path,
     files: &gwt_docker::DockerFiles,
 ) -> Result<Option<PathBuf>, String> {
@@ -634,7 +634,7 @@ pub(crate) fn docker_compose_file_for_launch(
         .next())
 }
 
-pub(crate) fn docker_devcontainer_defaults(
+pub fn docker_devcontainer_defaults(
     project_root: &Path,
     files: &gwt_docker::DockerFiles,
 ) -> Option<DevContainerLaunchDefaults> {
@@ -678,7 +678,7 @@ pub(crate) fn docker_devcontainer_defaults(
     })
 }
 
-pub(crate) fn compose_workspace_mount_target(
+pub fn compose_workspace_mount_target(
     project_root: &Path,
     service: &gwt_docker::ComposeService,
 ) -> Option<String> {
@@ -689,7 +689,7 @@ pub(crate) fn compose_workspace_mount_target(
         .map(|mount| mount.target.clone())
 }
 
-pub(crate) fn mount_source_matches_project_root(source: &str, project_root: &Path) -> bool {
+pub fn mount_source_matches_project_root(source: &str, project_root: &Path) -> bool {
     let normalized = source
         .trim()
         .trim_end_matches(['/', '\\'])

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -33,7 +33,7 @@ type PtyWriterRegistry = Arc<RwLock<HashMap<String, Arc<PtyHandle>>>>;
 const CLIENT_QUEUE_CAPACITY: usize = 64;
 
 #[derive(Clone, Default)]
-pub(super) struct ClientHub {
+pub struct ClientHub {
     clients: Arc<Mutex<HashMap<String, mpsc::Sender<String>>>>,
 }
 
@@ -93,7 +93,7 @@ struct ServerState {
     pty_writers: PtyWriterRegistry,
 }
 
-pub(super) struct EmbeddedServer {
+pub struct EmbeddedServer {
     url: String,
     hook_forward_token: String,
     shutdown_tx: Option<oneshot::Sender<()>>,
@@ -178,7 +178,7 @@ impl EmbeddedServer {
     }
 }
 
-pub(super) async fn health_handler() -> &'static str {
+pub async fn health_handler() -> &'static str {
     "ok"
 }
 
@@ -363,7 +363,7 @@ fn handle_frontend_message(
     );
 }
 
-pub(super) fn hook_forward_authorized(headers: &HeaderMap, expected_token: &str) -> bool {
+pub fn hook_forward_authorized(headers: &HeaderMap, expected_token: &str) -> bool {
     headers
         .get(AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
@@ -371,7 +371,7 @@ pub(super) fn hook_forward_authorized(headers: &HeaderMap, expected_token: &str)
         .is_some_and(|token| token == expected_token)
 }
 
-pub(super) fn websocket_origin_authorized(headers: &HeaderMap) -> bool {
+pub fn websocket_origin_authorized(headers: &HeaderMap) -> bool {
     let Some(origin) = headers.get(ORIGIN) else {
         return true;
     };
@@ -390,7 +390,7 @@ pub(super) fn websocket_origin_authorized(headers: &HeaderMap) -> bool {
 }
 
 #[cfg(test)]
-pub(super) fn broadcast_runtime_hook_event(clients: &ClientHub, event: RuntimeHookEvent) {
+pub fn broadcast_runtime_hook_event(clients: &ClientHub, event: RuntimeHookEvent) {
     clients.dispatch(vec![OutboundEvent::broadcast(
         gwt::BackendEvent::RuntimeHookEvent { event },
     )]);

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -3,74 +3,74 @@ use axum::{
     response::{Html, IntoResponse},
 };
 
-pub(crate) fn index_html() -> &'static str {
+pub fn index_html() -> &'static str {
     include_str!("../web/index.html")
 }
 
-pub(crate) fn app_js() -> &'static str {
+pub fn app_js() -> &'static str {
     include_str!("../web/app.js")
 }
 
-pub(crate) fn branch_cleanup_modal_js() -> &'static str {
+pub fn branch_cleanup_modal_js() -> &'static str {
     include_str!("../web/branch-cleanup-modal.js")
 }
 
-pub(crate) fn migration_modal_js() -> &'static str {
+pub fn migration_modal_js() -> &'static str {
     include_str!("../web/migration-modal.js")
 }
 
-pub(crate) fn xterm_js() -> &'static str {
+pub fn xterm_js() -> &'static str {
     include_str!("../web/vendor/xterm/xterm.mjs")
 }
 
-pub(crate) fn xterm_fit_js() -> &'static str {
+pub fn xterm_fit_js() -> &'static str {
     include_str!("../web/vendor/xterm/addon-fit.mjs")
 }
 
-pub(crate) fn xterm_css() -> &'static str {
+pub fn xterm_css() -> &'static str {
     include_str!("../web/vendor/xterm/xterm.css")
 }
 
-pub(crate) async fn index_handler() -> Html<&'static str> {
+pub async fn index_handler() -> Html<&'static str> {
     Html(index_html())
 }
 
-pub(crate) async fn app_js_handler() -> impl IntoResponse {
+pub async fn app_js_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
         app_js(),
     )
 }
 
-pub(crate) async fn branch_cleanup_modal_js_handler() -> impl IntoResponse {
+pub async fn branch_cleanup_modal_js_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
         branch_cleanup_modal_js(),
     )
 }
 
-pub(crate) async fn migration_modal_js_handler() -> impl IntoResponse {
+pub async fn migration_modal_js_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
         migration_modal_js(),
     )
 }
 
-pub(crate) async fn xterm_js_handler() -> impl IntoResponse {
+pub async fn xterm_js_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
         xterm_js(),
     )
 }
 
-pub(crate) async fn xterm_fit_js_handler() -> impl IntoResponse {
+pub async fn xterm_fit_js_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
         xterm_fit_js(),
     )
 }
 
-pub(crate) async fn xterm_css_handler() -> impl IntoResponse {
+pub async fn xterm_css_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/css; charset=utf-8")],
         xterm_css(),

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 const DETACHED_REPO_CACHE_DIR: &str = "__detached__";
 const SPEC_LABEL: &str = "gwt-spec";
 const ISSUE_CACHE_REFRESH_META_FILE: &str = "refresh-meta.json";
-pub(crate) const ISSUE_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+pub const ISSUE_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct IssueCacheRefreshMeta {
@@ -30,33 +30,33 @@ struct IssueCacheRefreshMeta {
     ttl_minutes: u64,
 }
 
-pub(crate) fn issue_cache_base_root() -> PathBuf {
+pub fn issue_cache_base_root() -> PathBuf {
     gwt_cache_dir().join("issues")
 }
 
-pub(crate) fn detached_issue_cache_root() -> PathBuf {
+pub fn detached_issue_cache_root() -> PathBuf {
     issue_cache_base_root().join(DETACHED_REPO_CACHE_DIR)
 }
 
-pub(crate) fn issue_cache_root_for_repo_hash(repo_hash: &RepoHash) -> PathBuf {
+pub fn issue_cache_root_for_repo_hash(repo_hash: &RepoHash) -> PathBuf {
     issue_cache_base_root().join(repo_hash.as_str())
 }
 
-pub(crate) fn issue_cache_root_for_repo_slug(owner: &str, repo: &str) -> PathBuf {
+pub fn issue_cache_root_for_repo_slug(owner: &str, repo: &str) -> PathBuf {
     let remote = format!("https://github.com/{owner}/{repo}.git");
     issue_cache_root_for_repo_hash(&compute_repo_hash(&remote))
 }
 
-pub(crate) fn issue_cache_root_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
+pub fn issue_cache_root_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
     crate::index_worker::detect_repo_hash(repo_path)
         .map(|repo_hash| issue_cache_root_for_repo_hash(&repo_hash))
 }
 
-pub(crate) fn issue_cache_root_for_repo_path_or_detached(repo_path: &Path) -> PathBuf {
+pub fn issue_cache_root_for_repo_path_or_detached(repo_path: &Path) -> PathBuf {
     issue_cache_root_for_repo_path(repo_path).unwrap_or_else(detached_issue_cache_root)
 }
 
-pub(crate) fn sync_issue_cache_from_remote_if_missing(
+pub fn sync_issue_cache_from_remote_if_missing(
     repo_path: &Path,
     cache_root: &Path,
 ) -> Result<(), String> {
@@ -70,7 +70,7 @@ pub(crate) fn sync_issue_cache_from_remote_if_missing(
     sync_issue_cache_from_remote(repo_path, cache_root)
 }
 
-pub(crate) fn sync_issue_cache_from_remote_if_stale(
+pub fn sync_issue_cache_from_remote_if_stale(
     repo_path: &Path,
     cache_root: &Path,
     ttl: Duration,
@@ -85,10 +85,7 @@ pub(crate) fn sync_issue_cache_from_remote_if_stale(
     Ok(true)
 }
 
-pub(crate) fn sync_issue_cache_from_remote(
-    repo_path: &Path,
-    cache_root: &Path,
-) -> Result<(), String> {
+pub fn sync_issue_cache_from_remote(repo_path: &Path, cache_root: &Path) -> Result<(), String> {
     let snapshots = fetch_issue_list_snapshots(repo_path)?;
     if snapshots.is_empty() {
         fs::create_dir_all(cache_root).map_err(|err| err.to_string())?;
@@ -115,7 +112,7 @@ pub(crate) fn sync_issue_cache_from_remote(
     Ok(())
 }
 
-pub(crate) fn issue_cache_has_entries(cache_root: &Path) -> bool {
+pub fn issue_cache_has_entries(cache_root: &Path) -> bool {
     let Ok(entries) = fs::read_dir(cache_root) else {
         return false;
     };

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn resolve_launch_worktree_request(
+pub fn resolve_launch_worktree_request(
     repo_path: &Path,
     branch_name: Option<&str>,
     base_branch: Option<&str>,
@@ -121,7 +121,7 @@ pub(crate) fn resolve_launch_worktree_request(
     Ok(())
 }
 
-pub(crate) fn resolve_launch_worktree(
+pub fn resolve_launch_worktree(
     repo_path: &Path,
     config: &mut gwt_agent::LaunchConfig,
 ) -> Result<(), String> {
@@ -134,7 +134,7 @@ pub(crate) fn resolve_launch_worktree(
     )
 }
 
-pub(crate) fn resolve_shell_launch_worktree(
+pub fn resolve_shell_launch_worktree(
     repo_path: &Path,
     config: &mut ShellLaunchConfig,
 ) -> Result<(), String> {
@@ -147,7 +147,7 @@ pub(crate) fn resolve_shell_launch_worktree(
     )
 }
 
-pub(crate) fn build_shell_process_launch(
+pub fn build_shell_process_launch(
     repo_path: &Path,
     config: &mut ShellLaunchConfig,
 ) -> Result<ProcessLaunch, String> {
@@ -223,9 +223,9 @@ pub(crate) fn build_shell_process_launch(
     })
 }
 
-pub(crate) const WINDOWS_HOST_SHELL_EXPRESSION_ENV: &str = "GWT_WINDOWS_HOST_SHELL_EXPRESSION";
+pub const WINDOWS_HOST_SHELL_EXPRESSION_ENV: &str = "GWT_WINDOWS_HOST_SHELL_EXPRESSION";
 
-pub(crate) fn windows_shell_process_command(shell: gwt_agent::WindowsShellKind) -> &'static str {
+pub fn windows_shell_process_command(shell: gwt_agent::WindowsShellKind) -> &'static str {
     match shell {
         gwt_agent::WindowsShellKind::CommandPrompt => "cmd.exe",
         gwt_agent::WindowsShellKind::WindowsPowerShell => "powershell",
@@ -241,7 +241,7 @@ fn interactive_windows_shell_args(shell: gwt_agent::WindowsShellKind) -> Vec<Str
     }
 }
 
-pub(crate) fn apply_windows_host_shell_wrapper(
+pub fn apply_windows_host_shell_wrapper(
     config: &mut gwt_agent::LaunchConfig,
 ) -> Result<(), String> {
     if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Host {
@@ -330,7 +330,7 @@ fn build_powershell_command_script(command: &str, args: &[String]) -> String {
     )
 }
 
-pub(crate) fn apply_host_package_runner_fallback(config: &mut gwt_agent::LaunchConfig) -> bool {
+pub fn apply_host_package_runner_fallback(config: &mut gwt_agent::LaunchConfig) -> bool {
     apply_host_package_runner_fallback_with_probe(
         config,
         "npx".to_string(),
@@ -338,7 +338,7 @@ pub(crate) fn apply_host_package_runner_fallback(config: &mut gwt_agent::LaunchC
     )
 }
 
-pub(crate) fn apply_host_package_runner_fallback_with_probe<F>(
+pub fn apply_host_package_runner_fallback_with_probe<F>(
     config: &mut gwt_agent::LaunchConfig,
     fallback_executable: String,
     mut probe: F,
@@ -428,7 +428,7 @@ fn probe_host_package_runner(
     )
 }
 
-pub(crate) fn probe_host_package_runner_with_timeout(
+pub fn probe_host_package_runner_with_timeout(
     command: &str,
     args: Vec<String>,
     env_vars: &HashMap<String, String>,
@@ -474,7 +474,7 @@ pub(crate) fn probe_host_package_runner_with_timeout(
     }
 }
 
-pub(crate) fn command_matches_runner(command: &str, runner: &str) -> bool {
+pub fn command_matches_runner(command: &str, runner: &str) -> bool {
     let path = Path::new(command);
     path.file_stem()
         .and_then(|stem| stem.to_str())
@@ -482,7 +482,7 @@ pub(crate) fn command_matches_runner(command: &str, runner: &str) -> bool {
         .is_some_and(|name| name.eq_ignore_ascii_case(runner))
 }
 
-pub(crate) fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
+pub fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
     if !gwt_docker::docker_available() {
         return Err("Docker is not installed or not available on PATH".to_string());
     }
@@ -495,7 +495,7 @@ pub(crate) fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
     Ok(())
 }
 
-pub(crate) fn install_launch_gwt_bin_env(
+pub fn install_launch_gwt_bin_env(
     env_vars: &mut HashMap<String, String>,
     runtime_target: gwt_agent::LaunchRuntimeTarget,
 ) -> Result<(), String> {
@@ -505,7 +505,7 @@ pub(crate) fn install_launch_gwt_bin_env(
     })
 }
 
-pub(crate) fn install_launch_gwt_bin_env_with_lookup(
+pub fn install_launch_gwt_bin_env_with_lookup(
     env_vars: &mut HashMap<String, String>,
     runtime_target: gwt_agent::LaunchRuntimeTarget,
     current_exe: &Path,

--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -9,14 +9,14 @@ use std::{
 use crate::{app_runtime::AppEventProxy, UserEvent};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProjectIndexBootstrapRequest {
+pub enum ProjectIndexBootstrapRequest {
     Spawned,
     AlreadyRunning,
     SpawnFailed,
 }
 
 #[derive(Clone, Default)]
-pub(crate) struct ProjectIndexBootstrapService {
+pub struct ProjectIndexBootstrapService {
     in_flight: Arc<Mutex<HashSet<PathBuf>>>,
 }
 

--- a/crates/gwt/src/repo_browser.rs
+++ b/crates/gwt/src/repo_browser.rs
@@ -10,7 +10,7 @@ use gwt::{
     BranchEntriesPhase, BranchListEntry, BranchScope,
 };
 
-pub(crate) fn spawn_branch_load_async(
+pub fn spawn_branch_load_async(
     proxy: AppEventProxy,
     client_id: ClientId,
     window_id: String,
@@ -28,7 +28,7 @@ pub(crate) fn spawn_branch_load_async(
     });
 }
 
-pub(crate) fn preferred_issue_launch_branch(entries: &[BranchListEntry]) -> Option<String> {
+pub fn preferred_issue_launch_branch(entries: &[BranchListEntry]) -> Option<String> {
     let mut locals = entries
         .iter()
         .filter(|entry| entry.scope == BranchScope::Local)

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -1,10 +1,10 @@
 use super::*;
 
-pub(crate) fn combined_window_id(tab_id: &str, raw_id: &str) -> String {
+pub fn combined_window_id(tab_id: &str, raw_id: &str) -> String {
     format!("{tab_id}::{raw_id}")
 }
 
-pub(crate) fn should_auto_close_agent_window(
+pub fn should_auto_close_agent_window(
     active_agent_sessions: &HashMap<String, ActiveAgentSession>,
     window_id: &str,
     status: &WindowProcessStatus,
@@ -12,7 +12,7 @@ pub(crate) fn should_auto_close_agent_window(
     matches!(status, WindowProcessStatus::Stopped) && active_agent_sessions.contains_key(window_id)
 }
 
-pub(crate) fn close_window_from_workspace(
+pub fn close_window_from_workspace(
     tabs: &mut [ProjectTabRuntime],
     window_lookup: &mut HashMap<String, WindowAddress>,
     window_details: &mut HashMap<String, String>,
@@ -32,15 +32,15 @@ pub(crate) fn close_window_from_workspace(
     true
 }
 
-pub(crate) fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool {
+pub fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool {
     window.preset.requires_process() && window.status == WindowProcessStatus::Running
 }
 
-pub(crate) fn current_app_version() -> &'static str {
+pub fn current_app_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
-pub(crate) fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
+pub fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
     gwt::WorkspaceView {
         viewport: tab.workspace.persisted().viewport.clone(),
         windows: tab
@@ -57,7 +57,7 @@ pub(crate) fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceV
     }
 }
 
-pub(crate) fn app_state_view_from_parts(
+pub fn app_state_view_from_parts(
     tabs: &[ProjectTabRuntime],
     active_tab_id: Option<&str>,
     recent_projects: &[gwt::RecentProjectEntry],
@@ -86,7 +86,7 @@ pub(crate) fn app_state_view_from_parts(
     }
 }
 
-pub(crate) fn normalize_active_tab_id(
+pub fn normalize_active_tab_id(
     tabs: &[ProjectTabRuntime],
     active_tab_id: Option<String>,
 ) -> Option<String> {
@@ -100,7 +100,7 @@ pub(crate) fn normalize_active_tab_id(
     }
 }
 
-pub(crate) fn dedupe_recent_projects(
+pub fn dedupe_recent_projects(
     entries: Vec<gwt::RecentProjectEntry>,
 ) -> Vec<gwt::RecentProjectEntry> {
     let mut deduped: Vec<gwt::RecentProjectEntry> = Vec::new();
@@ -120,13 +120,13 @@ pub(crate) fn dedupe_recent_projects(
 /// disk. Called once at load time so subsequent `persist()` writes a clean
 /// list back. A separate function (rather than baked into `dedupe_*`) so
 /// tests and callers can exercise the path predicate without filesystem.
-pub(crate) fn prune_missing_recent_projects(
+pub fn prune_missing_recent_projects(
     entries: Vec<gwt::RecentProjectEntry>,
 ) -> Vec<gwt::RecentProjectEntry> {
     prune_missing_recent_projects_with(entries, std::path::Path::exists)
 }
 
-pub(crate) fn prune_missing_recent_projects_with(
+pub fn prune_missing_recent_projects_with(
     entries: Vec<gwt::RecentProjectEntry>,
     exists: impl Fn(&Path) -> bool,
 ) -> Vec<gwt::RecentProjectEntry> {
@@ -136,7 +136,7 @@ pub(crate) fn prune_missing_recent_projects_with(
         .collect()
 }
 
-pub(crate) fn fallback_project_target(path: PathBuf) -> ProjectOpenTarget {
+pub fn fallback_project_target(path: PathBuf) -> ProjectOpenTarget {
     ProjectOpenTarget {
         title: gwt::project_title_from_path(&path),
         project_root: path,
@@ -145,7 +145,7 @@ pub(crate) fn fallback_project_target(path: PathBuf) -> ProjectOpenTarget {
     }
 }
 
-pub(crate) fn resolve_project_target(path: &Path) -> Result<ProjectOpenTarget, String> {
+pub fn resolve_project_target(path: &Path) -> Result<ProjectOpenTarget, String> {
     let canonical = dunce::canonicalize(path)
         .map_err(|error| format!("failed to open project {}: {error}", path.display()))?;
     if !canonical.is_dir() {
@@ -186,7 +186,7 @@ pub(crate) fn resolve_project_target(path: &Path) -> Result<ProjectOpenTarget, S
     })
 }
 
-pub(crate) fn normalize_branch_name(branch_name: &str) -> String {
+pub fn normalize_branch_name(branch_name: &str) -> String {
     if let Some(name) = branch_name.strip_prefix("refs/remotes/") {
         return name.strip_prefix("origin/").unwrap_or(name).to_string();
     }
@@ -196,7 +196,7 @@ pub(crate) fn normalize_branch_name(branch_name: &str) -> String {
     branch_name.to_string()
 }
 
-pub(crate) fn synthetic_branch_entry(branch_name: &str) -> BranchListEntry {
+pub fn synthetic_branch_entry(branch_name: &str) -> BranchListEntry {
     BranchListEntry {
         name: branch_name.to_string(),
         scope: gwt::BranchScope::Local,
@@ -210,7 +210,7 @@ pub(crate) fn synthetic_branch_entry(branch_name: &str) -> BranchListEntry {
     }
 }
 
-pub(crate) fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> {
+pub fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> {
     match preset {
         WindowPreset::Issue => Some(KnowledgeKind::Issue),
         WindowPreset::Spec => Some(KnowledgeKind::Spec),
@@ -219,7 +219,7 @@ pub(crate) fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<Knowledg
     }
 }
 
-pub(crate) fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
+pub fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
     if current_git_branch(repo_path)
         .as_ref()
         .is_ok_and(|current| current == branch_name)
@@ -237,7 +237,7 @@ pub(crate) fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Optio
         .map(|worktree| worktree.path)
 }
 
-pub(crate) fn first_available_worktree_path(
+pub fn first_available_worktree_path(
     preferred_path: &Path,
     worktrees: &[gwt_git::WorktreeInfo],
 ) -> Option<PathBuf> {
@@ -255,20 +255,20 @@ pub(crate) fn first_available_worktree_path(
     None
 }
 
-pub(crate) fn suffixed_worktree_path(path: &Path, suffix: usize) -> Option<PathBuf> {
+pub fn suffixed_worktree_path(path: &Path, suffix: usize) -> Option<PathBuf> {
     let file_name = path.file_name()?.to_str()?;
     let mut candidate = path.to_path_buf();
     candidate.set_file_name(format!("{file_name}-{suffix}"));
     Some(candidate)
 }
 
-pub(crate) fn worktree_path_is_occupied(path: &Path, worktrees: &[gwt_git::WorktreeInfo]) -> bool {
+pub fn worktree_path_is_occupied(path: &Path, worktrees: &[gwt_git::WorktreeInfo]) -> bool {
     worktrees
         .iter()
         .any(|worktree| same_worktree_path(&worktree.path, path))
 }
 
-pub(crate) fn same_worktree_path(left: &Path, right: &Path) -> bool {
+pub fn same_worktree_path(left: &Path, right: &Path) -> bool {
     if left == right {
         return true;
     }
@@ -279,7 +279,7 @@ pub(crate) fn same_worktree_path(left: &Path, right: &Path) -> bool {
     }
 }
 
-pub(crate) fn origin_remote_ref(branch_name: &str) -> String {
+pub fn origin_remote_ref(branch_name: &str) -> String {
     if let Some(ref_name) = branch_name.strip_prefix("refs/remotes/") {
         ref_name.to_string()
     } else if branch_name.starts_with("origin/") {
@@ -289,7 +289,7 @@ pub(crate) fn origin_remote_ref(branch_name: &str) -> String {
     }
 }
 
-pub(crate) fn current_git_branch(repo_path: &Path) -> Result<String, String> {
+pub fn current_git_branch(repo_path: &Path) -> Result<String, String> {
     let output = gwt_core::process::hidden_command("git")
         .args(["branch", "--show-current"])
         .current_dir(repo_path)
@@ -310,7 +310,7 @@ pub(crate) fn current_git_branch(repo_path: &Path) -> Result<String, String> {
     }
 }
 
-pub(crate) fn local_branch_exists(repo_path: &Path, branch_name: &str) -> Result<bool, String> {
+pub fn local_branch_exists(repo_path: &Path, branch_name: &str) -> Result<bool, String> {
     let output = gwt_core::process::hidden_command("git")
         .args([
             "show-ref",
@@ -333,7 +333,7 @@ pub(crate) fn local_branch_exists(repo_path: &Path, branch_name: &str) -> Result
     }
 }
 
-pub(crate) fn resolve_launch_spec_with_fallback(
+pub fn resolve_launch_spec_with_fallback(
     preset: WindowPreset,
     shell: &gwt::ShellProgram,
 ) -> Result<gwt::LaunchSpec, gwt::PresetResolveError> {
@@ -342,27 +342,27 @@ pub(crate) fn resolve_launch_spec_with_fallback(
 }
 
 #[cfg(test)]
-pub(crate) fn spawn_env() -> HashMap<String, String> {
+pub fn spawn_env() -> HashMap<String, String> {
     let (env, _) =
         gwt_agent::LaunchEnvironment::from_base_env(gwt_agent::environment::host_process_env())
             .into_parts();
     env
 }
 
-pub(crate) fn geometry_to_pty_size(geometry: &WindowGeometry) -> (u16, u16) {
+pub fn geometry_to_pty_size(geometry: &WindowGeometry) -> (u16, u16) {
     let cols = ((geometry.width.max(420.0) - 26.0) / 8.4).floor() as u16;
     let rows = ((geometry.height.max(260.0) - 58.0) / 18.0).floor() as u16;
     (cols.max(20), rows.max(6))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FrontDoorRoute {
+pub enum FrontDoorRoute {
     Gui,
     RepoBackedCli,
     DetachedCli,
 }
 
-pub(crate) fn front_door_route(argv: &[String]) -> FrontDoorRoute {
+pub fn front_door_route(argv: &[String]) -> FrontDoorRoute {
     match argv.get(1).map(String::as_str) {
         Some("issue" | "pr" | "actions") => FrontDoorRoute::RepoBackedCli,
         Some(top_verb) if gwt::cli::should_dispatch_cli(argv) => {
@@ -382,9 +382,9 @@ pub(crate) fn attach_parent_console_for_cli() {
 }
 
 #[cfg(not(windows))]
-pub(crate) fn attach_parent_console_for_cli() {}
+pub fn attach_parent_console_for_cli() {}
 
-pub(crate) fn run_cli(argv: &[String]) -> io::Result<()> {
+pub fn run_cli(argv: &[String]) -> io::Result<()> {
     match front_door_route(argv) {
         FrontDoorRoute::RepoBackedCli => {
             let repo_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
@@ -483,7 +483,7 @@ mod windows_console {
     }
 }
 
-pub(crate) fn resolve_repo_coordinates() -> Option<(String, String)> {
+pub fn resolve_repo_coordinates() -> Option<(String, String)> {
     // Issue #2054: support multi-remote git repos where `origin` points at a
     // local mirror and the GitHub URL lives under a different remote name.
     // Resolution order:
@@ -496,7 +496,7 @@ pub(crate) fn resolve_repo_coordinates() -> Option<(String, String)> {
 
 /// Pure resolver kept independent of git invocation so it can be unit-tested
 /// against synthetic remote fixtures.
-pub(crate) fn select_repo_coordinates(
+pub fn select_repo_coordinates(
     remotes: &[(String, String)],
     overrides: &RepoEnvOverrides,
 ) -> Option<(String, String)> {
@@ -531,7 +531,7 @@ pub(crate) fn select_repo_coordinates(
 }
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct RepoEnvOverrides {
+pub struct RepoEnvOverrides {
     pub github_repo: Option<String>,
     pub remote: Option<String>,
 }
@@ -558,7 +558,7 @@ fn load_remote_urls() -> Vec<(String, String)> {
     parse_git_remote_v(&String::from_utf8_lossy(&output.stdout))
 }
 
-pub(crate) fn parse_git_remote_v(text: &str) -> Vec<(String, String)> {
+pub fn parse_git_remote_v(text: &str) -> Vec<(String, String)> {
     let mut seen = std::collections::HashSet::new();
     let mut out = Vec::new();
     for line in text.lines() {
@@ -589,7 +589,7 @@ fn parse_owner_repo_pair(value: &str) -> Option<(String, String)> {
     Some((owner.to_string(), repo.to_string()))
 }
 
-pub(crate) fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
+pub fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
     if let Some(rest) = url.strip_prefix("git@github.com:") {
         let trimmed = rest.trim_end_matches(".git");
         let mut parts = trimmed.splitn(2, '/');

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -1,15 +1,13 @@
 use super::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum StartupUpdateAction {
+pub enum StartupUpdateAction {
     Publish,
     Stop,
     Retry,
 }
 
-pub(crate) fn classify_startup_update_state(
-    state: &gwt_core::update::UpdateState,
-) -> StartupUpdateAction {
+pub fn classify_startup_update_state(state: &gwt_core::update::UpdateState) -> StartupUpdateAction {
     match state {
         gwt_core::update::UpdateState::Available {
             asset_url: Some(_), ..
@@ -22,7 +20,7 @@ pub(crate) fn classify_startup_update_state(
     }
 }
 
-pub(crate) fn spawn_startup_update_check(
+pub fn spawn_startup_update_check(
     runtime: &Runtime,
     clients: ClientHub,
     update_proxy: EventLoopProxy<UserEvent>,
@@ -66,7 +64,7 @@ pub(crate) fn spawn_startup_update_check(
 /// Called from a background thread so the GUI remains responsive during download.
 /// On success, this function calls `std::process::exit(0)` and never returns.
 /// On any failure, it returns silently.
-pub(crate) fn apply_update_and_exit() {
+pub fn apply_update_and_exit() {
     let current_exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(_) => return,


### PR DESCRIPTION
## Summary

Drops redundant `pub(crate)` qualifiers from items in bin-private modules. `cargo clippy --fix` with `clippy::redundant-pub-crate` flagged 25 files where `pub(crate)` is functionally identical to `pub` because the containing module is declared as `mod foo;` (not `pub mod foo;`) in `crates/gwt/src/main.rs` — the bin crate has no external consumers, so any qualifier ≥ `pub(crate)` resolves to the same effective visibility.

## Changes

25 files touched, 180 ins / 191 del (net −11 LOC).

Bin-private modules cleaned (declared in `main.rs` without `pub`):

- `runtime_support`, `project_index_bootstrap`, `repo_browser`, `update_front_door`

Plus knock-on cleanups for the same lint in `cfg(test)` test_support and several `app_runtime/` and `cli/` submodules where the parent module path is already crate-private.

Each change is mechanical: `pub(crate)` → `pub`. Behavior unchanged because every affected module is private at the crate boundary.

## Verification

- `cargo test --workspace --lib` — all groups pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Closing Issues

None — clippy hygiene cleanup.

## Related Issues / Links

- PR #2342 / #2343 — sibling clippy auto-fix sweeps
- PR #2325-#2330 — earlier clippy auto-fix rounds

## Checklist

- [x] No behavior change (visibility unchanged at the crate boundary)
- [x] All workspace lints + tests + fmt clean
- [x] Mechanical clippy auto-fix only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Expanded public API surface by making previously internal types and functions publicly accessible. This includes runtime management systems, command-line operations, Docker container utilities, and helper functions. No behavioral changes to existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->