### PR TITLE
feat(ui): SPEC-2356 follow-up — idle agent windows retain dim agent color identification

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -350,9 +350,13 @@ body::after {
 }
 
 [data-agent-state="idle"] {
-  --agent-color: var(--color-state-idle);
+  /* SPEC-2356 — idle state tints with the agent colour at 50% chroma so
+     observers can still identify the agent (claude/codex/gemini/...) even
+     when nothing is happening. The pulse animation is suppressed; only a
+     static rim remains. */
+  --agent-color: color-mix(in oklab, var(--current-agent, var(--color-state-idle)) 55%, var(--color-state-idle));
   box-shadow: 0 0 0 1px var(--agent-color);
-  opacity: 0.78;
+  opacity: 0.82;
 }
 
 [data-agent-state="blocked"] {


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Living Telemetry detail polish: idle agent ウィンドウでも agent 色 (Claude=amber / Codex=cyan / Gemini=magenta 等) を 55% chroma で tint し続けることで、 状態に関係なく agent identification を維持する。 旧仕様では idle に遷移した瞬間に rim が gray になり Claude/Codex の区別がつかなくなっていた。

## Changes

- `868b1a2a` — idle agent color identification
  - `[data-agent-state="idle"]` の `--agent-color` を `color-mix(in oklab, var(--current-agent, var(--color-state-idle)) 55%, var(--color-state-idle))` に
  - opacity 0.78 → 0.82 で僅かに明るく、 active との対比は static vs pulse animation で表現

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)
- ✅ frontend bundle / smoke / unit 全 GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 / #2372 / #2374 / #2377 / #2378 / #2380 / #2382 / #2384 / #2385 / #2386 / #2387 / #2388 (merged)

## Risk / Impact

- 影響範囲: components.css の `[data-agent-state="idle"]` ブロックのみ
- 互換性: DOM / 機能変更なし
- ユーザー体験: 多数の agent ウィンドウが idle 状態にあるとき、 どの agent かを rim 色だけで識別できる

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
