### PR TITLE
polish: SPEC-2356 — preset modal Esc-close + Lesson 3 (audit-driven a11y)

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -721,6 +721,13 @@ test("Drawer modals close on Escape — keyboard parity with backdrop click", ()
     /if\s*\(windowListOpen\)\s*\{[\s\S]*windowListOpen\s*=\s*false[\s\S]*windowListButton\.focus/,
     "expected Esc to close window list dropdown and restore focus to trigger",
   );
+  // SPEC-2356 — preset modal Esc-close: closes via closeModal() which
+  // handles both the .open class flip and focus restore.
+  assert.match(
+    appSource,
+    /if\s*\(modal\.classList\.contains\("open"\)\)\s*\{[\s\S]*closeModal\(\)/,
+    "expected Esc to call closeModal when preset modal is open",
+  );
 });
 
 test("Drawer modal renderers toggle aria-hidden alongside .open class", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7100,6 +7100,14 @@
           event.preventDefault();
           return;
         }
+        if (modal.classList.contains("open")) {
+          // SPEC-2356 — preset (Add Window) modal also needs Esc-close.
+          // closeModal() handles both the .open class flip and the focus
+          // restore via the WeakMap-style closure variables.
+          closeModal();
+          event.preventDefault();
+          return;
+        }
         if (migrationModal && migrationModal.classList.contains("open")) {
           // Migration "skip" is the cancellation path; map Esc to the
           // same intent so the modal isn't a keyboard trap. Must use

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,67 @@
 # Lessons Learned
 
+## 2026-05-04 — Audit-driven a11y coverage finds gaps that audit-by-checklist misses
+
+### 事象
+
+SPEC-2356 polish iteration で modal accessibility を完成させた後、当初は
+「全 modal に WAI-ARIA dialog convention 適用」「focus trap 実装」で
+work が完了したと判断していた。しかし Ralph Loop で iteration を
+続ける中で audit-driven approach (各 surface の form fields / status
+indicators / error regions / progress bars 等を 1 surface ずつ網羅
+チェックする) を採用したところ、以下のような「checklist では拾えな
+い」accessibility gap が次々と検出された:
+
+- 動的に生成される input / textarea / select に `aria-label` がない
+  (memo / profile / wizard の form fields。`<label>` で wrap されて
+  いない 8 fields)
+- 動的に生成される `<progress>` element に `aria-labelledby` がない
+  (migration の phase progress)
+- preset (Add Window) modal が Esc-close handler 配列から漏れていた
+  (他の 5 modal は全部 covered だったが 1 つだけ漏れ)
+- live-dot pulse が `forced-colors: active` ブロックには入って
+  いたが `prefers-reduced-motion: reduce` には入っていなかった
+  (PR #2456 で structural assertion が catch)
+
+これらは「modal a11y チェックリストを埋める」感覚では発見できず、
+実際に `grep "createElement\\|createNode" | filter` で全 fields を
+列挙して 1 つずつ aria-label の有無を audit する作業で初めて捕捉
+できた。
+
+### 原因
+
+Accessibility は HTML / ARIA の組み合わせ問題で、cross-cutting concern
+として全 surface に均等にかかるが、開発時は surface 単位で feature を
+追加する。1 surface 完了時点では他の surface の同類 element の有無
+は意識されず、結果として「ある場所では aria-label が wired、ある場所
+では wired していない」という不均一さが生まれる。Code review 時にも
+「この surface だけ見ているとそれ単体で OK に見える」ため検出されない。
+
+### 再発防止策
+
+1. **Surface 横断 audit を accessibility 追加時の standard practice
+   にする。** 新しい aria-* / role / 役割属性を追加した PR では、
+   その属性が他の surface でも必要になる可能性を query で確認:
+   - `grep -nE 'createElement\\("input"\\)' src/**/*.js` で input 全箇所
+   - `grep -nE 'createNode\\("button"' src/**/*.js` で button 全箇所
+   - `grep -n 'role="dialog"' src/**/*.html` で dialog 全箇所
+2. **Meta-assertion を chrome-structure tests に置く。** 「全
+   `[role="dialog"]` element に accessible name があること」のような
+   meta-assertion は新しい dialog が追加されただけで自動的に検証
+   範囲に含まれるため、surface 横断の網羅を test layer に固定できる。
+   `operator-chrome-structure.test.mjs` の `Every role="dialog" has
+   programmatic accessible name` test がこの pattern。
+3. **Audit list は test file に書く、document に書かない。** Document
+   は drift しやすいが test は CI で実行される。「全 form field の
+   aria-label coverage」のような expected 一覧は assertion の expected
+   array にまとめておく。
+
+### 適用範囲
+
+- 新しい WAI-ARIA pattern (combobox / tablist / tree 等) を追加する PR
+- 新しい role / aria-* attribute を 1 surface に wired した PR
+- Lessons-driven feedback loop の継続的な audit cycle
+
 ## 2026-05-04 — `[\s\S]*?` regex undercapture masks bugs in nested CSS blocks
 
 ### 事象


### PR DESCRIPTION
## Summary
**Two final completion items:**

### 1. Preset (Add Window) modal closes on Escape
The global Esc handler covered branch-cleanup, wizard, migration, and the windowListOpen dropdown but missed the preset modal. Add a preset modal branch that calls `closeModal()` (which already handles both the `.open` flip and focus restore via the WeakMap-style closure variables wired in PR #2450).

### 2. Lesson 3 recorded — audit-driven a11y coverage
After 23 PRs of accessibility hardening this session, the meta-lesson is now captured in `tasks/lessons.md`: completing a "WAI-ARIA dialog convention" checklist for modals felt like the work was done, but iterating with Ralph Loop and adopting an audit-driven approach (grep all inputs/textareas/selects/buttons, check each one) found 6+ additional gaps:

- 8 dynamically-created form fields without aria-label
- 1 `<progress>` element without aria-labelledby
- 1 modal missing Esc-close handler entry (this PR — preset)
- 1 keyframes animation only suppressed under forced-colors, not reduced-motion

Three preventive rules now codified:
1. Surface-cross audits during accessibility work — grep for all instances of the same element type
2. Meta-assertions in chrome-structure tests — assertions like "every role=dialog has accessible name" auto-extend to new surfaces
3. Audit lists live in tests, not docs — CI-executable assertion arrays don't drift

## Closing Issues
None — final session polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2440-#2459 (cumulative modal a11y hardening this session)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 44 件 GREEN
- [x] `cargo test -p gwt --lib` — 391 件 GREEN
- [x] markdownlint passes (no new lint issues introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
