### PR TITLE
test(gwt-docker): retry read_invocation under FS flush latency (partial fix for Issue #2349)

### DIFF
--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -905,7 +905,37 @@ mod tests {
     }
 
     fn read_invocation(path: &PathBuf) -> String {
-        fs::read_to_string(path).expect("read invocation log")
+        // Issue #2349: `compose_restart_invokes_docker_with_expected_arguments`
+        // (and a few sibling compose_* tests using the same fake-docker
+        // pattern) flake intermittently. The leading hypothesis is FS
+        // flush latency between the fake docker shell script's `> file`
+        // close and the parent test's read — kernels generally make
+        // writes-via-closed-fd visible to a subsequent read on the same
+        // host, but slow CI runners or APFS / tmpfs eventual-consistency
+        // edge cases occasionally observe an empty file.
+        //
+        // Retry up to 50 times × 10 ms (= 500 ms total) before giving
+        // up. The healthy path returns on the first attempt; the retry
+        // tail is invisible during normal runs and only kicks in when
+        // the file genuinely needs the OS a moment longer to settle.
+        for attempt in 0..50 {
+            match fs::read_to_string(path) {
+                Ok(content) if !content.is_empty() => return content,
+                Ok(_) => {
+                    // File exists but empty — fake docker may not have
+                    // flushed yet. Wait and retry.
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    // File doesn't exist yet — same FS flush window.
+                }
+                Err(err) => panic!("read invocation log (attempt {attempt}): {err}"),
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        panic!(
+            "read invocation log: file at {} still empty / missing after 500ms",
+            path.display()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Defends `read_invocation` (the test helper used by ~10 `compose_*` tests in `gwt-docker`) against the leading hypothesis from Issue #2349: FS flush latency between the fake docker shell script's `> /log` close and the parent test's `fs::read_to_string`. Test-only hardening — production code untouched.

## Why

Issue #2349 captures repeated observations of `compose_restart_invokes_docker_with_expected_arguments` flaking on local `cargo test --workspace` runs. Two occurrences this session, both recovered on rerun. The Issue body lists three hypothesized causes:

1. **FS flush latency** (kernels make writes-via-closed-fd visible, but slow CI runners / APFS / tmpfs eventual-consistency edges sometimes observe empty file)
2. tempdir race
3. cargo build/recompile contention

This PR addresses (1) only — the simplest and most defensible fix. If the flake recurs after this lands, the new panic message points at hypotheses (2) or (3).

## Changes

`crates/gwt-docker/src/container.rs::read_invocation` now retries instead of `panic!` on first read:

```rust
fn read_invocation(path: &PathBuf) -> String {
    for attempt in 0..50 {
        match fs::read_to_string(path) {
            Ok(content) if !content.is_empty() => return content,
            Ok(_) => { /* empty — wait */ }
            Err(err) if err.kind() == ErrorKind::NotFound => { /* same */ }
            Err(err) => panic!("read invocation log (attempt {attempt}): {err}"),
        }
        std::thread::sleep(Duration::from_millis(10));
    }
    panic!("read invocation log: file at {} still empty / missing after 500ms", path.display());
}
```

Three states handled distinctly:

- `Ok(content)` non-empty → return immediately (healthy path, first attempt)
- `Ok(empty)` / `NotFound` → wait 10 ms and retry (FS not flushed yet)
- Other errors → panic with attempt count for diagnostic clarity

Total retry budget: 50 × 10 ms = 500 ms. Healthy runs are unaffected; the retry tail is invisible during normal execution.

## Why this is defensible

Even if FS flush *isn't* the cause:

- The retry only kicks in when the file is empty / missing — exact symptom of the flake
- 500 ms total ceiling matches typical CI runner FS settle latency
- Healthy first-attempt path returns immediately (no slowdown for passing runs)
- Failure path now has a richer error message ("still empty after 500ms") that distinguishes from genuine read errors

## Verification

- `cargo test -p gwt-docker --lib compose` — 3 sequential runs all pass
- `cargo test -p gwt-docker --lib` — 63/63 pass
- `cargo clippy -p gwt-docker --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Closing Issues

Partial — addresses one of three hypothesized causes for Issue #2349. Issue stays open until the flake is confirmed resolved or a new occurrence rules out FS flush.

## Related Issues / Links

- Issue #2349 — the original flake report with rule-out chain and 3 hypothesized causes

## Checklist

- [x] Test-only change (no production code touched)
- [x] `read_invocation`'s contract preserved for healthy callers
- [x] Failure path now carries diagnostic context (path + 500ms threshold)
- [x] All workspace lints + tests + fmt clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of test helper for Docker invocation logging by implementing retry logic to handle intermittent read failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->