### PR TITLE
feat(ui): SPEC-2356 follow-up — Operator-tinted text selection (chrome / panel surfaces)

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1128,3 +1128,19 @@ kbd.op-kbd {
     scrollbar-color: auto;
   }
 }
+
+/* ============================================================
+   Text selection — Operator-tinted (token-driven).
+   ============================================================ */
+
+:root[data-theme] ::selection {
+  background: color-mix(in oklab, var(--color-state-active) 36%, transparent);
+  color: var(--color-text-strong);
+}
+
+/* Inside terminal panes xterm.js paints its own selection layer; this
+   default is for the chrome and panel surfaces only. */
+:root[data-theme] .terminal-root ::selection {
+  background: transparent;
+  color: inherit;
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の visible polish: text selection background が default の OS 青色で Operator chrome に相性悪かった問題を、 `--color-state-active` を 36% mix した tint で置換。 terminal pane では xterm.js の独自 selection layer を温存。

## Changes

- `ec41c1ed` — Operator-tinted text selection
  - `:root[data-theme] ::selection`: `color-mix(in oklab, var(--color-state-active) 36%, transparent)` 背景 + `var(--color-text-strong)` 文字
  - `.terminal-root ::selection`: 透明に戻して xterm.js の selection に干渉しない

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356
- ... 直近全 22 PRs (merged) ...

## Risk / Impact

- 影響範囲: ::selection styling のみ
- 互換性: terminal pane の copy 動作 (xterm.js) 不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
