### PR TITLE
fix(gui): Light テーマでのエージェント端末の二重枠とサイドバーボタンUA枠を解消

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1326,3 +1326,75 @@ test("agent cards style all four Living Telemetry states (active / blocked / idl
   assert.match(css, /\.op-agent-card\[data-state="idle"\]\s*\.op-agent-state\s*\{[^}]*--color-state-idle/);
   assert.match(css, /\.op-agent-card\[data-state="done"\]\s*\.op-agent-state\s*\{[^}]*--color-state-done/);
 });
+
+test("terminal surface body stays on the dark Operator canvas across themes (FR-013)", () => {
+  // SPEC-2356 FR-013 改定: terminal window の body 領域 (.window-body と
+  // terminal-root padding) は xterm の Dark Operator background と連続させ
+  // るため、Light テーマでも Dark Operator background に固定する。Light で
+  // --color-canvas (#e9edf0) が見えると xterm 周囲に「外枠」が現れて二重
+  // 枠になるので、ここで結合してしまうのが正解。
+  const surfaceTerminalRule =
+    /\.surface-terminal\s+\.window-body\s*\{[^}]*background:\s*([^;]+);/;
+  const match = html.match(surfaceTerminalRule);
+  assert.ok(match, "expected .surface-terminal .window-body rule with explicit background");
+  const value = match[1].trim();
+  assert.doesNotMatch(
+    value,
+    /var\(\s*--color-canvas\s*\)/,
+    `.surface-terminal .window-body must not follow --color-canvas (got "${value}")`,
+  );
+  assert.doesNotMatch(
+    value,
+    /var\(\s*--color-surface(?:-elevated)?\s*\)/,
+    `.surface-terminal .window-body must not follow surface tokens (got "${value}")`,
+  );
+  // Accept either an explicit dark hex (Dark Operator canvas) or a dedicated
+  // dark canvas token.  We codify the value contract so the regression cannot
+  // silently flip back to a light token.
+  const usesDarkOperatorBackground =
+    /^#0a0d12$/i.test(value) || /var\(\s*--color-canvas-dark\s*\)/.test(value);
+  assert.ok(
+    usesDarkOperatorBackground,
+    `.surface-terminal .window-body must use Dark Operator canvas (#0a0d12 or --color-canvas-dark); got "${value}"`,
+  );
+});
+
+test("non-terminal surface bodies still follow the overall theme (FR-013 boundary)", () => {
+  // The Dark fix is scoped to .surface-terminal.  Other surfaces (Board /
+  // Logs / File Tree / Branches / Knowledge / Mock / Memo / Profile) must
+  // keep tracking the active theme via --color-surface so tabbed windows
+  // still flip body color when a non-terminal tab is selected.
+  const otherSurfaceRule =
+    /(?:\.surface-(?:file-tree|branches|board|logs|knowledge|mock|memo|profile)\s+\.window-body,?\s*)+\{[^}]*background:\s*var\(\s*--color-surface\s*\)/;
+  assert.match(
+    html,
+    otherSurfaceRule,
+    "non-terminal surface bodies must continue to use var(--color-surface)",
+  );
+});
+
+test("Sidebar Layer buttons reset UA chrome so Windows WebView2 stops drawing default border (FR-030)", () => {
+  // SPEC-2356 FR-030 / US-4 AS-11: WebView2 / Chromium の `<button>` UA
+  // default は border + grey background を出す。`.op-layer` は indicator
+  // dot + label color + token-driven focus ring のみで状態を表現するため、
+  // base rule で UA chrome を解除する必要がある。
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  const layerRule = css.match(/\.op-layer\s*\{([^}]*)\}/);
+  assert.ok(layerRule, "expected base .op-layer rule in components.css");
+  const body = layerRule[1];
+  assert.match(
+    body,
+    /appearance:\s*none/,
+    ".op-layer must declare appearance:none to disable UA <button> chrome",
+  );
+  assert.match(
+    body,
+    /border:\s*0/,
+    ".op-layer must zero out border so WebView2 stops drawing the default frame",
+  );
+  assert.match(
+    body,
+    /background:\s*transparent/,
+    ".op-layer must clear background so the sidebar surface shows through",
+  );
+});

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -710,8 +710,14 @@
         display: none;
       }
 
+      /* SPEC-2356 FR-013 (revised): the terminal surface body must stay
+         continuous with the xterm Dark Operator background (#0a0d12). If
+         Light theme leaks var(--color-canvas) here, the xterm region picks
+         up a pale gray frame around the dark terminal and the window looks
+         double-framed. Chrome (titlebar / tab strip) still follows the
+         overall theme; this override is scoped to the body only. */
       .surface-terminal .window-body {
-        background: var(--color-canvas);
+        background: #0a0d12;
       }
 
       .surface-file-tree .window-body,

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -244,6 +244,13 @@ body::after {
   font-family: var(--font-body);
   font-size: var(--type-sm);
   color: var(--color-text);
+  /* SPEC-2356 FR-030: WebView2 / Chromium の <button> UA chrome (border +
+     grey background) を解除し、状態は indicator dot + label color + token
+     focus ring のみで表現する。macOS WebKit では UA default が控えめだが
+     Windows で灰色枠が出ていたのを統一して消す。 */
+  appearance: none;
+  border: 0;
+  background: transparent;
 }
 
 .op-layer__indicator {


### PR DESCRIPTION
## Summary

- Light テーマでエージェント端末ウィンドウの xterm 周囲に出ていた light gray の「外枠」を解消するため、`.surface-terminal .window-body` の background を Dark Operator (`#0a0d12`) 固定にした。chrome (タイトルバー・タブ strip・外枠 border) は overall theme に追従。
- Windows WebView2 / Chromium で目立っていたサイドバーボタンの灰色 UA 枠を解消するため、`.op-layer` に `appearance: none / border: 0 / background: transparent` を追加し、状態は indicator dot + label 色 + token 駆動 focus ring で表現する。
- SPEC-2356 を改定: FR-013 と US-3 AS-5 を「chrome=タイトルバー等のみ追従、body=Dark 固定」に明確化、US-3 AS-9/AS-10 / US-4 AS-11 / FR-030 を追加、Phase 8 と T-119〜T-128 を追記。
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` に三本の構造 regression を追加し、CSS 上の契約を test-first で固定。

## Test plan

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 新規 3 テストを含む 68 全 GREEN
- [x] `pnpm run test:frontend-unit` — 236 tests GREEN
- [x] `pnpm run test:frontend-bundle` — node --check GREEN
- [x] `cargo test -p gwt-core -p gwt` — GREEN
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — GREEN
- [x] `cargo fmt -- --check` — GREEN
- [x] `cargo build -p gwt` — GREEN
- [ ] Windows / macOS / Linux 三 platform で gwt を起動し、Light テーマ + agent terminal active + サイドバーボタンの目視確認 (T-128 の手動 GUI smoke、未実施)

Refs: SPEC-2356 (#2356)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
