### PR TITLE
feat(ui): SPEC-2356 follow-up — Status Strip reflects WebSocket connection state

### DIFF
--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -387,6 +387,13 @@
       function setConnectionState(connected) {
         connectionDot.classList.toggle("connected", connected);
         connectionLabel.textContent = connected ? "Connected" : "Reconnecting";
+        // SPEC-2356 — propagate connection state to the Operator Status Strip
+        // so the LIVE cell visibly reflects whether the WebSocket bridge is
+        // up. The class is set on the strip element and consumed via CSS.
+        const strip = document.getElementById("op-status-strip");
+        if (strip) {
+          strip.classList.toggle("op-status-strip--offline", !connected);
+        }
         if (!connected) {
           for (const [windowId] of branchListStateMap.entries()) {
             if (

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1556,3 +1556,20 @@ kbd.op-kbd {
     animation: none;
   }
 }
+
+/* SPEC-2356 — Status Strip "offline" state when WebSocket bridge is down.
+   The LIVE indicator dot shifts from active to blocked colour, the entire
+   strip dim slightly, and counter values slide back to muted because they
+   are no longer fresh. */
+:root[data-theme] .op-status-strip--offline .op-status-strip__live-dot {
+  background: var(--color-state-blocked);
+  animation: none;
+}
+
+:root[data-theme] .op-status-strip--offline {
+  opacity: 0.85;
+}
+
+:root[data-theme] .op-status-strip--offline .op-status-strip__value {
+  color: var(--color-text-muted);
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Status Strip integrity polish: WebSocket bridge が disconnect している間、 Status Strip 全体を "offline" 状態に切り替えて live indicator が blocked 色になり、 counter values が muted 表示になる。 chrome の "LIVE" 表示が嘘になるのを防ぐ。

## Changes

- `da3cb744` — Status Strip offline mode
  - `setConnectionState`: `connected` フラグを `.op-status-strip` の `.op-status-strip--offline` modifier として伝播
  - `components.css`:
    - offline 時に live-dot 背景を `var(--color-state-blocked)` + animation off
    - strip opacity 0.85
    - counter values を `var(--color-text-muted)`

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 41 PRs

## Risk / Impact

- 影響範囲: setConnectionState + Status Strip CSS のみ
- 互換性: connection-dot の既存挙動は不変、 Status Strip は modifier 追加のみ

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
