### PR TITLE
feat(ui): SPEC-2356 follow-up — theme toggle exposes live preference via aria-label

### DIFF
--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -43,6 +43,11 @@ function wireThemeToggle({ doc, themeManager }) {
     value.textContent = pref === "auto"
       ? `AUTO ${eff === "dark" ? "▮" : "▯"}`
       : pref.toUpperCase();
+    // SPEC-2356 — expose the live preference to assistive tech.
+    btn.setAttribute(
+      "aria-label",
+      `Theme: ${pref === "auto" ? `auto (currently ${eff})` : pref}. Click to cycle.`,
+    );
   };
 
   renderLabel();


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の accessibility polish: Theme toggle ボタンの `aria-label` を preference 変更のたびに動的に更新する。 `Theme: auto (currently dark). Click to cycle.` のように現在の preference / effective theme / 操作後の予測動作を screen reader に伝える。

## Changes

- `a9d9dec8` — theme toggle aria-label update on each render
  - `wireThemeToggle.renderLabel()` 内で `aria-label` を毎回再生成

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)
- ✅ frontend bundle GREEN

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 59 PRs

## Risk / Impact

- 影響範囲: theme toggle aria-label のみ
- 互換性: visible behavior 不変
- アクセシビリティ: screen reader users が現在の theme 状態と次に押した時の動作を即座に知れる

## Checklist

- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
