### PR TITLE
chore(release): v9.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.20.4] - 2026-05-06
+
+### Bug Fixes
+
+- **gui:** Launch Agentの設定復元を保持
+
 ## [9.20.3] - 2026-05-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "axum",
  "base64",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "chrono",
  "dunce",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "reqwest",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "dirs",
  "serde",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "dirs",
  "gwt-core",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "chrono",
  "fs2",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.20.3"
+version = "9.20.4"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.20.3"
+version = "9.20.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -204,6 +204,17 @@ pub struct LaunchWizardPreviousProfile {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentLaunchDraft {
+    model: String,
+    reasoning: String,
+    version: String,
+    mode: String,
+    resume_session_id: Option<String>,
+    skip_permissions: bool,
+    codex_fast_mode: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShellLaunchConfig {
     pub working_dir: Option<PathBuf>,
     pub branch: Option<String>,
@@ -502,6 +513,7 @@ pub struct LaunchWizardState {
     pub base_branch_name: Option<String>,
     pub launch_target: LaunchTargetKind,
     pub agent_id: String,
+    agent_drafts: HashMap<String, AgentLaunchDraft>,
     pub model: String,
     pub reasoning: String,
     pub version: String,
@@ -578,6 +590,7 @@ impl LaunchWizardState {
             base_branch_name: None,
             launch_target: LaunchTargetKind::Agent,
             agent_id: String::new(),
+            agent_drafts: HashMap::new(),
             model: String::new(),
             reasoning: String::new(),
             version: String::new(),
@@ -1090,10 +1103,13 @@ impl LaunchWizardState {
                 });
             }
             LaunchWizardStep::AgentSelect => {
-                if let Some(agent) = self.detected_agents.get(self.selected) {
-                    self.agent_id = agent.id.clone();
+                if let Some(agent_id) = self
+                    .detected_agents
+                    .get(self.selected)
+                    .map(|agent| agent.id.clone())
+                {
+                    self.set_agent_id(&agent_id);
                 }
-                self.sync_selected_agent_options();
             }
             LaunchWizardStep::ModelSelect => {
                 if let Some(model) =
@@ -1365,6 +1381,9 @@ impl LaunchWizardState {
     }
 
     fn set_launch_target(&mut self, target: LaunchTargetKind) {
+        if self.launch_target_is_agent() && target == LaunchTargetKind::Shell {
+            self.save_current_agent_draft();
+        }
         self.launch_target = target;
         if self.launch_target_is_shell() {
             self.mode = "normal".to_string();
@@ -1372,7 +1391,7 @@ impl LaunchWizardState {
             self.skip_permissions = false;
             self.codex_fast_mode = false;
         } else {
-            self.sync_selected_agent_options();
+            self.restore_agent_draft_or_defaults();
         }
     }
 
@@ -1383,11 +1402,12 @@ impl LaunchWizardState {
             .position(|candidate| candidate.id == agent_id)
         {
             Some(index) => {
+                self.save_current_agent_draft();
                 self.agent_id = agent_id.to_string();
                 if self.step == LaunchWizardStep::AgentSelect {
                     self.selected = index;
                 }
-                self.sync_selected_agent_options();
+                self.restore_agent_draft_or_defaults();
             }
             _ => {
                 self.error = Some("Agent option is unavailable".to_string());
@@ -1918,6 +1938,76 @@ impl LaunchWizardState {
         self.selected_agent()
             .map(|agent| self.current_version_options_for(agent))
             .unwrap_or_default()
+    }
+
+    fn current_agent_draft_key(&self) -> Option<String> {
+        if !self.launch_target_is_agent() {
+            return None;
+        }
+        if !self.agent_id.is_empty() {
+            return Some(self.agent_id.clone());
+        }
+        self.detected_agents.first().map(|agent| agent.id.clone())
+    }
+
+    fn save_current_agent_draft(&mut self) {
+        let Some(agent_id) = self.current_agent_draft_key() else {
+            return;
+        };
+        self.agent_drafts.insert(
+            agent_id,
+            AgentLaunchDraft {
+                model: self.model.clone(),
+                reasoning: self.reasoning.clone(),
+                version: self.version.clone(),
+                mode: self.mode.clone(),
+                resume_session_id: self.resume_session_id.clone(),
+                skip_permissions: self.skip_permissions,
+                codex_fast_mode: self.codex_fast_mode && self.agent_is_codex(),
+            },
+        );
+    }
+
+    fn restore_agent_draft_or_defaults(&mut self) {
+        let draft = self.agent_drafts.get(&self.agent_id).cloned();
+        match draft {
+            Some(draft) => self.apply_agent_draft(draft),
+            None => self.reset_agent_draft_defaults(),
+        }
+        self.sync_selected_agent_options();
+        self.normalize_execution_mode();
+    }
+
+    fn apply_agent_draft(&mut self, draft: AgentLaunchDraft) {
+        self.model = draft.model;
+        self.reasoning = draft.reasoning;
+        self.version = draft.version;
+        self.mode = draft.mode;
+        self.resume_session_id = draft.resume_session_id;
+        self.skip_permissions = draft.skip_permissions;
+        self.codex_fast_mode = draft.codex_fast_mode && self.agent_is_codex();
+    }
+
+    fn reset_agent_draft_defaults(&mut self) {
+        self.model.clear();
+        self.reasoning.clear();
+        self.version.clear();
+        self.mode = "normal".to_string();
+        self.resume_session_id = None;
+        self.skip_permissions = false;
+        self.codex_fast_mode = false;
+    }
+
+    fn normalize_execution_mode(&mut self) {
+        if !EXECUTION_MODE_OPTIONS
+            .iter()
+            .any(|option| option.value == self.mode)
+        {
+            self.mode = "normal".to_string();
+            self.resume_session_id = None;
+        } else if self.mode != "resume" {
+            self.resume_session_id = None;
+        }
     }
 
     fn current_reasoning_options(&self) -> &'static [ReasoningDisplayOption] {
@@ -4372,6 +4462,96 @@ mod tests {
             .launch_summary
             .iter()
             .any(|item| item.label == "Fast mode" && item.value == "on"));
+    }
+
+    #[test]
+    fn switching_agents_restores_each_agents_open_wizard_draft() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "codex".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetModel {
+            model: "gpt-5.4".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetReasoning {
+            reasoning: "high".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetVersion {
+            version: "0.110.0".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetExecutionMode {
+            mode: "continue".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetSkipPermissions { enabled: true });
+        state.apply(LaunchWizardAction::SetCodexFastMode { enabled: true });
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetModel {
+            model: "sonnet".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetReasoning {
+            reasoning: "low".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetVersion {
+            version: "installed".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetExecutionMode {
+            mode: "normal".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetSkipPermissions { enabled: false });
+
+        let claude_view = state.view();
+        assert_eq!(claude_view.selected_agent_id, "claude");
+        assert_eq!(claude_view.selected_model, "sonnet");
+        assert_eq!(claude_view.selected_reasoning, "low");
+        assert_eq!(claude_view.selected_version, "installed");
+        assert_eq!(claude_view.selected_execution_mode, "normal");
+        assert!(!claude_view.skip_permissions);
+        assert!(!claude_view.show_codex_fast_mode);
+        assert!(!claude_view.codex_fast_mode);
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "codex".to_string(),
+        });
+
+        let codex_view = state.view();
+        assert_eq!(codex_view.selected_agent_id, "codex");
+        assert_eq!(codex_view.selected_model, "gpt-5.4");
+        assert_eq!(codex_view.selected_reasoning, "high");
+        assert_eq!(codex_view.selected_version, "0.110.0");
+        assert_eq!(codex_view.selected_execution_mode, "continue");
+        assert!(codex_view.skip_permissions);
+        assert!(codex_view.codex_fast_mode);
+    }
+
+    #[test]
+    fn hidden_codex_fast_mode_draft_does_not_affect_claude_launch() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "codex".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetCodexFastMode { enabled: true });
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetSkipPermissions { enabled: false });
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
+        assert!(!config.codex_fast_mode);
+        assert!(!config.skip_permissions);
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.20.3",
+  "version": "9.20.4",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.20.4 では Launch Agent の設定復元に関するバグ修正を行います。直前リリース (v9.20.3) で導入された Launch settings / Runtime グルーピングと併せ、ユーザーが Launch Wizard を開いている間にエージェントを切り替えても、各エージェントごとの draft 設定（model / reasoning / version / execution mode / skip permissions / Codex fast mode）が保持されるようになります。

## Changes

### Bug Fixes
- **gui:** Launch Agent の設定復元を保持 (a366cfeb)
  - Launch Wizard を開いた状態で Codex → Claude → Codex のように agent を切り替えた際、これまで失われていた per-agent な draft 値を維持する
  - 永続的な per-agent デフォルトは増やさず、現在開いている Launch Wizard セッション内に閉じた変更

## Version

- Previous: `v9.20.3`
- New: `v9.20.4`
- Bump: patch (HAS_FIX=1, HAS_FEAT=0, HAS_BREAKING=0)

## Closing Issues

None

## Related Issues / Links

- #2014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Launch Agent wizard settings are now preserved when switching between agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->