### PR TITLE
fix(gui): stabilize terminal SGR / resize / visibility (SPEC-1919 P14 + SPEC-2008 P24)

### DIFF
--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -29,8 +29,12 @@ pub struct Pane {
     parser: vt100::Parser,
     scrollback: ScrollbackStorage,
     status: PaneStatus,
-    /// Accumulator for incomplete lines from raw PTY output.
-    line_buf: String,
+    /// Accumulator for incomplete lines from raw PTY output. Holds raw bytes
+    /// (including SGR escape sequences) until a `\n` boundary is reached, then
+    /// the completed line is split off and pushed into `scrollback` with both
+    /// a plain-text rendering and the original byte stream so SGR formatting
+    /// can be replayed later (SPEC-1919 FR-003j).
+    line_buf: Vec<u8>,
 }
 
 fn resize_parser_preserving_state(parser: &mut vt100::Parser, rows: u16, cols: u16) {
@@ -76,7 +80,7 @@ impl Pane {
             parser,
             scrollback,
             status: PaneStatus::Running,
-            line_buf: String::new(),
+            line_buf: Vec::new(),
         })
     }
 
@@ -108,17 +112,18 @@ impl Pane {
         // Update vt100 screen state
         self.parser.process(data);
 
-        // Capture lines for scrollback
-        let text = String::from_utf8_lossy(data);
-        self.line_buf.push_str(&text);
+        // Capture raw bytes for scrollback. SGR escape sequences (CSI ... m)
+        // never contain `\n`, so byte-level newline splitting preserves both
+        // the visible text and the SGR formatting in `formatted`.
+        self.line_buf.extend_from_slice(data);
 
-        // Split on newlines and push completed lines into the ring buffer.
-        // Uses drain to avoid repeated allocation from slicing.
-        while let Some(pos) = self.line_buf.find('\n') {
-            let line: String = self.line_buf.drain(..pos).collect();
+        while let Some(pos) = self.line_buf.iter().position(|b| *b == b'\n') {
+            let raw: Vec<u8> = self.line_buf.drain(..pos).collect();
             self.line_buf.drain(..1); // consume the '\n'
+            let text = String::from_utf8_lossy(&raw).into_owned();
             self.scrollback.push_line(ScrollbackLine {
-                text: line,
+                text,
+                formatted: raw,
                 wrapped: false,
             });
         }

--- a/crates/gwt-terminal/src/scrollback.rs
+++ b/crates/gwt-terminal/src/scrollback.rs
@@ -4,10 +4,21 @@
 //! Memory-efficient: each entry is text + basic attributes.
 
 /// A single stored line with text content and optional attributes.
-#[derive(Debug, Clone)]
+///
+/// `formatted` carries the SGR-bearing escape stream (`\x1b[...m...`) that
+/// reproduces the original cell foreground / background color, bold, italic,
+/// underline, and inverse attributes when written verbatim into a terminal
+/// emulator (e.g. xterm.js). `text` keeps the plain text rendering for
+/// search / contents export paths that do not understand escape codes.
+/// SPEC-1919 FR-003j / SC-005b require both representations so scrollback
+/// replay does not collapse colored history into default-color text.
+#[derive(Debug, Clone, Default)]
 pub struct ScrollbackLine {
-    /// Plain text content of the line.
+    /// Plain text content of the line (formatting stripped).
     pub text: String,
+    /// SGR-bearing byte stream suitable for replay into a terminal emulator.
+    /// Empty when no formatting information is available.
+    pub formatted: Vec<u8>,
     /// Whether the line was wrapped (soft wrap) vs. explicit newline.
     pub wrapped: bool,
 }
@@ -122,6 +133,7 @@ mod tests {
         s.push_line(ScrollbackLine {
             text: "hello".to_string(),
             wrapped: false,
+            ..Default::default()
         });
         assert_eq!(s.len(), 1);
         let lines = s.get_lines(0, 1);
@@ -137,6 +149,7 @@ mod tests {
             s.push_line(ScrollbackLine {
                 text: format!("line-{i}"),
                 wrapped: false,
+                ..Default::default()
             });
         }
         assert_eq!(s.len(), 5);
@@ -154,6 +167,7 @@ mod tests {
             s.push_line(ScrollbackLine {
                 text: format!("line-{i}"),
                 wrapped: false,
+                ..Default::default()
             });
         }
         // Capacity 3, pushed 5 -> oldest 2 evicted, remaining: line-2, line-3, line-4
@@ -172,6 +186,7 @@ mod tests {
             s.push_line(ScrollbackLine {
                 text: format!("line-{i}"),
                 wrapped: false,
+                ..Default::default()
             });
         }
         let lines = s.get_lines(2, 2);
@@ -187,6 +202,7 @@ mod tests {
             s.push_line(ScrollbackLine {
                 text: format!("line-{i}"),
                 wrapped: false,
+                ..Default::default()
             });
         }
         let lines = s.get_lines(1, 100);
@@ -201,6 +217,7 @@ mod tests {
         s.push_line(ScrollbackLine {
             text: "a".to_string(),
             wrapped: false,
+            ..Default::default()
         });
         let lines = s.get_lines(5, 1);
         assert!(lines.is_empty());
@@ -212,6 +229,7 @@ mod tests {
         s.push_line(ScrollbackLine {
             text: "a".to_string(),
             wrapped: false,
+            ..Default::default()
         });
         let lines = s.get_lines(0, 0);
         assert!(lines.is_empty());
@@ -224,6 +242,7 @@ mod tests {
             s.push_line(ScrollbackLine {
                 text: format!("line-{i}"),
                 wrapped: false,
+                ..Default::default()
             });
         }
         assert_eq!(s.len(), 5);
@@ -254,6 +273,7 @@ mod tests {
             s.push_line(ScrollbackLine {
                 text: format!("L{i}"),
                 wrapped: false,
+                ..Default::default()
             });
         }
         assert_eq!(s.len(), cap);
@@ -271,8 +291,44 @@ mod tests {
         s.push_line(ScrollbackLine {
             text: "wrapped line".to_string(),
             wrapped: true,
+            ..Default::default()
         });
         let lines = s.get_lines(0, 1);
         assert!(lines[0].wrapped);
+    }
+
+    #[test]
+    fn test_sgr_attributes_preserved_in_formatted_bytes() {
+        // SPEC-1919 FR-003j / SC-005b: scrollback push_line must retain the
+        // SGR-bearing escape stream so a later replay can reconstruct the
+        // original foreground / background / bold / italic / underline /
+        // inverse cell attributes; storing only plain text + wrap flag would
+        // lose color on scroll-back through xterm.js.
+        let mut s = ScrollbackStorage::new(10);
+        let formatted = b"\x1b[31;1mALERT\x1b[0m normal".to_vec();
+        s.push_line(ScrollbackLine {
+            text: "ALERT normal".to_string(),
+            formatted: formatted.clone(),
+            wrapped: false,
+        });
+        let lines = s.get_lines(0, 1);
+        assert_eq!(lines[0].text, "ALERT normal");
+        assert_eq!(
+            lines[0].formatted, formatted,
+            "expected SGR-bearing formatted bytes to round-trip through scrollback"
+        );
+        // CSI introducer + final 'm' byte must be present so the line can be
+        // replayed verbatim into xterm.js without losing color/style.
+        let has_csi_m = lines[0].formatted.windows(2).enumerate().any(|(idx, win)| {
+            win == [0x1b, b'['] && {
+                let tail = &lines[0].formatted[idx + 2..];
+                tail.iter().take(16).any(|b| *b == b'm')
+            }
+        });
+        assert!(
+            has_csi_m,
+            "scrollback line should retain at least one CSI ... m SGR escape; got {:?}",
+            lines[0].formatted
+        );
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1884,10 +1884,17 @@ impl AppRuntime {
             .runtimes
             .iter()
             .filter_map(|(id, runtime)| {
+                // SPEC-1919 FR-001a: snapshot replay must reproduce SGR
+                // attributes (color, bold, italic, underline, inverse) so
+                // tab switch / focus cycle / WebSocket reconnect do not
+                // collapse colored history into default-color text. Use
+                // vt100 `Screen::contents_formatted()` which emits a CSI
+                // escape stream xterm.js can replay verbatim, instead of
+                // `Screen::contents()` which strips formatting.
                 let snapshot = runtime
                     .pane
                     .lock()
-                    .map(|pane| pane.screen().contents().into_bytes())
+                    .map(|pane| pane.screen().contents_formatted())
                     .unwrap_or_default();
                 (!snapshot.is_empty()).then_some((id.clone(), snapshot))
             })
@@ -6027,6 +6034,88 @@ exit 0
             .decode(snapshot.expect("terminal snapshot event"))
             .expect("decode terminal snapshot");
         assert!(String::from_utf8_lossy(&decoded).contains("hello from frontend ready"));
+    }
+
+    #[test]
+    fn app_runtime_frontend_ready_replays_terminal_snapshot_with_sgr_attributes() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "shell-1",
+            WindowPreset::Shell,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "shell-1");
+        let (command, args) = if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec![
+                    "/d".to_string(),
+                    "/s".to_string(),
+                    "/c".to_string(),
+                    "exit /b 0".to_string(),
+                ],
+            )
+        } else {
+            (
+                "/bin/sh".to_string(),
+                vec!["-lc".to_string(), "exit 0".to_string()],
+            )
+        };
+        let mut pane = Pane::new(
+            window_id.clone(),
+            command,
+            args,
+            80,
+            24,
+            HashMap::new(),
+            None,
+        )
+        .expect("pane");
+        // Write red foreground + bold "ALERT" then reset, then default-color text.
+        pane.process_bytes(b"\x1b[31;1mALERT\x1b[0m normal\n");
+
+        runtime.runtimes.insert(
+            window_id.clone(),
+            WindowRuntime {
+                pane: Arc::new(Mutex::new(pane)),
+                output_thread: None,
+                status_thread: None,
+            },
+        );
+
+        let events =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::FrontendReady);
+
+        let snapshot = events.iter().find_map(|event| match &event.event {
+            BackendEvent::TerminalSnapshot { id, data_base64 } if id == &window_id => {
+                Some(data_base64)
+            }
+            _ => None,
+        });
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(snapshot.expect("terminal snapshot event"))
+            .expect("decode terminal snapshot");
+        // Visible text must be present.
+        assert!(
+            String::from_utf8_lossy(&decoded).contains("ALERT"),
+            "expected ALERT text in snapshot bytes, got: {:?}",
+            String::from_utf8_lossy(&decoded)
+        );
+        // SGR escape sequence introducing a styled run (CSI ... m) must be present
+        // so that xterm.js can replay foreground / bold / etc. from the snapshot.
+        let has_sgr = decoded.windows(2).enumerate().any(|(idx, win)| {
+            win == [0x1b, b'['] && {
+                let tail = &decoded[idx + 2..];
+                tail.iter().take(16).any(|b| *b == b'm')
+            }
+        });
+        assert!(
+            has_sgr,
+            "expected SGR escape (CSI ... m) in TerminalSnapshot bytes so xterm.js can replay color/style; raw snapshot bytes: {:?}",
+            decoded
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

GUI terminal の安定化を **SPEC-1919 Phase 14 (TTY)** と **SPEC-2008 Phase 24 (Window host)** の 2 SPEC を並行で 1 PR にまとめて修正します。ユーザー報告の 3 症状を全てカバー:

1. **症状 1 (window 切替後にスクロール不可)** — SPEC-2008 Phase 24
2. **症状 2 (色がデフォルト色に潰れる)** — SPEC-1919 Phase 14
3. **症状 3 (resize するまで wrap 固定)** — SPEC-2008 Phase 24

### SPEC-1919 Phase 14: snapshot replay と scrollback で SGR 保持

- `crates/gwt/src/app_runtime/mod.rs:1890`: `pane.screen().contents()` (plain text) → `pane.screen().contents_formatted()` に置換し、TerminalSnapshot replay 経路で CSI escape sequence が xterm.js に届くようにする。
- `crates/gwt-terminal/src/scrollback.rs`: `ScrollbackLine` に `formatted: Vec<u8>` field を追加し、SGR 込みの byte stream を ring buffer 内で保持。`Default` を derive して既存 call site への影響を最小化。
- `crates/gwt-terminal/src/pane.rs`: `process_bytes` を raw byte buffer + `\n` byte 境界 split に切り替え、`text` (plain) と `formatted` (raw bytes with SGR) の両方を scrollback に push。SGR escape (CSI ... m) は `\n` を含まないため byte-level splitting は安全。

### SPEC-2008 Phase 24: resize / visibility transition で per-terminal fit fan-out

- `crates/gwt/web/app.js` `canRefreshTerminalViewport` (~L1293): 判定に `element.hidden` を追加。tab group の非アクティブ tab で `fitAddon.fit()` が 0×0 measurement を行って xterm.js の cols/rows を 0 で固定してしまう既知バグを排除する。
- `crates/gwt/web/app.js` workspace render loop (~L7092-7098): `element.hidden = !visibleWindowData(...)` 直後に hidden → visible 遷移を検知し、`scheduleTerminalFocusActivation` (Phase 22 で追加された fit + viewport refresh + focus helper) を起動。tab 切替後に手動 resize なしで scrollback wheel / trackpad が即動作する。
- `crates/gwt/web/app.js` `window.addEventListener("resize", ...)` (~L8246): host resize listener に `terminalMap` を回す per-terminal `fitTerminal(id, true)` fan-out を追加し、xterm.js cols/rows と backend PTY cols/rows を同期させる。fitTerminal は既に `canRefreshTerminalViewport` で gated されているので minimized / hidden tab は自動 skip。

### 新規 RED→GREEN tests (5 件)

| Test | SPEC | レイヤー |
|---|---|---|
| `scrollback::tests::test_sgr_attributes_preserved_in_formatted_bytes` | 1919 SC-005b | gwt-terminal unit |
| `app_runtime::tests::app_runtime_frontend_ready_replays_terminal_snapshot_with_sgr_attributes` | 1919 SC-005a | gwt integration |
| `embedded_web::tests::embedded_web_host_window_resize_fans_out_terminal_fit` | 2008 SC-031 | embedded contract |
| `embedded_web::tests::embedded_web_can_refresh_terminal_viewport_skips_hidden_tabs` | 2008 SC-030 (predicate side) | embedded contract |
| `embedded_web::tests::embedded_web_tab_visibility_transition_triggers_terminal_focus_activation` | 2008 SC-030 (transition side) | embedded contract |

関連: SPEC-1919 Phase 14 / SPEC-2008 Phase 24 / Issue #2096 (closed: Plan mode wheel scroll resize-to-revive、症状方向性が一致) / Issue #2513 (closed: resize 中 flicker + 入力停止)。

## Test plan

- [x] `cargo test -p gwt-core -p gwt-terminal -p gwt` — 162 + 50 + 14 + 498 + 262 + 他 unit/integration GREEN
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo build -p gwt` — clean
- [x] `pnpm test:frontend-bundle` — node syntax check pass
- [x] `pnpm test:frontend-unit` — 290 tests GREEN
- [ ] **macOS 手動 smoke (T151 + T-190)** — 本 PR merge 後に reviewer 環境で実機確認推奨:
  - 色付き出力 (`git diff --color=always`、`ls -G`、agent colored prompt) → 別 pane / 別 window へ focus → 戻った時に色が保持されている (SPEC-1919)
  - 同 pane で長時間色付き出力 → scroll back で過去行も色が保持されている (SPEC-1919)
  - tab グループに複数 terminal を入れ、tab 切替直後に scrollback (ホイール / Shift+PgUp) が手動 resize なしで即動作 (SPEC-2008)
  - OS host window resize 後、全 terminal の wrap が手動 per-terminal resize なしで即追従 (SPEC-2008)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
