### PR TITLE
feat(ui): SPEC-2356 follow-up — collapsed sidebar shows accent strip on Project Bar

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1682,3 +1682,23 @@ kbd.op-kbd {
     transition: none;
   }
 }
+
+/* SPEC-2356 — when sidebar is collapsed, the chrome should hint the
+   "expand" affordance via a small accent strip on the left edge of the
+   project bar, so users with no kbd shortcut memory still notice the
+   sidebar can come back. */
+:root[data-theme][data-op-sidebar="collapsed"] .project-bar {
+  box-shadow: inset 3px 0 0 var(--color-state-active);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme][data-op-sidebar="collapsed"] .project-bar {
+    box-shadow: inset 3px 0 0 var(--color-state-active);
+  }
+}
+
+@media (forced-colors: active) {
+  :root[data-theme][data-op-sidebar="collapsed"] .project-bar {
+    box-shadow: inset 3px 0 0 Highlight;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の affordance polish: `⌘\` で sidebar が collapsed の時、 Project Bar の左端に 3px accent line を表示して "expand" affordance を hint する。 ⌘\ を覚えていない user でも sidebar が hidden 状態にあることを視覚的に認識できる。

## Changes

- `68c5aa7d` — collapsed sidebar accent strip
  - `:root[data-theme][data-op-sidebar="collapsed"] .project-bar`: `box-shadow: inset 3px 0 0 var(--color-state-active)`
  - forced-colors では `Highlight` system color にフォールバック

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 55 PRs

## Risk / Impact

- 影響範囲: collapsed 状態の Project Bar `box-shadow` のみ
- 互換性: collapsed 状態は新規追加 (PR #2418 で導入)、 既存 expanded 状態には影響なし

## Checklist

- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
