### PR TITLE
feat(ui): SPEC-2356 follow-up — Status Strip BLOCKED cell pulses when count > 0

### DIFF
--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -150,6 +150,15 @@ export function applyTelemetryCounts(doc, counts = {}) {
   };
   if ("active" in counts) markLive("agents", (counts.active ?? 0) > 0);
   if ("branches" in counts) markLive("git", (counts.branches ?? 0) > 0);
+  // SPEC-2356 — toggle the blocked alert state so the BLOCKED cell pulses when
+  // anything actually needs attention, and stays still otherwise.
+  if ("blocked" in counts) {
+    const blockedCell = doc.querySelector(".op-status-strip__cell--blocked");
+    if (blockedCell) {
+      if ((counts.blocked ?? 0) > 0) blockedCell.classList.add("op-status-strip__cell--alert");
+      else blockedCell.classList.remove("op-status-strip__cell--alert");
+    }
+  }
   setText("op-strip-active", counts.active ?? 0);
   setText("op-strip-idle", counts.idle ?? 0);
   setText("op-strip-blocked", counts.blocked ?? 0);

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1531,3 +1531,28 @@ kbd.op-kbd {
     outline: 2px solid Highlight;
   }
 }
+
+/* SPEC-2356 — when blocked count > 0 the BLOCKED cell pulses subtly so
+   the user notices something needs attention. The animation is keyframed
+   on opacity (no shadow / repaint cost) and disabled by reduced-motion
+   and forced-colors. */
+@keyframes op-status-strip-blocked-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+
+:root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value {
+  animation: op-status-strip-blocked-pulse var(--motion-pulse) ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  :root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Status Strip detail polish: BLOCKED cell が `count > 0` のときだけ subtle opacity pulse でユーザーの attention を惹くようにする。 reduced-motion / forced-colors 環境では animation を切る。

## Changes

- `b6d335c4` — Status Strip BLOCKED pulse
  - `applyTelemetryCounts`: `blocked > 0` で `.op-status-strip__cell--alert` modifier 付与、 0 で除去
  - `components.css`: `.op-status-strip__cell--alert .op-status-strip__value` に opacity 1 ↔ 0.55 の pulse animation (`var(--motion-pulse)`)
  - reduced-motion / forced-colors では animation off

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 40 PRs

## Risk / Impact

- 影響範囲: Status Strip BLOCKED cell のみ
- 互換性: 既存の counter 表示 / aria-label は不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
