### PR TITLE
feat(ui): SPEC-2356 follow-up — micro hover transitions on Operator row buttons

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1613,3 +1613,30 @@ kbd.op-kbd {
     transition: none;
   }
 }
+
+/* SPEC-2356 — micro motion on hover for the few row-style buttons that
+   take a click action. Smooth enough not to be distracting but clearly
+   responsive. reduced-motion env keeps the original snap. */
+:root[data-theme] .recent-project-row,
+:root[data-theme] .preset-button,
+:root[data-theme] .live-session-button,
+:root[data-theme] .launch-choice-button,
+:root[data-theme] .arrange-button,
+:root[data-theme] .add-button,
+:root[data-theme] .wizard-button {
+  transition: background var(--motion-fast) var(--motion-curve),
+              border-color var(--motion-fast) var(--motion-curve),
+              color var(--motion-fast) var(--motion-curve);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme] .recent-project-row,
+  :root[data-theme] .preset-button,
+  :root[data-theme] .live-session-button,
+  :root[data-theme] .launch-choice-button,
+  :root[data-theme] .arrange-button,
+  :root[data-theme] .add-button,
+  :root[data-theme] .wizard-button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の motion polish: row 系 button (recent-project / preset / live-session / launch-choice / arrange / add / wizard) の hover で background / border-color / color が **120ms ease で滑らかに変化** する。 reduced-motion 環境では snap を保証。

## Changes

- `b8ef7e68` — row hover transitions
  - 7 種の button class に `transition: background/border-color/color var(--motion-fast) var(--motion-curve)`
  - prefers-reduced-motion: reduce で transition off

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 49 PRs

## Risk / Impact

- 影響範囲: components.css の transition rule のみ
- 互換性: snap → 120ms smooth に変更、 reduced-motion で snap 維持

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
