### PR TITLE
chore(release): v9.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.20.0] - 2026-05-06
+
+### Bug Fixes
+
+- **gui:** Sync canvas grid with viewport
+
+### Features
+
+- Support workspace home without default worktree
+
+### Miscellaneous Tasks
+
+- Merge develop into workspace home work
+
 ## [9.19.2] - 2026-05-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "axum",
  "base64",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.19.2"
+version = "9.20.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.19.2"
+version = "9.20.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -493,6 +493,9 @@ pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
         .map_err(|e| GwtError::Git(format!("rev-parse --git-common-dir: {e}")))?;
 
     if !output.status.success() {
+        if let Some(bare_child) = first_child_bare_repository(repo_path) {
+            return Ok(std::fs::canonicalize(&bare_child).unwrap_or(bare_child));
+        }
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         return Err(GwtError::Git(format!(
             "rev-parse --git-common-dir: {stderr}"
@@ -516,6 +519,20 @@ pub fn main_worktree_root(repo_path: &Path) -> Result<PathBuf> {
     }
 
     Ok(common_dir)
+}
+
+fn first_child_bare_repository(repo_path: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(repo_path).ok()?;
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .filter(|path| {
+            path.join("HEAD").exists()
+                && path.join("objects").exists()
+                && path.join("refs").exists()
+        })
+        .min()
 }
 
 /// Derive a sibling worktree path from the repo root and branch name.
@@ -883,6 +900,20 @@ prunable gitdir file points to non-existent location
         assert_eq!(
             comparable_path(&sibling_worktree_path(&layout_root, "feature/banner")),
             comparable_path(&expected_parent.join("feature").join("banner"))
+        );
+    }
+
+    #[test]
+    fn main_worktree_root_accepts_workspace_home_with_child_bare_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare_repo_path = tmp.path().join("gwt.git");
+        init_bare_git_repo(&bare_repo_path);
+
+        let layout_root = main_worktree_root(tmp.path()).unwrap();
+
+        assert_eq!(
+            comparable_path(&layout_root),
+            comparable_path(&std::fs::canonicalize(&bare_repo_path).unwrap())
         );
     }
 

--- a/crates/gwt/src/branch_cleanup.rs
+++ b/crates/gwt/src/branch_cleanup.rs
@@ -70,6 +70,14 @@ pub fn cleanup_selected_branches(
                     ),
                 };
             }
+            if !is_gwt_workspace_branch(&target_branch) {
+                return BranchCleanupResultEntry {
+                    branch: entry.name.clone(),
+                    execution_branch: Some(target_branch),
+                    status: BranchCleanupResultStatus::Failed,
+                    message: blocked_reason_message(BranchCleanupBlockedReason::NonWorkspaceBranch),
+                };
+            }
 
             match manager.cleanup_branch(&target_branch) {
                 Ok(()) => {
@@ -122,6 +130,10 @@ pub fn cleanup_selected_branches(
         .collect()
 }
 
+fn is_gwt_workspace_branch(branch_name: &str) -> bool {
+    branch_name.starts_with("work/")
+}
+
 fn blocked_reason_message(reason: BranchCleanupBlockedReason) -> String {
     match reason {
         BranchCleanupBlockedReason::ProtectedBranch => {
@@ -135,6 +147,9 @@ fn blocked_reason_message(reason: BranchCleanupBlockedReason) -> String {
         }
         BranchCleanupBlockedReason::RemoteTrackingWithoutLocal => {
             "Cannot clean up a remote-tracking branch without a local counterpart".to_string()
+        }
+        BranchCleanupBlockedReason::NonWorkspaceBranch => {
+            "Only gwt-managed workspaces can be cleaned up".to_string()
         }
         BranchCleanupBlockedReason::Unknown => "Cannot clean up this branch".to_string(),
     }
@@ -215,6 +230,10 @@ mod tests {
             "Cannot clean up a remote-tracking branch without a local counterpart"
         );
         assert_eq!(
+            blocked_reason_message(BranchCleanupBlockedReason::NonWorkspaceBranch),
+            "Only gwt-managed workspaces can be cleaned up"
+        );
+        assert_eq!(
             blocked_reason_message(BranchCleanupBlockedReason::Unknown),
             "Cannot clean up this branch"
         );
@@ -239,5 +258,28 @@ mod tests {
         assert_eq!(results[0].execution_branch.as_deref(), Some("feature/demo"));
         assert_eq!(results[0].status, BranchCleanupResultStatus::Failed);
         assert_eq!(results[0].message, "Cannot clean up a protected branch");
+    }
+
+    #[test]
+    fn cleanup_selected_branches_preserves_non_workspace_branch() {
+        let repo = tempdir().expect("tempdir");
+        let mut entry = sample_entry("feature/demo");
+        entry.cleanup.availability = BranchCleanupAvailability::Safe;
+        entry.cleanup.execution_branch = Some("feature/demo".to_string());
+
+        let results = cleanup_selected_branches(
+            repo.path(),
+            &[entry],
+            &[String::from("feature/demo")],
+            false,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].execution_branch.as_deref(), Some("feature/demo"));
+        assert_eq!(results[0].status, BranchCleanupResultStatus::Failed);
+        assert_eq!(
+            results[0].message,
+            "Only gwt-managed workspaces can be cleaned up"
+        );
     }
 }

--- a/crates/gwt/src/branch_list.rs
+++ b/crates/gwt/src/branch_list.rs
@@ -24,6 +24,7 @@ pub enum BranchCleanupBlockedReason {
     CurrentHead,
     ActiveSession,
     RemoteTrackingWithoutLocal,
+    NonWorkspaceBranch,
     Unknown,
 }
 
@@ -83,7 +84,8 @@ pub fn list_branch_entries(repo_path: &Path) -> std::io::Result<Vec<BranchListEn
 }
 
 pub fn list_branch_inventory(repo_path: &Path) -> std::io::Result<Vec<BranchListEntry>> {
-    let branches = gwt_git::branch::list_branches(repo_path)
+    let git_root = git_command_root(repo_path)?;
+    let branches = gwt_git::branch::list_branches(&git_root)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
     Ok(adapt_branch_inventory(branches))
 }
@@ -93,9 +95,10 @@ pub fn hydrate_branch_entries_with_active_sessions(
     entries: Vec<BranchListEntry>,
     active_session_branches: &HashSet<String>,
 ) -> std::io::Result<Vec<BranchListEntry>> {
-    let gone_branches = gwt_git::list_gone_branches(repo_path)
+    let git_root = git_command_root(repo_path)?;
+    let gone_branches = gwt_git::list_gone_branches(&git_root)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
-    let cleanup_targets = build_cleanup_targets(repo_path, &entries, &gone_branches)?;
+    let cleanup_targets = build_cleanup_targets(&git_root, &entries, &gone_branches)?;
     Ok(hydrate_branch_entries(
         entries,
         active_session_branches,
@@ -133,6 +136,11 @@ fn build_cleanup_targets(
         cleanup_targets.insert(branch.name.clone(), target);
     }
     Ok(cleanup_targets)
+}
+
+fn git_command_root(repo_path: &Path) -> std::io::Result<std::path::PathBuf> {
+    gwt_git::worktree::main_worktree_root(repo_path)
+        .map_err(|error| std::io::Error::other(error.to_string()))
 }
 
 fn adapt_branch_inventory(branches: Vec<gwt_git::Branch>) -> Vec<BranchListEntry> {
@@ -243,7 +251,6 @@ fn build_cleanup_info(
             BranchCleanupBlockedReason::ActiveSession,
         );
     }
-
     let merge_target = cleanup_targets
         .get(execution_branch_name)
         .cloned()

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1328,6 +1328,23 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_active_work_hides_internal_git_identity_from_user_summary() {
+        let html = frontend_bundle_source();
+        let active_work_block = html
+            .split("function renderActiveWorkOverview()")
+            .nth(1)
+            .and_then(|tail| tail.split("function mapAgentTelemetryState").next())
+            .expect("active work render block");
+
+        assert!(
+            !active_work_block.contains("appendMeta(meta, activeWorkProjection.branch)")
+                && !active_work_block.contains("compactPathLabel(agent.worktree_path)")
+                && !active_work_block.contains("appendMeta(agentMeta, agent.branch)"),
+            "Active Work must not expose branch names or worktree paths in the normal user summary",
+        );
+    }
+
+    #[test]
     fn embedded_web_board_messages_put_user_on_right_and_agent_on_left() {
         let html = frontend_bundle_source();
         fn css_block<'a>(html: &'a str, selector: &str) -> &'a str {

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -570,7 +570,7 @@ mod tests {
     fn embedded_web_canvas_apply_viewport_debounces_raster_hint_reset() {
         let js = app_js();
         let apply_viewport = regex::Regex::new(
-            r#"(?s)function applyViewport\(\)\s*\{\s*stage\.style\.transform = `translate\(\$\{viewport\.x\}px, \$\{viewport\.y\}px\) scale\(\$\{viewport\.zoom\}\)`;\s*stage\.style\.willChange = "transform";\s*if \(viewportRasterTimer !== null\) \{\s*clearTimeout\(viewportRasterTimer\);\s*\}\s*viewportRasterTimer = setTimeout\(\(\) => \{\s*stage\.style\.willChange = "auto";\s*viewportRasterTimer = null;\s*\}, 300\);\s*\}"#,
+            r#"(?s)function applyViewport\(\)\s*\{\s*stage\.style\.transform = `translate\(\$\{viewport\.x\}px, \$\{viewport\.y\}px\) scale\(\$\{viewport\.zoom\}\)`;\s*applyWorldGridViewport\(\);\s*stage\.style\.willChange = "transform";\s*if \(viewportRasterTimer !== null\) \{\s*clearTimeout\(viewportRasterTimer\);\s*\}\s*viewportRasterTimer = setTimeout\(\(\) => \{\s*stage\.style\.willChange = "auto";\s*viewportRasterTimer = null;\s*\}, 300\);\s*\}"#,
         )
         .expect("valid regex");
 
@@ -581,6 +581,33 @@ mod tests {
         assert!(
             apply_viewport.is_match(js),
             "expected viewport application to opt into the transform layer only during motion and reset it after 300ms",
+        );
+    }
+
+    #[test]
+    fn embedded_web_canvas_grid_tracks_viewport_as_world_space_cue() {
+        let html = index_html();
+        let js = app_js();
+
+        assert!(
+            html.contains("id=\"canvas-world-grid\""),
+            "expected canvas to expose a dedicated world-space grid layer",
+        );
+        assert!(
+            html.contains(".canvas-world-grid"),
+            "expected embedded html to define the world-space grid CSS",
+        );
+        assert!(
+            js.contains("const worldGrid = document.getElementById(\"canvas-world-grid\")"),
+            "expected frontend to bind the world-space grid element",
+        );
+        assert!(
+            js.contains("function applyWorldGridViewport()"),
+            "expected grid viewport sync to live behind a named helper",
+        );
+        assert!(
+            js.contains("applyWorldGridViewport();"),
+            "expected applyViewport to update the grid whenever viewport state changes",
         );
     }
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2758,7 +2758,7 @@ mod tests {
             .expect("git init --bare");
         assert!(status.success(), "git init --bare failed");
         let target = resolve_project_target(&bare).expect("bare repo target");
-        assert_eq!(target.kind, ProjectKind::Bare);
+        assert_eq!(target.kind, ProjectKind::Git);
         assert_eq!(target.project_root, dunce::canonicalize(&bare).unwrap());
     }
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -174,7 +174,7 @@ pub fn resolve_project_target(path: &Path) -> Result<ProjectOpenTarget, String> 
         ),
         gwt_git::RepoType::Bare {
             develop_worktree: None,
-        } => (canonical.clone(), gwt::ProjectKind::Bare, false),
+        } => (canonical.clone(), gwt::ProjectKind::Git, false),
         gwt_git::RepoType::NonRepo => (canonical.clone(), gwt::ProjectKind::NonRepo, false),
     };
 
@@ -710,6 +710,11 @@ mod tests {
             .expect("git init bare");
 
         let target = super::resolve_project_target(tmp.path()).expect("bare target");
+        assert_eq!(
+            target.kind,
+            gwt::ProjectKind::Git,
+            "Bare repo containers without a default worktree must open as Git projects with Workspace Home"
+        );
         assert!(
             !target.needs_migration,
             "Bare layout must not request migration"

--- a/crates/gwt/src/start_work.rs
+++ b/crates/gwt/src/start_work.rs
@@ -7,7 +7,7 @@ use std::{
 
 pub const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 3] =
     ["origin/develop", "origin/main", "origin/master"];
-
+pub const START_WORK_REMOTE_HEAD_REF: &str = "origin/HEAD";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StartWorkError {
     MissingBaseBranch,
@@ -18,7 +18,7 @@ impl std::fmt::Display for StartWorkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::MissingBaseBranch => f.write_str(
-                "No default base branch found (origin/develop, origin/main, origin/master)",
+                "No default base branch found (origin/HEAD, origin/develop, origin/main, origin/master)",
             ),
             Self::ReservationIo(error) => {
                 write!(f, "Failed to reserve Start Work branch name: {error}")
@@ -32,6 +32,9 @@ impl std::error::Error for StartWorkError {}
 pub fn resolve_start_work_base_branch_with(
     mut remote_branch_exists: impl FnMut(&str) -> bool,
 ) -> Result<String, StartWorkError> {
+    if remote_branch_exists(START_WORK_REMOTE_HEAD_REF) {
+        return Ok(START_WORK_REMOTE_HEAD_REF.to_string());
+    }
     START_WORK_BASE_BRANCH_CANDIDATES
         .iter()
         .copied()
@@ -41,8 +44,10 @@ pub fn resolve_start_work_base_branch_with(
 }
 
 pub fn resolve_start_work_base_branch(repo_path: &Path) -> Result<String, StartWorkError> {
+    let git_root = gwt_git::worktree::main_worktree_root(repo_path)
+        .unwrap_or_else(|_| repo_path.to_path_buf());
     resolve_start_work_base_branch_with(|candidate| {
-        git_ref_exists(repo_path, &format!("refs/remotes/{candidate}"))
+        git_ref_exists(&git_root, &remote_tracking_ref(candidate))
     })
 }
 
@@ -139,6 +144,14 @@ fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
+fn remote_tracking_ref(remote_ref: &str) -> String {
+    if remote_ref.starts_with("refs/remotes/") {
+        remote_ref.to_string()
+    } else {
+        format!("refs/remotes/{remote_ref}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -146,12 +159,27 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::{
-        reserve_start_work_branch_name_with, reserve_start_work_branch_name_with_reservations,
-        resolve_start_work_base_branch_with, StartWorkError,
+        remote_tracking_ref, reserve_start_work_branch_name_with,
+        reserve_start_work_branch_name_with_reservations, resolve_start_work_base_branch_with,
+        StartWorkError,
     };
 
     #[test]
-    fn start_work_base_branch_uses_develop_main_master_order() {
+    fn start_work_base_branch_prefers_remote_head_before_named_fallbacks() {
+        let existing = HashSet::from([
+            "origin/HEAD".to_string(),
+            "origin/develop".to_string(),
+            "origin/main".to_string(),
+        ]);
+        let resolved =
+            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
+                .expect("resolve base branch");
+
+        assert_eq!(resolved, "origin/HEAD");
+    }
+
+    #[test]
+    fn start_work_base_branch_falls_back_to_develop_main_master_order() {
         let existing = HashSet::from(["origin/main".to_string(), "origin/master".to_string()]);
         let resolved =
             resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
@@ -165,6 +193,18 @@ mod tests {
         let error = resolve_start_work_base_branch_with(|_| false).expect_err("missing base");
 
         assert_eq!(error, StartWorkError::MissingBaseBranch);
+    }
+
+    #[test]
+    fn start_work_remote_tracking_ref_does_not_double_origin_prefix() {
+        assert_eq!(
+            remote_tracking_ref("origin/HEAD"),
+            "refs/remotes/origin/HEAD"
+        );
+        assert_eq!(
+            remote_tracking_ref("origin/develop"),
+            "refs/remotes/origin/develop"
+        );
     }
 
     #[test]

--- a/crates/gwt/tests/branch_cleanup_test.rs
+++ b/crates/gwt/tests/branch_cleanup_test.rs
@@ -30,27 +30,27 @@ fn cleanup_selected_branches_deletes_local_and_remote_branch() {
         ],
     );
     run_git(&repo, &["push", "-u", "origin", "main"]);
-    run_git(&repo, &["checkout", "-qb", "feature/prune-me"]);
-    std::fs::write(repo.join("feature.txt"), "feature\n").expect("write feature");
-    run_git(&repo, &["add", "feature.txt"]);
+    run_git(&repo, &["checkout", "-qb", "work/prune-me"]);
+    std::fs::write(repo.join("work.txt"), "work\n").expect("write work");
+    run_git(&repo, &["add", "work.txt"]);
     run_git(&repo, &["commit", "-qm", "feature"]);
-    run_git(&repo, &["push", "-u", "origin", "feature/prune-me"]);
+    run_git(&repo, &["push", "-u", "origin", "work/prune-me"]);
     run_git(&repo, &["checkout", "main"]);
     run_git(&repo, &["fetch", "origin", "--prune"]);
 
     let entries =
         list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
     let results =
-        cleanup_selected_branches(&repo, &entries, &[String::from("feature/prune-me")], true);
+        cleanup_selected_branches(&repo, &entries, &[String::from("work/prune-me")], true);
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].status, BranchCleanupResultStatus::Success);
     assert!(
-        !branch_exists(&repo, "refs/heads/feature/prune-me"),
+        !branch_exists(&repo, "refs/heads/work/prune-me"),
         "local branch should be deleted"
     );
     assert!(
-        !branch_exists(&repo, "refs/remotes/origin/feature/prune-me"),
+        !branch_exists(&repo, "refs/remotes/origin/work/prune-me"),
         "remote-tracking branch should be deleted"
     );
 }

--- a/crates/gwt/tests/start_work_test.rs
+++ b/crates/gwt/tests/start_work_test.rs
@@ -91,6 +91,6 @@ fn start_work_launch_confirmation_materializes_reserved_work_branch_and_worktree
         git_output(&worktree, &["branch", "--show-current"]),
         reserved_branch
     );
-    assert_eq!(base_branch, "origin/develop");
+    assert_eq!(base_branch, "origin/HEAD");
     assert!(git_output(&repo, &["for-each-ref", "refs/heads/work"]).contains(&reserved_branch));
 }

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -160,6 +160,28 @@ test("workspace windows expose role badges and hide panel runtime chips", () => 
   );
 });
 
+test("canvas world grid is synchronized from viewport state", () => {
+  assert.ok(
+    document.querySelector("#canvas-world-grid.canvas-world-grid"),
+    "expected canvas to expose a dedicated world-space grid layer",
+  );
+  assert.match(
+    appSource,
+    /const\s+worldGrid\s*=\s*document\.getElementById\("canvas-world-grid"\)/,
+    "expected app.js to bind the canvas world grid element",
+  );
+  assert.match(
+    appSource,
+    /function\s+applyWorldGridViewport\(\)[\s\S]+viewport\.x[\s\S]+viewport\.y[\s\S]+viewport\.zoom/,
+    "expected world grid sync to derive position and size from the viewport",
+  );
+  assert.match(
+    appSource,
+    /function\s+applyViewport\(\)[\s\S]+applyWorldGridViewport\(\)/,
+    "expected applyViewport to update the grid together with the stage transform",
+  );
+});
+
 test("Workspace active work overview behaves like a command center", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -52,6 +52,7 @@
       const alignButton = document.getElementById("align-button");
       const windowListButton = document.getElementById("window-list-button");
       const windowListPanel = document.getElementById("window-list-panel");
+      const worldGrid = document.getElementById("canvas-world-grid");
       const activeWorkCount = document.getElementById("op-active-work-count");
       const activeWorkSummary = document.getElementById("op-active-work-summary");
       const activeWorkAgents = document.getElementById("op-active-work-agents");
@@ -1038,8 +1039,30 @@
         return Number.parseFloat(value || "0");
       }
 
+      function applyWorldGridViewport() {
+        if (!worldGrid) {
+          return;
+        }
+        const gridSize = 32 * viewport.zoom;
+        const majorGridSize = gridSize * 4;
+        const gridPosition = `${viewport.x}px ${viewport.y}px`;
+        worldGrid.style.backgroundSize = [
+          `${gridSize}px ${gridSize}px`,
+          `${gridSize}px ${gridSize}px`,
+          `${majorGridSize}px ${majorGridSize}px`,
+          `${majorGridSize}px ${majorGridSize}px`,
+        ].join(", ");
+        worldGrid.style.backgroundPosition = [
+          gridPosition,
+          gridPosition,
+          gridPosition,
+          gridPosition,
+        ].join(", ");
+      }
+
       function applyViewport() {
         stage.style.transform = `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`;
+        applyWorldGridViewport();
         stage.style.willChange = "transform";
         if (viewportRasterTimer !== null) {
           clearTimeout(viewportRasterTimer);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1239,7 +1239,6 @@
           if (category === "done") counts.done = Math.max(counts.done, 1);
           counts.blocked = Math.max(counts.blocked, blockedAgents);
           counts.agents = Math.max(counts.agents, activeAgents + blockedAgents);
-          counts.branches = activeWorkProjection.branch ? 1 : "—";
         }
         try {
           window.__operatorShell.applyTelemetryCounts(counts);
@@ -1334,7 +1333,6 @@
         );
         const meta = createNode("div", "op-work-meta");
         appendMeta(meta, activeWorkProjection.owner);
-        appendMeta(meta, activeWorkProjection.branch);
         appendMeta(meta, activeWorkProjection.pr_number ? `PR #${activeWorkProjection.pr_number}` : "");
         activeWorkSummary.appendChild(meta);
         activeWorkSummary.appendChild(
@@ -1401,8 +1399,6 @@
           card.appendChild(head);
 
           const agentMeta = createNode("div", "op-agent-meta");
-          appendMeta(agentMeta, agent.branch);
-          appendMeta(agentMeta, compactPathLabel(agent.worktree_path));
           appendMeta(agentMeta, agent.last_board_entry_id ? "Board linked" : "");
           card.appendChild(agentMeta);
 
@@ -5567,6 +5563,8 @@
             return "A running agent session is using this branch";
           case "remote_tracking_without_local":
             return "Remote-tracking branch without a local counterpart";
+          case "non_workspace_branch":
+            return "Only gwt-managed workspaces can be cleaned up";
           default:
             return "This branch cannot be cleaned up";
         }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -213,19 +213,31 @@
         inset: 0;
         overflow: hidden;
         cursor: grab;
+        background: var(--color-canvas);
       }
 
       .canvas.panning {
         cursor: grabbing;
       }
 
+      .canvas-world-grid {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background-image:
+          linear-gradient(to right, var(--bg-scan-grid) 1px, transparent 1px),
+          linear-gradient(to bottom, var(--bg-scan-grid) 1px, transparent 1px),
+          linear-gradient(to right, var(--color-border) 1px, transparent 1px),
+          linear-gradient(to bottom, var(--color-border) 1px, transparent 1px);
+        background-size: 32px 32px, 32px 32px, 128px 128px, 128px 128px;
+        background-position: 0 0;
+        opacity: 0.9;
+      }
+
       .canvas-stage {
         position: absolute;
         inset: 0;
         transform-origin: 0 0;
-        /* SPEC-2356 — body::before already paints the Operator scan grid,
-           so the legacy 24px slate grid here only doubled the noise.
-           Leaving the stage transparent lets the Operator backdrop show. */
         background: transparent;
       }
 
@@ -3171,6 +3183,7 @@
             <span class="hint__copy">Drag windows | Scroll/drag canvas to pan | Middle-click drag anywhere | Ctrl/Cmd + wheel to zoom</span>
           </div>
           <div class="canvas" id="canvas">
+            <div class="canvas-world-grid" id="canvas-world-grid" aria-hidden="true"></div>
             <div class="canvas-stage" id="canvas-stage"></div>
           </div>
           <div class="project-picker" id="project-picker">

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -586,7 +586,21 @@ body::after {
 }
 
 .canvas {
-  background: transparent;
+  background: var(--color-canvas);
+}
+
+.canvas-world-grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to right, var(--bg-scan-grid) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--bg-scan-grid) 1px, transparent 1px),
+    linear-gradient(to right, var(--color-border) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--color-border) 1px, transparent 1px);
+  background-size: 32px 32px, 32px 32px, 128px 128px, 128px 128px;
+  background-position: 0 0;
+  opacity: 0.9;
 }
 
 /* Existing floating actions become Operator-styled */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.19.2",
+  "version": "9.20.0",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.20.0 minor release. Adds Workspace Home support for repositories without a default worktree and improves canvas panning feedback by synchronizing the grid with viewport movement.

## Changes

- feat: support workspace home without default worktree (#2488)
- fix(gui): sync canvas grid with viewport (#2489)

## Version

v9.20.0 (minor)

## Closing Issues

None

## Related Issues / Links

#1934
#2008
#2359

## Testing

- cargo fmt --check
- cargo test -p gwt-core -p gwt
- cargo clippy --all-targets --all-features -- -D warnings
- bash scripts/check-release-flow.sh
- pre-push hook: coverage 90.67% and skill frontmatter validation
