### PR TITLE
fix(ui): improve light theme readability

### DIFF
--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -166,6 +166,63 @@ for (const themeName of ["dark", "light"]) {
   }
 }
 
+// SPEC-2356 follow-up — Light Operator must be readable beyond the bare
+// WCAG text pairs. The previous light palette technically passed text
+// contrast, but white / bone surfaces and very faint borders made controls
+// difficult to distinguish. Lock the surface stack and chrome separators to
+// minimum practical visual separation so the regression is caught by unit
+// tests instead of only by manual review.
+test("[light] surface stack has visible separation between canvas, elevated, and surface", () => {
+  const surfaceOnCanvas = contrastRatio(light["--color-surface"], light["--color-canvas"]);
+  const elevatedOnSurface = contrastRatio(light["--color-surface-elevated"], light["--color-surface"]);
+  const elevatedOnCanvas = contrastRatio(light["--color-surface-elevated"], light["--color-canvas"]);
+
+  assert.ok(
+    surfaceOnCanvas >= 1.15,
+    `surface on canvas separation ${surfaceOnCanvas.toFixed(2)} < 1.15`,
+  );
+  assert.ok(
+    elevatedOnSurface >= 1.08,
+    `surface-elevated on surface separation ${elevatedOnSurface.toFixed(2)} < 1.08`,
+  );
+  assert.ok(
+    elevatedOnCanvas >= 1.08,
+    `surface-elevated on canvas separation ${elevatedOnCanvas.toFixed(2)} < 1.08`,
+  );
+});
+
+test("[light] chrome borders remain visible on light surfaces", () => {
+  const bgTokens = ["--color-surface", "--color-surface-elevated"];
+  for (const bgToken of bgTokens) {
+    const bg = parseColor(light[bgToken]);
+    const border = compositeColor(parseColor(light["--color-border"]), bg);
+    const strong = compositeColor(parseColor(light["--color-border-strong"]), bg);
+    const borderRatio = contrastRatioRgb(border, bg);
+    const strongRatio = contrastRatioRgb(strong, bg);
+
+    assert.ok(
+      borderRatio >= 1.4,
+      `regular border on ${bgToken}: ${borderRatio.toFixed(2)} < 1.4`,
+    );
+    assert.ok(
+      strongRatio >= 2.0,
+      `strong border on ${bgToken}: ${strongRatio.toFixed(2)} < 2.0`,
+    );
+  }
+});
+
+test("[light] active tint is visible on light surfaces", () => {
+  for (const bgToken of ["--color-surface", "--color-surface-elevated"]) {
+    const bg = parseColor(light[bgToken]);
+    const tint = mixRgb(parseColor(light["--color-state-active"]), bg, 0.14);
+    const ratio = contrastRatioRgb(tint, bg);
+    assert.ok(
+      ratio >= 1.18,
+      `active tint on ${bgToken}: ${ratio.toFixed(2)} < 1.18`,
+    );
+  }
+});
+
 test("dark and light token sets define identical semantic keys", () => {
   const darkKeys = Object.keys(dark).sort();
   const lightKeys = Object.keys(light).sort();
@@ -271,6 +328,9 @@ function parseColor(value) {
   if ((m = v.match(/^rgb\(\s*(\d+)\s*[\s,]\s*(\d+)\s*[\s,]\s*(\d+)\s*\)$/))) {
     return [Number(m[1]), Number(m[2]), Number(m[3])];
   }
+  if ((m = v.match(/^rgba\(\s*(\d+)\s*[\s,]\s*(\d+)\s*[\s,]\s*(\d+)\s*[\s,]\s*([\d.]+)\s*\)$/))) {
+    return [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+  }
   if ((m = v.match(/^hsl\(\s*([\d.]+)(?:deg)?\s*[\s,]\s*([\d.]+)%\s*[\s,]\s*([\d.]+)%\s*\)$/))) {
     return hslToRgb(Number(m[1]), Number(m[2]), Number(m[3]));
   }
@@ -316,6 +376,23 @@ function oklchToRgb(L, C, h) {
   return [Math.round(toSrgb(lr) * 255), Math.round(toSrgb(lg) * 255), Math.round(toSrgb(lb) * 255)];
 }
 
+function compositeColor(fg, bg) {
+  const alpha = fg.length > 3 ? fg[3] : 1;
+  return [
+    Math.round(fg[0] * alpha + bg[0] * (1 - alpha)),
+    Math.round(fg[1] * alpha + bg[1] * (1 - alpha)),
+    Math.round(fg[2] * alpha + bg[2] * (1 - alpha)),
+  ];
+}
+
+function mixRgb(fg, bg, fgWeight) {
+  return [
+    Math.round(fg[0] * fgWeight + bg[0] * (1 - fgWeight)),
+    Math.round(fg[1] * fgWeight + bg[1] * (1 - fgWeight)),
+    Math.round(fg[2] * fgWeight + bg[2] * (1 - fgWeight)),
+  ];
+}
+
 function relativeLuminance([r, g, b]) {
   const lin = (c) => {
     const cs = c / 255;
@@ -324,10 +401,14 @@ function relativeLuminance([r, g, b]) {
   return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
 }
 
-function contrastRatio(fg, bg) {
-  const L1 = relativeLuminance(parseColor(fg));
-  const L2 = relativeLuminance(parseColor(bg));
+function contrastRatioRgb(fg, bg) {
+  const L1 = relativeLuminance(fg);
+  const L2 = relativeLuminance(bg);
   const a = Math.max(L1, L2);
   const b = Math.min(L1, L2);
   return (a + 0.05) / (b + 0.05);
+}
+
+function contrastRatio(fg, bg) {
+  return contrastRatioRgb(parseColor(fg), parseColor(bg));
 }

--- a/crates/gwt/web/styles/tokens.css
+++ b/crates/gwt/web/styles/tokens.css
@@ -103,47 +103,49 @@
 }
 
 :root[data-theme="light"] {
-  /* Surface palette — bone + ink */
-  --color-canvas: #f5f3ee;
+  /* Surface palette — drafting table + ink.
+     Keep the light flagship bright, but give canvas / cards / chrome enough
+     luminance separation to remain scannable in dense work sessions. */
+  --color-canvas: #e9edf0;
   --color-surface: #ffffff;
-  --color-surface-elevated: #fbfaf6;
+  --color-surface-elevated: #f3f6f7;
   --color-overlay: rgba(20, 22, 26, 0.62);
   --color-scrim: rgba(20, 22, 26, 0.45);
 
   /* Text */
-  --color-text: #1a1d24;
+  --color-text: #151922;
   --color-text-strong: #000000;
-  --color-text-muted: #4a5159;
-  --color-text-disabled: #9ca3af;
+  --color-text-muted: #3f4752;
+  --color-text-disabled: #737d89;
 
   /* Display */
   --color-display-fg: #0a0d12;
 
   /* Status Strip — inverted dark strip on light canvas (Mission control feel) */
-  --color-status-strip-bg: #1a1d24;
-  --color-status-strip-fg: #f5f3ee;
-  --color-status-strip-divider: rgba(245, 243, 238, 0.18);
+  --color-status-strip-bg: #151922;
+  --color-status-strip-fg: #f4f7f8;
+  --color-status-strip-divider: rgba(244, 247, 248, 0.22);
 
   /* Buttons */
-  --color-button-bg: #1a1d24;
-  --color-button-bg-hover: #2a3140;
+  --color-button-bg: #151922;
+  --color-button-bg-hover: #263141;
   --color-button-fg: #ffffff;
-  --color-button-border: rgba(26, 29, 36, 0.18);
+  --color-button-border: rgba(21, 25, 34, 0.28);
 
   /* Borders */
-  --color-border: rgba(26, 29, 36, 0.10);
-  --color-border-strong: rgba(26, 29, 36, 0.28);
-  --color-focus-ring: #0e7490;
+  --color-border: rgba(21, 25, 34, 0.18);
+  --color-border-strong: rgba(21, 25, 34, 0.38);
+  --color-focus-ring: #075f73;
 
   /* Link */
-  --color-link: #0e7490;
-  --color-link-hover: #155e75;
+  --color-link: #075f73;
+  --color-link-hover: #064e5d;
 
   /* Live status semantics */
-  --color-state-active: #0e7490;
-  --color-state-idle: #6b7280;
-  --color-state-blocked: #b91c1c;
-  --color-state-done: #4b5563;
+  --color-state-active: #075f73;
+  --color-state-idle: #4b5563;
+  --color-state-blocked: #991b1b;
+  --color-state-done: #334155;
 
   /* Agent colors — dark-tuned chroma for bone background */
   --agent-claude: #92400e;
@@ -159,8 +161,8 @@
   --bg-depth-glow: radial-gradient(ellipse at top, rgba(14, 116, 144, 0.06), transparent 60%);
 
   /* Shadow */
-  --shadow-1: 0 1px 2px rgba(20, 22, 26, 0.06);
-  --shadow-2: 0 8px 24px rgba(20, 22, 26, 0.10);
+  --shadow-1: 0 1px 2px rgba(21, 25, 34, 0.10);
+  --shadow-2: 0 10px 28px rgba(21, 25, 34, 0.16);
   --shadow-glow-active: 0 0 0 1px var(--agent-color, var(--color-state-active)),
                         0 0 12px 0 color-mix(in oklab, var(--agent-color, var(--color-state-active)) 30%, transparent);
 


### PR DESCRIPTION
## Summary

- Improves the light theme readability that regressed after the dark mode refresh by increasing visible separation between the canvas, surfaces, borders, and active states.
- Adds regression coverage for light-theme non-text contrast so future token changes preserve surface stack, border, and active tint visibility.
- Updates SPEC #2356 artifacts to capture the light-mode follow-up requirements and completed verification tasks.

## Changes

- `crates/gwt/web/styles/tokens.css`: Retuned light theme surface, border, focus, link, state, and shadow tokens while leaving dark theme tokens unchanged.
- `crates/gwt/web/__tests__/contrast.test.mjs`: Added light-theme separation assertions and RGBA compositing helpers for surface, border, and active tint regression coverage.
- `SPEC #2356`: Added light-mode acceptance coverage, follow-up plan items, and completed task evidence.

## Testing

- [x] `node --test crates/gwt/web/__tests__/contrast.test.mjs` — RED first with the old tokens (`surface on canvas separation 1.11 < 1.15`, `regular border on --color-surface: 1.22 < 1.4`), then GREEN with 97 passing tests.
- [x] `npm run test:frontend-unit` — GREEN with 233 passing frontend unit tests after the develop merge.
- [x] `npm run test:frontend-bundle` — GREEN.
- [x] `cargo test -p gwt-core -p gwt` — GREEN.
- [x] `cargo fmt -- --check` — GREEN.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — GREEN.
- [x] `cargo build -p gwt` — GREEN.
- [x] `bunx commitlint --from HEAD~2 --to HEAD` — GREEN.
- [x] `git push` pre-push hook — GREEN; coverage 90.70% against the 90.00% threshold.

## Closing Issues

- None

## Related Issues / Links

- #2356

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation/spec updated where applicable
- [x] Migration/backfill plan included or not needed for this token-only CSS/test change
- [x] CHANGELOG impact considered via `fix(ui): improve light theme readability`

## Context

- This follow-up keeps the dark mode improvements intact while fixing light mode readability by strengthening token-level contrast rather than adding component-specific overrides.

## Risk / Impact

- **Affected areas**: GUI light theme colors, borders, focus/link/state tones, and shadows.
- **Rollback plan**: Revert the `fix(ui): improve light theme readability` commit if the light palette needs to be restored.

## Screenshots

- Not captured in this pass; the change is covered by automated light-theme contrast regression tests for the affected token relationships.
