### PR TITLE
fix(launch): hydrate process PATH at startup for macOS GUI launches

### DIFF
--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -72,13 +72,33 @@ where
 ///
 /// Idempotent: re-running on an already-hydrated PATH yields the same value
 /// because `push_unique_path` deduplicates entries. No-op on Windows.
+///
+/// Reads the current process env via `vars_os` (not `vars`) so a single
+/// non-Unicode environment variable does not panic startup. Skips writing to
+/// `std::env` if the computed PATH is empty so we never blank a usable PATH.
 pub fn apply_host_path_hydration_to_std_env() {
     if cfg!(windows) {
         return;
     }
-    if let Some(hydrated) = compute_hydrated_path(std::env::vars()) {
+    if let Some(hydrated) = current_process_hydrated_path() {
         std::env::set_var("PATH", hydrated);
     }
+}
+
+/// Compute the hydrated PATH from the running process env.
+///
+/// Returns `None` when the hydrated PATH is empty so `apply_host_path_hydration_to_std_env`
+/// never overwrites a usable `std::env::PATH` with a blank value (which would
+/// disable command lookup for subsequent `Command::new(...)` calls).
+fn current_process_hydrated_path() -> Option<String> {
+    let base_env: Vec<(String, String)> = std::env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.into_string().ok()?;
+            let value = value.into_string().ok()?;
+            Some((key, value))
+        })
+        .collect();
+    compute_hydrated_path(base_env).filter(|hydrated| !hydrated.is_empty())
 }
 
 /// Effective environment assembled from the active profile and launch context.
@@ -696,6 +716,47 @@ mod tests {
         match original {
             Some(value) => std::env::set_var("PATH", value),
             None => std::env::remove_var("PATH"),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn compute_hydrated_path_returns_empty_string_when_no_paths_available_on_linux() {
+        // On Linux there is no path_helper, so an env with no PATH and no
+        // HOME yields an empty hydrated PATH. The guard inside
+        // apply_host_path_hydration_to_std_env must skip this case so that
+        // `std::env::PATH` is never blanked.
+        let result = compute_hydrated_path(Vec::<(String, String)>::new());
+        assert_eq!(result.as_deref(), Some(""));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn apply_host_path_hydration_to_std_env_does_not_blank_path_when_no_inputs_on_linux() {
+        let _lock = path_env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let original_path = std::env::var_os("PATH");
+        let original_home = std::env::var_os("HOME");
+        std::env::remove_var("PATH");
+        std::env::remove_var("HOME");
+
+        apply_host_path_hydration_to_std_env();
+
+        if let Some(value) = std::env::var_os("PATH") {
+            assert!(
+                !value.is_empty(),
+                "apply_host_path_hydration_to_std_env must not write an empty PATH"
+            );
+        }
+
+        match original_path {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+        match original_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
         }
     }
 

--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -45,6 +45,42 @@ where
     env
 }
 
+/// Compute the hydrated `PATH` for the given base environment.
+///
+/// On non-Windows the result includes macOS `/usr/libexec/path_helper` output
+/// and `~/.bun/bin`, `~/.local/bin`, `~/.cargo/bin` if they exist. On Windows
+/// the result echoes the input PATH (if any) without modification. Returns
+/// `None` only when no PATH entries can be derived (input had no PATH and
+/// hydration found no fallbacks).
+pub fn compute_hydrated_path<I>(base_env: I) -> Option<String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut env: HashMap<String, String> = base_env.into_iter().collect();
+    hydrate_host_path(&mut env);
+    env.get("PATH").cloned()
+}
+
+/// Apply host PATH hydration to the running process's `std::env`.
+///
+/// MUST be called from `main` BEFORE any thread is spawned and before any
+/// other env mutation. macOS GUI launches via launchd inherit the minimal
+/// `/usr/bin:/bin:/usr/sbin:/sbin` PATH which omits `/usr/local/bin` and
+/// `/opt/homebrew/bin`; without this hydration, child processes spawned by
+/// the app cannot resolve `docker`, `gh`, `claude`, `codex`, `bunx`, or `npx`
+/// that live in those directories.
+///
+/// Idempotent: re-running on an already-hydrated PATH yields the same value
+/// because `push_unique_path` deduplicates entries. No-op on Windows.
+pub fn apply_host_path_hydration_to_std_env() {
+    if cfg!(windows) {
+        return;
+    }
+    if let Some(hydrated) = compute_hydrated_path(std::env::vars()) {
+        std::env::set_var("PATH", hydrated);
+    }
+}
+
 /// Effective environment assembled from the active profile and launch context.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LaunchEnvironment {
@@ -563,5 +599,129 @@ mod tests {
         assert!(!env.contains_key(GWT_SESSION_RUNTIME_PATH_ENV));
         assert!(!env.contains_key(GWT_HOOK_FORWARD_TOKEN_ENV));
         assert!(!env.contains_key(GWT_PROJECT_ROOT_ENV));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn compute_hydrated_path_preserves_existing_entries() {
+        let home = tempfile::tempdir().unwrap();
+        let base_env = vec![
+            (
+                "PATH".to_string(),
+                "/usr/bin:/bin:/usr/sbin:/sbin".to_string(),
+            ),
+            ("HOME".to_string(), home.path().display().to_string()),
+        ];
+
+        let hydrated = compute_hydrated_path(base_env).expect("hydrated PATH");
+        let entries = std::env::split_paths(&hydrated).collect::<Vec<_>>();
+
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
+        assert!(entries.contains(&PathBuf::from("/usr/sbin")));
+        assert!(entries.contains(&PathBuf::from("/sbin")));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn compute_hydrated_path_adds_user_bins_when_present() {
+        let home = tempfile::tempdir().unwrap();
+        for relative in [".bun/bin", ".local/bin", ".cargo/bin"] {
+            std::fs::create_dir_all(home.path().join(relative)).unwrap();
+        }
+        let base_env = vec![
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("HOME".to_string(), home.path().display().to_string()),
+        ];
+
+        let hydrated = compute_hydrated_path(base_env).expect("hydrated PATH");
+        let entries = std::env::split_paths(&hydrated).collect::<Vec<_>>();
+
+        assert!(entries.contains(&home.path().join(".bun/bin")));
+        assert!(entries.contains(&home.path().join(".local/bin")));
+        assert!(entries.contains(&home.path().join(".cargo/bin")));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn compute_hydrated_path_is_idempotent() {
+        let home = tempfile::tempdir().unwrap();
+        for relative in [".bun/bin", ".cargo/bin"] {
+            std::fs::create_dir_all(home.path().join(relative)).unwrap();
+        }
+        let base_env = vec![
+            ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ("HOME".to_string(), home.path().display().to_string()),
+        ];
+
+        let first = compute_hydrated_path(base_env.clone()).expect("first hydration");
+        let second = compute_hydrated_path(vec![
+            ("PATH".to_string(), first.clone()),
+            ("HOME".to_string(), home.path().display().to_string()),
+        ])
+        .expect("second hydration");
+
+        let first_entries = std::env::split_paths(&first).collect::<Vec<_>>();
+        let second_entries = std::env::split_paths(&second).collect::<Vec<_>>();
+        assert_eq!(first_entries, second_entries);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn compute_hydrated_path_includes_macos_path_helper_paths() {
+        let base_env = vec![
+            (
+                "PATH".to_string(),
+                "/usr/bin:/bin:/usr/sbin:/sbin".to_string(),
+            ),
+            ("HOME".to_string(), String::new()),
+        ];
+
+        let hydrated = compute_hydrated_path(base_env).expect("hydrated PATH");
+        let entries = std::env::split_paths(&hydrated).collect::<Vec<_>>();
+
+        assert!(
+            entries.contains(&PathBuf::from("/usr/local/bin")),
+            "expected /usr/local/bin in hydrated PATH; got {hydrated}"
+        );
+    }
+
+    #[test]
+    fn apply_host_path_hydration_to_std_env_does_not_panic() {
+        let _lock = path_env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let original = std::env::var_os("PATH");
+        apply_host_path_hydration_to_std_env();
+        match original {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn apply_host_path_hydration_to_std_env_preserves_existing_path_entries() {
+        let _lock = path_env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let original = std::env::var_os("PATH");
+        std::env::set_var("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+
+        apply_host_path_hydration_to_std_env();
+        let after = std::env::var("PATH").unwrap_or_default();
+        let entries = std::env::split_paths(&after).collect::<Vec<_>>();
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
+
+        match original {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+
+    fn path_env_test_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -4726,6 +4726,13 @@ mod tests {
 }
 
 fn main() -> wry::Result<()> {
+    // Hydrate process PATH before any subprocess can spawn. macOS GUI launches
+    // via launchd inherit a minimal PATH that omits /usr/local/bin and
+    // /opt/homebrew/bin, breaking docker / gh / claude / codex / bunx / npx
+    // resolution. This call MUST run before any thread starts and before CLI
+    // dispatch so spawned children inherit the augmented PATH.
+    gwt_agent::environment::apply_host_path_hydration_to_std_env();
+
     let argv: Vec<String> = std::env::args().collect();
     if !matches!(
         front_door_route(&argv),


### PR DESCRIPTION
## Summary

- macOS の GUI 起動 (Finder/Dock 経由) では launchd が `/usr/bin:/bin:/usr/sbin:/sbin` という最小 PATH しか継承させないため、Launch Agent → Docker 選択時の preflight (`ensure_docker_launch_runtime_ready` → `gwt_docker::detect::docker_available`) が `/usr/local/bin/docker` を見つけられず "Docker is not installed or not available on PATH" を返していました
- 既存の `hydrate_host_path` は LaunchEnvironment 用 HashMap でしか PATH を補完せず、`std::env` 自体は launchd の最小 PATH のままだったのが root cause
- `gwt-agent` に `pub fn apply_host_path_hydration_to_std_env` を追加し、既存 `hydrate_host_path` を再利用しつつ `std::env::set_var("PATH", ...)` で process 全体の PATH を上書きします
- `crates/gwt/src/main.rs::main()` の最初期 (Runtime::new・thread spawn・CLI dispatch より前) で 1 回だけ呼び出すことで、Docker preflight だけでなく gh / claude / codex / bunx / npx / daemon subprocess 等 **すべての `Command::new` 系解決** が同時に修正されます
- Windows は早期 return で no-op、Docker container env (`std::iter::empty()` 起点) も影響なし

## Context

- 報告: Launch Agent で Docker 選択時に `~/.gwt/projects/.../logs/gwt.log.2026-05-09:20-21` で `Docker is not installed or not available on PATH` エラー
- 検証: 実行中の `/Applications/GWT.app` PID 11973 の PATH を `ps eww` で確認したところ launchd 最小 PATH のみ。Docker 自体は `/usr/local/bin/docker -> /Applications/Docker.app/...` (v29.3.1) で正常インストール済み
- デグレード経路を 7 観点 (set_var thread safety / 既存 PATH リーダー / Docker container env / 既存テスト / `host_process_env` 二重実行 / subprocess 波及 / path_helper 失敗 fallback) で徹底検証し問題なしを確認。詳細は plan ファイルを参照: `/Users/akiojin/.claude/plans/launch-agent-docker-snug-moth.md`

## Test plan

- [x] `cargo test -p gwt-agent --lib environment::` 全 GREEN (15/15)
- [x] `cargo test -p gwt-agent --lib` 全 GREEN (198/198)
- [x] `cargo test -p gwt --lib` 全 GREEN (478/478)
- [x] `cargo test -p gwt-docker` 全 GREEN (63 + 1 integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` pass
- [x] `cargo fmt -- --check` pass
- [x] `cargo build -p gwt` pass
- [ ] 実機 (macOS GUI) で `/Applications/GWT.app` を Finder 起動 → Launch Agent → Docker 選択 → `BuildingImage` overlay まで進むことを確認
- [ ] `ps eww -p <pid> | tr ' ' '\n' | grep ^PATH=` で `/usr/local/bin` が含まれることを確認
- [ ] terminal 起動 (`cargo run -p gwt`) でも regression なし

## Files changed

- `crates/gwt-agent/src/environment.rs`: `pub fn compute_hydrated_path` と `pub fn apply_host_path_hydration_to_std_env` を追加。test 6 件追加 (preserve / user bins / idempotent / macOS path_helper / does not panic / preserves existing entries via std::env)
- `crates/gwt/src/main.rs`: `fn main()` 入口に `gwt_agent::environment::apply_host_path_hydration_to_std_env()` を追加。意図と前提を inline コメントに明記

Refs SPEC-1936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PATH environment handling for spawned child processes. Processes now inherit a complete and properly configured PATH, including user bin directories. This particularly benefits macOS GUI launch environments that previously started with a minimal PATH.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2564)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->