### PR TITLE
fix(ui): SPEC-2356 follow-up — knowledge / memo / profile surfaces to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1036,24 +1036,27 @@
         display: grid;
         gap: 8px;
         padding: 12px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.24);
-        background: #f8fafc;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface-elevated);
       }
 
       .knowledge-section-title {
-        font-size: 12px;
+        font-family: var(--font-display);
+        font-stretch: 75%;
+        font-size: var(--type-xs);
         font-weight: 700;
-        color: #334155;
-        text-transform: none;
+        letter-spacing: var(--tracking-display);
+        color: var(--color-text-strong);
+        text-transform: uppercase;
       }
 
       .knowledge-section-body {
         margin: 0;
-        font-family: inherit;
-        font-size: 12px;
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
         line-height: 1.5;
-        color: #334155;
+        color: var(--color-text);
         white-space: pre-wrap;
         overflow-wrap: anywhere;
       }
@@ -1074,7 +1077,7 @@
       .memo-note-list {
         overflow: auto;
         padding: 8px 0;
-        border-right: 1px solid rgba(148, 163, 184, 0.18);
+        border-right: 1px solid var(--color-border);
       }
 
       .memo-editor-pane {
@@ -1086,16 +1089,18 @@
       }
 
       .memo-status {
-        font-size: 12px;
-        color: #475569;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .memo-status.info {
-        color: #1d4ed8;
+        color: var(--color-state-active);
       }
 
       .memo-status.error {
-        color: #b91c1c;
+        color: var(--color-state-blocked);
       }
 
       .memo-note-row {
@@ -1104,18 +1109,19 @@
         width: 100%;
         padding: 12px;
         border: none;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        border-bottom: 1px solid var(--color-border);
         background: transparent;
+        color: var(--color-text);
         text-align: left;
         cursor: pointer;
       }
 
       .memo-note-row:hover {
-        background: rgba(59, 130, 246, 0.06);
+        background: color-mix(in oklab, var(--color-state-active) 8%, transparent);
       }
 
       .memo-note-row.selected {
-        background: rgba(59, 130, 246, 0.12);
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
       }
 
       .memo-note-header,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1180,11 +1180,21 @@
       .memo-body-input {
         width: 100%;
         padding: 10px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        background: #ffffff;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface);
         font: inherit;
-        color: #0f172a;
+        font-family: var(--font-body);
+        color: var(--color-text);
+      }
+      .memo-title-input::placeholder,
+      .memo-body-input::placeholder {
+        color: var(--color-text-muted);
+      }
+      .memo-title-input:focus,
+      .memo-body-input:focus {
+        outline: none;
+        border-color: var(--color-focus-ring);
       }
 
       .memo-title-input {
@@ -1221,7 +1231,7 @@
 
       .profile-list-pane {
         overflow: auto;
-        border-right: 1px solid rgba(148, 163, 184, 0.18);
+        border-right: 1px solid var(--color-border);
         padding: 8px 0;
       }
 
@@ -1234,12 +1244,14 @@
       }
 
       .profile-status {
-        font-size: 12px;
-        color: #475569;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .profile-status.info {
-        color: #1d4ed8;
+        color: var(--color-state-active);
       }
 
       .profile-status.error {


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の継続 polish: 個別サーフェス (knowledge bridge / memo / profile) の inline CSS を Operator tokens に置換し、 dark/light 両テーマで一貫した可読性を確保する。 ユーザーが触れる input field やステータス表示が hardcoded slate → tokens 駆動になり、 light テーマで浮いていた箇所が解消される。

## Changes

- `74ff58cf` — knowledge bridge surface
  - `.knowledge-section`: 背景 `var(--color-surface-elevated)` / border `var(--color-border)` / radius `var(--radius-md)`
  - `.knowledge-section-title`: Hubot Sans Condensed + uppercase + `var(--tracking-display)`
  - `.knowledge-section-body`: Mona Sans + `var(--type-sm)` + `var(--color-text)`
  - memo: `.memo-status` (info/error) を `--color-state-active/blocked` に、 `.memo-note-row` hover/selected を `color-mix(in oklab, var(--color-state-active) ...%, transparent)` に
- `7cfc952a` — memo input + profile pane
  - `.memo-title-input` / `.memo-body-input`: `--color-surface` 背景 + `--color-border-strong` + `--color-text`、 focus border `--color-focus-ring`、 placeholder `--color-text-muted`
  - `.profile-list-pane` border を `var(--color-border)` に
  - `.profile-status`: JetBrains Mono + `--type-xs` + muted/info を tokens に

## Testing

- ✅ `cargo test -p gwt` (380 + 187 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ `npm run test:frontend-bundle` / `test:frontend-smoke` / `test:frontend-unit` 全 GREEN

## Closing Issues

None (SPEC-2356 は #2358 で実質完了、 polish の連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 (merged)

## Risk / Impact

- 影響範囲: knowledge / memo / profile の inline CSS 数値リテラル置換のみ
- 互換性: DOM 構造 / class name / 機能変更なし
- ユーザー体験: light テーマでの可読性が向上 (input は `--color-surface` で contextual、 focus は `--color-focus-ring` で明示)

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced (全て var() / color-mix() 経由)
- [x] No new tests required (既存テスト契約に変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
