### PR TITLE
feat(ui): SPEC-2356 follow-up — Operator-themed scrollbars (token-driven, theme-aware)

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1081,3 +1081,50 @@ kbd.op-kbd {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+/* ============================================================
+   Scrollbar styling — Operator-themed, theme-aware.
+
+   Without this rule, browsers fall back to native scrollbars which
+   look starkly out of place against the carbon Dark theme.
+   Webkit / Blink based engines (which the WebView uses) get a
+   compact, token-driven scrollbar; standard `scrollbar-color` is
+   provided as a parallel hint for Firefox-based runtimes.
+   ============================================================ */
+
+:root[data-theme] {
+  scrollbar-color: var(--color-border-strong) transparent;
+  scrollbar-width: thin;
+}
+
+:root[data-theme] ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+:root[data-theme] ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+:root[data-theme] ::-webkit-scrollbar-thumb {
+  background: color-mix(in oklab, var(--color-text-muted) 32%, transparent);
+  border-radius: var(--radius-pill);
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+:root[data-theme] ::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklab, var(--color-text-muted) 56%, transparent);
+  background-clip: content-box;
+}
+
+:root[data-theme] ::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* In forced-colors mode let the system paint scrollbars; do not override */
+@media (forced-colors: active) {
+  :root[data-theme] {
+    scrollbar-color: auto;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の visible polish: native scrollbar が dark theme の carbon 背景上で明灰色 thumb として浮いていた問題を、 tokens 駆動の Operator scrollbar に置換して解消。 webkit (WebView) と Firefox の両方をカバーし、 forced-colors 環境では system scrollbar に戻す。

## Changes

- `b1d75169` — Operator-themed scrollbars
  - `scrollbar-color: var(--color-border-strong) transparent` + `scrollbar-width: thin` (Firefox)
  - `::-webkit-scrollbar` 10px / 10px
  - `::-webkit-scrollbar-thumb` を `color-mix(in oklab, var(--color-text-muted) 32%, transparent)`、 hover で 56%
  - `forced-colors: active` で `scrollbar-color: auto` に戻し、 system が描画する

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- #2358 / #2360 / #2361 / #2362 / #2363 / #2364 / #2366 / #2367 / #2368 / #2370 / #2372 / #2374 / #2377 / #2378 / #2380 / #2382 / #2384 / #2385 / #2386 / #2387 / #2388 / #2389 (merged)

## Risk / Impact

- 影響範囲: scrollbar styling のみ
- 互換性: 既存のスクロール動作 / overflow 設定は不変
- ユーザー体験: dark/light 両テーマで scrollbar が chrome に同化。 forced-colors では accessibility のため system 描画に切替

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
