### PR TITLE
fix(ui): SPEC-2356 follow-up — resize-handle gradient to tokens (full sweep complete)

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2209,7 +2209,12 @@
         height: 18px;
         cursor: nwse-resize;
         background:
-          linear-gradient(135deg, transparent 0 50%, rgba(148, 163, 184, 0.5) 50% 60%, transparent 60% 70%, rgba(148, 163, 184, 0.5) 70% 80%, transparent 80%);
+          linear-gradient(135deg,
+            transparent 0 50%,
+            color-mix(in oklab, var(--color-text-muted) 50%, transparent) 50% 60%,
+            transparent 60% 70%,
+            color-mix(in oklab, var(--color-text-muted) 50%, transparent) 70% 80%,
+            transparent 80%);
       }
 
       /* SPEC-2008 FR-035: shared modal frame primitives. Surface modals


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の **inline literal 完全消滅**: inline `<style>` ブロック内に残っていた最後の `rgba(148, 163, 184, 0.5)` (resize-handle の diagonal stripe gradient) を `color-mix(in oklab, var(--color-text-muted) 50%, transparent)` に置換。 grep `(rgba|#[0-9a-f]{3,8})` の結果が **0 件** (data:image SVG noise filter を除く)。

## Changes

- `e83c1dbb` — resize-handle gradient
  - `.resize-handle` の `linear-gradient` 内の `rgba(148, 163, 184, 0.5)` を `color-mix(in oklab, var(--color-text-muted) 50%, transparent)` に
  - これで inline `<style>` ブロック内のすべての colour リテラル (color / background / border / box-shadow / linear-gradient) が tokens 駆動になり dual-theme の完全浸透を達成

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)
- ✅ `grep -cE "(rgba|#[0-9a-f]{3,8})" index.html` (data:image を除く) → **0 件**

## Closing Issues

None (SPEC-2356 polish 完了)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 / #2372 / #2374 / #2377 / #2378 / #2380 / #2382 / #2384 (merged)

## Risk / Impact

- 影響範囲: resize-handle gradient のみ
- 互換性: DOM / 機能変更なし
- 視覚: dark/light 両テーマで diagonal stripe が `--color-text-muted` 50% で対比 (旧 hardcoded slate light が dark で浮いていた箇所が解消)

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced (final state: **0 hardcoded colour literals in inline `<style>`**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the resize handle appearance to use theme-based colors instead of hard-coded values, ensuring better visual consistency and proper adaptation across light and dark theme modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->