### PR TITLE
feat(scripts): SPEC-2041 Phase 19 Gate 2 mock update server

### DIFF
--- a/scripts/mock-update-server.cjs
+++ b/scripts/mock-update-server.cjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * SPEC-2041 Phase 19 Gate 2 mock smoke server.
+ *
+ * Drives the update-modal flow against a synthetic GitHub Releases endpoint
+ * so the post-click flow (downloading -> ready -> Restart now / Later) can be
+ * exercised without publishing real releases. Combine with the
+ * `GWT_UPDATE_API_BASE_URL` env override that landed alongside this script.
+ *
+ * Usage:
+ *   node scripts/mock-update-server.cjs --port 18080 --version 99.99.0 \
+ *     [--asset path/to/gwt-macos-arm64.tar.gz]
+ *
+ * Then in another shell:
+ *   GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
+ *
+ * The server returns a synthetic release at
+ *   GET /repos/akiojin/gwt/releases/latest
+ * that points `browser_download_url` at the mock's own /assets/<filename>
+ * endpoint so the prepare path can both observe progress and (when --asset is
+ * a real tarball) succeed the restart-now path. Without --asset the download
+ * still completes but extraction fails — useful for smoking the failure
+ * modal (`update_apply_error` with stage="Download asset" or
+ * stage="Persist pending").
+ */
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+const opts = {
+  port: 18080,
+  version: "99.99.0",
+  asset: null,
+};
+for (let i = 0; i < args.length; i++) {
+  const flag = args[i];
+  const value = args[i + 1];
+  if (flag === "--port") {
+    opts.port = parseInt(value, 10);
+    i += 1;
+  } else if (flag === "--version") {
+    opts.version = value;
+    i += 1;
+  } else if (flag === "--asset") {
+    opts.asset = value;
+    i += 1;
+  } else if (flag === "--help" || flag === "-h") {
+    printUsage();
+    process.exit(0);
+  }
+}
+
+function printUsage() {
+  console.log(`SPEC-2041 Phase 19 Gate 2 mock smoke server
+
+Usage:
+  node scripts/mock-update-server.cjs [--port PORT] [--version VERSION] [--asset PATH]
+
+Options:
+  --port      TCP port to bind on 127.0.0.1 (default: 18080)
+  --version   Tag name to advertise as the latest release (default: 99.99.0)
+  --asset     Local path to a real tarball/zip to serve as the asset.
+              When omitted, the server returns a 32-byte payload so the
+              download stage succeeds and extraction surfaces a failure
+              modal -- handy for smoking the failure UX.
+
+Then run gwt with:
+  GWT_UPDATE_API_BASE_URL=http://127.0.0.1:PORT ./target/release/gwt
+`);
+}
+
+let assetBuffer;
+let assetName = pickAssetName(process.platform, process.arch);
+if (opts.asset) {
+  if (!fs.existsSync(opts.asset)) {
+    console.error(`[mock] --asset path does not exist: ${opts.asset}`);
+    process.exit(1);
+  }
+  assetBuffer = fs.readFileSync(opts.asset);
+  assetName = path.basename(opts.asset);
+} else {
+  // 32 bytes of random payload so the download progress callback fires at
+  // least once and the persist path runs. The eventual extract_archive will
+  // fail with `Invalid gzip` / `not a tar archive`, exercising the failure
+  // modal.
+  assetBuffer = Buffer.alloc(32, 0x5a);
+}
+
+function pickAssetName(platform, arch) {
+  if (platform === "darwin" && arch === "arm64") return "gwt-macos-arm64.tar.gz";
+  if (platform === "darwin" && (arch === "x64" || arch === "x86_64"))
+    return "gwt-macos-x86_64.tar.gz";
+  if (platform === "linux" && arch === "x64") return "gwt-linux-x86_64.tar.gz";
+  if (platform === "linux" && arch === "arm64")
+    return "gwt-linux-aarch64.tar.gz";
+  if (platform === "win32") return "gwt-windows-x86_64.zip";
+  return "gwt-update.tar.gz";
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  console.log(`[mock] ${req.method} ${url.pathname}`);
+
+  if (
+    url.pathname.startsWith("/repos/") &&
+    url.pathname.endsWith("/releases/latest")
+  ) {
+    const baseUrl = `http://127.0.0.1:${opts.port}`;
+    const release = {
+      tag_name: `v${opts.version}`,
+      html_url: `${baseUrl}/release-page`,
+      assets: [
+        {
+          name: assetName,
+          browser_download_url: `${baseUrl}/assets/${assetName}`,
+        },
+      ],
+    };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(release));
+    return;
+  }
+
+  if (url.pathname.startsWith("/assets/")) {
+    res.writeHead(200, {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": String(assetBuffer.length),
+    });
+    res.end(assetBuffer);
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "text/plain" });
+  res.end("Not Found");
+});
+
+server.listen(opts.port, "127.0.0.1", () => {
+  console.log(
+    `[mock] update server listening on http://127.0.0.1:${opts.port}`,
+  );
+  console.log(`[mock] advertising tag v${opts.version} (asset: ${assetName})`);
+  console.log("[mock] run gwt with:");
+  console.log(
+    `  GWT_UPDATE_API_BASE_URL=http://127.0.0.1:${opts.port} ./target/release/gwt`,
+  );
+  console.log("[mock] press ctrl-c to stop.");
+});


### PR DESCRIPTION
## Summary

- SPEC-2041 Phase 19 Gate 2 mock smoke の foundation。GWT_UPDATE_API_BASE_URL env override (PR #2630 で landed) と組み合わせて、実 GitHub Release を公開せずに modal flow を local で smoke できるようにする
- Node.js 1 file (`scripts/mock-update-server.cjs`)、依存追加なし、production code には触れない (test/tooling-only)

## Changes

`scripts/mock-update-server.cjs` (新規):

- `--port` (default 18080) で 127.0.0.1 に bind する HTTP server
- `GET /repos/akiojin/gwt/releases/latest` → synthetic release JSON で応答
- `GET /assets/<filename>` → tarball/zip を提供 (`--asset PATH` で実 binary、未指定時は 32 byte の dummy payload で download progress + failure modal を smoke)
- platform/arch 自動検出 (darwin arm64/x64, linux x64/arm64, win32 x64)

使用例:

```sh
node scripts/mock-update-server.cjs --port 18080 --version 99.99.0
GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
```

## Testing

- `node scripts/mock-update-server.cjs --help` 想定 usage を出力
- production code の変更なし、既存 cargo / frontend tests は影響を受けない

## Closing Issues

None

## Related Issues

- SPEC-2041 Phase 19 (T-137 / Gate 2)
- PR #2630 で landed した GWT_UPDATE_API_BASE_URL env override (commit 7693de8c) と pair で機能する

## Checklist

- [x] Conventional Commits 準拠 (`feat(scripts):`)
- [x] production code 不変 (tooling-only)
- [x] test/lint へ影響なし
- [ ] Gate 2 実証 (本 script + 実 binary を組み合わせた実機 smoke は後続セッション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
