### PR TITLE
fix(gui): preserve window controls tab flow

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -566,6 +566,15 @@ test("window controls peek 帯 targets only collapsible control groups", () => {
   assert.ok(actionsGroup, "expected continuous window controls actions group");
   assert.ok(primaryGroup, "expected primary window controls group");
   assert.ok(addGroup, "expected add-window control group");
+
+  const floatingControls = document.getElementById("floating-window-controls");
+  assert.ok(floatingControls, "expected floating window controls root");
+  const toolbarChildren = Array.from(floatingControls.children);
+  assert.ok(
+    toolbarChildren.indexOf(windowControlsPeek) < toolbarChildren.indexOf(actionsGroup),
+    "peek must precede actions in DOM order so forward Tab enters the revealed controls",
+  );
+
   assert.ok(actionsGroup.contains(primaryGroup), "primary controls must stay inside the continuous actions group");
   assert.ok(actionsGroup.contains(addGroup), "add controls must stay inside the continuous actions group");
 
@@ -764,6 +773,8 @@ test("components.css hover-reveals only the marked floating window control group
   // Palette and Zoom controls remain in the toolbar regardless.
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
   assert.match(css, /#floating-window-controls-actions[\s\S]*?display:\s*none/);
+  assert.match(css, /#floating-window-controls-actions\s*\{[^}]*order:\s*1/);
+  assert.match(css, /\.op-window-controls-peek\s*\{[^}]*order:\s*2/);
   assert.match(
     css,
     /\[data-op-window-controls="revealed"\][\s\S]+?#floating-window-controls-actions[\s\S]*?display:\s*flex/,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3359,6 +3359,14 @@
             <button class="arrange-button" id="zoom-out-button" aria-label="Zoom out">-</button>
             <button class="arrange-button" id="zoom-reset-button" aria-label="Reset zoom">100%</button>
             <button class="arrange-button" id="zoom-in-button" aria-label="Zoom in">+</button>
+            <div
+              class="op-window-controls-peek"
+              role="button"
+              tabindex="0"
+              aria-label="Show window controls"
+              aria-controls="floating-window-controls-actions"
+              data-hover-reveal="window-controls"
+            ></div>
             <div class="floating-window-controls-group" id="floating-window-controls-actions">
               <div class="floating-window-controls-group" id="floating-window-controls-primary">
                 <button class="arrange-button" id="tile-button" aria-label="Tile windows" data-window-control="true">Tile</button>
@@ -3381,14 +3389,6 @@
                 <button class="add-button" id="add-button" aria-label="Add window" data-window-control="true">+</button>
               </div>
             </div>
-            <div
-              class="op-window-controls-peek"
-              role="button"
-              tabindex="0"
-              aria-label="Show window controls"
-              aria-controls="floating-window-controls-actions"
-              data-hover-reveal="window-controls"
-            ></div>
           </div>
           <div
             class="op-sidebar-peek"

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -711,6 +711,7 @@ body::after {
    / Windows) and add (+) groups are auto-hidden until pointer hover /
    keyboard focus / pointer tap on the peek 帯. */
 .op-window-controls-peek {
+  order: 2;
   width: 32px;
   height: 24px;
   border-radius: var(--radius-md);
@@ -1923,6 +1924,7 @@ kbd.op-kbd {
    until [data-op-window-controls="revealed"] is set by the hover-reveal state
    machine. Palette and Zoom controls remain in the toolbar regardless. */
 :root[data-theme] #floating-window-controls-actions {
+  order: 1;
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- Preserves forward keyboard tab flow from the Window controls peek strip into the revealed Tile / Stack / Windows / Add actions.
- Keeps the visual hover path from the right-edge peek strip to Add window continuous by using CSS order rather than DOM order.

## Changes

- `crates/gwt/web/index.html`: moves `.op-window-controls-peek` before `#floating-window-controls-actions` in DOM order so Tab advances into the revealed controls.
- `crates/gwt/web/styles/components.css`: assigns `order: 1` to the action group and `order: 2` to the peek strip so the visual order remains actions then peek.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds a regression contract for DOM tab order and visual-order CSS.

## Testing

- [x] `pnpm exec node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — RED before implementation, then GREEN.
- [x] `pnpm exec node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/operator-shell-hover-reveal.test.mjs crates/gwt/web/__tests__/operator-shell-runtime.test.mjs` — 86 tests pass.
- [x] `pnpm run test:frontend-unit` — 260 tests pass.
- [x] `pnpm run test:frontend-bundle` — syntax checks pass.
- [x] `cargo test -p gwt-core -p gwt` — Rust tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes.
- [x] `cargo fmt -- --check` — passes.
- [x] `cargo build -p gwt` — passes.
- [x] `git diff --check` — passes.

## Closing Issues

- None

## Related Issues / Links

- #2356
- Follow-up to #2525 review thread

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2356 tasks)
- [x] Migration/backfill plan included (not needed: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level GUI bug fix)

## Context

- PR #2525 fixed the pointer path to Add window by placing the peek strip visually after the action group. A review thread caught the keyboard side effect: DOM order also moved the peek strip after the actions, so forward Tab from the focused peek skipped the revealed controls.

## Risk / Impact

- **Affected areas**: Operator Chrome bottom-right floating controls.
- **Rollback plan**: Revert this PR to restore the previous DOM order.

## Screenshots

- Not attached; this is a keyboard/hover ordering fix covered by frontend structure and behavior tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced window controls peek element with improved accessibility attributes (`aria-controls` targeting and ARIA relationships).

* **Style**
  * Adjusted visual ordering of the peek element within floating window controls.

* **Tests**
  * Extended test coverage for peek element behavior, including DOM ordering verification and accessibility assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->