### PR TITLE
feat(ui): SPEC-2356 follow-up — Project Bar accent line under the chrome edge

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1152,3 +1152,42 @@ kbd.op-kbd {
   color: var(--color-text-muted);
   margin-bottom: var(--space-4);
 }
+
+/* ============================================================
+   Project Bar accent — subtle gradient strip under the bar.
+
+   The accent line sits at the bottom edge of the Project Bar and
+   flows along the agent state token's chroma so that the chrome
+   reads as part of the Mission Control system. The line is
+   render-cheap (1px linear-gradient) and silent under
+   `forced-colors: active`.
+   ============================================================ */
+
+:root[data-theme] .project-bar::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    color-mix(in oklab, var(--color-state-active) 56%, transparent) 18%,
+    color-mix(in oklab, var(--agent-codex) 36%, transparent) 50%,
+    color-mix(in oklab, var(--color-state-active) 56%, transparent) 82%,
+    transparent 100%
+  );
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+@media (forced-colors: active) {
+  :root[data-theme] .project-bar::after {
+    background: none;
+  }
+}
+
+.project-bar {
+  position: relative; /* anchor the ::after accent line */
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Phase 2 detail polish: Project Bar 下端に **1px の accent line** を配置し、 chrome が "通電している" 印象を加える。 state-active + agent-codex (cyan) の chroma を混合した薄いグラデーションで、 dark/light どちらでも控えめに dialog box の上をうっすら走る。

## Changes

- `c824ae00` — Project Bar accent line
  - `.project-bar` を `position: relative` に (anchor)
  - `.project-bar::after` で底辺 1px の linear-gradient
    - 端: transparent → 中央 cyan 帯 → 端 transparent
    - opacity 0.55 で控えめ
  - `forced-colors: active` で `background: none` (system border 優先)

## Testing

- ✅ `cargo test -p gwt` (390 + 200 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 25 PRs

## Risk / Impact

- 影響範囲: Project Bar `::after` のみ
- 互換性: layout / interaction 変更なし
- ユーザー体験: chrome が Mission Control 系の signature を獲得し、 通電している印象が増す

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
