### PR TITLE
feat(ui): SPEC-2356 — Shift+Tab focus-trap test + project tab aria-current

### DIFF
--- a/crates/gwt/web/__tests__/focus-trap.test.mjs
+++ b/crates/gwt/web/__tests__/focus-trap.test.mjs
@@ -140,6 +140,22 @@ test("Tab from outside the trap pulls focus into the first element", () => {
   release();
 });
 
+test("Shift+Tab from outside the trap pulls focus to the last element", () => {
+  const stub = makeStubDoc({ focusables: ["b1", "b2", "b3"] });
+  const outside = { id: "outside", focus() {} };
+  const release = createFocusTrap(stub.container, { document: stub.doc });
+
+  stub.setActive(outside);
+  const event = tabEvent(true); // Shift+Tab
+  stub.doc.dispatch("keydown", event);
+  assert.equal(event.defaultPrevented, true);
+  // Shift+Tab from outside wraps to LAST, mirroring how Tab-out-from-end
+  // wraps to first. Without this, Shift+Tab from outside would land on
+  // first which violates the natural reverse-tab cycle.
+  assert.equal(stub.focusCalls[0].id, stub.items[2].id);
+  release();
+});
+
 test("release() detaches the listener", () => {
   const stub = makeStubDoc({ focusables: ["b1", "b2"] });
   const release = createFocusTrap(stub.container, { document: stub.doc });

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -327,6 +327,24 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   }
 });
 
+test("Project tabs mark the active project with aria-current=\"page\"", () => {
+  // Project tabs use role="button" but represent a navigation choice. The
+  // appropriate ARIA pattern is aria-current="page" on the active tab so
+  // screen readers announce it as the current location. Inactive tabs
+  // must explicitly clear the attribute so the previously-active tab
+  // doesn't retain the marker after a switch.
+  assert.match(
+    appSource,
+    /button\.setAttribute\("aria-current",\s*"page"\)/,
+    "expected the active project tab to set aria-current=\"page\"",
+  );
+  assert.match(
+    appSource,
+    /button\.removeAttribute\("aria-current"\)/,
+    "expected inactive project tabs to remove aria-current",
+  );
+});
+
 test("Error regions declare role=\"alert\" so screen readers announce them", () => {
   // Without role="alert" (or aria-live="assertive"), errors that appear
   // in wizard-error and project-picker-error are silent for screen reader

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -676,8 +676,15 @@
           button.title = tab.project_root;
           button.setAttribute("role", "button");
           button.tabIndex = 0;
+          // SPEC-2356 — aria-current="page" announces the active tab to
+          // screen readers without changing the role semantics. Inactive
+          // tabs explicitly clear the attribute so the previously-active
+          // tab doesn't keep the marker after a switch.
           if (tab.id === appState.active_tab_id) {
             button.classList.add("active");
+            button.setAttribute("aria-current", "page");
+          } else {
+            button.removeAttribute("aria-current");
           }
           button.innerHTML = `
             <span class="project-tab-label">${tab.title}</span>


### PR DESCRIPTION
## Summary
**Two final accessibility wins:**

### 1. Pin Shift+Tab from outside the focus trap wraps to the last
The focus-trap implementation already handled this (PR #2453), but the unit tests only covered plain Tab. Add the Shift+Tab partner test so future refactors can't accidentally break the reverse-tab cycle without breaking CI.

### 2. Project tabs mark the active project with aria-current="page"
Project tabs use `role="button"` but represent a navigation choice. Without an aria-current marker, screen readers announce all tabs as identical buttons; the active one was only visually distinguished via the `.active` class.

- Active tab: `aria-current="page"` (announced as "current page" by NVDA, "current item" by VoiceOver)
- Inactive tabs: aria-current explicitly removed so a previously-active tab doesn't retain the marker after a switch

`aria-current="page"` is the correct value here per the WAI-ARIA 1.2 spec — these are top-level navigation choices switching the entire project context.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2453 (focus trap)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/focus-trap.test.mjs` — 11 件 GREEN (+1 件)
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 40 件 GREEN (+1 件)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
