### PR TITLE
docs(spec-1939): align Playwright README test names + add manual smoke seed recipe

### DIFF
--- a/crates/gwt/playwright/README.md
+++ b/crates/gwt/playwright/README.md
@@ -58,14 +58,14 @@ The spec covers (chromium-dark + chromium-light):
 | `ready surfaces the green badge with the steady-state label` | T-IDX-104 green |
 | `skipped keeps the badge hidden so non-git projects do not flash chrome` | T-IDX-104 hidden 分岐 |
 | `error surfaces the red badge with the failure title` | T-IDX-104 error title |
-| `badge click dispatches settings:open with target=index` | T-IDX-105 dispatch |
-| `badge transitions repair_required -> repairing -> ready over WebSocket events` | T-IDX-109 state machine |
-| `project tab dot reflects aggregated worktree health` | T-IDX-107 single-worktree |
+| `badge click dispatches settings:open with target=index (T-IDX-105)` | T-IDX-105 dispatch |
+| `badge transitions repair_required -> repairing -> ready over WebSocket events (T-IDX-109)` | T-IDX-109 state machine |
+| `project tab dot reflects aggregated worktree health (T-IDX-107)` | T-IDX-107 single-worktree |
 | `multi-worktree dot aggregates: unhealthy in one worktree turns the dot red` | T-IDX-107 multi-worktree |
-| `badge click opens Settings.Index tab and renders the scope health table` | T-IDX-106 panel + table |
+| `badge click opens Settings.Index tab and renders the scope health table (T-IDX-106)` | T-IDX-106 panel + table |
 | `Settings.Index scope-row Rebuild all dispatches without worktree_hash` | T-IDX-102 scope-row dispatch |
-| `Settings.Index per-cell Rebuild dispatches rebuild_index_cell IPC` | T-IDX-102 per-cell / T-IDX-110 retry |
-| `repairing click shows a progress toast` | T-IDX-108 toast |
+| `Settings.Index per-cell Rebuild dispatches rebuild_index_cell IPC (T-IDX-102/T-IDX-110)` | T-IDX-102 per-cell / T-IDX-110 retry |
+| `repairing click shows a progress toast (T-IDX-108)` | T-IDX-108 toast |
 
 ### Optional production debugging seams
 

--- a/docs/spec-1939-phase-12-manual-smoke.md
+++ b/docs/spec-1939-phase-12-manual-smoke.md
@@ -29,10 +29,27 @@ SPEC-1939 Issue #2584 can close.
    the gwt GUI's *Start Work* flow against an existing project — agent
    CLIs do not create worktrees, so do not invoke `git worktree add`
    from automation.
-4. Optional: pre-seed an unhealthy index scope by deleting one
-   worktree's chroma store under `~/.gwt/index/<repo-hash>/worktrees/
-   <wt-hash>/files/`. This forces the bootstrap path into
-   `repair_required` so the auto-rebuild orchestrator runs.
+4. Optional: pre-seed an unhealthy index scope so the bootstrap path
+   enters `repair_required` and the auto-rebuild orchestrator runs.
+   The chroma stores live under `~/.gwt/index/<repo-hash>/worktrees/
+   <wt-hash>/files/`. The 16-char `repo-hash` is computed from the
+   project's git remote URL (or local path when no remote is set), and
+   each worktree gets its own `wt-hash` directory. The simplest recipe:
+
+   ```bash
+   # 1. List the indexed worktrees for the active gwt project (run from
+   #    inside the project's repo root):
+   ls -d ~/.gwt/index/*/worktrees/*/
+
+   # 2. Pick one of those `<wt-hash>/` directories and remove its `files/`
+   #    chroma store to force `manifest_missing`:
+   rm -rf ~/.gwt/index/<repo-hash>/worktrees/<wt-hash>/files
+   ```
+
+   When you re-launch `gwt`, the bootstrap probe should detect the
+   missing chroma store, surface the red `Index: repair` badge for one
+   tick, then transition through `Index: repairing` (yellow + spinner)
+   to `Index: ready` (green) once the orchestrator rebuilds the scope.
 
 ## T-IDX-111 — macOS manual smoke
 


### PR DESCRIPTION
## Summary

SPEC-1939 Phase 12 のドキュメント整備で、reviewer 動線の hygiene を 2 箇所改善します:

### 1. `crates/gwt/playwright/README.md` test name alignment (commit `993b5e3a`)

実際の `test()` title (例: `"badge click dispatches settings:open with target=index (T-IDX-105)"`) と README cell 文字列が一致するよう、6 件の test 名に `(T-IDX-XXX)` suffix を追加しました。

```diff
-| `badge click dispatches settings:open with target=index` | T-IDX-105 dispatch |
+| `badge click dispatches settings:open with target=index (T-IDX-105)` | T-IDX-105 dispatch |
```

reviewer が README で `T-IDX-109` を検索 → そのまま `npm run test:visual --grep "(T-IDX-109)"` で同テストに到達できる状態になります。スコープ列は無変更。

### 2. `docs/spec-1939-phase-12-manual-smoke.md` seed recipe (commit `bc725554`)

オプションの「unhealthy index scope の事前 seed」手順が `~/.gwt/index/<repo-hash>/worktrees/<wt-hash>/files/` のパラメタライズだけで、reviewer に hash 探索を丸投げしていたため、具体的な shell snippet を追加:

```bash
# 1. List the indexed worktrees for the active gwt project:
ls -d ~/.gwt/index/*/worktrees/*/

# 2. Pick one of those `<wt-hash>/` directories and remove its `files/` chroma
#    store to force `manifest_missing`:
rm -rf ~/.gwt/index/<repo-hash>/worktrees/<wt-hash>/files
```

期待される badge transition (`Index: repair` -> `Index: repairing` -> `Index: ready`) も末尾に明記し、orchestrator が走ったかを reviewer が読み取れるようにしました。

## Test plan

- [x] `npx markdownlint-cli docs/spec-1939-phase-12-manual-smoke.md crates/gwt/playwright/README.md` clean
- [x] spec ファイルとの 1:1 対応を grep で確認 (`grep -n 'test(' crates/gwt/playwright/tests/index-status.spec.ts` の 13 件と README 13 行が完全一致)
- [x] 実機で `ls -d ~/.gwt/index/*/worktrees/*/` を走らせ、出力フォーマットが doc snippet と一致することを確認

## Notes

production behavior は触らない。documentation only。SPEC-1939 Phase 12 の追加整備で、T-IDX-111/112 を担当する reviewer の動線を一段なめらかにします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
