### PR TITLE
feat(ui): SPEC-2356 follow-up — Command Palette trigger button shows kbd + label

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3028,12 +3028,14 @@
           </div>
           <div class="floating-actions">
             <button
-              class="arrange-button"
+              class="arrange-button op-palette-trigger"
               id="op-palette-button"
               aria-label="Command palette"
               title="Command palette (⌘K / ⌘P)"
+              aria-keyshortcuts="Meta+K Meta+P"
             >
-              ⌘K
+              <span class="op-palette-trigger__label">⌘K</span>
+              <span class="op-palette-trigger__hint">Palette</span>
             </button>
             <button class="arrange-button" id="tile-button" aria-label="Tile windows">Tile</button>
             <button class="arrange-button" id="stack-button" aria-label="Stack windows">Stack</button>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1472,3 +1472,26 @@ kbd.op-kbd {
     color: Highlight;
   }
 }
+
+/* Command Palette trigger button — emphasises the ⌘K hotkey */
+:root[data-theme] .op-palette-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+:root[data-theme] .op-palette-trigger__label {
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-state-active);
+}
+
+:root[data-theme] .op-palette-trigger__hint {
+  font-family: var(--font-display);
+  font-stretch: 75%;
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Command Palette trigger polish: floating actions の単純な `⌘K` ボタンから "⌘K · Palette" に拡張。 ⌘K を mono cyan で目立たせ、 "Palette" は Hubot Sans Condensed display で意味付ける。 `aria-keyshortcuts="Meta+K Meta+P"` で screen reader / WAI-ARIA からも hotkey が認識される。

## Changes

- `9930d392` — Command Palette trigger button polish
  - `index.html`: ボタン内を `<span class="op-palette-trigger__label">⌘K</span>` + `<span class="op-palette-trigger__hint">Palette</span>` に分割、 `aria-keyshortcuts="Meta+K Meta+P"` を追加
  - `components.css`: `.op-palette-trigger` を flex、 label を Mono + state-active、 hint を Hubot Condensed display + muted

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 34 PRs

## Risk / Impact

- 影響範囲: floating actions の Command Palette トリガ button のみ
- 互換性: button click handler / hotkey 不変
- ユーザー体験: ⌘K hotkey の存在を視覚的にも明示、 a11y 経由でも認識可能

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
