### PR TITLE
fix(gui): preserve grouped window geometry across tab switches

### DIFF
--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -272,23 +272,32 @@ impl WorkspaceState {
         let Some(index) = self.window_index(id) else {
             return false;
         };
-        let window = &mut self.persisted.windows[index];
-        if window.maximized {
-            if let Some(geometry) = window.pre_maximize_geometry.take() {
-                window.geometry = geometry;
+        let group_id = self.persisted.windows[index].tab_group_id.clone();
+        let was_maximized = self.persisted.windows[index].maximized;
+        let restore_geometry = self.persisted.windows[index].pre_maximize_geometry.clone();
+        let pre_geometry = self.persisted.windows[index].geometry.clone();
+        let target_geometry = WindowGeometry {
+            x: bounds.x + ARRANGE_PADDING,
+            y: bounds.y + ARRANGE_PADDING,
+            width: (bounds.width - ARRANGE_PADDING * 2.0).max(0.0),
+            height: (bounds.height - ARRANGE_PADDING * 2.0).max(0.0),
+        };
+
+        for member in self.group_member_indices(group_id.as_deref(), index) {
+            let window = &mut self.persisted.windows[member];
+            if was_maximized {
+                if let Some(geometry) = restore_geometry.clone() {
+                    window.geometry = geometry;
+                }
+                window.pre_maximize_geometry = None;
+                window.maximized = false;
+                window.minimized = false;
+            } else {
+                window.pre_maximize_geometry = Some(pre_geometry.clone());
+                window.geometry = target_geometry.clone();
+                window.minimized = false;
+                window.maximized = true;
             }
-            window.maximized = false;
-            window.minimized = false;
-        } else {
-            window.pre_maximize_geometry = Some(window.geometry.clone());
-            window.geometry = WindowGeometry {
-                x: bounds.x + ARRANGE_PADDING,
-                y: bounds.y + ARRANGE_PADDING,
-                width: (bounds.width - ARRANGE_PADDING * 2.0).max(0.0),
-                height: (bounds.height - ARRANGE_PADDING * 2.0).max(0.0),
-            };
-            window.minimized = false;
-            window.maximized = true;
         }
         self.bring_to_front(index);
         true
@@ -298,17 +307,25 @@ impl WorkspaceState {
         let Some(index) = self.window_index(id) else {
             return false;
         };
-        let window = &mut self.persisted.windows[index];
-        if window.minimized {
-            window.minimized = false;
-        } else {
-            if window.maximized {
-                if let Some(geometry) = window.pre_maximize_geometry.take() {
-                    window.geometry = geometry;
+        let group_id = self.persisted.windows[index].tab_group_id.clone();
+        let was_minimized = self.persisted.windows[index].minimized;
+        let was_maximized = self.persisted.windows[index].maximized;
+        let restore_geometry = self.persisted.windows[index].pre_maximize_geometry.clone();
+
+        for member in self.group_member_indices(group_id.as_deref(), index) {
+            let window = &mut self.persisted.windows[member];
+            if was_minimized {
+                window.minimized = false;
+            } else {
+                if was_maximized {
+                    if let Some(geometry) = restore_geometry.clone() {
+                        window.geometry = geometry;
+                    }
+                    window.pre_maximize_geometry = None;
+                    window.maximized = false;
                 }
-                window.maximized = false;
+                window.minimized = true;
             }
-            window.minimized = true;
         }
         self.bring_to_front(index);
         true
@@ -318,32 +335,40 @@ impl WorkspaceState {
         let Some(index) = self.window_index(id) else {
             return false;
         };
-        let window = &mut self.persisted.windows[index];
-        if window.maximized {
-            if let Some(geometry) = window.pre_maximize_geometry.take() {
-                window.geometry = geometry;
-            }
-            window.maximized = false;
-            window.minimized = false;
-        } else if window.minimized {
-            window.minimized = false;
-        } else {
+        let window = &self.persisted.windows[index];
+        let was_maximized = window.maximized;
+        let was_minimized = window.minimized;
+        if !was_maximized && !was_minimized {
             return false;
+        }
+        let group_id = window.tab_group_id.clone();
+        let restore_geometry = window.pre_maximize_geometry.clone();
+
+        for member in self.group_member_indices(group_id.as_deref(), index) {
+            let window = &mut self.persisted.windows[member];
+            if was_maximized {
+                if let Some(geometry) = restore_geometry.clone() {
+                    window.geometry = geometry;
+                }
+                window.pre_maximize_geometry = None;
+                window.maximized = false;
+                window.minimized = false;
+            } else {
+                window.minimized = false;
+            }
         }
         self.bring_to_front(index);
         true
     }
 
     pub fn update_geometry(&mut self, id: &str, geometry: WindowGeometry) -> bool {
-        let Some(window) = self
-            .persisted
-            .windows
-            .iter_mut()
-            .find(|window| window.id == id)
-        else {
+        let Some(index) = self.window_index(id) else {
             return false;
         };
-        window.geometry = geometry;
+        let group_id = self.persisted.windows[index].tab_group_id.clone();
+        for member in self.group_member_indices(group_id.as_deref(), index) {
+            self.persisted.windows[member].geometry = geometry.clone();
+        }
         true
     }
 
@@ -410,13 +435,14 @@ impl WorkspaceState {
         let Some(group_id) = self.persisted.windows[index].tab_group_id.clone() else {
             return self.focus_window(id, None);
         };
-        let group_geometry = self.persisted.windows[index].geometry.clone();
+        // SPEC-2008 FR-043C: chrome 状態 (geometry / maximize / minimize /
+        // pre_maximize_geometry) は group-aware mutator で常時同期されている
+        // ため、activate ではアクティブマーカと z_index のみを更新する。
         let next_z_index = self.persisted.next_z_index;
         self.persisted.next_z_index += 1;
         for window in &mut self.persisted.windows {
             if window.tab_group_id.as_deref() == Some(&group_id) {
                 window.tab_group_active = window.id == id;
-                window.geometry = group_geometry.clone();
                 window.z_index = next_z_index;
             }
         }
@@ -585,6 +611,29 @@ impl WorkspaceState {
             .windows
             .iter()
             .position(|window| window.id == id)
+    }
+
+    // SPEC-2008 FR-043C: group-aware mutator が触るべき index 集合を返す。
+    // group_id が None なら fallback として primary_index 単独を返し、未グループ
+    // ウィンドウでも同じコードパスを使い回せるようにする。
+    fn group_member_indices(&self, group_id: Option<&str>, primary_index: usize) -> Vec<usize> {
+        let Some(group_id) = group_id else {
+            return vec![primary_index];
+        };
+        let members: Vec<usize> = self
+            .persisted
+            .windows
+            .iter()
+            .enumerate()
+            .filter_map(|(index, window)| {
+                (window.tab_group_id.as_deref() == Some(group_id)).then_some(index)
+            })
+            .collect();
+        if members.is_empty() {
+            vec![primary_index]
+        } else {
+            members
+        }
     }
 
     fn bring_to_front(&mut self, index: usize) {
@@ -1342,5 +1391,140 @@ mod tests {
                 .any(|window| window.tab_group_active),
             "source group must keep one visible active tab after active tab moves out"
         );
+    }
+
+    // SPEC-2008 US-14 / FR-043C: tab グループに属するウィンドウの geometry /
+    // maximize / minimize / pre_maximize_geometry を変更する mutator は、同じ
+    // tab_group_id を持つ全メンバーへ同一の値を伝播しなければならない。
+    // activate_window_tab はアクティブマーカと z_index 以外の chrome 状態を
+    // 変更してはならない。
+    #[test]
+    fn geometry_update_propagates_across_grouped_tabs() {
+        let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
+        assert!(workspace.dock_window_tab("codex-1", "claude-1"));
+
+        let new_geometry = WindowGeometry {
+            x: 432.0,
+            y: 256.0,
+            width: 880.0,
+            height: 540.0,
+        };
+        assert!(workspace.update_geometry("codex-1", new_geometry.clone()));
+
+        assert_eq!(
+            workspace.window("codex-1").expect("codex").geometry,
+            new_geometry,
+            "active tab must record its updated geometry"
+        );
+        assert_eq!(
+            workspace.window("claude-1").expect("claude").geometry,
+            new_geometry,
+            "grouped sibling tab must adopt the same geometry so tab switch does not reset chrome"
+        );
+
+        assert!(workspace.activate_window_tab("claude-1"));
+        assert_eq!(
+            workspace.window("claude-1").expect("claude").geometry,
+            new_geometry,
+            "activate must not overwrite the propagated geometry"
+        );
+        assert_eq!(
+            workspace.window("codex-1").expect("codex").geometry,
+            new_geometry,
+            "previously-active tab must keep the propagated geometry after switching back"
+        );
+    }
+
+    #[test]
+    fn maximize_propagates_across_grouped_tabs() {
+        let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
+        assert!(workspace.dock_window_tab("codex-1", "claude-1"));
+        let pre_geometry = workspace.window("codex-1").expect("codex").geometry.clone();
+
+        let bounds = WindowGeometry {
+            x: 0.0,
+            y: 0.0,
+            width: 1440.0,
+            height: 900.0,
+        };
+        assert!(workspace.maximize_window("codex-1", bounds.clone()));
+
+        let codex = workspace.window("codex-1").expect("codex");
+        let claude = workspace.window("claude-1").expect("claude");
+        assert!(codex.maximized);
+        assert!(
+            claude.maximized,
+            "grouped sibling must share maximize state"
+        );
+        assert_eq!(codex.geometry, claude.geometry);
+        assert_eq!(
+            codex.pre_maximize_geometry.as_ref(),
+            Some(&pre_geometry),
+            "pre_maximize_geometry must record the geometry shared before maximize"
+        );
+        assert_eq!(
+            claude.pre_maximize_geometry.as_ref(),
+            Some(&pre_geometry),
+            "grouped sibling must share pre_maximize_geometry so restore is symmetric"
+        );
+
+        assert!(workspace.maximize_window("codex-1", bounds));
+        let codex = workspace.window("codex-1").expect("codex");
+        let claude = workspace.window("claude-1").expect("claude");
+        assert!(!codex.maximized, "second toggle must restore");
+        assert!(!claude.maximized, "grouped sibling must restore together");
+        assert_eq!(codex.geometry, pre_geometry);
+        assert_eq!(claude.geometry, pre_geometry);
+        assert!(codex.pre_maximize_geometry.is_none());
+        assert!(claude.pre_maximize_geometry.is_none());
+    }
+
+    #[test]
+    fn minimize_and_restore_propagate_across_grouped_tabs() {
+        let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
+        assert!(workspace.dock_window_tab("codex-1", "claude-1"));
+
+        assert!(workspace.minimize_window("codex-1"));
+        assert!(workspace.window("codex-1").expect("codex").minimized);
+        assert!(
+            workspace.window("claude-1").expect("claude").minimized,
+            "grouped sibling must share minimize state"
+        );
+
+        assert!(workspace.restore_window("codex-1"));
+        assert!(!workspace.window("codex-1").expect("codex").minimized);
+        assert!(
+            !workspace.window("claude-1").expect("claude").minimized,
+            "grouped sibling must restore together"
+        );
+    }
+
+    #[test]
+    fn activate_window_tab_preserves_grouped_chrome_state() {
+        let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
+        assert!(workspace.dock_window_tab("codex-1", "claude-1"));
+
+        let new_geometry = WindowGeometry {
+            x: 320.0,
+            y: 180.0,
+            width: 960.0,
+            height: 600.0,
+        };
+        assert!(workspace.update_geometry("codex-1", new_geometry.clone()));
+        let snapshot = workspace.window("codex-1").expect("codex").clone();
+
+        assert!(workspace.activate_window_tab("claude-1"));
+        let claude = workspace.window("claude-1").expect("claude");
+        let codex = workspace.window("codex-1").expect("codex");
+        assert!(claude.tab_group_active);
+        assert!(!codex.tab_group_active);
+        assert_eq!(claude.geometry, new_geometry);
+        assert_eq!(codex.geometry, new_geometry);
+        assert_eq!(claude.maximized, snapshot.maximized);
+        assert_eq!(codex.maximized, snapshot.maximized);
+        assert_eq!(claude.minimized, snapshot.minimized);
+        assert_eq!(codex.minimized, snapshot.minimized);
+        assert_eq!(claude.pre_maximize_geometry, snapshot.pre_maximize_geometry);
+        assert_eq!(codex.pre_maximize_geometry, snapshot.pre_maximize_geometry);
     }
 }


### PR DESCRIPTION
## Summary

- タブグループ内の active タブを移動 / リサイズ / maximize / minimize した後、別タブを切り替えると以前のジオメトリが全タブへ複製されてしまい、位置やサイズが「リセット」されたように見える回帰を解消した。
- `update_geometry` / `maximize_window` / `minimize_window` / `restore_window` を group-aware mutation に変更し、`activate_window_tab` から chrome 状態の上書きを撤去 (アクティブマーカと z_index のみ更新) して、SPEC-2008 US-14 / FR-043C の不変条件「タブグループは同じ chrome 状態を共有する」を一貫させた。
- SPEC-2008 spec.md に受け入れシナリオ #10、FR-043C、SC-020A を追加。

## Changes

- `crates/gwt/src/workspace.rs`:
  - `update_geometry` / `maximize_window` / `minimize_window` / `restore_window` を `group_member_indices` ヘルパ経由でグループ全員へ伝播するように変更。
  - `activate_window_tab` から `geometry` 上書きを撤去。アクティブマーカと z_index のみ更新する。
  - private helper `group_member_indices(group_id, primary_index)` を追加 (未グループは primary_index 単独で fallback)。
  - `mod tests` に SPEC-2008 FR-043C 用テスト 4 本追加 (`geometry_update_propagates_across_grouped_tabs`、`maximize_propagates_across_grouped_tabs`、`minimize_and_restore_propagate_across_grouped_tabs`、`activate_window_tab_preserves_grouped_chrome_state`)。
- SPEC-2008 (#2008) spec.md (GitHub Issue 経由):
  - US-14 受け入れシナリオに #10 (タブ切替後も chrome 状態が保持される) を追加。
  - FR-043C を新設 (group-aware mutator 不変条件)。
  - SC-020A を新設 (workspace unit test での状態固定)。

## Testing

- [x] `cargo test -p gwt --lib -- workspace::tests::` — 36 tests, 0 failed
- [x] `cargo test -p gwt -p gwt-core --lib` — 686 tests, 0 failed
- [x] `cargo test -p gwt --test window_controls_protocol_test` — 1 test, 0 failed
- [x] `cargo clippy -p gwt --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `bun test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/window-docking.test.mjs` — 87 tests, 0 failed

## Closing Issues

- None

## Related Issues / Links

- #2008 (SPEC-2008 US-14 / FR-043C 反映)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — README 変更不要 (内部的バグ修正のため)
- [ ] Migration/backfill plan included (if schema/data change) — schema 変更なし
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — patch 範囲、`fix:` プレフィックスでリリース時に取り込まれる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Window maximize, minimize, and restore operations now consistently apply to all windows within a tab group.
  * Window size and position changes are now synchronized across grouped windows.
  * Switching active tabs preserves grouped window state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2569)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->