### PR TITLE
fix(migration): restore external worktrees on rollback

### DIFF
--- a/crates/gwt-core/src/migration/backup.rs
+++ b/crates/gwt-core/src/migration/backup.rs
@@ -31,12 +31,21 @@ impl From<io::Error> for BackupError {
 
 /// The directory name reserved for migration backups under `<project_root>`.
 pub const BACKUP_DIR_NAME: &str = ".gwt-migration-backup";
+const EXTERNAL_BACKUPS_DIR_NAME: &str = ".external-worktrees";
 
 /// Snapshot returned by [`create`]; used by rollback to find the source.
 #[derive(Debug, Clone)]
 pub struct BackupSnapshot {
     pub project_root: PathBuf,
     pub backup_dir: PathBuf,
+    pub external_roots: Vec<ExternalBackupSnapshot>,
+}
+
+/// Backup copy for a linked worktree that lives outside `project_root`.
+#[derive(Debug, Clone)]
+pub struct ExternalBackupSnapshot {
+    pub original_path: PathBuf,
+    pub backup_path: PathBuf,
 }
 
 /// Create a full snapshot of `project_root` into
@@ -44,6 +53,15 @@ pub struct BackupSnapshot {
 /// is renamed with a UTC timestamp suffix so the previous attempt is not
 /// silently overwritten.
 pub fn create(project_root: &Path) -> Result<BackupSnapshot, BackupError> {
+    create_with_external_roots(project_root, &[])
+}
+
+/// Create a full project snapshot plus explicit copies of linked worktrees that
+/// live outside `project_root`.
+pub fn create_with_external_roots(
+    project_root: &Path,
+    external_roots: &[PathBuf],
+) -> Result<BackupSnapshot, BackupError> {
     let backup_dir = project_root.join(BACKUP_DIR_NAME);
 
     if backup_dir.exists() {
@@ -57,9 +75,25 @@ pub fn create(project_root: &Path) -> Result<BackupSnapshot, BackupError> {
     fs::create_dir_all(&backup_dir)?;
     copy_dir_contents(project_root, &backup_dir, &[BACKUP_DIR_NAME])?;
 
+    let mut external_snapshots = Vec::with_capacity(external_roots.len());
+    for (index, external_root) in external_roots.iter().enumerate() {
+        if !external_root.exists() {
+            continue;
+        }
+        let backup_path = backup_dir
+            .join(EXTERNAL_BACKUPS_DIR_NAME)
+            .join(format!("{index}-{}", backup_name(external_root)));
+        copy_dir_contents(external_root, &backup_path, &[])?;
+        external_snapshots.push(ExternalBackupSnapshot {
+            original_path: external_root.clone(),
+            backup_path,
+        });
+    }
+
     Ok(BackupSnapshot {
         project_root: project_root.to_path_buf(),
         backup_dir,
+        external_roots: external_snapshots,
     })
 }
 
@@ -93,7 +127,15 @@ pub fn restore(snapshot: &BackupSnapshot) -> Result<(), BackupError> {
     }
 
     // Step 2: copy backup contents back to project root.
-    copy_dir_contents(backup_dir, project_root, &[])?;
+    copy_dir_contents(backup_dir, project_root, &[EXTERNAL_BACKUPS_DIR_NAME])?;
+
+    for external in &snapshot.external_roots {
+        remove_path_if_exists(&external.original_path)?;
+        if let Some(parent) = external.original_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        copy_dir_contents(&external.backup_path, &external.original_path, &[])?;
+    }
 
     Ok(())
 }
@@ -155,4 +197,33 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn remove_path_if_exists(path: &Path) -> io::Result<()> {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path)
+    } else if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        Ok(())
+    }
+}
+
+fn backup_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("worktree")
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }

--- a/crates/gwt/src/migration/executor.rs
+++ b/crates/gwt/src/migration/executor.rs
@@ -36,13 +36,24 @@ pub fn execute_migration(
     })?;
 
     progress(MigrationPhase::Backup, 0);
-    let snapshot = backup::create(project_root).map_err(|e| MigrationError {
-        phase: MigrationPhase::Backup,
-        message: e.to_string(),
-        recovery: RecoveryState::Untouched,
-    })?;
+    let planned_worktrees = git_migration::list_worktrees(project_root).unwrap_or_default();
+    let external_roots = external_worktree_roots(project_root, &planned_worktrees);
+    let snapshot =
+        backup::create_with_external_roots(project_root, &external_roots).map_err(|e| {
+            MigrationError {
+                phase: MigrationPhase::Backup,
+                message: e.to_string(),
+                recovery: RecoveryState::Untouched,
+            }
+        })?;
 
-    let outcome = run_post_backup(project_root, &options, &snapshot, &mut progress);
+    let outcome = run_post_backup(
+        project_root,
+        &options,
+        &snapshot,
+        &planned_worktrees,
+        &mut progress,
+    );
 
     match outcome {
         Ok(out) => {
@@ -74,6 +85,7 @@ fn run_post_backup(
     project_root: &Path,
     options: &MigrationOptions,
     snapshot: &BackupSnapshot,
+    planned_worktrees: &[WorktreeMigration],
     progress: &mut impl FnMut(MigrationPhase, u8),
 ) -> Result<MigrationOutcome, MigrationError> {
     progress(MigrationPhase::Bareify, 0);
@@ -104,7 +116,13 @@ fn run_post_backup(
     })?;
 
     progress(MigrationPhase::Worktrees, 0);
-    let mut worktrees = migration_worktrees(project_root, &dot_git, &bare_repo_path, options)?;
+    let mut worktrees = migration_worktrees(
+        project_root,
+        &dot_git,
+        &bare_repo_path,
+        options,
+        planned_worktrees,
+    )?;
     worktrees.sort_by_key(|worktree| !worktree.is_main_repo);
     remove_copied_worktree_metadata(&bare_repo_path).map_err(|e| MigrationError {
         phase: MigrationPhase::Worktrees,
@@ -222,12 +240,32 @@ fn run_post_backup(
     })
 }
 
+fn external_worktree_roots(project_root: &Path, worktrees: &[WorktreeMigration]) -> Vec<PathBuf> {
+    worktrees
+        .iter()
+        .filter(|worktree| !worktree.is_main_repo)
+        .filter(|worktree| !path_is_inside(&worktree.path, project_root))
+        .map(|worktree| worktree.path.clone())
+        .collect()
+}
+
+fn path_is_inside(path: &Path, root: &Path) -> bool {
+    let canonical_root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let canonical_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    canonical_path == canonical_root || canonical_path.starts_with(&canonical_root)
+}
+
 fn migration_worktrees(
     project_root: &Path,
     dot_git: &Path,
     bare_repo_path: &Path,
     options: &MigrationOptions,
+    planned_worktrees: &[WorktreeMigration],
 ) -> Result<Vec<WorktreeMigration>, MigrationError> {
+    if !planned_worktrees.is_empty() {
+        return Ok(planned_worktrees.to_vec());
+    }
+
     match git_migration::list_worktrees(project_root) {
         Ok(worktrees) if !worktrees.is_empty() => Ok(worktrees),
         Ok(_) | Err(_) => {

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -340,6 +340,88 @@ fn t104_e2e_failure_injected_during_bareify_rolls_back_to_original_layout() {
 }
 
 #[test]
+fn t108_e2e_worktree_failure_rolls_back_external_linked_worktree() {
+    // SPEC-1934 US-6.6 / FR-028: rollback must restore linked worktrees that
+    // live outside the project root. The branch name intentionally maps to the
+    // same path as the new bare repository, forcing the worktree phase to fail
+    // after the old external worktree has been evacuated and removed.
+    let sandbox = tempfile::tempdir().unwrap();
+    let project = sandbox.path().join("repo");
+    let external_parent = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    init_repo_with_commit(&project);
+
+    let project_dir_name = project
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap()
+        .to_string();
+    let conflicting_branch = format!("{project_dir_name}.git");
+    let external_path = external_parent.path().join("external-worktree");
+
+    run_git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &conflicting_branch,
+            external_path.to_str().unwrap(),
+        ],
+    );
+    std::fs::write(
+        external_path.join("README.md"),
+        "# sample external dirty branch\n",
+    )
+    .unwrap();
+    std::fs::write(external_path.join("scratch.txt"), "external untracked").unwrap();
+
+    let result = execute_migration(&project, MigrationOptions::default(), |_phase, _pct| {});
+
+    let err = result.expect_err("conflicting worktree target must fail migration");
+    assert_eq!(err.phase, MigrationPhase::Worktrees);
+    assert_eq!(err.recovery, RecoveryState::RolledBack);
+
+    assert!(
+        project.join(".git").is_dir(),
+        "original project .git directory must be restored"
+    );
+    assert!(
+        !project.join(".gwt/project.toml").exists(),
+        "failed migration must not leave project.toml"
+    );
+    assert!(
+        external_path.is_dir(),
+        "external linked worktree must be restored after rollback"
+    );
+    assert!(
+        external_path.join(".git").is_file(),
+        "external linked worktree git marker must be restored"
+    );
+    assert_eq!(
+        std::fs::read_to_string(external_path.join("README.md")).unwrap(),
+        "# sample external dirty branch\n",
+        "external tracked modifications must survive rollback"
+    );
+    assert_eq!(
+        std::fs::read_to_string(external_path.join("scratch.txt")).unwrap(),
+        "external untracked",
+        "external untracked files must survive rollback"
+    );
+
+    let status = gwt_core::process::hidden_command("git")
+        .args(["status", "--short"])
+        .current_dir(&external_path)
+        .output()
+        .expect("git status");
+    assert!(
+        status.status.success(),
+        "external worktree must remain a valid Git worktree: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+}
+
+#[test]
 fn t107_repo_hash_remains_stable_across_migration() {
     // SPEC-2021 / SC-019: project_scope_hash is computed from the origin URL
     // (or the path when no origin exists). Migration must not move the


### PR DESCRIPTION
## Summary

Completes the next SPEC-1934 rollback slice:

- Preserve external linked worktrees in the migration backup snapshot when they live outside the project root.
- Restore those external roots during rollback so dirty tracked files, untracked files, and `.git` marker files survive a worktree-phase failure.
- Reuse the pre-mutation worktree inventory for migration execution so backup and migration operate on the same worktree set.
- Add an E2E regression that fails after an external linked worktree has been evacuated and removed, then proves rollback restores it as a valid Git worktree.

## Changes

- `crates/gwt-core/src/migration/backup.rs`
  - Added `create_with_external_roots`.
  - Extended `BackupSnapshot` with external linked worktree backup metadata.
  - Restores external worktree roots after restoring the project root.
- `crates/gwt/src/migration/executor.rs`
  - Captures worktree inventory before backup.
  - Includes external linked worktree paths in the backup snapshot.
  - Reuses that inventory in the worktree migration phase.
- `crates/gwt/tests/migration_e2e_test.rs`
  - Added `t108_e2e_worktree_failure_rolls_back_external_linked_worktree`.

## Testing

- RED check: `cargo test -p gwt --test migration_e2e_test t108_e2e_worktree_failure_rolls_back_external_linked_worktree -- --nocapture` first failed because the external worktree was missing after rollback.
- PASS: `cargo test -p gwt --test migration_e2e_test t108_e2e_worktree_failure_rolls_back_external_linked_worktree -- --nocapture`
- PASS: `cargo test -p gwt-core --test migration_workflow_test -- --nocapture`
- PASS: `cargo test -p gwt --test migration_e2e_test -- --nocapture`
- PASS: `cargo test -p gwt-core -p gwt-git -p gwt`
- PASS: `cargo clippy --all-targets --all-features -- -D warnings`
- PASS: `cargo build -p gwt`
- PASS: `cargo fmt -- --check`
- PASS: `git diff --check`
- PASS: `bunx commitlint --from HEAD~1 --to HEAD`
- PASS: pre-push CI-equivalent hook
  - `cargo-llvm-cov` filtered line coverage: `90.25%` (threshold `90.00%`)
  - `lint:skills` validated 28 frontmatter blocks.

## Related

- Related SPEC: #1934
- Closing Issues: None. SPEC-1934 still has startup backup detection, GUI Skip/Quit, coverage, and manual smoke follow-ups open.
