### PR TITLE
fix(gui): refresh theme toggle preference state

### DIFF
--- a/crates/gwt/web/__tests__/theme-manager.test.mjs
+++ b/crates/gwt/web/__tests__/theme-manager.test.mjs
@@ -38,6 +38,19 @@ test("setTheme persists and notifies subscribers", () => {
   assert.equal(env.documentTheme, "light");
 });
 
+test("setTheme notifies subscribers when preference changes but effective theme is unchanged", () => {
+  const env = makeEnv({ stored: null, prefersDark: true });
+  const mgr = createThemeManager(env);
+  const events = [];
+  mgr.subscribe((eff) => events.push({ eff, pref: mgr.getPreference() }));
+
+  mgr.setTheme("dark");
+
+  assert.equal(env.storage.get("gwt:ui:theme"), "dark");
+  assert.equal(env.documentTheme, "dark");
+  assert.deepEqual(events, [{ eff: "dark", pref: "dark" }]);
+});
+
 test("setTheme rejects invalid values, falling back to auto", () => {
   const env = makeEnv({ stored: null, prefersDark: false });
   const mgr = createThemeManager(env);

--- a/crates/gwt/web/theme-manager.js
+++ b/crates/gwt/web/theme-manager.js
@@ -42,6 +42,7 @@ export function createThemeManager(env) {
     getEffective() { return lastEffective; },
     setTheme(next) {
       const normalized = normalize(next);
+      const previousPreference = preference;
       preference = normalized;
       if (normalized === "auto") storage.delete(STORAGE_KEY);
       else storage.set(STORAGE_KEY, normalized);
@@ -52,6 +53,7 @@ export function createThemeManager(env) {
         notify(eff);
       } else {
         applyDocument(eff); // make sure document attr is correct even when no change
+        if (normalized !== previousPreference) notify(eff);
       }
     },
     subscribe(fn) {


### PR DESCRIPTION
## Summary

- Fixes the Operator theme segmented control so `aria-checked` refreshes when the saved preference changes but the effective theme stays the same.
- Adds a regression test for the auto(dark) -> dark path that live Playwright exposed during SPEC-2356 backlog reconciliation.

## Changes

- `crates/gwt/web/theme-manager.js`: notify subscribers when the theme preference changes even if the computed effective theme is unchanged.
- `crates/gwt/web/__tests__/theme-manager.test.mjs`: covers the preference-change/same-effective-theme case so the Project Bar radiogroup re-renders correctly.

## Testing

- [x] `node --test crates/gwt/web/__tests__/theme-manager.test.mjs crates/gwt/web/__tests__/theme-segmented.test.mjs` — 16 passed.
- [x] `npm run test:frontend-unit` — 308 passed.
- [x] `npm run test:frontend-bundle` — syntax checks passed.
- [x] `GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:55545/ npx playwright test --config crates/gwt/playwright/playwright.config.ts crates/gwt/playwright/tests/chrome.spec.ts crates/gwt/playwright/tests/theme-toggle.spec.ts crates/gwt/playwright/tests/reduced-motion.spec.ts` — 16 passed against live gwt.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] pre-push coverage hook — 90.32% line coverage, threshold met.

## Closing Issues

- Closes #2356

## Related Issues / Links

- #1784

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2356 tasks reconciliation updated)
- [x] Migration/backfill plan included (no schema/data migration)
- [x] CHANGELOG impact considered (patch-level GUI fix)

## Context

- SPEC-2356 completion verification found that the live Project Bar radiogroup could update `data-theme` while leaving the preference radio state stale for same-effective-theme transitions.
