### PR TITLE
test(ui): SPEC-2356 — assert Project Bar brand prefix and Mission Briefing dismiss affordance

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -222,3 +222,20 @@ test("Command Palette trigger button declares aria-keyshortcuts", () => {
   assert.ok(shortcut.includes("Meta+K"), "trigger must declare Meta+K");
   assert.ok(shortcut.includes("Meta+P"), "trigger must declare Meta+P");
 });
+
+test("Project Bar brand prefix wraps GWT OPERATOR with bracket flank", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  // The pseudo-element content lives only in CSS, not in the DOM, so we
+  // assert the rule itself contains the bracket-flanked brand string.
+  const projectBarBefore = css.match(/\.project-bar::before\s*\{[\s\S]*?\}/);
+  assert.ok(projectBarBefore, "expected .project-bar::before rule");
+  assert.match(projectBarBefore[0], /content:\s*"⌜ GWT · OPERATOR ⌟"/);
+});
+
+test("Mission Briefing splash has dismissible affordance (pointer-events + cursor)", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  const briefing = css.match(/\.op-briefing\s*\{[\s\S]*?\}/);
+  assert.ok(briefing, "expected .op-briefing rule");
+  assert.match(briefing[0], /pointer-events:\s*auto/);
+  assert.match(briefing[0], /cursor:\s*pointer/);
+});


### PR DESCRIPTION
## Summary

SPEC-2356 chrome-structure test 拡張: PR #2425 (Project Bar bracket-flank brand) + PR #2428 (Mission Briefing pointer-events fix) で導入した契約を chrome-structure テストで lockin。 frontend test assertions 16 → 17 件に増加。

## Changes

- `cb3931e4` — chrome assertions for brand + dismissibility
  - `.project-bar::before` の content が `⌜ GWT · OPERATOR ⌟` を含む assertion
  - `.op-briefing` が `pointer-events: auto` + `cursor: pointer` を持つ assertion (click-to-dismiss が動作する保証)

## Testing

- ✅ `node --test operator-chrome-structure.test.mjs` (17 件 GREEN)
- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 56 PRs
- #2425 / #2428 (lockin 対象)

## Risk / Impact

- 影響範囲: chrome-structure test ファイル only

## Checklist

- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
