### PR TITLE
refactor(gui): SPEC-1939/2008 follow-up bundle (behavior tests + fixture seam)

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2575,28 +2575,31 @@ mod tests {
     #[test]
     fn embedded_web_host_window_resize_fans_out_terminal_fit() {
         let js = app_js();
-        let host_resize_listener = regex::Regex::new(
-            r#"(?s)window\.addEventListener\("resize",\s*\(\)\s*=>\s*\{(?P<body>.*?)\}\);"#,
-        )
-        .expect("valid regex");
-        let captures = host_resize_listener.captures(js).expect(
-            "expected an OS host window resize listener wired through window.addEventListener",
-        );
+        // After SPEC-2008 Phase 24 follow-up (PR #2590), the host resize
+        // fan-out is dispatched through `attachHostResizeReflow` from
+        // `terminal-viewport-reflow.js`. The behaviour assertion lives in
+        // `__tests__/terminal-viewport-reflow.test.mjs`; this Rust contract
+        // only confirms the wiring stays in the bundle.
+        let attach_call = regex::Regex::new(r#"(?s)attachHostResizeReflow\(\{(?P<body>.*?)\}\);"#)
+            .expect("valid regex");
+        let captures = attach_call
+            .captures(js)
+            .expect("expected attachHostResizeReflow wiring for host window.resize");
         let body = captures.name("body").map(|m| m.as_str()).unwrap_or("");
         assert!(
-            body.contains("syncMaximizedWindowsToViewport()"),
-            "expected host resize listener to keep maximized window sync, body: {body}",
-        );
-        assert!(
-            body.contains("terminalMap"),
-            "expected host resize listener to iterate terminalMap so per-terminal fit \
+            body.contains("terminalIds: () => terminalMap.keys()")
+                || body.contains("terminalMap.keys()"),
+            "expected attachHostResizeReflow to iterate terminalMap so per-terminal fit \
              can fan out to every visible terminal window (SPEC-2008 FR-050), body: {body}",
         );
         assert!(
-            body.contains("fitTerminal(") && body.contains(", true)"),
-            "expected host resize listener to call fitTerminal(id, true) for each terminal \
-             so xterm.js cols/rows refit and UpdateWindowGeometry persists to the backend; \
-             body: {body}",
+            body.contains("fitTerminal,"),
+            "expected attachHostResizeReflow to receive fitTerminal so cols/rows refit and \
+             UpdateWindowGeometry persists to the backend; body: {body}",
+        );
+        assert!(
+            body.contains("syncMaximizedWindowsToViewport()"),
+            "expected attachHostResizeReflow.beforeFan to keep maximized window sync, body: {body}",
         );
     }
 
@@ -2613,28 +2616,25 @@ mod tests {
             .find(signature)
             .expect("expected canRefreshTerminalViewport predicate definition");
         let after = &js[start..];
-        // Body extends until the next top-level `function ` declaration in
-        // the bundle. This avoids brittle non-greedy regex matching that
-        // trips on the early-return braces inside the predicate.
         let end_offset = after[signature.len()..]
             .find("\n      function ")
             .map(|i| signature.len() + i)
             .unwrap_or(after.len());
         let body = &after[..end_offset];
+        // After SPEC-2008 Phase 24 follow-up, the predicate delegates to
+        // `viewportEligibleForRefresh` in `terminal-viewport-reflow.js`.
+        // Behaviour (.hidden short-circuit + minimised short-circuit) is
+        // pinned by `__tests__/terminal-viewport-reflow.test.mjs`; this
+        // Rust contract only confirms the wiring stays in the bundle.
         assert!(
-            body.contains("minimized"),
-            "expected canRefreshTerminalViewport to keep minimized check; body: {body}",
+            body.contains("viewportEligibleForRefresh({"),
+            "expected canRefreshTerminalViewport to delegate to viewportEligibleForRefresh \
+             (SPEC-2008 FR-051 + Phase 24 follow-up); body: {body}",
         );
         assert!(
-            body.contains("element?.hidden") || body.contains("element.hidden"),
-            "expected canRefreshTerminalViewport to also skip windows whose DOM element is \
-             hidden (.hidden attribute set during tab visibility transition, SPEC-2008 FR-051); \
-             body: {body}",
-        );
-        assert!(
-            body.contains("windowMap.get(windowId)"),
-            "expected canRefreshTerminalViewport to look up the DOM element via windowMap so \
-             the hidden-tab check sees the actual element flag; body: {body}",
+            body.contains("windowMap.get(windowId)") && body.contains("workspaceWindowById"),
+            "expected predicate to forward both the DOM element and the workspace window \
+             so the helper can short-circuit on .hidden / minimized; body: {body}",
         );
     }
 
@@ -2654,10 +2654,18 @@ mod tests {
             .captures(js)
             .expect("expected the workspace.windows visibility loop that sets element.hidden");
         let body = captures.name("body").map(|m| m.as_str()).unwrap_or("");
+        // After SPEC-2008 Phase 24 follow-up, the loop delegates to
+        // `applyVisibilityTransition` from `terminal-viewport-reflow.js`.
+        // Hidden->visible behaviour is pinned by the linkedom behaviour
+        // test; here we only assert the wiring is intact.
         assert!(
-            body.contains("element.hidden") && body.contains("visibleWindowData"),
-            "expected the visibility loop to keep element.hidden = !visibleWindowData(...); \
-             body: {body}",
+            body.contains("applyVisibilityTransition({"),
+            "expected the visibility loop to delegate to applyVisibilityTransition \
+             so element.hidden mutation + reveal hook share one helper; body: {body}",
+        );
+        assert!(
+            body.contains("visibleWindowData(windowData)"),
+            "expected the loop to compute shouldHide from visibleWindowData; body: {body}",
         );
         assert!(
             body.contains("scheduleTerminalFocusActivation(") && body.contains("terminalMap"),

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -92,6 +92,11 @@ pub fn index_settings_panel_js() -> &'static str {
     include_str!("../web/index-settings-panel.js")
 }
 
+// SPEC-2008 Phase 24 — terminal viewport reflow primitives.
+pub fn terminal_viewport_reflow_js() -> &'static str {
+    include_str!("../web/terminal-viewport-reflow.js")
+}
+
 pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
     RootJsModuleAsset {
         path: "/branch-cleanup-modal.js",
@@ -162,6 +167,11 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
         path: "/index-settings-panel.js",
         source: index_settings_panel_js,
         marker: "renderIndexSettingsPanel",
+    },
+    RootJsModuleAsset {
+        path: "/terminal-viewport-reflow.js",
+        source: terminal_viewport_reflow_js,
+        marker: "attachHostResizeReflow",
     },
 ];
 
@@ -540,9 +550,9 @@ mod tests {
         );
         assert!(
             html.contains("function canRefreshTerminalViewport(windowId)")
-                && html.contains("!workspaceWindowById(windowId)?.minimized")
+                && html.contains("viewportEligibleForRefresh({")
                 && refresh_call.is_match(html),
-            "expected terminal viewport refresh to skip minimized windows",
+            "expected terminal viewport refresh predicate to delegate to viewportEligibleForRefresh",
         );
         assert!(
             !html.contains(

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -69,7 +69,7 @@ impl IndexRebuildScope {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProjectIndexStatusState {
     Ready,
@@ -97,7 +97,7 @@ impl fmt::Display for ProjectIndexStatusState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct RebuildProgress {
     pub scopes_done: u32,
     pub scopes_total: u32,
@@ -105,7 +105,7 @@ pub struct RebuildProgress {
 
 /// Per-scope health detail for `(scope, worktree?)` pairs surfaced via
 /// `ProjectIndexStatus` events (SPEC-1939 FR-038 / FR-053).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct ScopeHealthView {
     pub healthy: bool,
     pub repair_required: bool,
@@ -144,7 +144,7 @@ impl ScopeHealthView {
 /// Aggregated scope health: `issues` and `specs` are repo-shared and emitted
 /// once per project, while `files` and `files_docs` are per-worktree, keyed
 /// by `worktree_hash` (SPEC-1939 FR-053).
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct ProjectIndexScopes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub issues: Option<ScopeHealthView>,
@@ -171,13 +171,13 @@ impl ProjectIndexScopes {
 
 /// Worktree metadata indexed by worktree hash for the per-worktree health
 /// table (SPEC-1939 FR-053).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct WorktreeMeta {
     pub branch: String,
     pub path: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct ProjectIndexStatusView {
     pub state: ProjectIndexStatusState,
     pub detail: String,
@@ -372,10 +372,54 @@ fn count_unhealthy_scopes(scopes: &ProjectIndexScopes) -> usize {
     count
 }
 
+/// Environment variable used by Playwright e2e and integration tests to
+/// inject a fake `ProjectIndexStatusView` instead of running the real
+/// Python runner. The value is a path to a JSON file that deserializes into
+/// a `ProjectIndexStatusView`. SPEC-1939 T-IDX-109/110 follow-up scaffolding.
+pub const GWT_INDEX_TEST_FIXTURE_ENV: &str = "GWT_INDEX_TEST_FIXTURE";
+
+/// Try to load an aggregated status fixture from `GWT_INDEX_TEST_FIXTURE`.
+/// Returns `None` when the env var is absent. Errors during read / parse
+/// surface as a synthetic `Error` status so the GUI / orchestrator path
+/// behaves the same as a real runner failure.
+fn load_test_fixture_status() -> Option<ProjectIndexStatusView> {
+    let path = std::env::var(GWT_INDEX_TEST_FIXTURE_ENV).ok()?;
+    if path.trim().is_empty() {
+        return None;
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(payload) => match serde_json::from_str::<ProjectIndexStatusView>(&payload) {
+            Ok(view) => {
+                tracing::info!(
+                    target: "gwt::index",
+                    fixture = %path,
+                    state = %view.state,
+                    "GWT_INDEX_TEST_FIXTURE applied — bypassing real runner"
+                );
+                Some(view)
+            }
+            Err(error) => Some(ProjectIndexStatusView::new(
+                ProjectIndexStatusState::Error,
+                format!("GWT_INDEX_TEST_FIXTURE parse error: {error}"),
+            )),
+        },
+        Err(error) => Some(ProjectIndexStatusView::new(
+            ProjectIndexStatusState::Error,
+            format!("GWT_INDEX_TEST_FIXTURE read error ({path}): {error}"),
+        )),
+    }
+}
+
 /// Aggregate per-worktree status for a project root by listing every active
 /// worktree from `git worktree list --porcelain`, probing each via the
 /// runner, and combining the results with [`build_aggregated_status_view`].
+///
+/// When `GWT_INDEX_TEST_FIXTURE` is set, the fixture JSON is loaded instead
+/// — this is the seam used by Playwright e2e (SPEC-1939 T-IDX-109/110).
 pub fn aggregate_project_index_status_for_path(project_root: &Path) -> ProjectIndexStatusView {
+    if let Some(fixture) = load_test_fixture_status() {
+        return fixture;
+    }
     match aggregate_project_index_status_for_path_inner(project_root) {
         Ok(status) => status,
         Err(error) => ProjectIndexStatusView::new(ProjectIndexStatusState::Error, error),
@@ -1187,6 +1231,77 @@ mod tests {
         assert_eq!(view.worktrees.len(), 2);
         assert_eq!(view.worktrees["wtAhash"].branch, "develop");
         assert_eq!(view.worktrees["wtBhash"].path, "/abs/wtB");
+    }
+
+    #[test]
+    fn aggregate_uses_test_fixture_when_env_var_set() {
+        // SPEC-1939 T-IDX-109/110 follow-up scaffolding: when
+        // GWT_INDEX_TEST_FIXTURE is set, the aggregator returns the parsed
+        // fixture verbatim. Playwright e2e drives gwt with this env var so
+        // tests can assert badge transitions deterministically without
+        // running real Python.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fixture_path = temp.path().join("status.json");
+        let fixture = ProjectIndexStatusView {
+            state: ProjectIndexStatusState::RepairRequired,
+            detail: "fixture-driven repair_required".to_string(),
+            repair_started_at: None,
+            progress: None,
+            scopes: ProjectIndexScopes {
+                specs: Some(ScopeHealthView::unhealthy("count_mismatch")),
+                ..Default::default()
+            },
+            worktrees: BTreeMap::new(),
+        };
+        std::fs::write(
+            &fixture_path,
+            serde_json::to_string(&fixture).expect("serialize"),
+        )
+        .expect("write fixture");
+
+        // The lib uses std::env which is process-wide; isolate by saving /
+        // restoring the previous value.
+        let previous = std::env::var(GWT_INDEX_TEST_FIXTURE_ENV).ok();
+        // Safety: tests in this lib run with `--test-threads` allowed to be
+        // > 1, but no other test reads this env var. Set / restore is
+        // unconditional.
+        // SAFETY: setting / removing process env is unsafe in std 1.89+.
+        unsafe {
+            std::env::set_var(GWT_INDEX_TEST_FIXTURE_ENV, &fixture_path);
+        }
+        let view = aggregate_project_index_status_for_path(temp.path());
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var(GWT_INDEX_TEST_FIXTURE_ENV, value),
+                None => std::env::remove_var(GWT_INDEX_TEST_FIXTURE_ENV),
+            }
+        }
+
+        assert_eq!(view.state, ProjectIndexStatusState::RepairRequired);
+        assert_eq!(view.detail, "fixture-driven repair_required");
+        assert!(view.scopes.specs.is_some());
+    }
+
+    #[test]
+    fn aggregate_test_fixture_invalid_json_surfaces_error_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fixture_path = temp.path().join("status.json");
+        std::fs::write(&fixture_path, "{ this is not json }").expect("write fixture");
+
+        let previous = std::env::var(GWT_INDEX_TEST_FIXTURE_ENV).ok();
+        unsafe {
+            std::env::set_var(GWT_INDEX_TEST_FIXTURE_ENV, &fixture_path);
+        }
+        let view = aggregate_project_index_status_for_path(temp.path());
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var(GWT_INDEX_TEST_FIXTURE_ENV, value),
+                None => std::env::remove_var(GWT_INDEX_TEST_FIXTURE_ENV),
+            }
+        }
+
+        assert_eq!(view.state, ProjectIndexStatusState::Error);
+        assert!(view.detail.contains("parse error"));
     }
 
     #[test]

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -1,108 +1,198 @@
-// SPEC-2008 Phase 24 / T-184..T-186 — terminal viewport reflow on resize
-// and tab visibility transitions. These tests pin the contract via
-// source-level assertions on app.js. Behavior runs through the IIFE-scoped
-// `fitTerminal` / `canRefreshTerminalViewport` / `scheduleTerminalFocusActivation`
-// helpers, so we assert that the listener / activation hooks call into them
-// rather than re-implementing xterm.js + window state inside the test.
+// SPEC-2008 Phase 24 / T-184..T-186 — terminal viewport reflow on host
+// resize and tab visibility transitions. Behaviour tests drive the
+// extracted controller (terminal-viewport-reflow.js) so the operation
+// shape is exercised end-to-end (`tasks/lessons.md` 2026-05-07 lesson —
+// window interaction features need behavior tests, not only source-string
+// contract). app.js still imports the same primitives, and a thin
+// source-string assertion at the bottom makes sure the wiring stays in
+// place.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { parseHTML } from "linkedom";
+
+import {
+  applyVisibilityTransition,
+  attachHostResizeReflow,
+  viewportEligibleForRefresh,
+} from "../terminal-viewport-reflow.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
 
-test("window.resize listener fans out fitTerminal(persist=true) across visible terminals (T-187)", () => {
-  // The resize handler block must (1) keep the existing
-  // `syncMaximizedWindowsToViewport()` call, (2) iterate over `terminalMap`
-  // keys, (3) skip via `canRefreshTerminalViewport`, and (4) call
-  // `fitTerminal(windowId, true)` so backend PTY receives
-  // `UpdateWindowGeometry`.
-  const resizeBlockMatch = appSource.match(
-    /window\.addEventListener\("resize",\s*\(\)\s*=>\s*\{([\s\S]*?)\n\s*\}\);/,
-  );
-  assert.ok(resizeBlockMatch, "window.resize listener block must exist");
-  const resizeBody = resizeBlockMatch[1];
+function fixtureWindow() {
+  const { document } = parseHTML(`<!doctype html><body></body>`);
+  return document.defaultView;
+}
 
-  assert.match(resizeBody, /syncMaximizedWindowsToViewport\(\);/);
-  assert.match(
-    resizeBody,
-    /for\s*\(\s*const\s+windowId\s+of\s+terminalMap\.keys\(\)\s*\)/,
-    "resize listener must iterate over terminalMap windows",
+test("attachHostResizeReflow fans fitTerminal(persist=true) across visible terminals (T-184/T-187)", () => {
+  const window = fixtureWindow();
+  const terminals = ["wtA", "wtB", "wtC"];
+  const fitCalls = [];
+  const beforeFanCalls = [];
+
+  const dispose = attachHostResizeReflow({
+    window,
+    terminalIds: () => terminals,
+    canRefreshViewport: (id) => id !== "wtB", // wtB is hidden / minimised.
+    fitTerminal: (id, persist) => fitCalls.push([id, persist]),
+    beforeFan: () => beforeFanCalls.push("flushed"),
+  });
+
+  window.dispatchEvent(new window.Event("resize"));
+
+  assert.deepEqual(beforeFanCalls, ["flushed"]);
+  assert.deepEqual(fitCalls, [
+    ["wtA", true],
+    ["wtC", true],
+  ]);
+
+  // dispose detaches the listener so subsequent resize events do not
+  // double-fire fan-out (regression against repeated wiring).
+  dispose();
+  window.dispatchEvent(new window.Event("resize"));
+  assert.deepEqual(fitCalls.length, 2, "dispose() must remove the listener");
+});
+
+test("applyVisibilityTransition fires onReveal only on hidden -> visible with terminal (T-185/T-188)", () => {
+  const { document } = parseHTML(`<!doctype html><body></body>`);
+  const make = (hidden) => {
+    const el = document.createElement("section");
+    el.hidden = hidden;
+    return el;
+  };
+
+  // hidden -> visible with terminal: must call onReveal and clear .hidden.
+  let revealed = 0;
+  const hiddenWithTerminal = make(true);
+  const fired = applyVisibilityTransition({
+    element: hiddenWithTerminal,
+    shouldHide: false,
+    hasTerminal: true,
+    onReveal: () => {
+      revealed += 1;
+    },
+  });
+  assert.equal(fired, true);
+  assert.equal(revealed, 1);
+  assert.equal(hiddenWithTerminal.hidden, false);
+
+  // hidden -> visible but no terminal runtime yet: do NOT fire (avoids
+  // scheduling fit on a window that has not mounted xterm).
+  let revealedNoTerm = 0;
+  const hiddenNoTerminal = make(true);
+  const firedNoTerm = applyVisibilityTransition({
+    element: hiddenNoTerminal,
+    shouldHide: false,
+    hasTerminal: false,
+    onReveal: () => {
+      revealedNoTerm += 1;
+    },
+  });
+  assert.equal(firedNoTerm, false);
+  assert.equal(revealedNoTerm, 0);
+  assert.equal(hiddenNoTerminal.hidden, false);
+
+  // visible -> visible: no transition, do NOT fire.
+  let revealedVisible = 0;
+  const visibleEl = make(false);
+  applyVisibilityTransition({
+    element: visibleEl,
+    shouldHide: false,
+    hasTerminal: true,
+    onReveal: () => {
+      revealedVisible += 1;
+    },
+  });
+  assert.equal(revealedVisible, 0);
+
+  // visible -> hidden: do NOT fire and apply the new hidden state.
+  let revealedHide = 0;
+  const becomingHidden = make(false);
+  applyVisibilityTransition({
+    element: becomingHidden,
+    shouldHide: true,
+    hasTerminal: true,
+    onReveal: () => {
+      revealedHide += 1;
+    },
+  });
+  assert.equal(revealedHide, 0);
+  assert.equal(becomingHidden.hidden, true);
+});
+
+test("viewportEligibleForRefresh skips display:none and minimised windows (T-186)", () => {
+  const { document } = parseHTML(`<!doctype html><body></body>`);
+  const visibleEl = document.createElement("section");
+  visibleEl.hidden = false;
+  const hiddenEl = document.createElement("section");
+  hiddenEl.hidden = true;
+
+  // Hidden element short-circuits before the workspace state is consulted.
+  assert.equal(
+    viewportEligibleForRefresh({ element: hiddenEl, workspaceWindow: { minimized: false } }),
+    false,
+    ".hidden element must skip refresh",
   );
-  assert.match(
-    resizeBody,
-    /canRefreshTerminalViewport\(windowId\)/,
-    "resize listener must skip windows that fail the refresh predicate",
+
+  // Visible + minimised: the existing minimised short-circuit still wins.
+  assert.equal(
+    viewportEligibleForRefresh({ element: visibleEl, workspaceWindow: { minimized: true } }),
+    false,
+    "minimised workspace state must skip refresh",
   );
-  assert.match(
-    resizeBody,
-    /fitTerminal\(windowId,\s*true\)/,
-    "resize listener must call fitTerminal with persist=true so backend PTY gets UpdateWindowGeometry",
+
+  // Visible + not minimised: refresh allowed.
+  assert.equal(
+    viewportEligibleForRefresh({ element: visibleEl, workspaceWindow: { minimized: false } }),
+    true,
+  );
+
+  // Defensive: missing element / workspaceWindow falls back to allow.
+  assert.equal(
+    viewportEligibleForRefresh({ element: null, workspaceWindow: null }),
+    true,
   );
 });
 
-test("renderWindows reflows hidden -> visible terminal tabs after activation (T-188)", () => {
-  // The transition detection block lives inside the workspace render. We
-  // require an "wasHidden" capture before mutating element.hidden plus a
-  // call to scheduleTerminalFocusActivation for any window that flips
-  // hidden -> visible and has a live terminal runtime.
-  assert.match(
-    appSource,
-    /const\s+wasHidden\s*=\s*element\.hidden;/,
-    "render must capture pre-mutation hidden state for transition detection",
-  );
-  assert.match(
-    appSource,
-    /const\s+shouldHide\s*=\s*!visibleWindowData\(windowData\);/,
-    "render must compute the new hidden state from workspace data",
-  );
-  assert.match(
-    appSource,
-    /element\.hidden\s*=\s*shouldHide;/,
-    "render must apply the new hidden state to the element",
-  );
-  assert.match(
-    appSource,
-    /if\s*\(wasHidden\s*&&\s*!shouldHide\s*&&\s*terminalMap\.has\(windowData\.id\)\)/,
-    "render must detect hidden -> visible transitions for terminal-bearing windows",
-  );
-  assert.match(
-    appSource,
-    /scheduleTerminalFocusActivation\(windowId\)/,
-    "render must call scheduleTerminalFocusActivation on hidden -> visible transitions",
+test("attachHostResizeReflow throws when given a non-DOM window", () => {
+  assert.throws(
+    () =>
+      attachHostResizeReflow({
+        window: null,
+        terminalIds: () => [],
+        canRefreshViewport: () => true,
+        fitTerminal: () => {},
+      }),
+    /requires a DOM window/,
   );
 });
 
-test("canRefreshTerminalViewport refuses refresh while the host element is .hidden (T-186)", () => {
-  // Match from the function header to the closing brace at column 6
-  // (function body indentation in the IIFE). element.hidden must
-  // short-circuit before the workspace minimized check so display:none
-  // tabs skip both fit and refresh.
-  const predicateMatch = appSource.match(
-    /function\s+canRefreshTerminalViewport\(windowId\)\s*\{([\s\S]*?)\n      \}/,
-  );
-  assert.ok(predicateMatch, "canRefreshTerminalViewport function must exist");
-  const body = predicateMatch[1];
-
-  assert.match(body, /windowMap\.get\(windowId\)/);
+test("app.js wires the reflow controller for resize, transition, and predicate", () => {
+  // Source-string contract retained per the lesson — limited to wiring
+  // detection so a future refactor that drops the import / call surfaces
+  // immediately, without claiming behaviour coverage.
   assert.match(
-    body,
-    /element\.hidden/,
-    "predicate must consult element.hidden so display:none tabs skip fit/refresh",
+    appSource,
+    /from "\/terminal-viewport-reflow\.js"/,
+    "app.js must import terminal-viewport-reflow primitives",
   );
   assert.match(
-    body,
-    /workspaceWindowById\(windowId\)\?\.minimized/,
-    "predicate must keep the existing minimized short-circuit",
+    appSource,
+    /attachHostResizeReflow\(\{[\s\S]*?fitTerminal,\s*\n[\s\S]*?\}\)/,
+    "host resize fan-out must dispatch through the reflow controller",
   );
-  // Order: element.hidden short-circuit must precede the minimized check.
-  const hiddenIdx = body.indexOf("element.hidden");
-  const minimizedIdx = body.indexOf("workspaceWindowById(windowId)?.minimized");
-  assert.ok(
-    hiddenIdx >= 0 && minimizedIdx > hiddenIdx,
-    "element.hidden short-circuit must come before the minimized check",
+  assert.match(
+    appSource,
+    /applyVisibilityTransition\(\{/,
+    "render path must apply visibility transition through the helper",
+  );
+  assert.match(
+    appSource,
+    /viewportEligibleForRefresh\(\{/,
+    "canRefreshTerminalViewport must consult the shared predicate",
   );
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -29,6 +29,11 @@
         formatIndexStatusLabel,
       } from "/index-status-controller.js";
       import { renderIndexSettingsPanel } from "/index-settings-panel.js";
+      import {
+        applyVisibilityTransition,
+        attachHostResizeReflow,
+        viewportEligibleForRefresh,
+      } from "/terminal-viewport-reflow.js";
 
       // SPEC-2356 Operator Design System — boot the chrome shell as soon as the
       // module loads so the theme toggle, command palette, hotkey overlay,
@@ -1362,17 +1367,15 @@
         });
       }
 
-      // SPEC-2008 Phase 24 / T-188: extend the predicate so a hidden tab
-      // (display:none on the window element) is treated the same as a
-      // minimized window. xterm.js's fit / refresh do nothing useful while
-      // the host is invisible, and skipping here prevents stale measurement
-      // from leaking into the next visible cycle.
+      // SPEC-2008 Phase 24 / T-188: a hidden tab (display:none) skips fit /
+      // refresh just like a minimized window. The shared predicate lives in
+      // `terminal-viewport-reflow.js` so the host resize controller and
+      // unit tests can reuse it.
       function canRefreshTerminalViewport(windowId) {
-        const element = windowMap.get(windowId);
-        if (element && element.hidden) {
-          return false;
-        }
-        return !workspaceWindowById(windowId)?.minimized;
+        return viewportEligibleForRefresh({
+          element: windowMap.get(windowId),
+          workspaceWindow: workspaceWindowById(windowId),
+        });
       }
 
       function fitTerminal(windowId, persist = false) {
@@ -7250,22 +7253,20 @@
         // for tab-grouped terminal windows so the newly visible terminal
         // gets fit + viewport refresh + focus on the same animation frame
         // cycle. Without this, scrollback wheel input requires a manual
-        // OS-level resize before xterm picks up the new measurement.
-        const reflowAfterActivation = [];
+        // OS-level resize before xterm picks up the new measurement. The
+        // transition logic lives in `terminal-viewport-reflow.js` so a
+        // behavior test (linkedom + element stub) can exercise the
+        // hidden-to-visible activation path directly.
         for (const windowData of workspace.windows) {
           ensureWindow(windowData);
           const element = windowMap.get(windowData.id);
-          if (element) {
-            const wasHidden = element.hidden;
-            const shouldHide = !visibleWindowData(windowData);
-            element.hidden = shouldHide;
-            if (wasHidden && !shouldHide && terminalMap.has(windowData.id)) {
-              reflowAfterActivation.push(windowData.id);
-            }
-          }
-        }
-        for (const windowId of reflowAfterActivation) {
-          scheduleTerminalFocusActivation(windowId);
+          if (!element) continue;
+          applyVisibilityTransition({
+            element,
+            shouldHide: !visibleWindowData(windowData),
+            hasTerminal: terminalMap.has(windowData.id),
+            onReveal: () => scheduleTerminalFocusActivation(windowData.id),
+          });
         }
 
         requestAnimationFrame(syncMaximizedWindowsToViewport);
@@ -8414,21 +8415,21 @@
           event.preventDefault();
         }
       });
-      window.addEventListener("resize", () => {
-        frontendUnits.projectWorkspaceShell.renderWindowList();
-        syncMaximizedWindowsToViewport();
-        // SPEC-2008 Phase 24 / T-187: window.resize must fan out
-        // `fitTerminal(persist=true)` to every visible terminal window so
-        // xterm cols/rows stay aligned with the host viewport and the
-        // backend PTY is informed via UpdateWindowGeometry. Skipping here
-        // is what kept text wrapping fixed at the previous viewport width
-        // until the user manually resized each window.
-        for (const windowId of terminalMap.keys()) {
-          if (!canRefreshTerminalViewport(windowId)) {
-            continue;
-          }
-          fitTerminal(windowId, true);
-        }
+      // SPEC-2008 Phase 24 / T-187: host resize must fan out `fitTerminal
+      // (persist=true)` to every visible terminal so xterm cols/rows stay
+      // aligned with the viewport and `UpdateWindowGeometry` reaches the
+      // backend PTY. The fan-out lives in `terminal-viewport-reflow.js`
+      // so the behavior is exercised by linkedom unit tests rather than
+      // only source-string contract.
+      attachHostResizeReflow({
+        window,
+        terminalIds: () => terminalMap.keys(),
+        canRefreshViewport: canRefreshTerminalViewport,
+        fitTerminal,
+        beforeFan: () => {
+          frontendUnits.projectWorkspaceShell.renderWindowList();
+          syncMaximizedWindowsToViewport();
+        },
       });
       window.addEventListener("pointerdown", (event) => {
         if (!windowListOpen) {

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -1,0 +1,70 @@
+// SPEC-2008 Phase 24 — operation-shape primitives for host resize and tab
+// visibility transitions. Pure module so __tests__ can drive the
+// behavior with linkedom + stubs (`tasks/lessons.md` 2026-05-07 lesson —
+// window interaction features must be covered by behavior tests, not just
+// source-string contracts).
+
+/**
+ * Attach a host `window.resize` listener that refreshes every visible
+ * terminal viewport. The caller supplies the terminal id iterator,
+ * predicate, and per-id fit hook so the controller stays decoupled from
+ * the IIFE-scoped state in `app.js`.
+ *
+ * Returns a `dispose` function that detaches the listener — useful for
+ * tests, harmless in production (bound to the lifetime of the page).
+ */
+export function attachHostResizeReflow({
+  window,
+  terminalIds,
+  canRefreshViewport,
+  fitTerminal,
+  beforeFan,
+}) {
+  if (!window || typeof window.addEventListener !== "function") {
+    throw new TypeError("attachHostResizeReflow requires a DOM window");
+  }
+  const handler = () => {
+    if (typeof beforeFan === "function") beforeFan();
+    for (const windowId of terminalIds()) {
+      if (typeof canRefreshViewport === "function" && !canRefreshViewport(windowId)) {
+        continue;
+      }
+      fitTerminal(windowId, true);
+    }
+  };
+  window.addEventListener("resize", handler);
+  return () => window.removeEventListener("resize", handler);
+}
+
+/**
+ * Apply the `.hidden` mutation for a single tab and notify the caller when
+ * a hidden -> visible transition occurs against a terminal-bearing window.
+ * Returns `true` if the activation hook was fired.
+ */
+export function applyVisibilityTransition({
+  element,
+  shouldHide,
+  hasTerminal,
+  onReveal,
+}) {
+  if (!element) return false;
+  const wasHidden = element.hidden === true;
+  element.hidden = !!shouldHide;
+  const becameVisible = wasHidden && !shouldHide;
+  if (becameVisible && hasTerminal && typeof onReveal === "function") {
+    onReveal();
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Predicate used by both the host resize fan-out and the existing
+ * `fitTerminal` short-circuit. Pulled out so a unit test can pin the
+ * `.hidden` short-circuit ahead of the workspace `minimized` check.
+ */
+export function viewportEligibleForRefresh({ element, workspaceWindow }) {
+  if (element && element.hidden) return false;
+  if (workspaceWindow && workspaceWindow.minimized) return false;
+  return true;
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,36 @@
 # Lessons Learned
 
+## 2026-05-10 — Read tasks/lessons.md before designing tests for window interaction features
+
+### 事象
+
+SPEC-2008 Phase 24 (terminal viewport reflow) を `crates/gwt/web/app.js` に
+実装した PR #2588 で、frontend test を全て source-string regex assertion で
+書いた。直後に「2026-05-07 — Window interaction features need behavior
+tests」の lesson と矛盾している指摘を別 Agent から受け、後追いで behavior
+test ベースの follow-up PR #2590 を作成する手戻りが発生した。
+
+### 原因
+
+実装着手前に `tasks/lessons.md` を確認しなかった。ホット領域の lesson は
+過去の同種失敗をまとめており、参照すれば即座に適切なテスト設計を選べる。
+2026-05-07 lesson は「window interaction features は behavior test で操作
+可能性を検証する。source-string contract は配線漏れ検出に限定する」と
+明示していたが、これを参照せずに既存 helper の延長で source-string
+assertion だけを書いてしまった。
+
+### 再発防止策
+
+1. `crates/gwt/web/` の interaction (resize / drag / hidden→visible / click
+   dispatch / keyboard / pointer) を変更する作業では、最初に
+   `tasks/lessons.md` の関連 lesson (特に 2026-05-07 window interaction)
+   を読んで、test 設計を確定してからコードに着手する。
+2. test 設計時は behavior test を default、source-string assertion は
+   wiring 漏れ検出限定で 1〜2 件に留める。
+3. 同種の問題ドメインで複数 lesson が並ぶ場合 (2026-05-07 が 2 件あった
+   ように)、AGENTS.md の `Self-Improvement Loop` に従い該当領域の lesson
+   をすべて並べて読み返す。
+
 ## 2026-05-07 — Hook fixes must separate diagnostics from shipped behavior
 
 ### 事象


### PR DESCRIPTION
## Summary

SPEC-2008 Phase 24 follow-up と SPEC-1939 Phase 12 follow-up のラウンドアップ PR。テスト設計を `tasks/lessons.md` 2026-05-07 lesson に揃え、Playwright e2e (T-IDX-109/110) のための fixture seam を足す。

### 変更内容

1. **terminal viewport reflow controller 抽出 + behavior test (SPEC-2008 Phase 24 follow-up)**:
   - `crates/gwt/web/terminal-viewport-reflow.js` に `attachHostResizeReflow` / `applyVisibilityTransition` / `viewportEligibleForRefresh` を切り出し
   - `app.js` の resize listener / visibility transition / `canRefreshTerminalViewport` predicate を controller 経由に置換
   - `__tests__/terminal-viewport-reflow.test.mjs` を behavior test 5 件 (linkedom + DOM stub) に書き換え、wiring assertion 1 件のみ残置 (lesson の「配線漏れ検出に限定」指針)
   - `embedded_web.rs` bundle に登録 + 既存 predicate assertion を新形に追従

2. **lesson 追加**:
   - `tasks/lessons.md` に 2026-05-10 「Read tasks/lessons.md before designing tests for window interaction features」を追加。今回 source-string 一辺倒で書いて手戻りした事象 / 原因 / 再発防止策を記録

3. **GWT_INDEX_TEST_FIXTURE seam (SPEC-1939 Phase 12 follow-up / Issue #2584)**:
   - `crates/gwt/src/index_worker.rs` の `aggregate_project_index_status_for_path` に env 経由 fixture loader を追加。`GWT_INDEX_TEST_FIXTURE` が設定されている時は JSON を `ProjectIndexStatusView` として deserialize し real Python runner / git worktree 列挙を bypass
   - 読み取り / parse 失敗は production と等価な `Error` view として表面化
   - `ProjectIndexStatusView` 系の構造体に `serde::Deserialize` を追加 (deserialize fixture 用)
   - 新規 RED→GREEN test 2 件: 正常 fixture 適用 / 壊れた fixture の Error 化

## Test plan

- [x] `node --test crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs` (5/5)
- [x] `bun run test:frontend-unit` 全体 (306/306)
- [x] `bun run test:frontend-bundle`
- [x] `cargo test -p gwt --lib index_worker::` (19/19、新 fixture test 2 件含む)
- [x] `cargo test -p gwt-core -p gwt` 全 GREEN
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [ ] T-IDX-109/110 Playwright spec 本体は別 PR (Issue #2584) で実装

## Notes

PR #2588 (SPEC-2008 Phase 24 本体、merged) は behavior test を含まず source-string 一辺倒だったため、`tasks/lessons.md` 2026-05-07 lesson に矛盾していました。本 PR で controller 抽出 + behavior test に書き換えて lesson 順守を回復しています。

`GWT_INDEX_TEST_FIXTURE` は production の標準起動経路には影響せず (env 未設定時は今まで通り)、Playwright e2e で seed として使う前提です。実際の Playwright spec は Issue #2584 の T-IDX-109/110 で別 PR として書きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test fixture support for project index status configuration, enabling easier testing scenarios

* **Improvements**
  * Enhanced terminal viewport reflow behavior during window resize events
  * Improved terminal visibility transitions and refresh eligibility checks
  * Better handling of minimized and hidden window states for terminal viewport rendering

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2590)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->