### PR TITLE
fix(board): avoid repeated projection rebuilds

### DIFF
--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -910,14 +910,28 @@ fn projection_needs_rebuild(projection: &BoardProjection, manifest: &EventSegmen
     if projection.newest_entry_id != projection.entries.last().map(|entry| entry.id.clone()) {
         return true;
     }
-    if let Some(expected_newest_entry_id) = manifest
+    if let Some((last_appended_entry_id, last_appended_created_at)) = manifest
         .segments
         .iter()
         .rev()
         .find(|segment| segment.entries > 0)
-        .and_then(|segment| segment.last_entry_id.as_deref())
+        .and_then(|segment| {
+            Some((
+                segment.last_entry_id.as_deref()?,
+                segment.last_created_at.as_ref()?,
+            ))
+        })
     {
-        if projection.newest_entry_id.as_deref() != Some(expected_newest_entry_id) {
+        let last_append_should_be_hot = projection
+            .entries
+            .first()
+            .is_some_and(|oldest| last_appended_created_at >= &oldest.created_at);
+        if last_append_should_be_hot
+            && !projection
+                .entries
+                .iter()
+                .any(|entry| entry.id == last_appended_entry_id)
+        {
             return true;
         }
     }
@@ -1799,6 +1813,80 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["entry-segmented", "entry-late-legacy"]
         );
+    }
+
+    #[test]
+    fn backdated_late_legacy_import_is_not_repaired_repeatedly() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut newer_segmented = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "newer segmented entry",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        newer_segmented.id = "entry-newer-segmented".to_string();
+        newer_segmented.created_at = Utc.with_ymd_and_hms(2026, 5, 4, 0, 2, 0).unwrap();
+        newer_segmented.updated_at = newer_segmented.created_at;
+        post_entry(dir.path(), newer_segmented).unwrap();
+
+        let mut older_legacy = BoardEntry::new(
+            AuthorKind::Agent,
+            "Claude Code",
+            BoardEntryKind::Decision,
+            "older late legacy entry",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        older_legacy.id = "entry-older-legacy".to_string();
+        older_legacy.created_at = Utc.with_ymd_and_hms(2026, 5, 4, 0, 1, 0).unwrap();
+        older_legacy.updated_at = older_legacy.created_at;
+        write_events(
+            &coordination_events_path(dir.path()),
+            &[CoordinationEvent::MessageAppended {
+                entry: older_legacy.clone(),
+            }],
+        );
+        write_atomic_json(
+            &coordination_board_projection_path(dir.path()),
+            &build_hot_projection(vec![older_legacy], Utc::now()),
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(dir.path()).unwrap();
+        let projection: BoardProjection =
+            load_json_or_default(&coordination_board_projection_path(dir.path())).unwrap();
+        let manifest = load_event_manifest(dir.path()).unwrap();
+
+        assert_eq!(
+            snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["entry-older-legacy", "entry-newer-segmented"]
+        );
+        assert_eq!(
+            manifest
+                .segments
+                .iter()
+                .rev()
+                .find(|segment| segment.entries > 0)
+                .and_then(|segment| segment.last_entry_id.as_deref()),
+            Some("entry-older-legacy")
+        );
+        assert_eq!(
+            projection.newest_entry_id.as_deref(),
+            Some("entry-newer-segmented")
+        );
+        assert!(!projection_needs_rebuild(&projection, &manifest));
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,34 @@
 # Lessons Learned
 
+## 2026-05-04 — Board projection guards must distinguish append order from chronology
+
+### 事象
+
+PR #2390 の Codex review で、 `projection_needs_rebuild` が
+`manifest.last_entry_id` を Board projection の `newest_entry_id` と
+比較している点を指摘された。 late legacy `events.jsonl` import では、
+古い `created_at` の legacy entry が新しい segmented entry の後に
+append されうる。その場合、 projection は時系列順で正しく
+`newest_entry_id = newer segmented entry` を指すが、 manifest の
+last append は older legacy entry になる。
+
+### 原因
+
+Board の hot projection は chronological order の view だが、 segment
+manifest の `last_entry_id` は append order の metadata。 両者を同じ
+"newest" として扱ったため、 backdated legacy import 後に整合済み
+projection を毎回不整合扱いし、 load hot path で不要な rebuild を
+繰り返す可能性があった。
+
+### 再発防止策
+
+storage metadata を guard に使う前に、 その metadata が **append
+order / chronological order / update order** のどれを表すかを明示する。
+異なる order 軸を比較しない。 hot projection の整合性を見る場合は、
+最後に append された entry が projection の時系列 window に入るとき
+だけ「projection 内に存在するか」を検査し、 chronological newest ID
+とは比較しない。
+
 ## 2026-05-04 — multi-round correction loops on the same docs are a smell, not a feature
 
 ### 事象


### PR DESCRIPTION
## Summary

- Fixes the follow-up review from #2390 by distinguishing Board segment append order from chronological projection order.
- Prevents repeated projection rebuilds when a late legacy import appends an older entry after newer segmented events.

## Changes

- `crates/gwt-core/src/coordination.rs`: update `projection_needs_rebuild` so the last appended segment entry is only required in the hot projection when its timestamp falls inside the current projection window.
- `crates/gwt-core/src/coordination.rs`: add regression coverage for a backdated late legacy import that should not trigger repeated repair.
- `tasks/lessons.md`: record the append-order vs chronology lesson for future Board projection work.
- `SPEC-1974`: add Phase 12.5 tasks documenting the review follow-up.

## Testing

- [x] `cargo test -p gwt-core coordination::tests::backdated_late_legacy_import_is_not_repaired_repeatedly -- --exact` — failed before the fix and passed after the fix.
- [x] `cargo test -p gwt-core coordination::tests` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed after the latest `origin/develop` merge.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` — passed.
- [x] `git push origin feature/update-board` — pre-push checks passed with filtered line coverage 90.47%.

## Closing Issues

None

## Related Issues / Links

- #1974
- #2390

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check` not applicable)
- [x] Documentation not required for user-facing docs; internal lesson and SPEC-1974 tasks updated
- [x] Migration/backfill plan included (existing projection repair path unchanged; no schema migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- #2390 fixed truncated Board projections. A follow-up review identified that the rebuild guard still compared append-order metadata against chronological projection metadata, which can misclassify older late legacy imports as missing newest entries.

## Risk / Impact

- **Affected areas**: Board projection repair guard in `gwt-core`.
- **Rollback plan**: revert this PR; Board projections fall back to the previous conservative rebuild behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved projection rebuild detection logic to correctly handle backdated legacy data imports, reducing unnecessary repeated rebuilds by properly validating entry ordering and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->