### PR TITLE
fix(ui): SPEC-2356 follow-up — wizard buttons + picker overlay + update toast to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2556,11 +2556,13 @@
       .wizard-error {
         margin-bottom: 12px;
         padding: 10px 12px;
-        border-radius: 6px;
-        background: rgba(239, 68, 68, 0.08);
-        border: 1px solid rgba(239, 68, 68, 0.18);
-        font-size: 12px;
-        color: #b91c1c;
+        border-radius: var(--radius-md);
+        background: color-mix(in oklab, var(--color-state-blocked) 12%, transparent);
+        border: 1px solid color-mix(in oklab, var(--color-state-blocked) 32%, transparent);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-state-blocked);
       }
 
       .wizard-footer {
@@ -2581,19 +2583,22 @@
       .wizard-button {
         height: 36px;
         padding: 0 12px;
-        border-radius: 6px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        background: #f8fafc;
-        color: #0f172a;
-        font-size: 12px;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface-elevated);
+        color: var(--color-text);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
         font-weight: 600;
+        text-transform: uppercase;
         cursor: pointer;
       }
 
       .wizard-button.primary {
-        background: #0f172a;
-        color: #ffffff;
-        border-color: #0f172a;
+        background: var(--color-state-active);
+        color: var(--color-canvas);
+        border-color: var(--color-state-active);
       }
 
       @media (max-width: 720px) {
@@ -2630,7 +2635,8 @@
         align-items: center;
         justify-content: center;
         padding: 24px;
-        background: rgba(237, 241, 246, 0.72);
+        background: var(--color-overlay);
+        backdrop-filter: blur(2px);
         z-index: 1200;
       }
 
@@ -2737,20 +2743,22 @@
         bottom: 20px;
         right: 20px;
         padding: 10px 16px;
-        background: rgba(255, 255, 255, 0.96);
-        border: 1px solid rgba(59, 130, 246, 0.4);
-        border-radius: 8px;
-        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+        background: var(--color-surface-elevated);
+        border: 1px solid var(--color-focus-ring);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-2);
         backdrop-filter: blur(8px);
-        font-size: 13px;
-        color: #1e40af;
+        font-family: var(--font-mono);
+        font-size: var(--type-sm);
+        letter-spacing: var(--tracking-mono);
+        color: var(--color-state-active);
         cursor: pointer;
         z-index: 9999;
         transition: opacity 0.3s;
       }
 
       .update-toast:hover {
-        background: rgba(239, 246, 255, 0.98);
+        background: color-mix(in oklab, var(--color-state-active) 14%, var(--color-surface-elevated));
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: Launch Wizard の操作ボタンとエラー表示、 Project Picker / Onboarding overlay、 update-toast の inline CSS を tokens 駆動に置換。 wizard 終端の primary action と error feedback がそれぞれ Operator state token の `--color-state-active` / `--color-state-blocked` で semantic に表現される。

## Changes

- `cea853af` — wizard buttons + picker overlay + update toast
  - `.wizard-button` / `.wizard-button.primary`: tokens 化、 primary 背景を `--color-state-active` + `--color-canvas` 文字、 全体 Mono uppercase
  - `.wizard-error`: `color-mix(in oklab, var(--color-state-blocked) ...%, transparent)` semantic
  - `.project-picker` / `.project-onboarding` overlay 背景を `var(--color-overlay)` + blur(2px) に
  - `.update-toast`: `var(--color-surface-elevated)` 背景 + Mono + `--color-state-active` accent、 hover で `color-mix(... 14%, transparent)`

## Testing

- ✅ `cargo test -p gwt` (389 + 197 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 / #2372 / #2374 (merged)

## Risk / Impact

- 影響範囲: wizard / picker overlay / update-toast inline CSS
- 互換性: DOM / 機能変更なし

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
