### PR TITLE
ci(coverage): avoid rustup pre-push false failures

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -17,17 +17,6 @@ ensure_coverage_tooling() {
     exit 1
   fi
 
-  if command -v rustup >/dev/null 2>&1; then
-    echo "Ensuring llvm-tools-preview is available..."
-    if ! rustup component add llvm-tools-preview; then
-      echo "Failed to install llvm-tools-preview." >&2
-      echo "Run manually: rustup component add llvm-tools-preview" >&2
-      exit 1
-    fi
-  else
-    echo "rustup not found; assuming llvm tools are provided by the active toolchain."
-  fi
-
   if cargo llvm-cov --version >/dev/null 2>&1; then
     return
   fi
@@ -37,6 +26,17 @@ ensure_coverage_tooling() {
     echo "Failed to install cargo-llvm-cov." >&2
     echo "Run manually: cargo install cargo-llvm-cov --locked" >&2
     exit 1
+  fi
+
+  if command -v rustup >/dev/null 2>&1; then
+    echo "Ensuring llvm-tools-preview is available..."
+    if ! rustup component add llvm-tools-preview; then
+      echo "Warning: failed to install llvm-tools-preview." >&2
+      echo "Continuing; cargo llvm-cov will validate llvm tool availability." >&2
+      echo "Manual recovery: rustup component add llvm-tools-preview" >&2
+    fi
+  else
+    echo "rustup not found; assuming llvm tools are provided by the active toolchain."
   fi
 
   if ! cargo llvm-cov --version >/dev/null 2>&1; then

--- a/scripts/verify-husky-hooks.sh
+++ b/scripts/verify-husky-hooks.sh
@@ -35,6 +35,19 @@ require_not_contains() {
   fi
 }
 
+require_order() {
+  local file="$1"
+  local first="$2"
+  local second="$3"
+  local first_line
+  local second_line
+  first_line=$(grep -Fn "$first" "$file" | head -n 1 | cut -d: -f1 || true)
+  second_line=$(grep -Fn "$second" "$file" | head -n 1 | cut -d: -f1 || true)
+  if [ -z "$first_line" ] || [ -z "$second_line" ] || [ "$first_line" -ge "$second_line" ]; then
+    fail "Expected '$first' to appear before '$second' in $file"
+  fi
+}
+
 require_file "$PACKAGE_JSON"
 require_contains "$PACKAGE_JSON" '"prepare": "test -n \"$CI\" || bunx husky install"'
 require_contains "$PACKAGE_JSON" "\"lint:skills\": \"bash scripts/validate-skill-frontmatter.sh\""
@@ -47,6 +60,7 @@ require_contains "$PRE_PUSH" "ensure_coverage_tooling"
 require_contains "$PRE_PUSH" "rustup component add llvm-tools-preview"
 require_contains "$PRE_PUSH" "cargo install cargo-llvm-cov --locked"
 require_contains "$PRE_PUSH" "cargo llvm-cov --version"
+require_order "$PRE_PUSH" "if cargo llvm-cov --version >/dev/null 2>&1; then" "if command -v rustup >/dev/null 2>&1; then"
 require_contains "$PRE_PUSH" "cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json"
 require_contains "$PRE_PUSH" "node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90"
 require_contains "$PRE_PUSH" "bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md --ignore tasks/todo.md"


### PR DESCRIPTION
## Summary

- Avoid false local pre-push failures by checking whether `cargo llvm-cov` already works before invoking `rustup`.
- Add a Husky verification assertion that preserves the safe ordering.

## Changes

- `.husky/pre-push`: return early when `cargo llvm-cov --version` succeeds, and only attempt `rustup component add llvm-tools-preview` after installing missing coverage tooling.
- `.husky/pre-push`: treat `llvm-tools-preview` auto-install failure as a warning so the coverage command remains the source of truth.
- `scripts/verify-husky-hooks.sh`: add `require_order` and assert that the `cargo llvm-cov` availability check precedes the rustup component install path.

## Testing

- [x] `pnpm lint:husky` — first failed before the hook change, then passed after the hook order was fixed.
- [x] `sh .husky/pre-push` — full pre-push checks passed, including clippy, fmt, coverage, markdownlint, and skill lint.
- [x] `bunx --package @commitlint/cli commitlint --from origin/develop --to HEAD` — commit message passed commitlint.

## Closing Issues

None

## Related Issues / Links

- #2354

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, hook checks)
- [x] Documentation updated (not needed: internal hook behavior only)
- [x] Migration/backfill plan included (not needed: no schema or data migration)
- [x] CHANGELOG impact considered (CI-only follow-up; no breaking change)

## Context

- Follow-up to the Codex review on #2354: the previous ordering could fail push in environments where `cargo llvm-cov` is already usable but `rustup component add` is unavailable.

## Risk / Impact

- **Affected areas**: local Git pre-push coverage setup.
- **Rollback plan**: revert this PR to restore the prior auto-install ordering.
