### PR TITLE
docs(skills): align release quick reference

### DIFF
--- a/.codex/skills/release/SKILL.md
+++ b/.codex/skills/release/SKILL.md
@@ -1,21 +1,19 @@
 ---
 name: release
-description: "developブランチでバージョン更新を行い、mainへのRelease PRを作成します。Use when the user says '/release', 'リリース', 'release PR', or wants to create a new version release."
+description: "Update the version on develop and create a Release PR to main. Use when the user says '/release', 'リリース', 'release PR', or wants to create a new version release."
 ---
 
 # Release
 
-developブランチでバージョン更新・CHANGELOG更新を行い、main への Release PR を作成します。
+Update the version and changelog on `develop`, then create or update the Release PR to `main`.
 
 ## Instructions
 
-このスキルは `.claude/commands/release.md` に定義されたリリースフローに従って実行してください。
-
-詳細な手順は `.claude/commands/release.md` を参照してください。
+Follow the release flow defined in `.claude/commands/release.md`. Treat that command file as the canonical procedure for branch checks, version classification, approval, file mutation, issue reference collection, and PR creation.
 
 ## Quick Reference
 
-### フロー概要
+### Flow
 
 ```
 develop (バージョン更新・CHANGELOG更新) → main (PR)
@@ -23,21 +21,21 @@ develop (バージョン更新・CHANGELOG更新) → main (PR)
                                   GitHub Release & npm publish (自動)
 ```
 
-### 前提条件
+### Preconditions
 
-- `develop` ブランチにチェックアウトしていること
-- `git-cliff` がインストールされていること
-- `gh` CLI が認証済み
-- 前回リリースタグ以降にコミットがあること
+- Work is running on the `develop` branch.
+- `git-cliff` is installed.
+- GitHub authentication is available.
+- At least one unreleased commit exists after the latest `v*` tag.
 
-### 主な手順
+### Main Steps
 
-1. ブランチ確認（developであること）
-2. リモート同期（fetch & pull）
-3. リリース対象コミット確認
-4. バージョン判定（git-cliff --bumped-version）
-5. ファイル更新（Cargo.toml, package.json, Cargo.lock, CHANGELOG.md）
-6. リリースコミット作成
-7. developをプッシュ
-8. develop → main のPR作成
-9. 完了メッセージ表示
+1. Confirm the current branch is `develop`.
+2. Fetch `origin/main`, `origin/develop`, and tags, then pull `origin/develop`.
+3. Identify the latest `v*` tag and confirm there are unreleased commits.
+4. Classify the next version from commits after the latest tag: breaking change -> major, `feat` -> minor, `fix` -> patch, otherwise patch. Do not use `git-cliff --bumped-version`.
+5. Present the computed version, changelog preview, and commit list to the user, then wait for explicit approval.
+6. Update `Cargo.toml`, `package.json`, `Cargo.lock`, and `CHANGELOG.md`.
+7. Create `chore(release): v{VERSION}` on `develop` and push it.
+8. Collect Closing Issues with `scripts/release_issue_refs.py`; keep `gwt-spec` Issues reference-only.
+9. Create or update the `develop -> main` Release PR and report the result.


### PR DESCRIPTION
## Summary

- Align the release skill quick reference with the canonical `/release` command workflow so agents use the current release classification rules.
- Record SPEC-1932 completion evidence for the release-flow reconciliation work.

## Changes

- `.codex/skills/release/SKILL.md`: Points agents to `.claude/commands/release.md` as the canonical release runbook, uses latest-tag-relative version classification, and explicitly avoids `git-cliff --bumped-version`.
- `SPEC-1932 tasks`: Marks the remaining release-flow reconciliation tasks complete with verification evidence.

## Testing

- [x] `npm run --silent test:release-assets` - passed.
- [x] `python3 -m unittest scripts/test_release_issue_refs.py` - passed.
- [x] `npm run --silent test:release-flow` - passed.
- [x] `npm run lint:skills` - passed.
- [x] `bunx markdownlint-cli .codex/skills/release/SKILL.md` - passed.
- [x] `git diff --check` - passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.
- [x] `git push origin work/20260510-0358` - pre-push checks passed with filtered line coverage 90.34% (threshold 90.00%).

## Closing Issues

- Closes #1932

## Related Issues / Links

- #1932

## Checklist

- [ ] Tests added/updated - not applicable; this is a docs/skill runbook alignment with existing release-flow tests exercised.
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) - release-flow checks, skill lint, markdownlint, diff check, commitlint, and pre-push coverage passed; no production code changed.
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) - not applicable; no schema or data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- SPEC-1932 reconciles release workflow documentation with the implemented release checks: latest-tag-relative version classification, release asset validation, and keeping `gwt-spec` references out of auto-close release issue collection.
