### PR TITLE
fix(gui): regroup launch agent settings

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -770,6 +770,73 @@ test("Launch wizard choice buttons expose toggle state via aria-pressed", () => 
   );
 });
 
+test("Launch wizard separates launch settings from runtime controls", () => {
+  assert.equal(
+    appSource.includes("wizardAdvancedOpen"),
+    false,
+    "Launch wizard should not keep an Advanced disclosure state",
+  );
+  for (const retiredCopy of ["Advanced", "Show advanced", "Hide advanced"]) {
+    assert.equal(
+      appSource.includes(`"${retiredCopy}"`),
+      false,
+      `Launch wizard should not render ${retiredCopy}`,
+    );
+  }
+
+  const launchSettingsStart = appSource.indexOf(
+    'createLaunchSection(\n            "Launch settings"',
+  );
+  const linkedIssueStart = appSource.indexOf(
+    'createLaunchSection(\n            "Linked issue"',
+  );
+  const runtimeStart = appSource.indexOf(
+    'createLaunchSection(\n            "Runtime"',
+  );
+
+  assert.notEqual(launchSettingsStart, -1, "expected Launch settings section");
+  assert.notEqual(linkedIssueStart, -1, "expected Linked issue section");
+  assert.notEqual(runtimeStart, -1, "expected Runtime section");
+  assert.ok(
+    launchSettingsStart < linkedIssueStart && linkedIssueStart < runtimeStart,
+    "expected Launch settings before Linked issue and Runtime after Linked issue",
+  );
+
+  const launchSettingsBlock = appSource.slice(
+    launchSettingsStart,
+    linkedIssueStart,
+  );
+  for (const copy of ["Version", "Skip permission prompts", "Codex fast mode"]) {
+    assert.ok(
+      launchSettingsBlock.includes(`"${copy}"`),
+      `expected Launch settings to include ${copy}`,
+    );
+  }
+  assert.equal(
+    launchSettingsBlock.includes('"Runtime target"'),
+    false,
+    "Launch settings should not contain runtime target controls",
+  );
+
+  const runtimeBlock = appSource.slice(
+    runtimeStart,
+    appSource.indexOf("wizardBody.appendChild(panel);"),
+  );
+  for (const copy of ["Runtime target", "Docker service", "Docker lifecycle"]) {
+    assert.ok(
+      runtimeBlock.includes(`"${copy}"`),
+      `expected Runtime to include ${copy}`,
+    );
+  }
+  for (const copy of ["Version", "Skip permission prompts", "Codex fast mode"]) {
+    assert.equal(
+      runtimeBlock.includes(`"${copy}"`),
+      false,
+      `Runtime should not contain ${copy}`,
+    );
+  }
+});
+
 test("Selected list rows mark active item with aria-current", () => {
   // Same pattern as project tabs (PR #2455): list-style buttons with a
   // selected state need aria-current to announce which row is active.

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -190,7 +190,6 @@
           state: Object.freeze([
             "launchWizard",
             "wizardWasOpen",
-            "wizardAdvancedOpen",
             "wizardBranchDraft",
             "wizardBranchBackendValue",
           ]),
@@ -249,7 +248,6 @@
       let activeWorkProjection = null;
       let pendingBoardEntryFocusId = null;
       let wizardWasOpen = false;
-      let wizardAdvancedOpen = false;
       let wizardBranchDraft = "";
       let wizardBranchBackendValue = "";
       let branchCleanupWindowId = null;
@@ -4096,7 +4094,6 @@
       function syncWizardDraftState() {
         if (!launchWizard) {
           wizardWasOpen = false;
-          wizardAdvancedOpen = false;
           wizardBranchDraft = "";
           wizardBranchBackendValue = "";
           return;
@@ -4104,9 +4101,6 @@
 
         if (!wizardWasOpen) {
           wizardWasOpen = true;
-          wizardAdvancedOpen =
-            launchWizard.selected_runtime_target === "docker" ||
-            Boolean(launchWizard.selected_docker_service);
           wizardBranchDraft = launchWizard.branch_name || "";
           wizardBranchBackendValue = wizardBranchDraft;
           return;
@@ -4527,6 +4521,59 @@
           panel.appendChild(section);
         }
 
+        if (
+          launchWizard.show_version ||
+          launchWizard.show_skip_permissions ||
+          launchWizard.show_codex_fast_mode
+        ) {
+          const section = createLaunchSection(
+            "Launch settings",
+            "Version, permissions, and tool-specific launch behavior.",
+          );
+          const grid = createNode("div", "launch-form-grid");
+          if (launchWizard.show_version) {
+            appendSelectField(
+              grid,
+              "Version",
+              launchWizard.version_options || [],
+              launchWizard.selected_version,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_version",
+                  version: value,
+                }),
+            );
+          }
+          if (launchWizard.show_skip_permissions) {
+            appendCheckboxField(
+              grid,
+              "Permissions",
+              "Skip permission prompts",
+              launchWizard.skip_permissions,
+              (enabled) =>
+                sendWizardAction({
+                  kind: "set_skip_permissions",
+                  enabled,
+                }),
+            );
+          }
+          if (launchWizard.show_codex_fast_mode) {
+            appendCheckboxField(
+              grid,
+              "Codex fast mode",
+              "Use the fast service tier",
+              launchWizard.codex_fast_mode,
+              (enabled) =>
+                sendWizardAction({
+                  kind: "set_codex_fast_mode",
+                  enabled,
+                }),
+            );
+          }
+          section.appendChild(grid);
+          panel.appendChild(section);
+        }
+
         if (launchWizard.show_agent_settings) {
           const section = createLaunchSection(
             "Linked issue",
@@ -4561,122 +4608,64 @@
           panel.appendChild(section);
         }
 
-        {
+        if (
+          launchWizard.show_runtime_target ||
+          (launchWizard.show_docker_service &&
+            (launchWizard.docker_service_options || []).length > 0) ||
+          (launchWizard.show_docker_lifecycle &&
+            (launchWizard.docker_lifecycle_options || []).length > 0)
+        ) {
           const section = createLaunchSection(
-            "Advanced",
-            "Runtime target, versions, and launch flags.",
+            "Runtime",
+            "Choose where the session runs and how Docker services are used.",
           );
-          const toggleRow = createNode("div", "launch-toggle-row");
-          toggleRow.appendChild(
-            createNode(
-              "div",
-              "launch-note",
-              wizardAdvancedOpen
-                ? "Docker, version, permissions, and tool-specific flags."
-                : "Show runtime and launch flags.",
-            ),
-          );
-          const toggleButton = createNode(
-            "button",
-            "wizard-button",
-            wizardAdvancedOpen ? "Hide advanced" : "Show advanced",
-          );
-          toggleButton.type = "button";
-          toggleButton.addEventListener("click", () => {
-            wizardAdvancedOpen = !wizardAdvancedOpen;
-            renderLaunchWizard();
-          });
-          toggleRow.appendChild(toggleButton);
-          section.appendChild(toggleRow);
-
-          if (wizardAdvancedOpen) {
-            const grid = createNode("div", "launch-form-grid");
-            if (launchWizard.show_runtime_target) {
-              appendSelectField(
-                grid,
-                "Runtime target",
-                launchWizard.runtime_target_options || [],
-                launchWizard.selected_runtime_target,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_runtime_target",
-                    target: runtimeTargetPayload(value),
-                  }),
-              );
-            }
-            if (
-              launchWizard.show_docker_service &&
-              (launchWizard.docker_service_options || []).length > 0
-            ) {
-              appendSelectField(
-                grid,
-                "Docker service",
-                launchWizard.docker_service_options || [],
-                launchWizard.selected_docker_service,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_docker_service",
-                    service: value,
-                  }),
-              );
-            }
-            if (
-              launchWizard.show_docker_lifecycle &&
-              (launchWizard.docker_lifecycle_options || []).length > 0
-            ) {
-              appendSelectField(
-                grid,
-                "Docker lifecycle",
-                launchWizard.docker_lifecycle_options || [],
-                launchWizard.selected_docker_lifecycle,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_docker_lifecycle",
-                    intent: dockerLifecyclePayload(value),
-                  }),
-              );
-            }
-            if (launchWizard.show_version) {
-              appendSelectField(
-                grid,
-                "Version",
-                launchWizard.version_options || [],
-                launchWizard.selected_version,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_version",
-                    version: value,
-                  }),
-              );
-            }
-            if (launchWizard.show_skip_permissions) {
-              appendCheckboxField(
-                grid,
-                "Permissions",
-                "Skip permission prompts",
-                launchWizard.skip_permissions,
-                (enabled) =>
-                  sendWizardAction({
-                    kind: "set_skip_permissions",
-                    enabled,
-                  }),
-              );
-            }
-            if (launchWizard.show_codex_fast_mode) {
-              appendCheckboxField(
-                grid,
-                "Codex fast mode",
-                "Use the fast service tier",
-                launchWizard.codex_fast_mode,
-                (enabled) =>
-                  sendWizardAction({
-                    kind: "set_codex_fast_mode",
-                    enabled,
-                  }),
-              );
-            }
-            section.appendChild(grid);
+          const grid = createNode("div", "launch-form-grid");
+          if (launchWizard.show_runtime_target) {
+            appendSelectField(
+              grid,
+              "Runtime target",
+              launchWizard.runtime_target_options || [],
+              launchWizard.selected_runtime_target,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_runtime_target",
+                  target: runtimeTargetPayload(value),
+                }),
+            );
           }
+          if (
+            launchWizard.show_docker_service &&
+            (launchWizard.docker_service_options || []).length > 0
+          ) {
+            appendSelectField(
+              grid,
+              "Docker service",
+              launchWizard.docker_service_options || [],
+              launchWizard.selected_docker_service,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_docker_service",
+                  service: value,
+                }),
+            );
+          }
+          if (
+            launchWizard.show_docker_lifecycle &&
+            (launchWizard.docker_lifecycle_options || []).length > 0
+          ) {
+            appendSelectField(
+              grid,
+              "Docker lifecycle",
+              launchWizard.docker_lifecycle_options || [],
+              launchWizard.selected_docker_lifecycle,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_docker_lifecycle",
+                  intent: dockerLifecyclePayload(value),
+                }),
+            );
+          }
+          section.appendChild(grid);
 
           panel.appendChild(section);
         }


### PR DESCRIPTION
## Summary

- Regroups Launch Agent wizard fields so non-advanced launch choices are visible without an Advanced disclosure.
- Separates runtime and Docker controls from launch settings to make version, permissions, and fast mode easier to scan.

## Changes

- `crates/gwt/web/app.js`: Removed the Advanced disclosure state and rendering from the Launch Agent wizard.
- `crates/gwt/web/app.js`: Added a Launch settings section for Version, Skip permission prompts, and Codex fast mode.
- `crates/gwt/web/app.js`: Added a Runtime section for Runtime target, Docker service, and Docker lifecycle.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: Added a structural regression test for the new section grouping.
- `SPEC #2014`: Updated spec, plan, and tasks with the Launch Agent settings grouping requirement and verification evidence.

## Testing

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 65 tests passed.
- [x] `pnpm test:frontend-bundle` — JavaScript syntax checks passed.
- [x] `pnpm test:frontend-unit` — 228 tests passed.
- [x] `cargo test -p gwt embedded_web_ -- --nocapture` — 67 tests passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — all selected Rust tests passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `git push` pre-push checks — passed with filtered line coverage 90.69% (threshold 90.00%).

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This follows SPEC #2014 and moves fields out of the former Advanced grouping based on the requested Launch Agent wizard semantics.

## Risk / Impact

- **Affected areas**: Launch Agent wizard frontend rendering only; backend launch payloads and actions are unchanged.
- **Rollback plan**: Revert `fix(gui): regroup launch agent settings` if the grouping causes a UX regression.
