### PR TITLE
test(ui): SPEC-2356 — assert operator-shell wires for theme aria, sidebar hotkey, briefing dismiss

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -239,3 +239,38 @@ test("Mission Briefing splash has dismissible affordance (pointer-events + curso
   assert.match(briefing[0], /pointer-events:\s*auto/);
   assert.match(briefing[0], /cursor:\s*pointer/);
 });
+
+test("operator-shell wires theme toggle aria-label updates on every render", () => {
+  const operatorShell = readFileSync(resolve(here, "../operator-shell.js"), "utf8");
+  // wireThemeToggle.renderLabel must update aria-label every render so
+  // screen readers know the live preference + effective theme.
+  assert.match(
+    operatorShell,
+    /btn\.setAttribute\(\s*"aria-label"/,
+    "expected wireThemeToggle to update aria-label on every render",
+  );
+  assert.match(
+    operatorShell,
+    /Theme: \$\{pref === "auto" \? `auto/,
+    "expected aria-label format to disclose preference + effective theme",
+  );
+});
+
+test("operator-shell wires sidebar collapse hotkey and Mission Briefing early dismiss", () => {
+  const operatorShell = readFileSync(resolve(here, "../operator-shell.js"), "utf8");
+  // The source contains `cmd+\\\\` (escaped backslash in JS source).
+  assert.ok(
+    operatorShell.includes('hotkey.register("cmd+\\\\"'),
+    "expected Cmd+backslash hotkey registration for sidebar collapse",
+  );
+  assert.match(
+    operatorShell,
+    /opSidebar\s*===\s*"collapsed"/,
+    "expected collapsed state toggle on documentElement.dataset.opSidebar",
+  );
+  assert.match(
+    operatorShell,
+    /earlyDismiss/,
+    "expected Mission Briefing earlyDismiss helper",
+  );
+});


### PR DESCRIPTION
## Summary

SPEC-2356 chrome-structure test 拡張: operator-shell.js の最近の PR (#2418, #2427, #2433) で導入した実装契約を chrome-structure テストで lockin。 future の編集で wiring が外れない。

## Changes

- `e72a6152` — operator-shell wiring assertions
  - `wireThemeToggle.renderLabel()` 内 `aria-label` 毎回更新の実装 (#2433)
  - `cmd+\` (Cmd+backslash) hotkey + `dataset.opSidebar === "collapsed"` toggle (#2418)
  - `earlyDismiss` ヘルパ存在 (#2427)

frontend-unit 総 assertions 数 61 → 63 件に増加。

## Testing

- ✅ `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` (19 件 GREEN)
- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 60 PRs
- #2418 / #2427 / #2433 (lockin 対象)

## Risk / Impact

- 影響範囲: chrome-structure test ファイル only

## Checklist

- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
