### PR TITLE
test(gwt): drop SPEC-2008 Phase 24 Rust contract guards (deferred to #2590)

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -540,7 +540,7 @@ mod tests {
         );
         assert!(
             html.contains("function canRefreshTerminalViewport(windowId)")
-                && html.contains("workspaceWindowById(windowId)?.minimized")
+                && html.contains("!workspaceWindowById(windowId)?.minimized")
                 && refresh_call.is_match(html),
             "expected terminal viewport refresh to skip minimized windows",
         );
@@ -2553,107 +2553,6 @@ mod tests {
         assert!(
             js.contains("querySelector(\".modal-shell\")"),
             "expected app.js to resolve at least one modal dialog through the `.modal-shell` primitive",
-        );
-    }
-
-    /// SPEC-2008 FR-050 Phase 24: an OS host window (WebView) `resize` event
-    /// must fan out per-terminal `fitTerminal()` so xterm.js cols/rows stay
-    /// aligned with the new viewport, and `UpdateWindowGeometry` must be sent
-    /// for each visible terminal so the backend PTY cols/rows match. Without
-    /// this fan-out the wrap stays stuck until the user resizes a single
-    /// terminal manually.
-    #[test]
-    fn embedded_web_host_window_resize_fans_out_terminal_fit() {
-        let js = app_js();
-        let host_resize_listener = regex::Regex::new(
-            r#"(?s)window\.addEventListener\("resize",\s*\(\)\s*=>\s*\{(?P<body>.*?)\}\);"#,
-        )
-        .expect("valid regex");
-        let captures = host_resize_listener.captures(js).expect(
-            "expected an OS host window resize listener wired through window.addEventListener",
-        );
-        let body = captures.name("body").map(|m| m.as_str()).unwrap_or("");
-        assert!(
-            body.contains("syncMaximizedWindowsToViewport()"),
-            "expected host resize listener to keep maximized window sync, body: {body}",
-        );
-        assert!(
-            body.contains("terminalMap"),
-            "expected host resize listener to iterate terminalMap so per-terminal fit \
-             can fan out to every visible terminal window (SPEC-2008 FR-050), body: {body}",
-        );
-        assert!(
-            body.contains("fitTerminal(") && body.contains(", true)"),
-            "expected host resize listener to call fitTerminal(id, true) for each terminal \
-             so xterm.js cols/rows refit and UpdateWindowGeometry persists to the backend; \
-             body: {body}",
-        );
-    }
-
-    /// SPEC-2008 FR-051 Phase 24: `canRefreshTerminalViewport` must reject
-    /// hidden terminals (display:none-equivalent `.hidden` attribute set when
-    /// a window-tab is non-active) so a fit during the hidden phase cannot
-    /// pollute xterm.js with cols/rows = 0. The check must consider both
-    /// minimized and the DOM `element.hidden` flag.
-    #[test]
-    fn embedded_web_can_refresh_terminal_viewport_skips_hidden_tabs() {
-        let js = app_js();
-        let signature = "function canRefreshTerminalViewport(windowId) {";
-        let start = js
-            .find(signature)
-            .expect("expected canRefreshTerminalViewport predicate definition");
-        let after = &js[start..];
-        // Body extends until the next top-level `function ` declaration in
-        // the bundle. This avoids brittle non-greedy regex matching that
-        // trips on the early-return braces inside the predicate.
-        let end_offset = after[signature.len()..]
-            .find("\n      function ")
-            .map(|i| signature.len() + i)
-            .unwrap_or(after.len());
-        let body = &after[..end_offset];
-        assert!(
-            body.contains("minimized"),
-            "expected canRefreshTerminalViewport to keep minimized check; body: {body}",
-        );
-        assert!(
-            body.contains("element?.hidden") || body.contains("element.hidden"),
-            "expected canRefreshTerminalViewport to also skip windows whose DOM element is \
-             hidden (.hidden attribute set during tab visibility transition, SPEC-2008 FR-051); \
-             body: {body}",
-        );
-        assert!(
-            body.contains("windowMap.get(windowId)"),
-            "expected canRefreshTerminalViewport to look up the DOM element via windowMap so \
-             the hidden-tab check sees the actual element flag; body: {body}",
-        );
-    }
-
-    /// SPEC-2008 FR-051 Phase 24: when a window tab transitions from
-    /// `.hidden = true` to `.hidden = false` (tab switch / focus cycle /
-    /// window list / Command Palette), the terminal must run fit + viewport
-    /// refresh + focus on the next animation frame so scrollback wheel input
-    /// works without a user-driven resize.
-    #[test]
-    fn embedded_web_tab_visibility_transition_triggers_terminal_focus_activation() {
-        let js = app_js();
-        let visibility_block = regex::Regex::new(
-            r"(?s)for \(const windowData of workspace\.windows\) \{(?P<body>.*?)\}\s*\n\s*requestAnimationFrame\(syncMaximizedWindowsToViewport\);",
-        )
-        .expect("valid regex");
-        let captures = visibility_block
-            .captures(js)
-            .expect("expected the workspace.windows visibility loop that sets element.hidden");
-        let body = captures.name("body").map(|m| m.as_str()).unwrap_or("");
-        assert!(
-            body.contains("element.hidden") && body.contains("visibleWindowData"),
-            "expected the visibility loop to keep element.hidden = !visibleWindowData(...); \
-             body: {body}",
-        );
-        assert!(
-            body.contains("scheduleTerminalFocusActivation(") && body.contains("terminalMap"),
-            "expected hidden->visible transition to schedule terminal focus activation \
-             (fit + viewport refresh + focus) so scrollback responds without a manual \
-             resize (SPEC-2008 FR-051); body: {body}",
         );
     }
 }


### PR DESCRIPTION
## Summary

PR #2589 で merge した SPEC-2008 Phase 24 用の Rust source-string contract test 3 件を develop から取り下げます。

並行 PR #2590 (https://github.com/akiojin/gwt/pull/2590) が `crates/gwt/web/app.js` の `canRefreshTerminalViewport` / `window.resize` listener / visibility transition loop を `crates/gwt/web/terminal-viewport-reflow.js` の `viewportEligibleForRefresh` / `attachHostResizeReflow` / `applyVisibilityTransition` helper に切り出しているため、PR #2589 で追加した以下 3 件の Rust contract test は PR #2590 merge 後に false negative を起こします:

- `embedded_web_host_window_resize_fans_out_terminal_fit`
- `embedded_web_can_refresh_terminal_viewport_skips_hidden_tabs`
- `embedded_web_tab_visibility_transition_triggers_terminal_focus_activation`

加えて、既存テスト `embedded_web_terminal_writes_refresh_viewport_after_xterm_parse` 内の minimized check assertion は PR #2589 で `!workspaceWindowById(...)?.minimized` → `workspaceWindowById(...)?.minimized` に変更しましたが、PR #2590 が同じ箇所を `viewportEligibleForRefresh({` に再変更するため、本 PR で元の `!workspaceWindowById(...)?.minimized` 形式に戻しておきます (PR #2590 が conflict なく rebase 可能な状態にするため)。

## なぜ取り下げるか

`tasks/lessons.md` 2026-05-07 lesson:
> Window interaction features need behavior tests, not only source-string contracts.

PR #2590 が linkedom + DOM stub による behavior test 5 件で同じ behavior を gating します (test:frontend-unit 306/306 GREEN)。Rust 側の弱い source-string check (regex/contains assertion で JS 構造を固定) は behavior test より informationally 弱く、helper 抽出のような refactor で false negative を出すだけで真の動作回帰検出には貢献しません。

PR #2589 description で「Rust contract test は behavior test に対する additive guard」と書きましたが、PR #2590 の helper 抽出を考慮すると brittle さが additive value を上回ると判断したため、自分で取り下げます。

## 残す内容

PR #2589 の `tasks/lessons.md` 2026-05-10 entry (gwt-build-spec preflight gap の記録) はそのまま develop に残し続けます。本 PR は touch しません。

## Test plan

- [x] `cargo test -p gwt --bin gwt embedded_web::tests::embedded_web_terminal_writes_refresh_viewport_after_xterm_parse` — GREEN (`!workspaceWindowById(...)?.minimized` 形式に戻して既存 develop の app.js とマッチ)
- [x] pre-commit hook (gwt-core 162 + gwt 全 GREEN)

## 関連

- PR #2587 (SPEC-1919 SGR、merged)
- PR #2588 (SPEC-2008 viewport reflow、merged)
- PR #2589 (本 cleanup の対象、merged: lessons.md + 取り下げ対象 Rust tests)
- PR #2590 (SPEC-2008 behavior test refactor、CONFLICTING、本 PR merge 後に rebase で解消)
- Issue #2591 ([skill-preflight] gwt-build-spec が Board active claim を確認すべき)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
