### PR TITLE
docs(ui): SPEC-2356 follow-up — document Cmd+backslash sidebar toggle in Hotkey Overlay

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3166,6 +3166,13 @@
             </div>
           </div>
           <div class="op-hotkey-card__group">
+            <h3 class="op-hotkey-card__group-title">Layout</h3>
+            <div class="op-hotkey-card__row">
+              <span>Toggle sidebar</span>
+              <kbd class="op-kbd">⌘ \</kbd>
+            </div>
+          </div>
+          <div class="op-hotkey-card__group">
             <h3 class="op-hotkey-card__group-title">Help</h3>
             <div class="op-hotkey-card__row">
               <span>This card</span>


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の docs polish: PR #2418 で導入した `Cmd+\` (Sidebar Layers toggle) を Hotkey Overlay (⌘?) の cheat sheet にも追加し、 "Layout" 新グループに位置付ける。

## Changes

- `5e7ff8db` — Hotkey Overlay docs
  - "Layout" group を新設、 `⌘ \\ Toggle sidebar` の row を追加
  - 既存の Navigation / Help group は不変

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)
- ✅ frontend unit (61 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 45 PRs

## Risk / Impact

- 影響範囲: Hotkey Overlay markup のみ
- 互換性: 既存 hotkey / cheat sheet 不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Layout" section to the hotkey reference overlay with the "Toggle sidebar" command mapped to ⌘ \\.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->