### PR TITLE
fix(gui): harden titlebar dock targeting

### DIFF
--- a/crates/gwt/web/__tests__/window-docking.test.mjs
+++ b/crates/gwt/web/__tests__/window-docking.test.mjs
@@ -73,3 +73,22 @@ test("titlebar docking is only an entry point for ungrouped source windows", () 
     "dragging a grouped window titlebar must keep moving the group, not redock the tab",
   );
 });
+
+test("titlebar docking ignores invalid pointer points", () => {
+  const windows = [
+    {
+      id: "source",
+      geometry: { x: 40, y: 40, width: 200, height: 120 },
+      z_index: 1,
+    },
+    {
+      id: "target",
+      geometry: { x: 100, y: 100, width: 220, height: 140 },
+      z_index: 9,
+    },
+  ];
+
+  assert.equal(findTitlebarDockTarget(windows, null, "source"), null);
+  assert.equal(findTitlebarDockTarget(windows, { x: Number.NaN, y: 112 }, "source"), null);
+  assert.equal(findTitlebarDockTarget(windows, { x: 130, y: Number.POSITIVE_INFINITY }, "source"), null);
+});

--- a/crates/gwt/web/window-docking.js
+++ b/crates/gwt/web/window-docking.js
@@ -6,6 +6,9 @@ export function findTitlebarDockTarget(
   sourceId,
   hitHeight = TITLEBAR_DOCK_HIT_HEIGHT,
 ) {
+  if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+    return null;
+  }
   const windowList = windows || [];
   const sourceWindow = windowList.find((windowData) => windowData?.id === sourceId);
   if (sourceWindow?.tab_group_id) {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -7,29 +7,22 @@
 SPEC-2008 Window Tabs で backend / protocol / persistence と grouped tab
 strip は実装済みだったが、ungrouped window から tab group を作る初回
 入口がなく、ユーザーは実際にはタブ化できなかった。既存 frontend test
-は `dock_window_tab` などの文字列存在を見ていたため、titlebar drag が
-有効な drop target を解決できるか、body/canvas drop を dock 扱いしな
-いかを検出できなかった。
+は配線の存在確認に偏っており、実際の操作可能性を検出できなかった。
 
 ### 原因
 
-DOM 生成や event 名の存在を source-string contract で固定しても、pointer
-座標、target hit-test、z-index、hidden tab の除外といった interaction
-behavior は保証されない。さらに embedded frontend の asset route は
-`/assets/xterm/...` や font route を Rust server が提供するため、単純な
-static file server を Playwright smoke の代替にすると 404 や boot 差分
-が混ざる。
+DOM 生成や event 名の存在を source-string contract で固定しても、
+interaction behavior は保証されない。操作の入口、対象判定、負例、既存
+動作との境界は、ユーザーが実際に使う流れに近い形で検証する必要がある。
 
 ### 再発防止策
 
-1. Pointer / DnD / keyboard interaction を追加するときは、可能な限り
-   hit-test や state transition を小さな純粋関数に切り出し、`node --test`
-   で座標・負例・優先順位まで固定する。
+1. Pointer / DnD / keyboard interaction を追加するときは、操作可能性と
+   負例を behavior test で確認する。
 2. Source-string contract は配線漏れ検出に限定し、操作可能性の唯一の
    根拠にしない。
-3. GUI smoke で embedded frontend を検証する場合は `cargo run -p gwt --bin gwt`
-   が出す `gwt browser URL` を使う。static web root 配信は embedded route
-   と同等ではない。
+3. 詳細な test plan / implementation note は SPEC / PR に集約する。
+   関連: SPEC #2008 / PR #2510。
 
 ## 2026-05-04 — Audit-driven a11y coverage finds gaps that audit-by-checklist misses
 


### PR DESCRIPTION
## Summary

- Follows up PR #2510 with the remaining review fixes that landed after the PR was merged.
- Hardens titlebar dock target lookup so invalid pointer inputs safely return no target.
- Keeps the SPEC-2008 lesson entry conceptual and points detailed implementation notes back to SPEC/PR records.

## Changes

- `crates/gwt/web/window-docking.js`: Adds a defensive `Number.isFinite` pointer guard before reading `point.x` / `point.y`.
- `crates/gwt/web/__tests__/window-docking.test.mjs`: Adds coverage for null, NaN, and Infinity pointer inputs.
- `tasks/lessons.md`: Removes implementation-level details from the new lesson and links to SPEC #2008 / PR #2510.

## Testing

- [x] `pnpm test:frontend-bundle` - passed.
- [x] `pnpm test:frontend-unit` - passed, 243 tests.
- [x] `cargo fmt -- --check` - passed.
- [x] `git diff --check` - passed.
- [x] `pnpm exec commitlint --from HEAD~1 --to HEAD` - passed.
- [x] Commit-time backend tests - passed.
- [x] Pre-push CI-equivalent checks - passed, coverage 90.72%.
- [ ] `pnpm exec markdownlint tasks/lessons.md` - not run; `markdownlint` command is not installed in this workspace.

## Closing Issues

- None

## Related Issues / Links

- #2008
- #2510

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo fmt`, frontend checks, commitlint)
- [x] Documentation updated (if user-facing change) - Internal lesson entry adjusted per review.
- [x] Migration/backfill plan included (if schema/data change) - No schema/data migration required.
- [x] CHANGELOG impact considered (breaking change flagged in commit) - Patch fix, no breaking change.

## Context

PR #2510 was auto-merged before commit `009b5c1e` was included in `develop`, leaving one follow-up commit on `work/20260506-1747`.

## Risk / Impact

- **Affected areas**: Titlebar docking hit-test helper and local lessons documentation.
- **Rollback plan**: Revert this PR; PR #2510 remains merged without this defensive helper hardening and lesson cleanup.
