### PR TITLE
feat(ui): SPEC-2356 — Escape closes branch-cleanup and migration modals

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -327,6 +327,28 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   }
 });
 
+test("Drawer modals close on Escape — keyboard parity with backdrop click", () => {
+  // The Hotkey overlay and Command Palette already had Esc-close (PR #2440).
+  // branch-cleanup and migration modals previously closed only on backdrop
+  // click — keyboard users were trapped. app.js must wire a global keydown
+  // that maps Escape to the same close path for both modals.
+  assert.match(
+    appSource,
+    /event\.key\s*!==?\s*"Escape"/,
+    "expected app.js to gate keydown on Escape",
+  );
+  assert.match(
+    appSource,
+    /branchCleanupModal\.classList\.contains\("open"\)[\s\S]*closeBranchCleanupModal/,
+    "expected Esc to call closeBranchCleanupModal when that modal is open",
+  );
+  assert.match(
+    appSource,
+    /migrationModal\s*&&\s*migrationModal\.classList\.contains\("open"\)[\s\S]*skip_migration/,
+    "expected Esc to send skip_migration when migration modal is open",
+  );
+});
+
 test("Drawer modal renderers toggle aria-hidden alongside .open class", () => {
   const branchCleanupSrc = readFileSync(
     resolve(here, "../branch-cleanup-modal.js"),

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -6982,6 +6982,35 @@
           frontendUnits.branchesFileTreeSurface.closeBranchCleanupModal();
         }
       });
+      // SPEC-2356 — keyboard equivalent for clicking the modal backdrop.
+      // Without this, Esc only worked for the Hotkey overlay and Command
+      // Palette; users were trapped in branch-cleanup / migration with
+      // pointer escape only.
+      document.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") return;
+        if (branchCleanupModal.classList.contains("open")) {
+          // Reuse the same close path as backdrop click and explicit
+          // Cancel button so all three pathways behave identically.
+          frontendUnits.branchesFileTreeSurface.closeBranchCleanupModal();
+          event.preventDefault();
+          return;
+        }
+        if (migrationModal && migrationModal.classList.contains("open")) {
+          // Migration "skip" is the cancellation path; map Esc to the
+          // same intent so the modal isn't a keyboard trap. Must use
+          // tab_id (not id) to match the backend protocol.
+          const tabId = migrationModalState.tabId;
+          migrationModalState.open = false;
+          migrationModalState.stage = "confirm";
+          migrationModalState.message = "";
+          migrationModalState.recovery = "";
+          renderMigrationModal();
+          if (tabId) {
+            send({ kind: "skip_migration", tab_id: tabId });
+          }
+          event.preventDefault();
+        }
+      });
       window.addEventListener("resize", () => {
         frontendUnits.projectWorkspaceShell.renderWindowList();
         syncMaximizedWindowsToViewport();


### PR DESCRIPTION
## Summary
**Escape closes branch-cleanup and migration modals (keyboard parity with backdrop click).**

The Hotkey overlay and Command Palette already had Esc-close (PR #2440). branch-cleanup and migration modals previously closed only on backdrop click — keyboard users had no escape path and the modals violated WAI-ARIA dialog conventions (Esc must close any non-destructive dialog).

### Wiring
Add a global keydown handler in `app.js` that maps Escape to the same close path as backdrop click:
- **branch-cleanup**: reuses `closeBranchCleanupModal` — the same path the Cancel button and backdrop click already use
- **migration**: replicates `onSkip` — clears modal state, renders, sends `skip_migration` to the backend (using `tab_id`, matching the protocol)

### Verification
Pin via chrome-structure assertion that confirms `app.js` gates keydown on `Escape` AND wires both close paths.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2440 (Hotkey overlay + Command Palette Esc-close)
- #2446 (modal dialog role/aria-modal wiring — companion)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 31 件 GREEN (+1 件)
- [x] `node --test crates/gwt/web/__tests__/*.test.mjs` — 152 件 GREEN
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
