### PR TITLE
refactor(gui): centralize update CTA asset wiring

### DIFF
--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -111,94 +111,65 @@ impl EmbeddedServer {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let hook_forward_token = Uuid::new_v4().to_string();
 
-        let app = Router::new()
-            .route("/", get(embedded_web::index_handler))
-            .route("/app.js", get(embedded_web::app_js_handler))
-            .route(
-                "/branch-cleanup-modal.js",
-                get(embedded_web::branch_cleanup_modal_js_handler),
-            )
-            .route(
-                "/migration-modal.js",
-                get(embedded_web::migration_modal_js_handler),
-            )
-            .route(
-                "/window-docking.js",
-                get(embedded_web::window_docking_js_handler),
-            )
-            .route(
-                "/board-surface.js",
-                get(embedded_web::board_surface_js_handler),
-            )
-            .route("/update-cta.js", get(embedded_web::update_cta_js_handler))
-            .route(
-                "/assets/xterm/xterm.mjs",
-                get(embedded_web::xterm_js_handler),
-            )
-            .route(
-                "/assets/xterm/addon-fit.mjs",
-                get(embedded_web::xterm_fit_js_handler),
-            )
-            .route(
-                "/assets/xterm/xterm.css",
-                get(embedded_web::xterm_css_handler),
-            )
-            // SPEC-2356 Operator Design System — module + styles + fonts.
-            .route(
-                "/theme-manager.js",
-                get(embedded_web::theme_manager_js_handler),
-            )
-            .route(
-                "/theme-toggle.js",
-                get(embedded_web::theme_toggle_js_handler),
-            )
-            .route("/hotkey.js", get(embedded_web::hotkey_js_handler))
-            .route(
-                "/operator-shell.js",
-                get(embedded_web::operator_shell_js_handler),
-            )
-            .route("/focus-trap.js", get(embedded_web::focus_trap_js_handler))
-            .route(
-                "/styles/tokens.css",
-                get(embedded_web::styles_tokens_css_handler),
-            )
-            .route(
-                "/styles/typography.css",
-                get(embedded_web::styles_typography_css_handler),
-            )
-            .route(
-                "/styles/components.css",
-                get(embedded_web::styles_components_css_handler),
-            )
-            .route(
-                "/assets/fonts/MonaSans.woff2",
-                get(embedded_web::font_mona_sans_handler),
-            )
-            .route(
-                "/assets/fonts/HubotSans-Regular.woff2",
-                get(embedded_web::font_hubot_regular_handler),
-            )
-            .route(
-                "/assets/fonts/HubotSans-Bold.woff2",
-                get(embedded_web::font_hubot_bold_handler),
-            )
-            .route(
-                "/assets/fonts/HubotSansCondensed-Bold.woff2",
-                get(embedded_web::font_hubot_condensed_bold_handler),
-            )
-            .route(
-                "/assets/fonts/JetBrainsMono.woff2",
-                get(embedded_web::font_jetbrains_mono_handler),
-            )
-            .route("/healthz", get(health_handler))
-            .route("/internal/hook-live", post(hook_live_handler))
-            .route("/ws", get(websocket_handler))
-            .with_state(ServerState {
-                proxy,
-                clients,
-                hook_forward_token: hook_forward_token.clone(),
-                pty_writers,
-            });
+        let app = route_root_js_modules(
+            Router::new()
+                .route("/", get(embedded_web::index_handler))
+                .route("/app.js", get(embedded_web::app_js_handler)),
+        )
+        .route(
+            "/assets/xterm/xterm.mjs",
+            get(embedded_web::xterm_js_handler),
+        )
+        .route(
+            "/assets/xterm/addon-fit.mjs",
+            get(embedded_web::xterm_fit_js_handler),
+        )
+        .route(
+            "/assets/xterm/xterm.css",
+            get(embedded_web::xterm_css_handler),
+        )
+        // SPEC-2356 Operator Design System — styles + fonts.
+        .route(
+            "/styles/tokens.css",
+            get(embedded_web::styles_tokens_css_handler),
+        )
+        .route(
+            "/styles/typography.css",
+            get(embedded_web::styles_typography_css_handler),
+        )
+        .route(
+            "/styles/components.css",
+            get(embedded_web::styles_components_css_handler),
+        )
+        .route(
+            "/assets/fonts/MonaSans.woff2",
+            get(embedded_web::font_mona_sans_handler),
+        )
+        .route(
+            "/assets/fonts/HubotSans-Regular.woff2",
+            get(embedded_web::font_hubot_regular_handler),
+        )
+        .route(
+            "/assets/fonts/HubotSans-Bold.woff2",
+            get(embedded_web::font_hubot_bold_handler),
+        )
+        .route(
+            "/assets/fonts/HubotSansCondensed-Bold.woff2",
+            get(embedded_web::font_hubot_condensed_bold_handler),
+        )
+        .route(
+            "/assets/fonts/JetBrainsMono.woff2",
+            get(embedded_web::font_jetbrains_mono_handler),
+        )
+        .route("/healthz", get(health_handler))
+        .route("/internal/hook-live", post(hook_live_handler))
+        .route("/ws", get(websocket_handler))
+        .with_state(ServerState {
+            proxy,
+            clients,
+            hook_forward_token: hook_forward_token.clone(),
+            pty_writers,
+        });
 
         runtime.spawn(async move {
             let server = axum::serve(listener, app).with_graceful_shutdown(async {
@@ -232,6 +203,17 @@ impl EmbeddedServer {
             token: self.hook_forward_token.clone(),
         }
     }
+}
+
+fn route_root_js_modules(mut router: Router<ServerState>) -> Router<ServerState> {
+    for asset in embedded_web::root_js_module_assets() {
+        let asset = *asset;
+        router = router.route(
+            asset.path,
+            get(move || async move { embedded_web::root_js_module_response(asset) }),
+        );
+    }
+    router
 }
 
 pub async fn health_handler() -> &'static str {

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -3,6 +3,15 @@ use axum::{
     response::{Html, IntoResponse},
 };
 
+const JS_CONTENT_TYPE: &str = "text/javascript; charset=utf-8";
+
+#[derive(Clone, Copy)]
+pub struct RootJsModuleAsset {
+    pub path: &'static str,
+    pub source: fn() -> &'static str,
+    pub marker: &'static str,
+}
+
 pub fn index_html() -> &'static str {
     include_str!("../web/index.html")
 }
@@ -64,6 +73,63 @@ pub fn focus_trap_js() -> &'static str {
     include_str!("../web/focus-trap.js")
 }
 
+pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
+    RootJsModuleAsset {
+        path: "/branch-cleanup-modal.js",
+        source: branch_cleanup_modal_js,
+        marker: "renderBranchCleanupModal",
+    },
+    RootJsModuleAsset {
+        path: "/migration-modal.js",
+        source: migration_modal_js,
+        marker: "renderMigrationModal",
+    },
+    RootJsModuleAsset {
+        path: "/window-docking.js",
+        source: window_docking_js,
+        marker: "findTitlebarDockTarget",
+    },
+    RootJsModuleAsset {
+        path: "/board-surface.js",
+        source: board_surface_js,
+        marker: "boardEntryMentionsSelf",
+    },
+    RootJsModuleAsset {
+        path: "/update-cta.js",
+        source: update_cta_js,
+        marker: "createUpdateCtaController",
+    },
+    RootJsModuleAsset {
+        path: "/theme-manager.js",
+        source: theme_manager_js,
+        marker: "createThemeManager",
+    },
+    RootJsModuleAsset {
+        path: "/theme-toggle.js",
+        source: theme_toggle_js,
+        marker: "wireThemeToggle",
+    },
+    RootJsModuleAsset {
+        path: "/hotkey.js",
+        source: hotkey_js,
+        marker: "createHotkeyManager",
+    },
+    RootJsModuleAsset {
+        path: "/operator-shell.js",
+        source: operator_shell_js,
+        marker: "initOperatorShell",
+    },
+    RootJsModuleAsset {
+        path: "/focus-trap.js",
+        source: focus_trap_js,
+        marker: "createFocusTrap",
+    },
+];
+
+pub fn root_js_module_assets() -> &'static [RootJsModuleAsset] {
+    ROOT_JS_MODULE_ASSETS
+}
+
 pub fn styles_tokens_css() -> &'static str {
     include_str!("../web/styles/tokens.css")
 }
@@ -102,101 +168,31 @@ pub async fn index_handler() -> Html<&'static str> {
 }
 
 pub async fn app_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        app_js(),
-    )
+    js_response(app_js())
 }
 
-pub async fn branch_cleanup_modal_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        branch_cleanup_modal_js(),
-    )
+fn js_response(source: &'static str) -> impl IntoResponse {
+    ([(header::CONTENT_TYPE, JS_CONTENT_TYPE)], source)
 }
 
-pub async fn migration_modal_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        migration_modal_js(),
-    )
-}
-
-pub async fn window_docking_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        window_docking_js(),
-    )
-}
-
-pub async fn board_surface_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        board_surface_js(),
-    )
-}
-
-pub async fn update_cta_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        update_cta_js(),
-    )
+pub fn root_js_module_response(asset: RootJsModuleAsset) -> impl IntoResponse {
+    let source = (asset.source)();
+    debug_assert!(source.contains(asset.marker));
+    js_response(source)
 }
 
 pub async fn xterm_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        xterm_js(),
-    )
+    js_response(xterm_js())
 }
 
 pub async fn xterm_fit_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        xterm_fit_js(),
-    )
+    js_response(xterm_fit_js())
 }
 
 pub async fn xterm_css_handler() -> impl IntoResponse {
     (
         [(header::CONTENT_TYPE, "text/css; charset=utf-8")],
         xterm_css(),
-    )
-}
-
-// SPEC-2356 — Operator Design System: module + style + font handlers.
-pub async fn theme_manager_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        theme_manager_js(),
-    )
-}
-
-pub async fn theme_toggle_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        theme_toggle_js(),
-    )
-}
-
-pub async fn hotkey_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        hotkey_js(),
-    )
-}
-
-pub async fn operator_shell_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        operator_shell_js(),
-    )
-}
-
-pub async fn focus_trap_js_handler() -> impl IntoResponse {
-    (
-        [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-        focus_trap_js(),
     )
 }
 
@@ -253,22 +249,9 @@ pub async fn font_jetbrains_mono_handler() -> impl IntoResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        app_js, board_surface_js, branch_cleanup_modal_js, index_html, update_cta_js,
-        window_docking_js, xterm_css, xterm_fit_js, xterm_js,
-    };
-    use super::{
-        app_js_handler, board_surface_js_handler, branch_cleanup_modal_js_handler,
-        update_cta_js_handler, window_docking_js_handler, xterm_css_handler, xterm_fit_js_handler,
-        xterm_js_handler,
-    };
-    // SPEC-2356 — Operator Design System modules.
-    use super::{focus_trap_js, hotkey_js, operator_shell_js, theme_manager_js, theme_toggle_js};
-    use super::{
-        focus_trap_js_handler, hotkey_js_handler, operator_shell_js_handler,
-        theme_manager_js_handler, theme_toggle_js_handler,
-    };
-
+    use super::{app_js, index_html, xterm_css, xterm_fit_js, xterm_js};
+    use super::{app_js_handler, xterm_css_handler, xterm_fit_js_handler, xterm_js_handler};
+    use super::{root_js_module_assets, root_js_module_response};
     fn frontend_bundle_source() -> &'static str {
         concat!(
             include_str!("../web/index.html"),
@@ -547,29 +530,21 @@ mod tests {
 
     #[test]
     fn embedded_web_secondary_assets_are_embedded() {
-        assert!(!branch_cleanup_modal_js().is_empty());
         assert!(!xterm_js().is_empty());
         assert!(!xterm_fit_js().is_empty());
         assert!(xterm_css().contains(".xterm"));
-        // SPEC-2356 — Operator Design System modules. Assert they ship in
-        // the binary so a missing include_str! macro fails CI rather than
-        // silently 404ing in production.
-        assert!(!theme_manager_js().is_empty());
-        assert!(!theme_toggle_js().is_empty());
-        assert!(!hotkey_js().is_empty());
-        assert!(!operator_shell_js().is_empty());
-        assert!(!focus_trap_js().is_empty());
-        assert!(!window_docking_js().is_empty());
-        assert!(!board_surface_js().is_empty());
-        assert!(!update_cta_js().is_empty());
-        assert!(theme_manager_js().contains("createThemeManager"));
-        assert!(theme_toggle_js().contains("wireThemeToggle"));
-        assert!(hotkey_js().contains("createHotkeyManager"));
-        assert!(operator_shell_js().contains("initOperatorShell"));
-        assert!(focus_trap_js().contains("createFocusTrap"));
-        assert!(window_docking_js().contains("findTitlebarDockTarget"));
-        assert!(board_surface_js().contains("boardEntryMentionsSelf"));
-        assert!(update_cta_js().contains("createUpdateCtaController"));
+        // Root module registry is the include coverage source: a missing
+        // include_str! macro fails CI rather than silently 404ing in production.
+        for asset in root_js_module_assets() {
+            let source = (asset.source)();
+            assert!(!source.is_empty(), "expected {} to be embedded", asset.path);
+            assert!(
+                source.contains(asset.marker),
+                "expected {} to contain marker {}",
+                asset.path,
+                asset.marker,
+            );
+        }
     }
 
     #[tokio::test]
@@ -586,33 +561,18 @@ mod tests {
                 .unwrap(),
             js,
         );
-        assert_eq!(
-            branch_cleanup_modal_js_handler()
-                .await
-                .into_response()
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .unwrap(),
-            js,
-        );
-        assert_eq!(
-            board_surface_js_handler()
-                .await
-                .into_response()
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .unwrap(),
-            js,
-        );
-        assert_eq!(
-            update_cta_js_handler()
-                .await
-                .into_response()
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .unwrap(),
-            js,
-        );
+        for asset in root_js_module_assets() {
+            assert_eq!(
+                root_js_module_response(*asset)
+                    .into_response()
+                    .headers()
+                    .get(header::CONTENT_TYPE)
+                    .unwrap(),
+                js,
+                "expected {} to use JavaScript content type",
+                asset.path,
+            );
+        }
         assert_eq!(
             xterm_js_handler()
                 .await
@@ -640,25 +600,6 @@ mod tests {
                 .unwrap(),
             "text/css; charset=utf-8",
         );
-        // SPEC-2356 — Operator Design System module handlers. Each module
-        // serve JavaScript with the same charset; the assertion catches
-        // regressions if a handler ever changes its content-type.
-        for handler_response in [
-            theme_manager_js_handler().await.into_response(),
-            theme_toggle_js_handler().await.into_response(),
-            hotkey_js_handler().await.into_response(),
-            operator_shell_js_handler().await.into_response(),
-            focus_trap_js_handler().await.into_response(),
-            window_docking_js_handler().await.into_response(),
-        ] {
-            assert_eq!(
-                handler_response
-                    .headers()
-                    .get(header::CONTENT_TYPE)
-                    .unwrap(),
-                js,
-            );
-        }
     }
 
     #[test]
@@ -1169,23 +1110,26 @@ mod tests {
 
     #[test]
     fn embedded_web_serves_every_root_module_import() {
-        let js = app_js();
         let embedded_web_source = include_str!("embedded_web.rs");
         let embedded_server_source = include_str!("embedded_server.rs");
+        let mut module_graph_source = String::from(app_js());
+        for asset in root_js_module_assets() {
+            module_graph_source.push('\n');
+            module_graph_source.push_str((asset.source)());
+        }
 
-        for module_path in [
-            "/branch-cleanup-modal.js",
-            "/migration-modal.js",
-            "/board-surface.js",
-            "/update-cta.js",
-        ] {
+        assert!(
+            embedded_server_source.contains("root_js_module_assets()"),
+            "expected embedded server root module routes to be registry-driven",
+        );
+
+        for asset in root_js_module_assets() {
+            let module_path = asset.path;
+            let relative_module_path = format!("./{}", module_path.trim_start_matches('/'));
             assert!(
-                js.contains(module_path),
-                "expected app.js to import {module_path}",
-            );
-            assert!(
-                embedded_server_source.contains(&format!("\"{module_path}\"")),
-                "expected embedded server to route {module_path}",
+                module_graph_source.contains(module_path)
+                    || module_graph_source.contains(&relative_module_path),
+                "expected frontend module graph to import {module_path}",
             );
 
             let source_name = module_path
@@ -1196,9 +1140,31 @@ mod tests {
                 embedded_web_source.contains(&format!("fn {source_name}_js()")),
                 "expected embedded web module source function for {module_path}",
             );
+        }
+    }
+
+    #[test]
+    fn embedded_web_root_js_module_registry_covers_app_imports() {
+        let registry_paths: Vec<&str> = root_js_module_assets()
+            .iter()
+            .map(|asset| asset.path)
+            .collect();
+
+        for module_path in [
+            "/branch-cleanup-modal.js",
+            "/migration-modal.js",
+            "/window-docking.js",
+            "/board-surface.js",
+            "/update-cta.js",
+            "/theme-manager.js",
+            "/theme-toggle.js",
+            "/hotkey.js",
+            "/operator-shell.js",
+            "/focus-trap.js",
+        ] {
             assert!(
-                embedded_web_source.contains(&format!("fn {source_name}_js_handler()")),
-                "expected embedded web module handler for {module_path}",
+                registry_paths.contains(&module_path),
+                "expected root JS registry to include {module_path}",
             );
         }
     }

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -10,11 +10,13 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { parseHTML } from "linkedom";
 import { createUpdateCtaController } from "../update-cta.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
 const indexHtml = readFileSync(resolve(here, "../index.html"), "utf8");
+const componentsCss = readFileSync(resolve(here, "../styles/components.css"), "utf8");
 
 test("update_state renders one reusable update CTA", () => {
   const fixture = createFixture();
@@ -119,17 +121,18 @@ test("legacy split update toast and button surfaces are removed", () => {
 });
 
 test("index.html declares a fixed bottom-right unified update CTA style", () => {
-  const styleMatch = indexHtml.match(/\.update-cta\s*\{[^}]+\}/);
-  assert.ok(styleMatch, "expected .update-cta rule inside <style>");
+  const styleMatch = componentsCss.match(/\.update-cta\s*\{[^}]+\}/);
+  assert.ok(styleMatch, "expected .update-cta rule inside components.css");
   assert.match(styleMatch[0], /position:\s*fixed/);
   assert.match(styleMatch[0], /bottom:\s*\d+px/);
   assert.match(styleMatch[0], /right:\s*\d+px/);
-  assert.match(indexHtml, /\.update-cta\.is-applying\s*\{/);
-  assert.match(indexHtml, /\.update-cta\.is-error\s*\{/);
+  assert.match(componentsCss, /\.update-cta\.is-applying\s*\{/);
+  assert.match(componentsCss, /\.update-cta\.is-error\s*\{/);
+  assert.doesNotMatch(indexHtml, /\.update-cta\s*\{/);
 });
 
 function createFixture({ confirmResult = true } = {}) {
-  const document = new FakeDocument();
+  const { document } = parseHTML("<!doctype html><html><body></body></html>");
   const sent = [];
   const confirmCalls = [];
   const versionUpdates = [];
@@ -152,91 +155,4 @@ function createFixture({ confirmResult = true } = {}) {
       },
     },
   };
-}
-
-class FakeDocument {
-  constructor() {
-    this.body = new FakeElement("body", this);
-    this.elementsById = new Map();
-  }
-
-  createElement(tagName) {
-    return new FakeElement(tagName, this);
-  }
-
-  getElementById(id) {
-    return this.elementsById.get(id) || null;
-  }
-
-  querySelectorAll(selector) {
-    if (!selector.startsWith("#")) return [];
-    const element = this.getElementById(selector.slice(1));
-    return element ? [element] : [];
-  }
-
-  registerId(element, id) {
-    if (id) {
-      this.elementsById.set(id, element);
-    }
-  }
-}
-
-class FakeElement {
-  constructor(tagName, ownerDocument) {
-    this.tagName = tagName.toUpperCase();
-    this.ownerDocument = ownerDocument;
-    this.children = [];
-    this.dataset = {};
-    this.attributes = new Map();
-    this._classNames = new Set();
-    this.classList = {
-      add: (...tokens) => tokens.forEach((token) => this._classNames.add(token)),
-      remove: (...tokens) => tokens.forEach((token) => this._classNames.delete(token)),
-      toggle: (token, force) => {
-        const shouldAdd = force === undefined ? !this._classNames.has(token) : Boolean(force);
-        if (shouldAdd) this._classNames.add(token);
-        else this._classNames.delete(token);
-      },
-      contains: (token) => this._classNames.has(token),
-    };
-    this.textContent = "";
-    this.disabled = false;
-    this.onclick = null;
-  }
-
-  set id(value) {
-    this._id = value;
-    this.ownerDocument.registerId(this, value);
-  }
-
-  get id() {
-    return this._id;
-  }
-
-  set className(value) {
-    this._classNames = new Set(String(value).split(/\s+/).filter(Boolean));
-  }
-
-  get className() {
-    return Array.from(this._classNames).join(" ");
-  }
-
-  setAttribute(name, value) {
-    this.attributes.set(name, String(value));
-  }
-
-  getAttribute(name) {
-    return this.attributes.get(name) || null;
-  }
-
-  appendChild(child) {
-    this.children.push(child);
-    return child;
-  }
-
-  click() {
-    if (this.onclick) {
-      this.onclick();
-    }
-  }
 }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -3131,43 +3131,6 @@
         white-space: nowrap;
       }
 
-      .update-cta {
-        position: fixed;
-        bottom: 20px;
-        right: 20px;
-        padding: 10px 16px;
-        background: var(--color-surface-elevated);
-        border: 1px solid var(--color-focus-ring);
-        border-radius: var(--radius-lg);
-        box-shadow: var(--shadow-2);
-        backdrop-filter: blur(8px);
-        font-family: var(--font-mono);
-        font-size: var(--type-sm);
-        letter-spacing: var(--tracking-mono);
-        color: var(--color-state-active);
-        cursor: pointer;
-        z-index: 9999;
-        transition: background 0.2s, border-color 0.2s, color 0.2s;
-      }
-
-      .update-cta:hover {
-        background: color-mix(in oklab, var(--color-state-active) 14%, var(--color-surface-elevated));
-      }
-
-      .update-cta.is-applying {
-        color: var(--color-state-idle);
-        cursor: progress;
-      }
-
-      .update-cta.is-error {
-        border-color: var(--color-state-blocked);
-        color: var(--color-state-blocked);
-      }
-
-      .update-cta:focus-visible {
-        outline: 2px solid var(--color-focus-ring);
-        outline-offset: 2px;
-      }
     </style>
   </head>
   <body>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -135,6 +135,46 @@ body::after {
   font-weight: 500;
 }
 
+/* SPEC-2041 — unified update CTA. A single actionable surface replaces the
+   earlier split toast + persistent button flow. */
+.update-cta {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 10px 16px;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-focus-ring);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-2);
+  backdrop-filter: blur(8px);
+  font-family: var(--font-mono);
+  font-size: var(--type-sm);
+  letter-spacing: var(--tracking-mono);
+  color: var(--color-state-active);
+  cursor: pointer;
+  z-index: 9999;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.update-cta:hover {
+  background: color-mix(in oklab, var(--color-state-active) 14%, var(--color-surface-elevated));
+}
+
+.update-cta.is-applying {
+  color: var(--color-state-idle);
+  cursor: progress;
+}
+
+.update-cta.is-error {
+  border-color: var(--color-state-blocked);
+  color: var(--color-state-blocked);
+}
+
+.update-cta:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 /* SPEC-2356 FR-024 — segmented theme toggle (AUTO / DARK / LIGHT). Replaces
    the prior single-cycle button so AUTO is reachable in one interaction. */
 .op-theme-toggle {


### PR DESCRIPTION
## Summary

Follow-up to the update CTA architecture review. This keeps the already merged update notification behavior intact while centralizing the root JavaScript asset routing and moving the update CTA styles into the component stylesheet.

## Changes

- Centralizes root JavaScript module registration in `embedded_web.rs` and routes those assets from `embedded_server.rs`.
- Moves `.update-cta` styling out of inline `index.html` and into `styles/components.css`.
- Reworks the update CTA unit test harness to use `linkedom` and assert CSS locality.
- Adds backend regression coverage that the embedded root module registry covers every root-level frontend module import.

## Testing

- `node --test crates/gwt/web/__tests__/update-button.test.mjs`
- `cargo test -p gwt embedded_web --all-features`
- `pnpm test:frontend-unit`
- `pnpm test:frontend-bundle`
- `cargo test -p gwt-core -p gwt --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo build -p gwt`
- pre-push checks, including coverage: 90.91%

## Closing Issues

None

## Related Issues

- #2041
- #2526

## Checklist

- [x] Tests updated or added for changed behavior
- [x] Local verification completed
- [x] Commit message validated with commitlint
- [x] SPEC artifacts updated through `gwtd issue spec`
