### PR TITLE
docs(skills): add Board claim preflight

### DIFF
--- a/.codex/skills/gwt-build-spec/SKILL.md
+++ b/.codex/skills/gwt-build-spec/SKILL.md
@@ -65,10 +65,28 @@ Determine the mode at entry:
 ### SPEC mode
 
 1. `gwtd issue spec <N>` で SPEC の全セクション（spec, plan, tasks）を読み込む。
-2. Identify the next incomplete task slice in dependency order:
+2. Run the Board active-claim preflight for the target SPEC before choosing a
+   task slice:
+   - Read the current Board with `gwtd board show --json` when available, or
+     `gwtd board show` as the fallback.
+   - Look for active `claim` entries from another session that mention the same
+     owner (`#<N>` or `SPEC-<N>`) or the same phase label (`Phase <N>`,
+     `Phase <label>`) as the task slice under consideration.
+   - If a matching claim exists, pause before Phase 2 and present the conflict:
+     propose joining that session with a Board handoff request, splitting the
+     work through `gwt-discussion`, or continuing only after the user explicitly
+     accepts duplicate risk.
+   - Intentional parallel work is allowed only when write scopes are disjoint.
+     Post a fresh Board `claim` that includes a `Boundary:` line naming the
+     files/modules owned by this session before continuing.
+   - Acceptance scenario: Given another session has an active Board claim for
+     `SPEC-2008 Phase 24`, when `gwt-build-spec` starts for SPEC-2008, then the
+     preflight reports the claim and requires user confirmation before any RED
+     test or production edit is made.
+3. Identify the next incomplete task slice in dependency order:
    - Setup before Foundational work
    - Foundational before story-specific work
-3. SPEC セクションの読み書きは `gwtd issue spec <N> --section <name>` / `gwtd issue spec <N> --edit <name> -f <file>` を使用する。
+4. SPEC セクションの読み書きは `gwtd issue spec <N> --section <name>` / `gwtd issue spec <N> --edit <name> -f <file>` を使用する。
 
 ### Standalone mode
 

--- a/.codex/skills/gwt-discussion/SKILL.md
+++ b/.codex/skills/gwt-discussion/SKILL.md
@@ -154,6 +154,23 @@ exception path. Keep the same one-question-at-a-time discipline.
 4. If an existing Issue number or URL is already the primary owner, capture it
    in the `Intake Memo`.
 5. If a clear owner exists, present it before going further.
+6. If the clear owner is an existing SPEC, run the Board active-claim preflight
+   before changing `.gwt/discussion.md` or any SPEC/plan artifacts:
+   - Read the current Board with `gwtd board show --json` when available, or
+     `gwtd board show` as the fallback.
+   - Look for active `claim` entries from another session that mention the same
+     owner (`#<N>` or `SPEC-<N>`) or the same phase/topic under discussion.
+   - If a matching claim exists, pause the discussion flow and present the
+     conflict: join that session with a Board handoff request, redesign a
+     disjoint work split, or continue only after the user explicitly accepts
+     duplicate risk.
+   - Intentional parallel discussion/planning is allowed only when ownership is
+     disjoint. Post a fresh Board `claim` with a `Boundary:` line naming the
+     topic, artifacts, or files owned by this session before continuing.
+   - Acceptance scenario: Given another session has an active Board claim for
+     `SPEC-2008 Phase 24`, when `gwt-discussion --deepen SPEC-2008` starts,
+     then the preflight reports the claim and requires user confirmation before
+     producing an Action Delta or changing SPEC artifacts.
 
 ### Phase 2: Investigation
 

--- a/.codex/skills/gwt-plan-spec/SKILL.md
+++ b/.codex/skills/gwt-plan-spec/SKILL.md
@@ -79,14 +79,31 @@ Establish the implementation landscape before designing.
 1. **Load source artifacts.** Read `spec.md` and `.gwt/memory/constitution.md`.
    Refuse to continue only when `spec.md` is missing or a user decision still blocks planning.
 
-2. **Identify affected scope.** List files, modules, services, and external constraints
+2. **Run Board active-claim preflight.** Once the target SPEC number is known,
+   read the current Board with `gwtd board show --json` when available, or
+   `gwtd board show` as the fallback.
+   - Look for active `claim` entries from another session that mention the same
+     owner (`#<N>` or `SPEC-<N>`) or the planning phase being refreshed.
+   - If a matching claim exists, pause before changing artifacts and present the
+     conflict: join that session with a Board handoff request, discuss a
+     disjoint planning split, or continue only after the user explicitly accepts
+     duplicate risk.
+   - Intentional parallel planning is allowed only when artifact ownership is
+     disjoint. Post a fresh Board `claim` with a `Boundary:` line naming the
+     sections/files owned by this session before editing.
+   - Acceptance scenario: Given another session has an active Board claim for
+     `SPEC-1935 plan refresh`, when `gwt-plan-spec` starts for SPEC-1935, then
+     the preflight reports the claim and requires user confirmation before
+     `plan`, `tasks`, or related artifacts are edited.
+
+3. **Identify affected scope.** List files, modules, services, and external constraints
    that the work touches. Record assumptions explicitly.
 
-3. **Run the constitution check.** Evaluate the work against every rule in
+4. **Run the constitution check.** Evaluate the work against every rule in
    `.gwt/memory/constitution.md`. If a rule is violated, either redesign or record the
    justification in `Complexity Tracking`.
 
-4. **Answer the Required Plan Gates** from the constitution:
+5. **Answer the Required Plan Gates** from the constitution:
    - What files/modules are affected?
    - What constitution constraints apply?
    - Which risks or complexity additions are accepted, and why?


### PR DESCRIPTION
## Summary

Adds Board active-claim preflight guidance to the three SPEC coordination skills
that can start or reshape long-running SPEC work.

## Changes

- Adds `gwtd board show` preflight steps to `gwt-build-spec`, `gwt-plan-spec`,
  and `gwt-discussion`.
- Documents the required pause-and-present flow when another session already
  claims the same SPEC owner or phase.
- Documents intentional parallel-work rules through explicit Board `Boundary:`
  lines.
- Adds natural-language acceptance scenarios to the affected skill workflows.

## Testing

- `bun run lint:skills`
- `bunx markdownlint-cli --config .markdownlint.json .codex/skills/gwt-build-spec/SKILL.md .codex/skills/gwt-plan-spec/SKILL.md .codex/skills/gwt-discussion/SKILL.md`
- `git diff --check`
- Acceptance text check for the three updated `SKILL.md` files
- `bunx commitlint --from HEAD~1 --to HEAD`

## Closing Issues

Closes #2591

## Related Issues

- #1935

## Checklist

- [x] Skill frontmatter remains valid.
- [x] Markdown lint passes for edited skill files.
- [x] CLI warning implementation is intentionally left to the optional follow-up
      path described in #2591.
