### PR TITLE
feat(ui): SPEC-2356 follow-up — Status Strip clock with mission-control blinking colons

### DIFF
--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -94,10 +94,28 @@ function wireStatusStripClock({ doc }) {
   const clock = doc.getElementById("op-strip-clock");
   if (!clock) return;
 
+  // SPEC-2356 — render the clock with separately-styled colon glyphs so the
+  // mission-control "blink" effect can target only the separators while the
+  // numbers stay rock-steady. Clears + rebuilds via DOM nodes (no innerHTML
+  // because the security hook flags textContent-as-template-string).
   const reduced = matchReduced(doc);
+  const setClock = (h, m, s) => {
+    while (clock.firstChild) clock.removeChild(clock.firstChild);
+    const append = (text, isColon) => {
+      const span = doc.createElement("span");
+      if (isColon) span.className = "op-strip-clock__colon";
+      span.textContent = text;
+      clock.appendChild(span);
+    };
+    append(pad2(h), false);
+    append(":", true);
+    append(pad2(m), false);
+    append(":", true);
+    append(pad2(s), false);
+  };
   const tick = () => {
     const now = new Date();
-    clock.textContent = `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())}`;
+    setClock(now.getHours(), now.getMinutes(), now.getSeconds());
   };
   tick();
 

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1351,3 +1351,28 @@ kbd.op-kbd {
   color: var(--color-text-muted);
   text-align: center;
 }
+
+/* Mission-control blinking colons in the live clock */
+@keyframes op-strip-clock-blink {
+  0%, 60% { opacity: 1; }
+  70%, 100% { opacity: 0.35; }
+}
+
+:root[data-theme] .op-strip-clock__colon {
+  display: inline-block;
+  animation: op-strip-clock-blink var(--motion-pulse) ease-in-out infinite;
+  margin: 0 0.05em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme] .op-strip-clock__colon {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+@media (forced-colors: active) {
+  :root[data-theme] .op-strip-clock__colon {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Status Strip detail polish: live clock の colon (":") を別 span に分離し、 mission-control 風の blink animation を colon にのみ掛ける。 数字は rock-steady、 colon だけが薄く明滅する。

## Changes

- `46aff20f` — blinking colon clock
  - `operator-shell.js`: `tick()` を span 分割版に書き換え (`pad2` + `<span class="op-strip-clock__colon">:</span>` 交互 append)
    - DOM ノード組み立て、 innerHTML 不使用 (security hook 整合)
  - `components.css`:
    - `@keyframes op-strip-clock-blink` で 60% 不透明 → 35%
    - `.op-strip-clock__colon` を `var(--motion-pulse)` で animate
    - `prefers-reduced-motion: reduce` / `forced-colors: active` で animation 停止

## Testing

- ✅ `cargo test -p gwt` (391 + 201 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 28 PRs

## Risk / Impact

- 影響範囲: live clock render と CSS のみ
- 互換性: clock format / data flow 不変
- ユーザー体験: chrome に通電サインが追加され、 mission-control 感が向上

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
