### PR TITLE
fix(start-work): preserve blocked coordination state

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -502,11 +502,28 @@ fn upsert_workspace_agent(
     agents: &mut Vec<gwt_core::workspace_projection::WorkspaceAgentSummary>,
     summary: gwt_core::workspace_projection::WorkspaceAgentSummary,
 ) {
+    use gwt_core::workspace_projection::WorkspaceStatusCategory;
+
     if let Some(existing) = agents
         .iter_mut()
         .find(|agent| agent.session_id == summary.session_id)
     {
-        *existing = summary;
+        existing.agent_id = summary.agent_id;
+        existing.display_name = summary.display_name;
+        existing.worktree_path = summary.worktree_path;
+        existing.branch = summary.branch;
+        if existing.status_category != WorkspaceStatusCategory::Blocked {
+            existing.status_category = summary.status_category;
+        }
+        if summary.current_focus.is_some() {
+            existing.current_focus = summary.current_focus;
+        }
+        if summary.last_board_entry_id.is_some() {
+            existing.last_board_entry_id = summary.last_board_entry_id;
+        }
+        if summary.updated_at > existing.updated_at {
+            existing.updated_at = summary.updated_at;
+        }
     } else {
         agents.push(summary);
     }
@@ -3539,10 +3556,11 @@ mod tests {
     use tracing_subscriber::{layer::Context, prelude::*, Layer};
 
     use super::{
-        dispatch_agent_launch_success, ActiveAgentSession, AgentLaunchCompletion, AppEventProxy,
-        AppRuntime, BlockingTaskSpawner, DispatchTarget, KnowledgeLoadRequest,
-        KnowledgeRefreshTask, KnowledgeSearchRequest, LaunchWizardMemoryCache, LaunchWizardSession,
-        OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent, WindowRuntime,
+        dispatch_agent_launch_success, save_start_work_workspace_projection, ActiveAgentSession,
+        AgentLaunchCompletion, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
+        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest,
+        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProcessLaunch,
+        ProjectTabRuntime, UserEvent, WindowRuntime,
     };
     use crate::{combined_window_id, same_worktree_path, PtyWriterRegistry};
 
@@ -6464,6 +6482,70 @@ exit 0
             } if projection.next_action.as_deref() == Some("Run final verification")
                 && projection.board_refs == vec![board_entry_id.clone()]
         )));
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_preserves_blocked_agent_board_state() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        let worktree = temp.path().join("repo-work-20260504-1234");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Board],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let session = ActiveAgentSession {
+            window_id: "tab-1::agent-1".to_string(),
+            session_id: "session-1".to_string(),
+            agent_id: "codex".to_string(),
+            branch_name: "work/20260504-1234".to_string(),
+            display_name: "Codex".to_string(),
+            worktree_path: worktree.clone(),
+            tab_id: "tab-1".to_string(),
+        };
+        runtime
+            .active_agent_sessions
+            .insert(session.window_id.clone(), session.clone());
+        save_start_work_workspace_projection(&repo, &session, "develop", None)
+            .expect("save initial projection");
+        let blocked = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Blocked,
+            "Waiting for API credentials",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1")
+        .with_origin_agent_id("codex")
+        .with_origin_branch("work/20260504-1234");
+
+        let event = runtime
+            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
+            .expect("active projection broadcast");
+
+        assert!(matches!(
+            event,
+            OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::ActiveWorkProjection { projection },
+            } if projection.status_category == "blocked"
+                && projection.blocked_agents == 1
+                && projection.board_refs == vec![blocked.id.clone()]
+                && projection.next_action.as_deref() == Some("Resolve blocker")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve blocked Board milestone state when active Start Work sessions are merged into the Workspace projection.
- Keep runtime session fields current without clearing persisted coordination context.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: update `upsert_workspace_agent` to refresh session runtime fields while retaining blocked status, current focus, and last Board entry metadata.
- `crates/gwt/src/app_runtime/mod.rs`: add a regression test proving an agent-originated blocked Board milestone stays visible in `active_work_projection` broadcasts.

## Testing

- [x] RED: `cargo test -p gwt app_runtime_active_work_projection_preserves_blocked_agent_board_state -- --nocapture` — failed before implementation because the projection broadcast was not blocked.
- [x] GREEN: `cargo test -p gwt app_runtime_active_work_projection_preserves_blocked_agent_board_state -- --nocapture` — passed after implementation.
- [x] `cargo test -p gwt app_runtime_start_work_launch_completion_merges_agents_and_broadcasts_projection -- --nocapture` — passed.
- [x] `cargo test -p gwt app_runtime_post_board_entry_updates_workspace_projection_current_state -- --nocapture` — passed.
- [x] `cargo test -p gwt active_work_projection -- --nocapture` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git push origin feature/branches` — pre-push CI-equivalent checks passed with filtered line coverage 90.18%.

## Closing Issues

- None

## Related Issues / Links

- #2359
- #2369

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2359 progress is tracked through the PR and Board handoff)
- [ ] Migration/backfill plan included (not applicable: no schema or persistent data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- PR #2369 was auto-merged, then Codex review reported that merging active sessions could overwrite persisted blocked Board state. This follow-up fixes that coordination regression.

## Risk / Impact

- **Affected areas**: Workspace projection merge, Board blocker visibility, and active work projection broadcasts.
- **Rollback plan**: Revert this PR if blocked Board milestones stop reflecting expected runtime state.
