### PR TITLE
chore(release): v9.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.20.1] - 2026-05-06
+
+### Bug Fixes
+
+- Make active work sidebar actionable
+- **gui:** Replace chrome text toggles with edge handles
+- **gui:** Align window controls aria target
+- Show owner purpose in agent window titles
+
+### Miscellaneous Tasks
+
+- Merge develop into work branch
+
 ## [9.20.0] - 2026-05-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "axum",
  "base64",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "chrono",
  "dunce",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "dirs",
  "serde",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.20.0"
+version = "9.20.1"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.20.0"
+version = "9.20.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -574,8 +574,19 @@ fn active_agent_summary_from_session(
 fn agent_launch_purpose_title(
     project_root: &Path,
     linked_issue_number: Option<u64>,
+    branch_name: Option<&str>,
+    issue_link_cache_dir: &Path,
 ) -> Option<String> {
-    let issue_number = linked_issue_number?;
+    linked_issue_number
+        .and_then(|issue_number| issue_title_from_cache(project_root, issue_number))
+        .or_else(|| {
+            linked_issue_number_for_branch(project_root, branch_name, issue_link_cache_dir)
+                .and_then(|issue_number| issue_title_from_cache(project_root, issue_number))
+        })
+        .or_else(|| workspace_projection_owner_title(project_root))
+}
+
+fn issue_title_from_cache(project_root: &Path, issue_number: u64) -> Option<String> {
     let repo_hash = gwt_core::repo_hash::detect_repo_hash(project_root)?;
     let cache_root = gwt_core::paths::gwt_cache_dir()
         .join("issues")
@@ -584,6 +595,32 @@ fn agent_launch_purpose_title(
         gwt_github::Cache::new(cache_root).load_entry(gwt_github::IssueNumber(issue_number))?;
     let title = entry.snapshot.title.trim();
     (!title.is_empty()).then(|| title.to_string())
+}
+
+fn linked_issue_number_for_branch(
+    project_root: &Path,
+    branch_name: Option<&str>,
+    issue_link_cache_dir: &Path,
+) -> Option<u64> {
+    let branch_name = branch_name?.trim();
+    if branch_name.is_empty() {
+        return None;
+    }
+    let repo_hash = gwt::index_worker::detect_repo_hash(project_root)?;
+    let path = issue_link_cache_dir
+        .join("issue-links")
+        .join(format!("{}.json", repo_hash.as_str()));
+    let bytes = std::fs::read(path).ok()?;
+    let store = serde_json::from_slice::<IssueBranchLinkStore>(&bytes).ok()?;
+    store.branches.get(branch_name).copied()
+}
+
+fn workspace_projection_owner_title(project_root: &Path) -> Option<String> {
+    let projection = gwt_core::workspace_projection::load_workspace_projection(project_root)
+        .ok()
+        .flatten()?;
+    let owner = projection.owner?.trim().to_string();
+    (!owner.is_empty()).then_some(owner)
 }
 
 fn upsert_workspace_agent(
@@ -2851,14 +2888,19 @@ impl AppRuntime {
         config: gwt_agent::LaunchConfig,
         bounds: WindowGeometry,
     ) -> Result<Vec<OutboundEvent>, String> {
+        let issue_link_cache_dir = self.issue_link_cache_dir.clone();
         let tab = self
             .tab_mut(tab_id)
             .ok_or_else(|| "Project tab not found".to_string())?;
         let project_root_path = tab.project_root.clone();
         let project_root = project_root_path.display().to_string();
         let title = config.display_name.clone();
-        let purpose_title =
-            agent_launch_purpose_title(&project_root_path, config.linked_issue_number);
+        let purpose_title = agent_launch_purpose_title(
+            &project_root_path,
+            config.linked_issue_number,
+            config.branch.as_deref(),
+            &issue_link_cache_dir,
+        );
         let window = tab
             .workspace
             .add_window_with_title(WindowPreset::Agent, title, false, bounds);
@@ -7300,6 +7342,93 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_agent_window_initial_title_uses_branch_issue_link_title() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_repo(&repo);
+        Cache::new(issue_cache_root(&repo))
+            .write_snapshot(&sample_issue_snapshot(
+                2468,
+                "SPEC: Branch linked purpose",
+                &["gwt-spec"],
+                "Spec body",
+                "2026-05-06T00:00:00Z",
+            ))
+            .expect("write issue cache");
+        write_issue_link_store(
+            &repo,
+            HashMap::from([("work/20260506-1257".to_string(), 2468)]),
+        );
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let config = gwt_agent::AgentLaunchBuilder::new(gwt_agent::AgentId::Codex)
+            .branch("work/20260506-1257")
+            .build();
+
+        runtime
+            .spawn_agent_window("tab-1", config, canvas_bounds())
+            .expect("spawn agent window");
+
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .find(|window| window.preset == WindowPreset::Agent)
+            .expect("agent window");
+        assert_eq!(
+            agent_window.purpose_title.as_deref(),
+            Some("SPEC: Branch linked purpose")
+        );
+        assert_eq!(agent_window.title, "Codex");
+    }
+
+    #[test]
+    fn app_runtime_agent_window_initial_title_falls_back_to_projection_owner() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_repo(&repo);
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.owner = Some("SPEC-2008".to_string());
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let config = gwt_agent::AgentLaunchBuilder::new(gwt_agent::AgentId::Codex)
+            .branch("work/20260506-1257")
+            .build();
+
+        runtime
+            .spawn_agent_window("tab-1", config, canvas_bounds())
+            .expect("spawn agent window");
+
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .find(|window| window.preset == WindowPreset::Agent)
+            .expect("agent window");
+        assert_eq!(agent_window.purpose_title.as_deref(), Some("SPEC-2008"));
+        assert_eq!(agent_window.title, "Codex");
+    }
+
+    #[test]
     fn app_runtime_board_milestone_updates_same_session_agent_window_dynamic_title_only() {
         let _env_lock = env_test_lock()
             .lock()
@@ -7398,6 +7527,40 @@ exit 0
                 .dynamic_title
                 .as_deref(),
             None
+        );
+    }
+
+    #[test]
+    fn app_runtime_runtime_hook_state_does_not_update_agent_window_dynamic_title() {
+        let temp = tempdir().expect("tempdir");
+        let mut tab = sample_project_tab_with_window(
+            "tab-1",
+            "codex-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        tab.workspace
+            .set_dynamic_title("codex-1", Some("Board milestone focus".to_string()));
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "codex-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            sample_active_agent_session("tab-1", &window_id),
+        );
+
+        let events = runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"));
+
+        assert!(events
+            .iter()
+            .any(|event| matches!(event.event, BackendEvent::TerminalStatus { .. })));
+        let tab = runtime.tab("tab-1").expect("tab");
+        assert_eq!(
+            tab.workspace
+                .window("codex-1")
+                .expect("codex window")
+                .dynamic_title
+                .as_deref(),
+            Some("Board milestone focus")
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -386,11 +386,53 @@ test("chrome visibility uses edge handles instead of Project Bar text toggles", 
   assert.equal(sidebarToggle.textContent.trim(), "<<");
   assert.equal(windowControlsToggle.textContent.trim(), "vv");
   assert.equal(sidebarToggle.getAttribute("aria-controls"), "op-sidebar");
-  assert.equal(windowControlsToggle.getAttribute("aria-controls"), "floating-window-controls");
+  assert.equal(
+    windowControlsToggle.getAttribute("aria-controls"),
+    "floating-window-controls-primary floating-window-controls-add",
+  );
   assert.equal(sidebarToggle.getAttribute("aria-expanded"), "true");
   assert.equal(windowControlsToggle.getAttribute("aria-expanded"), "true");
   assert.match(sidebarToggle.getAttribute("aria-label") ?? "", /hide sidebar/i);
   assert.match(windowControlsToggle.getAttribute("aria-label") ?? "", /hide window controls/i);
+});
+
+test("window controls edge handle targets only collapsible control groups", () => {
+  const windowControlsToggle = document.getElementById("op-window-controls-edge-toggle");
+  assert.ok(windowControlsToggle, "expected bottom window controls edge visibility handle");
+
+  const controlledIds = (windowControlsToggle.getAttribute("aria-controls") ?? "")
+    .split(/\s+/)
+    .filter(Boolean);
+  assert.deepEqual(controlledIds, [
+    "floating-window-controls-primary",
+    "floating-window-controls-add",
+  ]);
+  assert.ok(!controlledIds.includes("floating-window-controls"));
+
+  const primaryGroup = document.getElementById("floating-window-controls-primary");
+  const addGroup = document.getElementById("floating-window-controls-add");
+  assert.ok(primaryGroup, "expected primary window controls group");
+  assert.ok(addGroup, "expected add-window control group");
+
+  for (const id of ["tile-button", "stack-button", "align-button", "window-list-button"]) {
+    const control = document.getElementById(id);
+    assert.ok(control, `expected ${id}`);
+    assert.ok(primaryGroup.contains(control), `${id} must be inside the primary controlled group`);
+  }
+
+  const addButton = document.getElementById("add-button");
+  assert.ok(addButton, "expected add-button");
+  assert.ok(addGroup.contains(addButton), "add-button must be inside the add controlled group");
+
+  for (const id of ["op-palette-button", "zoom-out-button", "zoom-reset-button", "zoom-in-button"]) {
+    const control = document.getElementById(id);
+    assert.ok(control, `expected ${id}`);
+    assert.equal(
+      primaryGroup.contains(control) || addGroup.contains(control),
+      false,
+      `${id} must remain outside collapsible window controls groups`,
+    );
+  }
 });
 
 test("floating window controls mark only window operations as hideable", () => {
@@ -516,7 +558,9 @@ test("app state rendering dismisses Mission Briefing so startup cannot stay on s
 
 test("components.css hides only marked floating window controls", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
-  assert.match(css, /\[data-op-window-controls="hidden"\][\s\S]+\.floating-actions \[data-window-control="true"\]/);
+  assert.match(css, /\[data-op-window-controls="hidden"\][\s\S]+#floating-window-controls-primary/);
+  assert.match(css, /\[data-op-window-controls="hidden"\][\s\S]+#floating-window-controls-add/);
+  assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+\.floating-actions \[data-window-control="true"\]/);
   assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+#op-palette-button/);
   assert.doesNotMatch(css, /\[data-op-window-controls="hidden"\][\s\S]+#zoom-reset-button/);
 });

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -110,8 +110,8 @@ test("Workspace sidebar exposes active work and per-agent overview", () => {
   );
   assert.match(
     appSource,
-    /function\s+renderActiveWorkOverview\(\)[\s\S]+activeWorkProjection\.agents/,
-    "expected frontend to render per-agent projection data, not only aggregate counters",
+    /function\s+renderActiveWorkOverview\(\)[\s\S]+activeWorkFocusableAgents\(activeWorkProjection\)/,
+    "expected frontend to render focusable per-agent projection data, not only aggregate counters",
   );
   assert.match(
     appSource,
@@ -207,6 +207,39 @@ test("Workspace active work overview behaves like a command center", () => {
     appSource,
     /data-board-entry-id/,
     "expected Board timeline entries to be addressable from Workspace links",
+  );
+});
+
+test("Active Work sidebar only focuses live Agent windows and falls back to Quick Start", () => {
+  assert.match(
+    appSource,
+    /function\s+activeWorkFocusableAgents\(projection\)[\s\S]+workspaceWindowById\(agent\.window_id\)/,
+    "expected Active Work cards to be filtered against live workspace windows",
+  );
+  assert.match(
+    appSource,
+    /function\s+renderActiveWorkQuickStart\(\)[\s\S]+Quick Start[\s\S]+kind:\s*"open_start_work"/,
+    "expected no-Agent Active Work state to offer Quick Start through Start Work",
+  );
+  assert.match(
+    appSource,
+    /function\s+focusActiveWorkAgentWindow\(agent\)[\s\S]+restore_window[\s\S]+focusWindowRemotely\(agent\.window_id,\s*\{\s*center:\s*true\s*\}\)/,
+    "expected Focus to restore minimized Agent windows before focusing them",
+  );
+  assert.match(
+    appSource,
+    /function\s+agentStatusLabel\(state\)[\s\S]+Running[\s\S]+Blocked[\s\S]+Idle[\s\S]+Done/,
+    "expected raw active/blocked/idle/done status values to be mapped to user-facing labels",
+  );
+  assert.doesNotMatch(
+    appSource,
+    /createNode\("div",\s*"op-agent-state",\s*state\)/,
+    "Active Work must not render raw status wire values such as ACTIVE",
+  );
+  assert.match(
+    appSource,
+    /function\s+renderAppState\(nextState\)[\s\S]+renderActiveWorkOverview\(\)/,
+    "expected workspace changes to re-evaluate whether Active Work agents are still focusable",
   );
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -334,15 +334,30 @@ test("Command Palette trigger button declares aria-keyshortcuts", () => {
   assert.ok(shortcut.includes("Meta+P"), "trigger must declare Meta+P");
 });
 
-test("Project Bar exposes persistent chrome visibility toggles", () => {
-  const sidebarToggle = document.getElementById("op-sidebar-toggle");
-  const windowControlsToggle = document.getElementById("op-window-controls-toggle");
-  assert.ok(sidebarToggle, "expected Project Bar sidebar visibility toggle");
-  assert.ok(windowControlsToggle, "expected Project Bar window controls visibility toggle");
-  assert.equal(sidebarToggle.getAttribute("aria-pressed"), "true");
-  assert.equal(windowControlsToggle.getAttribute("aria-pressed"), "true");
-  assert.match(sidebarToggle.getAttribute("aria-label") ?? "", /sidebar/i);
-  assert.match(windowControlsToggle.getAttribute("aria-label") ?? "", /window controls/i);
+test("chrome visibility uses edge handles instead of Project Bar text toggles", () => {
+  assert.equal(
+    document.getElementById("op-sidebar-toggle"),
+    null,
+    "Project Bar must not expose a SIDEBAR text toggle",
+  );
+  assert.equal(
+    document.getElementById("op-window-controls-toggle"),
+    null,
+    "Project Bar must not expose a WINDOWS text toggle",
+  );
+
+  const sidebarToggle = document.getElementById("op-sidebar-edge-toggle");
+  const windowControlsToggle = document.getElementById("op-window-controls-edge-toggle");
+  assert.ok(sidebarToggle, "expected sidebar edge visibility handle");
+  assert.ok(windowControlsToggle, "expected bottom window controls edge visibility handle");
+  assert.equal(sidebarToggle.textContent.trim(), "<<");
+  assert.equal(windowControlsToggle.textContent.trim(), "vv");
+  assert.equal(sidebarToggle.getAttribute("aria-controls"), "op-sidebar");
+  assert.equal(windowControlsToggle.getAttribute("aria-controls"), "floating-window-controls");
+  assert.equal(sidebarToggle.getAttribute("aria-expanded"), "true");
+  assert.equal(windowControlsToggle.getAttribute("aria-expanded"), "true");
+  assert.match(sidebarToggle.getAttribute("aria-label") ?? "", /hide sidebar/i);
+  assert.match(windowControlsToggle.getAttribute("aria-label") ?? "", /hide window controls/i);
 });
 
 test("floating window controls mark only window operations as hideable", () => {
@@ -490,6 +505,10 @@ test("operator-shell persists sidebar and window controls visibility independent
   assert.match(operatorShell, /WINDOW_CONTROLS_KEY\s*=\s*"gwt:ui:window-controls"/);
   assert.match(operatorShell, /opWindowControls/);
   assert.match(operatorShell, /window-controls-changed/);
+  assert.match(operatorShell, /op-sidebar-edge-toggle/);
+  assert.match(operatorShell, /op-window-controls-edge-toggle/);
+  assert.doesNotMatch(operatorShell, /op-sidebar-toggle/);
+  assert.doesNotMatch(operatorShell, /op-window-controls-toggle/);
 });
 
 test("components.css declares Status Strip BLOCKED pulse + live indicator", () => {

--- a/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
+++ b/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
@@ -57,6 +57,10 @@ test("Operator shell toggles chrome visibility through edge handles", async () =
     const windowControlsHandle = document.getElementById("op-window-controls-edge-toggle");
     assert.ok(sidebarHandle, "fixture must include sidebar edge handle");
     assert.ok(windowControlsHandle, "fixture must include window controls edge handle");
+    assert.equal(
+      windowControlsHandle.getAttribute("aria-controls"),
+      "floating-window-controls-primary floating-window-controls-add",
+    );
 
     sidebarHandle.click();
     assert.equal(document.documentElement.dataset.opSidebar, "collapsed");

--- a/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
+++ b/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
@@ -33,6 +33,50 @@ test("Operator shell fails open when browser storage and media APIs are unavaila
   assert.equal(briefing.hidden, true, "Mission Briefing must not block app startup");
 });
 
+test("Operator shell toggles chrome visibility through edge handles", async () => {
+  const { initOperatorShell } = await importOperatorShell();
+  const { document, window } = parseHTML(html);
+  const storage = memoryStorage();
+  const testWindow = {
+    ...window,
+    localStorage: storage,
+    sessionStorage: memoryStorage(),
+    matchMedia: () => {
+      throw new Error("skip animated shell loops in runtime fixture");
+    },
+  };
+
+  const originalWarn = console.warn;
+  const originalCustomEvent = globalThis.CustomEvent;
+  console.warn = () => {};
+  globalThis.CustomEvent = window.CustomEvent;
+  try {
+    initOperatorShell({ document, window: testWindow });
+
+    const sidebarHandle = document.getElementById("op-sidebar-edge-toggle");
+    const windowControlsHandle = document.getElementById("op-window-controls-edge-toggle");
+    assert.ok(sidebarHandle, "fixture must include sidebar edge handle");
+    assert.ok(windowControlsHandle, "fixture must include window controls edge handle");
+
+    sidebarHandle.click();
+    assert.equal(document.documentElement.dataset.opSidebar, "collapsed");
+    assert.equal(sidebarHandle.textContent, ">>");
+    assert.equal(sidebarHandle.getAttribute("aria-expanded"), "false");
+    assert.equal(sidebarHandle.getAttribute("aria-label"), "Show sidebar");
+    assert.equal(storage.getItem("gwt:ui:sidebar-collapsed"), "true");
+
+    windowControlsHandle.click();
+    assert.equal(document.documentElement.dataset.opWindowControls, "hidden");
+    assert.equal(windowControlsHandle.textContent, "^^");
+    assert.equal(windowControlsHandle.getAttribute("aria-expanded"), "false");
+    assert.equal(windowControlsHandle.getAttribute("aria-label"), "Show window controls");
+    assert.equal(storage.getItem("gwt:ui:window-controls"), "hidden");
+  } finally {
+    console.warn = originalWarn;
+    globalThis.CustomEvent = originalCustomEvent;
+  }
+});
+
 function throwingStorage() {
   return {
     getItem() {
@@ -43,6 +87,21 @@ function throwingStorage() {
     },
     removeItem() {
       throw new Error("storage unavailable");
+    },
+  };
+}
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
     },
   };
 }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -868,6 +868,7 @@
         renderProjectOnboarding(tab);
         renderWorkspace(tab?.workspace || emptyWorkspace());
         renderWindowList();
+        renderActiveWorkOverview();
       }
 
       let presetModalFocusReturn = null;
@@ -1270,10 +1271,55 @@
         }
       }
 
-      function activeWorkAgentCount(projection) {
+      function activeWorkFocusableAgents(projection) {
         const agents = Array.isArray(projection?.agents) ? projection.agents : [];
-        if (agents.length > 0) return agents.length;
-        return Number(projection?.active_agents || 0) + Number(projection?.blocked_agents || 0);
+        return agents.filter((agent) => {
+          if (!agent?.window_id) return false;
+          const windowData = workspaceWindowById(agent.window_id);
+          if (!windowData || !presetSupportsWaitingStatus(windowData.preset)) return false;
+          const status = String(windowData.status || "running").toLowerCase();
+          return status !== "stopped" && status !== "exited" && status !== "error";
+        });
+      }
+
+      function agentStatusLabel(state) {
+        switch (String(state || "").toLowerCase()) {
+          case "active":
+            return "Running";
+          case "blocked":
+            return "Blocked";
+          case "idle":
+            return "Idle";
+          case "done":
+            return "Done";
+          default:
+            return "Unknown";
+        }
+      }
+
+      function focusActiveWorkAgentWindow(agent) {
+        if (!agent?.window_id) return;
+        const windowData = workspaceWindowById(agent.window_id);
+        if (!windowData) return;
+        if (windowData.minimized) {
+          send({ kind: "restore_window", id: agent.window_id });
+        }
+        focusWindowRemotely(agent.window_id, { center: true });
+      }
+
+      function renderActiveWorkQuickStart() {
+        activeWorkSummary.appendChild(createNode("div", "op-work-title", "Quick Start"));
+        activeWorkSummary.appendChild(
+          createNode("div", "op-work-status", "No agents are running."),
+        );
+        const actions = createNode("div", "op-work-actions");
+        const quickStart = createNode("button", "op-work-action", "Quick Start");
+        quickStart.type = "button";
+        quickStart.addEventListener("click", () => {
+          send({ kind: "open_start_work" });
+        });
+        actions.appendChild(quickStart);
+        activeWorkSummary.appendChild(actions);
       }
 
       function projectionIssueNumber(projection) {
@@ -1341,15 +1387,18 @@
 
         if (!activeWorkProjection) {
           if (activeWorkCount) activeWorkCount.textContent = "0";
-          activeWorkSummary.appendChild(createNode("div", "op-work-empty", "No active work"));
+          renderActiveWorkQuickStart();
           return;
         }
 
-        const agents = Array.isArray(activeWorkProjection.agents)
-          ? activeWorkProjection.agents
-          : [];
-        const agentCount = activeWorkAgentCount(activeWorkProjection);
+        const agents = activeWorkFocusableAgents(activeWorkProjection);
+        const agentCount = agents.length;
         if (activeWorkCount) activeWorkCount.textContent = String(agentCount);
+
+        if (agentCount === 0) {
+          renderActiveWorkQuickStart();
+          return;
+        }
 
         activeWorkSummary.appendChild(
           createNode("div", "op-work-title", activeWorkProjection.title || "Active Work"),
@@ -1393,15 +1442,8 @@
           activeWorkSummary.appendChild(actions);
         }
 
-        if (agents.length === 0) {
-          activeWorkAgents.appendChild(
-            createNode("div", "op-work-empty", "Agent details unavailable"),
-          );
-          return;
-        }
-
         for (const agent of agents) {
-          const state = agent.status_category || "unknown";
+          const state = String(agent.status_category || "unknown").toLowerCase();
           const coordinationKind = String(agent.last_board_entry_kind || "").toLowerCase();
           const coordinationLabel = coordinationKindLabel(coordinationKind);
           const card = createNode("article", "op-agent-card");
@@ -1417,7 +1459,7 @@
           if (coordinationLabel) {
             chips.appendChild(createNode("div", "op-agent-kind", coordinationLabel));
           }
-          chips.appendChild(createNode("div", "op-agent-state", state));
+          chips.appendChild(createNode("div", "op-agent-state", agentStatusLabel(state)));
           head.appendChild(chips);
           card.appendChild(head);
 
@@ -1437,14 +1479,12 @@
           }
 
           const agentActions = createNode("div", "op-agent-actions");
-          if (agent.window_id) {
-            const focusButton = createNode("button", "op-agent-action", "Focus");
-            focusButton.type = "button";
-            focusButton.addEventListener("click", () => {
-              focusWindowRemotely(agent.window_id, { center: true });
-            });
-            agentActions.appendChild(focusButton);
-          }
+          const focusButton = createNode("button", "op-agent-action", "Focus");
+          focusButton.type = "button";
+          focusButton.addEventListener("click", () => {
+            focusActiveWorkAgentWindow(agent);
+          });
+          agentActions.appendChild(focusButton);
           if (agent.last_board_entry_id) {
             const boardButton = createNode("button", "op-agent-action", "Open Entry");
             boardButton.type = "button";

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3060,24 +3060,6 @@
             <button class="arrange-button" id="open-project-button" aria-label="Open project">
               Open Project
             </button>
-            <button
-              class="op-chrome-toggle"
-              id="op-sidebar-toggle"
-              type="button"
-              aria-label="Hide sidebar"
-              aria-pressed="true"
-            >
-              Sidebar
-            </button>
-            <button
-              class="op-chrome-toggle"
-              id="op-window-controls-toggle"
-              type="button"
-              aria-label="Hide window controls"
-              aria-pressed="true"
-            >
-              Windows
-            </button>
             <div
               class="op-theme-toggle"
               id="op-theme-toggle"
@@ -3211,7 +3193,15 @@
               </button>
             </div>
           </div>
-          <div class="floating-actions">
+          <div class="floating-actions" id="floating-window-controls">
+            <button
+              class="op-edge-handle op-edge-handle--windows"
+              id="op-window-controls-edge-toggle"
+              type="button"
+              aria-label="Hide window controls"
+              aria-controls="floating-window-controls"
+              aria-expanded="true"
+            >vv</button>
             <button
               class="arrange-button op-palette-trigger"
               id="op-palette-button"
@@ -3242,6 +3232,14 @@
             <button class="arrange-button" id="zoom-in-button" aria-label="Zoom in">+</button>
             <button class="add-button" id="add-button" aria-label="Add window" data-window-control="true">+</button>
           </div>
+          <button
+            class="op-edge-handle op-edge-handle--sidebar"
+            id="op-sidebar-edge-toggle"
+            type="button"
+            aria-label="Hide sidebar"
+            aria-controls="op-sidebar"
+            aria-expanded="true"
+          ><<</button>
         </div>
         <footer
           class="op-status-strip"

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -279,6 +279,12 @@
         gap: 8px;
       }
 
+      .floating-window-controls-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
       .window-list-shell {
         position: relative;
       }
@@ -3199,7 +3205,7 @@
               id="op-window-controls-edge-toggle"
               type="button"
               aria-label="Hide window controls"
-              aria-controls="floating-window-controls"
+              aria-controls="floating-window-controls-primary floating-window-controls-add"
               aria-expanded="true"
             >vv</button>
             <button
@@ -3212,25 +3218,29 @@
               <span class="op-palette-trigger__label">⌘K</span>
               <span class="op-palette-trigger__hint">Palette</span>
             </button>
-            <button class="arrange-button" id="tile-button" aria-label="Tile windows" data-window-control="true">Tile</button>
-            <button class="arrange-button" id="stack-button" aria-label="Stack windows" data-window-control="true">Stack</button>
-            <button class="arrange-button" id="align-button" aria-label="Align windows without resizing" data-window-control="true">Align</button>
-            <div class="window-list-shell" data-window-control="true">
-              <button
-                class="arrange-button"
-                id="window-list-button"
-                aria-label="List windows"
-                aria-expanded="false"
-                data-window-control="true"
-              >
-                Windows
-              </button>
-              <div class="window-list-panel" id="window-list-panel" hidden></div>
+            <div class="floating-window-controls-group" id="floating-window-controls-primary">
+              <button class="arrange-button" id="tile-button" aria-label="Tile windows" data-window-control="true">Tile</button>
+              <button class="arrange-button" id="stack-button" aria-label="Stack windows" data-window-control="true">Stack</button>
+              <button class="arrange-button" id="align-button" aria-label="Align windows without resizing" data-window-control="true">Align</button>
+              <div class="window-list-shell" data-window-control="true">
+                <button
+                  class="arrange-button"
+                  id="window-list-button"
+                  aria-label="List windows"
+                  aria-expanded="false"
+                  data-window-control="true"
+                >
+                  Windows
+                </button>
+                <div class="window-list-panel" id="window-list-panel" hidden></div>
+              </div>
             </div>
             <button class="arrange-button" id="zoom-out-button" aria-label="Zoom out">-</button>
             <button class="arrange-button" id="zoom-reset-button" aria-label="Reset zoom">100%</button>
             <button class="arrange-button" id="zoom-in-button" aria-label="Zoom in">+</button>
-            <button class="add-button" id="add-button" aria-label="Add window" data-window-control="true">+</button>
+            <div class="floating-window-controls-group" id="floating-window-controls-add">
+              <button class="add-button" id="add-button" aria-label="Add window" data-window-control="true">+</button>
+            </div>
           </div>
           <button
             class="op-edge-handle op-edge-handle--sidebar"

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -94,8 +94,8 @@ function hideMissionBriefingImmediately(doc) {
 // ------------------------------------------------------------
 
 function wireChromeVisibility({ doc, win }) {
-  const sidebarButton = doc.getElementById("op-sidebar-toggle");
-  const windowControlsButton = doc.getElementById("op-window-controls-toggle");
+  const sidebarButton = doc.getElementById("op-sidebar-edge-toggle");
+  const windowControlsButton = doc.getElementById("op-window-controls-edge-toggle");
   const root = doc.documentElement;
 
   let sidebarVisible = readBoolean(win, SIDEBAR_COLLAPSED_KEY, false) !== true;
@@ -105,7 +105,8 @@ function wireChromeVisibility({ doc, win }) {
     if (sidebarVisible) delete root.dataset.opSidebar;
     else root.dataset.opSidebar = "collapsed";
     if (!sidebarButton) return;
-    sidebarButton.setAttribute("aria-pressed", sidebarVisible ? "true" : "false");
+    sidebarButton.textContent = sidebarVisible ? "<<" : ">>";
+    sidebarButton.setAttribute("aria-expanded", sidebarVisible ? "true" : "false");
     sidebarButton.setAttribute("aria-label", sidebarVisible ? "Hide sidebar" : "Show sidebar");
   };
 
@@ -113,7 +114,8 @@ function wireChromeVisibility({ doc, win }) {
     if (windowControlsVisible) delete root.dataset.opWindowControls;
     else root.dataset.opWindowControls = "hidden";
     if (!windowControlsButton) return;
-    windowControlsButton.setAttribute("aria-pressed", windowControlsVisible ? "true" : "false");
+    windowControlsButton.textContent = windowControlsVisible ? "vv" : "^^";
+    windowControlsButton.setAttribute("aria-expanded", windowControlsVisible ? "true" : "false");
     windowControlsButton.setAttribute(
       "aria-label",
       windowControlsVisible ? "Hide window controls" : "Show window controls",

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1779,7 +1779,8 @@ kbd.op-kbd {
   left: 8px;
 }
 
-:root[data-theme][data-op-window-controls="hidden"] .floating-actions [data-window-control="true"] {
+:root[data-theme][data-op-window-controls="hidden"] #floating-window-controls-primary,
+:root[data-theme][data-op-window-controls="hidden"] #floating-window-controls-add {
   display: none;
 }
 

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -465,6 +465,10 @@ body::after {
   color: var(--agent-codex);
 }
 
+.op-agent-state {
+  text-transform: none;
+}
+
 .op-agent-card[data-state="blocked"] .op-agent-state {
   border-color: var(--color-state-blocked);
   color: var(--color-state-blocked);

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -133,39 +133,6 @@ body::after {
   font-weight: 500;
 }
 
-/* Project Bar trailing chrome buttons */
-.op-chrome-toggle {
-  appearance: none;
-  background: transparent;
-  border: 1px solid var(--color-border-strong);
-  color: var(--color-text);
-  height: 26px;
-  padding: 0 var(--space-3);
-  border-radius: var(--radius-pill);
-  font: inherit;
-  font-family: var(--font-mono);
-  font-size: var(--type-xs);
-  letter-spacing: var(--tracking-mono);
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: border-color var(--motion-fast) var(--motion-curve),
-              color var(--motion-fast) var(--motion-curve),
-              background var(--motion-fast) var(--motion-curve);
-}
-
-.op-chrome-toggle:hover,
-.op-chrome-toggle:focus-visible {
-  outline: none;
-  border-color: var(--color-focus-ring);
-  color: var(--color-focus-ring);
-}
-
-.op-chrome-toggle[aria-pressed="false"] {
-  color: var(--color-text-muted);
-  border-color: var(--color-border);
-  background: color-mix(in oklab, var(--color-text-muted) 10%, transparent);
-}
-
 /* SPEC-2356 FR-024 — segmented theme toggle (AUTO / DARK / LIGHT). Replaces
    the prior single-cycle button so AUTO is reachable in one interaction. */
 .op-theme-toggle {
@@ -587,6 +554,45 @@ body::after {
 
 .canvas {
   background: var(--color-canvas);
+}
+
+.op-edge-handle {
+  appearance: none;
+  width: 34px;
+  min-width: 34px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: var(--shadow-1);
+  z-index: 35;
+}
+
+.op-edge-handle:hover {
+  background: var(--color-button-bg-hover);
+  border-color: var(--color-focus-ring);
+  color: var(--color-focus-ring);
+}
+
+.op-edge-handle--sidebar {
+  position: absolute;
+  top: 50%;
+  left: -17px;
+  transform: translateY(-50%);
+}
+
+.op-edge-handle--windows {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
 }
 
 .canvas-world-grid {
@@ -1405,6 +1411,7 @@ kbd.op-kbd {
 :root[data-theme] .recent-project-row:focus-visible,
 :root[data-theme] .live-session-button:focus-visible,
 :root[data-theme] .launch-choice-button:focus-visible,
+:root[data-theme] .op-edge-handle:focus-visible,
 /* SPEC-2356 — keyboard-navigable row patterns added in PRs #2464/#2465.
    Without these focus-visible rules, keyboard users couldn't see which
    row currently has focus when Tab'ing through the file tree or
@@ -1764,8 +1771,17 @@ kbd.op-kbd {
   display: none;
 }
 
+:root[data-theme][data-op-sidebar="collapsed"] .op-edge-handle--sidebar {
+  left: 8px;
+}
+
 :root[data-theme][data-op-window-controls="hidden"] .floating-actions [data-window-control="true"] {
   display: none;
+}
+
+:root[data-theme][data-op-window-controls="hidden"] .op-edge-handle--windows {
+  border-color: var(--color-state-active);
+  color: var(--color-state-active);
 }
 
 /* SPEC-2356 — smooth Sidebar collapse transition.
@@ -1791,6 +1807,7 @@ kbd.op-kbd {
 :root[data-theme] .launch-choice-button,
 :root[data-theme] .arrange-button,
 :root[data-theme] .add-button,
+:root[data-theme] .op-edge-handle,
 :root[data-theme] .wizard-button {
   transition: background var(--motion-fast) var(--motion-curve),
               border-color var(--motion-fast) var(--motion-curve),
@@ -1804,6 +1821,7 @@ kbd.op-kbd {
   :root[data-theme] .launch-choice-button,
   :root[data-theme] .arrange-button,
   :root[data-theme] .add-button,
+  :root[data-theme] .op-edge-handle,
   :root[data-theme] .wizard-button {
     transition: none;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.20.0",
+  "version": "9.20.1",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Patch release v9.20.1 collecting four GUI/UX bug fixes since v9.20.0.
- Closes the workflow loop opened by Active Work sidebar, edge handle chrome, agent window titles, and ARIA scope follow-up.

## Changes

- fix: make active work sidebar actionable (#2491)
- fix(gui): replace chrome text toggles with edge handles (#2492)
- fix(gui): align window controls aria target (#2494)
- fix: show owner purpose in agent window titles (#2493)

## Version

- v9.20.1 (patch bump from v9.20.0)
- Conventional Commits since v9.20.0: `fix` x4, `feat` x0, BREAKING x0

## Closing Issues

None

## Related Issues / Links

- #2356
- #2359
- #2492

> Note: gwt-spec issue #2359 is excluded from auto-close by policy. PRs #2492 and #2494 referenced #2356 / #2492 only via Related Issues / Links, so they will not auto-close on this release.
