### PR TITLE
fix(ui): SPEC-2356 follow-up — Mission Briefing accessible role/aria-live/aria-label

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3081,7 +3081,14 @@
           </div>
         </footer>
       </div>
-      <div class="op-briefing" id="op-briefing" aria-hidden="true">
+      <div
+        class="op-briefing"
+        id="op-briefing"
+        role="status"
+        aria-live="polite"
+        aria-label="Operator boot sequence"
+        aria-hidden="true"
+      >
         <h1 class="op-briefing__title">gwt://operator</h1>
         <div class="op-briefing__stamp" id="op-briefing-stamp"></div>
         <div class="op-briefing__lines" id="op-briefing-lines">


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の accessibility polish: Mission Briefing splash に `role="status"` + `aria-live="polite"` + `aria-label="Operator boot sequence"` を付与し、 staged reveal lines が screen reader に穏やかにアナウンスされる。 splash 終了後の `aria-hidden` 切替は既存どおり、 boot 中だけ読み上げ対象に。

## Changes

- `09ddec11` — Mission Briefing aria
  - `role="status"` (assertive ではなく live region として読み上げ)
  - `aria-live="polite"` (進行中の操作を妨げない)
  - `aria-label="Operator boot sequence"` で意味付け

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 32 PRs

## Risk / Impact

- 影響範囲: Mission Briefing element の aria 属性のみ
- 互換性: visible behavior 変化なし、 screen reader users にとって明確化

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
