### PR TITLE
docs(skills): require PR update summary reports

### DIFF
--- a/.codex/skills/gwt-manage-pr/SKILL.md
+++ b/.codex/skills/gwt-manage-pr/SKILL.md
@@ -14,6 +14,48 @@ next-step guidance returned from this workflow.
 
 Canonical agent-facing surface is `gwtd pr ...` / `gwtd actions ...` for PR inspection, create/update, and fix flows. The current implementation may still use GitHub REST / `gh` internally as transport, while GraphQL remains the transport for unresolved review threads and thread reply/resolve.
 
+## Final Report Contract
+
+Every final user-facing report from this workflow MUST state whether a PR was
+created, updated, fixed, or left unchanged. When a PR was created, pushed to,
+or fixed, include a `PR Update Summary` derived from the actual diff, commit
+range, and PR body. Do not invent changes from intent alone.
+
+`PR Update Summary` must include:
+
+- PR number and URL
+- base/head branches
+- commit count or updated commit range
+- 2-5 bullets describing what the PR updates
+- related Issue/SPEC numbers, or `None`
+- verification and CI/review status
+
+For **check** and **NO ACTION** results, explicitly say no PR update was made.
+If an existing PR is only inspected, summarize the current PR status separately
+from `PR Update Summary` so the report does not imply new changes were pushed.
+
+Final report shape:
+
+```text
+## PR Result
+- Action: Created | Updated | Fixed | Checked | No Action
+- PR: #<number> <url> | None
+- Branches: <base> <- <head>
+
+### PR Update Summary
+- Commits: <count or range>
+- Updates:
+  - <what changed>
+- Related: #<issue/spec> | None
+- Verification: <commands/checks and status>
+
+### Next
+- <remaining blocker or "None">
+```
+
+Omit `PR Update Summary` only when no PR was created, updated, or fixed; in
+that case include `PR Update: none` in the result.
+
 ## gwtd resolution
 
 Before executing any `gwtd ...` command from this skill or its references,


### PR DESCRIPTION
## Summary

- Require `gwt-manage-pr` final reports to say what PR update was created, pushed, or fixed so handoffs are explicit.

## Changes

- `.codex/skills/gwt-manage-pr/SKILL.md`: Add a `Final Report Contract` that requires action status, PR metadata, branch metadata, update bullets, related Issues/SPECs, and verification status.
- `.codex/skills/gwt-manage-pr/SKILL.md`: Require check and no-action flows to state that no PR update was made so inspection reports do not imply new changes.

## Testing

- [x] `pnpm lint:skills` — validated 28 `SKILL.md` frontmatter blocks.
- [x] `bunx markdownlint-cli .codex/skills/gwt-manage-pr/SKILL.md` — completed without Markdown lint errors.
- [x] `git diff --check` — completed without whitespace errors.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — validated the commit message.

## Closing Issues

- None

## Related Issues / Links

- #1935

## Checklist

- [ ] Tests added/updated — N/A: docs-only skill contract change; validated with skill and Markdown lint.
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — applicable lint checks passed; Rust/Svelte checks are N/A for this docs-only change.
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema or data change.
- [x] CHANGELOG impact considered (breaking change flagged in commit)
