### PR TITLE
feat(runtime): bridge runtime events through daemon

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3365,8 +3365,30 @@ impl AppRuntime {
         id: String,
         data: Vec<u8>,
     ) -> Vec<OutboundEvent> {
-        if !self.window_lookup.contains_key(&id) {
+        self.handle_runtime_output_inner(id, data, true)
+    }
+
+    pub(crate) fn handle_daemon_runtime_output(
+        &mut self,
+        id: String,
+        data: Vec<u8>,
+    ) -> Vec<OutboundEvent> {
+        self.handle_runtime_output_inner(id, data, false)
+    }
+
+    fn handle_runtime_output_inner(
+        &mut self,
+        id: String,
+        data: Vec<u8>,
+        publish_to_daemon: bool,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(&id).cloned() else {
             return Vec::new();
+        };
+        if publish_to_daemon {
+            if let Some(tab) = self.tab(&address.tab_id) {
+                publish_runtime_output_change(&tab.project_root, &id, &data);
+            }
         }
         vec![OutboundEvent::broadcast(BackendEvent::TerminalOutput {
             id,
@@ -3380,6 +3402,25 @@ impl AppRuntime {
         status: WindowProcessStatus,
         detail: Option<String>,
     ) -> Vec<OutboundEvent> {
+        self.handle_runtime_status_inner(id, status, detail, true)
+    }
+
+    pub(crate) fn handle_daemon_runtime_status(
+        &mut self,
+        id: String,
+        status: WindowProcessStatus,
+        detail: Option<String>,
+    ) -> Vec<OutboundEvent> {
+        self.handle_runtime_status_inner(id, status, detail, false)
+    }
+
+    fn handle_runtime_status_inner(
+        &mut self,
+        id: String,
+        status: WindowProcessStatus,
+        detail: Option<String>,
+        publish_to_daemon: bool,
+    ) -> Vec<OutboundEvent> {
         let Some(_address) = self.window_lookup.get(&id).cloned() else {
             self.remove_window_state_tracking(&id);
             self.deregister_pty_writer(&id);
@@ -3387,6 +3428,13 @@ impl AppRuntime {
             self.window_details.remove(&id);
             return Vec::new();
         };
+        if publish_to_daemon {
+            if let Some(address) = self.window_lookup.get(&id) {
+                if let Some(tab) = self.tab(&address.tab_id) {
+                    publish_runtime_status_change(&tab.project_root, &id, status, detail.clone());
+                }
+            }
+        }
 
         self.window_pty_statuses.insert(id.clone(), status);
         let composed_status = self.recompute_window_state(&id).unwrap_or(status);
@@ -3445,6 +3493,26 @@ impl AppRuntime {
         &mut self,
         event: gwt::RuntimeHookEvent,
     ) -> Vec<OutboundEvent> {
+        self.handle_runtime_hook_event_inner(event, true)
+    }
+
+    pub(crate) fn handle_daemon_runtime_hook_event(
+        &mut self,
+        event: gwt::RuntimeHookEvent,
+    ) -> Vec<OutboundEvent> {
+        self.handle_runtime_hook_event_inner(event, false)
+    }
+
+    fn handle_runtime_hook_event_inner(
+        &mut self,
+        event: gwt::RuntimeHookEvent,
+        publish_to_daemon: bool,
+    ) -> Vec<OutboundEvent> {
+        if publish_to_daemon {
+            if let Some(project_root) = event.project_root.as_deref().map(PathBuf::from) {
+                publish_runtime_hook_change(&project_root, &event);
+            }
+        }
         let mut events = vec![OutboundEvent::broadcast(BackendEvent::RuntimeHookEvent {
             event: event.clone(),
         })];
@@ -4834,6 +4902,105 @@ fn update_issue_branch_link_with_cache_dir(
     gwt_github::cache::write_atomic(&path, &bytes)
         .map_err(|error| format!("failed to write issue linkage store: {error}"))
 }
+
+#[cfg(unix)]
+fn publish_runtime_output_change(project_root: &Path, id: &str, data: &[u8]) {
+    let project_root_owned = project_root.to_path_buf();
+    let id = id.to_string();
+    let data = data.to_vec();
+    let _ = std::thread::Builder::new()
+        .name("gwt-runtime-output-daemon-publish".to_string())
+        .spawn(move || {
+            let payload =
+                gwt::runtime_daemon_events::runtime_output_payload(&id, &data, std::process::id());
+            let result = gwt::daemon_publisher::publish_event(
+                &project_root_owned,
+                gwt::runtime_daemon_events::RUNTIME_OUTPUT_CHANNEL,
+                payload,
+            );
+            if let Err(err) = result {
+                tracing::debug!(
+                    error = %err,
+                    project_root = %project_root_owned.display(),
+                    window_id = %id,
+                    "runtime output daemon publish failed (non-fatal)"
+                );
+            }
+        });
+}
+
+#[cfg(not(unix))]
+fn publish_runtime_output_change(_project_root: &Path, _id: &str, _data: &[u8]) {}
+
+#[cfg(unix)]
+fn publish_runtime_status_change(
+    project_root: &Path,
+    id: &str,
+    status: WindowProcessStatus,
+    detail: Option<String>,
+) {
+    let project_root_owned = project_root.to_path_buf();
+    let id = id.to_string();
+    let _ = std::thread::Builder::new()
+        .name("gwt-runtime-status-daemon-publish".to_string())
+        .spawn(move || {
+            let payload = gwt::runtime_daemon_events::runtime_status_payload(
+                &id,
+                status,
+                detail,
+                std::process::id(),
+            );
+            let result = gwt::daemon_publisher::publish_event(
+                &project_root_owned,
+                gwt::runtime_daemon_events::RUNTIME_STATUS_CHANNEL,
+                payload,
+            );
+            if let Err(err) = result {
+                tracing::debug!(
+                    error = %err,
+                    project_root = %project_root_owned.display(),
+                    window_id = %id,
+                    "runtime status daemon publish failed (non-fatal)"
+                );
+            }
+        });
+}
+
+#[cfg(not(unix))]
+fn publish_runtime_status_change(
+    _project_root: &Path,
+    _id: &str,
+    _status: WindowProcessStatus,
+    _detail: Option<String>,
+) {
+}
+
+#[cfg(unix)]
+fn publish_runtime_hook_change(project_root: &Path, event: &gwt::RuntimeHookEvent) {
+    let project_root_owned = project_root.to_path_buf();
+    let event = event.clone();
+    let _ = std::thread::Builder::new()
+        .name("gwt-runtime-hook-daemon-publish".to_string())
+        .spawn(move || {
+            let payload =
+                gwt::runtime_daemon_events::runtime_hook_payload(&event, std::process::id());
+            let result = gwt::daemon_publisher::publish_event(
+                &project_root_owned,
+                gwt::runtime_daemon_events::RUNTIME_HOOK_CHANNEL,
+                payload,
+            );
+            if let Err(err) = result {
+                tracing::debug!(
+                    error = %err,
+                    project_root = %project_root_owned.display(),
+                    "runtime hook daemon publish failed (non-fatal)"
+                );
+            }
+        });
+}
+
+#[cfg(not(unix))]
+fn publish_runtime_hook_change(_project_root: &Path, _event: &gwt::RuntimeHookEvent) {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -24,6 +24,7 @@ pub mod preset;
 pub mod process;
 pub mod profile_dispatch;
 pub mod protocol;
+pub mod runtime_daemon_events;
 pub mod start_work;
 pub mod system_settings;
 pub mod window_state;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -474,20 +474,61 @@ fn spawn_board_daemon_subscriber(
     Some(
         gwt::daemon_subscriber::DaemonSubscriber::spawn_with_resolver(
             resolver,
-            vec!["board".to_string(), "workspace".to_string()],
-            move |channel, _payload| {
-                if channel == "board" {
-                    let _ = proxy_for_callback.send_event(UserEvent::BoardProjectionChanged {
-                        project_root: project_root_for_callback.clone(),
-                    });
-                } else if channel == "workspace" {
-                    let _ = proxy_for_callback.send_event(UserEvent::WorkspaceProjectionChanged {
-                        project_root: project_root_for_callback.clone(),
-                    });
+            daemon_subscriber_channels(),
+            move |channel, payload| {
+                if let Some(event) = daemon_broadcast_user_event(
+                    &channel,
+                    payload,
+                    &project_root_for_callback,
+                    std::process::id(),
+                ) {
+                    let _ = proxy_for_callback.send_event(event);
                 }
             },
         ),
     )
+}
+
+#[cfg(unix)]
+fn daemon_subscriber_channels() -> Vec<String> {
+    vec![
+        "board".to_string(),
+        "workspace".to_string(),
+        gwt::runtime_daemon_events::RUNTIME_OUTPUT_CHANNEL.to_string(),
+        gwt::runtime_daemon_events::RUNTIME_STATUS_CHANNEL.to_string(),
+        gwt::runtime_daemon_events::RUNTIME_HOOK_CHANNEL.to_string(),
+    ]
+}
+
+#[cfg(unix)]
+fn daemon_broadcast_user_event(
+    channel: &str,
+    payload: serde_json::Value,
+    project_root: &Path,
+    current_pid: u32,
+) -> Option<UserEvent> {
+    if channel == "board" {
+        return Some(UserEvent::BoardProjectionChanged {
+            project_root: project_root.to_path_buf(),
+        });
+    }
+    if channel == "workspace" {
+        return Some(UserEvent::WorkspaceProjectionChanged {
+            project_root: project_root.to_path_buf(),
+        });
+    }
+
+    match gwt::runtime_daemon_events::decode_runtime_daemon_event(channel, payload, current_pid)? {
+        gwt::runtime_daemon_events::RuntimeDaemonEvent::Output { id, data } => {
+            Some(UserEvent::DaemonRuntimeOutput { id, data })
+        }
+        gwt::runtime_daemon_events::RuntimeDaemonEvent::Status { id, status, detail } => {
+            Some(UserEvent::DaemonRuntimeStatus { id, status, detail })
+        }
+        gwt::runtime_daemon_events::RuntimeDaemonEvent::Hook { event } => {
+            Some(UserEvent::DaemonRuntimeHook(event))
+        }
+    }
 }
 
 // Liveness probe shared with `cli::daemon` and `daemon_publisher`;
@@ -526,7 +567,16 @@ enum UserEvent {
         id: String,
         data: Vec<u8>,
     },
+    DaemonRuntimeOutput {
+        id: String,
+        data: Vec<u8>,
+    },
     RuntimeStatus {
+        id: String,
+        status: WindowProcessStatus,
+        detail: Option<String>,
+    },
+    DaemonRuntimeStatus {
         id: String,
         status: WindowProcessStatus,
         detail: Option<String>,
@@ -538,6 +588,7 @@ enum UserEvent {
         project_root: PathBuf,
     },
     RuntimeHook(gwt::RuntimeHookEvent),
+    DaemonRuntimeHook(gwt::RuntimeHookEvent),
     LaunchProgress {
         window_id: String,
         message: String,
@@ -638,6 +689,110 @@ mod tests {
             width: 1400.0,
             height: 900.0,
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_subscriber_channels_include_runtime_h2_channels() {
+        let channels = super::daemon_subscriber_channels();
+
+        assert!(channels.iter().any(|channel| channel == "board"));
+        assert!(channels.iter().any(|channel| channel == "workspace"));
+        assert!(channels
+            .iter()
+            .any(|channel| channel == gwt::runtime_daemon_events::RUNTIME_OUTPUT_CHANNEL));
+        assert!(channels
+            .iter()
+            .any(|channel| channel == gwt::runtime_daemon_events::RUNTIME_STATUS_CHANNEL));
+        assert!(channels
+            .iter()
+            .any(|channel| channel == gwt::runtime_daemon_events::RUNTIME_HOOK_CHANNEL));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_broadcast_runtime_payloads_map_to_non_republishing_user_events() {
+        let project_root = Path::new("/tmp/gwt-project");
+        let output_payload =
+            gwt::runtime_daemon_events::runtime_output_payload("tab-1::shell-1", b"hello", 42);
+        let status_payload = gwt::runtime_daemon_events::runtime_status_payload(
+            "tab-1::shell-1",
+            WindowProcessStatus::Error,
+            Some("boom".to_string()),
+            42,
+        );
+        let hook_event = RuntimeHookEvent {
+            kind: RuntimeHookEventKind::RuntimeState,
+            source_event: Some("Stop".to_string()),
+            gwt_session_id: Some("session-1".to_string()),
+            agent_session_id: Some("agent-1".to_string()),
+            project_root: Some(project_root.display().to_string()),
+            branch: Some("work/runtime".to_string()),
+            status: Some("waiting".to_string()),
+            tool_name: None,
+            message: None,
+            occurred_at: "2026-05-10T00:00:00Z".to_string(),
+        };
+        let hook_payload = gwt::runtime_daemon_events::runtime_hook_payload(&hook_event, 42);
+
+        match super::daemon_broadcast_user_event(
+            gwt::runtime_daemon_events::RUNTIME_OUTPUT_CHANNEL,
+            output_payload.clone(),
+            project_root,
+            99,
+        ) {
+            Some(UserEvent::DaemonRuntimeOutput { id, data }) => {
+                assert_eq!(id, "tab-1::shell-1");
+                assert_eq!(data, b"hello");
+            }
+            other => panic!("unexpected runtime output event: {other:?}"),
+        }
+        match super::daemon_broadcast_user_event(
+            gwt::runtime_daemon_events::RUNTIME_STATUS_CHANNEL,
+            status_payload.clone(),
+            project_root,
+            99,
+        ) {
+            Some(UserEvent::DaemonRuntimeStatus { id, status, detail }) => {
+                assert_eq!(id, "tab-1::shell-1");
+                assert_eq!(status, WindowProcessStatus::Error);
+                assert_eq!(detail.as_deref(), Some("boom"));
+            }
+            other => panic!("unexpected runtime status event: {other:?}"),
+        }
+        match super::daemon_broadcast_user_event(
+            gwt::runtime_daemon_events::RUNTIME_HOOK_CHANNEL,
+            hook_payload.clone(),
+            project_root,
+            99,
+        ) {
+            Some(UserEvent::DaemonRuntimeHook(event)) => {
+                assert_eq!(event, hook_event);
+            }
+            other => panic!("unexpected runtime hook event: {other:?}"),
+        }
+
+        assert!(super::daemon_broadcast_user_event(
+            gwt::runtime_daemon_events::RUNTIME_OUTPUT_CHANNEL,
+            output_payload,
+            project_root,
+            42,
+        )
+        .is_none());
+        assert!(super::daemon_broadcast_user_event(
+            gwt::runtime_daemon_events::RUNTIME_STATUS_CHANNEL,
+            status_payload,
+            project_root,
+            42,
+        )
+        .is_none());
+        assert!(super::daemon_broadcast_user_event(
+            gwt::runtime_daemon_events::RUNTIME_HOOK_CHANNEL,
+            hook_payload,
+            project_root,
+            42,
+        )
+        .is_none());
     }
 
     #[test]
@@ -5046,8 +5201,16 @@ fn main() -> wry::Result<()> {
                 let events = app.handle_runtime_output(id, data);
                 clients.dispatch(events);
             }
+            Event::UserEvent(UserEvent::DaemonRuntimeOutput { id, data }) => {
+                let events = app.handle_daemon_runtime_output(id, data);
+                clients.dispatch(events);
+            }
             Event::UserEvent(UserEvent::RuntimeStatus { id, status, detail }) => {
                 let events = app.handle_runtime_status(id, status, detail);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::DaemonRuntimeStatus { id, status, detail }) => {
+                let events = app.handle_daemon_runtime_status(id, status, detail);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::BoardProjectionChanged { project_root }) => {
@@ -5060,6 +5223,10 @@ fn main() -> wry::Result<()> {
             }
             Event::UserEvent(UserEvent::RuntimeHook(event)) => {
                 let events = app.handle_runtime_hook_event(event);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::DaemonRuntimeHook(event)) => {
+                let events = app.handle_daemon_runtime_hook_event(event);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::LaunchProgress { window_id, message }) => {

--- a/crates/gwt/src/runtime_daemon_events.rs
+++ b/crates/gwt/src/runtime_daemon_events.rs
@@ -1,0 +1,199 @@
+use base64::{engine::general_purpose, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::WindowProcessStatus;
+
+pub const RUNTIME_OUTPUT_CHANNEL: &str = "runtime_output";
+pub const RUNTIME_STATUS_CHANNEL: &str = "runtime_status";
+pub const RUNTIME_HOOK_CHANNEL: &str = "runtime_hook";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeDaemonEvent {
+    Output {
+        id: String,
+        data: Vec<u8>,
+    },
+    Status {
+        id: String,
+        status: WindowProcessStatus,
+        detail: Option<String>,
+    },
+    Hook {
+        event: crate::RuntimeHookEvent,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuntimeOutputPayload {
+    source_pid: u32,
+    id: String,
+    data_base64: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuntimeStatusPayload {
+    source_pid: u32,
+    id: String,
+    status: WindowProcessStatus,
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuntimeHookPayload {
+    source_pid: u32,
+    event: crate::RuntimeHookEvent,
+}
+
+pub fn runtime_output_payload(id: &str, data: &[u8], source_pid: u32) -> Value {
+    serde_json::to_value(RuntimeOutputPayload {
+        source_pid,
+        id: id.to_string(),
+        data_base64: general_purpose::STANDARD.encode(data),
+    })
+    .expect("runtime output payload serializes")
+}
+
+pub fn runtime_status_payload(
+    id: &str,
+    status: WindowProcessStatus,
+    detail: Option<String>,
+    source_pid: u32,
+) -> Value {
+    serde_json::to_value(RuntimeStatusPayload {
+        source_pid,
+        id: id.to_string(),
+        status,
+        detail,
+    })
+    .expect("runtime status payload serializes")
+}
+
+pub fn runtime_hook_payload(event: &crate::RuntimeHookEvent, source_pid: u32) -> Value {
+    serde_json::to_value(RuntimeHookPayload {
+        source_pid,
+        event: event.clone(),
+    })
+    .expect("runtime hook payload serializes")
+}
+
+pub fn decode_runtime_daemon_event(
+    channel: &str,
+    payload: Value,
+    current_pid: u32,
+) -> Option<RuntimeDaemonEvent> {
+    match channel {
+        RUNTIME_OUTPUT_CHANNEL => {
+            let payload: RuntimeOutputPayload = serde_json::from_value(payload).ok()?;
+            if payload.source_pid == current_pid {
+                return None;
+            }
+            let data = general_purpose::STANDARD
+                .decode(payload.data_base64.as_bytes())
+                .ok()?;
+            Some(RuntimeDaemonEvent::Output {
+                id: payload.id,
+                data,
+            })
+        }
+        RUNTIME_STATUS_CHANNEL => {
+            let payload: RuntimeStatusPayload = serde_json::from_value(payload).ok()?;
+            if payload.source_pid == current_pid {
+                return None;
+            }
+            Some(RuntimeDaemonEvent::Status {
+                id: payload.id,
+                status: payload.status,
+                detail: payload.detail,
+            })
+        }
+        RUNTIME_HOOK_CHANNEL => {
+            let payload: RuntimeHookPayload = serde_json::from_value(payload).ok()?;
+            if payload.source_pid == current_pid {
+                return None;
+            }
+            Some(RuntimeDaemonEvent::Hook {
+                event: payload.event,
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        decode_runtime_daemon_event, runtime_hook_payload, runtime_output_payload,
+        runtime_status_payload, RuntimeDaemonEvent, RUNTIME_HOOK_CHANNEL, RUNTIME_OUTPUT_CHANNEL,
+        RUNTIME_STATUS_CHANNEL,
+    };
+    use crate::{RuntimeHookEvent, RuntimeHookEventKind, WindowProcessStatus};
+
+    #[test]
+    fn runtime_output_payload_round_trips_and_ignores_same_process() {
+        let payload = runtime_output_payload("tab-1::shell-1", b"hello", 42);
+
+        assert_eq!(
+            decode_runtime_daemon_event(RUNTIME_OUTPUT_CHANNEL, payload.clone(), 99),
+            Some(RuntimeDaemonEvent::Output {
+                id: "tab-1::shell-1".to_string(),
+                data: b"hello".to_vec(),
+            })
+        );
+        assert_eq!(
+            decode_runtime_daemon_event(RUNTIME_OUTPUT_CHANNEL, payload, 42),
+            None
+        );
+    }
+
+    #[test]
+    fn runtime_status_payload_round_trips_and_ignores_same_process() {
+        let payload = runtime_status_payload(
+            "tab-1::shell-1",
+            WindowProcessStatus::Error,
+            Some("boom".to_string()),
+            42,
+        );
+
+        assert_eq!(
+            decode_runtime_daemon_event(RUNTIME_STATUS_CHANNEL, payload.clone(), 99),
+            Some(RuntimeDaemonEvent::Status {
+                id: "tab-1::shell-1".to_string(),
+                status: WindowProcessStatus::Error,
+                detail: Some("boom".to_string()),
+            })
+        );
+        assert_eq!(
+            decode_runtime_daemon_event(RUNTIME_STATUS_CHANNEL, payload, 42),
+            None
+        );
+    }
+
+    #[test]
+    fn runtime_hook_payload_round_trips_and_ignores_same_process() {
+        let event = RuntimeHookEvent {
+            kind: RuntimeHookEventKind::RuntimeState,
+            source_event: Some("Stop".to_string()),
+            gwt_session_id: Some("session-1".to_string()),
+            agent_session_id: Some("agent-1".to_string()),
+            project_root: Some("/tmp/project".to_string()),
+            branch: Some("work/runtime".to_string()),
+            status: Some("waiting".to_string()),
+            tool_name: None,
+            message: None,
+            occurred_at: "2026-05-10T00:00:00Z".to_string(),
+        };
+        let payload = runtime_hook_payload(&event, 42);
+
+        assert_eq!(
+            decode_runtime_daemon_event(RUNTIME_HOOK_CHANNEL, payload.clone(), 99),
+            Some(RuntimeDaemonEvent::Hook {
+                event: event.clone(),
+            })
+        );
+        assert_eq!(
+            decode_runtime_daemon_event(RUNTIME_HOOK_CHANNEL, payload, 42),
+            None
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Bridges runtime output, status, and hook events through the existing gwtd daemon broadcast channel so attached gwt instances share one runtime event source.
- Adds source-pid echo suppression so the publishing process keeps its local hot path while daemon-subscribed events do not loop back into another publish.
- Updates SPEC-2077 tasks for Phase H2/H3 and leaves Phase H4 open because launch lifecycle ownership needs a separate design.

## Changes

- `crates/gwt/src/runtime_daemon_events.rs`: adds typed runtime daemon channels, JSON payload builders, decoding, base64 terminal output transport, and self-pid filtering tests.
- `crates/gwt/src/app_runtime/mod.rs`: publishes local runtime output/status/hook changes to gwtd best-effort and adds non-republishing daemon handlers.
- `crates/gwt/src/main.rs`: subscribes the daemon listener to runtime channels and maps daemon frames into daemon-specific user events.
- `~/.gwt/cache/issues/.../2077/sections/tasks.md`: marks SPEC-2077 H2/H3 tasks complete with verification evidence and records H4 as remaining work.

## Testing

- [x] `cargo test -p gwt runtime_daemon_events -- --nocapture` - passed.
- [x] `cargo test -p gwt daemon_broadcast_runtime_payloads_map_to_non_republishing_user_events -- --nocapture` - passed.
- [x] `cargo test -p gwt daemon_ -- --nocapture` - passed.
- [x] `cargo test -p gwt runtime_status -- --nocapture` - passed.
- [x] `cargo test -p gwt runtime_hook -- --nocapture` - passed.
- [x] `cargo test -p gwt-core -p gwt` - passed.
- [x] `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `cargo build -p gwt` - passed.
- [x] Pre-push CI-equivalent coverage hook - passed, filtered line coverage 90.37%.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.

## Closing Issues

- None

## Related Issues / Links

- #2077

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2077 tasks updated; no user-facing docs change required)
- [x] Migration/backfill plan included (no schema/data migration)
- [x] CHANGELOG impact considered (feature commit, no breaking change)

## Context

- SPEC-2077 Phase H2/H3 moves runtime output/status and managed hook event fanout onto the daemon broadcast primitive that Phase H1 established for Board projection events.

## Risk / Impact

- **Affected areas**: GUI runtime event dispatch, daemon subscriber channel list, terminal output/status fanout, hook live event broadcast.
- **Rollback plan**: Revert this PR; existing local runtime event dispatch remains the source of truth when daemon publish fails.

## Notes

- Phase H4 remains open. `handle_launch_complete` and `handle_shell_launch_complete` own `ProcessLaunch`, PTY spawning, active session registration, issue branch linkage, and workspace projection persistence, so they need a dedicated RED test and daemon-owned launch lifecycle design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for publishing and receiving runtime events (output, status, and hook changes) through daemon channels.
  * Implemented event payload serialization and deserialization layer for daemon communication.

* **Refactor**
  * Refactored runtime event handlers to enable multi-channel event routing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2611)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->