### PR TITLE
fix(migration): detect interrupted migration backups

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1902,6 +1902,7 @@ impl AppRuntime {
         // frontend during state hydration so the modal opens without waiting
         // for another roundtrip.
         events.extend(self.migration_detected_replies(client_id));
+        events.extend(self.migration_recovery_replies(client_id));
         events
     }
 
@@ -2035,6 +2036,7 @@ impl AppRuntime {
                 // layout, surface the confirmation modal alongside the regular
                 // workspace broadcast.
                 events.extend(self.migration_detected_broadcasts());
+                events.extend(self.migration_recovery_broadcasts());
                 events
             }
             Err(error) => vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
@@ -2087,6 +2089,30 @@ impl AppRuntime {
         }
     }
 
+    fn has_migration_backup(tab: &ProjectTabRuntime) -> bool {
+        tab.project_root
+            .join(gwt_core::migration::backup::BACKUP_DIR_NAME)
+            .is_dir()
+    }
+
+    fn migration_backup_error_event_for(&self, tab: &ProjectTabRuntime) -> BackendEvent {
+        let backup_path = tab
+            .project_root
+            .join(gwt_core::migration::backup::BACKUP_DIR_NAME);
+        BackendEvent::MigrationError {
+            tab_id: tab.id.clone(),
+            phase: gwt_core::migration::MigrationPhase::Backup
+                .as_str()
+                .to_string(),
+            message: format!(
+                "Previous migration backup found at {}. A migration may have been interrupted before cleanup; inspect or restore the backup before starting another migration.",
+                backup_path.display()
+            ),
+            recovery: recovery_state_label(gwt_core::migration::RecoveryState::Partial)
+                .to_string(),
+        }
+    }
+
     /// SPEC-1934 US-6.1 broadcast variant: used by `open_project_path_events`
     /// to inform every connected frontend that a tab needs migration.
     pub(crate) fn migration_detected_broadcasts(&self) -> Vec<OutboundEvent> {
@@ -2094,6 +2120,17 @@ impl AppRuntime {
             .iter()
             .filter(|tab| tab.migration_pending)
             .map(|tab| OutboundEvent::broadcast(self.migration_detected_event_for(tab)))
+            .collect()
+    }
+
+    /// SPEC-1934 US-6.6/T-085: if a previous migration was interrupted after
+    /// Backup, surface the leftover snapshot on launch so the user does not
+    /// start another destructive migration over an unresolved backup.
+    pub(crate) fn migration_recovery_broadcasts(&self) -> Vec<OutboundEvent> {
+        self.tabs
+            .iter()
+            .filter(|tab| tab.migration_pending && Self::has_migration_backup(tab))
+            .map(|tab| OutboundEvent::broadcast(self.migration_backup_error_event_for(tab)))
             .collect()
     }
 
@@ -2105,6 +2142,14 @@ impl AppRuntime {
             .iter()
             .filter(|tab| tab.migration_pending)
             .map(|tab| OutboundEvent::reply(client_id, self.migration_detected_event_for(tab)))
+            .collect()
+    }
+
+    pub(crate) fn migration_recovery_replies(&self, client_id: &str) -> Vec<OutboundEvent> {
+        self.tabs
+            .iter()
+            .filter(|tab| tab.migration_pending && Self::has_migration_backup(tab))
+            .map(|tab| OutboundEvent::reply(client_id, self.migration_backup_error_event_for(tab)))
             .collect()
     }
 
@@ -10504,5 +10549,46 @@ exit 0
         let events = runtime.skip_migration_events("tab-1");
         assert!(events.is_empty(), "skip must not emit events itself");
         assert!(!runtime.tabs[0].migration_pending);
+    }
+
+    #[test]
+    fn open_project_with_existing_migration_backup_emits_recovery_error() {
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        init_repo(&project);
+        fs::create_dir_all(project.join(gwt_core::migration::backup::BACKUP_DIR_NAME))
+            .expect("migration backup dir");
+
+        let mut runtime = sample_runtime(temp.path(), Vec::new(), None);
+        let events = runtime.open_project_path_events(project.clone());
+
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                OutboundEvent {
+                    target: DispatchTarget::Broadcast,
+                    event: BackendEvent::MigrationDetected { .. },
+                }
+            )),
+            "Normal Git layout should still open a migration-pending tab"
+        );
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                OutboundEvent {
+                    target: DispatchTarget::Broadcast,
+                    event: BackendEvent::MigrationError {
+                        phase,
+                        recovery,
+                        message,
+                        ..
+                    },
+                } if phase == "backup"
+                    && recovery == "partial"
+                    && message.contains(".gwt-migration-backup")
+            )),
+            "existing migration backup must be surfaced as a recovery error"
+        );
     }
 }

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -1,6 +1,9 @@
 //! End-to-end tests for the SPEC-1934 US-6 migration orchestrator.
 
-use std::path::Path;
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
 
 use gwt::migration::execute_migration;
 use gwt_core::config::BareProjectConfig;
@@ -301,11 +304,13 @@ fn t104_e2e_failure_injected_during_bareify_rolls_back_to_original_layout() {
     // wiped by the rollback (it should be preserved as it pre-existed).
     std::fs::write(bare_target.join("preexisting.txt"), "marker").unwrap();
 
+    let started = Instant::now();
     let result = execute_migration(
         project.path(),
         MigrationOptions::default(),
         |_phase, _pct| {},
     );
+    let elapsed = started.elapsed();
 
     let err = result.expect_err("migration must fail when bare target exists");
     assert_eq!(err.phase, MigrationPhase::Bareify);
@@ -336,6 +341,10 @@ fn t104_e2e_failure_injected_during_bareify_rolls_back_to_original_layout() {
     assert!(
         !project.path().join(".gwt/project.toml").exists(),
         "no project.toml must be written when migration fails"
+    );
+    assert!(
+        elapsed <= Duration::from_secs(30),
+        "rollback should complete within 30 seconds for the typical E2E fixture; took {elapsed:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Detect interrupted Normal-to-Bare migrations by surfacing an unresolved `.gwt-migration-backup/` snapshot at project open and frontend reconnect time.
- Keep the existing migration modal protocol by emitting the current `MigrationError` envelope after `MigrationDetected`, so users see a recovery warning instead of starting another migration over a backup.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: adds startup and frontend-sync recovery broadcasts for migration-pending tabs with `.gwt-migration-backup/`.
- `crates/gwt/src/app_runtime/mod.rs`: adds a regression test for opening a Normal Git project with an existing migration backup.
- `crates/gwt/tests/migration_e2e_test.rs`: adds NFR-007 evidence that the failure-injected rollback path completes within 30 seconds.

## Testing

- [x] `cargo test -p gwt app_runtime::tests::open_project_with_existing_migration_backup_emits_recovery_error -- --nocapture` — passed
- [x] `cargo test -p gwt --test migration_e2e_test t104_e2e_failure_injected_during_bareify_rolls_back_to_original_layout -- --nocapture` — passed
- [x] `cargo test -p gwt --test migration_e2e_test -- --nocapture` — passed
- [x] `cargo test -p gwt-core -p gwt-git -p gwt` — passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed
- [x] `cargo build -p gwt` — passed
- [x] `cargo fmt -- --check` — passed
- [x] `git diff --check` — passed
- [x] pre-push coverage — passed, filtered line coverage `90.25%`

## Closing Issues

- None

## Related Issues / Links

- #1934

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-1934 tasks updated)
- [x] Migration/backfill plan included (no schema/data migration; unresolved backup detection only)
- [x] CHANGELOG impact considered (patch fix)

## Context

- SPEC-1934 still had Phase 9 follow-up tasks for startup backup detection after an interrupted migration. This PR closes T-084/T-085/T-086 while leaving final coverage/manual tasks and later GUI dismissal work for separate slices.

## Risk / Impact

- **Affected areas**: AppRuntime project open, frontend sync migration events, migration E2E tests.
- **Rollback plan**: Revert this PR; no persisted schema or data format changes are introduced.
