### PR TITLE
fix(gui): canonicalize per-cell rebuild project root for proxy events

### DIFF
--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -353,14 +353,20 @@ pub(crate) fn spawn_per_cell_rebuild_with(
         dyn Fn(&Path) -> gwt::ProjectIndexStatusView + Send + Sync + 'static,
     >,
 ) -> ProjectIndexBootstrapRequest {
-    let project_root_label = project_root.display().to_string();
-    let project_root_for_closure = project_root.clone();
+    // Canonicalise so the proxy events share the same project_root key the
+    // bootstrap path uses (`spawn_with` -> `normalize_project_root`).
+    // Without this, the frontend `indexStatusByProjectRoot` would keep two
+    // separate entries for the same project (raw vs canonical path),
+    // breaking Settings.Index real-time updates after a per-cell rebuild.
+    let canonical_project_root = normalize_project_root(&project_root);
+    let project_root_label = canonical_project_root.display().to_string();
+    let project_root_for_closure = canonical_project_root.clone();
     let worktree_hash_for_closure = worktree_hash.clone();
     let proxy_for_closure = proxy.clone();
     let rebuild_runner_for_closure = rebuild_runner.clone();
     let final_status_for_closure = final_status_provider.clone();
 
-    service.spawn_rebuild_with(project_root, scope, worktree_hash, move || {
+    service.spawn_rebuild_with(canonical_project_root, scope, worktree_hash, move || {
         let started_at = chrono::Utc::now();
         // Optimistic transition: switch the badge to `repairing(0/1)`
         // immediately so observers see auto-rebuild start before the
@@ -610,6 +616,140 @@ mod tests {
             gwt::ProjectIndexStatusState::Ready,
         );
         assert_eq!(status.detail, "retry ready");
+    }
+
+    #[test]
+    fn spawn_per_cell_rebuild_emits_repairing_then_final_status_via_proxy() {
+        // SPEC-1939 T-IDX-109 (subset): exercise the per-cell IPC path
+        // end-to-end by injecting a fake runner + final-status provider so
+        // the test does not invoke real Python. The recorded proxy events
+        // must follow `Repairing(0/1)` -> final, mirroring what the
+        // frontend `setIndexStatus` consumes from WebSocket.
+        let service = super::ProjectIndexBootstrapService::new_for_test();
+        let temp = tempdir().expect("tempdir");
+        let project_root = temp.path().to_path_buf();
+        // spawn_per_cell_rebuild_with canonicalises the project root so
+        // proxy events share a key with the bootstrap path.
+        let project_root_label = dunce::canonicalize(&project_root)
+            .unwrap_or_else(|_| project_root.clone())
+            .display()
+            .to_string();
+        let (proxy, events) = AppEventProxy::stub();
+
+        let runner_calls = Arc::new(AtomicUsize::new(0));
+        let runner_calls_handle = runner_calls.clone();
+        let rebuild_runner: Arc<gwt::IndexRebuildRunnerFn> =
+            Arc::new(move |_root, scope, worktree_hash| {
+                assert_eq!(scope, IndexRebuildScope::Files);
+                assert_eq!(worktree_hash, Some("wtAhash"));
+                runner_calls_handle.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            });
+        let final_status_provider: Arc<
+            dyn Fn(&Path) -> gwt::ProjectIndexStatusView + Send + Sync + 'static,
+        > = Arc::new(|_path| {
+            gwt::ProjectIndexStatusView::new(
+                gwt::ProjectIndexStatusState::Ready,
+                "ready after IPC rebuild",
+            )
+        });
+
+        let request = super::spawn_per_cell_rebuild_with(
+            service,
+            proxy,
+            project_root.clone(),
+            IndexRebuildScope::Files,
+            Some("wtAhash".to_string()),
+            rebuild_runner,
+            final_status_provider,
+        );
+        assert_eq!(request, super::ProjectIndexBootstrapRequest::Spawned);
+
+        let final_view = wait_for_project_status(
+            &events,
+            &project_root_label,
+            gwt::ProjectIndexStatusState::Ready,
+        );
+        assert_eq!(final_view.detail, "ready after IPC rebuild");
+        assert_eq!(runner_calls.load(Ordering::SeqCst), 1);
+
+        // The transient Repairing event must have been emitted before the
+        // Ready event.
+        let recorded = events.lock().expect("events");
+        let mut saw_repairing_before_ready = false;
+        for event in recorded.iter() {
+            if let UserEvent::ProjectIndexStatus {
+                project_root,
+                status,
+            } = event
+            {
+                if project_root != &project_root_label {
+                    continue;
+                }
+                if status.state == gwt::ProjectIndexStatusState::Repairing {
+                    saw_repairing_before_ready = true;
+                    let progress = status.progress.expect("progress on repairing");
+                    assert_eq!(progress.scopes_total, 1);
+                }
+                if status.state == gwt::ProjectIndexStatusState::Ready {
+                    assert!(
+                        saw_repairing_before_ready,
+                        "Ready must follow at least one Repairing event"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn spawn_per_cell_rebuild_emits_error_state_when_runner_fails() {
+        // SPEC-1939 T-IDX-110 (subset): runner failure surfaces as `error`
+        // with the rebuild reason, mirroring what the badge / Settings.Index
+        // shows on auto-rebuild failure.
+        let service = super::ProjectIndexBootstrapService::new_for_test();
+        let temp = tempdir().expect("tempdir");
+        let project_root = temp.path().to_path_buf();
+        // spawn_per_cell_rebuild_with canonicalises the project root so
+        // proxy events share a key with the bootstrap path.
+        let project_root_label = dunce::canonicalize(&project_root)
+            .unwrap_or_else(|_| project_root.clone())
+            .display()
+            .to_string();
+        let (proxy, events) = AppEventProxy::stub();
+
+        let rebuild_runner: Arc<gwt::IndexRebuildRunnerFn> =
+            Arc::new(|_root, _scope, _worktree_hash| Err("synthetic IPC failure".to_string()));
+        let final_status_provider: Arc<
+            dyn Fn(&Path) -> gwt::ProjectIndexStatusView + Send + Sync + 'static,
+        > = Arc::new(|_path| {
+            gwt::ProjectIndexStatusView::new(
+                gwt::ProjectIndexStatusState::Ready,
+                "should not be used",
+            )
+        });
+
+        let request = super::spawn_per_cell_rebuild_with(
+            service,
+            proxy,
+            project_root.clone(),
+            IndexRebuildScope::Specs,
+            None,
+            rebuild_runner,
+            final_status_provider,
+        );
+        assert_eq!(request, super::ProjectIndexBootstrapRequest::Spawned);
+
+        let final_view = wait_for_project_status(
+            &events,
+            &project_root_label,
+            gwt::ProjectIndexStatusState::Error,
+        );
+        assert!(
+            final_view.detail.contains("synthetic IPC failure"),
+            "detail should carry the failure reason: {}",
+            final_view.detail
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

SPEC-1939 follow-up (Issue #2584 関連) として、PR1 で導入した `spawn_per_cell_rebuild_with` が proxy event に raw `project_root.display()` を流していた問題を修正します。bootstrap 経路 (`spawn_with` → `normalize_project_root`) と整合させ、frontend の `indexStatusByProjectRoot.set(projectRoot, …)` で同一プロジェクトに raw / canonical の二重 entry が生まれる潜在バグを塞ぎます。

- `spawn_per_cell_rebuild_with` で `normalize_project_root(&project_root)` を 1 回だけ計算し、event label / closure project_root / `spawn_rebuild_with` に渡す path を全て canonical に統一
- T-IDX-109/110 のロジックを Rust 統合テストでカバー:
  - `spawn_per_cell_rebuild_emits_repairing_then_final_status_via_proxy`: fake runner + final-status provider で IPC 経路の `Repairing(0/1)` → Ready transition と canonical project_root を assert
  - `spawn_per_cell_rebuild_emits_error_state_when_runner_fails`: runner 失敗が `Error` 状態で detail に reason を乗せて表面化することを assert

## Test plan

- [x] `cargo test -p gwt --bin gwt project_index_bootstrap` (6/6)
- [x] `cargo test -p gwt-core -p gwt` 全 GREEN
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`

## Notes

production の影響: per-cell rebuild の最終状態が同じ `indexStatusByProjectRoot` キーで届くようになり、Settings.Index real-time update (PR3) が canonical / raw 双方の path で開かれた project でも単一エントリで更新されるようになります。

Playwright e2e (T-IDX-109/110 本体) と manual smoke (T-IDX-111/112) は Issue #2584 に残置のため、本 PR では含めません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate project roots could be tracked in the frontend/aggregator state during per-cell rebuilds.

* **Tests**
  * Added unit tests validating per-cell rebuild status events and error handling behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2585)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->