### PR TITLE
feat(ui): SPEC-2356 — branch rows are keyboard-navigable with click+dblclick parity

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -398,6 +398,28 @@ test("Every keyframes-driven animation has a prefers-reduced-motion override", (
   }
 });
 
+test("Branch rows are keyboard-navigable with click + dblclick parity", () => {
+  // Branch rows are <div>s with both click (select) and dblclick (open
+  // launch wizard) handlers. Keyboard parity:
+  //   Enter / Space → select (same as click)
+  //   Cmd/Ctrl + Enter → activate (same as dblclick — open wizard)
+  // Without keyboard support, keyboard-only users could Tab to a row
+  // but couldn't pick branches or launch agents from the Branches
+  // surface at all.
+  assert.match(
+    appSource,
+    /row\.tabIndex\s*=\s*0[\s\S]*row\.setAttribute\("role",\s*"button"\)[\s\S]*createBranchRow|createBranchRow[\s\S]*row\.tabIndex\s*=\s*0[\s\S]*row\.setAttribute\("role",\s*"button"\)/,
+    "expected createBranchRow to set tabindex and role=button",
+  );
+  // The keydown handler must distinguish plain Enter/Space (select)
+  // from modified Enter (activate / open wizard).
+  assert.match(
+    appSource,
+    /event\.metaKey\s*\|\|\s*event\.ctrlKey[\s\S]*activate\(\)/,
+    "expected modified Enter to invoke activate (open launch wizard)",
+  );
+});
+
 test("File tree rows are keyboard-navigable (tabindex + role + keydown)", () => {
   // <div>-based rows can't be Tab'd to or activated with the keyboard
   // unless explicitly opted in. Add tabindex, role="button", and a

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -4446,6 +4446,13 @@
         const row = document.createElement("div");
         row.className = "branch-row";
         row.dataset.branchName = branchName;
+        // SPEC-2356 — make the row keyboard-navigable. tabindex=0 puts
+        // the row in the natural Tab order; role="button" tells assistive
+        // tech the row is activatable. The keydown handler below mirrors
+        // the click handler for Enter/Space (matches the file tree
+        // pattern from PR #2464).
+        row.tabIndex = 0;
+        row.setAttribute("role", "button");
 
         const toggle = document.createElement("button");
         toggle.type = "button";
@@ -4503,22 +4510,36 @@
           summary,
         };
 
-        row.addEventListener("click", () => {
+        const select = () => {
           const state = ensureBranchListState(windowId);
           state.selectedBranchName = branchName;
           state.notice = "";
           renderBranches(windowId);
-        });
-        row.addEventListener("dblclick", () => {
-          const state = ensureBranchListState(windowId);
-          state.selectedBranchName = branchName;
-          state.notice = "";
-          renderBranches(windowId);
+        };
+        const activate = () => {
+          select();
           send({
             kind: "open_launch_wizard",
             id: windowId,
             branch_name: branchName,
           });
+        };
+        row.addEventListener("click", select);
+        row.addEventListener("dblclick", activate);
+        // SPEC-2356 — keyboard activation parity:
+        //   Enter/Space → select (same as click)
+        //   Cmd/Ctrl+Enter → activate (same as dblclick — open wizard)
+        // Without this, keyboard-only users could Tab to a branch row
+        // (after the tabindex/role wiring above) but couldn't select
+        // or open the launch wizard from it.
+        row.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+            activate();
+          } else {
+            select();
+          }
         });
 
         return row;


### PR DESCRIPTION
## Summary
**Branch rows are keyboard-navigable with click+dblclick parity.**

Audit-driven extension of the file tree keyboard-nav pattern (PR #2464) to the Branches surface. Branch rows are `<div>`s with both click (select the branch) and dblclick (open launch wizard for that branch) handlers, but no keyboard support — keyboard-only users could Tab nowhere from the Branches list.

### Wiring
- `tabIndex = 0` + `role="button"` so the row is focusable and announced
- keydown handler that distinguishes:
  - **Enter / Space** → select (same as click)
  - **Cmd/Ctrl + Enter** → activate (same as dblclick → open wizard)

The click/dblclick handlers were extracted into shared `select` and `activate` closures so the keyboard and pointer paths share one implementation, preventing drift.

### Verification
Pin via chrome-structure assertion that confirms tabindex + role on `createBranchRow` AND the modified-Enter → activate branch in the keydown handler.

## Closing Issues
None — incremental polish on SPEC-2356 (#2356).

## Related Issues
- #2356 (SPEC: Operator Design System & Mission Control IA)
- #2464 (file tree row keyboard nav — same pattern)

## Test plan
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 49 件 GREEN (+1 件)
- [x] `cargo test -p gwt --lib` — 391 件 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
