### PR TITLE
fix(ui): SPEC-2356 follow-up — Status Strip aria-live with semantic labels

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3054,28 +3054,34 @@
             <button class="add-button" id="add-button" aria-label="Add window">+</button>
           </div>
         </div>
-        <footer class="op-status-strip" id="op-status-strip" aria-label="Operator status strip">
+        <footer
+          class="op-status-strip"
+          id="op-status-strip"
+          role="status"
+          aria-live="polite"
+          aria-label="Operator status strip"
+        >
           <div class="op-status-strip__cell">
             <span class="op-status-strip__live-dot" aria-hidden="true"></span>
             <span class="op-status-strip__label">LIVE</span>
           </div>
           <div class="op-status-strip__cell">
             <span class="op-status-strip__label">ACTIVE</span>
-            <span class="op-status-strip__value" id="op-strip-active">0</span>
+            <span class="op-status-strip__value" id="op-strip-active" aria-label="Active agents">0</span>
           </div>
           <div class="op-status-strip__cell">
             <span class="op-status-strip__label">IDLE</span>
-            <span class="op-status-strip__value" id="op-strip-idle">0</span>
+            <span class="op-status-strip__value" id="op-strip-idle" aria-label="Idle agents">0</span>
           </div>
           <div class="op-status-strip__cell op-status-strip__cell--blocked">
             <span class="op-status-strip__label">BLOCKED</span>
-            <span class="op-status-strip__value" id="op-strip-blocked">0</span>
+            <span class="op-status-strip__value" id="op-strip-blocked" aria-label="Blocked agents">0</span>
           </div>
           <div class="op-status-strip__cell">
             <span class="op-status-strip__label">BR</span>
-            <span class="op-status-strip__value" id="op-strip-branches">—</span>
+            <span class="op-status-strip__value" id="op-strip-branches" aria-label="Branches">—</span>
           </div>
-          <div class="op-status-strip__cell">
+          <div class="op-status-strip__cell" aria-hidden="true">
             <span class="op-status-strip__label">T</span>
             <span class="op-status-strip__value" id="op-strip-clock">--:--:--</span>
           </div>


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Status Strip accessibility polish: footer に `role="status"` + `aria-live="polite"`、 counters の値に semantic aria-label を付与する。 screen reader が "Active agents 4, Idle 2, ..." と穏やかに状態変化を伝えるようになる。 clock は秒単位の連続更新で読み上げが煩雑になるため `aria-hidden` で除外。

## Changes

- `bae447f7` — Status Strip aria
  - footer: `role="status"` + `aria-live="polite"` + `aria-label="Operator status strip"`
  - ACTIVE / IDLE / BLOCKED / BR の value にそれぞれ `aria-label="Active/Idle/Blocked agents"` / `"Branches"`
  - clock cell に `aria-hidden="true"` (秒更新を screen reader からは除外)

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 33 PRs

## Risk / Impact

- 影響範囲: Status Strip 要素の aria 属性のみ
- 互換性: visible behavior 変化なし
- アクセシビリティ: agent telemetry が screen reader 経由でも常時把握可能に

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
