### PR TITLE
fix(workspace): restore kanban vertical scroll

### DIFF
--- a/crates/gwt/web/__tests__/kanban-structure.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-structure.test.mjs
@@ -121,6 +121,31 @@ test("components.css declares the kanban-board grid layout", () => {
   );
 });
 
+test("Kanban shell lets column bodies own vertical scrolling", () => {
+  const listPaneRule = componentsCss.match(/\.kanban-shell\s+\.kanban-list-pane\s*\{[^}]+\}/);
+  assert.ok(
+    listPaneRule,
+    "expected .kanban-shell .kanban-list-pane rule to constrain the board viewport",
+  );
+  assert.match(listPaneRule[0], /display:\s*flex/);
+  assert.match(listPaneRule[0], /flex-direction:\s*column/);
+  assert.match(
+    listPaneRule[0],
+    /overflow:\s*hidden/,
+    "Kanban list pane should not own vertical scroll; column bodies should",
+  );
+
+  const boardRule = componentsCss.match(/\.kanban-board\s*\{[^}]+\}/);
+  assert.ok(boardRule, "expected .kanban-board { ... } rule in components.css");
+  assert.match(boardRule[0], /overflow-x:\s*auto/);
+  assert.match(boardRule[0], /overflow-y:\s*hidden/);
+
+  const columnBodyRule = componentsCss.match(/\.kanban-column-body\s*\{[^}]+\}/);
+  assert.ok(columnBodyRule, "expected .kanban-column-body { ... } rule");
+  assert.match(columnBodyRule[0], /overflow-y:\s*auto/);
+  assert.match(columnBodyRule[0], /min-height:\s*0/);
+});
+
 test("components.css declares column and card classes", () => {
   // Cards and columns need their own selectors so the renderer can style
   // them independently. Without these classes the renderer can't apply

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -425,6 +425,21 @@ test("Workspace Overview uses the shared full-window Kanban + detail layout", ()
   );
 });
 
+test("Workspace Overview Kanban root participates in full-window layout", () => {
+  const fullWindowRootRule = inlineStyle.match(
+    /\.file-tree-root,[\s\S]*?\.mock-root\s*\{[^}]+\}/,
+  );
+  assert.ok(fullWindowRootRule, "expected shared full-window root layout rule");
+  assert.match(
+    fullWindowRootRule[0],
+    /\.workspace-kanban-root/,
+    "Workspace Kanban root must fill the window body so column bodies can scroll",
+  );
+  assert.match(fullWindowRootRule[0], /position:\s*absolute/);
+  assert.match(fullWindowRootRule[0], /display:\s*flex/);
+  assert.match(fullWindowRootRule[0], /flex-direction:\s*column/);
+});
+
 test("Workspace Overview legacy drawer scaffold is retired", () => {
   assert.doesNotMatch(
     html,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -886,6 +886,7 @@
       .board-root,
       .logs-root,
       .knowledge-root,
+      .workspace-kanban-root,
       .mock-root {
         position: absolute;
         inset: 0;

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2182,6 +2182,13 @@ kbd.op-kbd {
   align-items: stretch;
 }
 
+.kanban-shell .kanban-list-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .kanban-board[data-hide-done="true"] .kanban-column[data-phase="done"] {
   display: none;
 }


### PR DESCRIPTION
## Summary

- Restore vertical scrolling inside Workspace Overview / Knowledge Bridge Kanban columns so long card lists remain reachable inside constrained windows.
- Keep horizontal board scrolling available while preventing the outer list pane from stealing vertical overflow.

## Changes

- `crates/gwt/web/index.html`: include `.workspace-kanban-root` in the shared full-window surface root layout.
- `crates/gwt/web/styles/components.css`: constrain Kanban list panes with flex layout and hidden outer overflow so column bodies own vertical scroll.
- `crates/gwt/web/__tests__/kanban-structure.test.mjs`: add CSS regression coverage for Kanban overflow ownership.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: add regression coverage that Workspace Kanban fills the window body.

## Testing

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/kanban-structure.test.mjs` - 93/93 pass.
- [x] `pnpm test:frontend-unit` - 279/279 pass.
- [x] `npm run test:frontend-bundle` - syntax checks pass.
- [x] `cargo fmt -- --check` - pass.
- [x] `cargo test -p gwt-core -p gwt --all-features` - pass after rerunning outside the sandbox for filesystem-sensitive persistence tests.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - pass.
- [x] `cargo build -p gwt` - pass.
- [x] `git diff --check` - pass.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - pass.

## Closing Issues

None

## Related Issues / Links

- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2359 updated; README change not required for a layout bug fix)
- [x] Migration/backfill plan included (not applicable; no schema/data change)
- [x] CHANGELOG impact considered (patch bug fix)

## Risk / Impact

- **Affected areas**: Workspace Overview Kanban and Knowledge Bridge Kanban layout only.
- **Rollback plan**: Revert this commit to restore the previous overflow behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kanban board scrolling behavior to ensure vertical scrolling is constrained to column bodies while horizontal scrolling remains available for the board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->