### PR TITLE
feat(migration): migrate linked worktrees

### DIFF
--- a/crates/gwt-git/src/migration.rs
+++ b/crates/gwt-git/src/migration.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use gwt_core::{process::hidden_command, GwtError, Result};
+use gwt_core::{migration::WorktreeMigration, process::hidden_command, GwtError, Result};
 
 /// Clone a Normal repository's `origin` URL into `<target>` as a bare repo
 /// (FR-021). The full history is preserved so subsequent worktree adds resolve
@@ -120,6 +120,126 @@ pub fn copy_hooks_to_bare(source_dot_git: &Path, bare: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Parse `git worktree list --porcelain` output into migration worktree
+/// records. Detached worktrees are ignored because the migration layout is
+/// branch-addressed.
+pub fn parse_worktree_list_porcelain(stdout: &str, project_root: &Path) -> Vec<WorktreeMigration> {
+    #[derive(Default)]
+    struct Entry {
+        path: Option<PathBuf>,
+        branch: Option<String>,
+        is_locked: bool,
+    }
+
+    fn flush(
+        entries: &mut Vec<WorktreeMigration>,
+        current: &mut Entry,
+        project_root: &Path,
+        canonical_project_root: Option<&Path>,
+    ) {
+        let Some(path) = current.path.take() else {
+            *current = Entry::default();
+            return;
+        };
+        let Some(branch) = current.branch.take() else {
+            *current = Entry::default();
+            return;
+        };
+        let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        let is_main_repo = canonical_project_root
+            .map(|root| canonical_path == root)
+            .unwrap_or_else(|| path == project_root);
+        entries.push(WorktreeMigration {
+            path,
+            branch,
+            is_main_repo,
+            is_dirty: false,
+            is_locked: current.is_locked,
+        });
+        *current = Entry::default();
+    }
+
+    let canonical_project_root = std::fs::canonicalize(project_root).ok();
+    let mut entries = Vec::new();
+    let mut current = Entry::default();
+
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            flush(
+                &mut entries,
+                &mut current,
+                project_root,
+                canonical_project_root.as_deref(),
+            );
+            current.path = Some(PathBuf::from(rest.trim()));
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            let branch = rest
+                .trim()
+                .strip_prefix("refs/heads/")
+                .unwrap_or_else(|| rest.trim())
+                .to_string();
+            if !branch.is_empty() {
+                current.branch = Some(branch);
+            }
+        } else if line.starts_with("locked") {
+            current.is_locked = true;
+        } else if line.is_empty() {
+            flush(
+                &mut entries,
+                &mut current,
+                project_root,
+                canonical_project_root.as_deref(),
+            );
+        }
+    }
+    flush(
+        &mut entries,
+        &mut current,
+        project_root,
+        canonical_project_root.as_deref(),
+    );
+
+    entries
+}
+
+/// List branch-backed worktrees for a Normal repository and mark their current
+/// dirty state.
+pub fn list_worktrees(project_root: &Path) -> Result<Vec<WorktreeMigration>> {
+    let output = hidden_command("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(project_root)
+        .output()
+        .map_err(|e| GwtError::Git(format!("git worktree list: {e}")))?;
+    if !output.status.success() {
+        return Err(GwtError::Git(format!(
+            "git worktree list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut worktrees = parse_worktree_list_porcelain(&stdout, project_root);
+    for worktree in &mut worktrees {
+        worktree.is_dirty = worktree_dirty(&worktree.path).unwrap_or(false);
+    }
+    Ok(worktrees)
+}
+
+fn worktree_dirty(path: &Path) -> Result<bool> {
+    let output = hidden_command("git")
+        .args(["status", "--porcelain"])
+        .current_dir(path)
+        .output()
+        .map_err(|e| GwtError::Git(format!("git status --porcelain: {e}")))?;
+    if !output.status.success() {
+        return Err(GwtError::Git(format!(
+            "git status --porcelain failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
 /// File-system entries that must never be moved by the dirty-file

--- a/crates/gwt-git/tests/migration_test.rs
+++ b/crates/gwt-git/tests/migration_test.rs
@@ -6,8 +6,8 @@
 
 use gwt_git::migration::{
     add_worktree_clean, add_worktree_no_checkout, bareify_local, clone_bare_from_normal,
-    copy_hooks_to_bare, evacuate_dirty_files, init_submodules, restore_evacuated_files,
-    set_upstream,
+    copy_hooks_to_bare, evacuate_dirty_files, init_submodules, parse_worktree_list_porcelain,
+    restore_evacuated_files, set_upstream,
 };
 use gwt_git::repository::{detect_repo_type, install_develop_protection, RepoType};
 
@@ -242,6 +242,28 @@ fn t052_dirty_worktree_evacuate_no_checkout_restore_round_trip() {
         std::fs::read_to_string(new_worktree.join("nested").join("note.md")).unwrap(),
         "still here"
     );
+}
+
+#[test]
+fn t054_parse_worktree_list_porcelain_identifies_branch_worktrees() {
+    let project = tempfile::tempdir().unwrap();
+    let root = project.path();
+    let stdout = format!(
+        "worktree {root}\nHEAD abc\nbranch refs/heads/main\n\nworktree {root}/feature/clean\nHEAD def\nbranch refs/heads/feature/clean\n\nworktree {root}/detached\nHEAD 123\ndetached\n\n",
+        root = root.display()
+    );
+
+    let worktrees = parse_worktree_list_porcelain(&stdout, root);
+
+    assert_eq!(
+        worktrees.len(),
+        2,
+        "detached worktree is not branch-addressed"
+    );
+    assert!(worktrees[0].is_main_repo);
+    assert_eq!(worktrees[0].branch, "main");
+    assert!(!worktrees[1].is_main_repo);
+    assert_eq!(worktrees[1].branch, "feature/clean");
 }
 
 #[test]

--- a/crates/gwt/src/migration/executor.rs
+++ b/crates/gwt/src/migration/executor.rs
@@ -7,7 +7,7 @@
 
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use chrono::Utc;
@@ -16,6 +16,7 @@ use gwt_core::migration::backup::{self, BackupSnapshot};
 use gwt_core::migration::rollback;
 use gwt_core::migration::types::{
     MigrationError, MigrationOptions, MigrationOutcome, MigrationPhase, RecoveryState,
+    WorktreeMigration,
 };
 use gwt_core::migration::validator;
 use gwt_git::migration as git_migration;
@@ -103,70 +104,92 @@ fn run_post_backup(
     })?;
 
     progress(MigrationPhase::Worktrees, 0);
-    let branch = current_branch(&dot_git, project_root)
-        .or_else(|| current_branch(&bare_repo_path, &bare_repo_path))
-        .or_else(|| options.branch_override.clone())
-        .unwrap_or_else(|| "develop".to_string());
-    let branch_worktree = project_root.join(&branch);
+    let mut worktrees = migration_worktrees(project_root, &dot_git, &bare_repo_path, options)?;
+    worktrees.sort_by_key(|worktree| !worktree.is_main_repo);
+    remove_copied_worktree_metadata(&bare_repo_path).map_err(|e| MigrationError {
+        phase: MigrationPhase::Worktrees,
+        message: e.to_string(),
+        recovery: RecoveryState::Partial,
+    })?;
 
-    // Step 1: evacuate everything except `.git`, the bare repo, and the
-    // backup. The evacuation root lives inside the backup dir so it is
-    // automatically excluded from the walk (`.gwt-migration-backup` is in
-    // EVACUATION_EXCLUSIONS).
-    let evacuation_root = snapshot.backup_dir.join("evacuation");
-    if let Err(e) = fs::create_dir_all(&evacuation_root) {
-        return Err(MigrationError {
-            phase: MigrationPhase::Worktrees,
-            message: format!("create evacuation dir: {e}"),
-            recovery: RecoveryState::Partial,
-        });
+    let main_exclusions =
+        main_worktree_top_level_exclusions(project_root, &bare_target, &worktrees);
+    let mut migrated_worktrees = Vec::with_capacity(worktrees.len());
+    for worktree in &worktrees {
+        let target = worktree_target_path(project_root, &worktree.branch);
+        let evacuation_root = snapshot
+            .backup_dir
+            .join("evacuation")
+            .join(sanitize_branch_for_path(&worktree.branch));
+
+        if let Err(e) = fs::create_dir_all(&evacuation_root) {
+            return Err(MigrationError {
+                phase: MigrationPhase::Worktrees,
+                message: format!("create evacuation dir: {e}"),
+                recovery: RecoveryState::Partial,
+            });
+        }
+
+        if worktree.is_main_repo {
+            move_top_level_into(project_root, &evacuation_root, &main_exclusions).map_err(|e| {
+                MigrationError {
+                    phase: MigrationPhase::Worktrees,
+                    message: e.to_string(),
+                    recovery: RecoveryState::Partial,
+                }
+            })?;
+        } else {
+            git_migration::evacuate_dirty_files(&worktree.path, &evacuation_root).map_err(|e| {
+                MigrationError {
+                    phase: MigrationPhase::Worktrees,
+                    message: e.to_string(),
+                    recovery: RecoveryState::Partial,
+                }
+            })?;
+            if worktree.path.exists() {
+                fs::remove_dir_all(&worktree.path).map_err(|e| MigrationError {
+                    phase: MigrationPhase::Worktrees,
+                    message: format!("remove old worktree {}: {e}", worktree.path.display()),
+                    recovery: RecoveryState::Partial,
+                })?;
+            }
+        }
+
+        git_migration::add_worktree_no_checkout(&bare_repo_path, &target, &worktree.branch)
+            .map_err(|e| MigrationError {
+                phase: MigrationPhase::Worktrees,
+                message: e.to_string(),
+                recovery: RecoveryState::Partial,
+            })?;
+
+        git_migration::restore_evacuated_files(&evacuation_root, &target).map_err(|e| {
+            MigrationError {
+                phase: MigrationPhase::Worktrees,
+                message: e.to_string(),
+                recovery: RecoveryState::Partial,
+            }
+        })?;
+
+        // Best-effort index refresh after restoring the evacuated tree.
+        let _ = gwt_core::process::hidden_command("git")
+            .args(["reset"])
+            .current_dir(&target)
+            .output();
+
+        migrated_worktrees.push(target);
     }
-    let bare_basename = bare_target
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string());
-    move_top_level_into(project_root, &evacuation_root, bare_basename.as_deref()).map_err(|e| {
-        MigrationError {
-            phase: MigrationPhase::Worktrees,
-            message: e.to_string(),
-            recovery: RecoveryState::Partial,
-        }
-    })?;
 
-    // Step 2: create the new worktree, importing whatever the bare repo has at HEAD.
-    git_migration::add_worktree_no_checkout(&bare_repo_path, &branch_worktree, &branch).map_err(
-        |e| MigrationError {
-            phase: MigrationPhase::Worktrees,
-            message: e.to_string(),
-            recovery: RecoveryState::Partial,
-        },
-    )?;
-
-    // Step 3: bring evacuated files into the new worktree.
-    git_migration::restore_evacuated_files(&evacuation_root, &branch_worktree).map_err(|e| {
-        MigrationError {
-            phase: MigrationPhase::Worktrees,
-            message: e.to_string(),
-            recovery: RecoveryState::Partial,
-        }
-    })?;
-
-    // Step 4: re-sync the index so the working tree reports the same status as
-    // before the migration. Best-effort: if the worktree had no checkout we
-    // still want to clear `git status` of the synthetic deletions added by
-    // `--no-checkout`.
-    let _ = gwt_core::process::hidden_command("git")
-        .args(["reset"])
-        .current_dir(&branch_worktree)
-        .output();
-
-    // Cleanup the evacuation scratch dir.
-    let _ = fs::remove_dir_all(&evacuation_root);
+    let _ = fs::remove_dir_all(snapshot.backup_dir.join("evacuation"));
 
     progress(MigrationPhase::Submodules, 0);
-    let _ = git_migration::init_submodules(&branch_worktree);
+    for worktree in &migrated_worktrees {
+        let _ = git_migration::init_submodules(worktree);
+    }
 
     progress(MigrationPhase::Tracking, 0);
-    let _ = git_migration::set_upstream(&branch_worktree, &branch);
+    for (migration, worktree) in worktrees.iter().zip(migrated_worktrees.iter()) {
+        let _ = git_migration::set_upstream(worktree, &migration.branch);
+    }
 
     progress(MigrationPhase::Cleanup, 0);
     if dot_git.exists() {
@@ -190,10 +213,98 @@ fn run_post_backup(
     })?;
 
     Ok(MigrationOutcome {
-        branch_worktree_path: branch_worktree,
+        branch_worktree_path: migrated_worktrees
+            .first()
+            .cloned()
+            .unwrap_or_else(|| project_root.to_path_buf()),
         bare_repo_path,
-        migrated_worktrees: vec![project_root.join(&branch)],
+        migrated_worktrees,
     })
+}
+
+fn migration_worktrees(
+    project_root: &Path,
+    dot_git: &Path,
+    bare_repo_path: &Path,
+    options: &MigrationOptions,
+) -> Result<Vec<WorktreeMigration>, MigrationError> {
+    match git_migration::list_worktrees(project_root) {
+        Ok(worktrees) if !worktrees.is_empty() => Ok(worktrees),
+        Ok(_) | Err(_) => {
+            let branch = current_branch(dot_git, project_root)
+                .or_else(|| current_branch(bare_repo_path, bare_repo_path))
+                .or_else(|| options.branch_override.clone())
+                .unwrap_or_else(|| "develop".to_string());
+            Ok(vec![WorktreeMigration {
+                path: project_root.to_path_buf(),
+                branch,
+                is_main_repo: true,
+                is_dirty: false,
+                is_locked: false,
+            }])
+        }
+    }
+}
+
+fn remove_copied_worktree_metadata(bare_repo_path: &Path) -> std::io::Result<()> {
+    let worktrees = bare_repo_path.join("worktrees");
+    match fs::remove_dir_all(worktrees) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn worktree_target_path(project_root: &Path, branch: &str) -> PathBuf {
+    branch
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .fold(project_root.to_path_buf(), |path, segment| {
+            path.join(segment)
+        })
+}
+
+fn sanitize_branch_for_path(branch: &str) -> String {
+    branch
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn main_worktree_top_level_exclusions(
+    project_root: &Path,
+    bare_target: &Path,
+    worktrees: &[WorktreeMigration],
+) -> Vec<String> {
+    let mut exclusions = Vec::new();
+    if let Some(name) = bare_target.file_name().and_then(|name| name.to_str()) {
+        exclusions.push(name.to_string());
+    }
+
+    let canonical_project_root =
+        std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+
+    for worktree in worktrees.iter().filter(|worktree| !worktree.is_main_repo) {
+        let canonical_worktree =
+            std::fs::canonicalize(&worktree.path).unwrap_or_else(|_| worktree.path.clone());
+        let Ok(relative) = canonical_worktree.strip_prefix(&canonical_project_root) else {
+            continue;
+        };
+        let Some(Component::Normal(first)) = relative.components().next() else {
+            continue;
+        };
+        exclusions.push(first.to_string_lossy().to_string());
+    }
+
+    exclusions.sort();
+    exclusions.dedup();
+    exclusions
 }
 
 fn bareify_local_or_fail(
@@ -232,13 +343,10 @@ fn read_origin_url(dot_git: &Path) -> Option<String> {
     }
 }
 
-/// Move every entry of `src` into `dst`, except `.git`, the migration
-/// backup, and an optional named directory (the bare repo we just created).
-fn move_top_level_into(
-    src: &Path,
-    dst: &Path,
-    extra_exclusion: Option<&str>,
-) -> std::io::Result<()> {
+/// Move every top-level entry of `src` into `dst`, except `.git`, the
+/// migration backup, and caller-provided top-level exclusions such as the bare
+/// repo and linked worktree parent directories.
+fn move_top_level_into(src: &Path, dst: &Path, extra_exclusions: &[String]) -> std::io::Result<()> {
     const ALWAYS_EXCLUDED: &[&str] = &[".git", ".gwt-migration-backup"];
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
@@ -248,7 +356,10 @@ fn move_top_level_into(
         if ALWAYS_EXCLUDED.iter().any(|e| **e == *name_str) {
             continue;
         }
-        if extra_exclusion == Some(&name_str) {
+        if extra_exclusions
+            .iter()
+            .any(|excluded| excluded == &name_str)
+        {
             continue;
         }
         let from = entry.path();

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -127,6 +127,109 @@ fn t101_dirty_normal_repo_preserves_uncommitted_changes_after_migration() {
 }
 
 #[test]
+fn t102_e2e_multi_worktree_migration_preserves_each_branch_worktree() {
+    // SPEC-1934 US-6.4: a Normal Git repo with multiple linked worktrees must
+    // migrate each worktree into the nested bare layout, not fold linked
+    // worktree directories into the main branch worktree.
+    let project = tempfile::tempdir().unwrap();
+    init_repo_with_commit(project.path());
+    let main_branch = current_branch(project.path());
+    let project_dir_name = project
+        .path()
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo")
+        .to_string();
+
+    let clean_path = project.path().join("feature").join("clean");
+    run_git(
+        project.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/clean",
+            clean_path.to_str().unwrap(),
+        ],
+    );
+    std::fs::write(clean_path.join("feature.txt"), "clean branch\n").unwrap();
+    run_git(&clean_path, &["add", "feature.txt"]);
+    run_git(&clean_path, &["commit", "-m", "feature clean"]);
+
+    let dirty_path = project.path().join("bugfix").join("dirty");
+    run_git(
+        project.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "bugfix/dirty",
+            dirty_path.to_str().unwrap(),
+        ],
+    );
+    std::fs::write(dirty_path.join("README.md"), "# sample dirty branch\n").unwrap();
+    std::fs::write(dirty_path.join("scratch.txt"), "untracked dirty").unwrap();
+
+    let outcome = execute_migration(
+        project.path(),
+        MigrationOptions::default(),
+        |_phase, _pct| {},
+    )
+    .expect("execute_migration");
+
+    let bare = project.path().join(format!("{project_dir_name}.git"));
+    let main_target = project.path().join(&main_branch);
+    let clean_target = project.path().join("feature").join("clean");
+    let dirty_target = project.path().join("bugfix").join("dirty");
+
+    assert!(bare.is_dir(), "bare repo must exist");
+    assert!(main_target.join("README.md").is_file());
+    assert_eq!(
+        std::fs::read_to_string(clean_target.join("feature.txt")).unwrap(),
+        "clean branch\n",
+        "clean linked worktree content must stay with its branch"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dirty_target.join("README.md")).unwrap(),
+        "# sample dirty branch\n",
+        "dirty linked worktree modifications must survive"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dirty_target.join("scratch.txt")).unwrap(),
+        "untracked dirty",
+        "dirty linked worktree untracked files must survive"
+    );
+    assert!(
+        !main_target.join("feature").exists(),
+        "linked worktree directories must not be restored inside the main branch worktree"
+    );
+
+    let mut migrated = outcome.migrated_worktrees.clone();
+    migrated.sort();
+    let mut expected = vec![
+        main_target.clone(),
+        clean_target.clone(),
+        dirty_target.clone(),
+    ];
+    expected.sort();
+    assert_eq!(migrated, expected);
+
+    for target in [&main_target, &clean_target, &dirty_target] {
+        let output = gwt_core::process::hidden_command("git")
+            .args(["status", "--short"])
+            .current_dir(target)
+            .output()
+            .expect("git status");
+        assert!(
+            output.status.success(),
+            "{} must be a valid migrated worktree: {}",
+            target.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
 fn t103_e2e_locked_worktree_blocks_migration_with_no_changes() {
     // SPEC-1934 US-6.5: locked worktree が見つかったらマイグレーションを中止
     // し、リポジトリレイアウトは未変更で残らなければならない。


### PR DESCRIPTION
## Summary

Adds the SPEC-1934 multi-worktree migration follow-up for normal Git repositories:

- Parse `git worktree list --porcelain` in `gwt-git` so migration can discover branch-backed linked worktrees before mutating the repository.
- Migrate the main worktree and each linked branch worktree into the nested bare layout instead of folding linked worktree contents into the main migrated tree.
- Remove copied stale `.git/worktrees` metadata before recreating linked worktrees in the new bare repository.
- Preserve clean and dirty linked worktree file contents, including untracked files, through evacuation and restore.
- Normalize canonical paths during evacuation so macOS `/var` and `/private/var` aliases do not invalidate exclusion matching.

## Changes

- `crates/gwt-git/src/migration.rs`
  - Added worktree porcelain parsing and repository worktree discovery helpers.
- `crates/gwt/src/migration/executor.rs`
  - Added multi-worktree migration orchestration and stale metadata cleanup.
  - Extended the migration outcome to include all migrated worktree paths.
- `crates/gwt-git/tests/migration_test.rs`
  - Added parser coverage for branch-backed worktree discovery.
- `crates/gwt/tests/migration_e2e_test.rs`
  - Added E2E coverage proving main, clean linked, and dirty linked worktrees survive migration.

## Testing

- RED check: `cargo test -p gwt --test migration_e2e_test t102_e2e_multi_worktree_migration_preserves_each_branch_worktree -- --nocapture` failed before implementation because linked worktree content was missing after migration.
- PASS: `cargo test -p gwt-git --test migration_test -- --nocapture`
- PASS: `cargo test -p gwt --test migration_e2e_test -- --nocapture`
- PASS: `cargo test -p gwt-core -p gwt-git -p gwt`
  - First broad run hit the existing unrelated `cli::hook::runtime_state::tests::codex_runtime_state_rejects_missing_hook_session_id` environment-race flake.
  - The failing test passed alone, and the full command passed on rerun.
- PASS: `cargo clippy --all-targets --all-features -- -D warnings`
- PASS: `cargo build -p gwt`
- PASS: `cargo fmt -- --check`
- PASS: `git diff --check`
- PASS: `bunx commitlint --from HEAD~1 --to HEAD`
- PASS: pre-push CI-equivalent hook
  - `cargo-llvm-cov` filtered line coverage: `90.26%` (threshold `90.00%`)
  - `lint:skills` validated 28 frontmatter blocks.

## Related

- Related SPEC: #1934
- Closing Issues: None. SPEC-1934 still has rollback, GUI, manual smoke, and coverage follow-up tasks open.
