### PR TITLE
fix(gui): sync canvas grid with viewport

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -570,7 +570,7 @@ mod tests {
     fn embedded_web_canvas_apply_viewport_debounces_raster_hint_reset() {
         let js = app_js();
         let apply_viewport = regex::Regex::new(
-            r#"(?s)function applyViewport\(\)\s*\{\s*stage\.style\.transform = `translate\(\$\{viewport\.x\}px, \$\{viewport\.y\}px\) scale\(\$\{viewport\.zoom\}\)`;\s*stage\.style\.willChange = "transform";\s*if \(viewportRasterTimer !== null\) \{\s*clearTimeout\(viewportRasterTimer\);\s*\}\s*viewportRasterTimer = setTimeout\(\(\) => \{\s*stage\.style\.willChange = "auto";\s*viewportRasterTimer = null;\s*\}, 300\);\s*\}"#,
+            r#"(?s)function applyViewport\(\)\s*\{\s*stage\.style\.transform = `translate\(\$\{viewport\.x\}px, \$\{viewport\.y\}px\) scale\(\$\{viewport\.zoom\}\)`;\s*applyWorldGridViewport\(\);\s*stage\.style\.willChange = "transform";\s*if \(viewportRasterTimer !== null\) \{\s*clearTimeout\(viewportRasterTimer\);\s*\}\s*viewportRasterTimer = setTimeout\(\(\) => \{\s*stage\.style\.willChange = "auto";\s*viewportRasterTimer = null;\s*\}, 300\);\s*\}"#,
         )
         .expect("valid regex");
 
@@ -581,6 +581,33 @@ mod tests {
         assert!(
             apply_viewport.is_match(js),
             "expected viewport application to opt into the transform layer only during motion and reset it after 300ms",
+        );
+    }
+
+    #[test]
+    fn embedded_web_canvas_grid_tracks_viewport_as_world_space_cue() {
+        let html = index_html();
+        let js = app_js();
+
+        assert!(
+            html.contains("id=\"canvas-world-grid\""),
+            "expected canvas to expose a dedicated world-space grid layer",
+        );
+        assert!(
+            html.contains(".canvas-world-grid"),
+            "expected embedded html to define the world-space grid CSS",
+        );
+        assert!(
+            js.contains("const worldGrid = document.getElementById(\"canvas-world-grid\")"),
+            "expected frontend to bind the world-space grid element",
+        );
+        assert!(
+            js.contains("function applyWorldGridViewport()"),
+            "expected grid viewport sync to live behind a named helper",
+        );
+        assert!(
+            js.contains("applyWorldGridViewport();"),
+            "expected applyViewport to update the grid whenever viewport state changes",
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -160,6 +160,28 @@ test("workspace windows expose role badges and hide panel runtime chips", () => 
   );
 });
 
+test("canvas world grid is synchronized from viewport state", () => {
+  assert.ok(
+    document.querySelector("#canvas-world-grid.canvas-world-grid"),
+    "expected canvas to expose a dedicated world-space grid layer",
+  );
+  assert.match(
+    appSource,
+    /const\s+worldGrid\s*=\s*document\.getElementById\("canvas-world-grid"\)/,
+    "expected app.js to bind the canvas world grid element",
+  );
+  assert.match(
+    appSource,
+    /function\s+applyWorldGridViewport\(\)[\s\S]+viewport\.x[\s\S]+viewport\.y[\s\S]+viewport\.zoom/,
+    "expected world grid sync to derive position and size from the viewport",
+  );
+  assert.match(
+    appSource,
+    /function\s+applyViewport\(\)[\s\S]+applyWorldGridViewport\(\)/,
+    "expected applyViewport to update the grid together with the stage transform",
+  );
+});
+
 test("Workspace active work overview behaves like a command center", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -52,6 +52,7 @@
       const alignButton = document.getElementById("align-button");
       const windowListButton = document.getElementById("window-list-button");
       const windowListPanel = document.getElementById("window-list-panel");
+      const worldGrid = document.getElementById("canvas-world-grid");
       const activeWorkCount = document.getElementById("op-active-work-count");
       const activeWorkSummary = document.getElementById("op-active-work-summary");
       const activeWorkAgents = document.getElementById("op-active-work-agents");
@@ -1038,8 +1039,30 @@
         return Number.parseFloat(value || "0");
       }
 
+      function applyWorldGridViewport() {
+        if (!worldGrid) {
+          return;
+        }
+        const gridSize = 32 * viewport.zoom;
+        const majorGridSize = gridSize * 4;
+        const gridPosition = `${viewport.x}px ${viewport.y}px`;
+        worldGrid.style.backgroundSize = [
+          `${gridSize}px ${gridSize}px`,
+          `${gridSize}px ${gridSize}px`,
+          `${majorGridSize}px ${majorGridSize}px`,
+          `${majorGridSize}px ${majorGridSize}px`,
+        ].join(", ");
+        worldGrid.style.backgroundPosition = [
+          gridPosition,
+          gridPosition,
+          gridPosition,
+          gridPosition,
+        ].join(", ");
+      }
+
       function applyViewport() {
         stage.style.transform = `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`;
+        applyWorldGridViewport();
         stage.style.willChange = "transform";
         if (viewportRasterTimer !== null) {
           clearTimeout(viewportRasterTimer);

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -213,19 +213,31 @@
         inset: 0;
         overflow: hidden;
         cursor: grab;
+        background: var(--color-canvas);
       }
 
       .canvas.panning {
         cursor: grabbing;
       }
 
+      .canvas-world-grid {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background-image:
+          linear-gradient(to right, var(--bg-scan-grid) 1px, transparent 1px),
+          linear-gradient(to bottom, var(--bg-scan-grid) 1px, transparent 1px),
+          linear-gradient(to right, var(--color-border) 1px, transparent 1px),
+          linear-gradient(to bottom, var(--color-border) 1px, transparent 1px);
+        background-size: 32px 32px, 32px 32px, 128px 128px, 128px 128px;
+        background-position: 0 0;
+        opacity: 0.9;
+      }
+
       .canvas-stage {
         position: absolute;
         inset: 0;
         transform-origin: 0 0;
-        /* SPEC-2356 — body::before already paints the Operator scan grid,
-           so the legacy 24px slate grid here only doubled the noise.
-           Leaving the stage transparent lets the Operator backdrop show. */
         background: transparent;
       }
 
@@ -3171,6 +3183,7 @@
             <span class="hint__copy">Drag windows | Scroll/drag canvas to pan | Middle-click drag anywhere | Ctrl/Cmd + wheel to zoom</span>
           </div>
           <div class="canvas" id="canvas">
+            <div class="canvas-world-grid" id="canvas-world-grid" aria-hidden="true"></div>
             <div class="canvas-stage" id="canvas-stage"></div>
           </div>
           <div class="project-picker" id="project-picker">

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -586,7 +586,21 @@ body::after {
 }
 
 .canvas {
-  background: transparent;
+  background: var(--color-canvas);
+}
+
+.canvas-world-grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to right, var(--bg-scan-grid) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--bg-scan-grid) 1px, transparent 1px),
+    linear-gradient(to right, var(--color-border) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--color-border) 1px, transparent 1px);
+  background-size: 32px 32px, 32px 32px, 128px 128px, 128px 128px;
+  background-position: 0 0;
+  opacity: 0.9;
 }
 
 /* Existing floating actions become Operator-styled */


### PR DESCRIPTION
## Summary

- Sync the canvas grid with viewport pan and zoom so the background visibly moves with windows.
- Add a dedicated world-space grid layer and keep the fixed page backdrop out of the canvas surface.

## Changes

- `crates/gwt/web/index.html`: adds the `canvas-world-grid` layer and base canvas grid styling.
- `crates/gwt/web/styles/components.css`: mirrors the Operator canvas grid styling for the shared component sheet.
- `crates/gwt/web/app.js`: updates grid background position and spacing from the same viewport state as the stage transform.
- `crates/gwt/src/embedded_web.rs`: adds embedded frontend contract coverage for viewport-synced grid behavior.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds frontend structure coverage for the world grid contract.

## Testing

- [x] `cargo test -p gwt embedded_web_canvas_grid_tracks_viewport_as_world_space_cue` — RED before implementation, then passes.
- [x] `cargo test -p gwt embedded_web_canvas` — 4/4 canvas embedded contract tests pass.
- [x] `pnpm test:frontend-bundle` — frontend bundle syntax checks pass.
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs --test-name-pattern 'canvas world grid'` — 62/62 structure tests pass with the name filter active.
- [x] `pnpm test:frontend-unit` — 224/224 frontend unit tests pass.
- [x] `cargo test -p gwt-core -p gwt` — all Rust package tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo build -p gwt` — passes.
- [x] Playwright smoke over local static frontend — background drag, middle drag, plain wheel pan, Ctrl/Cmd wheel zoom, and zoom button all update stage transform and grid position/size together.
- [x] Pre-push coverage hook — 90.68% line coverage, threshold 90.00% met.

## Closing Issues

None

## Related Issues / Links

- #2008

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #2008 spec/plan/tasks updated)
- [x] Migration/backfill plan included (no schema/data migration required)
- [x] CHANGELOG impact considered (patch fix, non-breaking)

## Context

- Canvas panning previously moved only windows because the visible grid came from the fixed page backdrop, making the workspace feel static during pan.

## Risk / Impact

- **Affected areas**: GUI canvas viewport rendering and Operator canvas styling.
- **Rollback plan**: Revert this PR; no persistence or protocol data changes are introduced.
