### PR TITLE
feat(ui): SPEC-2356 follow-up — universal input/select/textarea focus-visible ring

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1513,3 +1513,21 @@ kbd.op-kbd {
   color: var(--color-state-active);
   border-color: var(--color-state-active);
 }
+
+/* SPEC-2356 — universal focus ring on input/select/textarea elements
+   without their own dedicated focus rule. Token-driven, never overrides
+   surface-specific input rules that already use border-color. */
+:root[data-theme] input:focus-visible,
+:root[data-theme] select:focus-visible,
+:root[data-theme] textarea:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+@media (forced-colors: active) {
+  :root[data-theme] input:focus-visible,
+  :root[data-theme] select:focus-visible,
+  :root[data-theme] textarea:focus-visible {
+    outline: 2px solid Highlight;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の accessibility polish: `<input>` / `<select>` / `<textarea>` の `:focus-visible` で universal focus ring を追加。 既存 input には border-color highlight があるが完全網羅でなかったため、 default fallback として 2px の `--color-focus-ring` outline を入れる。 forced-colors では `Highlight` system color に切替。

## Changes

- `2fbe1e2b` — universal input focus ring
  - `:root[data-theme] input/select/textarea:focus-visible`: `outline: 2px solid var(--color-focus-ring); outline-offset: 1px`
  - `forced-colors: active` 用 fallback で `Highlight`

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 36 PRs

## Risk / Impact

- 影響範囲: input focus styling のみ
- 互換性: 既存の border-color focus 表現は維持 (outline は overlay)

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
