### PR TITLE
feat(ui): SPEC-2356 — wizard modal full WAI-ARIA + focus management

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -301,7 +301,7 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   // modal-shell with role="dialog" + aria-modal="true". Without this, screen
   // readers don't recognize the modal as a dialog and the inert state isn't
   // signaled when closed.
-  for (const id of ["branch-cleanup-modal", "migration-modal", "preset-modal"]) {
+  for (const id of ["branch-cleanup-modal", "migration-modal", "preset-modal", "wizard-modal"]) {
     const backdrop = document.getElementById(id);
     assert.ok(backdrop, `expected modal backdrop #${id}`);
     assert.equal(
@@ -397,6 +397,11 @@ test("Drawer modals close on Escape — keyboard parity with backdrop click", ()
     appSource,
     /migrationModal\s*&&\s*migrationModal\.classList\.contains\("open"\)[\s\S]*skip_migration/,
     "expected Esc to send skip_migration when migration modal is open",
+  );
+  assert.match(
+    appSource,
+    /wizardModal\.classList\.contains\("open"\)[\s\S]*launchWizardSurface\.sendAction\(\{\s*kind:\s*"cancel"/,
+    "expected Esc to send cancel when wizard modal is open",
   );
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -378,6 +378,26 @@ test("Drawer modal renderers move focus into dialog on fresh open", () => {
   }
 });
 
+test("Wizard modal manages focus on open and restores on close", () => {
+  // The wizard modal's renderer lives in app.js (not a separate module),
+  // so focus management is wired inline. Verify the same pattern as the
+  // drawer modals: wizardFocusReturn captures activeElement on open,
+  // wizardDialog.focus({ preventScroll: true }) moves focus into the
+  // dialog, and wizardFocusReturn.focus() restores on close.
+  assert.match(appSource, /let\s+wizardFocusReturn\s*=\s*null/);
+  assert.match(appSource, /wizardFocusReturn\s*=\s*document\.activeElement/);
+  assert.match(
+    appSource,
+    /wizardDialog\.focus\(\{\s*preventScroll:\s*true\s*\}\)/,
+    "expected wizardDialog focus on open with preventScroll",
+  );
+  assert.match(
+    appSource,
+    /wizardFocusReturn\.focus\(\{\s*preventScroll:\s*true\s*\}\)/,
+    "expected wizardFocusReturn focus on close with preventScroll",
+  );
+});
+
 test("Drawer modals close on Escape — keyboard parity with backdrop click", () => {
   // The Hotkey overlay and Command Palette already had Esc-close (PR #2440).
   // branch-cleanup and migration modals previously closed only on backdrop

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3716,12 +3716,22 @@
         }
       }
 
+      let wizardFocusReturn = null;
+
       function renderLaunchWizard() {
         if (!launchWizard) {
+          const wasOpenBeforeClose = wizardModal.classList.contains("open");
           wizardModal.classList.remove("open");
           // SPEC-2356 — keep aria-hidden in lockstep with .open so screen
           // readers stop announcing the wizard when it slides closed.
           wizardModal.setAttribute("aria-hidden", "true");
+          // SPEC-2356 — restore focus to the trigger that opened the wizard
+          // so keyboard users land back on Start Work / Launch Agent / etc.
+          if (wasOpenBeforeClose && wizardFocusReturn && typeof wizardFocusReturn.focus === "function") {
+            try { wizardFocusReturn.focus({ preventScroll: true }); }
+            catch { wizardFocusReturn.focus(); }
+            wizardFocusReturn = null;
+          }
           wizardModal.classList.remove("is-drawer");
           wizardDialog?.classList.remove("is-drawer-shell");
           wizardSummary.innerHTML = "";
@@ -3740,8 +3750,20 @@
         const isStartWorkMode = launchWizard.show_branch_controls === false;
         wizardModal.classList.toggle("is-drawer", isStartWorkMode);
         wizardDialog?.classList.toggle("is-drawer-shell", isStartWorkMode);
+        const wasOpenWizard = wizardModal.classList.contains("open");
+        if (!wasOpenWizard) {
+          // Capture trigger BEFORE flipping .open so render-driven focus
+          // moves don't overwrite our save.
+          wizardFocusReturn = document.activeElement;
+        }
         wizardModal.classList.add("open");
         wizardModal.removeAttribute("aria-hidden");
+        if (!wasOpenWizard && wizardDialog && typeof wizardDialog.focus === "function") {
+          // SPEC-2356 — move focus into the dialog so screen readers
+          // announce "Launch Agent dialog" and keyboard users land inside.
+          try { wizardDialog.focus({ preventScroll: true }); }
+          catch { wizardDialog.focus(); }
+        }
         if (wizardTitle) wizardTitle.textContent = launchWizard.title || "Launch Agent";
         wizardMeta.textContent = launchWizard.show_branch_controls === false
           ? "Workspace launch"

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3719,6 +3719,9 @@
       function renderLaunchWizard() {
         if (!launchWizard) {
           wizardModal.classList.remove("open");
+          // SPEC-2356 — keep aria-hidden in lockstep with .open so screen
+          // readers stop announcing the wizard when it slides closed.
+          wizardModal.setAttribute("aria-hidden", "true");
           wizardModal.classList.remove("is-drawer");
           wizardDialog?.classList.remove("is-drawer-shell");
           wizardSummary.innerHTML = "";
@@ -3738,6 +3741,7 @@
         wizardModal.classList.toggle("is-drawer", isStartWorkMode);
         wizardDialog?.classList.toggle("is-drawer-shell", isStartWorkMode);
         wizardModal.classList.add("open");
+        wizardModal.removeAttribute("aria-hidden");
         if (wizardTitle) wizardTitle.textContent = launchWizard.title || "Launch Agent";
         wizardMeta.textContent = launchWizard.show_branch_controls === false
           ? "Workspace launch"
@@ -6984,14 +6988,21 @@
       });
       // SPEC-2356 — keyboard equivalent for clicking the modal backdrop.
       // Without this, Esc only worked for the Hotkey overlay and Command
-      // Palette; users were trapped in branch-cleanup / migration with
-      // pointer escape only.
+      // Palette; users were trapped in branch-cleanup / migration / wizard
+      // with pointer escape only.
       document.addEventListener("keydown", (event) => {
         if (event.key !== "Escape") return;
         if (branchCleanupModal.classList.contains("open")) {
           // Reuse the same close path as backdrop click and explicit
           // Cancel button so all three pathways behave identically.
           frontendUnits.branchesFileTreeSurface.closeBranchCleanupModal();
+          event.preventDefault();
+          return;
+        }
+        if (wizardModal.classList.contains("open")) {
+          // Wizard cancel is the explicit cancellation path; map Esc to
+          // the same action so the modal isn't a keyboard trap.
+          frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
           event.preventDefault();
           return;
         }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3250,8 +3250,14 @@
           </div>
         </div>
       </div>
-      <div class="modal-backdrop" id="wizard-modal">
-        <div class="modal-shell is-wizard">
+      <div class="modal-backdrop" id="wizard-modal" aria-hidden="true">
+        <div
+          class="modal-shell is-wizard"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="wizard-title"
+          tabindex="-1"
+        >
           <div class="modal-header wizard-header">
             <div>
               <h2 class="wizard-title" id="wizard-title">Launch Agent</h2>


### PR DESCRIPTION
## Summary
**Launch wizard modal — full WAI-ARIA dialog convention + focus management lifecycle.**

The launch-wizard modal had backdrop-click cancel but lacked the rest of the WAI-ARIA dialog wiring + focus management that was added to drawer modals in PRs #2440 / #2446 / #2447 / #2448.

### Static markup additions (index.html)
- `aria-hidden="true"` initial state on the backdrop
- `role="dialog"` + `aria-modal="true"` + `aria-labelledby="wizard-title"` (reuses the existing h2 id) + `tabindex="-1"` on the modal-shell

### Dynamic toggling (app.js renderLaunchWizard)
- `aria-hidden` flipped in lockstep with `.open` on both the open and close paths
- Esc-close: global keydown handler matches wizard-modal and dispatches `cancel` via `launchWizardSurface.sendAction({ kind: "cancel" })`

### Focus management lifecycle (app.js)
Inline pattern mirroring the WeakMap-based drawer modal flow:
- Module-scoped `let wizardFocusReturn = null;`
- On closed→open: capture `document.activeElement` BEFORE adding `.open`, then move focus to `wizardDialog` with `preventScroll: true`
- On open→closed: restore focus to the captured element, null the reference
- Re-renders during the open state keep `wasOpenWizard=true` so the focus move only fires once per modal lifetime

### Verification
Two chrome-structure assertions pin the wizard pattern:
1. The existing modal a11y check now iterates all four IDs (branch-cleanup, migration, preset, wizard)
2. New assertion verifies the wizard focus management wiring in app.js

The Esc-close assertion also confirms wizard cancel is wired.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2440 / #2446 / #2447 / #2448 (companion modal a11y)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 34 件 GREEN (+1 件 wizard focus)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
