### PR TITLE
fix(gui): align no-overlap and persist tile/stack/align resize

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -387,11 +387,13 @@ mod tests {
         );
         assert!(
             html.contains("const wasMinimized = element.classList.contains(\"minimized\")")
-                && html.contains(
-                    "const shouldPersistTerminalGeometry = wasMinimized && !windowData.minimized",
-                )
+                && html.contains("const previousWidth = parseFloat(element.style.width")
+                && html.contains("const previousHeight = parseFloat(element.style.height")
+                && html.contains("const dimensionsChanged =")
+                && html.contains("(wasMinimized && !windowData.minimized) || dimensionsChanged",)
                 && html.contains("fitTerminal(windowData.id, shouldPersistTerminalGeometry)"),
-            "expected restored terminals to persist fitted geometry after becoming visible",
+            "expected terminals to persist fitted geometry to backend on \
+             restore-from-minimized OR window resize (Tile/Stack/Align)",
         );
     }
 

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -476,29 +476,40 @@ impl WorkspaceState {
         let count = open_indices.len();
         let columns = (count as f64).sqrt().ceil() as usize;
         let rows = count.div_ceil(columns);
-        let cell_width = ((bounds.width
-            - ARRANGE_PADDING * 2.0
-            - ARRANGE_PADDING * (columns.saturating_sub(1)) as f64)
-            / columns as f64)
-            .max(MIN_WINDOW_WIDTH);
-        let cell_height = ((bounds.height
-            - ARRANGE_PADDING * 2.0
-            - ARRANGE_PADDING * (rows.saturating_sub(1)) as f64)
-            / rows as f64)
-            .max(MIN_WINDOW_HEIGHT);
 
-        for (index, window_index) in open_indices.iter().enumerate() {
-            let window = &mut self.persisted.windows[*window_index];
-            let column = index % columns;
-            let row = index / columns;
+        for &window_index in open_indices {
+            let window = &mut self.persisted.windows[window_index];
             if let Some(geometry) = window.pre_maximize_geometry.take() {
                 window.geometry.width = geometry.width;
                 window.geometry.height = geometry.height;
             }
-            window.geometry.x =
-                bounds.x + ARRANGE_PADDING + column as f64 * (cell_width + ARRANGE_PADDING);
-            window.geometry.y =
-                bounds.y + ARRANGE_PADDING + row as f64 * (cell_height + ARRANGE_PADDING);
+        }
+
+        let mut column_widths = vec![0.0_f64; columns];
+        let mut row_heights = vec![0.0_f64; rows];
+        for (index, &window_index) in open_indices.iter().enumerate() {
+            let column = index % columns;
+            let row = index / columns;
+            let window = &self.persisted.windows[window_index];
+            column_widths[column] = column_widths[column].max(window.geometry.width);
+            row_heights[row] = row_heights[row].max(window.geometry.height);
+        }
+
+        let mut column_offsets = vec![bounds.x + ARRANGE_PADDING; columns];
+        for c in 1..columns {
+            column_offsets[c] = column_offsets[c - 1] + column_widths[c - 1] + ARRANGE_PADDING;
+        }
+        let mut row_offsets = vec![bounds.y + ARRANGE_PADDING; rows];
+        for r in 1..rows {
+            row_offsets[r] = row_offsets[r - 1] + row_heights[r - 1] + ARRANGE_PADDING;
+        }
+
+        for (index, &window_index) in open_indices.iter().enumerate() {
+            let column = index % columns;
+            let row = index / columns;
+            let window = &mut self.persisted.windows[window_index];
+            window.geometry.x = column_offsets[column];
+            window.geometry.y = row_offsets[row];
             window.maximized = false;
         }
     }
@@ -915,12 +926,72 @@ mod tests {
         let codex = workspace.window("codex-1").expect("codex");
         let file_tree = workspace.window("file-tree-1").expect("file tree");
 
+        // bounds: x=100, y=40, width=1000, height=760, padding=24
+        // columns=2, rows=2; column 0 max width = max(claude=720, file-tree=420) = 720
+        // column 1 max width = codex=720; row 0 max height = 420; row 1 max height = 520.
         assert_eq!(claude.geometry.x, 124.0);
         assert_eq!(claude.geometry.y, 64.0);
-        assert_eq!(codex.geometry.x, 612.0);
+        assert_eq!(codex.geometry.x, 868.0);
         assert_eq!(codex.geometry.y, 64.0);
         assert_eq!(file_tree.geometry.x, 124.0);
-        assert_eq!(file_tree.geometry.y, 432.0);
+        assert_eq!(file_tree.geometry.y, 508.0);
+    }
+
+    #[test]
+    fn align_arrangement_does_not_overlap_windows_with_varying_sizes() {
+        let mut workspace = WorkspaceState::from_persisted(empty_workspace_state());
+        let preset_sizes = [
+            (800.0, 360.0),
+            (420.0, 540.0),
+            (600.0, 380.0),
+            (500.0, 470.0),
+        ];
+        let mut ids = Vec::new();
+        for (width, height) in preset_sizes {
+            let window = workspace.add_window(WindowPreset::Settings, arrange_bounds());
+            ids.push(window.id.clone());
+            assert!(workspace.update_geometry(
+                &window.id,
+                WindowGeometry {
+                    x: 0.0,
+                    y: 0.0,
+                    width,
+                    height,
+                },
+            ));
+        }
+
+        assert!(workspace.arrange_windows(ArrangeMode::Align, arrange_bounds()));
+
+        let snapshot: Vec<_> = ids
+            .iter()
+            .map(|id| {
+                let window = workspace.window(id).expect("added window");
+                (id.clone(), window.geometry.clone())
+            })
+            .collect();
+
+        for (i, (id_a, a)) in snapshot.iter().enumerate() {
+            for (id_b, b) in snapshot.iter().skip(i + 1) {
+                let separated = a.x + a.width <= b.x
+                    || b.x + b.width <= a.x
+                    || a.y + a.height <= b.y
+                    || b.y + b.height <= a.y;
+                assert!(
+                    separated,
+                    "{id_a} and {id_b} overlap after Align: {:?} vs {:?}",
+                    a, b
+                );
+            }
+        }
+
+        // Width/height of every window must remain untouched (FR-004 / SC-017).
+        for ((id, geometry), (expected_width, expected_height)) in
+            snapshot.iter().zip(preset_sizes.iter())
+        {
+            assert_eq!(geometry.width, *expected_width, "{id} width preserved");
+            assert_eq!(geometry.height, *expected_height, "{id} height preserved");
+        }
     }
 
     #[test]
@@ -940,7 +1011,9 @@ mod tests {
         assert_eq!(claude.pre_maximize_geometry, None);
         assert_eq!(claude.geometry.width, original.width);
         assert_eq!(claude.geometry.height, original.height);
-        assert_eq!(claude.geometry.x, 612.0);
+        // After maximize, claude.z=3 sorts after codex.z=2 -> open_indices = [codex, claude].
+        // column 0 width = codex.width = 720, column 1 width = claude.width = 720.
+        assert_eq!(claude.geometry.x, 868.0);
         assert_eq!(claude.geometry.y, 64.0);
     }
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -6695,7 +6695,13 @@
           delete element.dataset.agentColor;
         }
         const wasMinimized = element.classList.contains("minimized");
-        const shouldPersistTerminalGeometry = wasMinimized && !windowData.minimized;
+        const previousWidth = parseFloat(element.style.width || "0");
+        const previousHeight = parseFloat(element.style.height || "0");
+        const dimensionsChanged =
+          previousWidth !== windowData.geometry.width ||
+          previousHeight !== windowData.geometry.height;
+        const shouldPersistTerminalGeometry =
+          (wasMinimized && !windowData.minimized) || dimensionsChanged;
         element.classList.toggle("minimized", Boolean(windowData.minimized));
         element.classList.toggle("maximized", Boolean(windowData.maximized));
         element.classList.toggle("tabbed", windowTabsFor(windowData).length > 1);


### PR DESCRIPTION
## Summary

- Align 実行時にウィンドウが重なる問題と、Tile / Stack / Align 直後にターミナル内描画が崩れる問題をまとめて修正します。
- `arrange_align` を列内最大幅・行内最大高でセル間隔を累積するアルゴリズムへ変更し、ウィンドウの幅・高さを維持したまま重なりを排除します。
- `renderWindow` の terminal geometry persist 判定を window 幅・高さ差分でも true にし、Tile / Stack / Align 直後でも backend PTY へ cols/rows が反映されるようにします。

## Context

- Align 実装は SPEC-2008 FR-004 / SC-017 通り「セル位置のみ更新、幅・高さ維持」だったが、cell 幅は viewport を等分割するため、ウィンドウ実幅 > cell 幅で隣セルへ侵入し重なっていた。
- `renderWindow` は arrange 経路で `fitTerminal(id, false)` のみ呼び、xterm の fit() はするが backend PTY へ cols/rows を送らないため、PTY 出力の折り返しと xterm 表示が整合せず描画崩れが発生していた。
- どちらも SPEC-2008 (Issue #2008) US-2 / US-4 / FR-004 / FR-007 が owner。FR-004 / SC-017 / FR-007 / US-2 受け入れシナリオ 5 に列内最大幅・行内最大高で重ならない記述と arrange 時の cols/rows 反映を追加し、SC-024 / US-2 受け入れシナリオ 6 を新設した。

## Changes

- `crates/gwt/src/workspace.rs`: `arrange_align` を列内最大幅・行内最大高でセル間隔を累積するアルゴリズムへ書き換え。異サイズ 4 ウィンドウで重なり非発生 unit test を追加し、既存 2 テストを新座標へ更新。
- `crates/gwt/web/app.js`: `renderWindow` で前回の `element.style.width / height` を読み取り、`(wasMinimized && !windowData.minimized) || dimensionsChanged` を `shouldPersistTerminalGeometry` に渡すよう拡張。
- `crates/gwt/src/embedded_web.rs`: terminal viewport refresh contract test を新しい persist 判定文字列を期待する形へ更新。
- SPEC-2008 (Issue #2008) `spec` / `tasks` セクションの FR-004 / FR-007 / SC-017 / SC-024 / US-2 受け入れシナリオ 5・6 と Phase 18 を更新（GitHub Issue 直接編集、リポジトリ差分外）。

## Testing

- [x] `cargo test -p gwt-core -p gwt` — 全テスト pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning なし
- [x] `cargo fmt -- --check` — 差分なし
- [x] `cargo build -p gwt` — ビルド成功
- [ ] 手動 GUI smoke (`cargo run -p gwt`): 複数 window で Tile / Stack / Align 直後にターミナル `printf` 出力で行折り返し・カーソル位置が崩れないこと、サイズ違いの 4 ウィンドウで Align が重ならず整列することを目視確認 — Reason: 開発環境 GUI が必要なため reviewer 側で確認をお願いします。

## Closing Issues

- None

## Related Issues / Links

- #2008 (SPEC-2008: Canvas ワークスペース — ビューポート・ウィンドウマネージャ・ターミナルサーフェス, in-progress)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — SPEC-2008 spec/tasks セクションを GitHub Issue 上で更新
- [x] Migration/backfill plan included (if schema/data change) — N/A: スキーマ変更なし
- [x] CHANGELOG impact considered (breaking change flagged in commit) — fix のため非破壊。CHANGELOG はリリース時に Conventional Commits 経由で自動反映される

## Notes

- 手動 GUI smoke (Phase 18 T-143) は実機 GUI でのみ確認可能なため、reviewer 側で目視確認をお願いします。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window alignment to dynamically calculate column and row dimensions based on actual window sizes rather than fixed grid sizing.
  * Enhanced preservation of window geometry during maximize, minimize, and resize operations.
  * Refined terminal rendering to better detect and maintain dimension changes during window operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->