### PR TITLE
docs: restore --mention flag in board post documentation

### DIFF
--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -221,7 +221,7 @@ fn format_board_help() -> String {
         "  show [--json]                           Print the Board snapshot",
         "  post --kind <kind> (--body <text> | -f <file>)",
         "       [--title-summary <text>] [--parent <id>] [--topic <t>]*",
-        "       [--owner <n>]* [--target <id>]*",
+        "       [--owner <n>]* [--target <id>]* [--mention <kind:id>]*",
         "                                          Append a Board entry",
         "",
         "Kinds: request, status, next, claim, impact, question, blocked, handoff, decision",
@@ -443,4 +443,38 @@ fn parse_owner_repo(value: &str) -> Option<(String, String)> {
         return None;
     }
     Some((owner.to_string(), repo.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_board_help_documents_mention_flag() {
+        // Regression: PR #2600 missed `--mention` from the board post help text
+        // even though the parser at `cli/board.rs` accepts it. This assertion
+        // keeps the user-visible help in sync with the parser surface so
+        // operators do not assume an audience flag is missing.
+        let help = format_board_help();
+        assert!(
+            help.contains("--mention <kind:id>"),
+            "board help must document --mention flag (parser accepts it). help:\n{help}",
+        );
+    }
+
+    #[test]
+    fn format_board_help_documents_post_audience_flags() {
+        let help = format_board_help();
+        for flag in [
+            "--target <id>",
+            "--owner <n>",
+            "--topic <t>",
+            "--parent <id>",
+        ] {
+            assert!(
+                help.contains(flag),
+                "board help must document {flag}. help:\n{help}",
+            );
+        }
+    }
 }

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -301,7 +301,9 @@ pub enum ActionsCommand {
 pub enum BoardCommand {
     /// `gwtd board show [--json]`.
     Show { json: bool },
-    /// `gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--target <id>] [--mention <kind:id>]`.
+    /// `gwtd board post --kind <kind> (--body <text> | -f <file>)
+    /// [--title-summary <text>] [--parent <id>] [--topic <t>]*
+    /// [--owner <n>]* [--target <id>]* [--mention <kind:id>]*`.
     Post(Box<BoardPostCommand>),
 }
 

--- a/docs/spec-1939-phase-12-manual-smoke.md
+++ b/docs/spec-1939-phase-12-manual-smoke.md
@@ -85,7 +85,8 @@ deferred — no Windows host` in the Board, and rely on the
 After running the checklist, post a status update:
 
 ```bash
-gwtd board post --kind status --owner SPEC-1939 --topic phase-12-smoke --body $'\
+gwtd board post --kind status --owner SPEC-1939 --topic phase-12-smoke \
+  --mention user:akiojin --body $'\
 SPEC-1939 Phase 12 macOS smoke (T-IDX-111) 完了:\n\
 - 1: pass\n\
 - 2: pass\n\
@@ -98,10 +99,12 @@ SPEC-1939 Phase 12 macOS smoke (T-IDX-111) 完了:\n\
 Windows (T-IDX-112): <pass | best-effort deferred>'
 ```
 
-(`gwtd board post --help` lists the valid flags: `--kind`, `--body | -f`,
-`--title-summary`, `--parent`, `--topic`, `--owner`, `--target`. Use
-`--target <session-id|branch|agent-id>` to highlight the post for
-specific agents — there is no user-mention flag.)
+Valid `gwtd board post` flags (per the parser at `crates/gwt/src/cli/board.rs`):
+`--kind`, `--body | -f`, `--title-summary`, `--parent`, `--topic`, `--owner`,
+`--target <session-id|branch|agent-id>`, and `--mention <kind:id>` (e.g.
+`user:akiojin`, `agent:codex`). `--target` highlights a post for a specific
+agent / branch / session; `--mention` records a typed audience marker that
+ships with the entry payload.
 
 When the smoke passes on macOS, comment on Issue #2584 with the Board
 link to close the Phase 12 verification follow-up.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,38 @@
 # Lessons Learned
 
+## 2026-05-10 — Verify CLI commands and flags exist before shipping them in docs
+
+### 事象
+
+`docs/spec-1939-phase-12-manual-smoke.md` (PR #2599 で develop merged) に、
+実在しないサブコマンド `gwtd start-work develop /tmp/...` と、存在しない
+フラグ `--mention user:akiojin` を含めてしまった。reviewer が checklist
+通りに手を動かすと両方とも即詰まる状態で、follow-up PR #2600 でドキュ
+メントを修正する手戻りが発生した。
+
+### 原因
+
+reviewer 向けの手順を書く際、command line snippet を「自分の記憶」だけで
+書き起こし、`gwtd --help` / `gwtd --help <subcommand>` で実在を確認しな
+かった。`gwtd` のサブコマンドは `issue / pr / actions / board / hook /
+index / discuss / plan / build / pane / workspace / update / daemon` のみ
+で、worktree 作成は GUI の Start Work flow が責任を持つ設計 (AGENTS.md
+の「`git checkout -b`、`git switch -c`、`git branch -D`、`git worktree
+add/remove` は禁止」と整合) になっている。`gwtd board post` の audience
+flag は `--target <id>` のみで、`--mention` は存在しない。
+
+### 再発防止策
+
+1. user 向け手順 (docs / README / lesson テンプレ / SPEC sample) に CLI
+   snippet を埋め込む際は、commit 前に `gwtd --help <subcommand>` または
+   `gwtd <subcommand> --help` で全 flag / subcommand の実在を確認する。
+2. agent 自身が普段叩かないサブコマンド (CI 出力、Board 投稿、Issue 操
+   作の組み合わせ等) を doc に固定する場合は、必ず実 invocation で
+   reproduce してから snippet を確定する。
+3. 既存 doc を参考にする場合でも、過去の typo がそのまま伝播する可能性
+   があるので、参照元の commit / PR で実際に動いた証跡 (CI ログ・成功し
+   た board entry など) を一度確認する。
+
 ## 2026-05-10 — Read tasks/lessons.md before designing tests for window interaction features
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,37 +1,44 @@
 # Lessons Learned
 
-## 2026-05-10 — Verify CLI commands and flags exist before shipping them in docs
+## 2026-05-10 — Verify CLI commands and flags against the parser, not just the help text
 
 ### 事象
 
 `docs/spec-1939-phase-12-manual-smoke.md` (PR #2599 で develop merged) に、
-実在しないサブコマンド `gwtd start-work develop /tmp/...` と、存在しない
-フラグ `--mention user:akiojin` を含めてしまった。reviewer が checklist
-通りに手を動かすと両方とも即詰まる状態で、follow-up PR #2600 でドキュ
-メントを修正する手戻りが発生した。
+実在しないサブコマンド `gwtd start-work develop /tmp/...` を含めてしまい、
+follow-up PR #2600 で修正したものの、その PR で「`gwtd board post` には
+`--mention` フラグは存在しない」と誤った claim を書いてしまった。実際に
+は `crates/gwt/src/cli/board.rs:234` の parser に `--mention <kind:id>` が
+landing 済みで、tests (`board_family_parse_post_collects_typed_mentions`)
+でも `--mention user:akiojin` 形式が gating されていたため、Codex review
+(PRRT_kwDOPLof2M6A4JHA) で指摘され、二度目の follow-up が必要になった。
 
 ### 原因
 
-reviewer 向けの手順を書く際、command line snippet を「自分の記憶」だけで
-書き起こし、`gwtd --help` / `gwtd --help <subcommand>` で実在を確認しな
-かった。`gwtd` のサブコマンドは `issue / pr / actions / board / hook /
-index / discuss / plan / build / pane / workspace / update / daemon` のみ
-で、worktree 作成は GUI の Start Work flow が責任を持つ設計 (AGENTS.md
-の「`git checkout -b`、`git switch -c`、`git branch -D`、`git worktree
-add/remove` は禁止」と整合) になっている。`gwtd board post` の audience
-flag は `--target <id>` のみで、`--mention` は存在しない。
+最初の修正で `gwtd --help board post` (実体は `crates/gwt/src/bin/gwtd.rs::
+format_board_help()`) の出力だけを根拠にし、parser source (`cli/board.rs`)
+や cli.rs の集中 usage 文字列を読まなかった。`bin/gwtd.rs` の subcommand
+help は手書きで cli.rs / parser から自動生成されておらず、`--mention` の
+ように後から landing したフラグが反映されていない場合がある。help text
+を「正本」と仮定してしまったのが事故の構造的原因。
 
 ### 再発防止策
 
-1. user 向け手順 (docs / README / lesson テンプレ / SPEC sample) に CLI
-   snippet を埋め込む際は、commit 前に `gwtd --help <subcommand>` または
-   `gwtd <subcommand> --help` で全 flag / subcommand の実在を確認する。
-2. agent 自身が普段叩かないサブコマンド (CI 出力、Board 投稿、Issue 操
-   作の組み合わせ等) を doc に固定する場合は、必ず実 invocation で
-   reproduce してから snippet を確定する。
-3. 既存 doc を参考にする場合でも、過去の typo がそのまま伝播する可能性
-   があるので、参照元の commit / PR で実際に動いた証跡 (CI ログ・成功し
-   た board entry など) を一度確認する。
+1. CLI flag / subcommand の有無を doc / lesson に固定する場合、`gwtd
+   <subcommand> --help` だけでなく、parser 側 (`crates/gwt/src/cli/*.rs`
+   の `--flag` arm) と test (`board_family_parse_post_*` 等) の両方で
+   確認する。help 文字列は手書きのため、フラグの抜けが発生する。
+2. user 向け手順に CLI snippet を埋め込む際は、commit 前に **実 invocation
+   で reproduce** してから snippet を確定する (例: 実際に `gwtd board post
+   --mention user:akiojin --body 'test'` を投げて成功するかを board entry
+   で確認)。help 文字列は古い場合がある。
+3. もし help と parser に乖離があったら、help 側も合わせて修正する
+   (`crates/gwt/src/bin/gwtd.rs::format_*_help()`)。ドキュメントを書く
+   作業の副産物として help 同期も行うことで、次の reviewer が同じ事故を
+   踏まなくなる。
+4. 既存 doc / 既存テストの flag 列挙 (parser の `--mention` arm、cli.rs
+   の集中 usage 文字列) を参照元として優先し、help の subcommand 出力は
+   second-source 扱いとする。
 
 ## 2026-05-10 — Read tasks/lessons.md before designing tests for window interaction features
 


### PR DESCRIPTION
## Summary

PR #2600 で `docs/spec-1939-phase-12-manual-smoke.md` を修正した際に、「`gwtd board post` には user-mention flag は存在しない」と誤った claim を追記してしまいました。実際には `crates/gwt/src/cli/board.rs:234` の parser が `--mention <kind:id>` を受け付け、`board_family_parse_post_collects_typed_mentions` test (同 file `:417`) で gating されています。Codex review (PRRT_kwDOPLof2M6A4JHA) で指摘されたため、本 PR で次を修正します:

### 変更点

1. **`crates/gwt/src/bin/gwtd.rs::format_board_help()`** — subcommand help text に `--mention <kind:id>*` を追加。これまで help には載っていなかったが parser は受け付けていたため、surface を同期。
2. **`docs/spec-1939-phase-12-manual-smoke.md`** — Board recording snippet に `--mention user:akiojin` を復活、末尾の flag 説明を「parser に裏付けされた flag 一覧 + `--mention` の意味」に書き換え (deny-list ではなく positive list)。
3. **`tasks/lessons.md`** — 既存 lesson を「help text を正本と仮定せず、parser source / tests も確認する」に書き直し。`bin/gwtd.rs::format_*_help()` が手書きで自動生成されていない構造的原因を明記。
4. **regression tests** — `crates/gwt/src/bin/gwtd.rs` に `tests` module を追加し、`format_board_help` が `--mention <kind:id>` / `--target` / `--owner` / `--topic` / `--parent` を documenting しているかを assert (next time someone drops a flag, unit test fires before reviewer).

## Test plan

- [x] `cargo test -p gwt --bin gwtd format_board_help` — 2 tests pass
- [x] `cargo test -p gwt --bin gwt --lib cli::board` — 16 tests pass (parser unchanged, regression unaffected)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo run --bin gwtd -- --help board post` で `--mention <kind:id>*` が表示されることを確認

## Notes

- production behavior は変えていない (`--mention` は元々 parser に landed 済み、今回 help text と doc を parser に追従させただけ)。
- Codex review thread (PRRT_kwDOPLof2M6A4JHA) を resolve します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `gwtd board post` command help text to document the `--mention` flag.
  * Reformatted CLI command documentation with improved flag descriptions and usage clarity.
  * Enhanced manual smoke test documentation with complete flag references and behavior descriptions.

* **Tests**
  * Added regression tests to validate help text accuracy for command flags.

* **Chores**
  * Added lessons learned documentation regarding CLI documentation validation practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2602)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->