### PR TITLE
feat(launch): add info-level structured logging across launch agent flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "which",
 ]
@@ -1405,6 +1406,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/gwt-agent/Cargo.toml
+++ b/crates/gwt-agent/Cargo.toml
@@ -29,3 +29,4 @@ dunce.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 serde_yaml.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/gwt-agent/src/environment.rs
+++ b/crates/gwt-agent/src/environment.rs
@@ -80,9 +80,37 @@ pub fn apply_host_path_hydration_to_std_env() {
     if cfg!(windows) {
         return;
     }
-    if let Some(hydrated) = current_process_hydrated_path() {
-        std::env::set_var("PATH", hydrated);
-    }
+    let before = std::env::var("PATH").unwrap_or_default();
+    let before_count = std::env::split_paths(&before).count();
+    let home = std::env::var("HOME").unwrap_or_default();
+    let Some(hydrated) = current_process_hydrated_path() else {
+        tracing::info!(
+            target: "gwt::launch::startup",
+            stage = "path_hydration",
+            outcome = "skipped",
+            reason = "no_hydrated_path",
+            path_before = %before,
+            path_entry_count_before = before_count,
+            home = %home,
+            "host PATH hydration skipped"
+        );
+        return;
+    };
+    let after_count = std::env::split_paths(&hydrated).count();
+    let added = after_count.saturating_sub(before_count);
+    std::env::set_var("PATH", &hydrated);
+    tracing::info!(
+        target: "gwt::launch::startup",
+        stage = "path_hydration",
+        outcome = "applied",
+        path_before = %before,
+        path_after = %hydrated,
+        path_entry_count_before = before_count,
+        path_entry_count_after = after_count,
+        path_entries_added = added,
+        home = %home,
+        "host PATH hydration applied"
+    );
 }
 
 /// Compute the hydrated PATH from the running process env.
@@ -784,5 +812,48 @@ mod tests {
     fn path_env_test_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn apply_host_path_hydration_to_std_env_emits_info_event_with_path_summary() {
+        use crate::test_capture::{CaptureLayer, CapturedEvents};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let _lock = path_env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let original_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", "/usr/bin:/bin");
+
+        let events = CapturedEvents::new();
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer::new(events.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            apply_host_path_hydration_to_std_env();
+        });
+
+        match original_path {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+
+        let captured = events.snapshot();
+        let info_events: Vec<_> = captured
+            .iter()
+            .filter(|event| event.level == tracing::Level::INFO)
+            .filter(|event| event.target == "gwt::launch::startup")
+            .collect();
+        assert!(
+            !info_events.is_empty(),
+            "expected at least one INFO event with target gwt::launch::startup; captured = {:?}",
+            captured
+        );
+        let event = info_events[0];
+        assert_eq!(
+            event.fields.get("stage").map(String::as_str),
+            Some("path_hydration")
+        );
+        assert!(event.fields.contains_key("path_before"));
+        assert!(event.fields.contains_key("path_entry_count_before"));
     }
 }

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -16,6 +16,9 @@ pub mod store;
 pub mod types;
 pub mod version_cache;
 
+#[cfg(test)]
+pub(crate) mod test_capture;
+
 pub use audit::{
     is_secret_env_key, redact_env_value_for_audit, redact_secrets_in_agent, REDACTED_PLACEHOLDER,
 };

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -628,6 +628,42 @@ fn command_matches_runner(command: &str, runner: &str) -> bool {
 }
 
 fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
+    let path = std::env::var("PATH").unwrap_or_default();
+    let docker_bin = std::env::var("GWT_DOCKER_BIN").unwrap_or_else(|_| "docker".to_string());
+    tracing::info!(
+        target: "gwt::launch::preflight",
+        runtime_target = "docker",
+        attempted_binary = %docker_bin,
+        path = %path,
+        "docker preflight started"
+    );
+    let result = run_docker_preflight();
+    match &result {
+        Ok(()) => {
+            tracing::info!(
+                target: "gwt::launch::preflight",
+                runtime_target = "docker",
+                outcome = "ready",
+                attempted_binary = %docker_bin,
+                "docker preflight completed"
+            );
+        }
+        Err(error) => {
+            tracing::error!(
+                target: "gwt::launch::preflight",
+                runtime_target = "docker",
+                outcome = "failed",
+                attempted_binary = %docker_bin,
+                path = %path,
+                error = %error,
+                "docker preflight failed"
+            );
+        }
+    }
+    result
+}
+
+fn run_docker_preflight() -> Result<(), String> {
     if !gwt_docker::docker_available() {
         return Err("Docker is not installed or not available on PATH".to_string());
     }
@@ -1782,5 +1818,73 @@ mod tests {
 
         assert!(working_dir.is_none());
         assert!(env_vars.is_empty());
+    }
+
+    #[test]
+    fn ensure_docker_launch_runtime_ready_emits_preflight_started_and_failure_when_docker_missing()
+    {
+        use crate::test_capture::{CaptureLayer, CapturedEvents};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let _lock = preflight_env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous_bin = std::env::var_os("GWT_DOCKER_BIN");
+        std::env::set_var("GWT_DOCKER_BIN", "/this-binary-does-not-exist-for-gwt-test");
+
+        let events = CapturedEvents::new();
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer::new(events.clone()));
+        let result =
+            tracing::subscriber::with_default(subscriber, ensure_docker_launch_runtime_ready);
+
+        match previous_bin {
+            Some(value) => std::env::set_var("GWT_DOCKER_BIN", value),
+            None => std::env::remove_var("GWT_DOCKER_BIN"),
+        }
+
+        assert!(result.is_err(), "expected Err for missing docker binary");
+
+        let captured = events.snapshot();
+        let preflight_events: Vec<_> = captured
+            .iter()
+            .filter(|event| event.target == "gwt::launch::preflight")
+            .collect();
+        let info_started: Vec<_> = preflight_events
+            .iter()
+            .filter(|event| {
+                event.level == tracing::Level::INFO
+                    && event.fields.get("message").map(String::as_str)
+                        == Some("docker preflight started")
+            })
+            .collect();
+        let error_failed: Vec<_> = preflight_events
+            .iter()
+            .filter(|event| {
+                event.level == tracing::Level::ERROR
+                    && event.fields.get("message").map(String::as_str)
+                        == Some("docker preflight failed")
+            })
+            .collect();
+        assert!(
+            !info_started.is_empty(),
+            "expected an INFO 'docker preflight started' event; captured = {:?}",
+            captured
+        );
+        assert!(
+            !error_failed.is_empty(),
+            "expected an ERROR 'docker preflight failed' event; captured = {:?}",
+            captured
+        );
+        let started = info_started[0];
+        assert_eq!(
+            started.fields.get("attempted_binary").map(String::as_str),
+            Some("/this-binary-does-not-exist-for-gwt-test")
+        );
+        assert!(started.fields.contains_key("path"));
+    }
+
+    fn preflight_env_test_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
     }
 }

--- a/crates/gwt-agent/src/test_capture.rs
+++ b/crates/gwt-agent/src/test_capture.rs
@@ -1,0 +1,92 @@
+//! Shared tracing capture helpers for the gwt-agent test modules.
+//!
+//! Tests that want to assert on emitted `tracing` events install a
+//! [`CaptureLayer`] over the registry and inspect the snapshot afterwards.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tracing::{field::Visit, Event, Level, Subscriber};
+use tracing_subscriber::{
+    layer::{Context, Layer},
+    registry::LookupSpan,
+};
+
+#[derive(Clone, Debug)]
+pub struct CapturedEvent {
+    pub level: Level,
+    pub target: String,
+    pub fields: HashMap<String, String>,
+}
+
+#[derive(Clone, Default)]
+pub struct CapturedEvents(Arc<Mutex<Vec<CapturedEvent>>>);
+
+impl CapturedEvents {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn snapshot(&self) -> Vec<CapturedEvent> {
+        self.0.lock().expect("captured events").clone()
+    }
+}
+
+pub struct CaptureLayer {
+    events: CapturedEvents,
+}
+
+impl CaptureLayer {
+    pub fn new(events: CapturedEvents) -> Self {
+        Self { events }
+    }
+}
+
+struct CaptureVisitor<'a>(&'a mut CapturedEvent);
+
+impl<'a> Visit for CaptureVisitor<'a> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0
+            .fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.0
+            .fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0
+            .fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.0
+            .fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut captured = CapturedEvent {
+            level: *event.metadata().level(),
+            target: event.metadata().target().to_string(),
+            fields: HashMap::new(),
+        };
+        event.record(&mut CaptureVisitor(&mut captured));
+        self.events
+            .0
+            .lock()
+            .expect("captured events")
+            .push(captured);
+    }
+}

--- a/crates/gwt-docker/Cargo.toml
+++ b/crates/gwt-docker/Cargo.toml
@@ -17,3 +17,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/gwt-docker/src/detect.rs
+++ b/crates/gwt-docker/src/detect.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Detected Docker files in a directory.
 #[derive(Debug, Clone, Default)]
@@ -30,17 +30,46 @@ impl DockerFiles {
 
 /// Run a docker sub-command and return whether it succeeded.
 fn docker_probe(args: &[&str], label: &str) -> bool {
-    let result = std::process::Command::new(docker_binary())
-        .args(args)
-        .output();
+    let binary = docker_binary();
+    let attempted_binary = binary.to_string_lossy().into_owned();
+    let result = std::process::Command::new(&binary).args(args).output();
     match result {
         Ok(output) => {
             let ok = output.status.success();
-            debug!(category = "docker", ok = ok, label = label, "probe");
+            info!(
+                target: "gwt::launch::probe",
+                category = "docker",
+                label = label,
+                attempted_binary = %attempted_binary,
+                ok = ok,
+                "docker probe"
+            );
+            if !ok {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stderr = stderr.trim();
+                if !stderr.is_empty() {
+                    debug!(
+                        target: "gwt::launch::probe",
+                        category = "docker",
+                        label = label,
+                        attempted_binary = %attempted_binary,
+                        stderr = %stderr,
+                        "docker probe stderr"
+                    );
+                }
+            }
             ok
         }
         Err(e) => {
-            debug!(category = "docker", error = %e, label = label, "probe failed");
+            info!(
+                target: "gwt::launch::probe",
+                category = "docker",
+                label = label,
+                attempted_binary = %attempted_binary,
+                ok = false,
+                error = %e,
+                "docker probe failed"
+            );
             false
         }
     }
@@ -209,5 +238,103 @@ mod tests {
     #[test]
     fn daemon_running_returns_bool() {
         let _ = daemon_running();
+    }
+
+    #[test]
+    fn docker_probe_emits_info_event_with_label_and_attempted_binary() {
+        use std::sync::{Arc, Mutex};
+        use tracing::{Event, Level, Subscriber};
+        use tracing_subscriber::{
+            layer::{Context, Layer, SubscriberExt},
+            registry::LookupSpan,
+        };
+
+        #[derive(Clone, Debug)]
+        struct CapturedEvent {
+            level: Level,
+            target: String,
+            fields: std::collections::HashMap<String, String>,
+        }
+
+        struct CaptureLayer {
+            events: Arc<Mutex<Vec<CapturedEvent>>>,
+        }
+
+        struct CaptureVisitor<'a>(&'a mut CapturedEvent);
+
+        impl<'a> tracing::field::Visit for CaptureVisitor<'a> {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                self.0
+                    .fields
+                    .insert(field.name().to_string(), format!("{value:?}"));
+            }
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                self.0
+                    .fields
+                    .insert(field.name().to_string(), value.to_string());
+            }
+            fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+                self.0
+                    .fields
+                    .insert(field.name().to_string(), value.to_string());
+            }
+        }
+
+        impl<S> Layer<S> for CaptureLayer
+        where
+            S: Subscriber + for<'a> LookupSpan<'a>,
+        {
+            fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+                let mut captured = CapturedEvent {
+                    level: *event.metadata().level(),
+                    target: event.metadata().target().to_string(),
+                    fields: std::collections::HashMap::new(),
+                };
+                event.record(&mut CaptureVisitor(&mut captured));
+                self.events.lock().unwrap().push(captured);
+            }
+        }
+
+        let _lock = docker_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous_bin = std::env::var_os("GWT_DOCKER_BIN");
+        std::env::set_var("GWT_DOCKER_BIN", "/this-binary-does-not-exist-gwt-test");
+
+        let events = Arc::new(Mutex::new(Vec::<CapturedEvent>::new()));
+        let layer = CaptureLayer {
+            events: Arc::clone(&events),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let _ = docker_available();
+        });
+
+        match previous_bin {
+            Some(value) => std::env::set_var("GWT_DOCKER_BIN", value),
+            None => std::env::remove_var("GWT_DOCKER_BIN"),
+        }
+
+        let captured = events.lock().unwrap().clone();
+        let info_events: Vec<_> = captured
+            .iter()
+            .filter(|event| event.level == Level::INFO && event.target == "gwt::launch::probe")
+            .collect();
+        assert!(
+            !info_events.is_empty(),
+            "expected at least one INFO event with target gwt::launch::probe; captured = {:?}",
+            captured
+        );
+        let event = info_events[0];
+        assert_eq!(
+            event.fields.get("label").map(String::as_str),
+            Some("docker CLI")
+        );
+        assert!(event.fields.contains_key("attempted_binary"));
+    }
+
+    fn docker_test_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
     }
 }

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -516,6 +516,42 @@ pub fn command_matches_runner(command: &str, runner: &str) -> bool {
 }
 
 pub fn ensure_docker_launch_runtime_ready() -> Result<(), String> {
+    let path = std::env::var("PATH").unwrap_or_default();
+    let docker_bin = std::env::var("GWT_DOCKER_BIN").unwrap_or_else(|_| "docker".to_string());
+    tracing::info!(
+        target: "gwt::launch::preflight",
+        runtime_target = "docker",
+        attempted_binary = %docker_bin,
+        path = %path,
+        "docker preflight started"
+    );
+    let result = run_docker_preflight();
+    match &result {
+        Ok(()) => {
+            tracing::info!(
+                target: "gwt::launch::preflight",
+                runtime_target = "docker",
+                outcome = "ready",
+                attempted_binary = %docker_bin,
+                "docker preflight completed"
+            );
+        }
+        Err(error) => {
+            tracing::error!(
+                target: "gwt::launch::preflight",
+                runtime_target = "docker",
+                outcome = "failed",
+                attempted_binary = %docker_bin,
+                path = %path,
+                error = %error,
+                "docker preflight failed"
+            );
+        }
+    }
+    result
+}
+
+fn run_docker_preflight() -> Result<(), String> {
     if !gwt_docker::docker_available() {
         return Err("Docker is not installed or not available on PATH".to_string());
     }


### PR DESCRIPTION
## Summary

- PR #2564 (`fix(launch): hydrate process PATH...`) の bug 調査時、launch agent flow に info-level structured log がほぼ存在せず、process PATH や `docker_available()` の判定経過を log だけから特定できませんでした。今回はその gap を Issue #2572 として登録し、主要境界に info-level structured logging を追加します
- 既定 RUST_LOG=info の設定で、Launch Agent → Docker 選択時の preflight トレースが `~/.gwt/projects/<repo-hash>/logs/gwt.log.*` に並ぶようになります

## Context

ユーザー frustration:
- 「Launch Agent関連のログが仕込まれていないのか…。終わってる…。」
- 「普通は全てにおいてログを仕込むやろ」

調査により判明した既存の gap:
- `gwt-docker/src/detect.rs::docker_probe` は debug 止まりで RUST_LOG=info では見えない
- `gwt-agent/src/prepare.rs::ensure_docker_launch_runtime_ready` および `gwt/src/launch_runtime.rs::ensure_docker_launch_runtime_ready` は tracing 呼び出し 0 件
- `gwt-agent/src/environment.rs::apply_host_path_hydration_to_std_env` (PR #2564 で追加) も log なし
- `gwt/src/app_runtime/mod.rs::log_*_error` は失敗時のみ。成功 path / 進行中 phase が見えない

## Changes

### Instrumentation

- **`crates/gwt-agent/src/environment.rs::apply_host_path_hydration_to_std_env`**:
  - target `gwt::launch::startup` で hydrated PATH の before/after、entry count、`HOME` を info 出力
- **`crates/gwt-agent/src/prepare.rs::ensure_docker_launch_runtime_ready`** および **`crates/gwt/src/launch_runtime.rs::ensure_docker_launch_runtime_ready`**:
  - target `gwt::launch::preflight` で preflight 開始 (info) → outcome (info ready / error failed) を出力
  - 失敗時は full PATH と error 詳細を error log に含める
- **`crates/gwt-docker/src/detect.rs::docker_probe`**:
  - debug → info に昇格、target `gwt::launch::probe` で label / attempted_binary / ok / error を構造化出力

### Sanitize 方針

Issue #2572 で確認済み: PATH は full 値を info で出します。logs/ 配下は元来ユーザーローカルで sensitive 扱いのため、診断価値を最優先しました。token / API key を扱う既存 `sanitize_launch_log_error` の経路は変更しません。

### Test infra 追加

- `crates/gwt-agent/src/test_capture.rs`: tracing event capture helper を crate-private で追加
- `tracing-subscriber` を `gwt-agent` と `gwt-docker` の dev-dep に追加 (workspace level は既存)

### Tests 追加

- `apply_host_path_hydration_to_std_env_emits_info_event_with_path_summary` (gwt-agent)
- `ensure_docker_launch_runtime_ready_emits_preflight_started_and_failure_when_docker_missing` (gwt-agent, GWT_DOCKER_BIN=/nonexistent で失敗 path を観測)
- `docker_probe_emits_info_event_with_label_and_attempted_binary` (gwt-docker, 同様)

## Closing Issues

Closes #2572

## Test plan

- [x] `cargo test -p gwt-agent` 200 passed
- [x] `cargo test -p gwt-agent -p gwt-docker -p gwt` all GREEN (gwt 497, gwt bin 258, integration tests 多数 全 ok)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` pass
- [x] `cargo fmt -- --check` pass
- [ ] follow-up: 実機で `RUST_LOG=info` (default) のまま gwt 起動 → Launch Agent → Docker 選択 → `gwt.log.*` に preflight_started / docker_probe (3 件) / preflight_completed が並ぶことを確認
- [ ] follow-up: `GWT_DOCKER_BIN=/nonexistent gwt` で起動 → Launch Agent → Docker 選択 → preflight_failed に attempted_binary / path / error が含まれることを確認

## Checklist

- [x] commitlint 準拠 (`feat(launch):` prefix)
- [x] 既存 error path log (`log_window_launch_error`) は変更せず、info 系を手前で追加
- [x] PATH は full で出す (Issue #2572 で確認済み)
- [x] `gwt-docker` debug → info 昇格 (1 起動あたり probe 数件のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
