### PR TITLE
docs: document hook forward bridge

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -200,6 +200,14 @@ Managed hooks は user hook を保持しながら、Agent state、workflow guard
 Board reminders、discussion/plan/build Stop checks、coordination-event summaries
 を追加します。
 
+gwt から起動された Agent に live GUI / browser backend がある場合、managed hook
+は local hook-forward bridge も有効にします。この bridge は、その session に
+gwt が注入した loopback endpoint と bearer token だけへ hook event を POST し、
+既存の live event stream 経由で frontend client へ fan-out します。gwt 外から
+起動した session には転送先が注入されないため、`gwt hook forward` は silent
+no-op のままです。古い転送先、接続拒否、validation error、delivery timeout は
+fail-open の診断情報として扱われ、Agent の tool call を block しません。
+
 ## ワークスペース基盤
 
 Agent session の隔離と再現性のため、gwt は各プロジェクトをワークスペース

--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ Managed hooks preserve user hooks while adding gwt runtime behavior for agent
 state, workflow guardrails, Board reminders, discussion/plan/build Stop checks,
 and coordination-event summaries.
 
+When an agent is launched by gwt with a live GUI/browser backend, managed hooks
+also enable the local hook-forward bridge. The bridge posts hook events only to
+the loopback endpoint and bearer token that gwt injects for that session, then
+fans them out through the existing live event stream. Sessions started outside
+gwt do not receive that target and `gwt hook forward` remains a silent no-op;
+stale targets, refused connections, validation errors, and delivery timeouts are
+fail-open diagnostics and do not block agent tool calls.
+
 ## Workspace Foundation
 
 For isolation and repeatable agent sessions, gwt can manage each project as a


### PR DESCRIPTION
## Summary

- Document the local hook-forward bridge so operators know it is limited to gwt-launched live GUI and browser sessions.
- Capture the fail-open behavior for stale endpoints, invalid tokens, refused connections, and timeout diagnostics.

## Changes

- `README.md`: Adds English operator guidance for the hook-forward bridge, injected loopback endpoint, bearer token, non-gwt no-op behavior, and fail-open diagnostics.
- `README.ja.md`: Adds the equivalent Japanese guidance so both READMEs stay aligned.
- `SPEC #2022 tasks`: Marks the remaining verification and documentation tasks complete with command evidence.

## Testing

- [x] `bunx markdownlint-cli README.md README.ja.md` - passed.
- [x] `rg -n "remote forward|arbitrary remote|configure.*forward|forward endpoint" README.md README.ja.md` - no matches, confirming docs do not describe arbitrary remote forwarding.
- [x] `cargo test -p gwt-skills settings_local -- --nocapture` - passed.
- [x] `cargo test -p gwt --test daemon_runtime_hook_test -- --nocapture` - passed.
- [x] `cargo test -p gwt-core -p gwt -p gwt-skills` - passed.
- [x] `cargo clippy -p gwt-core -p gwt -p gwt-skills --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `git diff --check` - passed.
- [x] `cargo build -p gwt` - passed.
- [x] Pre-push coverage gate - passed with 90.33% filtered line coverage.

## Closing Issues

- Closes #2022

## Related Issues / Links

- #2022

## Checklist

- [ ] Tests added/updated - Documentation-only change; existing hook-forward tests covered the behavior and were rerun.
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) - Not applicable; no schema or data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit)
