### PR TITLE
fix(ui): SPEC-2356 follow-up — Knowledge Bridge deeper surface (chips, list, search) to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -845,18 +845,25 @@
         min-width: 0;
         height: 32px;
         padding: 0 10px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        background: #ffffff;
-        font-size: 12px;
-        color: #0f172a;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface);
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
+        color: var(--color-text);
+      }
+      .knowledge-search:focus {
+        outline: none;
+        border-color: var(--color-focus-ring);
       }
 
       .knowledge-status {
         display: none;
         padding: 10px 12px;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-        font-size: 12px;
+        border-bottom: 1px solid var(--color-border);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
       }
 
       .knowledge-status.visible {
@@ -864,13 +871,13 @@
       }
 
       .knowledge-status.info {
-        background: rgba(59, 130, 246, 0.08);
-        color: #1d4ed8;
+        background: color-mix(in oklab, var(--color-state-active) 12%, transparent);
+        color: var(--color-state-active);
       }
 
       .knowledge-status.error {
-        background: rgba(239, 68, 68, 0.08);
-        color: #b91c1c;
+        background: color-mix(in oklab, var(--color-state-blocked) 12%, transparent);
+        color: var(--color-state-blocked);
       }
 
       .knowledge-split {
@@ -887,7 +894,7 @@
       }
 
       .knowledge-list-pane {
-        border-right: 1px solid rgba(148, 163, 184, 0.18);
+        border-right: 1px solid var(--color-border);
         overflow: auto;
       }
 
@@ -906,18 +913,19 @@
         width: 100%;
         padding: 12px;
         border: none;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        border-bottom: 1px solid var(--color-border);
         background: transparent;
+        color: var(--color-text);
         cursor: pointer;
         text-align: left;
       }
 
       .knowledge-row:hover {
-        background: rgba(59, 130, 246, 0.06);
+        background: color-mix(in oklab, var(--color-state-active) 8%, transparent);
       }
 
       .knowledge-row.selected {
-        background: rgba(59, 130, 246, 0.12);
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
       }
 
       .knowledge-row:last-child {
@@ -939,16 +947,19 @@
 
       .knowledge-row-title {
         min-width: 0;
-        font-size: 13px;
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
         font-weight: 600;
-        color: #0f172a;
+        color: var(--color-text-strong);
         overflow-wrap: anywhere;
       }
 
       .knowledge-row-number,
       .knowledge-detail-subtitle {
-        font-size: 11px;
-        color: #64748b;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .knowledge-row-meta {
@@ -957,48 +968,54 @@
       }
 
       .knowledge-meta-copy {
-        font-size: 11px;
-        color: #475569;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .knowledge-chip,
       .knowledge-state-chip {
         padding: 4px 8px;
-        border-radius: 999px;
-        font-size: 11px;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        text-transform: uppercase;
       }
 
       .knowledge-chip {
-        background: rgba(59, 130, 246, 0.1);
-        color: #1d4ed8;
+        background: color-mix(in oklab, var(--agent-codex) 18%, transparent);
+        color: var(--agent-codex);
       }
 
       .knowledge-state-chip.open {
-        background: rgba(16, 185, 129, 0.12);
-        color: #047857;
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+        color: var(--color-state-active);
       }
 
       .knowledge-state-chip.closed {
-        background: rgba(148, 163, 184, 0.18);
-        color: #475569;
+        background: color-mix(in oklab, var(--color-text-muted) 18%, transparent);
+        color: var(--color-text-muted);
       }
 
       .knowledge-state-chip.unavailable,
       .knowledge-state-chip.idle {
-        background: rgba(245, 158, 11, 0.14);
-        color: #b45309;
+        background: color-mix(in oklab, var(--agent-claude) 18%, transparent);
+        color: var(--agent-claude);
       }
 
       .knowledge-detail-empty,
       .knowledge-empty {
         padding: 16px 12px;
-        font-size: 12px;
-        color: #64748b;
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
+        color: var(--color-text-muted);
       }
 
       .knowledge-detail-header {
         padding: 12px;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        border-bottom: 1px solid var(--color-border);
         display: grid;
         gap: 8px;
       }


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: Knowledge Bridge surface (Issue / SPEC / PR cache-backed 閲覧) のリスト / 詳細部分の inline CSS を Operator tokens 駆動に置換。 検索フィールドの focus highlight や state chip の semantic 色付けを Operator agent token / state token に整列させる。

## Changes

- `a4642c0b` — Knowledge bridge deeper
  - `.knowledge-search` input field: tokens 化、 focus 時に `--color-focus-ring` highlight
  - `.knowledge-status` (info/error): semantic state token
  - `.knowledge-list-pane` / `.knowledge-row` border / hover / selected を tokens + `color-mix(in oklab, var(--color-state-active) ...%, transparent)` に
  - `.knowledge-row-title`: Mona Sans + `--color-text-strong`
  - meta 系 (`row-number`, `detail-subtitle`, `meta-copy`): Mono + muted
  - `.knowledge-chip` を `--agent-codex` (cyan) ベース pill に
  - `.knowledge-state-chip`: open = state-active、 closed = muted、 unavailable/idle = `--agent-claude` (amber)
  - `.knowledge-detail-empty` / `.knowledge-empty` を Body + muted

## Testing

- ✅ `cargo test -p gwt` (388 + 194 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 (merged)

## Risk / Impact

- 影響範囲: Knowledge bridge inline CSS のみ
- 互換性: DOM / 機能変更なし
- ユーザー体験: Issue/SPEC/PR list の chip が agent / state 色で識別性向上、 hover/selected が dark/light 両テーマで読みやすい

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced
- [x] No new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
