### PR TITLE
fix(hooks): catch reversed PR CI polling sleeps

### DIFF
--- a/crates/gwt/src/cli/hook/block_bash_policy.rs
+++ b/crates/gwt/src/cli/hook/block_bash_policy.rs
@@ -77,16 +77,16 @@ fn evaluate_github_workflow_cli(command: &str) -> Option<HookOutput> {
 
 fn evaluate_long_pr_ci_polling_sleep(command: &str) -> Option<HookOutput> {
     let segments = super::segments::split_command_segments(command);
-    for index in 0..segments.len() {
-        let tokens = command_tokens(&segments[index]);
-        if !is_long_sleep_segment(&tokens) {
-            continue;
-        }
+    let has_pr_ci_polling = segments
+        .iter()
+        .any(|segment| is_pr_ci_polling_segment(segment));
+    if !has_pr_ci_polling {
+        return None;
+    }
 
-        if segments[index + 1..]
-            .iter()
-            .any(|segment| is_pr_ci_polling_segment(segment))
-        {
+    for segment in &segments {
+        let tokens = command_tokens(segment);
+        if is_long_sleep_segment(&tokens) {
             return Some(long_pr_ci_polling_sleep_block_decision(command));
         }
     }
@@ -101,16 +101,34 @@ fn is_long_sleep_segment(tokens: &[&str]) -> bool {
         return false;
     }
 
-    tokens
-        .get(1)
-        .and_then(|duration| parse_sleep_seconds(duration))
-        .is_some_and(|seconds| seconds >= 120)
+    parse_sleep_args_seconds(&tokens[1..]).is_some_and(|seconds| seconds >= 120.0)
 }
 
-fn parse_sleep_seconds(duration: &str) -> Option<u64> {
+fn parse_sleep_args_seconds(args: &[&str]) -> Option<f64> {
+    let mut total = 0.0;
+    let mut parsed_any = false;
+    for arg in args {
+        let seconds = parse_sleep_duration_seconds(arg)?;
+        total += seconds;
+        parsed_any = true;
+    }
+    parsed_any.then_some(total)
+}
+
+fn parse_sleep_duration_seconds(duration: &str) -> Option<f64> {
     let duration = duration.trim_matches(|ch| ch == '\'' || ch == '"');
-    let numeric = duration.strip_suffix('s').unwrap_or(duration);
-    numeric.parse().ok()
+    let (numeric, multiplier) = match duration.chars().last() {
+        Some('s') => (&duration[..duration.len() - 1], 1.0),
+        Some('m') => (&duration[..duration.len() - 1], 60.0),
+        Some('h') => (&duration[..duration.len() - 1], 60.0 * 60.0),
+        Some('d') => (&duration[..duration.len() - 1], 24.0 * 60.0 * 60.0),
+        _ => (duration, 1.0),
+    };
+    let value: f64 = numeric.parse().ok()?;
+    if value.is_sign_negative() {
+        return None;
+    }
+    Some(value * multiplier)
 }
 
 fn is_pr_ci_polling_segment(segment: &str) -> bool {
@@ -185,6 +203,13 @@ Blocked command: {command}"
 fn command_tokens(segment: &str) -> Vec<&str> {
     let raw: Vec<&str> = segment.split_whitespace().collect();
     let mut start = 0;
+
+    while raw
+        .get(start)
+        .is_some_and(|token| matches!(*token, "do" | "then"))
+    {
+        start += 1;
+    }
 
     if raw.get(start) == Some(&"env") {
         start += 1;

--- a/crates/gwt/tests/hook_block_bash_policy_test.rs
+++ b/crates/gwt/tests/hook_block_bash_policy_test.rs
@@ -77,8 +77,11 @@ fn blocks_workflow_focused_github_cli_commands() {
 #[test]
 fn blocks_long_sleep_pr_ci_polling_commands() {
     block("sleep 280 && gwtd pr view 1949");
+    block("gwtd pr checks 1949; sleep 280");
+    block("while true; do gwtd pr checks 1949; sleep 2m; done");
     block("sleep 280 && /Applications/GWT.app/Contents/MacOS/gwtd pr checks 1949");
     block("sleep 280 && gh run view 123456789");
+    block("gh run view 123456789; sleep 0.5h");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Follow up on Codex review feedback from PR #2467.
- Block long PR/CI polling sleeps when the polling command appears before the sleep.
- Parse suffixed, fractional, and multi-argument sleep durations before applying the 120-second threshold.

## Changes
- Treat any command containing both PR/CI polling and a long sleep as blocked, regardless of segment order.
- Support `s`, `m`, `h`, and `d` suffixes plus fractional values such as `0.5h`.
- Skip shell loop keywords such as `do` and `then` when identifying polling commands inside loop bodies.

## Testing
- [x] `cargo test -p gwt --test hook_block_bash_policy_test blocks_long_sleep_pr_ci_polling_commands -- --nocapture`
- [x] `cargo test -p gwt --test hook_block_bash_policy_test -- --nocapture`
- [x] `cargo test -p gwt block_bash_policy::tests -- --nocapture`
- [x] `cargo fmt -- --check`
- [x] `cargo test -p gwt-core -p gwt -p gwt-skills`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build -p gwt`

## Closing Issues
None

## Related Issues
- Follow-up to #2467

## Checklist
- [x] Tests updated
- [x] Local verification passed
- [x] Commitlint passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bash policy enforcement to more accurately detect and block PR/CI polling commands followed by extended sleep periods, now supporting multiple sleep formats (seconds, minutes, hours, days).
  
* **Tests**
  * Expanded test coverage for bash command pattern detection, including chained commands and infinite polling loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->