### PR TITLE
feat(theme): segmented AUTO/DARK/LIGHT toggle replaces cycle button

### DIFF
--- a/crates/gwt/playwright/tests/theme-toggle.spec.ts
+++ b/crates/gwt/playwright/tests/theme-toggle.spec.ts
@@ -1,4 +1,4 @@
-/* SPEC-2356 — theme toggle round-trip (US-3 AS-2/AS-3). */
+/* SPEC-2356 — theme toggle round-trip (US-3 AS-2/AS-3/AS-6/AS-7). */
 import { test, expect } from "@playwright/test";
 
 const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:0/";
@@ -6,14 +6,31 @@ const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:0/";
 test.describe("Theme toggle", () => {
   test.skip(!process.env.GWT_PLAYWRIGHT_BASE_URL, "no GWT_PLAYWRIGHT_BASE_URL set");
 
-  test("toggles dark ↔ light within 200ms (NFR-008)", async ({ page }) => {
+  test("segmented control commits preference and reflects via data-theme + aria-checked", async ({ page }) => {
     await page.goto(BASE);
     const html = page.locator("html");
-    await page.locator("#op-theme-toggle").click(); // → dark
+    const auto = page.locator('#op-theme-toggle [data-theme-value="auto"]');
+    const dark = page.locator('#op-theme-toggle [data-theme-value="dark"]');
+    const light = page.locator('#op-theme-toggle [data-theme-value="light"]');
+
+    // FR-024 — radiogroup container with three exclusive options.
+    await expect(page.locator("#op-theme-toggle")).toHaveAttribute("role", "radiogroup");
+    await expect(auto).toHaveAttribute("role", "radio");
+
+    await dark.click();
     await expect(html).toHaveAttribute("data-theme", "dark");
+    await expect(dark).toHaveAttribute("aria-checked", "true");
+    await expect(auto).toHaveAttribute("aria-checked", "false");
+    await expect(light).toHaveAttribute("aria-checked", "false");
+
     const t0 = Date.now();
-    await page.locator("#op-theme-toggle").click(); // → light
+    await light.click();
     await expect(html).toHaveAttribute("data-theme", "light");
-    expect(Date.now() - t0).toBeLessThan(800); // generous, real budget 200ms
+    expect(Date.now() - t0).toBeLessThan(800); // generous, real budget 200ms (NFR-008)
+    await expect(light).toHaveAttribute("aria-checked", "true");
+
+    // US3-AS7 — AUTO must be reachable directly from any state.
+    await auto.click();
+    await expect(auto).toHaveAttribute("aria-checked", "true");
   });
 });

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -307,17 +307,18 @@ test("Mission Briefing splash has dismissible affordance (pointer-events + curso
   assert.match(briefing[0], /cursor:\s*pointer/);
 });
 
-test("operator-shell wires theme toggle aria-label updates on every render", () => {
-  const operatorShell = readFileSync(resolve(here, "../operator-shell.js"), "utf8");
-  // wireThemeToggle.renderLabel must update aria-label every render so
-  // screen readers know the live preference + effective theme.
+test("theme-toggle wires aria-label updates on every render", () => {
+  // SPEC-2356 FR-024 — segmented toggle exposes the live preference + effective
+  // theme via the radiogroup container's aria-label so screen readers always
+  // announce the current state.
+  const themeToggle = readFileSync(resolve(here, "../theme-toggle.js"), "utf8");
   assert.match(
-    operatorShell,
-    /btn\.setAttribute\(\s*"aria-label"/,
-    "expected wireThemeToggle to update aria-label on every render",
+    themeToggle,
+    /root\.setAttribute\(\s*"aria-label"/,
+    "expected segmented theme toggle to update aria-label on every render",
   );
   assert.match(
-    operatorShell,
+    themeToggle,
     /Theme: \$\{pref === "auto" \? `auto/,
     "expected aria-label format to disclose preference + effective theme",
   );

--- a/crates/gwt/web/__tests__/theme-segmented.test.mjs
+++ b/crates/gwt/web/__tests__/theme-segmented.test.mjs
@@ -1,0 +1,167 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { parseHTML } from "linkedom";
+import { wireThemeToggle } from "../theme-toggle.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const indexHtml = readFileSync(resolve(here, "../index.html"), "utf8");
+
+// SPEC-2356 FR-024 / US3-AS6, AS7 — segmented theme toggle
+// (AUTO / DARK / LIGHT exposed in parallel, no cycle).
+
+function makeStubManager(initialPref = "auto", initialEff = "light") {
+  let preference = initialPref;
+  let effective = initialEff;
+  const subscribers = new Set();
+  return {
+    setTheme: (value) => {
+      preference = value;
+      if (value !== "auto") effective = value;
+      for (const fn of subscribers) fn(effective);
+    },
+    getPreference: () => preference,
+    getEffective: () => effective,
+    subscribe: (fn) => {
+      subscribers.add(fn);
+      return () => subscribers.delete(fn);
+    },
+    _setEffective: (eff) => {
+      effective = eff;
+      for (const fn of subscribers) fn(effective);
+    },
+  };
+}
+
+function bootDom() {
+  const { document, window } = parseHTML(indexHtml);
+  // linkedom does not track document.activeElement on focus(); shim it so the
+  // segmented toggle handler can read the focused option deterministically.
+  let active = null;
+  Object.defineProperty(document, "activeElement", {
+    configurable: true,
+    get: () => active,
+  });
+  for (const el of document.querySelectorAll("button, [tabindex]")) {
+    const original = el.focus?.bind(el);
+    el.focus = () => {
+      active = el;
+      original?.();
+    };
+  }
+  return { doc: document, win: window };
+}
+
+// linkedom only ships a generic Event constructor; build typed-ish events by
+// instantiating Event then patching the properties our handlers read.
+function click(doc, target) {
+  const ev = new doc.defaultView.Event("click", { bubbles: true, cancelable: true });
+  Object.defineProperty(ev, "target", { value: target, configurable: true });
+  target.dispatchEvent(ev);
+}
+
+function keydown(doc, target, key) {
+  const ev = new doc.defaultView.Event("keydown", { bubbles: true, cancelable: true });
+  Object.defineProperty(ev, "key", { value: key, configurable: true });
+  Object.defineProperty(ev, "target", { value: target, configurable: true });
+  target.dispatchEvent(ev);
+}
+
+test("index.html exposes a segmented theme toggle (radiogroup with auto/dark/light)", () => {
+  const { doc } = bootDom();
+  const root = doc.getElementById("op-theme-toggle");
+  assert.ok(root, "#op-theme-toggle root must exist");
+  assert.equal(root.getAttribute("role"), "radiogroup", "root must be radiogroup");
+  const buttons = root.querySelectorAll("[data-theme-value]");
+  assert.equal(buttons.length, 3, "must expose AUTO / DARK / LIGHT buttons");
+  const values = Array.from(buttons).map((b) => b.dataset.themeValue);
+  assert.deepEqual(values, ["auto", "dark", "light"]);
+  for (const btn of buttons) {
+    assert.equal(btn.getAttribute("role"), "radio", "each option must be role=radio");
+    assert.ok(btn.hasAttribute("aria-checked"), "each option must declare aria-checked");
+  }
+});
+
+test("wireThemeToggle marks the active preference exclusively via aria-checked", () => {
+  const { doc } = bootDom();
+  const mgr = makeStubManager("auto");
+  wireThemeToggle({ doc, themeManager: mgr });
+
+  const buttons = Array.from(doc.querySelectorAll("#op-theme-toggle [data-theme-value]"));
+  const checked = buttons.filter((b) => b.getAttribute("aria-checked") === "true");
+  assert.equal(checked.length, 1, "exactly one option must be aria-checked=true");
+  assert.equal(checked[0].dataset.themeValue, "auto");
+});
+
+test("clicking a segmented option calls setTheme(value) and updates aria-checked", () => {
+  const { doc } = bootDom();
+  const mgr = makeStubManager("auto");
+  wireThemeToggle({ doc, themeManager: mgr });
+
+  const lightBtn = doc.querySelector('#op-theme-toggle [data-theme-value="light"]');
+  click(doc, lightBtn);
+
+  assert.equal(mgr.getPreference(), "light");
+  const buttons = Array.from(doc.querySelectorAll("#op-theme-toggle [data-theme-value]"));
+  const checked = buttons.find((b) => b.getAttribute("aria-checked") === "true");
+  assert.equal(checked.dataset.themeValue, "light");
+});
+
+test("AUTO can be re-selected after a manual override (no dead-end cycle)", () => {
+  const { doc } = bootDom();
+  const mgr = makeStubManager("auto");
+  wireThemeToggle({ doc, themeManager: mgr });
+
+  const dark = doc.querySelector('#op-theme-toggle [data-theme-value="dark"]');
+  click(doc, dark);
+  assert.equal(mgr.getPreference(), "dark");
+
+  const auto = doc.querySelector('#op-theme-toggle [data-theme-value="auto"]');
+  click(doc, auto);
+  assert.equal(mgr.getPreference(), "auto", "AUTO must be reachable directly");
+});
+
+test("Arrow keys move roving tabindex across segmented options", () => {
+  const { doc } = bootDom();
+  const mgr = makeStubManager("auto");
+  wireThemeToggle({ doc, themeManager: mgr });
+
+  const buttons = Array.from(doc.querySelectorAll("#op-theme-toggle [data-theme-value]"));
+  // Active option (auto) carries tabindex=0; others carry tabindex=-1.
+  assert.equal(buttons[0].getAttribute("tabindex"), "0");
+  assert.equal(buttons[1].getAttribute("tabindex"), "-1");
+  assert.equal(buttons[2].getAttribute("tabindex"), "-1");
+
+  buttons[0].focus();
+  keydown(doc, buttons[0], "ArrowRight");
+  assert.equal(doc.activeElement?.dataset.themeValue, "dark", "ArrowRight moves focus to next option");
+
+  keydown(doc, doc.activeElement, "ArrowLeft");
+  assert.equal(doc.activeElement?.dataset.themeValue, "auto", "ArrowLeft wraps to previous option");
+});
+
+test("Enter on a focused option commits that preference", () => {
+  const { doc } = bootDom();
+  const mgr = makeStubManager("auto");
+  wireThemeToggle({ doc, themeManager: mgr });
+
+  const dark = doc.querySelector('#op-theme-toggle [data-theme-value="dark"]');
+  dark.focus();
+  keydown(doc, dark, "Enter");
+  assert.equal(mgr.getPreference(), "dark");
+});
+
+test("AUTO option exposes an effective indicator that follows getEffective()", () => {
+  const { doc } = bootDom();
+  const mgr = makeStubManager("auto", "light");
+  wireThemeToggle({ doc, themeManager: mgr });
+
+  const indicator = doc.getElementById("op-theme-effective-indicator");
+  assert.ok(indicator, "AUTO option must expose an effective indicator span");
+  assert.equal(indicator.textContent, "▯", "light effective renders the unfilled glyph");
+
+  mgr._setEffective("dark");
+  assert.equal(indicator.textContent, "▮", "dark effective renders the filled glyph");
+});

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -2978,16 +2978,44 @@
             >
               Windows
             </button>
-            <button
+            <div
               class="op-theme-toggle"
               id="op-theme-toggle"
-              type="button"
-              aria-label="Toggle theme"
-              data-theme-state="auto"
+              role="radiogroup"
+              aria-label="Theme: auto"
             >
-              <span class="op-theme-toggle__label">Theme</span>
-              <span id="op-theme-toggle-value">AUTO</span>
-            </button>
+              <button
+                class="op-theme-toggle__option"
+                type="button"
+                role="radio"
+                data-theme-value="auto"
+                aria-checked="true"
+                tabindex="0"
+              >
+                <span class="op-theme-toggle__label">AUTO</span>
+                <span
+                  class="op-theme-toggle__indicator"
+                  id="op-theme-effective-indicator"
+                  aria-hidden="true"
+                >▯</span>
+              </button>
+              <button
+                class="op-theme-toggle__option"
+                type="button"
+                role="radio"
+                data-theme-value="dark"
+                aria-checked="false"
+                tabindex="-1"
+              >DARK</button>
+              <button
+                class="op-theme-toggle__option"
+                type="button"
+                role="radio"
+                data-theme-value="light"
+                aria-checked="false"
+                tabindex="-1"
+              >LIGHT</button>
+            </div>
           </div>
         </div>
         <aside class="op-sidebar" id="op-sidebar" aria-label="Operator sidebar layers">

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -5,6 +5,7 @@
 
 import { createThemeManager, createBrowserEnv } from "/theme-manager.js";
 import { createHotkeyManager } from "/hotkey.js";
+import { wireThemeToggle as wireSegmentedThemeToggle } from "/theme-toggle.js";
 
 const SIDEBAR_KEY = "gwt:ui:sidebar";
 const SIDEBAR_COLLAPSED_KEY = "gwt:ui:sidebar-collapsed";
@@ -91,35 +92,14 @@ function wireChromeVisibility({ doc, win }) {
 }
 
 // ------------------------------------------------------------
-// Theme toggle (Project Bar)
+// Theme toggle (Project Bar) — segmented radiogroup
 // ------------------------------------------------------------
+// SPEC-2356 FR-024: AUTO / DARK / LIGHT are exposed as a parallel radiogroup
+// so AUTO is reachable from any state in a single click. Implementation lives
+// in `/theme-toggle.js` so it is unit-testable under Node.
 
-function wireThemeToggle({ doc, themeManager }) {
-  const btn = doc.getElementById("op-theme-toggle");
-  const value = doc.getElementById("op-theme-toggle-value");
-  if (!btn || !value) return;
-
-  const renderLabel = () => {
-    const pref = themeManager.getPreference();
-    const eff = themeManager.getEffective();
-    btn.dataset.themeState = pref;
-    value.textContent = pref === "auto"
-      ? `AUTO ${eff === "dark" ? "▮" : "▯"}`
-      : pref.toUpperCase();
-    // SPEC-2356 — expose the live preference to assistive tech.
-    btn.setAttribute(
-      "aria-label",
-      `Theme: ${pref === "auto" ? `auto (currently ${eff})` : pref}. Click to cycle.`,
-    );
-  };
-
-  renderLabel();
-  themeManager.subscribe(renderLabel);
-
-  btn.addEventListener("click", () => {
-    const cycle = { auto: "dark", dark: "light", light: "auto" };
-    themeManager.setTheme(cycle[themeManager.getPreference()] ?? "auto");
-  });
+function wireThemeToggle(opts) {
+  wireSegmentedThemeToggle(opts);
 }
 
 // ------------------------------------------------------------

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -134,7 +134,6 @@ body::after {
 }
 
 /* Project Bar trailing chrome buttons */
-.op-theme-toggle,
 .op-chrome-toggle {
   appearance: none;
   background: transparent;
@@ -154,8 +153,6 @@ body::after {
               background var(--motion-fast) var(--motion-curve);
 }
 
-.op-theme-toggle:hover,
-.op-theme-toggle:focus-visible,
 .op-chrome-toggle:hover,
 .op-chrome-toggle:focus-visible {
   outline: none;
@@ -169,9 +166,63 @@ body::after {
   background: color-mix(in oklab, var(--color-text-muted) 10%, transparent);
 }
 
-.op-theme-toggle__label {
-  margin-right: var(--space-2);
+/* SPEC-2356 FR-024 — segmented theme toggle (AUTO / DARK / LIGHT). Replaces
+   the prior single-cycle button so AUTO is reachable in one interaction. */
+.op-theme-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  height: 26px;
+  padding: 2px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-strong);
+  background: color-mix(in oklab, var(--color-text-muted) 8%, transparent);
+  gap: 2px;
+}
+
+.op-theme-toggle__option {
+  appearance: none;
+  background: transparent;
+  border: 0;
   color: var(--color-text-muted);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  text-transform: uppercase;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  transition: color var(--motion-fast) var(--motion-curve),
+              background var(--motion-fast) var(--motion-curve);
+}
+
+.op-theme-toggle__option:hover {
+  color: var(--color-text);
+}
+
+.op-theme-toggle__option[aria-checked="true"] {
+  background: var(--color-button-bg);
+  color: var(--color-button-fg);
+  font-weight: 700;
+}
+
+.op-theme-toggle__option:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.op-theme-toggle__indicator {
+  font-size: 0.85em;
+  color: var(--color-state-active);
+}
+
+.op-theme-toggle__option[aria-checked="true"] .op-theme-toggle__indicator {
+  /* On the active AUTO chip the foreground is already button-fg; keep the
+     indicator visible by inheriting that high-contrast color. */
+  color: inherit;
 }
 
 /* ============================================================
@@ -1347,10 +1398,7 @@ kbd.op-kbd {
   outline-offset: 2px;
 }
 
-:root[data-theme] .op-theme-toggle:focus-visible {
-  /* override the existing `border-color` focus state with the unified
-     ring, but keep the border-color animation so the toggle still
-     reads like an operator chrome button. */
+:root[data-theme] .op-theme-toggle__option:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
@@ -1788,15 +1836,6 @@ kbd.op-kbd {
   :root[data-theme][data-op-sidebar="collapsed"] .project-bar {
     box-shadow: inset 3px 0 0 Highlight;
   }
-}
-
-/* SPEC-2356 — Theme toggle value + label distinct typography.
-   The "AUTO ▮" / "DARK" / "LIGHT" value is mono cyan to match
-   Operator-state semantics; the leading "Theme" label stays muted.
-   This makes the toggle read like a rotary switch indicator. */
-:root[data-theme] #op-theme-toggle-value {
-  color: var(--color-state-active);
-  font-weight: 700;
 }
 
 /* SPEC-2356 — Project Tab active-state subtle accent strip on the bottom

--- a/crates/gwt/web/theme-toggle.js
+++ b/crates/gwt/web/theme-toggle.js
@@ -1,0 +1,67 @@
+// SPEC-2356 FR-024 — Segmented theme toggle.
+// Wires a 3-button radiogroup (AUTO / DARK / LIGHT) to the theme manager so
+// every preference is reachable in a single interaction. Replaces the prior
+// cycle button whose AUTO state was effectively invisible.
+
+const ORDER = ["auto", "dark", "light"];
+
+export function wireThemeToggle({ doc, themeManager }) {
+  const root = doc.getElementById("op-theme-toggle");
+  if (!root) return;
+
+  const buttons = ORDER
+    .map((value) => root.querySelector(`[data-theme-value="${value}"]`))
+    .filter((el) => el);
+  if (buttons.length !== ORDER.length) return;
+
+  const indicator = doc.getElementById("op-theme-effective-indicator");
+
+  const render = () => {
+    const pref = themeManager.getPreference();
+    const eff = themeManager.getEffective();
+    for (const btn of buttons) {
+      const value = btn.dataset.themeValue;
+      const active = value === pref;
+      btn.setAttribute("aria-checked", active ? "true" : "false");
+      btn.setAttribute("tabindex", active ? "0" : "-1");
+    }
+    if (indicator) indicator.textContent = eff === "dark" ? "▮" : "▯";
+    root.setAttribute(
+      "aria-label",
+      `Theme: ${pref === "auto" ? `auto (currently ${eff})` : pref}`,
+    );
+  };
+
+  render();
+  themeManager.subscribe(render);
+
+  root.addEventListener("click", (event) => {
+    const target = event.target;
+    const btn = typeof target?.closest === "function"
+      ? target.closest("[data-theme-value]")
+      : null;
+    if (!btn || !root.contains(btn)) return;
+    themeManager.setTheme(btn.dataset.themeValue);
+  });
+
+  root.addEventListener("keydown", (event) => {
+    const key = event.key;
+    if (key !== "ArrowLeft" && key !== "ArrowRight" && key !== "Enter" && key !== " ") return;
+
+    const focused = doc.activeElement;
+    const idx = buttons.indexOf(focused);
+    if (idx < 0) return;
+
+    if (key === "ArrowLeft" || key === "ArrowRight") {
+      event.preventDefault();
+      const dir = key === "ArrowLeft" ? -1 : 1;
+      const next = buttons[(idx + dir + buttons.length) % buttons.length];
+      next.focus();
+      return;
+    }
+
+    // Enter / Space commits the focused option's preference.
+    event.preventDefault();
+    themeManager.setTheme(focused.dataset.themeValue);
+  });
+}


### PR DESCRIPTION
## Summary

- SPEC-2356 FR-024 / US3-AS6, AS7 を実装。テーマトグルを「AUTO への戻り経路が見えない」サイクル方式から、AUTO / DARK / LIGHT を並列表示する `role="radiogroup"` の 3 択 segmented control に置換した。
- AUTO は副次インジケータ (`▮` / `▯`) で effective theme を読み取れる。クリック・矢印キー (←→ で roving tabindex、Enter/Space で確定) のいずれでも全 preference に到達可能。
- 既存 `theme-manager.js` API は変更せず、wireThemeToggle を `theme-toggle.js` に独立モジュール化して Node 単体テストから直接 import 可能にした。

## Acceptance / Verification

- US3-AS6: Project Bar に AUTO / DARK / LIGHT 3 ボタンが並列表示され、現在 preference のみ `aria-checked="true"`。
- US3-AS7: 任意の状態から AUTO ボタンを 1 操作で再選択でき、preference が `auto` に戻る。
- frontend-unit 217/217 GREEN（追加 `theme-segmented.test.mjs` 7 件含む）。
- `cargo test -p gwt-core -p gwt` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo build -p gwt` / `cargo fmt --check` すべて GREEN。
- Playwright `theme-toggle.spec.ts` を 3 ボタン仕様に書き換え（role/aria-checked/data-theme、NFR-008 200ms 反映、AUTO 直接復帰）。

## Out of scope (follow-up)

ユーザー報告にあったサイドバー / Agent window / Board・dialog・modal・toast の白×白コントラスト破綻 (FR-025) は本 PR では対応していない。tokens 経由で配色されているコンポーネントが理論上 WCAG AA を通過する harness を備えており、再現箇所の具体要素 (スクリーンショット) を特定してから別 PR で対応する。tasks セクションに T-105 / T-106 / T-107 を follow-up として追加済み。

## Test plan

- [x] frontend-unit (`node --test crates/gwt/web/__tests__/*.test.mjs`)
- [x] cargo test / clippy / build / fmt
- [ ] Playwright (`GWT_PLAYWRIGHT_BASE_URL` 経由、CI で実行)
- [ ] WebView 起動 → AUTO/DARK/LIGHT 各ボタン押下、矢印キー操作、AUTO 復帰の手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
