### PR TITLE
feat(ui): SPEC-2356 — window list Esc-close + drawer aria-busy

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -441,6 +441,11 @@ test("Drawer modals close on Escape — keyboard parity with backdrop click", ()
     /wizardModal\.classList\.contains\("open"\)[\s\S]*launchWizardSurface\.sendAction\(\{\s*kind:\s*"cancel"/,
     "expected Esc to send cancel when wizard modal is open",
   );
+  assert.match(
+    appSource,
+    /if\s*\(windowListOpen\)\s*\{[\s\S]*windowListOpen\s*=\s*false[\s\S]*windowListButton\.focus/,
+    "expected Esc to close window list dropdown and restore focus to trigger",
+  );
 });
 
 test("Drawer modal renderers toggle aria-hidden alongside .open class", () => {

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -327,6 +327,33 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   }
 });
 
+test("Drawer modal renderers signal busy state via aria-busy during async stages", () => {
+  // The branch-cleanup running stage and migration running stage are
+  // synchronous async operations. Without aria-busy, screen readers don't
+  // signal that the dialog is in a loading state — users may try to
+  // interact with controls that are about to disappear.
+  const branchCleanupSrc = readFileSync(
+    resolve(here, "../branch-cleanup-modal.js"),
+    "utf8",
+  );
+  const migrationSrc = readFileSync(
+    resolve(here, "../migration-modal.js"),
+    "utf8",
+  );
+  for (const [src, name] of [[branchCleanupSrc, "branch-cleanup-modal"], [migrationSrc, "migration-modal"]]) {
+    assert.match(
+      src,
+      /dialogEl\.setAttribute\("aria-busy",\s*"true"\)/,
+      `${name} must set aria-busy="true" during the running stage`,
+    );
+    assert.match(
+      src,
+      /dialogEl\.setAttribute\("aria-busy",\s*"false"\)/,
+      `${name} must clear aria-busy in non-running stages`,
+    );
+  }
+});
+
 test("Drawer modal renderers restore focus on close (WeakMap pattern)", () => {
   // Companion to fresh-open focus management: when the modal closes the
   // trigger element captured at open time must regain focus, otherwise

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7027,7 +7027,8 @@
       // SPEC-2356 — keyboard equivalent for clicking the modal backdrop.
       // Without this, Esc only worked for the Hotkey overlay and Command
       // Palette; users were trapped in branch-cleanup / migration / wizard
-      // with pointer escape only.
+      // with pointer escape only. The window list dropdown also gets Esc
+      // close so the operator chrome offers consistent keyboard escape.
       document.addEventListener("keydown", (event) => {
         if (event.key !== "Escape") return;
         if (branchCleanupModal.classList.contains("open")) {
@@ -7056,6 +7057,19 @@
           renderMigrationModal();
           if (tabId) {
             send({ kind: "skip_migration", tab_id: tabId });
+          }
+          event.preventDefault();
+          return;
+        }
+        if (windowListOpen) {
+          // Close the Windows dropdown and return focus to its trigger
+          // button (matches the modal pattern of restoring focus to the
+          // element that opened the dropdown).
+          windowListOpen = false;
+          frontendUnits.projectWorkspaceShell.renderWindowList();
+          if (windowListButton && typeof windowListButton.focus === "function") {
+            try { windowListButton.focus({ preventScroll: true }); }
+            catch { windowListButton.focus(); }
           }
           event.preventDefault();
         }

--- a/crates/gwt/web/branch-cleanup-modal.js
+++ b/crates/gwt/web/branch-cleanup-modal.js
@@ -62,6 +62,14 @@ export function renderBranchCleanupModal({
   }
   modalEl.classList.add("open");
   modalEl.removeAttribute("aria-hidden");
+  // SPEC-2356 — aria-busy signals to screen readers that the dialog is
+  // in a loading state. Set true during the async "running" stage and
+  // clear (set false) once we move into confirm or result.
+  if (state.cleanupModal.stage === "running") {
+    dialogEl.setAttribute("aria-busy", "true");
+  } else {
+    dialogEl.setAttribute("aria-busy", "false");
+  }
   while (dialogEl.firstChild) {
     dialogEl.removeChild(dialogEl.firstChild);
   }

--- a/crates/gwt/web/migration-modal.js
+++ b/crates/gwt/web/migration-modal.js
@@ -82,11 +82,21 @@ export function renderMigrationModal({
   }
   modalEl.classList.add("open");
   modalEl.removeAttribute("aria-hidden");
+
+  const m = state.migrationModal;
+
+  // SPEC-2356 — aria-busy signals to screen readers that the dialog is in
+  // a loading state during the async migration. Set true during running,
+  // false otherwise.
+  if (m.stage === "running") {
+    dialogEl.setAttribute("aria-busy", "true");
+  } else {
+    dialogEl.setAttribute("aria-busy", "false");
+  }
+
   while (dialogEl.firstChild) {
     dialogEl.removeChild(dialogEl.firstChild);
   }
-
-  const m = state.migrationModal;
 
   if (m.stage === "running") {
     dialogEl.appendChild(createNode("h2", "", "Migrating repository"));


### PR DESCRIPTION
## Summary
**Two small accessibility wins:**

### 1. Escape closes Windows dropdown and restores focus to trigger
The Windows dropdown panel had toggle-on-click, close-on-outside-pointerdown, and close-on-row-click — but no keyboard equivalent for Esc. Even after pointerdown-close, focus stayed wherever it was.

Extended the global Esc handler in `app.js` to:
- close the dropdown when `windowListOpen` is true
- restore focus to `windowListButton` (the trigger) with `preventScroll`, matching WCAG SC 2.1.2 (No Keyboard Trap) and 2.4.3 (Focus Order)
- `preventDefault` so Esc doesn't bubble

### 2. Drawer modals signal busy state via aria-busy
The branch-cleanup and migration modals have async "running" stages where the user waits for the backend. Without `aria-busy`, screen readers don't signal that the dialog is in a loading state.

Both renderers now set `aria-busy="true"` on the dialog element during the running stage, and `aria-busy="false"` otherwise. The attribute flips in lockstep with stage transitions.

### Verification
Two new chrome-structure assertions:
1. window list branch in global keydown handler closes dropdown AND focuses trigger
2. Both drawer renderers wire both `aria-busy="true"` and `="false"` paths

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2447 (initial Esc-close for modals)
- #2448 (drawer focus management)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 36 件 GREEN (+1 件)
- [x] `node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs migration-modal.smoke.test.mjs` — 10 件 GREEN (regression)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
