### PR TITLE
fix(hooks): block long PR CI polling sleeps

### DIFF
--- a/.claude/skills/gwt-manage-pr/references/fix-flow.md
+++ b/.claude/skills/gwt-manage-pr/references/fix-flow.md
@@ -77,7 +77,7 @@ Blocking items: <N>
 
 ### Category labels
 
-`CONFLICT`, `BRANCH-BEHIND`, `CI-FAILURE`, `CHANGE-REQUEST`, `UNRESOLVED-THREAD`, `REVIEW-COMMENT`
+`CONFLICT`, `BRANCH-BEHIND`, `CI-FAILURE`, `CI-PENDING`, `CHANGE-REQUEST`, `UNRESOLVED-THREAD`, `REVIEW-COMMENT`
 
 ### Auto-fix judgment
 
@@ -144,9 +144,9 @@ Blocking items: <N>
 - Re-run inspection with `--mode all` (regardless of initial mode).
 - Exit code 0 --> all resolved --> report success.
 - Exit code 1 --> issues remain --> go back to step 4.
-- No iteration limit. Continue until all resolved.
-- CI pending/queued --> poll at 30-second intervals until ALL checks complete.
-- After fix push, re-enter polling for new CI run.
+- CI pending/queued --> check at most 3 times with `gwtd pr checks <number>`, waiting no more than 30 seconds between checks.
+- If checks are still pending after the bounded checks, post `gwtd board post --kind blocked` with the PR number, pending check names, and resume command, then stop instead of sleeping indefinitely.
+- After fix push, run the same bounded CI check path for the new run.
 
 ## Loop Safety Guard
 

--- a/.codex/skills/gwt-manage-pr/references/fix-flow.md
+++ b/.codex/skills/gwt-manage-pr/references/fix-flow.md
@@ -77,7 +77,7 @@ Blocking items: <N>
 
 ### Category labels
 
-`CONFLICT`, `BRANCH-BEHIND`, `CI-FAILURE`, `CHANGE-REQUEST`, `UNRESOLVED-THREAD`, `REVIEW-COMMENT`
+`CONFLICT`, `BRANCH-BEHIND`, `CI-FAILURE`, `CI-PENDING`, `CHANGE-REQUEST`, `UNRESOLVED-THREAD`, `REVIEW-COMMENT`
 
 ### Auto-fix judgment
 
@@ -144,9 +144,9 @@ Blocking items: <N>
 - Re-run inspection with `--mode all` (regardless of initial mode).
 - Exit code 0 --> all resolved --> report success.
 - Exit code 1 --> issues remain --> go back to step 4.
-- No iteration limit. Continue until all resolved.
-- CI pending/queued --> poll at 30-second intervals until ALL checks complete.
-- After fix push, re-enter polling for new CI run.
+- CI pending/queued --> check at most 3 times with `gwtd pr checks <number>`, waiting no more than 30 seconds between checks.
+- If checks are still pending after the bounded checks, post `gwtd board post --kind blocked` with the PR number, pending check names, and resume command, then stop instead of sleeping indefinitely.
+- After fix push, run the same bounded CI check path for the new run.
 
 ## Loop Safety Guard
 

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -1076,8 +1076,10 @@ mod tests {
             );
         }
 
-        {
-            let relative = ".claude/skills/gwt-manage-pr/references/fix-flow.md";
+        for relative in [
+            ".claude/skills/gwt-manage-pr/references/fix-flow.md",
+            ".codex/skills/gwt-manage-pr/references/fix-flow.md",
+        ] {
             let fix_flow = std::fs::read_to_string(workspace_root.join(relative))
                 .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
             assert!(
@@ -1091,6 +1093,20 @@ mod tests {
             assert!(
                 !fix_flow.contains("--required-only"),
                 "unexpected nonexistent gwtd pr checks --required-only guidance in {relative}"
+            );
+            assert!(
+                !fix_flow.contains("No iteration limit"),
+                "unexpected unbounded PR fix loop guidance in {relative}"
+            );
+            assert!(
+                !fix_flow.contains("poll at 30-second intervals until ALL checks complete"),
+                "unexpected CI polling-until-complete guidance in {relative}"
+            );
+            assert!(
+                fix_flow.contains("CI pending/queued --> check at most 3 times")
+                    && fix_flow.contains("gwtd board post --kind blocked")
+                    && fix_flow.contains("stop instead of sleeping indefinitely"),
+                "expected bounded CI wait handoff guidance in {relative}"
             );
             assert!(
                 !fix_flow.contains("Fallback: `gh pr comment`."),

--- a/crates/gwt/src/cli/hook/block_bash_policy.rs
+++ b/crates/gwt/src/cli/hook/block_bash_policy.rs
@@ -15,6 +15,7 @@ pub fn evaluate_bash_command(command: &str, worktree_root: &Path) -> Option<Hook
         .or_else(|| block_cd_command::evaluate_bash_command(command, worktree_root))
         .or_else(|| block_file_ops::evaluate_bash_command(command, worktree_root))
         .or_else(|| block_git_dir_override::evaluate_bash_command(command))
+        .or_else(|| evaluate_long_pr_ci_polling_sleep(command))
         .or_else(|| evaluate_github_workflow_cli(command))
 }
 
@@ -72,6 +73,81 @@ fn evaluate_github_workflow_cli(command: &str) -> Option<HookOutput> {
         }
     }
     None
+}
+
+fn evaluate_long_pr_ci_polling_sleep(command: &str) -> Option<HookOutput> {
+    let segments = super::segments::split_command_segments(command);
+    for index in 0..segments.len() {
+        let tokens = command_tokens(&segments[index]);
+        if !is_long_sleep_segment(&tokens) {
+            continue;
+        }
+
+        if segments[index + 1..]
+            .iter()
+            .any(|segment| is_pr_ci_polling_segment(segment))
+        {
+            return Some(long_pr_ci_polling_sleep_block_decision(command));
+        }
+    }
+    None
+}
+
+fn is_long_sleep_segment(tokens: &[&str]) -> bool {
+    let Some(command_name) = tokens.first().copied() else {
+        return false;
+    };
+    if normalize_command_name(command_name) != "sleep" {
+        return false;
+    }
+
+    tokens
+        .get(1)
+        .and_then(|duration| parse_sleep_seconds(duration))
+        .is_some_and(|seconds| seconds >= 120)
+}
+
+fn parse_sleep_seconds(duration: &str) -> Option<u64> {
+    let duration = duration.trim_matches(|ch| ch == '\'' || ch == '"');
+    let numeric = duration.strip_suffix('s').unwrap_or(duration);
+    numeric.parse().ok()
+}
+
+fn is_pr_ci_polling_segment(segment: &str) -> bool {
+    let tokens = command_tokens(segment);
+    let Some(command_name) = tokens.first().copied().map(normalize_command_name) else {
+        return false;
+    };
+
+    match command_name.as_str() {
+        "gwtd" => matches!(tokens.get(1).copied(), Some("pr" | "actions")),
+        "gh" => tokens
+            .get(1)
+            .copied()
+            .is_some_and(|subcommand| matches!(subcommand, "pr" | "run" | "api")),
+        _ => false,
+    }
+}
+
+fn normalize_command_name(token: &str) -> String {
+    let token = token.trim_matches(|ch| ch == '\'' || ch == '"');
+    Path::new(token)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(token)
+        .to_string()
+}
+
+fn long_pr_ci_polling_sleep_block_decision(command: &str) -> HookOutput {
+    HookOutput::pre_tool_use_permission(
+        "Long PR/CI polling sleeps are not allowed",
+        format!(
+            "Do not keep Claude Code idle while waiting for PR or CI state changes.\n\n\
+Run `gwtd pr checks <number>` once. If checks are still pending or queued, post the wait state with \
+`gwtd board post --kind blocked --body '<what is pending and how to resume>'`, then hand off instead of sleeping indefinitely.\n\n\
+Blocked command: {command}"
+        ),
+    )
 }
 
 fn is_blocked_issue_subcommand(subcommand: Option<&str>) -> bool {
@@ -190,4 +266,46 @@ fn gh_api_target<'a>(tokens: &'a [&'a str]) -> Option<&'a str> {
         i += if consumes_value { 2 } else { 1 };
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_long_sleep_before_gwtd_pr_polling() {
+        let decision = evaluate_bash_command(
+            "sleep 280 && /Applications/GWT.app/Contents/MacOS/gwtd pr view 123",
+            Path::new("/worktree"),
+        )
+        .expect("expected long PR polling sleep to be blocked");
+
+        assert_eq!(
+            decision.summary(),
+            "Long PR/CI polling sleeps are not allowed"
+        );
+        assert!(decision.detail().contains("gwtd pr checks <number>"));
+    }
+
+    #[test]
+    fn blocks_long_sleep_before_gh_run_polling() {
+        let decision = evaluate_bash_command(
+            "sleep 280 && gh run view 123456 --log",
+            Path::new("/worktree"),
+        )
+        .expect("expected long GitHub Actions polling sleep to be blocked");
+
+        assert_eq!(
+            decision.summary(),
+            "Long PR/CI polling sleeps are not allowed"
+        );
+    }
+
+    #[test]
+    fn allows_short_sleep_before_gwtd_pr_check() {
+        let decision =
+            evaluate_bash_command("sleep 30 && gwtd pr checks 123", Path::new("/worktree"));
+
+        assert!(decision.is_none());
+    }
 }

--- a/crates/gwt/tests/hook_block_bash_policy_test.rs
+++ b/crates/gwt/tests/hook_block_bash_policy_test.rs
@@ -75,6 +75,19 @@ fn blocks_workflow_focused_github_cli_commands() {
 }
 
 #[test]
+fn blocks_long_sleep_pr_ci_polling_commands() {
+    block("sleep 280 && gwtd pr view 1949");
+    block("sleep 280 && /Applications/GWT.app/Contents/MacOS/gwtd pr checks 1949");
+    block("sleep 280 && gh run view 123456789");
+}
+
+#[test]
+fn allows_bounded_or_non_pr_sleep_commands() {
+    allow("sleep 30 && gwtd pr checks 1949");
+    allow("sleep 280 && echo done");
+}
+
+#[test]
 fn github_workflow_block_message_points_to_canonical_gwt_surfaces() {
     // `permissionDecisionReason` is the single field PreToolUse actually
     // surfaces, so the canonical alternatives and the blocked command
@@ -91,6 +104,27 @@ fn github_workflow_block_message_points_to_canonical_gwt_surfaces() {
         "gwtd actions logs",
         "gwt-search",
         "Blocked command: gh pr view 1949",
+    ] {
+        assert!(
+            visible.contains(required),
+            "{required:?} missing from permission_decision_reason: {visible}"
+        );
+    }
+}
+
+#[test]
+fn long_sleep_pr_ci_block_message_points_to_board_handoff() {
+    let command = "sleep 280 && gwtd pr checks 1949";
+    let decision = block_bash_policy::evaluate_bash_command(command, &root())
+        .expect("long PR polling sleep must block");
+    let visible = decision.permission_decision_reason();
+
+    for required in [
+        "Long PR/CI polling sleeps are not allowed",
+        "gwtd pr checks <number>",
+        "gwtd board post --kind blocked",
+        "instead of sleeping indefinitely",
+        command,
     ] {
         assert!(
             visible.contains(required),


### PR DESCRIPTION
## Summary
- Block long PR/CI polling sleeps in the PreToolUse Bash policy.
- Update gwt-manage-pr fix guidance to use bounded CI checks and Board blocked handoff instead of unbounded polling.
- Add tests for the policy behavior and managed skill guidance.

## Changes
- Detect `sleep >= 120` followed by `gwtd pr/actions` or `gh pr/run/api` commands and deny it with a handoff-oriented recovery message.
- Keep short sleeps and non-PR/CI sleeps allowed.
- Replace the gwt-manage-pr `No iteration limit` CI loop with at most 3 checks, 30 seconds apart, then a Board blocked handoff.

## Testing
- [x] `cargo test -p gwt block_bash_policy::tests -- --nocapture`
- [x] `cargo test -p gwt --test hook_block_bash_policy_test -- --nocapture`
- [x] `cargo test -p gwt-skills tests::gwt_spec_skills_require_user_language_outputs -- --nocapture`
- [x] `cargo test -p gwt-core -p gwt -p gwt-skills`
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build -p gwt`

## Closing Issues
None

## Related Issues
None

## Checklist
- [x] Tests updated
- [x] Local verification passed
- [x] Commitlint passed
