### PR TITLE
fix(gui): restore terminal focus after window switches

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -933,6 +933,32 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_programmatic_terminal_focus_reactivates_xterm_after_render() {
+        let js = app_js();
+        let render_activation = regex::Regex::new(
+            r#"(?s)const topmostId = topmostWindowId\(workspace\);.*?focusWindowLocally\(topmostId\);.*?scheduleTerminalFocusActivation\(topmostId\);"#,
+        )
+        .expect("valid regex");
+        let activation_helper = regex::Regex::new(
+            r#"(?s)function scheduleTerminalFocusActivation\(windowId\)\s*\{.*?requestAnimationFrame\(\(\) => \{.*?const activeRuntime = terminalMap\.get\(windowId\);.*?fitTerminal\(windowId,\s*false\);.*?scheduleTerminalViewportRefresh\(windowId\);.*?activeRuntime\.terminal\.focus\(\);"#,
+        )
+        .expect("valid regex");
+
+        assert!(
+            js.contains("function scheduleTerminalFocusActivation(windowId)"),
+            "expected a shared xterm activation helper for programmatic window focus",
+        );
+        assert!(
+            activation_helper.is_match(js),
+            "expected programmatic terminal activation to refit, refresh, and focus xterm after render",
+        );
+        assert!(
+            render_activation.is_match(js),
+            "expected workspace render to reactivate the topmost terminal for cycle focus, window list, command palette, and tab activation",
+        );
+    }
+
+    #[test]
     fn embedded_web_socket_protocol_wiring_uses_named_handlers() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1546,6 +1546,23 @@
         runtime.terminal.refresh(0, runtime.terminal.rows - 1);
       }
 
+      function scheduleTerminalFocusActivation(windowId) {
+        const runtime = terminalMap.get(windowId);
+        if (!runtime || runtime.activationFrame !== null) {
+          return;
+        }
+        runtime.activationFrame = requestAnimationFrame(() => {
+          runtime.activationFrame = null;
+          const activeRuntime = terminalMap.get(windowId);
+          if (!activeRuntime || !canRefreshTerminalViewport(windowId)) {
+            return;
+          }
+          fitTerminal(windowId, false);
+          scheduleTerminalViewportRefresh(windowId);
+          activeRuntime.terminal.focus();
+        });
+      }
+
       function sendGeometry(windowId, cols, rows) {
         const element = windowMap.get(windowId);
         if (!element) {
@@ -2316,7 +2333,13 @@
           });
           send({ kind: "terminal_input", id: windowId, data });
         });
-        const runtime = { terminal, fitAddon, cleanup, viewportRefreshFrame: null };
+        const runtime = {
+          terminal,
+          fitAddon,
+          cleanup,
+          viewportRefreshFrame: null,
+          activationFrame: null,
+        };
         terminalMap.set(windowId, runtime);
         decoderMap.set(windowId, new TextDecoder());
         requestAnimationFrame(() => fitTerminal(windowId, true));
@@ -7399,6 +7422,9 @@
           if (runtime && runtime.viewportRefreshFrame !== null) {
             cancelAnimationFrame(runtime.viewportRefreshFrame);
           }
+          if (runtime && runtime.activationFrame !== null) {
+            cancelAnimationFrame(runtime.activationFrame);
+          }
           runtime?.cleanup?.();
           runtime?.terminal.dispose();
           terminalMap.delete(windowId);
@@ -7438,10 +7464,7 @@
         const topmostId = topmostWindowId(workspace);
         if (topmostId && ids.has(topmostId)) {
           focusWindowLocally(topmostId);
-          const runtime = terminalMap.get(topmostId);
-          if (runtime) {
-            runtime.terminal.focus();
-          }
+          scheduleTerminalFocusActivation(topmostId);
         } else {
           focusedId = null;
         }


### PR DESCRIPTION
## Summary

- Restores xterm activation after programmatic window focus changes so terminal scrollback can respond without resizing the window.
- Applies the activation path to workspace-rendered focus changes, including keyboard cycling, window list selection, command palette activation, and tab activation.
- Keeps stale animation-frame callbacks from focusing closed terminal windows.

## Changes

- `crates/gwt/web/app.js`: adds `scheduleTerminalFocusActivation()` to run terminal fit, viewport refresh, and xterm focus on the next animation frame after a terminal becomes topmost.
- `crates/gwt/web/app.js`: uses the shared activation helper from `renderWorkspace()` and cancels pending activation frames during runtime cleanup.
- `crates/gwt/src/embedded_web.rs`: adds an embedded frontend contract test for programmatic terminal focus reactivation after render.

## Testing

- [x] `cargo test -p gwt embedded_web_programmatic_terminal_focus_reactivates_xterm_after_render -- --nocapture` — failed before the implementation, then passed after the fix.
- [x] `cargo test -p gwt embedded_web -- --nocapture` — passed.
- [x] `pnpm test:frontend-bundle` — passed.
- [x] `pnpm test:frontend-unit` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] Pre-push coverage — passed, filtered line coverage 90.93% against the 90.00% threshold.
- [ ] Manual macOS trackpad smoke — not run in this non-interactive agent environment; SPEC-2008 task T-174 remains the follow-up verification item.

## Closing Issues

None

## Related Issues / Links

- #2008
- #1919

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2008 spec/tasks updated; README not needed for this bug fix)
- [x] Migration/backfill plan included (not applicable: no schema or data change)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Risk / Impact

- **Affected areas**: GUI terminal focus and viewport refresh after programmatic window activation.
- **Rollback plan**: Revert `b7099724` if the activation frame introduces unexpected focus behavior.

## Notes

- The fix intentionally activates every workspace-rendered topmost terminal path, not only `Cmd+Shift+Left/Right`, because the underlying bug is stale xterm activation after programmatic focus.
