### PR TITLE
fix(gui): count only agent presets in Sidebar Layers telemetry

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -122,6 +122,32 @@ test("frontend handles active work projection as status-strip telemetry", () => 
   );
 });
 
+test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
+  // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
+  // without checking preset, so every workspace window with data-agent-state
+  // (Board / Workspace / Logs / Branches / etc.) inflated counts.agents and
+  // the Sidebar Layers "Agents" row showed e.g. 4 when only 2 agent panes
+  // were live. The DOM walk must scope to presets that represent agent panes.
+  const fnMatch = appSource.match(
+    /function\s+recomputeOperatorTelemetry[\s\S]*?(?=\n\s+function\s+\w)/,
+  );
+  assert.ok(
+    fnMatch,
+    "expected recomputeOperatorTelemetry definition in app.js",
+  );
+  const body = fnMatch[0];
+  assert.match(
+    body,
+    /windowMap\.entries\(\)/,
+    "recomputeOperatorTelemetry must iterate windowMap.entries() so it can resolve each window's preset before counting it as an agent",
+  );
+  assert.match(
+    body,
+    /presetSupportsWaitingStatus/,
+    "recomputeOperatorTelemetry must filter via presetSupportsWaitingStatus(preset) so non-agent windows do not inflate the Sidebar Agents counter",
+  );
+});
+
 test("Workspace sidebar exposes active work and per-agent overview", () => {
   assert.ok(
     document.querySelector("#op-active-work"),

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1429,9 +1429,15 @@
       function recomputeOperatorTelemetry() {
         if (!window.__operatorShell?.applyTelemetryCounts) return;
         const counts = { active: 0, idle: 0, blocked: 0, done: 0, agents: 0 };
-        for (const el of windowMap.values()) {
+        for (const [windowId, el] of windowMap.entries()) {
           const state = el?.dataset?.agentState;
           if (!state) continue;
+          // SPEC-2356 follow-up: only count live agent panes. Other workspace
+          // windows (Board / Workspace / Logs / Branches / etc.) carry
+          // data-agent-state for overlay/animation purposes but must not
+          // inflate the Sidebar Layers Agents row or Status Strip cells.
+          const windowData = workspaceWindowById(windowId);
+          if (!windowData || !presetSupportsWaitingStatus(windowData.preset)) continue;
           if (state in counts) counts[state] += 1;
           counts.agents += 1;
         }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4875,3 +4875,36 @@ embedded serving と unit test は追加したが、`package.json` の
 2. frontend module 分割の差分レビューでは、`rg "from \"/.*\\.js\""`
    で root import を確認し、配信・syntax check・unit test の3点が
    揃っているかを見る。
+
+## 2026-05-10 — Agent カウントは `windowMap` 走査ではなく preset で判定する
+
+### 事象
+
+Sidebar Layers の Agents 行が、実 Agent pane 数 (2) ではなく
+全 workspace window 数 (Agent 2 + Board / Workspace 等 2 = 4) を
+表示していた。`recomputeOperatorTelemetry()` が `windowMap.values()`
+を走査し、`data-agent-state` を持つ window をすべて `counts.agents`
+に加算していた。
+
+### 原因
+
+`data-agent-state` は CSS overlay / animation 用に **全 window** へ
+打たれる DOM marker であり、agent 種別を表すものではない。Agent 判定の
+真実源は `presetSupportsWaitingStatus(preset)` (`agent | claude | codex`)
+だが、`recomputeOperatorTelemetry` ではこの述語を呼ばずに DOM の
+data 属性だけで判定していた。同じく `activeWorkProjection` 由来の
+`Math.max(counts.agents, activeAgents + blockedAgents)` も二重計上の
+温床になり得る。
+
+### 再発防止策
+
+1. `windowMap.values()` / `.entries()` を走査して "agent らしさ" を
+   集計する箇所では、必ず `presetSupportsWaitingStatus(preset)` を経由
+   する。`workspaceWindowById(windowId)` で `windowData.preset` を解決
+   してから判定する。
+2. `data-agent-state` は CSS / overlay 用途であり、agent 判定の
+   primary signal として使わない。差分レビューでは
+   `rg "dataset.agentState" crates/gwt/web` で利用箇所を確認する。
+3. Sidebar / Status Strip / Mission Briefing が共有する集計関数は、
+   regression を `operator-chrome-structure` 等の source-level
+   assertion で固定し、preset filter の脱落を CI で拾う。


### PR DESCRIPTION
## Summary

- `recomputeOperatorTelemetry` walked **every** entry in `windowMap` (Board / Workspace / Logs / Branches / etc.) and treated any window with `data-agent-state` as an agent, so the Sidebar **Layers → Agents** row inflated to e.g. 4 when only 2 agent panes were live.
- The fix scopes the DOM walk to presets that represent live agent panes by reusing the existing `presetSupportsWaitingStatus(preset)` predicate (`agent` / `claude` / `codex`). `data-agent-state` itself remains on every window because CSS overlays still rely on it; only the aggregation path is filtered.
- Adds an `operator-chrome-structure` source-level assertion so a future regression in `recomputeOperatorTelemetry` (e.g. dropping the preset filter) fails the test suite.

## Why

SPEC-2356 Living Telemetry intends the Agents row to project the count of live agent panes. With the old code, `op-layer-count-agents` rose by 1 for every non-agent surface that opened — undermining Sidebar Layers, Status Strip, and Mission Briefing trust simultaneously. Confirmed via `gwtd pane list` (2 agent panes) vs the UI showing 4.

## Test plan

- [x] `pnpm run test:frontend-bundle`
- [x] `pnpm run test:frontend-unit` (284 / 284 pass)
- [x] `pnpm run test:frontend-smoke`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p gwt-core -p gwt --all-features`
- [x] Pre-push coverage gate (90.53% ≥ 90.00%)
- [ ] Manual GUI verification: open 2 agent panes + 2 non-agent windows (Board / Workspace), confirm Sidebar Layers Agents row shows `2`.

## Owner SPEC

SPEC-2356 — Operator Design System / Living Telemetry. No new SPEC required (existing implementation defect).