### PR TITLE
test(ui): SPEC-2356 — comprehensive text contrast across every surface + agent colors

### DIFF
--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -18,6 +18,8 @@ const REQUIRED_PAIRS = [
   ["--color-text", "--color-canvas", NORMAL_AA, "body text on canvas"],
   ["--color-text", "--color-surface", NORMAL_AA, "body text on surface"],
   ["--color-text-muted", "--color-canvas", NORMAL_AA, "muted text on canvas"],
+  ["--color-text-muted", "--color-surface", NORMAL_AA, "muted text on surface"],
+  ["--color-text-muted", "--color-surface-elevated", NORMAL_AA, "muted text on surface-elevated (palette placeholder etc)"],
   ["--color-text-strong", "--color-canvas", NORMAL_AA, "strong text on canvas"],
   ["--color-display-fg", "--color-canvas", LARGE_AA, "display text on canvas"],
   ["--color-status-strip-fg", "--color-status-strip-bg", NORMAL_AA, "status strip text"],

--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -35,6 +35,15 @@ const REQUIRED_PAIRS = [
   ["--agent-gemini", "--color-canvas", LARGE_AA, "agent gemini indicator"],
   ["--agent-opencode", "--color-canvas", LARGE_AA, "agent opencode indicator"],
   ["--agent-copilot", "--color-canvas", LARGE_AA, "agent copilot indicator"],
+  // Agent colors are also used as TEXT (e.g. .op-agent-kind chip foreground
+  // for codex). Lock in NORMAL_AA on surface bg for every agent so future
+  // surfaces that route agent colors to text don't introduce contrast
+  // regressions.
+  ["--agent-claude", "--color-surface", NORMAL_AA, "agent claude as text on surface"],
+  ["--agent-codex", "--color-surface", NORMAL_AA, "agent codex as text on surface"],
+  ["--agent-gemini", "--color-surface", NORMAL_AA, "agent gemini as text on surface"],
+  ["--agent-opencode", "--color-surface", NORMAL_AA, "agent opencode as text on surface"],
+  ["--agent-copilot", "--color-surface", NORMAL_AA, "agent copilot as text on surface"],
 ];
 
 for (const themeName of ["dark", "light"]) {

--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -17,10 +17,13 @@ const LARGE_AA = 3.0;
 const REQUIRED_PAIRS = [
   ["--color-text", "--color-canvas", NORMAL_AA, "body text on canvas"],
   ["--color-text", "--color-surface", NORMAL_AA, "body text on surface"],
+  ["--color-text", "--color-surface-elevated", NORMAL_AA, "body text on surface-elevated"],
   ["--color-text-muted", "--color-canvas", NORMAL_AA, "muted text on canvas"],
   ["--color-text-muted", "--color-surface", NORMAL_AA, "muted text on surface"],
   ["--color-text-muted", "--color-surface-elevated", NORMAL_AA, "muted text on surface-elevated (palette placeholder etc)"],
   ["--color-text-strong", "--color-canvas", NORMAL_AA, "strong text on canvas"],
+  ["--color-text-strong", "--color-surface", NORMAL_AA, "strong text on surface"],
+  ["--color-text-strong", "--color-surface-elevated", NORMAL_AA, "strong text on surface-elevated"],
   ["--color-display-fg", "--color-canvas", LARGE_AA, "display text on canvas"],
   ["--color-status-strip-fg", "--color-status-strip-bg", NORMAL_AA, "status strip text"],
   ["--color-button-fg", "--color-button-bg", NORMAL_AA, "primary button label"],


### PR DESCRIPTION
## Summary
**Comprehensive text contrast assertions across every surface variant.**

The required-pairs set in `contrast.test.mjs` previously asserted only `--color-canvas` for the three text tokens, plus agent indicators at LARGE_AA. Extending to fully cover what actually renders on chrome surfaces:

### Body / muted / strong text on surface variants (+10 assertions)
- `--color-text` on `--color-surface` and `--color-surface-elevated`
- `--color-text-muted` on `--color-surface` and `--color-surface-elevated` (placeholder text)
- `--color-text-strong` on `--color-surface` and `--color-surface-elevated`

### Agent colors at NORMAL_AA when used as text on surface (+10 assertions)
- 5 agents × 2 themes — currently used by `.op-agent-kind` chip; future surfaces that route agent colors to text get the contrast guarantee in place

| Pair (text on bg) | Dark | Light |
|---|---|---|
| text on surface | 15.29:1 ✓ | 16.87:1 ✓ |
| text on elevated | 13.70:1 ✓ | 16.15:1 ✓ |
| muted on surface | 10.20:1 ✓ | 8.04:1 ✓ |
| muted on elevated | 9.14:1 ✓ | 7.70:1 ✓ |
| strong on surface | 18.43:1 ✓ | 21.00:1 ✓ |
| strong on elevated | 16.51:1 ✓ | 20.11:1 ✓ |
| claude text on surface | 11.04:1 ✓ | 7.09:1 ✓ |
| codex text on surface | 10.20:1 ✓ | 7.27:1 ✓ |
| gemini text on surface | 7.49:1 ✓ | 8.24:1 ✓ |
| opencode text on surface | 10.57:1 ✓ | 7.13:1 ✓ |
| copilot text on surface | 7.25:1 ✓ | 10.36:1 ✓ |

All clear AA with margin. Locking them in prevents future drift.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2441 / #2442 / #2443 (lessons-driven assertion expansion)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/contrast.test.mjs` — 81 件 GREEN (+20 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
