### PR TITLE
fix(ui): SPEC-2356 follow-up — Project Picker / Onboarding cards to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2577,41 +2577,53 @@
       .project-onboarding-card {
         width: min(560px, calc(100vw - 40px));
         padding: 18px;
-        border-radius: 6px;
-        background: rgba(255, 255, 255, 0.98);
-        border: 1px solid rgba(148, 163, 184, 0.32);
-        box-shadow: 0 22px 56px rgba(15, 23, 42, 0.18);
+        border-radius: var(--radius-lg);
+        background: var(--color-surface-elevated);
+        border: 1px solid var(--color-border-strong);
+        box-shadow: var(--shadow-2);
       }
 
       .project-picker-title,
       .project-onboarding-title {
         margin: 0 0 8px;
-        font-size: 20px;
-        color: #0f172a;
+        font-family: var(--font-display);
+        font-stretch: 75%;
+        font-weight: 700;
+        font-size: var(--type-xl);
+        letter-spacing: var(--tracking-display);
+        text-transform: uppercase;
+        color: var(--color-display-fg);
       }
 
       .project-picker-copy,
       .project-onboarding-copy {
         margin: 0 0 16px;
-        font-size: 13px;
-        color: #475569;
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
+        color: var(--color-text-muted);
       }
 
       .project-picker-error {
         margin-bottom: 12px;
         padding: 10px 12px;
-        border-radius: 6px;
-        background: rgba(239, 68, 68, 0.08);
-        border: 1px solid rgba(239, 68, 68, 0.18);
-        color: #b91c1c;
-        font-size: 12px;
+        border-radius: var(--radius-md);
+        background: color-mix(in oklab, var(--color-state-blocked) 12%, transparent);
+        border: 1px solid color-mix(in oklab, var(--color-state-blocked) 32%, transparent);
+        color: var(--color-state-blocked);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
       }
 
       .picker-section-label {
         margin: 16px 0 8px;
-        font-size: 12px;
-        font-weight: 600;
-        color: #475569;
+        font-family: var(--font-display);
+        font-stretch: 75%;
+        font-weight: 700;
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-display);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
       }
 
       .project-recent-list {
@@ -2623,28 +2635,32 @@
         width: 100%;
         text-align: left;
         padding: 10px 12px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.28);
-        background: #f8fafc;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface);
+        color: var(--color-text);
         cursor: pointer;
       }
 
       .recent-project-row:hover {
-        background: #eef4ff;
+        background: color-mix(in oklab, var(--color-state-active) 12%, var(--color-surface));
       }
 
       .recent-project-title {
         display: block;
-        font-size: 13px;
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
         font-weight: 600;
-        color: #0f172a;
+        color: var(--color-text-strong);
       }
 
       .recent-project-meta {
         display: block;
         margin-top: 4px;
-        font-size: 12px;
-        color: #64748b;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: 起動直後にユーザーが最初に体験する **Project Picker** と **Project Onboarding** card の inline CSS を Operator tokens 駆動に置換。 起動時の "first impression" 画面が dual-theme と Operator 言語に統合される。

## Changes

- `c382145b` — Project Picker / Onboarding
  - `.project-picker-card` / `.project-onboarding-card`: 背景 `--color-surface-elevated` + `--color-border-strong` + `--shadow-2` + `--radius-lg`
  - title を Hubot Sans Condensed Bold uppercase に + `--color-display-fg`
  - copy を Mona Sans body + muted color
  - error を Mono uppercase + `color-mix(in oklab, var(--color-state-blocked) ...%, transparent)` semantic
  - `.picker-section-label` を Hubot Sans Condensed display tracking に
  - `.recent-project-row`: tokens 駆動、 hover `color-mix(in oklab, var(--color-state-active) 12%, var(--color-surface))`
  - title / meta を Body / Mono で対応

## Testing

- ✅ `cargo test -p gwt` (388 + 194 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 (merged)

## Risk / Impact

- 影響範囲: Project Picker / Onboarding inline CSS のみ
- 互換性: DOM / 機能変更なし
- ユーザー体験: 起動直後の "first impression" surface が Operator 言語に統合される効果が最も大きい

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced
- [x] No new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
