### PR TITLE
feat(ui): SPEC-2356 follow-up — add op-divider utility class for token-driven separators

### DIFF
--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1762,3 +1762,29 @@ kbd.op-kbd {
 :root[data-theme] .project-tab {
   position: relative;
 }
+
+/* SPEC-2356 — Operator divider utility class.
+   `.op-divider` renders a 1px horizontal line that picks up the
+   `--color-border` token. Use it in dialogs / drawers / panels to
+   carve sections apart while staying token-driven. The vertical
+   variant `.op-divider--vertical` is 1px wide for inline use. */
+:root[data-theme] .op-divider {
+  display: block;
+  width: 100%;
+  height: 1px;
+  background: var(--color-border);
+  border: 0;
+  margin: var(--space-2) 0;
+}
+
+:root[data-theme] .op-divider--strong {
+  background: var(--color-border-strong);
+}
+
+:root[data-theme] .op-divider--vertical {
+  display: inline-block;
+  width: 1px;
+  height: 1em;
+  margin: 0 var(--space-2);
+  vertical-align: middle;
+}


### PR DESCRIPTION
## Summary

SPEC-2356 Operator Design System の utility expansion: 将来の sub-component で使えるよう divider utility class を整備する。 `.op-divider` (1px 水平線) / `.op-divider--strong` (border-strong) / `.op-divider--vertical` (1px inline 縦線) すべて tokens 駆動。

## Changes

- `6e83768c` — op-divider utility
  - `.op-divider`: 1px 水平 + `--color-border` + space-2 margin
  - `.op-divider--strong`: `--color-border-strong` で強め
  - `.op-divider--vertical`: 1px 縦 inline + space-2 horizontal margin

## Testing

- ✅ `cargo test -p gwt` (391 + 202 件 GREEN)

## Closing Issues

None (SPEC-2356 polish 連続)

## Related Issues

- #2356 SPEC-2356 + 直近 62 PRs

## Risk / Impact

- 影響範囲: components.css に utility rules 追加のみ
- 互換性: 既存 markup には影響なし、 opt-in utility

## Checklist

- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
