### PR TITLE
feat(ui): SPEC-2356 — drawer modals full focus management lifecycle

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -327,6 +327,28 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   }
 });
 
+test("Drawer modal renderers restore focus on close (WeakMap pattern)", () => {
+  // Companion to fresh-open focus management: when the modal closes the
+  // trigger element captured at open time must regain focus, otherwise
+  // keyboard users land on document.body. Both renderers must implement
+  // the WeakMap-keyed return-focus pattern.
+  const branchCleanupSrc = readFileSync(
+    resolve(here, "../branch-cleanup-modal.js"),
+    "utf8",
+  );
+  const migrationSrc = readFileSync(
+    resolve(here, "../migration-modal.js"),
+    "utf8",
+  );
+  for (const [src, name] of [[branchCleanupSrc, "branch-cleanup-modal"], [migrationSrc, "migration-modal"]]) {
+    assert.match(src, /const\s+focusReturnMap\s*=\s*new\s+WeakMap\(\)/, `${name} must define focusReturnMap WeakMap`);
+    assert.match(src, /focusReturnMap\.set\(modalEl,\s*ownerDoc\.activeElement\)/, `${name} must save activeElement on open`);
+    assert.match(src, /focusReturnMap\.get\(modalEl\)/, `${name} must read trigger on close`);
+    assert.match(src, /focusReturnMap\.delete\(modalEl\)/, `${name} must clear the map after close`);
+    assert.match(src, /returnTo\.focus\(\{\s*preventScroll:\s*true\s*\}\)/, `${name} must restore focus with preventScroll`);
+  }
+});
+
 test("Drawer modal renderers move focus into dialog on fresh open", () => {
   // The Hotkey overlay (PR #2440) already does this; the drawer modals
   // need parity so screen readers announce them and keyboard users land

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -327,6 +327,35 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   }
 });
 
+test("Drawer modal renderers move focus into dialog on fresh open", () => {
+  // The Hotkey overlay (PR #2440) already does this; the drawer modals
+  // need parity so screen readers announce them and keyboard users land
+  // inside. Re-renders during running/result stages must NOT re-move focus
+  // (users keep their place navigating buttons).
+  const branchCleanupSrc = readFileSync(
+    resolve(here, "../branch-cleanup-modal.js"),
+    "utf8",
+  );
+  const migrationSrc = readFileSync(
+    resolve(here, "../migration-modal.js"),
+    "utf8",
+  );
+  for (const [src, name] of [[branchCleanupSrc, "branch-cleanup-modal"], [migrationSrc, "migration-modal"]]) {
+    // Each renderer must capture wasOpen BEFORE adding the .open class
+    // and gate the focus move on !wasOpen.
+    assert.match(
+      src,
+      /const\s+wasOpen\s*=\s*modalEl\.classList\.contains\("open"\)/,
+      `${name} must capture wasOpen before adding the .open class`,
+    );
+    assert.match(
+      src,
+      /!wasOpen[\s\S]*dialogEl\.focus\(\{\s*preventScroll:\s*true\s*\}\)/,
+      `${name} must focus dialogEl with preventScroll only on fresh open`,
+    );
+  }
+});
+
 test("Drawer modals close on Escape — keyboard parity with backdrop click", () => {
   // The Hotkey overlay and Command Palette already had Esc-close (PR #2440).
   // branch-cleanup and migration modals previously closed only on backdrop

--- a/crates/gwt/web/branch-cleanup-modal.js
+++ b/crates/gwt/web/branch-cleanup-modal.js
@@ -32,6 +32,10 @@ export function renderBranchCleanupModal({
   const supportsRemoteDelete = selectedEntries.some((entry) =>
     Boolean(entry.cleanup.upstream),
   );
+  // SPEC-2356 — capture whether this is a fresh open (transition from
+  // closed) so we can move focus into the dialog. Re-renders during the
+  // running / result stages skip the focus move so users keep their place.
+  const wasOpen = modalEl.classList.contains("open");
   modalEl.classList.add("open");
   modalEl.removeAttribute("aria-hidden");
   while (dialogEl.firstChild) {
@@ -176,4 +180,10 @@ export function renderBranchCleanupModal({
   submit.addEventListener("click", onSubmit);
   footer.appendChild(submit);
   dialogEl.appendChild(footer);
+  // SPEC-2356 — on a fresh open (transition from closed → open), move focus
+  // to the dialog so screen readers announce it and keyboard users land
+  // inside the modal instead of staying on the trigger button.
+  if (!wasOpen && typeof dialogEl.focus === "function") {
+    try { dialogEl.focus({ preventScroll: true }); } catch { dialogEl.focus(); }
+  }
 }

--- a/crates/gwt/web/branch-cleanup-modal.js
+++ b/crates/gwt/web/branch-cleanup-modal.js
@@ -4,6 +4,11 @@
 // pure function over the dependency bag; app.js wires the DOM refs, state
 // lookup, helpers, and callbacks.
 
+// SPEC-2356 — remember the element focused when the modal opens so we can
+// restore focus to it on close. WeakMap keyed on the modal element survives
+// across renderer calls without leaking when the element is detached.
+const focusReturnMap = new WeakMap();
+
 export function renderBranchCleanupModal({
   modalEl,
   dialogEl,
@@ -19,12 +24,24 @@ export function renderBranchCleanupModal({
   onDeleteRemoteToggle,
 }) {
   if (!windowId || !state || !state.cleanupModal.open) {
+    const wasOpenBeforeClose = modalEl.classList.contains("open");
     modalEl.classList.remove("open");
     // SPEC-2356 — flip aria-hidden alongside the .open class so screen
     // readers stop announcing the dialog when it slides closed.
     modalEl.setAttribute("aria-hidden", "true");
     while (dialogEl.firstChild) {
       dialogEl.removeChild(dialogEl.firstChild);
+    }
+    // SPEC-2356 — restore focus to whatever was focused when the modal
+    // opened (typically the Cleanup button that triggered it). Without
+    // this, focus would land on document.body and keyboard users would
+    // lose their place.
+    if (wasOpenBeforeClose) {
+      const returnTo = focusReturnMap.get(modalEl);
+      focusReturnMap.delete(modalEl);
+      if (returnTo && typeof returnTo.focus === "function") {
+        try { returnTo.focus({ preventScroll: true }); } catch { returnTo.focus(); }
+      }
     }
     return;
   }
@@ -36,6 +53,13 @@ export function renderBranchCleanupModal({
   // closed) so we can move focus into the dialog. Re-renders during the
   // running / result stages skip the focus move so users keep their place.
   const wasOpen = modalEl.classList.contains("open");
+  if (!wasOpen) {
+    // Save the trigger so close() can restore focus there.
+    const ownerDoc = modalEl.ownerDocument || (typeof document !== "undefined" ? document : null);
+    if (ownerDoc) {
+      focusReturnMap.set(modalEl, ownerDoc.activeElement);
+    }
+  }
   modalEl.classList.add("open");
   modalEl.removeAttribute("aria-hidden");
   while (dialogEl.firstChild) {

--- a/crates/gwt/web/migration-modal.js
+++ b/crates/gwt/web/migration-modal.js
@@ -3,6 +3,11 @@
 // the dependency bag so app.js can wire DOM refs, state, and callbacks while
 // the renderer stays unit-testable.
 
+// SPEC-2356 — remember the trigger that opened the modal so close can
+// restore focus there. WeakMap keyed on modal element matches the
+// branch-cleanup-modal pattern.
+const focusReturnMap = new WeakMap();
+
 const PHASE_LABELS = {
   confirm: "Preparing",
   validate: "Validating workspace",
@@ -45,12 +50,22 @@ export function renderMigrationModal({
   onQuit,
 }) {
   if (!state || !state.migrationModal || !state.migrationModal.open) {
+    const wasOpenBeforeClose = modalEl.classList.contains("open");
     modalEl.classList.remove("open");
     // SPEC-2356 — flip aria-hidden alongside the .open class so screen
     // readers stop announcing the dialog when it slides closed.
     modalEl.setAttribute("aria-hidden", "true");
     while (dialogEl.firstChild) {
       dialogEl.removeChild(dialogEl.firstChild);
+    }
+    // SPEC-2356 — restore focus to whatever was focused when the modal
+    // opened so keyboard users don't lose their place.
+    if (wasOpenBeforeClose) {
+      const returnTo = focusReturnMap.get(modalEl);
+      focusReturnMap.delete(modalEl);
+      if (returnTo && typeof returnTo.focus === "function") {
+        try { returnTo.focus({ preventScroll: true }); } catch { returnTo.focus(); }
+      }
     }
     return;
   }
@@ -59,6 +74,12 @@ export function renderMigrationModal({
   // the dialog only on the initial render (subsequent re-renders during
   // running / done stages keep focus where the user already navigated).
   const wasOpen = modalEl.classList.contains("open");
+  if (!wasOpen) {
+    const ownerDoc = modalEl.ownerDocument || (typeof document !== "undefined" ? document : null);
+    if (ownerDoc) {
+      focusReturnMap.set(modalEl, ownerDoc.activeElement);
+    }
+  }
   modalEl.classList.add("open");
   modalEl.removeAttribute("aria-hidden");
   while (dialogEl.firstChild) {

--- a/crates/gwt/web/migration-modal.js
+++ b/crates/gwt/web/migration-modal.js
@@ -55,6 +55,10 @@ export function renderMigrationModal({
     return;
   }
 
+  // SPEC-2356 — capture fresh-open transition so we can move focus into
+  // the dialog only on the initial render (subsequent re-renders during
+  // running / done stages keep focus where the user already navigated).
+  const wasOpen = modalEl.classList.contains("open");
   modalEl.classList.add("open");
   modalEl.removeAttribute("aria-hidden");
   while (dialogEl.firstChild) {
@@ -196,4 +200,9 @@ export function renderMigrationModal({
   footer.appendChild(migrate);
 
   dialogEl.appendChild(footer);
+  // SPEC-2356 — on a fresh open, move focus to the dialog so screen readers
+  // announce "Worktree migration dialog" and keyboard users land inside.
+  if (!wasOpen && typeof dialogEl.focus === "function") {
+    try { dialogEl.focus({ preventScroll: true }); } catch { dialogEl.focus(); }
+  }
 }


### PR DESCRIPTION
## Summary
**Drawer modals: full focus management lifecycle (move into dialog on open + restore to trigger on close).**

The Hotkey overlay (PR #2440) already had this; the drawer modals (branch-cleanup, migration) had `role="dialog"` + `tabindex="-1"` wired in PR #2446 but no JS focus management — screen readers didn't announce them, keyboard users stayed on the trigger, and on close focus fell to `document.body`.

### Fresh open → focus into dialog
- Each renderer captures `wasOpen = modalEl.classList.contains("open")` BEFORE adding `.open`
- Bottom of the confirm-stage render: gate `dialogEl.focus({ preventScroll: true })` on `!wasOpen`
- Re-renders during running / result / done stages keep `wasOpen=true` and skip the focus move

### Close → restore to trigger
- Module-level `focusReturnMap` (WeakMap keyed on `modalEl`) survives across renderer calls without leaking
- On closed→open: save `document.activeElement` (the trigger button) into the map
- On open→closed: look up the saved element, call `.focus({ preventScroll: true })`, then `delete()`
- Guarded by `wasOpenBeforeClose` so re-renders while already closed don't trigger spurious focus moves

### Verification
Two chrome-structure assertions pin both halves:
1. Both renderers capture `wasOpen` BEFORE adding `.open` and gate `dialogEl.focus(...)` on `!wasOpen`
2. Both renderers wire the full WeakMap pattern: definition, set on open, get/delete on close, `preventScroll` focus call

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2440 (Hotkey overlay focus management — same pattern)
- #2446 / #2447 (companion modal a11y)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 33 件 GREEN (+2 件)
- [x] `node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs migration-modal.smoke.test.mjs` — 10 件 GREEN (regression)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
