### PR TITLE
fix: close gwt verification gaps

### DIFF
--- a/crates/gwt-core/tests/migration_workflow_test.rs
+++ b/crates/gwt-core/tests/migration_workflow_test.rs
@@ -2,12 +2,14 @@
 
 use gwt_core::config::BareProjectConfig;
 use gwt_core::migration::backup::{self, BACKUP_DIR_NAME};
+use gwt_core::migration::executor;
 use gwt_core::migration::rollback;
 use gwt_core::migration::validator::{
     self, check_disk_space, check_locked_worktrees, check_write_permission, evaluate_disk_space,
     ValidationError,
 };
-use gwt_core::migration::MigrationPhase;
+use gwt_core::migration::MigrationOptions;
+use gwt_core::migration::{MigrationError, MigrationPhase, RecoveryState};
 
 #[test]
 fn t013_bare_project_config_round_trip() {
@@ -220,6 +222,44 @@ fn t030_backup_create_copies_tree_into_backup_dir() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn t030_backup_create_skips_symlinks_in_project_and_nested_dirs() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("target.txt"), "target").unwrap();
+    symlink("target.txt", tmp.path().join("link.txt")).unwrap();
+    std::fs::create_dir_all(tmp.path().join("nested")).unwrap();
+    std::fs::write(tmp.path().join("nested").join("inner.txt"), "inner").unwrap();
+    symlink(
+        "inner.txt",
+        tmp.path().join("nested").join("inner-link.txt"),
+    )
+    .unwrap();
+
+    let snapshot = backup::create(tmp.path()).expect("backup::create");
+
+    assert!(snapshot.backup_dir.join("target.txt").is_file());
+    assert!(
+        !snapshot.backup_dir.join("link.txt").exists(),
+        "top-level symlinks must not be copied into the backup"
+    );
+    assert!(snapshot
+        .backup_dir
+        .join("nested")
+        .join("inner.txt")
+        .is_file());
+    assert!(
+        !snapshot
+            .backup_dir
+            .join("nested")
+            .join("inner-link.txt")
+            .exists(),
+        "nested symlinks must not be copied into the backup"
+    );
+}
+
 #[test]
 fn t030_backup_create_excludes_self() {
     let tmp = tempfile::tempdir().unwrap();
@@ -230,6 +270,36 @@ fn t030_backup_create_excludes_self() {
     // The backup directory must not contain a recursive copy of itself.
     assert!(!snapshot.backup_dir.join(BACKUP_DIR_NAME).exists());
     assert!(snapshot.backup_dir.join("real.txt").is_file());
+}
+
+#[test]
+fn t030_backup_create_with_external_roots_skips_missing_and_sanitizes_names() {
+    let project = tempfile::tempdir().unwrap();
+    let external_parent = tempfile::tempdir().unwrap();
+    let external = external_parent.path().join("linked worktree@one");
+    std::fs::create_dir_all(&external).unwrap();
+    std::fs::write(external.join("dirty.txt"), "dirty").unwrap();
+    let missing = external_parent.path().join("missing-worktree");
+
+    let snapshot =
+        backup::create_with_external_roots(project.path(), &[missing.clone(), external.clone()])
+            .expect("backup::create_with_external_roots");
+
+    assert_eq!(snapshot.external_roots.len(), 1);
+    let external_snapshot = &snapshot.external_roots[0];
+    assert_eq!(external_snapshot.original_path, external);
+    assert!(external_snapshot
+        .backup_path
+        .ends_with("1-linked_worktree_one"));
+    assert!(external_snapshot.backup_path.join("dirty.txt").is_file());
+    assert!(
+        !snapshot
+            .backup_dir
+            .join(".external-worktrees")
+            .join("0-missing-worktree")
+            .exists(),
+        "missing external roots must be ignored instead of creating empty backups"
+    );
 }
 
 #[test]
@@ -265,6 +335,39 @@ fn t032_backup_create_renames_existing_backup() {
 }
 
 #[test]
+fn t034_backup_restore_restores_external_roots_and_removes_added_dirs() {
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(project.path().join("root.txt"), "v1").unwrap();
+    let external_parent = tempfile::tempdir().unwrap();
+    let external = external_parent.path().join("linked-worktree");
+    std::fs::create_dir_all(external.join("dir")).unwrap();
+    std::fs::write(external.join("dir").join("tracked.txt"), "before").unwrap();
+
+    let snapshot =
+        backup::create_with_external_roots(project.path(), std::slice::from_ref(&external))
+            .expect("backup::create_with_external_roots");
+
+    std::fs::remove_file(project.path().join("root.txt")).unwrap();
+    std::fs::write(project.path().join("migration-junk.txt"), "junk").unwrap();
+    std::fs::remove_dir_all(&external).unwrap();
+    std::fs::create_dir_all(external.join("new-dir")).unwrap();
+    std::fs::write(external.join("new-dir").join("junk.txt"), "junk").unwrap();
+
+    backup::restore(&snapshot).expect("backup::restore");
+
+    assert_eq!(
+        std::fs::read_to_string(project.path().join("root.txt")).unwrap(),
+        "v1"
+    );
+    assert!(!project.path().join("migration-junk.txt").exists());
+    assert_eq!(
+        std::fs::read_to_string(external.join("dir").join("tracked.txt")).unwrap(),
+        "before"
+    );
+    assert!(!external.join("new-dir").exists());
+}
+
+#[test]
 fn t034_backup_restore_returns_files_to_project_root() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("keep.txt"), "v1").unwrap();
@@ -297,6 +400,24 @@ fn t034_backup_restore_returns_files_to_project_root() {
 }
 
 #[test]
+fn t035_backup_discard_removes_existing_snapshot_and_ignores_missing_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "alpha").unwrap();
+    let snapshot = backup::create(tmp.path()).expect("backup::create");
+    let backup_dir = snapshot.backup_dir.clone();
+
+    backup::discard(snapshot).expect("discard existing backup");
+    assert!(!backup_dir.exists());
+
+    let missing_snapshot = backup::BackupSnapshot {
+        project_root: tmp.path().to_path_buf(),
+        backup_dir,
+        external_roots: Vec::new(),
+    };
+    backup::discard(missing_snapshot).expect("discard missing backup is a no-op");
+}
+
+#[test]
 fn t036_rollback_uses_backup_to_restore_partial_changes() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("a"), "1").unwrap();
@@ -317,6 +438,72 @@ fn t036_rollback_uses_backup_to_restore_partial_changes() {
         !tmp.path().join("partial.bin").exists(),
         "rollback must clear partial files"
     );
+}
+
+#[test]
+fn t036_rollback_surfaces_backup_restore_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snapshot = backup::BackupSnapshot {
+        project_root: tmp.path().join("missing-project-root"),
+        backup_dir: tmp.path().join("missing-backup"),
+        external_roots: Vec::new(),
+    };
+
+    let err = rollback::rollback_migration(&snapshot).expect_err("rollback must fail");
+    let message = err.to_string();
+    assert!(message.contains("rollback failed: backup io error:"));
+}
+
+#[test]
+fn t040_executor_stub_returns_untouched_confirm_error() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let err = executor::execute_migration(tmp.path(), MigrationOptions::default(), |_, _| {
+        panic!("stub executor must not emit progress")
+    })
+    .expect_err("stub executor must return the explicit not-implemented error");
+
+    assert_eq!(err.phase, MigrationPhase::Confirm);
+    assert_eq!(err.recovery, RecoveryState::Untouched);
+    assert!(err.message.contains("execute_migration is not implemented"));
+    assert!(err
+        .to_string()
+        .contains("migration failed at phase confirm"));
+}
+
+#[test]
+fn t040_migration_error_display_includes_phase_recovery_and_message() {
+    let err = MigrationError {
+        phase: MigrationPhase::Backup,
+        message: "disk failed".to_string(),
+        recovery: RecoveryState::Partial,
+    };
+
+    assert_eq!(
+        err.to_string(),
+        "migration failed at phase backup (recovery: Partial): disk failed"
+    );
+}
+
+#[test]
+fn t020_validation_error_display_and_io_conversion_are_stable() {
+    let disk = ValidationError::InsufficientDiskSpace {
+        required: 20,
+        available: 10,
+    };
+    assert_eq!(
+        disk.to_string(),
+        "insufficient disk space: required 20 bytes, available 10 bytes"
+    );
+
+    let locked = ValidationError::LockedWorktrees(vec!["/tmp/wt".into()]);
+    assert!(locked.to_string().contains("locked worktrees:"));
+
+    let denied = ValidationError::WritePermissionDenied("/tmp/project".into());
+    assert_eq!(denied.to_string(), "write permission denied: /tmp/project");
+
+    let io_error: ValidationError = std::io::Error::other("boom").into();
+    assert_eq!(io_error.to_string(), "validator io error: boom");
 }
 
 #[test]

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -240,6 +240,14 @@ pub struct WorktreeProbeOutcome {
     pub status_payload: Result<serde_json::Value, String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitWorktreeListEntry {
+    path: PathBuf,
+    branch: Option<String>,
+    bare: bool,
+    prunable: bool,
+}
+
 /// Translate a single scope sub-payload from the runner status JSON into a
 /// [`ScopeHealthView`]. Returns `None` if the payload is not an object.
 pub fn parse_scope_health(payload: &serde_json::Value) -> Option<ScopeHealthView> {
@@ -496,27 +504,85 @@ pub fn list_worktree_probe_inputs(repo_root: &Path) -> Result<Vec<WorktreeProbeI
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
     }
 
-    let mut inputs = Vec::new();
-    let mut current_path: Option<PathBuf> = None;
-    let mut current_branch: Option<String> = None;
+    parse_worktree_probe_inputs(&String::from_utf8_lossy(&output.stdout))
+}
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    for line in stdout.lines().chain(std::iter::once("")) {
-        if let Some(rest) = line.strip_prefix("worktree ") {
-            if let Some(path) = current_path.take() {
-                push_worktree_probe_input(&mut inputs, path, current_branch.take())?;
-            }
-            current_path = Some(canonicalize_path(PathBuf::from(rest)));
-        } else if let Some(branch) = line.strip_prefix("branch ") {
-            current_branch = Some(branch.trim_start_matches("refs/heads/").to_string());
-        } else if line.is_empty() {
-            if let Some(path) = current_path.take() {
-                push_worktree_probe_input(&mut inputs, path, current_branch.take())?;
-            }
+fn parse_worktree_probe_inputs(stdout: &str) -> Result<Vec<WorktreeProbeInput>, String> {
+    let mut inputs = Vec::new();
+    for entry in parse_git_worktree_porcelain(stdout) {
+        if !git_worktree_entry_is_active(&entry) {
+            continue;
         }
+        push_worktree_probe_input(&mut inputs, entry.path, entry.branch)?;
     }
 
     Ok(inputs)
+}
+
+fn parse_git_worktree_paths(stdout: &str) -> Vec<PathBuf> {
+    parse_git_worktree_porcelain(stdout)
+        .into_iter()
+        .filter(git_worktree_entry_is_active)
+        .map(|entry| entry.path)
+        .collect()
+}
+
+fn git_worktree_entry_is_active(entry: &GitWorktreeListEntry) -> bool {
+    !entry.bare && !entry.prunable && entry.path.exists()
+}
+
+fn parse_git_worktree_porcelain(stdout: &str) -> Vec<GitWorktreeListEntry> {
+    let mut entries = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_branch: Option<String> = None;
+    let mut current_bare = false;
+    let mut current_prunable = false;
+
+    let flush = |entries: &mut Vec<GitWorktreeListEntry>,
+                 current_path: &mut Option<PathBuf>,
+                 current_branch: &mut Option<String>,
+                 current_bare: &mut bool,
+                 current_prunable: &mut bool| {
+        if let Some(path) = current_path.take() {
+            entries.push(GitWorktreeListEntry {
+                path,
+                branch: current_branch.take(),
+                bare: *current_bare,
+                prunable: *current_prunable,
+            });
+        }
+        *current_bare = false;
+        *current_prunable = false;
+    };
+
+    for line in stdout.lines().chain(std::iter::once("")) {
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            flush(
+                &mut entries,
+                &mut current_path,
+                &mut current_branch,
+                &mut current_bare,
+                &mut current_prunable,
+            );
+            current_path = Some(canonicalize_path(PathBuf::from(rest)));
+        } else if let Some(branch) = line.strip_prefix("branch ") {
+            current_branch = Some(branch.trim_start_matches("refs/heads/").to_string());
+        } else if line == "bare" {
+            current_bare = true;
+        } else if line.starts_with("prunable") {
+            current_prunable = true;
+        } else if line.is_empty() {
+            flush(
+                &mut entries,
+                &mut current_path,
+                &mut current_branch,
+                &mut current_bare,
+                &mut current_prunable,
+            );
+        }
+    }
+
+    entries
 }
 
 fn push_worktree_probe_input(
@@ -1005,12 +1071,7 @@ fn list_git_worktree_paths(project_root: &Path) -> Result<Vec<PathBuf>, String> 
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
     }
 
-    let mut worktrees = Vec::new();
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        if let Some(path) = line.strip_prefix("worktree ") {
-            worktrees.push(canonicalize_path(PathBuf::from(path)));
-        }
-    }
+    let mut worktrees = parse_git_worktree_paths(&String::from_utf8_lossy(&output.stdout));
 
     if worktrees.is_empty() {
         worktrees.push(canonicalize_path(project_root.to_path_buf()));
@@ -1060,6 +1121,59 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn worktree_probe_input_parser_skips_bare_prunable_and_missing_worktrees() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bare = temp.path().join("gwt.git");
+        let develop = temp.path().join("develop");
+        let work = temp.path().join("work");
+        let missing = temp.path().join("stale");
+        std::fs::create_dir_all(&bare).expect("bare dir");
+        std::fs::create_dir_all(&develop).expect("develop dir");
+        std::fs::create_dir_all(&work).expect("work dir");
+        let stdout = format!(
+            "\
+worktree {bare}
+bare
+
+worktree {missing}
+HEAD 1111111111111111111111111111111111111111
+prunable gitdir file points to non-existent location
+
+worktree {develop}
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/develop
+
+worktree {work}
+HEAD 3333333333333333333333333333333333333333
+detached
+
+",
+            bare = bare.display(),
+            missing = missing.display(),
+            develop = develop.display(),
+            work = work.display(),
+        );
+
+        let inputs = parse_worktree_probe_inputs(&stdout).expect("parse probe inputs");
+
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs[0].path, canonicalize_path(develop.clone()));
+        assert_eq!(inputs[0].branch, "develop");
+        assert_eq!(
+            inputs[0].worktree_hash,
+            compute_worktree_hash(&canonicalize_path(develop.clone()))
+                .expect("develop hash")
+                .to_string()
+        );
+        assert_eq!(inputs[1].path, canonicalize_path(work.clone()));
+        assert_eq!(inputs[1].branch, "(detached)");
+        assert_eq!(
+            parse_git_worktree_paths(&stdout),
+            vec![canonicalize_path(develop), canonicalize_path(work)]
+        );
     }
 
     struct PanicRunnerSpawner;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -181,36 +181,40 @@ fn broadcast_log_entry(clients: &ClientHub, entry: gwt_core::logging::LogEvent) 
 }
 
 fn spawn_project_index_status_check(
-    runtime: &Runtime,
+    _runtime: &Runtime,
     proxy: EventLoopProxy<UserEvent>,
     project_root: Option<PathBuf>,
 ) {
-    let project_root_label = project_root
-        .as_ref()
-        .map(|path| path.display().to_string())
-        .unwrap_or_default();
-    drop(runtime.spawn(async move {
-        let status = match project_root {
-            Some(path) => tokio::task::spawn_blocking(move || {
-                gwt::index_worker::project_index_status_for_path(&path)
-            })
-            .await
-            .unwrap_or_else(|err| {
-                gwt::ProjectIndexStatusView::new(
-                    gwt::ProjectIndexStatusState::Error,
-                    format!("Project index status task failed: {err}"),
-                )
-            }),
-            None => gwt::ProjectIndexStatusView::new(
+    dispatch_project_index_status_check_with(
+        AppEventProxy::new(proxy),
+        project_root,
+        |proxy, root| {
+            crate::project_index_bootstrap::ProjectIndexBootstrapService::global()
+                .spawn(proxy, root)
+        },
+    );
+}
+
+fn dispatch_project_index_status_check_with(
+    proxy: AppEventProxy,
+    project_root: Option<PathBuf>,
+    spawn_bootstrap: impl FnOnce(
+        AppEventProxy,
+        PathBuf,
+    ) -> crate::project_index_bootstrap::ProjectIndexBootstrapRequest,
+) -> Option<crate::project_index_bootstrap::ProjectIndexBootstrapRequest> {
+    let Some(project_root) = project_root else {
+        proxy.send(UserEvent::ProjectIndexStatus {
+            project_root: String::new(),
+            status: gwt::ProjectIndexStatusView::new(
                 gwt::ProjectIndexStatusState::Skipped,
                 "No current directory",
             ),
-        };
-        let _ = proxy.send_event(UserEvent::ProjectIndexStatus {
-            project_root: project_root_label,
-            status,
         });
-    }));
+        return None;
+    };
+
+    Some(spawn_bootstrap(proxy, project_root))
 }
 
 fn record_update_available(
@@ -1066,6 +1070,78 @@ mod tests {
 
         assert_eq!(surface.browser_url, "http://127.0.0.1:44557/");
         assert_eq!(surface.webview_url, "http://127.0.0.1:44557/");
+    }
+
+    #[test]
+    fn project_index_status_check_without_project_root_emits_skipped_status() {
+        let (proxy, events) = AppEventProxy::stub();
+
+        let request =
+            super::dispatch_project_index_status_check_with(proxy, None, |_proxy, _root| {
+                panic!("bootstrap must not run without an active project root");
+            });
+
+        assert_eq!(request, None);
+        let recorded = events.lock().expect("events");
+        assert!(
+            matches!(
+                recorded.as_slice(),
+                [UserEvent::ProjectIndexStatus {
+                    project_root,
+                    status,
+                }] if project_root.is_empty()
+                    && status.state == gwt::ProjectIndexStatusState::Skipped
+                    && status.detail == "No current directory"
+            ),
+            "startup without a project should emit a single skipped index status: {recorded:?}",
+        );
+    }
+
+    #[test]
+    fn project_index_status_check_delegates_project_root_to_bootstrap_path() {
+        let temp = tempdir().expect("tempdir");
+        let (proxy, events) = AppEventProxy::stub();
+        let captured_root = Arc::new(Mutex::new(None));
+        let captured_root_for_closure = captured_root.clone();
+
+        let request = super::dispatch_project_index_status_check_with(
+            proxy,
+            Some(temp.path().to_path_buf()),
+            move |proxy, project_root| {
+                *captured_root_for_closure.lock().expect("captured root") =
+                    Some(project_root.clone());
+                proxy.send(UserEvent::ProjectIndexStatus {
+                    project_root: project_root.display().to_string(),
+                    status: gwt::ProjectIndexStatusView::new(
+                        gwt::ProjectIndexStatusState::Ready,
+                        "bootstrap status",
+                    ),
+                });
+                crate::project_index_bootstrap::ProjectIndexBootstrapRequest::Spawned
+            },
+        );
+
+        assert_eq!(
+            request,
+            Some(crate::project_index_bootstrap::ProjectIndexBootstrapRequest::Spawned)
+        );
+        assert_eq!(
+            captured_root.lock().expect("captured root").as_deref(),
+            Some(temp.path())
+        );
+        let recorded = events.lock().expect("events");
+        assert!(
+            matches!(
+                recorded.as_slice(),
+                [UserEvent::ProjectIndexStatus {
+                    project_root,
+                    status,
+                }] if project_root == &temp.path().display().to_string()
+                    && status.state == gwt::ProjectIndexStatusState::Ready
+                    && status.detail == "bootstrap status"
+            ),
+            "startup with a project must receive the bootstrap status event: {recorded:?}",
+        );
     }
 
     #[test]

--- a/crates/gwt/src/migration/executor.rs
+++ b/crates/gwt/src/migration/executor.rs
@@ -98,7 +98,10 @@ fn run_post_backup(
 
     let bare_repo_path = match origin_url.as_deref() {
         Some(url) => match git_migration::clone_bare_from_normal(url, &bare_target) {
-            Ok(p) => p,
+            Ok(p) => {
+                refresh_bare_refs_from_local(&dot_git, &p)?;
+                p
+            }
             Err(_) => bareify_local_or_fail(project_root, &bare_target)?,
         },
         None => bareify_local_or_fail(project_root, &bare_target)?,
@@ -354,6 +357,36 @@ fn bareify_local_or_fail(
         message: e.to_string(),
         recovery: RecoveryState::Partial,
     })
+}
+
+fn refresh_bare_refs_from_local(
+    dot_git: &Path,
+    bare_repo_path: &Path,
+) -> Result<(), MigrationError> {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["fetch"])
+        .arg(dot_git)
+        .args(["+refs/*:refs/*"])
+        .current_dir(bare_repo_path)
+        .output()
+        .map_err(|e| MigrationError {
+            phase: MigrationPhase::Bareify,
+            message: format!("refresh bare refs from local git dir: {e}"),
+            recovery: RecoveryState::Partial,
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(MigrationError {
+            phase: MigrationPhase::Bareify,
+            message: format!(
+                "refresh bare refs from local git dir failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ),
+            recovery: RecoveryState::Partial,
+        })
+    }
 }
 
 fn derive_bare_repo_name(project_root: &Path) -> String {

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -22,6 +22,20 @@ fn run_git(dir: &Path, args: &[&str]) {
     );
 }
 
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    let output = gwt_core::process::hidden_command("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
 fn init_repo_with_commit(path: &Path) {
     run_git(path, &["init", "."]);
     // Configure a deterministic identity so commits succeed in CI sandboxes.
@@ -94,6 +108,66 @@ fn t100_e2e_normal_to_nested_bare_worktree_layout() {
     // Outcome reflects the layout.
     assert_eq!(outcome.bare_repo_path, bare);
     assert_eq!(outcome.branch_worktree_path, worktree);
+}
+
+#[test]
+fn t143_e2e_remote_ahead_migration_preserves_local_head() {
+    // A real copied Workbench smoke exposed that cloning origin during
+    // migration can move the migrated worktree to a newer remote HEAD. The
+    // migration must preserve the user's local branch HEAD and restore dirty
+    // files on top of that exact commit.
+    let sandbox = tempfile::tempdir().unwrap();
+    let remote = sandbox.path().join("remote.git");
+    let seed = sandbox.path().join("seed");
+    let project = sandbox.path().join("project");
+
+    std::fs::create_dir_all(&seed).unwrap();
+    run_git(&seed, &["init", "-b", "develop", "."]);
+    run_git(&seed, &["config", "user.email", "test@example.com"]);
+    run_git(&seed, &["config", "user.name", "Test"]);
+    std::fs::write(seed.join("README.md"), "v1\n").unwrap();
+    run_git(&seed, &["add", "README.md"]);
+    run_git(&seed, &["commit", "-m", "v1"]);
+    run_git(
+        sandbox.path(),
+        &["init", "--bare", remote.to_str().unwrap()],
+    );
+    run_git(
+        &seed,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    run_git(&seed, &["push", "-u", "origin", "develop"]);
+    run_git(&remote, &["symbolic-ref", "HEAD", "refs/heads/develop"]);
+
+    run_git(
+        sandbox.path(),
+        &["clone", remote.to_str().unwrap(), project.to_str().unwrap()],
+    );
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test"]);
+    let local_head_before = git_stdout(&project, &["rev-parse", "HEAD"]);
+
+    std::fs::write(seed.join("README.md"), "v2 from remote\n").unwrap();
+    run_git(&seed, &["add", "README.md"]);
+    run_git(&seed, &["commit", "-m", "v2"]);
+    run_git(&seed, &["push", "origin", "develop"]);
+
+    std::fs::write(project.join("README.md"), "local dirty\n").unwrap();
+
+    execute_migration(&project, MigrationOptions::default(), |_phase, _pct| {})
+        .expect("execute_migration");
+
+    let worktree = project.join("develop");
+    assert_eq!(
+        git_stdout(&worktree, &["rev-parse", "HEAD"]),
+        local_head_before,
+        "migration must preserve the local branch HEAD, not advance to the remote HEAD"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree.join("README.md")).unwrap(),
+        "local dirty\n",
+        "dirty file content must be restored on top of the preserved local HEAD"
+    );
 }
 
 #[test]

--- a/crates/gwt/web/__tests__/migration-modal.smoke.test.mjs
+++ b/crates/gwt/web/__tests__/migration-modal.smoke.test.mjs
@@ -40,7 +40,7 @@ function makeState(overrides = {}) {
       open: true,
       stage: "confirm",
       tabId: "tab-1",
-      projectRoot: "/Users/akiojin/Workbench/llmlb",
+      projectRoot: "/Users/akiojin/Workbench/gwt",
       branch: "develop",
       hasDirty: false,
       hasLocked: false,
@@ -93,7 +93,7 @@ test("confirm stage paints title, project root, and three action buttons", () =>
     /Migrate to Bare \+ Worktree layout/,
     "header should be present",
   );
-  assert.match(dialogEl.textContent, /llmlb/);
+  assert.match(dialogEl.textContent, /gwt/);
   const buttons = dialogEl.querySelectorAll("button");
   assert.equal(buttons.length, 3, "Quit / Skip / Migrate buttons");
   const labels = Array.from(buttons).map((b) => b.textContent);
@@ -161,4 +161,52 @@ test("error stage exposes the failing phase, message, and recovery hint", () => 
   const buttons = dialogEl.querySelectorAll("button");
   assert.equal(buttons.length, 1, "only Close button");
   assert.equal(buttons[0].textContent, "Close");
+});
+
+test("running and error stages expose selectable DOM text without overlay copy shim", () => {
+  const { modalEl, dialogEl, createNode } = mount();
+  renderMigrationModal({
+    modalEl,
+    dialogEl,
+    state: makeState({ stage: "running", phase: "bareify", percent: 42 }),
+    createNode,
+    onMigrate: noop,
+    onSkip: noop,
+    onQuit: noop,
+  });
+
+  assert.match(dialogEl.textContent, /Building bare repository/);
+  assert.ok(
+    dialogEl.querySelector(".migration-modal-phase-label"),
+    "running phase label must be plain DOM text for native WebView selection",
+  );
+  assert.equal(
+    dialogEl.querySelector(".overlay-copy-button"),
+    null,
+    "migration modal must not install the terminal overlay copy shim",
+  );
+
+  renderMigrationModal({
+    modalEl,
+    dialogEl,
+    state: makeState({
+      stage: "error",
+      phase: "worktrees",
+      message: "git worktree add failed",
+      recovery: "rolled_back",
+    }),
+    createNode,
+    onMigrate: noop,
+    onSkip: noop,
+    onQuit: noop,
+  });
+
+  const errorMessage = dialogEl.querySelector(".migration-modal-error-message");
+  assert.ok(errorMessage, "error message must render as a DOM text node");
+  assert.equal(errorMessage.textContent, "git worktree add failed");
+  assert.equal(
+    dialogEl.querySelector(".overlay-copy-button"),
+    null,
+    "error modal must rely on native selection instead of an overlay copy shim",
+  );
 });

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1092,6 +1092,33 @@ test("Drawer + preset modals have role/aria-modal/aria-hidden wiring", () => {
   }
 });
 
+test("WebView modal text uses native selection and terminal overlays use explicit copy", () => {
+  const modalShellRule = inlineStyle.match(/\.modal-shell\s*\{[\s\S]*?\}/);
+  assert.ok(modalShellRule, "expected shared modal shell CSS rule");
+  assert.doesNotMatch(
+    modalShellRule[0],
+    /user-select\s*:\s*none/,
+    "modal shells must not disable browser-native text selection",
+  );
+
+  const visibleOverlayRule = inlineStyle.match(
+    /\.terminal-overlay\.visible\s*\{[\s\S]*?\}/,
+  );
+  assert.ok(visibleOverlayRule, "expected visible terminal overlay CSS rule");
+  assert.match(visibleOverlayRule[0], /pointer-events:\s*auto/);
+  assert.match(visibleOverlayRule[0], /user-select:\s*text/);
+
+  const overlayMessageRule = inlineStyle.match(/\.overlay-message\s*\{[\s\S]*?\}/);
+  assert.ok(overlayMessageRule, "expected terminal overlay message CSS rule");
+  assert.match(overlayMessageRule[0], /user-select:\s*text/);
+  assert.match(appSource, /copyButton\.className\s*=\s*"overlay-copy-button"/);
+  assert.match(
+    appSource,
+    /copyButton\.addEventListener\("click"[\s\S]*copyTerminalOverlayMessage\(windowData\.id\)/,
+    "terminal overlays must use an explicit copy button instead of modal-shell auto-copy",
+  );
+});
+
 test("Every keyframes-driven animation has a prefers-reduced-motion override", () => {
   // Catch the gap where someone adds a new @keyframes + animation without
   // pairing it with a reduced-motion override. Approach: for each


### PR DESCRIPTION
## Summary

- Close the remaining gwt-local verification gaps for migration smoke, WebView copy behavior, and Project Index macOS smoke.
- Fix Project Index startup status so the GUI receives the aggregate bootstrap payload and can self-repair unhealthy worktree indexes.
- Ignore bare, prunable, and missing Git worktrees when computing Project Index aggregate health so stale worktree metadata does not block auto-repair.

## Changes

- `crates/gwt/src/main.rs`: route startup Project Index status checks through `ProjectIndexBootstrapService` and add focused tests for skipped/no-project and aggregate-bootstrap project paths.
- `crates/gwt/src/index_worker.rs`: parse `git worktree list --porcelain` into active entries and exclude bare, prunable, or missing worktrees from aggregate probes.
- SPEC/Board metadata: mark SPEC-1934 T-117, SPEC-1924 WebView copy closure, and SPEC-1939 T-IDX-111 macOS smoke evidence complete.

## Testing

- [x] `cargo test -p gwt worktree_probe_input_parser_skips_bare_prunable_and_missing_worktrees -- --nocapture` — passed.
- [x] `cargo test -p gwt project_index_status_check -- --nocapture` — passed.
- [x] `cargo test -p gwt project_index_bootstrap -- --nocapture` — passed.
- [x] `cargo test -p gwt project_index_status -- --nocapture` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git push` pre-push checks — passed with filtered line coverage 90.34%.
- [x] macOS real-GUI Project Index smoke — passed against `/Users/akiojin/Workbench/gwt/develop`, observing `repair_required -> repairing -> ready`, Settings.Index rendering, per-cell Rebuild, and final `files ready documents=439`.

## Closing Issues

- None

## Related Issues / Links

- #1934
- #1924
- #1939
- #1999

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This PR contains the remaining autonomous gwt work from the goal audit. It deliberately avoids SPEC-1939 Phase 13 because another session has an active Board claim for badge removal.

## Risk / Impact

- **Affected areas**: GUI startup Project Index status events, Project Index aggregate worktree health, migration/WebView copy test coverage.
- **Rollback plan**: revert this PR; no data migration or schema change is introduced.

## Screenshots

- Project Index smoke evidence: `/var/folders/p8/3j934ld94g5drz6_x1zy39m80000gn/T/gwt-spec-1939-smoke-1778416671961.png`
