### PR TITLE
chore(release): v9.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.24.1] - 2026-05-08
+
+### Bug Fixes
+
+- **workspace:** Restore kanban vertical scroll
+
 ## [9.24.0] - 2026-05-08
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "axum",
  "base64",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "chrono",
  "dunce",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "dirs",
  "serde",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.24.0"
+version = "9.24.1"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.24.0"
+version = "9.24.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/web/__tests__/kanban-structure.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-structure.test.mjs
@@ -121,6 +121,31 @@ test("components.css declares the kanban-board grid layout", () => {
   );
 });
 
+test("Kanban shell lets column bodies own vertical scrolling", () => {
+  const listPaneRule = componentsCss.match(/\.kanban-shell\s+\.kanban-list-pane\s*\{[^}]+\}/);
+  assert.ok(
+    listPaneRule,
+    "expected .kanban-shell .kanban-list-pane rule to constrain the board viewport",
+  );
+  assert.match(listPaneRule[0], /display:\s*flex/);
+  assert.match(listPaneRule[0], /flex-direction:\s*column/);
+  assert.match(
+    listPaneRule[0],
+    /overflow:\s*hidden/,
+    "Kanban list pane should not own vertical scroll; column bodies should",
+  );
+
+  const boardRule = componentsCss.match(/\.kanban-board\s*\{[^}]+\}/);
+  assert.ok(boardRule, "expected .kanban-board { ... } rule in components.css");
+  assert.match(boardRule[0], /overflow-x:\s*auto/);
+  assert.match(boardRule[0], /overflow-y:\s*hidden/);
+
+  const columnBodyRule = componentsCss.match(/\.kanban-column-body\s*\{[^}]+\}/);
+  assert.ok(columnBodyRule, "expected .kanban-column-body { ... } rule");
+  assert.match(columnBodyRule[0], /overflow-y:\s*auto/);
+  assert.match(columnBodyRule[0], /min-height:\s*0/);
+});
+
 test("components.css declares column and card classes", () => {
   // Cards and columns need their own selectors so the renderer can style
   // them independently. Without these classes the renderer can't apply

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -425,6 +425,21 @@ test("Workspace Overview uses the shared full-window Kanban + detail layout", ()
   );
 });
 
+test("Workspace Overview Kanban root participates in full-window layout", () => {
+  const fullWindowRootRule = inlineStyle.match(
+    /\.file-tree-root,[\s\S]*?\.mock-root\s*\{[^}]+\}/,
+  );
+  assert.ok(fullWindowRootRule, "expected shared full-window root layout rule");
+  assert.match(
+    fullWindowRootRule[0],
+    /\.workspace-kanban-root/,
+    "Workspace Kanban root must fill the window body so column bodies can scroll",
+  );
+  assert.match(fullWindowRootRule[0], /position:\s*absolute/);
+  assert.match(fullWindowRootRule[0], /display:\s*flex/);
+  assert.match(fullWindowRootRule[0], /flex-direction:\s*column/);
+});
+
 test("Workspace Overview legacy drawer scaffold is retired", () => {
   assert.doesNotMatch(
     html,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -886,6 +886,7 @@
       .board-root,
       .logs-root,
       .knowledge-root,
+      .workspace-kanban-root,
       .mock-root {
         position: absolute;
         inset: 0;

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2182,6 +2182,13 @@ kbd.op-kbd {
   align-items: stretch;
 }
 
+.kanban-shell .kanban-list-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .kanban-board[data-hide-done="true"] .kanban-column[data-phase="done"] {
   display: none;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.24.0",
+  "version": "9.24.1",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.24.1 はパッチリリースです。Workspace / Knowledge Kanban の column body が縦スクロールできなかった問題（SPEC-2359 follow-up）を修正します。

## Changes

- **fix(workspace): restore kanban vertical scroll** — Workspace Kanban の root に `workspace-kanban-root` クラスを追加し、`.kanban-shell .kanban-list-pane` を flex / `min-height: 0` / `overflow: hidden` に調整して、column body 側が縦スクロールを所有するように修正しました。

## Version

- 9.24.0 → **9.24.1** (patch)

## Closing Issues

None

## Related Issues / Links

- #2359 (PR #2553 で参照のみ。本リリースで auto-close されません)
