### PR TITLE
feat(kanban): SPEC-2017 Knowledge Bridge を Kanban view に置換

### DIFF
--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -283,6 +283,41 @@ impl Cache {
             Err(e) => Err(CacheError::Io(e)),
         }
     }
+
+    /// SPEC-2017 T-008 — Atomically rewrite the `labels` array on the
+    /// cached `meta.json` for `number`.
+    ///
+    /// This is the local mirror of a Kanban phase change: after the
+    /// frontend D&D pushes the new labels through the GitHub API, the
+    /// cache needs to reflect the same labels so the next render shows
+    /// the card in the right column without waiting for a full refresh.
+    ///
+    /// `body.md`, `sections/*`, and `comments/*` are intentionally left
+    /// alone — only the labels array is rewritten. Returns
+    /// [`CacheError::Io`] when the entry is missing on disk so the
+    /// caller can surface a typed error instead of silently succeeding.
+    pub fn apply_phase_change(
+        &self,
+        number: IssueNumber,
+        new_labels: Vec<String>,
+    ) -> Result<(), CacheError> {
+        let meta_path = self.issue_dir(number).join("meta.json");
+        let meta_bytes = match fs::read(&meta_path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(CacheError::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("issue #{} not in cache", number.0),
+                )));
+            }
+            Err(err) => return Err(CacheError::Io(err)),
+        };
+        let mut meta: CacheMeta = serde_json::from_slice(&meta_bytes)?;
+        meta.labels = new_labels;
+        let updated_bytes = serde_json::to_vec_pretty(&meta)?;
+        write_atomic(&meta_path, &updated_bytes)?;
+        Ok(())
+    }
 }
 
 /// Write bytes to `path` atomically via a `.tmp-<pid>-<nanos>` sibling file

--- a/crates/gwt-github/tests/cache_test.rs
+++ b/crates/gwt-github/tests/cache_test.rs
@@ -335,3 +335,72 @@ fn write_snapshot_prunes_stale_comment_files() {
 fn _ensure_comment_is_used(c: Comment) -> Comment {
     c
 }
+
+// SPEC-2017 T-008: apply_phase_change rewrites the labels array on the cached
+// meta.json atomically and leaves the rest of the entry intact. The next
+// load_entry must reflect the new labels without a remote refresh.
+#[test]
+fn apply_phase_change_overwrites_labels_and_persists_to_meta() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let body = mk_body_with_spec_and_tasks_in_body("spec", "tasks");
+    cache.write_snapshot(&mk_snapshot(7, body)).unwrap();
+
+    cache
+        .apply_phase_change(
+            IssueNumber(7),
+            vec!["gwt-spec".to_string(), "phase/implementation".to_string()],
+        )
+        .unwrap();
+
+    let reloaded = cache.load_entry(IssueNumber(7)).unwrap();
+    assert_eq!(
+        reloaded.snapshot.labels,
+        vec!["gwt-spec".to_string(), "phase/implementation".to_string()],
+    );
+    // meta.json is the persisted source of truth; verify the file itself.
+    let meta_bytes = fs::read(tmp.path().join("7/meta.json")).unwrap();
+    let meta_json: serde_json::Value = serde_json::from_slice(&meta_bytes).unwrap();
+    let labels = meta_json
+        .get("labels")
+        .and_then(|v| v.as_array())
+        .expect("meta.json should preserve the labels array");
+    let label_strings: Vec<&str> = labels.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(label_strings, vec!["gwt-spec", "phase/implementation"]);
+}
+
+#[test]
+fn apply_phase_change_returns_error_when_entry_is_missing() {
+    // No prior write_snapshot for #404 — apply_phase_change must surface
+    // a typed error so the caller can map it to a user-friendly message
+    // instead of silently succeeding.
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let result = cache.apply_phase_change(IssueNumber(404), vec!["phase/draft".to_string()]);
+    assert!(
+        result.is_err(),
+        "apply_phase_change on a missing entry must error",
+    );
+}
+
+#[test]
+fn apply_phase_change_does_not_disturb_body_or_sections() {
+    // The cache also stores body.md and sections/*.md. A phase change
+    // must not touch those — otherwise local edits in flight could be
+    // clobbered by a phase write-back.
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let body = mk_body_with_spec_and_tasks_in_body("immutable spec", "immutable tasks");
+    cache
+        .write_snapshot(&mk_snapshot(11, body.clone()))
+        .unwrap();
+
+    cache
+        .apply_phase_change(IssueNumber(11), vec!["phase/done".to_string()])
+        .unwrap();
+
+    let body_on_disk = fs::read_to_string(tmp.path().join("11/body.md")).unwrap();
+    assert_eq!(body_on_disk, body, "body.md must remain byte-identical");
+    let spec_section = fs::read_to_string(tmp.path().join("11/sections/spec.md")).unwrap();
+    assert_eq!(spec_section, "immutable spec");
+}

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -323,6 +323,22 @@ fn knowledge_error_event(
     }
 }
 
+fn knowledge_phase_update_error_event(
+    id: impl Into<String>,
+    request_id: u64,
+    issue_number: u64,
+    message: impl Into<String>,
+) -> BackendEvent {
+    BackendEvent::KnowledgeBridgePhaseUpdated {
+        id: id.into(),
+        request_id,
+        issue_number,
+        result: gwt::protocol::KnowledgePhaseUpdateResult::Error {
+            message: message.into(),
+        },
+    }
+}
+
 fn knowledge_view_events(
     client_id: String,
     id: String,
@@ -1005,6 +1021,18 @@ impl AppRuntime {
                     refresh: false,
                     list_scope: list_scope.unwrap_or(gwt::KnowledgeListScope::Open),
                 },
+            ),
+            FrontendEvent::UpdateKnowledgeBridgePhase {
+                id,
+                request_id,
+                issue_number,
+                target_phase,
+            } => self.update_knowledge_bridge_phase_events(
+                &client_id,
+                &id,
+                request_id,
+                issue_number,
+                target_phase.as_deref(),
             ),
             FrontendEvent::RunBranchCleanup {
                 id,
@@ -2111,6 +2139,96 @@ impl AppRuntime {
                 client_id, event,
             )]));
         });
+    }
+
+    /// SPEC-2017 US-8 — Apply a Kanban phase change to the owning
+    /// GitHub Issue. Validates that the target window is a knowledge
+    /// bridge surface and dispatches a blocking task that calls
+    /// `gwt::update_knowledge_phase`. The result is delivered as
+    /// [`BackendEvent::KnowledgeBridgePhaseUpdated`] so the optimistic
+    /// frontend UI can either confirm or rollback.
+    pub(crate) fn update_knowledge_bridge_phase_events(
+        &self,
+        client_id: &str,
+        id: &str,
+        request_id: u64,
+        issue_number: u64,
+        target_phase: Option<&str>,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                knowledge_phase_update_error_event(
+                    id,
+                    request_id,
+                    issue_number,
+                    "Window not found",
+                ),
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                knowledge_phase_update_error_event(
+                    id,
+                    request_id,
+                    issue_number,
+                    "Project tab not found",
+                ),
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                knowledge_phase_update_error_event(
+                    id,
+                    request_id,
+                    issue_number,
+                    "Window not found",
+                ),
+            )];
+        };
+        if knowledge_kind_for_preset(window.preset).is_none() {
+            return vec![OutboundEvent::reply(
+                client_id,
+                knowledge_phase_update_error_event(
+                    id,
+                    request_id,
+                    issue_number,
+                    "Window is not a knowledge bridge",
+                ),
+            )];
+        }
+
+        let proxy = self.proxy.clone();
+        let client_id = client_id.to_string();
+        let id_owned = id.to_string();
+        let project_root = tab.project_root.clone();
+        let target_phase = target_phase.map(str::to_string);
+        self.blocking_tasks.spawn(move || {
+            let event = match gwt::update_knowledge_phase(
+                &project_root,
+                issue_number,
+                target_phase.as_deref(),
+            ) {
+                Ok(fresh_entry) => BackendEvent::KnowledgeBridgePhaseUpdated {
+                    id: id_owned,
+                    request_id,
+                    issue_number,
+                    result: gwt::protocol::KnowledgePhaseUpdateResult::Ok { fresh_entry },
+                },
+                Err(error) => BackendEvent::KnowledgeBridgePhaseUpdated {
+                    id: id_owned,
+                    request_id,
+                    issue_number,
+                    result: gwt::protocol::KnowledgePhaseUpdateResult::Error { message: error },
+                },
+            };
+            proxy.send(UserEvent::Dispatch(vec![OutboundEvent::reply(
+                &client_id, event,
+            )]));
+        });
+        Vec::new()
     }
 
     pub(crate) fn run_branch_cleanup_events(

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -172,6 +172,41 @@ fn issue_cache_refresh_is_stale(cache_root: &Path, ttl: Duration) -> bool {
         .map_or(true, |age| age >= ttl)
 }
 
+/// SPEC-2017 US-8 — Apply label add / remove operations to a GitHub
+/// Issue via `gh issue edit`. The flags are passed in a single command
+/// so the API call is atomic; either all labels are written or none
+/// are. `labels_to_add` and `labels_to_remove` are deduplicated by the
+/// caller (`update_knowledge_phase`).
+pub(crate) fn write_issue_labels_via_gh(
+    repo_path: &Path,
+    issue_number: u64,
+    labels_to_add: &[String],
+    labels_to_remove: &[String],
+) -> Result<(), String> {
+    if labels_to_add.is_empty() && labels_to_remove.is_empty() {
+        return Ok(());
+    }
+    let mut command = gwt_core::process::hidden_command(gh_executable());
+    command.args(["issue", "edit", &issue_number.to_string()]);
+    for label in labels_to_add {
+        command.arg("--add-label").arg(label);
+    }
+    for label in labels_to_remove {
+        command.arg("--remove-label").arg(label);
+    }
+    let output = command
+        .current_dir(repo_path)
+        .output()
+        .map_err(|err| format!("gh issue edit #{issue_number}: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "gh issue edit #{issue_number}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
 fn fetch_issue_list_snapshots(repo_path: &Path) -> Result<Vec<IssueSnapshot>, String> {
     let output = gwt_core::process::hidden_command(gh_executable())
         .args([

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -16,6 +16,67 @@ use crate::issue_cache::{
 const SPEC_LABEL: &str = "gwt-spec";
 const KNOWLEDGE_SEARCH_RESULT_LIMIT: usize = 50;
 
+/// Canonical SPEC phase labels in lifecycle order.
+///
+/// `phase/<value>` labels matching one of these values map to the canonical
+/// phase. Any other `phase/*` label is reported as unknown/legacy via
+/// [`ExtractedPhase::has_unknown_phase`] and not promoted to a column.
+pub const KNOWLEDGE_PHASE_LABELS: &[&str] =
+    &["draft", "planning", "implementation", "review", "done"];
+
+/// Result of [`extract_phase`]: the canonical phase (if any), whether any
+/// unknown `phase/*` label is present, and whether the entry is a SPEC
+/// (`gwt-spec` label).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ExtractedPhase {
+    pub phase: Option<String>,
+    pub has_unknown_phase: bool,
+    pub is_spec: bool,
+}
+
+/// Extract the canonical phase from an Issue's labels, plus auxiliary flags
+/// used by Kanban grouping.
+///
+/// - `phase` is `Some("<canonical>")` when exactly one of `phase/draft`,
+///   `phase/planning`, `phase/implementation`, `phase/review`, `phase/done`
+///   appears. The first canonical match wins; further canonical or legacy
+///   `phase/*` labels also raise `has_unknown_phase` so the UI can surface a
+///   warning for malformed input.
+/// - `has_unknown_phase` is `true` when any `phase/*` label outside the
+///   canonical set is present, OR when more than one canonical phase label
+///   is present.
+/// - `is_spec` mirrors the `gwt-spec` label.
+pub fn extract_phase(labels: &[String]) -> ExtractedPhase {
+    let mut phase: Option<String> = None;
+    let mut has_unknown_phase = false;
+    let mut is_spec = false;
+
+    for label in labels {
+        if label == SPEC_LABEL {
+            is_spec = true;
+            continue;
+        }
+        let Some(rest) = label.strip_prefix("phase/") else {
+            continue;
+        };
+        if KNOWLEDGE_PHASE_LABELS.contains(&rest) {
+            if phase.is_none() {
+                phase = Some(rest.to_string());
+            } else {
+                has_unknown_phase = true;
+            }
+        } else {
+            has_unknown_phase = true;
+        }
+    }
+
+    ExtractedPhase {
+        phase,
+        has_unknown_phase,
+        is_spec,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum KnowledgeKind {
@@ -40,6 +101,20 @@ pub struct KnowledgeListItem {
     pub labels: Vec<String>,
     pub linked_branch_count: usize,
     pub match_score: Option<u8>,
+    /// Canonical phase value (`"draft"`, `"planning"`, `"implementation"`,
+    /// `"review"`, `"done"`) when a `phase/*` label is present, otherwise
+    /// `None`. Used by the Kanban view for column grouping.
+    #[serde(default)]
+    pub phase: Option<String>,
+    /// `true` when an unknown / legacy `phase/*` label is present (or when
+    /// more than one canonical phase label is set). The UI shows a warning
+    /// indicator for these entries.
+    #[serde(default)]
+    pub has_unknown_phase: bool,
+    /// `true` when the entry carries the `gwt-spec` label. Plain Issues are
+    /// always grouped into the Backlog column and are not draggable.
+    #[serde(default)]
+    pub is_spec: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -501,6 +576,7 @@ fn issue_list_item(
     linked_branches: &HashMap<u64, Vec<String>>,
     match_score: Option<u8>,
 ) -> KnowledgeListItem {
+    let phase_info = extract_phase(&entry.snapshot.labels);
     KnowledgeListItem {
         number: entry.snapshot.number.0,
         title: entry.snapshot.title.clone(),
@@ -512,6 +588,9 @@ fn issue_list_item(
             .map(Vec::len)
             .unwrap_or_default(),
         match_score,
+        phase: phase_info.phase,
+        has_unknown_phase: phase_info.has_unknown_phase,
+        is_spec: phase_info.is_spec,
     }
 }
 
@@ -520,6 +599,7 @@ fn spec_list_item(
     linked_branches: &HashMap<u64, Vec<String>>,
     match_score: Option<u8>,
 ) -> KnowledgeListItem {
+    let phase_info = extract_phase(&entry.snapshot.labels);
     KnowledgeListItem {
         number: entry.snapshot.number.0,
         title: entry.snapshot.title.clone(),
@@ -531,6 +611,9 @@ fn spec_list_item(
             .map(Vec::len)
             .unwrap_or_default(),
         match_score,
+        phase: phase_info.phase,
+        has_unknown_phase: phase_info.has_unknown_phase,
+        is_spec: phase_info.is_spec,
     }
 }
 
@@ -1349,5 +1432,63 @@ Extra context.
         assert_eq!(view.entries[0].number, 22);
         assert_eq!(view.entries[0].match_score, Some(100));
         assert_eq!(view.selected_number, Some(22));
+    }
+
+    #[test]
+    fn extract_phase_recognizes_canonical_phase_labels() {
+        let cases = [
+            ("phase/draft", "draft"),
+            ("phase/planning", "planning"),
+            ("phase/implementation", "implementation"),
+            ("phase/review", "review"),
+            ("phase/done", "done"),
+        ];
+        for (label, expected) in cases {
+            let extracted = extract_phase(&[label.to_string()]);
+            assert_eq!(
+                extracted.phase.as_deref(),
+                Some(expected),
+                "label={}",
+                label
+            );
+            assert!(!extracted.has_unknown_phase, "label={}", label);
+            assert!(!extracted.is_spec, "label={}", label);
+        }
+    }
+
+    #[test]
+    fn extract_phase_returns_none_when_no_phase_labels() {
+        let extracted = extract_phase(&["bug".to_string(), "documentation".to_string()]);
+        assert!(extracted.phase.is_none());
+        assert!(!extracted.has_unknown_phase);
+        assert!(!extracted.is_spec);
+    }
+
+    #[test]
+    fn extract_phase_flags_unknown_phase_label_as_warning() {
+        let extracted = extract_phase(&["phase/legacy".to_string()]);
+        assert!(extracted.phase.is_none());
+        assert!(extracted.has_unknown_phase);
+        assert!(!extracted.is_spec);
+    }
+
+    #[test]
+    fn extract_phase_detects_gwt_spec_label() {
+        let extracted = extract_phase(&["gwt-spec".to_string(), "phase/planning".to_string()]);
+        assert_eq!(extracted.phase.as_deref(), Some("planning"));
+        assert!(!extracted.has_unknown_phase);
+        assert!(extracted.is_spec);
+    }
+
+    #[test]
+    fn extract_phase_keeps_first_canonical_when_multiple_phase_labels() {
+        let extracted = extract_phase(&[
+            "phase/draft".to_string(),
+            "phase/implementation".to_string(),
+        ]);
+        // first canonical wins; second triggers unknown flag because two
+        // canonical labels at once is malformed input
+        assert_eq!(extracted.phase.as_deref(), Some("draft"));
+        assert!(extracted.has_unknown_phase);
     }
 }

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -305,6 +305,116 @@ pub fn search_knowledge_bridge(
     )
 }
 
+/// SPEC-2017 US-8 — Apply a Kanban phase change to the GitHub Issue
+/// owning `issue_number` and return the freshly-rebuilt
+/// [`KnowledgeListItem`].
+///
+/// `target_phase` semantics:
+/// - `None` → remove every `phase/*` label (Backlog drop)
+/// - `Some(canonical)` → ensure exactly the matching `phase/<canonical>`
+///   label is set, removing any other `phase/*` labels first
+///
+/// The function shells out to `gh issue edit --add-label / --remove-label`
+/// (matching the existing `sync_issue_cache_from_remote` pattern) and
+/// updates the local Issue cache via [`Cache::apply_phase_change`] so
+/// subsequent [`load_knowledge_bridge`] calls reflect the change without
+/// waiting for a full refresh.
+///
+/// Returns the rebuilt [`KnowledgeListItem`] on success, or a human-
+/// readable error string on failure (network, permission, unknown phase,
+/// missing cache entry).
+pub fn update_knowledge_phase(
+    repo_path: &Path,
+    issue_number: u64,
+    target_phase: Option<&str>,
+) -> Result<KnowledgeListItem, String> {
+    update_knowledge_phase_with_label_writer(
+        repo_path,
+        issue_number,
+        target_phase,
+        |labels_to_add, labels_to_remove| {
+            crate::issue_cache::write_issue_labels_via_gh(
+                repo_path,
+                issue_number,
+                labels_to_add,
+                labels_to_remove,
+            )
+        },
+    )
+}
+
+/// Internal seam that lets unit tests substitute a fake label writer
+/// for the gh CLI shell-out. Production callers go through
+/// [`update_knowledge_phase`] which always wires up the gh writer.
+pub(crate) fn update_knowledge_phase_with_label_writer<F>(
+    repo_path: &Path,
+    issue_number: u64,
+    target_phase: Option<&str>,
+    label_writer: F,
+) -> Result<KnowledgeListItem, String>
+where
+    F: FnOnce(&[String], &[String]) -> Result<(), String>,
+{
+    if let Some(value) = target_phase {
+        if !KNOWLEDGE_PHASE_LABELS.contains(&value) {
+            return Err(format!(
+                "unknown phase '{value}' (expected one of {:?})",
+                KNOWLEDGE_PHASE_LABELS
+            ));
+        }
+    }
+    let cache_root = issue_cache_root_for_repo_path_or_detached(repo_path);
+    let cache = Cache::new(cache_root);
+    let entry = cache
+        .load_entry(gwt_github::IssueNumber(issue_number))
+        .ok_or_else(|| format!("Issue #{issue_number} not in local cache"))?;
+    let target_label = target_phase.map(|value| format!("phase/{value}"));
+    let labels_to_remove: Vec<String> = entry
+        .snapshot
+        .labels
+        .iter()
+        .filter(|label| {
+            label.starts_with("phase/") && Some(label.as_str()) != target_label.as_deref()
+        })
+        .cloned()
+        .collect();
+    let labels_to_add: Vec<String> = target_label
+        .as_ref()
+        .filter(|target| !entry.snapshot.labels.iter().any(|label| label == *target))
+        .cloned()
+        .into_iter()
+        .collect();
+    if !labels_to_add.is_empty() || !labels_to_remove.is_empty() {
+        label_writer(&labels_to_add, &labels_to_remove)?;
+    }
+    let mut updated_labels: Vec<String> = entry
+        .snapshot
+        .labels
+        .iter()
+        .filter(|label| !labels_to_remove.contains(label))
+        .cloned()
+        .collect();
+    for label in &labels_to_add {
+        if !updated_labels.contains(label) {
+            updated_labels.push(label.clone());
+        }
+    }
+    cache
+        .apply_phase_change(gwt_github::IssueNumber(issue_number), updated_labels)
+        .map_err(|error| format!("apply phase change to cache: {error}"))?;
+    let refreshed = cache
+        .load_entry(gwt_github::IssueNumber(issue_number))
+        .ok_or_else(|| format!("Issue #{issue_number} disappeared after cache update"))?;
+    let linked_branches: HashMap<u64, Vec<String>> = HashMap::new();
+    Ok(
+        if refreshed.snapshot.labels.contains(&SPEC_LABEL.to_string()) {
+            spec_list_item(&refreshed, &linked_branches, None)
+        } else {
+            issue_list_item(&refreshed, &linked_branches, None)
+        },
+    )
+}
+
 pub(crate) fn search_knowledge_bridge_with_client<C: SemanticSearchClient + ?Sized>(
     repo_path: &Path,
     kind: KnowledgeKind,
@@ -1490,5 +1600,168 @@ Extra context.
         // canonical labels at once is malformed input
         assert_eq!(extracted.phase.as_deref(), Some("draft"));
         assert!(extracted.has_unknown_phase);
+    }
+
+    // SPEC-2017 T-027 — phase write-back orchestration coverage. The
+    // tests use `update_knowledge_phase_with_label_writer` to inject a
+    // closure that captures (and optionally fails) the gh CLI call so
+    // we don't need a live `gh` binary on the test runner.
+
+    #[test]
+    fn update_knowledge_phase_replaces_existing_phase_label() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        init_repo(&repo);
+        let cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path(&repo).expect("cache root");
+        Cache::new(cache_root)
+            .write_snapshot(&issue_snapshot(
+                100,
+                "Coverage spec",
+                "Body",
+                &["gwt-spec", "phase/draft"],
+                IssueState::Open,
+            ))
+            .expect("write snapshot");
+
+        let captured: std::cell::RefCell<Option<(Vec<String>, Vec<String>)>> =
+            std::cell::RefCell::new(None);
+        let result = update_knowledge_phase_with_label_writer(
+            &repo,
+            100,
+            Some("implementation"),
+            |add, remove| {
+                *captured.borrow_mut() = Some((add.to_vec(), remove.to_vec()));
+                Ok(())
+            },
+        )
+        .expect("update phase");
+        let snapshot = captured.into_inner().expect("label writer called");
+        assert_eq!(snapshot.0, vec!["phase/implementation".to_string()]);
+        assert_eq!(snapshot.1, vec!["phase/draft".to_string()]);
+        assert_eq!(result.phase.as_deref(), Some("implementation"));
+        assert!(result.is_spec);
+        assert!(!result.has_unknown_phase);
+    }
+
+    #[test]
+    fn update_knowledge_phase_to_backlog_removes_every_phase_label() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        init_repo(&repo);
+        let cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path(&repo).expect("cache root");
+        Cache::new(cache_root)
+            .write_snapshot(&issue_snapshot(
+                200,
+                "Spec to backlog",
+                "Body",
+                &["gwt-spec", "phase/review"],
+                IssueState::Open,
+            ))
+            .expect("write snapshot");
+
+        let captured: std::cell::RefCell<Option<(Vec<String>, Vec<String>)>> =
+            std::cell::RefCell::new(None);
+        let result = update_knowledge_phase_with_label_writer(&repo, 200, None, |add, remove| {
+            *captured.borrow_mut() = Some((add.to_vec(), remove.to_vec()));
+            Ok(())
+        })
+        .expect("update phase");
+        let snapshot = captured.into_inner().expect("label writer called");
+        assert!(
+            snapshot.0.is_empty(),
+            "Backlog drop must not add any phase label"
+        );
+        assert_eq!(snapshot.1, vec!["phase/review".to_string()]);
+        assert!(result.phase.is_none());
+    }
+
+    #[test]
+    fn update_knowledge_phase_rejects_unknown_target() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        let result = update_knowledge_phase_with_label_writer(
+            &repo,
+            999,
+            Some("legacy"),
+            |_add, _remove| panic!("label writer must not be invoked"),
+        );
+        let err = result.expect_err("unknown phase target should error");
+        assert!(err.contains("unknown phase"), "got: {err}");
+    }
+
+    #[test]
+    fn update_knowledge_phase_propagates_label_writer_failure() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        init_repo(&repo);
+        let cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path(&repo).expect("cache root");
+        Cache::new(cache_root)
+            .write_snapshot(&issue_snapshot(
+                300,
+                "Failing spec",
+                "Body",
+                &["gwt-spec", "phase/draft"],
+                IssueState::Open,
+            ))
+            .expect("write snapshot");
+
+        let result = update_knowledge_phase_with_label_writer(
+            &repo,
+            300,
+            Some("planning"),
+            |_add, _remove| Err("gh issue edit #300: 422 Unprocessable Entity".to_string()),
+        );
+        let err = result.expect_err("label writer failure must surface");
+        assert!(err.contains("422"), "got: {err}");
+        // Cache must NOT be updated when the GitHub call failed —
+        // otherwise the local cache drifts away from the source of truth.
+        let cache_root =
+            crate::issue_cache::issue_cache_root_for_repo_path(&repo).expect("cache root");
+        let entry = Cache::new(cache_root)
+            .load_entry(gwt_github::IssueNumber(300))
+            .expect("entry exists");
+        assert_eq!(
+            entry.snapshot.labels,
+            vec!["gwt-spec".to_string(), "phase/draft".to_string()],
+            "labels must remain unchanged after writer failure",
+        );
+    }
+
+    #[test]
+    fn update_knowledge_phase_reports_missing_cache_entry() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        init_repo(&repo);
+        let result =
+            update_knowledge_phase_with_label_writer(&repo, 404, Some("draft"), |_add, _remove| {
+                panic!("label writer must not run when cache miss")
+            });
+        let err = result.expect_err("missing cache entry must error");
+        assert!(err.contains("not in local cache"), "got: {err}");
     }
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -52,8 +52,8 @@ pub use gwt_agent::{ClaudeCodeOpenaiCompatInput, PresetDefinition, PresetId};
 pub use index_worker::{ProjectIndexStatusState, ProjectIndexStatusView};
 pub use knowledge_bridge::{
     load_knowledge_bridge, refresh_knowledge_bridge_cache, search_knowledge_bridge,
-    KnowledgeBridgeView, KnowledgeDetailSection, KnowledgeDetailView, KnowledgeKind,
-    KnowledgeListItem, KnowledgeListScope,
+    update_knowledge_phase, KnowledgeBridgeView, KnowledgeDetailSection, KnowledgeDetailView,
+    KnowledgeKind, KnowledgeListItem, KnowledgeListScope,
 };
 pub use launch_wizard::{
     build_agent_options, build_builtin_agent_options, default_wizard_version_cache_path,

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -147,6 +147,19 @@ pub enum FrontendEvent {
         number: u64,
         list_scope: Option<KnowledgeListScope>,
     },
+    /// SPEC-2017 US-8 — Kanban D&D writes a phase change back to the
+    /// owning GitHub Issue. `target_phase=None` means Backlog (every
+    /// `phase/*` label is removed); `Some("draft" | "planning" |
+    /// "implementation" | "review" | "done")` means assign exactly that
+    /// canonical phase. The frontend includes `request_id` so the
+    /// matching [`BackendEvent::KnowledgeBridgePhaseUpdated`] response
+    /// can clear the pending optimistic-UI entry.
+    UpdateKnowledgeBridgePhase {
+        id: String,
+        request_id: u64,
+        issue_number: u64,
+        target_phase: Option<String>,
+    },
     RunBranchCleanup {
         id: String,
         branches: Vec<String>,
@@ -464,6 +477,21 @@ pub enum BackendEvent {
         list_scope: Option<KnowledgeListScope>,
         detail: KnowledgeDetailView,
     },
+    /// SPEC-2017 US-8 — Result of an
+    /// [`FrontendEvent::UpdateKnowledgeBridgePhase`] request. On
+    /// success the backend returns the freshly-rebuilt cache entry so
+    /// the optimistic Kanban card can be replaced with authoritative
+    /// labels and counters; on failure it returns a human-readable
+    /// `message` so the frontend can roll back from `dndSnapshot` and
+    /// surface a toast. `request_id` mirrors the originating frame so
+    /// the `pendingPhaseUpdates` map can be reconciled even when
+    /// multiple drops are in flight.
+    KnowledgeBridgePhaseUpdated {
+        id: String,
+        request_id: u64,
+        issue_number: u64,
+        result: KnowledgePhaseUpdateResult,
+    },
     BranchCleanupResult {
         id: String,
         results: Vec<BranchCleanupResultEntry>,
@@ -587,6 +615,24 @@ pub enum CustomAgentErrorCode {
     InvalidInput,
     NotFound,
     Probe,
+}
+
+/// SPEC-2017 US-8 — Outcome of an
+/// [`FrontendEvent::UpdateKnowledgeBridgePhase`] request, embedded in
+/// [`BackendEvent::KnowledgeBridgePhaseUpdated`]. Tagged so the
+/// frontend can branch on `result.kind === "ok" | "error"` without
+/// pattern-matching on optional fields.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum KnowledgePhaseUpdateResult {
+    /// Phase write-back succeeded. `fresh_entry` is the rebuilt cache
+    /// entry (with the new labels / state / phase) so the optimistic
+    /// Kanban card can be overwritten with authoritative data.
+    Ok { fresh_entry: KnowledgeListItem },
+    /// Phase write-back failed. `message` is human-readable so the
+    /// toast / log can show it directly; the frontend rolls back the
+    /// optimistic UI from `state.dndSnapshot`.
+    Error { message: String },
 }
 
 #[cfg(test)]

--- a/crates/gwt/web/__tests__/kanban-dnd.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-dnd.test.mjs
@@ -1,0 +1,138 @@
+// SPEC-2017 Kanban D&D — phase write-back through WebSocket
+//
+// HTML5 Drag and Drop wiring tests. The renderer + drop handler live in
+// app.js, so we assert the source pattern (same approach as
+// kanban-structure.test.mjs and operator-chrome-structure.test.mjs).
+// Real DOM event simulation isn't useful here because dispatch happens
+// through the WebSocket transport; we just need to verify the source
+// has the right hook points and rollback discipline.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
+
+test("Kanban cards wire HTML5 dragstart so cards can be picked up", () => {
+  // SPEC-2017 US-8: cards are .kanban-card buttons. The dragstart
+  // listener marks them as the dragged card (DOM class) and stores
+  // the issue number on dataTransfer so the drop handler can find
+  // the entry. We assert addEventListener("dragstart", ...) hook.
+  assert.match(
+    appSource,
+    /addEventListener\("dragstart"/,
+    "expected app.js to wire dragstart for Kanban cards",
+  );
+  assert.match(
+    appSource,
+    /dataTransfer\.setData/,
+    "expected dragstart to set dataTransfer payload",
+  );
+});
+
+test("dragstart captures dndSnapshot for rollback on failure", () => {
+  // SPEC-2017 US-8: on dragstart we snapshot the source phase so
+  // a failed write-back can rollback the optimistic UI change. The
+  // snapshot lives on state.dndSnapshot keyed by issue number plus
+  // origin column. Without the snapshot rollback is impossible.
+  assert.match(
+    appSource,
+    /state\.dndSnapshot\s*=/,
+    "expected dragstart handler to set state.dndSnapshot",
+  );
+});
+
+test("drop handler sends update_knowledge_bridge_phase WebSocket message", () => {
+  // SPEC-2017 US-8: dropping on a target column triggers a
+  // WebSocket request with kind="update_knowledge_bridge_phase"
+  // carrying issue number, target_phase (or null for Backlog), and a
+  // request id so the response can be matched back to the pending
+  // update. The kind name mirrors the
+  // FrontendEvent::UpdateKnowledgeBridgePhase serde rename.
+  assert.match(
+    appSource,
+    /addEventListener\("drop"/,
+    "expected app.js to wire drop on Kanban columns",
+  );
+  assert.match(
+    appSource,
+    /update_knowledge_bridge_phase/,
+    "expected drop to dispatch update_knowledge_bridge_phase WebSocket message",
+  );
+});
+
+test("Backlog drop sends target_phase=null", () => {
+  // SPEC-2017 US-8: dropping a card on the Backlog column means
+  // "remove every phase/* label". The protocol uses target_phase=null
+  // to express that, so the handler can distinguish "set to draft"
+  // from "remove all phase labels". Without this distinction Backlog
+  // becomes unreachable through D&D.
+  assert.match(
+    appSource,
+    /target_phase[^,;]*null|targetPhase[^,;]*null/,
+    "expected Backlog drop to use target_phase=null",
+  );
+});
+
+test("knowledge_bridge_phase_updated Ok response clears pendingPhaseUpdates", () => {
+  // SPEC-2017 US-8: the optimistic UI keeps the moved card in
+  // pendingPhaseUpdates until the server confirms. On success the
+  // pending entry is removed and fresh_entry overwrites the card so
+  // labels / counts reflect the GitHub source of truth. The response
+  // event kind matches the BackendEvent::KnowledgeBridgePhaseUpdated
+  // serde rename.
+  assert.match(
+    appSource,
+    /knowledge_bridge_phase_updated/,
+    "expected app.js to handle knowledge_bridge_phase_updated response",
+  );
+  assert.match(
+    appSource,
+    /pendingPhaseUpdates[\s\S]{0,300}?\.delete\(/,
+    "expected success path to clear pendingPhaseUpdates entry",
+  );
+});
+
+test("knowledge_phase_updated Error response triggers rollback from dndSnapshot", () => {
+  // SPEC-2017 US-8: GitHub label write-back can fail (network,
+  // permission, rate limit). The error path must restore the card
+  // to its origin column using dndSnapshot — otherwise the user
+  // sees the optimistic move stick around as a phantom write.
+  assert.match(
+    appSource,
+    /dndSnapshot[\s\S]{0,300}?(rollback|restore|origin)|rollback[\s\S]{0,300}?dndSnapshot/,
+    "expected error response to rollback from dndSnapshot",
+  );
+});
+
+test("Plain Issue cards are not draggable", () => {
+  // SPEC-2017 US-10: gwt-spec ラベル無し Issue は phase ラベルを持た
+  // ないので D&D 不可。renderer は is_spec=false のカードに
+  // draggable=false を設定する。これが無いと plain Issue が phase
+  // カラムに入ってしまい、書き戻しで失敗する。
+  assert.match(
+    appSource,
+    /draggable\s*=\s*!isPlain|draggable\s*=\s*false/,
+    "expected plain Issue cards to set draggable=false",
+  );
+});
+
+test("Drop target columns get visual feedback during dragover", () => {
+  // SPEC-2017 US-8: the drop target column should show a hover
+  // affordance (outline / background change) so the user knows
+  // where the card will land. CSS class .is-drop-target is
+  // toggled by dragenter / dragleave handlers.
+  assert.match(
+    appSource,
+    /addEventListener\("dragover"|addEventListener\("dragenter"/,
+    "expected dragover/dragenter wired for drop feedback",
+  );
+  assert.match(
+    appSource,
+    /is-drop-target/,
+    "expected .is-drop-target class to appear in app.js drop feedback",
+  );
+});

--- a/crates/gwt/web/__tests__/kanban-drawer.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-drawer.test.mjs
@@ -1,0 +1,122 @@
+// SPEC-2017 US-9 Kanban Drawer — slide-over detail surface
+//
+// The Kanban view replaces the old right-pane detail with the
+// SPEC-2356 Drawer pattern (`.op-drawer` + `.op-drawer-backdrop`).
+// Card clicks open the Drawer with `role=dialog` + focus-trap; Esc /
+// backdrop click close it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
+const indexHtml = readFileSync(resolve(here, "../index.html"), "utf8");
+// Combined source for chrome-structure assertions that may live in
+// either app.js (when injected dynamically) or index.html (when part
+// of the static modal layer).
+const chromeSource = `${indexHtml}\n${appSource}`;
+const componentsCss = readFileSync(
+  resolve(here, "../styles/components.css"),
+  "utf8",
+);
+
+test("Knowledge Bridge Drawer has role=dialog + aria-modal=true", () => {
+  // SPEC-2017 US-9 + SPEC-2356: the Drawer is a modal surface, not a
+  // panel, so it must announce itself to assistive tech with both
+  // role=dialog and aria-modal=true. Without aria-modal screen
+  // readers leak focus to the underlying surface during navigation.
+  assert.match(
+    chromeSource,
+    /class="op-drawer kanban-drawer"|class="kanban-drawer op-drawer"/,
+    "expected Knowledge Bridge to use the SPEC-2356 .op-drawer pattern (with .kanban-drawer modifier)",
+  );
+  // The kanban-drawer block in index.html declares role=dialog +
+  // aria-modal=true — assert the pair appears within a 500-char
+  // window of the kanban-drawer class so we don't accidentally
+  // accept role=dialog from a sibling modal.
+  assert.match(
+    chromeSource,
+    /kanban-drawer[\s\S]{0,500}?role="dialog"[\s\S]{0,500}?aria-modal="true"|kanban-drawer[\s\S]{0,500}?aria-modal="true"[\s\S]{0,500}?role="dialog"/,
+    "expected Knowledge Bridge Drawer to declare role=dialog + aria-modal=true",
+  );
+});
+
+test("Drawer is wired to focus-trap on open", () => {
+  // SPEC-2017 US-9: opening the Drawer must call createFocusTrap so
+  // Tab cannot leak focus back to the Kanban Board behind the
+  // backdrop. The release function returned by createFocusTrap is
+  // stored so close can dismantle the trap symmetrically.
+  assert.match(
+    appSource,
+    /kanban-drawer[\s\S]{0,500}?createFocusTrap|createFocusTrap[\s\S]{0,500}?kanbanDrawerFocusTrap/,
+    "expected Knowledge Bridge Drawer to invoke createFocusTrap on open",
+  );
+});
+
+test("Drawer Esc / backdrop click closes the surface", () => {
+  // SPEC-2017 US-9: per WAI-ARIA dialog pattern, Esc must dismiss
+  // the modal. Backdrop click is also expected (parallel to existing
+  // wizard / migration / branch-cleanup modals).
+  assert.match(
+    appSource,
+    /closeKnowledgeBridgeDrawer|closeKanbanDrawer/,
+    "expected app.js to expose a close function for the Kanban Drawer",
+  );
+  // The handler may use either `if (event.key !== "Escape") return`
+  // (early-return style, which is how the rest of the codebase
+  // handles global Esc) or `if (event.key === "Escape")` directly.
+  // Both patterns are acceptable; we just need a keydown handler
+  // that wires Esc to closeKanbanDrawer.
+  assert.match(
+    appSource,
+    /(?:key !== "Escape"[\s\S]{0,2500}?closeKanbanDrawer|key === "Escape"[\s\S]{0,500}?closeKanbanDrawer|kanban-drawer[\s\S]{0,500}?Escape)/,
+    "expected Esc keydown to close the Kanban Drawer",
+  );
+});
+
+test("Drawer reuses .op-drawer styles via .kanban-drawer modifier class", () => {
+  // We don't redefine the Drawer geometry — we add a modifier class
+  // for Kanban-specific tweaks (e.g. detail section spacing). The
+  // base .op-drawer / .op-drawer-backdrop / @media reduced-motion
+  // rules already exist (SPEC-2356) so we just verify the modifier
+  // is declared.
+  assert.match(
+    componentsCss,
+    /\.kanban-drawer\b/,
+    "expected .kanban-drawer modifier rule in components.css",
+  );
+});
+
+test("Drawer footer hosts a Launch Agent action when launch_issue_number is set", () => {
+  // SPEC-2017 US-9 + existing renderer behavior: when the detail has
+  // a launch_issue_number we surface a Launch Agent button so the
+  // user can jump straight to wizard. This was already in the
+  // pre-Drawer renderer — keep the behavior, move the button into
+  // the Drawer footer.
+  assert.match(
+    appSource,
+    /Launch Agent[\s\S]{0,400}?openIssueLaunchWizard|openIssueLaunchWizard[\s\S]{0,400}?Launch Agent/,
+    "expected the Drawer to include the Launch Agent action",
+  );
+});
+
+test("Card click opens the Drawer (replaces side-pane detail)", () => {
+  // The renderer wires .kanban-card click to open the Drawer with
+  // the entry's number. The previous behavior loaded detail into a
+  // right-side pane via requestKnowledgeDetail; we keep
+  // requestKnowledgeDetail for fetch but route the rendered output
+  // into the Drawer body.
+  assert.match(
+    appSource,
+    /openKnowledgeBridgeDrawer|openKanbanDrawer/,
+    "expected an open function for the Kanban Drawer",
+  );
+  assert.match(
+    appSource,
+    /addEventListener\("click"[\s\S]{0,500}?(openKanbanDrawer|openKnowledgeBridgeDrawer)|kanban-card[\s\S]{0,500}?(openKanbanDrawer|openKnowledgeBridgeDrawer)/,
+    "expected card click to call the Drawer open function",
+  );
+});

--- a/crates/gwt/web/__tests__/kanban-structure.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-structure.test.mjs
@@ -147,3 +147,42 @@ test("Kanban cards declare warning indicator hook for unknown phase", () => {
     "expected app.js to honor entry.has_unknown_phase",
   );
 });
+
+// SPEC-2017 US-10: plain Issue cards must surface a (plain) chip and
+// stay non-draggable. The renderer derives both off entry.is_spec ===
+// false and never lets a plain Issue acquire phase metadata.
+test("Plain Issue cards declare draggable=!isPlain and a (plain) chip", () => {
+  // is_spec=false → isPlain=true → draggable=false. The negation
+  // pattern (`!isPlain`) is the canonical form in renderKanbanCard.
+  assert.match(
+    appSource,
+    /const isPlain = entry\.is_spec === false/,
+    "expected renderKanbanCard to derive isPlain from is_spec",
+  );
+  assert.match(
+    appSource,
+    /card\.draggable\s*=\s*!isPlain/,
+    "expected card.draggable to flip on isPlain",
+  );
+  assert.match(
+    appSource,
+    /kanban-card-chip--plain[\s\S]{0,200}?\(plain\)/,
+    "expected the (plain) chip to use the kanban-card-chip--plain class",
+  );
+});
+
+// SPEC-2017 US-11: closed Issue routing into the Done column. The
+// renderer overrides entry.phase with "done" whenever entry.state is
+// "closed", and the state chip uses kanban-card-chip--state-closed.
+test("Closed Issue cards land in Done with the closed state chip class", () => {
+  assert.match(
+    appSource,
+    /entry\.state === "closed" \? "done"/,
+    "expected closed entries to be routed to the done column",
+  );
+  assert.match(
+    appSource,
+    /kanban-card-chip--state-\$\{entry\.state\}|kanban-card-chip--state-closed/,
+    "expected the state chip class to be derived from entry.state",
+  );
+});

--- a/crates/gwt/web/__tests__/kanban-structure.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-structure.test.mjs
@@ -1,0 +1,149 @@
+// SPEC-2017 Kanban View — DOM 構造アサーション
+//
+// 6 カラム Kanban (Backlog / Draft / Planning / Implementation / Review /
+// Done) が CSS とレンダラに実装されていることを検証する。実 DOM は
+// app.js の renderKnowledgeBridge() が動的に作るので、テストは
+// components.css のスタイル宣言と app.js のソースパターンを確認する
+// （chrome-structure テストと同じ手法）。
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
+const componentsCss = readFileSync(
+  resolve(here, "../styles/components.css"),
+  "utf8",
+);
+
+const CANONICAL_PHASES = [
+  "backlog",
+  "draft",
+  "planning",
+  "implementation",
+  "review",
+  "done",
+];
+
+test("renderKnowledgeBridge emits all six Kanban columns by data-phase", () => {
+  // The renderer must create one .kanban-column per canonical phase plus
+  // Backlog. We assert the renderer mentions each data-phase value so the
+  // skeleton is complete; missing one would lose a whole pipeline stage.
+  for (const phase of CANONICAL_PHASES) {
+    const pattern = new RegExp(`data-phase=\\\\?"${phase}\\\\?"`);
+    assert.match(
+      appSource,
+      pattern,
+      `expected app.js renderer to emit data-phase="${phase}"`,
+    );
+  }
+});
+
+test("Kanban toolbar exposes Hide done toggle id", () => {
+  // The Hide done toggle is the new replacement for listScope (open/closed).
+  // It is identifiable by id so localStorage persistence can wire to it.
+  assert.match(
+    appSource,
+    /kanban-hide-done/,
+    "expected Hide done toggle id (kanban-hide-done) referenced in app.js",
+  );
+});
+
+test("renderKnowledgeBridge groups entries into kanban columns by phase", () => {
+  // The renderer must use entry.phase to assign data-phase on each card,
+  // and fall back to "backlog" when phase is null.
+  assert.match(
+    appSource,
+    /entry\.phase\s*\|\|\s*"backlog"/,
+    "expected app.js to fall back to 'backlog' when entry.phase is null",
+  );
+  assert.match(
+    appSource,
+    /\.kanban-column\[data-phase=/,
+    "expected app.js to look up kanban column by data-phase",
+  );
+});
+
+test("Plain (non-spec) entries fall into the Backlog column", () => {
+  // Plain GitHub Issues (no gwt-spec label, is_spec=false) carry no phase
+  // labels at all and must land in Backlog with a (plain) marker.
+  assert.match(
+    appSource,
+    /entry\.is_spec\s*===\s*false/,
+    "expected app.js to branch on entry.is_spec === false for plain issues",
+  );
+  assert.match(
+    appSource,
+    /\(plain\)/,
+    "expected app.js to display a (plain) marker on non-spec cards",
+  );
+});
+
+test("Closed issues land in the Done column", () => {
+  // closed Issues carry GitHub state == "closed" but no phase/done label.
+  // The renderer must promote them to the Done column so they appear with
+  // phase/done open Issues under one header.
+  assert.match(
+    appSource,
+    /entry\.state\s*===\s*"closed"/,
+    "expected app.js to detect closed state",
+  );
+  assert.match(
+    appSource,
+    /"done"/,
+    "expected app.js to assign closed entries to the done column",
+  );
+});
+
+test("Hide done toggle persists to localStorage", () => {
+  // The toggle state must persist via localStorage so reloads honor the
+  // user's preference. This is the replacement for the old listScope.
+  assert.match(
+    appSource,
+    /localStorage[\s\S]{0,200}?kanban-hide-done|kanban-hide-done[\s\S]{0,200}?localStorage/,
+    "expected app.js to persist Hide done state via localStorage",
+  );
+});
+
+test("components.css declares the kanban-board grid layout", () => {
+  // The Kanban board must use CSS grid. Fixed-width columns risk being
+  // unreadable on narrow viewports, so we want a responsive grid template
+  // that allows horizontal scroll.
+  const boardRule = componentsCss.match(/\.kanban-board\s*\{[^}]+\}/);
+  assert.ok(boardRule, "expected .kanban-board { ... } rule in components.css");
+  assert.match(
+    boardRule[0],
+    /grid-template-columns/,
+    ".kanban-board should declare grid-template-columns",
+  );
+});
+
+test("components.css declares column and card classes", () => {
+  // Cards and columns need their own selectors so the renderer can style
+  // them independently. Without these classes the renderer can't apply
+  // Operator tokens consistently.
+  assert.match(
+    componentsCss,
+    /\.kanban-column\b/,
+    "expected .kanban-column rule in components.css",
+  );
+  assert.match(
+    componentsCss,
+    /\.kanban-card\b/,
+    "expected .kanban-card rule in components.css",
+  );
+});
+
+test("Kanban cards declare warning indicator hook for unknown phase", () => {
+  // Issues with phase/legacy or multiple canonical labels expose
+  // has_unknown_phase = true. The renderer must surface a visual warning
+  // so users notice malformed metadata.
+  assert.match(
+    appSource,
+    /has_unknown_phase/,
+    "expected app.js to honor entry.has_unknown_phase",
+  );
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2289,6 +2289,24 @@
         });
       }
 
+      // SPEC-2017 US-8 — push a Kanban phase change to the backend.
+      // The optimistic UI move lives in renderKanbanCard's drop handler;
+      // this helper just wires the WebSocket request and reserves a
+      // request_id so knowledge_bridge_phase_updated can correlate the
+      // response back to a specific drop. target_phase=null means
+      // "Backlog" — the backend strips every phase/* label.
+      function sendUpdateKnowledgePhase(windowId, issueNumber, targetPhase) {
+        const requestId = nextKnowledgeLoadRequestId++;
+        send({
+          kind: "update_knowledge_bridge_phase",
+          id: windowId,
+          request_id: requestId,
+          issue_number: issueNumber,
+          target_phase: targetPhase,
+        });
+        return requestId;
+      }
+
       function openIssueLaunchWizard(windowId, issueNumber) {
         send({
           kind: "open_issue_launch_wizard",
@@ -4820,6 +4838,75 @@
         return "Empty";
       }
 
+      // SPEC-2017 US-8 — wire dragover / dragenter / dragleave / drop on
+      // a Kanban column once. dragover preventDefault is required for
+      // the drop event to fire; we also light up .is-drop-target as a
+      // visual affordance. drop translates the column data-phase into
+      // an `update_knowledge_bridge_phase` request, optimistically
+      // moves the card DOM, and registers a pending entry so the card
+      // shows a spinner until the response confirms.
+      function wireKanbanColumnDropTarget(windowId, column) {
+        column.addEventListener("dragover", (event) => {
+          event.preventDefault();
+          if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = "move";
+          }
+        });
+        column.addEventListener("dragenter", (event) => {
+          event.preventDefault();
+          column.classList.add("is-drop-target");
+        });
+        column.addEventListener("dragleave", (event) => {
+          // dragleave fires for child element transitions; only clear
+          // the marker when leaving the column itself.
+          if (event.target === column) {
+            column.classList.remove("is-drop-target");
+          }
+        });
+        column.addEventListener("drop", (event) => {
+          event.preventDefault();
+          column.classList.remove("is-drop-target");
+          const raw = event.dataTransfer?.getData("text/plain");
+          const issueNumber = raw ? Number.parseInt(raw, 10) : NaN;
+          if (!Number.isFinite(issueNumber)) {
+            return;
+          }
+          const state = ensureKnowledgeBridgeState(
+            windowId,
+            knowledgeKindForPreset(workspaceWindowById(windowId)?.preset),
+          );
+          const phaseKey = column.dataset.phase;
+          if (!phaseKey) return;
+          const targetPhase = phaseKey === "backlog" || phaseKey === "done"
+            ? phaseKey === "done"
+              ? "done"
+              : null
+            : phaseKey;
+          // Optimistic UI: rewrite the entry's phase locally and
+          // rerender so the card lands in the target column instantly.
+          if (Array.isArray(state.entries)) {
+            const index = state.entries.findIndex(
+              (entry) => entry.number === issueNumber,
+            );
+            if (index >= 0) {
+              state.entries[index] = {
+                ...state.entries[index],
+                phase: targetPhase,
+                has_unknown_phase: false,
+              };
+            }
+          }
+          if (!state.pendingPhaseUpdates) {
+            state.pendingPhaseUpdates = new Map();
+          }
+          state.pendingPhaseUpdates.set(
+            issueNumber,
+            sendUpdateKnowledgePhase(windowId, issueNumber, targetPhase),
+          );
+          renderKnowledgeBridge(windowId);
+        });
+      }
+
       function renderKanbanCard(windowId, state, entry) {
         const card = createNode("button", "kanban-card");
         card.type = "button";
@@ -4907,6 +4994,31 @@
           requestKnowledgeDetail(windowId, state.kind, entry.number);
           renderKnowledgeBridge(windowId);
         });
+
+        // SPEC-2017 US-8 — D&D wire-up. Plain (is_spec=false) cards
+        // skip these handlers entirely (draggable=false above) so they
+        // can still be clicked but never picked up.
+        if (!isPlain) {
+          card.addEventListener("dragstart", (event) => {
+            // Snapshot the original entry so a failed write-back can
+            // restore it; the snapshot keeps the entire entry value
+            // because labels / phase / state all change on success.
+            state.dndSnapshot = {
+              issueNumber: entry.number,
+              entry: { ...entry },
+              originPhase:
+                entry.state === "closed" ? "done" : entry.phase || "backlog",
+            };
+            card.classList.add("is-dragging");
+            if (event.dataTransfer) {
+              event.dataTransfer.effectAllowed = "move";
+              event.dataTransfer.setData("text/plain", String(entry.number));
+            }
+          });
+          card.addEventListener("dragend", () => {
+            card.classList.remove("is-dragging");
+          });
+        }
         return card;
       }
 
@@ -4984,6 +5096,10 @@
             body.innerHTML = "";
           }
           columnsByPhase.set(column.dataset.phase, column);
+          if (column.dataset.kanbanWired !== "true") {
+            wireKanbanColumnDropTarget(windowId, column);
+            column.dataset.kanbanWired = "true";
+          }
         }
         const counts = new Map();
         for (const entry of visibleEntries) {
@@ -6884,6 +7000,52 @@
             state.loading = false;
             state.error = event.message;
             frontendUnits.logsSurface.renderLogs(event.id);
+            break;
+          }
+          case "knowledge_bridge_phase_updated": {
+            // SPEC-2017 US-8 — phase write-back response. On Ok we
+            // overwrite the optimistic card with fresh_entry and clear
+            // the pending marker so the spinner stops; on Error we
+            // rollback from dndSnapshot and surface a toast.
+            const state = frontendUnits.knowledgeSettingsSurface.ensureKnowledgeBridgeState(
+              event.id,
+              knowledgeKindForPreset(workspaceWindowById(event.id)?.preset),
+            );
+            if (state.pendingPhaseUpdates) {
+              state.pendingPhaseUpdates.delete(event.issue_number);
+            }
+            if (event.result?.kind === "ok") {
+              const fresh = event.result.fresh_entry;
+              if (fresh && Array.isArray(state.entries)) {
+                const index = state.entries.findIndex(
+                  (entry) => entry.number === fresh.number,
+                );
+                if (index >= 0) {
+                  state.entries[index] = fresh;
+                }
+              }
+              state.dndSnapshot = null;
+            } else {
+              const message =
+                event.result?.message || "Failed to update phase. Reverting.";
+              if (
+                state.dndSnapshot &&
+                state.dndSnapshot.issueNumber === event.issue_number &&
+                Array.isArray(state.entries)
+              ) {
+                const index = state.entries.findIndex(
+                  (entry) => entry.number === event.issue_number,
+                );
+                if (index >= 0 && state.dndSnapshot.entry) {
+                  // Restore the card data captured at dragstart so the
+                  // labels / phase / state mirror the pre-drop reality.
+                  state.entries[index] = state.dndSnapshot.entry;
+                }
+                state.dndSnapshot = null;
+              }
+              state.error = message;
+            }
+            frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(event.id);
             break;
           }
           case "knowledge_error": {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -813,6 +813,125 @@
         }
       }
 
+      // SPEC-2017 US-9 — Kanban Drawer (slide-over detail). Reuses the
+      // SPEC-2356 .op-drawer pattern; backdrop click and Esc both
+      // dismiss it; createFocusTrap keeps Tab within the dialog while
+      // open. State is module-scoped because only one Drawer is open
+      // at a time even when multiple Kanban windows exist.
+      let kanbanDrawerFocusReturn = null;
+      let kanbanDrawerFocusTrapRelease = null;
+      let kanbanDrawerActiveContext = null;
+      function openKanbanDrawer(context) {
+        const drawer = document.getElementById("kanban-drawer");
+        const backdrop = document.getElementById("kanban-drawer-backdrop");
+        if (!drawer || !backdrop) return;
+        kanbanDrawerActiveContext = context || null;
+        kanbanDrawerFocusReturn = document.activeElement;
+        backdrop.hidden = false;
+        backdrop.dataset.open = "true";
+        drawer.hidden = false;
+        drawer.dataset.open = "true";
+        renderKanbanDrawerBody();
+        try { drawer.focus({ preventScroll: true }); }
+        catch { drawer.focus(); }
+        if (typeof kanbanDrawerFocusTrapRelease === "function") {
+          kanbanDrawerFocusTrapRelease();
+        }
+        kanbanDrawerFocusTrapRelease = createFocusTrap(drawer, { document });
+      }
+
+      function closeKanbanDrawer() {
+        const drawer = document.getElementById("kanban-drawer");
+        const backdrop = document.getElementById("kanban-drawer-backdrop");
+        if (!drawer || !backdrop) return;
+        if (drawer.dataset.open !== "true") return;
+        drawer.dataset.open = "false";
+        backdrop.dataset.open = "false";
+        // Hide after the transition so prefers-reduced-motion users
+        // still see the focus trap dismantle cleanly.
+        backdrop.hidden = true;
+        drawer.hidden = true;
+        if (typeof kanbanDrawerFocusTrapRelease === "function") {
+          kanbanDrawerFocusTrapRelease();
+          kanbanDrawerFocusTrapRelease = null;
+        }
+        if (
+          kanbanDrawerFocusReturn &&
+          typeof kanbanDrawerFocusReturn.focus === "function"
+        ) {
+          try { kanbanDrawerFocusReturn.focus({ preventScroll: true }); }
+          catch { kanbanDrawerFocusReturn.focus(); }
+        }
+        kanbanDrawerFocusReturn = null;
+        kanbanDrawerActiveContext = null;
+      }
+
+      function renderKanbanDrawerBody() {
+        const body = document.getElementById("kanban-drawer-body");
+        const titleEl = document.getElementById("kanban-drawer-title");
+        const footer = document.getElementById("kanban-drawer-footer");
+        if (!body || !titleEl || !footer) return;
+        const context = kanbanDrawerActiveContext;
+        if (!context) {
+          body.innerHTML = "";
+          footer.innerHTML = "";
+          titleEl.textContent = "Detail";
+          return;
+        }
+        const state = ensureKnowledgeBridgeState(context.windowId, context.kind);
+        const detail = state.detail;
+        body.innerHTML = "";
+        footer.innerHTML = "";
+        titleEl.textContent = detail?.title || "Loading detail";
+        if (state.detailLoading || !detail) {
+          body.appendChild(
+            createNode(
+              "div",
+              "kanban-drawer-section-body",
+              state.detailLoading ? "Loading detail" : "No cached detail available",
+            ),
+          );
+          return;
+        }
+        if (detail.subtitle) {
+          body.appendChild(
+            createNode("div", "knowledge-detail-subtitle", detail.subtitle),
+          );
+        }
+        if ((detail.labels || []).length > 0) {
+          const labelRow = createNode("div", "knowledge-label-row");
+          for (const label of detail.labels) {
+            labelRow.appendChild(createNode("span", "kanban-card-chip", label));
+          }
+          body.appendChild(labelRow);
+        }
+        for (const section of detail.sections || []) {
+          const card = createNode("section", "kanban-drawer-section");
+          card.appendChild(
+            createNode("div", "kanban-drawer-section-title", section.title),
+          );
+          card.appendChild(
+            createNode("pre", "kanban-drawer-section-body", section.body),
+          );
+          body.appendChild(card);
+        }
+        if (
+          detail.launch_issue_number !== null &&
+          detail.launch_issue_number !== undefined
+        ) {
+          const launchButton = createNode(
+            "button",
+            "wizard-button primary",
+            "Launch Agent",
+          );
+          launchButton.type = "button";
+          launchButton.addEventListener("click", () => {
+            openIssueLaunchWizard(context.windowId, detail.launch_issue_number);
+          });
+          footer.appendChild(launchButton);
+        }
+      }
+
       function clamp(value, min) {
         return Math.max(min, value);
       }
@@ -4988,11 +5107,14 @@
         }
 
         card.addEventListener("click", () => {
-          if (state.selectedNumber === entry.number && !state.detailLoading) {
-            return;
-          }
+          // SPEC-2017 US-9 — clicking a card opens the Drawer with the
+          // freshest detail. We always request detail (cheap; cache-
+          // backed) so reopening on the same card still pulls live
+          // comment / linked-branch updates, and we always (re)open
+          // the Drawer so a previously dismissed Drawer reappears.
           requestKnowledgeDetail(windowId, state.kind, entry.number);
           renderKnowledgeBridge(windowId);
+          openKanbanDrawer({ windowId, kind: state.kind, number: entry.number });
         });
 
         // SPEC-2017 US-8 — D&D wire-up. Plain (is_spec=false) cards
@@ -6936,6 +7058,25 @@
             }
             state.detailLoading = false;
             frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(event.id);
+            // SPEC-2017 US-9 — refresh the Drawer body when the detail
+            // is for the entry the Drawer is currently showing. This
+            // also handles the swap-on-different-card case (T-034):
+            // requestKnowledgeDetail was just dispatched for the new
+            // number, so the new detail will arrive here and overwrite
+            // the body without re-mounting the Drawer.
+            const drawer = document.getElementById("kanban-drawer");
+            if (
+              drawer &&
+              drawer.dataset.open === "true" &&
+              kanbanDrawerActiveContext &&
+              kanbanDrawerActiveContext.windowId === event.id
+            ) {
+              kanbanDrawerActiveContext = {
+                ...kanbanDrawerActiveContext,
+                number: event.detail?.number ?? kanbanDrawerActiveContext.number,
+              };
+              renderKanbanDrawerBody();
+            }
             break;
           }
           case "branch_cleanup_result": {
@@ -7503,6 +7644,22 @@
           frontendUnits.branchesFileTreeSurface.closeBranchCleanupModal();
         }
       });
+      // SPEC-2017 US-9 — wire the Kanban Drawer close affordances:
+      // the explicit × button and the backdrop click both close the
+      // modal. The Esc handler is registered globally a few blocks
+      // below.
+      const kanbanDrawerCloseButton = document.getElementById(
+        "kanban-drawer-close",
+      );
+      if (kanbanDrawerCloseButton) {
+        kanbanDrawerCloseButton.addEventListener("click", closeKanbanDrawer);
+      }
+      const kanbanDrawerBackdrop = document.getElementById(
+        "kanban-drawer-backdrop",
+      );
+      if (kanbanDrawerBackdrop) {
+        kanbanDrawerBackdrop.addEventListener("click", closeKanbanDrawer);
+      }
       // SPEC-2356 — keyboard equivalent for clicking the modal backdrop.
       // Without this, Esc only worked for the Hotkey overlay and Command
       // Palette; users were trapped in branch-cleanup / migration / wizard
@@ -7545,6 +7702,15 @@
           if (tabId) {
             send({ kind: "skip_migration", tab_id: tabId });
           }
+          event.preventDefault();
+          return;
+        }
+        // SPEC-2017 US-9 — Esc dismisses the Kanban Drawer. Checked
+        // before the windowList dropdown because the Drawer is a
+        // modal surface and outranks the dropdown affordance.
+        const kanbanDrawer = document.getElementById("kanban-drawer");
+        if (kanbanDrawer && kanbanDrawer.dataset.open === "true") {
+          closeKanbanDrawer();
           event.preventDefault();
           return;
         }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1909,6 +1909,15 @@
             emptyMessage: "",
             baseEmptyMessage: "",
             refreshEnabled: true,
+            // SPEC-2017 — Kanban state. hideDone hydrates from
+            // localStorage so the user's preference survives reloads;
+            // dndSnapshot stores the pre-drop column index to enable
+            // optimistic-UI rollback when phase write-back fails;
+            // pendingPhaseUpdates tracks in-flight requests so cards
+            // render a spinner until the server confirms the move.
+            hideDone: readKanbanHideDonePreference(),
+            dndSnapshot: null,
+            pendingPhaseUpdates: new Map(),
           });
         }
         const state = knowledgeBridgeStateMap.get(windowId);
@@ -1916,7 +1925,35 @@
         if (!state.listScope) {
           state.listScope = "open";
         }
+        if (state.hideDone === undefined) {
+          state.hideDone = readKanbanHideDonePreference();
+        }
+        if (!state.pendingPhaseUpdates) {
+          state.pendingPhaseUpdates = new Map();
+        }
         return state;
+      }
+
+      function readKanbanHideDonePreference() {
+        try {
+          if (typeof localStorage === "undefined") return false;
+          return localStorage.getItem("kanban-hide-done") === "1";
+        } catch (_err) {
+          return false;
+        }
+      }
+
+      function writeKanbanHideDonePreference(value) {
+        try {
+          if (typeof localStorage === "undefined") return;
+          if (value) {
+            localStorage.setItem("kanban-hide-done", "1");
+          } else {
+            localStorage.removeItem("kanban-hide-done");
+          }
+        } catch (_err) {
+          // localStorage may be unavailable in private mode; ignore.
+        }
       }
 
       function clearKnowledgeBridgeState(windowId) {
@@ -1930,6 +1967,8 @@
           state.searchInFlight = false;
           state.inFlightSearchRequestId = 0;
           state.detailRequestId = 0;
+          state.pendingPhaseUpdates?.clear();
+          state.dndSnapshot = null;
         }
         knowledgeBridgeStateMap.delete(windowId);
       }
@@ -4774,6 +4813,103 @@
         renderKnowledgeBridge(windowId);
       }
 
+      function kanbanEmptyMessage(state, phase) {
+        if (state.searching) return "Searching";
+        if (state.loading) return "Loading";
+        if (phase === "backlog") return "No backlog items";
+        return "Empty";
+      }
+
+      function renderKanbanCard(windowId, state, entry) {
+        const card = createNode("button", "kanban-card");
+        card.type = "button";
+        card.dataset.issueNumber = String(entry.number);
+        // Plain (non-spec) Issues cannot be moved through phase columns
+        // because they carry no canonical phase labels. We surface a
+        // (plain) chip and disable HTML5 D&D so the user understands
+        // the constraint at a glance.
+        const isPlain = entry.is_spec === false;
+        card.draggable = !isPlain;
+        if (isPlain) {
+          card.classList.add("kanban-card--plain");
+        }
+        if (state.selectedNumber === entry.number) {
+          card.classList.add("is-selected");
+          // SPEC-2356 — selected card announces aria-current="true" so
+          // screen readers read which Kanban card is currently shown
+          // in the detail pane (parallel to project tabs and the old
+          // knowledge-row pattern).
+          card.setAttribute("aria-current", "true");
+        } else {
+          card.removeAttribute("aria-current");
+        }
+        if (state.pendingPhaseUpdates && state.pendingPhaseUpdates.has(entry.number)) {
+          card.classList.add("is-pending");
+        }
+
+        const head = createNode("div", "kanban-card-head");
+        head.appendChild(
+          createNode("span", "kanban-card-number", `#${entry.number}`),
+        );
+        const stateChip = createNode(
+          "span",
+          `kanban-card-chip kanban-card-chip--state-${entry.state}`,
+          entry.state,
+        );
+        head.appendChild(stateChip);
+        card.appendChild(head);
+
+        card.appendChild(
+          createNode("div", "kanban-card-title", entry.title),
+        );
+
+        const meta = createNode("div", "kanban-card-meta");
+        if (isPlain) {
+          meta.appendChild(
+            createNode("span", "kanban-card-chip kanban-card-chip--plain", "(plain)"),
+          );
+        }
+        if (entry.has_unknown_phase) {
+          meta.appendChild(
+            createNode(
+              "span",
+              "kanban-card-chip kanban-card-chip--warning",
+              "Unknown phase",
+            ),
+          );
+        }
+        if (Number.isFinite(entry.match_score)) {
+          meta.appendChild(
+            createNode(
+              "span",
+              "kanban-card-chip",
+              `${entry.match_score}% match`,
+            ),
+          );
+        }
+        if ((entry.linked_branch_count || 0) > 0) {
+          meta.appendChild(
+            createNode(
+              "span",
+              "kanban-card-chip",
+              `${entry.linked_branch_count} branch${entry.linked_branch_count === 1 ? "" : "es"}`,
+            ),
+          );
+        }
+        if (meta.childElementCount > 0) {
+          card.appendChild(meta);
+        }
+
+        card.addEventListener("click", () => {
+          if (state.selectedNumber === entry.number && !state.detailLoading) {
+            return;
+          }
+          requestKnowledgeDetail(windowId, state.kind, entry.number);
+          renderKnowledgeBridge(windowId);
+        });
+        return card;
+      }
+
       function renderKnowledgeBridge(windowId) {
         const element = windowMap.get(windowId);
         if (!element) {
@@ -4783,13 +4919,14 @@
           windowId,
           knowledgeKindForPreset(workspaceWindowById(windowId)?.preset),
         );
-        const list = element.querySelector(".knowledge-list");
+        const board = element.querySelector(".kanban-board");
         const detailPane = element.querySelector(".knowledge-detail-pane");
         const status = element.querySelector(".knowledge-status");
         const refreshButton = element.querySelector("[data-action='refresh-knowledge']");
         const searchInput = element.querySelector(".knowledge-search");
         const scopeButtons = element.querySelectorAll("[data-knowledge-scope]");
-        if (!list || !detailPane || !status || !refreshButton || !searchInput) {
+        const hideDoneToggle = element.querySelector("[data-action='kanban-hide-done']");
+        if (!board || !detailPane || !status || !refreshButton || !searchInput) {
           return;
         }
 
@@ -4803,6 +4940,10 @@
           button.classList.toggle("active", active);
           button.disabled = state.loading && !active;
         }
+        if (hideDoneToggle) {
+          hideDoneToggle.checked = state.hideDone === true;
+        }
+        board.dataset.hideDone = state.hideDone === true ? "true" : "false";
 
         status.className = "knowledge-status";
         status.textContent = "";
@@ -4820,87 +4961,55 @@
         } else if (state.loading && state.entries.length === 0) {
           status.classList.add("visible", "info");
           status.textContent = "Loading cache-backed data";
-        } else if (state.emptyMessage && state.entries.length === 0) {
+        } else if (state.entries.length === 0 && !state.searching) {
           status.classList.add("visible", "info");
-          status.textContent = state.emptyMessage;
+          status.textContent = state.emptyMessage || "No cached items";
         }
 
-        list.innerHTML = "";
+        // SPEC-2017 — Kanban grouping. Each entry routes to a single
+        // column: closed Issues land in "done" regardless of phase
+        // label so the Done column unifies state="closed" with the
+        // phase/done open Issues; otherwise we trust entry.phase, with
+        // null falling back to "backlog" so plain Issues and unlabeled
+        // SPECs are never lost. Unknown phase labels stay in their
+        // backend-extracted column but flag has_unknown_phase so the
+        // card can warn the user about malformed metadata.
         const visibleEntries = state.query.trim()
           ? state.entries
           : filteredKnowledgeEntries(state);
-        if (visibleEntries.length === 0) {
-          const empty = createNode("div", "knowledge-empty workspace-empty-state");
-          if (state.searching) {
-            empty.textContent = "Searching semantic index";
-          } else if (state.entries.length === 0) {
-            empty.textContent = state.emptyMessage || "No cached items";
-          } else {
-            empty.textContent = "No semantic matches";
+        const columnsByPhase = new Map();
+        for (const column of board.querySelectorAll(".kanban-column[data-phase]")) {
+          const body = column.querySelector("[data-role='body']");
+          if (body) {
+            body.innerHTML = "";
           }
-          list.appendChild(empty);
-        } else {
-          for (const entry of visibleEntries) {
-            const row = createNode("button", "knowledge-row");
-            row.type = "button";
-            if (state.selectedNumber === entry.number) {
-              row.classList.add("selected");
-              // SPEC-2356 — selected knowledge entry gets aria-current
-              // so screen readers announce which row is currently
-              // displayed in the detail pane (parallel to project tabs).
-              row.setAttribute("aria-current", "true");
-            } else {
-              row.removeAttribute("aria-current");
-            }
-            const main = createNode("div", "knowledge-row-main");
-            const titleWrap = createNode("div", "");
-            titleWrap.appendChild(
-              createNode("div", "knowledge-row-number", `#${entry.number}`),
+          columnsByPhase.set(column.dataset.phase, column);
+        }
+        const counts = new Map();
+        for (const entry of visibleEntries) {
+          const phaseKey =
+            entry.state === "closed" ? "done" : entry.phase || "backlog";
+          const column = columnsByPhase.get(phaseKey) || columnsByPhase.get("backlog");
+          if (!column) continue;
+          const body = column.querySelector("[data-role='body']");
+          if (!body) continue;
+          const card = renderKanbanCard(windowId, state, entry);
+          body.appendChild(card);
+          counts.set(phaseKey, (counts.get(phaseKey) || 0) + 1);
+        }
+        for (const [phase, column] of columnsByPhase) {
+          const countLabel = column.querySelector("[data-role='count']");
+          if (countLabel) {
+            countLabel.textContent = String(counts.get(phase) || 0);
+          }
+          const body = column.querySelector("[data-role='body']");
+          if (body && body.childElementCount === 0) {
+            const empty = createNode(
+              "div",
+              "kanban-column-empty",
+              kanbanEmptyMessage(state, phase),
             );
-            titleWrap.appendChild(
-              createNode("div", "knowledge-row-title", entry.title),
-            );
-            main.appendChild(titleWrap);
-            const stateChip = createNode(
-              "span",
-              `knowledge-state-chip ${entry.state}`,
-              entry.state,
-            );
-            main.appendChild(stateChip);
-            row.appendChild(main);
-
-            const meta = createNode("div", "knowledge-row-meta");
-            meta.appendChild(createNode("span", "knowledge-meta-copy", entry.meta));
-            if (Number.isFinite(entry.match_score)) {
-              meta.appendChild(
-                createNode(
-                  "span",
-                  "knowledge-chip knowledge-match-score",
-                  `${entry.match_score}% match`,
-                ),
-              );
-            }
-            if ((entry.linked_branch_count || 0) > 0) {
-              meta.appendChild(
-                createNode(
-                  "span",
-                  "knowledge-chip",
-                  `${entry.linked_branch_count} linked branch${entry.linked_branch_count === 1 ? "" : "es"}`,
-                ),
-              );
-            }
-            for (const label of entry.labels || []) {
-              meta.appendChild(createNode("span", "knowledge-chip", label));
-            }
-            row.appendChild(meta);
-            row.addEventListener("click", () => {
-              if (state.selectedNumber === entry.number && !state.detailLoading) {
-                return;
-              }
-              requestKnowledgeDetail(windowId, state.kind, entry.number);
-              renderKnowledgeBridge(windowId);
-            });
-            list.appendChild(row);
+            body.appendChild(empty);
           }
         }
 
@@ -5677,9 +5786,17 @@
 
         if (surface === "knowledge") {
           const knowledgeKind = knowledgeKindForPreset(windowData.preset);
+          // SPEC-2017 — Knowledge Bridge surface is a 6-column Kanban Board:
+          // Backlog / Draft / Planning / Implementation / Review / Done.
+          // The columns are hard-coded so the source carries every
+          // canonical data-phase literal (asserted by kanban-structure
+          // tests) and so the renderer can simply locate columns via
+          // .kanban-column[data-phase="..."]. The right-hand detail
+          // pane survives Phase 1 unchanged; SPEC-2017 Phase 3 replaces
+          // it with the SPEC-2356 Drawer pattern.
           body.innerHTML = `
-            <div class="knowledge-root">
-              <div class="workspace-toolbar is-stacked">
+            <div class="knowledge-root kanban-root">
+              <div class="workspace-toolbar kanban-toolbar is-stacked">
                 <div class="workspace-toolbar-main">
                   <div class="knowledge-heading">${knowledgeHeading(knowledgeKind)}</div>
                   ${
@@ -5691,15 +5808,67 @@
                       : ""
                   }
                   <input class="knowledge-search" type="search" placeholder="${knowledgeSearchPlaceholder(knowledgeKind)}" />
+                  <label class="kanban-hide-done-toggle" for="kanban-hide-done-${windowData.id}">
+                    <input
+                      type="checkbox"
+                      id="kanban-hide-done-${windowData.id}"
+                      class="kanban-hide-done"
+                      data-action="kanban-hide-done"
+                    />
+                    <span>Hide done</span>
+                  </label>
                 </div>
                 <div class="workspace-toolbar-actions">
                   <button class="icon-button" data-action="refresh-knowledge" aria-label="Refresh cached knowledge">↻</button>
                 </div>
               </div>
               <div class="knowledge-status"></div>
-              <div class="knowledge-split workspace-split">
-                <div class="knowledge-list-pane">
-                  <div class="knowledge-list"></div>
+              <div class="knowledge-split workspace-split kanban-shell">
+                <div class="knowledge-list-pane kanban-list-pane">
+                  <div class="kanban-board" role="list" aria-label="Knowledge Bridge Kanban Board">
+                    <div class="kanban-column" data-phase="backlog" aria-label="Backlog column">
+                      <div class="kanban-column-header">
+                        <span class="kanban-column-name">Backlog</span>
+                        <span class="kanban-column-count" data-role="count">0</span>
+                      </div>
+                      <div class="kanban-column-body" data-role="body"></div>
+                    </div>
+                    <div class="kanban-column" data-phase="draft" aria-label="Draft column">
+                      <div class="kanban-column-header">
+                        <span class="kanban-column-name">Draft</span>
+                        <span class="kanban-column-count" data-role="count">0</span>
+                      </div>
+                      <div class="kanban-column-body" data-role="body"></div>
+                    </div>
+                    <div class="kanban-column" data-phase="planning" aria-label="Planning column">
+                      <div class="kanban-column-header">
+                        <span class="kanban-column-name">Planning</span>
+                        <span class="kanban-column-count" data-role="count">0</span>
+                      </div>
+                      <div class="kanban-column-body" data-role="body"></div>
+                    </div>
+                    <div class="kanban-column" data-phase="implementation" aria-label="Implementation column">
+                      <div class="kanban-column-header">
+                        <span class="kanban-column-name">Implementation</span>
+                        <span class="kanban-column-count" data-role="count">0</span>
+                      </div>
+                      <div class="kanban-column-body" data-role="body"></div>
+                    </div>
+                    <div class="kanban-column" data-phase="review" aria-label="Review column">
+                      <div class="kanban-column-header">
+                        <span class="kanban-column-name">Review</span>
+                        <span class="kanban-column-count" data-role="count">0</span>
+                      </div>
+                      <div class="kanban-column-body" data-role="body"></div>
+                    </div>
+                    <div class="kanban-column" data-phase="done" aria-label="Done column">
+                      <div class="kanban-column-header">
+                        <span class="kanban-column-name">Done</span>
+                        <span class="kanban-column-count" data-role="count">0</span>
+                      </div>
+                      <div class="kanban-column-body" data-role="body"></div>
+                    </div>
+                  </div>
                 </div>
                 <div class="knowledge-detail-pane"></div>
               </div>
@@ -5744,6 +5913,24 @@
                 windowData.id,
               );
             });
+          // SPEC-2017 — Hide done toggle persists via localStorage so
+          // reloads honour the user preference. The hidden state hides
+          // the Done column entirely (CSS-driven via data-hide-done on
+          // the board) and updates state in place without reloading.
+          const hideDoneToggle = body.querySelector("[data-action='kanban-hide-done']");
+          if (hideDoneToggle) {
+            hideDoneToggle.checked = state.hideDone === true;
+            hideDoneToggle.addEventListener("change", (event) => {
+              event.stopPropagation();
+              state.hideDone = hideDoneToggle.checked === true;
+              frontendUnits.knowledgeSettingsSurface.persistKanbanHideDone(
+                state.hideDone,
+              );
+              frontendUnits.knowledgeSettingsSurface.renderKnowledgeBridge(
+                windowData.id,
+              );
+            });
+          }
           if (!state.detail && !state.loading) {
             frontendUnits.knowledgeSettingsSurface.requestKnowledgeBridge(
               windowData.id,
@@ -6292,6 +6479,7 @@
         renderSettingsAgentList,
         setSettingsStatus,
         completeAddFromPreset,
+        persistKanbanHideDone: writeKanbanHideDonePreference,
       });
 
       const frontendUnits = Object.freeze({

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3309,6 +3309,43 @@
           tabindex="-1"
         ></div>
       </div>
+
+      <!-- SPEC-2017 US-9: Knowledge Bridge Drawer. Re-uses the
+           SPEC-2356 .op-drawer / .op-drawer-backdrop pattern (slide-
+           over + backdrop + reduced-motion fallback). Body content
+           (KnowledgeDetailView) is rendered dynamically by app.js
+           when a Kanban card is clicked. -->
+      <div
+        class="op-drawer-backdrop"
+        id="kanban-drawer-backdrop"
+        data-open="false"
+        hidden
+      ></div>
+      <aside
+        class="op-drawer kanban-drawer"
+        id="kanban-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="kanban-drawer-title"
+        data-open="false"
+        hidden
+        tabindex="-1"
+      >
+        <header class="op-drawer__header">
+          <h2
+            class="op-drawer__title"
+            id="kanban-drawer-title"
+          >Detail</h2>
+          <button
+            type="button"
+            class="op-drawer__close"
+            id="kanban-drawer-close"
+            aria-label="Close detail drawer"
+          >×</button>
+        </header>
+        <div class="op-drawer__body" id="kanban-drawer-body"></div>
+        <footer class="op-drawer__footer" id="kanban-drawer-footer"></footer>
+      </aside>
     </div>
 
     <script type="module" src="/app.js"></script>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1842,3 +1842,237 @@ kbd.op-kbd {
   margin: 0 var(--space-2);
   vertical-align: middle;
 }
+
+/* ============================================================
+   SPEC-2017 Kanban View — Knowledge Bridge phase board
+   ============================================================
+   6-column board (Backlog / Draft / Planning / Implementation /
+   Review / Done) that replaces the legacy flat list. Tokens come
+   from tokens.css so dark/light/forced-colors swap automatically.
+   .kanban-board uses CSS grid with a fluid 220px minimum so cards
+   stay readable, and overflow-x: auto allows horizontal scroll on
+   narrow viewports rather than collapsing columns. */
+
+.kanban-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.kanban-toolbar-spacer {
+  flex: 1;
+}
+
+.kanban-hide-done-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.kanban-hide-done-toggle input {
+  accent-color: var(--color-state-active);
+}
+
+.kanban-board {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(220px, 1fr));
+  gap: var(--space-3);
+  padding: var(--space-3);
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
+
+.kanban-board[data-hide-done="true"] .kanban-column[data-phase="done"] {
+  display: none;
+}
+
+.kanban-column {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  overflow: hidden;
+}
+
+.kanban-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  font-family: var(--font-display);
+  font-stretch: 75%;
+  font-weight: 700;
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+  color: var(--color-display-fg);
+}
+
+.kanban-column-count {
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text-muted);
+}
+
+.kanban-column-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.kanban-column.is-drop-target {
+  outline: 2px dashed var(--color-state-active);
+  outline-offset: -4px;
+  background: color-mix(in oklab, var(--color-state-active) 6%, var(--color-surface));
+}
+
+.kanban-column-empty {
+  padding: var(--space-3);
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text-muted);
+}
+
+.kanban-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+
+.kanban-card:hover {
+  background: color-mix(in oklab, var(--color-state-active) 8%, var(--color-surface-elevated));
+}
+
+.kanban-card.is-selected {
+  border-color: var(--color-state-active);
+  box-shadow: 0 0 0 1px var(--color-state-active);
+}
+
+.kanban-card[draggable="true"]:active {
+  cursor: grabbing;
+}
+
+.kanban-card[draggable="false"] {
+  cursor: default;
+  opacity: 0.85;
+}
+
+.kanban-card.is-dragging {
+  opacity: 0.5;
+}
+
+.kanban-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.kanban-card-number {
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-text-muted);
+}
+
+.kanban-card-title {
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  color: var(--color-text-strong);
+  overflow-wrap: anywhere;
+}
+
+.kanban-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.kanban-card-chip {
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  text-transform: uppercase;
+  background: color-mix(in oklab, var(--agent-codex) 18%, transparent);
+  color: var(--agent-codex);
+}
+
+.kanban-card-chip--plain {
+  background: color-mix(in oklab, var(--color-text-muted) 18%, transparent);
+  color: var(--color-text-muted);
+}
+
+.kanban-card-chip--warning {
+  background: color-mix(in oklab, var(--color-state-blocked) 22%, transparent);
+  color: var(--color-state-blocked);
+}
+
+.kanban-card-chip--state-open {
+  background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+  color: var(--color-state-active);
+}
+
+.kanban-card-chip--state-closed {
+  background: color-mix(in oklab, var(--color-text-muted) 18%, transparent);
+  color: var(--color-text-muted);
+}
+
+.kanban-card-pending {
+  display: inline-block;
+  width: 0.75em;
+  height: 0.75em;
+  border-radius: 50%;
+  border: 2px solid var(--color-state-active);
+  border-top-color: transparent;
+  animation: kanban-card-spin 0.9s linear infinite;
+}
+
+@keyframes kanban-card-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kanban-card-pending {
+    animation: none;
+    border-top-color: var(--color-state-active);
+  }
+}
+

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1029,6 +1029,26 @@ kbd.op-kbd {
   body::before, body::after { display: none; }
   [data-agent-state] { animation: none; }
   .op-status-strip__live-dot { animation: none; }
+  /* SPEC-2017 US-9 — Kanban surface in forced-colors mode. Drop our
+     token-derived backgrounds so system colors paint the columns,
+     cards, and chips. Borders fall back to ButtonText so the column
+     boundaries remain visible against the system canvas. */
+  .kanban-board,
+  .kanban-column,
+  .kanban-card,
+  .kanban-card-chip {
+    background: Canvas;
+    color: CanvasText;
+    border-color: ButtonText;
+  }
+  .kanban-column.is-drop-target {
+    outline-color: Highlight;
+    background: Canvas;
+  }
+  .kanban-card.is-selected {
+    outline: 2px solid Highlight;
+    box-shadow: none;
+  }
 }
 
 /* ============================================================
@@ -2075,4 +2095,53 @@ kbd.op-kbd {
     border-top-color: var(--color-state-active);
   }
 }
+
+/* SPEC-2017 US-9 — Kanban Drawer modifier on the SPEC-2356 Drawer.
+   The base `.op-drawer` already provides slide / focus / reduced-
+   motion behavior. The modifier just adds Kanban-specific spacing
+   and gives the body element a wider scroll area so SPEC sections
+   (spec/plan/tasks/notes/comments) stay readable. */
+.kanban-drawer .op-drawer__body {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.kanban-drawer .op-drawer__footer {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
+.kanban-drawer-section {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+}
+
+.kanban-drawer-section-title {
+  font-family: var(--font-display);
+  font-stretch: 75%;
+  font-weight: 700;
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-display);
+  color: var(--color-text-strong);
+  text-transform: uppercase;
+}
+
+.kanban-drawer-section-body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  line-height: 1.5;
+  color: var(--color-text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "cargo test -p gwt-core -p gwt --all-features",
     "test:frontend-bundle": "node --check crates/gwt/web/app.js && node --check crates/gwt/web/branch-cleanup-modal.js && node --check crates/gwt/web/migration-modal.js && node --check crates/gwt/web/theme-manager.js && node --check crates/gwt/web/hotkey.js && node --check crates/gwt/web/operator-shell.js && node --check crates/gwt/web/focus-trap.js",
     "test:frontend-smoke": "node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs crates/gwt/web/__tests__/migration-modal.smoke.test.mjs",
-    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/board-surface.test.mjs crates/gwt/web/__tests__/focus-trap.test.mjs crates/gwt/web/__tests__/kanban-structure.test.mjs",
+    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/board-surface.test.mjs crates/gwt/web/__tests__/focus-trap.test.mjs crates/gwt/web/__tests__/kanban-structure.test.mjs crates/gwt/web/__tests__/kanban-dnd.test.mjs",
     "test:visual": "playwright test --config crates/gwt/playwright/playwright.config.ts",
     "test:release-assets": "node scripts/test_release_assets.cjs",
     "test:release-flow": "bash scripts/check-release-flow.sh",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "cargo test -p gwt-core -p gwt --all-features",
     "test:frontend-bundle": "node --check crates/gwt/web/app.js && node --check crates/gwt/web/branch-cleanup-modal.js && node --check crates/gwt/web/migration-modal.js && node --check crates/gwt/web/theme-manager.js && node --check crates/gwt/web/hotkey.js && node --check crates/gwt/web/operator-shell.js && node --check crates/gwt/web/focus-trap.js",
     "test:frontend-smoke": "node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs crates/gwt/web/__tests__/migration-modal.smoke.test.mjs",
-    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/board-surface.test.mjs crates/gwt/web/__tests__/focus-trap.test.mjs",
+    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/board-surface.test.mjs crates/gwt/web/__tests__/focus-trap.test.mjs crates/gwt/web/__tests__/kanban-structure.test.mjs",
     "test:visual": "playwright test --config crates/gwt/playwright/playwright.config.ts",
     "test:release-assets": "node scripts/test_release_assets.cjs",
     "test:release-flow": "bash scripts/check-release-flow.sh",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "cargo test -p gwt-core -p gwt --all-features",
     "test:frontend-bundle": "node --check crates/gwt/web/app.js && node --check crates/gwt/web/branch-cleanup-modal.js && node --check crates/gwt/web/migration-modal.js && node --check crates/gwt/web/theme-manager.js && node --check crates/gwt/web/hotkey.js && node --check crates/gwt/web/operator-shell.js && node --check crates/gwt/web/focus-trap.js",
     "test:frontend-smoke": "node --test crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs crates/gwt/web/__tests__/migration-modal.smoke.test.mjs",
-    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/board-surface.test.mjs crates/gwt/web/__tests__/focus-trap.test.mjs crates/gwt/web/__tests__/kanban-structure.test.mjs crates/gwt/web/__tests__/kanban-dnd.test.mjs",
+    "test:frontend-unit": "node --test crates/gwt/web/__tests__/contrast.test.mjs crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/hotkey.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/board-surface.test.mjs crates/gwt/web/__tests__/focus-trap.test.mjs crates/gwt/web/__tests__/kanban-structure.test.mjs crates/gwt/web/__tests__/kanban-dnd.test.mjs crates/gwt/web/__tests__/kanban-drawer.test.mjs",
     "test:visual": "playwright test --config crates/gwt/playwright/playwright.config.ts",
     "test:release-assets": "node scripts/test_release_assets.cjs",
     "test:release-flow": "bash scripts/check-release-flow.sh",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4720,3 +4720,61 @@ Playwright が必須。
 
 - 新しいフロントテストは「ロジック単体は `node --test`、 描画 / インタラクションは Playwright」に二分する。 ブラウザ起動が必要かをロジックレベルで判定する。
 - `package.json` には `test:frontend-unit` (Node native) と `test:visual` (Playwright) を分離して定義する。 CI も別ジョブで実行し、 失敗箇所が一目で分かるようにする。
+
+## 2026-05-06 — 楽観的 UI の rollback は pre-mutation snapshot で即時に行う
+
+### 事象
+
+SPEC-2017 Phase 2 で Kanban D&D を実装した際、最初の design では
+drop 時にサーバー応答を待ってから DOM 更新する pessimistic UI を
+検討していたが、レビューで「drop した瞬間にカードがビジュアルで動か
+ないと操作が成立したか不明」と指摘されて楽観的 UI に転換した。
+最初の楽観的 UI 実装では「失敗時は再度 load_knowledge_bridge を呼ぶ」
+という rollback 戦略を取ったが、これだと再取得の非同期応答が来るまで
+楽観的に動かしたカードが target column に留まり続け、矛盾した
+状態が続いてしまう。
+
+### 原因
+
+楽観的 UI における rollback は、サーバー応答待ちの非同期性ではなく、
+クライアント側の「pre-mutation snapshot」で即時に行うべきだった。
+最初の設計は「rollback = サーバーから再ダウンロード」という
+pessimistic fallback に引きずられていた。
+
+### 再発防止策
+
+- 楽観的 UI を実装するときは、drop / submit 時に必ず pre-mutation
+  snapshot を取り、エラー応答時はそのスナップショットから即時
+  rollback する。サーバー再取得は最後の手段。
+- `dndSnapshot` のような state スロットを設計初期に確保し、UI 操作と
+  非同期通信の境界を明確にする。
+- WebSocket protocol の error response には、UI rollback に必要な情報
+  （request_id / target / error message）を必ず含め、フロントが
+  サーバー再取得に依存しなくて済むようにする。
+
+## 2026-05-06 — Drawer 化のときは右ペインを残置せず Drawer に詳細を寄せる
+
+### 事象
+
+SPEC-2017 Phase 1 では Knowledge Bridge を Kanban に置換しつつ、
+既存の右ペイン (`.knowledge-detail-pane`) は残したまま着地させた。
+Phase 3 で Drawer を導入する際、最初は右ペインも Drawer も両方
+表示する案を検討したが、レイアウト的に Kanban Board の横幅を著しく
+圧迫し、6 カラムが画面に収まらなくなる問題が出た。
+
+### 原因
+
+「既存 UI を残置すれば破壊的変更を最小化できる」という保守的な
+考えに引きずられたが、Kanban のような横幅を要求する surface では
+右ペインの占有を完全に取り除いた方が UX 的にも実装的にも素直
+だった。SPEC-2356 で確立済の Drawer pattern (`.op-drawer`) は
+右からスライドする一時的な surface なので、Kanban の横幅を奪わない。
+
+### 再発防止策
+
+- 横幅制約のある surface (Kanban / Timeline / Wide Table 等) で詳細
+  ペインを併存させる場合、必ず Drawer / Slide-over パターンを採用
+  する。永続ペインは縦長 surface (List / Tree / Form) でのみ正当化
+  される。
+- 既存 UI を残置するか Drawer に寄せるかの判断は、機能の差分よりも
+  「surface の横幅要件」を起点に行う。


### PR DESCRIPTION
## Summary

- SPEC-2017: Knowledge Bridge ウィンドウを従来のフラットなリストから 6 カラム Kanban Board (Backlog / Draft / Planning / Implementation / Review / Done) に完全置換した
- HTML5 Drag and Drop で phase ラベルを GitHub に書き戻し、楽観的 UI + 失敗時 rollback で UX を担保
- カードクリックで SPEC-2356 Drawer パターン (.op-drawer) を呼び出し、focus-trap + Esc-close + WAI-ARIA dialog 準拠

## Changes

### Phase 1 (US-7): Kanban DOM
- Backend: `KnowledgeListItem` に `phase` / `has_unknown_phase` / `is_spec` を追加、`extract_phase` ヘルパー導入 (`knowledge_bridge.rs`)
- Frontend: `app.js` の `renderKnowledgeBridge` を Kanban 描画に置換、`renderKanbanCard` 追加。Hide done トグルを `localStorage` に永続化
- CSS: `components.css` に Kanban セクションを追加 (Operator tokens 経由、reduced-motion 対応)
- 旧 `.knowledge-list` フラットリストを廃止 (旧 `.knowledge-detail-pane` と `listScope` open/closed トグルは Phase 4 follow-up で削除)

### Phase 2 (US-8): D&D phase 遷移
- Protocol: `FrontendEvent::UpdateKnowledgeBridgePhase` ↔ `BackendEvent::KnowledgeBridgePhaseUpdated` (`KnowledgePhaseUpdateResult::{Ok{fresh_entry}, Error{message}}`) を `protocol.rs` に追加
- Backend: `Cache::apply_phase_change` (atomic meta.json 書き換え) + `update_knowledge_phase` 関数 (gh CLI shell-out 経由) を追加
- Frontend: HTML5 D&D wire (dragstart/dragend/dragover/dragenter/dragleave/drop)、`dndSnapshot` で pre-mutation snapshot、`pendingPhaseUpdates` で in-flight tracking、エラー応答時の即時 rollback
- Plain Issue (`is_spec=false`) は `draggable=false` + `(plain)` chip で D&D 不可

### Phase 3 (US-9): Drawer 詳細閲覧
- 新規 Drawer: index.html に `.op-drawer.kanban-drawer` markup (role=dialog + aria-modal=true + aria-labelledby)
- app.js に `openKanbanDrawer` / `closeKanbanDrawer` / `renderKanbanDrawerBody` を追加、`createFocusTrap` 起動、Esc / backdrop click / × ボタンで close、別カードクリックで Drawer 中身を差し替え (再 open しない)
- Drawer footer に Launch Agent ボタンを設置、既存 launch wizard を Issue 番号付きで起動
- `KnowledgeDetailView` の `subtitle` / `labels` / `sections` を `.kanban-drawer-section` 単位で描画

### Polish / Cross-Cutting
- WCAG 2.1 AA: 既存 `contrast.test.mjs` の REQUIRED_PAIRS が Kanban 関連トークンを既にカバー済 (`--color-text` × `--color-surface(-elevated)`、`--color-state-active` 等)
- `@media (prefers-reduced-motion: reduce)` で Kanban カード spinner / Drawer スライドを縮退
- `@media (forced-colors: active)` で Kanban surface を system colors (Canvas / CanvasText / ButtonText / Highlight) に fallback
- `tasks/lessons.md` に「楽観的 UI rollback は pre-mutation snapshot で即時に行う」「Drawer 化のときは右ペインを残置せず Drawer に詳細を寄せる」の 2 件を追記

## Testing

- [x] `cargo test -p gwt -p gwt-core -p gwt-github --all-features` GREEN (800+ tests)
  - `update_knowledge_phase` 5 件: phase ラベル置換 / Backlog drop でラベル全削除 / 不正 phase 早期リジェクト / GitHub 失敗時のキャッシュ unchanged / cache miss
  - `apply_phase_change` 3 件: success / missing entry / body 不変
  - `extract_phase` 5 件: canonical / none / legacy / multi / spec
- [x] `cargo clippy --all-targets --all-features -- -D warnings` GREEN
- [x] `cargo fmt --check` GREEN
- [x] `pnpm test:frontend-unit` GREEN (198 tests)
  - kanban-structure.test.mjs 11/11
  - kanban-dnd.test.mjs 8/8
  - kanban-drawer.test.mjs 6/6
- [x] `pnpm test:frontend-bundle` GREEN (Node syntax check on 7 web modules)
- [ ] 手動 GUI 検証: 1) Kanban 6 カラム表示確認 2) D&D で phase ラベル書き戻し確認 3) カードクリック → Drawer open → Esc で close 4) Hide done トグル → Done カラム消失 5) closed Issue が Done に統合される
- [ ] Playwright snapshot test (T-063): follow-up PR で対応

## Closing Issues

Refs #2017

## Related Issues

- #2356 (Operator Design System の Drawer パターン + focus-trap.js を再利用)

## Follow-up

- T-063: Playwright snapshot for Kanban × Dark/Light × Hide done on/off
- T-064: release_assets test 更新 (現状不要、フォローアップで再評価)
- T-065: 旧 `listScope` state + open/closed トグル UI + protocol の `KnowledgeListScope` Option を削除 (13 frontend + 多数 backend 参照、独立 PR 推奨)

## Checklist

- [x] Conventional Commits 形式 (`feat(kanban):` prefix)
- [x] cargo fmt / clippy / test GREEN
- [x] フロント単体テスト GREEN
- [x] WCAG 2.1 AA contrast / reduced-motion / forced-colors
- [x] tasks/lessons.md 更新済
- [ ] GUI 手動検証 (PR 作成者が実施): D&D 操作、Drawer 開閉、Hide done 永続化を一通り確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Kanban board with six columns (Backlog, Draft, Planning, Implementation, Review, Done) for organizing knowledge items by phase
  * Drag-and-drop support to move items between phases with optimistic UI updates
  * Hide done toggle with persistent preference storage
  * Kanban drawer for viewing and managing item details
  * Phase change tracking with automatic rollback on errors

* **Tests**
  * Added comprehensive test coverage for Kanban functionality and UI structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->