### PR TITLE
feat(ui): SPEC-2356 follow-up — Cmd+backslash toggles Sidebar Layers

### DIFF
--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -447,6 +447,15 @@ function wireGlobalHotkeys({ doc, hotkey, palette }) {
   hotkey.register("cmd+b", send("open-board"));
   hotkey.register("cmd+g", send("open-git"));
   hotkey.register("cmd+l", send("open-logs"));
+  // SPEC-2356 — Cmd+\ collapses/expands the Sidebar Layers, freeing canvas
+  // real estate when the user wants more room for floating windows.
+  hotkey.register("cmd+\\", () => {
+    const root = doc.documentElement;
+    const next = root.dataset.opSidebar === "collapsed" ? "" : "collapsed";
+    if (next) root.dataset.opSidebar = next;
+    else delete root.dataset.opSidebar;
+    return true;
+  });
 
   if (typeof palette?.close === "function") {
     doc.addEventListener("keydown", (e) => {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1589,3 +1589,13 @@ kbd.op-kbd {
 :root[data-theme] .op-palette__row[data-selected="true"] .op-palette__hint {
   color: var(--color-state-active);
 }
+
+/* SPEC-2356 — Cmd+\ collapses Sidebar Layers; the grid template tightens
+   to push canvas-area against the project bar's left edge. */
+:root[data-theme][data-op-sidebar="collapsed"] #app {
+  grid-template-columns: 0 1fr;
+}
+
+:root[data-theme][data-op-sidebar="collapsed"] .op-sidebar {
+  display: none;
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の hotkey 拡張: `Cmd+\` (Mac) / `Ctrl+\` (Linux/Windows) で Sidebar Layers を collapse/expand させる。 floating windows に画面を譲りたい時に右側を広く使える。

## Changes

- `ef15f963` — Cmd+backslash sidebar toggle
  - `wireGlobalHotkeys` に `cmd+\\` を register
  - toggle ハンドラ: `<html data-op-sidebar="collapsed">` の有無を切替
  - `components.css`: collapsed 時に `#app` の grid-template-columns を `0 1fr` に、 `.op-sidebar` を `display: none`

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 44 PRs

## Risk / Impact

- 影響範囲: hotkey + grid 制御 のみ
- 互換性: 既存の sidebar layer state persistence (localStorage) 不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
