### PR TITLE
fix(migration): honor migration quit action

### DIFF
--- a/crates/gwt/src/app_runtime/migration.rs
+++ b/crates/gwt/src/app_runtime/migration.rs
@@ -127,12 +127,10 @@ impl AppRuntime {
         })]
     }
 
-    /// SPEC-1934 US-6.8: user chose Quit. Phase 10.4 will translate this into
-    /// a `UserEvent::QuitApp` once the runtime helper lands (T-097); the
-    /// frontend already closes the modal optimistically.
+    /// SPEC-1934 US-6.8: user chose Quit. Leave the repository untouched and
+    /// ask the GUI event loop to exit through the normal shutdown path.
     pub(crate) fn quit_migration_events(&mut self, _tab_id: &str) -> Vec<OutboundEvent> {
-        // TODO(T-097): proxy.send(UserEvent::QuitApp) once the dispatch
-        // helper lands.
+        self.proxy.send(UserEvent::QuitApp);
         Vec::new()
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -10552,6 +10552,80 @@ exit 0
     }
 
     #[test]
+    fn skip_migration_events_keeps_normal_git_and_redetects_on_next_launch() {
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        init_repo(&project);
+
+        let mut runtime = sample_runtime(temp.path(), Vec::new(), None);
+        let open_events = runtime.open_project_path_events(project.clone());
+        let tab_id = runtime.active_tab_id.clone().expect("active tab");
+
+        assert!(open_events.iter().any(|event| matches!(
+            event,
+            OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::MigrationDetected { .. },
+            }
+        )));
+
+        let skip_events = runtime.skip_migration_events(&tab_id);
+        assert!(skip_events.is_empty(), "skip must not mutate repository");
+        assert!(matches!(
+            gwt_git::detect_repo_type(&project),
+            gwt_git::RepoType::Normal {
+                needs_migration: true,
+                ..
+            }
+        ));
+
+        let mut next_runtime = sample_runtime(temp.path(), Vec::new(), None);
+        let next_events = next_runtime.open_project_path_events(project);
+
+        assert!(
+            next_events.iter().any(|event| matches!(
+                event,
+                OutboundEvent {
+                    target: DispatchTarget::Broadcast,
+                    event: BackendEvent::MigrationDetected { .. },
+                }
+            )),
+            "skip is launch-local; the modal must be shown again next launch"
+        );
+    }
+
+    #[test]
+    fn quit_migration_events_requests_app_quit_without_repository_changes() {
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        init_repo(&project);
+
+        let tab = migration_pending_tab("tab-1", project.clone());
+        let (mut runtime, recorded_events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+        let events = runtime.quit_migration_events("tab-1");
+
+        assert!(
+            events.is_empty(),
+            "quit is delivered through the event proxy"
+        );
+        let recorded_events = recorded_events.lock().expect("recorded events");
+        assert!(recorded_events
+            .iter()
+            .any(|event| matches!(event, UserEvent::QuitApp)));
+        assert!(matches!(
+            gwt_git::detect_repo_type(&project),
+            gwt_git::RepoType::Normal {
+                needs_migration: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn open_project_with_existing_migration_backup_emits_recovery_error() {
         let temp = tempdir().expect("tempdir");
         let project = temp.path().join("project");

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -635,6 +635,9 @@ enum UserEvent {
         message: String,
         recovery: gwt_core::migration::RecoveryState,
     },
+    /// SPEC-1934 US-6.8: user chose Quit from the migration modal. The event
+    /// loop exits through the same cleanup path as a window close request.
+    QuitApp,
     #[cfg(target_os = "macos")]
     MenuEvent(muda::MenuEvent),
 }
@@ -5169,6 +5172,14 @@ fn main() -> wry::Result<()> {
             } => {
                 // Kill every PTY / agent before the event loop exits so no
                 // child process outlives the window.
+                app.stop_all_runtimes();
+                board_projection_watchers.shutdown();
+                #[cfg(unix)]
+                board_daemon_subscribers.shutdown();
+                server.shutdown();
+                *control_flow = ControlFlow::Exit;
+            }
+            Event::UserEvent(UserEvent::QuitApp) => {
                 app.stop_all_runtimes();
                 board_projection_watchers.shutdown();
                 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Finish the SPEC-1934 Skip/Quit backend dismissal slice.
- Skip stays launch-local: the repository remains a Normal Git layout and the migration prompt is re-detected on the next launch.
- Quit now requests application shutdown through the normal cleanup path without mutating the repository.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: adds AppRuntime coverage for Skip re-detection and Quit repository preservation.
- `crates/gwt/src/app_runtime/migration.rs`: routes `quit_migration` through the app event proxy.
- `crates/gwt/src/main.rs`: adds `UserEvent::QuitApp` and handles it through the same runtime/server shutdown path as `CloseRequested`.

## Testing

- [x] `cargo test -p gwt app_runtime::tests::quit_migration_events_requests_app_quit_without_repository_changes -- --nocapture` — RED first, failed because `UserEvent::QuitApp` did not exist
- [x] `cargo test -p gwt migration_events -- --nocapture` — passed
- [x] `cargo test -p gwt-core -p gwt-git -p gwt` — passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed
- [x] `cargo build -p gwt` — passed
- [x] `cargo fmt -- --check` — passed
- [x] `git diff --check` — passed
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed
- [x] pre-push coverage — passed, filtered line coverage `90.25%`

## Closing Issues

- None

## Related Issues / Links

- #1934

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-1934 tasks updated)
- [x] Migration/backfill plan included (no schema/data migration)
- [x] CHANGELOG impact considered (patch fix)

## Context

- PR #2615 merged the startup recovery slice (`9ebc89ab`). This PR carries the later `ca89cf1a` Skip/Quit slice that was pushed after #2615 had already merged.
- SPEC-1934 T-105/T-106 are now marked complete in the SPEC tasks section; T-116/T-117 remain open.

## Risk / Impact

- **Affected areas**: migration modal Quit handling, AppRuntime tests, GUI event loop shutdown path.
- **Rollback plan**: Revert this PR; no persisted schema or data format changes are introduced.
