### PR TITLE
feat(ui): SPEC-2356 follow-up — soften theme-switch with cross-fade on chrome surfaces

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1640,3 +1640,31 @@ kbd.op-kbd {
     transition: none;
   }
 }
+
+/* SPEC-2356 — soften theme-switch by transitioning core surface tokens.
+   When the user flips dark↔light through the toggle or ⌘ command, the
+   chrome doesn't snap; surface backgrounds + text colours fade through
+   the change in 200ms. reduced-motion / forced-colors keep the snap. */
+:root[data-theme] body,
+:root[data-theme] .op-sidebar,
+:root[data-theme] .op-status-strip,
+:root[data-theme] .project-bar,
+:root[data-theme] .modal-shell,
+:root[data-theme] .workspace-window,
+:root[data-theme] .titlebar {
+  transition: background var(--motion-medium) var(--motion-curve),
+              color var(--motion-medium) var(--motion-curve),
+              border-color var(--motion-medium) var(--motion-curve);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme] body,
+  :root[data-theme] .op-sidebar,
+  :root[data-theme] .op-status-strip,
+  :root[data-theme] .project-bar,
+  :root[data-theme] .modal-shell,
+  :root[data-theme] .workspace-window,
+  :root[data-theme] .titlebar {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の motion polish: theme トグル / `theme-cycle` で dark↔light が切替わるとき、 各 chrome surface の背景 / 文字 / ボーダーが **200ms ease で滑らかに cross-fade** する。 snap 切替のハードな印象を緩和し、 Operator chrome の "通電" 感を保つ。

## Changes

- `60dce485` — theme switch cross-fade
  - 対象: body / .op-sidebar / .op-status-strip / .project-bar / .modal-shell / .workspace-window / .titlebar
  - `transition: background/color/border-color var(--motion-medium) var(--motion-curve)`
  - prefers-reduced-motion: reduce で transition off (NFR-008 の "≤ 200ms" 整合)

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 50 PRs

## Risk / Impact

- 影響範囲: chrome surface の transition のみ
- 互換性: snap → 200ms cross-fade、 reduced-motion で snap 維持

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added smooth transitions when switching themes across the interface, enhancing visual consistency across all components.
  * Respects accessibility preferences by disabling animations for users with reduced motion enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->