### PR TITLE
feat(board): scale storage and history loading

### DIFF
--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -17,7 +17,12 @@ use crate::{paths::gwt_project_dir_for_repo_path, GwtError, Result};
 pub const COORDINATION_RELATIVE_DIR: &str = ".gwt/coordination";
 pub const EVENTS_FILE_NAME: &str = "events.jsonl";
 pub const BOARD_PROJECTION_FILE_NAME: &str = "board.latest.json";
+pub const EVENTS_MANIFEST_FILE_NAME: &str = "events.manifest.json";
+pub const EVENTS_SEGMENTS_DIR_NAME: &str = "events";
+pub const HOT_PROJECTION_ENTRY_LIMIT: usize = 500;
+pub const EVENT_SEGMENT_MAX_BYTES: u64 = 8 * 1024 * 1024;
 const MIGRATION_MARKER_FILE_NAME: &str = ".migration-complete";
+const EVENT_MANIFEST_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -174,6 +179,14 @@ pub enum CoordinationEvent {
 pub struct BoardProjection {
     #[serde(default)]
     pub entries: Vec<BoardEntry>,
+    #[serde(default)]
+    pub has_more_before: bool,
+    #[serde(default)]
+    pub oldest_entry_id: Option<String>,
+    #[serde(default)]
+    pub newest_entry_id: Option<String>,
+    #[serde(default)]
+    pub total_entries: usize,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -181,9 +194,53 @@ impl Default for BoardProjection {
     fn default() -> Self {
         Self {
             entries: Vec::new(),
+            has_more_before: false,
+            oldest_entry_id: None,
+            newest_entry_id: None,
+            total_entries: 0,
             updated_at: Utc::now(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BoardHistoryPage {
+    #[serde(default)]
+    pub entries: Vec<BoardEntry>,
+    #[serde(default)]
+    pub has_more_before: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct EventSegmentManifest {
+    version: u32,
+    active_segment: String,
+    #[serde(default)]
+    segments: Vec<EventSegmentMeta>,
+    updated_at: DateTime<Utc>,
+}
+
+impl EventSegmentManifest {
+    fn total_entries(&self) -> usize {
+        self.segments.iter().map(|segment| segment.entries).sum()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct EventSegmentMeta {
+    file: String,
+    #[serde(default)]
+    entries: usize,
+    #[serde(default)]
+    bytes: u64,
+    #[serde(default)]
+    first_created_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    last_created_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    first_entry_id: Option<String>,
+    #[serde(default)]
+    last_entry_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -198,6 +255,14 @@ pub fn coordination_dir(worktree_root: &Path) -> PathBuf {
 
 pub fn coordination_events_path(worktree_root: &Path) -> PathBuf {
     coordination_dir(worktree_root).join(EVENTS_FILE_NAME)
+}
+
+pub fn coordination_events_segments_dir(worktree_root: &Path) -> PathBuf {
+    coordination_dir(worktree_root).join(EVENTS_SEGMENTS_DIR_NAME)
+}
+
+pub fn coordination_events_manifest_path(worktree_root: &Path) -> PathBuf {
+    coordination_dir(worktree_root).join(EVENTS_MANIFEST_FILE_NAME)
 }
 
 pub fn coordination_board_projection_path(worktree_root: &Path) -> PathBuf {
@@ -216,14 +281,12 @@ pub fn ensure_repo_local_files(worktree_root: &Path) -> Result<()> {
 
     let dir = coordination_dir(worktree_root);
     std::fs::create_dir_all(&dir)?;
-
-    if !coordination_events_path(worktree_root).exists() {
-        File::create(coordination_events_path(worktree_root))?;
-    }
+    ensure_segment_storage(&dir)?;
     if !coordination_board_projection_path(worktree_root).exists() {
+        let snapshot = rebuild_snapshot_from_segments_root(&dir)?;
         write_atomic_json(
             &coordination_board_projection_path(worktree_root),
-            &BoardProjection::default(),
+            &snapshot.board,
         )?;
     }
 
@@ -267,16 +330,25 @@ fn append_event_locked(
     worktree_root: &Path,
     event: &CoordinationEvent,
 ) -> Result<CoordinationSnapshot> {
-    let event_path = coordination_events_path(worktree_root);
-    let mut file = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&event_path)?;
-    serde_json::to_writer(&mut file, event).map_err(json_error)?;
-    file.write_all(b"\n")?;
-    file.sync_all()?;
-
-    let snapshot = rebuild_snapshot_from_events(&event_path)?;
+    let manifest = append_event_to_segments(worktree_root, event, EVENT_SEGMENT_MAX_BYTES)?;
+    let mut projection: BoardProjection =
+        load_json_or_default(&coordination_board_projection_path(worktree_root))?;
+    match event {
+        CoordinationEvent::MessageAppended { entry } => {
+            projection.entries.push(entry.clone());
+            projection.entries.sort_by_key(|entry| entry.created_at);
+            if projection.entries.len() > HOT_PROJECTION_ENTRY_LIMIT {
+                let start = projection.entries.len() - HOT_PROJECTION_ENTRY_LIMIT;
+                projection.entries = projection.entries.split_off(start);
+            }
+            projection.total_entries = manifest.total_entries();
+            projection.has_more_before = projection.total_entries > projection.entries.len();
+            projection.oldest_entry_id = projection.entries.first().map(|entry| entry.id.clone());
+            projection.newest_entry_id = projection.entries.last().map(|entry| entry.id.clone());
+            projection.updated_at = Utc::now();
+        }
+    }
+    let snapshot = CoordinationSnapshot { board: projection };
     write_atomic_json(
         &coordination_board_projection_path(worktree_root),
         &snapshot.board,
@@ -321,11 +393,43 @@ pub fn rebuild_snapshot_from_events(event_path: &Path) -> Result<CoordinationSna
     let now = Utc::now();
 
     Ok(CoordinationSnapshot {
-        board: BoardProjection {
-            entries: board_entries,
-            updated_at: now,
-        },
+        board: build_hot_projection(board_entries, now),
     })
+}
+
+pub fn rebuild_snapshot_from_segments(worktree_root: &Path) -> Result<CoordinationSnapshot> {
+    ensure_repo_local_files(worktree_root)?;
+    rebuild_snapshot_from_segments_root(&coordination_dir(worktree_root))
+}
+
+fn rebuild_snapshot_from_segments_root(coordination_root: &Path) -> Result<CoordinationSnapshot> {
+    let entries = load_board_entries_from_segments_root(coordination_root)?;
+    Ok(CoordinationSnapshot {
+        board: build_hot_projection(entries, Utc::now()),
+    })
+}
+
+fn build_hot_projection(
+    mut entries: Vec<BoardEntry>,
+    updated_at: DateTime<Utc>,
+) -> BoardProjection {
+    entries.sort_by_key(|entry| entry.created_at);
+    let total_entries = entries.len();
+    let has_more_before = total_entries > HOT_PROJECTION_ENTRY_LIMIT;
+    if has_more_before {
+        let start = total_entries - HOT_PROJECTION_ENTRY_LIMIT;
+        entries = entries.split_off(start);
+    }
+    let oldest_entry_id = entries.first().map(|entry| entry.id.clone());
+    let newest_entry_id = entries.last().map(|entry| entry.id.clone());
+    BoardProjection {
+        entries,
+        has_more_before,
+        oldest_entry_id,
+        newest_entry_id,
+        total_entries,
+        updated_at,
+    }
 }
 
 fn load_json_or_default<T>(path: &Path) -> Result<T>
@@ -371,6 +475,137 @@ fn coordination_repo_root(worktree_root: &Path) -> Option<PathBuf> {
 
 fn coordination_migration_marker_path(project_dir: &Path) -> PathBuf {
     project_dir.join(MIGRATION_MARKER_FILE_NAME)
+}
+
+fn coordination_events_segments_dir_from_root(coordination_root: &Path) -> PathBuf {
+    coordination_root.join(EVENTS_SEGMENTS_DIR_NAME)
+}
+
+fn coordination_events_manifest_path_from_root(coordination_root: &Path) -> PathBuf {
+    coordination_root.join(EVENTS_MANIFEST_FILE_NAME)
+}
+
+fn coordination_legacy_events_path_from_root(coordination_root: &Path) -> PathBuf {
+    coordination_root.join(EVENTS_FILE_NAME)
+}
+
+fn initial_segment_file_name() -> String {
+    segment_file_name(1)
+}
+
+fn segment_file_name(index: usize) -> String {
+    format!("{index:016}.jsonl")
+}
+
+fn initial_event_manifest() -> EventSegmentManifest {
+    let active_segment = initial_segment_file_name();
+    EventSegmentManifest {
+        version: EVENT_MANIFEST_VERSION,
+        active_segment: active_segment.clone(),
+        segments: vec![EventSegmentMeta {
+            file: active_segment,
+            entries: 0,
+            bytes: 0,
+            first_created_at: None,
+            last_created_at: None,
+            first_entry_id: None,
+            last_entry_id: None,
+        }],
+        updated_at: Utc::now(),
+    }
+}
+
+fn ensure_segment_storage(coordination_root: &Path) -> Result<()> {
+    std::fs::create_dir_all(coordination_root)?;
+    let manifest_path = coordination_events_manifest_path_from_root(coordination_root);
+    let segments_dir = coordination_events_segments_dir_from_root(coordination_root);
+    let legacy_events_path = coordination_legacy_events_path_from_root(coordination_root);
+
+    if manifest_path.exists() {
+        let manifest = load_event_manifest_from_dir(coordination_root)?;
+        std::fs::create_dir_all(&segments_dir)?;
+        let active_path = segments_dir.join(&manifest.active_segment);
+        if !active_path.exists() {
+            File::create(active_path)?;
+        }
+        return Ok(());
+    }
+
+    if legacy_events_path.exists() {
+        migrate_legacy_event_log_to_segments(coordination_root)?;
+        return Ok(());
+    }
+
+    if segments_dir.exists() {
+        let manifest = rebuild_event_manifest_from_segments(coordination_root)?;
+        write_event_manifest(coordination_root, &manifest)?;
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&segments_dir)?;
+    let manifest = initial_event_manifest();
+    File::create(segments_dir.join(&manifest.active_segment))?;
+    write_event_manifest(coordination_root, &manifest)
+}
+
+fn rebuild_event_manifest_from_segments(coordination_root: &Path) -> Result<EventSegmentManifest> {
+    let segments_dir = coordination_events_segments_dir_from_root(coordination_root);
+    std::fs::create_dir_all(&segments_dir)?;
+    let mut segment_files = std::fs::read_dir(&segments_dir)?
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                return None;
+            }
+            let file_name = path.file_name()?.to_str()?.to_string();
+            Some(file_name)
+        })
+        .collect::<Vec<_>>();
+    segment_files.sort();
+
+    if segment_files.is_empty() {
+        let manifest = initial_event_manifest();
+        File::create(segments_dir.join(&manifest.active_segment))?;
+        return Ok(manifest);
+    }
+
+    let mut segments = Vec::with_capacity(segment_files.len());
+    for file in segment_files {
+        let path = segments_dir.join(&file);
+        let events = load_events_from_path(&path)?;
+        let mut meta = EventSegmentMeta {
+            file,
+            entries: 0,
+            bytes: path.metadata().map(|metadata| metadata.len()).unwrap_or(0),
+            first_created_at: None,
+            last_created_at: None,
+            first_entry_id: None,
+            last_entry_id: None,
+        };
+        for event in events {
+            let CoordinationEvent::MessageAppended { entry } = event;
+            meta.entries += 1;
+            if meta.first_created_at.is_none() {
+                meta.first_created_at = Some(entry.created_at);
+                meta.first_entry_id = Some(entry.id.clone());
+            }
+            meta.last_created_at = Some(entry.created_at);
+            meta.last_entry_id = Some(entry.id);
+        }
+        segments.push(meta);
+    }
+
+    let active_segment = segments
+        .last()
+        .map(|segment| segment.file.clone())
+        .unwrap_or_else(initial_segment_file_name);
+    Ok(EventSegmentManifest {
+        version: EVENT_MANIFEST_VERSION,
+        active_segment,
+        segments,
+        updated_at: Utc::now(),
+    })
 }
 
 fn discover_legacy_coordination_dirs(worktree_root: &Path) -> Vec<PathBuf> {
@@ -437,6 +672,182 @@ fn migrate_legacy_coordination_dirs(project_dir: &Path, legacy_dirs: &[PathBuf])
     }
     std::fs::write(coordination_migration_marker_path(project_dir), b"complete")?;
     Ok(())
+}
+
+fn migrate_legacy_event_log_to_segments(coordination_root: &Path) -> Result<()> {
+    if coordination_events_manifest_path_from_root(coordination_root).exists() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(coordination_root)?;
+    let legacy_events_path = coordination_legacy_events_path_from_root(coordination_root);
+    let mut events = if legacy_events_path.exists() {
+        load_events_from_path(&legacy_events_path)?
+    } else {
+        Vec::new()
+    };
+    events.sort_by_key(coordination_event_timestamp);
+    write_events_to_segments(coordination_root, &events, EVENT_SEGMENT_MAX_BYTES)?;
+    if legacy_events_path.exists() {
+        std::fs::remove_file(legacy_events_path)?;
+    }
+    let snapshot = rebuild_snapshot_from_segments_root(coordination_root)?;
+    write_atomic_json(
+        &coordination_root.join(BOARD_PROJECTION_FILE_NAME),
+        &snapshot.board,
+    )?;
+    Ok(())
+}
+
+fn write_events_to_segments(
+    coordination_root: &Path,
+    events: &[CoordinationEvent],
+    max_segment_bytes: u64,
+) -> Result<EventSegmentManifest> {
+    let segments_dir = coordination_events_segments_dir_from_root(coordination_root);
+    if segments_dir.exists() {
+        std::fs::remove_dir_all(&segments_dir)?;
+    }
+    std::fs::create_dir_all(&segments_dir)?;
+    let mut manifest = initial_event_manifest();
+    File::create(segments_dir.join(&manifest.active_segment))?;
+    write_event_manifest(coordination_root, &manifest)?;
+
+    for event in events {
+        append_event_to_segments_root(coordination_root, event, max_segment_bytes)?;
+    }
+    manifest = load_event_manifest_from_dir(coordination_root)?;
+    Ok(manifest)
+}
+
+fn append_event_to_segments(
+    worktree_root: &Path,
+    event: &CoordinationEvent,
+    max_segment_bytes: u64,
+) -> Result<EventSegmentManifest> {
+    let coordination_root = coordination_dir(worktree_root);
+    append_event_to_segments_root(&coordination_root, event, max_segment_bytes)
+}
+
+fn append_event_to_segments_root(
+    coordination_root: &Path,
+    event: &CoordinationEvent,
+    max_segment_bytes: u64,
+) -> Result<EventSegmentManifest> {
+    ensure_segment_storage(coordination_root)?;
+    let segments_dir = coordination_events_segments_dir_from_root(coordination_root);
+    let mut manifest = load_event_manifest_from_dir(coordination_root)?;
+    let event_bytes = serialized_event_line(event)?;
+
+    if manifest.segments.is_empty() {
+        manifest = initial_event_manifest();
+        File::create(segments_dir.join(&manifest.active_segment))?;
+    }
+
+    let active_index = manifest
+        .segments
+        .iter()
+        .position(|segment| segment.file == manifest.active_segment)
+        .unwrap_or(manifest.segments.len() - 1);
+
+    let active_bytes = manifest.segments[active_index].bytes;
+    if manifest.segments[active_index].entries > 0
+        && active_bytes + event_bytes.len() as u64 > max_segment_bytes
+    {
+        let next_file = segment_file_name(manifest.segments.len() + 1);
+        manifest.active_segment = next_file.clone();
+        manifest.segments.push(EventSegmentMeta {
+            file: next_file.clone(),
+            entries: 0,
+            bytes: 0,
+            first_created_at: None,
+            last_created_at: None,
+            first_entry_id: None,
+            last_entry_id: None,
+        });
+        File::create(segments_dir.join(next_file))?;
+    }
+
+    let active_index = manifest
+        .segments
+        .iter()
+        .position(|segment| segment.file == manifest.active_segment)
+        .unwrap_or(manifest.segments.len() - 1);
+    let active_path = segments_dir.join(&manifest.active_segment);
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&active_path)?;
+    file.write_all(&event_bytes)?;
+    file.sync_all()?;
+
+    update_segment_meta(
+        &mut manifest.segments[active_index],
+        event,
+        event_bytes.len() as u64,
+    );
+    manifest.updated_at = Utc::now();
+    write_event_manifest(coordination_root, &manifest)?;
+    Ok(manifest)
+}
+
+fn serialized_event_line(event: &CoordinationEvent) -> Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec(event).map_err(json_error)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn update_segment_meta(segment: &mut EventSegmentMeta, event: &CoordinationEvent, bytes: u64) {
+    segment.entries += 1;
+    segment.bytes += bytes;
+    let CoordinationEvent::MessageAppended { entry } = event;
+    if segment.first_created_at.is_none() {
+        segment.first_created_at = Some(entry.created_at);
+        segment.first_entry_id = Some(entry.id.clone());
+    }
+    segment.last_created_at = Some(entry.created_at);
+    segment.last_entry_id = Some(entry.id.clone());
+}
+
+#[cfg(test)]
+fn load_event_manifest(worktree_root: &Path) -> Result<EventSegmentManifest> {
+    ensure_repo_local_files(worktree_root)?;
+    load_event_manifest_from_dir(&coordination_dir(worktree_root))
+}
+
+fn load_event_manifest_from_dir(coordination_root: &Path) -> Result<EventSegmentManifest> {
+    let path = coordination_events_manifest_path_from_root(coordination_root);
+    let manifest: EventSegmentManifest = load_json_or_default(&path)?;
+    if manifest.version == 0 || manifest.segments.is_empty() {
+        Ok(initial_event_manifest())
+    } else {
+        Ok(manifest)
+    }
+}
+
+fn write_event_manifest(coordination_root: &Path, manifest: &EventSegmentManifest) -> Result<()> {
+    write_atomic_json(
+        &coordination_events_manifest_path_from_root(coordination_root),
+        manifest,
+    )
+}
+
+fn load_board_entries_from_segments_root(coordination_root: &Path) -> Result<Vec<BoardEntry>> {
+    let manifest = load_event_manifest_from_dir(coordination_root)?;
+    let segments_dir = coordination_events_segments_dir_from_root(coordination_root);
+    let mut entries = Vec::new();
+    for segment in manifest.segments {
+        let path = segments_dir.join(segment.file);
+        if !path.exists() {
+            continue;
+        }
+        for event in load_events_from_path(&path)? {
+            let CoordinationEvent::MessageAppended { entry } = event;
+            entries.push(entry);
+        }
+    }
+    entries.sort_by_key(|entry| entry.created_at);
+    Ok(entries)
 }
 
 fn load_events_from_path(path: &Path) -> Result<Vec<CoordinationEvent>> {
@@ -608,13 +1019,28 @@ pub fn write_reminders_state(
 /// Return Board entries whose `updated_at` is strictly later than `since`,
 /// sorted chronologically (same ordering as the projection).
 pub fn load_entries_since(worktree_root: &Path, since: DateTime<Utc>) -> Result<Vec<BoardEntry>> {
-    let snapshot = load_snapshot(worktree_root)?;
-    Ok(snapshot
-        .board
-        .entries
-        .into_iter()
-        .filter(|entry| entry.updated_at > since)
-        .collect())
+    ensure_repo_local_files(worktree_root)?;
+    let coordination_root = coordination_dir(worktree_root);
+    let manifest = load_event_manifest_from_dir(&coordination_root)?;
+    let segments_dir = coordination_events_segments_dir_from_root(&coordination_root);
+    let mut entries = Vec::new();
+    for segment in manifest.segments {
+        if segment
+            .last_created_at
+            .is_some_and(|last_created_at| last_created_at <= since)
+        {
+            continue;
+        }
+        let path = segments_dir.join(segment.file);
+        for event in load_events_from_path(&path)? {
+            let CoordinationEvent::MessageAppended { entry } = event;
+            if entry.updated_at > since {
+                entries.push(entry);
+            }
+        }
+    }
+    entries.sort_by_key(|entry| entry.created_at);
+    Ok(entries)
 }
 
 /// Check whether `author` has posted a message of the given `kind` within the
@@ -635,6 +1061,51 @@ pub fn has_recent_post_by(
         .any(|entry| entry.author == author && entry.kind == *kind && entry.updated_at > threshold))
 }
 
+pub fn board_entry_exists(worktree_root: &Path, entry_id: &str) -> Result<bool> {
+    ensure_repo_local_files(worktree_root)?;
+    let entry_id = entry_id.trim();
+    if entry_id.is_empty() {
+        return Ok(false);
+    }
+
+    let coordination_root = coordination_dir(worktree_root);
+    let manifest = load_event_manifest_from_dir(&coordination_root)?;
+    let segments_dir = coordination_events_segments_dir_from_root(&coordination_root);
+    for segment in manifest.segments.into_iter().rev() {
+        let path = segments_dir.join(segment.file);
+        for event in load_events_from_path(&path)? {
+            let CoordinationEvent::MessageAppended { entry } = event;
+            if entry.id == entry_id {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+pub fn load_entries_before(
+    worktree_root: &Path,
+    before_entry_id: Option<&str>,
+    limit: usize,
+) -> Result<BoardHistoryPage> {
+    ensure_repo_local_files(worktree_root)?;
+    if limit == 0 {
+        return Ok(BoardHistoryPage::default());
+    }
+
+    let entries = load_board_entries_from_segments_root(&coordination_dir(worktree_root))?;
+    let cutoff = before_entry_id
+        .and_then(|id| entries.iter().position(|entry| entry.id == id))
+        .unwrap_or(entries.len());
+    let older = &entries[..cutoff];
+    let has_more_before = older.len() > limit;
+    let start = older.len().saturating_sub(limit);
+    Ok(BoardHistoryPage {
+        entries: older[start..].to_vec(),
+        has_more_before,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::{str::FromStr, sync::Arc, thread};
@@ -652,11 +1123,70 @@ mod tests {
         let snapshot = load_snapshot(dir.path()).unwrap();
 
         assert!(snapshot.board.entries.is_empty());
-        assert!(coordination_events_path(dir.path()).exists());
+        assert!(coordination_events_manifest_path(dir.path()).exists());
+        assert!(coordination_events_segments_dir(dir.path()).is_dir());
         assert!(coordination_board_projection_path(dir.path()).exists());
         assert!(!coordination_dir(dir.path())
             .join("cards.latest.json")
             .exists());
+    }
+
+    #[test]
+    fn legacy_events_jsonl_migrates_to_segments_on_first_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let events_path = coordination_events_path(dir.path());
+        let mut first = BoardEntry::new(
+            AuthorKind::User,
+            "user",
+            BoardEntryKind::Request,
+            "legacy first",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        first.id = "entry-1".to_string();
+        first.created_at = Utc.with_ymd_and_hms(2026, 5, 4, 0, 0, 0).unwrap();
+        first.updated_at = first.created_at;
+        let mut second = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "legacy second",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        second.id = "entry-2".to_string();
+        second.created_at = Utc.with_ymd_and_hms(2026, 5, 4, 0, 1, 0).unwrap();
+        second.updated_at = second.created_at;
+        write_events(
+            &events_path,
+            &[
+                CoordinationEvent::MessageAppended { entry: first },
+                CoordinationEvent::MessageAppended { entry: second },
+            ],
+        );
+
+        let snapshot = load_snapshot(dir.path()).unwrap();
+
+        assert_eq!(
+            snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["legacy first", "legacy second"]
+        );
+        assert!(!events_path.exists());
+        let manifest = load_event_manifest(dir.path()).unwrap();
+        assert_eq!(manifest.total_entries(), 2);
+        assert_eq!(manifest.segments.len(), 1);
+        assert!(coordination_events_segments_dir(dir.path())
+            .join(&manifest.segments[0].file)
+            .is_file());
     }
 
     #[test]
@@ -735,7 +1265,11 @@ mod tests {
             snapshot.board.entries[0].body,
             "Need a coordination surface"
         );
-        let raw = std::fs::read_to_string(coordination_events_path(dir.path())).unwrap();
+        let manifest = load_event_manifest(dir.path()).unwrap();
+        let raw = std::fs::read_to_string(
+            coordination_events_segments_dir(dir.path()).join(&manifest.segments[0].file),
+        )
+        .unwrap();
         assert!(raw.contains("\"type\":\"message_appended\""));
     }
 
@@ -776,11 +1310,209 @@ mod tests {
         )
         .unwrap();
 
-        let rebuilt = rebuild_snapshot_from_events(&coordination_events_path(dir.path())).unwrap();
+        let rebuilt = rebuild_snapshot_from_segments(dir.path()).unwrap();
 
         assert_eq!(rebuilt.board.entries.len(), 2);
         assert_eq!(rebuilt.board.entries[0].body, "Initial request");
         assert_eq!(rebuilt.board.entries[1].body, "Investigating");
+    }
+
+    #[test]
+    fn hot_projection_keeps_latest_entries_with_history_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut events = Vec::new();
+        for idx in 0..(HOT_PROJECTION_ENTRY_LIMIT + 1) {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                format!("entry-{idx}"),
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            entry.id = format!("entry-{idx}");
+            entry.created_at = Utc.with_ymd_and_hms(2026, 5, 4, 0, 0, 0).unwrap()
+                + chrono::Duration::seconds(idx as i64);
+            entry.updated_at = entry.created_at;
+            events.push(CoordinationEvent::MessageAppended { entry });
+        }
+        write_events_to_segments(
+            &coordination_dir(dir.path()),
+            &events,
+            EVENT_SEGMENT_MAX_BYTES,
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(dir.path()).unwrap();
+
+        assert_eq!(snapshot.board.entries.len(), HOT_PROJECTION_ENTRY_LIMIT);
+        assert!(snapshot.board.has_more_before);
+        assert_eq!(snapshot.board.total_entries, HOT_PROJECTION_ENTRY_LIMIT + 1);
+        assert_eq!(snapshot.board.oldest_entry_id.as_deref(), Some("entry-1"));
+        assert_eq!(
+            snapshot.board.newest_entry_id.as_deref(),
+            Some(format!("entry-{HOT_PROJECTION_ENTRY_LIMIT}").as_str())
+        );
+    }
+
+    #[test]
+    fn board_entry_exists_checks_segment_history_outside_hot_projection() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut events = Vec::new();
+        for idx in 0..(HOT_PROJECTION_ENTRY_LIMIT + 1) {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                format!("entry-{idx}"),
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            entry.id = format!("entry-{idx}");
+            entry.created_at = Utc.with_ymd_and_hms(2026, 5, 4, 0, 0, 0).unwrap()
+                + chrono::Duration::seconds(idx as i64);
+            entry.updated_at = entry.created_at;
+            events.push(CoordinationEvent::MessageAppended { entry });
+        }
+        write_events_to_segments(
+            &coordination_dir(dir.path()),
+            &events,
+            EVENT_SEGMENT_MAX_BYTES,
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(dir.path()).unwrap();
+        assert!(!snapshot
+            .board
+            .entries
+            .iter()
+            .any(|entry| entry.id == "entry-0"));
+        assert!(board_entry_exists(dir.path(), "entry-0").unwrap());
+        assert!(!board_entry_exists(dir.path(), "missing-entry").unwrap());
+    }
+
+    #[test]
+    fn append_event_to_segments_rotates_when_max_bytes_is_exceeded() {
+        let dir = tempfile::tempdir().unwrap();
+        ensure_repo_local_files(dir.path()).unwrap();
+
+        for idx in 0..3 {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                format!("entry-{idx}-{}", "x".repeat(80)),
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            entry.id = format!("entry-{idx}");
+            entry.created_at =
+                Utc.with_ymd_and_hms(2026, 5, 4, 0, 0, 0).unwrap() + chrono::Duration::seconds(idx);
+            entry.updated_at = entry.created_at;
+            append_event_to_segments(
+                dir.path(),
+                &CoordinationEvent::MessageAppended { entry },
+                128,
+            )
+            .unwrap();
+        }
+
+        let manifest = load_event_manifest(dir.path()).unwrap();
+        assert!(
+            manifest.segments.len() >= 2,
+            "expected at least 2 segments, got {:?}",
+            manifest.segments
+        );
+        assert_eq!(manifest.total_entries(), 3);
+    }
+
+    #[test]
+    fn missing_manifest_and_projection_rebuild_from_existing_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        ensure_repo_local_files(dir.path()).unwrap();
+
+        for idx in 0..6 {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                format!("entry-{idx}-{}", "x".repeat(80)),
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            entry.id = format!("entry-{idx}");
+            entry.created_at =
+                Utc.with_ymd_and_hms(2026, 5, 4, 0, 0, 0).unwrap() + chrono::Duration::seconds(idx);
+            entry.updated_at = entry.created_at;
+            append_event_to_segments(
+                dir.path(),
+                &CoordinationEvent::MessageAppended { entry },
+                128,
+            )
+            .unwrap();
+        }
+        std::fs::remove_file(coordination_events_manifest_path(dir.path())).unwrap();
+        std::fs::remove_file(coordination_board_projection_path(dir.path())).unwrap();
+
+        let snapshot = load_snapshot(dir.path()).unwrap();
+        let manifest = load_event_manifest(dir.path()).unwrap();
+
+        assert!(manifest.segments.len() >= 2);
+        assert_eq!(manifest.total_entries(), 6);
+        assert_eq!(snapshot.board.total_entries, 6);
+        assert_eq!(
+            snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["entry-0", "entry-1", "entry-2", "entry-3", "entry-4", "entry-5"]
+        );
+    }
+
+    #[test]
+    fn load_entries_before_returns_older_entries_in_chronological_order() {
+        let dir = tempfile::tempdir().unwrap();
+
+        for idx in 0..5 {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                format!("entry-{idx}"),
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            entry.id = format!("entry-{idx}");
+            entry.created_at =
+                Utc.with_ymd_and_hms(2026, 5, 4, 0, 0, 0).unwrap() + chrono::Duration::seconds(idx);
+            entry.updated_at = entry.created_at;
+            post_entry(dir.path(), entry).unwrap();
+        }
+
+        let page = load_entries_before(dir.path(), Some("entry-3"), 2).unwrap();
+
+        assert_eq!(
+            page.entries
+                .iter()
+                .map(|entry| entry.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["entry-1", "entry-2"]
+        );
+        assert!(page.has_more_before);
     }
 
     #[test]
@@ -843,7 +1575,8 @@ mod tests {
 
         let project_dir = gwt_project_dir_for_repo_path(&repo).join("coordination");
         assert_eq!(coordination_dir(&repo), project_dir);
-        assert!(project_dir.join(EVENTS_FILE_NAME).exists());
+        assert!(project_dir.join(EVENTS_MANIFEST_FILE_NAME).exists());
+        assert!(project_dir.join(EVENTS_SEGMENTS_DIR_NAME).is_dir());
         assert!(project_dir.join(BOARD_PROJECTION_FILE_NAME).exists());
         assert!(!legacy_coordination_dir(&repo).exists());
     }
@@ -881,7 +1614,8 @@ mod tests {
             vec![
                 ".lock".to_string(),
                 "board.latest.json".to_string(),
-                "events.jsonl".to_string(),
+                "events".to_string(),
+                "events.manifest.json".to_string(),
             ]
         );
     }
@@ -934,7 +1668,8 @@ mod tests {
         migrate_legacy_coordination_dirs(&project_dir, &[legacy_one.clone(), legacy_two.clone()])
             .unwrap();
 
-        let snapshot = rebuild_snapshot_from_events(&project_dir.join(EVENTS_FILE_NAME)).unwrap();
+        migrate_legacy_event_log_to_segments(&project_dir).unwrap();
+        let snapshot = rebuild_snapshot_from_segments_root(&project_dir).unwrap();
         assert_eq!(
             snapshot
                 .board
@@ -974,11 +1709,15 @@ mod tests {
 
         migrate_legacy_coordination_dirs(&project_dir, std::slice::from_ref(&legacy_dir)).unwrap();
 
-        let raw = std::fs::read_to_string(project_dir.join(EVENTS_FILE_NAME)).unwrap();
+        migrate_legacy_event_log_to_segments(&project_dir).unwrap();
+        let manifest = load_event_manifest_from_dir(&project_dir).unwrap();
+        let raw =
+            std::fs::read_to_string(project_dir.join("events").join(&manifest.segments[0].file))
+                .unwrap();
         assert!(raw.contains("\"type\":\"message_appended\""));
         assert!(!raw.contains("\"type\":\"board_post\""));
 
-        let snapshot = rebuild_snapshot_from_events(&project_dir.join(EVENTS_FILE_NAME)).unwrap();
+        let snapshot = rebuild_snapshot_from_segments_root(&project_dir).unwrap();
         assert_eq!(snapshot.board.entries.len(), 1);
         assert_eq!(snapshot.board.entries[0].body, "legacy board post");
         assert!(!legacy_dir.exists());

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -108,25 +108,21 @@ impl AppRuntime {
         let owners = sanitize_board_list(&owners);
         let targets = sanitize_board_list(&targets);
 
-        let snapshot = match coordination::load_snapshot(&tab.project_root) {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                return vec![OutboundEvent::reply(
-                    client_id,
-                    BackendEvent::BoardError {
-                        id,
-                        message: error.to_string(),
-                    },
-                )];
-            }
-        };
         if let Some(parent_id) = parent_id.as_deref() {
-            if !snapshot
-                .board
-                .entries
-                .iter()
-                .any(|entry| entry.id == parent_id)
+            let parent_exists = match coordination::board_entry_exists(&tab.project_root, parent_id)
             {
+                Ok(parent_exists) => parent_exists,
+                Err(error) => {
+                    return vec![OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::BoardError {
+                            id,
+                            message: error.to_string(),
+                        },
+                    )];
+                }
+            };
+            if !parent_exists {
                 return vec![OutboundEvent::reply(
                     client_id,
                     BackendEvent::BoardError {
@@ -159,6 +155,7 @@ impl AppRuntime {
                     BackendEvent::BoardEntries {
                         id,
                         entries: snapshot.board.entries,
+                        has_more_before: snapshot.board.has_more_before,
                     },
                 )];
                 if let Some(entry) = latest_entry.as_ref() {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -819,6 +819,11 @@ impl AppRuntime {
             }
             FrontendEvent::LoadBranches { id } => self.load_branches_events(&client_id, &id),
             FrontendEvent::LoadBoard { id } => self.load_board_events(&client_id, &id),
+            FrontendEvent::LoadBoardHistory {
+                id,
+                before_entry_id,
+                limit,
+            } => self.load_board_history_events(&client_id, &id, before_entry_id.as_deref(), limit),
             FrontendEvent::LoadProfile { id } => self.load_profile_events(&client_id, &id),
             FrontendEvent::LoadMemo { id } => self.load_memo_events(&client_id, &id),
             FrontendEvent::LoadLogs { id } => self.load_logs_events(&client_id, &id),
@@ -1495,6 +1500,71 @@ impl AppRuntime {
                 BackendEvent::BoardEntries {
                     id: id.to_string(),
                     entries: snapshot.board.entries,
+                    has_more_before: snapshot.board.has_more_before,
+                },
+            )],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: error.to_string(),
+                },
+            )],
+        }
+    }
+
+    pub(crate) fn load_board_history_events(
+        &self,
+        client_id: &str,
+        id: &str,
+        before_entry_id: Option<&str>,
+        limit: usize,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        if window.preset != WindowPreset::Board {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window is not a Board surface".to_string(),
+                },
+            )];
+        }
+
+        match gwt_core::coordination::load_entries_before(&tab.project_root, before_entry_id, limit)
+        {
+            Ok(page) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardHistoryPage {
+                    id: id.to_string(),
+                    entries: page.entries,
+                    has_more_before: page.has_more_before,
                 },
             )],
             Err(error) => vec![OutboundEvent::reply(
@@ -1584,6 +1654,7 @@ impl AppRuntime {
                 events.push(OutboundEvent::broadcast(BackendEvent::BoardEntries {
                     id: combined_window_id(&tab.id, &window.id),
                     entries: snapshot.board.entries.clone(),
+                    has_more_before: snapshot.board.has_more_before,
                 }));
             }
         }
@@ -5210,11 +5281,72 @@ exit 0
             &events[..],
             [OutboundEvent {
                 target: DispatchTarget::Client(client_id),
-                event: BackendEvent::BoardEntries { id, entries },
+                event: BackendEvent::BoardEntries { id, entries, .. },
             }] if client_id == "client-1"
                 && id == &window_id
                 && entries.len() == 1
                 && entries[0].body == "Need review"
+        ));
+    }
+
+    #[test]
+    fn app_runtime_load_board_history_replies_with_older_page() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        for idx in 0..4 {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                format!("entry-{idx}"),
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            entry.id = format!("entry-{idx}");
+            entry.created_at = chrono::Utc::now() + chrono::Duration::seconds(idx);
+            entry.updated_at = entry.created_at;
+            post_entry(&repo, entry).expect("seed board entry");
+        }
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo,
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "board-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LoadBoardHistory {
+                id: window_id.clone(),
+                before_entry_id: Some("entry-3".to_string()),
+                limit: 2,
+            },
+        );
+
+        assert!(matches!(
+            &events[..],
+            [OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::BoardHistoryPage {
+                    id,
+                    entries,
+                    has_more_before,
+                },
+            }] if client_id == "client-1"
+                && id == &window_id
+                && entries.iter().map(|entry| entry.body.as_str()).collect::<Vec<_>>() == vec!["entry-1", "entry-2"]
+                && *has_more_before
         ));
     }
 
@@ -6206,7 +6338,7 @@ exit 0
             event,
             OutboundEvent {
                 target: DispatchTarget::Client(client_id),
-                event: BackendEvent::BoardEntries { id, entries },
+                event: BackendEvent::BoardEntries { id, entries, .. },
             } if client_id == "client-1"
                 && id == &window_id
                 && entries.iter().any(|entry|
@@ -6223,6 +6355,76 @@ exit 0
             && entry.parent_id.as_deref() == Some(parent.id.as_str())
             && entry.related_topics == vec!["coordination".to_string(), "phase-1b".to_string()]
             && entry.related_owners == vec!["2018".to_string()]));
+    }
+
+    #[test]
+    fn app_runtime_post_board_entry_accepts_reply_to_history_parent() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let parent_id = "history-parent".to_string();
+        for idx in 0..505 {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                format!("history entry {idx}"),
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            if idx == 0 {
+                entry.id = parent_id.clone();
+            }
+            post_entry(&repo, entry).expect("seed board entry");
+        }
+        let snapshot = load_snapshot(&repo).expect("load board snapshot");
+        assert!(!snapshot
+            .board
+            .entries
+            .iter()
+            .any(|entry| entry.id == parent_id));
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo.clone(),
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "board-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::PostBoardEntry {
+                id: window_id.clone(),
+                entry_kind: BoardEntryKind::Next,
+                body: "Reply to older context".to_string(),
+                parent_id: Some(parent_id.clone()),
+                topics: vec![],
+                owners: vec![],
+                targets: Vec::new(),
+            },
+        );
+
+        assert!(events.iter().any(|event| matches!(
+            event,
+            OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::BoardEntries { id, entries, .. },
+            } if client_id == "client-1"
+                && id == &window_id
+                && entries.iter().any(|entry|
+                    entry.body == "Reply to older context"
+                    && entry.parent_id.as_deref() == Some(parent_id.as_str())
+                )
+        )));
     }
 
     #[test]
@@ -6369,7 +6571,7 @@ exit 0
                 event,
                 OutboundEvent {
                     target: DispatchTarget::Broadcast,
-                    event: BackendEvent::BoardEntries { id, entries },
+                    event: BackendEvent::BoardEntries { id, entries, .. },
                 } if *id == expected_id
                     && entries.len() == 1
                     && entries[0].body == "External update"

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -163,9 +163,26 @@ fn sessions_dir_for_current_runtime() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use gwt_agent::{AgentId, Session};
-    use gwt_core::coordination::load_snapshot;
+    use gwt_core::coordination::{coordination_events_segments_dir, load_snapshot};
 
     use super::*;
+
+    fn assert_no_board_entries_or_events(root: &std::path::Path) {
+        let snapshot = load_snapshot(root).unwrap();
+        assert!(snapshot.board.entries.is_empty());
+        let event_lines = std::fs::read_dir(coordination_events_segments_dir(root))
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl"))
+            .map(|entry| {
+                std::fs::read_to_string(entry.path())
+                    .unwrap()
+                    .lines()
+                    .count()
+            })
+            .sum::<usize>();
+        assert_eq!(event_lines, 0);
+    }
 
     #[test]
     fn pending_discussion_for_session_reads_active_discussion_candidate() {
@@ -249,11 +266,7 @@ mod tests {
 
         sync_coordination_for_session(&session, "PreToolUse");
 
-        let snapshot = load_snapshot(dir.path()).unwrap();
-        assert!(snapshot.board.entries.is_empty());
-        let events =
-            std::fs::read_to_string(dir.path().join(".gwt/coordination/events.jsonl")).unwrap();
-        assert_eq!(events.lines().count(), 0);
+        assert_no_board_entries_or_events(dir.path());
     }
 
     #[test]
@@ -263,12 +276,7 @@ mod tests {
 
         sync_coordination_for_session(&session, "SessionStart");
 
-        let snapshot = load_snapshot(dir.path()).unwrap();
-        assert!(snapshot.board.entries.is_empty());
-
-        let events =
-            std::fs::read_to_string(dir.path().join(".gwt/coordination/events.jsonl")).unwrap();
-        assert_eq!(events.lines().count(), 0);
+        assert_no_board_entries_or_events(dir.path());
     }
 
     #[test]
@@ -278,12 +286,7 @@ mod tests {
 
         sync_coordination_for_session(&session, "Stop");
 
-        let snapshot = load_snapshot(dir.path()).unwrap();
-        assert!(snapshot.board.entries.is_empty());
-
-        let events =
-            std::fs::read_to_string(dir.path().join(".gwt/coordination/events.jsonl")).unwrap();
-        assert_eq!(events.lines().count(), 0);
+        assert_no_board_entries_or_events(dir.path());
     }
 
     #[test]
@@ -294,12 +297,7 @@ mod tests {
         sync_coordination_for_session(&session, "PreToolUse");
         sync_coordination_for_session(&session, "PostToolUse");
 
-        let snapshot = load_snapshot(dir.path()).unwrap();
-        assert!(snapshot.board.entries.is_empty());
-
-        let events =
-            std::fs::read_to_string(dir.path().join(".gwt/coordination/events.jsonl")).unwrap();
-        assert_eq!(events.lines().count(), 0);
+        assert_no_board_entries_or_events(dir.path());
     }
 
     #[test]

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1269,10 +1269,12 @@ mod tests {
         assert!(
             html.contains("pendingSubmit: null")
                 && html.contains("existingEntryIds: new Set")
-                && html.contains("const completedSubmit = Boolean(state.pendingSubmit")
-                && html.contains("!state.pendingSubmit.existingEntryIds.has(entry.id)")
+                && html.contains("const pendingSubmit = state.pendingSubmit;")
+                && html.contains("const completedSubmit = Boolean(pendingSubmit")
+                && html.contains("!pendingSubmit.existingEntryIds.has(entry.id)")
                 && html.contains("state.composerBody = \"\";")
-                && html.contains("state.pendingSubmit = null;"),
+                && html.contains("state.pendingSubmit = null;")
+                && html.contains("state.pendingSelfPostScroll = true;"),
             "expected Board post success to clear drafts only after matching submitted entry appears",
         );
         assert!(

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -107,6 +107,12 @@ pub enum FrontendEvent {
     LoadBoard {
         id: String,
     },
+    LoadBoardHistory {
+        id: String,
+        before_entry_id: Option<String>,
+        #[serde(default = "default_board_history_limit")]
+        limit: usize,
+    },
     LoadProfile {
         id: String,
     },
@@ -264,6 +270,10 @@ pub enum FrontendEvent {
     },
 }
 
+fn default_board_history_limit() -> usize {
+    50
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct WorkspaceView {
     pub viewport: CanvasViewport,
@@ -381,6 +391,13 @@ pub enum BackendEvent {
     BoardEntries {
         id: String,
         entries: Vec<BoardEntry>,
+        #[serde(default)]
+        has_more_before: bool,
+    },
+    BoardHistoryPage {
+        id: String,
+        entries: Vec<BoardEntry>,
+        has_more_before: bool,
     },
     ProfileSnapshot {
         id: String,
@@ -710,6 +727,7 @@ mod tests {
                 vec!["coordination".to_string()],
                 vec!["2018".to_string()],
             )],
+            has_more_before: false,
         };
 
         let value = serde_json::to_value(&event).expect("serialize board entries");
@@ -726,6 +744,50 @@ mod tests {
             value["entries"][0]["related_topics"][0],
             Value::String("coordination".to_string()),
             "expected board snapshot payload to keep related topics on the wire",
+        );
+    }
+
+    #[test]
+    fn board_history_page_serializes_cursor_contract() {
+        let frontend: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "load_board_history",
+            "id": "board-1",
+            "before_entry_id": "entry-3",
+            "limit": 50
+        }))
+        .expect("deserialize board history request");
+        assert!(matches!(
+            frontend,
+            FrontendEvent::LoadBoardHistory {
+                id,
+                before_entry_id: Some(before_entry_id),
+                limit
+            } if id == "board-1" && before_entry_id == "entry-3" && limit == 50
+        ));
+
+        let backend = BackendEvent::BoardHistoryPage {
+            id: "board-1".to_string(),
+            entries: vec![BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "Older update",
+                None,
+                None,
+                vec![],
+                vec![],
+            )],
+            has_more_before: true,
+        };
+        let value = serde_json::to_value(&backend).expect("serialize board history page");
+        assert_eq!(
+            value.get("kind"),
+            Some(&Value::String("board_history_page".to_string()))
+        );
+        assert_eq!(value["has_more_before"], Value::Bool(true));
+        assert_eq!(
+            value["entries"][0]["body"],
+            Value::String("Older update".into())
         );
     }
 

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -1,0 +1,27 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
+
+test("Board surface requests older history with cursor-based paging", () => {
+  assert.match(appSource, /function\s+requestOlderBoardEntries/);
+  assert.match(appSource, /kind:\s*"load_board_history"/);
+  assert.match(appSource, /case\s+"board_history_page"/);
+  assert.match(appSource, /function\s+mergeBoardEntries/);
+  assert.match(appSource, /hasMoreBefore/);
+});
+
+test("Board surface scrolls to bottom after the user's own post succeeds", () => {
+  assert.match(appSource, /pendingSelfPostScroll\s*=\s*true/);
+  assert.match(appSource, /forceBoardScrollToBottom/);
+});
+
+test("Board surface follows external posts only when already near bottom", () => {
+  assert.match(appSource, /shouldFollowBoardBottom/);
+  assert.match(appSource, /preserveBoardScrollPosition/);
+  assert.match(appSource, /newEntriesAvailable/);
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -157,6 +157,7 @@
             "ensureBoardState",
             "renderBoard",
             "requestBoard",
+            "requestOlderBoardEntries",
             "submitBoardEntry",
           ]),
         }),
@@ -1718,6 +1719,13 @@
             composerKind: "status",
             composerBody: "",
             pendingSubmit: null,
+            hasMoreBefore: false,
+            oldestEntryId: null,
+            loadingOlder: false,
+            pendingSelfPostScroll: false,
+            preserveBoardScrollPosition: false,
+            shouldFollowBoardBottom: true,
+            newEntriesAvailable: false,
           });
         }
         return boardStateMap.get(windowId);
@@ -1784,6 +1792,25 @@
         send({
           kind: "load_board",
           id: windowId,
+        });
+      }
+
+      function requestOlderBoardEntries(windowId) {
+        const state = ensureBoardState(windowId);
+        if (state.loading || state.loadingOlder || !state.hasMoreBefore) {
+          return;
+        }
+        const beforeEntryId = state.oldestEntryId || state.entries[0]?.id || null;
+        if (!beforeEntryId) {
+          return;
+        }
+        state.loadingOlder = true;
+        state.error = "";
+        send({
+          kind: "load_board_history",
+          id: windowId,
+          before_entry_id: beforeEntryId,
+          limit: 50,
         });
       }
 
@@ -3055,6 +3082,35 @@
         renderBoard(windowId);
       }
 
+      function forceBoardScrollToBottom(scroller) {
+        scroller.scrollTop = scroller.scrollHeight;
+      }
+
+      function preserveBoardScrollPosition(scroller, previousScrollTop, previousScrollHeight) {
+        const delta = scroller.scrollHeight - previousScrollHeight;
+        scroller.scrollTop = previousScrollTop + Math.max(0, delta);
+      }
+
+      function mergeBoardEntries(existingEntries, incomingEntries) {
+        const merged = new Map();
+        for (const entry of existingEntries || []) {
+          if (entry.id) {
+            merged.set(entry.id, entry);
+          }
+        }
+        for (const entry of incomingEntries || []) {
+          if (entry.id) {
+            merged.set(entry.id, entry);
+          }
+        }
+        return Array.from(merged.values()).sort((left, right) => {
+          const leftKey = String(left.created_at || left.updated_at || "");
+          const rightKey = String(right.created_at || right.updated_at || "");
+          return leftKey.localeCompare(rightKey)
+            || String(left.id || "").localeCompare(String(right.id || ""));
+        });
+      }
+
       function handleBoardHookEvent(event) {
         const hookEvent = event.event;
         if (!hookEvent || hookEvent.kind !== "coordination_event") {
@@ -3096,13 +3152,18 @@
           return;
         }
 
+        const entryCountLabel = `${state.entries.length} entr${state.entries.length === 1 ? "y" : "ies"}`;
         status.textContent = state.error
           ? state.error
           : state.loading
             ? state.submitting
               ? "Saving entry..."
               : "Loading coordination..."
-            : `${state.entries.length} entr${state.entries.length === 1 ? "y" : "ies"}`;
+            : state.loadingOlder
+              ? `Loading earlier entries... - ${entryCountLabel}`
+              : state.newEntriesAvailable
+                ? `${entryCountLabel} - New updates`
+                : entryCountLabel;
         status.className = "board-status";
         if (state.error) {
           status.classList.add("error");
@@ -3117,15 +3178,43 @@
         const scroller = timeline.parentElement;
         const stickyBottomThreshold = 64;
         const previousScrollTop = scroller ? scroller.scrollTop : 0;
+        const previousScrollHeight = scroller ? scroller.scrollHeight : 0;
         const previousScrollMax = scroller
           ? scroller.scrollHeight - scroller.clientHeight
           : 0;
-        const wasNearBottom =
+        const shouldFollowBoardBottom =
           !scroller ||
           previousScrollMax <= 0 ||
           previousScrollMax - previousScrollTop <= stickyBottomThreshold;
+        state.shouldFollowBoardBottom = shouldFollowBoardBottom;
+        if (scroller && scroller.dataset.boardScrollBound !== "true") {
+          scroller.dataset.boardScrollBound = "true";
+          scroller.addEventListener("scroll", () => {
+            const scrollMax = scroller.scrollHeight - scroller.clientHeight;
+            const isNearBottom =
+              scrollMax <= 0 || scrollMax - scroller.scrollTop <= stickyBottomThreshold;
+            state.shouldFollowBoardBottom = isNearBottom;
+            if (isNearBottom) {
+              state.newEntriesAvailable = false;
+            }
+            if (scroller.scrollTop <= 48) {
+              requestOlderBoardEntries(windowId);
+            }
+          });
+        }
 
         timeline.innerHTML = "";
+        if (state.hasMoreBefore) {
+          const loadOlder = createNode(
+            "button",
+            "board-load-older",
+            state.loadingOlder ? "Loading earlier entries..." : "Load earlier entries",
+          );
+          loadOlder.type = "button";
+          loadOlder.disabled = state.loadingOlder;
+          loadOlder.addEventListener("click", () => requestOlderBoardEntries(windowId));
+          timeline.appendChild(loadOlder);
+        }
         if (!state.loading && state.entries.length === 0) {
           timeline.appendChild(
             createNode("div", "board-empty workspace-empty-state", "No coordination entries yet."),
@@ -3162,8 +3251,16 @@
         }
 
         if (scroller) {
-          if (wasNearBottom) {
-            scroller.scrollTop = scroller.scrollHeight;
+          if (state.pendingSelfPostScroll) {
+            forceBoardScrollToBottom(scroller);
+            state.pendingSelfPostScroll = false;
+            state.newEntriesAvailable = false;
+          } else if (state.preserveBoardScrollPosition) {
+            preserveBoardScrollPosition(scroller, previousScrollTop, previousScrollHeight);
+            state.preserveBoardScrollPosition = false;
+          } else if (shouldFollowBoardBottom) {
+            forceBoardScrollToBottom(scroller);
+            state.newEntriesAvailable = false;
           } else {
             scroller.scrollTop = previousScrollTop;
           }
@@ -5771,6 +5868,7 @@
       const boardSurface = Object.freeze({
         ensureBoardState,
         requestBoard,
+        requestOlderBoardEntries,
         renderBoard,
         submitBoardEntry,
         handleRuntimeHookEvent: handleBoardHookEvent,
@@ -5930,16 +6028,29 @@
           case "board_entries": {
             const state = frontendUnits.boardSurface.ensureBoardState(event.id);
             const incomingEntries = event.entries || [];
-            const completedSubmit = Boolean(state.pendingSubmit)
+            const existingEntryIds = new Set(state.entries.map((entry) => entry.id));
+            const incomingEntryIds = new Set(incomingEntries.map((entry) => entry.id));
+            const retainedHistory = state.entries.some(
+              (entry) => Boolean(entry.id) && !incomingEntryIds.has(entry.id),
+            );
+            const addedEntry = incomingEntries.some(
+              (entry) => Boolean(entry.id) && !existingEntryIds.has(entry.id),
+            );
+            const pendingSubmit = state.pendingSubmit;
+            const completedSubmit = Boolean(pendingSubmit)
               && incomingEntries.some((entry) => {
                 const parentId = entry.parent_id || null;
                 return Boolean(entry.id)
-                  && !state.pendingSubmit.existingEntryIds.has(entry.id)
-                  && parentId === state.pendingSubmit.parentId
+                  && !pendingSubmit.existingEntryIds.has(entry.id)
+                  && parentId === pendingSubmit.parentId
                   && String(entry.author_kind || "").toLowerCase() === "user"
-                  && String(entry.body || "").trim() === state.pendingSubmit.body;
+                  && String(entry.body || "").trim() === pendingSubmit.body;
               });
-            state.entries = incomingEntries;
+            state.entries = mergeBoardEntries(state.entries, incomingEntries);
+            state.hasMoreBefore = retainedHistory
+              ? state.hasMoreBefore
+              : Boolean(event.has_more_before);
+            state.oldestEntryId = state.entries[0]?.id || null;
             if (
               state.replyParentId &&
               !state.entries.some((entry) => entry.id === state.replyParentId)
@@ -5947,14 +6058,32 @@
               state.replyParentId = null;
             }
             if (completedSubmit) {
-              if (state.composerBody.trim() === state.pendingSubmit.body) {
+              if (state.composerBody.trim() === pendingSubmit.body) {
                 state.composerBody = "";
               }
               state.replyParentId = null;
               state.pendingSubmit = null;
               state.submitting = false;
+              state.pendingSelfPostScroll = true;
+            } else if (addedEntry && !state.shouldFollowBoardBottom) {
+              state.newEntriesAvailable = true;
             }
             state.loading = false;
+            state.error = "";
+            frontendUnits.boardSurface.renderBoard(event.id);
+            break;
+          }
+          case "board_history_page": {
+            const state = frontendUnits.boardSurface.ensureBoardState(event.id);
+            const existingEntryIds = new Set(state.entries.map((entry) => entry.id));
+            const olderEntries = (event.entries || []).filter(
+              (entry) => !entry.id || !existingEntryIds.has(entry.id),
+            );
+            state.entries = olderEntries.concat(state.entries);
+            state.hasMoreBefore = Boolean(event.has_more_before);
+            state.oldestEntryId = state.entries[0]?.id || null;
+            state.loadingOlder = false;
+            state.preserveBoardScrollPosition = olderEntries.length > 0;
             state.error = "";
             frontendUnits.boardSurface.renderBoard(event.id);
             break;
@@ -6147,6 +6276,7 @@
           case "board_error": {
             const state = frontendUnits.boardSurface.ensureBoardState(event.id);
             state.loading = false;
+            state.loadingOlder = false;
             state.submitting = false;
             state.pendingSubmit = null;
             state.error = event.message;

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1437,6 +1437,29 @@
         gap: 12px;
       }
 
+      .board-load-older {
+        align-self: center;
+        min-height: 30px;
+        padding: 6px 12px;
+        border: 1px solid var(--color-border-strong);
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        color: var(--color-text-muted);
+        background: var(--color-surface-elevated);
+        cursor: pointer;
+      }
+
+      .board-load-older:hover:not(:disabled) {
+        color: var(--color-text);
+        border-color: var(--color-focus-ring);
+      }
+
+      .board-load-older:disabled {
+        cursor: default;
+        opacity: 0.72;
+      }
+
       .board-composer-bar {
         border-top: 1px solid var(--color-border);
         background: color-mix(in oklab, var(--color-surface) 94%, transparent);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "cargo test -p gwt-core -p gwt --all-features",
     "test:frontend-bundle": "node --check crates/gwt/web/app.js && node --check crates/gwt/web/branch-cleanup-modal.js && node --check crates/gwt/web/migration-modal.js && node --check crates/gwt/web/theme-manager.js && node --check crates/gwt/web/hotkey.js && node --check crates/gwt/web/operator-shell.js",
     "test:frontend-smoke": "node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs crates/gwt/web/__tests__/migration-modal.smoke.test.mjs",
-    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs",
+    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/board-surface.test.mjs",
     "test:visual": "playwright test --config crates/gwt/playwright/playwright.config.ts",
     "test:release-assets": "node scripts/test_release_assets.cjs",
     "test:release-flow": "bash scripts/check-release-flow.sh",


### PR DESCRIPTION
## Summary

- Board storage now keeps JSONL as segmented event logs with a manifest and hot projection so high-volume posting does not require replaying the full history.
- The Board UI now supports cursor-based older history loading and preserves scroll position for external updates while scrolling to the newest own post after submission.
- SPEC-1974 and SPEC-2018 artifacts were updated to capture the storage and scroll behavior decisions.

## Changes

- `crates/gwt-core/src/coordination.rs`: Added segmented Board event storage, manifest recovery, hot projection rebuilds, legacy `events.jsonl` migration, lazy history paging, and parent lookup across segment history.
- `crates/gwt/src/protocol.rs`: Added Board history request/response wire events and `has_more_before` snapshot metadata.
- `crates/gwt/src/app_runtime/mod.rs` and `crates/gwt/src/app_runtime/board.rs`: Wired `load_board_history`, returned cursor metadata, and allowed replies to parents outside the hot projection.
- `crates/gwt/web/app.js` and `crates/gwt/web/index.html`: Added older-entry loading, scroll preservation, own-post bottom follow, and load-more control styling.
- `crates/gwt/web/__tests__/board-surface.test.mjs`: Added frontend source tests for history paging and scroll behavior.
- SPEC artifacts: Updated SPEC-1974 plan/tasks and SPEC-2018 spec content for the storage and autoscroll behavior.

## Testing

- [x] `node --test crates/gwt/web/__tests__/board-surface.test.mjs` - passed.
- [x] `npm run test:frontend-bundle` - passed.
- [x] `npm run test:frontend-unit` - passed, 55 tests.
- [x] `npm run test:frontend-smoke` - passed, 10 tests.
- [x] `cargo test -p gwt-core coordination::tests -- --nocapture` - passed before full suite.
- [x] `cargo test -p gwt app_runtime_load_board_history_replies_with_older_page -- --nocapture` - passed before full suite.
- [x] `cargo test -p gwt app_runtime_post_board_entry_accepts_reply_to_history_parent -- --nocapture` - passed before full suite.
- [x] `cargo test -p gwt-core -p gwt --all-features` - passed after latest `origin/develop` merge.
- [x] `cargo test -p gwt-skills --all-features` - passed after latest `origin/develop` merge.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `cargo build -p gwt` - passed.
- [x] `git diff --check` - passed.
- [x] Pre-push hook - passed with filtered line coverage 90.30%.

## Closing Issues

None

## Related Issues / Links

- #1974
- #2018

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (N/A: README surface is unchanged; SPEC artifacts were updated)
- [x] Migration/backfill plan included (legacy `events.jsonl` migrates into segmented JSONL and projection rebuilds are recoverable)
- [x] CHANGELOG impact considered (feature commit is non-breaking)

## Context

- The Board needs to remain local-file based while tolerating a much larger post volume than a single replayed JSONL file can handle.
- The selected design keeps append-only JSONL semantics, bounds the hot read path to the latest 500 entries, and loads older history only when the user asks or scrolls near the top.

## Risk / Impact

- **Affected areas**: Board persistence, Board protocol, Board runtime events, and Board GUI scroll behavior.
- **Rollback plan**: Revert this PR; legacy `events.jsonl` migration runs only when the new Board storage is initialized.

## Screenshots

- Not attached: the user-visible change is scroll/history behavior, covered by the added frontend source tests rather than a static layout comparison.
