### PR TITLE
feat(ui): SPEC-2356 follow-up — Project Tab hover bottom indicator

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1742,3 +1742,23 @@ kbd.op-kbd {
     background: Highlight;
   }
 }
+
+/* SPEC-2356 — Project Tab hover bottom indicator
+   active tab gets a strong accent strip already; hovered (non-active)
+   tabs get a soft hint so the user knows tab switching is possible.
+   Keeps Mission Control visual vocabulary consistent. */
+:root[data-theme] .project-tab:hover:not(.active)::after {
+  content: "";
+  position: absolute;
+  left: 25%;
+  right: 25%;
+  bottom: -1px;
+  height: 1px;
+  background: color-mix(in oklab, var(--color-state-active) 50%, transparent);
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+:root[data-theme] .project-tab {
+  position: relative;
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の Project Tab affordance polish: active 以外の project tab の hover 時に弱い 1px cyan accent strip を表示し、 tab switching が可能なことを hint する。 active tab はすでに 2px 強い accent を持つので階層的に読み取れる。

## Changes

- `2caf1cdc` — Project Tab hover indicator
  - `.project-tab:hover:not(.active)::after`: bottom 1px, 中央 25%-75% に `color-mix(in oklab, var(--color-state-active) 50%, transparent)` 帯
  - `.project-tab` に `position: relative` 確保 (`.active::after` と同 anchor)

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 61 PRs

## Risk / Impact

- 影響範囲: project-tab hover styling のみ
- 互換性: 既存 active accent は不変

## Checklist

- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
