### PR TITLE
test(gwtd): tighten board help regression to require * repetition marker

### DIFF
--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -452,28 +452,34 @@ mod tests {
     #[test]
     fn format_board_help_documents_mention_flag() {
         // Regression: PR #2600 missed `--mention` from the board post help text
-        // even though the parser at `cli/board.rs` accepts it. This assertion
-        // keeps the user-visible help in sync with the parser surface so
-        // operators do not assume an audience flag is missing.
+        // even though the parser at `cli/board.rs` accepts it. The parser also
+        // collects `--mention` repeatedly (BoardPostCommand::mentions is a
+        // Vec<String>), so the help token must keep the `*` repetition marker.
+        // Asserting the closing-bracket-then-star form prevents future drift
+        // where the marker is accidentally trimmed but the bare flag survives.
         let help = format_board_help();
         assert!(
-            help.contains("--mention <kind:id>"),
-            "board help must document --mention flag (parser accepts it). help:\n{help}",
+            help.contains("[--mention <kind:id>]*"),
+            "board help must document repeatable --mention flag (parser accepts it). help:\n{help}",
         );
     }
 
     #[test]
     fn format_board_help_documents_post_audience_flags() {
+        // Each entry pairs the bracketed flag token with its expected
+        // repetition marker. `--parent` is singular per the parser; the rest
+        // are Vec<String> in BoardPostCommand and must keep the `*` marker so
+        // operators know they can pass each flag multiple times.
         let help = format_board_help();
-        for flag in [
-            "--target <id>",
-            "--owner <n>",
-            "--topic <t>",
-            "--parent <id>",
+        for expected in [
+            "[--target <id>]*",
+            "[--owner <n>]*",
+            "[--topic <t>]*",
+            "[--parent <id>]",
         ] {
             assert!(
-                help.contains(flag),
-                "board help must document {flag}. help:\n{help}",
+                help.contains(expected),
+                "board help must document {expected}. help:\n{help}",
             );
         }
     }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,21 @@
 # Lessons Learned
 
+## 2026-05-10 — Auto-merge can fire before review-feedback corrections land
+
+### 事象
+
+PR #2602 で CodeRabbit からの指摘 (`PRRT_kwDOPLof2M6A4N7G`: `format_board_help_documents_mention_flag` assertion が `*` 反復マーカーを要求していない) を修正する commit (`2a8853f6`) を push した直後、auto-merge が一つ前の SHA (`c3ec646a`) に対して既に発火しており、PR #2602 は強化前のテストのまま develop に landed した。CodeRabbit suggestion を適用したつもりが、その commit は次の PR (#2603) で別途 land させる必要が生じた。
+
+### 原因
+
+`Auto Merge PR` workflow は「PR の checks が全部 green になった瞬間」に発火する。CodeRabbit が PR にコメントしてから、こちらが修正 commit を push して新しい checks が走り始めるまでの空白期間に、prior commit の checks が完了して auto-merge が prior SHA で merge を実行してしまう競合が発生し得る。auto-merge は SHA-pinned ではないため、新 commit は merge 後に取り残される。
+
+### 再発防止策
+
+1. CodeRabbit / Codex review でアクション可能な提案を受けたら、修正 commit を push する **前** に PR の auto-merge 進行度を確認する (`gwtd pr checks <n>` で `Enable auto-merge` 状態確認)。すでに大半が SUCCESS になっている場合、修正 commit を push しても auto-merge が prior SHA を選ぶ余地が残る。
+2. もしどうしても prior commit が先に merge してしまうリスクがあるなら、修正 commit は **次の PR で land させる前提** で書く (本 PR #2603 はその対応)。同時に、その follow-up を必ず開くことを reviewer 通知の reply に明記する。
+3. `gwtd pr edit <n> --add-label hold` などで auto-merge を一時的に無効化する手段があれば優先する (現時点で gwtd には専用 flag はないので、修正 commit + immediate watch を運用ルールにする)。
+
 ## 2026-05-10 — Verify CLI commands and flags against the parser, not just the help text
 
 ### 事象


### PR DESCRIPTION
## Summary

CodeRabbit thread (PR #2602 / `PRRT_kwDOPLof2M6A4N7G`) で指摘された「`format_board_help_documents_mention_flag` の assertion が `*` 反復マーカーを要求していない」を修正する commit (`2a8853f6`) は CodeRabbit 提案を適用後に push したのですが、auto-merge が一つ前の SHA (`c3ec646a`) に対して既に発火していたため PR #2602 には乗らず、本 PR で land させます。

### 変更点 (commit `2a8853f6`)

- `format_board_help_documents_mention_flag` を `[--mention <kind:id>]*` の bracketed + `*` 形式に強化。`*` が落ちた場合に test が失敗するようにする (parser は `BoardPostCommand::mentions: Vec<String>` で繰り返し受け付ける)。
- `format_board_help_documents_post_audience_flags` も同様の drift 防止に拡張: `[--target <id>]*` / `[--owner <n>]*` / `[--topic <t>]*` (parser はいずれも `Vec<String>`) を要求し、`[--parent <id>]` だけは singular なので `*` を付けない。

## Test plan

- [x] `cargo test -p gwt --bin gwtd format_board_help` — 2 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`

## Notes

production behavior 等価。テストの厳格化のみ。Codex/CodeRabbit から再度指摘される前に本来 PR #2602 に乗るべきだった patch を、別 PR で develop に取り込みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
