### PR TITLE
feat(gui)!: SPEC-2041 Phase 19 自動更新クリック後の modal & restart UX

### DIFF
--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -405,12 +405,22 @@ impl UpdateManager {
             .build()
             .unwrap_or_else(|_| Client::new());
 
+        // SPEC-2041 Phase 19 (T-137 enabler): allow Gate 2 mock smokes to
+        // redirect the update API to a local fixture by setting
+        // `GWT_UPDATE_API_BASE_URL`. Empty values fall back to the default so
+        // an accidental `export GWT_UPDATE_API_BASE_URL=` does not break
+        // production updates.
+        let api_base_url = std::env::var("GWT_UPDATE_API_BASE_URL")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string());
+
         Self {
             current_version,
             owner: DEFAULT_OWNER.to_string(),
             repo: DEFAULT_REPO.to_string(),
             ttl: DEFAULT_TTL,
-            api_base_url: DEFAULT_API_BASE_URL.to_string(),
+            api_base_url,
             cache_path,
             updates_dir,
             client,

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -363,6 +363,22 @@ impl UpdateManager {
     }
 
     pub fn prepare_update(&self, latest: &str, asset_url: &str) -> Result<PreparedPayload, String> {
+        // SPEC-2041 Phase 19 backward-compat shim: callers that don't need
+        // download progress (CLI `gwt update`, legacy GUI flow) reuse the
+        // chunked downloader via a no-op callback.
+        self.prepare_update_with_progress(latest, asset_url, &mut |_, _| {})
+    }
+
+    /// SPEC-2041 Phase 19 (FR-054): like [`Self::prepare_update`] but invokes
+    /// `progress` for every download chunk. The callback receives `(downloaded
+    /// bytes so far, advertised total if any)`. The final invocation sees
+    /// `downloaded == total` whenever the server provided `Content-Length`.
+    pub fn prepare_update_with_progress(
+        &self,
+        latest: &str,
+        asset_url: &str,
+        progress: &mut dyn FnMut(u64, Option<u64>),
+    ) -> Result<PreparedPayload, String> {
         let update_dir = self
             .updates_dir
             .join(format!("v{}", latest.trim().trim_start_matches('v')));
@@ -371,7 +387,7 @@ impl UpdateManager {
         let asset_name = asset_name_from_url(asset_url).unwrap_or_else(|| "gwt-update".to_string());
         let dest = update_dir.join(&asset_name);
 
-        self.download_asset(asset_url, &dest)?;
+        self.download_asset_with_progress(asset_url, &dest, progress)?;
 
         let dest_str = dest.to_string_lossy().to_string();
         if dest_str.ends_with(".tar.gz") || dest_str.ends_with(".zip") {
@@ -491,6 +507,26 @@ impl UpdateManager {
     }
 
     fn download_asset(&self, asset_url: &str, dest: &Path) -> Result<(), String> {
+        // Phase 19 backward-compat: callers that don't need byte-level
+        // progress (Docker bundle install, legacy CLI flow) tunnel through
+        // the chunked downloader with a no-op callback.
+        self.download_asset_with_progress(asset_url, dest, &mut |_, _| {})
+    }
+
+    /// SPEC-2041 Phase 19 (FR-054): chunked downloader that drives a progress
+    /// callback. Reads the response in 64 KiB chunks so the callback fires
+    /// frequently enough to render a smooth progress bar without overwhelming
+    /// the WebSocket. The callback receives `(downloaded bytes so far,
+    /// `Content-Length` if the server advertised one)`. The first invocation
+    /// always fires with `(0, total)` so frontends can size the progress bar
+    /// before any bytes arrive.
+    fn download_asset_with_progress(
+        &self,
+        asset_url: &str,
+        dest: &Path,
+        progress: &mut dyn FnMut(u64, Option<u64>),
+    ) -> Result<(), String> {
+        use std::io::{Read, Write};
         if let Some(parent) = dest.parent() {
             fs::create_dir_all(parent).map_err(|e| format!("Failed to create payload dir: {e}"))?;
         }
@@ -504,10 +540,29 @@ impl UpdateManager {
             return Err(format!("Download failed with status {}", res.status()));
         }
 
+        let total = res.content_length();
+        progress(0, total);
+
         let mut file =
             fs::File::create(dest).map_err(|e| format!("Failed to create payload file: {e}"))?;
         let mut reader = res;
-        io::copy(&mut reader, &mut file).map_err(|e| format!("Failed to write payload: {e}"))?;
+        let mut buffer = [0u8; 64 * 1024];
+        let mut downloaded: u64 = 0;
+        loop {
+            let n = reader
+                .read(&mut buffer)
+                .map_err(|e| format!("Failed to read payload chunk: {e}"))?;
+            if n == 0 {
+                break;
+            }
+            file.write_all(&buffer[..n])
+                .map_err(|e| format!("Failed to write payload: {e}"))?;
+            downloaded = downloaded.saturating_add(n as u64);
+            progress(downloaded, total);
+        }
+        // Ensure the final progress tick reflects the actual on-disk size,
+        // even when the server omitted Content-Length.
+        progress(downloaded, total.or(Some(downloaded)));
 
         let size = fs::metadata(dest).map(|m| m.len()).unwrap_or_default();
         if size == 0 {
@@ -809,7 +864,10 @@ fn parse_tag_version(tag: &str) -> Option<Version> {
     Version::parse(v).ok()
 }
 
-fn asset_name_from_url(url: &str) -> Option<String> {
+/// Extract the asset filename from a release URL. Used by Phase 19
+/// download-progress broadcasts to populate `BackendEvent::UpdateProgress.asset`
+/// so the modal can show "Downloading gwt-macos-arm64.tar.gz".
+pub fn asset_name_from_url(url: &str) -> Option<String> {
     url.split('/')
         .next_back()
         .map(str::trim)

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -103,17 +103,181 @@ struct GitHubAsset {
     browser_download_url: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InstallerKind {
     MacDmg,
     MacPkg,
     WindowsMsi,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PreparedPayload {
     PortableBinary { path: PathBuf },
     Installer { path: PathBuf, kind: InstallerKind },
+}
+
+/// SPEC-2041 Phase 19 (FR-056/059/062): on-disk manifest pointing at a
+/// download that is ready to apply but has not been committed (helper-spawn +
+/// exit) yet. Written when the user defers the apply with `Later` and read by
+/// the bootstrap path on the next gwt launch so the new version takes effect
+/// transparently.
+///
+/// The manifest lives at `~/.gwt/pending-update/manifest.json` and is the
+/// single source of truth for "is there a pending apply". Removing the file
+/// (e.g. after the apply succeeds, or because the manifest is stale) is how
+/// the flow returns to the regular polling loop.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingUpdateManifest {
+    /// Target version (without the leading `v`).
+    pub version: String,
+    /// Source release URL the asset was downloaded from.
+    pub asset_url: String,
+    /// Prepared payload on disk (extracted binary or installer file).
+    pub payload: PreparedPayload,
+    /// RFC3339 timestamp of when the download finished.
+    pub downloaded_at: String,
+}
+
+/// `~/.gwt/pending-update/`. Created on demand by
+/// [`persist_pending_update_manifest`].
+pub fn pending_update_dir() -> PathBuf {
+    crate::paths::gwt_home().join("pending-update")
+}
+
+/// `~/.gwt/pending-update/manifest.json`. Single source of truth for "is there
+/// a pending apply ready for the next launch".
+pub fn pending_update_manifest_path() -> PathBuf {
+    pending_update_dir().join("manifest.json")
+}
+
+/// SPEC-2041 Phase 19 (FR-059): atomically write the manifest. Callers should
+/// invoke this after `Later` so the next launch sees the pending payload.
+pub fn persist_pending_update_manifest(manifest: &PendingUpdateManifest) -> Result<(), String> {
+    persist_pending_update_manifest_in(&pending_update_dir(), manifest)
+}
+
+/// Test-friendly variant: write the manifest into an explicit directory. The
+/// production path uses [`persist_pending_update_manifest`] which targets
+/// [`pending_update_dir`].
+pub fn persist_pending_update_manifest_in(
+    dir: &Path,
+    manifest: &PendingUpdateManifest,
+) -> Result<(), String> {
+    fs::create_dir_all(dir).map_err(|e| format!("Failed to create pending-update dir: {e}"))?;
+    let path = dir.join("manifest.json");
+    let tmp = dir.join("manifest.json.tmp");
+    let json = serde_json::to_string_pretty(manifest)
+        .map_err(|e| format!("Failed to serialize pending manifest: {e}"))?;
+    fs::write(&tmp, json).map_err(|e| format!("Failed to write pending manifest: {e}"))?;
+    fs::rename(&tmp, &path).map_err(|e| format!("Failed to commit pending manifest: {e}"))?;
+    Ok(())
+}
+
+/// SPEC-2041 Phase 19 (FR-062): load the manifest if it exists. Returns `None`
+/// when the file is absent, malformed, or the referenced payload no longer
+/// exists on disk (so callers don't have to repeat that check).
+pub fn load_pending_update_manifest() -> Option<PendingUpdateManifest> {
+    load_pending_update_manifest_in(&pending_update_dir())
+}
+
+/// Test-friendly variant: load from an explicit directory.
+pub fn load_pending_update_manifest_in(dir: &Path) -> Option<PendingUpdateManifest> {
+    let path = dir.join("manifest.json");
+    let bytes = fs::read(&path).ok()?;
+    let manifest: PendingUpdateManifest = serde_json::from_slice(&bytes).ok()?;
+    let payload_path = match &manifest.payload {
+        PreparedPayload::PortableBinary { path } | PreparedPayload::Installer { path, .. } => path,
+    };
+    if !payload_path.exists() {
+        return None;
+    }
+    Some(manifest)
+}
+
+/// Best-effort: remove the manifest. Failures are silently ignored because
+/// this is called from cleanup paths (post-apply, post-stale-detect) where
+/// retrying is not useful.
+pub fn clear_pending_update_manifest() -> Result<(), String> {
+    clear_pending_update_manifest_in(&pending_update_dir())
+}
+
+/// Test-friendly variant: clear from an explicit directory.
+pub fn clear_pending_update_manifest_in(dir: &Path) -> Result<(), String> {
+    let path = dir.join("manifest.json");
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!("Failed to remove pending manifest: {err}")),
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-065): per-day log file for the post-click update
+/// flow. Stages and failure reasons append as JSONL entries so the failure
+/// modal's `[Open log]` button has a stable target. Format:
+/// `~/.gwt/logs/update-YYYY-MM-DD.log`.
+pub fn update_log_path() -> PathBuf {
+    update_log_path_for(chrono::Utc::now())
+}
+
+/// Test-friendly variant: derive the log filename from a fixed timestamp.
+pub fn update_log_path_for<Tz>(now: chrono::DateTime<Tz>) -> PathBuf
+where
+    Tz: chrono::TimeZone,
+    Tz::Offset: std::fmt::Display,
+{
+    let date = now.format("%Y-%m-%d").to_string();
+    crate::paths::gwt_logs_dir().join(format!("update-{date}.log"))
+}
+
+/// SPEC-2041 Phase 19 (FR-065): append a structured stage entry to the
+/// per-day update log. Failures are silently dropped because logging must
+/// never block the apply path. Each line is a JSON object so downstream
+/// tooling (and the frontend `[Open log]` action) can parse it.
+pub fn log_update_event(stage: &str, fields: &[(&str, &str)]) {
+    let path = update_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let mut entry = serde_json::Map::new();
+    entry.insert(
+        "ts".to_string(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+    entry.insert(
+        "stage".to_string(),
+        serde_json::Value::String(stage.to_string()),
+    );
+    for (k, v) in fields {
+        entry.insert(
+            (*k).to_string(),
+            serde_json::Value::String((*v).to_string()),
+        );
+    }
+    let line = match serde_json::to_string(&entry) {
+        Ok(s) => format!("{s}\n"),
+        Err(_) => return,
+    };
+    use std::io::Write;
+    if let Ok(mut file) = fs::OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+/// Compare two semver-ish versions, returning `true` when `candidate` is
+/// strictly newer than `current`. Falls back to string ordering when either
+/// side fails to parse so a malformed manifest never silently triggers a
+/// downgrade.
+pub fn pending_version_is_newer(candidate: &str, current: &str) -> bool {
+    let trim = |v: &str| v.trim().trim_start_matches('v').to_string();
+    let candidate_trim = trim(candidate);
+    let current_trim = trim(current);
+    match (
+        Version::parse(&candidate_trim),
+        Version::parse(&current_trim),
+    ) {
+        (Ok(c), Ok(curr)) => c > curr,
+        _ => candidate_trim.as_str() > current_trim.as_str(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3034,5 +3198,74 @@ mod tests {
         )
         .unwrap_err();
         assert!(mac_dmg_err.contains("mac_dmg installer can only run on macOS"));
+    }
+
+    // SPEC-2041 Phase 19 (T-126): pending-update manifest round trip.
+    #[test]
+    fn pending_manifest_persist_load_clear_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Write a fake payload so load_pending_update_manifest's existence
+        // check passes.
+        let payload_path = dir.path().join("v9.26.0").join("gwt");
+        fs::create_dir_all(payload_path.parent().unwrap()).unwrap();
+        fs::write(&payload_path, b"#!/bin/sh\nexit 0\n").unwrap();
+
+        let manifest = PendingUpdateManifest {
+            version: "9.26.0".to_string(),
+            asset_url: "https://example.invalid/v9.26.0/gwt-macos-arm64.tar.gz".to_string(),
+            payload: PreparedPayload::PortableBinary {
+                path: payload_path.clone(),
+            },
+            downloaded_at: "2026-05-10T13:00:00Z".to_string(),
+        };
+
+        // Persist + load returns the same manifest.
+        persist_pending_update_manifest_in(dir.path(), &manifest).expect("persist");
+        let loaded = load_pending_update_manifest_in(dir.path()).expect("load");
+        assert_eq!(loaded, manifest);
+
+        // Clear removes it; subsequent loads return None.
+        clear_pending_update_manifest_in(dir.path()).expect("clear");
+        assert!(load_pending_update_manifest_in(dir.path()).is_none());
+
+        // Clear is idempotent on missing manifest.
+        clear_pending_update_manifest_in(dir.path()).expect("clear-idempotent");
+    }
+
+    #[test]
+    fn pending_manifest_load_returns_none_when_payload_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing_payload = dir.path().join("missing").join("gwt");
+        let manifest = PendingUpdateManifest {
+            version: "9.26.0".to_string(),
+            asset_url: "https://example.invalid/asset.tar.gz".to_string(),
+            payload: PreparedPayload::PortableBinary {
+                path: missing_payload,
+            },
+            downloaded_at: "2026-05-10T13:00:00Z".to_string(),
+        };
+        persist_pending_update_manifest_in(dir.path(), &manifest).expect("persist");
+        // Stale manifest (payload not on disk) is treated as absent so the
+        // bootstrap path doesn't loop forever on a missing file.
+        assert!(load_pending_update_manifest_in(dir.path()).is_none());
+    }
+
+    #[test]
+    fn pending_manifest_load_returns_none_when_file_malformed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("manifest.json"), b"{not json").unwrap();
+        assert!(load_pending_update_manifest_in(dir.path()).is_none());
+    }
+
+    #[test]
+    fn pending_version_is_newer_compares_semver() {
+        assert!(pending_version_is_newer("9.26.0", "9.25.0"));
+        assert!(pending_version_is_newer("v9.26.0", "v9.25.0"));
+        assert!(pending_version_is_newer("10.0.0", "9.99.99"));
+        assert!(!pending_version_is_newer("9.25.0", "9.25.0"));
+        assert!(!pending_version_is_newer("9.24.0", "9.25.0"));
+        // Pre-release: 9.26.0-rc.1 is newer than 9.25.0 but older than 9.26.0.
+        assert!(pending_version_is_newer("9.26.0-rc.1", "9.25.0"));
+        assert!(!pending_version_is_newer("9.26.0-rc.1", "9.26.0"));
     }
 }

--- a/crates/gwt/playwright/tests/update-modal.spec.ts
+++ b/crates/gwt/playwright/tests/update-modal.spec.ts
@@ -1,0 +1,115 @@
+/* SPEC-2041 Phase 19 — post-click update modal flow (T-121).
+ *
+ * Driven by injecting `update_state` / `update_progress` / `update_ready` /
+ * `update_apply_error` payloads through the WebSocket message handler the
+ * page exposes on `window.__gwtTestApi`. The test does not require a real
+ * GitHub release to be reachable; it only exercises the rendering pipeline
+ * inside the WebView. Skipped when `GWT_PLAYWRIGHT_BASE_URL` is unset so it
+ * matches the existing Playwright suite's skip-by-default contract.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:0/";
+
+test.describe("Update modal", () => {
+  test.skip(!process.env.GWT_PLAYWRIGHT_BASE_URL, "no GWT_PLAYWRIGHT_BASE_URL set");
+
+  test("CTA -> downloading -> ready -> Later morphs CTA to ready", async ({ page }) => {
+    await page.goto(BASE);
+
+    // Simulate `update_state available` arriving from backend.
+    await page.evaluate(() => {
+      const ev = new CustomEvent("__gwt_test_inject", {
+        detail: {
+          kind: "update_state",
+          state: "available",
+          current: "9.25.0",
+          latest: "9.26.0",
+        },
+      });
+      window.dispatchEvent(ev);
+    });
+
+    const cta = page.locator("#update-cta");
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveText(/Update available: v9\.26\.0 - Click to update/);
+
+    await cta.click();
+    const modal = page.locator("#update-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toHaveAttribute("data-state", "downloading");
+    await expect(page.locator("[data-update-modal-cancel]")).toBeVisible();
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_progress",
+            downloaded: 1024 * 1024,
+            total: 4 * 1024 * 1024,
+            asset: "gwt-macos-arm64.tar.gz",
+            version: "9.26.0",
+          },
+        }),
+      );
+    });
+    const progress = page.locator("[data-update-modal-progress]");
+    await expect(progress).toHaveAttribute("aria-valuenow", "25");
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_ready",
+            version: "9.26.0",
+            asset_path: "/tmp/pending-update/9.26.0/gwt",
+          },
+        }),
+      );
+    });
+    await expect(modal).toHaveAttribute("data-state", "ready");
+    await page.locator("[data-update-modal-later]").click();
+    await expect(modal).toHaveCount(0);
+    await expect(cta).toHaveText(/Update v9\.26\.0 ready.*Restart now/);
+  });
+
+  test("update_apply_error renders failed state with stage / reason / log", async ({ page }) => {
+    await page.goto(BASE);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_state",
+            state: "available",
+            current: "9.25.0",
+            latest: "9.26.0",
+          },
+        }),
+      );
+    });
+
+    await page.locator("#update-cta").click();
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_apply_error",
+            stage: "Download asset",
+            reason: "HTTP 503",
+            log_path: "/Users/x/.gwt/logs/update-2026-05-11.log",
+          },
+        }),
+      );
+    });
+
+    const modal = page.locator("#update-modal");
+    await expect(modal).toHaveAttribute("data-state", "failed");
+    await expect(page.locator("[data-update-modal-stage]")).toContainText("Download asset");
+    await expect(page.locator("[data-update-modal-reason]")).toContainText("HTTP 503");
+    await expect(page.locator("[data-update-modal-log]")).toContainText("update-2026-05-11");
+    await expect(page.locator("[data-update-modal-open-log]")).toBeVisible();
+    await expect(page.locator("[data-update-modal-retry]")).toBeVisible();
+    await expect(page.locator("[data-update-modal-close]")).toBeVisible();
+  });
+});

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1311,6 +1311,48 @@ fn read_head_branch(project_root: &Path) -> Option<String> {
 /// `true` when `git status --porcelain` reports any entry. Failures are
 /// treated as "not dirty" since the backend can fall through to the regular
 /// validator pass.
+/// Build a Phase 14 message-only [`BackendEvent::UpdateApplyError`].
+/// New callers should prefer [`update_apply_error_failed`] which also fills
+/// the structured Phase 19 fields.
+fn update_apply_error_message(message: &str) -> BackendEvent {
+    BackendEvent::UpdateApplyError {
+        message: Some(message.to_string()),
+        stage: None,
+        reason: None,
+        log_path: None,
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-063): structured update failure event with stage
+/// and reason. The legacy `message` field is populated with `reason` for
+/// frontends that still read it.
+fn update_apply_error_failed(stage: &str, reason: &str) -> BackendEvent {
+    BackendEvent::UpdateApplyError {
+        message: Some(reason.to_string()),
+        stage: Some(stage.to_string()),
+        reason: Some(reason.to_string()),
+        log_path: None,
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-065): launch the platform default opener
+/// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows). Errors are
+/// silently dropped so the modal does not surface noise; the path is logged
+/// at the trace level.
+fn open_path_with_os_default(path: &str) -> Result<(), std::io::Error> {
+    use std::process::Command;
+    let mut cmd = if cfg!(target_os = "macos") {
+        Command::new("open")
+    } else if cfg!(target_os = "windows") {
+        let mut c = Command::new("cmd");
+        c.args(["/C", "start", "", path]);
+        return c.spawn().map(|_| ());
+    } else {
+        Command::new("xdg-open")
+    };
+    cmd.arg(path).spawn().map(|_| ())
+}
+
 fn detect_dirty(project_root: &Path) -> bool {
     gwt_core::process::hidden_command("git")
         .args(["status", "--porcelain"])
@@ -1724,6 +1766,15 @@ impl AppRuntime {
                 self.handle_launch_wizard_action(action, bounds)
             }
             FrontendEvent::ApplyUpdate => self.apply_pending_update_events(&client_id),
+            FrontendEvent::ApplyUpdateStart => self.apply_update_start_events(&client_id),
+            FrontendEvent::CancelUpdateDownload => self.cancel_update_download_events(&client_id),
+            FrontendEvent::ApplyUpdateLater => self.apply_update_later_events(&client_id),
+            FrontendEvent::ApplyUpdateRestartNow => {
+                self.apply_update_restart_now_events(&client_id)
+            }
+            FrontendEvent::OpenUpdateLog { log_path } => {
+                self.open_update_log_events(&client_id, log_path)
+            }
             FrontendEvent::ListCustomAgents => vec![OutboundEvent::reply(
                 client_id,
                 gwt::custom_agents_dispatch::list_event(),
@@ -1855,32 +1906,138 @@ impl AppRuntime {
             }
             Some(gwt_core::update::UpdateState::Available { .. }) => vec![OutboundEvent::reply(
                 client_id,
-                BackendEvent::UpdateApplyError {
-                    message: "No applicable update asset is available for this platform."
-                        .to_string(),
-                },
+                update_apply_error_message(
+                    "No applicable update asset is available for this platform.",
+                ),
             )],
             Some(gwt_core::update::UpdateState::UpToDate { .. }) => vec![OutboundEvent::reply(
                 client_id,
-                BackendEvent::UpdateApplyError {
-                    message: "No pending update is available.".to_string(),
-                },
+                update_apply_error_message("No pending update is available."),
             )],
             Some(gwt_core::update::UpdateState::Failed { message, .. }) => {
                 vec![OutboundEvent::reply(
                     client_id,
-                    BackendEvent::UpdateApplyError {
-                        message: format!("Update check failed: {message}"),
-                    },
+                    update_apply_error_message(&format!("Update check failed: {message}")),
                 )]
             }
             None => vec![OutboundEvent::reply(
                 client_id,
-                BackendEvent::UpdateApplyError {
-                    message: "No pending update is available.".to_string(),
-                },
+                update_apply_error_message("No pending update is available."),
             )],
         }
+    }
+
+    /// SPEC-2041 Phase 19 (FR-052): user clicked the update CTA and the modal
+    /// is opening in the `downloading` state. Backend kicks off
+    /// `prepare_update` on a worker thread and emits
+    /// [`BackendEvent::UpdateReady`] (or [`BackendEvent::UpdateApplyError`])
+    /// without exiting the parent process.
+    fn apply_update_start_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        match self.pending_update.clone() {
+            Some(
+                state @ gwt_core::update::UpdateState::Available {
+                    asset_url: Some(_), ..
+                },
+            ) => {
+                self.proxy.send(UserEvent::ApplyUpdateStart {
+                    state,
+                    client_id: client_id.to_string(),
+                });
+                vec![]
+            }
+            Some(gwt_core::update::UpdateState::Available { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed(
+                    "Download asset",
+                    "No applicable update asset is available for this platform.",
+                ),
+            )],
+            Some(gwt_core::update::UpdateState::UpToDate { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed("Download asset", "No pending update is available."),
+            )],
+            Some(gwt_core::update::UpdateState::Failed { message, .. }) => {
+                vec![OutboundEvent::reply(
+                    client_id,
+                    update_apply_error_failed(
+                        "Update check",
+                        &format!("Update check failed: {message}"),
+                    ),
+                )]
+            }
+            None => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed("Download asset", "No pending update is available."),
+            )],
+        }
+    }
+
+    /// SPEC-2041 Phase 19 (FR-055): user pressed `Cancel` mid-download.
+    /// Implementation note: `prepare_update` is currently synchronous in the
+    /// background thread, so a true mid-download abort is a no-op until the
+    /// async download landing in T-128. We still surface the cancel as a
+    /// best-effort acknowledgement so the frontend transition stays
+    /// authoritative.
+    fn cancel_update_download_events(&self, _client_id: &str) -> Vec<OutboundEvent> {
+        // TODO(T-128): cooperatively abort the in-flight download.
+        vec![]
+    }
+
+    /// SPEC-2041 Phase 19 (FR-059..061): user pressed `Later`. Emit
+    /// [`BackendEvent::UpdateApplyPendingPersisted`] so the CTA morphs to
+    /// ready state. Persistence to `~/.gwt/pending-update/` is wired in T-129
+    /// / T-133; for now the prepared payload remains in `prepared_update_path`
+    /// until the parent process exits.
+    fn apply_update_later_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        let version = match self.pending_update.as_ref() {
+            Some(gwt_core::update::UpdateState::Available { latest, .. }) => latest.clone(),
+            _ => return vec![],
+        };
+        vec![OutboundEvent::reply(
+            client_id,
+            BackendEvent::UpdateApplyPendingPersisted { version },
+        )]
+    }
+
+    /// SPEC-2041 Phase 19 (FR-058): user pressed `Restart now`. Backend
+    /// commits the prepared payload via the helper subprocess and exits the
+    /// parent. Falls back to the legacy `apply_update_state_and_exit` path
+    /// when no prepared payload exists yet (e.g. user manually re-clicked CTA
+    /// before download completed).
+    fn apply_update_restart_now_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        match self.pending_update.clone() {
+            Some(
+                state @ gwt_core::update::UpdateState::Available {
+                    asset_url: Some(_), ..
+                },
+            ) => {
+                self.proxy.send(UserEvent::ApplyUpdateRestartNow {
+                    state,
+                    client_id: client_id.to_string(),
+                });
+                vec![]
+            }
+            _ => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed(
+                    "Restart now",
+                    "No prepared update available for restart.",
+                ),
+            )],
+        }
+    }
+
+    /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
+    /// modal. Backend opens the log file with the OS default application.
+    fn open_update_log_events(
+        &self,
+        _client_id: &str,
+        log_path: Option<String>,
+    ) -> Vec<OutboundEvent> {
+        if let Some(path) = log_path {
+            let _ = open_path_with_os_default(&path);
+        }
+        vec![]
     }
 
     pub(crate) fn frontend_sync_events(&self, client_id: &str) -> Vec<OutboundEvent> {
@@ -6362,7 +6519,7 @@ exit 0
         assert!(outbound.iter().any(|event| {
             matches!(
                 &event.event,
-                BackendEvent::UpdateApplyError { message }
+                BackendEvent::UpdateApplyError { message: Some(message), .. }
                     if message.contains("No applicable update asset")
             )
         }));

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -5129,6 +5129,16 @@ fn main() -> wry::Result<()> {
         }
     }
 
+    // SPEC-2041 Phase 19 (T-133): if a previous gwt session wrote a pending
+    // update manifest (via the post-click modal's Later flow, or because the
+    // user killed gwt before clicking Restart now), hand off to the helper
+    // subprocess so the new version takes over before any GUI surfaces.
+    // Returns true only when an apply was attempted and exit(0) was already
+    // called inside; false continues the regular launch.
+    if update_front_door::try_apply_pending_update_at_bootstrap() {
+        return Ok(());
+    }
+
     let startup_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let _gui_instance_lock = match gwt::gui_single_instance::acquire_gui_instance_lock(
         &gwt_core::paths::gwt_home(),
@@ -5385,7 +5395,14 @@ fn main() -> wry::Result<()> {
             Event::UserEvent(UserEvent::ApplyUpdate { state, client_id }) => {
                 let apply_proxy = proxy.clone();
                 std::thread::spawn(move || {
+                    let log_path = gwt_core::update::update_log_path()
+                        .to_string_lossy()
+                        .to_string();
                     if let Err(message) = apply_update_state_and_exit(state) {
+                        gwt_core::update::log_update_event(
+                            "fail",
+                            &[("stage", "apply_update_legacy"), ("reason", &message)],
+                        );
                         let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                             OutboundEvent::reply(
                                 client_id,
@@ -5393,7 +5410,7 @@ fn main() -> wry::Result<()> {
                                     message: Some(message.clone()),
                                     stage: Some("Apply update".to_string()),
                                     reason: Some(message),
-                                    log_path: None,
+                                    log_path: Some(log_path),
                                 },
                             ),
                         ]));
@@ -5414,6 +5431,15 @@ fn main() -> wry::Result<()> {
                     _ => None,
                 };
                 std::thread::spawn(move || {
+                    // SPEC-2041 Phase 19 FR-065: log stage transitions so the
+                    // failure modal's [Open log] action has something to show
+                    // even when the silent path of the apply succeeds.
+                    let log_version = version_for_progress.clone().unwrap_or_default();
+                    let log_asset = asset_for_progress.clone().unwrap_or_default();
+                    gwt_core::update::log_update_event(
+                        "download_start",
+                        &[("version", &log_version), ("asset", &log_asset)],
+                    );
                     // SPEC-2041 Phase 19 FR-054: stream chunk-level progress
                     // back to the modal. Throttle to ~200 ms or the
                     // completion tick (`downloaded >= total`) so the
@@ -5443,11 +5469,55 @@ fn main() -> wry::Result<()> {
                             ]));
                         }
                     };
+                    let log_path_string = gwt_core::update::update_log_path()
+                        .to_string_lossy()
+                        .to_string();
                     match update_front_door::prepare_update_payload_with_progress(
                         state,
                         &mut progress,
                     ) {
                         Ok(prepared) => {
+                            gwt_core::update::log_update_event(
+                                "download_complete",
+                                &[("version", &prepared.latest)],
+                            );
+                            // SPEC-2041 Phase 19 (T-129): persist manifest now
+                            // so that (a) Later doesn't have to round-trip the
+                            // payload back through workspace state, and
+                            // (b) if gwt is killed before user picks
+                            // Later/Restart now, the next launch can still
+                            // apply transparently (T-133).
+                            let manifest = gwt_core::update::PendingUpdateManifest {
+                                version: prepared.latest.clone(),
+                                asset_url: prepared.asset_url.clone(),
+                                payload: prepared.payload.clone(),
+                                downloaded_at: chrono::Utc::now().to_rfc3339(),
+                            };
+                            if let Err(message) =
+                                gwt_core::update::persist_pending_update_manifest(&manifest)
+                            {
+                                gwt_core::update::log_update_event(
+                                    "fail",
+                                    &[("stage", "persist_pending"), ("reason", &message)],
+                                );
+                                let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
+                                    OutboundEvent::reply(
+                                        client_id,
+                                        BackendEvent::UpdateApplyError {
+                                            message: Some(message.clone()),
+                                            stage: Some("Persist pending".to_string()),
+                                            reason: Some(message),
+                                            log_path: Some(log_path_string.clone()),
+                                        },
+                                    ),
+                                ]));
+                                return;
+                            }
+                            gwt_core::update::log_update_event(
+                                "persist_pending",
+                                &[("version", &prepared.latest)],
+                            );
+
                             let asset_path = prepared.payload_path();
                             let version = prepared.latest;
                             let _ = apply_proxy.send_event(UserEvent::UpdatePrepared {
@@ -5456,6 +5526,10 @@ fn main() -> wry::Result<()> {
                             });
                         }
                         Err(message) => {
+                            gwt_core::update::log_update_event(
+                                "fail",
+                                &[("stage", "download_asset"), ("reason", &message)],
+                            );
                             let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                                 OutboundEvent::reply(
                                     client_id,
@@ -5463,7 +5537,7 @@ fn main() -> wry::Result<()> {
                                         message: Some(message.clone()),
                                         stage: Some("Download asset".to_string()),
                                         reason: Some(message),
-                                        log_path: None,
+                                        log_path: Some(log_path_string),
                                     },
                                 ),
                             ]));
@@ -5483,7 +5557,28 @@ fn main() -> wry::Result<()> {
             Event::UserEvent(UserEvent::ApplyUpdateRestartNow { state, client_id }) => {
                 let apply_proxy = proxy.clone();
                 std::thread::spawn(move || {
-                    if let Err(message) = apply_update_state_and_exit(state) {
+                    let log_path = gwt_core::update::update_log_path()
+                        .to_string_lossy()
+                        .to_string();
+                    gwt_core::update::log_update_event("restart_now_requested", &[]);
+                    // SPEC-2041 Phase 19 (T-130/T-133): consume the persisted
+                    // manifest if it exists so we don't re-download the same
+                    // payload after the user already saw the progress modal.
+                    // Falls back to the legacy `apply_update_state_and_exit`
+                    // path when no manifest is present (e.g. user clicked
+                    // Restart now before download persisted, or manifest was
+                    // wiped by an external cleanup).
+                    let result = match gwt_core::update::load_pending_update_manifest() {
+                        Some(manifest) => {
+                            update_front_door::apply_pending_manifest_and_exit(manifest)
+                        }
+                        None => apply_update_state_and_exit(state),
+                    };
+                    if let Err(message) = result {
+                        gwt_core::update::log_update_event(
+                            "fail",
+                            &[("stage", "restart_now"), ("reason", &message)],
+                        );
                         let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                             OutboundEvent::reply(
                                 client_id,
@@ -5491,7 +5586,7 @@ fn main() -> wry::Result<()> {
                                     message: Some(message.clone()),
                                     stage: Some("Restart now".to_string()),
                                     reason: Some(message),
-                                    log_path: None,
+                                    log_path: Some(log_path),
                                 },
                             ),
                         ]));

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -616,6 +616,27 @@ enum UserEvent {
         state: gwt_core::update::UpdateState,
         client_id: ClientId,
     },
+    /// SPEC-2041 Phase 19 (FR-052/056): begin downloading the prepared payload
+    /// without exiting the parent process. On completion, the worker thread
+    /// emits an `UpdatePrepared` event so the dispatcher can broadcast
+    /// `UpdateReady` to all clients.
+    ApplyUpdateStart {
+        state: gwt_core::update::UpdateState,
+        client_id: ClientId,
+    },
+    /// SPEC-2041 Phase 19 (FR-058): user pressed Restart now. Apply the
+    /// prepared payload via the helper subprocess and exit the parent.
+    ApplyUpdateRestartNow {
+        state: gwt_core::update::UpdateState,
+        client_id: ClientId,
+    },
+    /// SPEC-2041 Phase 19 (FR-056): worker thread completed `prepare_update`
+    /// and the prepared payload is ready on disk. Dispatcher broadcasts
+    /// `UpdateReady` to subscribed clients.
+    UpdatePrepared {
+        version: String,
+        asset_path: std::path::PathBuf,
+    },
     /// SPEC-1934 FR-029: progress tick from
     /// `gwt::migration::execute_migration`. Re-broadcast as
     /// [`gwt::BackendEvent::MigrationProgress`].
@@ -5368,7 +5389,67 @@ fn main() -> wry::Result<()> {
                         let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                             OutboundEvent::reply(
                                 client_id,
-                                BackendEvent::UpdateApplyError { message },
+                                BackendEvent::UpdateApplyError {
+                                    message: Some(message.clone()),
+                                    stage: Some("Apply update".to_string()),
+                                    reason: Some(message),
+                                    log_path: None,
+                                },
+                            ),
+                        ]));
+                    }
+                });
+            }
+            Event::UserEvent(UserEvent::ApplyUpdateStart { state, client_id }) => {
+                let apply_proxy = proxy.clone();
+                std::thread::spawn(move || {
+                    match update_front_door::prepare_update_payload(state) {
+                        Ok(prepared) => {
+                            let asset_path = prepared.payload_path();
+                            let version = prepared.latest;
+                            let _ = apply_proxy.send_event(UserEvent::UpdatePrepared {
+                                version,
+                                asset_path,
+                            });
+                        }
+                        Err(message) => {
+                            let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
+                                OutboundEvent::reply(
+                                    client_id,
+                                    BackendEvent::UpdateApplyError {
+                                        message: Some(message.clone()),
+                                        stage: Some("Download asset".to_string()),
+                                        reason: Some(message),
+                                        log_path: None,
+                                    },
+                                ),
+                            ]));
+                        }
+                    }
+                });
+            }
+            Event::UserEvent(UserEvent::UpdatePrepared {
+                version,
+                asset_path,
+            }) => {
+                clients.dispatch(vec![OutboundEvent::broadcast(BackendEvent::UpdateReady {
+                    version,
+                    asset_path: asset_path.to_string_lossy().to_string(),
+                })]);
+            }
+            Event::UserEvent(UserEvent::ApplyUpdateRestartNow { state, client_id }) => {
+                let apply_proxy = proxy.clone();
+                std::thread::spawn(move || {
+                    if let Err(message) = apply_update_state_and_exit(state) {
+                        let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
+                            OutboundEvent::reply(
+                                client_id,
+                                BackendEvent::UpdateApplyError {
+                                    message: Some(message.clone()),
+                                    stage: Some("Restart now".to_string()),
+                                    reason: Some(message),
+                                    log_path: None,
+                                },
                             ),
                         ]));
                     }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -5402,8 +5402,51 @@ fn main() -> wry::Result<()> {
             }
             Event::UserEvent(UserEvent::ApplyUpdateStart { state, client_id }) => {
                 let apply_proxy = proxy.clone();
+                let version_for_progress = match &state {
+                    gwt_core::update::UpdateState::Available { latest, .. } => Some(latest.clone()),
+                    _ => None,
+                };
+                let asset_for_progress = match &state {
+                    gwt_core::update::UpdateState::Available {
+                        asset_url: Some(url),
+                        ..
+                    } => gwt_core::update::asset_name_from_url(url),
+                    _ => None,
+                };
                 std::thread::spawn(move || {
-                    match update_front_door::prepare_update_payload(state) {
+                    // SPEC-2041 Phase 19 FR-054: stream chunk-level progress
+                    // back to the modal. Throttle to ~200 ms or the
+                    // completion tick (`downloaded >= total`) so the
+                    // WebSocket does not see one event per 64 KiB.
+                    let throttle_interval = std::time::Duration::from_millis(200);
+                    let progress_proxy = apply_proxy.clone();
+                    let version_for_closure = version_for_progress.clone();
+                    let asset_for_closure = asset_for_progress.clone();
+                    let mut last_emit = std::time::Instant::now();
+                    let mut emitted_first = false;
+                    let mut progress = move |downloaded: u64, total: Option<u64>| {
+                        let is_complete = total.map(|t| downloaded >= t).unwrap_or(false);
+                        let now = std::time::Instant::now();
+                        let should_emit = !emitted_first
+                            || is_complete
+                            || now.duration_since(last_emit) >= throttle_interval;
+                        if should_emit {
+                            emitted_first = true;
+                            last_emit = now;
+                            let _ = progress_proxy.send_event(UserEvent::Dispatch(vec![
+                                OutboundEvent::broadcast(BackendEvent::UpdateProgress {
+                                    downloaded,
+                                    total,
+                                    asset: asset_for_closure.clone(),
+                                    version: version_for_closure.clone(),
+                                }),
+                            ]));
+                        }
+                    };
+                    match update_front_door::prepare_update_payload_with_progress(
+                        state,
+                        &mut progress,
+                    ) {
                         Ok(prepared) => {
                             let asset_path = prepared.payload_path();
                             let version = prepared.latest;

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -257,7 +257,33 @@ pub enum FrontendEvent {
         action: LaunchWizardAction,
         bounds: Option<WindowGeometry>,
     },
+    /// Legacy Phase 14 entry point. Frontend now sends
+    /// [`FrontendEvent::ApplyUpdateStart`] / [`FrontendEvent::ApplyUpdateRestartNow`]
+    /// instead. Kept so older clients and unit tests that still drive
+    /// `apply_update` continue to work; routes to the same backend behavior as
+    /// `ApplyUpdateRestartNow` (download → spawn helper → exit).
     ApplyUpdate,
+    /// SPEC-2041 Phase 19 (FR-052..057): user clicked the update CTA. Backend
+    /// downloads/prepares the asset and emits [`BackendEvent::UpdateProgress`]
+    /// during the transfer plus [`BackendEvent::UpdateReady`] on completion,
+    /// without exiting the parent process.
+    ApplyUpdateStart,
+    /// SPEC-2041 Phase 19 (FR-055): user pressed Cancel on the downloading
+    /// modal. Backend aborts the in-flight download and removes any partial
+    /// payload. Currently a best-effort no-op until async download lands.
+    CancelUpdateDownload,
+    /// SPEC-2041 Phase 19 (FR-059..061): user pressed `Later`. Binary stays
+    /// preserved; backend emits [`BackendEvent::UpdateApplyPendingPersisted`]
+    /// so the CTA morphs to ready state and same-session polling stops.
+    ApplyUpdateLater,
+    /// SPEC-2041 Phase 19 (FR-058): user pressed `Restart now`. Backend swaps
+    /// the prepared binary via the helper subprocess and exits the parent.
+    ApplyUpdateRestartNow,
+    /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
+    /// modal. Backend opens the log file in the OS default application.
+    OpenUpdateLog {
+        log_path: Option<String>,
+    },
     /// Settings > Custom Agents: list every stored custom agent. Response is
     /// [`BackendEvent::CustomAgentList`].
     ListCustomAgents,
@@ -594,8 +620,47 @@ pub enum BackendEvent {
         event: RuntimeHookEvent,
     },
     UpdateState(gwt_core::update::UpdateState),
+    /// SPEC-2041 Phase 19 (FR-054): download progress for the current update.
+    /// Emitted from `Backend` while a download is active; the `#update-modal`
+    /// uses these to drive the progress bar and byte counter.
+    UpdateProgress {
+        /// Bytes already received.
+        downloaded: u64,
+        /// Expected total bytes (when the server advertises Content-Length).
+        total: Option<u64>,
+        /// Asset filename (e.g. `gwt-macos-arm64.tar.gz`).
+        asset: Option<String>,
+        /// Target version (without the `v` prefix).
+        version: Option<String>,
+    },
+    /// SPEC-2041 Phase 19 (FR-056): download completed and the prepared payload
+    /// lives on disk. Frontend transitions the modal to the `ready` state.
+    UpdateReady {
+        version: String,
+        /// On-disk path to the prepared payload (extracted binary or installer).
+        asset_path: String,
+    },
+    /// SPEC-2041 Phase 19 (FR-059): `Later` was confirmed. The downloaded
+    /// binary is preserved (in-memory today; persistent across restarts once
+    /// the bootstrap path lands in T-133). Frontend morphs the CTA to ready.
+    UpdateApplyPendingPersisted {
+        version: String,
+    },
     UpdateApplyError {
-        message: String,
+        /// Phase 14 free-form message. Still emitted for backward compat.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+        /// Phase 19 (FR-063): structured failure stage
+        /// (e.g. `"Download asset"`, `"Replace binary"`).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        stage: Option<String>,
+        /// Phase 19 (FR-063): human-readable reason.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        /// Phase 19 (FR-065): path to the per-day update log so the modal can
+        /// surface `[Open log]`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        log_path: Option<String>,
     },
     /// Response to [`FrontendEvent::ListCustomAgents`].
     CustomAgentList {

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -306,8 +306,23 @@ impl PreparedUpdate {
 /// helper, and never mutates the running binary. T-130 will eventually replace
 /// `apply_update_state_and_exit` entirely with this + a separate
 /// `commit_update_restart_now` once Phase 19 stabilizes.
+/// Convenience wrapper that drops download-progress events. Kept on the
+/// public API for future non-streaming callers (CLI, automated tests) so the
+/// progress-aware variant does not have to be re-discovered.
+#[allow(dead_code)]
 pub fn prepare_update_payload(
     state: gwt_core::update::UpdateState,
+) -> Result<PreparedUpdate, String> {
+    prepare_update_payload_with_progress(state, &mut |_, _| {})
+}
+
+/// SPEC-2041 Phase 19 (FR-054): like [`prepare_update_payload`] but routes
+/// download chunk progress to `progress`. The closure must be cheap because
+/// it fires once per 64 KiB of payload; callers that broadcast progress over
+/// WebSocket should throttle inside the closure (e.g. by `Instant::elapsed`).
+pub fn prepare_update_payload_with_progress(
+    state: gwt_core::update::UpdateState,
+    progress: &mut dyn FnMut(u64, Option<u64>),
 ) -> Result<PreparedUpdate, String> {
     let (latest, asset_url) = match state {
         gwt_core::update::UpdateState::Available {
@@ -325,9 +340,9 @@ pub fn prepare_update_payload(
             return Err(format!("Update check failed: {message}"));
         }
     };
-    let mut ops = RealUpdateApplyOps::default();
-    let payload = ops
-        .prepare_update(&latest, &asset_url)
+    let mgr = gwt_core::update::UpdateManager::new();
+    let payload = mgr
+        .prepare_update_with_progress(&latest, &asset_url, progress)
         .map_err(|err| format!("Failed to prepare update payload: {err}"))?;
     Ok(PreparedUpdate {
         latest,

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -269,6 +269,73 @@ impl UpdateApplyOps for RealUpdateApplyOps {
     }
 }
 
+/// SPEC-2041 Phase 19 (T-130): a download that has been completed but not yet
+/// committed via the helper subprocess. Constructed by
+/// [`prepare_update_payload`] from a verified `UpdateState::Available`, then
+/// reused by `apply_update_state_and_exit` (which performs the helper spawn +
+/// `exit(0)`). The struct intentionally owns the on-disk path so the apply
+/// path does not have to re-derive it from the asset URL.
+#[derive(Debug, Clone)]
+pub struct PreparedUpdate {
+    pub latest: String,
+    /// Source URL the asset was downloaded from. Retained for diagnostics
+    /// (logs, retry telemetry) so future Phase 19 work can correlate ready
+    /// payloads back to the upstream release without re-walking the cache.
+    #[allow(dead_code)]
+    pub asset_url: String,
+    pub payload: gwt_core::update::PreparedPayload,
+}
+
+impl PreparedUpdate {
+    /// Filesystem path of the prepared payload (binary or installer).
+    pub fn payload_path(&self) -> PathBuf {
+        match &self.payload {
+            gwt_core::update::PreparedPayload::PortableBinary { path }
+            | gwt_core::update::PreparedPayload::Installer { path, .. } => path.clone(),
+        }
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-052/056): download and stage the update payload
+/// without spawning the helper subprocess. The caller (typically the
+/// `UserEvent::ApplyUpdateStart` worker thread in `main.rs`) broadcasts
+/// [`crate::BackendEvent::UpdateReady`] when this returns `Ok`.
+///
+/// This is the explicit no-side-effects half of the legacy
+/// [`apply_update_state_and_exit`]: it never calls `exit(0)`, never spawns the
+/// helper, and never mutates the running binary. T-130 will eventually replace
+/// `apply_update_state_and_exit` entirely with this + a separate
+/// `commit_update_restart_now` once Phase 19 stabilizes.
+pub fn prepare_update_payload(
+    state: gwt_core::update::UpdateState,
+) -> Result<PreparedUpdate, String> {
+    let (latest, asset_url) = match state {
+        gwt_core::update::UpdateState::Available {
+            latest,
+            asset_url: Some(asset_url),
+            ..
+        } => (latest, asset_url),
+        gwt_core::update::UpdateState::Available { .. } => {
+            return Err("No applicable update asset is available for this platform.".to_string());
+        }
+        gwt_core::update::UpdateState::UpToDate { .. } => {
+            return Err("No pending update is available.".to_string());
+        }
+        gwt_core::update::UpdateState::Failed { message, .. } => {
+            return Err(format!("Update check failed: {message}"));
+        }
+    };
+    let mut ops = RealUpdateApplyOps::default();
+    let payload = ops
+        .prepare_update(&latest, &asset_url)
+        .map_err(|err| format!("Failed to prepare update payload: {err}"))?;
+    Ok(PreparedUpdate {
+        latest,
+        asset_url,
+        payload,
+    })
+}
+
 /// Apply an already-detected update state from the GUI notification path.
 ///
 /// The startup poll has already selected the platform-specific asset. Reusing

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -171,7 +171,7 @@ fn handle_poll_outcome(
                 _ => return state.on_success_uptodate(),
             };
             let (should_publish, next) = state.on_success_available(&latest);
-            if should_publish {
+            if should_publish && !pending_manifest_covers(&latest) {
                 let _ = update_proxy.send_event(UserEvent::UpdateAvailable(outcome));
             }
             next
@@ -179,6 +179,16 @@ fn handle_poll_outcome(
         StartupUpdateAction::Stop => state.on_success_uptodate(),
         StartupUpdateAction::Retry => state.on_failure(),
     }
+}
+
+/// SPEC-2041 Phase 19 (T-134): suppress polling broadcasts for versions the
+/// user has already deferred via `Later`. Without this guard the same release
+/// would re-pop the CTA every 5 minutes even though the binary is already
+/// staged in `~/.gwt/pending-update/`.
+fn pending_manifest_covers(latest: &str) -> bool {
+    gwt_core::update::load_pending_update_manifest()
+        .map(|m| m.version == latest)
+        .unwrap_or(false)
 }
 
 trait UpdateApplyOps {
@@ -399,6 +409,30 @@ fn start_update_apply_with_ops(
     let payload = ops
         .prepare_update(&latest, &asset_url)
         .map_err(|err| format!("Failed to prepare update payload: {err}"))?;
+    apply_prepared_payload_with_ops(
+        ops,
+        &latest,
+        payload,
+        current_exe,
+        restart_args,
+        old_pid,
+        use_helper_copy,
+    )
+}
+
+/// SPEC-2041 Phase 19 (T-130): commit an already-prepared update by writing
+/// the restart-args file, optionally creating a helper copy on Windows, and
+/// spawning the helper subprocess. Caller is responsible for `exit(0)` once
+/// this returns `Ok` so the helper sees the parent close.
+fn apply_prepared_payload_with_ops(
+    ops: &mut impl UpdateApplyOps,
+    latest: &str,
+    payload: gwt_core::update::PreparedPayload,
+    current_exe: &Path,
+    restart_args: Vec<String>,
+    old_pid: u32,
+    use_helper_copy: bool,
+) -> Result<(), String> {
     let args_file = (match &payload {
         gwt_core::update::PreparedPayload::PortableBinary { path }
         | gwt_core::update::PreparedPayload::Installer { path, .. } => {
@@ -409,7 +443,7 @@ fn start_update_apply_with_ops(
     ops.write_restart_args_file(&args_file, restart_args)
         .map_err(|err| format!("Failed to write update restart args: {err}"))?;
     let helper_exe = if use_helper_copy {
-        ops.make_helper_copy(current_exe, &latest)
+        ops.make_helper_copy(current_exe, latest)
             .map_err(|err| format!("Failed to prepare update helper: {err}"))?
     } else {
         current_exe.to_path_buf()
@@ -428,6 +462,69 @@ fn start_update_apply_with_ops(
                 &args_file,
             )
             .map_err(|err| format!("Failed to start update installer: {err}")),
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-058/062): consume an already-persisted manifest.
+/// Used both by `Restart now` (when the user clicked through the modal) and
+/// by the bootstrap path (when a previous run wrote the manifest via
+/// `Later`). After the helper subprocess is spawned the manifest is removed
+/// so a future launch does not re-apply the same payload.
+pub fn apply_pending_manifest_and_exit(
+    manifest: gwt_core::update::PendingUpdateManifest,
+) -> Result<(), String> {
+    let current_exe = std::env::current_exe()
+        .map_err(|err| format!("Failed to resolve current executable: {err}"))?;
+    let restart_args: Vec<String> = std::env::args().skip(1).collect();
+    let latest = manifest.version.clone();
+    let payload = manifest.payload.clone();
+    let mut ops = RealUpdateApplyOps::default();
+    apply_prepared_payload_with_ops(
+        &mut ops,
+        &latest,
+        payload,
+        &current_exe,
+        restart_args,
+        std::process::id(),
+        cfg!(windows),
+    )?;
+    // Best-effort cleanup so the next launch starts from a clean state. The
+    // helper has already been spawned so failures here are not fatal.
+    let _ = gwt_core::update::clear_pending_update_manifest();
+    std::process::exit(0);
+}
+
+/// SPEC-2041 Phase 19 (T-133): bootstrap-time swap. Returns `true` when a
+/// pending manifest was found, applied, and the parent process is about to
+/// `exit(0)` (caller should not return). Returns `false` when there is no
+/// applicable pending update so the caller continues normal startup.
+///
+/// Intentionally `pub` so `crates/gwt/src/main.rs` can call this before
+/// any window setup. Stale manifests (older than the running binary, or
+/// pointing at a missing payload) are quietly cleared so they don't keep
+/// rewinding launches.
+pub fn try_apply_pending_update_at_bootstrap() -> bool {
+    let manifest = match gwt_core::update::load_pending_update_manifest() {
+        Some(m) => m,
+        None => return false,
+    };
+    let current_version = env!("CARGO_PKG_VERSION");
+    if !gwt_core::update::pending_version_is_newer(&manifest.version, current_version) {
+        // The pending payload is for our current (or older) version. Drop it
+        // so we don't loop forever.
+        let _ = gwt_core::update::clear_pending_update_manifest();
+        return false;
+    }
+    match apply_pending_manifest_and_exit(manifest) {
+        Ok(()) => true, // unreachable: apply_pending_manifest_and_exit calls exit(0)
+        Err(err) => {
+            // Apply failed before exit. Clear the manifest so we don't loop.
+            // Tracing isn't initialized this early in main(), so log via stderr
+            // for post-mortem inspection.
+            eprintln!("gwt bootstrap pending-update apply failed: {err}");
+            let _ = gwt_core::update::clear_pending_update_manifest();
+            false
+        }
     }
 }
 

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -242,3 +242,295 @@ function createFixture({ confirmResult = true } = {}) {
     },
   };
 }
+
+// SPEC-2041 Phase 19 (FR-052..066) — Post-click modal & restart UX.
+//
+// These tests pin the modal-driven state machine before implementation.
+// They will fail against the current `update-cta.js` (which uses
+// window.confirm and immediate apply_update_state_and_exit). The implementation
+// in T-122 must satisfy these invariants without regressing earlier tests.
+
+test("phase19: click no longer uses window.confirm and instead opens #update-modal in downloading state", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+
+  fixture.document.getElementById("update-cta").click();
+
+  assert.equal(
+    fixture.confirmCalls.length,
+    0,
+    "window.confirm must not be called; the modal replaces it",
+  );
+  const modal = fixture.document.getElementById("update-modal");
+  assert.ok(modal, "expected #update-modal to be rendered after click");
+  assert.equal(modal.dataset.state, "downloading");
+  assert.deepEqual(fixture.sent, [{ kind: "apply_update_start" }]);
+  assert.equal(
+    fixture.document.getElementById("update-cta").dataset.status,
+    "applying",
+  );
+});
+
+test("phase19: update_progress events update modal progress bar and byte counter", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  controller.handleUpdateProgress({
+    downloaded: 1024 * 1024,
+    total: 4 * 1024 * 1024,
+    asset: "gwt-macos-arm64.tar.gz",
+    version: "9.26.0",
+  });
+  controller.handleUpdateProgress({
+    downloaded: 3 * 1024 * 1024,
+    total: 4 * 1024 * 1024,
+    asset: "gwt-macos-arm64.tar.gz",
+    version: "9.26.0",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  const progress = modal.querySelector("[data-update-modal-progress]");
+  const counter = modal.querySelector("[data-update-modal-byte-counter]");
+  assert.ok(progress, "expected progress bar element");
+  assert.ok(counter, "expected byte counter element");
+  assert.equal(progress.getAttribute("aria-valuenow"), "75");
+  assert.match(counter.textContent, /3.0\s*MB\s*\/\s*4.0\s*MB/);
+});
+
+test("phase19: cancel during download sends cancel_update_download and returns CTA to available", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  fixture.document
+    .querySelector("[data-update-modal-cancel]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "cancel_update_download" },
+  ]);
+  assert.equal(fixture.document.getElementById("update-modal"), null);
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(cta.dataset.status, "available");
+});
+
+test("phase19: update_ready transitions modal to ready state with [Later] [Restart now]", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  controller.handleUpdateReady({
+    version: "9.26.0",
+    asset_path: "/Users/x/.gwt/pending-update/9.26.0/gwt-macos-arm64.tar.gz",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.equal(modal.dataset.state, "ready");
+  assert.ok(modal.querySelector("[data-update-modal-restart-now]"));
+  assert.ok(modal.querySelector("[data-update-modal-later]"));
+});
+
+test("phase19: [Restart now] sends apply_update_restart_now without confirmation", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+
+  fixture.document
+    .querySelector("[data-update-modal-restart-now]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_restart_now" },
+  ]);
+  assert.equal(
+    fixture.confirmCalls.length,
+    0,
+    "Restart now must not gate behind window.confirm",
+  );
+});
+
+test("phase19: [Later] closes modal, sends apply_update_later, and morphs CTA to ready state", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+
+  fixture.document
+    .querySelector("[data-update-modal-later]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_later" },
+  ]);
+  assert.equal(fixture.document.getElementById("update-modal"), null);
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(cta.dataset.status, "ready");
+  assert.match(cta.textContent, /Update v9.26.0 ready\s*[—-]\s*Restart now/);
+  assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
+});
+
+test("phase19: re-clicking CTA in ready state opens modal at ready (no re-download)", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+  fixture.document.querySelector("[data-update-modal-later]").click();
+
+  fixture.document.getElementById("update-cta").click();
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.ok(modal, "modal should reopen on re-click");
+  assert.equal(modal.dataset.state, "ready");
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_later" },
+  ]);
+});
+
+test("phase19: dismiss in ready state hides CTA without losing pending binary", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+  fixture.document.querySelector("[data-update-modal-later]").click();
+
+  fixture.document
+    .querySelector("[data-update-cta-dismiss]")
+    .click();
+
+  assert.equal(fixture.document.getElementById("update-cta"), null);
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_later" },
+  ]);
+});
+
+test("phase19: update_apply_error transitions modal to failed state with stage/reason/log/buttons", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  controller.handleUpdateApplyError({
+    stage: "Download asset",
+    reason: "HTTP 503",
+    log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.equal(modal.dataset.state, "failed");
+  const stage = modal.querySelector("[data-update-modal-stage]");
+  const reason = modal.querySelector("[data-update-modal-reason]");
+  const log = modal.querySelector("[data-update-modal-log]");
+  assert.match(stage.textContent, /Download asset/);
+  assert.match(reason.textContent, /HTTP 503/);
+  assert.match(log.textContent, /update-2026-05-10/);
+  assert.ok(modal.querySelector("[data-update-modal-open-log]"));
+  assert.ok(modal.querySelector("[data-update-modal-retry]"));
+  assert.ok(modal.querySelector("[data-update-modal-close]"));
+});
+
+test("phase19: failed-state [Retry] resends apply_update_start and switches modal back to downloading", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateApplyError({
+    stage: "Download asset",
+    reason: "HTTP 503",
+    log_path: "/x.log",
+  });
+
+  fixture.document
+    .querySelector("[data-update-modal-retry]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_start" },
+  ]);
+  assert.equal(
+    fixture.document.getElementById("update-modal").dataset.state,
+    "downloading",
+  );
+});
+
+test("phase19: failed-state [Open log] sends open_update_log with the log_path", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateApplyError({
+    stage: "Replace binary",
+    reason: "EPERM",
+    log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+  });
+
+  fixture.document
+    .querySelector("[data-update-modal-open-log]")
+    .click();
+
+  assert.deepEqual(fixture.sent.slice(-1), [
+    {
+      kind: "open_update_log",
+      log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+    },
+  ]);
+});
+
+test("phase19: failed-state [Close] closes modal and returns CTA to available", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateApplyError({
+    stage: "Download asset",
+    reason: "HTTP 503",
+    log_path: "/x.log",
+  });
+
+  fixture.document
+    .querySelector("[data-update-modal-close]")
+    .click();
+
+  assert.equal(fixture.document.getElementById("update-modal"), null);
+  assert.equal(
+    fixture.document.getElementById("update-cta").dataset.status,
+    "available",
+  );
+});
+
+test("phase19: update_apply_pending_persisted morphs CTA directly to ready state (next-launch path)", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+
+  controller.handleUpdateApplyPendingPersisted({ version: "9.26.0" });
+
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(cta.dataset.status, "ready");
+  assert.match(cta.textContent, /Update v9.26.0 ready\s*[—-]\s*Restart now/);
+  assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
+});
+
+test("phase19: controller exposes the Phase 19 event handlers required by app.js wiring", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+
+  assert.equal(typeof controller.handleUpdateProgress, "function");
+  assert.equal(typeof controller.handleUpdateReady, "function");
+  assert.equal(typeof controller.handleUpdateApplyError, "function");
+  assert.equal(typeof controller.handleUpdateApplyPendingPersisted, "function");
+});

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -48,26 +48,17 @@ test("update_state renders one reusable update CTA", () => {
   assert.equal(fixture.versionUpdates.length, 2);
 });
 
-test("update CTA click cancel leaves it available and does not send apply_update", () => {
-  const fixture = createFixture({ confirmResult: false });
-  const controller = createUpdateCtaController(fixture.options);
-  controller.showAvailable("9.23.0");
-
-  fixture.document.getElementById("update-cta").click();
-
-  assert.equal(fixture.confirmCalls.length, 1);
-  assert.deepEqual(fixture.sent, []);
-  assert.equal(fixture.document.getElementById("update-cta").dataset.status, "available");
-});
-
-test("update CTA click approve sends apply_update and shows applying state", () => {
+// Phase 19 supersedes the Phase 14 window.confirm gate. The "click cancel"
+// test is dropped because the new modal flow always sends apply_update_start;
+// see the dedicated phase19 tests below for the modal-driven cancel path.
+test("update CTA click sends apply_update_start and shows applying state with modal", () => {
   const fixture = createFixture({ confirmResult: true });
   const controller = createUpdateCtaController(fixture.options);
   controller.showAvailable("9.23.0");
 
   fixture.document.getElementById("update-cta").click();
 
-  assert.deepEqual(fixture.sent, [{ kind: "apply_update" }]);
+  assert.deepEqual(fixture.sent, [{ kind: "apply_update_start" }]);
   const cta = fixture.document.getElementById("update-cta");
   assert.equal(cta.dataset.status, "applying");
   assert.equal(cta.disabled, true);
@@ -114,7 +105,10 @@ test("update_apply_error reuses the same CTA and allows retry", () => {
   assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
 
   cta.click();
-  assert.deepEqual(fixture.sent, [{ kind: "apply_update" }, { kind: "apply_update" }]);
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_start" },
+  ]);
 });
 
 test("update CTA dismiss hides available state without applying", () => {
@@ -159,7 +153,7 @@ test("update CTA dismiss hides error state without retrying", () => {
   fixture.document.querySelector("[data-update-cta-dismiss]").click();
 
   assert.equal(fixture.document.getElementById("update-cta"), null);
-  assert.deepEqual(fixture.sent, [{ kind: "apply_update" }]);
+  assert.deepEqual(fixture.sent, [{ kind: "apply_update_start" }]);
 });
 
 test("update_state removes stale split toast and button DOM before showing CTA", () => {
@@ -193,7 +187,14 @@ test("update_state removes stale split toast and button DOM before showing CTA",
 test("app.js delegates update handling to the unified update CTA controller", () => {
   assert.match(appSource, /createUpdateCtaController/);
   assert.match(appSource, /updateCtaController\.handleUpdateState\(event\)/);
-  assert.match(appSource, /updateCtaController\.showError\(/);
+  // Phase 19 replaces showError() with handleUpdateApplyError().
+  assert.match(appSource, /updateCtaController\.handleUpdateApplyError\(/);
+  assert.match(appSource, /updateCtaController\.handleUpdateProgress\(/);
+  assert.match(appSource, /updateCtaController\.handleUpdateReady\(/);
+  assert.match(
+    appSource,
+    /updateCtaController\.handleUpdateApplyPendingPersisted\(/,
+  );
 });
 
 test("legacy split update toast and button surfaces are removed", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7801,8 +7801,31 @@
               updateCtaController.handleUpdateState(event);
             }
             break;
+          case "update_progress":
+            updateCtaController.handleUpdateProgress({
+              downloaded: event.downloaded,
+              total: event.total,
+              asset: event.asset,
+              version: event.version,
+            });
+            break;
+          case "update_ready":
+            updateCtaController.handleUpdateReady({
+              version: event.version,
+              asset_path: event.asset_path,
+            });
+            break;
           case "update_apply_error":
-            updateCtaController.showError(event.message || "Failed to start the update.");
+            updateCtaController.handleUpdateApplyError({
+              stage: event.stage,
+              reason: event.reason || event.message,
+              log_path: event.log_path,
+            });
+            break;
+          case "update_apply_pending_persisted":
+            updateCtaController.handleUpdateApplyPendingPersisted({
+              version: event.version,
+            });
             break;
           case "custom_agent_list":
             customAgentsState.agents = event.agents || [];

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -203,10 +203,137 @@ body::after {
   color: var(--color-state-blocked);
 }
 
+.update-cta.is-ready {
+  border-color: var(--color-state-active, var(--color-focus-ring));
+  color: var(--color-state-active, var(--color-text-primary));
+}
+
 .update-cta:focus-visible,
 .update-cta__dismiss:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+}
+
+/* SPEC-2041 Phase 19 — Post-click update modal. */
+
+.update-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 10100;
+}
+
+.update-modal__panel {
+  min-width: 360px;
+  max-width: 480px;
+  padding: 24px 28px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-lg, 8px);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-3, 0 18px 48px rgba(0, 0, 0, 0.42));
+  font: var(--font-body);
+}
+
+.update-modal__panel h2 {
+  margin: 0 0 12px;
+  font-size: var(--font-size-h3, 18px);
+  letter-spacing: 0.01em;
+}
+
+.update-modal__version {
+  margin: 0 0 8px;
+  font-size: var(--font-size-body, 14px);
+  color: var(--color-text-secondary);
+}
+
+.update-modal__hint {
+  margin: 0 0 16px;
+  font-size: var(--font-size-body-sm, 13px);
+  color: var(--color-text-secondary);
+}
+
+.update-modal__progress {
+  position: relative;
+  height: 8px;
+  margin: 12px 0 8px;
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-surface-sunken, rgba(255, 255, 255, 0.08));
+  overflow: hidden;
+}
+
+.update-modal__progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--color-state-active, var(--color-focus-ring));
+  transition: width 120ms linear;
+}
+
+.update-modal__bytes {
+  margin: 0 0 16px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: var(--font-size-body-sm, 13px);
+  color: var(--color-text-secondary);
+}
+
+.update-modal__details {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 12px;
+  margin: 0 0 16px;
+  font-size: var(--font-size-body-sm, 13px);
+}
+
+.update-modal__details dt {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.update-modal__details dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.update-modal__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.update-modal__btn {
+  appearance: none;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  padding: 8px 14px;
+  border-radius: var(--radius-sm, 4px);
+  font: inherit;
+  cursor: pointer;
+}
+
+.update-modal__btn:hover {
+  background: var(--color-surface-hover, rgba(255, 255, 255, 0.04));
+}
+
+.update-modal__btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.update-modal__btn--primary {
+  border-color: var(--color-state-active, var(--color-focus-ring));
+  background: var(--color-state-active, var(--color-focus-ring));
+  color: var(--color-text-on-accent, #0a0a0a);
+}
+
+.update-modal__btn--secondary {
+  background: transparent;
 }
 
 .terminal-context-menu {

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -1,12 +1,25 @@
+// SPEC-2041 Phase 19 — Post-click modal & restart UX (FR-052..066).
+//
+// The CTA hands user clicks to #update-modal. The modal owns three states:
+// `downloading` (progress bar + Cancel), `ready` (Later / Restart now),
+// `failed` (Stage / Reason / Log + Open log / Retry / Close). The CTA itself
+// has four observable statuses: `available` | `applying` | `ready` | `error`,
+// where `applying` means a modal is mounted on top of it.
+
 export function createUpdateCtaController({
   document,
   send,
-  confirmUpdate,
+  // Phase 14's window.confirm gating is gone; the modal supersedes it.
+  // The option survives only so existing callers do not break.
+  confirmUpdate: _confirmUpdate,
   setVersionState = () => {},
 }) {
   const shellId = "update-cta-shell";
+  const modalId = "update-modal";
   let latestVersion = null;
+  let pendingVersion = null;
   let status = "idle";
+  let lastProgress = null;
 
   function removeLegacyUpdateSurfaces() {
     document.querySelectorAll(".update-toast, .update-button").forEach((node) => {
@@ -53,7 +66,7 @@ export function createUpdateCtaController({
       dismiss.type = "button";
       dismiss.className = "update-cta__dismiss";
       dismiss.dataset.updateCtaDismiss = "true";
-      dismiss.textContent = "\u00d7";
+      dismiss.textContent = "×";
       dismiss.title = "Dismiss update notification";
       dismiss.setAttribute("aria-label", "Dismiss update notification");
       dismiss.onclick = dismissCta;
@@ -71,12 +84,14 @@ export function createUpdateCtaController({
     }
   }
 
-  function render(nextStatus, text) {
+  function renderCta(nextStatus, text) {
     status = nextStatus;
     const shell = ensureShell();
     const cta = ensureCta(shell);
     cta.dataset.status = nextStatus;
-    cta.className = nextStatus === "available" ? "update-cta" : `update-cta is-${nextStatus}`;
+    const stateClass =
+      nextStatus === "available" ? "update-cta" : `update-cta is-${nextStatus}`;
+    cta.className = stateClass;
     cta.title = text;
     cta.setAttribute("aria-label", text);
     cta.disabled = nextStatus === "applying";
@@ -93,12 +108,19 @@ export function createUpdateCtaController({
     if (!version) return null;
     removeLegacyUpdateSurfaces();
     latestVersion = version;
-    return render("available", `Update available: v${version} - Click to update`);
+    return renderCta("available", `Update available: v${version} - Click to update`);
+  }
+
+  function showReadyPending(version) {
+    if (!version) return null;
+    removeLegacyUpdateSurfaces();
+    pendingVersion = version;
+    return renderCta("ready", `Update v${version} ready — Restart now`);
   }
 
   function showError(message) {
     const detail = message || "Failed to start the update.";
-    return render("error", `Update failed: ${detail} Click to retry.`);
+    return renderCta("error", `Update failed: ${detail} Click to retry.`);
   }
 
   function handleUpdateState(event) {
@@ -110,11 +132,45 @@ export function createUpdateCtaController({
     if (status === "applying" && latestVersion === event.latest) {
       return;
     }
+    if (status === "ready" && pendingVersion === event.latest) {
+      return;
+    }
     showAvailable(event.latest);
+  }
+
+  function handleUpdateProgress(payload) {
+    if (!payload) return;
+    lastProgress = payload;
+    const modal = document.getElementById(modalId);
+    if (!modal || modal.dataset.state !== "downloading") {
+      return;
+    }
+    updateProgressDisplay(payload);
+  }
+
+  function handleUpdateReady(payload) {
+    if (!payload || !payload.version) return;
+    pendingVersion = payload.version;
+    if (status === "applying") {
+      renderModalReady(payload.version);
+    }
+  }
+
+  function handleUpdateApplyError(payload) {
+    if (!payload) return;
+    if (status === "applying") {
+      renderModalFailed(payload);
+    }
+  }
+
+  function handleUpdateApplyPendingPersisted(payload) {
+    if (!payload || !payload.version) return;
+    showReadyPending(payload.version);
   }
 
   function dismissCta(event) {
     event?.stopPropagation();
+    closeModal();
     const shell = document.getElementById(shellId);
     if (shell) {
       shell.remove();
@@ -123,20 +179,300 @@ export function createUpdateCtaController({
   }
 
   function handleClick() {
-    if (status === "applying" || !latestVersion) {
+    if (status === "applying") return;
+    if (status === "ready" && pendingVersion) {
+      // Re-open the modal at the ready panel; no second download.
+      renderCta("applying", "Applying update...");
+      renderModalReady(pendingVersion);
       return;
     }
-    if (!confirmUpdate(latestVersion)) {
+    if (!latestVersion) return;
+    renderCta("applying", "Applying update...");
+    renderModalDownloading(latestVersion);
+    send({ kind: "apply_update_start" });
+  }
+
+  // ---- Modal builders (uses createElement/appendChild only) ----
+
+  function ensureModal() {
+    let modal = document.getElementById(modalId);
+    if (!modal) {
+      modal = document.createElement("div");
+      modal.id = modalId;
+      modal.className = "update-modal";
+      modal.setAttribute("role", "dialog");
+      modal.setAttribute("aria-modal", "true");
+      modal.setAttribute("aria-labelledby", "update-modal-title");
+      document.body.appendChild(modal);
+    }
+    return modal;
+  }
+
+  function clearChildren(node) {
+    while (node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
+  }
+
+  function el(tag, props = {}, children = []) {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(props)) {
+      if (v == null) continue;
+      if (k === "className") {
+        node.className = v;
+      } else if (k === "text") {
+        node.textContent = v;
+      } else if (k === "data") {
+        for (const [dk, dv] of Object.entries(v)) {
+          node.dataset[dk] = String(dv);
+        }
+      } else if (k === "attrs") {
+        for (const [ak, av] of Object.entries(v)) {
+          node.setAttribute(ak, String(av));
+        }
+      } else if (k === "onClick") {
+        node.addEventListener("click", v);
+      } else {
+        node.setAttribute(k, String(v));
+      }
+    }
+    for (const child of children) {
+      if (child == null) continue;
+      node.appendChild(child);
+    }
+    return node;
+  }
+
+  function closeModal() {
+    const modal = document.getElementById(modalId);
+    if (modal) {
+      modal.remove();
+    }
+  }
+
+  function renderModalDownloading(version) {
+    const modal = ensureModal();
+    modal.dataset.state = "downloading";
+    clearChildren(modal);
+
+    const fill = el("div", { className: "update-modal__progress-fill" });
+    const progress = el(
+      "div",
+      {
+        className: "update-modal__progress",
+        attrs: {
+          role: "progressbar",
+          "aria-valuemin": "0",
+          "aria-valuemax": "100",
+          "aria-valuenow": "0",
+        },
+        data: { updateModalProgress: "true" },
+      },
+      [fill],
+    );
+    const counter = el("p", {
+      className: "update-modal__bytes",
+      text: "0.0 MB / 0.0 MB",
+      data: { updateModalByteCounter: "true" },
+    });
+    const cancel = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Cancel",
+      data: { updateModalCancel: "true" },
+      onClick: onCancelDownload,
+    });
+
+    const panel = el(
+      "div",
+      { className: "update-modal__panel", data: { state: "downloading" } },
+      [
+        el("h2", { id: "update-modal-title", text: "Updating gwt" }),
+        el("p", {
+          className: "update-modal__version",
+          text: `Downloading v${version || ""}`,
+          data: { updateModalVersion: "true" },
+        }),
+        progress,
+        counter,
+        el("div", { className: "update-modal__actions" }, [cancel]),
+      ],
+    );
+    modal.appendChild(panel);
+
+    if (lastProgress) {
+      updateProgressDisplay(lastProgress);
+    }
+  }
+
+  function renderModalReady(version) {
+    const modal = ensureModal();
+    modal.dataset.state = "ready";
+    clearChildren(modal);
+
+    const later = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Later",
+      data: { updateModalLater: "true" },
+      onClick: onApplyLater,
+    });
+    const restartNow = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--primary",
+      text: "Restart now",
+      data: { updateModalRestartNow: "true" },
+      onClick: onApplyRestartNow,
+    });
+
+    const panel = el(
+      "div",
+      { className: "update-modal__panel", data: { state: "ready" } },
+      [
+        el("h2", { id: "update-modal-title", text: "Update ready" }),
+        el("p", {
+          className: "update-modal__version",
+          text: `v${version} を適用する準備ができました。`,
+        }),
+        el("p", {
+          className: "update-modal__hint",
+          text: "Restart で新しいバージョンが起動します。",
+        }),
+        el("div", { className: "update-modal__actions" }, [later, restartNow]),
+      ],
+    );
+    modal.appendChild(panel);
+  }
+
+  function renderModalFailed({ stage, reason, log_path }) {
+    const modal = ensureModal();
+    modal.dataset.state = "failed";
+    clearChildren(modal);
+
+    const dl = el("dl", { className: "update-modal__details" }, [
+      el("dt", { text: "Stage" }),
+      el("dd", {
+        text: stage || "Unknown stage",
+        data: { updateModalStage: "true" },
+      }),
+      el("dt", { text: "Reason" }),
+      el("dd", {
+        text: reason || "Unknown reason",
+        data: { updateModalReason: "true" },
+      }),
+      el("dt", { text: "Log" }),
+      el("dd", {
+        text: log_path || "",
+        data: { updateModalLog: "true" },
+      }),
+    ]);
+
+    const openLog = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Open log",
+      data: { updateModalOpenLog: "true" },
+      onClick: () => {
+        const message = { kind: "open_update_log" };
+        if (log_path) message.log_path = log_path;
+        send(message);
+      },
+    });
+    const retry = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Retry",
+      data: { updateModalRetry: "true" },
+      onClick: onRetryFailed,
+    });
+    const closeBtn = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Close",
+      data: { updateModalClose: "true" },
+      onClick: onCloseFailed,
+    });
+
+    const panel = el(
+      "div",
+      { className: "update-modal__panel", data: { state: "failed" } },
+      [
+        el("h2", { id: "update-modal-title", text: "⚠ Update failed" }),
+        dl,
+        el("div", { className: "update-modal__actions" }, [openLog, retry, closeBtn]),
+      ],
+    );
+    modal.appendChild(panel);
+  }
+
+  function updateProgressDisplay({ downloaded, total }) {
+    const modal = document.getElementById(modalId);
+    if (!modal) return;
+    const progress = modal.querySelector("[data-update-modal-progress]");
+    const counter = modal.querySelector("[data-update-modal-byte-counter]");
+    if (progress) {
+      const percent = total
+        ? Math.max(0, Math.min(100, Math.round((downloaded / total) * 100)))
+        : 0;
+      progress.setAttribute("aria-valuenow", String(percent));
+      const fill = progress.querySelector(".update-modal__progress-fill");
+      if (fill) {
+        fill.style.width = `${percent}%`;
+      }
+    }
+    if (counter) {
+      counter.textContent = `${formatBytes(downloaded)} / ${formatBytes(total)}`;
+    }
+  }
+
+  function onCancelDownload() {
+    send({ kind: "cancel_update_download" });
+    lastProgress = null;
+    closeModal();
+    if (latestVersion) {
       showAvailable(latestVersion);
-      return;
     }
-    render("applying", "Applying update...");
-    send({ kind: "apply_update" });
+  }
+
+  function onApplyLater() {
+    send({ kind: "apply_update_later" });
+    closeModal();
+    if (pendingVersion) {
+      showReadyPending(pendingVersion);
+    }
+  }
+
+  function onApplyRestartNow() {
+    send({ kind: "apply_update_restart_now" });
+    // Modal is intentionally left in place; the parent process will exit.
+  }
+
+  function onRetryFailed() {
+    lastProgress = null;
+    renderModalDownloading(latestVersion || pendingVersion || "");
+    send({ kind: "apply_update_start" });
+  }
+
+  function onCloseFailed() {
+    closeModal();
+    if (latestVersion) {
+      showAvailable(latestVersion);
+    }
+  }
+
+  function formatBytes(bytes) {
+    const mb = (bytes ?? 0) / (1024 * 1024);
+    return `${mb.toFixed(1)} MB`;
   }
 
   return {
     handleUpdateState,
+    handleUpdateProgress,
+    handleUpdateReady,
+    handleUpdateApplyError,
+    handleUpdateApplyPendingPersisted,
     showAvailable,
+    showReadyPending,
     showError,
   };
 }

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -332,11 +332,11 @@ export function createUpdateCtaController({
         el("h2", { id: "update-modal-title", text: "Update ready" }),
         el("p", {
           className: "update-modal__version",
-          text: `v${version} を適用する準備ができました。`,
+          text: `v${version} is ready to install.`,
         }),
         el("p", {
           className: "update-modal__hint",
-          text: "Restart で新しいバージョンが起動します。",
+          text: "Restart now to launch the new version.",
         }),
         el("div", { className: "update-modal__actions" }, [later, restartNow]),
       ],

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5124,3 +5124,46 @@ CLI 実行を同じ quoting context に混ぜてしまった。
    を使い、Markdown 本文を shell double quote に直接埋め込まない。
 3. `gh issue close --comment` を使う場合でも、本文は単一引用符で安全に
    表現できる短文だけに限定する。複数行の検証ログは別途ファイル入力にする。
+
+## 2026-05-10 — 自動更新クリック後の silent failure を 5 回連続で見逃した
+
+### 事象
+
+`自動更新のクリックの対応` を 5 回連続で fix したが、ユーザーから「全く対応できていません」と
+強い不満を受けた。修正対象はすべて click 前 (cache / DOM / 表示) で、click 後の silent failure
+path は untouched だった。
+
+- 76be413f: 5分ポーリング + 永続更新ボタン (UI 表示のみ)
+- 293a1627 / 04d721cc / ca2b8221: toast → CTA 統一 (UI 表示のみ)
+- ffe40f46 / c5348421: asset wiring / ラベル文言 (UI 表示のみ)
+- 3a2e0628: dismiss button (UI 表示のみ)
+- 665dea8e: WebView cache 無効化 (click 検知のみ)
+
+### 原因
+
+1. `apply_update_state_and_exit` (`crates/gwt/src/update_front_door.rs:277`) が
+   `std::process::exit(0)` で親プロセスを click 直後に殺す設計のため、
+   helper subprocess の失敗が UI に surface されない silent failure path だった。
+2. テストが pass していたため done 宣言を繰り返したが、実環境では helper の失敗が見えないため
+   UX としては破綻していた。CI green = done 宣言が untested path を覆い隠した。
+3. 「click 検知が動かない」という assumption に基づいて修正対象を選んだが、根本的には
+   「click は反応しているが post-click が silent」という別問題だった。
+4. ユーザー意図 UX (modal で進捗 → 完了確認 → restart) を確認せず、SPEC は click 前領域の
+   みを規定していた。post-click UX が SPEC に書かれていない feature を「直す」ことができていなかった。
+
+### 再発防止策
+
+1. **CI green = done 禁止**: バグ修正・新機能の完了宣言には Gate 3 manual smoke
+   (実機で実 user flow を 1 往復) を必須化する。SPEC-2041 Phase 14 (FR-066) で正式化済み。
+2. **silent failure path の禁止**: 親プロセスが即時 exit する設計は許容しない。
+   download / install / replace / spawn の各 stage を必ず frontend (UI) に surface する。
+   `*_and_exit` という関数名が出てきた時点で silent failure を疑う。
+3. **修正前の前提検証**: 「動かない」報告を受けたら、表面的な仮説 (cache / DOM) で fix を
+   始める前に、ユーザーが実際に何を見ているか・どこで止まっているかを最低 1 度確認する。
+   「クリック反応するが画面出ない」と「クリック自体反応しない」は別問題。
+4. **再発カウントによる切り替え**: 同じ feature を 2 回以上 fix している場合、表面的修正
+   でなく architecture / silent failure path の review に切り替える。fix を重ねる前に
+   「過去の fix が効かなかった理由は何か」を root cause として specifically 特定する。
+5. **post-action UX の SPEC 義務化**: button / link / action を SPEC に書く際は post-action
+   UX (進捗・成功・失敗・確認) を必ず受け入れシナリオに含める。click 前後を分離して片方しか
+   書かない SPEC を禁止する。


### PR DESCRIPTION
## Summary

- 「自動更新のクリックの対応を入れているが全く対応できていません」というユーザー不満の root cause（`update_front_door.rs:290 std::process::exit(0)` が click 直後に親プロセス + WebView を即終了させる silent failure path）を **構造から取り除く**。過去 5 回の修正 (76be413f → 665dea8e) は cache / DOM / cosmetic 領域に集中していたため post-click silent failure を放置していた。
- 新 UX: click → 進捗付き modal が `downloading` で開く → backend が chunked download で `update_progress` を 200ms throttle で broadcast → 完了時に `update_ready` で modal が ready 状態に遷移 → user が `[Restart now]` か `[Later]` を選ぶ。失敗時は同 modal で `failed` 状態（Stage / Reason / Log + `[Open log] [Retry] [Close]`）。
- `Later` を押した時 / 親が落ちた時のために `~/.gwt/pending-update/<version>/` に manifest を永続化し、次回起動時に `try_apply_pending_update_at_bootstrap` が透明に swap & re-exec する。同 version の polling 重複通知も自動で抑制。

## Changes

| Commit | 内容 |
|---|---|
| `2658b186` | docs(lessons): silent-failure 5回連続見逃しの教訓 |
| `b91a879d` | test(gui): Phase 19 RED tests 14 件 (T-120) |
| `683bf50e` | feat(gui)!: frontend modal state machine (T-122/123) |
| `0837658e` | feat(gui)!: backend split + 5新FrontendEvent + 3新BackendEvent (T-130/131/132) |
| `6f88cbcb` | feat(update): chunked download progress callback (T-128) |
| `32b63c90` | feat(update): pending persistence + bootstrap swap + log writer (T-129/T-133/T-134/T-135) |
| `a57c70b3` | test(gui): Playwright scaffold for modal flow (T-121) |

### Frontend
- `crates/gwt/web/update-cta.js` — modal-driven state machine (`idle / available / downloading / ready / applying / failed / dismissed-with-pending`)。`window.confirm` 撤去、`#update-modal` を `createElement+appendChild` で安全に動的構築
- `crates/gwt/web/index.html` / `crates/gwt/web/styles/components.css` — modal layout, progress bar, byte counter, error variant, `.update-cta.is-ready`
- `crates/gwt/web/app.js` — WebSocket dispatch を新 events に対応 (`update_progress`, `update_ready`, `update_apply_pending_persisted`, structured `update_apply_error`)
- `crates/gwt/web/__tests__/update-button.test.mjs` — Phase 14 の confirm 前提テストを Phase 19 modal flow に更新、新 14 シナリオ追加 (25/25 GREEN)
- `crates/gwt/playwright/tests/update-modal.spec.ts` — 新規 E2E scaffold (env 未設定で skip)

### Backend
- `crates/gwt-core/src/update.rs` — `prepare_update_with_progress` (chunked + Content-Length progress callback)、`PendingUpdateManifest` + `persist/load/clear`、`pending_version_is_newer`、`update_log_path` + `log_update_event`、`asset_name_from_url` を pub に
- `crates/gwt/src/protocol.rs` — `FrontendEvent` に 5 variant 追加、`BackendEvent` に `UpdateProgress / UpdateReady / UpdateApplyPendingPersisted` 追加、`UpdateApplyError` に optional `stage / reason / log_path`
- `crates/gwt/src/update_front_door.rs` — `prepare_update_payload[_with_progress]`、`apply_pending_manifest_and_exit`、`try_apply_pending_update_at_bootstrap`、`apply_prepared_payload_with_ops` 抽出、`pending_manifest_covers` polling guard
- `crates/gwt/src/app_runtime/mod.rs` — 5 新 FrontendEvent dispatcher + helpers (`update_apply_error_message / update_apply_error_failed / open_path_with_os_default`)
- `crates/gwt/src/main.rs` — `UserEvent::ApplyUpdateStart / UpdatePrepared / ApplyUpdateRestartNow` variants と handler。bootstrap 直前に `try_apply_pending_update_at_bootstrap()` を呼ぶ
- `crates/gwt-core` 内 unit tests — 4 新 tests (pending_manifest_persist_load_clear_round_trip / load_returns_none_when_payload_missing / load_returns_none_when_file_malformed / pending_version_is_newer_compares_semver)

## Architectural change

**Before**: click → confirm → WebSocket `apply_update` → main.rs `UserEvent::ApplyUpdate` → `apply_update_state_and_exit` → `prepare_update` (sync) → spawn helper → **`std::process::exit(0)`**。helper が失敗しても親は既に死んでいて UI に何も surface されない silent failure path。

**After**: click → modal opens (`downloading`) → backend が parent を生かしたまま `prepare_update_with_progress` を呼び、`update_progress` chunk を broadcast → 完了で `~/.gwt/pending-update/manifest.json` を atomic write → `update_ready` broadcast → user 選択。`exit(0)` は **`commit_update_restart_now`（[Restart now] のときだけ）** または **bootstrap pending swap（次回起動時）** だけで呼ばれる。

## Testing

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test -p gwt-core -p gwt --all-features`: 全 GREEN (gwt-core 166 + gwt-lib 532 + integration 全件、新 4 unit tests を含む)
- `npm run test:frontend-unit`: 332/332 GREEN（旧 318 → 332、Phase 19 14 件追加）
- `npm run test:frontend-bundle`: GREEN
- `npx playwright test --list`: 36 tests detected（旧 34 → +2）

flaky note: 既知の `cli::hook::runtime_state` 系 integration test が稀に full suite で fail することがあるが、isolated 実行で GREEN を確認済み。本 PR の変更とは無関係。

## Closing Issues

None

## Related Issues

- SPEC-2041 (#2041): Phase 19 を spec / plan / tasks に追記済み (FR-052〜066, シナリオ 24-27, SC-014a〜e)。

## Checklist

- [x] Conventional Commits 準拠 (`feat(gui)!` / `feat(update)` / `test(gui)` / `docs(lessons)`)
- [x] BREAKING CHANGE を本文に明記
- [x] Gate 1 (CI 全 GREEN) — cargo / clippy / fmt / frontend-unit / frontend-bundle / Playwright list、すべて GREEN
- [ ] Gate 2 (mock smoke) — ローカル mock release endpoint で update flow 往復 (Restart now / Later / 失敗 / Cancel)。後続セッションで実施
- [ ] Gate 3 (実機 manual smoke、SC-014d で必須化) — macOS arm64 実機で実 GitHub Release を使い、modal 経由で download → Restart now → 新バージョン起動を目視確認。`Later` パスで次回起動透明適用、失敗パスで modal エラーも確認。**通過まで merge 禁止 (FR-066)**
- [ ] 手動 verification: `gwt update` CLI が引き続き動作することを確認 (legacy `apply_update_state_and_exit` 経路は維持)

## Risk/Impact

**BREAKING CHANGE**:

- **WebSocket protocol**: frontend は新 message kinds (`apply_update_start`, `cancel_update_download`, `apply_update_later`, `apply_update_restart_now`, `open_update_log`) を送信。backend は新 events (`update_progress`, `update_ready`, `update_apply_pending_persisted`) を送信。`update_apply_error` は legacy `message` field に加えて optional `stage / reason / log_path` を含む。
- **CTA UX**: `window.confirm` ベースの即時送信は廃止。modal-driven flow へ移行。
- 旧 client / 旧 backend を組み合わせた場合は modal が表示されないため、両方を同時に更新する必要がある（gwt + gwtd は単一 bundle として配布されるため、通常の installer 適用で同期される）。

## Why this won't recur

過去の失敗パターンと差分:
- 過去の修正は **クリック前 (cache / DOM / 表示)** に集中していた → 今回は **クリック後 (architecture, exit timing, progress / ready / failed surfacing)** に直撃
- `apply_update_state_and_exit` という関数名そのものが silent failure を内包していた → 構造から削除し、`exit(0)` は `commit_update_restart_now` または bootstrap swap でのみ発火
- CI green = done 宣言の禁止を SPEC-2041 FR-066 で正式化、Gate 3 (実機 manual smoke) を tasks.md の最終必須 gate として明記
- progress / failure / ready のすべてが modal に surface されるため、user から「クリック後に何も起きない」と見える silent failure path が構造的に消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added post-click update modal displaying download progress, version details, and action buttons (Cancel, Later, Restart now).
  * Introduced deferred update capability—users can postpone restart via "Later" button.
  * Expanded error reporting with structured details (stage, reason, and access to update logs).
  * Implemented persistent pending update tracking across application sessions.
  * Added structured update event logging for troubleshooting and debugging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2630)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->