### PR TITLE
docs: fix invalid commands in SPEC-1939 Phase 12 manual smoke checklist

### DIFF
--- a/docs/spec-1939-phase-12-manual-smoke.md
+++ b/docs/spec-1939-phase-12-manual-smoke.md
@@ -24,11 +24,11 @@ SPEC-1939 Issue #2584 can close.
    cargo build -p gwt --release
    ```
 3. A multi-worktree project with at least 2 active worktrees. The gwt
-   repo itself works; otherwise:
-   ```bash
-   gwtd start-work develop /tmp/gwt-smoke-a
-   gwtd start-work develop /tmp/gwt-smoke-b
-   ```
+   repo itself works (this repository's `develop` worktree plus any
+   feature worktree). Otherwise, materialise additional worktrees from
+   the gwt GUI's *Start Work* flow against an existing project — agent
+   CLIs do not create worktrees, so do not invoke `git worktree add`
+   from automation.
 4. Optional: pre-seed an unhealthy index scope by deleting one
    worktree's chroma store under `~/.gwt/index/<repo-hash>/worktrees/
    <wt-hash>/files/`. This forces the bootstrap path into
@@ -85,7 +85,7 @@ deferred — no Windows host` in the Board, and rely on the
 After running the checklist, post a status update:
 
 ```bash
-gwtd board post --kind status --mention user:akiojin --body $'\
+gwtd board post --kind status --owner SPEC-1939 --topic phase-12-smoke --body $'\
 SPEC-1939 Phase 12 macOS smoke (T-IDX-111) 完了:\n\
 - 1: pass\n\
 - 2: pass\n\
@@ -97,6 +97,11 @@ SPEC-1939 Phase 12 macOS smoke (T-IDX-111) 完了:\n\
 \n\
 Windows (T-IDX-112): <pass | best-effort deferred>'
 ```
+
+(`gwtd board post --help` lists the valid flags: `--kind`, `--body | -f`,
+`--title-summary`, `--parent`, `--topic`, `--owner`, `--target`. Use
+`--target <session-id|branch|agent-id>` to highlight the post for
+specific agents — there is no user-mention flag.)
 
 When the smoke passes on macOS, comment on Issue #2584 with the Board
 link to close the Phase 12 verification follow-up.


### PR DESCRIPTION
## Summary

PR #2599 と同タイミングで landing した `docs/spec-1939-phase-12-manual-smoke.md` (commit 6c9f51f3) が、実在しない `gwtd start-work` サブコマンドと、存在しない `--mention` フラグを案内していたため、reviewer が checklist のとおりに手を動かすと即詰まる状態になっていました。本 PR で修正します。

### Before (broken)

```bash
gwtd start-work develop /tmp/gwt-smoke-a
gwtd start-work develop /tmp/gwt-smoke-b
```

```bash
gwtd board post --kind status --mention user:akiojin --body $'...'
```

### After

- 「multi-worktree は gwt GUI の *Start Work* フローでマテリアライズせよ。`git worktree add` は agent ではなく GUI が責任を持つ」(AGENTS.md 準拠) に書き換え
- Board snippet を `--owner SPEC-1939 --topic phase-12-smoke` に置換し、有効な flag だけを使う
- 末尾に `gwtd board post --help` のフラグ一覧を補足し、`--target` で agents を highlight する正しい運用を明記

### tasks/lessons.md 追加

同じ事象を再発させないため、`tasks/lessons.md` に「2026-05-10 — Verify CLI commands and flags exist before shipping them in docs」を追記しました。`gwtd` snippet を doc に固定する際は `gwtd --help <subcommand>` で実在確認することを明文化しています。

## 検証

- [x] `gwtd issue view 2584` (Phase 12 follow-up Issue が OPEN であること)
- [x] `gwtd --help`, `gwtd --help board post` (subcommand / flag の正本確認)
- [x] `npx markdownlint-cli docs/spec-1939-phase-12-manual-smoke.md` clean

## Notes

production behavior は触らない。documentation only。Phase 12 の自動化済み frontend 振る舞いは PR #2570 / #2571 / #2574 / #2577 / #2588 / #2590 / #2599 で landing 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
