### PR TITLE
feat(ui): SPEC-2356 follow-up — Mission Briefing intro progress bar (boot sweep)

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3093,6 +3093,7 @@
             ▪ board sync
           </div>
         </div>
+        <div class="op-briefing__progress" aria-hidden="true"></div>
         <div class="op-briefing__online">— OPERATOR ONLINE —</div>
       </div>
       <div class="op-palette-backdrop" id="op-palette-backdrop" aria-hidden="true">

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1376,3 +1376,55 @@ kbd.op-kbd {
     animation: none;
   }
 }
+
+/* ============================================================
+   Mission Briefing intro — animated progress bar between lines.
+
+   While the staged reveal lines come in, a subtle progress bar
+   sweeps from 0 → 100% behind the message column, finishing as
+   the OPERATOR ONLINE marker fades in. Visual, no functional
+   meaning; reduced-motion / forced-colors environments hide it.
+   ============================================================ */
+.op-briefing__progress {
+  position: relative;
+  width: min(360px, 64vw);
+  height: 2px;
+  background: color-mix(in oklab, var(--color-text-muted) 16%, transparent);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  margin-bottom: var(--space-4);
+}
+
+.op-briefing__progress::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    var(--color-state-active) 35%,
+    var(--agent-codex) 65%,
+    transparent 100%
+  );
+  width: 100%;
+  transform: translateX(-100%);
+  animation: op-briefing-sweep 1.4s ease-out forwards;
+}
+
+@keyframes op-briefing-sweep {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .op-briefing__progress::after {
+    animation: none;
+    transform: translateX(0);
+  }
+}
+
+@media (forced-colors: active) {
+  .op-briefing__progress { display: none; }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Mission Briefing intro polish: staged reveal lines に合わせて progress bar が 0% → 100% にスイープする boot sequence を追加。 OPERATOR ONLINE マーカーの fade-in と同期して完走し、 mission-control 風の起動演出を強化する。

## Changes

- `055c9452` — Mission Briefing progress bar
  - `index.html`: `<div class="op-briefing__progress">` を staged lines と OPERATOR ONLINE の間に
  - `components.css`:
    - `.op-briefing__progress`: `min(360px, 64vw) × 2px` 薄い軌道
    - `.op-briefing__progress::after`: `--color-state-active` → `--agent-codex` (cyan) gradient bar、 1.4s ease-out で `translateX(-100%) → 0`
    - prefers-reduced-motion: reduce で animation off
    - forced-colors: active で progress 非表示

## Testing

- ✅ `cargo test -p gwt` (391 + 201 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 30 PRs

## Risk / Impact

- 影響範囲: Mission Briefing markup + CSS のみ
- 互換性: sessionStorage gate / staged reveal lines 不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
