### PR TITLE
chore(release): v9.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.20.3] - 2026-05-06
+
+### Bug Fixes
+
+- **ui:** Improve light theme readability
+- **gui:** Apply pending update from toast
+- **gui:** Regroup launch agent settings
+
+### Miscellaneous Tasks
+
+- Merge origin/develop into work branch
+- Merge develop into work branch
+
 ## [9.20.2] - 2026-05-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "axum",
  "base64",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "chrono",
  "dunce",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "dirs",
  "serde",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "chrono",
  "fs2",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.20.2"
+version = "9.20.3"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.20.2"
+version = "9.20.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1180,10 +1180,7 @@ impl AppRuntime {
             FrontendEvent::LaunchWizardAction { action, bounds } => {
                 self.handle_launch_wizard_action(action, bounds)
             }
-            FrontendEvent::ApplyUpdate => {
-                std::thread::spawn(apply_update_and_exit);
-                vec![]
-            }
+            FrontendEvent::ApplyUpdate => self.apply_pending_update_events(&client_id),
             FrontendEvent::ListCustomAgents => vec![OutboundEvent::reply(
                 client_id,
                 gwt::custom_agents_dispatch::list_event(),
@@ -1252,6 +1249,46 @@ impl AppRuntime {
                 client_id, event,
             )]));
         });
+    }
+
+    fn apply_pending_update_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        match self.pending_update.clone() {
+            Some(
+                state @ gwt_core::update::UpdateState::Available {
+                    asset_url: Some(_), ..
+                },
+            ) => {
+                self.proxy.send(UserEvent::ApplyUpdate(state));
+                vec![]
+            }
+            Some(gwt_core::update::UpdateState::Available { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::UpdateApplyError {
+                    message: "No applicable update asset is available for this platform."
+                        .to_string(),
+                },
+            )],
+            Some(gwt_core::update::UpdateState::UpToDate { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::UpdateApplyError {
+                    message: "No pending update is available.".to_string(),
+                },
+            )],
+            Some(gwt_core::update::UpdateState::Failed { message, .. }) => {
+                vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::UpdateApplyError {
+                        message: format!("Update check failed: {message}"),
+                    },
+                )]
+            }
+            None => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::UpdateApplyError {
+                    message: "No pending update is available.".to_string(),
+                },
+            )],
+        }
     }
 
     pub(crate) fn frontend_sync_events(&self, client_id: &str) -> Vec<OutboundEvent> {
@@ -4642,6 +4679,76 @@ exit 0
             event.event,
             BackendEvent::UpdateState(gwt_core::update::UpdateState::UpToDate { .. })
         )));
+    }
+
+    #[test]
+    fn app_runtime_apply_update_uses_pending_available_update_state() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Shell],
+        );
+        let (mut runtime, events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+        runtime.pending_update = Some(gwt_core::update::UpdateState::Available {
+            current: "9.20.1".to_string(),
+            latest: "9.20.2".to_string(),
+            release_url: "https://example.invalid/releases/v9.20.2".to_string(),
+            asset_url: Some("https://example.invalid/gwt-macos-universal.dmg".to_string()),
+            checked_at: chrono::Utc::now(),
+        });
+
+        let outbound =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::ApplyUpdate);
+
+        assert!(outbound.is_empty(), "apply worker dispatch is internal");
+        wait_for_recorded_event("pending update apply", &events, |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    UserEvent::ApplyUpdate(gwt_core::update::UpdateState::Available {
+                        latest,
+                        asset_url: Some(asset_url),
+                        ..
+                    }) if latest == "9.20.2"
+                        && asset_url == "https://example.invalid/gwt-macos-universal.dmg"
+                )
+            })
+        });
+    }
+
+    #[test]
+    fn app_runtime_apply_update_without_applicable_pending_update_reports_error() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Shell],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.pending_update = Some(gwt_core::update::UpdateState::Available {
+            current: "9.20.1".to_string(),
+            latest: "9.20.2".to_string(),
+            release_url: "https://example.invalid/releases/v9.20.2".to_string(),
+            asset_url: None,
+            checked_at: chrono::Utc::now(),
+        });
+
+        let outbound =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::ApplyUpdate);
+
+        assert!(outbound.iter().any(|event| {
+            matches!(
+                &event.event,
+                BackendEvent::UpdateApplyError { message }
+                    if message.contains("No applicable update asset")
+            )
+        }));
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -92,7 +92,7 @@ pub(crate) use runtime_support::{
 pub(crate) use runtime_support::{
     parse_github_remote_url, spawn_env, suffixed_worktree_path, worktree_path_is_occupied,
 };
-pub(crate) use update_front_door::{apply_update_and_exit, spawn_startup_update_check};
+pub(crate) use update_front_door::{apply_update_state_and_exit, spawn_startup_update_check};
 #[cfg(test)]
 pub(crate) use update_front_door::{classify_startup_update_state, StartupUpdateAction};
 
@@ -151,6 +151,14 @@ fn spawn_project_index_status_check(runtime: &Runtime, proxy: EventLoopProxy<Use
             status,
         });
     }));
+}
+
+fn record_update_available(
+    app: &mut AppRuntime,
+    state: gwt_core::update::UpdateState,
+) -> Vec<OutboundEvent> {
+    app.pending_update = Some(state.clone());
+    vec![OutboundEvent::broadcast(BackendEvent::UpdateState(state))]
 }
 
 fn board_projection_watch_key(project_root: &Path) -> PathBuf {
@@ -482,6 +490,7 @@ enum UserEvent {
     IssueLaunchWizardPrepared(IssueLaunchWizardPrepared),
     Dispatch(Vec<OutboundEvent>),
     UpdateAvailable(gwt_core::update::UpdateState),
+    ApplyUpdate(gwt_core::update::UpdateState),
     /// SPEC-1934 FR-029: progress tick from
     /// `gwt::migration::execute_migration`. Re-broadcast as
     /// [`gwt::BackendEvent::MigrationProgress`].
@@ -1312,6 +1321,48 @@ mod tests {
             event.event,
             BackendEvent::UpdateState(gwt_core::update::UpdateState::UpToDate { .. })
         )));
+    }
+
+    #[test]
+    fn update_available_event_records_pending_update_before_broadcast() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Shell],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let state = gwt_core::update::UpdateState::Available {
+            current: "9.20.1".to_string(),
+            latest: "9.20.2".to_string(),
+            release_url: "https://example.invalid/releases/v9.20.2".to_string(),
+            asset_url: Some("https://example.invalid/gwt-macos-universal.dmg".to_string()),
+            checked_at: Utc::now(),
+        };
+
+        let events = super::record_update_available(&mut runtime, state);
+
+        assert!(matches!(
+            runtime.pending_update,
+            Some(gwt_core::update::UpdateState::Available {
+                ref latest,
+                asset_url: Some(_),
+                ..
+            }) if latest == "9.20.2"
+        ));
+        assert!(matches!(
+            events.as_slice(),
+            [OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::UpdateState(gwt_core::update::UpdateState::Available {
+                    latest,
+                    asset_url: Some(_),
+                    ..
+                }),
+            }] if latest == "9.20.2"
+        ));
     }
 
     #[test]
@@ -4641,7 +4692,10 @@ fn main() -> wry::Result<()> {
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::UpdateAvailable(state)) => {
-                app.pending_update = Some(state);
+                clients.dispatch(record_update_available(&mut app, state));
+            }
+            Event::UserEvent(UserEvent::ApplyUpdate(state)) => {
+                std::thread::spawn(move || apply_update_state_and_exit(state));
             }
             Event::UserEvent(UserEvent::MigrationProgress {
                 tab_id,

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -554,6 +554,9 @@ pub enum BackendEvent {
         event: RuntimeHookEvent,
     },
     UpdateState(gwt_core::update::UpdateState),
+    UpdateApplyError {
+        message: String,
+    },
     /// Response to [`FrontendEvent::ListCustomAgents`].
     CustomAgentList {
         agents: Vec<CustomCodingAgent>,

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -95,7 +95,7 @@ pub fn classify_startup_update_state(state: &gwt_core::update::UpdateState) -> S
 
 pub fn spawn_startup_update_check(
     runtime: &Runtime,
-    clients: ClientHub,
+    _clients: ClientHub,
     update_proxy: EventLoopProxy<UserEvent>,
 ) {
     if gwt_core::update::is_ci() {
@@ -127,7 +127,7 @@ pub fn spawn_startup_update_check(
             match classify_startup_update_state(&update_state) {
                 StartupUpdateAction::Retry => continue,
                 _ => {
-                    handle_poll_outcome(&mut state, update_state, &clients, &update_proxy);
+                    handle_poll_outcome(&mut state, update_state, &update_proxy);
                     initial_resolved = true;
                     break;
                 }
@@ -148,7 +148,7 @@ pub fn spawn_startup_update_check(
             .await;
             match outcome {
                 Ok(update_state) => {
-                    handle_poll_outcome(&mut state, update_state, &clients, &update_proxy);
+                    handle_poll_outcome(&mut state, update_state, &update_proxy);
                 }
                 Err(_) => {
                     state.on_failure();
@@ -161,7 +161,6 @@ pub fn spawn_startup_update_check(
 fn handle_poll_outcome(
     state: &mut PollState,
     outcome: gwt_core::update::UpdateState,
-    clients: &ClientHub,
     update_proxy: &EventLoopProxy<UserEvent>,
 ) -> Duration {
     match classify_startup_update_state(&outcome) {
@@ -172,10 +171,7 @@ fn handle_poll_outcome(
             };
             let (should_publish, next) = state.on_success_available(&latest);
             if should_publish {
-                let _ = update_proxy.send_event(UserEvent::UpdateAvailable(outcome.clone()));
-                clients.dispatch(vec![OutboundEvent::broadcast(BackendEvent::UpdateState(
-                    outcome,
-                ))]);
+                let _ = update_proxy.send_event(UserEvent::UpdateAvailable(outcome));
             }
             next
         }
@@ -184,18 +180,23 @@ fn handle_poll_outcome(
     }
 }
 
-/// Download and apply a pending update, then exit.
+/// Apply an already-detected update state from the GUI notification path.
 ///
-/// Called from a background thread so the GUI remains responsive during download.
-/// On success, this function calls `std::process::exit(0)` and never returns.
-/// On any failure, it returns silently.
-pub fn apply_update_and_exit() {
+/// The startup poll has already selected the platform-specific asset. Reusing
+/// that state avoids a second network/cache check that can make a clicked toast
+/// appear to do nothing when the re-check does not return `Available`.
+pub fn apply_update_state_and_exit(state: gwt_core::update::UpdateState) {
     let current_exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(_) => return,
     };
-    let mgr = gwt_core::update::UpdateManager::new();
-    let state = mgr.check_for_executable(false, Some(&current_exe));
+    apply_update_state_with_current_exe_and_exit(state, current_exe);
+}
+
+fn apply_update_state_with_current_exe_and_exit(
+    state: gwt_core::update::UpdateState,
+    current_exe: std::path::PathBuf,
+) {
     let (latest, asset_url) = match state {
         gwt_core::update::UpdateState::Available {
             latest,
@@ -204,7 +205,12 @@ pub fn apply_update_and_exit() {
         } => (latest, asset_url),
         _ => return,
     };
-    let payload = match mgr.prepare_update(&latest, &asset_url) {
+    apply_update_payload_and_exit(&latest, &asset_url, current_exe);
+}
+
+fn apply_update_payload_and_exit(latest: &str, asset_url: &str, current_exe: std::path::PathBuf) {
+    let mgr = gwt_core::update::UpdateManager::new();
+    let payload = match mgr.prepare_update(latest, asset_url) {
         Ok(p) => p,
         Err(_) => return,
     };
@@ -225,7 +231,7 @@ pub fn apply_update_and_exit() {
         return;
     }
     let helper_exe = if cfg!(windows) {
-        match mgr.make_helper_copy(&current_exe, &latest) {
+        match mgr.make_helper_copy(&current_exe, latest) {
             Ok(path) => path,
             Err(_) => return,
         }

--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -166,6 +166,63 @@ for (const themeName of ["dark", "light"]) {
   }
 }
 
+// SPEC-2356 follow-up — Light Operator must be readable beyond the bare
+// WCAG text pairs. The previous light palette technically passed text
+// contrast, but white / bone surfaces and very faint borders made controls
+// difficult to distinguish. Lock the surface stack and chrome separators to
+// minimum practical visual separation so the regression is caught by unit
+// tests instead of only by manual review.
+test("[light] surface stack has visible separation between canvas, elevated, and surface", () => {
+  const surfaceOnCanvas = contrastRatio(light["--color-surface"], light["--color-canvas"]);
+  const elevatedOnSurface = contrastRatio(light["--color-surface-elevated"], light["--color-surface"]);
+  const elevatedOnCanvas = contrastRatio(light["--color-surface-elevated"], light["--color-canvas"]);
+
+  assert.ok(
+    surfaceOnCanvas >= 1.15,
+    `surface on canvas separation ${surfaceOnCanvas.toFixed(2)} < 1.15`,
+  );
+  assert.ok(
+    elevatedOnSurface >= 1.08,
+    `surface-elevated on surface separation ${elevatedOnSurface.toFixed(2)} < 1.08`,
+  );
+  assert.ok(
+    elevatedOnCanvas >= 1.08,
+    `surface-elevated on canvas separation ${elevatedOnCanvas.toFixed(2)} < 1.08`,
+  );
+});
+
+test("[light] chrome borders remain visible on light surfaces", () => {
+  const bgTokens = ["--color-surface", "--color-surface-elevated"];
+  for (const bgToken of bgTokens) {
+    const bg = parseColor(light[bgToken]);
+    const border = compositeColor(parseColor(light["--color-border"]), bg);
+    const strong = compositeColor(parseColor(light["--color-border-strong"]), bg);
+    const borderRatio = contrastRatioRgb(border, bg);
+    const strongRatio = contrastRatioRgb(strong, bg);
+
+    assert.ok(
+      borderRatio >= 1.4,
+      `regular border on ${bgToken}: ${borderRatio.toFixed(2)} < 1.4`,
+    );
+    assert.ok(
+      strongRatio >= 2.0,
+      `strong border on ${bgToken}: ${strongRatio.toFixed(2)} < 2.0`,
+    );
+  }
+});
+
+test("[light] active tint is visible on light surfaces", () => {
+  for (const bgToken of ["--color-surface", "--color-surface-elevated"]) {
+    const bg = parseColor(light[bgToken]);
+    const tint = mixRgb(parseColor(light["--color-state-active"]), bg, 0.14);
+    const ratio = contrastRatioRgb(tint, bg);
+    assert.ok(
+      ratio >= 1.18,
+      `active tint on ${bgToken}: ${ratio.toFixed(2)} < 1.18`,
+    );
+  }
+});
+
 test("dark and light token sets define identical semantic keys", () => {
   const darkKeys = Object.keys(dark).sort();
   const lightKeys = Object.keys(light).sort();
@@ -271,6 +328,9 @@ function parseColor(value) {
   if ((m = v.match(/^rgb\(\s*(\d+)\s*[\s,]\s*(\d+)\s*[\s,]\s*(\d+)\s*\)$/))) {
     return [Number(m[1]), Number(m[2]), Number(m[3])];
   }
+  if ((m = v.match(/^rgba\(\s*(\d+)\s*[\s,]\s*(\d+)\s*[\s,]\s*(\d+)\s*[\s,]\s*([\d.]+)\s*\)$/))) {
+    return [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+  }
   if ((m = v.match(/^hsl\(\s*([\d.]+)(?:deg)?\s*[\s,]\s*([\d.]+)%\s*[\s,]\s*([\d.]+)%\s*\)$/))) {
     return hslToRgb(Number(m[1]), Number(m[2]), Number(m[3]));
   }
@@ -316,6 +376,23 @@ function oklchToRgb(L, C, h) {
   return [Math.round(toSrgb(lr) * 255), Math.round(toSrgb(lg) * 255), Math.round(toSrgb(lb) * 255)];
 }
 
+function compositeColor(fg, bg) {
+  const alpha = fg.length > 3 ? fg[3] : 1;
+  return [
+    Math.round(fg[0] * alpha + bg[0] * (1 - alpha)),
+    Math.round(fg[1] * alpha + bg[1] * (1 - alpha)),
+    Math.round(fg[2] * alpha + bg[2] * (1 - alpha)),
+  ];
+}
+
+function mixRgb(fg, bg, fgWeight) {
+  return [
+    Math.round(fg[0] * fgWeight + bg[0] * (1 - fgWeight)),
+    Math.round(fg[1] * fgWeight + bg[1] * (1 - fgWeight)),
+    Math.round(fg[2] * fgWeight + bg[2] * (1 - fgWeight)),
+  ];
+}
+
 function relativeLuminance([r, g, b]) {
   const lin = (c) => {
     const cs = c / 255;
@@ -324,10 +401,14 @@ function relativeLuminance([r, g, b]) {
   return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
 }
 
-function contrastRatio(fg, bg) {
-  const L1 = relativeLuminance(parseColor(fg));
-  const L2 = relativeLuminance(parseColor(bg));
+function contrastRatioRgb(fg, bg) {
+  const L1 = relativeLuminance(fg);
+  const L2 = relativeLuminance(bg);
   const a = Math.max(L1, L2);
   const b = Math.min(L1, L2);
   return (a + 0.05) / (b + 0.05);
+}
+
+function contrastRatio(fg, bg) {
+  return contrastRatioRgb(parseColor(fg), parseColor(bg));
 }

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -770,6 +770,73 @@ test("Launch wizard choice buttons expose toggle state via aria-pressed", () => 
   );
 });
 
+test("Launch wizard separates launch settings from runtime controls", () => {
+  assert.equal(
+    appSource.includes("wizardAdvancedOpen"),
+    false,
+    "Launch wizard should not keep an Advanced disclosure state",
+  );
+  for (const retiredCopy of ["Advanced", "Show advanced", "Hide advanced"]) {
+    assert.equal(
+      appSource.includes(`"${retiredCopy}"`),
+      false,
+      `Launch wizard should not render ${retiredCopy}`,
+    );
+  }
+
+  const launchSettingsStart = appSource.indexOf(
+    'createLaunchSection(\n            "Launch settings"',
+  );
+  const linkedIssueStart = appSource.indexOf(
+    'createLaunchSection(\n            "Linked issue"',
+  );
+  const runtimeStart = appSource.indexOf(
+    'createLaunchSection(\n            "Runtime"',
+  );
+
+  assert.notEqual(launchSettingsStart, -1, "expected Launch settings section");
+  assert.notEqual(linkedIssueStart, -1, "expected Linked issue section");
+  assert.notEqual(runtimeStart, -1, "expected Runtime section");
+  assert.ok(
+    launchSettingsStart < linkedIssueStart && linkedIssueStart < runtimeStart,
+    "expected Launch settings before Linked issue and Runtime after Linked issue",
+  );
+
+  const launchSettingsBlock = appSource.slice(
+    launchSettingsStart,
+    linkedIssueStart,
+  );
+  for (const copy of ["Version", "Skip permission prompts", "Codex fast mode"]) {
+    assert.ok(
+      launchSettingsBlock.includes(`"${copy}"`),
+      `expected Launch settings to include ${copy}`,
+    );
+  }
+  assert.equal(
+    launchSettingsBlock.includes('"Runtime target"'),
+    false,
+    "Launch settings should not contain runtime target controls",
+  );
+
+  const runtimeBlock = appSource.slice(
+    runtimeStart,
+    appSource.indexOf("wizardBody.appendChild(panel);"),
+  );
+  for (const copy of ["Runtime target", "Docker service", "Docker lifecycle"]) {
+    assert.ok(
+      runtimeBlock.includes(`"${copy}"`),
+      `expected Runtime to include ${copy}`,
+    );
+  }
+  for (const copy of ["Version", "Skip permission prompts", "Codex fast mode"]) {
+    assert.equal(
+      runtimeBlock.includes(`"${copy}"`),
+      false,
+      `Runtime should not contain ${copy}`,
+    );
+  }
+});
+
 test("Selected list rows mark active item with aria-current", () => {
   // Same pattern as project tabs (PR #2455): list-style buttons with a
   // selected state need aria-current to announce which row is active.

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -47,6 +47,19 @@ test("app.js update-button click handler runs window.confirm then apply_update",
   );
 });
 
+test("app.js update toast click handler uses the same apply_update path", () => {
+  // トーストと永続ボタンで backend の適用入口を分岐させない。
+  const toastBlock = appSource.match(
+    /function showUpdateToast[\s\S]{0,1600}?apply_update/,
+  );
+  assert.ok(toastBlock, "expected update toast click path to reach apply_update");
+  assert.match(
+    toastBlock[0],
+    /window\.confirm|confirm\s*\(/,
+    "update toast click must guard apply_update with window.confirm",
+  );
+});
+
 test("update_state handler delegates to showUpdateButton for persistence", () => {
   // case "update_state" が新しいボタン renderer を呼ぶことで FR-036 の永続表示
   // が成立する。トースト呼び出しは初回のみ条件分岐される必要がある。
@@ -58,6 +71,18 @@ test("update_state handler delegates to showUpdateButton for persistence", () =>
     handlerSlice[0],
     /showUpdateButton/,
     "update_state handler must call showUpdateButton",
+  );
+});
+
+test("app.js surfaces backend update apply failures", () => {
+  const handlerSlice = appSource.match(
+    /case "update_apply_error"[\s\S]{0,500}/,
+  );
+  assert.ok(handlerSlice, "expected update_apply_error handler in app.js");
+  assert.match(
+    handlerSlice[0],
+    /alert\s*\(/,
+    "update apply failures must be visible to the user",
   );
 });
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -190,7 +190,6 @@
           state: Object.freeze([
             "launchWizard",
             "wizardWasOpen",
-            "wizardAdvancedOpen",
             "wizardBranchDraft",
             "wizardBranchBackendValue",
           ]),
@@ -249,7 +248,6 @@
       let activeWorkProjection = null;
       let pendingBoardEntryFocusId = null;
       let wizardWasOpen = false;
-      let wizardAdvancedOpen = false;
       let wizardBranchDraft = "";
       let wizardBranchBackendValue = "";
       let branchCleanupWindowId = null;
@@ -4096,7 +4094,6 @@
       function syncWizardDraftState() {
         if (!launchWizard) {
           wizardWasOpen = false;
-          wizardAdvancedOpen = false;
           wizardBranchDraft = "";
           wizardBranchBackendValue = "";
           return;
@@ -4104,9 +4101,6 @@
 
         if (!wizardWasOpen) {
           wizardWasOpen = true;
-          wizardAdvancedOpen =
-            launchWizard.selected_runtime_target === "docker" ||
-            Boolean(launchWizard.selected_docker_service);
           wizardBranchDraft = launchWizard.branch_name || "";
           wizardBranchBackendValue = wizardBranchDraft;
           return;
@@ -4527,6 +4521,59 @@
           panel.appendChild(section);
         }
 
+        if (
+          launchWizard.show_version ||
+          launchWizard.show_skip_permissions ||
+          launchWizard.show_codex_fast_mode
+        ) {
+          const section = createLaunchSection(
+            "Launch settings",
+            "Version, permissions, and tool-specific launch behavior.",
+          );
+          const grid = createNode("div", "launch-form-grid");
+          if (launchWizard.show_version) {
+            appendSelectField(
+              grid,
+              "Version",
+              launchWizard.version_options || [],
+              launchWizard.selected_version,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_version",
+                  version: value,
+                }),
+            );
+          }
+          if (launchWizard.show_skip_permissions) {
+            appendCheckboxField(
+              grid,
+              "Permissions",
+              "Skip permission prompts",
+              launchWizard.skip_permissions,
+              (enabled) =>
+                sendWizardAction({
+                  kind: "set_skip_permissions",
+                  enabled,
+                }),
+            );
+          }
+          if (launchWizard.show_codex_fast_mode) {
+            appendCheckboxField(
+              grid,
+              "Codex fast mode",
+              "Use the fast service tier",
+              launchWizard.codex_fast_mode,
+              (enabled) =>
+                sendWizardAction({
+                  kind: "set_codex_fast_mode",
+                  enabled,
+                }),
+            );
+          }
+          section.appendChild(grid);
+          panel.appendChild(section);
+        }
+
         if (launchWizard.show_agent_settings) {
           const section = createLaunchSection(
             "Linked issue",
@@ -4561,122 +4608,64 @@
           panel.appendChild(section);
         }
 
-        {
+        if (
+          launchWizard.show_runtime_target ||
+          (launchWizard.show_docker_service &&
+            (launchWizard.docker_service_options || []).length > 0) ||
+          (launchWizard.show_docker_lifecycle &&
+            (launchWizard.docker_lifecycle_options || []).length > 0)
+        ) {
           const section = createLaunchSection(
-            "Advanced",
-            "Runtime target, versions, and launch flags.",
+            "Runtime",
+            "Choose where the session runs and how Docker services are used.",
           );
-          const toggleRow = createNode("div", "launch-toggle-row");
-          toggleRow.appendChild(
-            createNode(
-              "div",
-              "launch-note",
-              wizardAdvancedOpen
-                ? "Docker, version, permissions, and tool-specific flags."
-                : "Show runtime and launch flags.",
-            ),
-          );
-          const toggleButton = createNode(
-            "button",
-            "wizard-button",
-            wizardAdvancedOpen ? "Hide advanced" : "Show advanced",
-          );
-          toggleButton.type = "button";
-          toggleButton.addEventListener("click", () => {
-            wizardAdvancedOpen = !wizardAdvancedOpen;
-            renderLaunchWizard();
-          });
-          toggleRow.appendChild(toggleButton);
-          section.appendChild(toggleRow);
-
-          if (wizardAdvancedOpen) {
-            const grid = createNode("div", "launch-form-grid");
-            if (launchWizard.show_runtime_target) {
-              appendSelectField(
-                grid,
-                "Runtime target",
-                launchWizard.runtime_target_options || [],
-                launchWizard.selected_runtime_target,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_runtime_target",
-                    target: runtimeTargetPayload(value),
-                  }),
-              );
-            }
-            if (
-              launchWizard.show_docker_service &&
-              (launchWizard.docker_service_options || []).length > 0
-            ) {
-              appendSelectField(
-                grid,
-                "Docker service",
-                launchWizard.docker_service_options || [],
-                launchWizard.selected_docker_service,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_docker_service",
-                    service: value,
-                  }),
-              );
-            }
-            if (
-              launchWizard.show_docker_lifecycle &&
-              (launchWizard.docker_lifecycle_options || []).length > 0
-            ) {
-              appendSelectField(
-                grid,
-                "Docker lifecycle",
-                launchWizard.docker_lifecycle_options || [],
-                launchWizard.selected_docker_lifecycle,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_docker_lifecycle",
-                    intent: dockerLifecyclePayload(value),
-                  }),
-              );
-            }
-            if (launchWizard.show_version) {
-              appendSelectField(
-                grid,
-                "Version",
-                launchWizard.version_options || [],
-                launchWizard.selected_version,
-                (value) =>
-                  sendWizardAction({
-                    kind: "set_version",
-                    version: value,
-                  }),
-              );
-            }
-            if (launchWizard.show_skip_permissions) {
-              appendCheckboxField(
-                grid,
-                "Permissions",
-                "Skip permission prompts",
-                launchWizard.skip_permissions,
-                (enabled) =>
-                  sendWizardAction({
-                    kind: "set_skip_permissions",
-                    enabled,
-                  }),
-              );
-            }
-            if (launchWizard.show_codex_fast_mode) {
-              appendCheckboxField(
-                grid,
-                "Codex fast mode",
-                "Use the fast service tier",
-                launchWizard.codex_fast_mode,
-                (enabled) =>
-                  sendWizardAction({
-                    kind: "set_codex_fast_mode",
-                    enabled,
-                  }),
-              );
-            }
-            section.appendChild(grid);
+          const grid = createNode("div", "launch-form-grid");
+          if (launchWizard.show_runtime_target) {
+            appendSelectField(
+              grid,
+              "Runtime target",
+              launchWizard.runtime_target_options || [],
+              launchWizard.selected_runtime_target,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_runtime_target",
+                  target: runtimeTargetPayload(value),
+                }),
+            );
           }
+          if (
+            launchWizard.show_docker_service &&
+            (launchWizard.docker_service_options || []).length > 0
+          ) {
+            appendSelectField(
+              grid,
+              "Docker service",
+              launchWizard.docker_service_options || [],
+              launchWizard.selected_docker_service,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_docker_service",
+                  service: value,
+                }),
+            );
+          }
+          if (
+            launchWizard.show_docker_lifecycle &&
+            (launchWizard.docker_lifecycle_options || []).length > 0
+          ) {
+            appendSelectField(
+              grid,
+              "Docker lifecycle",
+              launchWizard.docker_lifecycle_options || [],
+              launchWizard.selected_docker_lifecycle,
+              (value) =>
+                sendWizardAction({
+                  kind: "set_docker_lifecycle",
+                  intent: dockerLifecyclePayload(value),
+                }),
+            );
+          }
+          section.appendChild(grid);
 
           panel.appendChild(section);
         }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7489,6 +7489,9 @@
               showUpdateButton(event.latest);
             }
             break;
+          case "update_apply_error":
+            window.alert(event.message || "Failed to start the update.");
+            break;
           case "custom_agent_list":
             customAgentsState.agents = event.agents || [];
             customAgentsState.loading = false;

--- a/crates/gwt/web/styles/tokens.css
+++ b/crates/gwt/web/styles/tokens.css
@@ -103,47 +103,49 @@
 }
 
 :root[data-theme="light"] {
-  /* Surface palette — bone + ink */
-  --color-canvas: #f5f3ee;
+  /* Surface palette — drafting table + ink.
+     Keep the light flagship bright, but give canvas / cards / chrome enough
+     luminance separation to remain scannable in dense work sessions. */
+  --color-canvas: #e9edf0;
   --color-surface: #ffffff;
-  --color-surface-elevated: #fbfaf6;
+  --color-surface-elevated: #f3f6f7;
   --color-overlay: rgba(20, 22, 26, 0.62);
   --color-scrim: rgba(20, 22, 26, 0.45);
 
   /* Text */
-  --color-text: #1a1d24;
+  --color-text: #151922;
   --color-text-strong: #000000;
-  --color-text-muted: #4a5159;
-  --color-text-disabled: #9ca3af;
+  --color-text-muted: #3f4752;
+  --color-text-disabled: #737d89;
 
   /* Display */
   --color-display-fg: #0a0d12;
 
   /* Status Strip — inverted dark strip on light canvas (Mission control feel) */
-  --color-status-strip-bg: #1a1d24;
-  --color-status-strip-fg: #f5f3ee;
-  --color-status-strip-divider: rgba(245, 243, 238, 0.18);
+  --color-status-strip-bg: #151922;
+  --color-status-strip-fg: #f4f7f8;
+  --color-status-strip-divider: rgba(244, 247, 248, 0.22);
 
   /* Buttons */
-  --color-button-bg: #1a1d24;
-  --color-button-bg-hover: #2a3140;
+  --color-button-bg: #151922;
+  --color-button-bg-hover: #263141;
   --color-button-fg: #ffffff;
-  --color-button-border: rgba(26, 29, 36, 0.18);
+  --color-button-border: rgba(21, 25, 34, 0.28);
 
   /* Borders */
-  --color-border: rgba(26, 29, 36, 0.10);
-  --color-border-strong: rgba(26, 29, 36, 0.28);
-  --color-focus-ring: #0e7490;
+  --color-border: rgba(21, 25, 34, 0.18);
+  --color-border-strong: rgba(21, 25, 34, 0.38);
+  --color-focus-ring: #075f73;
 
   /* Link */
-  --color-link: #0e7490;
-  --color-link-hover: #155e75;
+  --color-link: #075f73;
+  --color-link-hover: #064e5d;
 
   /* Live status semantics */
-  --color-state-active: #0e7490;
-  --color-state-idle: #6b7280;
-  --color-state-blocked: #b91c1c;
-  --color-state-done: #4b5563;
+  --color-state-active: #075f73;
+  --color-state-idle: #4b5563;
+  --color-state-blocked: #991b1b;
+  --color-state-done: #334155;
 
   /* Agent colors — dark-tuned chroma for bone background */
   --agent-claude: #92400e;
@@ -159,8 +161,8 @@
   --bg-depth-glow: radial-gradient(ellipse at top, rgba(14, 116, 144, 0.06), transparent 60%);
 
   /* Shadow */
-  --shadow-1: 0 1px 2px rgba(20, 22, 26, 0.06);
-  --shadow-2: 0 8px 24px rgba(20, 22, 26, 0.10);
+  --shadow-1: 0 1px 2px rgba(21, 25, 34, 0.10);
+  --shadow-2: 0 10px 28px rgba(21, 25, 34, 0.16);
   --shadow-glow-active: 0 0 0 1px var(--agent-color, var(--color-state-active)),
                         0 0 12px 0 color-mix(in oklab, var(--agent-color, var(--color-state-active)) 30%, transparent);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.20.2",
+  "version": "9.20.3",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.20.3 patch release: GUI とライトモードの視認性、Launch Agent 設定構成、更新トースト適用の3件のバグ修正をまとめたパッチリリースです。

## Changes

- **fix(ui):** improve light theme readability — Operator Design System のライトモード surface separation / borders / hover/active / state/accent legibility をトークン層単位で再調整 (#2500, related #2356)
- **fix(gui):** apply pending update from toast — 更新通知トースト/永続ボタンが pending の `UpdateState` を使って apply_update を起動するよう修正 (#2499, related #2041)
- **fix(gui):** regroup launch agent settings — Launch Agent ADVANCED を廃止し、Version/Skip permissions/Codex fast mode を Launch settings、Docker 系を Runtime セクションに整理 (#2498, related #2014)

## Version

v9.20.3

## Closing Issues

None

## Related Issues / Links

- #2014
- #2041
- #2356
