### PR TITLE
feat(ui): SPEC-2356 — file tree gains aria-current + aria-expanded

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -427,18 +427,18 @@ test("Selected list rows mark active item with aria-current", () => {
     // setAttribute and removeAttribute calls exist somewhere in app.js.
     // The descriptive label is just for the failure message.
   }
-  // Count occurrences — should be at least 4 set + 4 remove for the
-  // four list-with-selection surfaces (knowledge / memo / profile /
-  // logs) plus the project-tabs case from PR #2455.
+  // Count occurrences — should be at least 5 set + 5 remove for the
+  // five list-with-selection surfaces (knowledge / memo / profile /
+  // logs / file-tree) plus the project-tabs case from PR #2455.
   const setMatches = appSource.match(/setAttribute\("aria-current",\s*"(true|page)"\)/g) || [];
   const removeMatches = appSource.match(/removeAttribute\("aria-current"\)/g) || [];
   assert.ok(
-    setMatches.length >= 5,
-    `expected >= 5 aria-current set calls (project tab + 4 row types), got ${setMatches.length}`,
+    setMatches.length >= 6,
+    `expected >= 6 aria-current set calls (project tab + 5 row types), got ${setMatches.length}`,
   );
   assert.ok(
-    removeMatches.length >= 5,
-    `expected >= 5 aria-current remove calls (one per set call), got ${removeMatches.length}`,
+    removeMatches.length >= 6,
+    `expected >= 6 aria-current remove calls (one per set call), got ${removeMatches.length}`,
   );
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -398,6 +398,25 @@ test("Every keyframes-driven animation has a prefers-reduced-motion override", (
   }
 });
 
+test("File tree directory rows expose collapse state via aria-expanded", () => {
+  // The file tree shows directories with ▾/▸ caret glyphs to indicate
+  // expand/collapse state visually. Without aria-expanded, screen
+  // readers can't tell whether a directory is open or closed, so the
+  // user has to guess via context. File (non-directory) rows must
+  // explicitly removeAttribute so a row that was a directory and
+  // became a file (via state change) doesn't keep the marker.
+  assert.match(
+    appSource,
+    /isDirectory[\s\S]*row\.setAttribute\("aria-expanded",\s*expanded\s*\?\s*"true"\s*:\s*"false"\)/,
+    "expected directory rows to set aria-expanded based on expanded state",
+  );
+  assert.match(
+    appSource,
+    /row\.removeAttribute\("aria-expanded"\)/,
+    "expected non-directory rows to remove aria-expanded",
+  );
+});
+
 test("Launch wizard choice buttons expose toggle state via aria-pressed", () => {
   // The wizard's agent / preset picker uses createChoiceButton for
   // mutually-exclusive options. Without aria-pressed, screen readers

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -4371,6 +4371,16 @@
 
             const expanded = state.expanded.has(entry.path);
             const isDirectory = entry.kind === "directory";
+            // SPEC-2356 — directory rows expose collapse state via
+            // aria-expanded so screen readers announce "expanded" or
+            // "collapsed" alongside the visual ▾/▸ caret. File rows
+            // (non-directories) should not expose aria-expanded —
+            // that would falsely signal the element is collapsible.
+            if (isDirectory) {
+              row.setAttribute("aria-expanded", expanded ? "true" : "false");
+            } else {
+              row.removeAttribute("aria-expanded");
+            }
             row.innerHTML = `
               <span class="tree-caret">${isDirectory ? (expanded ? "▾" : "▸") : ""}</span>
               <span class="tree-icon ${isDirectory ? "dir" : "file"}">${isDirectory ? "▣" : "•"}</span>

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -4358,8 +4358,14 @@
           for (const entry of entries) {
             const row = document.createElement("div");
             row.className = "file-tree-row";
+            // SPEC-2356 — file tree rows have a selected state but are
+            // <div>s, not buttons. aria-current="true" works on any
+            // element and announces "current item" to screen readers.
             if (state.selectedPath === entry.path) {
               row.classList.add("selected");
+              row.setAttribute("aria-current", "true");
+            } else {
+              row.removeAttribute("aria-current");
             }
             row.style.paddingLeft = `${12 + depth * 18}px`;
 


### PR DESCRIPTION
## Summary
**File tree gains both aria-current (selection) and aria-expanded (collapse state).**

### 1. aria-current for the selected file
File tree rows had `.selected` class but no programmatic state. Screen readers couldn't tell which row is currently displayed in the detail pane. `aria-current="true"` works on any element and announces "current item".

### 2. aria-expanded for directory rows
Directories show ▾/▸ caret glyphs to indicate collapse state. Without `aria-expanded`, screen readers couldn't announce whether a directory is open or closed.

- Directory rows: `aria-expanded="true|false"` wired to the same `expanded` boolean the caret uses
- File (non-directory) rows: `removeAttribute("aria-expanded")` so a row that was a directory and became a file via state change doesn't retain the marker

### Verification
The chrome-structure assertions:
1. Set/remove aria-current pair count >= 6 (project tab + 5 row types)
2. Directory rows set aria-expanded based on expanded state
3. Non-directory rows remove aria-expanded explicitly

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2461 (list-row aria-current pattern)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 47 件 GREEN (+2 件)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
