### PR TITLE
fix(ui): SPEC-2356 — Status Strip cell values clear WCAG AA in light theme

### DIFF
--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -47,6 +47,40 @@ for (const themeName of ["dark", "light"]) {
   }
 }
 
+// SPEC-2356 — Status Strip is a permanent dark chrome band. Its scoped state
+// palette in components.css must clear WCAG AA against both themes' strip bg.
+const STRIP_PALETTE = {
+  active: "#22d3ee",
+  idle: "#94a3b8",
+  blocked: "#f87171",
+};
+
+for (const themeName of ["dark", "light"]) {
+  const theme = themeName === "dark" ? dark : light;
+  for (const [stateName, color] of Object.entries(STRIP_PALETTE)) {
+    test(`[${themeName}] WCAG AA: status strip ${stateName} (${color}) on strip bg`, () => {
+      const bg = theme["--color-status-strip-bg"];
+      assert.ok(bg, `--color-status-strip-bg missing in ${themeName}`);
+      const ratio = contrastRatio(color, bg);
+      assert.ok(
+        ratio >= NORMAL_AA,
+        `strip ${stateName}: ratio ${ratio.toFixed(2)} < ${NORMAL_AA} (${color} on ${bg})`,
+      );
+    });
+  }
+}
+
+test("components.css scopes the on-strip state palette to bright on-dark variants", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  const stripBlock = css.match(/\.op-status-strip\s*\{([\s\S]*?)\n\}/);
+  assert.ok(stripBlock, "expected .op-status-strip block");
+  // The block must override --color-state-active/-idle/-blocked locally so
+  // the strip cell values render with AA-clearing colors regardless of theme.
+  assert.match(stripBlock[1], /--color-state-active:\s*#22d3ee/i);
+  assert.match(stripBlock[1], /--color-state-idle:\s*#94a3b8/i);
+  assert.match(stripBlock[1], /--color-state-blocked:\s*#f87171/i);
+});
+
 test("dark and light token sets define identical semantic keys", () => {
   const darkKeys = Object.keys(dark).sort();
   const lightKeys = Object.keys(light).sort();

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -455,6 +455,14 @@ body::after {
   border-top: 1px solid var(--color-border);
   z-index: 10;
   gap: var(--space-3);
+  /* SPEC-2356 — the strip bg is dark in BOTH themes (it is a permanent dark
+     chrome band). Scope the state-color tokens locally to bright on-dark
+     variants so cell value contrast clears WCAG AA in light theme too —
+     light theme's default state colors are tuned for light bg and would
+     otherwise fail (e.g. dark red blocked on dark strip bg = 2.6:1). */
+  --color-state-active: #22d3ee;
+  --color-state-idle: #94a3b8;
+  --color-state-blocked: #f87171;
 }
 
 .op-status-strip__cell {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,50 @@
 # Lessons Learned
 
+## 2026-05-04 — Chrome-structure assertions alone don't catch contrast regressions
+
+### 事象
+
+SPEC-2356 polish iteration の PR #2439 で、Status Strip の ACTIVE / IDLE
+セルに state-color tinting を追加した。chrome-structure assertions で
+「`color: var(--color-state-*)` が定義されていること」を機械的に検証して
+GREEN になったため merge した。しかし light-theme で実際に rendering を
+確認すると、IDLE = 3.49:1 / ACTIVE = 3.15:1 / BLOCKED = 2.61:1 と
+すべて WCAG AA (4.5:1) を下回っていた。BLOCKED の 2.61:1 は PR #2439 で
+新規導入した訳ではなく、それ以前から存在した既存バグだったが、PR #2439
+が assertion で「現状維持」をロックインしてしまった。
+
+### 原因
+
+Status Strip の bg は dark/light 両テーマで dark (`#050709` / `#1a1d24`)
+である一方、`--color-state-*` トークンは theme 別に「その theme の bg
+に合う色」として tuned されていた。light-theme の state-* は light bg
+向けの暗い saturated 色で、dark な strip bg に重ねると contrast が
+急落する。chrome-structure tests は「セレクタとプロパティが存在するか」
+しか検証していなかったため、実際の color 値と bg の組み合わせは見逃し
+た。
+
+### 再発防止策
+
+1. **テキストを表示する chrome surface には必ず contrast assertion を
+   追加する** ―― selector 存在チェック (chrome-structure tests) だけでは
+   AA 違反を検出できない。`contrast.test.mjs` に theme × state ×
+   surface_bg の組み合わせを必ず assert する (PR #2441 で active / idle /
+   blocked × dark / light の 6 件 + structure 1 件を追加)。
+2. **theme-agnostic な surface (両テーマで bg が同じ系統の chrome) は、
+   token を local に scope-override して固定値にする** ―― theme tokens
+   をそのまま使うと、片方のテーマで AA を満たしても他方で破綻する。
+   `.op-status-strip { --color-state-*: #...; }` のように surface 単位で
+   scoped custom property override を入れて、「両テーマで同じ on-bg
+   palette」を強制する。
+
+### 適用範囲
+
+- `--color-state-*` を直接 chrome surface に流しているすべての箇所
+  (現在は Status Strip のみ; 将来 Header chrome / Floating overlay 等に
+  同パターンが現れたら必ず scoped override + contrast test を併設)。
+- chrome-structure assertions を新設するときは、検証対象が「テキスト
+  色」を含むなら **必ず併せて contrast assertion を追加** する。
+
 ## 2026-05-04 — Cache restore failures must not block the release pipeline
 
 ### 事象


### PR DESCRIPTION
## Summary
**WCAG AA contrast fix on Status Strip cell values + lesson record.**

PR #2439 propagated BLOCKED's existing tinting pattern to ACTIVE / IDLE cells, but didn't account for the fact that the Status Strip has a dark background in **both** themes (`--color-status-strip-bg` = `#050709` in dark, `#1a1d24` in light — both dark by design as a permanent chrome band).

Light theme's `--color-state-*` tokens are tuned for light backgrounds. When applied to the dark light-theme strip bg, they fail WCAG AA badly:

| State | Light theme value | Contrast vs strip bg | Verdict |
|---|---|---|---|
| idle | `#6b7280` | 3.49:1 | ✗ |
| active | `#0e7490` | 3.15:1 | ✗ |
| blocked | `#b91c1c` | 2.61:1 | ✗ |

(BLOCKED's 2.61 was a pre-existing bug — PR #2439 just widened the failure surface.)

### Fix
Scope the on-strip state palette to bright on-dark variants via CSS custom property override on `.op-status-strip`. Both themes now use the same on-strip values:

| State | New on-strip value | Dark bg | Light bg |
|---|---|---|---|
| active | `#22d3ee` | 11.16:1 ✓ | 9.33:1 ✓ |
| idle | `#94a3b8` | 7.87:1 ✓ | 6.58:1 ✓ |
| blocked | `#f87171` | 7.29:1 ✓ | 6.10:1 ✓ |

### Lessons recorded
Also adds `tasks/lessons.md` entry: "chrome-structure assertions alone don't catch contrast regressions". Two preventive rules now codified for future polish work:
1. Any chrome-structure assertion pinning text color **must** be paired with a `contrast.test.mjs` assertion against the actual surface bg
2. Theme-agnostic surfaces (chrome that's dark in both themes, etc.) should scope the state palette via a local custom property override

## Closing Issues
None — bug fix on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2439 (introduced the contrast regression)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/contrast.test.mjs` — 35 件 GREEN (+7 件 new)
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 28 件 GREEN
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
