### PR TITLE
feat(gui)!: drop project-bar Index badge (SPEC-1939 Phase 13)

### DIFF
--- a/crates/gwt/playwright/README.md
+++ b/crates/gwt/playwright/README.md
@@ -1,7 +1,9 @@
-# Playwright — SPEC-2356 Operator Design System / SPEC-1939 Phase 12 e2e
+# Playwright — SPEC-2356 Operator Design System / SPEC-1939 Phase 12 / 13 e2e
 
 Visual regression baseline for the Operator Design System surfaces and
-behaviour e2e for the Project Index status badge (SPEC-1939 Phase 12).
+behaviour e2e for the Project Index health UX (SPEC-1939 Phase 12, with
+the Phase 13 badge withdrawal applied — see "SPEC-1939 Phase 12 / 13 e2e"
+below).
 
 ## Run
 
@@ -25,7 +27,7 @@ npx playwright test --update-snapshots --config crates/gwt/playwright/playwright
 | `tests/theme-toggle.spec.ts` | Dark↔Light 200ms 切替、xterm 追従 | live-gwt (skip-if-no-`GWT_PLAYWRIGHT_BASE_URL`) |
 | `tests/reduced-motion.spec.ts` | Living Telemetry 縮退 | live-gwt (skip-if-no-`GWT_PLAYWRIGHT_BASE_URL`) |
 | `tests/kanban.spec.ts` | SPEC-2017 Knowledge Bridge Kanban visual snapshots | embedded-frontend fixture |
-| `tests/index-status.spec.ts` | SPEC-1939 Phase 12 Index status badge / Settings.Index / project tab dot / per-cell rebuild | embedded-frontend fixture |
+| `tests/index-status.spec.ts` | SPEC-1939 Phase 13 Index status surface (per-tab dot / Settings.Index / per-cell rebuild) | embedded-frontend fixture |
 
 `live-gwt` specs require the CI workflow (or a developer) to launch a
 real `gwt` instance and export `GWT_PLAYWRIGHT_BASE_URL`. `embedded-frontend`
@@ -33,7 +35,7 @@ specs serve `crates/gwt/web/**` through Playwright `page.route` and stub
 `WebSocket` directly, so they run unmodified under the standard
 `Visual Regression` workflow.
 
-## SPEC-1939 Phase 12 e2e
+## SPEC-1939 Phase 12 / 13 e2e
 
 `tests/index-status.spec.ts` follows the SPEC-2017 Kanban fixture pattern
 (`tests/kanban.spec.ts`): the spec serves the embedded frontend assets
@@ -42,6 +44,13 @@ deterministic backend that emits canned `workspace_state` and
 `project_index_status` events. **No live gwt process / xvfb / WebKit
 required**, so the suite runs reliably under the existing
 `Visual Regression` workflow without any extra orchestration.
+
+> **Phase 13 scope change.** The project-bar `Index:` badge has been
+> withdrawn (concept separation between repo-shared `issues`/`specs`
+> and per-worktree `files`/`files-docs`). The earlier badge state /
+> spinner / progress-toast tests have been removed; remaining coverage
+> drives the per-tab dot aggregator and Settings.Index panel via the
+> canonical `settings:open` event.
 
 To reproduce locally, simply run:
 
@@ -53,19 +62,12 @@ The spec covers (chromium-dark + chromium-light):
 
 | Test | カバー範囲 |
 |---|---|
-| `repair_required surfaces the red badge as a clickable button` | T-IDX-105 button + ARIA + label |
-| `repairing surfaces the yellow badge with a spinner glyph` | T-IDX-104 yellow + spinner |
-| `ready surfaces the green badge with the steady-state label` | T-IDX-104 green |
-| `skipped keeps the badge hidden so non-git projects do not flash chrome` | T-IDX-104 hidden 分岐 |
-| `error surfaces the red badge with the failure title` | T-IDX-104 error title |
-| `badge click dispatches settings:open with target=index (T-IDX-105)` | T-IDX-105 dispatch |
-| `badge transitions repair_required -> repairing -> ready over WebSocket events (T-IDX-109)` | T-IDX-109 state machine |
+| `project-bar Index badge has been withdrawn (Phase 13)` | Phase 13 撤去確認 (`#index-status` が DOM に存在しない) |
 | `project tab dot reflects aggregated worktree health (T-IDX-107)` | T-IDX-107 single-worktree |
 | `multi-worktree dot aggregates: unhealthy in one worktree turns the dot red` | T-IDX-107 multi-worktree |
-| `badge click opens Settings.Index tab and renders the scope health table (T-IDX-106)` | T-IDX-106 panel + table |
+| `Settings.Index renders the scope health table from project_index_status (T-IDX-106)` | T-IDX-106 panel + table (settings:open 直接 dispatch) |
 | `Settings.Index scope-row Rebuild all dispatches without worktree_hash` | T-IDX-102 scope-row dispatch |
 | `Settings.Index per-cell Rebuild dispatches rebuild_index_cell IPC (T-IDX-102/T-IDX-110)` | T-IDX-102 per-cell / T-IDX-110 retry |
-| `repairing click shows a progress toast (T-IDX-108)` | T-IDX-108 toast |
 
 ### Optional production debugging seams
 

--- a/crates/gwt/playwright/tests/index-status.spec.ts
+++ b/crates/gwt/playwright/tests/index-status.spec.ts
@@ -1,161 +1,26 @@
-/* SPEC-1939 Phase 12 / T-IDX-102..T-IDX-110 — Project Index status badge.
- *
- * Reuses the SPEC-2017 Kanban fixture pattern: the embedded frontend is
- * served via `installEmbeddedRoutes` (`_helpers/embedded-frontend.ts`) and
- * the WebSocket is stubbed with a deterministic backend that emits canned
- * `workspace_state` + `project_index_status` events. No xvfb / wry / live
- * gwt process required, so the suite stays reliable in headless CI.
+/* SPEC-1939 Phase 13 — project-bar Index badge withdrawn. The remaining
+ * coverage exercises the per-tab dot aggregator and the Settings.Index
+ * panel (per-cell rebuild IPC) using the SPEC-2017 Kanban fixture pattern:
+ * the embedded frontend is served via `installEmbeddedRoutes`
+ * (`_helpers/embedded-frontend.ts`) and the WebSocket is stubbed with a
+ * deterministic backend that emits canned `workspace_state` +
+ * `project_index_status` events. No xvfb / wry / live gwt process required.
  */
 import { expect, test } from "@playwright/test";
 import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
 
-test.describe("Project Index status badge", () => {
+test.describe("Project Index status surface", () => {
   test.use({ viewport: { width: 1440, height: 900 } });
 
-  test("repair_required surfaces the red badge as a clickable button", async ({ page }) => {
+  test("project-bar Index badge has been withdrawn (Phase 13)", async ({ page }) => {
     await installEmbeddedRoutes(page);
     await installIndexStatusBackend(page, { state: "repair_required" });
 
     await page.goto(APP_URL);
 
-    const badge = page.locator("#index-status");
-    await expect(badge).toBeVisible({ timeout: 10_000 });
-    await expect(badge).toHaveAttribute("type", "button");
-    await expect(badge).toHaveAttribute("aria-label", /index/i);
-    await expect(badge).toContainText(/Index:\s+repair$/);
-    await expect(badge).toHaveClass(/repair_required/);
-  });
-
-  test("repairing surfaces the yellow badge with a spinner glyph", async ({ page }) => {
-    await installEmbeddedRoutes(page);
-    await installIndexStatusBackend(page, { state: "repairing" });
-
-    await page.goto(APP_URL);
-
-    const badge = page.locator("#index-status");
-    await expect(badge).toBeVisible({ timeout: 10_000 });
-    await expect(badge).toContainText(/Index:\s+repairing/);
-    await expect(badge).toHaveClass(/repairing/);
-  });
-
-  test("ready surfaces the green badge with the steady-state label", async ({ page }) => {
-    await installEmbeddedRoutes(page);
-    await installIndexStatusBackend(page, { state: "ready" });
-
-    await page.goto(APP_URL);
-
-    const badge = page.locator("#index-status");
-    await expect(badge).toBeVisible({ timeout: 10_000 });
-    await expect(badge).toContainText(/Index:\s+ready/);
-    await expect(badge).toHaveClass(/ready/);
-  });
-
-  test("skipped keeps the badge hidden so non-git projects do not flash chrome", async ({
-    page,
-  }) => {
-    await installEmbeddedRoutes(page);
-    await installIndexStatusBackend(page, { state: "skipped" });
-
-    await page.goto(APP_URL);
-
-    // Wait for the workspace state to settle (project tab attached, status
-    // dispatched) before asserting the badge is hidden — otherwise the
-    // assertion can race with the initial render.
+    // The project tab still mounts, but the legacy badge slot must be gone.
     await expect(page.locator(".project-tab")).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator("#index-status")).toBeHidden();
-  });
-
-  test("error surfaces the red badge with the failure title", async ({ page }) => {
-    await installEmbeddedRoutes(page);
-    await installIndexStatusBackend(page, { state: "error" });
-
-    await page.goto(APP_URL);
-
-    const badge = page.locator("#index-status");
-    await expect(badge).toBeVisible({ timeout: 10_000 });
-    await expect(badge).toContainText(/Index:\s+error/);
-    await expect(badge).toHaveClass(/error/);
-    await expect(badge).toHaveAttribute("title", /failed/i);
-  });
-
-  test("badge click dispatches settings:open with target=index (T-IDX-105)", async ({ page }) => {
-    await installEmbeddedRoutes(page);
-    await installIndexStatusBackend(page, { state: "repair_required" });
-
-    await page.goto(APP_URL);
-    await expect(page.locator("#index-status")).toBeVisible({ timeout: 10_000 });
-
-    const dispatched = await page.evaluate(async () => {
-      return await new Promise((resolve) => {
-        const handler = (event) => {
-          const detail = event.detail || {};
-          document.removeEventListener("settings:open", handler);
-          resolve({ target: detail.target ?? "" });
-        };
-        document.addEventListener("settings:open", handler, { once: true });
-        const badge = document.getElementById("index-status");
-        if (!badge) {
-          resolve(null);
-          return;
-        }
-        badge.click();
-        setTimeout(() => resolve(null), 2_000);
-      });
-    });
-    expect(dispatched).toEqual({ target: "index" });
-  });
-
-  test("badge transitions repair_required -> repairing -> ready over WebSocket events (T-IDX-109)", async ({
-    page,
-  }) => {
-    await installEmbeddedRoutes(page);
-    // Initial state: repair_required.
-    await installIndexStatusBackend(page, { state: "repair_required" });
-
-    await page.goto(APP_URL);
-
-    const badge = page.locator("#index-status");
-    await expect(badge).toHaveClass(/repair_required/, { timeout: 10_000 });
-    await expect(badge).toContainText(/Index:\s+repair$/);
-
-    // Drive a repairing(1/2) update through the fixture WebSocket. The
-    // fixture exposes itself on window.__gwtFixtureWebSocket so tests can
-    // simulate orchestrator state-machine progress without a real backend.
-    await page.evaluate(() => {
-      const ws = window.__gwtFixtureWebSocket;
-      ws.emit({
-        kind: "project_index_status",
-        project_root: "/fixture",
-        status: {
-          state: "repairing",
-          detail: "",
-          progress: { scopes_done: 1, scopes_total: 2 },
-          scopes: {},
-          worktrees: {},
-        },
-      });
-    });
-    await expect(badge).toHaveClass(/repairing/, { timeout: 5_000 });
-    await expect(badge).toContainText(/Index:\s+repairing/);
-
-    // Final transition to ready.
-    await page.evaluate(() => {
-      const ws = window.__gwtFixtureWebSocket;
-      ws.emit({
-        kind: "project_index_status",
-        project_root: "/fixture",
-        status: {
-          state: "ready",
-          detail: "",
-          progress: null,
-          scopes: {},
-          worktrees: {},
-        },
-      });
-    });
-    await expect(badge).toHaveClass(/ready/, { timeout: 5_000 });
-    await expect(badge).toContainText(/Index:\s+ready/);
-    await expect(badge).not.toHaveClass(/repairing/);
+    await expect(page.locator("#index-status")).toHaveCount(0);
   });
 
   test("project tab dot reflects aggregated worktree health (T-IDX-107)", async ({ page }) => {
@@ -333,7 +198,7 @@ test.describe("Project Index status badge", () => {
     await expect(dot).toHaveAttribute("data-state", "ready", { timeout: 5_000 });
   });
 
-  test("badge click opens Settings.Index tab and renders the scope health table (T-IDX-106)", async ({
+  test("Settings.Index renders the scope health table from project_index_status (T-IDX-106)", async ({
     page,
   }) => {
     await installEmbeddedRoutes(page);
@@ -361,8 +226,15 @@ test.describe("Project Index status badge", () => {
     });
 
     await page.goto(APP_URL);
-    await expect(page.locator("#index-status")).toBeVisible({ timeout: 10_000 });
-    await page.locator("#index-status").click();
+    await expect(page.locator(".project-tab")).toBeVisible({ timeout: 10_000 });
+
+    // SPEC-1939 Phase 13: badge entry point is gone; tests drive the
+    // Settings.Index tab directly via the canonical `settings:open` event.
+    await page.evaluate(() => {
+      document.dispatchEvent(
+        new CustomEvent("settings:open", { detail: { target: "index" }, bubbles: true }),
+      );
+    });
 
     // The Settings window mounts asynchronously after the create_window
     // round-trip. The Index panel is one of three tabs and should be
@@ -402,8 +274,12 @@ test.describe("Project Index status badge", () => {
     });
 
     await page.goto(APP_URL);
-    await expect(page.locator("#index-status")).toBeVisible({ timeout: 10_000 });
-    await page.locator("#index-status").click();
+    await expect(page.locator(".project-tab")).toBeVisible({ timeout: 10_000 });
+    await page.evaluate(() => {
+      document.dispatchEvent(
+        new CustomEvent("settings:open", { detail: { target: "index" }, bubbles: true }),
+      );
+    });
 
     const issuesRow = page
       .locator("[data-settings-panel='index'] tr[data-scope='issues']")
@@ -461,8 +337,12 @@ test.describe("Project Index status badge", () => {
     });
 
     await page.goto(APP_URL);
-    await expect(page.locator("#index-status")).toBeVisible({ timeout: 10_000 });
-    await page.locator("#index-status").click();
+    await expect(page.locator(".project-tab")).toBeVisible({ timeout: 10_000 });
+    await page.evaluate(() => {
+      document.dispatchEvent(
+        new CustomEvent("settings:open", { detail: { target: "index" }, bubbles: true }),
+      );
+    });
 
     // Wait for Settings.Index to render the row, then click the per-cell
     // Rebuild button.
@@ -498,22 +378,6 @@ test.describe("Project Index status badge", () => {
     });
   });
 
-  test("repairing click shows a progress toast (T-IDX-108)", async ({ page }) => {
-    await installEmbeddedRoutes(page);
-    await installIndexStatusBackend(page, {
-      state: "repairing",
-      progress: { scopes_done: 1, scopes_total: 4 },
-    });
-
-    await page.goto(APP_URL);
-    await expect(page.locator("#index-status")).toBeVisible({ timeout: 10_000 });
-
-    await page.locator("#index-status").click();
-
-    const toast = page.locator("#index-status-toast");
-    await expect(toast).toHaveAttribute("data-visible", "true");
-    await expect(toast).toContainText(/1 of 4 scope/);
-  });
 });
 
 async function installIndexStatusBackend(page, indexStatus) {

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -166,7 +166,7 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
     RootJsModuleAsset {
         path: "/index-status-controller.js",
         source: index_status_controller_js,
-        marker: "formatIndexStatusLabel",
+        marker: "aggregateProjectTabDotState",
     },
     RootJsModuleAsset {
         path: "/index-settings-panel.js",
@@ -905,51 +905,48 @@ mod tests {
     }
 
     #[test]
-    fn embedded_web_project_bar_renders_index_status_badge() {
+    fn embedded_web_project_bar_omits_index_status_badge() {
         let html = index_html();
         let js = app_js();
 
+        // SPEC-1939 Phase 13: project-bar Index badge withdrawn. The badge
+        // surface and its supporting controller / progress-toast wiring must
+        // not ship in the embedded assets. The aggregated payload still
+        // drives the per-tab dot and the Settings.Index panel.
         assert!(
-            html.contains("id=\"index-status\""),
-            "expected project bar to expose project index status badge",
+            !html.contains("id=\"index-status\""),
+            "SPEC-1939 Phase 13: project-bar Index badge must be removed",
         );
         assert!(
-            html.contains("type=\"button\"") && html.contains("class=\"index-status\""),
-            "SPEC-1939 T-IDX-105: expected #index-status to be a clickable button",
+            !html.contains(".index-status ")
+                && !html.contains(".index-status.")
+                && !html.contains(".index-status-toast"),
+            "SPEC-1939 Phase 13: index-status / toast CSS rules must be removed",
         );
         assert!(
-            html.contains(".index-status.ready")
-                && html.contains(".index-status.error")
-                && html.contains(".index-status.repairing"),
-            "expected embedded css to define index health states including repairing",
+            !html.contains("animation: index-status-spin"),
+            "SPEC-1939 Phase 13: badge spinner animation must be removed",
         );
         assert!(
-            html.contains("animation: index-status-spin"),
-            "SPEC-1939 T-IDX-104: expected repairing badge to render a spinner",
+            !js.contains("formatIndexStatusLabel")
+                && !js.contains("indexStatusLabel")
+                && !js.contains("showRepairingProgressToast")
+                && !js.contains("renderIndexStatus("),
+            "SPEC-1939 Phase 13: badge formatter / toast helpers must be removed from app.js",
         );
         assert!(
             js.contains("function setIndexStatus(projectRoot, status)")
                 && js.contains("case \"project_index_status\""),
-            "expected frontend to consume project_index_status events",
-        );
-        assert!(
-            js.contains("formatIndexStatusLabel(state)")
-                && js.contains("dispatchOpenIndexSettings(indexStatusLabel)"),
-            "SPEC-1939 T-IDX-103/105: renderIndexStatus must use the shared controller",
+            "frontend must still consume project_index_status events for the dot + Settings panel",
         );
         assert!(
             js.contains("buildSettingsTab(\"index\", \"Index\", false)")
                 && js.contains("renderIndexSettingsPanel({"),
-            "SPEC-1939 T-IDX-106: Settings window must mount an Index tab + panel",
-        );
-        assert!(
-            js.contains("showRepairingProgressToast(status)")
-                && html.contains(".index-status-toast"),
-            "SPEC-1939 T-IDX-108: repairing click should show a progress toast",
+            "SPEC-1939 T-IDX-106: Settings window must keep the Index tab + panel",
         );
         assert!(
             html.contains(".project-tab-dot") && js.contains("aggregateProjectTabDotState(status)"),
-            "SPEC-1939 T-IDX-107: project tab must render an aggregated worktree health dot",
+            "SPEC-1939 T-IDX-107: project tab must keep its aggregated worktree health dot",
         );
     }
 

--- a/crates/gwt/web/__tests__/index-status-controller.test.mjs
+++ b/crates/gwt/web/__tests__/index-status-controller.test.mjs
@@ -1,5 +1,6 @@
-// SPEC-1939 Phase 12 / T-IDX-103..T-IDX-105 — index status badge formatter
-// + click → settings:open dispatch coverage.
+// SPEC-1939 Phase 13 — project-bar Index badge withdrawn. The remaining
+// coverage exercises the per-tab dot aggregator and the Settings.Index
+// navigation event helper that other entry points still consume.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -10,7 +11,6 @@ import { parseHTML } from "linkedom";
 import {
   aggregateProjectTabDotState,
   dispatchOpenIndexSettings,
-  formatIndexStatusLabel,
   INDEX_STATUS_OPEN_SETTINGS_EVENT,
   INDEX_STATUS_OPEN_SETTINGS_TARGET,
 } from "../index-status-controller.js";
@@ -19,59 +19,6 @@ const here = dirname(fileURLToPath(import.meta.url));
 const indexHtml = readFileSync(resolve(here, "../index.html"), "utf8");
 const componentsCss = readFileSync(resolve(here, "../styles/components.css"), "utf8");
 const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
-
-test("formatIndexStatusLabel hides badge for empty / skipped", () => {
-  for (const state of ["", null, undefined, "skipped"]) {
-    const formatted = formatIndexStatusLabel(state);
-    assert.equal(formatted.hidden, true, `state=${String(state)} should hide`);
-    assert.equal(formatted.label, "");
-    assert.equal(formatted.className, "index-status");
-    assert.equal(formatted.title, "");
-  }
-});
-
-test("formatIndexStatusLabel labels each visible state distinctly", () => {
-  assert.deepEqual(formatIndexStatusLabel("ready"), {
-    hidden: false,
-    label: "Index: ready",
-    className: "index-status ready",
-    title: "Project index is ready",
-  });
-
-  assert.deepEqual(formatIndexStatusLabel("repairing"), {
-    hidden: false,
-    label: "Index: repairing",
-    className: "index-status repairing",
-    title: "Auto-rebuild in progress",
-  });
-
-  assert.deepEqual(formatIndexStatusLabel("repair_required"), {
-    hidden: false,
-    label: "Index: repair",
-    className: "index-status repair_required",
-    title: "Auto-rebuild not started",
-  });
-
-  assert.deepEqual(formatIndexStatusLabel("error"), {
-    hidden: false,
-    label: "Index: error",
-    className: "index-status error",
-    title: "Auto-rebuild failed",
-  });
-
-  // Unknown / "checking" defaults to neutral checking copy.
-  assert.deepEqual(formatIndexStatusLabel("checking"), {
-    hidden: false,
-    label: "Index: checking",
-    className: "index-status checking",
-    title: "Checking project index health",
-  });
-  assert.equal(
-    formatIndexStatusLabel("anything-else").label,
-    "Index: checking",
-    "unknown state falls back to checking",
-  );
-});
 
 test("dispatchOpenIndexSettings emits settings:open with target=index", () => {
   const { document } = parseHTML(`<!doctype html><body><button id="badge"></button></body>`);
@@ -88,54 +35,24 @@ test("dispatchOpenIndexSettings emits settings:open with target=index", () => {
   assert.equal(captured.detail.target, INDEX_STATUS_OPEN_SETTINGS_TARGET);
 });
 
-test("index-status badge in index.html is a button with accessible label", () => {
+test("project-bar Index badge has been withdrawn (SPEC-1939 Phase 13)", () => {
   const { document } = parseHTML(indexHtml);
-  const badge = document.getElementById("index-status");
-
-  assert.ok(badge, "#index-status element exists");
   assert.equal(
-    badge.tagName.toUpperCase(),
-    "BUTTON",
-    "badge must be a clickable button (T-IDX-105)",
-  );
-  assert.equal(badge.getAttribute("type"), "button");
-  assert.match(
-    badge.getAttribute("aria-label") || "",
-    /index/i,
-    "badge should have an accessible label",
-  );
-  // Hidden by default until backend reports a state.
-  assert.ok(badge.hasAttribute("hidden"));
-});
-
-test("index.html declares spinner / yellow CSS for repairing", () => {
-  // Either the inline <style> in index.html or components.css must define
-  // the `.index-status.repairing` rule with explicit yellow tokens.
-  const repairingInline = /\.index-status\.repairing\b/.test(indexHtml);
-  const repairingComponents = /\.index-status\.repairing\b/.test(componentsCss);
-  assert.ok(
-    repairingInline && repairingComponents,
-    "repairing must be styled in both index.html and components.css",
-  );
-  assert.match(
-    indexHtml,
-    /\.index-status\.repairing::before[\s\S]*animation: index-status-spin/,
-    "repairing should render a spinner pseudo-element",
-  );
-});
-
-test("renderIndexStatus in app.js consumes formatIndexStatusLabel", () => {
-  assert.ok(
-    appSource.includes('from "/index-status-controller.js"'),
-    "app.js should import index-status-controller",
+    document.getElementById("index-status"),
+    null,
+    "#index-status badge must not exist in the embedded HTML",
   );
   assert.ok(
-    appSource.includes("formatIndexStatusLabel(state)"),
-    "renderIndexStatus should delegate to formatIndexStatusLabel",
+    !indexHtml.includes(".index-status "),
+    "embedded inline <style> must not declare .index-status rules",
   );
   assert.ok(
-    appSource.includes("dispatchOpenIndexSettings(indexStatusLabel)"),
-    "click handler should dispatch settings:open via the shared helper",
+    !componentsCss.includes(".index-status"),
+    "components.css must not declare .index-status rules",
+  );
+  assert.ok(
+    !indexHtml.includes("index-status-toast"),
+    "embedded HTML must not declare the index-status progress toast",
   );
 });
 
@@ -206,13 +123,21 @@ test("aggregateProjectTabDotState returns '' when no worktree health is reported
   assert.equal(aggregateProjectTabDotState(null), "");
 });
 
-test("app.js wires the shared aggregator and progress toast helpers", () => {
+test("app.js still wires the per-tab dot aggregator", () => {
   assert.ok(
     appSource.includes("aggregateProjectTabDotState(status)"),
     "renderProjectTabs should consume the shared aggregator",
   );
   assert.ok(
-    appSource.includes("showRepairingProgressToast(status)"),
-    "indexStatusLabel click should call the progress toast helper",
+    !appSource.includes("formatIndexStatusLabel"),
+    "app.js must not import or call the removed formatIndexStatusLabel helper",
+  );
+  assert.ok(
+    !appSource.includes("showRepairingProgressToast"),
+    "app.js must not retain the badge progress toast helper",
+  );
+  assert.ok(
+    !appSource.includes("indexStatusLabel"),
+    "app.js must not retain references to the removed badge element",
   );
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -23,11 +23,7 @@
       import { createWorkspaceKanbanSurface } from "/workspace-kanban-surface.js";
       import { createUpdateCtaController } from "/update-cta.js";
       import { createTerminalContextMenuController } from "/terminal-context-menu.js";
-      import {
-        aggregateProjectTabDotState,
-        dispatchOpenIndexSettings,
-        formatIndexStatusLabel,
-      } from "/index-status-controller.js";
+      import { aggregateProjectTabDotState } from "/index-status-controller.js";
       import { renderIndexSettingsPanel } from "/index-settings-panel.js";
       import { renderCustomAgentEnvEditor } from "/custom-agent-env-editor.js";
       import {
@@ -116,7 +112,6 @@
       const connectionDot = document.getElementById("connection-dot");
       const connectionLabel = document.getElementById("connection-label");
       const appVersionLabel = document.getElementById("app-version");
-      const indexStatusLabel = document.getElementById("index-status");
 
       const decoderMap = new Map();
       const pendingOutputMap = new Map();
@@ -307,61 +302,11 @@
       let projectError = "";
       const TERMINAL_SELECTION_DRAG_THRESHOLD = 4;
 
-      function renderIndexStatus() {
-        const activeProjectRoot = activeProjectTab()?.project_root || "";
-        const indexStatusState =
-          (activeProjectRoot && indexStatusByProjectRoot.get(activeProjectRoot)) || {
-            state: "",
-            detail: "",
-          };
-        const state = indexStatusState.state || "";
-        const formatted = formatIndexStatusLabel(state);
-        indexStatusLabel.hidden = formatted.hidden;
-        indexStatusLabel.className = formatted.className;
-        indexStatusLabel.textContent = formatted.label;
-        indexStatusLabel.title = indexStatusState.detail || formatted.title;
-      }
-
-      indexStatusLabel.addEventListener("click", () => {
-        if (indexStatusLabel.hidden) return;
-        const activeProjectRoot = activeProjectTab()?.project_root || "";
-        const status =
-          (activeProjectRoot && indexStatusByProjectRoot.get(activeProjectRoot)) || null;
-        if (status?.state === "repairing") {
-          showRepairingProgressToast(status);
-          return;
-        }
-        dispatchOpenIndexSettings(indexStatusLabel);
-      });
-
-      // SPEC-1939 T-IDX-108: while badge is `repairing`, click shows a
-      // progress toast sourced from the aggregated payload's `progress`
-      // field. No cancel button is provided because plan.md keeps the
-      // failure path visible (one shot per scope, then `error` for retry).
-      function showRepairingProgressToast(status) {
-        const progress = status?.progress || {};
-        const done = Number.isFinite(progress.scopes_done) ? progress.scopes_done : 0;
-        const total = Number.isFinite(progress.scopes_total) ? progress.scopes_total : 0;
-        const text = total > 0
-          ? `Rebuilding project index: ${done} of ${total} scope(s) completed`
-          : "Rebuilding project index…";
-        let toast = document.getElementById("index-status-toast");
-        if (!toast) {
-          toast = document.createElement("div");
-          toast.id = "index-status-toast";
-          toast.className = "index-status-toast";
-          toast.setAttribute("role", "status");
-          toast.setAttribute("aria-live", "polite");
-          document.body.appendChild(toast);
-        }
-        toast.textContent = text;
-        toast.dataset.visible = "true";
-        if (toast._hideTimer) clearTimeout(toast._hideTimer);
-        toast._hideTimer = setTimeout(() => {
-          toast.dataset.visible = "false";
-        }, 3500);
-      }
-
+      // SPEC-1939 Phase 13: project-bar Index badge withdrawn. The
+      // aggregated payload now feeds only the per-tab dot indicator and the
+      // Settings.Index panel; the project-bar surface no longer renders an
+      // Index summary because repo-shared (issues/specs) and per-worktree
+      // (files/files-docs) scopes were being collapsed into a single state.
       function setIndexStatus(projectRoot, status) {
         if (!projectRoot) {
           return;
@@ -374,7 +319,6 @@
           scopes: status?.scopes || {},
           worktrees: status?.worktrees || {},
         });
-        renderIndexStatus();
         renderIndexPanelInAllSettingsWindows();
         refreshProjectTabDots();
       }
@@ -1024,7 +968,6 @@
         setVersionState(appState.app_version, versionState.latest);
         renderProjectTabs();
         renderProjectPicker();
-        renderIndexStatus();
         updateActionAvailability();
         const tab = activeProjectTab();
         renderProjectOnboarding(tab);

--- a/crates/gwt/web/index-status-controller.js
+++ b/crates/gwt/web/index-status-controller.js
@@ -1,69 +1,7 @@
-// SPEC-1939 Phase 12 / T-IDX-103..T-IDX-105 — pure formatter for the
-// project bar Index status badge. The summary badge is intentionally short:
-// scope/worktree details belong to the Settings.Index tab, which is wired
-// in PR3.
-//
-// State machine:
-//   ""        | "skipped"        -> hidden (no badge)
-//   "ready"                       -> "Index: ready" (active color)
-//   "checking"                    -> "Index: checking" (default neutral)
-//   "repair_required"             -> "Index: repair" (red, "auto-rebuild not started")
-//   "repairing"                   -> "Index: repairing" (yellow, spinner)
-//   "error"                       -> "Index: error" (red, "auto-rebuild failed")
-
-const READY_TITLE = "Project index is ready";
-const CHECKING_TITLE = "Checking project index health";
-const REPAIRING_TITLE = "Auto-rebuild in progress";
-const REPAIR_REQUIRED_TITLE = "Auto-rebuild not started";
-const ERROR_TITLE = "Auto-rebuild failed";
-
-export function formatIndexStatusLabel(state) {
-  if (!state || state === "skipped") {
-    return {
-      hidden: true,
-      label: "",
-      className: "index-status",
-      title: "",
-    };
-  }
-  switch (state) {
-    case "ready":
-      return {
-        hidden: false,
-        label: "Index: ready",
-        className: "index-status ready",
-        title: READY_TITLE,
-      };
-    case "repairing":
-      return {
-        hidden: false,
-        label: "Index: repairing",
-        className: "index-status repairing",
-        title: REPAIRING_TITLE,
-      };
-    case "repair_required":
-      return {
-        hidden: false,
-        label: "Index: repair",
-        className: "index-status repair_required",
-        title: REPAIR_REQUIRED_TITLE,
-      };
-    case "error":
-      return {
-        hidden: false,
-        label: "Index: error",
-        className: "index-status error",
-        title: ERROR_TITLE,
-      };
-    default:
-      return {
-        hidden: false,
-        label: "Index: checking",
-        className: "index-status checking",
-        title: CHECKING_TITLE,
-      };
-  }
-}
+// SPEC-1939 Phase 13 — project-bar Index badge withdrawn (concept separation).
+// `formatIndexStatusLabel` removed. The remaining helpers drive the per-tab
+// `.project-tab-dot` and the Settings.Index navigation event consumed by
+// callers other than the deleted badge.
 
 export const INDEX_STATUS_OPEN_SETTINGS_EVENT = "settings:open";
 export const INDEX_STATUS_OPEN_SETTINGS_TARGET = "index";
@@ -106,8 +44,8 @@ export function aggregateProjectTabDotState(status) {
 }
 
 // Dispatch the canonical settings:open event consumed by the Settings.Index
-// tab handler (PR3). Kept in this module so `renderIndexStatus` and any
-// other badge interaction share the same payload shape.
+// tab handler (PR3). Callers (Settings button, command palette, future
+// affordances) reuse this helper so the navigation event shape stays canonical.
 export function dispatchOpenIndexSettings(target) {
   const dispatchTarget = target || (typeof document !== "undefined" ? document : null);
   if (!dispatchTarget) return;

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -171,66 +171,6 @@
         display: none;
       }
 
-      .index-status {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        height: 32px;
-        padding: 0 10px;
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius-md);
-        background: var(--color-surface-elevated);
-        color: var(--color-text-muted);
-        font-family: var(--font-mono);
-        font-size: var(--type-xs);
-        letter-spacing: var(--tracking-mono);
-        font-weight: 700;
-        white-space: nowrap;
-        cursor: pointer;
-      }
-
-      .index-status:focus-visible {
-        outline: 2px solid var(--color-state-active);
-        outline-offset: 2px;
-      }
-
-      .index-status.ready {
-        border-color: var(--color-state-active);
-        color: var(--color-state-active);
-      }
-
-      .index-status.repair_required,
-      .index-status.error {
-        border-color: var(--color-state-blocked);
-        color: var(--color-state-blocked);
-      }
-
-      .index-status.repairing {
-        border-color: var(--agent-claude);
-        color: var(--agent-claude);
-      }
-
-      .index-status.repairing::before {
-        content: "";
-        display: inline-block;
-        width: 10px;
-        height: 10px;
-        border-radius: 50%;
-        border: 2px solid currentColor;
-        border-top-color: transparent;
-        animation: index-status-spin 0.85s linear infinite;
-      }
-
-      @keyframes index-status-spin {
-        to {
-          transform: rotate(360deg);
-        }
-      }
-
-      .index-status[hidden] {
-        display: none;
-      }
-
       /* SPEC-1939 T-IDX-107 — per-worktree health dot on project tabs. */
       .project-tab-dot {
         display: inline-block;
@@ -249,31 +189,6 @@
       }
       .project-tab-dot[data-state="repairing"] {
         background: var(--agent-claude);
-      }
-
-      /* SPEC-1939 T-IDX-108 — progress toast for repairing badge click. */
-      .index-status-toast {
-        position: fixed;
-        right: 16px;
-        bottom: 16px;
-        max-width: 480px;
-        padding: 10px 14px;
-        background: var(--color-surface-elevated);
-        color: var(--color-text);
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius-md);
-        box-shadow: var(--shadow-glow-active, 0 4px 16px rgba(0, 0, 0, 0.2));
-        font-size: var(--type-xs);
-        font-family: var(--font-mono);
-        opacity: 0;
-        transform: translateY(8px);
-        pointer-events: none;
-        transition: opacity 200ms ease, transform 200ms ease;
-        z-index: 50;
-      }
-      .index-status-toast[data-visible="true"] {
-        opacity: 1;
-        transform: translateY(0);
       }
 
       /* SPEC-1939 T-IDX-106 — Settings.Index health table. */
@@ -3146,13 +3061,6 @@
         <div class="project-bar">
           <div class="project-tabs" id="project-tabs"></div>
           <div class="project-actions">
-            <button
-              type="button"
-              class="index-status"
-              id="index-status"
-              aria-label="Project index health"
-              hidden
-            ></button>
             <span class="app-version" id="app-version" hidden></span>
             <button class="arrange-button" id="project-workspace-overview-button" aria-label="Workspace overview">
               Workspace

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1378,16 +1378,11 @@ kbd.op-kbd {
   background: color-mix(in oklab, var(--color-text) 24%, transparent);
 }
 
-:root[data-theme] .app-version,
-:root[data-theme] .index-status {
+:root[data-theme] .app-version {
   background: var(--color-surface-elevated);
   color: var(--color-text-muted);
   border-color: var(--color-border);
 }
-:root[data-theme] .index-status.ready { color: var(--color-state-active); border-color: var(--color-state-active); }
-:root[data-theme] .index-status.repair_required,
-:root[data-theme] .index-status.error { color: var(--color-state-blocked); border-color: var(--color-state-blocked); }
-:root[data-theme] .index-status.repairing { color: var(--agent-claude); border-color: var(--agent-claude); }
 
 :root[data-theme] .hint {
   color: var(--color-text-muted);

--- a/docs/spec-1939-phase-12-manual-smoke.md
+++ b/docs/spec-1939-phase-12-manual-smoke.md
@@ -1,16 +1,23 @@
-# SPEC-1939 Phase 12 — manual smoke checklist
+# SPEC-1939 Phase 12 / 13 — manual smoke checklist
 
 T-IDX-111 (macOS) and T-IDX-112 (Windows best-effort) require a human
 reviewer to drive a real `gwt` GUI build because the fit between
 xterm.js / wry / tao / OS window chrome is not exercisable from
 Playwright's embedded-frontend fixture pattern.
 
-The Playwright behaviour suite (`crates/gwt/playwright/tests/index-status.
-spec.ts`, 13 tests × 2 themes) gates **frontend logic** end-to-end:
-state-machine transitions, click → `settings:open`, Settings.Index table,
-per-cell / scope-row Rebuild dispatch, project tab dot aggregation, and
-the progress toast. Manual smoke just confirms that the same frontend
-renders correctly when wired to the real backend.
+The Playwright behaviour suite (`crates/gwt/playwright/tests/index-status.spec.ts`)
+gates **frontend logic** end-to-end after Phase 13: per-tab dot aggregation,
+Settings.Index table rendering, and per-cell / scope-row Rebuild dispatch
+through the `settings:open` event. Manual smoke just confirms that the
+same frontend renders correctly when wired to the real backend.
+
+> **Phase 13 scope change.** The project-bar `Index: ready / repair / …`
+> badge has been withdrawn (concept separation: `issues` / `specs` are
+> repo-shared while `files` / `files-docs` are per-worktree, so a single
+> aggregated badge mixed scopes and produced cross-branch contamination).
+> All steps that previously inspected the badge or its progress toast are
+> removed. Use the per-tab dot for Files/Files-docs health and the
+> Settings → Index tab for full per-scope details.
 
 Use this checklist when verifying a release candidate. Record the
 outcome in the Board (`gwtd board post --kind status --body ...`) so
@@ -32,13 +39,10 @@ SPEC-1939 Issue #2584 can close.
 4. Optional: pre-seed an unhealthy index scope so the bootstrap path
    enters `repair_required` and the auto-rebuild orchestrator runs.
    The chroma stores live under `~/.gwt/index/<repo-hash>/worktrees/
-   <wt-hash>/files/`. The 16-char `repo-hash` is computed from the
-   project's git remote URL (or local path when no remote is set), and
-   each worktree gets its own `wt-hash` directory. The simplest recipe:
+   <wt-hash>/files/`. The simplest recipe:
 
    ```bash
-   # 1. List the indexed worktrees for the active gwt project (run from
-   #    inside the project's repo root):
+   # 1. List the indexed worktrees for the active gwt project:
    ls -d ~/.gwt/index/*/worktrees/*/
 
    # 2. Pick one of those `<wt-hash>/` directories and remove its `files/`
@@ -46,49 +50,43 @@ SPEC-1939 Issue #2584 can close.
    rm -rf ~/.gwt/index/<repo-hash>/worktrees/<wt-hash>/files
    ```
 
-   When you re-launch `gwt`, the bootstrap probe should detect the
-   missing chroma store, surface the red `Index: repair` badge for one
-   tick, then transition through `Index: repairing` (yellow + spinner)
-   to `Index: ready` (green) once the orchestrator rebuilds the scope.
+   When you re-launch `gwt`, the per-tab dot for the affected worktree
+   should turn red while the orchestrator rebuilds, transition through
+   yellow (repairing), and end on green (ready) once the rebuild
+   completes. The project-bar surface stays unchanged because the badge
+   no longer exists.
 
 ## T-IDX-111 — macOS manual smoke
 
 Open the project and confirm each step in order. Stop and capture a
 screenshot if any step fails.
 
-1. **Bootstrap badge transitions.** Launch `gwt` in the multi-worktree
-   project. The top-bar badge should briefly show `Index: checking`,
-   transition to `Index: repair` (red) when the unhealthy scope is
-   detected, then `Index: repairing` (yellow + spinner) once the
-   orchestrator starts, and finally `Index: ready` (green).
-2. **Project tab dot aggregation.** While the transition runs, the
-   project tab's coloured dot must follow the same colour: red →
-   yellow → green. Other project tabs must stay green throughout.
-3. **Settings.Index tab opens via badge click.** Click the badge during
-   any non-`ready` state. The Settings window must open with the
-   `Index` tab pre-selected (`data-settings-tab=index`).
-4. **Health table renders.** The Index tab must list `(scope, worktree)`
+1. **Project tab dot aggregation.** Launch `gwt` in the multi-worktree
+   project. While the orchestrator runs, the affected project tab's
+   coloured dot must follow red → yellow → green. Other project tabs
+   must stay green throughout. The project-bar surface (Workspace /
+   Open Project / theme toggle) must NOT show any `Index:` badge.
+2. **Settings → Index tab opens.** Open Settings (existing entry point
+   such as the Settings menu / button or any keybinding wired to it).
+   Switch to the `Index` tab.
+3. **Health table renders.** The Index tab must list `(scope, worktree)`
    cells with `last_repair_at` / `document_count` / `reason`. The
    unhealthy worktree's `files` cell must read `manifest_missing` (or
-   the reason you seeded).
-5. **Per-cell Rebuild → green dot.** Click the per-cell `Rebuild`
+   the reason you seeded). Repo-shared scopes (`issues`, `specs`) must
+   appear without per-worktree columns.
+4. **Per-cell Rebuild → green dot.** Click the per-cell `Rebuild`
    button on the unhealthy worktree's `files` row. The cell must flip
-   to ready, the project tab dot must return to green, and a fresh
-   `Index: ready` (green) badge must remain stable.
-6. **Progress toast on repairing click.** While the badge is
-   `Index: repairing`, click it. A toast like `Rebuilding project
-   index: X of Y scope(s) completed` must appear in the bottom-right
-   for ~3.5 s.
-7. **No flicker / focus loss.** Throughout the run, the host window
+   to ready and the project tab dot must return to green.
+5. **No flicker / focus loss.** Throughout the run, the host window
    must not flicker, and keyboard focus must not jump.
 
 ## T-IDX-112 — Windows best-effort smoke
 
 Repeat the macOS checklist on Windows. Pay extra attention to:
 
-- Badge button click does **not** open Settings as a flickering window
-  (white frame ≤ 1 frame).
-- xterm scrollback continues to scroll while the badge transitions —
+- Settings window mount does **not** flash a white frame > 1 frame
+  when opened from the Index entry path.
+- xterm scrollback continues to scroll while the orchestrator runs —
   there is a known interaction with terminal viewport reflow
   (SPEC-2008 Phase 24 covers this; mention any regression in the smoke
   Board post).
@@ -104,14 +102,12 @@ After running the checklist, post a status update:
 ```bash
 gwtd board post --kind status --owner SPEC-1939 --topic phase-12-smoke \
   --mention user:akiojin --body $'\
-SPEC-1939 Phase 12 macOS smoke (T-IDX-111) 完了:\n\
-- 1: pass\n\
-- 2: pass\n\
-- 3: pass\n\
-- 4: pass\n\
-- 5: pass\n\
-- 6: pass\n\
-- 7: pass\n\
+SPEC-1939 Phase 12/13 macOS smoke (T-IDX-111) 完了:\n\
+- 1 (tab dot aggregation): pass\n\
+- 2 (Settings.Index opens): pass\n\
+- 3 (health table): pass\n\
+- 4 (per-cell Rebuild → green dot): pass\n\
+- 5 (no flicker / focus loss): pass\n\
 \n\
 Windows (T-IDX-112): <pass | best-effort deferred>'
 ```
@@ -124,4 +120,4 @@ agent / branch / session; `--mention` records a typed audience marker that
 ships with the entry payload.
 
 When the smoke passes on macOS, comment on Issue #2584 with the Board
-link to close the Phase 12 verification follow-up.
+link to close the Phase 12 / 13 verification follow-up.


### PR DESCRIPTION
## Summary

- WebView GUI 上部に出ていた `Index: ready / repair / repairing / error / checking` バッジを撤去 (SPEC-1939 Phase 13)。バッジは `issues`/`specs` (repo-shared) と `files`/`files-docs` (per-worktree) の health を 1 state に折り畳んでおり、project-level インデックスと branch-level インデックスを project-bar に混在表示する概念ずれと、別 worktree の `files` 不健全が現在の project-bar を汚染するクロスブランチ汚染の原因になっていた。
- Index ヘルスは Phase 12 で導入済みの **per-tab dot** (各 tab の worktree について `aggregateProjectTabDotState` が `files`/`files-docs` のみを集約) と **Settings → Index タブ** (`renderIndexSettingsPanel` が全 scope × 全 worktree を per-cell Rebuild 付きで描画) で過不足なく確認できる。
- 公開データ層 (`ProjectIndexStatusView` / `ProjectIndexScopes` / WebSocket `project_index_status` event) は不変。今回は **GUI 上部 surface のみ** の整理。

## Affected files

- `crates/gwt/web/index.html` / `crates/gwt/web/styles/components.css`: `#index-status` button、`.index-status*` / `.index-status-toast*` CSS、`@keyframes index-status-spin` を削除。
- `crates/gwt/web/index-status-controller.js`: `formatIndexStatusLabel` を削除。`aggregateProjectTabDotState` と `dispatchOpenIndexSettings` は他 entry 用に export を維持。
- `crates/gwt/web/app.js`: badge wiring (import / `indexStatusLabel` / `renderIndexStatus` / 進捗 toast / click→Settings) を削除。`indexStatusByProjectRoot` Map は per-tab dot と Settings.Index panel 用に保持。
- `crates/gwt/src/embedded_web.rs`: アセットマーカーを `aggregateProjectTabDotState` に変更し、project-bar アサーションを「badge が存在しない」検証へ置換。
- `crates/gwt/web/__tests__/index-status-controller.test.mjs`: badge formatter テストを削除し、撤去確認とヘルパー回帰テストを追加。
- `crates/gwt/playwright/tests/index-status.spec.ts`: badge 状態 / spinner / progress toast / click 遷移を gating する 7 spec を削除。Phase 13 撤去確認 + Settings.Index 系は `settings:open` を直接 dispatch する形に集約 (12 case = 6 spec × 2 theme)。
- `crates/gwt/playwright/README.md` / `docs/spec-1939-phase-12-manual-smoke.md`: badge 関連手順と説明を Phase 13 撤回に合わせて更新。
- SPEC-1939 GitHub Issue (#1939) の plan / tasks に Phase 13 (T-IDX-117〜T-IDX-123) を追加済み。Phase 12 の FR-048 / FR-051 / SC-031 / SC-032 / SC-035 は本 Phase 13 が supersede する。

## Coordination

- Board に `kind=claim --mention agent:claude-code` で着手宣言済み (SPEC-1939 Phase 13 / project-bar Index badge 削除)。Phase 12 e2e を整備していた Ralph Loop ライン (#2594/#2597/#2599/#2600) は MERGED 済み・open PR なし。
- 今回の削除に対応して、当該 Ralph Loop が積んだ badge 系 e2e は本 PR で除却し、Phase 13 撤去確認 + Settings.Index は新形式に置換。

## Test plan

- [x] `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` clean。
- [x] `cargo test -p gwt-core -p gwt` 全 GREEN。`embedded_web::tests::embedded_web_project_bar_omits_index_status_badge` で badge 不在を検証。
- [x] `npm run test:frontend-unit` 318/318 PASS。`__tests__/index-status-controller.test.mjs` で `formatIndexStatusLabel` 削除を確認、`aggregateProjectTabDotState` 系は維持で GREEN。
- [x] `npx playwright test crates/gwt/playwright/tests/index-status.spec.ts` 12/12 PASS (chromium-dark + chromium-light、6 spec × 2 theme)。
- [x] `bunx commitlint --from HEAD~1 --to HEAD` PASS (Conventional Commit `feat(gui)!:` + BREAKING CHANGE notice)。
- [ ] **Manual GUI smoke** (T-IDX-111 macOS hard gate): `docs/spec-1939-phase-12-manual-smoke.md` の Phase 13 圧縮版チェックリストに沿って、project-bar に `Index:` 表示が出ないこと、tab dot が files=unhealthy 時に赤、Settings → Index タブが従来通り開けることをレビュアーが実機で確認。

## Breaking change notice

GUI 上部の `Index: ...` バッジが消える。Index ヘルスは引き続き project tab dot (色付きドット) と Settings → Index タブ (per-scope × per-worktree health table + Rebuild) で確認できる。WebSocket / Rust データ層の互換は崩していない。
