### PR TITLE
feat(ui): SPEC-2356 follow-up — connection hint exposes role/aria-live to screen readers

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2993,10 +2993,10 @@
           </div>
         </aside>
         <div class="canvas-area">
-          <div class="hint">
-            <span class="connection-dot" id="connection-dot"></span>
-            <span id="connection-label">Connecting</span>
-            <span>Drag windows | Scroll/drag canvas to pan | Middle-click drag anywhere | Ctrl/Cmd + wheel to zoom</span>
+          <div class="hint" role="status" aria-live="polite">
+            <span class="connection-dot" id="connection-dot" aria-hidden="true"></span>
+            <span id="connection-label" aria-label="Connection state">Connecting</span>
+            <span class="hint__copy">Drag windows | Scroll/drag canvas to pan | Middle-click drag anywhere | Ctrl/Cmd + wheel to zoom</span>
           </div>
           <div class="canvas" id="canvas">
             <div class="canvas-stage" id="canvas-stage"></div>


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の accessibility polish: canvas hint の connection state が screen reader にも適切に伝わるよう、 `.hint` に `role="status"` + `aria-live="polite"`、 dot に `aria-hidden`、 label に `aria-label` を付与する。

## Changes

- `8b8916a9` — connection hint a11y
  - `.hint`: `role="status"` + `aria-live="polite"` (Connecting/Connected/Reconnecting の遷移を screen reader に穏やかにアナウンス)
  - `.connection-dot`: `aria-hidden="true"` (純装飾)
  - `#connection-label`: `aria-label="Connection state"`
  - copy span に `.hint__copy` クラス付与 (将来の styling 用)

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 42 PRs

## Risk / Impact

- 影響範囲: hint markup の aria 属性のみ
- 互換性: visible behavior 変化なし

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
