### PR TITLE
fix(start-work): keep next milestones blocked

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -144,12 +144,13 @@ impl WorkspaceProjection {
                     BoardEntryKind::Status
                     | BoardEntryKind::Claim
                     | BoardEntryKind::Handoff
-                    | BoardEntryKind::Decision
-                    | BoardEntryKind::Next => {
+                    | BoardEntryKind::Decision => {
                         agent.status_category = WorkspaceStatusCategory::Active;
                     }
-                    BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {
-                    }
+                    BoardEntryKind::Next
+                    | BoardEntryKind::Request
+                    | BoardEntryKind::Impact
+                    | BoardEntryKind::Question => {}
                 }
             }
         }
@@ -402,6 +403,63 @@ mod tests {
         assert_eq!(
             projection.effective_status_category(),
             WorkspaceStatusCategory::Active
+        );
+    }
+
+    #[test]
+    fn board_milestone_next_keeps_blocked_agent_blocked() {
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        projection.agents.push(WorkspaceAgentSummary {
+            session_id: "sess-1".to_string(),
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            worktree_path: None,
+            branch: None,
+            last_board_entry_id: None,
+            updated_at: Utc::now(),
+        });
+        let mut blocked = BoardEntry::new(
+            crate::coordination::AuthorKind::Agent,
+            "codex",
+            BoardEntryKind::Blocked,
+            "Waiting for credentials",
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_origin_session_id("sess-1");
+        blocked.id = "blocked-1".to_string();
+        projection.record_board_milestone(&blocked);
+
+        let mut next = BoardEntry::new(
+            crate::coordination::AuthorKind::Agent,
+            "codex",
+            BoardEntryKind::Next,
+            "Try a different credential source",
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .with_origin_session_id("sess-1");
+        next.id = "next-1".to_string();
+        projection.record_board_milestone(&next);
+
+        assert_eq!(
+            projection.agents[0].status_category,
+            WorkspaceStatusCategory::Blocked
+        );
+        assert_eq!(
+            projection.effective_status_category(),
+            WorkspaceStatusCategory::Blocked
+        );
+        assert_eq!(projection.status_text, "Waiting for credentials");
+        assert_eq!(
+            projection.next_action.as_deref(),
+            Some("Try a different credential source")
         );
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -6625,6 +6625,84 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_active_work_projection_keeps_blocked_agent_after_next_milestone() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        let worktree = temp.path().join("repo-work-20260504-1234");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Board],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let session = ActiveAgentSession {
+            window_id: "tab-1::agent-1".to_string(),
+            session_id: "session-1".to_string(),
+            agent_id: "codex".to_string(),
+            branch_name: "work/20260504-1234".to_string(),
+            display_name: "Codex".to_string(),
+            worktree_path: worktree.clone(),
+            tab_id: "tab-1".to_string(),
+        };
+        runtime
+            .active_agent_sessions
+            .insert(session.window_id.clone(), session.clone());
+        save_start_work_workspace_projection(&repo, &session, "develop", None)
+            .expect("save initial projection");
+        let blocked = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Blocked,
+            "Waiting for API credentials",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1");
+        runtime
+            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
+            .expect("blocked projection broadcast");
+        let next = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Next,
+            "Try alternate credential source",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1");
+
+        let event = runtime
+            .record_workspace_board_milestone_event("tab-1", &repo, &next)
+            .expect("blocked projection broadcast");
+
+        assert!(matches!(
+            event,
+            OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::ActiveWorkProjection { projection },
+            } if projection.status_category == "blocked"
+                && projection.active_agents == 0
+                && projection.blocked_agents == 1
+                && projection.status_text == "Waiting for API credentials"
+                && projection.next_action.as_deref() == Some("Try alternate credential source")
+                && projection.branch.as_deref() == Some("work/20260504-1234")
+        ));
+    }
+
+    #[test]
     fn app_runtime_board_projection_change_broadcasts_to_matching_board_windows_only() {
         let _env_lock = env_test_lock()
             .lock()


### PR DESCRIPTION
## Summary

- Keeps `next` Board milestones from clearing an agent's blocked state so Workspace and Board stay consistent.
- Adds core and app-runtime regression coverage for the blocked-plus-next milestone sequence.

## Changes

- `crates/gwt-core/src/workspace_projection.rs`: Limits blocked-agent recovery to progress milestones (`status`, `claim`, `handoff`, `decision`) and keeps `next` as a next-action update only.
- `crates/gwt-core/src/workspace_projection.rs`: Adds a projection regression test proving `next` preserves the blocked category and blocker text.
- `crates/gwt/src/app_runtime/mod.rs`: Adds an app-runtime projection regression test proving the broadcast view remains blocked after a `next` milestone.

## Testing

- [x] `cargo test -p gwt-core board_milestone_next_keeps_blocked_agent_blocked -- --nocapture` - passed.
- [x] `cargo test -p gwt app_runtime_active_work_projection_keeps_blocked_agent_after_next_milestone -- --nocapture` - passed.
- [x] `cargo test -p gwt-core board_milestone_restores_blocked_agent_to_active_on_progress -- --nocapture` - passed.
- [x] `cargo test -p gwt app_runtime_active_work_projection_recovers_blocked_agent_after_status_milestone -- --nocapture` - passed.
- [x] `cargo test -p gwt-core -p gwt` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `git diff --check` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `git push origin feature/branches` pre-push checks - passed with filtered line coverage 90.21%.

## Closing Issues

None

## Related Issues / Links

- #2359
- #2373

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not required: internal projection behavior only)
- [x] Migration/backfill plan included (not required: no schema/data changes)
- [x] CHANGELOG impact considered (patch-level bug fix, no breaking change)
