### PR TITLE
fix(workspace): block mutating git title guard bypass

### DIFF
--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -302,10 +302,7 @@ fn is_read_only_segment(segment: &str) -> bool {
         "env" => tokens
             .get(1)
             .is_none_or(|token| is_read_only_command_token(token)),
-        "git" => tokens
-            .get(1)
-            .copied()
-            .is_some_and(is_read_only_git_subcommand),
+        "git" => is_read_only_git_tokens(&tokens[1..]),
         "gwtd" => is_read_only_gwtd_tokens(&tokens[1..]),
         _ => false,
     }
@@ -374,21 +371,79 @@ fn normalize_command_name(token: &str) -> String {
         .to_string()
 }
 
-fn is_read_only_git_subcommand(subcommand: &str) -> bool {
-    matches!(
-        subcommand,
-        "branch"
-            | "cat-file"
-            | "config"
-            | "diff"
-            | "log"
-            | "ls-files"
-            | "ls-tree"
-            | "remote"
-            | "rev-parse"
-            | "show"
-            | "status"
-    )
+fn is_read_only_git_tokens(tokens: &[&str]) -> bool {
+    match tokens {
+        ["cat-file" | "diff" | "log" | "ls-files" | "ls-tree" | "rev-parse" | "show" | "status", ..] => {
+            true
+        }
+        ["branch", rest @ ..] => is_read_only_git_branch_args(rest),
+        ["config", rest @ ..] => is_read_only_git_config_args(rest),
+        ["remote", rest @ ..] => is_read_only_git_remote_args(rest),
+        _ => false,
+    }
+}
+
+fn is_read_only_git_branch_args(args: &[&str]) -> bool {
+    const MUTATING_FLAGS: &[&str] = &[
+        "-c",
+        "-C",
+        "-d",
+        "-D",
+        "-m",
+        "-M",
+        "-u",
+        "--copy",
+        "--delete",
+        "--edit-description",
+        "--move",
+        "--set-upstream-to",
+        "--track",
+        "--unset-upstream",
+    ];
+    if args.iter().any(|arg| {
+        MUTATING_FLAGS.contains(arg)
+            || arg
+                .split_once('=')
+                .is_some_and(|(flag, _)| MUTATING_FLAGS.contains(&flag))
+    }) {
+        return false;
+    }
+    args.iter().all(|arg| arg.starts_with('-'))
+}
+
+fn is_read_only_git_config_args(args: &[&str]) -> bool {
+    const READ_FLAGS: &[&str] = &[
+        "--get",
+        "--get-all",
+        "--get-color",
+        "--get-colorbool",
+        "--get-regexp",
+        "--get-urlmatch",
+        "--list",
+        "--name-only",
+        "-l",
+    ];
+    const MUTATING_FLAGS: &[&str] = &[
+        "--add",
+        "--edit",
+        "--remove-section",
+        "--rename-section",
+        "--replace-all",
+        "--set",
+        "--unset",
+        "--unset-all",
+    ];
+    args.iter().any(|arg| READ_FLAGS.contains(arg))
+        && !args.iter().any(|arg| {
+            MUTATING_FLAGS.contains(arg)
+                || arg
+                    .split_once('=')
+                    .is_some_and(|(flag, _)| MUTATING_FLAGS.contains(&flag))
+        })
+}
+
+fn is_read_only_git_remote_args(args: &[&str]) -> bool {
+    matches!(args, [] | ["-v" | "--verbose"] | ["show" | "get-url", ..])
 }
 
 fn is_read_only_gwtd_tokens(tokens: &[&str]) -> bool {
@@ -682,6 +737,40 @@ Coverage requirements.
     }
 
     #[test]
+    fn title_summary_guard_allows_read_only_git_config() {
+        let event = HookEvent {
+            tool_name: Some("Bash".to_string()),
+            tool_input: Some(serde_json::json!({
+                "command": "git config --list --show-origin"
+            })),
+            transcript_path: None,
+            cwd: None,
+        };
+
+        assert_eq!(
+            evaluate_title_summary_guard(&event, true).expect("guard output"),
+            HookOutput::Silent
+        );
+    }
+
+    #[test]
+    fn title_summary_guard_allows_read_only_git_remote() {
+        let event = HookEvent {
+            tool_name: Some("Bash".to_string()),
+            tool_input: Some(serde_json::json!({
+                "command": "git remote -v"
+            })),
+            transcript_path: None,
+            cwd: None,
+        };
+
+        assert_eq!(
+            evaluate_title_summary_guard(&event, true).expect("guard output"),
+            HookOutput::Silent
+        );
+    }
+
+    #[test]
     fn title_summary_guard_blocks_mutating_exploration_like_sed_in_place() {
         let event = HookEvent {
             tool_name: Some("Bash".to_string()),
@@ -704,6 +793,40 @@ Coverage requirements.
             tool_name: Some("Bash".to_string()),
             tool_input: Some(serde_json::json!({
                 "command": "find target -name '*.tmp' -delete"
+            })),
+            transcript_path: None,
+            cwd: None,
+        };
+
+        assert!(matches!(
+            evaluate_title_summary_guard(&event, true).expect("guard output"),
+            HookOutput::PreToolUsePermission { .. }
+        ));
+    }
+
+    #[test]
+    fn title_summary_guard_blocks_mutating_git_config() {
+        let event = HookEvent {
+            tool_name: Some("Bash".to_string()),
+            tool_input: Some(serde_json::json!({
+                "command": "git config user.name Codex"
+            })),
+            transcript_path: None,
+            cwd: None,
+        };
+
+        assert!(matches!(
+            evaluate_title_summary_guard(&event, true).expect("guard output"),
+            HookOutput::PreToolUsePermission { .. }
+        ));
+    }
+
+    #[test]
+    fn title_summary_guard_blocks_mutating_git_remote() {
+        let event = HookEvent {
+            tool_name: Some("Bash".to_string()),
+            tool_input: Some(serde_json::json!({
+                "command": "git remote add origin https://example.com/repo.git"
             })),
             transcript_path: None,
             cwd: None,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4908,3 +4908,26 @@ data 属性だけで判定していた。同じく `activeWorkProjection` 由来
 3. Sidebar / Status Strip / Mission Briefing が共有する集計関数は、
    regression を `operator-chrome-structure` 等の source-level
    assertion で固定し、preset filter の脱落を CI で拾う。
+
+## 2026-05-10 — Git read-only 判定は subcommand 名だけで許可しない
+
+### 事象
+
+title-summary 未設定時の read-only exploration allowlist が `git config` と
+`git remote` を subcommand 名だけで許可していたため、`git config user.name ...`
+や `git remote add ...` のような変更系 command が title-summary gate を通過した。
+
+### 原因
+
+Git の subcommand は同じ名前でも読み取りと変更の両方を持つものがあるが、
+`is_read_only_git_subcommand` が引数を見ずに `config` / `remote` / `branch`
+全体を read-only として扱っていた。allowlist の単位が粗く、guard の目的
+である「作業開始前の変更を止める」契約と一致していなかった。
+
+### 再発防止策
+
+1. Hook guard の read-only 判定では command 名だけでなく引数まで見る。
+2. `git config` / `git remote` / `git branch` のように読み書きが混在する
+   subcommand は、明示的な読み取り形式だけを allowlist する。
+3. allowlist を広げる場合は、読み取り positive test と変更 blocking test
+   を必ず対で追加する。


### PR DESCRIPTION
## Summary

- Fix the title-summary guard bypass where mutating Git commands were treated as read-only exploration.
- Keep explicit read-only `git config` and `git remote` commands available before title-summary is set.

## Changes

- Replace Git subcommand-name-only read-only detection with argument-aware Git token classification.
- Allow only explicit read forms for mixed read/write subcommands such as `git config`, `git remote`, and `git branch`.
- Add regression coverage for blocked mutating `git config user.name ...` and `git remote add ...` commands.
- Add preservation coverage for read-only `git config --list --show-origin` and `git remote -v` commands.
- Record the review lesson in `tasks/lessons.md`.

## Testing

- `cargo test -p gwt title_summary_guard_blocks_mutating_git -- --nocapture` (RED before implementation, then GREEN)
- `cargo test -p gwt title_summary_guard -- --nocapture`
- `cargo test -p gwt-core -p gwt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`
- `cargo fmt -- --check`
- `git diff --check`
- `bunx markdownlint-cli -c .markdownlint.json tasks/lessons.md`
- `bunx commitlint --from origin/develop --to HEAD`

## Closing Issues

None

## Related Issues

Refs #2359
Refs #2576

## Checklist

- [x] PR title follows Conventional Commits.
- [x] PR body was derived from the actual diff and commit range.
- [x] Local tests, lint, build, format check, markdownlint, diff check, and commitlint passed.
- [x] Follow-up was created from a branch synchronized with `origin/develop`.
