### PR TITLE
test(ui): SPEC-2356 — chrome structure asserts hotkey overlay layout group + Cmd+backslash

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -128,12 +128,18 @@ test("Branches remains a branch browser, not a planning workspace", () => {
   );
 });
 
-test("hotkey overlay lists ⌘P/⌘B/⌘G/⌘L/⌘?/Esc", () => {
+test("hotkey overlay lists ⌘P/⌘B/⌘G/⌘L/⌘?/Esc plus the layout toggle", () => {
   const overlay = document.getElementById("op-hotkey-overlay");
   assert.ok(overlay, "hotkey overlay missing");
   const text = overlay.textContent.replace(/\s+/g, " ");
-  for (const phrase of ["⌘ P", "⌘ B", "⌘ G", "⌘ L", "⌘ K", "⌘ ?", "Esc"]) {
+  for (const phrase of ["⌘ P", "⌘ B", "⌘ G", "⌘ L", "⌘ K", "⌘ ?", "⌘ \\", "Esc"]) {
     assert.ok(text.includes(phrase), `expected ${phrase} in hotkey overlay`);
+  }
+  const groups = Array.from(overlay.querySelectorAll(".op-hotkey-card__group-title")).map((el) =>
+    el.textContent?.trim().toLowerCase(),
+  );
+  for (const expected of ["navigation", "layout", "help"]) {
+    assert.ok(groups.includes(expected), `expected hotkey overlay group "${expected}", got ${groups.join("/")}`);
   }
 });
 


### PR DESCRIPTION
## Summary

SPEC-2356 chrome-structure test 拡張: PR #2418 / #2419 で導入した `⌘\` Sidebar collapse hotkey とそれを記載した "Layout" group が Hotkey Overlay に存在することを assertion で lockin。

## Changes

- `f582f6dc` — chrome structure assertion update
  - `hotkey overlay lists ⌘P/⌘B/⌘G/⌘L/⌘?/Esc` test に `⌘ \` を追加
  - "Navigation" / "Layout" / "Help" group titles の存在 assertion を追加

## Testing

- ✅ `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` (15 件 pass)
- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 47 PRs

## Risk / Impact

- 影響範囲: chrome-structure test ファイル only
- 互換性: 既存テスト assertion を strict 化 + 追加 assertion

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
