### PR TITLE
fix(ui): SPEC-2356 follow-up — project-tab + app-version + index-status to tokens

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -108,17 +108,17 @@
         max-width: 280px;
         height: 32px;
         padding: 0 8px 0 10px;
-        border: 1px solid rgba(148, 163, 184, 0.28);
-        border-radius: 6px;
-        background: #f8fafc;
-        color: #334155;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-surface-elevated);
+        color: var(--color-text);
         cursor: pointer;
       }
 
       .project-tab.active {
-        border-color: rgba(37, 99, 235, 0.34);
-        background: rgba(59, 130, 246, 0.1);
-        color: #0f172a;
+        border-color: var(--color-focus-ring);
+        background: color-mix(in oklab, var(--color-state-active) 14%, var(--color-surface-elevated));
+        color: var(--color-text-strong);
       }
 
       .project-tab-label {
@@ -126,7 +126,8 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        font-size: 12px;
+        font-family: var(--font-body);
+        font-size: var(--type-xs);
         font-weight: 600;
       }
 
@@ -134,14 +135,14 @@
         width: 18px;
         height: 18px;
         border: none;
-        border-radius: 4px;
-        background: rgba(148, 163, 184, 0.18);
+        border-radius: var(--radius-sm);
+        background: color-mix(in oklab, var(--color-text-muted) 18%, transparent);
         color: inherit;
         cursor: pointer;
       }
 
       .project-tab-close:hover {
-        background: rgba(148, 163, 184, 0.28);
+        background: color-mix(in oklab, var(--color-text-muted) 28%, transparent);
       }
 
       .project-actions {
@@ -155,11 +156,13 @@
         align-items: center;
         height: 32px;
         padding: 0 10px;
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        border-radius: 6px;
-        background: #f8fafc;
-        color: #475569;
-        font-size: 12px;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-surface-elevated);
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
         font-weight: 600;
         white-space: nowrap;
       }
@@ -173,11 +176,13 @@
         align-items: center;
         height: 32px;
         padding: 0 10px;
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        border-radius: 6px;
-        background: #f8fafc;
-        color: #475569;
-        font-size: 12px;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-surface-elevated);
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-size: var(--type-xs);
+        letter-spacing: var(--tracking-mono);
         font-weight: 700;
         white-space: nowrap;
       }


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System 連続 polish: Project Bar 上の主要 UI 要素 (project tab / close button / app version chip / index status chip) の inline CSS を Operator tokens に置換。 上部 chrome の hardcoded slate light が完全撤廃される。 mac OS の menu bar 横並び chrome として常時可視のため、 dual-theme 整合は重要。

## Changes

- `90aacf1a` — project-tab + app-version + index-status
  - `.project-tab`: tokens border + `--color-surface-elevated` 背景 + `--color-text`、 active で `var(--color-focus-ring)` border + `color-mix(in oklab, var(--color-state-active) 14%, ...)` 背景
  - `.project-tab-label`: Body + `--type-xs`
  - `.project-tab-close`: `color-mix(in oklab, var(--color-text-muted) 18%, transparent)` 背景、 hover で 28%
  - `.app-version` / `.index-status`: `--color-surface-elevated` + tokens border + Mono uppercase

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 / #2372 / #2374 / #2377 (merged)

## Risk / Impact

- 影響範囲: Project Bar inline CSS のみ
- 互換性: DOM / 機能変更なし

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
