### PR TITLE
fix(gui): apply pending update from toast

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1180,10 +1180,7 @@ impl AppRuntime {
             FrontendEvent::LaunchWizardAction { action, bounds } => {
                 self.handle_launch_wizard_action(action, bounds)
             }
-            FrontendEvent::ApplyUpdate => {
-                std::thread::spawn(apply_update_and_exit);
-                vec![]
-            }
+            FrontendEvent::ApplyUpdate => self.apply_pending_update_events(&client_id),
             FrontendEvent::ListCustomAgents => vec![OutboundEvent::reply(
                 client_id,
                 gwt::custom_agents_dispatch::list_event(),
@@ -1252,6 +1249,46 @@ impl AppRuntime {
                 client_id, event,
             )]));
         });
+    }
+
+    fn apply_pending_update_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        match self.pending_update.clone() {
+            Some(
+                state @ gwt_core::update::UpdateState::Available {
+                    asset_url: Some(_), ..
+                },
+            ) => {
+                self.proxy.send(UserEvent::ApplyUpdate(state));
+                vec![]
+            }
+            Some(gwt_core::update::UpdateState::Available { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::UpdateApplyError {
+                    message: "No applicable update asset is available for this platform."
+                        .to_string(),
+                },
+            )],
+            Some(gwt_core::update::UpdateState::UpToDate { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::UpdateApplyError {
+                    message: "No pending update is available.".to_string(),
+                },
+            )],
+            Some(gwt_core::update::UpdateState::Failed { message, .. }) => {
+                vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::UpdateApplyError {
+                        message: format!("Update check failed: {message}"),
+                    },
+                )]
+            }
+            None => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::UpdateApplyError {
+                    message: "No pending update is available.".to_string(),
+                },
+            )],
+        }
     }
 
     pub(crate) fn frontend_sync_events(&self, client_id: &str) -> Vec<OutboundEvent> {
@@ -4642,6 +4679,76 @@ exit 0
             event.event,
             BackendEvent::UpdateState(gwt_core::update::UpdateState::UpToDate { .. })
         )));
+    }
+
+    #[test]
+    fn app_runtime_apply_update_uses_pending_available_update_state() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Shell],
+        );
+        let (mut runtime, events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+        runtime.pending_update = Some(gwt_core::update::UpdateState::Available {
+            current: "9.20.1".to_string(),
+            latest: "9.20.2".to_string(),
+            release_url: "https://example.invalid/releases/v9.20.2".to_string(),
+            asset_url: Some("https://example.invalid/gwt-macos-universal.dmg".to_string()),
+            checked_at: chrono::Utc::now(),
+        });
+
+        let outbound =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::ApplyUpdate);
+
+        assert!(outbound.is_empty(), "apply worker dispatch is internal");
+        wait_for_recorded_event("pending update apply", &events, |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    UserEvent::ApplyUpdate(gwt_core::update::UpdateState::Available {
+                        latest,
+                        asset_url: Some(asset_url),
+                        ..
+                    }) if latest == "9.20.2"
+                        && asset_url == "https://example.invalid/gwt-macos-universal.dmg"
+                )
+            })
+        });
+    }
+
+    #[test]
+    fn app_runtime_apply_update_without_applicable_pending_update_reports_error() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Shell],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.pending_update = Some(gwt_core::update::UpdateState::Available {
+            current: "9.20.1".to_string(),
+            latest: "9.20.2".to_string(),
+            release_url: "https://example.invalid/releases/v9.20.2".to_string(),
+            asset_url: None,
+            checked_at: chrono::Utc::now(),
+        });
+
+        let outbound =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::ApplyUpdate);
+
+        assert!(outbound.iter().any(|event| {
+            matches!(
+                &event.event,
+                BackendEvent::UpdateApplyError { message }
+                    if message.contains("No applicable update asset")
+            )
+        }));
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -92,7 +92,7 @@ pub(crate) use runtime_support::{
 pub(crate) use runtime_support::{
     parse_github_remote_url, spawn_env, suffixed_worktree_path, worktree_path_is_occupied,
 };
-pub(crate) use update_front_door::{apply_update_and_exit, spawn_startup_update_check};
+pub(crate) use update_front_door::{apply_update_state_and_exit, spawn_startup_update_check};
 #[cfg(test)]
 pub(crate) use update_front_door::{classify_startup_update_state, StartupUpdateAction};
 
@@ -151,6 +151,14 @@ fn spawn_project_index_status_check(runtime: &Runtime, proxy: EventLoopProxy<Use
             status,
         });
     }));
+}
+
+fn record_update_available(
+    app: &mut AppRuntime,
+    state: gwt_core::update::UpdateState,
+) -> Vec<OutboundEvent> {
+    app.pending_update = Some(state.clone());
+    vec![OutboundEvent::broadcast(BackendEvent::UpdateState(state))]
 }
 
 fn board_projection_watch_key(project_root: &Path) -> PathBuf {
@@ -482,6 +490,7 @@ enum UserEvent {
     IssueLaunchWizardPrepared(IssueLaunchWizardPrepared),
     Dispatch(Vec<OutboundEvent>),
     UpdateAvailable(gwt_core::update::UpdateState),
+    ApplyUpdate(gwt_core::update::UpdateState),
     /// SPEC-1934 FR-029: progress tick from
     /// `gwt::migration::execute_migration`. Re-broadcast as
     /// [`gwt::BackendEvent::MigrationProgress`].
@@ -1312,6 +1321,48 @@ mod tests {
             event.event,
             BackendEvent::UpdateState(gwt_core::update::UpdateState::UpToDate { .. })
         )));
+    }
+
+    #[test]
+    fn update_available_event_records_pending_update_before_broadcast() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Shell],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let state = gwt_core::update::UpdateState::Available {
+            current: "9.20.1".to_string(),
+            latest: "9.20.2".to_string(),
+            release_url: "https://example.invalid/releases/v9.20.2".to_string(),
+            asset_url: Some("https://example.invalid/gwt-macos-universal.dmg".to_string()),
+            checked_at: Utc::now(),
+        };
+
+        let events = super::record_update_available(&mut runtime, state);
+
+        assert!(matches!(
+            runtime.pending_update,
+            Some(gwt_core::update::UpdateState::Available {
+                ref latest,
+                asset_url: Some(_),
+                ..
+            }) if latest == "9.20.2"
+        ));
+        assert!(matches!(
+            events.as_slice(),
+            [OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::UpdateState(gwt_core::update::UpdateState::Available {
+                    latest,
+                    asset_url: Some(_),
+                    ..
+                }),
+            }] if latest == "9.20.2"
+        ));
     }
 
     #[test]
@@ -4641,7 +4692,10 @@ fn main() -> wry::Result<()> {
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::UpdateAvailable(state)) => {
-                app.pending_update = Some(state);
+                clients.dispatch(record_update_available(&mut app, state));
+            }
+            Event::UserEvent(UserEvent::ApplyUpdate(state)) => {
+                std::thread::spawn(move || apply_update_state_and_exit(state));
             }
             Event::UserEvent(UserEvent::MigrationProgress {
                 tab_id,

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -554,6 +554,9 @@ pub enum BackendEvent {
         event: RuntimeHookEvent,
     },
     UpdateState(gwt_core::update::UpdateState),
+    UpdateApplyError {
+        message: String,
+    },
     /// Response to [`FrontendEvent::ListCustomAgents`].
     CustomAgentList {
         agents: Vec<CustomCodingAgent>,

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -95,7 +95,7 @@ pub fn classify_startup_update_state(state: &gwt_core::update::UpdateState) -> S
 
 pub fn spawn_startup_update_check(
     runtime: &Runtime,
-    clients: ClientHub,
+    _clients: ClientHub,
     update_proxy: EventLoopProxy<UserEvent>,
 ) {
     if gwt_core::update::is_ci() {
@@ -127,7 +127,7 @@ pub fn spawn_startup_update_check(
             match classify_startup_update_state(&update_state) {
                 StartupUpdateAction::Retry => continue,
                 _ => {
-                    handle_poll_outcome(&mut state, update_state, &clients, &update_proxy);
+                    handle_poll_outcome(&mut state, update_state, &update_proxy);
                     initial_resolved = true;
                     break;
                 }
@@ -148,7 +148,7 @@ pub fn spawn_startup_update_check(
             .await;
             match outcome {
                 Ok(update_state) => {
-                    handle_poll_outcome(&mut state, update_state, &clients, &update_proxy);
+                    handle_poll_outcome(&mut state, update_state, &update_proxy);
                 }
                 Err(_) => {
                     state.on_failure();
@@ -161,7 +161,6 @@ pub fn spawn_startup_update_check(
 fn handle_poll_outcome(
     state: &mut PollState,
     outcome: gwt_core::update::UpdateState,
-    clients: &ClientHub,
     update_proxy: &EventLoopProxy<UserEvent>,
 ) -> Duration {
     match classify_startup_update_state(&outcome) {
@@ -172,10 +171,7 @@ fn handle_poll_outcome(
             };
             let (should_publish, next) = state.on_success_available(&latest);
             if should_publish {
-                let _ = update_proxy.send_event(UserEvent::UpdateAvailable(outcome.clone()));
-                clients.dispatch(vec![OutboundEvent::broadcast(BackendEvent::UpdateState(
-                    outcome,
-                ))]);
+                let _ = update_proxy.send_event(UserEvent::UpdateAvailable(outcome));
             }
             next
         }
@@ -184,18 +180,23 @@ fn handle_poll_outcome(
     }
 }
 
-/// Download and apply a pending update, then exit.
+/// Apply an already-detected update state from the GUI notification path.
 ///
-/// Called from a background thread so the GUI remains responsive during download.
-/// On success, this function calls `std::process::exit(0)` and never returns.
-/// On any failure, it returns silently.
-pub fn apply_update_and_exit() {
+/// The startup poll has already selected the platform-specific asset. Reusing
+/// that state avoids a second network/cache check that can make a clicked toast
+/// appear to do nothing when the re-check does not return `Available`.
+pub fn apply_update_state_and_exit(state: gwt_core::update::UpdateState) {
     let current_exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(_) => return,
     };
-    let mgr = gwt_core::update::UpdateManager::new();
-    let state = mgr.check_for_executable(false, Some(&current_exe));
+    apply_update_state_with_current_exe_and_exit(state, current_exe);
+}
+
+fn apply_update_state_with_current_exe_and_exit(
+    state: gwt_core::update::UpdateState,
+    current_exe: std::path::PathBuf,
+) {
     let (latest, asset_url) = match state {
         gwt_core::update::UpdateState::Available {
             latest,
@@ -204,7 +205,12 @@ pub fn apply_update_and_exit() {
         } => (latest, asset_url),
         _ => return,
     };
-    let payload = match mgr.prepare_update(&latest, &asset_url) {
+    apply_update_payload_and_exit(&latest, &asset_url, current_exe);
+}
+
+fn apply_update_payload_and_exit(latest: &str, asset_url: &str, current_exe: std::path::PathBuf) {
+    let mgr = gwt_core::update::UpdateManager::new();
+    let payload = match mgr.prepare_update(latest, asset_url) {
         Ok(p) => p,
         Err(_) => return,
     };
@@ -225,7 +231,7 @@ pub fn apply_update_and_exit() {
         return;
     }
     let helper_exe = if cfg!(windows) {
-        match mgr.make_helper_copy(&current_exe, &latest) {
+        match mgr.make_helper_copy(&current_exe, latest) {
             Ok(path) => path,
             Err(_) => return,
         }

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -47,6 +47,19 @@ test("app.js update-button click handler runs window.confirm then apply_update",
   );
 });
 
+test("app.js update toast click handler uses the same apply_update path", () => {
+  // トーストと永続ボタンで backend の適用入口を分岐させない。
+  const toastBlock = appSource.match(
+    /function showUpdateToast[\s\S]{0,1600}?apply_update/,
+  );
+  assert.ok(toastBlock, "expected update toast click path to reach apply_update");
+  assert.match(
+    toastBlock[0],
+    /window\.confirm|confirm\s*\(/,
+    "update toast click must guard apply_update with window.confirm",
+  );
+});
+
 test("update_state handler delegates to showUpdateButton for persistence", () => {
   // case "update_state" が新しいボタン renderer を呼ぶことで FR-036 の永続表示
   // が成立する。トースト呼び出しは初回のみ条件分岐される必要がある。
@@ -58,6 +71,18 @@ test("update_state handler delegates to showUpdateButton for persistence", () =>
     handlerSlice[0],
     /showUpdateButton/,
     "update_state handler must call showUpdateButton",
+  );
+});
+
+test("app.js surfaces backend update apply failures", () => {
+  const handlerSlice = appSource.match(
+    /case "update_apply_error"[\s\S]{0,500}/,
+  );
+  assert.ok(handlerSlice, "expected update_apply_error handler in app.js");
+  assert.match(
+    handlerSlice[0],
+    /alert\s*\(/,
+    "update apply failures must be visible to the user",
   );
 });
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7489,6 +7489,9 @@
               showUpdateButton(event.latest);
             }
             break;
+          case "update_apply_error":
+            window.alert(event.message || "Failed to start the update.");
+            break;
           case "custom_agent_list":
             customAgentsState.agents = event.agents || [];
             customAgentsState.loading = false;


### PR DESCRIPTION
## Summary

- Fixes the update toast click path so it applies the already-detected pending update instead of running a fresh update check.
- Records pending update state before broadcasting availability, keeping the toast action and backend state in sync.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: routes `apply_update` frontend events through pending `UpdateState` and reports a structured apply error when no applicable update exists.
- `crates/gwt/src/main.rs`: adds `UserEvent::ApplyUpdate` and records update availability before broadcasting to clients.
- `crates/gwt/src/update_front_door.rs`: applies a supplied available update state and stops direct client broadcasting from the poller.
- `crates/gwt/src/protocol.rs`: adds the `update_apply_error` backend event.
- `crates/gwt/web/app.js`: surfaces backend apply failures and keeps toast/button apply behavior aligned.
- `crates/gwt/web/__tests__/update-button.test.mjs`: covers toast click apply behavior and backend failure alerts.

## Testing

- [x] `node --test crates/gwt/web/__tests__/update-button.test.mjs` — 8 tests passed.
- [x] `pnpm test:frontend-unit` — 229 tests passed.
- [x] `pnpm test:frontend-bundle` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] pre-push CI-equivalent checks — coverage 90.69%, skill frontmatter validation passed.

## Closing Issues

- None

## Related Issues / Links

- #2041

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not required: behavior fix only)
- [x] Migration/backfill plan included (not required: no schema/data change)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- The update toast was shown from a successful update check, but clicking it re-entered the generic update command path that could fail to start the apply flow instead of using the pending update state behind the toast.

## Risk / Impact

- **Affected areas**: GUI update notification and update apply dispatch.
- **Rollback plan**: Revert this PR to restore the previous update apply dispatch path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added confirmation dialog before applying updates
  * Implemented error alerts when updates fail to apply

* **Improvements**
  * Enhanced update flow with better error messaging

* **Tests**
  * Added tests to verify update application behavior and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->