### PR TITLE
feat(ui): SPEC-2356 follow-up — OPERATOR ONLINE marker gains cyan glow

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -943,6 +943,9 @@ kbd.op-kbd {
   font-size: var(--type-md);
   text-transform: uppercase;
   opacity: 0;
+  /* SPEC-2356 — soft cyan glow on the OPERATOR ONLINE marker so it reads
+     as the boot complete signal. */
+  text-shadow: 0 0 12px color-mix(in oklab, var(--color-state-active) 60%, transparent);
   animation: op-briefing-online-in var(--motion-slow) ease-out forwards;
   animation-delay: calc(var(--motion-slow) * 4);
 }


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Mission Briefing detail polish: "OPERATOR ONLINE" マーカーに 12px の cyan text-shadow を加える。 boot complete signal が一段強く読み取れる、 mission-control の決め台詞らしい印象に。

## Changes

- `9a2e3245` — OPERATOR ONLINE glow
  - `.op-briefing__online`: `text-shadow: 0 0 12px color-mix(in oklab, var(--color-state-active) 60%, transparent)`

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 52 PRs

## Risk / Impact

- 影響範囲: `.op-briefing__online` の text-shadow only
- 互換性: forced-colors では text-shadow が無視される

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
