### PR TITLE
test(gwt-docker): include path in intermediate read_invocation panic (coderabbit follow-up)

### DIFF
--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -928,7 +928,10 @@ mod tests {
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                     // File doesn't exist yet — same FS flush window.
                 }
-                Err(err) => panic!("read invocation log (attempt {attempt}): {err}"),
+                Err(err) => panic!(
+                    "read invocation log {} (attempt {attempt}): {err}",
+                    path.display()
+                ),
             }
             std::thread::sleep(std::time::Duration::from_millis(10));
         }


### PR DESCRIPTION
## Summary

Tiny diagnostic-message follow-up to PR #2351 — CodeRabbit caught that `read_invocation`'s immediate-panic arm (unexpected I/O error) omitted `path` while the timeout-panic arm (file still empty after 500 ms) included it. Aligned both messages to include `path.display()`.

## Why

If an unexpected I/O error fires in CI for one of the ~10 `compose_*` tests sharing the fake-docker fixture, the error message needs to identify which test's log path triggered it.

## Changes

`crates/gwt-docker/src/container.rs::read_invocation` — extended the inner-arm panic message from `"read invocation log (attempt {attempt}): {err}"` to `"read invocation log {path} (attempt {attempt}): {err}"`.

## Verification

- `cargo test -p gwt-docker --lib compose` — 30/30 pass
- `cargo clippy -p gwt-docker --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Closing Issues

None — addresses CodeRabbit feedback on PR #2351.

## Related Issues / Links

- PR #2351 — original `read_invocation` retry hardening
- Issue #2349 — flake context

## Checklist

- [x] No behavior change (test diagnostic message only)
- [x] Both panic arms now consistently include the path
- [x] All workspace lints + tests + fmt clean
