### PR TITLE
feat(workspace): support workspace home without default worktree

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -493,6 +493,9 @@ pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
         .map_err(|e| GwtError::Git(format!("rev-parse --git-common-dir: {e}")))?;
 
     if !output.status.success() {
+        if let Some(bare_child) = first_child_bare_repository(repo_path) {
+            return Ok(std::fs::canonicalize(&bare_child).unwrap_or(bare_child));
+        }
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         return Err(GwtError::Git(format!(
             "rev-parse --git-common-dir: {stderr}"
@@ -516,6 +519,20 @@ pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
     }
 
     Ok(common_dir)
+}
+
+fn first_child_bare_repository(repo_path: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(repo_path).ok()?;
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .filter(|path| {
+            path.join("HEAD").exists()
+                && path.join("objects").exists()
+                && path.join("refs").exists()
+        })
+        .min()
 }
 
 /// Derive a sibling worktree path from the repo root and branch name.
@@ -883,6 +900,20 @@ prunable gitdir file points to non-existent location
         assert_eq!(
             comparable_path(&sibling_worktree_path(&layout_root, "feature/banner")),
             comparable_path(&expected_parent.join("feature").join("banner"))
+        );
+    }
+
+    #[test]
+    fn main_worktree_root_accepts_workspace_home_with_child_bare_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare_repo_path = tmp.path().join("gwt.git");
+        init_bare_git_repo(&bare_repo_path);
+
+        let layout_root = main_worktree_root(tmp.path()).unwrap();
+
+        assert_eq!(
+            comparable_path(&layout_root),
+            comparable_path(&std::fs::canonicalize(&bare_repo_path).unwrap())
         );
     }
 

--- a/crates/gwt/src/branch_cleanup.rs
+++ b/crates/gwt/src/branch_cleanup.rs
@@ -70,6 +70,14 @@ pub fn cleanup_selected_branches(
                     ),
                 };
             }
+            if !is_gwt_workspace_branch(&target_branch) {
+                return BranchCleanupResultEntry {
+                    branch: entry.name.clone(),
+                    execution_branch: Some(target_branch),
+                    status: BranchCleanupResultStatus::Failed,
+                    message: blocked_reason_message(BranchCleanupBlockedReason::NonWorkspaceBranch),
+                };
+            }
 
             match manager.cleanup_branch(&target_branch) {
                 Ok(()) => {
@@ -122,6 +130,10 @@ pub fn cleanup_selected_branches(
         .collect()
 }
 
+fn is_gwt_workspace_branch(branch_name: &str) -> bool {
+    branch_name.starts_with("work/")
+}
+
 fn blocked_reason_message(reason: BranchCleanupBlockedReason) -> String {
     match reason {
         BranchCleanupBlockedReason::ProtectedBranch => {
@@ -135,6 +147,9 @@ fn blocked_reason_message(reason: BranchCleanupBlockedReason) -> String {
         }
         BranchCleanupBlockedReason::RemoteTrackingWithoutLocal => {
             "Cannot clean up a remote-tracking branch without a local counterpart".to_string()
+        }
+        BranchCleanupBlockedReason::NonWorkspaceBranch => {
+            "Only gwt-managed workspaces can be cleaned up".to_string()
         }
         BranchCleanupBlockedReason::Unknown => "Cannot clean up this branch".to_string(),
     }
@@ -215,6 +230,10 @@ mod tests {
             "Cannot clean up a remote-tracking branch without a local counterpart"
         );
         assert_eq!(
+            blocked_reason_message(BranchCleanupBlockedReason::NonWorkspaceBranch),
+            "Only gwt-managed workspaces can be cleaned up"
+        );
+        assert_eq!(
             blocked_reason_message(BranchCleanupBlockedReason::Unknown),
             "Cannot clean up this branch"
         );
@@ -239,5 +258,28 @@ mod tests {
         assert_eq!(results[0].execution_branch.as_deref(), Some("feature/demo"));
         assert_eq!(results[0].status, BranchCleanupResultStatus::Failed);
         assert_eq!(results[0].message, "Cannot clean up a protected branch");
+    }
+
+    #[test]
+    fn cleanup_selected_branches_preserves_non_workspace_branch() {
+        let repo = tempdir().expect("tempdir");
+        let mut entry = sample_entry("feature/demo");
+        entry.cleanup.availability = BranchCleanupAvailability::Safe;
+        entry.cleanup.execution_branch = Some("feature/demo".to_string());
+
+        let results = cleanup_selected_branches(
+            repo.path(),
+            &[entry],
+            &[String::from("feature/demo")],
+            false,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].execution_branch.as_deref(), Some("feature/demo"));
+        assert_eq!(results[0].status, BranchCleanupResultStatus::Failed);
+        assert_eq!(
+            results[0].message,
+            "Only gwt-managed workspaces can be cleaned up"
+        );
     }
 }

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -24,6 +24,7 @@ pub enum BranchCleanupBlockedReason {
     CurrentHead,
     ActiveSession,
     RemoteTrackingWithoutLocal,
+    NonWorkspaceBranch,
     Unknown,
 }
 
@@ -83,7 +84,8 @@ pub fn list_branch_entries(repo_path: &Path) -> std::io::Result<Vec<BranchListEn
 }
 
 pub fn list_branch_inventory(repo_path: &Path) -> std::io::Result<Vec<BranchListEntry>> {
-    let branches = gwt_git::branch::list_branches(repo_path)
+    let git_root = git_command_root(repo_path)?;
+    let branches = gwt_git::branch::list_branches(&git_root)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
     Ok(adapt_branch_inventory(branches))
 }
@@ -93,9 +95,10 @@ pub fn hydrate_branch_entries_with_active_sessions(
     entries: Vec<BranchListEntry>,
     active_session_branches: &HashSet<String>,
 ) -> std::io::Result<Vec<BranchListEntry>> {
-    let gone_branches = gwt_git::list_gone_branches(repo_path)
+    let git_root = git_command_root(repo_path)?;
+    let gone_branches = gwt_git::list_gone_branches(&git_root)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
-    let cleanup_targets = build_cleanup_targets(repo_path, &entries, &gone_branches)?;
+    let cleanup_targets = build_cleanup_targets(&git_root, &entries, &gone_branches)?;
     Ok(hydrate_branch_entries(
         entries,
         active_session_branches,
@@ -133,6 +136,11 @@ fn build_cleanup_targets(
         cleanup_targets.insert(branch.name.clone(), target);
     }
     Ok(cleanup_targets)
+}
+
+fn git_command_root(repo_path: &Path) -> std::io::Result<std::path::PathBuf> {
+    gwt_git::worktree::main_worktree_root(repo_path)
+        .map_err(|error| std::io::Error::other(error.to_string()))
 }
 
 fn adapt_branch_inventory(branches: Vec<gwt_git::Branch>) -> Vec<BranchListEntry> {
@@ -243,7 +251,6 @@ fn build_cleanup_info(
             BranchCleanupBlockedReason::ActiveSession,
         );
     }
-
     let merge_target = cleanup_targets
         .get(execution_branch_name)
         .cloned()

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1328,6 +1328,23 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_active_work_hides_internal_git_identity_from_user_summary() {
+        let html = frontend_bundle_source();
+        let active_work_block = html
+            .split("function renderActiveWorkOverview()")
+            .nth(1)
+            .and_then(|tail| tail.split("function mapAgentTelemetryState").next())
+            .expect("active work render block");
+
+        assert!(
+            !active_work_block.contains("appendMeta(meta, activeWorkProjection.branch)")
+                && !active_work_block.contains("compactPathLabel(agent.worktree_path)")
+                && !active_work_block.contains("appendMeta(agentMeta, agent.branch)"),
+            "Active Work must not expose branch names or worktree paths in the normal user summary",
+        );
+    }
+
+    #[test]
     fn embedded_web_board_messages_put_user_on_right_and_agent_on_left() {
         let html = frontend_bundle_source();
         fn css_block<'a>(html: &'a str, selector: &str) -> &'a str {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2758,7 +2758,7 @@ mod tests {
             .expect("git init --bare");
         assert!(status.success(), "git init --bare failed");
         let target = resolve_project_target(&bare).expect("bare repo target");
-        assert_eq!(target.kind, ProjectKind::Bare);
+        assert_eq!(target.kind, ProjectKind::Git);
         assert_eq!(target.project_root, dunce::canonicalize(&bare).unwrap());
     }
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -174,7 +174,7 @@ pub fn resolve_project_target(path: &Path) -> Result<ProjectOpenTarget, String> 
         ),
         gwt_git::RepoType::Bare {
             develop_worktree: None,
-        } => (canonical.clone(), gwt::ProjectKind::Bare, false),
+        } => (canonical.clone(), gwt::ProjectKind::Git, false),
         gwt_git::RepoType::NonRepo => (canonical.clone(), gwt::ProjectKind::NonRepo, false),
     };
 
@@ -710,6 +710,11 @@ mod tests {
             .expect("git init bare");
 
         let target = super::resolve_project_target(tmp.path()).expect("bare target");
+        assert_eq!(
+            target.kind,
+            gwt::ProjectKind::Git,
+            "Bare repo containers without a default worktree must open as Git projects with Workspace Home"
+        );
         assert!(
             !target.needs_migration,
             "Bare layout must not request migration"

--- a/crates/gwt/src/start_work.rs
+++ b/crates/gwt/src/start_work.rs
@@ -7,7 +7,7 @@ use std::{
 
 pub const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 3] =
     ["origin/develop", "origin/main", "origin/master"];
-
+pub const START_WORK_REMOTE_HEAD_REF: &str = "origin/HEAD";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StartWorkError {
     MissingBaseBranch,
@@ -18,7 +18,7 @@ impl std::fmt::Display for StartWorkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::MissingBaseBranch => f.write_str(
-                "No default base branch found (origin/develop, origin/main, origin/master)",
+                "No default base branch found (origin/HEAD, origin/develop, origin/main, origin/master)",
             ),
             Self::ReservationIo(error) => {
                 write!(f, "Failed to reserve Start Work branch name: {error}")
@@ -32,6 +32,9 @@ impl std::error::Error for StartWorkError {}
 pub fn resolve_start_work_base_branch_with(
     mut remote_branch_exists: impl FnMut(&str) -> bool,
 ) -> Result<String, StartWorkError> {
+    if remote_branch_exists(START_WORK_REMOTE_HEAD_REF) {
+        return Ok(START_WORK_REMOTE_HEAD_REF.to_string());
+    }
     START_WORK_BASE_BRANCH_CANDIDATES
         .iter()
         .copied()
@@ -41,8 +44,10 @@ pub fn resolve_start_work_base_branch_with(
 }
 
 pub fn resolve_start_work_base_branch(repo_path: &Path) -> Result<String, StartWorkError> {
+    let git_root = gwt_git::worktree::main_worktree_root(repo_path)
+        .unwrap_or_else(|_| repo_path.to_path_buf());
     resolve_start_work_base_branch_with(|candidate| {
-        git_ref_exists(repo_path, &format!("refs/remotes/{candidate}"))
+        git_ref_exists(&git_root, &remote_tracking_ref(candidate))
     })
 }
 
@@ -139,6 +144,14 @@ fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
+fn remote_tracking_ref(remote_ref: &str) -> String {
+    if remote_ref.starts_with("refs/remotes/") {
+        remote_ref.to_string()
+    } else {
+        format!("refs/remotes/{remote_ref}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -146,12 +159,27 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::{
-        reserve_start_work_branch_name_with, reserve_start_work_branch_name_with_reservations,
-        resolve_start_work_base_branch_with, StartWorkError,
+        remote_tracking_ref, reserve_start_work_branch_name_with,
+        reserve_start_work_branch_name_with_reservations, resolve_start_work_base_branch_with,
+        StartWorkError,
     };
 
     #[test]
-    fn start_work_base_branch_uses_develop_main_master_order() {
+    fn start_work_base_branch_prefers_remote_head_before_named_fallbacks() {
+        let existing = HashSet::from([
+            "origin/HEAD".to_string(),
+            "origin/develop".to_string(),
+            "origin/main".to_string(),
+        ]);
+        let resolved =
+            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
+                .expect("resolve base branch");
+
+        assert_eq!(resolved, "origin/HEAD");
+    }
+
+    #[test]
+    fn start_work_base_branch_falls_back_to_develop_main_master_order() {
         let existing = HashSet::from(["origin/main".to_string(), "origin/master".to_string()]);
         let resolved =
             resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
@@ -165,6 +193,18 @@ mod tests {
         let error = resolve_start_work_base_branch_with(|_| false).expect_err("missing base");
 
         assert_eq!(error, StartWorkError::MissingBaseBranch);
+    }
+
+    #[test]
+    fn start_work_remote_tracking_ref_does_not_double_origin_prefix() {
+        assert_eq!(
+            remote_tracking_ref("origin/HEAD"),
+            "refs/remotes/origin/HEAD"
+        );
+        assert_eq!(
+            remote_tracking_ref("origin/develop"),
+            "refs/remotes/origin/develop"
+        );
     }
 
     #[test]

--- a/crates/gwt/tests/branch_cleanup_test.rs
+++ b/crates/gwt/tests/branch_cleanup_test.rs
@@ -30,27 +30,27 @@ fn cleanup_selected_branches_deletes_local_and_remote_branch() {
         ],
     );
     run_git(&repo, &["push", "-u", "origin", "main"]);
-    run_git(&repo, &["checkout", "-qb", "feature/prune-me"]);
-    std::fs::write(repo.join("feature.txt"), "feature\n").expect("write feature");
-    run_git(&repo, &["add", "feature.txt"]);
+    run_git(&repo, &["checkout", "-qb", "work/prune-me"]);
+    std::fs::write(repo.join("work.txt"), "work\n").expect("write work");
+    run_git(&repo, &["add", "work.txt"]);
     run_git(&repo, &["commit", "-qm", "feature"]);
-    run_git(&repo, &["push", "-u", "origin", "feature/prune-me"]);
+    run_git(&repo, &["push", "-u", "origin", "work/prune-me"]);
     run_git(&repo, &["checkout", "main"]);
     run_git(&repo, &["fetch", "origin", "--prune"]);
 
     let entries =
         list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
     let results =
-        cleanup_selected_branches(&repo, &entries, &[String::from("feature/prune-me")], true);
+        cleanup_selected_branches(&repo, &entries, &[String::from("work/prune-me")], true);
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].status, BranchCleanupResultStatus::Success);
     assert!(
-        !branch_exists(&repo, "refs/heads/feature/prune-me"),
+        !branch_exists(&repo, "refs/heads/work/prune-me"),
         "local branch should be deleted"
     );
     assert!(
-        !branch_exists(&repo, "refs/remotes/origin/feature/prune-me"),
+        !branch_exists(&repo, "refs/remotes/origin/work/prune-me"),
         "remote-tracking branch should be deleted"
     );
 }

--- a/crates/gwt/tests/start_work_test.rs
+++ b/crates/gwt/tests/start_work_test.rs
@@ -91,6 +91,6 @@ fn start_work_launch_confirmation_materializes_reserved_work_branch_and_worktree
         git_output(&worktree, &["branch", "--show-current"]),
         reserved_branch
     );
-    assert_eq!(base_branch, "origin/develop");
+    assert_eq!(base_branch, "origin/HEAD");
     assert!(git_output(&repo, &["for-each-ref", "refs/heads/work"]).contains(&reserved_branch));
 }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1239,7 +1239,6 @@
           if (category === "done") counts.done = Math.max(counts.done, 1);
           counts.blocked = Math.max(counts.blocked, blockedAgents);
           counts.agents = Math.max(counts.agents, activeAgents + blockedAgents);
-          counts.branches = activeWorkProjection.branch ? 1 : "—";
         }
         try {
           window.__operatorShell.applyTelemetryCounts(counts);
@@ -1334,7 +1333,6 @@
         );
         const meta = createNode("div", "op-work-meta");
         appendMeta(meta, activeWorkProjection.owner);
-        appendMeta(meta, activeWorkProjection.branch);
         appendMeta(meta, activeWorkProjection.pr_number ? `PR #${activeWorkProjection.pr_number}` : "");
         activeWorkSummary.appendChild(meta);
         activeWorkSummary.appendChild(
@@ -1401,8 +1399,6 @@
           card.appendChild(head);
 
           const agentMeta = createNode("div", "op-agent-meta");
-          appendMeta(agentMeta, agent.branch);
-          appendMeta(agentMeta, compactPathLabel(agent.worktree_path));
           appendMeta(agentMeta, agent.last_board_entry_id ? "Board linked" : "");
           card.appendChild(agentMeta);
 
@@ -5567,6 +5563,8 @@
             return "A running agent session is using this branch";
           case "remote_tracking_without_local":
             return "Remote-tracking branch without a local counterpart";
+          case "non_workspace_branch":
+            return "Only gwt-managed workspaces can be cleaned up";
           default:
             return "This branch cannot be cleaned up";
         }


### PR DESCRIPTION
## Summary

- Workspace Home now opens cleanly even when the repository has no default develop/main worktree.
- Start Work now derives its base from origin/HEAD first so users do not need to understand branch/worktree internals.
- Workspace cleanup now protects non-gwt branches while still allowing gwt-managed work/* workspace cleanup.

## Changes

- `crates/gwt/src/start_work.rs`: Prefer `origin/HEAD`, fix remote tracking ref resolution, and cover fallback ordering with tests.
- `crates/gwt-git/src/worktree.rs`: Resolve bare repository containers as Workspace Home roots when no default worktree exists.
- `crates/gwt/src/runtime_support.rs` and `crates/gwt/src/main.rs`: Treat bare layout containers without default worktree migration prompts as Git Workspace Home.
- `crates/gwt/src/branch_cleanup.rs` and `crates/gwt/src/branch_list.rs`: Gate actual cleanup deletion to gwt-managed `work/*` branches and make branch inventory work from Workspace Home.
- `crates/gwt/web/app.js` and `crates/gwt/src/embedded_web.rs`: Hide branch/worktree identity from normal Active Work summaries while preserving internal launch metadata.
- `crates/gwt/tests/branch_cleanup_test.rs` and `crates/gwt/tests/start_work_test.rs`: Update integration coverage for workspace cleanup and Start Work base selection.

## Testing

- [x] `cargo test -p gwt-core -p gwt-git -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-unit` — passed.
- [x] Pre-push hook — passed with filtered line coverage 90.67% against the 90.00% threshold.

## Closing Issues

None

## Related Issues / Links

- #2359
- #1934

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend unit/bundle checks)
- [x] Documentation updated (SPEC #2359 and #1934 updated; README change not required)
- [x] Migration/backfill plan included (legacy/non-workspace branches are preserved; only `work/*` is deletable)
- [x] CHANGELOG impact considered (feature commit uses `feat:`)

## Context

- The Workspace surface should be the user-facing concept; branch names, worktree directory names, and cleanup internals should not be required user knowledge.
- Migration and legacy layouts must remain safe while the application moves away from assuming local develop/main worktrees.

## Risk / Impact

- **Affected areas**: Start Work base selection, Workspace Home opening, Active Work summary rendering, branch cleanup execution, and migration-adjacent bare repo handling.
- **Rollback plan**: Revert this PR to restore the previous branch/worktree-visible behavior and cleanup rules.

## Screenshots

- Not attached; the visible Active Work copy change is covered by `embedded_web_active_work_hides_internal_git_identity_from_user_summary`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for child bare repositories within workspace homes
  * Enhanced base-branch resolution to prefer origin/HEAD references

* **Bug Fixes**
  * Added safeguard to prevent cleanup of non-workspace branches
  * Improved classification of bare Git repositories as Git projects

* **Tests**
  * Extended test coverage for new branch management and workspace detection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->