### PR TITLE
fix(start-work): recover blocked agent state

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -137,8 +137,19 @@ impl WorkspaceProjection {
                 agent.last_board_entry_id = Some(entry.id.clone());
                 agent.current_focus = Some(entry.body.clone());
                 agent.updated_at = entry.updated_at;
-                if entry.kind == BoardEntryKind::Blocked {
-                    agent.status_category = WorkspaceStatusCategory::Blocked;
+                match entry.kind {
+                    BoardEntryKind::Blocked => {
+                        agent.status_category = WorkspaceStatusCategory::Blocked;
+                    }
+                    BoardEntryKind::Status
+                    | BoardEntryKind::Claim
+                    | BoardEntryKind::Handoff
+                    | BoardEntryKind::Decision
+                    | BoardEntryKind::Next => {
+                        agent.status_category = WorkspaceStatusCategory::Active;
+                    }
+                    BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {
+                    }
                 }
             }
         }
@@ -335,6 +346,62 @@ mod tests {
         assert_eq!(
             projection.board_refs,
             vec!["next-1".to_string(), "blocked-1".to_string()]
+        );
+    }
+
+    #[test]
+    fn board_milestone_restores_blocked_agent_to_active_on_progress() {
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        projection.agents.push(WorkspaceAgentSummary {
+            session_id: "sess-1".to_string(),
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            worktree_path: None,
+            branch: None,
+            last_board_entry_id: None,
+            updated_at: Utc::now(),
+        });
+        let mut blocked = BoardEntry::new(
+            crate::coordination::AuthorKind::Agent,
+            "codex",
+            BoardEntryKind::Blocked,
+            "Waiting for credentials",
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_origin_session_id("sess-1");
+        blocked.id = "blocked-1".to_string();
+        projection.record_board_milestone(&blocked);
+
+        let mut status = BoardEntry::new(
+            crate::coordination::AuthorKind::Agent,
+            "codex",
+            BoardEntryKind::Status,
+            "Credentials are configured",
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_origin_session_id("sess-1");
+        status.id = "status-1".to_string();
+        projection.record_board_milestone(&status);
+
+        assert_eq!(
+            projection.agents[0].status_category,
+            WorkspaceStatusCategory::Active
+        );
+        assert_eq!(
+            projection.agents[0].current_focus.as_deref(),
+            Some("Credentials are configured")
+        );
+        assert_eq!(
+            projection.effective_status_category(),
+            WorkspaceStatusCategory::Active
         );
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -6549,6 +6549,82 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_active_work_projection_recovers_blocked_agent_after_status_milestone() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        let worktree = temp.path().join("repo-work-20260504-1234");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Board],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let session = ActiveAgentSession {
+            window_id: "tab-1::agent-1".to_string(),
+            session_id: "session-1".to_string(),
+            agent_id: "codex".to_string(),
+            branch_name: "work/20260504-1234".to_string(),
+            display_name: "Codex".to_string(),
+            worktree_path: worktree.clone(),
+            tab_id: "tab-1".to_string(),
+        };
+        runtime
+            .active_agent_sessions
+            .insert(session.window_id.clone(), session.clone());
+        save_start_work_workspace_projection(&repo, &session, "develop", None)
+            .expect("save initial projection");
+        let blocked = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Blocked,
+            "Waiting for API credentials",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1");
+        runtime
+            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
+            .expect("blocked projection broadcast");
+        let status = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "API credentials configured",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1");
+
+        let event = runtime
+            .record_workspace_board_milestone_event("tab-1", &repo, &status)
+            .expect("active projection broadcast");
+
+        assert!(matches!(
+            event,
+            OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::ActiveWorkProjection { projection },
+            } if projection.status_category == "active"
+                && projection.active_agents == 1
+                && projection.blocked_agents == 0
+                && projection.branch.as_deref() == Some("work/20260504-1234")
+        ));
+    }
+
+    #[test]
     fn app_runtime_board_projection_change_broadcasts_to_matching_board_windows_only() {
         let _env_lock = env_test_lock()
             .lock()


### PR DESCRIPTION
## Summary

- Allow an agent that was marked blocked by Board milestone state to recover to active after later progress milestones.
- Keep blocked state preservation from PR #2371 while preventing stale blocked status from sticking forever.

## Changes

- `crates/gwt-core/src/workspace_projection.rs`: update `record_board_milestone` so same-session `Status`, `Claim`, `Handoff`, `Decision`, and `Next` milestones restore the agent status to active.
- `crates/gwt-core/src/workspace_projection.rs`: add a core regression test for blocked-to-active recovery.
- `crates/gwt/src/app_runtime/mod.rs`: add app-runtime regression coverage proving `active_work_projection` broadcasts recover from blocked to active after a status milestone.

## Testing

- [x] `cargo test -p gwt-core board_milestone_restores_blocked_agent_to_active_on_progress -- --nocapture` — passed.
- [x] `cargo test -p gwt app_runtime_active_work_projection_recovers_blocked_agent_after_status_milestone -- --nocapture` — passed.
- [x] `cargo test -p gwt app_runtime_active_work_projection_preserves_blocked_agent_board_state -- --nocapture` — passed.
- [x] `cargo fmt -- --check` — passed after formatting.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git push origin feature/branches` — pre-push CI-equivalent checks passed with filtered line coverage 90.19%.

## Closing Issues

- None

## Related Issues / Links

- #2359
- #2371

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2359 progress is tracked through PR and issue comments)
- [ ] Migration/backfill plan included (not applicable: no schema or persistent data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- PR #2371 fixed blocked-state preservation, then Codex review correctly identified that blocked agents also need a recovery path when later Board milestones indicate progress.

## Risk / Impact

- **Affected areas**: Board milestone projection, Workspace projection effective status, and active work projection broadcasts.
- **Rollback plan**: Revert this PR if Board milestone status transitions regress.
