### PR TITLE
feat(workspace): harden active work command center

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -47,6 +47,10 @@ pub struct WorkspaceAgentSummary {
     pub worktree_path: Option<PathBuf>,
     pub branch: Option<String>,
     pub last_board_entry_id: Option<String>,
+    #[serde(default)]
+    pub last_board_entry_kind: Option<BoardEntryKind>,
+    #[serde(default)]
+    pub coordination_scope: Option<String>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -137,6 +141,8 @@ impl WorkspaceProjection {
                 .find(|agent| agent.session_id == session_id)
             {
                 agent.last_board_entry_id = Some(entry.id.clone());
+                agent.last_board_entry_kind = Some(entry.kind.clone());
+                agent.coordination_scope = coordination_scope_for_entry(entry);
                 agent.current_focus = Some(entry.body.clone());
                 agent.updated_at = entry.updated_at;
                 match entry.kind {
@@ -158,6 +164,23 @@ impl WorkspaceProjection {
         }
 
         self.updated_at = entry.updated_at;
+    }
+}
+
+fn coordination_scope_for_entry(entry: &BoardEntry) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(owner) = entry.related_owners.first() {
+        parts.push(owner.clone());
+    }
+    if let Some(topic) = entry.related_topics.first() {
+        if !parts.iter().any(|part| part == topic) {
+            parts.push(topic.clone());
+        }
+    }
+    if parts.is_empty() {
+        entry.origin_branch.clone()
+    } else {
+        Some(parts.join(" / "))
     }
 }
 
@@ -247,6 +270,8 @@ mod tests {
             worktree_path: None,
             branch: None,
             last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
             updated_at: Utc::now(),
         });
 
@@ -276,6 +301,8 @@ mod tests {
         .expect("legacy summary");
 
         assert_eq!(summary.window_id, None);
+        assert_eq!(summary.last_board_entry_kind, None);
+        assert_eq!(summary.coordination_scope, None);
     }
 
     #[test]
@@ -292,6 +319,8 @@ mod tests {
             worktree_path: None,
             branch: None,
             last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
             updated_at: Utc::now(),
         });
 
@@ -385,6 +414,8 @@ mod tests {
             worktree_path: None,
             branch: None,
             last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
             updated_at: Utc::now(),
         });
         let mut blocked = BoardEntry::new(
@@ -442,6 +473,8 @@ mod tests {
             worktree_path: None,
             branch: None,
             last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
             updated_at: Utc::now(),
         });
         let mut blocked = BoardEntry::new(
@@ -484,6 +517,52 @@ mod tests {
         assert_eq!(
             projection.next_action.as_deref(),
             Some("Try a different credential source")
+        );
+    }
+
+    #[test]
+    fn board_milestone_records_agent_coordination_kind_and_scope() {
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        projection.agents.push(WorkspaceAgentSummary {
+            session_id: "sess-1".to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            worktree_path: None,
+            branch: None,
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            updated_at: Utc::now(),
+        });
+        let mut handoff = BoardEntry::new(
+            crate::coordination::AuthorKind::Agent,
+            "codex",
+            BoardEntryKind::Handoff,
+            "Implementation complete; reviewer should check visual states",
+            None,
+            None,
+            vec!["workspace-ux".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("sess-1");
+        handoff.id = "handoff-1".to_string();
+
+        projection.record_board_milestone(&handoff);
+
+        assert_eq!(
+            projection.agents[0].last_board_entry_kind,
+            Some(BoardEntryKind::Handoff)
+        );
+        assert_eq!(
+            projection.agents[0].coordination_scope.as_deref(),
+            Some("SPEC-2359 / workspace-ux")
+        );
+        assert_eq!(
+            projection.agents[0].current_focus.as_deref(),
+            Some("Implementation complete; reviewer should check visual states")
         );
     }
 }

--- a/crates/gwt-core/tests/workspace_projection.rs
+++ b/crates/gwt-core/tests/workspace_projection.rs
@@ -30,6 +30,8 @@ fn projection(project_root: &Path) -> WorkspaceProjection {
             worktree_path: Some(project_root.join("../work/20260504-1200")),
             branch: Some("work/20260504-1200".to_string()),
             last_board_entry_id: Some("board-1".to_string()),
+            last_board_entry_kind: Some(gwt_core::coordination::BoardEntryKind::Status),
+            coordination_scope: Some("SPEC-2359 / start-work".to_string()),
             updated_at: Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap(),
         }],
         git_details: Some(GitDetails {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -470,8 +470,8 @@ fn active_work_projection_from_saved(
         .map(active_work_agent_view_from_summary)
         .collect::<Vec<_>>();
     agents.sort_by(|left, right| {
-        active_work_agent_status_rank(&left.status_category)
-            .cmp(&active_work_agent_status_rank(&right.status_category))
+        active_work_agent_priority_rank(left)
+            .cmp(&active_work_agent_priority_rank(right))
             .then_with(|| left.display_name.cmp(&right.display_name))
             .then_with(|| left.session_id.cmp(&right.session_id))
     });
@@ -493,13 +493,20 @@ fn active_work_projection_from_saved(
     }
 }
 
-fn active_work_agent_status_rank(status_category: &str) -> u8 {
-    match status_category {
+fn active_work_agent_priority_rank(agent: &gwt::ActiveWorkAgentView) -> u8 {
+    match agent.status_category.as_str() {
         "blocked" => 0,
-        "active" => 1,
-        "idle" => 2,
-        "done" => 3,
-        _ => 4,
+        "active" => match agent.last_board_entry_kind.as_deref() {
+            Some("handoff") => 1,
+            Some("next") => 2,
+            Some("claim") => 3,
+            Some("decision") => 4,
+            Some("status") => 5,
+            _ => 6,
+        },
+        "idle" => 7,
+        "done" => 8,
+        _ => 9,
     }
 }
 
@@ -519,6 +526,11 @@ fn active_work_agent_view_from_summary(
             .as_ref()
             .map(|path| path.display().to_string()),
         last_board_entry_id: agent.last_board_entry_id.clone(),
+        last_board_entry_kind: agent
+            .last_board_entry_kind
+            .as_ref()
+            .map(|kind| kind.as_str().to_string()),
+        coordination_scope: agent.coordination_scope.clone(),
         updated_at: agent.updated_at.to_rfc3339(),
     }
 }
@@ -537,6 +549,8 @@ fn active_agent_summary_from_session(
         worktree_path: Some(session.worktree_path.clone()),
         branch: Some(session.branch_name.clone()),
         last_board_entry_id: None,
+        last_board_entry_kind: None,
+        coordination_scope: None,
         updated_at,
     }
 }
@@ -564,6 +578,12 @@ fn upsert_workspace_agent(
         }
         if summary.last_board_entry_id.is_some() {
             existing.last_board_entry_id = summary.last_board_entry_id;
+        }
+        if summary.last_board_entry_kind.is_some() {
+            existing.last_board_entry_kind = summary.last_board_entry_kind;
+        }
+        if summary.coordination_scope.is_some() {
+            existing.coordination_scope = summary.coordination_scope;
         }
         if summary.updated_at > existing.updated_at {
             existing.updated_at = summary.updated_at;
@@ -3689,11 +3709,11 @@ mod tests {
     use tracing_subscriber::{layer::Context, prelude::*, Layer};
 
     use super::{
-        dispatch_agent_launch_success, save_start_work_workspace_projection, ActiveAgentSession,
-        AgentLaunchCompletion, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
-        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest,
-        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProcessLaunch,
-        ProjectTabRuntime, UserEvent, WindowRuntime,
+        active_work_projection_from_saved, dispatch_agent_launch_success,
+        save_start_work_workspace_projection, ActiveAgentSession, AgentLaunchCompletion,
+        AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget, KnowledgeLoadRequest,
+        KnowledgeRefreshTask, KnowledgeSearchRequest, LaunchWizardMemoryCache, LaunchWizardSession,
+        OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent, WindowRuntime,
     };
     use crate::{combined_window_id, same_worktree_path, PtyWriterRegistry};
 
@@ -6874,6 +6894,56 @@ exit 0
                 && projection.board_refs == vec![blocked.id.clone()]
                 && projection.next_action.as_deref() == Some("Resolve blocker")
         ));
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_prioritizes_handoff_agents() {
+        use gwt_core::workspace_projection::{
+            WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
+        };
+
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        let now = chrono::Utc::now();
+        projection.agents.push(WorkspaceAgentSummary {
+            session_id: "session-active".to_string(),
+            window_id: Some("tab-1::agent-active".to_string()),
+            agent_id: "codex".to_string(),
+            display_name: "Alpha".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Implementing tests".to_string()),
+            worktree_path: None,
+            branch: Some("work/20260504-1234".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            updated_at: now,
+        });
+        projection.agents.push(WorkspaceAgentSummary {
+            session_id: "session-handoff".to_string(),
+            window_id: Some("tab-1::agent-handoff".to_string()),
+            agent_id: "codex".to_string(),
+            display_name: "Zulu".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Review visual state coverage".to_string()),
+            worktree_path: None,
+            branch: Some("work/20260504-1234".to_string()),
+            last_board_entry_id: Some("board-handoff".to_string()),
+            last_board_entry_kind: Some(BoardEntryKind::Handoff),
+            coordination_scope: Some("SPEC-2359 / workspace-ux".to_string()),
+            updated_at: now,
+        });
+
+        let view = active_work_projection_from_saved(projection);
+
+        assert_eq!(view.agents[0].session_id, "session-handoff");
+        assert_eq!(
+            view.agents[0].last_board_entry_kind.as_deref(),
+            Some("handoff")
+        );
+        assert_eq!(
+            view.agents[0].coordination_scope.as_deref(),
+            Some("SPEC-2359 / workspace-ux")
+        );
     }
 
     #[test]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -343,6 +343,8 @@ pub struct ActiveWorkAgentView {
     pub branch: Option<String>,
     pub worktree_path: Option<String>,
     pub last_board_entry_id: Option<String>,
+    pub last_board_entry_kind: Option<String>,
+    pub coordination_scope: Option<String>,
     pub updated_at: String,
 }
 
@@ -718,6 +720,8 @@ mod tests {
                     branch: Some("work/20260504-1200".to_string()),
                     worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),
                     last_board_entry_id: Some("board-1".to_string()),
+                    last_board_entry_kind: Some("handoff".to_string()),
+                    coordination_scope: Some("SPEC-2359 / start-work".to_string()),
                     updated_at: "2026-05-04T12:00:00Z".to_string(),
                 }],
             },
@@ -742,6 +746,18 @@ mod tests {
                 .pointer("/projection/agents/0/last_board_entry_id")
                 .and_then(Value::as_str),
             Some("board-1")
+        );
+        assert_eq!(
+            value
+                .pointer("/projection/agents/0/last_board_entry_kind")
+                .and_then(Value::as_str),
+            Some("handoff")
+        );
+        assert_eq!(
+            value
+                .pointer("/projection/agents/0/coordination_scope")
+                .and_then(Value::as_str),
+            Some("SPEC-2359 / start-work")
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -89,6 +89,34 @@ test("Workspace sidebar exposes active work and per-agent overview", () => {
   );
 });
 
+test("Workspace active work overview behaves like a command center", () => {
+  assert.match(
+    appSource,
+    /Add Agent to This Work/,
+    "expected Workspace-origin launch copy to make same-work agent addition explicit",
+  );
+  assert.match(
+    appSource,
+    /last_board_entry_kind/,
+    "expected agent cards to expose the latest coordination milestone kind",
+  );
+  assert.match(
+    appSource,
+    /coordination_scope/,
+    "expected agent cards to expose owner/topic scope for each agent",
+  );
+  assert.match(
+    appSource,
+    /function\s+focusBoardEntry\(/,
+    "expected Board actions to deep-link to the referenced coordination entry",
+  );
+  assert.match(
+    appSource,
+    /data-board-entry-id/,
+    "expected Board timeline entries to be addressable from Workspace links",
+  );
+});
+
 test("Branches remains a branch browser, not a planning workspace", () => {
   const branchPreset = document.querySelector('.preset-button[data-preset="branches"]');
   assert.ok(branchPreset, "expected Branches preset to remain available");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -162,6 +162,7 @@
             "requestBoard",
             "requestOlderBoardEntries",
             "submitBoardEntry",
+            "focusBoardEntry",
           ]),
         }),
         logStateMap: Object.freeze({
@@ -234,6 +235,7 @@
       let viewportRasterTimer = null;
       let launchWizard = null;
       let activeWorkProjection = null;
+      let pendingBoardEntryFocusId = null;
       let wizardWasOpen = false;
       let wizardAdvancedOpen = false;
       let wizardBranchDraft = "";
@@ -1011,6 +1013,46 @@
         container.appendChild(createNode("span", "", value));
       }
 
+      function coordinationKindLabel(kind) {
+        switch (String(kind || "").toLowerCase()) {
+          case "blocked":
+            return "Blocked";
+          case "handoff":
+            return "Handoff";
+          case "next":
+            return "Next";
+          case "claim":
+            return "Claim";
+          case "decision":
+            return "Decision";
+          case "status":
+            return "Status";
+          default:
+            return "";
+        }
+      }
+
+      function activeBoardWindowIds() {
+        return (activeWorkspace().windows || [])
+          .filter((windowData) => windowData.preset === "board" && !windowData.minimized)
+          .map((windowData) => windowData.id);
+      }
+
+      function focusBoardEntry(entryId) {
+        if (!entryId) {
+          focusOrSpawnPreset("board");
+          return;
+        }
+        pendingBoardEntryFocusId = entryId;
+        for (const windowId of activeBoardWindowIds()) {
+          const state = ensureBoardState(windowId);
+          state.focusEntryId = entryId;
+          state.pendingFocusScroll = true;
+          renderBoard(windowId);
+        }
+        focusOrSpawnPreset("board");
+      }
+
       function renderActiveWorkOverview() {
         if (!activeWorkSummary || !activeWorkAgents) return;
         activeWorkSummary.innerHTML = "";
@@ -1048,7 +1090,7 @@
 
         const actions = createNode("div", "op-work-actions");
         if (activeWorkProjection.branch) {
-          const addAgent = createNode("button", "op-work-action", "Add Agent");
+          const addAgent = createNode("button", "op-work-action", "Add Agent to This Work");
           addAgent.type = "button";
           addAgent.addEventListener("click", () => {
             send({
@@ -1059,10 +1101,12 @@
           });
           actions.appendChild(addAgent);
         }
-        if ((activeWorkProjection.board_refs || []).length > 0) {
-          const openBoard = createNode("button", "op-work-action", "Open Board");
+        const boardRefs = activeWorkProjection.board_refs || [];
+        const latestBoardRef = boardRefs.length > 0 ? boardRefs[boardRefs.length - 1] : "";
+        if (latestBoardRef) {
+          const openBoard = createNode("button", "op-work-action", "Open Latest Board Entry");
           openBoard.type = "button";
-          openBoard.addEventListener("click", () => focusOrSpawnPreset("board"));
+          openBoard.addEventListener("click", () => focusBoardEntry(latestBoardRef));
           actions.appendChild(openBoard);
         }
         if (actions.childNodes.length > 0) {
@@ -1078,15 +1122,23 @@
 
         for (const agent of agents) {
           const state = agent.status_category || "unknown";
+          const coordinationKind = String(agent.last_board_entry_kind || "").toLowerCase();
+          const coordinationLabel = coordinationKindLabel(coordinationKind);
           const card = createNode("article", "op-agent-card");
           card.dataset.state = state;
+          if (coordinationKind) card.dataset.kind = coordinationKind;
           if (agent.last_board_entry_id) card.dataset.boardRef = agent.last_board_entry_id;
 
           const head = createNode("div", "op-agent-head");
           head.appendChild(
             createNode("div", "op-agent-name", agent.display_name || agent.agent_id || "Agent"),
           );
-          head.appendChild(createNode("div", "op-agent-state", state));
+          const chips = createNode("div", "op-agent-chips");
+          if (coordinationLabel) {
+            chips.appendChild(createNode("div", "op-agent-kind", coordinationLabel));
+          }
+          chips.appendChild(createNode("div", "op-agent-state", state));
+          head.appendChild(chips);
           card.appendChild(head);
 
           const agentMeta = createNode("div", "op-agent-meta");
@@ -1095,8 +1147,15 @@
           appendMeta(agentMeta, agent.last_board_entry_id ? "Board linked" : "");
           card.appendChild(agentMeta);
 
+          if (agent.coordination_scope) {
+            card.appendChild(createNode("div", "op-agent-scope", agent.coordination_scope));
+          }
+
           if (agent.current_focus) {
-            card.appendChild(createNode("div", "op-agent-focus", agent.current_focus));
+            const focusText = coordinationLabel
+              ? `${coordinationLabel}: ${agent.current_focus}`
+              : agent.current_focus;
+            card.appendChild(createNode("div", "op-agent-focus", focusText));
           }
 
           const agentActions = createNode("div", "op-agent-actions");
@@ -1109,9 +1168,9 @@
             agentActions.appendChild(focusButton);
           }
           if (agent.last_board_entry_id) {
-            const boardButton = createNode("button", "op-agent-action", "Board");
+            const boardButton = createNode("button", "op-agent-action", "Open Entry");
             boardButton.type = "button";
-            boardButton.addEventListener("click", () => focusOrSpawnPreset("board"));
+            boardButton.addEventListener("click", () => focusBoardEntry(agent.last_board_entry_id));
             agentActions.appendChild(boardButton);
           }
           if (agentActions.childNodes.length > 0) {
@@ -1864,6 +1923,8 @@
             preserveBoardScrollPosition: false,
             shouldFollowBoardBottom: true,
             newEntriesAvailable: false,
+            focusEntryId: null,
+            pendingFocusScroll: false,
           });
         }
         return boardStateMap.get(windowId);
@@ -3289,6 +3350,10 @@
         if (!status || !timeline || !composer) {
           return;
         }
+        if (pendingBoardEntryFocusId && !state.focusEntryId) {
+          state.focusEntryId = pendingBoardEntryFocusId;
+          state.pendingFocusScroll = true;
+        }
 
         const entryCountLabel = `${state.entries.length} entr${state.entries.length === 1 ? "y" : "ies"}`;
         status.textContent = state.error
@@ -3358,6 +3423,7 @@
             createNode("div", "board-empty workspace-empty-state", "No coordination entries yet."),
           );
         }
+        let focusTarget = null;
         for (const entry of state.entries) {
           const authorKind = String(entry.author_kind || "").toLowerCase();
           let card;
@@ -3370,6 +3436,14 @@
           }
           if (entry.agent_color) {
             card.dataset.agentColor = entry.agent_color;
+          }
+          if (entry.id) {
+            card.setAttribute("data-board-entry-id", entry.id);
+          }
+          if (state.focusEntryId && entry.id === state.focusEntryId) {
+            card.classList.add("focus-target");
+            card.tabIndex = -1;
+            focusTarget = card;
           }
 
           const meta = createNode("div", "board-message-meta");
@@ -3389,7 +3463,12 @@
         }
 
         if (scroller) {
-          if (state.pendingSelfPostScroll) {
+          if (focusTarget && state.pendingFocusScroll) {
+            focusTarget.scrollIntoView({ block: "center" });
+            focusTarget.focus({ preventScroll: true });
+            state.pendingFocusScroll = false;
+            pendingBoardEntryFocusId = null;
+          } else if (state.pendingSelfPostScroll) {
             forceBoardScrollToBottom(scroller);
             state.pendingSelfPostScroll = false;
             state.newEntriesAvailable = false;

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1566,6 +1566,11 @@
         background: var(--color-surface);
       }
 
+      .board-message.focus-target {
+        border-color: var(--color-focus-ring);
+        box-shadow: 0 0 0 1px var(--color-focus-ring), var(--shadow-2);
+      }
+
       .board-message-meta {
         display: inline-flex;
         align-items: center;

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -344,6 +344,11 @@ body::after {
   border-color: var(--color-state-active);
 }
 
+.op-agent-card[data-kind="handoff"] {
+  border-color: var(--agent-codex);
+  box-shadow: inset 3px 0 0 var(--agent-codex);
+}
+
 .op-agent-head {
   display: flex;
   align-items: center;
@@ -360,7 +365,15 @@ body::after {
   white-space: nowrap;
 }
 
-.op-agent-state {
+.op-agent-chips {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.op-agent-state,
+.op-agent-kind {
   flex-shrink: 0;
   border-radius: var(--radius-pill);
   border: 1px solid var(--color-border);
@@ -372,6 +385,11 @@ body::after {
   text-transform: uppercase;
 }
 
+.op-agent-kind {
+  border-color: color-mix(in oklab, var(--agent-codex) 62%, transparent);
+  color: var(--agent-codex);
+}
+
 .op-agent-card[data-state="blocked"] .op-agent-state {
   border-color: var(--color-state-blocked);
   color: var(--color-state-blocked);
@@ -380,6 +398,14 @@ body::after {
 .op-agent-card[data-state="active"] .op-agent-state {
   border-color: var(--color-state-active);
   color: var(--color-state-active);
+}
+
+.op-agent-scope {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  overflow-wrap: anywhere;
 }
 
 .op-agent-focus {


### PR DESCRIPTION
## Summary

- Hardened Workspace Active Work into a command-center view so operators can see each agent's coordination state without opening every terminal.
- Preserved Branches as the branch browser and Board as the event log while adding focused handoff from Workspace to the relevant Board entry.

## Changes

- `crates/gwt-core/src/workspace_projection.rs`: persist latest coordination milestone kind and scope per agent with legacy JSON defaults.
- `crates/gwt/src/protocol.rs` and `crates/gwt/src/app_runtime/mod.rs`: expose coordination fields in `ActiveWorkAgentView` and prioritize blocked, handoff, and active agents in the Workspace projection.
- `crates/gwt/web/app.js`, `crates/gwt/web/index.html`, and `crates/gwt/web/styles/components.css`: render milestone chips, scope labels, same-work Add Agent copy, and Board entry focus links.
- `crates/gwt-core/tests/workspace_projection.rs` and `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: cover the new projection and frontend contracts.

## Testing

- [x] `cargo test -p gwt-core board_milestone_records_agent_coordination_kind_and_scope -- --nocapture` — passed after RED confirmation.
- [x] `cargo test -p gwt active_work_projection_uses_distinct_wire_event_from_canvas_workspace_state -- --nocapture` — passed after RED confirmation.
- [x] `cargo test -p gwt app_runtime_active_work_projection_prioritizes_handoff_agents -- --nocapture` — passed.
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — passed after RED confirmation.
- [x] `cargo test -p gwt-core workspace_projection -- --nocapture` — passed.
- [x] `cargo test -p gwt active_work_projection -- --nocapture` — passed.
- [x] `cargo test -p gwt workspace_add_agent -- --nocapture` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-unit` — passed.
- [x] `npm run test:frontend-smoke` — passed.
- [x] `cargo test -p gwt embedded_web_branches_surface_remains_branch_browser -- --nocapture` — passed.
- [x] `cargo test -p gwt embedded_web_board_surface_does_not_render_workspace_or_planning_cards -- --nocapture` — passed.
- [x] `cargo test -p gwt embedded_web_start_work_mode_hides_branch_controls_in_shared_wizard_renderer -- --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `npm run test:visual` — command completed successfully; Playwright skipped 8 tests in this local environment.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] Pre-push hook — passed with coverage 90.51% against the 90.00% threshold.

## Closing Issues

None

## Related Issues / Links

- #2359
- #2356
- #2018
- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend tests)
- [x] Documentation updated (SPEC-2359 tasks updated; README unaffected)
- [x] Migration/backfill plan included (new serialized fields are optional with serde defaults)
- [x] CHANGELOG impact considered (minor feature via `feat:` commit)

## Context

- PR #2398 merged the Workspace IA foundation. This follow-up addresses the UX review that the Active Work area still needed command-center quality for multi-agent coordination.

## Risk / Impact

- **Affected areas**: Workspace Active Work projection, Board focus rendering, Operator sidebar copy and card styling.
- **Rollback plan**: Revert commit `ba525ae0`.

## Screenshots

- Not attached from this non-interactive run; UI coverage is represented by frontend contract/unit/smoke tests, and `npm run test:visual` completed locally with all Playwright visual tests skipped in this environment.
