### PR TITLE
feat(ui): SPEC-2356 follow-up — workspace empty state with bracket ornament

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -753,6 +753,20 @@
         font-family: var(--font-body);
         font-size: var(--type-sm);
         color: var(--color-text-muted);
+        text-align: center;
+        line-height: 1.6;
+      }
+      /* SPEC-2356 — Operator empty state: a small bracket pair flanks the
+         message so empty surfaces still feel "wired" to the chrome. */
+      .workspace-empty-state::before {
+        content: "⌜ ";
+        color: var(--color-border-strong);
+        font-family: var(--font-mono);
+      }
+      .workspace-empty-state::after {
+        content: " ⌟";
+        color: var(--color-border-strong);
+        font-family: var(--font-mono);
       }
 
       .branch-toolbar {


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の empty state polish: surface に何も無い時に表示される共通 `.workspace-empty-state` (file-tree / branches / board / logs / mock / knowledge / memo / profile が share) を center 揃え + 行間広めにし、 Operator 言語の bracket ornament `⌜ ⌟` を flanking で添える。 空 surface でも "wired" に見える。

## Changes

- `bfc59a17` — workspace empty state polish
  - center 揃え + `line-height: 1.6` で読みやすさ向上
  - `::before` `::after` で `⌜ … ⌟` bracket、 `var(--color-border-strong)` の muted 色
  - SPEC-2008 FR-034 共通 primitive contract は維持 (font-size token `var(--type-sm)` + tokens color)

## Testing

- ✅ `cargo test -p gwt` (391 + 201 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 29 PRs

## Risk / Impact

- 影響範囲: `.workspace-empty-state` のみ
- 互換性: SPEC-2008 FR-034 contract は維持

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
