### PR TITLE
feat(ui): SPEC-2356 — list rows aria-current + choice buttons aria-pressed

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -398,6 +398,38 @@ test("Every keyframes-driven animation has a prefers-reduced-motion override", (
   }
 });
 
+test("Selected list rows mark active item with aria-current", () => {
+  // Same pattern as project tabs (PR #2455): list-style buttons with a
+  // selected state need aria-current to announce which row is active.
+  // Coverage: knowledge-row, memo-note-row, profile-row, logs-entry.
+  // The set/remove pair is required so a previously-selected row
+  // doesn't retain the marker after the user picks a different row.
+  for (const desc of [
+    "knowledge",
+    "memo note",
+    "profile",
+    "logs entry",
+  ]) {
+    // Each list iterates over its rows and conditionally sets
+    // aria-current="true" on the selected one. We assert both the
+    // setAttribute and removeAttribute calls exist somewhere in app.js.
+    // The descriptive label is just for the failure message.
+  }
+  // Count occurrences — should be at least 4 set + 4 remove for the
+  // four list-with-selection surfaces (knowledge / memo / profile /
+  // logs) plus the project-tabs case from PR #2455.
+  const setMatches = appSource.match(/setAttribute\("aria-current",\s*"(true|page)"\)/g) || [];
+  const removeMatches = appSource.match(/removeAttribute\("aria-current"\)/g) || [];
+  assert.ok(
+    setMatches.length >= 5,
+    `expected >= 5 aria-current set calls (project tab + 4 row types), got ${setMatches.length}`,
+  );
+  assert.ok(
+    removeMatches.length >= 5,
+    `expected >= 5 aria-current remove calls (one per set call), got ${removeMatches.length}`,
+  );
+});
+
 test("Project tabs mark the active project with aria-current=\"page\"", () => {
   // Project tabs use role="button" but represent a navigation choice. The
   // appropriate ARIA pattern is aria-current="page" on the active tab so

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -398,6 +398,18 @@ test("Every keyframes-driven animation has a prefers-reduced-motion override", (
   }
 });
 
+test("Launch wizard choice buttons expose toggle state via aria-pressed", () => {
+  // The wizard's agent / preset picker uses createChoiceButton for
+  // mutually-exclusive options. Without aria-pressed, screen readers
+  // can't announce which option is currently chosen — they just hear
+  // a button list with no selection state.
+  assert.match(
+    appSource,
+    /button\.setAttribute\("aria-pressed",\s*selected\s*\?\s*"true"\s*:\s*"false"\)/,
+    "expected createChoiceButton to set aria-pressed based on selected",
+  );
+});
+
 test("Selected list rows mark active item with aria-current", () => {
   // Same pattern as project tabs (PR #2455): list-style buttons with a
   // selected state need aria-current to announce which row is active.

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2423,6 +2423,9 @@
           row.type = "button";
           if (selectedEntry && selectedEntry.id === entry.id) {
             row.classList.add("selected");
+            row.setAttribute("aria-current", "true");
+          } else {
+            row.removeAttribute("aria-current");
           }
           row.addEventListener("click", () => {
             state.selectedEntryId = entry.id;
@@ -2708,6 +2711,9 @@
           row.type = "button";
           if (note.id === state.selectedNoteId) {
             row.classList.add("selected");
+            row.setAttribute("aria-current", "true");
+          } else {
+            row.removeAttribute("aria-current");
           }
           row.addEventListener("click", () => selectMemoNote(windowId, note.id));
 
@@ -3081,6 +3087,9 @@
           row.type = "button";
           if (profile.name === state.selectedProfile) {
             row.classList.add("selected");
+            row.setAttribute("aria-current", "true");
+          } else {
+            row.removeAttribute("aria-current");
           }
           row.addEventListener("click", () => selectProfile(windowId, profile.name));
           const header = createNode("div", "profile-row-header");
@@ -4777,6 +4786,12 @@
             row.type = "button";
             if (state.selectedNumber === entry.number) {
               row.classList.add("selected");
+              // SPEC-2356 — selected knowledge entry gets aria-current
+              // so screen readers announce which row is currently
+              // displayed in the detail pane (parallel to project tabs).
+              row.setAttribute("aria-current", "true");
+            } else {
+              row.removeAttribute("aria-current");
             }
             const main = createNode("div", "knowledge-row-main");
             const titleWrap = createNode("div", "");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3607,6 +3607,12 @@
       function createChoiceButton(option, selected, onSelect) {
         const button = createNode("button", "launch-choice-button");
         button.type = "button";
+        // SPEC-2356 — choice buttons toggle between mutually-exclusive
+        // options (which agent to launch / which preset). aria-pressed
+        // exposes the toggled state so screen readers announce which
+        // option is currently selected without relying on the visual
+        // .selected class alone.
+        button.setAttribute("aria-pressed", selected ? "true" : "false");
         if (selected) {
           button.classList.add("selected");
         }


### PR DESCRIPTION
## Summary
**Two more audit-driven a11y wins:**

### 1. List rows with selection state mark active row with aria-current
4 list-with-selection surfaces beyond the project tabs (PR #2455) lacked `aria-current`:
- `knowledge-row` (Knowledge Bridge)
- `memo-note-row` (Memo notes)
- `profile-row` (Profile editor)
- `logs-entry` (Logs)

Pattern: set `aria-current="true"` on selected row + `removeAttribute` on inactive rows so a previously-selected row doesn't retain the marker.

### 2. Launch wizard choice buttons expose aria-pressed
The `createChoiceButton` helper renders mutually-exclusive picker options (which agent / which preset). It had a `.selected` CSS class but no programmatic toggle state — screen readers heard a flat button list with no indication of selection.

Add `aria-pressed="true|false"` wired to the same `selected` parameter. Screen readers now announce: "Claude, button, pressed" vs "Codex, button, not pressed".

`aria-pressed` is appropriate for this single-select toggle pattern (`role="radio"` with radiogroup would be more semantic but requires restructuring; `aria-pressed` is the standard accepted alternative for button-based picker lists).

### Verification
Two chrome-structure assertions pin both:
1. Counts setAttribute/removeAttribute aria-current calls (>= 5 each: 4 row types + project tab from #2455)
2. Verifies `createChoiceButton` sets aria-pressed based on selected

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2455 (project tab aria-current)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 46 件 GREEN (+2 件)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
