### PR TITLE
fix(gui): scope Workspace Overview to active project on tab transitions

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -692,6 +692,33 @@ fn active_work_projection_from_saved_with_journal(
     }
 }
 
+fn empty_active_work_projection_view(
+    tab_id: &str,
+    tab: &ProjectTabRuntime,
+) -> gwt::ActiveWorkProjectionView {
+    gwt::ActiveWorkProjectionView {
+        id: tab_id.to_string(),
+        title: format!("{} workspace", tab.title),
+        status_category: "idle".to_string(),
+        status_text: String::new(),
+        summary: None,
+        owner: None,
+        next_action: None,
+        active_agents: 0,
+        blocked_agents: 0,
+        branch: None,
+        worktree_path: None,
+        pr_number: None,
+        pr_url: None,
+        pr_state: None,
+        pr_created_at: None,
+        board_refs: Vec::new(),
+        journal_entries: Vec::new(),
+        cleanup_candidate: None,
+        agents: Vec::new(),
+    }
+}
+
 fn active_work_cleanup_candidate_view_from_candidate(
     candidate: gwt_core::workspace_projection::WorkspaceCleanupCandidate,
 ) -> gwt::ActiveWorkCleanupCandidateView {
@@ -1929,6 +1956,23 @@ impl AppRuntime {
         ))
     }
 
+    /// Like `active_work_projection_broadcast_for_active_tab`, but always emits an event
+    /// when an active tab exists — falling back to an empty projection so that frontends
+    /// clear stale per-project data when the tab focus moves to a project without
+    /// any saved projection or live agent sessions.
+    fn active_work_projection_broadcast_on_tab_change(&self) -> Option<OutboundEvent> {
+        let tab_id = self.active_tab_id.as_ref()?;
+        let tab = self.tab(tab_id)?;
+        let projection = self
+            .active_work_projection_for_tab(tab_id, tab)
+            .unwrap_or_else(|| empty_active_work_projection_view(tab_id, tab));
+        Some(OutboundEvent::broadcast(
+            BackendEvent::ActiveWorkProjection {
+                projection: Box::new(projection),
+            },
+        ))
+    }
+
     fn active_work_projection_for_tab(
         &self,
         tab_id: &str,
@@ -2029,6 +2073,9 @@ impl AppRuntime {
         match self.open_project_path(path) {
             Ok(wizard_closed) => {
                 let mut events = vec![self.workspace_state_broadcast()];
+                if let Some(event) = self.active_work_projection_broadcast_on_tab_change() {
+                    events.push(event);
+                }
                 if wizard_closed {
                     events.push(self.launch_wizard_state_broadcast(None));
                 }
@@ -2177,6 +2224,9 @@ impl AppRuntime {
         let wizard_closed = self.set_active_tab(tab_id.to_string());
         let _ = self.persist();
         let mut events = vec![self.workspace_state_broadcast()];
+        if let Some(event) = self.active_work_projection_broadcast_on_tab_change() {
+            events.push(event);
+        }
         if wizard_closed {
             events.push(self.launch_wizard_state_broadcast(None));
         }
@@ -2225,6 +2275,9 @@ impl AppRuntime {
         let _ = self.persist();
 
         let mut events = vec![self.workspace_state_broadcast()];
+        if let Some(event) = self.active_work_projection_broadcast_on_tab_change() {
+            events.push(event);
+        }
         if wizard_closed {
             events.push(self.launch_wizard_state_broadcast(None));
         }
@@ -6622,7 +6675,7 @@ exit 0
 
         let events = runtime.select_project_tab_events("tab-2");
 
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 3);
         assert!(matches!(events[0].target, DispatchTarget::Broadcast));
         assert!(matches!(
             events[0].event,
@@ -6631,8 +6684,96 @@ exit 0
         assert!(matches!(events[1].target, DispatchTarget::Broadcast));
         assert!(matches!(
             events[1].event,
+            BackendEvent::ActiveWorkProjection { .. }
+        ));
+        assert!(matches!(events[2].target, DispatchTarget::Broadcast));
+        assert!(matches!(
+            events[2].event,
             BackendEvent::LaunchWizardState { wizard: None }
         ));
+    }
+
+    #[test]
+    fn app_runtime_select_project_tab_emits_active_work_projection_for_new_active_tab() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let other = temp.path().join("other");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&other).expect("create other");
+        let tabs = vec![
+            sample_project_tab("tab-1", "Repo", repo, ProjectKind::NonRepo, &[]),
+            sample_project_tab("tab-2", "Other", other, ProjectKind::NonRepo, &[]),
+        ];
+        let mut runtime = sample_runtime(temp.path(), tabs, Some("tab-1"));
+
+        let events = runtime.select_project_tab_events("tab-2");
+
+        let projection = events
+            .iter()
+            .find_map(|event| match &event.event {
+                BackendEvent::ActiveWorkProjection { projection } => Some(projection),
+                _ => None,
+            })
+            .expect("ActiveWorkProjection broadcast for newly selected tab");
+        assert_eq!(
+            projection.id, "tab-2",
+            "projection must reflect the newly active tab"
+        );
+    }
+
+    #[test]
+    fn app_runtime_close_project_tab_emits_active_work_projection_when_active_changes() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let other = temp.path().join("other");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&other).expect("create other");
+        let tabs = vec![
+            sample_project_tab("tab-1", "Repo", repo, ProjectKind::NonRepo, &[]),
+            sample_project_tab("tab-2", "Other", other, ProjectKind::NonRepo, &[]),
+        ];
+        let mut runtime = sample_runtime(temp.path(), tabs, Some("tab-1"));
+
+        let events = runtime.close_project_tab_events("tab-1");
+
+        let projection = events
+            .iter()
+            .find_map(|event| match &event.event {
+                BackendEvent::ActiveWorkProjection { projection } => Some(projection),
+                _ => None,
+            })
+            .expect("ActiveWorkProjection broadcast after closing the active tab");
+        assert_eq!(
+            projection.id, "tab-2",
+            "projection must reflect the new active tab after close"
+        );
+    }
+
+    #[test]
+    fn app_runtime_open_project_path_emits_active_work_projection_for_new_tab() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tabs = vec![sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo,
+            ProjectKind::NonRepo,
+            &[],
+        )];
+        let mut runtime = sample_runtime(temp.path(), tabs, Some("tab-1"));
+
+        let other = temp.path().join("other-project");
+        fs::create_dir_all(&other).expect("create other");
+
+        let events = runtime.open_project_path_events(other.clone());
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(&event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "opening a new project must emit ActiveWorkProjection for the new active tab"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1777,21 +1777,29 @@ mod tests {
 
         let select_events = runtime.select_project_tab_events("tab-2");
 
-        assert_eq!(select_events.len(), 2);
+        assert_eq!(select_events.len(), 3);
         assert_eq!(runtime.active_tab_id.as_deref(), Some("tab-2"));
         assert!(runtime.launch_wizard.is_none());
         assert!(matches!(
             select_events[1].event,
+            BackendEvent::ActiveWorkProjection { .. }
+        ));
+        assert!(matches!(
+            select_events[2].event,
             BackendEvent::LaunchWizardState { wizard: None }
         ));
 
         runtime.launch_wizard = Some(sample_launch_wizard_session("tab-2", &other));
         let close_events = runtime.close_project_tab_events("tab-2");
 
-        assert_eq!(close_events.len(), 2);
+        assert_eq!(close_events.len(), 3);
         assert_eq!(runtime.tabs.len(), 1);
         assert_eq!(runtime.active_tab_id.as_deref(), Some("tab-1"));
         assert!(runtime.launch_wizard.is_none());
+        assert!(matches!(
+            close_events[1].event,
+            BackendEvent::ActiveWorkProjection { .. }
+        ));
         assert!(runtime
             .window_lookup
             .keys()

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -400,13 +400,13 @@ test("Workspace Overview is separate from live-only Active Work", () => {
     "expected Sidebar to expose a Workspace Overview entry even when Active Work is hidden",
   );
   assert.ok(
-    document.querySelector("#project-workspace-overview-button"),
-    "expected Project Bar to expose Workspace Overview",
+    !document.querySelector("#project-workspace-overview-button"),
+    "Workspace Overview is per-project content and must live in the Sidebar, not the global Project Bar",
   );
   assert.match(
     appSource,
     /function\s+openWorkspaceOverview\(/,
-    "expected a shared opener for Sidebar and Project Bar",
+    "expected a shared opener for the Sidebar entry",
   );
   assert.match(
     appSource,
@@ -417,11 +417,6 @@ test("Workspace Overview is separate from live-only Active Work", () => {
     appSource,
     /op-workspace-overview-entry[\s\S]+openWorkspaceOverview/,
     "expected Sidebar Workspace Overview entry to open the overview",
-  );
-  assert.match(
-    appSource,
-    /project-workspace-overview-button[\s\S]+openWorkspaceOverview/,
-    "expected Project Bar Workspace Overview button to open the same overview",
   );
 });
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -89,9 +89,6 @@
       const activeWorkSummary = document.getElementById("op-active-work-summary");
       const activeWorkAgents = document.getElementById("op-active-work-agents");
       const workspaceOverviewEntry = document.getElementById("op-workspace-overview-entry");
-      const projectWorkspaceOverviewButton = document.getElementById(
-        "project-workspace-overview-button",
-      );
       const zoomOutButton = document.getElementById("zoom-out-button");
       const zoomResetButton = document.getElementById("zoom-reset-button");
       const zoomInButton = document.getElementById("zoom-in-button");
@@ -8287,9 +8284,6 @@
       }
       if (workspaceOverviewEntry) {
         workspaceOverviewEntry.addEventListener("click", openWorkspaceOverview);
-      }
-      if (projectWorkspaceOverviewButton) {
-        projectWorkspaceOverviewButton.addEventListener("click", openWorkspaceOverview);
       }
       // SPEC-2356 — keyboard equivalent for clicking the modal backdrop.
       // Without this, Esc only worked for the Hotkey overlay and Command

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -231,6 +231,20 @@
         display: none;
       }
 
+      .op-sidebar__section--project-status {
+        padding: 0;
+      }
+
+      .op-sidebar__section--project-status .index-status {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+      }
+
+      .op-sidebar__section--project-status:has(.index-status[hidden]) {
+        display: none;
+      }
+
       /* SPEC-1939 T-IDX-107 — per-worktree health dot on project tabs. */
       .project-tab-dot {
         display: inline-block;
@@ -3146,17 +3160,7 @@
         <div class="project-bar">
           <div class="project-tabs" id="project-tabs"></div>
           <div class="project-actions">
-            <button
-              type="button"
-              class="index-status"
-              id="index-status"
-              aria-label="Project index health"
-              hidden
-            ></button>
             <span class="app-version" id="app-version" hidden></span>
-            <button class="arrange-button" id="project-workspace-overview-button" aria-label="Workspace overview">
-              Workspace
-            </button>
             <button class="arrange-button" id="open-project-button" aria-label="Open project">
               Open Project
             </button>
@@ -3261,6 +3265,15 @@
               <div class="op-work-empty">No active work</div>
             </div>
             <div class="op-agent-list" id="op-active-work-agents"></div>
+          </div>
+          <div class="op-sidebar__section op-sidebar__section--project-status">
+            <button
+              type="button"
+              class="index-status"
+              id="index-status"
+              aria-label="Project index health"
+              hidden
+            ></button>
           </div>
         </aside>
         <div class="canvas-area">


### PR DESCRIPTION
## Summary

- 上部バー (`.project-bar`) からプロジェクト固有コンテンツを排除: `Workspace` ボタンを削除し、`index-status` をサイドバー末尾の `op-sidebar__section--project-status` セクションへ移設。Workspace Overview はサイドバーの `Workspace Overview` 入口のみから開く統一した IA に変更。
- `select_project_tab_events` / `close_project_tab_events` / `open_project_path_events` から新ヘルパ `active_work_projection_broadcast_on_tab_change` を呼び、新アクティブタブの projection が無い場合でも空の `ActiveWorkProjection` を broadcast。frontend の `activeWorkProjection` が確実に新プロジェクトの値で置換され、Workspace Overview / Active Work / index-status がタブ切替に追従する。
- 既存ヘルパ `active_work_projection_broadcast_for_active_tab` (4 箇所のエージェント状態変化系コールサイト) は変更せず、tab-transition 専用ヘルパとして責務を分離。

Closes #2625

## Test plan

- [x] `cargo test -p gwt-core -p gwt --all-features` — 162 + 278 + 子クレート すべて GREEN。新規 3 テスト含む:
  - `app_runtime_select_project_tab_emits_active_work_projection_for_new_active_tab`
  - `app_runtime_close_project_tab_emits_active_work_projection_when_active_changes`
  - `app_runtime_open_project_path_emits_active_work_projection_for_new_tab`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bun run test:frontend-bundle` — 14 ファイル node --check OK
- [x] `bun run test:frontend-unit` — 322 件 GREEN（`operator-chrome-structure` の `project-workspace-overview-button` 不在 assertion 含む）
- [ ] 手動 GUI 検証: gwt と llmlb の 2 タブを切替えながら、サイドバー Workspace Overview / Active Work / index-status が新アクティブプロジェクトの内容に追従することを確認。タブを閉じた直後・新規プロジェクトを Open Project で開いた直後の追従も確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active Work projection now updates automatically whenever you switch between project tabs, keeping your workspace context current.

* **Style**
  * Workspace Overview control moved to the sidebar for clearer navigation.
  * Project index health indicator relocated from the top navigation bar to a dedicated sidebar section.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2626)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->