### PR TITLE
feat(ui): SPEC-2356 follow-up — unified focus-visible ring on Operator interactive surfaces

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1040,3 +1040,40 @@ kbd.op-kbd {
   color: var(--color-border-strong);
   font-family: var(--font-mono);
 }
+
+/* ============================================================
+   Focus styles — keyboard accessibility (Operator focus ring).
+
+   Every interactive surface that the Operator chrome introduces
+   gets a unified `--color-focus-ring` outline on `:focus-visible`,
+   so power users navigating with Tab / arrow keys always know
+   where focus is. The ring lifts above the element via
+   `outline-offset` so it does not get clipped by tight chrome.
+   ============================================================ */
+
+:root[data-theme] .op-layer:focus-visible,
+:root[data-theme] .op-status-strip__cell:focus-visible,
+:root[data-theme] .op-palette__row:focus-visible,
+:root[data-theme] .op-drawer__close:focus-visible,
+:root[data-theme] .arrange-button:focus-visible,
+:root[data-theme] .add-button:focus-visible,
+:root[data-theme] .wizard-button:focus-visible,
+:root[data-theme] .preset-button:focus-visible,
+:root[data-theme] .branch-filter-button:focus-visible,
+:root[data-theme] .branch-cleanup-toggle:focus-visible,
+:root[data-theme] .icon-button:focus-visible,
+:root[data-theme] .text-button:focus-visible,
+:root[data-theme] .recent-project-row:focus-visible,
+:root[data-theme] .live-session-button:focus-visible,
+:root[data-theme] .launch-choice-button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+:root[data-theme] .op-theme-toggle:focus-visible {
+  /* override the existing `border-color` focus state with the unified
+     ring, but keep the border-color animation so the toggle still
+     reads like an operator chrome button. */
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の accessibility polish: キーボードナビゲーション (Tab / arrow keys) で focus を失わないよう、 Operator interactive surface 全種に統一 `--color-focus-ring` の 2px outline を `:focus-visible` で付与する。 power user の操作精度が dramatically 向上。

## Changes

- `d09edbec` — focus-visible ring on Operator interactive surfaces
  - chrome 系: `.op-layer` / `.op-status-strip__cell` / `.op-palette__row` / `.op-drawer__close` / `.op-theme-toggle`
  - button 系: `.arrange-button` / `.add-button` / `.wizard-button` / `.preset-button` / `.branch-filter-button` / `.branch-cleanup-toggle` / `.icon-button` / `.text-button`
  - row 系: `.recent-project-row` / `.live-session-button` / `.launch-choice-button`
  - 統一 `outline: 2px solid var(--color-focus-ring); outline-offset: 2px;`

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 / #2372 / #2374 / #2377 / #2378 / #2380 / #2382 / #2384 / #2385 / #2386 / #2387 (merged)

## Risk / Impact

- 影響範囲: components.css 末尾に focus-visible rules 追加
- 互換性: DOM / 機能変更なし
- アクセシビリティ: keyboard navigation 時の focus indicator が dual-theme で常に明確に表示される

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
