### PR TITLE
fix(ui): SPEC-2356 follow-up — Mission Briefing splash accepts click + shows pointer cursor

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -892,7 +892,12 @@ kbd.op-kbd {
   font-family: var(--font-mono);
   color: var(--color-text-muted);
   font-size: var(--type-sm);
-  pointer-events: none;
+  /* SPEC-2356 — splash should accept click-to-dismiss (`pointer-events`
+     auto) but the cursor hints at the affordance. The hidden state still
+     uses `display: none` from the [hidden] attr, so events stop firing
+     once the splash is exited. */
+  pointer-events: auto;
+  cursor: pointer;
   opacity: 1;
   transition: opacity var(--motion-slow) var(--motion-curve);
 }


### PR DESCRIPTION
## Summary

PR #2427 で追加した Mission Briefing の click-to-dismiss が実際に発火するよう、 `.op-briefing` の `pointer-events` を `none` → `auto` に修正し、 ユーザーに affordance を伝える `cursor: pointer` を追加する。

旧仕様では splash 自体が `pointer-events: none` だったため、 click が要素に届かず click 早期 dismiss が発火していなかった。

## Changes

- `173dbde6` — pointer-events fix
  - `.op-briefing`: `pointer-events: none` → `auto`、 `cursor: pointer` 追加
  - hidden 状態は既存の `[hidden]` で `display: none` されるため event 停止保証

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 54 PRs
- #2427 (click-to-dismiss を機能させる必要なフォロー)

## Risk / Impact

- 影響範囲: `.op-briefing` の pointer-events / cursor
- 互換性: splash 表示中の 1450ms (reduced-motion で 250ms) は canvas クリックが届かなくなるが、 splash 自体が click で即時消えるため net で UX 改善

## Checklist

- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
