### PR TITLE
feat(ui): SPEC-2356 — preset modal full focus management lifecycle

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -378,6 +378,24 @@ test("Drawer modal renderers move focus into dialog on fresh open", () => {
   }
 });
 
+test("Preset (Add Window) modal manages focus on open and restores on close", () => {
+  // The "+" Add Window modal opens via openModal()/closeModal() in app.js.
+  // Verify the same focus-management pattern is wired: capture trigger,
+  // move focus to modal-shell on open, restore on close.
+  assert.match(appSource, /let\s+presetModalFocusReturn\s*=\s*null/);
+  assert.match(appSource, /presetModalFocusReturn\s*=\s*document\.activeElement/);
+  assert.match(
+    appSource,
+    /presetShell\.focus\(\{\s*preventScroll:\s*true\s*\}\)/,
+    "expected preset modal shell focus on open with preventScroll",
+  );
+  assert.match(
+    appSource,
+    /presetModalFocusReturn\.focus\(\{\s*preventScroll:\s*true\s*\}\)/,
+    "expected preset modal restore focus on close with preventScroll",
+  );
+});
+
 test("Wizard modal manages focus on open and restores on close", () => {
   // The wizard modal's renderer lives in app.js (not a separate module),
   // so focus management is wired inline. Verify the same pattern as the

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -767,14 +767,30 @@
         renderWindowList();
       }
 
+      let presetModalFocusReturn = null;
       function openModal() {
+        // SPEC-2356 — capture trigger BEFORE adding .open so we can
+        // restore focus on close. The preset modal is invoked via the
+        // "+" Add Window button; without restore, focus falls to body.
+        presetModalFocusReturn = document.activeElement;
         modal.classList.add("open");
         modal.removeAttribute("aria-hidden");
+        const presetShell = modal.querySelector(".modal-shell");
+        if (presetShell && typeof presetShell.focus === "function") {
+          try { presetShell.focus({ preventScroll: true }); }
+          catch { presetShell.focus(); }
+        }
       }
 
       function closeModal() {
+        const wasOpenPreset = modal.classList.contains("open");
         modal.classList.remove("open");
         modal.setAttribute("aria-hidden", "true");
+        if (wasOpenPreset && presetModalFocusReturn && typeof presetModalFocusReturn.focus === "function") {
+          try { presetModalFocusReturn.focus({ preventScroll: true }); }
+          catch { presetModalFocusReturn.focus(); }
+          presetModalFocusReturn = null;
+        }
       }
 
       function clamp(value, min) {


### PR DESCRIPTION
## Summary
**Preset (Add Window) modal manages focus on open and restores on close.**

PR #2446 added the WAI-ARIA dialog wiring (`role="dialog"` / `aria-modal` / `aria-hidden` / `aria-labelledby`) but no JS focus management — when the user opened the modal via the "+" button, focus stayed on the trigger; when they closed it, focus fell to `document.body`.

This is the final modal getting full focus management lifecycle, matching the pattern across all four:
- Hotkey overlay (PR #2440)
- branch-cleanup-modal (PR #2448 WeakMap pattern)
- migration-modal (PR #2448 WeakMap pattern)
- wizard modal (PR #2449 closure pattern)
- **preset modal (this PR — closure pattern)**

### Implementation
Closure-scoped `let presetModalFocusReturn = null;` (matching the wizard pattern):
- On `openModal()`: capture `document.activeElement` BEFORE adding `.open`, then move focus to `.modal-shell` with `preventScroll: true`
- On `closeModal()`: restore focus to the captured element with `preventScroll`, null the reference
- Guarded by `wasOpenPreset` so spurious calls during closed state don't trigger focus moves

### Verification
Pin via chrome-structure assertion that confirms `app.js` declares `presetModalFocusReturn`, captures `activeElement`, and calls `focus()` with `preventScroll` on both `presetShell` (open) and `presetModalFocusReturn` (close).

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2440 / #2446 / #2447 / #2448 / #2449 (companion modal a11y)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 35 件 GREEN (+1 件)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
