### PR TITLE
refactor(gui): remove legacy Knowledge Bridge list scope

### DIFF
--- a/crates/gwt/playwright/tests/kanban.spec.ts
+++ b/crates/gwt/playwright/tests/kanban.spec.ts
@@ -276,7 +276,6 @@ async function installKanbanBackend(page, { hideDone, theme }) {
               id: message.id,
               knowledge_kind: message.knowledge_kind,
               request_id: message.request_id,
-              list_scope: message.list_scope ?? null,
               entries,
               selected_number: 2017,
               empty_message: null,

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -75,7 +75,6 @@ pub struct KnowledgeSearchRequest<'a> {
     pub(crate) query: &'a str,
     pub(crate) request_id: u64,
     pub(crate) selected_number: Option<u64>,
-    pub(crate) list_scope: gwt::KnowledgeListScope,
 }
 
 pub struct KnowledgeLoadRequest<'a> {
@@ -84,7 +83,6 @@ pub struct KnowledgeLoadRequest<'a> {
     pub(crate) request_id: Option<u64>,
     pub(crate) selected_number: Option<u64>,
     pub(crate) refresh: bool,
-    pub(crate) list_scope: gwt::KnowledgeListScope,
 }
 
 struct KnowledgeRefreshTask {
@@ -95,7 +93,6 @@ struct KnowledgeRefreshTask {
     request_id: Option<u64>,
     selected_number: Option<u64>,
     force: bool,
-    list_scope: gwt::KnowledgeListScope,
 }
 
 struct KnowledgeSearchTask {
@@ -106,7 +103,6 @@ struct KnowledgeSearchTask {
     query: String,
     request_id: u64,
     selected_number: Option<u64>,
-    list_scope: gwt::KnowledgeListScope,
 }
 
 pub struct WindowRuntime {
@@ -477,14 +473,12 @@ fn knowledge_error_event(
     message: impl Into<String>,
     request_id: Option<u64>,
     query: Option<String>,
-    list_scope: Option<gwt::KnowledgeListScope>,
 ) -> BackendEvent {
     BackendEvent::KnowledgeError {
         id: id.into(),
         knowledge_kind: kind,
         request_id,
         query,
-        list_scope,
         message: message.into(),
     }
 }
@@ -510,7 +504,6 @@ fn knowledge_view_events(
     id: String,
     kind: KnowledgeKind,
     request_id: Option<u64>,
-    list_scope: gwt::KnowledgeListScope,
     view: gwt::KnowledgeBridgeView,
 ) -> Vec<OutboundEvent> {
     vec![
@@ -520,7 +513,6 @@ fn knowledge_view_events(
                 id: id.clone(),
                 knowledge_kind: kind,
                 request_id,
-                list_scope: Some(list_scope),
                 entries: view.entries,
                 selected_number: view.selected_number,
                 empty_message: view.empty_message,
@@ -533,7 +525,6 @@ fn knowledge_view_events(
                 id,
                 knowledge_kind: kind,
                 request_id,
-                list_scope: Some(list_scope),
                 detail: view.detail,
             },
         ),
@@ -1567,7 +1558,6 @@ impl AppRuntime {
                 request_id,
                 selected_number,
                 refresh,
-                list_scope,
             } => self.load_knowledge_bridge_events(
                 &client_id,
                 KnowledgeLoadRequest {
@@ -1576,7 +1566,6 @@ impl AppRuntime {
                     request_id,
                     selected_number,
                     refresh,
-                    list_scope: list_scope.unwrap_or(gwt::KnowledgeListScope::Open),
                 },
             ),
             FrontendEvent::SearchKnowledgeBridge {
@@ -1585,7 +1574,6 @@ impl AppRuntime {
                 query,
                 request_id,
                 selected_number,
-                list_scope,
             } => self.search_knowledge_bridge_events(
                 &client_id,
                 KnowledgeSearchRequest {
@@ -1594,7 +1582,6 @@ impl AppRuntime {
                     query: &query,
                     request_id,
                     selected_number,
-                    list_scope: list_scope.unwrap_or(gwt::KnowledgeListScope::Open),
                 },
             ),
             FrontendEvent::SelectKnowledgeBridgeEntry {
@@ -1602,7 +1589,6 @@ impl AppRuntime {
                 knowledge_kind,
                 request_id,
                 number,
-                list_scope,
             } => self.load_knowledge_bridge_events(
                 &client_id,
                 KnowledgeLoadRequest {
@@ -1611,7 +1597,6 @@ impl AppRuntime {
                     request_id,
                     selected_number: Some(number),
                     refresh: false,
-                    list_scope: list_scope.unwrap_or(gwt::KnowledgeListScope::Open),
                 },
             ),
             FrontendEvent::UpdateKnowledgeBridgePhase {
@@ -2729,40 +2714,19 @@ impl AppRuntime {
         let Some(address) = self.window_lookup.get(id) else {
             return vec![OutboundEvent::reply(
                 client_id,
-                knowledge_error_event(
-                    id,
-                    kind,
-                    "Window not found",
-                    request.request_id,
-                    None,
-                    Some(request.list_scope),
-                ),
+                knowledge_error_event(id, kind, "Window not found", request.request_id, None),
             )];
         };
         let Some(tab) = self.tab(&address.tab_id) else {
             return vec![OutboundEvent::reply(
                 client_id,
-                knowledge_error_event(
-                    id,
-                    kind,
-                    "Project tab not found",
-                    request.request_id,
-                    None,
-                    Some(request.list_scope),
-                ),
+                knowledge_error_event(id, kind, "Project tab not found", request.request_id, None),
             )];
         };
         let Some(window) = tab.workspace.window(&address.raw_id) else {
             return vec![OutboundEvent::reply(
                 client_id,
-                knowledge_error_event(
-                    id,
-                    kind,
-                    "Window not found",
-                    request.request_id,
-                    None,
-                    Some(request.list_scope),
-                ),
+                knowledge_error_event(id, kind, "Window not found", request.request_id, None),
             )];
         };
         if knowledge_kind_for_preset(window.preset) != Some(kind) {
@@ -2774,7 +2738,6 @@ impl AppRuntime {
                     "Window is not a knowledge bridge",
                     request.request_id,
                     None,
-                    Some(request.list_scope),
                 ),
             )];
         }
@@ -2788,18 +2751,11 @@ impl AppRuntime {
                 request_id: request.request_id,
                 selected_number: request.selected_number,
                 force: true,
-                list_scope: request.list_scope,
             });
             return Vec::new();
         }
 
-        match load_knowledge_bridge(
-            &tab.project_root,
-            kind,
-            request.selected_number,
-            false,
-            request.list_scope,
-        ) {
+        match load_knowledge_bridge(&tab.project_root, kind, request.selected_number, false) {
             Ok(view) => {
                 if request.request_id.is_some() && view.refresh_enabled {
                     self.spawn_knowledge_bridge_refresh(KnowledgeRefreshTask {
@@ -2810,7 +2766,6 @@ impl AppRuntime {
                         request_id: request.request_id,
                         selected_number: request.selected_number,
                         force: false,
-                        list_scope: request.list_scope,
                     });
                 }
                 knowledge_view_events(
@@ -2818,20 +2773,12 @@ impl AppRuntime {
                     id.to_string(),
                     kind,
                     request.request_id,
-                    request.list_scope,
                     view,
                 )
             }
             Err(error) => vec![OutboundEvent::reply(
                 client_id,
-                knowledge_error_event(
-                    id,
-                    kind,
-                    error,
-                    request.request_id,
-                    None,
-                    Some(request.list_scope),
-                ),
+                knowledge_error_event(id, kind, error, request.request_id, None),
             )],
         }
     }
@@ -2845,7 +2792,6 @@ impl AppRuntime {
             request_id,
             selected_number,
             force,
-            list_scope,
         } = task;
         let proxy = self.proxy.clone();
         self.blocking_tasks.spawn(move || {
@@ -2855,14 +2801,7 @@ impl AppRuntime {
                     if force {
                         proxy.send(UserEvent::Dispatch(vec![OutboundEvent::reply(
                             client_id,
-                            knowledge_error_event(
-                                id,
-                                kind,
-                                error,
-                                request_id,
-                                None,
-                                Some(list_scope),
-                            ),
+                            knowledge_error_event(id, kind, error, request_id, None),
                         )]));
                     }
                     return;
@@ -2871,21 +2810,14 @@ impl AppRuntime {
             if !force && !refreshed {
                 return;
             }
-            let event = match gwt::load_knowledge_bridge(
-                &project_root,
-                kind,
-                selected_number,
-                false,
-                list_scope,
-            ) {
-                Ok(view) => {
-                    knowledge_view_events(client_id, id, kind, request_id, list_scope, view)
-                }
-                Err(error) => vec![OutboundEvent::reply(
-                    client_id,
-                    knowledge_error_event(id, kind, error, request_id, None, Some(list_scope)),
-                )],
-            };
+            let event =
+                match gwt::load_knowledge_bridge(&project_root, kind, selected_number, false) {
+                    Ok(view) => knowledge_view_events(client_id, id, kind, request_id, view),
+                    Err(error) => vec![OutboundEvent::reply(
+                        client_id,
+                        knowledge_error_event(id, kind, error, request_id, None),
+                    )],
+                };
             proxy.send(UserEvent::Dispatch(event));
         });
     }
@@ -2906,7 +2838,6 @@ impl AppRuntime {
                     "Window not found",
                     Some(request.request_id),
                     Some(request.query.to_string()),
-                    Some(request.list_scope),
                 ),
             )];
         };
@@ -2919,7 +2850,6 @@ impl AppRuntime {
                     "Project tab not found",
                     Some(request.request_id),
                     Some(request.query.to_string()),
-                    Some(request.list_scope),
                 ),
             )];
         };
@@ -2932,7 +2862,6 @@ impl AppRuntime {
                     "Window not found",
                     Some(request.request_id),
                     Some(request.query.to_string()),
-                    Some(request.list_scope),
                 ),
             )];
         };
@@ -2945,7 +2874,6 @@ impl AppRuntime {
                     "Window is not a knowledge bridge",
                     Some(request.request_id),
                     Some(request.query.to_string()),
-                    Some(request.list_scope),
                 ),
             )];
         }
@@ -2958,7 +2886,6 @@ impl AppRuntime {
             query: request.query.to_string(),
             request_id: request.request_id,
             selected_number: request.selected_number,
-            list_scope: request.list_scope,
         });
         Vec::new()
     }
@@ -2972,37 +2899,25 @@ impl AppRuntime {
             query,
             request_id,
             selected_number,
-            list_scope,
         } = task;
         let proxy = self.proxy.clone();
         self.blocking_tasks.spawn(move || {
-            let event = match gwt::search_knowledge_bridge(
-                &project_root,
-                kind,
-                &query,
-                selected_number,
-                list_scope,
-            ) {
-                Ok(view) => BackendEvent::KnowledgeSearchResults {
-                    id: id.clone(),
-                    knowledge_kind: kind,
-                    query: query.clone(),
-                    request_id,
-                    list_scope: Some(list_scope),
-                    entries: view.entries,
-                    selected_number: view.selected_number,
-                    empty_message: view.empty_message,
-                    refresh_enabled: view.refresh_enabled,
-                },
-                Err(error) => knowledge_error_event(
-                    id,
-                    kind,
-                    error,
-                    Some(request_id),
-                    Some(query),
-                    Some(list_scope),
-                ),
-            };
+            let event =
+                match gwt::search_knowledge_bridge(&project_root, kind, &query, selected_number) {
+                    Ok(view) => BackendEvent::KnowledgeSearchResults {
+                        id: id.clone(),
+                        knowledge_kind: kind,
+                        query: query.clone(),
+                        request_id,
+                        entries: view.entries,
+                        selected_number: view.selected_number,
+                        empty_message: view.empty_message,
+                        refresh_enabled: view.refresh_enabled,
+                    },
+                    Err(error) => {
+                        knowledge_error_event(id, kind, error, Some(request_id), Some(query))
+                    }
+                };
             proxy.send(UserEvent::Dispatch(vec![OutboundEvent::reply(
                 client_id, event,
             )]));
@@ -8315,7 +8230,6 @@ exit 0
                 request_id: None,
                 selected_number: Some(42),
                 refresh: false,
-                list_scope: gwt::KnowledgeListScope::Open,
             },
         );
         assert_eq!(issue_events.len(), 2);
@@ -8350,7 +8264,6 @@ exit 0
                 request_id: None,
                 selected_number: Some(1930),
                 refresh: false,
-                list_scope: gwt::KnowledgeListScope::Open,
             },
         );
         assert_eq!(spec_events.len(), 2);
@@ -8400,7 +8313,6 @@ exit 0
                 query: "semantic query",
                 request_id: 9,
                 selected_number: None,
-                list_scope: gwt::KnowledgeListScope::Open,
             },
         );
 
@@ -8464,7 +8376,6 @@ exit 0
                 query: "semantic query".to_string(),
                 request_id: 9,
                 selected_number: None,
-                list_scope: Some(gwt::KnowledgeListScope::Open),
             },
         );
 
@@ -8541,7 +8452,6 @@ exit 0
                 request_id: Some(31),
                 selected_number: Some(43),
                 refresh: true,
-                list_scope: Some(gwt::KnowledgeListScope::Open),
             },
         );
 
@@ -8630,7 +8540,6 @@ exit 0
                 request_id: Some(32),
                 selected_number: None,
                 refresh: true,
-                list_scope: Some(gwt::KnowledgeListScope::Closed),
             },
         );
 
@@ -8650,13 +8559,11 @@ exit 0
                                     id,
                                     knowledge_kind,
                                     request_id,
-                                    list_scope,
                                     message,
                                     ..
                                 } if id == &window_id
                                     && *knowledge_kind == gwt::KnowledgeKind::Issue
                                     && *request_id == Some(32)
-                                    && *list_scope == Some(gwt::KnowledgeListScope::Closed)
                                     && message.contains("gh refresh failed")
                             )
                         })
@@ -8704,7 +8611,6 @@ exit 0
             request_id: Some(33),
             selected_number: None,
             force: false,
-            list_scope: gwt::KnowledgeListScope::Open,
         });
         wait_for_path("stale knowledge refresh gh invocation", &marker);
         assert!(
@@ -8724,7 +8630,6 @@ exit 0
             request_id: Some(34),
             selected_number: Some(43),
             force: false,
-            list_scope: gwt::KnowledgeListScope::Open,
         });
         thread::sleep(Duration::from_millis(250));
         assert!(
@@ -8757,7 +8662,6 @@ exit 0
                 request_id: None,
                 selected_number: None,
                 refresh: false,
-                list_scope: gwt::KnowledgeListScope::Open,
             },
         );
 

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -425,14 +425,7 @@ impl AppRuntime {
         let Some(address) = self.window_lookup.get(id).cloned() else {
             return vec![OutboundEvent::reply(
                 client_id,
-                knowledge_error_event(
-                    id,
-                    KnowledgeKind::Issue,
-                    "Window not found",
-                    None,
-                    None,
-                    None,
-                ),
+                knowledge_error_event(id, KnowledgeKind::Issue, "Window not found", None, None),
             )];
         };
         let Some(tab) = self.tab(&address.tab_id) else {
@@ -444,21 +437,13 @@ impl AppRuntime {
                     "Project tab not found",
                     None,
                     None,
-                    None,
                 ),
             )];
         };
         let Some(window) = tab.workspace.window(&address.raw_id) else {
             return vec![OutboundEvent::reply(
                 client_id,
-                knowledge_error_event(
-                    id,
-                    KnowledgeKind::Issue,
-                    "Window not found",
-                    None,
-                    None,
-                    None,
-                ),
+                knowledge_error_event(id, KnowledgeKind::Issue, "Window not found", None, None),
             )];
         };
         let Some(kind) = knowledge_kind_for_preset(window.preset) else {
@@ -468,7 +453,6 @@ impl AppRuntime {
                     id,
                     KnowledgeKind::Issue,
                     "Window is not a knowledge bridge",
-                    None,
                     None,
                     None,
                 ),
@@ -520,14 +504,7 @@ impl AppRuntime {
         if self.tab(&tab_id).is_none() {
             return vec![OutboundEvent::reply(
                 &client_id,
-                knowledge_error_event(
-                    id,
-                    knowledge_kind,
-                    "Project tab not found",
-                    None,
-                    None,
-                    None,
-                ),
+                knowledge_error_event(id, knowledge_kind, "Project tab not found", None, None),
             )];
         }
 
@@ -542,12 +519,12 @@ impl AppRuntime {
                 Ok(()) => vec![self.launch_wizard_state_outbound()],
                 Err(error) => vec![OutboundEvent::reply(
                     &client_id,
-                    knowledge_error_event(id, knowledge_kind, error, None, None, None),
+                    knowledge_error_event(id, knowledge_kind, error, None, None),
                 )],
             },
             Err(error) => vec![OutboundEvent::reply(
                 &client_id,
-                knowledge_error_event(id, knowledge_kind, error, None, None, None),
+                knowledge_error_event(id, knowledge_kind, error, None, None),
             )],
         }
     }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1485,13 +1485,12 @@ mod tests {
             "expected knowledge bridge refresh affordance to describe cache-backed reloads",
         );
         assert!(
-            html.contains("data-knowledge-scope=\"open\"")
-                && html.contains("data-knowledge-scope=\"closed\""),
-            "expected issue knowledge bridge surface to expose open and closed cache tabs",
+            !html.contains("data-knowledge-scope="),
+            "expected Kanban bridge to remove legacy open/closed cache tabs",
         );
         assert!(
-            html.contains("list_scope"),
-            "expected knowledge bridge requests to carry the active issue list scope",
+            !html.contains("list_scope"),
+            "expected Kanban bridge requests to omit legacy issue list scope",
         );
         assert!(
             html.contains("Loading cache-backed data"),

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -85,13 +85,6 @@ pub enum KnowledgeKind {
     Pr,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum KnowledgeListScope {
-    Open,
-    Closed,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KnowledgeListItem {
     pub number: u64,
@@ -244,7 +237,6 @@ pub fn load_knowledge_bridge(
     kind: KnowledgeKind,
     selected_number: Option<u64>,
     refresh: bool,
-    list_scope: KnowledgeListScope,
 ) -> Result<KnowledgeBridgeView, String> {
     if !repo_path.is_dir() {
         return Err(format!(
@@ -267,9 +259,7 @@ pub fn load_knowledge_bridge(
     let entries = load_local_cache_entries_for_repo(repo_path)?;
     let linked_branches = load_linked_branches(repo_path);
     Ok(match kind {
-        KnowledgeKind::Issue => {
-            build_issue_view(entries, linked_branches, selected_number, list_scope)
-        }
+        KnowledgeKind::Issue => build_issue_view(entries, linked_branches, selected_number),
         KnowledgeKind::Spec => build_spec_view(entries, linked_branches, selected_number),
         KnowledgeKind::Pr => disabled_pr_view(),
     })
@@ -293,14 +283,12 @@ pub fn search_knowledge_bridge(
     kind: KnowledgeKind,
     query: &str,
     selected_number: Option<u64>,
-    list_scope: KnowledgeListScope,
 ) -> Result<KnowledgeBridgeView, String> {
     search_knowledge_bridge_with_client(
         repo_path,
         kind,
         query,
         selected_number,
-        list_scope,
         &RunnerSemanticSearchClient,
     )
 }
@@ -420,12 +408,11 @@ pub(crate) fn search_knowledge_bridge_with_client<C: SemanticSearchClient + ?Siz
     kind: KnowledgeKind,
     query: &str,
     selected_number: Option<u64>,
-    list_scope: KnowledgeListScope,
     client: &C,
 ) -> Result<KnowledgeBridgeView, String> {
     let query = query.trim();
     if query.is_empty() {
-        return load_knowledge_bridge(repo_path, kind, selected_number, false, list_scope);
+        return load_knowledge_bridge(repo_path, kind, selected_number, false);
     }
     if !repo_path.is_dir() {
         return Err(format!(
@@ -442,7 +429,7 @@ pub(crate) fn search_knowledge_bridge_with_client<C: SemanticSearchClient + ?Siz
 
     let mut entries = load_local_cache_entries_for_repo(repo_path)?
         .into_iter()
-        .filter(|entry| candidate_matches_kind_and_scope(entry, kind, list_scope))
+        .filter(|entry| candidate_matches_kind(entry, kind))
         .collect::<Vec<_>>();
     entries.sort_by(issue_entry_sort);
     let linked_branches = load_linked_branches(repo_path);
@@ -523,13 +510,8 @@ fn build_issue_view(
     mut entries: Vec<CacheEntry>,
     linked_branches: HashMap<u64, Vec<String>>,
     selected_number: Option<u64>,
-    list_scope: KnowledgeListScope,
 ) -> KnowledgeBridgeView {
     entries.retain(|entry| !is_spec_entry(entry));
-    entries.retain(|entry| match list_scope {
-        KnowledgeListScope::Open => entry.snapshot.state == IssueState::Open,
-        KnowledgeListScope::Closed => entry.snapshot.state == IssueState::Closed,
-    });
     entries.sort_by(issue_entry_sort);
 
     let list_items = entries
@@ -650,19 +632,9 @@ fn empty_detail(title: &str, body: &str) -> KnowledgeDetailView {
     }
 }
 
-fn candidate_matches_kind_and_scope(
-    entry: &CacheEntry,
-    kind: KnowledgeKind,
-    list_scope: KnowledgeListScope,
-) -> bool {
+fn candidate_matches_kind(entry: &CacheEntry, kind: KnowledgeKind) -> bool {
     match kind {
-        KnowledgeKind::Issue => {
-            !is_spec_entry(entry)
-                && match list_scope {
-                    KnowledgeListScope::Open => entry.snapshot.state == IssueState::Open,
-                    KnowledgeListScope::Closed => entry.snapshot.state == IssueState::Closed,
-                }
-        }
+        KnowledgeKind::Issue => !is_spec_entry(entry),
         KnowledgeKind::Spec => is_spec_entry(entry),
         KnowledgeKind::Pr => false,
     }
@@ -1133,14 +1105,8 @@ Extra context.
     fn load_knowledge_bridge_returns_non_repo_and_disabled_pr_views() {
         let dir = tempfile::tempdir().expect("tempdir");
 
-        let issue_view = load_knowledge_bridge(
-            dir.path(),
-            KnowledgeKind::Issue,
-            None,
-            false,
-            KnowledgeListScope::Open,
-        )
-        .expect("issue view");
+        let issue_view = load_knowledge_bridge(dir.path(), KnowledgeKind::Issue, None, false)
+            .expect("issue view");
         assert_eq!(issue_view.kind, KnowledgeKind::Issue);
         assert!(!issue_view.refresh_enabled);
         assert_eq!(
@@ -1148,14 +1114,8 @@ Extra context.
             Some("Knowledge Bridge is available only for Git projects.")
         );
 
-        let pr_view = load_knowledge_bridge(
-            dir.path(),
-            KnowledgeKind::Pr,
-            Some(12),
-            false,
-            KnowledgeListScope::Open,
-        )
-        .expect("pr view");
+        let pr_view =
+            load_knowledge_bridge(dir.path(), KnowledgeKind::Pr, Some(12), false).expect("pr view");
         assert_eq!(pr_view.kind, KnowledgeKind::Pr);
         assert!(!pr_view.refresh_enabled);
         assert_eq!(pr_view.detail.title, "PR Bridge");
@@ -1201,14 +1161,8 @@ Extra context.
             ],
         );
 
-        let issue_view = load_knowledge_bridge(
-            &repo,
-            KnowledgeKind::Issue,
-            Some(11),
-            false,
-            KnowledgeListScope::Open,
-        )
-        .expect("issue bridge");
+        let issue_view = load_knowledge_bridge(&repo, KnowledgeKind::Issue, Some(11), false)
+            .expect("issue bridge");
         let issue_entry = issue_view
             .entries
             .iter()
@@ -1234,14 +1188,8 @@ Extra context.
             .any(|section| section.title == "Linked branches"
                 && section.body == "- `feature/coverage`\n- `feature/coverage-followup`"));
 
-        let spec_view = load_knowledge_bridge(
-            &repo,
-            KnowledgeKind::Spec,
-            Some(22),
-            false,
-            KnowledgeListScope::Open,
-        )
-        .expect("spec bridge");
+        let spec_view = load_knowledge_bridge(&repo, KnowledgeKind::Spec, Some(22), false)
+            .expect("spec bridge");
         let spec_entry = spec_view
             .entries
             .iter()
@@ -1291,7 +1239,7 @@ Extra context.
     }
 
     #[test]
-    fn semantic_issue_search_respects_scope_filters_specs_and_scores_results() {
+    fn semantic_issue_search_filters_specs_and_scores_open_and_closed_results() {
         let _env_lock = crate::env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -1334,7 +1282,6 @@ Extra context.
             KnowledgeKind::Issue,
             "semantic search",
             None,
-            KnowledgeListScope::Open,
             &FakeSemanticSearchClient {
                 hits: vec![
                     SemanticSearchHit {
@@ -1354,10 +1301,14 @@ Extra context.
         )
         .expect("search view");
 
-        assert_eq!(view.entries.len(), 1);
-        assert_eq!(view.entries[0].number, 11);
-        assert_eq!(view.entries[0].match_score, Some(80));
-        assert_eq!(view.selected_number, Some(11));
+        assert_eq!(view.entries.len(), 2);
+        assert_eq!(view.entries[0].number, 12);
+        assert_eq!(view.entries[0].state, "closed");
+        assert_eq!(view.entries[0].match_score, Some(98));
+        assert_eq!(view.entries[1].number, 11);
+        assert_eq!(view.entries[1].state, "open");
+        assert_eq!(view.entries[1].match_score, Some(80));
+        assert_eq!(view.selected_number, Some(12));
     }
 
     #[test]
@@ -1407,7 +1358,6 @@ Extra context.
             KnowledgeKind::Issue,
             "semantic search",
             None,
-            KnowledgeListScope::Open,
             &FakeSemanticSearchClient {
                 hits: vec![SemanticSearchHit {
                     number: 11,
@@ -1466,14 +1416,8 @@ Extra context.
         }
         let _gh = ScopedEnvVar::set("GWT_TEST_GH", &fake_gh);
 
-        let view = load_knowledge_bridge(
-            &repo,
-            KnowledgeKind::Issue,
-            Some(11),
-            false,
-            KnowledgeListScope::Open,
-        )
-        .expect("issue bridge");
+        let view = load_knowledge_bridge(&repo, KnowledgeKind::Issue, Some(11), false)
+            .expect("issue bridge");
 
         assert_eq!(view.entries.len(), 1);
         assert_eq!(view.selected_number, Some(11));
@@ -1518,7 +1462,6 @@ Extra context.
             KnowledgeKind::Spec,
             "#22",
             None,
-            KnowledgeListScope::Open,
             &FakeSemanticSearchClient {
                 hits: vec![
                     SemanticSearchHit {

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -130,7 +130,6 @@ impl AppRuntime {
                     knowledge_kind: KnowledgeKind::Issue,
                     request_id: None,
                     query: None,
-                    list_scope: None,
                     message: "Window not found".to_string(),
                 },
             )];
@@ -143,7 +142,6 @@ impl AppRuntime {
                     knowledge_kind: KnowledgeKind::Issue,
                     request_id: None,
                     query: None,
-                    list_scope: None,
                     message: "Project tab not found".to_string(),
                 },
             )];
@@ -156,7 +154,6 @@ impl AppRuntime {
                     knowledge_kind: KnowledgeKind::Issue,
                     request_id: None,
                     query: None,
-                    list_scope: None,
                     message: "Window not found".to_string(),
                 },
             )];
@@ -169,7 +166,6 @@ impl AppRuntime {
                     knowledge_kind: KnowledgeKind::Issue,
                     request_id: None,
                     query: None,
-                    list_scope: None,
                     message: "Window is not a knowledge bridge".to_string(),
                 },
             )];
@@ -245,7 +241,6 @@ impl AppRuntime {
                     knowledge_kind,
                     request_id: None,
                     query: None,
-                    list_scope: None,
                     message: "Project tab not found".to_string(),
                 },
             )];
@@ -266,7 +261,6 @@ impl AppRuntime {
                     knowledge_kind,
                     request_id: None,
                     query: None,
-                    list_scope: None,
                     message: "Issue/Knowledge window closed".to_string(),
                 },
             )];
@@ -287,7 +281,6 @@ impl AppRuntime {
                         knowledge_kind,
                         request_id: None,
                         query: None,
-                        list_scope: None,
                         message: error,
                     },
                 )],
@@ -299,7 +292,6 @@ impl AppRuntime {
                     knowledge_kind,
                     request_id: None,
                     query: None,
-                    list_scope: None,
                     message: error,
                 },
             )],

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -61,7 +61,7 @@ pub use index_worker::{
 pub use knowledge_bridge::{
     load_knowledge_bridge, refresh_knowledge_bridge_cache, search_knowledge_bridge,
     update_knowledge_phase, KnowledgeBridgeView, KnowledgeDetailSection, KnowledgeDetailView,
-    KnowledgeKind, KnowledgeListItem, KnowledgeListScope,
+    KnowledgeKind, KnowledgeListItem,
 };
 pub use launch_wizard::{
     build_agent_options, build_builtin_agent_options, default_wizard_version_cache_path,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1814,7 +1814,6 @@ mod tests {
                 request_id: None,
                 selected_number: None,
                 refresh: false,
-                list_scope: gwt::KnowledgeListScope::Open,
             },
         );
         assert_eq!(knowledge_missing.len(), 1);
@@ -1831,7 +1830,6 @@ mod tests {
                 request_id: None,
                 selected_number: None,
                 refresh: false,
-                list_scope: gwt::KnowledgeListScope::Open,
             },
         );
         assert_eq!(knowledge_wrong.len(), 1);
@@ -2417,7 +2415,6 @@ mod tests {
                     request_id: None,
                     selected_number: None,
                     refresh: false,
-                    list_scope: None,
                 },
             )
             .is_empty());
@@ -2429,7 +2426,6 @@ mod tests {
                     knowledge_kind: KnowledgeKind::Issue,
                     request_id: None,
                     number: 42,
-                    list_scope: None,
                 },
             )
             .is_empty());

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -10,7 +10,7 @@ use crate::{
     branch_list::BranchListEntry,
     daemon_runtime::RuntimeHookEvent,
     file_tree::FileTreeEntry,
-    knowledge_bridge::{KnowledgeDetailView, KnowledgeKind, KnowledgeListItem, KnowledgeListScope},
+    knowledge_bridge::{KnowledgeDetailView, KnowledgeKind, KnowledgeListItem},
     launch_wizard::{LaunchWizardAction, LaunchWizardView},
     persistence::{
         CanvasViewport, PersistedWindowState, ProjectKind, WindowGeometry, WindowProcessStatus,
@@ -150,7 +150,6 @@ pub enum FrontendEvent {
         request_id: Option<u64>,
         selected_number: Option<u64>,
         refresh: bool,
-        list_scope: Option<KnowledgeListScope>,
     },
     SearchKnowledgeBridge {
         id: String,
@@ -158,7 +157,6 @@ pub enum FrontendEvent {
         query: String,
         request_id: u64,
         selected_number: Option<u64>,
-        list_scope: Option<KnowledgeListScope>,
     },
     SelectKnowledgeBridgeEntry {
         id: String,
@@ -166,7 +164,6 @@ pub enum FrontendEvent {
         #[serde(default)]
         request_id: Option<u64>,
         number: u64,
-        list_scope: Option<KnowledgeListScope>,
     },
     /// SPEC-2017 US-8 — Kanban D&D writes a phase change back to the
     /// owning GitHub Issue. `target_phase=None` means Backlog (every
@@ -516,7 +513,6 @@ pub enum BackendEvent {
         id: String,
         knowledge_kind: KnowledgeKind,
         request_id: Option<u64>,
-        list_scope: Option<KnowledgeListScope>,
         entries: Vec<KnowledgeListItem>,
         selected_number: Option<u64>,
         empty_message: Option<String>,
@@ -527,7 +523,6 @@ pub enum BackendEvent {
         knowledge_kind: KnowledgeKind,
         query: String,
         request_id: u64,
-        list_scope: Option<KnowledgeListScope>,
         entries: Vec<KnowledgeListItem>,
         selected_number: Option<u64>,
         empty_message: Option<String>,
@@ -537,7 +532,6 @@ pub enum BackendEvent {
         id: String,
         knowledge_kind: KnowledgeKind,
         request_id: Option<u64>,
-        list_scope: Option<KnowledgeListScope>,
         detail: KnowledgeDetailView,
     },
     /// SPEC-2017 US-8 — Result of an
@@ -580,7 +574,6 @@ pub enum BackendEvent {
         knowledge_kind: KnowledgeKind,
         request_id: Option<u64>,
         query: Option<String>,
-        list_scope: Option<KnowledgeListScope>,
         message: String,
     },
     ProjectOpenError {

--- a/crates/gwt/tests/knowledge_bridge_test.rs
+++ b/crates/gwt/tests/knowledge_bridge_test.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fs};
 
-use gwt::{load_knowledge_bridge, KnowledgeKind, KnowledgeListScope};
+use gwt::{load_knowledge_bridge, KnowledgeKind};
 use gwt_core::{paths::gwt_cache_dir, repo_hash::detect_repo_hash};
 use gwt_github::{
     Cache, CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt,
@@ -72,14 +72,8 @@ fn load_knowledge_bridge_filters_plain_issues_and_counts_linked_branches() {
         HashMap::from([("feature/issue-bridge".to_string(), 42)]),
     );
 
-    let loaded = load_knowledge_bridge(
-        &repo_path,
-        KnowledgeKind::Issue,
-        Some(42),
-        false,
-        KnowledgeListScope::Open,
-    )
-    .expect("load");
+    let loaded =
+        load_knowledge_bridge(&repo_path, KnowledgeKind::Issue, Some(42), false).expect("load");
 
     assert_eq!(loaded.kind, KnowledgeKind::Issue);
     assert_eq!(loaded.entries.len(), 1);
@@ -128,14 +122,8 @@ fn load_knowledge_bridge_filters_specs_and_exposes_cached_sections() {
         ))
         .expect("write spec");
 
-    let loaded = load_knowledge_bridge(
-        &repo_path,
-        KnowledgeKind::Spec,
-        Some(2017),
-        false,
-        KnowledgeListScope::Open,
-    )
-    .expect("load");
+    let loaded =
+        load_knowledge_bridge(&repo_path, KnowledgeKind::Spec, Some(2017), false).expect("load");
 
     assert_eq!(loaded.kind, KnowledgeKind::Spec);
     assert_eq!(loaded.entries.len(), 1);
@@ -163,14 +151,7 @@ fn load_knowledge_bridge_returns_disabled_pr_surface_until_cache_support_exists(
     fs::create_dir_all(&repo_path).expect("create repo");
     init_repo(&repo_path);
 
-    let loaded = load_knowledge_bridge(
-        &repo_path,
-        KnowledgeKind::Pr,
-        None,
-        false,
-        KnowledgeListScope::Open,
-    )
-    .expect("load");
+    let loaded = load_knowledge_bridge(&repo_path, KnowledgeKind::Pr, None, false).expect("load");
 
     assert_eq!(loaded.kind, KnowledgeKind::Pr);
     assert!(loaded.entries.is_empty());
@@ -187,7 +168,7 @@ fn load_knowledge_bridge_returns_disabled_pr_surface_until_cache_support_exists(
 }
 
 #[test]
-fn load_knowledge_bridge_separates_open_and_closed_issue_lists() {
+fn load_knowledge_bridge_includes_open_and_closed_issues_for_kanban() {
     let dir = tempdir().expect("tempdir");
     let repo_path = dir.path().join("repo");
     fs::create_dir_all(&repo_path).expect("create repo");
@@ -215,29 +196,18 @@ fn load_knowledge_bridge_separates_open_and_closed_issue_lists() {
         ))
         .expect("write closed issue");
 
-    let open_view = load_knowledge_bridge(
-        &repo_path,
-        KnowledgeKind::Issue,
-        None,
-        false,
-        KnowledgeListScope::Open,
-    )
-    .expect("load open issues");
-    assert_eq!(open_view.entries.len(), 1);
-    assert_eq!(open_view.entries[0].number, 42);
-    assert_eq!(open_view.detail.number, Some(42));
-
-    let closed_view = load_knowledge_bridge(
-        &repo_path,
-        KnowledgeKind::Issue,
-        None,
-        false,
-        KnowledgeListScope::Closed,
-    )
-    .expect("load closed issues");
-    assert_eq!(closed_view.entries.len(), 1);
-    assert_eq!(closed_view.entries[0].number, 43);
-    assert_eq!(closed_view.detail.number, Some(43));
+    let view =
+        load_knowledge_bridge(&repo_path, KnowledgeKind::Issue, None, false).expect("load issues");
+    assert_eq!(view.entries.len(), 2);
+    assert_eq!(
+        view.entries
+            .iter()
+            .map(|entry| entry.number)
+            .collect::<Vec<_>>(),
+        vec![42, 43],
+    );
+    assert!(view.entries.iter().any(|entry| entry.state == "closed"));
+    assert_eq!(view.detail.number, Some(42));
 }
 
 fn init_repo(repo_path: &std::path::Path) {

--- a/crates/gwt/tests/window_controls_protocol_test.rs
+++ b/crates/gwt/tests/window_controls_protocol_test.rs
@@ -112,8 +112,7 @@ fn frontend_event_deserializes_window_state_commands() {
         "knowledge_kind": "issue",
         "request_id": 7,
         "selected_number": 2017,
-        "refresh": true,
-        "list_scope": "closed"
+        "refresh": true
     }))
     .expect("load_knowledge_bridge should deserialize");
     match knowledge {
@@ -123,14 +122,12 @@ fn frontend_event_deserializes_window_state_commands() {
             request_id,
             selected_number,
             refresh,
-            list_scope,
         } => {
             assert_eq!(id, "project-1::issue-1");
             assert_eq!(knowledge_kind, gwt::KnowledgeKind::Issue);
             assert_eq!(request_id, Some(7));
             assert_eq!(selected_number, Some(2017));
             assert!(refresh);
-            assert_eq!(list_scope, Some(gwt::KnowledgeListScope::Closed));
         }
         other => panic!("unexpected event: {other:?}"),
     }

--- a/crates/gwt/web/__tests__/kanban-structure.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-structure.test.mjs
@@ -52,6 +52,19 @@ test("Kanban toolbar exposes Hide done toggle id", () => {
   );
 });
 
+test("Kanban removes legacy open and closed list scope controls", () => {
+  assert.doesNotMatch(
+    appSource,
+    /data-knowledge-scope/,
+    "Kanban should not render the legacy Open/Closed scope toggle",
+  );
+  assert.doesNotMatch(
+    appSource,
+    /listScope|list_scope|switchKnowledgeListScope/,
+    "Kanban should not keep the legacy listScope request contract",
+  );
+});
+
 test("renderKnowledgeBridge groups entries into kanban columns by phase", () => {
   // The renderer must use entry.phase to assign data-phase on each card,
   // and fall back to "backlog" when phase is null.

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2649,7 +2649,6 @@
         if (!knowledgeBridgeStateMap.has(windowId)) {
           knowledgeBridgeStateMap.set(windowId, {
             kind: knowledgeKind,
-            listScope: "open",
             entries: [],
             baseEntries: [],
             selectedNumber: null,
@@ -2683,9 +2682,6 @@
         }
         const state = knowledgeBridgeStateMap.get(windowId);
         state.kind = knowledgeKind || state.kind;
-        if (!state.listScope) {
-          state.listScope = "open";
-        }
         if (state.hideDone === undefined) {
           state.hideDone = readKanbanHideDonePreference();
         }
@@ -2915,8 +2911,6 @@
           request_id: requestId,
           selected_number: state.selectedNumber ?? null,
           refresh,
-          list_scope:
-            effectiveKind === "issue" ? state.listScope || "open" : null,
         });
       }
 
@@ -2932,14 +2926,6 @@
           state.selectedNumber =
             state.entries.length > 0 ? state.entries[0].number : null;
         }
-      }
-
-      function knowledgeEventScopeMatches(state, event) {
-        return !(
-          state.kind === "issue" &&
-          event.list_scope &&
-          event.list_scope !== state.listScope
-        );
       }
 
       function knowledgeDetailRequestMatches(state, event) {
@@ -2965,8 +2951,6 @@
           query,
           request_id: requestId,
           selected_number: state.selectedNumber ?? null,
-          list_scope:
-            effectiveKind === "issue" ? state.listScope || "open" : null,
         });
       }
 
@@ -3035,8 +3019,6 @@
           knowledge_kind: effectiveKind,
           request_id: requestId,
           number,
-          list_scope:
-            effectiveKind === "issue" ? state.listScope || "open" : null,
         });
       }
 
@@ -5302,12 +5284,10 @@
         }
       }
 
-      function knowledgeSearchPlaceholder(kind, listScope = "open") {
+      function knowledgeSearchPlaceholder(kind) {
         switch (kind) {
           case "issue":
-            return listScope === "closed"
-              ? "Semantic search closed issues"
-              : "Semantic search open issues";
+            return "Semantic search issues";
           case "spec":
             return "Semantic search cached SPECs";
           case "pr":
@@ -5333,36 +5313,6 @@
             .toLowerCase()
             .includes(query),
         );
-      }
-
-      function switchKnowledgeListScope(windowId, nextScope) {
-        const state = ensureKnowledgeBridgeState(
-          windowId,
-          knowledgeKindForPreset(workspaceWindowById(windowId)?.preset),
-        );
-        if (state.kind !== "issue" || state.listScope === nextScope || state.loading) {
-          return;
-        }
-        if (state.pendingSearchTimer) {
-          clearTimeout(state.pendingSearchTimer);
-          state.pendingSearchTimer = null;
-        }
-        state.listScope = nextScope;
-        state.entries = [];
-        state.baseEntries = [];
-        state.selectedNumber = null;
-        state.detail = null;
-        state.detailLoading = false;
-        state.query = "";
-        state.searching = false;
-        state.refreshing = false;
-        state.searchInFlight = false;
-        state.inFlightSearchRequestId = 0;
-        state.queuedSearchQuery = "";
-        state.loadRequestId += 1;
-        state.searchRequestId += 1;
-        requestKnowledgeBridge(windowId, state.kind, false);
-        renderKnowledgeBridge(windowId);
       }
 
       function kanbanEmptyMessage(state, phase) {
@@ -5570,22 +5520,13 @@
         const status = element.querySelector(".knowledge-status");
         const refreshButton = element.querySelector("[data-action='refresh-knowledge']");
         const searchInput = element.querySelector(".knowledge-search");
-        const scopeButtons = element.querySelectorAll("[data-knowledge-scope]");
         const hideDoneToggle = element.querySelector("[data-action='kanban-hide-done']");
         if (!board || !detailPane || !status || !refreshButton || !searchInput) {
           return;
         }
 
         refreshButton.disabled = !state.refreshEnabled || state.loading;
-        searchInput.placeholder = knowledgeSearchPlaceholder(
-          state.kind,
-          state.listScope,
-        );
-        for (const button of scopeButtons) {
-          const active = button.dataset.knowledgeScope === state.listScope;
-          button.classList.toggle("active", active);
-          button.disabled = state.loading && !active;
-        }
+        searchInput.placeholder = knowledgeSearchPlaceholder(state.kind);
         if (hideDoneToggle) {
           hideDoneToggle.checked = state.hideDone === true;
         }
@@ -6433,14 +6374,6 @@
               <div class="workspace-toolbar kanban-toolbar is-stacked">
                 <div class="workspace-toolbar-main">
                   <div class="knowledge-heading">${knowledgeHeading(knowledgeKind)}</div>
-                  ${
-                    knowledgeKind === "issue"
-                      ? `<div class="branch-filter-group">
-                  <button class="branch-filter-button" type="button" data-knowledge-scope="open">Open</button>
-                  <button class="branch-filter-button" type="button" data-knowledge-scope="closed">Closed</button>
-                </div>`
-                      : ""
-                  }
                   <input class="knowledge-search" type="search" placeholder="${knowledgeSearchPlaceholder(knowledgeKind)}" />
                   <label class="kanban-hide-done-toggle" for="kanban-hide-done-${windowData.id}">
                     <input
@@ -6525,15 +6458,6 @@
               knowledgeKind,
             );
           });
-          for (const button of body.querySelectorAll("[data-knowledge-scope]")) {
-            button.addEventListener("click", (event) => {
-              event.stopPropagation();
-              frontendUnits.knowledgeSettingsSurface.switchKnowledgeListScope(
-                windowData.id,
-                button.dataset.knowledgeScope,
-              );
-            });
-          }
           body
             .querySelector("[data-action='refresh-knowledge']")
             .addEventListener("click", (event) => {
@@ -7377,9 +7301,7 @@
         requestKnowledgeBridge,
         scheduleKnowledgeSearch,
         requestKnowledgeDetail,
-        knowledgeEventScopeMatches,
         knowledgeDetailRequestMatches,
-        switchKnowledgeListScope,
         renderKnowledgeBridge,
         renderSettingsWindow,
         renderSettingsAgentList,
@@ -7607,10 +7529,7 @@
               event.id,
               event.knowledge_kind,
             );
-            if (
-              (event.request_id && event.request_id !== state.loadRequestId) ||
-              !frontendUnits.knowledgeSettingsSurface.knowledgeEventScopeMatches(state, event)
-            ) {
+            if (event.request_id && event.request_id !== state.loadRequestId) {
               break;
             }
             const queuedQuery = state.query.trim();
@@ -7652,11 +7571,6 @@
             if (isInFlightResponse) {
               state.searchInFlight = false;
               state.inFlightSearchRequestId = 0;
-            }
-            if (
-              !frontendUnits.knowledgeSettingsSurface.knowledgeEventScopeMatches(state, event)
-            ) {
-              break;
             }
             if (
               event.request_id !== state.searchRequestId ||
@@ -7705,10 +7619,7 @@
               event.id,
               event.knowledge_kind,
             );
-            if (
-              !frontendUnits.knowledgeSettingsSurface.knowledgeDetailRequestMatches(state, event) ||
-              !frontendUnits.knowledgeSettingsSurface.knowledgeEventScopeMatches(state, event)
-            ) {
+            if (!frontendUnits.knowledgeSettingsSurface.knowledgeDetailRequestMatches(state, event)) {
               break;
             }
             const matchesLoadRequest =
@@ -7863,8 +7774,7 @@
             if (
               isSearchError &&
               (event.request_id !== state.inFlightSearchRequestId ||
-                event.query !== state.query.trim() ||
-                !frontendUnits.knowledgeSettingsSurface.knowledgeEventScopeMatches(state, event))
+                event.query !== state.query.trim())
             ) {
               if (event.request_id === state.inFlightSearchRequestId) {
                 state.searchInFlight = false;
@@ -7882,8 +7792,7 @@
             }
             if (
               !isSearchError &&
-              (!frontendUnits.knowledgeSettingsSurface.knowledgeDetailRequestMatches(state, event) ||
-                !frontendUnits.knowledgeSettingsSurface.knowledgeEventScopeMatches(state, event))
+              !frontendUnits.knowledgeSettingsSurface.knowledgeDetailRequestMatches(state, event)
             ) {
               break;
             }


### PR DESCRIPTION
## Summary

- Removes the legacy Knowledge Bridge open/closed list scope so Kanban uses one issue feed and the existing Done grouping.
- Keeps Hide done as the only Done visibility control, avoiding two overlapping ways to filter closed issues.

## Changes

- `crates/gwt/src/knowledge_bridge.rs`: Removes `KnowledgeListScope`, stops filtering Issue views by open/closed state, and updates semantic search to include both open and closed plain issues.
- `crates/gwt/src/protocol.rs` and `crates/gwt/src/app_runtime/mod.rs`: Removes `list_scope` from frontend/backend Knowledge Bridge request and response contracts.
- `crates/gwt/web/app.js`: Removes `listScope` frontend state, Open/Closed scope buttons, scope matching, and scope payloads.
- `crates/gwt/web/__tests__/kanban-structure.test.mjs`, `crates/gwt/src/embedded_web.rs`, and `crates/gwt/tests/knowledge_bridge_test.rs`: Adds regression coverage for the removed contract and open+closed issue feed.
- `crates/gwt/playwright/tests/kanban.spec.ts`: Simplifies the deterministic Kanban fixture by dropping `list_scope`.

## Testing

- [x] `node --test crates/gwt/web/__tests__/kanban-structure.test.mjs` - passed 14/14.
- [x] `cargo test -p gwt --test knowledge_bridge_test load_knowledge_bridge_includes_open_and_closed_issues_for_kanban` - passed.
- [x] `cargo test -p gwt embedded_web_knowledge_bridge_surface_uses_cache_backed_contract` - passed.
- [x] `cargo test -p gwt frontend_event_deserializes_window_state_commands` - passed.
- [x] `cargo test -p gwt --test knowledge_bridge_test` - passed 4/4.
- [x] `cargo test -p gwt knowledge_bridge::tests::semantic_issue_search_filters_specs_and_scores_open_and_closed_results -- --exact` - passed.
- [x] `cargo test -p gwt-core -p gwt` - passed.
- [x] `pnpm run test:frontend-unit` - passed 307/307.
- [x] `pnpm run test:frontend-bundle` - passed.
- [x] `pnpm run test:frontend-smoke` - passed 10/10.
- [x] `pnpm run test:release-assets` - passed.
- [x] `pnpm exec playwright test --config crates/gwt/playwright/playwright.config.ts crates/gwt/playwright/tests/kanban.spec.ts --project chromium-dark --project chromium-light` - passed 4/4.
- [x] `pnpm run test:visual` - passed 4, skipped 16.
- [x] `cargo fmt --check` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt` - passed.
- [x] `git diff --check` - passed.
- [x] `git push origin HEAD` - pre-push checks passed, including coverage 90.32% against the 90.00% threshold.

## Closing Issues

None

## Related Issues / Links

- #2017

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC tasks updated; no README change needed for this internal UI cleanup)
- [x] Migration/backfill plan included (N/A: no schema or persisted data migration)
- [x] CHANGELOG impact considered (refactor only; no breaking release note required)

## Context

- SPEC-2017 moved Knowledge Bridge Issue rendering to a Kanban board where closed issues are represented by the Done column.
- The old Open/Closed list scope predated that Kanban behavior and duplicated the newer Hide done control.

## Risk / Impact

- **Affected areas**: Knowledge Bridge Issue loading/search, frontend WebSocket contract, Kanban controls, and related tests.
- **Rollback plan**: Revert this PR to restore the previous list scope protocol and UI.

## Screenshots

- Not attached; the visible control removal is covered by Kanban Playwright visual snapshots in dark and light mode with Hide done on/off.
