### PR TITLE
feat(ui): SPEC-2356 follow-up — active project tab gets bottom accent strip

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1711,3 +1711,34 @@ kbd.op-kbd {
   color: var(--color-state-active);
   font-weight: 700;
 }
+
+/* SPEC-2356 — Project Tab active-state subtle accent strip on the bottom
+   so the active project reads as "currently selected" with the same
+   visual vocabulary as the Project Bar accent line. */
+:root[data-theme] .project-tab.active {
+  position: relative;
+}
+
+:root[data-theme] .project-tab.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    var(--color-state-active) 25%,
+    var(--color-state-active) 75%,
+    transparent 100%
+  );
+  border-radius: 2px;
+  pointer-events: none;
+}
+
+@media (forced-colors: active) {
+  :root[data-theme] .project-tab.active::after {
+    background: Highlight;
+  }
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Project Tab visibility polish: active な project tab に底辺 2px の cyan accent strip を表示し、 chrome の "currently selected" 視認性を向上。 Project Bar 自体の accent line と同じ visual vocabulary で gradient フェード。

## Changes

- `e75598b0` — active project tab accent strip
  - `.project-tab.active::after`: bottom -1px 高さ 2px の linear-gradient (transparent → state-active 25% → 75% → transparent)
  - forced-colors: active で `Highlight` system color にフォールバック

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 58 PRs

## Risk / Impact

- 影響範囲: `.project-tab.active::after` のみ
- 互換性: visible behavior 変化なし、 active tab がより明示的に

## Checklist

- [x] PR title follows Conventional Commits
- [x] No raw colour literals introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
