### PR TITLE
feat(ui): SPEC-2356 follow-up — Sidebar Quick rows show kbd badges + a11y shortcuts

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2970,25 +2970,25 @@
             <h3 class="op-sidebar__heading">
               <span>Quick</span>
             </h3>
-            <button class="op-layer" type="button" data-cmd="start-work">
+            <button class="op-layer" type="button" data-cmd="start-work" aria-label="Start Work">
               <span class="op-layer__indicator"></span>
               <span class="op-layer__label">Start Work</span>
-              <span class="op-layer__count">GO</span>
+              <kbd class="op-layer__kbd">GO</kbd>
             </button>
-            <button class="op-layer" type="button" data-cmd="open-board">
+            <button class="op-layer" type="button" data-cmd="open-board" aria-label="Open Board (Cmd+B)" aria-keyshortcuts="Meta+B">
               <span class="op-layer__indicator"></span>
               <span class="op-layer__label">Board</span>
-              <span class="op-layer__count">⌘B</span>
+              <kbd class="op-layer__kbd">⌘ B</kbd>
             </button>
-            <button class="op-layer" type="button" data-cmd="open-git">
+            <button class="op-layer" type="button" data-cmd="open-git" aria-label="Open Git (Cmd+G)" aria-keyshortcuts="Meta+G">
               <span class="op-layer__indicator"></span>
               <span class="op-layer__label">Git</span>
-              <span class="op-layer__count">⌘G</span>
+              <kbd class="op-layer__kbd">⌘ G</kbd>
             </button>
-            <button class="op-layer" type="button" data-cmd="open-logs">
+            <button class="op-layer" type="button" data-cmd="open-logs" aria-label="Open Logs (Cmd+L)" aria-keyshortcuts="Meta+L">
               <span class="op-layer__indicator"></span>
               <span class="op-layer__label">Logs</span>
-              <span class="op-layer__count">⌘L</span>
+              <kbd class="op-layer__kbd">⌘ L</kbd>
             </button>
           </div>
         </aside>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1495,3 +1495,21 @@ kbd.op-kbd {
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
+
+/* Sidebar Layer kbd badge — small kbd-styled chip on Quick rows */
+:root[data-theme] .op-layer__kbd {
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text);
+  background: color-mix(in oklab, var(--color-text-muted) 14%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 1px var(--space-1);
+}
+
+:root[data-theme] .op-layer:hover .op-layer__kbd {
+  background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+  color: var(--color-state-active);
+  border-color: var(--color-state-active);
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Sidebar Quick rows polish: Start Work / Board / Git / Logs の plain text shortcut indicator を kbd-styled badge に置換し、 a11y shortcuts (`aria-keyshortcuts="Meta+B/G/L"`) と明確な `aria-label` を付与する。 hover で state-active 色にハイライトされ、 ホットキー認識が視覚的にも screen reader 経由でも明確化。

## Changes

- `4774171c` — Sidebar Quick kbd badges
  - `index.html`: 各 Quick button に `aria-keyshortcuts` + `aria-label`、 `<span class="op-layer__count">` を `<kbd class="op-layer__kbd">⌘ B</kbd>` に
  - `components.css`: `.op-layer__kbd` を Mono + 1px tokens border、 hover で state-active highlight

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 35 PRs

## Risk / Impact

- 影響範囲: Sidebar Quick rows のみ
- 互換性: dispatch ロジック / hotkey 不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
