### PR TITLE
fix(ui): SPEC-2356 follow-up — File Tree row + Branch row + tree icon to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1752,32 +1752,34 @@
         gap: 8px;
         min-height: 30px;
         padding: 0 12px;
-        font-size: 13px;
-        color: #0f172a;
+        font-family: var(--font-mono);
+        font-size: var(--type-sm);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text);
         cursor: pointer;
       }
 
       .file-tree-row:hover {
-        background: rgba(59, 130, 246, 0.08);
+        background: color-mix(in oklab, var(--color-state-active) 10%, transparent);
       }
 
       .file-tree-row.selected {
-        background: rgba(59, 130, 246, 0.12);
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
       }
 
       .tree-caret {
         width: 12px;
-        color: #64748b;
+        color: var(--color-text-muted);
         text-align: center;
       }
 
       .tree-icon {
         width: 16px;
-        color: #2563eb;
+        color: var(--agent-codex);
       }
 
       .tree-icon.file {
-        color: #64748b;
+        color: var(--color-text-muted);
       }
 
       .tree-name {
@@ -1789,9 +1791,11 @@
 
       .file-tree-footer {
         padding: 10px 12px;
-        border-top: 1px solid rgba(148, 163, 184, 0.25);
-        font-size: 12px;
-        color: #475569;
+        border-top: 1px solid var(--color-border);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-text-muted);
       }
 
       .branch-row {
@@ -1799,20 +1803,20 @@
         grid-template-columns: auto minmax(0, 1fr) auto;
         gap: 10px;
         padding: 10px 12px;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        border-bottom: 1px solid var(--color-border);
         cursor: pointer;
       }
 
       .branch-row:hover {
-        background: rgba(59, 130, 246, 0.06);
+        background: color-mix(in oklab, var(--color-state-active) 8%, transparent);
       }
 
       .branch-row.selected {
-        background: rgba(59, 130, 246, 0.12);
+        background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
       }
 
       .branch-row.cleanup-selected {
-        box-shadow: inset 2px 0 0 #0f172a;
+        box-shadow: inset 2px 0 0 var(--color-focus-ring);
       }
 
       .branch-row:last-child {


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: File Tree (filename rendering) と Branch list の row 表示を Operator tokens に置換。 file-tree は JetBrains Mono で identifier 視認性を確保、 tree-icon は agent-codex (cyan) で directory を強調。

## Changes

- `15767ec4` — File Tree row + Branch row + tree icon
  - `.file-tree-row`: Mono + `--type-sm` + `--color-text`
  - `.file-tree-row` hover/selected: `color-mix(in oklab, var(--color-state-active) 10/18%, transparent)`
  - `.tree-caret` / `.tree-icon.file`: `--color-text-muted`
  - `.tree-icon` (directory): `--agent-codex` (cyan)
  - `.file-tree-footer`: Mono + xs + muted、 border `--color-border`
  - `.branch-row` border / hover / selected を tokens に
  - `.branch-row.cleanup-selected`: 旧 `inset 2px 0 0 #0f172a` を `var(--color-focus-ring)` に

## Testing

- ✅ `cargo test -p gwt` (389 + 197 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 / #2372 (merged)

## Risk / Impact

- 影響範囲: File Tree / Branch list の row inline CSS のみ
- 互換性: DOM / 機能変更なし
- ユーザー体験: file 名 / branch 名が JetBrains Mono で揃い、 directory icon が cyan で識別性向上

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced
- [x] No new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CSS styling for the file tree and branch list components to use consistent design tokens instead of hard-coded colors and sizes. Refined hover and selected states, as well as border and typography styling across these UI elements for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->