### PR TITLE
feat(ui): SPEC-2356 follow-up — prefers-contrast: more support (token-level boost)

### DIFF
--- a/crates/gwt/web/styles/tokens.css
+++ b/crates/gwt/web/styles/tokens.css
@@ -245,3 +245,21 @@
     --shadow-glow-active: 0 0 0 2px Highlight;
   }
 }
+
+/* SPEC-2356 — prefers-contrast: more
+   bump border / muted text contrast in both themes for users who request
+   higher visual separation. Token-only adjustment so dark/light flagships
+   share the same approach. */
+@media (prefers-contrast: more) {
+  :root[data-theme="dark"] {
+    --color-border: rgba(232, 234, 237, 0.30);
+    --color-border-strong: rgba(232, 234, 237, 0.55);
+    --color-text-muted: #d4dce4;
+  }
+
+  :root[data-theme="light"] {
+    --color-border: rgba(26, 29, 36, 0.30);
+    --color-border-strong: rgba(26, 29, 36, 0.55);
+    --color-text-muted: #2a2f37;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の accessibility polish: OS の `prefers-contrast: more` hint に応答し、 dark/light 両テーマで border / muted text の contrast を引き上げる。 完全 token-only の boost で、 既存の WCAG AA contrast 自動 assert (base ペア) は不変。

## Changes

- `6cca7e21` — prefers-contrast: more
  - Dark: `--color-border` 10% → 30%、 `--color-border-strong` 28% → 55%、 `--color-text-muted` を `#d4dce4` (より明るく) に
  - Light: `--color-border` 10% → 30%、 `--color-border-strong` 28% → 55%、 `--color-text-muted` を `#2a2f37` (より暗く) に
  - `@media (prefers-contrast: more)` で wrap、 該当 OS 設定の users にだけ適用

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)
- ✅ `node --test contrast.test.mjs` (28 件 GREEN、 base ペア assertion は不変)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 38 PRs

## Risk / Impact

- 影響範囲: tokens.css の `@media (prefers-contrast: more)` block のみ
- 互換性: prefers-contrast を実装していないブラウザでは無視される (no-op)
- アクセシビリティ: 高コントラストモード users の border 視認性が向上

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced (`prefers-contrast` block 内は意図的な color literal、 token-level boost のため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility for users with high-contrast display preferences, improving border and text visibility in both light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->