### PR TITLE
docs(spec-2041): SPEC-2041 Phase 19 Gate 3 manual smoke runbook

### DIFF
--- a/docs/spec-2041-phase-19-manual-smoke.md
+++ b/docs/spec-2041-phase-19-manual-smoke.md
@@ -1,0 +1,131 @@
+# SPEC-2041 Phase 19 — manual smoke checklist
+
+T-138 (Gate 3) requires a human reviewer to drive a real `gwt` GUI
+build against an actual GitHub Release because the post-click modal
+flow couples WebView rendering, WebSocket events, helper subprocess
+spawn, and OS process lifecycle in ways the Playwright fixture cannot
+exercise.
+
+SPEC-2041 FR-066 codifies this gate: **CI green is not done. Phase 19
+PRs may not be marked closed until this checklist passes on a release
+candidate.**
+
+Record the outcome in the Board
+(`gwtd board post --kind status --body ...`) and reference SPEC-2041
+Phase 19 (FR-066, SC-014d).
+
+## Prerequisites
+
+1. macOS arm64 (primary target). Linux x86_64 / arm64 and
+   Windows x86_64 are best-effort — same procedure, different
+   download asset name.
+2. Two real GitHub Releases:
+   - `vN` (current): the build the reviewer will install first.
+   - `vN+1` (target): the build the modal will download. Either
+     publish a real next release, or use an unreleased internal tag
+     against the mock server if `vN+1` is not yet ready.
+3. A clean `~/.gwt/pending-update/` directory before each run so the
+   bootstrap path starts from a known state:
+   ```sh
+   rm -rf ~/.gwt/pending-update
+   ```
+4. Optional — if testing against the local mock server in lieu of a
+   real release:
+   ```sh
+   node scripts/mock-update-server.cjs --port 18080 --version <vN+1> \
+     --asset path/to/real/gwt-macos-arm64.tar.gz
+   GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
+   ```
+
+## Gate 3.A — Restart-now happy path
+
+1. Install `vN` from the release asset matching your platform.
+2. Launch `gwt`. Wait up to 5 minutes (or restart with the polling
+   override) until the bottom-right `Update available: v<N+1> — Click
+   to update` CTA appears.
+3. Click the CTA. **Verify**: a centered modal opens immediately with
+   the title "Updating gwt", a progress bar, and a `Cancel` button.
+   The CTA itself flips to "Applying update..." and is disabled.
+4. **Verify**: the progress bar advances and the byte counter
+   (`X.Y MB / Z.W MB`) updates roughly every 200 ms while the
+   download proceeds. Update progress events should arrive over
+   WebSocket without UI freezes.
+5. When the download completes the modal transitions to "Update
+   ready" with `[Later]` and `[Restart now]` buttons. **Verify**:
+   no `window.confirm` appears.
+6. Click `[Restart now]`. **Verify**: the gwt window closes within
+   ~3 seconds and a new gwt window opens. Open the About / version
+   line and confirm it now reports `vN+1`.
+
+## Gate 3.B — Later → next-launch transparent apply
+
+1. Re-install `vN` (or rerun the smoke from the Gate 3.A starting
+   state if you can roll back to the manifest-cleared state).
+2. Launch `gwt`, click the CTA, wait for the `ready` modal.
+3. Click `[Later]`. **Verify**:
+   - the modal closes,
+   - the CTA morphs to `Update v<N+1> ready — Restart now` with a
+     visible dismiss `×`,
+   - `~/.gwt/pending-update/manifest.json` exists and points at the
+     prepared payload under `~/.gwt/updates/v<N+1>/...`.
+4. Quit gwt manually (cmd-Q / window close).
+5. Launch `gwt` again. **Verify**:
+   - the bootstrap path detects the manifest, swaps the binary, and
+     starts a new process running `vN+1`. The transition should be
+     close to instant — the user sees a momentary launch flash and
+     then the regular gwt window for the new version.
+   - `~/.gwt/pending-update/` no longer contains a manifest.
+
+## Gate 3.C — Failure UX (expected)
+
+1. Re-install `vN`.
+2. Launch the mock server with no `--asset` so it returns 32 bytes of
+   garbage:
+   ```sh
+   node scripts/mock-update-server.cjs --port 18080 --version <vN+1>
+   GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
+   ```
+3. Click the CTA. **Verify**: progress reaches 100 % (32 / 32 bytes)
+   then the modal transitions to the `failed` state with:
+   - title `⚠ Update failed`,
+   - `Stage:` "Persist pending" or "Download asset" depending on
+     where extract_archive aborts,
+   - `Reason:` something like "Failed to prepare update payload: …",
+   - `Log:` a path under `~/.gwt/logs/update-<YYYY-MM-DD>.log`,
+   - three buttons: `[Open log] [Retry] [Close]`.
+4. Click `[Open log]`. **Verify**: the OS default text viewer opens
+   the log file and the file contains JSONL entries for
+   `download_start`, `download_complete`, `fail` with the same
+   reason as the modal.
+5. Click `[Close]`. **Verify**: the modal closes and the CTA returns
+   to `Update available: v<N+1> — Click to update`.
+
+## Gate 3.D — Cancel mid-download
+
+1. Re-install `vN`. If you control the mock server, throttle it
+   (e.g. wrap with `pv` to slow the body) so the download takes
+   noticeably more than ~1 s.
+2. Click the CTA, then click `[Cancel]` while the progress bar is
+   below 100 %. **Verify**:
+   - the modal closes,
+   - the CTA returns to `Update available`,
+   - polling resumes (no manifest is created),
+   - any partial file under `~/.gwt/updates/v<N+1>/` is harmless
+     (the next start_download will overwrite it).
+
+## Reporting
+
+Post a single Board entry summarising the outcome:
+
+```
+gwtd board post --kind status --body $'SPEC-2041 Phase 19 Gate 3 manual smoke result:
+- 3.A Restart-now: PASS / FAIL
+- 3.B Later + next-launch swap: PASS / FAIL
+- 3.C Failure UX: PASS / FAIL
+- 3.D Cancel mid-download: PASS / FAIL
+Notes: <free-form observations, screenshots, log excerpts as needed>'
+```
+
+If any sub-gate fails, do not merge dependent work and reopen the
+relevant Phase 19 PR or file a follow-up issue against SPEC-2041
+referencing the failing FR.


### PR DESCRIPTION
## Summary

- SPEC-2041 Phase 19 T-138 (Gate 3 実機 manual smoke) のための reviewer 向け runbook を `docs/` に追加。
- production code には触れないドキュメントのみの追加 PR。

## Changes

`docs/spec-2041-phase-19-manual-smoke.md` (新規):

4 sub-gate に分割した checklist:
- **Gate 3.A Restart-now happy path**: modal → progress → ready → restart の往復
- **Gate 3.B Later → next-launch transparent apply**: manifest persistence + bootstrap swap
- **Gate 3.C Failure UX**: mock server 経由で extract_archive 失敗 → failed modal
- **Gate 3.D Cancel mid-download**: download 進行中の cancel + state cleanup

各 gate に「何をクリックする」「何を verify する」を明記し、reviewer が機械的に追えるように。

`scripts/mock-update-server.cjs` (PR #2631 で landed) と
`GWT_UPDATE_API_BASE_URL` env override (PR #2630 で landed) を組み合わせれば、
real GitHub release を待たずに Gate 3.C / 3.D を smoke 可能。
Gate 3.A / 3.B は real release と組み合わせる前提を明記。

reporting セクションで Board 投稿テンプレートも提供。

## Testing

ドキュメントのみの追加 (production code 不変):
- 既存 cargo / frontend tests 全 GREEN を維持
- markdown lint 互換 (既存 docs/spec-1939-* と同じ書式)

## Closing Issues

None

## Related Issues

- SPEC-2041 Phase 19 (T-138 / FR-066 / SC-014d)
- PR #2630, #2631, #2632, #2633 (MERGED) — 本 runbook はこれら architectural fix の reviewer 検証手順

## Checklist

- [x] Conventional Commits (`docs(spec-2041):`)
- [x] production behavior 不変 (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
