### PR TITLE
feat(ui): SPEC-2356 — modal dialogs declare role/aria-modal/aria-hidden

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -296,6 +296,61 @@ test("components.css uses op-divider utility class", () => {
   assert.match(css, /\.op-divider--strong/);
 });
 
+test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
+  // Every modal-backdrop must declare aria-hidden initially and contain a
+  // modal-shell with role="dialog" + aria-modal="true". Without this, screen
+  // readers don't recognize the modal as a dialog and the inert state isn't
+  // signaled when closed.
+  for (const id of ["branch-cleanup-modal", "migration-modal", "preset-modal"]) {
+    const backdrop = document.getElementById(id);
+    assert.ok(backdrop, `expected modal backdrop #${id}`);
+    assert.equal(
+      backdrop.getAttribute("aria-hidden"),
+      "true",
+      `${id} backdrop must start aria-hidden="true"`,
+    );
+    const shell = backdrop.querySelector(".modal-shell");
+    assert.ok(shell, `${id} must contain a .modal-shell`);
+    assert.equal(shell.getAttribute("role"), "dialog", `${id} shell needs role="dialog"`);
+    assert.equal(shell.getAttribute("aria-modal"), "true", `${id} shell needs aria-modal="true"`);
+    assert.equal(shell.getAttribute("tabindex"), "-1", `${id} shell needs tabindex="-1" for focus management`);
+    // Either aria-label or aria-labelledby must point at a real label
+    const label = shell.getAttribute("aria-label");
+    const labelledby = shell.getAttribute("aria-labelledby");
+    assert.ok(label || labelledby, `${id} shell needs aria-label or aria-labelledby`);
+    if (labelledby) {
+      assert.ok(
+        document.getElementById(labelledby),
+        `${id}: aria-labelledby="${labelledby}" must point at an existing element`,
+      );
+    }
+  }
+});
+
+test("Drawer modal renderers toggle aria-hidden alongside .open class", () => {
+  const branchCleanupSrc = readFileSync(
+    resolve(here, "../branch-cleanup-modal.js"),
+    "utf8",
+  );
+  const migrationSrc = readFileSync(
+    resolve(here, "../migration-modal.js"),
+    "utf8",
+  );
+  // Both renderers must flip aria-hidden in lockstep with the .open class.
+  for (const [src, name] of [[branchCleanupSrc, "branch-cleanup-modal"], [migrationSrc, "migration-modal"]]) {
+    assert.match(
+      src,
+      /modalEl\.setAttribute\("aria-hidden",\s*"true"\)/,
+      `${name} must set aria-hidden="true" on close`,
+    );
+    assert.match(
+      src,
+      /modalEl\.removeAttribute\("aria-hidden"\)/,
+      `${name} must remove aria-hidden on open`,
+    );
+  }
+});
+
 test("Hotkey overlay manages focus on open / close (modal dialog a11y)", () => {
   // The dialog must be focusable so we can move focus inside on open and
   // return it to the trigger on close — without this, screen readers don't

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -769,10 +769,12 @@
 
       function openModal() {
         modal.classList.add("open");
+        modal.removeAttribute("aria-hidden");
       }
 
       function closeModal() {
         modal.classList.remove("open");
+        modal.setAttribute("aria-hidden", "true");
       }
 
       function clamp(value, min) {

--- a/crates/gwt/web/branch-cleanup-modal.js
+++ b/crates/gwt/web/branch-cleanup-modal.js
@@ -20,6 +20,9 @@ export function renderBranchCleanupModal({
 }) {
   if (!windowId || !state || !state.cleanupModal.open) {
     modalEl.classList.remove("open");
+    // SPEC-2356 — flip aria-hidden alongside the .open class so screen
+    // readers stop announcing the dialog when it slides closed.
+    modalEl.setAttribute("aria-hidden", "true");
     while (dialogEl.firstChild) {
       dialogEl.removeChild(dialogEl.firstChild);
     }
@@ -30,6 +33,7 @@ export function renderBranchCleanupModal({
     Boolean(entry.cleanup.upstream),
   );
   modalEl.classList.add("open");
+  modalEl.removeAttribute("aria-hidden");
   while (dialogEl.firstChild) {
     dialogEl.removeChild(dialogEl.firstChild);
   }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3191,9 +3191,15 @@
           </div>
         </div>
       </div>
-      <div class="modal-backdrop" id="preset-modal">
-        <div class="modal-shell">
-          <h2>Add window</h2>
+      <div class="modal-backdrop" id="preset-modal" aria-hidden="true">
+        <div
+          class="modal-shell"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="preset-modal-title"
+          tabindex="-1"
+        >
+          <h2 id="preset-modal-title">Add window</h2>
           <div class="preset-section">
             <div class="preset-section-label">Workspace</div>
             <div class="preset-list">
@@ -3264,8 +3270,18 @@
           </div>
         </div>
       </div>
-      <div class="modal-backdrop is-drawer" id="branch-cleanup-modal">
-        <div class="modal-shell is-drawer-shell"></div>
+      <div
+        class="modal-backdrop is-drawer"
+        id="branch-cleanup-modal"
+        aria-hidden="true"
+      >
+        <div
+          class="modal-shell is-drawer-shell"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Branch cleanup"
+          tabindex="-1"
+        ></div>
       </div>
       <!-- SPEC-1934 US-6: confirmation modal shown when a Normal Git layout
            is detected at startup. Renderer lives in /migration-modal.js. -->
@@ -3274,8 +3290,18 @@
            `.modal-backdrop` / `.modal-shell` classes so existing renderers
            and smoke tests stay unchanged. The `is-drawer` opt-in class flips
            layout in components.css. -->
-      <div class="modal-backdrop is-drawer" id="migration-modal">
-        <div class="modal-shell is-drawer-shell"></div>
+      <div
+        class="modal-backdrop is-drawer"
+        id="migration-modal"
+        aria-hidden="true"
+      >
+        <div
+          class="modal-shell is-drawer-shell"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Worktree migration"
+          tabindex="-1"
+        ></div>
       </div>
     </div>
 

--- a/crates/gwt/web/migration-modal.js
+++ b/crates/gwt/web/migration-modal.js
@@ -46,6 +46,9 @@ export function renderMigrationModal({
 }) {
   if (!state || !state.migrationModal || !state.migrationModal.open) {
     modalEl.classList.remove("open");
+    // SPEC-2356 — flip aria-hidden alongside the .open class so screen
+    // readers stop announcing the dialog when it slides closed.
+    modalEl.setAttribute("aria-hidden", "true");
     while (dialogEl.firstChild) {
       dialogEl.removeChild(dialogEl.firstChild);
     }
@@ -53,6 +56,7 @@ export function renderMigrationModal({
   }
 
   modalEl.classList.add("open");
+  modalEl.removeAttribute("aria-hidden");
   while (dialogEl.firstChild) {
     dialogEl.removeChild(dialogEl.firstChild);
   }


### PR DESCRIPTION
## Summary
**Modal dialogs declare WAI-ARIA dialog role / aria-modal / aria-hidden.**

Caught while auditing accessibility coverage: the three modal-backdrop dialogs (branch-cleanup, migration, preset) had no aria wiring. Screen readers couldn't recognize them as dialogs, the inert state wasn't signaled when closed, and there was no programmatic name for assistive tech.

### Static markup additions (index.html)
| Modal ID | aria-hidden | shell role | aria-modal | label |
|---|---|---|---|---|
| `branch-cleanup-modal` | `"true"` initial | `dialog` | `true` | `aria-label="Branch cleanup"` |
| `migration-modal` | `"true"` initial | `dialog` | `true` | `aria-label="Worktree migration"` |
| `preset-modal` | `"true"` initial | `dialog` | `true` | `aria-labelledby="preset-modal-title"` |

All three modal-shell elements also receive `tabindex="-1"` so future focus management can target them programmatically.

### Dynamic toggling
- `branch-cleanup-modal.js` / `migration-modal.js` renderers now flip `aria-hidden` in lockstep with the `.open` class
- `app.js` `openModal` / `closeModal` (preset-modal) likewise

### Verification
Pin via two new chrome-structure assertions:
1. All three modal IDs have the required `role` / `aria-modal` / `aria-hidden` / `tabindex` / accessible name attributes
2. Both drawer renderers set/remove `aria-hidden` alongside the `.open` class transition

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2440 (companion: Hotkey overlay focus management)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 30 件 GREEN (+2 件)
- [x] `node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs migration-modal.smoke.test.mjs` — 10 件 GREEN (regression)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
