### PR TITLE
feat(ui): SPEC-2356 — a11y polish (combobox / dialog focus / drawer reduced-motion)

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -296,6 +296,21 @@ test("components.css uses op-divider utility class", () => {
   assert.match(css, /\.op-divider--strong/);
 });
 
+test("Hotkey overlay manages focus on open / close (modal dialog a11y)", () => {
+  // The dialog must be focusable so we can move focus inside on open and
+  // return it to the trigger on close — without this, screen readers don't
+  // announce the dialog and keyboard users get stranded after Esc.
+  const card = document.querySelector("#op-hotkey-overlay .op-hotkey-card");
+  assert.ok(card, "expected hotkey overlay card");
+  assert.equal(card.getAttribute("tabindex"), "-1");
+  assert.equal(card.getAttribute("role"), "dialog");
+  assert.equal(card.getAttribute("aria-modal"), "true");
+  // operator-shell.js wires the dynamic focus pieces.
+  assert.match(operatorShellSource, /returnFocusTo\s*=\s*doc\.activeElement/);
+  assert.match(operatorShellSource, /card\.focus\(\{\s*preventScroll:\s*true\s*\}\)/);
+  assert.match(operatorShellSource, /returnFocusTo\.focus/);
+});
+
 test("Command Palette implements the WAI-ARIA combobox/listbox pattern", () => {
   // The input must be a combobox that controls the list and announces the
   // active option via aria-activedescendant. Without these the listbox role

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -296,6 +296,27 @@ test("components.css uses op-divider utility class", () => {
   assert.match(css, /\.op-divider--strong/);
 });
 
+test("Command Palette implements the WAI-ARIA combobox/listbox pattern", () => {
+  // The input must be a combobox that controls the list and announces the
+  // active option via aria-activedescendant. Without these the listbox role
+  // already on the <ul> is meaningless to screen readers.
+  const paletteInput = document.querySelector("#op-palette-input");
+  assert.ok(paletteInput, "expected palette input");
+  assert.equal(paletteInput.getAttribute("role"), "combobox");
+  assert.equal(paletteInput.getAttribute("aria-controls"), "op-palette-list");
+  assert.equal(paletteInput.getAttribute("aria-autocomplete"), "list");
+  // aria-expanded starts false; operator-shell flips it on open/close.
+  assert.equal(paletteInput.getAttribute("aria-expanded"), "false");
+  assert.match(paletteInput.getAttribute("aria-label") ?? "", /command/i);
+  // operator-shell.js must wire the dynamic pieces.
+  assert.match(operatorShellSource, /input\.setAttribute\("aria-expanded",\s*"true"\)/);
+  assert.match(operatorShellSource, /input\.setAttribute\("aria-activedescendant"/);
+  assert.match(operatorShellSource, /input\.removeAttribute\("aria-activedescendant"\)/);
+  assert.match(operatorShellSource, /li\.setAttribute\("role",\s*"option"\)/);
+  assert.match(operatorShellSource, /li\.setAttribute\("aria-selected"/);
+  assert.match(operatorShellSource, /li\.id\s*=\s*`op-palette-row-\$\{idx\}`/);
+});
+
 test("op-drawer scaffold honors prefers-reduced-motion (parity with legacy is-drawer modal)", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
   // The legacy `.modal-backdrop.is-drawer .modal-shell.is-drawer-shell` already

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -296,6 +296,22 @@ test("components.css uses op-divider utility class", () => {
   assert.match(css, /\.op-divider--strong/);
 });
 
+test("op-drawer scaffold honors prefers-reduced-motion (parity with legacy is-drawer modal)", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  // The legacy `.modal-backdrop.is-drawer .modal-shell.is-drawer-shell` already
+  // suppresses its slide transform under reduced-motion. The forward-looking
+  // op-drawer scaffold needed parity — without this guard, future direct
+  // adoption would slide in even for users who opted out of motion.
+  const reducedMotionBlocks = css.match(
+    /@media\s*\(\s*prefers-reduced-motion:\s*reduce\s*\)\s*\{[\s\S]*?\n\}/g,
+  );
+  assert.ok(reducedMotionBlocks, "expected at least one prefers-reduced-motion block");
+  const opDrawerCovered = reducedMotionBlocks.some(
+    (block) => /\.op-drawer\b/.test(block) && /transition:\s*none/.test(block),
+  );
+  assert.ok(opDrawerCovered, ".op-drawer scaffold must drop its transition under reduced-motion");
+});
+
 test("mapAgentTelemetryState emits only the four Living Telemetry states CSS handles", () => {
   // app.js has a closure-scoped runtime→Living Telemetry mapper. CSS only
   // styles `[data-agent-state]` for active/idle/blocked/done — any drift

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3130,6 +3130,11 @@
             placeholder="Run a command…"
             autocomplete="off"
             data-hotkey-override="true"
+            role="combobox"
+            aria-controls="op-palette-list"
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Search commands"
           />
           <ul class="op-palette__list" id="op-palette-list" role="listbox"></ul>
         </div>

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3145,6 +3145,7 @@
           role="dialog"
           aria-modal="true"
           aria-label="Hotkey reference"
+          tabindex="-1"
         >
           <h2 class="op-hotkey-card__title">Operator Hotkeys</h2>
           <div class="op-hotkey-card__group">

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -249,14 +249,29 @@ function wireMissionBriefing({ doc, win }) {
 function wireHotkeyOverlay({ doc, hotkey }) {
   const overlay = doc.getElementById("op-hotkey-overlay");
   if (!overlay) return;
+  const card = overlay.querySelector(".op-hotkey-card");
+
+  // SPEC-2356 — modal-dialog focus management: remember the trigger so we can
+  // restore focus on close, and move focus into the dialog on open so screen
+  // readers announce "Hotkey reference dialog" instead of staying on whatever
+  // surface invoked ⌘?.
+  let returnFocusTo = null;
 
   const open = () => {
+    returnFocusTo = doc.activeElement instanceof Element ? doc.activeElement : null;
     overlay.dataset.open = "true";
     overlay.removeAttribute("aria-hidden");
+    if (card) {
+      try { card.focus({ preventScroll: true }); } catch { card.focus(); }
+    }
   };
   const close = () => {
     delete overlay.dataset.open;
     overlay.setAttribute("aria-hidden", "true");
+    if (returnFocusTo && typeof returnFocusTo.focus === "function") {
+      try { returnFocusTo.focus({ preventScroll: true }); } catch { returnFocusTo.focus(); }
+    }
+    returnFocusTo = null;
   };
 
   overlay.addEventListener("click", (e) => {

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -295,6 +295,9 @@ function wireCommandPalette({ doc, hotkey }) {
   function open() {
     overlay.dataset.open = "true";
     overlay.removeAttribute("aria-hidden");
+    // SPEC-2356 — combobox accessibility: announce that the popup is now open
+    // so screen readers attach the listbox to the input.
+    input.setAttribute("aria-expanded", "true");
     input.value = "";
     selectedIndex = 0;
     render();
@@ -304,6 +307,8 @@ function wireCommandPalette({ doc, hotkey }) {
   function close() {
     delete overlay.dataset.open;
     overlay.setAttribute("aria-hidden", "true");
+    input.setAttribute("aria-expanded", "false");
+    input.removeAttribute("aria-activedescendant");
     if (doc.activeElement === input) input.blur();
   }
 
@@ -338,6 +343,11 @@ function wireCommandPalette({ doc, hotkey }) {
         li.className = "op-palette__row";
         li.dataset.index = String(idx);
         li.dataset.selected = idx === selectedIndex ? "true" : "false";
+        // SPEC-2356 — combobox/listbox a11y: each row is an option with a
+        // stable id so the input can target it via aria-activedescendant.
+        li.id = `op-palette-row-${idx}`;
+        li.setAttribute("role", "option");
+        li.setAttribute("aria-selected", idx === selectedIndex ? "true" : "false");
         li.innerHTML = `<span></span><span class="op-palette__hint"></span>`;
         li.firstChild.textContent = a.label;
         li.lastChild.textContent = a.hint ?? "";
@@ -360,9 +370,17 @@ function wireCommandPalette({ doc, hotkey }) {
   function updateSelection() {
     const rows = list.querySelectorAll(".op-palette__row");
     rows.forEach((row, i) => {
-      row.dataset.selected = i === selectedIndex ? "true" : "false";
-      if (i === selectedIndex) row.scrollIntoView({ block: "nearest" });
+      const isSelected = i === selectedIndex;
+      row.dataset.selected = isSelected ? "true" : "false";
+      row.setAttribute("aria-selected", isSelected ? "true" : "false");
+      if (isSelected) {
+        row.scrollIntoView({ block: "nearest" });
+        // SPEC-2356 — point the combobox input at the active option so screen
+        // readers announce the highlighted command without moving DOM focus.
+        input.setAttribute("aria-activedescendant", row.id);
+      }
     });
+    if (rows.length === 0) input.removeAttribute("aria-activedescendant");
   }
 
   function execute(action) {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -672,6 +672,13 @@ body::after {
   transform: translateX(0);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .op-drawer-backdrop,
+  .op-drawer {
+    transition: none;
+  }
+}
+
 .op-drawer__header {
   padding: var(--space-4);
   border-bottom: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
**Three accessibility/motion polish wins on the Operator chrome:**

### 1. Command Palette implements WAI-ARIA combobox/listbox
The palette previously had `role="listbox"` on the `<ul>` but lacked the partner attributes that make screen readers actually announce the highlighted command. The visual cyan highlight on the active row was effectively invisible to assistive tech.

- Input gets `role="combobox"`, `aria-controls="op-palette-list"`, `aria-autocomplete="list"`, `aria-expanded` (toggled on open/close), `aria-label="Search commands"`
- Each row gets `role="option"`, a stable id (`op-palette-row-N`), and `aria-selected="true|false"`
- `updateSelection()` points the input's `aria-activedescendant` at the selected row's id so the screen reader announces it **without moving DOM focus** (key constraint of the combobox pattern)
- `close()` clears `aria-activedescendant` and flips `aria-expanded` back to `false`

### 2. Hotkey overlay manages focus on open / close (modal dialog a11y)
Pressing ⌘? opened the dialog without moving focus into it. Screen readers stayed announcing whatever surface invoked the hotkey, and keyboard users pressing Esc were stranded.

- Card gains `tabindex="-1"` so it can be programmatically focused
- On open, save `document.activeElement` and move focus to the card with `preventScroll: true`
- On close, restore focus to the trigger
- Guards around `preventScroll` for older browser fallbacks

### 3. op-drawer scaffold honors prefers-reduced-motion
Forward-looking `.op-drawer` / `.op-drawer-backdrop` previously slid regardless of motion preference. Now drops `transition` under `prefers-reduced-motion: reduce`, matching the legacy `.modal-backdrop.is-drawer` adapter.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 28 件 GREEN (+3 件 new assertions)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN
- [x] forced-colors fallback already covered by tokens.css

🤖 Generated with [Claude Code](https://claude.com/claude-code)
