### PR TITLE
fix(ui): SPEC-2356 follow-up — Logs surface (severity chips, entries, detail) to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1570,16 +1570,18 @@
       }
 
       .logs-status {
-        font-size: 12px;
-        color: #475569;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .logs-status.info {
-        color: #1d4ed8;
+        color: var(--color-state-active);
       }
 
       .logs-status.error {
-        color: #b91c1c;
+        color: var(--color-state-blocked);
       }
 
       .logs-layout {
@@ -1597,7 +1599,7 @@
 
       .logs-timeline {
         overflow: auto;
-        border-right: 1px solid rgba(148, 163, 184, 0.18);
+        border-right: 1px solid var(--color-border);
       }
 
       .logs-detail-pane {
@@ -1614,18 +1616,19 @@
         width: 100%;
         padding: 12px;
         border: none;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        border-bottom: 1px solid var(--color-border);
         background: transparent;
         text-align: left;
+        color: var(--color-text);
         cursor: pointer;
       }
 
       .logs-entry:hover {
-        background: rgba(59, 130, 246, 0.06);
+        background: color-mix(in oklab, var(--color-state-active) 8%, transparent);
       }
 
       .logs-entry.selected {
-        background: rgba(59, 130, 246, 0.12);
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
       }
 
       .logs-entry-header {
@@ -1637,37 +1640,42 @@
 
       .logs-severity-chip {
         padding: 4px 8px;
-        border-radius: 999px;
-        font-size: 11px;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
         font-weight: 700;
+        letter-spacing: var(--tracking-mono);
+        text-transform: uppercase;
       }
 
       .logs-severity-chip.debug {
-        background: rgba(148, 163, 184, 0.18);
-        color: #475569;
+        background: color-mix(in oklab, var(--color-text-muted) 18%, transparent);
+        color: var(--color-text-muted);
       }
 
       .logs-severity-chip.info {
-        background: rgba(59, 130, 246, 0.1);
-        color: #1d4ed8;
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+        color: var(--color-state-active);
       }
 
       .logs-severity-chip.warn {
-        background: rgba(245, 158, 11, 0.14);
-        color: #b45309;
+        background: color-mix(in oklab, var(--agent-claude) 18%, transparent);
+        color: var(--agent-claude);
       }
 
       .logs-severity-chip.error {
-        background: rgba(239, 68, 68, 0.12);
-        color: #b91c1c;
+        background: color-mix(in oklab, var(--color-state-blocked) 18%, transparent);
+        color: var(--color-state-blocked);
       }
 
       .logs-entry-source,
       .logs-entry-time,
       .logs-entry-detail,
       .logs-detail-meta {
-        font-size: 12px;
-        color: #475569;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .logs-entry-time {
@@ -1676,8 +1684,9 @@
 
       .logs-entry-message,
       .logs-detail-message {
-        font-size: 13px;
-        color: #0f172a;
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
+        color: var(--color-text);
         white-space: pre-wrap;
         overflow-wrap: anywhere;
       }
@@ -1685,11 +1694,13 @@
       .logs-detail-block {
         margin: 0;
         padding: 10px;
-        border-radius: 6px;
-        background: #f8fafc;
-        border: 1px solid rgba(148, 163, 184, 0.24);
-        font-family: inherit;
-        font-size: 12px;
+        border-radius: var(--radius-md);
+        background: var(--color-surface-elevated);
+        border: 1px solid var(--color-border);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text);
         line-height: 1.5;
         color: #334155;
         white-space: pre-wrap;


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: Logs surface (entries, severity chips, detail blocks) の inline CSS を Operator tokens 駆動に置換。 Logs は SRE 観点で頻繁に観察される surface のため、 severity chip の semantic 色 (debug / info / warn / error) を agent token と state token で整列させる。

## Changes

- `f10b3136` — Logs surface
  - `.logs-status` (info/error) を `--color-state-active/blocked` に、 Mono + `--type-xs`
  - `.logs-entry` hover / selected を `color-mix(in oklab, var(--color-state-active) 8/18%, transparent)` に
  - `.logs-severity-chip`: pill + Mono uppercase + 4 段階 (debug = muted、 info = state-active、 warn = `--agent-claude` amber、 error = state-blocked)
  - `.logs-entry-source` / `.logs-entry-time` / `.logs-detail-meta` を Mono + muted に
  - `.logs-entry-message` / `.logs-detail-message` を Body + `--color-text` に
  - `.logs-detail-block` を Mono コードブロック (`--color-surface-elevated` + `--color-border`)

## Testing

- ✅ `cargo test -p gwt` (380 + 187 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ `npm run test:frontend-bundle` / `test:frontend-smoke` / `test:frontend-unit` 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 (merged)

## Risk / Impact

- 影響範囲: Logs surface inline CSS のみ
- 互換性: DOM 構造 / class name / 機能変更なし
- ユーザー体験: severity chip が agent 色 / state 色で識別性が向上、 detail block が Mono コードブロックとして読みやすくなる

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced (tokens / color-mix() のみ)
- [x] No new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
