### PR TITLE
feat(ui): add operator chrome visibility toggles

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -254,6 +254,30 @@ test("Command Palette trigger button declares aria-keyshortcuts", () => {
   assert.ok(shortcut.includes("Meta+P"), "trigger must declare Meta+P");
 });
 
+test("Project Bar exposes persistent chrome visibility toggles", () => {
+  const sidebarToggle = document.getElementById("op-sidebar-toggle");
+  const windowControlsToggle = document.getElementById("op-window-controls-toggle");
+  assert.ok(sidebarToggle, "expected Project Bar sidebar visibility toggle");
+  assert.ok(windowControlsToggle, "expected Project Bar window controls visibility toggle");
+  assert.equal(sidebarToggle.getAttribute("aria-pressed"), "true");
+  assert.equal(windowControlsToggle.getAttribute("aria-pressed"), "true");
+  assert.match(sidebarToggle.getAttribute("aria-label") ?? "", /sidebar/i);
+  assert.match(windowControlsToggle.getAttribute("aria-label") ?? "", /window controls/i);
+});
+
+test("floating window controls mark only window operations as hideable", () => {
+  for (const id of ["tile-button", "stack-button", "window-list-button", "add-button"]) {
+    const button = document.getElementById(id);
+    assert.ok(button, `expected ${id}`);
+    assert.equal(button.dataset.windowControl, "true", `${id} should be hidden by the window controls toggle`);
+  }
+  for (const id of ["op-palette-button", "zoom-out-button", "zoom-reset-button", "zoom-in-button"]) {
+    const button = document.getElementById(id);
+    assert.ok(button, `expected ${id}`);
+    assert.notEqual(button.dataset.windowControl, "true", `${id} should remain visible when window controls are hidden`);
+  }
+});
+
 test("Project Bar brand prefix wraps GWT OPERATOR with bracket flank", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
   // The pseudo-element content lives only in CSS, not in the DOM, so we
@@ -296,14 +320,30 @@ test("operator-shell wires sidebar collapse hotkey and Mission Briefing early di
   );
   assert.match(
     operatorShell,
-    /opSidebar\s*===\s*"collapsed"/,
-    "expected collapsed state toggle on documentElement.dataset.opSidebar",
+    /toggleSidebar/,
+    "expected Cmd+backslash to route through the persistent sidebar visibility controller",
   );
+  assert.match(operatorShell, /root\.dataset\.opSidebar\s*=\s*"collapsed"/);
   assert.match(
     operatorShell,
     /earlyDismiss/,
     "expected Mission Briefing earlyDismiss helper",
   );
+});
+
+test("components.css hides only marked floating window controls", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  assert.match(css, /\[data-op-window-controls="hidden"\][\s\S]+\.floating-actions \[data-window-control="true"\]/);
+  assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+#op-palette-button/);
+  assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+#zoom-reset-button/);
+});
+
+test("operator-shell persists sidebar and window controls visibility independently", () => {
+  const operatorShell = readFileSync(resolve(here, "../operator-shell.js"), "utf8");
+  assert.match(operatorShell, /SIDEBAR_COLLAPSED_KEY\s*=\s*"gwt:ui:sidebar-collapsed"/);
+  assert.match(operatorShell, /WINDOW_CONTROLS_KEY\s*=\s*"gwt:ui:window-controls"/);
+  assert.match(operatorShell, /opWindowControls/);
+  assert.match(operatorShell, /window-controls-changed/);
 });
 
 test("components.css declares Status Strip BLOCKED pulse + live indicator", () => {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2923,6 +2923,24 @@
               Open Project
             </button>
             <button
+              class="op-chrome-toggle"
+              id="op-sidebar-toggle"
+              type="button"
+              aria-label="Hide sidebar"
+              aria-pressed="true"
+            >
+              Sidebar
+            </button>
+            <button
+              class="op-chrome-toggle"
+              id="op-window-controls-toggle"
+              type="button"
+              aria-label="Hide window controls"
+              aria-pressed="true"
+            >
+              Windows
+            </button>
+            <button
               class="op-theme-toggle"
               id="op-theme-toggle"
               type="button"
@@ -3037,14 +3055,15 @@
               <span class="op-palette-trigger__label">⌘K</span>
               <span class="op-palette-trigger__hint">Palette</span>
             </button>
-            <button class="arrange-button" id="tile-button" aria-label="Tile windows">Tile</button>
-            <button class="arrange-button" id="stack-button" aria-label="Stack windows">Stack</button>
-            <div class="window-list-shell">
+            <button class="arrange-button" id="tile-button" aria-label="Tile windows" data-window-control="true">Tile</button>
+            <button class="arrange-button" id="stack-button" aria-label="Stack windows" data-window-control="true">Stack</button>
+            <div class="window-list-shell" data-window-control="true">
               <button
                 class="arrange-button"
                 id="window-list-button"
                 aria-label="List windows"
                 aria-expanded="false"
+                data-window-control="true"
               >
                 Windows
               </button>
@@ -3053,7 +3072,7 @@
             <button class="arrange-button" id="zoom-out-button" aria-label="Zoom out">-</button>
             <button class="arrange-button" id="zoom-reset-button" aria-label="Reset zoom">100%</button>
             <button class="arrange-button" id="zoom-in-button" aria-label="Zoom in">+</button>
-            <button class="add-button" id="add-button" aria-label="Add window">+</button>
+            <button class="add-button" id="add-button" aria-label="Add window" data-window-control="true">+</button>
           </div>
         </div>
         <footer

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -7,6 +7,8 @@ import { createThemeManager, createBrowserEnv } from "/theme-manager.js";
 import { createHotkeyManager } from "/hotkey.js";
 
 const SIDEBAR_KEY = "gwt:ui:sidebar";
+const SIDEBAR_COLLAPSED_KEY = "gwt:ui:sidebar-collapsed";
+const WINDOW_CONTROLS_KEY = "gwt:ui:window-controls";
 const BRIEFING_KEY = "gwt:ui:briefing";
 
 export function initOperatorShell(deps = {}) {
@@ -17,14 +19,75 @@ export function initOperatorShell(deps = {}) {
   const hotkey = deps.hotkey ?? createHotkeyManager();
 
   wireThemeToggle({ doc, themeManager });
+  const chromeVisibility = wireChromeVisibility({ doc, win });
   wireSidebarLayers({ doc, win });
   wireStatusStripClock({ doc });
   wireMissionBriefing({ doc, win });
   wireHotkeyOverlay({ doc, hotkey });
   const palette = wireCommandPalette({ doc, hotkey });
-  wireGlobalHotkeys({ doc, hotkey, palette });
+  wireGlobalHotkeys({ doc, hotkey, palette, chromeVisibility });
 
   return { themeManager, hotkey, palette };
+}
+
+// ------------------------------------------------------------
+// Chrome visibility — persist full sidebar and window controls
+// ------------------------------------------------------------
+
+function wireChromeVisibility({ doc, win }) {
+  const sidebarButton = doc.getElementById("op-sidebar-toggle");
+  const windowControlsButton = doc.getElementById("op-window-controls-toggle");
+  const root = doc.documentElement;
+
+  let sidebarVisible = readBoolean(win, SIDEBAR_COLLAPSED_KEY, false) !== true;
+  let windowControlsVisible = readString(win, WINDOW_CONTROLS_KEY, "visible") !== "hidden";
+
+  const renderSidebar = () => {
+    if (sidebarVisible) delete root.dataset.opSidebar;
+    else root.dataset.opSidebar = "collapsed";
+    if (!sidebarButton) return;
+    sidebarButton.setAttribute("aria-pressed", sidebarVisible ? "true" : "false");
+    sidebarButton.setAttribute("aria-label", sidebarVisible ? "Hide sidebar" : "Show sidebar");
+  };
+
+  const renderWindowControls = () => {
+    if (windowControlsVisible) delete root.dataset.opWindowControls;
+    else root.dataset.opWindowControls = "hidden";
+    if (!windowControlsButton) return;
+    windowControlsButton.setAttribute("aria-pressed", windowControlsVisible ? "true" : "false");
+    windowControlsButton.setAttribute(
+      "aria-label",
+      windowControlsVisible ? "Hide window controls" : "Show window controls",
+    );
+  };
+
+  const setSidebarVisible = (next) => {
+    sidebarVisible = Boolean(next);
+    writeString(win, SIDEBAR_COLLAPSED_KEY, sidebarVisible ? "false" : "true");
+    renderSidebar();
+    doc.dispatchEvent(new CustomEvent("op:chrome-visibility-changed", {
+      detail: { sidebarVisible, windowControlsVisible },
+    }));
+  };
+
+  const setWindowControlsVisible = (next) => {
+    windowControlsVisible = Boolean(next);
+    writeString(win, WINDOW_CONTROLS_KEY, windowControlsVisible ? "visible" : "hidden");
+    renderWindowControls();
+    doc.dispatchEvent(new CustomEvent("op:window-controls-changed", {
+      detail: { visible: windowControlsVisible },
+    }));
+  };
+
+  sidebarButton?.addEventListener("click", () => setSidebarVisible(!sidebarVisible));
+  windowControlsButton?.addEventListener("click", () => setWindowControlsVisible(!windowControlsVisible));
+  renderSidebar();
+  renderWindowControls();
+
+  return {
+    toggleSidebar: () => setSidebarVisible(!sidebarVisible),
+    toggleWindowControls: () => setWindowControlsVisible(!windowControlsVisible),
+  };
 }
 
 // ------------------------------------------------------------
@@ -494,7 +557,7 @@ function createActionRegistry(doc) {
 // Global hotkeys (delegate to operator command bus)
 // ------------------------------------------------------------
 
-function wireGlobalHotkeys({ doc, hotkey, palette }) {
+function wireGlobalHotkeys({ doc, hotkey, palette, chromeVisibility }) {
   const send = (id) => () => {
     doc.dispatchEvent(new CustomEvent("op:command", { detail: { id } }));
     return true;
@@ -506,10 +569,7 @@ function wireGlobalHotkeys({ doc, hotkey, palette }) {
   // SPEC-2356 — Cmd+\ collapses/expands the Sidebar Layers, freeing canvas
   // real estate when the user wants more room for floating windows.
   hotkey.register("cmd+\\", () => {
-    const root = doc.documentElement;
-    const next = root.dataset.opSidebar === "collapsed" ? "" : "collapsed";
-    if (next) root.dataset.opSidebar = next;
-    else delete root.dataset.opSidebar;
+    chromeVisibility?.toggleSidebar?.();
     return true;
   });
 
@@ -539,6 +599,26 @@ function readJson(win, key, fallback) {
 
 function writeJson(win, key, value) {
   try { win.localStorage.setItem(key, JSON.stringify(value)); } catch { /* no-op */ }
+}
+
+function readString(win, key, fallback) {
+  try {
+    const raw = win.localStorage.getItem(key);
+    return typeof raw === "string" && raw.length > 0 ? raw : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeString(win, key, value) {
+  try { win.localStorage.setItem(key, value); } catch { /* no-op */ }
+}
+
+function readBoolean(win, key, fallback) {
+  const raw = readString(win, key, fallback ? "true" : "false");
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return fallback;
 }
 
 function matchReduced(doc) {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -133,8 +133,9 @@ body::after {
   font-weight: 500;
 }
 
-/* Theme toggle button (Project Bar trailing) */
-.op-theme-toggle {
+/* Project Bar trailing chrome buttons */
+.op-theme-toggle,
+.op-chrome-toggle {
   appearance: none;
   background: transparent;
   border: 1px solid var(--color-border-strong);
@@ -154,10 +155,18 @@ body::after {
 }
 
 .op-theme-toggle:hover,
-.op-theme-toggle:focus-visible {
+.op-theme-toggle:focus-visible,
+.op-chrome-toggle:hover,
+.op-chrome-toggle:focus-visible {
   outline: none;
   border-color: var(--color-focus-ring);
   color: var(--color-focus-ring);
+}
+
+.op-chrome-toggle[aria-pressed="false"] {
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+  background: color-mix(in oklab, var(--color-text-muted) 10%, transparent);
 }
 
 .op-theme-toggle__label {
@@ -1688,6 +1697,10 @@ kbd.op-kbd {
   display: none;
 }
 
+:root[data-theme][data-op-window-controls="hidden"] .floating-actions [data-window-control="true"] {
+  display: none;
+}
+
 /* SPEC-2356 — smooth Sidebar collapse transition.
    When user toggles ⌘\, the grid template columns animate from
    240px ↔ 0 instead of snapping. reduced-motion env keeps the
@@ -2143,5 +2156,4 @@ kbd.op-kbd {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
-
 


### PR DESCRIPTION
## Summary

Add Project Bar controls for hiding and showing Operator chrome surfaces.

## Changes

- Adds persistent Sidebar and Window controls toggles to the Project Bar.
- Persists sidebar collapse state in `gwt:ui:sidebar-collapsed` and window control visibility in `gwt:ui:window-controls`.
- Hides only Tile, Stack, Windows, and Add window controls while keeping Palette and Zoom controls visible.
- Updates SPEC-2356 spec, plan, and tasks sections for the new visibility behavior.

## Testing

- `pnpm exec node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`
- `pnpm test:frontend-unit`
- `pnpm test:frontend-bundle`
- `cargo test -p gwt-core -p gwt --all-features`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`
- `git diff --check`
- `bunx commitlint --from HEAD~1 --to HEAD`
- pre-push checks: coverage 90.63% >= 90%, lint:skills 28 frontmatter

## Closing Issues

None

## Related Issues

- #2356

## Checklist

- [x] SPEC-2356 updated
- [x] TDD RED/GREEN verified for frontend chrome structure
- [x] Frontend and Rust verification passed
- [x] Commit pushed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added toggle buttons to show/hide sidebar and window controls from the interface
  * Chrome visibility states now persist across sessions
  * Added keyboard shortcut (Cmd+Backslash) to toggle sidebar visibility
  * Expanded window management controls with tile and stack actions

* **Tests**
  * Added comprehensive test coverage for chrome visibility toggles and state persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->