### PR TITLE
feat(ui): SPEC-2356 — Status Strip cells tint with their state color

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -296,6 +296,29 @@ test("components.css uses op-divider utility class", () => {
   assert.match(css, /\.op-divider--strong/);
 });
 
+test("mapAgentTelemetryState emits only the four Living Telemetry states CSS handles", () => {
+  // app.js has a closure-scoped runtime→Living Telemetry mapper. CSS only
+  // styles `[data-agent-state]` for active/idle/blocked/done — any drift
+  // (e.g. emitting "warn" or "exited") would silently render no rim. Pin
+  // the contract so refactors can't introduce undeclared states.
+  const mapperBlock = appSource.match(
+    /function\s+mapAgentTelemetryState\s*\([^)]*\)\s*\{[\s\S]*?\n\s{6,8}\}/,
+  );
+  assert.ok(mapperBlock, "expected mapAgentTelemetryState to be defined in app.js");
+  const returnedStates = new Set();
+  for (const m of mapperBlock[0].matchAll(/return\s+"([^"]+)"/g)) {
+    returnedStates.add(m[1]);
+  }
+  const allowed = new Set(["active", "idle", "blocked", "done"]);
+  for (const state of returnedStates) {
+    assert.ok(allowed.has(state), `mapAgentTelemetryState returned undeclared state: ${state}`);
+  }
+  // And the four design states must all be reachable, not just allowed.
+  for (const required of allowed) {
+    assert.ok(returnedStates.has(required), `Living Telemetry state never emitted: ${required}`);
+  }
+});
+
 test("Status Strip ACTIVE / IDLE / BLOCKED cells all tint with their state color", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
   // The ACTIVE / IDLE cells previously had no tonal hint — only BLOCKED did.

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -296,6 +296,20 @@ test("components.css uses op-divider utility class", () => {
   assert.match(css, /\.op-divider--strong/);
 });
 
+test("Status Strip ACTIVE / IDLE / BLOCKED cells all tint with their state color", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  // The ACTIVE / IDLE cells previously had no tonal hint — only BLOCKED did.
+  // Add parallel symmetry so the three count cells render with matching state
+  // colors (cyan / gray / red) for at-a-glance scanning.
+  assert.match(css, /\.op-status-strip__cell--active\s+\.op-status-strip__value\s*\{[^}]*--color-state-active/);
+  assert.match(css, /\.op-status-strip__cell--idle\s+\.op-status-strip__value\s*\{[^}]*--color-state-idle/);
+  assert.match(css, /\.op-status-strip__cell--blocked\s+\.op-status-strip__value\s*\{[^}]*--color-state-blocked/);
+  // Markup also needs the modifiers wired so the CSS selectors actually match.
+  const indexHtml = readFileSync(resolve(here, "../index.html"), "utf8");
+  assert.match(indexHtml, /op-status-strip__cell\s+op-status-strip__cell--active/);
+  assert.match(indexHtml, /op-status-strip__cell\s+op-status-strip__cell--idle/);
+});
+
 test("agent cards style all four Living Telemetry states (active / blocked / idle / done)", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
   // Each of the four states must have a distinct visual treatment so operators

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3067,11 +3067,11 @@
             <span class="op-status-strip__live-dot" aria-hidden="true"></span>
             <span class="op-status-strip__label">LIVE</span>
           </div>
-          <div class="op-status-strip__cell">
+          <div class="op-status-strip__cell op-status-strip__cell--active">
             <span class="op-status-strip__label">ACTIVE</span>
             <span class="op-status-strip__value" id="op-strip-active" aria-label="Active agents">0</span>
           </div>
-          <div class="op-status-strip__cell">
+          <div class="op-status-strip__cell op-status-strip__cell--idle">
             <span class="op-status-strip__label">IDLE</span>
             <span class="op-status-strip__value" id="op-strip-idle" aria-label="Idle agents">0</span>
           </div>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -495,6 +495,14 @@ body::after {
   50% { opacity: 0.4; transform: scale(0.85); }
 }
 
+.op-status-strip__cell--active .op-status-strip__value {
+  color: var(--color-state-active);
+}
+
+.op-status-strip__cell--idle .op-status-strip__value {
+  color: var(--color-state-idle);
+}
+
 .op-status-strip__cell--blocked .op-status-strip__value {
   color: var(--color-state-blocked);
 }


### PR DESCRIPTION
## Summary
- **Status Strip cells**: ACTIVE / IDLE / BLOCKED all tint their value with the matching state color (cyan / gray / red) — previously only BLOCKED had a tonal hint, so the three count cells now form a coordinated state row at-a-glance
- **Markup**: `op-status-strip__cell--active` / `--idle` modifiers added so the new selectors actually match
- **Cross-surface symmetry**: harmonizes with the agent card chip foreground colors merged in PR #2438 — same state palette in both surfaces
- **Mapper contract pinned**: chrome-structure assertion verifies `mapAgentTelemetryState` (app.js) emits exactly the four CSS-handled states (active / idle / blocked / done). Catches refactor drift that could silently break rim animation.
- **op-drawer reduced-motion parity**: forward-looking `.op-drawer` / `.op-drawer-backdrop` scaffold previously slid regardless of motion preference. Now drops `transition` under `prefers-reduced-motion: reduce`, matching the legacy `.modal-backdrop.is-drawer` adapter. Pinned via assertion.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2438 (paired surface — agent cards)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 26 件 GREEN (+3 件 new assertions)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN
- [x] forced-colors fallback already covered by tokens.css

🤖 Generated with [Claude Code](https://claude.com/claude-code)
