### PR TITLE
feat(ui): SPEC-2356 follow-up — Sidebar Layer live indicator dot

### DIFF
--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -139,6 +139,17 @@ export function applyTelemetryCounts(doc, counts = {}) {
     const el = doc.getElementById(id);
     if (el) el.textContent = String(v);
   };
+  // SPEC-2356 — paint a Sidebar Layer's status hint based on whether the
+  // resource is "live" (active > 0). This lets the agents/git rows light up
+  // even when the user is not looking at the Status Strip.
+  const markLive = (layer, isLive) => {
+    const row = doc.querySelector(`.op-layer[data-layer="${layer}"]`);
+    if (!row) return;
+    if (isLive) row.dataset.live = "true";
+    else delete row.dataset.live;
+  };
+  if ("active" in counts) markLive("agents", (counts.active ?? 0) > 0);
+  if ("branches" in counts) markLive("git", (counts.branches ?? 0) > 0);
   setText("op-strip-active", counts.active ?? 0);
   setText("op-strip-idle", counts.idle ?? 0);
   setText("op-strip-blocked", counts.blocked ?? 0);

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1454,3 +1454,21 @@ kbd.op-kbd {
 @media (forced-colors: active) {
   .op-briefing__progress { display: none; }
 }
+
+/* SPEC-2356 — Sidebar Layer "live" hint:
+   when applyTelemetryCounts marks a layer with `data-live="true"` (e.g.
+   agents > 0 active windows, git > 0 branches), the layer label receives
+   a small leading dot tinted with `--color-state-active`. */
+:root[data-theme] .op-layer[data-live="true"] .op-layer__label::before {
+  content: "● ";
+  color: var(--color-state-active);
+  margin-right: 0;
+  font-size: 0.7em;
+  vertical-align: middle;
+}
+
+@media (forced-colors: active) {
+  :root[data-theme] .op-layer[data-live="true"] .op-layer__label::before {
+    color: Highlight;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Sidebar Layer detail polish: agents / git layer が "通電" 状態 (active agent や branches > 0) にあるとき、 layer 行のラベル先頭にドット (`●`) を点けて一瞥で識別できるようにする。 Status Strip を見なくても sidebar 側だけでシステムの稼働状態が把握できる。

## Changes

- `228521db` — Sidebar Layer live indicator
  - `operator-shell.js`: `applyTelemetryCounts` に `markLive(layer, isLive)` を追加。 `active > 0` で agents、 `branches > 0` で git layer に `data-live="true"` を付ける
  - `components.css`: `.op-layer[data-live="true"] .op-layer__label::before` で `var(--color-state-active)` の `●` を表示、 forced-colors では `Highlight` にフォールバック

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 31 PRs

## Risk / Impact

- 影響範囲: Sidebar Layer のみ
- 互換性: layer state persistence / DOM 変更なし

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Sidebar now displays live status indicators for active resources based on real-time telemetry
- Agents automatically marked as "live" when telemetry confirms they are running
- Git repositories automatically marked as "live" when branches are present
- Visual indicator dots next to resource labels help identify active resources at a glance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->