### PR TITLE
polish: SPEC-2356 — README a11y docs + focus-trap aria-disabled exclusion

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -270,7 +270,19 @@ Contrast) では system colors にフォールバックします。
 | `⌘L` | Logs サーフェスを focus |
 | `⌘?` | Hotkey Overlay (cheat sheet) を toggle |
 | `⌘\` | Sidebar Layers を折り畳み / 復帰 |
-| `Esc` | 開いている Palette / Overlay / Drawer を閉じる |
+| `Esc` | 開いている Palette / Overlay / Drawer / Dropdown を閉じる |
+
+### アクセシビリティ
+
+すべてのモーダルダイアログ (Command Palette / Hotkey Overlay / Branch
+Cleanup / Worktree Migration / Launch Wizard / Add Window) は WAI-ARIA
+dialog convention に従います。`role="dialog"` + accessible name、
+`aria-modal`、open 時にフォーカスがダイアログ内へ移動し close 時に
+トリガーへ戻る、Tab がダイアログ内で循環 (キーボードトラップなしの
+escape)、Esc で dismiss。非同期ロード段階は `aria-busy="true"` で
+スクリーンリーダーに進捗を伝えます。エラー領域は `role="alert"` で
+即座に読み上げられます。WCAG 2.1 AA コントラストは両テーマの全
+text/surface 組合せでテストレイヤーに pin されています。
 
 ## SPEC と runtime クイックリファレンス
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,19 @@ falls back to system colors so accessibility is preserved.
 | `⌘L` | Focus the Logs surface |
 | `⌘?` | Toggle the Hotkey Overlay (cheat sheet) |
 | `⌘\` | Collapse / expand the Sidebar Layers |
-| `Esc` | Close any open palette / overlay / drawer |
+| `Esc` | Close any open palette / overlay / drawer / dropdown |
+
+### Accessibility
+
+Every modal dialog (Command Palette, Hotkey Overlay, branch cleanup,
+worktree migration, launch wizard, Add Window) follows the WAI-ARIA
+dialog convention: `role="dialog"` with an accessible name, `aria-modal`,
+focus moves into the dialog on open and returns to the trigger on close,
+Tab cycles within the dialog (no keyboard trap escape), and Escape
+dismisses. Async loading stages signal `aria-busy="true"` so screen
+readers track progress. Error regions use `role="alert"` for immediate
+announcement. WCAG 2.1 AA contrast is asserted across every text /
+surface combination in both themes.
 
 ## SPEC and Runtime Quick Reference
 

--- a/crates/gwt/web/__tests__/focus-trap.test.mjs
+++ b/crates/gwt/web/__tests__/focus-trap.test.mjs
@@ -164,6 +164,34 @@ test("non-Tab keys are ignored", () => {
   release();
 });
 
+test("focusable selector excludes [disabled] and [aria-disabled=\"true\"]", async () => {
+  // Verify the constant in the module matches the documented contract.
+  // Use module URL import to read the file content.
+  const { readFileSync } = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
+  const { dirname, resolve } = await import("node:path");
+  const here = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(resolve(here, "../focus-trap.js"), "utf8");
+
+  // Each focusable role must exclude the disabled state — the trap should
+  // skip programmatically-disabled buttons (e.g. wizard Migrate when
+  // hasLocked is true).
+  for (const role of ["button", "input", "select", "textarea"]) {
+    assert.ok(
+      src.includes(`${role}:not([disabled]):not([aria-disabled="true"])`),
+      `${role} entry must exclude both [disabled] and [aria-disabled="true"]`,
+    );
+  }
+  assert.ok(
+    src.includes('[href]:not([aria-disabled="true"])'),
+    "[href] must exclude [aria-disabled=\"true\"]",
+  );
+  assert.ok(
+    src.includes('[tabindex]:not([tabindex="-1"]):not([aria-disabled="true"])'),
+    "[tabindex] must exclude tabindex=-1 and aria-disabled=true",
+  );
+});
+
 test("trap with no focusable children pins focus on the container", () => {
   const stub = makeStubDoc({ focusables: [] });
   const release = createFocusTrap(stub.container, { document: stub.doc });

--- a/crates/gwt/web/focus-trap.js
+++ b/crates/gwt/web/focus-trap.js
@@ -12,13 +12,18 @@
 // could call preventDefault first and the trap would never see the
 // event.
 
+// SPEC-2356 — focusable selector. Each entry excludes both the native
+// `disabled` attribute (where supported) and `aria-disabled="true"`. The
+// trap should treat aria-disabled elements as non-focusable so a button
+// that's been programmatically disabled (the wizard Migrate button when
+// hasLocked is true, for instance) doesn't trap users on it.
 const FOCUSABLE_SELECTOR = [
-  'button:not([disabled])',
-  '[href]',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
+  'button:not([disabled]):not([aria-disabled="true"])',
+  '[href]:not([aria-disabled="true"])',
+  'input:not([disabled]):not([aria-disabled="true"])',
+  'select:not([disabled]):not([aria-disabled="true"])',
+  'textarea:not([disabled]):not([aria-disabled="true"])',
+  '[tabindex]:not([tabindex="-1"]):not([aria-disabled="true"])',
 ].join(',');
 
 export function createFocusTrap(container, options = {}) {


### PR DESCRIPTION
## Summary
**Two final polish items wrapping up the SPEC-2356 accessibility iteration:**

### 1. README documents the accessibility guarantees
After 17 PRs of accessibility hardening across this session, the README hadn't yet documented what users can rely on. Add a brief "Accessibility" subsection under the Operator Design Language section in both README.md and README.ja.md:

- Every modal follows the WAI-ARIA dialog convention
- Focus moves into the dialog on open, returns to trigger on close
- Tab cycles within the dialog (focus trap)
- Escape dismisses any open palette / overlay / drawer / dropdown
- Async loading stages signal `aria-busy="true"`
- Error regions use `role="alert"`
- WCAG 2.1 AA contrast pinned at the test layer

### 2. Focus-trap selector excludes `[aria-disabled="true"]`
The focus-trap selector previously excluded the native `[disabled]` attribute but not `[aria-disabled="true"]`. A button that opts out of interaction via aria-disabled (the wizard Migrate button when `hasLocked` is true, for instance) would still be in the trap's Tab cycle and could keyboard-trap users on it.

Extend every focusable role's selector to exclude both disabled states. Verified via a new focus-trap unit test that reads the source and asserts the documented selector contract.

## Closing Issues
None — final polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2440-#2453 (cumulative modal a11y hardening this session)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/focus-trap.test.mjs` — 10 件 GREEN (+1 件 for aria-disabled selector)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN
- [x] Markdownlint passes (no new lint issues)
- [x] Both READMEs maintain symmetric structure (English + Japanese)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
