### PR TITLE
feat(ui): SPEC-2356 — error regions declare role="alert"

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -327,6 +327,20 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   }
 });
 
+test("Error regions declare role=\"alert\" so screen readers announce them", () => {
+  // Without role="alert" (or aria-live="assertive"), errors that appear
+  // in wizard-error and project-picker-error are silent for screen reader
+  // users — they only see them after manually navigating to the error
+  // element. role="alert" implies aria-live="assertive" + aria-atomic so
+  // the full message is announced immediately when the element becomes
+  // non-hidden.
+  for (const id of ["wizard-error", "project-picker-error"]) {
+    const el = document.getElementById(id);
+    assert.ok(el, `expected error region #${id}`);
+    assert.equal(el.getAttribute("role"), "alert", `${id} must have role="alert"`);
+  }
+});
+
 test("Drawer modal renderers signal busy state via aria-busy during async stages", () => {
   // The branch-cleanup running stage and migration running stage are
   // synchronous async operations. Without aria-busy, screen readers don't

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3007,7 +3007,7 @@
               <p class="project-picker-copy">
                 Restore previous workspaces or choose a new folder.
               </p>
-              <div class="project-picker-error" id="project-picker-error" hidden></div>
+              <div class="project-picker-error" id="project-picker-error" role="alert" hidden></div>
               <button class="wizard-button primary" id="picker-open-project">
                 Open Project...
               </button>
@@ -3265,7 +3265,7 @@
             </div>
             <button class="wizard-button" id="wizard-close-button">Close</button>
           </div>
-          <div class="wizard-error" id="wizard-error" hidden></div>
+          <div class="wizard-error" id="wizard-error" role="alert" hidden></div>
           <div class="wizard-summary" id="wizard-summary"></div>
           <div class="modal-body" id="wizard-body"></div>
           <div class="modal-footer wizard-footer">


### PR DESCRIPTION
## Summary
**Error regions declare `role="alert"` for screen reader announcement.**

The `wizard-error` and `project-picker-error` elements appeared silently for screen reader users — when an error showed (`hidden=false`), assistive tech only saw it if the user manually navigated to the element.

Adding `role="alert"` implies `aria-live="assertive"` + `aria-atomic="true"`, so the full error message is announced immediately when the element becomes non-hidden. This matches WCAG SC 4.1.3 (Status Messages) guidance for error notifications that need user attention.

### Coverage
- `#wizard-error` (Launch Wizard validation errors)
- `#project-picker-error` (project loading errors on the empty state)

### Verification
Pin via chrome-structure assertion that confirms both error elements have `role="alert"`.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 37 件 GREEN (+1 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
