### PR TITLE
fix(ui): SPEC-2356 follow-up — Profile surface deeper (rows, chips, sections, fields) to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1281,18 +1281,19 @@
         width: 100%;
         padding: 12px;
         border: none;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        border-bottom: 1px solid var(--color-border);
         background: transparent;
+        color: var(--color-text);
         text-align: left;
         cursor: pointer;
       }
 
       .profile-row:hover {
-        background: rgba(59, 130, 246, 0.06);
+        background: color-mix(in oklab, var(--color-state-active) 8%, transparent);
       }
 
       .profile-row.selected {
-        background: rgba(59, 130, 246, 0.12);
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
       }
 
       .profile-row-header,
@@ -1309,16 +1310,19 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        font-size: 13px;
+        font-family: var(--font-body);
+        font-size: var(--type-sm);
         font-weight: 600;
-        color: #0f172a;
+        color: var(--color-text-strong);
       }
 
       .profile-row-copy,
       .profile-row-meta,
       .profile-empty-copy {
-        font-size: 12px;
-        color: #475569;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .profile-row-chips {
@@ -1330,24 +1334,27 @@
 
       .profile-chip {
         padding: 4px 8px;
-        border-radius: 999px;
-        background: rgba(59, 130, 246, 0.08);
-        color: #1d4ed8;
-        font-size: 11px;
+        border-radius: var(--radius-pill);
+        background: color-mix(in oklab, var(--agent-codex) 18%, transparent);
+        color: var(--agent-codex);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        text-transform: uppercase;
       }
 
       .profile-chip.active {
-        background: rgba(16, 185, 129, 0.12);
-        color: #047857;
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+        color: var(--color-state-active);
       }
 
       .profile-section {
         display: grid;
         gap: 10px;
         padding: 12px;
-        border: 1px solid rgba(148, 163, 184, 0.2);
-        border-radius: 6px;
-        background: #ffffff;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-surface-elevated);
       }
 
       .profile-field {
@@ -1356,9 +1363,12 @@
       }
 
       .profile-field span {
-        font-size: 12px;
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        text-transform: uppercase;
         font-weight: 600;
-        color: #334155;
+        color: var(--color-text-muted);
       }
 
       .profile-field input,
@@ -1367,11 +1377,18 @@
         width: 100%;
         min-width: 0;
         padding: 10px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        background: #ffffff;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface);
         font: inherit;
-        color: #0f172a;
+        font-family: var(--font-body);
+        color: var(--color-text);
+      }
+      .profile-field input:focus,
+      .profile-table-row input:focus,
+      .profile-textarea:focus {
+        outline: none;
+        border-color: var(--color-focus-ring);
       }
 
       .profile-textarea {


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: **Profile** surface のリスト行・チップ・section・input field の inline CSS を Operator tokens に置換。 env profile を編集する Settings & Profile ウィンドウのため、 dual-theme 整合と Operator 言語への統合は重要。

## Changes

- `c42d737c` — Profile deeper
  - `.profile-row`: tokens border、 hover/selected を `color-mix(in oklab, var(--color-state-active) 8/18%, transparent)` に
  - `.profile-row-title`: Body + `--color-text-strong`
  - `.profile-row-copy/meta/empty-copy`: Mono + muted
  - `.profile-chip`: pill + `--agent-codex` (cyan) ベース、 active で `--color-state-active`
  - `.profile-section`: `--color-surface-elevated` + tokens border
  - `.profile-field span`: Mono uppercase + muted (label)
  - `.profile-field input` / `.profile-textarea` / `.profile-table-row input`: tokens + focus 時 `--color-focus-ring` highlight

## Testing

- ✅ `cargo test -p gwt` (389 + 195 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 (merged)

## Risk / Impact

- 影響範囲: Profile inline CSS のみ
- 互換性: DOM / 機能変更なし

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced
- [x] No new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
