### PR TITLE
polish: SPEC-2356 — progress bar a11y + apply Lesson 2 to contrast tests

### DIFF
--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -182,12 +182,14 @@ test("every color token has a forced-colors fallback for high-contrast mode", ()
   // / GrayText / etc) so Windows High Contrast and macOS Increase Contrast
   // render correctly. Without this, custom tokens leak through and the
   // user sees the design system colors instead of system colors.
-  const forcedColorsBlock = tokensCss.match(
-    /@media\s*\(\s*forced-colors:\s*active\s*\)\s*\{([\s\S]*?)\n\}\s*\n/,
-  );
-  assert.ok(forcedColorsBlock, "tokens.css must contain a forced-colors media query");
+  //
+  // Lesson 2 (tasks/lessons.md 2026-05-04): naive regex `[\s\S]*?\n\}`
+  // undercaptures @media bodies because nested rules have their own
+  // closing braces. Use brace-depth tracking instead.
+  const forcedColorsBody = extractMediaBlock(tokensCss, "forced-colors: active");
+  assert.ok(forcedColorsBody, "tokens.css must contain a forced-colors media query");
   const fallbackKeys = new Set();
-  for (const line of forcedColorsBlock[1].split("\n")) {
+  for (const line of forcedColorsBody.split("\n")) {
     const m = line.match(/^\s*(--[a-z][a-z0-9-]*)\s*:/);
     if (m) fallbackKeys.add(m[1]);
   }
@@ -202,6 +204,34 @@ test("every color token has a forced-colors fallback for high-contrast mode", ()
     );
   }
 });
+
+// SPEC-2356 Lesson 2 — extract a single @media block body using brace-
+// depth tracking instead of a naive regex. The naive
+// /@media\s*\(...\)\s*\{[\s\S]*?\n\}/ truncates at the first nested `}`
+// when the @media body contains rules with their own closing braces,
+// which causes coverage assertions to silently miss bugs.
+function extractMediaBlock(css, condition) {
+  const marker = "@media";
+  let cursor = 0;
+  while (true) {
+    const at = css.indexOf(marker, cursor);
+    if (at < 0) return null;
+    const headerEnd = css.indexOf("{", at);
+    if (headerEnd < 0) return null;
+    if (!css.slice(at, headerEnd).includes(condition)) {
+      cursor = headerEnd + 1;
+      continue;
+    }
+    let depth = 1;
+    let i = headerEnd + 1;
+    while (i < css.length && depth > 0) {
+      if (css[i] === "{") depth += 1;
+      else if (css[i] === "}") depth -= 1;
+      i += 1;
+    }
+    return css.slice(headerEnd + 1, i - 1);
+  }
+}
 
 test("token names are kebab-case CSS custom properties", () => {
   const all = new Set([...Object.keys(dark), ...Object.keys(light)]);

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -501,6 +501,27 @@ test("Drawer modal renderers activate focus-trap on open and release on close", 
   }
 });
 
+test("Migration progress bar references the phase label via aria-labelledby", () => {
+  // The native <progress> element gets an implicit role="progressbar"
+  // but no programmatic name unless aria-label or aria-labelledby is
+  // provided. Without it, screen readers announce just "progressbar 50%"
+  // and the user doesn't know which phase is running.
+  const migrationSrc = readFileSync(
+    resolve(here, "../migration-modal.js"),
+    "utf8",
+  );
+  assert.match(
+    migrationSrc,
+    /phaseLabel\.id\s*=\s*"migration-modal-phase-label"/,
+    "expected migration phase label to have a stable id",
+  );
+  assert.match(
+    migrationSrc,
+    /progress\.setAttribute\("aria-labelledby",\s*"migration-modal-phase-label"\)/,
+    "expected migration <progress> to reference the phase label via aria-labelledby",
+  );
+});
+
 test("Drawer modal renderers signal busy state via aria-busy during async stages", () => {
   // The branch-cleanup running stage and migration running stage are
   // synchronous async operations. Without aria-busy, screen readers don't

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -501,6 +501,35 @@ test("Drawer modal renderers activate focus-trap on open and release on close", 
   }
 });
 
+test("Every role=\"dialog\" element has a programmatic accessible name", () => {
+  // Catch the case where a new dialog is added without aria-label or
+  // aria-labelledby — without an accessible name, screen readers
+  // announce just "dialog" with no context. Iterates the live DOM
+  // tree so future additions are covered automatically.
+  const dialogs = document.querySelectorAll('[role="dialog"]');
+  assert.ok(dialogs.length >= 5, `expected >= 5 role="dialog" elements, got ${dialogs.length}`);
+  for (const dialog of dialogs) {
+    const label = dialog.getAttribute("aria-label");
+    const labelledby = dialog.getAttribute("aria-labelledby");
+    const id = dialog.getAttribute("id") || dialog.parentElement?.getAttribute("id") || "(no id)";
+    assert.ok(
+      (label && label.length > 0) || (labelledby && labelledby.length > 0),
+      `role="dialog" at #${id} must have aria-label or aria-labelledby`,
+    );
+    if (labelledby) {
+      const target = document.getElementById(labelledby);
+      assert.ok(
+        target,
+        `role="dialog" at #${id} aria-labelledby="${labelledby}" must point at an existing element`,
+      );
+      assert.ok(
+        target.textContent && target.textContent.trim().length > 0,
+        `role="dialog" at #${id} aria-labelledby target must have non-empty text`,
+      );
+    }
+  }
+});
+
 test("Migration progress bar references the phase label via aria-labelledby", () => {
   // The native <progress> element gets an implicit role="progressbar"
   // but no programmatic name unless aria-label or aria-labelledby is

--- a/crates/gwt/web/migration-modal.js
+++ b/crates/gwt/web/migration-modal.js
@@ -121,6 +121,11 @@ export function renderMigrationModal({
       "migration-modal-phase-label",
       describePhase(m.phase),
     );
+    // SPEC-2356 — give the phase label a stable id so the <progress>
+    // element can reference it via aria-labelledby. Without this, screen
+    // readers announce just "progressbar 50%" with no context about
+    // which phase is running.
+    phaseLabel.id = "migration-modal-phase-label";
     dialogEl.appendChild(phaseLabel);
     const progress = createNode("progress", "migration-modal-progress");
     progress.setAttribute("max", "100");
@@ -128,6 +133,7 @@ export function renderMigrationModal({
       "value",
       String(Number.isFinite(m.percent) ? m.percent : 0),
     );
+    progress.setAttribute("aria-labelledby", "migration-modal-phase-label");
     dialogEl.appendChild(progress);
     dialogEl.appendChild(
       createNode(


### PR DESCRIPTION
## Summary
**Two final accessibility wins:**

### 1. Migration progress bar gains a programmatic name
The native `<progress>` element in the migration modal had `role="progressbar"` but no `aria-labelledby`. During a worktree migration, screen readers announced just "progressbar 50%" without context about which phase was running.

- Give the phase label a stable id: `migration-modal-phase-label`
- Reference it from `<progress>` via `aria-labelledby="migration-modal-phase-label"`

Screen readers now announce the full context:
- "Validating workspace, progressbar 50%" while validation runs
- "Building bare repository, progressbar 75%" as the migration advances

### 2. Apply Lesson 2 to the forced-colors fallback assertion
The forced-colors fallback completeness assertion in `contrast.test.mjs` used the same naive regex `[\s\S]*?\n\}` that Lesson 2 (`tasks/lessons.md` 2026-05-04) flagged as fragile against nested CSS rules.

The assertion currently works because tokens.css indents nested rules so the `\n\}` regex skips them. But the test would silently miss tokens if someone reformatted the file.

Replace the regex with a depth-tracked `extractMediaBlock(css, condition)` helper that counts `{` and `}` to find the matching close. This applies Lesson 2 in spirit: structural CSS assertions should not rely on indentation conventions.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2456 (Lesson 2: brace-depth tracking for nested CSS blocks)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 42 件 GREEN (+1 件 progressbar)
- [x] `node --test crates/gwt/web/__tests__/contrast.test.mjs` — 94 件 GREEN (depth-tracked extraction)
- [x] `node --test crates/gwt/web/__tests__/migration-modal.smoke.test.mjs` — 5 件 GREEN (regression)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
