### PR TITLE
feat: add dynamic agent window purpose titles

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -37,7 +37,7 @@ pub struct BoardPostRequest {
 
 impl AppRuntime {
     pub(crate) fn post_board_entry_events(
-        &self,
+        &mut self,
         client_id: &str,
         request: BoardPostRequest,
     ) -> Vec<OutboundEvent> {
@@ -69,6 +69,8 @@ impl AppRuntime {
                 },
             )];
         };
+        let tab_id = tab.id.clone();
+        let project_root = tab.project_root.clone();
         let Some(window) = tab.workspace.window(&address.raw_id) else {
             return vec![OutboundEvent::reply(
                 client_id,
@@ -159,11 +161,9 @@ impl AppRuntime {
                     },
                 )];
                 if let Some(entry) = latest_entry.as_ref() {
-                    if let Some(event) = self.record_workspace_board_milestone_event(
-                        &tab.id,
-                        &tab.project_root,
-                        entry,
-                    ) {
+                    if let Some(event) =
+                        self.record_workspace_board_milestone_event(&tab_id, &project_root, entry)
+                    {
                         events.push(event);
                     }
                 }
@@ -180,7 +180,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn record_workspace_board_milestone_event(
-        &self,
+        &mut self,
         tab_id: &str,
         project_root: &Path,
         entry: &coordination::BoardEntry,
@@ -198,6 +198,7 @@ impl AppRuntime {
                 }
             };
         projection.record_board_milestone(entry);
+        self.update_agent_window_dynamic_title_for_board_entry(entry);
         if let Err(error) =
             workspace_projection::save_workspace_projection(project_root, &projection)
         {
@@ -217,6 +218,41 @@ impl AppRuntime {
         Some(OutboundEvent::broadcast(
             BackendEvent::ActiveWorkProjection { projection },
         ))
+    }
+
+    fn update_agent_window_dynamic_title_for_board_entry(
+        &mut self,
+        entry: &coordination::BoardEntry,
+    ) -> bool {
+        if !matches!(
+            entry.kind,
+            BoardEntryKind::Claim
+                | BoardEntryKind::Status
+                | BoardEntryKind::Blocked
+                | BoardEntryKind::Handoff
+                | BoardEntryKind::Decision
+                | BoardEntryKind::Next
+        ) {
+            return false;
+        }
+        let Some(origin_session_id) = entry.origin_session_id.as_deref() else {
+            return false;
+        };
+        let Some((window_id, _)) = self
+            .active_agent_sessions
+            .iter()
+            .find(|(_, session)| session.session_id == origin_session_id)
+        else {
+            return false;
+        };
+        let Some(address) = self.window_lookup.get(window_id).cloned() else {
+            return false;
+        };
+        let Some(tab) = self.tab_mut(&address.tab_id) else {
+            return false;
+        };
+        tab.workspace
+            .set_dynamic_title(&address.raw_id, Some(entry.body.clone()))
     }
 }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -571,6 +571,21 @@ fn active_agent_summary_from_session(
     }
 }
 
+fn agent_launch_purpose_title(
+    project_root: &Path,
+    linked_issue_number: Option<u64>,
+) -> Option<String> {
+    let issue_number = linked_issue_number?;
+    let repo_hash = gwt_core::repo_hash::detect_repo_hash(project_root)?;
+    let cache_root = gwt_core::paths::gwt_cache_dir()
+        .join("issues")
+        .join(repo_hash.as_str());
+    let entry =
+        gwt_github::Cache::new(cache_root).load_entry(gwt_github::IssueNumber(issue_number))?;
+    let title = entry.snapshot.title.trim();
+    (!title.is_empty()).then(|| title.to_string())
+}
+
 fn upsert_workspace_agent(
     agents: &mut Vec<gwt_core::workspace_projection::WorkspaceAgentSummary>,
     summary: gwt_core::workspace_projection::WorkspaceAgentSummary,
@@ -1812,7 +1827,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn handle_board_projection_changed_events(
-        &self,
+        &mut self,
         project_root: &Path,
     ) -> Vec<OutboundEvent> {
         let Ok(snapshot) = gwt_core::coordination::load_snapshot(project_root) else {
@@ -1837,12 +1852,17 @@ impl AppRuntime {
             }
         }
         if let Some(entry) = latest_entry.as_ref() {
-            if let Some(tab) = self.tabs.iter().find(|tab| {
-                same_worktree_path(&tab.project_root, project_root)
-                    && self.active_tab_id.as_deref() == Some(tab.id.as_str())
-            }) {
+            if let Some((tab_id, project_root)) = self
+                .tabs
+                .iter()
+                .find(|tab| {
+                    same_worktree_path(&tab.project_root, project_root)
+                        && self.active_tab_id.as_deref() == Some(tab.id.as_str())
+                })
+                .map(|tab| (tab.id.clone(), tab.project_root.clone()))
+            {
                 if let Some(event) =
-                    self.record_workspace_board_milestone_event(&tab.id, &tab.project_root, entry)
+                    self.record_workspace_board_milestone_event(&tab_id, &project_root, entry)
                 {
                     events.push(event);
                 }
@@ -2827,15 +2847,19 @@ impl AppRuntime {
         let tab = self
             .tab_mut(tab_id)
             .ok_or_else(|| "Project tab not found".to_string())?;
-        let project_root = tab.project_root.display().to_string();
-        let title = format!(
-            "{} · {}",
-            config.display_name,
-            config.branch.as_ref().unwrap_or(&"workspace".to_string())
-        );
+        let project_root_path = tab.project_root.clone();
+        let project_root = project_root_path.display().to_string();
+        let title = config.display_name.clone();
+        let purpose_title =
+            agent_launch_purpose_title(&project_root_path, config.linked_issue_number);
         let window = tab
             .workspace
             .add_window_with_title(WindowPreset::Agent, title, false, bounds);
+        if let Some(purpose_title) = purpose_title {
+            let _ = tab
+                .workspace
+                .set_purpose_title(&window.id, Some(purpose_title));
+        }
         self.register_window(tab_id, &window.id);
         let window_id = combined_window_id(tab_id, &window.id);
 
@@ -4149,6 +4173,8 @@ exit 0
             maximized: false,
             pre_maximize_geometry: None,
             persist: true,
+            purpose_title: None,
+            dynamic_title: None,
             agent_id: None,
             agent_color: None,
         }
@@ -7219,6 +7245,154 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_agent_window_initial_title_uses_linked_issue_title() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_repo(&repo);
+        Cache::new(issue_cache_root(&repo))
+            .write_snapshot(&sample_issue_snapshot(
+                2359,
+                "SPEC: Workspace purpose titles",
+                &["gwt-spec"],
+                "Spec body",
+                "2026-05-06T00:00:00Z",
+            ))
+            .expect("write issue cache");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let config = gwt_agent::AgentLaunchBuilder::new(gwt_agent::AgentId::Codex)
+            .branch("work/20260506-0736")
+            .linked_issue_number(2359)
+            .build();
+
+        runtime
+            .spawn_agent_window("tab-1", config, canvas_bounds())
+            .expect("spawn agent window");
+
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .find(|window| window.preset == WindowPreset::Agent)
+            .expect("agent window");
+        assert_eq!(
+            agent_window.purpose_title.as_deref(),
+            Some("SPEC: Workspace purpose titles")
+        );
+        assert_eq!(agent_window.title, "Codex");
+    }
+
+    #[test]
+    fn app_runtime_board_milestone_updates_same_session_agent_window_dynamic_title_only() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent_one =
+            sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent_one.title = "Codex".to_string();
+        agent_one.purpose_title = Some("Initial purpose".to_string());
+        let mut agent_two =
+            sample_window("agent-2", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent_two.title = "Claude".to_string();
+        agent_two.purpose_title = Some("Other purpose".to_string());
+        tab_workspace.windows.push(agent_one);
+        tab_workspace.windows.push(agent_two);
+        tab_workspace.next_z_index = 3;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let first_window_id = combined_window_id("tab-1", "agent-1");
+        let second_window_id = combined_window_id("tab-1", "agent-2");
+        runtime.active_agent_sessions.insert(
+            first_window_id.clone(),
+            ActiveAgentSession {
+                window_id: first_window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260506-0736".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.clone(),
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        runtime.active_agent_sessions.insert(
+            second_window_id,
+            ActiveAgentSession {
+                window_id: combined_window_id("tab-1", "agent-2"),
+                session_id: "session-2".to_string(),
+                agent_id: "claude".to_string(),
+                branch_name: "work/20260506-0737".to_string(),
+                display_name: "Claude".to_string(),
+                worktree_path: repo.clone(),
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        save_start_work_workspace_projection(
+            &repo,
+            runtime
+                .active_agent_sessions
+                .get(&first_window_id)
+                .expect("first session"),
+            "develop",
+            None,
+        )
+        .expect("save projection");
+        let milestone = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "Implement dynamic title sync",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1");
+
+        runtime
+            .record_workspace_board_milestone_event("tab-1", &repo, &milestone)
+            .expect("projection broadcast");
+
+        let tab = runtime.tab("tab-1").expect("tab");
+        assert_eq!(
+            tab.workspace
+                .window("agent-1")
+                .expect("agent 1")
+                .dynamic_title
+                .as_deref(),
+            Some("Implement dynamic title sync")
+        );
+        assert_eq!(
+            tab.workspace
+                .window("agent-2")
+                .expect("agent 2")
+                .dynamic_title
+                .as_deref(),
+            None
+        );
+    }
+
+    #[test]
     fn app_runtime_board_projection_change_broadcasts_to_matching_board_windows_only() {
         let _env_lock = env_test_lock()
             .lock()
@@ -7291,7 +7465,7 @@ exit 0
             WindowPreset::Board,
             WindowProcessStatus::Ready,
         );
-        let runtime = sample_runtime(temp.path(), vec![matching_tab, other_tab], Some("tab-1"));
+        let mut runtime = sample_runtime(temp.path(), vec![matching_tab, other_tab], Some("tab-1"));
 
         let events = runtime.handle_board_projection_changed_events(&repo);
 

--- a/crates/gwt/src/board_view.rs
+++ b/crates/gwt/src/board_view.rs
@@ -106,6 +106,8 @@ mod tests {
             maximized: false,
             pre_maximize_geometry: None,
             persist: true,
+            purpose_title: None,
+            dynamic_title: None,
             agent_id: None,
             agent_color: None,
         }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -727,6 +727,8 @@ mod tests {
             maximized: false,
             pre_maximize_geometry: None,
             persist: true,
+            purpose_title: None,
+            dynamic_title: None,
             agent_id: None,
             agent_color: None,
         }

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -54,6 +54,10 @@ impl WindowState {
 pub struct PersistedWindowState {
     pub id: String,
     pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose_title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dynamic_title: Option<String>,
     pub preset: WindowPreset,
     pub geometry: WindowGeometry,
     pub z_index: u32,
@@ -165,6 +169,8 @@ pub fn default_workspace_state() -> PersistedWorkspaceState {
                 maximized: false,
                 pre_maximize_geometry: None,
                 persist: true,
+                purpose_title: None,
+                dynamic_title: None,
                 agent_id: None,
                 agent_color: None,
             },
@@ -184,6 +190,8 @@ pub fn default_workspace_state() -> PersistedWorkspaceState {
                 maximized: false,
                 pre_maximize_geometry: None,
                 persist: true,
+                purpose_title: None,
+                dynamic_title: None,
                 agent_id: None,
                 agent_color: None,
             },
@@ -474,6 +482,8 @@ mod tests {
                         height: 480.0,
                     }),
                     persist: true,
+                    purpose_title: None,
+                    dynamic_title: None,
                     agent_id: None,
                     agent_color: None,
                 },
@@ -493,6 +503,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    purpose_title: None,
+                    dynamic_title: None,
                     agent_id: None,
                     agent_color: None,
                 },
@@ -590,6 +602,8 @@ mod tests {
             maximized: false,
             pre_maximize_geometry: None,
             persist: true,
+            purpose_title: Some("Review launch flow".into()),
+            dynamic_title: None,
             agent_id: Some("claude".into()),
             agent_color: Some(AgentColor::Yellow),
         };
@@ -602,9 +616,15 @@ mod tests {
             json.contains("\"agent_color\":\"yellow\""),
             "agent_color should be serialized as snake_case: {json}"
         );
+        assert!(
+            json.contains("\"purpose_title\":\"Review launch flow\""),
+            "purpose_title should be serialized when present: {json}"
+        );
 
         let parsed: PersistedWindowState = serde_json::from_str(&json).expect("parse");
         assert_eq!(parsed.agent_id.as_deref(), Some("claude"));
+        assert_eq!(parsed.purpose_title.as_deref(), Some("Review launch flow"));
+        assert_eq!(parsed.dynamic_title, None);
         assert!(
             parsed.agent_color.is_none(),
             "agent_color must be wire-only: skip_deserializing drops it"
@@ -649,6 +669,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    purpose_title: None,
+                    dynamic_title: None,
                     agent_id: None,
                     agent_color: None,
                 },
@@ -668,6 +690,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    purpose_title: None,
+                    dynamic_title: None,
                     agent_id: None,
                     agent_color: None,
                 },
@@ -872,6 +896,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    purpose_title: None,
+                    dynamic_title: None,
                     agent_id: None,
                     agent_color: None,
                 },
@@ -891,6 +917,8 @@ mod tests {
                     maximized: false,
                     pre_maximize_geometry: None,
                     persist: true,
+                    purpose_title: None,
+                    dynamic_title: None,
                     agent_id: None,
                     agent_color: None,
                 },

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -67,6 +67,32 @@ impl WorkspaceState {
         true
     }
 
+    pub fn set_purpose_title(&mut self, id: &str, title: Option<String>) -> bool {
+        let Some(window) = self
+            .persisted
+            .windows
+            .iter_mut()
+            .find(|window| window.id == id)
+        else {
+            return false;
+        };
+        window.purpose_title = title.and_then(normalize_title);
+        true
+    }
+
+    pub fn set_dynamic_title(&mut self, id: &str, title: Option<String>) -> bool {
+        let Some(window) = self
+            .persisted
+            .windows
+            .iter_mut()
+            .find(|window| window.id == id)
+        else {
+            return false;
+        };
+        window.dynamic_title = title.and_then(normalize_title);
+        true
+    }
+
     pub fn update_viewport(&mut self, viewport: CanvasViewport) {
         self.persisted.viewport = viewport;
     }
@@ -209,6 +235,8 @@ impl WorkspaceState {
             maximized: false,
             pre_maximize_geometry: None,
             persist,
+            purpose_title: None,
+            dynamic_title: None,
             agent_id: None,
             agent_color: None,
         };
@@ -412,6 +440,11 @@ impl WorkspaceState {
     }
 }
 
+fn normalize_title(title: String) -> Option<String> {
+    let trimmed = title.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -581,6 +614,8 @@ mod tests {
                 maximized: false,
                 pre_maximize_geometry: None,
                 persist: false,
+                purpose_title: None,
+                dynamic_title: None,
                 agent_id: None,
                 agent_color: None,
             }],

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -148,6 +148,24 @@ test("Workspace active work overview behaves like a command center", () => {
   );
 });
 
+test("Agent window chrome resolves dynamic purpose titles before legacy titles", () => {
+  assert.match(
+    appSource,
+    /function\s+windowDisplayTitle\(windowData\)[\s\S]+dynamic_title[\s\S]+purpose_title[\s\S]+title/,
+    "expected a shared display-title helper with dynamic > purpose > legacy title precedence",
+  );
+  assert.match(
+    appSource,
+    /window-list-title">\$\{escapeHtml\(windowDisplayTitle\(entry\)\)\}/,
+    "expected the Windows dropdown to escape the shared display-title helper output",
+  );
+  assert.match(
+    appSource,
+    /title-text"\)\.textContent\s*=\s*windowDisplayTitle\(windowData\)/,
+    "expected window titlebars to use the shared display-title helper",
+  );
+});
+
 test("Branches remains a branch browser, not a planning workspace", () => {
   const branchPreset = document.querySelector('.preset-button[data-preset="branches"]');
   assert.ok(branchPreset, "expected Branches preset to remain available");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -546,6 +546,29 @@
         return WINDOW_RUNTIME_STATE_LABELS[status] || WINDOW_RUNTIME_STATE_LABELS.running;
       }
 
+      function windowDisplayTitle(windowData) {
+        const candidates = [
+          windowData?.dynamic_title,
+          windowData?.purpose_title,
+          windowData?.title,
+          windowData?.agent_id,
+        ];
+        for (const value of candidates) {
+          const title = String(value || "").trim();
+          if (title) return title;
+        }
+        return "Window";
+      }
+
+      function escapeHtml(value) {
+        return String(value || "")
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
+
       function runtimeStateForWindow(windowData) {
         const cachedState = windowRuntimeStateMap.get(windowData.id);
         if (cachedState) {
@@ -597,7 +620,7 @@
           const runtimeLabel = windowRuntimeLabel(runtimeState);
           row.innerHTML = `
             <div class="window-list-copy">
-              <div class="window-list-title">${entry.title}</div>
+              <div class="window-list-title">${escapeHtml(windowDisplayTitle(entry))}</div>
               <div class="window-list-meta">
                 <span class="window-list-preset">${presetLabel(entry.preset)}</span>
                 <span class="window-list-geometry">${geometryLabel}</span>
@@ -6517,7 +6540,7 @@
           mountWindowBody(windowData, element);
         }
 
-        element.querySelector(".title-text").textContent = windowData.title;
+        element.querySelector(".title-text").textContent = windowDisplayTitle(windowData);
         if (windowData.agent_color) {
           element.dataset.agentColor = windowData.agent_color;
         } else {
@@ -6622,6 +6645,7 @@
         sendOpenProjectDialog,
         requestWindowList,
         renderWindowList,
+        windowDisplayTitle,
         toggleWindowList,
         renderProjectTabs,
         renderRecentProjects,


### PR DESCRIPTION
## Summary
Add dynamic purpose-based display titles for Agent windows so the title identifies what the Agent is doing instead of showing the worktree or branch name.

## Changes
- Store optional `purpose_title` and `dynamic_title` on persisted Agent windows while preserving legacy workspace JSON compatibility.
- Use linked Issue/SPEC titles as the initial Agent window purpose title and keep the primary Agent title to the agent display name.
- Update same-session Agent window `dynamic_title` from Board coordination milestones (`claim`, `status`, `blocked`, `handoff`, `decision`, `next`).
- Render titlebars and the Windows dropdown with shared precedence: `dynamic_title` > `purpose_title` > `title`, escaping dropdown text from Board-derived content.

## Testing
- `RUST_TEST_THREADS=1 cargo test -p gwt app_runtime_agent_window_initial_title_uses_linked_issue_title -- --nocapture`
- `RUST_TEST_THREADS=1 cargo test -p gwt app_runtime_board_milestone_updates_same_session_agent_window_dynamic_title_only -- --nocapture`
- `RUST_TEST_THREADS=1 cargo test -p gwt persisted_window_state_accepts_new_agent_id_field -- --nocapture`
- `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`
- `npm run test:frontend-bundle`
- `npm run test:frontend-unit`
- `RUST_TEST_THREADS=1 cargo test -p gwt-core -p gwt --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo build -p gwt`
- `bunx commitlint --from HEAD~1 --to HEAD`
- `git push` pre-push checks, including coverage threshold: 90.65%

## Closing Issues
None

## Related Issues
#2359

## Checklist
- [x] TDD RED/GREEN evidence recorded in SPEC-2359 tasks.
- [x] SPEC-2359 tasks T-062 through T-067 updated.
- [x] Full Rust, frontend, lint, format, build, diff, commitlint, and push verification passed.
