### PR TITLE
feat(workspace): show multi-agent active work overview

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -38,6 +38,8 @@ pub struct GitDetails {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceAgentSummary {
     pub session_id: String,
+    #[serde(default)]
+    pub window_id: Option<String>,
     pub agent_id: String,
     pub display_name: String,
     pub status_category: WorkspaceStatusCategory,
@@ -237,6 +239,7 @@ mod tests {
         projection.status_text = "Still describing the current task".to_string();
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
+            window_id: None,
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
             status_category: WorkspaceStatusCategory::Blocked,
@@ -258,11 +261,30 @@ mod tests {
     }
 
     #[test]
+    fn agent_summary_deserializes_legacy_payload_without_window_id() {
+        let summary: WorkspaceAgentSummary = serde_json::from_value(serde_json::json!({
+            "session_id": "sess-1",
+            "agent_id": "codex",
+            "display_name": "Codex",
+            "status_category": "active",
+            "current_focus": null,
+            "worktree_path": null,
+            "branch": "work/20260504-1200",
+            "last_board_entry_id": null,
+            "updated_at": "2026-05-04T12:00:00Z"
+        }))
+        .expect("legacy summary");
+
+        assert_eq!(summary.window_id, None);
+    }
+
+    #[test]
     fn effective_status_uses_active_agent_before_idle_projection() {
         let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Idle;
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
+            window_id: None,
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
             status_category: WorkspaceStatusCategory::Active,
@@ -355,6 +377,7 @@ mod tests {
         let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
+            window_id: None,
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
             status_category: WorkspaceStatusCategory::Active,
@@ -411,6 +434,7 @@ mod tests {
         let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
+            window_id: None,
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
             status_category: WorkspaceStatusCategory::Active,

--- a/crates/gwt-core/tests/workspace_projection.rs
+++ b/crates/gwt-core/tests/workspace_projection.rs
@@ -22,6 +22,7 @@ fn projection(project_root: &Path) -> WorkspaceProjection {
         next_action: Some("Run focused tests".to_string()),
         agents: vec![WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
+            window_id: Some("tab-1::agent-1".to_string()),
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
             status_category: WorkspaceStatusCategory::Active,

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -464,6 +464,17 @@ fn active_work_projection_from_saved(
         ),
         None => (agent_branch, agent_worktree, None),
     };
+    let mut agents = projection
+        .agents
+        .iter()
+        .map(active_work_agent_view_from_summary)
+        .collect::<Vec<_>>();
+    agents.sort_by(|left, right| {
+        active_work_agent_status_rank(&left.status_category)
+            .cmp(&active_work_agent_status_rank(&right.status_category))
+            .then_with(|| left.display_name.cmp(&right.display_name))
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
 
     gwt::ActiveWorkProjectionView {
         id: projection.id,
@@ -478,6 +489,37 @@ fn active_work_projection_from_saved(
         worktree_path,
         pr_number,
         board_refs: projection.board_refs,
+        agents,
+    }
+}
+
+fn active_work_agent_status_rank(status_category: &str) -> u8 {
+    match status_category {
+        "blocked" => 0,
+        "active" => 1,
+        "idle" => 2,
+        "done" => 3,
+        _ => 4,
+    }
+}
+
+fn active_work_agent_view_from_summary(
+    agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
+) -> gwt::ActiveWorkAgentView {
+    gwt::ActiveWorkAgentView {
+        session_id: agent.session_id.clone(),
+        window_id: agent.window_id.clone(),
+        agent_id: agent.agent_id.clone(),
+        display_name: agent.display_name.clone(),
+        status_category: workspace_status_category_wire(agent.status_category).to_string(),
+        current_focus: agent.current_focus.clone(),
+        branch: agent.branch.clone(),
+        worktree_path: agent
+            .worktree_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        last_board_entry_id: agent.last_board_entry_id.clone(),
+        updated_at: agent.updated_at.to_rfc3339(),
     }
 }
 
@@ -487,6 +529,7 @@ fn active_agent_summary_from_session(
 ) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
     gwt_core::workspace_projection::WorkspaceAgentSummary {
         session_id: session.session_id.clone(),
+        window_id: Some(session.window_id.clone()),
         agent_id: session.agent_id.clone(),
         display_name: session.display_name.clone(),
         status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
@@ -509,6 +552,7 @@ fn upsert_workspace_agent(
         .find(|agent| agent.session_id == summary.session_id)
     {
         existing.agent_id = summary.agent_id;
+        existing.window_id = summary.window_id;
         existing.display_name = summary.display_name;
         existing.worktree_path = summary.worktree_path;
         existing.branch = summary.branch;
@@ -1017,6 +1061,10 @@ impl AppRuntime {
                 branch_name,
                 linked_issue_number,
             } => self.open_launch_wizard(&id, &branch_name, linked_issue_number),
+            FrontendEvent::OpenActiveWorkLaunchWizard {
+                branch_name,
+                linked_issue_number,
+            } => self.open_active_work_launch_wizard(&branch_name, linked_issue_number),
             FrontendEvent::LaunchWizardAction { action, bounds } => {
                 self.handle_launch_wizard_action(action, bounds)
             }
@@ -1170,6 +1218,19 @@ impl AppRuntime {
 
         let first = sessions.first()?;
         let active_agents = sessions.len();
+        let now = chrono::Utc::now();
+        let mut agents = sessions
+            .iter()
+            .map(|session| {
+                let summary = active_agent_summary_from_session(session, now);
+                active_work_agent_view_from_summary(&summary)
+            })
+            .collect::<Vec<_>>();
+        agents.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.session_id.cmp(&right.session_id))
+        });
         Some(gwt::ActiveWorkProjectionView {
             id: tab_id.to_string(),
             title: format!("{} workspace", tab.title),
@@ -1187,6 +1248,7 @@ impl AppRuntime {
             worktree_path: Some(first.worktree_path.display().to_string()),
             pr_number: None,
             board_refs: Vec::new(),
+            agents,
         })
     }
 
@@ -4403,6 +4465,14 @@ exit 0
         assert_eq!(projection.status_category, "active");
         assert_eq!(projection.active_agents, 1);
         assert_eq!(projection.branch.as_deref(), Some("work/20260504-1234"));
+        assert_eq!(projection.agents.len(), 1);
+        assert_eq!(projection.agents[0].session_id, "session-1");
+        assert_eq!(projection.agents[0].display_name, "Codex");
+        assert_eq!(projection.agents[0].status_category, "active");
+        assert_eq!(
+            projection.agents[0].branch.as_deref(),
+            Some("work/20260504-1234")
+        );
         assert!(
             events.iter().all(|event| matches!(
                 &event.target,
@@ -4597,6 +4667,57 @@ exit 0
         assert!(view.show_runtime_target);
         assert_eq!(view.selected_runtime_target, "docker");
         assert_eq!(view.selected_docker_service.as_deref(), Some("app"));
+    }
+
+    #[test]
+    fn app_runtime_workspace_add_agent_opens_branch_launch_without_branches_window() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Board],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.active_agent_sessions.insert(
+            "tab-1::agent-1".to_string(),
+            ActiveAgentSession {
+                window_id: "tab-1::agent-1".to_string(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260504-1234".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.join("../repo-work-20260504-1234"),
+                tab_id: "tab-1".to_string(),
+            },
+        );
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenActiveWorkLaunchWizard {
+                branch_name: "work/20260504-1234".to_string(),
+                linked_issue_number: None,
+            },
+        );
+
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::LaunchWizardState { wizard: Some(_) })
+        ));
+        let view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("active work launch wizard")
+            .wizard
+            .view();
+        assert_eq!(view.mode, gwt::LaunchWizardMode::Branch);
+        assert_eq!(view.branch_name, "work/20260504-1234");
+        assert!(view.show_branch_controls);
+        assert_eq!(view.live_sessions.len(), 1);
+        assert_eq!(view.live_sessions[0].name, "Codex");
     }
 
     #[test]
@@ -6543,6 +6664,11 @@ exit 0
                 event: BackendEvent::ActiveWorkProjection { projection },
             } if projection.status_category == "blocked"
                 && projection.blocked_agents == 1
+                && projection.agents.iter().any(|agent|
+                    agent.session_id == "session-1"
+                        && agent.status_category == "blocked"
+                        && agent.last_board_entry_id.as_deref() == Some(blocked.id.as_str())
+                )
                 && projection.board_refs == vec![blocked.id.clone()]
                 && projection.next_action.as_deref() == Some("Resolve blocker")
         ));

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -165,6 +165,42 @@ impl AppRuntime {
         Ok(())
     }
 
+    pub(crate) fn open_active_work_launch_wizard(
+        &mut self,
+        branch_name: &str,
+        linked_issue_number: Option<u64>,
+    ) -> Vec<OutboundEvent> {
+        let Some(tab_id) = self.active_tab_id.clone() else {
+            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
+                message: "Open a project before adding an agent".to_string(),
+            })];
+        };
+        let Some(tab) = self.tab(&tab_id) else {
+            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
+                message: "Project tab not found".to_string(),
+            })];
+        };
+        if tab.kind != gwt::ProjectKind::Git {
+            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
+                message: "Add Agent requires a Git project".to_string(),
+            })];
+        }
+
+        let project_root = tab.project_root.clone();
+        match self.open_launch_wizard_for_branch(
+            &tab_id,
+            &project_root,
+            branch_name,
+            linked_issue_number,
+            None,
+        ) {
+            Ok(()) => vec![self.launch_wizard_state_outbound()],
+            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
+                message: error,
+            })],
+        }
+    }
+
     pub(crate) fn open_start_work(&mut self) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
             return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -87,8 +87,8 @@ pub use preset::{
     WindowPreset, WindowSurface,
 };
 pub use protocol::{
-    ActiveWorkProjectionView, AppStateView, ArrangeMode, BackendEvent, BranchEntriesPhase,
-    CustomAgentErrorCode, FocusCycleDirection, FrontendEvent, ProfileEntryView,
+    ActiveWorkAgentView, ActiveWorkProjectionView, AppStateView, ArrangeMode, BackendEvent,
+    BranchEntriesPhase, CustomAgentErrorCode, FocusCycleDirection, FrontendEvent, ProfileEntryView,
     ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView, RecentProjectView, WorkspaceView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -207,6 +207,10 @@ pub enum FrontendEvent {
         branch_name: String,
         linked_issue_number: Option<u64>,
     },
+    OpenActiveWorkLaunchWizard {
+        branch_name: String,
+        linked_issue_number: Option<u64>,
+    },
     LaunchWizardAction {
         action: LaunchWizardAction,
         bounds: Option<WindowGeometry>,
@@ -319,6 +323,20 @@ pub struct AppStateView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActiveWorkAgentView {
+    pub session_id: String,
+    pub window_id: Option<String>,
+    pub agent_id: String,
+    pub display_name: String,
+    pub status_category: String,
+    pub current_focus: Option<String>,
+    pub branch: Option<String>,
+    pub worktree_path: Option<String>,
+    pub last_board_entry_id: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkProjectionView {
     pub id: String,
     pub title: String,
@@ -332,6 +350,7 @@ pub struct ActiveWorkProjectionView {
     pub worktree_path: Option<String>,
     pub pr_number: Option<u64>,
     pub board_refs: Vec<String>,
+    pub agents: Vec<ActiveWorkAgentView>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -672,6 +691,18 @@ mod tests {
                 worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),
                 pr_number: None,
                 board_refs: vec!["board-1".to_string()],
+                agents: vec![super::ActiveWorkAgentView {
+                    session_id: "session-1".to_string(),
+                    window_id: Some("tab-1::agent-1".to_string()),
+                    agent_id: "codex".to_string(),
+                    display_name: "Codex".to_string(),
+                    status_category: "active".to_string(),
+                    current_focus: Some("Run launch tests".to_string()),
+                    branch: Some("work/20260504-1200".to_string()),
+                    worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),
+                    last_board_entry_id: Some("board-1".to_string()),
+                    updated_at: "2026-05-04T12:00:00Z".to_string(),
+                }],
             },
         };
 
@@ -681,6 +712,19 @@ mod tests {
             value.get("kind"),
             Some(&Value::String("active_work_projection".to_string())),
             "active work projection must not reuse canvas workspace_state"
+        );
+        assert_eq!(
+            value
+                .pointer("/projection/agents/0/display_name")
+                .and_then(Value::as_str),
+            Some("Codex"),
+            "active work projection must expose per-agent summaries for Workspace UI"
+        );
+        assert_eq!(
+            value
+                .pointer("/projection/agents/0/last_board_entry_id")
+                .and_then(Value::as_str),
+            Some("board-1")
         );
     }
 
@@ -693,6 +737,27 @@ mod tests {
         assert!(
             matches!(event, FrontendEvent::OpenStartWork),
             "Start Work must be a global command, not a Branches window event"
+        );
+    }
+
+    #[test]
+    fn frontend_event_accepts_workspace_add_agent_command() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "open_active_work_launch_wizard",
+            "branch_name": "work/20260504-1200",
+            "linked_issue_number": null
+        }))
+        .expect("deserialize workspace add-agent launch");
+
+        assert!(
+            matches!(
+                event,
+                FrontendEvent::OpenActiveWorkLaunchWizard {
+                    branch_name,
+                    linked_issue_number: None,
+                } if branch_name == "work/20260504-1200"
+            ),
+            "Workspace Add Agent must not depend on a Branches window id"
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -68,6 +68,27 @@ test("frontend handles active work projection as status-strip telemetry", () => 
   );
 });
 
+test("Workspace sidebar exposes active work and per-agent overview", () => {
+  assert.ok(
+    document.querySelector("#op-active-work"),
+    "expected Workspace shell to expose an active work overview region",
+  );
+  assert.ok(
+    document.querySelector("#op-active-work-agents"),
+    "expected Workspace shell to expose a per-agent list region",
+  );
+  assert.match(
+    appSource,
+    /function\s+renderActiveWorkOverview\(\)[\s\S]+activeWorkProjection\.agents/,
+    "expected frontend to render per-agent projection data, not only aggregate counters",
+  );
+  assert.match(
+    appSource,
+    /op-agent-card[\s\S]+last_board_entry_id/,
+    "expected agent cards to preserve board linkage for handoff/debugging",
+  );
+});
+
 test("Branches remains a branch browser, not a planning workspace", () => {
   const branchPreset = document.querySelector('.preset-button[data-preset="branches"]');
   assert.ok(branchPreset, "expected Branches preset to remain available");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -50,6 +50,9 @@
       const stackButton = document.getElementById("stack-button");
       const windowListButton = document.getElementById("window-list-button");
       const windowListPanel = document.getElementById("window-list-panel");
+      const activeWorkCount = document.getElementById("op-active-work-count");
+      const activeWorkSummary = document.getElementById("op-active-work-summary");
+      const activeWorkAgents = document.getElementById("op-active-work-agents");
       const zoomOutButton = document.getElementById("zoom-out-button");
       const zoomResetButton = document.getElementById("zoom-reset-button");
       const zoomInButton = document.getElementById("zoom-in-button");
@@ -980,6 +983,141 @@
           window.__operatorShell.applyTelemetryCounts(counts);
         } catch (e) {
           console.warn("operator telemetry update failed", e);
+        }
+      }
+
+      function activeWorkAgentCount(projection) {
+        const agents = Array.isArray(projection?.agents) ? projection.agents : [];
+        if (agents.length > 0) return agents.length;
+        return Number(projection?.active_agents || 0) + Number(projection?.blocked_agents || 0);
+      }
+
+      function projectionIssueNumber(projection) {
+        const owner = String(projection?.owner || "");
+        const match = owner.match(/^Issue\s+#(\d+)$/i);
+        return match ? Number(match[1]) : null;
+      }
+
+      function compactPathLabel(value) {
+        if (!value) return "";
+        const parts = String(value).split(/[\\/]+/).filter(Boolean);
+        if (parts.length <= 2) return String(value);
+        return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+      }
+
+      function appendMeta(container, value) {
+        if (!value) return;
+        container.appendChild(createNode("span", "", value));
+      }
+
+      function renderActiveWorkOverview() {
+        if (!activeWorkSummary || !activeWorkAgents) return;
+        activeWorkSummary.innerHTML = "";
+        activeWorkAgents.innerHTML = "";
+
+        if (!activeWorkProjection) {
+          if (activeWorkCount) activeWorkCount.textContent = "0";
+          activeWorkSummary.appendChild(createNode("div", "op-work-empty", "No active work"));
+          return;
+        }
+
+        const agents = Array.isArray(activeWorkProjection.agents)
+          ? activeWorkProjection.agents
+          : [];
+        const agentCount = activeWorkAgentCount(activeWorkProjection);
+        if (activeWorkCount) activeWorkCount.textContent = String(agentCount);
+
+        activeWorkSummary.appendChild(
+          createNode("div", "op-work-title", activeWorkProjection.title || "Active Work"),
+        );
+        const meta = createNode("div", "op-work-meta");
+        appendMeta(meta, activeWorkProjection.owner);
+        appendMeta(meta, activeWorkProjection.branch);
+        appendMeta(meta, activeWorkProjection.pr_number ? `PR #${activeWorkProjection.pr_number}` : "");
+        activeWorkSummary.appendChild(meta);
+        activeWorkSummary.appendChild(
+          createNode(
+            "div",
+            "op-work-status",
+            activeWorkProjection.next_action ||
+              activeWorkProjection.status_text ||
+              "Work is active",
+          ),
+        );
+
+        const actions = createNode("div", "op-work-actions");
+        if (activeWorkProjection.branch) {
+          const addAgent = createNode("button", "op-work-action", "Add Agent");
+          addAgent.type = "button";
+          addAgent.addEventListener("click", () => {
+            send({
+              kind: "open_active_work_launch_wizard",
+              branch_name: activeWorkProjection.branch,
+              linked_issue_number: projectionIssueNumber(activeWorkProjection),
+            });
+          });
+          actions.appendChild(addAgent);
+        }
+        if ((activeWorkProjection.board_refs || []).length > 0) {
+          const openBoard = createNode("button", "op-work-action", "Open Board");
+          openBoard.type = "button";
+          openBoard.addEventListener("click", () => focusOrSpawnPreset("board"));
+          actions.appendChild(openBoard);
+        }
+        if (actions.childNodes.length > 0) {
+          activeWorkSummary.appendChild(actions);
+        }
+
+        if (agents.length === 0) {
+          activeWorkAgents.appendChild(
+            createNode("div", "op-work-empty", "Agent details unavailable"),
+          );
+          return;
+        }
+
+        for (const agent of agents) {
+          const state = agent.status_category || "unknown";
+          const card = createNode("article", "op-agent-card");
+          card.dataset.state = state;
+          if (agent.last_board_entry_id) card.dataset.boardRef = agent.last_board_entry_id;
+
+          const head = createNode("div", "op-agent-head");
+          head.appendChild(
+            createNode("div", "op-agent-name", agent.display_name || agent.agent_id || "Agent"),
+          );
+          head.appendChild(createNode("div", "op-agent-state", state));
+          card.appendChild(head);
+
+          const agentMeta = createNode("div", "op-agent-meta");
+          appendMeta(agentMeta, agent.branch);
+          appendMeta(agentMeta, compactPathLabel(agent.worktree_path));
+          appendMeta(agentMeta, agent.last_board_entry_id ? "Board linked" : "");
+          card.appendChild(agentMeta);
+
+          if (agent.current_focus) {
+            card.appendChild(createNode("div", "op-agent-focus", agent.current_focus));
+          }
+
+          const agentActions = createNode("div", "op-agent-actions");
+          if (agent.window_id) {
+            const focusButton = createNode("button", "op-agent-action", "Focus");
+            focusButton.type = "button";
+            focusButton.addEventListener("click", () => {
+              focusWindowRemotely(agent.window_id, { center: true });
+            });
+            agentActions.appendChild(focusButton);
+          }
+          if (agent.last_board_entry_id) {
+            const boardButton = createNode("button", "op-agent-action", "Board");
+            boardButton.type = "button";
+            boardButton.addEventListener("click", () => focusOrSpawnPreset("board"));
+            agentActions.appendChild(boardButton);
+          }
+          if (agentActions.childNodes.length > 0) {
+            card.appendChild(agentActions);
+          }
+
+          activeWorkAgents.appendChild(card);
         }
       }
 
@@ -5821,6 +5959,7 @@
             break;
           case "active_work_projection":
             activeWorkProjection = event.projection || null;
+            renderActiveWorkOverview();
             recomputeOperatorTelemetry();
             break;
           case "window_list":
@@ -6719,4 +6858,5 @@
       });
 
       frontendUnits.projectWorkspaceShell.renderAppState(appState);
+      renderActiveWorkOverview();
       frontendUnits.socketTransport.connect();

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2799,6 +2799,16 @@
               <span class="op-layer__count" id="op-layer-count-hooks">0</span>
             </button>
           </div>
+          <div class="op-sidebar__section op-active-work" id="op-active-work" aria-live="polite">
+            <h3 class="op-sidebar__heading">
+              <span>Active Work</span>
+              <span class="op-sidebar__count" id="op-active-work-count">0</span>
+            </h3>
+            <div class="op-work-summary" id="op-active-work-summary">
+              <div class="op-work-empty">No active work</div>
+            </div>
+            <div class="op-agent-list" id="op-active-work-agents"></div>
+          </div>
           <div class="op-sidebar__section">
             <h3 class="op-sidebar__heading">
               <span>Quick</span>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -239,6 +239,156 @@ body::after {
   color: var(--color-text-muted);
 }
 
+.op-active-work {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.op-work-summary,
+.op-agent-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+}
+
+.op-work-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+
+.op-work-empty {
+  color: var(--color-text-muted);
+  font-size: var(--type-sm);
+}
+
+.op-work-title {
+  color: var(--color-text-strong);
+  font-family: var(--font-display);
+  font-size: var(--type-sm);
+  font-stretch: 80%;
+  font-weight: 700;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.op-work-meta,
+.op-agent-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text-muted);
+}
+
+.op-work-status {
+  color: var(--color-text);
+  font-size: var(--type-sm);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.op-work-actions,
+.op-agent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.op-work-action,
+.op-agent-action {
+  appearance: none;
+  border: 1px solid var(--color-button-border);
+  border-radius: var(--radius-md);
+  background: var(--color-button-bg);
+  color: var(--color-button-fg);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  min-height: 28px;
+  padding: 0 var(--space-2);
+}
+
+.op-work-action:hover,
+.op-work-action:focus-visible,
+.op-agent-action:hover,
+.op-agent-action:focus-visible {
+  outline: none;
+  border-color: var(--color-focus-ring);
+  background: var(--color-button-bg-hover);
+}
+
+.op-agent-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.op-agent-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+
+.op-agent-card[data-state="blocked"] {
+  border-color: var(--color-state-blocked);
+}
+
+.op-agent-card[data-state="active"] {
+  border-color: var(--color-state-active);
+}
+
+.op-agent-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.op-agent-name {
+  min-width: 0;
+  color: var(--color-text-strong);
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.op-agent-state {
+  flex-shrink: 0;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  padding: 0 var(--space-2);
+  text-transform: uppercase;
+}
+
+.op-agent-card[data-state="blocked"] .op-agent-state {
+  border-color: var(--color-state-blocked);
+  color: var(--color-state-blocked);
+}
+
+.op-agent-card[data-state="active"] .op-agent-state {
+  border-color: var(--color-state-active);
+  color: var(--color-state-active);
+}
+
+.op-agent-focus {
+  color: var(--color-text);
+  font-size: var(--type-sm);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 /* ============================================================
    Status Strip — bottom chrome
    ============================================================ */


### PR DESCRIPTION
## Summary

- Adds a Workspace-centered Active Work panel so users can see participating agents before opening terminal windows.
- Extends active work projection wire data with per-agent summaries so blocked/active state and Board linkage are visible.
- Adds Workspace-origin Add Agent launch flow for joining existing branch work without requiring the Branches surface.

## Changes

- `crates/gwt-core/src/workspace_projection.rs`: adds optional `window_id` to agent summaries with legacy JSON compatibility.
- `crates/gwt/src/protocol.rs` and `crates/gwt/src/app_runtime/*`: expose per-agent active work projection data and route Workspace Add Agent into Branch-mode Launch Wizard.
- `crates/gwt/web/*`: renders the Active Work / Agent overview in the Operator sidebar while keeping Canvas as the execution surface and Branches as a branch browser.

## Testing

- [x] `cargo test -p gwt active_work_projection -- --nocapture` — passed.
- [x] `cargo test -p gwt workspace_add_agent -- --nocapture` — passed.
- [x] `cargo test -p gwt-core workspace_projection -- --nocapture` — passed.
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-unit` — passed.
- [x] `npm run test:frontend-smoke` — passed.
- [x] `cargo test -p gwt embedded_web_branches_surface_remains_branch_browser -- --nocapture` — passed.
- [x] `cargo test -p gwt embedded_web_board_surface_does_not_render_workspace_or_planning_cards -- --nocapture` — passed.
- [x] `cargo test -p gwt embedded_web_start_work_mode_hides_branch_controls_in_shared_wizard_renderer -- --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] pre-push CI-equivalent checks — passed, coverage 90.22%.

## Closing Issues

- None

## Related Issues / Links

- #2359
- #2356
- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend checks)
- [x] Documentation updated (SPEC-2359 tasks section updated)
- [x] Migration/backfill plan included (legacy projection JSON without `window_id` remains accepted)
- [x] CHANGELOG impact considered (feature commit, no breaking change)

## Context

- This follows the Start Work / Add Agent discussion: Branches must remain a branch list, Board remains coordination history, and Workspace becomes the primary place to understand active work and participating agents.

## Risk / Impact

- **Affected areas**: active work projection protocol, Workspace projection persistence, Operator sidebar, Launch Wizard entrypoint routing.
- **Rollback plan**: revert this PR; legacy projection JSON remains readable because `window_id` is optional.

## Screenshots

- Not captured in this headless run. UI structure is covered by Operator Chrome frontend tests and embedded Branches/Board guardrail tests.
