### PR TITLE
fix(gui): align window controls aria target

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -386,11 +386,53 @@ test("chrome visibility uses edge handles instead of Project Bar text toggles", 
   assert.equal(sidebarToggle.textContent.trim(), "<<");
   assert.equal(windowControlsToggle.textContent.trim(), "vv");
   assert.equal(sidebarToggle.getAttribute("aria-controls"), "op-sidebar");
-  assert.equal(windowControlsToggle.getAttribute("aria-controls"), "floating-window-controls");
+  assert.equal(
+    windowControlsToggle.getAttribute("aria-controls"),
+    "floating-window-controls-primary floating-window-controls-add",
+  );
   assert.equal(sidebarToggle.getAttribute("aria-expanded"), "true");
   assert.equal(windowControlsToggle.getAttribute("aria-expanded"), "true");
   assert.match(sidebarToggle.getAttribute("aria-label") ?? "", /hide sidebar/i);
   assert.match(windowControlsToggle.getAttribute("aria-label") ?? "", /hide window controls/i);
+});
+
+test("window controls edge handle targets only collapsible control groups", () => {
+  const windowControlsToggle = document.getElementById("op-window-controls-edge-toggle");
+  assert.ok(windowControlsToggle, "expected bottom window controls edge visibility handle");
+
+  const controlledIds = (windowControlsToggle.getAttribute("aria-controls") ?? "")
+    .split(/\s+/)
+    .filter(Boolean);
+  assert.deepEqual(controlledIds, [
+    "floating-window-controls-primary",
+    "floating-window-controls-add",
+  ]);
+  assert.ok(!controlledIds.includes("floating-window-controls"));
+
+  const primaryGroup = document.getElementById("floating-window-controls-primary");
+  const addGroup = document.getElementById("floating-window-controls-add");
+  assert.ok(primaryGroup, "expected primary window controls group");
+  assert.ok(addGroup, "expected add-window control group");
+
+  for (const id of ["tile-button", "stack-button", "align-button", "window-list-button"]) {
+    const control = document.getElementById(id);
+    assert.ok(control, `expected ${id}`);
+    assert.ok(primaryGroup.contains(control), `${id} must be inside the primary controlled group`);
+  }
+
+  const addButton = document.getElementById("add-button");
+  assert.ok(addButton, "expected add-button");
+  assert.ok(addGroup.contains(addButton), "add-button must be inside the add controlled group");
+
+  for (const id of ["op-palette-button", "zoom-out-button", "zoom-reset-button", "zoom-in-button"]) {
+    const control = document.getElementById(id);
+    assert.ok(control, `expected ${id}`);
+    assert.equal(
+      primaryGroup.contains(control) || addGroup.contains(control),
+      false,
+      `${id} must remain outside collapsible window controls groups`,
+    );
+  }
 });
 
 test("floating window controls mark only window operations as hideable", () => {
@@ -516,7 +558,9 @@ test("app state rendering dismisses Mission Briefing so startup cannot stay on s
 
 test("components.css hides only marked floating window controls", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
-  assert.match(css, /\[data-op-window-controls="hidden"\][\s\S]+\.floating-actions \[data-window-control="true"\]/);
+  assert.match(css, /\[data-op-window-controls="hidden"\][\s\S]+#floating-window-controls-primary/);
+  assert.match(css, /\[data-op-window-controls="hidden"\][\s\S]+#floating-window-controls-add/);
+  assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+\.floating-actions \[data-window-control="true"\]/);
   assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+#op-palette-button/);
   assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+#zoom-reset-button/);
 });

--- a/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
+++ b/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
@@ -57,6 +57,10 @@ test("Operator shell toggles chrome visibility through edge handles", async () =
     const windowControlsHandle = document.getElementById("op-window-controls-edge-toggle");
     assert.ok(sidebarHandle, "fixture must include sidebar edge handle");
     assert.ok(windowControlsHandle, "fixture must include window controls edge handle");
+    assert.equal(
+      windowControlsHandle.getAttribute("aria-controls"),
+      "floating-window-controls-primary floating-window-controls-add",
+    );
 
     sidebarHandle.click();
     assert.equal(document.documentElement.dataset.opSidebar, "collapsed");

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -279,6 +279,12 @@
         gap: 8px;
       }
 
+      .floating-window-controls-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
       .window-list-shell {
         position: relative;
       }
@@ -3199,7 +3205,7 @@
               id="op-window-controls-edge-toggle"
               type="button"
               aria-label="Hide window controls"
-              aria-controls="floating-window-controls"
+              aria-controls="floating-window-controls-primary floating-window-controls-add"
               aria-expanded="true"
             >vv</button>
             <button
@@ -3212,25 +3218,29 @@
               <span class="op-palette-trigger__label">⌘K</span>
               <span class="op-palette-trigger__hint">Palette</span>
             </button>
-            <button class="arrange-button" id="tile-button" aria-label="Tile windows" data-window-control="true">Tile</button>
-            <button class="arrange-button" id="stack-button" aria-label="Stack windows" data-window-control="true">Stack</button>
-            <button class="arrange-button" id="align-button" aria-label="Align windows without resizing" data-window-control="true">Align</button>
-            <div class="window-list-shell" data-window-control="true">
-              <button
-                class="arrange-button"
-                id="window-list-button"
-                aria-label="List windows"
-                aria-expanded="false"
-                data-window-control="true"
-              >
-                Windows
-              </button>
-              <div class="window-list-panel" id="window-list-panel" hidden></div>
+            <div class="floating-window-controls-group" id="floating-window-controls-primary">
+              <button class="arrange-button" id="tile-button" aria-label="Tile windows" data-window-control="true">Tile</button>
+              <button class="arrange-button" id="stack-button" aria-label="Stack windows" data-window-control="true">Stack</button>
+              <button class="arrange-button" id="align-button" aria-label="Align windows without resizing" data-window-control="true">Align</button>
+              <div class="window-list-shell" data-window-control="true">
+                <button
+                  class="arrange-button"
+                  id="window-list-button"
+                  aria-label="List windows"
+                  aria-expanded="false"
+                  data-window-control="true"
+                >
+                  Windows
+                </button>
+                <div class="window-list-panel" id="window-list-panel" hidden></div>
+              </div>
             </div>
             <button class="arrange-button" id="zoom-out-button" aria-label="Zoom out">-</button>
             <button class="arrange-button" id="zoom-reset-button" aria-label="Reset zoom">100%</button>
             <button class="arrange-button" id="zoom-in-button" aria-label="Zoom in">+</button>
-            <button class="add-button" id="add-button" aria-label="Add window" data-window-control="true">+</button>
+            <div class="floating-window-controls-group" id="floating-window-controls-add">
+              <button class="add-button" id="add-button" aria-label="Add window" data-window-control="true">+</button>
+            </div>
           </div>
           <button
             class="op-edge-handle op-edge-handle--sidebar"

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1779,7 +1779,8 @@ kbd.op-kbd {
   left: 8px;
 }
 
-:root[data-theme][data-op-window-controls="hidden"] .floating-actions [data-window-control="true"] {
+:root[data-theme][data-op-window-controls="hidden"] #floating-window-controls-primary,
+:root[data-theme][data-op-window-controls="hidden"] #floating-window-controls-add {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- Fixes the post-merge review finding from #2492 by pointing the bottom window-controls edge handle at only the control groups that actually collapse.
- Keeps Palette and Zoom controls outside the collapsible region while Tile / Stack / Align / Windows / Add window remain hideable.

## Changes

- `crates/gwt/web/index.html`: wraps the collapsible window controls in `floating-window-controls-primary` and `floating-window-controls-add`, and updates `aria-controls` to reference those groups instead of the whole floating actions container.
- `crates/gwt/web/styles/components.css`: hides the ARIA-controlled groups when window controls are hidden, rather than hiding individual `data-window-control` descendants under the full toolbar.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds regression coverage that the edge handle controls only collapsible groups and excludes Palette/Zoom.
- `crates/gwt/web/__tests__/operator-shell-runtime.test.mjs`: verifies runtime fixtures use the corrected `aria-controls` contract.

## Testing

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — RED before implementation: failed on old `aria-controls="floating-window-controls"` and old CSS selector.
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/operator-shell-runtime.test.mjs` — passed, 66 tests.
- [x] `pnpm test:frontend-unit` — passed, 227 tests.
- [x] `pnpm test:frontend-bundle` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `git diff --check` — passed.
- [x] `pnpm exec playwright test --config crates/gwt/playwright/playwright.config.ts tests/chrome.spec.ts` — skipped by existing guard because `GWT_PLAYWRIGHT_BASE_URL` was unset.
- [x] `pnpm exec commitlint --from origin/develop --to HEAD` — passed.
- [x] `git push` pre-push checks — passed, coverage 90.67% against the 90% threshold.

## Closing Issues

- None

## Related Issues / Links

- #2356
- #2492

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend checks)
- [x] Documentation updated (not required: review follow-up clarifies existing SPEC #2356 behavior)
- [x] Migration/backfill plan included (not required: no schema or data change)
- [x] CHANGELOG impact considered (patch-level `fix(gui)`)

## Context

- PR #2492 was already merged, but Codex review left an unresolved accessibility thread: the handle advertised the entire floating toolbar as collapsed while Palette and Zoom remained visible. This PR makes the ARIA target match the actual collapsible controls.

## Risk / Impact

- **Affected areas**: Operator shell floating window controls only.
- **Rollback plan**: Revert commit `e0856e92` and the sync merge commit if the follow-up needs to be backed out.

## Screenshots

- Not captured in this environment; the available Playwright chrome smoke requires `GWT_PLAYWRIGHT_BASE_URL` and skipped by its existing guard. DOM/runtime/frontend tests cover the interaction and ARIA contract.
