### PR TITLE
fix(start-work): preserve coordination state

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -481,48 +481,93 @@ fn active_work_projection_from_saved(
     }
 }
 
+fn active_agent_summary_from_session(
+    session: &ActiveAgentSession,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
+    gwt_core::workspace_projection::WorkspaceAgentSummary {
+        session_id: session.session_id.clone(),
+        agent_id: session.agent_id.clone(),
+        display_name: session.display_name.clone(),
+        status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+        current_focus: None,
+        worktree_path: Some(session.worktree_path.clone()),
+        branch: Some(session.branch_name.clone()),
+        last_board_entry_id: None,
+        updated_at,
+    }
+}
+
+fn upsert_workspace_agent(
+    agents: &mut Vec<gwt_core::workspace_projection::WorkspaceAgentSummary>,
+    summary: gwt_core::workspace_projection::WorkspaceAgentSummary,
+) {
+    if let Some(existing) = agents
+        .iter_mut()
+        .find(|agent| agent.session_id == summary.session_id)
+    {
+        *existing = summary;
+    } else {
+        agents.push(summary);
+    }
+}
+
+fn merge_active_sessions_into_projection<'a>(
+    projection: &mut gwt_core::workspace_projection::WorkspaceProjection,
+    sessions: impl IntoIterator<Item = &'a ActiveAgentSession>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) {
+    for session in sessions {
+        upsert_workspace_agent(
+            &mut projection.agents,
+            active_agent_summary_from_session(session, updated_at),
+        );
+    }
+}
+
 fn save_start_work_workspace_projection(
     project_root: &Path,
     session: &ActiveAgentSession,
     base_branch: &str,
     linked_issue_number: Option<u64>,
 ) -> Result<(), String> {
-    use gwt_core::workspace_projection::{
-        GitDetails, WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
-    };
+    use gwt_core::workspace_projection::{GitDetails, WorkspaceStatusCategory};
 
     let now = chrono::Utc::now();
-    let projection = WorkspaceProjection {
-        id: format!("start-work:{}", session.branch_name),
-        project_root: project_root.to_path_buf(),
-        title: "Start Work".to_string(),
-        status_category: WorkspaceStatusCategory::Active,
-        status_text: format!("{} is running", session.display_name),
-        owner: linked_issue_number.map(|number| format!("Issue #{number}")),
-        next_action: Some("Check Board for latest updates".to_string()),
-        agents: vec![WorkspaceAgentSummary {
-            session_id: session.session_id.clone(),
-            agent_id: session.agent_id.clone(),
-            display_name: session.display_name.clone(),
-            status_category: WorkspaceStatusCategory::Active,
-            current_focus: None,
-            worktree_path: Some(session.worktree_path.clone()),
-            branch: Some(session.branch_name.clone()),
-            last_board_entry_id: None,
-            updated_at: now,
-        }],
-        git_details: Some(GitDetails {
-            branch: Some(session.branch_name.clone()),
-            worktree_path: Some(session.worktree_path.clone()),
-            base_branch: Some(base_branch.to_string()),
-            pr_number: None,
-            pr_state: None,
-            created_by_start_work: true,
-            created_at: now,
-        }),
-        board_refs: Vec::new(),
-        updated_at: now,
+    let mut projection =
+        gwt_core::workspace_projection::load_or_default_workspace_projection(project_root)
+            .map_err(|error| error.to_string())?;
+    projection.project_root = project_root.to_path_buf();
+    projection.title = "Start Work".to_string();
+    projection.status_category = WorkspaceStatusCategory::Active;
+    projection.next_action = Some("Check Board for latest updates".to_string());
+    if let Some(issue_number) = linked_issue_number {
+        projection.owner = Some(format!("Issue #{issue_number}"));
+    }
+    upsert_workspace_agent(
+        &mut projection.agents,
+        active_agent_summary_from_session(session, now),
+    );
+    let active_agents = projection
+        .agents
+        .iter()
+        .filter(|agent| agent.status_category == WorkspaceStatusCategory::Active)
+        .count();
+    projection.status_text = if active_agents == 1 {
+        format!("{} is running", session.display_name)
+    } else {
+        format!("{active_agents} active agents")
     };
+    projection.git_details = Some(GitDetails {
+        branch: Some(session.branch_name.clone()),
+        worktree_path: Some(session.worktree_path.clone()),
+        base_branch: Some(base_branch.to_string()),
+        pr_number: None,
+        pr_state: None,
+        created_by_start_work: true,
+        created_at: now,
+    });
+    projection.updated_at = now;
 
     gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
         .map_err(|error| error.to_string())
@@ -1089,17 +1134,23 @@ impl AppRuntime {
         tab_id: &str,
         tab: &ProjectTabRuntime,
     ) -> Option<gwt::ActiveWorkProjectionView> {
-        if let Ok(Some(projection)) =
-            gwt_core::workspace_projection::load_workspace_projection(&tab.project_root)
-        {
-            return Some(active_work_projection_from_saved(projection));
-        }
-
         let sessions = self
             .active_agent_sessions
             .values()
             .filter(|session| session.tab_id == tab_id)
             .collect::<Vec<_>>();
+        if let Ok(Some(projection)) =
+            gwt_core::workspace_projection::load_workspace_projection(&tab.project_root)
+        {
+            let mut projection = projection;
+            merge_active_sessions_into_projection(
+                &mut projection,
+                sessions.iter().copied(),
+                chrono::Utc::now(),
+            );
+            return Some(active_work_projection_from_saved(projection));
+        }
+
         let first = sessions.first()?;
         let active_agents = sessions.len();
         Some(gwt::ActiveWorkProjectionView {
@@ -2224,6 +2275,7 @@ impl AppRuntime {
                 let Some(window) = tab.workspace.window(&address.raw_id) else {
                     return self.launch_error_events(window_id, "Window not found".to_string());
                 };
+                let tab_id = address.tab_id.clone();
                 let project_root = tab.project_root.clone();
                 let geometry = window.geometry.clone();
 
@@ -2236,7 +2288,7 @@ impl AppRuntime {
                         branch_name,
                         display_name,
                         worktree_path: worktree_path.clone(),
-                        tab_id: address.tab_id,
+                        tab_id: tab_id.clone(),
                     },
                 );
                 self.refresh_launch_wizard_session_cache(&window_id);
@@ -2265,26 +2317,45 @@ impl AppRuntime {
                                 "issue branch linkage update skipped after agent launch"
                             );
                         }
+                        let mut start_work_projection_updated = false;
                         if let Some(base_branch) = base_branch.as_deref() {
                             let active_session = &self.active_agent_sessions[&window_id];
                             if active_session.branch_name.starts_with("work/") {
-                                if let Err(error) = save_start_work_workspace_projection(
+                                match save_start_work_workspace_projection(
                                     &project_root,
                                     active_session,
                                     base_branch,
                                     linked_issue_number,
                                 ) {
-                                    tracing::warn!(
-                                        project_root = %project_root.display(),
-                                        branch = %active_session.branch_name,
-                                        error = %error,
-                                        "workspace projection update skipped after Start Work launch"
-                                    );
+                                    Ok(()) => {
+                                        start_work_projection_updated = true;
+                                    }
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            project_root = %project_root.display(),
+                                            branch = %active_session.branch_name,
+                                            error = %error,
+                                            "workspace projection update skipped after Start Work launch"
+                                        );
+                                    }
                                 }
                             }
                         }
                         let _ = self.persist();
                         let mut events = vec![self.workspace_state_broadcast()];
+                        if start_work_projection_updated
+                            && self.active_tab_id.as_deref() == Some(tab_id.as_str())
+                        {
+                            if let Some(tab) = self.tab(&tab_id) {
+                                if let Some(projection) =
+                                    self.active_work_projection_for_tab(&tab_id, tab)
+                                {
+                                    events.push(OutboundEvent::broadcast(
+                                        BackendEvent::ActiveWorkProjection { projection },
+                                    ));
+                                }
+                            }
+                        }
                         events.extend(Self::status_events(
                             window_id,
                             WindowProcessStatus::Running,
@@ -4512,7 +4583,10 @@ exit 0
 
     #[test]
     fn app_runtime_open_start_work_uses_active_project_without_creating_git_environment() {
+        let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo");
         run_git(&repo, &["init", "-q", "-b", "main"]);
@@ -4838,6 +4912,115 @@ exit 0
         assert!(details.created_by_start_work);
         assert_eq!(projection.agents.len(), 1);
         assert_eq!(projection.agents[0].session_id, "session-1");
+    }
+
+    #[test]
+    fn app_runtime_start_work_launch_completion_merges_agents_and_broadcasts_projection() {
+        let _env_guard = env_test_lock().lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        let worktree_one = temp.path().join("repo-work-20260504-1234");
+        let worktree_two = temp.path().join("repo-work-20260504-1235");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&worktree_one).expect("create worktree one");
+        fs::create_dir_all(&worktree_two).expect("create worktree two");
+        let mut persisted = empty_workspace_state();
+        persisted.windows.push(sample_window(
+            "agent-1",
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        ));
+        persisted.windows.push(sample_window(
+            "agent-2",
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        ));
+        persisted.next_z_index = 3;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(persisted),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let launch = |cwd: PathBuf| {
+            let (command, args) = if cfg!(windows) {
+                (
+                    "cmd".to_string(),
+                    vec![
+                        "/d".to_string(),
+                        "/s".to_string(),
+                        "/c".to_string(),
+                        "exit /b 0".to_string(),
+                    ],
+                )
+            } else {
+                (
+                    "/bin/sh".to_string(),
+                    vec!["-lc".to_string(), "exit 0".to_string()],
+                )
+            };
+            ProcessLaunch {
+                command,
+                args,
+                env: HashMap::new(),
+                remove_env: Vec::new(),
+                cwd: Some(cwd),
+            }
+        };
+
+        let _first_events = runtime.handle_launch_complete(
+            combined_window_id("tab-1", "agent-1"),
+            Ok((
+                launch(worktree_one.clone()),
+                "session-1".to_string(),
+                "work/20260504-1234".to_string(),
+                "Codex 1".to_string(),
+                worktree_one,
+                gwt_agent::AgentId::Codex,
+                None,
+                Some("origin/main".to_string()),
+            )),
+        );
+        let second_events = runtime.handle_launch_complete(
+            combined_window_id("tab-1", "agent-2"),
+            Ok((
+                launch(worktree_two.clone()),
+                "session-2".to_string(),
+                "work/20260504-1235".to_string(),
+                "Codex 2".to_string(),
+                worktree_two,
+                gwt_agent::AgentId::Codex,
+                None,
+                Some("origin/main".to_string()),
+            )),
+        );
+
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let session_ids = projection
+            .agents
+            .iter()
+            .map(|agent| agent.session_id.as_str())
+            .collect::<std::collections::HashSet<_>>();
+
+        assert_eq!(projection.agents.len(), 2);
+        assert!(session_ids.contains("session-1"));
+        assert!(session_ids.contains("session-2"));
+        assert!(second_events.iter().any(|event| matches!(
+            event,
+            OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::ActiveWorkProjection { projection },
+            } if projection.active_agents == 2
+                && projection.branch.as_deref() == Some("work/20260504-1235")
+        )));
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -198,7 +198,9 @@ impl AppRuntime {
     ) -> Result<(), String> {
         let base_branch = gwt::start_work::resolve_start_work_base_branch(project_root)
             .map_err(|error| error.to_string())?;
-        let work_branch = gwt::start_work::reserve_start_work_branch_name(project_root, Utc::now());
+        let work_branch =
+            gwt::start_work::reserve_start_work_branch_name_for_project(project_root, Utc::now())
+                .map_err(|error| error.to_string())?;
         let quick_start_root = project_root.to_path_buf();
         let quick_start_entries = self
             .launch_wizard_cache

--- a/crates/gwt/src/start_work.rs
+++ b/crates/gwt/src/start_work.rs
@@ -1,5 +1,9 @@
 use chrono::{DateTime, Utc};
-use std::path::Path;
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 pub const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 3] =
     ["origin/develop", "origin/main", "origin/master"];
@@ -7,6 +11,7 @@ pub const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 3] =
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StartWorkError {
     MissingBaseBranch,
+    ReservationIo(String),
 }
 
 impl std::fmt::Display for StartWorkError {
@@ -15,6 +20,9 @@ impl std::fmt::Display for StartWorkError {
             Self::MissingBaseBranch => f.write_str(
                 "No default base branch found (origin/develop, origin/main, origin/master)",
             ),
+            Self::ReservationIo(error) => {
+                write!(f, "Failed to reserve Start Work branch name: {error}")
+            }
         }
     }
 }
@@ -62,6 +70,67 @@ pub fn reserve_start_work_branch_name(repo_path: &Path, now: DateTime<Utc>) -> S
     })
 }
 
+pub fn reserve_start_work_branch_name_for_project(
+    repo_path: &Path,
+    now: DateTime<Utc>,
+) -> Result<String, StartWorkError> {
+    let reservations_dir = gwt_core::paths::gwt_project_dir_for_repo_path(repo_path)
+        .join("workspace")
+        .join("start-work-reservations");
+    reserve_start_work_branch_name_with_reservations(
+        now,
+        |candidate| {
+            git_ref_exists(repo_path, &format!("refs/heads/{candidate}"))
+                || git_ref_exists(repo_path, &format!("refs/remotes/origin/{candidate}"))
+        },
+        &reservations_dir,
+    )
+}
+
+pub fn reserve_start_work_branch_name_with_reservations(
+    now: DateTime<Utc>,
+    mut branch_exists: impl FnMut(&str) -> bool,
+    reservations_dir: &Path,
+) -> Result<String, StartWorkError> {
+    fs::create_dir_all(reservations_dir)
+        .map_err(|error| StartWorkError::ReservationIo(error.to_string()))?;
+    let base = format!("work/{}", now.format("%Y%m%d-%H%M"));
+    for suffix in 1usize.. {
+        let candidate = if suffix == 1 {
+            base.clone()
+        } else {
+            format!("{base}-{suffix}")
+        };
+        if branch_exists(&candidate) {
+            continue;
+        }
+        match create_reservation(reservations_dir, &candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(StartWorkError::ReservationIo(error.to_string())),
+        }
+    }
+    unreachable!("unbounded suffix search should always return")
+}
+
+fn create_reservation(reservations_dir: &Path, branch_name: &str) -> std::io::Result<()> {
+    let path = reservation_path(reservations_dir, branch_name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(branch_name.as_bytes())?;
+    file.sync_all()
+}
+
+fn reservation_path(reservations_dir: &Path, branch_name: &str) -> PathBuf {
+    branch_name
+        .split('/')
+        .fold(reservations_dir.to_path_buf(), |path, segment| {
+            path.join(segment)
+        })
+}
+
 fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
     gwt_core::process::hidden_command("git")
         .args(["show-ref", "--verify", "--quiet", ref_name])
@@ -77,7 +146,8 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::{
-        reserve_start_work_branch_name_with, resolve_start_work_base_branch_with, StartWorkError,
+        reserve_start_work_branch_name_with, reserve_start_work_branch_name_with_reservations,
+        resolve_start_work_base_branch_with, StartWorkError,
     };
 
     #[test]
@@ -109,5 +179,26 @@ mod tests {
             reserve_start_work_branch_name_with(now, |candidate| existing.contains(candidate));
 
         assert_eq!(branch, "work/20260504-1234-3");
+    }
+
+    #[test]
+    fn start_work_branch_name_tracks_pending_reservations_without_git_refs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reservations_dir = temp.path().join("reservations");
+        let now = Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0).unwrap();
+
+        let first =
+            reserve_start_work_branch_name_with_reservations(now, |_| false, &reservations_dir)
+                .expect("first reservation");
+        let second =
+            reserve_start_work_branch_name_with_reservations(now, |_| false, &reservations_dir)
+                .expect("second reservation");
+
+        assert_eq!(first, "work/20260504-1234");
+        assert_eq!(second, "work/20260504-1234-2");
+        assert!(
+            reservations_dir.join("work").join("20260504-1234").exists(),
+            "reservation should be stored without creating a Git ref"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Preserve Start Work coordination state so multiple agents remain visible in Workspace and Board views.
- Prevent same-minute Start Work branch reservation collisions before Git refs or worktrees are materialized.
- Broadcast the active work projection immediately after launch completion so other windows receive the updated state.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: merge saved Workspace projection data with active sessions, upsert agent summaries, and broadcast `active_work_projection` after Start Work launch completion.
- `crates/gwt/src/app_runtime/wizard.rs`: reserve Start Work branch names through the project-scoped reservation path when opening Start Work.
- `crates/gwt/src/start_work.rs`: add project-scoped pending reservation storage and collision-aware branch name reservation without creating Git refs or worktrees.

## Testing

- [x] `cargo test -p gwt app_runtime_start_work_launch_completion_merges_agents_and_broadcasts_projection -- --nocapture` — passed after merging `origin/develop`.
- [x] `cargo test -p gwt --test start_work_test start_work_launch_confirmation_materializes_reserved_work_branch_and_worktree -- --nocapture` — passed after merging `origin/develop`.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `git push origin feature/branches` — pre-push CI-equivalent checks passed with filtered line coverage 90.13%.

## Closing Issues

- None

## Related Issues / Links

- #2359
- #2365

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2359 tasks and verification notes were updated)
- [ ] Migration/backfill plan included (not applicable: no schema or persistent data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- This is the arch-review follow-up for the post-merge Start Work branchless flow work. PR #2365 merged at `cd240435`; this PR carries the later fix commit `0b741f3a` plus the `origin/develop` merge needed to keep the branch current.

## Risk / Impact

- **Affected areas**: Start Work launch completion, Workspace projection persistence, active work projection broadcast, and branch reservation naming.
- **Rollback plan**: Revert this PR if coordination projection or Start Work reservation behavior regresses.
