### PR TITLE
fix(ui): SPEC-2356 follow-up — status-dot and icon-button token migration

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -598,7 +598,7 @@
       }
 
       .surface-terminal .window-body {
-        background: #020617;
+        background: var(--color-canvas);
       }
 
       .surface-file-tree .window-body,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -531,23 +531,23 @@
         width: 8px;
         height: 8px;
         border-radius: 999px;
-        background: #f59e0b;
+        background: var(--color-state-idle);
       }
 
       .status-chip.running .status-dot {
-        background: #22c55e;
+        background: var(--color-state-active);
       }
 
       .status-chip.waiting .status-dot {
-        background: #3b82f6;
+        background: var(--color-state-active);
       }
 
       .status-chip.error .status-dot {
-        background: #ef4444;
+        background: var(--color-state-blocked);
       }
 
       .status-chip.stopped .status-dot {
-        background: #94a3b8;
+        background: var(--color-state-done);
       }
 
       .window-actions {
@@ -560,13 +560,14 @@
         width: 24px;
         height: 24px;
         border: none;
-        border-radius: 4px;
-        background: rgba(148, 163, 184, 0.16);
+        border-radius: var(--radius-sm);
+        background: color-mix(in oklab, var(--color-text-muted) 16%, transparent);
+        color: var(--color-text);
         cursor: pointer;
       }
 
       .surface-terminal .icon-button {
-        color: #cbd5e1;
+        color: var(--color-text);
       }
 
       .surface-file-tree .icon-button,
@@ -575,11 +576,11 @@
       .surface-logs .icon-button,
       .surface-knowledge .icon-button,
       .surface-mock .icon-button {
-        color: #334155;
+        color: var(--color-text);
       }
 
       .icon-button:hover {
-        background: rgba(148, 163, 184, 0.28);
+        background: color-mix(in oklab, var(--color-text-muted) 28%, transparent);
       }
 
       .window-body {


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の継続 polish: 各ウィンドウタイトルバーの **status-dot** (running/waiting/error/stopped) と **icon-button** を Operator state tokens に、 **`.surface-terminal .window-body`** の `#020617` 直書きを `var(--color-canvas)` に置換。 inline `<style>` ブロックに残っていた `#f59e0b` / `#22c55e` / `#3b82f6` / `#ef4444` / `#94a3b8` 系の slate hardcode を semantic state token 経由にし、 light theme での視認性を確保する。

## Changes

- `23cb009d` — `.status-dot` と `.status-chip.{running,waiting,error,stopped} .status-dot` を `--color-state-{idle,active,active,blocked,done}` に。 `.icon-button` 背景を `color-mix(in oklab, var(--color-text-muted) 16%, transparent)` に、 hover を 28%、 surface 別 color override を `var(--color-text)` に統一 (旧 `#cbd5e1` / `#334155` を撤廃)。
- `ea84ee55` — `.surface-terminal .window-body` を `#020617` から `var(--color-canvas)` に。 dark テーマでは従来どおり deep carbon、 light では bone backdrop に揃って xterm Theme Adapter が描画する内容と背景の段差が消える。

## Testing

- ✅ `cargo test -p gwt` (380 + 187 件 GREEN, SPEC-2008 contract test も維持)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ `npm run test:frontend-bundle` / `test:frontend-smoke` / `test:frontend-unit` 全 GREEN

## Closing Issues

None (SPEC-2356 は #2358 で実質完了、 #2360 / 本 PR は連続する polish)

## Related Issues

- #2356 SPEC-2356
- #2358 (merged), #2360 (merged)

## Risk / Impact

- 影響範囲: inline CSS の数値リテラル置換のみ
- 互換性: 既存 SPEC とコンポーネント API 変更なし
- アクセシビリティ: light テーマ上の status-dot / icon-button 視認性が `--color-state-*` token 経由で WCAG 整合に

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced (全て var() / color-mix() 経由)
- [x] No new tests required (既存テスト契約に変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
