### PR TITLE
feat(ui): SPEC-2356 follow-up — Command Palette empty state when no commands match

### DIFF
--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -240,13 +240,22 @@ function wireCommandPalette({ doc, hotkey }) {
     const query = input.value.trim().toLowerCase();
     visible = actions.filter(query);
     if (selectedIndex >= visible.length) selectedIndex = Math.max(0, visible.length - 1);
+    while (list.firstChild) list.removeChild(list.firstChild);
+    if (visible.length === 0) {
+      const empty = doc.createElement("li");
+      empty.className = "op-palette__empty";
+      empty.textContent = query
+        ? `No commands match "` + query + `"`
+        : "No commands registered yet.";
+      list.appendChild(empty);
+      return;
+    }
     const groups = new Map();
     for (const a of visible) {
       const key = a.group ?? "Commands";
       if (!groups.has(key)) groups.set(key, []);
       groups.get(key).push(a);
     }
-    list.innerHTML = "";
     let idx = 0;
     for (const [group, items] of groups) {
       const head = doc.createElement("li");

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1341,3 +1341,13 @@ kbd.op-kbd {
 .project-bar {
   position: relative; /* anchor the ::after accent line */
 }
+
+.op-palette__empty {
+  list-style: none;
+  padding: var(--space-4) var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--type-sm);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text-muted);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Command Palette UX polish: query が一致するコマンドがない場合に "No commands match ..." の empty state を表示する。 旧仕様ではリストが空のまま、 何が起きているか分からなかった。

## Changes

- `467fa433` — palette empty state
  - `operator-shell.js`: render 内で `visible.length === 0` の場合 `<li class="op-palette__empty">` を作成
    - query 有り: ``No commands match "${query}"``
    - query 無し: `"No commands registered yet."`
  - `components.css`: `.op-palette__empty` を Mono + sm + muted、 center
  - 内部実装: `innerHTML = ""` を `while (list.firstChild) list.removeChild(...)` にリファクタ (XSS hook と整合)

## Testing

- ✅ `cargo test -p gwt` (391 + 201 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 27 PRs

## Risk / Impact

- 影響範囲: Command Palette render only
- 互換性: action 登録 API 不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
