### PR TITLE
test(ui): SPEC-2356 follow-up — assert a11y structure for chrome surfaces

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -168,3 +168,51 @@ test("font preload hints exist for Mona/Hubot/JetBrains", () => {
     assert.ok(preloads.some((h) => h.endsWith(`/assets/fonts/${expected}`)), `missing preload: ${expected}`);
   }
 });
+
+test("Mission Briefing has accessible role and live region", () => {
+  const briefing = document.getElementById("op-briefing");
+  assert.ok(briefing);
+  assert.equal(briefing.getAttribute("role"), "status");
+  assert.equal(briefing.getAttribute("aria-live"), "polite");
+  assert.match(briefing.getAttribute("aria-label") ?? "", /boot|operator/i);
+});
+
+test("Status Strip is exposed as a live region with semantic value labels", () => {
+  const strip = document.getElementById("op-status-strip");
+  assert.ok(strip);
+  assert.equal(strip.getAttribute("role"), "status");
+  assert.equal(strip.getAttribute("aria-live"), "polite");
+  for (const id of ["op-strip-active", "op-strip-idle", "op-strip-blocked", "op-strip-branches"]) {
+    const el = document.getElementById(id);
+    assert.ok(el, `expected element ${id}`);
+    assert.ok(el.getAttribute("aria-label"), `${id} must have an aria-label`);
+  }
+  // clock cell is intentionally hidden from screen readers (per-second updates)
+  const clockCell = document.getElementById("op-strip-clock")?.parentElement;
+  assert.ok(clockCell, "clock cell exists");
+  assert.equal(clockCell.getAttribute("aria-hidden"), "true");
+});
+
+test("Sidebar Quick rows expose aria-keyshortcuts and kbd badges", () => {
+  for (const [cmd, key] of [
+    ["open-board", "B"],
+    ["open-git", "G"],
+    ["open-logs", "L"],
+  ]) {
+    const button = document.querySelector(`.op-layer[data-cmd="${cmd}"]`);
+    assert.ok(button, `expected Quick row for ${cmd}`);
+    const shortcut = button.getAttribute("aria-keyshortcuts");
+    assert.ok(shortcut, `${cmd} must declare aria-keyshortcuts`);
+    assert.match(shortcut, new RegExp(`Meta\\+${key}`));
+    const kbd = button.querySelector("kbd.op-layer__kbd");
+    assert.ok(kbd, `${cmd} must show a kbd badge`);
+  }
+});
+
+test("Command Palette trigger button declares aria-keyshortcuts", () => {
+  const trigger = document.getElementById("op-palette-button");
+  assert.ok(trigger, "palette trigger exists");
+  const shortcut = trigger.getAttribute("aria-keyshortcuts") ?? "";
+  assert.ok(shortcut.includes("Meta+K"), "trigger must declare Meta+K");
+  assert.ok(shortcut.includes("Meta+P"), "trigger must declare Meta+P");
+});


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の accessibility 契約を chrome-structure テストで明示的に守る。 #2406〜#2409 で追加した role / aria-live / aria-keyshortcuts / kbd badge が将来の編集で外れないよう、 4 件の assertion を追加。 frontend unit テスト数が 49+ → 53+ に増加。

## Changes

- `fe10b1b4` — a11y structure assertions
  - Mission Briefing: `role="status"` + `aria-live="polite"` + `aria-label` (boot / operator)
  - Status Strip: `role="status"` + `aria-live` + ACTIVE/IDLE/BLOCKED/BR の `aria-label`、 clock cell の `aria-hidden="true"`
  - Sidebar Quick rows: Board/Git/Logs の `aria-keyshortcuts="Meta+B/G/L"` + `kbd.op-layer__kbd` 存在
  - Command Palette trigger: `aria-keyshortcuts="Meta+K Meta+P"`

## Testing

- ✅ `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` (15 件 pass、 +4 件追加)
- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 37 PRs

## Risk / Impact

- 影響範囲: chrome-structure テストファイル only
- 互換性: a11y 契約を locking するための assertion 追加のみ

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests follow existing structure (linkedom + node:test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
