### PR TITLE
feat(ui): SPEC-2356 follow-up — Mission Briefing intro stamp with current timestamp

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3039,6 +3039,7 @@
       </div>
       <div class="op-briefing" id="op-briefing" aria-hidden="true">
         <h1 class="op-briefing__title">gwt://operator</h1>
+        <div class="op-briefing__stamp" id="op-briefing-stamp"></div>
         <div class="op-briefing__lines" id="op-briefing-lines">
           <div class="op-briefing__line" data-state="ok" style="animation-delay: 60ms">
             ▪ resolving environment

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -146,6 +146,16 @@ function wireMissionBriefing({ doc, win }) {
     return;
   }
 
+  // SPEC-2356 — stamp the briefing with the current session timestamp so the
+  // splash reads like a mission-control boot log, not just a static splash.
+  const stamp = doc.getElementById("op-briefing-stamp");
+  if (stamp) {
+    const now = new Date();
+    const datePart = `${now.getFullYear()}.${pad2(now.getMonth() + 1)}.${pad2(now.getDate())}`;
+    const timePart = `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())}`;
+    stamp.textContent = `T+0 · ${datePart} ${timePart}`;
+  }
+
   const reduced = matchReduced(doc);
   const totalDelay = reduced.matches ? 250 : 1450;
 

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1144,3 +1144,11 @@ kbd.op-kbd {
   background: transparent;
   color: inherit;
 }
+
+.op-briefing__stamp {
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Mission Briefing intro polish: ただの static splash ではなく "mission-control boot log" として読めるよう、 起動時の timestamp stamp を追加。 `T+0 · YYYY.MM.DD HH:MM:SS` 形式で session が始まった瞬間の時刻が刻まれる。

## Changes

- `fb1df279` — Mission Briefing stamp
  - `index.html`: `<div class="op-briefing__stamp">` をタイトル直下に追加
  - `operator-shell.js`: `wireMissionBriefing` で起動時の Date を stamp 書込
  - `components.css`: `.op-briefing__stamp` を Mono + xs + muted で控えめに

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 23 PRs

## Risk / Impact

- 影響範囲: Mission Briefing markup と wiring のみ
- 互換性: sessionStorage gate / reduced-motion fallback 不変
- ユーザー体験: 起動 splash が timestamp 付きの mission boot log に進化

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
