### PR TITLE
fix(ui): SPEC-2356 — Status Strip live-dot honors prefers-reduced-motion

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -214,6 +214,12 @@ mod tests {
         app_js_handler, branch_cleanup_modal_js_handler, xterm_css_handler, xterm_fit_js_handler,
         xterm_js_handler,
     };
+    // SPEC-2356 — Operator Design System modules.
+    use super::{focus_trap_js, hotkey_js, operator_shell_js, theme_manager_js};
+    use super::{
+        focus_trap_js_handler, hotkey_js_handler, operator_shell_js_handler,
+        theme_manager_js_handler,
+    };
 
     fn frontend_bundle_source() -> &'static str {
         concat!(
@@ -432,6 +438,17 @@ mod tests {
         assert!(!xterm_js().is_empty());
         assert!(!xterm_fit_js().is_empty());
         assert!(xterm_css().contains(".xterm"));
+        // SPEC-2356 — Operator Design System modules. Assert they ship in
+        // the binary so a missing include_str! macro fails CI rather than
+        // silently 404ing in production.
+        assert!(!theme_manager_js().is_empty());
+        assert!(!hotkey_js().is_empty());
+        assert!(!operator_shell_js().is_empty());
+        assert!(!focus_trap_js().is_empty());
+        assert!(theme_manager_js().contains("createThemeManager"));
+        assert!(hotkey_js().contains("createHotkeyManager"));
+        assert!(operator_shell_js().contains("initOperatorShell"));
+        assert!(focus_trap_js().contains("createFocusTrap"));
     }
 
     #[tokio::test]
@@ -484,6 +501,23 @@ mod tests {
                 .unwrap(),
             "text/css; charset=utf-8",
         );
+        // SPEC-2356 — Operator Design System module handlers. All four
+        // serve JavaScript with the same charset; the assertion catches
+        // regressions if a handler ever changes its content-type.
+        for handler_response in [
+            theme_manager_js_handler().await.into_response(),
+            hotkey_js_handler().await.into_response(),
+            operator_shell_js_handler().await.into_response(),
+            focus_trap_js_handler().await.into_response(),
+        ] {
+            assert_eq!(
+                handler_response
+                    .headers()
+                    .get(header::CONTENT_TYPE)
+                    .unwrap(),
+                js,
+            );
+        }
     }
 
     #[test]

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -12,6 +12,37 @@ const { document } = parseHTML(html);
 const operatorShellSource = readFileSync(resolve(here, "../operator-shell.js"), "utf8");
 const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
 
+// SPEC-2356 — extract every @media block matching the supplied condition,
+// using brace-depth tracking so nested rules don't truncate the body.
+function extractMediaBlocks(css, condition) {
+  const out = [];
+  const marker = `@media`;
+  let cursor = 0;
+  while (true) {
+    const at = css.indexOf(marker, cursor);
+    if (at < 0) break;
+    const headerEnd = css.indexOf("{", at);
+    if (headerEnd < 0) break;
+    const header = css.slice(at, headerEnd);
+    if (!header.includes(condition)) {
+      cursor = headerEnd + 1;
+      continue;
+    }
+    // Walk forward from headerEnd, tracking brace depth.
+    let depth = 1;
+    let i = headerEnd + 1;
+    while (i < css.length && depth > 0) {
+      const ch = css[i];
+      if (ch === "{") depth += 1;
+      else if (ch === "}") depth -= 1;
+      i += 1;
+    }
+    out.push(css.slice(headerEnd + 1, i - 1));
+    cursor = i;
+  }
+  return out.join("\n");
+}
+
 test("index.html declares Operator chrome scaffold", () => {
   for (const sel of [
     "#op-theme-toggle",
@@ -324,6 +355,46 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
         `${id}: aria-labelledby="${labelledby}" must point at an existing element`,
       );
     }
+  }
+});
+
+test("Every keyframes-driven animation has a prefers-reduced-motion override", () => {
+  // Catch the gap where someone adds a new @keyframes + animation without
+  // pairing it with a reduced-motion override. Approach: for each
+  // keyframes name, find its `animation: <name>` use site, walk back to
+  // the enclosing selector, and verify that selector (or a parent
+  // matching it) appears in any prefers-reduced-motion block.
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  const keyframes = [...new Set([...css.matchAll(/@keyframes\s+([\w-]+)\s*\{/g)].map((m) => m[1]))];
+  assert.ok(keyframes.length >= 6, `expected >= 6 keyframes, got ${keyframes.length}`);
+
+  // CSS @media blocks have nested rules with their own closing braces, so
+  // a naive regex with `[^}]*` or `[\s\S]*?\n\}` undercaptures. Walk the
+  // string and use depth tracking to extract every prefers-reduced-motion
+  // block in full.
+  const reducedMotionUnion = extractMediaBlocks(css, "prefers-reduced-motion: reduce");
+  assert.ok(reducedMotionUnion.length > 0, "expected at least one prefers-reduced-motion block");
+
+  for (const name of keyframes) {
+    // Locate `animation: <name>` (skip the @keyframes definition itself).
+    const useIndex = css.search(new RegExp(`animation:[^;]*\\b${name}\\b[^;]*;`));
+    assert.ok(useIndex > 0, `@keyframes ${name} has no animation: use site`);
+    // Walk back from the use site to the most recent `{` to find the
+    // enclosing selector — that's the line that opens the rule.
+    const before = css.slice(0, useIndex);
+    const lastOpenBrace = before.lastIndexOf("{");
+    assert.ok(lastOpenBrace > 0, `cannot locate opening brace for ${name}`);
+    // Selector text is the line(s) immediately before the `{`. Walk
+    // backward to the previous `}` (or BOF) for the rule start.
+    const ruleStart = before.lastIndexOf("}", lastOpenBrace - 1);
+    const selectorText = before.slice(ruleStart + 1, lastOpenBrace).trim();
+    // Grab every class, attribute selector, or id used in the selector.
+    const tokens = selectorText.match(/\.[\w-]+|\[[\w-]+(="[^"]*")?\]|#[\w-]+/g) || [];
+    const hasOverride = tokens.some((tok) => reducedMotionUnion.includes(tok));
+    assert.ok(
+      hasOverride,
+      `@keyframes ${name} (selector "${selectorText}") has no prefers-reduced-motion override`,
+    );
   }
 });
 

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -606,6 +606,12 @@ body::after {
   [data-agent-state="blocked"] {
     animation: none;
   }
+  /* SPEC-2356 — Status Strip live dot pulses to signal "system is alive".
+     Motion-sensitive users get a static dot that still indicates online
+     state via colour, just without the scale+opacity pulse. */
+  .op-status-strip__live-dot {
+    animation: none;
+  }
 }
 
 /* ============================================================

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,50 @@
 # Lessons Learned
 
+## 2026-05-04 — `[\s\S]*?` regex undercapture masks bugs in nested CSS blocks
+
+### 事象
+
+SPEC-2356 polish iteration で `@media (prefers-reduced-motion: reduce)`
+ブロックを検証する chrome-structure assertion を書いたとき、最初は
+naive な regex `/@media\s*\([^)]*\)\s*\{[\s\S]*?\n\}/g` を使った。これだと
+ネストしたルール (`.selector { animation: none; }`) の最初の `}` で
+マッチが終了するため、ブロック全体ではなく最初のルールしか拾えない。
+その結果、`op-live-pulse` を使っている `.op-status-strip__live-dot`
+が reduced-motion で無効化されていない (実際は `forced-colors: active`
+にしか入っていなかった) 既存バグを assertion がスルーしてしまった。
+
+depth-tracked extraction (`{` `}` を数えて対応する閉じを探す) に
+書き直したところ、即座に live-dot が reduced-motion でカバーされて
+いないことが捕捉された。
+
+### 原因
+
+CSS の `@media` ブロックは内部に複数のルールを持ち、それぞれが `{}` を
+使う。regex の `[^}]*` や `[\s\S]*?\n\}` で「最初の `}` まで」を
+切ると、ブロックの先頭の少数ルールしか captured されない。assertion
+は cover されたか否かしか見ないので、cover 漏れが「該当ルールが存在
+しない」と誤判定され、本来検出すべきバグを GREEN で見逃してしまう。
+
+### 再発防止策
+
+1. **CSS の `@media` / 入れ子ブロックを regex で切るときは brace-depth
+   tracking を使う。** ヘルパ関数 `extractMediaBlocks(css, condition)`
+   を新設し、`{` と `}` を数えて対応する閉じを探す。テスト時は単純な
+   regex に逃げず、ヘルパを再利用する。
+2. **新しい coverage assertion を書いたら、その assertion が確実に
+   gap を捕捉できる「false case」を意識的に作って verify する。**
+   今回の assertion は最初から GREEN で通ってしまっていたが、もし
+   live-dot のような実バグが既に存在していれば即座に RED になるべき
+   だった。assertion 設計時は「バグがあれば落ちる」を必ず確認する。
+
+### 適用範囲
+
+- すべての CSS 構造解析 assertion (`@media` / `@supports` / `@keyframes` /
+  `@layer` 等のネストブロック)。
+- 同種のパターンを抱える HTML / source 解析 assertion も同じ落とし穴
+  を避けるため、構文認識の必要があるものは regex に逃げず depth /
+  parser を使う。
+
 ## 2026-05-04 — Chrome-structure assertions alone don't catch contrast regressions
 
 ### 事象


### PR DESCRIPTION
## Summary
**Real motion-accessibility bug + new keyframes-coverage assertion + lesson + Rust test parity.**

### The bug
A new chrome-structure assertion walks every `@keyframes` in `components.css`, finds the selector that uses it, and verifies the selector appears in a `prefers-reduced-motion: reduce` override block. The first run caught:

| Animation | Selector | Issue |
|---|---|---|
| `op-live-pulse` | `.op-status-strip__live-dot` | Only suppressed under `@media (forced-colors: active)` — motion-sensitive users still got a constantly-pulsing dot |

### The fix
Add `.op-status-strip__live-dot { animation: none; }` to the existing `prefers-reduced-motion` block alongside the `[data-agent-state]` overrides.

### The infrastructure improvement
A previous naive regex `/@media\s*\([^)]*\)\s*\{[\s\S]*?\n\}/g` undercaptured `@media` block bodies because nested rules have their own closing braces. The new test uses a depth-tracked `extractMediaBlocks(css, condition)` helper that counts `{` and `}` to find the matching close.

### The lesson recorded
`tasks/lessons.md` records two preventive rules:
1. CSS structural assertions must use brace-depth tracking to extract `@media` / `@keyframes` / `@supports` / `@layer` blocks
2. New coverage assertions need a "false case" verification step

### Bonus: Rust embedded_web test parity
`embedded_web_secondary_assets_are_embedded` and `embedded_web_asset_handlers_set_content_types` previously covered only the original assets (app, branch-cleanup-modal, xterm). Extended to assert that the SPEC-2356 Operator modules (theme-manager / hotkey / operator-shell / focus-trap) are also embedded with non-empty content + marker symbols, AND that all four handlers serve `text/javascript; charset=utf-8`. Without this, a future refactor could remove an `include_str!` macro and silently produce a 404, or change a handler's content-type and break browser MIME-strict module loading.

## Closing Issues
None — bug fix on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2441 (companion lesson: chrome-structure-vs-contrast)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 41 件 GREEN (+1 件 keyframes coverage)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN (existing tests extended with Operator module assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
