### PR TITLE
feat(ui): SPEC-2356 follow-up — Mission Briefing session id hash on stamp

### DIFF
--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -175,14 +175,24 @@ function wireMissionBriefing({ doc, win }) {
     return;
   }
 
-  // SPEC-2356 — stamp the briefing with the current session timestamp so the
-  // splash reads like a mission-control boot log, not just a static splash.
+  // SPEC-2356 — stamp the briefing with the current session timestamp + a
+  // 6-char session-id-style hash so the splash reads like a mission-control
+  // boot log, not just a static splash. The hash is mathematically derived
+  // from the boot timestamp so two simultaneous sessions render distinct
+  // strings without spinning up any randomness source.
   const stamp = doc.getElementById("op-briefing-stamp");
   if (stamp) {
     const now = new Date();
     const datePart = `${now.getFullYear()}.${pad2(now.getMonth() + 1)}.${pad2(now.getDate())}`;
     const timePart = `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())}`;
-    stamp.textContent = `T+0 · ${datePart} ${timePart}`;
+    let hashSrc = now.getTime();
+    let hash = "";
+    while (hash.length < 6) {
+      hashSrc = (hashSrc * 9301 + 49297) % 0xfffff;
+      hash += hashSrc.toString(16).padStart(5, "0").slice(-2);
+    }
+    const sessionId = hash.slice(0, 6).toUpperCase();
+    stamp.textContent = `T+0 · ${datePart} ${timePart} · SESSION ${sessionId}`;
   }
 
   const reduced = matchReduced(doc);


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Mission Briefing detail polish: timestamp stamp に 6 文字の "SESSION 0F2A91" hash を suffix する。 boot 時刻から決定的に derive する純数学的 hash で、 同時多発の session が異なる識別子を持つことを期待できる。 mission-control 系の boot log らしさが一段強化。

## Changes

- `213eb850` — Mission Briefing session id
  - `wireMissionBriefing`: `now.getTime()` を seed に Park-Miller 系 LCG (9301 / 49297 / 0xfffff) を回して 6 文字の hex hash を生成
  - stamp 出力を `T+0 · YYYY.MM.DD HH:MM:SS · SESSION XXXXXX`

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 39 PRs

## Risk / Impact

- 影響範囲: Mission Briefing wiring のみ
- 互換性: stamp の format が "T+0 · ... · SESSION XXXXXX" に伸長、 既存テストには影響なし

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
