### PR TITLE
fix(workspace): current focus を journal title で優先

### DIFF
--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -26,6 +26,14 @@ test("Workspace journal cards derive titles from each entry instead of the curre
         summary: "Update CTA dismiss PR",
         updated_at: "2026-05-08T14:07:07Z",
       },
+      {
+        id: "journal-focus-only",
+        status_category: "idle",
+        status_text: "Workspace update",
+        next_action: "Continue",
+        agent_current_focus: "Review thread title fallback",
+        updated_at: "2026-05-08T13:00:00Z",
+      },
     ],
     agents: [],
   };
@@ -53,6 +61,10 @@ test("Workspace journal cards derive titles from each entry instead of the curre
   assert.ok(
     titles.includes("Update CTA dismiss PR"),
     "journal cards without title_summary should derive a visible title from their own summary",
+  );
+  assert.ok(
+    titles.includes("Review thread title fallback"),
+    "focus-only journal cards should prefer agent_current_focus before generic status text",
   );
 });
 

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -58,9 +58,9 @@ export function createWorkspaceKanbanSurface({
       entry.title,
       entry.agent_title_summary,
       entry.summary,
+      entry.agent_current_focus,
       entry.status_text,
       entry.next_action,
-      entry.agent_current_focus,
     ]) {
       const title = compactWorkspaceTitle(value);
       if (title) return title;


### PR DESCRIPTION
## Summary

- Workspace Kanban journal card titles now prefer `agent_current_focus` before generic status or next-action text.
- This keeps focus-only journal updates distinguishable without changing projection or journal storage.

## Changes

- `crates/gwt/web/workspace-kanban-surface.js`: moved `agent_current_focus` earlier in the display-only journal title fallback chain.
- `crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs`: added a focus-only journal regression case that fails when generic status text wins.

## Testing

- [x] `node --test crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs` — passed, 3 tests passed.
- [x] `pnpm run test:frontend-bundle` — passed.
- [x] `pnpm run test:frontend-unit` — passed, 283 tests passed.
- [x] `pnpm run test:frontend-smoke` — passed, 10 tests passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `git diff --check` and `git diff --cached --check` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git push` — passed; pre-push coverage was 90.50%, above the 90.00% threshold.

## Closing Issues

None

## Related Issues / Links

- #2359
- #2555

## Checklist

- [x] Tests added/updated.
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`).
- [x] Documentation updated or not required for this display-only bugfix.
- [x] Migration/backfill plan included or not required because no schema or data format changed.
- [x] CHANGELOG impact considered; this is a patch-level bugfix.

## Context

- Follows up on review feedback from PR #2555 where focus-only journal entries could still collapse to generic titles.
