### PR TITLE
docs: SPEC-2356 — README に Cmd+backslash sidebar toggle を追記

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -269,6 +269,7 @@ Contrast) では system colors にフォールバックします。
 | `⌘G` | Git (Branches) サーフェスを focus |
 | `⌘L` | Logs サーフェスを focus |
 | `⌘?` | Hotkey Overlay (cheat sheet) を toggle |
+| `⌘\` | Sidebar Layers を折り畳み / 復帰 |
 | `Esc` | 開いている Palette / Overlay / Drawer を閉じる |
 
 ## SPEC と runtime クイックリファレンス

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ falls back to system colors so accessibility is preserved.
 | `⌘G` | Focus the Git (Branches) surface |
 | `⌘L` | Focus the Logs surface |
 | `⌘?` | Toggle the Hotkey Overlay (cheat sheet) |
+| `⌘\` | Collapse / expand the Sidebar Layers |
 | `Esc` | Close any open palette / overlay / drawer |
 
 ## SPEC and Runtime Quick Reference


### PR DESCRIPTION
## Summary

PR #2418 で導入した `Cmd+\` Sidebar Layers toggle を README.md / README.ja.md の hotkey 表にも追加。 ユーザー導線で hotkey 一覧を引いた時に発見できるようにする。

## Changes

- `d81dc58b` — README hotkey 表 update
  - 英日両方に `⌘\` の row を追加

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 46 PRs

## Risk / Impact

- 影響範囲: README 2 行の追記のみ
- 互換性: 不変

## Checklist

- [x] PR title follows Conventional Commits
- [x] Both README localisations updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
