### PR TITLE
fix(board): avoid unlocked manifest writes

### DIFF
--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -839,9 +839,7 @@ fn load_event_manifest_from_dir(coordination_root: &Path) -> Result<EventSegment
         .iter()
         .any(|segment| segment.entries > 0 && segment.max_updated_at.is_none())
     {
-        let rebuilt = rebuild_event_manifest_from_segments(coordination_root)?;
-        write_event_manifest(coordination_root, &rebuilt)?;
-        Ok(rebuilt)
+        rebuild_event_manifest_from_segments(coordination_root)
     } else {
         Ok(manifest)
     }
@@ -1829,6 +1827,82 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].body, "newer post appended first");
+    }
+
+    #[test]
+    fn legacy_segment_manifest_backfill_read_path_does_not_rewrite_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let segment_file = initial_segment_file_name();
+        let segment_path = coordination_events_segments_dir(dir.path()).join(&segment_file);
+
+        let mut newer_entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Claude",
+            BoardEntryKind::Status,
+            "newer pre-upgrade post",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        newer_entry.created_at = chrono::Utc.with_ymd_and_hms(2026, 4, 20, 0, 0, 0).unwrap();
+        newer_entry.updated_at = newer_entry.created_at;
+
+        let mut older_entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "older pre-upgrade post",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        older_entry.created_at = chrono::Utc.with_ymd_and_hms(2026, 4, 10, 0, 0, 0).unwrap();
+        older_entry.updated_at = older_entry.created_at;
+
+        write_events(
+            &segment_path,
+            &[
+                CoordinationEvent::MessageAppended {
+                    entry: newer_entry.clone(),
+                },
+                CoordinationEvent::MessageAppended { entry: older_entry },
+            ],
+        );
+        let bytes = segment_path.metadata().unwrap().len();
+        let legacy_manifest = serde_json::json!({
+            "version": EVENT_MANIFEST_VERSION,
+            "active_segment": segment_file,
+            "segments": [{
+                "file": segment_file,
+                "entries": 2,
+                "bytes": bytes,
+                "first_created_at": newer_entry.created_at,
+                "last_created_at": chrono::Utc.with_ymd_and_hms(2026, 4, 10, 0, 0, 0).unwrap(),
+                "first_entry_id": newer_entry.id,
+                "last_entry_id": "legacy-old"
+            }],
+            "updated_at": chrono::Utc.with_ymd_and_hms(2026, 4, 20, 0, 0, 1).unwrap()
+        });
+        std::fs::write(
+            coordination_events_manifest_path(dir.path()),
+            serde_json::to_vec_pretty(&legacy_manifest).unwrap(),
+        )
+        .unwrap();
+
+        let since = chrono::Utc.with_ymd_and_hms(2026, 4, 15, 0, 0, 0).unwrap();
+        let entries = load_entries_since(dir.path(), since).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].body, "newer pre-upgrade post");
+
+        let persisted_manifest: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(coordination_events_manifest_path(dir.path())).unwrap(),
+        )
+        .unwrap();
+        assert!(persisted_manifest["segments"][0]
+            .get("max_updated_at")
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Prevent legacy board manifest backfill from writing `events.manifest.json` on unlocked read paths.
- Keep read-side backfill in memory so `load_entries_since` and `board_entry_exists` can still read legacy segments safely.
- Persist rebuilt manifest metadata only through the append path, which already holds the coordination file lock.
- Add a regression test for the unlocked read path.

## Testing

- `cargo test -p gwt-core legacy_segment_manifest_backfill -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`
- `bunx commitlint --from HEAD~2 --to HEAD`
- Previous full local verification on the same code path:
  - `cargo test -p gwt-core -p gwt --all-features`
  - `git push origin feature/update-board` pre-push checks, including coverage: 90.40%

## Related

- Follow-up to #2381
- Original board storage PR #2375
- SPEC #1974
