### PR TITLE
fix(ui): SPEC-2356 follow-up — Branches surface (cleanup badges, branch identifiers) to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1765,35 +1765,36 @@
         width: 24px;
         height: 24px;
         margin-top: 2px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        background: #ffffff;
-        color: #475569;
-        font-size: 13px;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface);
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: var(--type-sm);
         font-weight: 700;
         cursor: pointer;
       }
 
       .branch-cleanup-toggle.safe {
-        color: #047857;
+        color: var(--color-state-active);
       }
 
       .branch-cleanup-toggle.risky {
-        color: #b45309;
+        color: var(--agent-claude);
       }
 
       .branch-cleanup-toggle.blocked {
-        color: #94a3b8;
+        color: var(--color-state-idle);
       }
 
       .branch-cleanup-toggle.loading {
-        color: #64748b;
+        color: var(--color-text-muted);
       }
 
       .branch-cleanup-toggle.selected {
-        background: #0f172a;
-        border-color: #0f172a;
-        color: #ffffff;
+        background: var(--color-button-bg);
+        border-color: var(--color-button-bg);
+        color: var(--color-button-fg);
       }
 
       .branch-main {
@@ -1806,9 +1807,10 @@
         gap: 8px;
         min-width: 0;
         margin-bottom: 4px;
-        font-size: 13px;
+        font-family: var(--font-mono);
+        font-size: var(--type-sm);
         font-weight: 600;
-        color: #0f172a;
+        color: var(--color-text-strong);
       }
 
       .branch-name-text {
@@ -1820,26 +1822,31 @@
 
       .branch-head {
         padding: 2px 6px;
-        border-radius: 999px;
-        background: rgba(16, 185, 129, 0.12);
-        color: #047857;
-        font-size: 10px;
+        border-radius: var(--radius-pill);
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+        color: var(--color-state-active);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
       }
 
       .branch-upstream,
       .branch-date {
-        font-size: 12px;
-        color: #475569;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .branch-cleanup-detail {
         margin-top: 4px;
-        font-size: 11px;
-        color: #64748b;
+        font-family: var(--font-body);
+        font-size: var(--type-xs);
+        color: var(--color-text-muted);
       }
 
       .branch-cleanup-detail.blocked {
-        color: #b45309;
+        color: var(--agent-claude);
       }
 
       .branch-meta {
@@ -1852,32 +1859,36 @@
 
       .branch-scope {
         padding: 4px 8px;
-        border-radius: 999px;
-        background: rgba(59, 130, 246, 0.1);
-        color: #1d4ed8;
-        font-size: 11px;
+        border-radius: var(--radius-pill);
+        background: color-mix(in oklab, var(--agent-codex) 18%, transparent);
+        color: var(--agent-codex);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
       }
 
       .branch-cleanup-badge {
         padding: 4px 8px;
-        border-radius: 999px;
-        font-size: 11px;
-        text-transform: capitalize;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        text-transform: uppercase;
       }
 
       .branch-cleanup-badge.safe {
-        background: rgba(16, 185, 129, 0.12);
-        color: #047857;
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+        color: var(--color-state-active);
       }
 
       .branch-cleanup-badge.risky {
-        background: rgba(245, 158, 11, 0.14);
-        color: #b45309;
+        background: color-mix(in oklab, var(--agent-claude) 18%, transparent);
+        color: var(--agent-claude);
       }
 
       .branch-cleanup-badge.blocked {
-        background: rgba(148, 163, 184, 0.18);
-        color: #475569;
+        background: color-mix(in oklab, var(--color-text-muted) 18%, transparent);
+        color: var(--color-text-muted);
       }
 
       .branch-cleanup-badge.loading {


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: Branches サーフェスの branch-cleanup-toggle / branch-name / branch-head / branch-upstream / branch-date / branch-scope / branch-cleanup-badge {safe/risky/blocked/loading} の inline CSS を Operator tokens 駆動に置換。 Branch list は Launch Wizard 経由でユーザーが頻繁に触れる surface のため、 dual-theme と semantic state token の整合は UX への影響が大きい。

## Changes

- `a669738e` — branch list / cleanup
  - `.branch-cleanup-toggle`: `--color-surface` 背景 + `--color-border-strong` border、 selected で `--color-button-bg/fg`
  - safe = `--color-state-active`、 risky = `--agent-claude` (amber)、 blocked = `--color-state-idle`、 loading = `--color-text-muted`
  - `.branch-name`: Mona Sans → JetBrains Mono + `--color-text-strong` (branch identifier は monospace の方が安定)
  - `.branch-head`: pill 形状で `color-mix(in oklab, var(--color-state-active) 18%, transparent)` 背景 + `--color-state-active` 文字
  - `.branch-upstream` / `.branch-date`: Mono + `--type-xs` + `--tracking-mono` + muted
  - `.branch-cleanup-detail.blocked`: `--agent-claude` に
  - `.branch-scope`: `--agent-codex` (cyan) ベース pill
  - `.branch-cleanup-badge`: pill + Mono uppercase + safe/risky/blocked で state token / agent token を使い分け

## Testing

- ✅ `cargo test -p gwt` (380 + 187 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ `npm run test:frontend-bundle` / `test:frontend-smoke` / `test:frontend-unit` 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 (merged)

## Risk / Impact

- 影響範囲: Branches surface inline CSS のみ
- 互換性: DOM 構造 / class name / 機能変更なし
- 視覚: dark/light 両テーマで branch name が JetBrains Mono で揃い、 cleanup badge が agent 色 + Mono uppercase で識別性が向上

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced (tokens / color-mix() のみ)
- [x] No new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
