### PR TITLE
chore(ci): make Operator Design System Playwright check skip-friendly

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -3,12 +3,6 @@ name: Visual Regression
 on:
   pull_request:
     branches: [develop, main]
-    paths:
-      - 'crates/gwt/web/**'
-      - 'crates/gwt/src/embedded_web.rs'
-      - 'crates/gwt/src/embedded_server.rs'
-      - 'crates/gwt/playwright/**'
-      - 'package.json'
 
 jobs:
   visual-regression:
@@ -17,8 +11,25 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect frontend changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE '^(crates/gwt/(web|playwright)/|crates/gwt/src/embedded_(web|server)\.rs|package\.json)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Frontend changes detected; running full visual regression suite."
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No frontend changes detected; reporting success without running playwright."
+          fi
 
       - name: Install WebView dependencies (Linux)
+        if: steps.detect.outputs.should_run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -27,32 +38,42 @@ jobs:
             libayatana-appindicator3-dev
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.detect.outputs.should_run == 'true'
+
       - uses: Swatinem/rust-cache@v2
+        if: steps.detect.outputs.should_run == 'true'
 
       - uses: actions/setup-node@v4
+        if: steps.detect.outputs.should_run == 'true'
         with:
           node-version: '20'
 
       - name: Install npm dependencies
+        if: steps.detect.outputs.should_run == 'true'
         run: npm install --no-audit --no-fund
 
       - name: Install Playwright browsers
+        if: steps.detect.outputs.should_run == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Build gwt
+        if: steps.detect.outputs.should_run == 'true'
         run: cargo build -p gwt --release
 
       - name: Frontend unit tests
+        if: steps.detect.outputs.should_run == 'true'
         run: npm run test:frontend-unit
 
       - name: Frontend smoke tests
+        if: steps.detect.outputs.should_run == 'true'
         run: npm run test:frontend-smoke
 
       - name: Visual regression
+        if: steps.detect.outputs.should_run == 'true'
         run: npm run test:visual
 
       - name: Upload diff artifacts on failure
-        if: failure()
+        if: failure() && steps.detect.outputs.should_run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-diff


### PR DESCRIPTION
## Summary

- `Operator Design System (Playwright)` workflow を全 PR で trigger するよう変更し、frontend file を触らない backend-only PR でも check が SUCCESS で完了するようにします
- 旧設計の `on.pull_request.paths` filter は path 不一致時に check 自体が登録されず、develop branch protection で required gate を満たせずに merge を block する原因でした (PR #2564 で実害発生)
- 新設計では job 内で `Detect frontend changes` step が PR base/head SHA を `git diff` で比較し、`should_run` 出力に応じて以降の playwright 関連 step をすべて gate します
- 検出 step は SHA を `env:` 経由で受け取り、project security hook が指摘する command injection 経路を避けています

## Context

backend-only な fix (例: #2564 の launchd PATH hydration、過去の launch_runtime / agent core 修正) は frontend に触れないため、path filter 起因で `Operator Design System (Playwright)` が起動せず、required check 不在による block を受けました。frontend 修正と同梱する形で回避していたケース (#2560, #2562 等) は path filter が match していたため問題が顕在化していませんでした。

## Changes

`.github/workflows/visual-regression.yml`:

- `on.pull_request` から `paths:` filter を削除し、develop / main 向け PR では常に workflow を起動
- 先頭に `Detect frontend changes` step を追加。`crates/gwt/(web|playwright)/`、`crates/gwt/src/embedded_(web|server).rs`、`package.json` のいずれかが変更されている場合のみ `should_run=true` を出力
- 既存の Install / build / frontend test / visual regression / artifact upload step すべてに `if: steps.detect.outputs.should_run == 'true'` を付与
- artifact upload は既存の `if: failure()` と AND を取り、回帰時のみ playwright artifact を保存する挙動を維持
- SHA 入力は `env: BASE_SHA / HEAD_SHA` を経由し、`run:` から `"$BASE_SHA"`/`"$HEAD_SHA"` で参照

## Closing Issues

Closes #2567

## Test plan

- [ ] このPR自身: backend-only ではなく `chore(ci):` で CI workflow を変更したため、`Detect frontend changes` step は `should_run=false` を返し、後続の play-wright step は skip されるはずである
- [ ] このPR自身: `Operator Design System (Playwright)` check 自体は SUCCESS で報告される
- [ ] follow-up: 次回の純 backend-only PR (gwt-agent / gwt-core / launch_runtime のみ) でも `Operator Design System (Playwright)` check が SUCCESS を返し auto-merge が動くこと
- [ ] follow-up: 次回の frontend 修正 PR (`crates/gwt/web/**` を触る) で `Detect frontend changes` が `should_run=true` を返し、`npm run test:visual` まで走ること

## Checklist

- [x] commitlint 準拠 (`chore(ci):` prefix)
- [x] YAML 構文 valid (Ruby YAML.load で確認)
- [x] github actions security guidance に従い SHA を env: 経由で参照
- [ ] 実 CI 上で挙動確認 (PR 作成後に確認する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
