### PR TITLE
feat(index): SPEC-1939 Phase 12 foundation — Repairing state + RebuildProgress

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4591,9 +4591,11 @@ exit 0
                     .expect("release bootstrap");
                 Ok(())
             },
-            |_project_root| gwt::ProjectIndexStatusView {
-                state: gwt::ProjectIndexStatusState::Ready,
-                detail: "test bootstrap complete".to_string(),
+            |_project_root| {
+                gwt::ProjectIndexStatusView::new(
+                    gwt::ProjectIndexStatusState::Ready,
+                    "test bootstrap complete",
+                )
             },
         );
         let spawn_elapsed = spawn_started.elapsed();
@@ -4661,10 +4663,10 @@ exit 0
             |proxy, project_root| {
                 proxy.send(UserEvent::ProjectIndexStatus {
                     project_root: project_root.display().to_string(),
-                    status: gwt::ProjectIndexStatusView {
-                        state: gwt::ProjectIndexStatusState::Ready,
-                        detail: "ready".to_string(),
-                    },
+                    status: gwt::ProjectIndexStatusView::new(
+                        gwt::ProjectIndexStatusState::Ready,
+                        "ready",
+                    ),
                 });
             },
         );

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -47,6 +47,7 @@ pub enum ProjectIndexStatusState {
     Skipped,
     Error,
     RepairRequired,
+    Repairing,
 }
 
 impl ProjectIndexStatusState {
@@ -56,6 +57,7 @@ impl ProjectIndexStatusState {
             Self::Skipped => "skipped",
             Self::Error => "error",
             Self::RepairRequired => "repair_required",
+            Self::Repairing => "repairing",
         }
     }
 }
@@ -66,19 +68,37 @@ impl fmt::Display for ProjectIndexStatusState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RebuildProgress {
+    pub scopes_done: u32,
+    pub scopes_total: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProjectIndexStatusView {
     pub state: ProjectIndexStatusState,
     pub detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair_started_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress: Option<RebuildProgress>,
+}
+
+impl ProjectIndexStatusView {
+    pub fn new(state: ProjectIndexStatusState, detail: impl Into<String>) -> Self {
+        Self {
+            state,
+            detail: detail.into(),
+            repair_started_at: None,
+            progress: None,
+        }
+    }
 }
 
 pub fn project_index_status_for_path(project_root: &Path) -> ProjectIndexStatusView {
     match project_index_status_for_path_inner(project_root) {
         Ok(status) => status,
-        Err(error) => ProjectIndexStatusView {
-            state: ProjectIndexStatusState::Error,
-            detail: error,
-        },
+        Err(error) => ProjectIndexStatusView::new(ProjectIndexStatusState::Error, error),
     }
 }
 
@@ -86,16 +106,16 @@ fn project_index_status_for_path_inner(
     project_root: &Path,
 ) -> Result<ProjectIndexStatusView, String> {
     let Some(repo_root) = resolve_git_worktree_root(project_root) else {
-        return Ok(ProjectIndexStatusView {
-            state: ProjectIndexStatusState::Skipped,
-            detail: "No git worktree detected".to_string(),
-        });
+        return Ok(ProjectIndexStatusView::new(
+            ProjectIndexStatusState::Skipped,
+            "No git worktree detected",
+        ));
     };
     let Some(repo_hash) = detect_repo_hash(&repo_root) else {
-        return Ok(ProjectIndexStatusView {
-            state: ProjectIndexStatusState::Skipped,
-            detail: "No origin remote configured".to_string(),
-        });
+        return Ok(ProjectIndexStatusView::new(
+            ProjectIndexStatusState::Skipped,
+            "No origin remote configured",
+        ));
     };
     let worktree_hash =
         compute_worktree_hash(&repo_root).map_err(|err| format!("compute worktree hash: {err}"))?;
@@ -131,10 +151,10 @@ fn project_index_status_for_path_inner(
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         let detail = if stderr.is_empty() { stdout } else { stderr };
-        return Ok(ProjectIndexStatusView {
-            state: ProjectIndexStatusState::Error,
-            detail: format!("runner exit {}: {detail}", output.status),
-        });
+        return Ok(ProjectIndexStatusView::new(
+            ProjectIndexStatusState::Error,
+            format!("runner exit {}: {detail}", output.status),
+        ));
     }
     let payload: serde_json::Value = serde_json::from_slice(&output.stdout)
         .map_err(|err| format!("parse project index status: {err}"))?;
@@ -154,15 +174,15 @@ fn project_index_status_for_path_inner(
         })
         .unwrap_or(0);
     if unhealthy == 0 {
-        Ok(ProjectIndexStatusView {
-            state: ProjectIndexStatusState::Ready,
-            detail: format!("Runtime ready; asset {}", report.runner_hash),
-        })
+        Ok(ProjectIndexStatusView::new(
+            ProjectIndexStatusState::Ready,
+            format!("Runtime ready; asset {}", report.runner_hash),
+        ))
     } else {
-        Ok(ProjectIndexStatusView {
-            state: ProjectIndexStatusState::RepairRequired,
-            detail: format!("{unhealthy} index scope(s) require repair"),
-        })
+        Ok(ProjectIndexStatusView::new(
+            ProjectIndexStatusState::RepairRequired,
+            format!("{unhealthy} index scope(s) require repair"),
+        ))
     }
 }
 
@@ -298,14 +318,95 @@ mod tests {
 
     #[test]
     fn project_index_status_state_serializes_stable_protocol_values() {
-        let status = ProjectIndexStatusView {
-            state: ProjectIndexStatusState::RepairRequired,
-            detail: "1 scope requires repair".to_string(),
-        };
+        let status = ProjectIndexStatusView::new(
+            ProjectIndexStatusState::RepairRequired,
+            "1 scope requires repair",
+        );
 
         let payload = serde_json::to_value(status).expect("serialize status");
 
         assert_eq!(payload["state"], "repair_required");
         assert_eq!(payload["detail"], "1 scope requires repair");
+    }
+
+    #[test]
+    fn project_index_status_state_serializes_repairing_variant() {
+        let status = ProjectIndexStatusView::new(
+            ProjectIndexStatusState::Repairing,
+            "rebuilding 1/4: issues",
+        );
+
+        let payload = serde_json::to_value(&status).expect("serialize status");
+
+        assert_eq!(payload["state"], "repairing");
+        assert_eq!(payload["detail"], "rebuilding 1/4: issues");
+        assert_eq!(ProjectIndexStatusState::Repairing.as_str(), "repairing");
+        assert_eq!(
+            format!("{}", ProjectIndexStatusState::Repairing),
+            "repairing"
+        );
+    }
+
+    #[test]
+    fn project_index_status_view_omits_repair_progress_when_absent() {
+        let view = ProjectIndexStatusView {
+            state: ProjectIndexStatusState::Ready,
+            detail: "Runtime ready".to_string(),
+            repair_started_at: None,
+            progress: None,
+        };
+
+        let payload = serde_json::to_value(&view).expect("serialize ready view");
+
+        assert_eq!(payload["state"], "ready");
+        assert!(
+            payload.get("repair_started_at").is_none(),
+            "repair_started_at should be omitted when None: {payload:?}"
+        );
+        assert!(
+            payload.get("progress").is_none(),
+            "progress should be omitted when None: {payload:?}"
+        );
+    }
+
+    #[test]
+    fn project_index_status_view_emits_repair_progress_when_present() {
+        let started = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+            chrono::NaiveDateTime::parse_from_str("2026-05-07T01:23:45", "%Y-%m-%dT%H:%M:%S")
+                .expect("parse fixed timestamp"),
+            chrono::Utc,
+        );
+        let view = ProjectIndexStatusView {
+            state: ProjectIndexStatusState::Repairing,
+            detail: "rebuilding 1/4: issues".to_string(),
+            repair_started_at: Some(started),
+            progress: Some(RebuildProgress {
+                scopes_done: 1,
+                scopes_total: 4,
+            }),
+        };
+
+        let payload = serde_json::to_value(&view).expect("serialize repairing view");
+
+        assert_eq!(payload["state"], "repairing");
+        assert_eq!(payload["repair_started_at"], "2026-05-07T01:23:45Z");
+        assert_eq!(payload["progress"]["scopes_done"], 1);
+        assert_eq!(payload["progress"]["scopes_total"], 4);
+    }
+
+    #[test]
+    fn project_index_status_state_variant_set_is_complete() {
+        let variants = [
+            ProjectIndexStatusState::Ready,
+            ProjectIndexStatusState::Skipped,
+            ProjectIndexStatusState::Error,
+            ProjectIndexStatusState::RepairRequired,
+            ProjectIndexStatusState::Repairing,
+        ];
+        let serialized: Vec<&'static str> = variants.iter().map(|state| state.as_str()).collect();
+        assert_eq!(
+            serialized,
+            vec!["ready", "skipped", "error", "repair_required", "repairing",]
+        );
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -137,14 +137,16 @@ fn spawn_project_index_status_check(runtime: &Runtime, proxy: EventLoopProxy<Use
                 gwt::index_worker::project_index_status_for_path(&path)
             })
             .await
-            .unwrap_or_else(|err| gwt::ProjectIndexStatusView {
-                state: gwt::ProjectIndexStatusState::Error,
-                detail: format!("Project index status task failed: {err}"),
+            .unwrap_or_else(|err| {
+                gwt::ProjectIndexStatusView::new(
+                    gwt::ProjectIndexStatusState::Error,
+                    format!("Project index status task failed: {err}"),
+                )
             }),
-            None => gwt::ProjectIndexStatusView {
-                state: gwt::ProjectIndexStatusState::Skipped,
-                detail: "No current directory".to_string(),
-            },
+            None => gwt::ProjectIndexStatusView::new(
+                gwt::ProjectIndexStatusState::Skipped,
+                "No current directory",
+            ),
         };
         let _ = proxy.send_event(UserEvent::ProjectIndexStatus {
             project_root: project_root_label,

--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -114,12 +114,12 @@ impl ProjectIndexBootstrapService {
                         );
                         proxy.send(UserEvent::ProjectIndexStatus {
                             project_root: project_root_label,
-                            status: gwt::ProjectIndexStatusView {
-                                state: gwt::ProjectIndexStatusState::Error,
-                                detail: format!(
+                            status: gwt::ProjectIndexStatusView::new(
+                                gwt::ProjectIndexStatusState::Error,
+                                format!(
                                     "Project index bootstrap failed after {elapsed_ms} ms: {error}"
                                 ),
-                            },
+                            ),
                         });
                     }
                 }
@@ -222,9 +222,8 @@ mod tests {
                     .expect("release bootstrap");
                 Ok(())
             },
-            |_project_root| gwt::ProjectIndexStatusView {
-                state: gwt::ProjectIndexStatusState::Ready,
-                detail: "ready".to_string(),
+            |_project_root| {
+                gwt::ProjectIndexStatusView::new(gwt::ProjectIndexStatusState::Ready, "ready")
             },
         );
         started_rx
@@ -282,9 +281,11 @@ mod tests {
                 proxy.clone(),
                 temp.path().to_path_buf(),
                 |_project_root: &Path| Ok(()),
-                |_project_root| gwt::ProjectIndexStatusView {
-                    state: gwt::ProjectIndexStatusState::Ready,
-                    detail: "retry ready".to_string(),
+                |_project_root| {
+                    gwt::ProjectIndexStatusView::new(
+                        gwt::ProjectIndexStatusState::Ready,
+                        "retry ready",
+                    )
                 },
             );
             if retry == super::ProjectIndexBootstrapRequest::Spawned {


### PR DESCRIPTION
## Summary

SPEC-1939 Phase 12 (Index Health UX Surface) の foundation コミット。Project Index の状態モデルに `Repairing` 状態と進捗フィールドを追加。後続のオーケストレータ・GUI・Settings.Index タブを支える土台。

- **T-IDX-095**: `ProjectIndexStatusState::Repairing` variant 追加 + serde で `"repairing"` にシリアライズ。既存 variant は据え置き
- **T-IDX-096**: `RebuildProgress { scopes_done, scopes_total }` 構造体と `ProjectIndexStatusView::new()` コンストラクタ。`repair_started_at: Option<DateTime<Utc>>` / `progress: Option<RebuildProgress>` を `#[serde(skip_serializing_if = "Option::is_none")]` 付きで追加し、現行ペイロードへの後方互換を維持
- 既存呼び出し元 (`project_index_status_for_path` / `project_index_bootstrap` / `app_runtime` tests / `main.rs`) を新コンストラクタ経由へ移行

## Why this PR exists

ユーザーから「Index: repair バッジが何を意味しているのか／どの worktree のものか分からない／自動修復しないなら出す意味は？」という指摘を受け、SPEC-1939 に Phase 12 (Index Health UX Surface) を追加した（spec/plan/tasks セクション更新済み）。Phase 12 全体は backend Rust + frontend JS + E2E + Settings UI を含む大きな範囲のため、本 PR は **状態モデルだけを切り出した foundation**。後続 PR で auto-rebuild orchestrator、in-flight 集合の granularity 拡張、WebSocket payload 拡張、Settings.Index タブ、worktree tab dot、上部バッジの click handler 改修を順次積み上げる。

## Scope (intentional)

含む:

- `Repairing` variant 追加と serde "repairing"
- `RebuildProgress` 構造体追加
- `ProjectIndexStatusView::new()` コンストラクタと `repair_started_at` / `progress` の Optional フィールド
- 既存呼び出し元の新コンストラクタ移行

含まない（後続 PR で実装）:

- Auto-rebuild orchestrator（T-IDX-097 / T-IDX-098）
- in-flight 集合を `(project_root, scope, worktree_hash)` granularity へ拡張（T-IDX-099）
- per-worktree status aggregator（T-IDX-100）
- WebSocket payload 拡張（T-IDX-101）
- Settings.Index タブ向け IPC entrypoint（T-IDX-102）
- Frontend `repairing` rendering / badge click / Settings.Index タブ / worktree tab dot（T-IDX-103〜T-IDX-108）
- E2E + manual smoke（T-IDX-109〜T-IDX-112）

## Test plan

- [x] `cargo test -p gwt --lib index_worker`（5 unit tests pass、含む新規 3 テスト）
- [x] `cargo test -p gwt -p gwt-core`（既存テストにも回帰なし）
- [x] `cargo clippy --all-targets --all-features -- -D warnings`（clean）
- [x] `cargo fmt -- --check`（clean）
- [x] `bunx commitlint --from HEAD~1 --to HEAD`（pass）

## Related

- SPEC: #1939 (gwt-spec: セマンティック検索基盤) — Phase 12 を追加（spec / plan / tasks 更新済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
