### PR TITLE
fix(update): SPEC-2041 Phase 19 review follow-ups (PRs #2630/#2631/#2634/#2635)

### DIFF
--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -264,9 +264,9 @@ pub fn log_update_event(stage: &str, fields: &[(&str, &str)]) {
 }
 
 /// Compare two semver-ish versions, returning `true` when `candidate` is
-/// strictly newer than `current`. Falls back to string ordering when either
-/// side fails to parse so a malformed manifest never silently triggers a
-/// downgrade.
+/// strictly newer than `current`. Refuses to act on unparseable input on
+/// either side so a malformed manifest cannot silently authorize an apply
+/// (CodeRabbit review on PR #2630).
 pub fn pending_version_is_newer(candidate: &str, current: &str) -> bool {
     let trim = |v: &str| v.trim().trim_start_matches('v').to_string();
     let candidate_trim = trim(candidate);
@@ -276,7 +276,9 @@ pub fn pending_version_is_newer(candidate: &str, current: &str) -> bool {
         Version::parse(&current_trim),
     ) {
         (Ok(c), Ok(curr)) => c > curr,
-        _ => candidate_trim.as_str() > current_trim.as_str(),
+        // Refuse to act on unparseable input so a malformed manifest cannot
+        // silently trigger an apply.
+        _ => false,
     }
 }
 
@@ -3353,5 +3355,10 @@ mod tests {
         // Pre-release: 9.26.0-rc.1 is newer than 9.25.0 but older than 9.26.0.
         assert!(pending_version_is_newer("9.26.0-rc.1", "9.25.0"));
         assert!(!pending_version_is_newer("9.26.0-rc.1", "9.26.0"));
+        // Malformed input (either side) refuses to authorize an apply
+        // (CodeRabbit review on PR #2630).
+        assert!(!pending_version_is_newer("abc", "9.25.0"));
+        assert!(!pending_version_is_newer("9.26.0", "not-a-version"));
+        assert!(!pending_version_is_newer("abc", "def"));
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1341,16 +1341,28 @@ fn update_apply_error_failed(stage: &str, reason: &str) -> BackendEvent {
 /// at the trace level.
 fn open_path_with_os_default(path: &str) -> Result<(), std::io::Error> {
     use std::process::Command;
-    let mut cmd = if cfg!(target_os = "macos") {
-        Command::new("open")
+    // Reap the spawned opener on a detached thread so repeated invocations
+    // do not accumulate zombie processes on Unix. `std::process::Child` has
+    // no Drop-time wait, so without this the PID stays in the process table
+    // until parent exit (CodeRabbit review on PR #2630).
+    let child = if cfg!(target_os = "macos") {
+        let mut cmd = Command::new("open");
+        cmd.arg(path);
+        cmd.spawn()?
     } else if cfg!(target_os = "windows") {
-        let mut c = Command::new("cmd");
-        c.args(["/C", "start", "", path]);
-        return c.spawn().map(|_| ());
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "start", "", path]);
+        cmd.spawn()?
     } else {
-        Command::new("xdg-open")
+        let mut cmd = Command::new("xdg-open");
+        cmd.arg(path);
+        cmd.spawn()?
     };
-    cmd.arg(path).spawn().map(|_| ())
+    std::thread::spawn(move || {
+        let mut child = child;
+        let _ = child.wait();
+    });
+    Ok(())
 }
 
 fn detect_dirty(project_root: &Path) -> bool {
@@ -1973,13 +1985,14 @@ impl AppRuntime {
     }
 
     /// SPEC-2041 Phase 19 (FR-055): user pressed `Cancel` mid-download.
-    /// Implementation note: `prepare_update` is currently synchronous in the
-    /// background thread, so a true mid-download abort is a no-op until the
-    /// async download landing in T-128. We still surface the cancel as a
-    /// best-effort acknowledgement so the frontend transition stays
-    /// authoritative.
+    /// `prepare_update` runs synchronously on a worker thread, so a true
+    /// mid-download abort is best-effort. We still defensively clear any
+    /// `~/.gwt/pending-update/manifest.json` that the worker may have
+    /// persisted between the user's click and the modal close — without this
+    /// guard, a race would leave the bootstrap path applying an update the
+    /// user explicitly cancelled (CodeRabbit P1 review on PR #2630).
     fn cancel_update_download_events(&self, _client_id: &str) -> Vec<OutboundEvent> {
-        // TODO(T-128): cooperatively abort the in-flight download.
+        let _ = gwt_core::update::clear_pending_update_manifest();
         vec![]
     }
 
@@ -2037,13 +2050,41 @@ impl AppRuntime {
 
     /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
     /// modal. Backend opens the log file with the OS default application.
+    /// The renderer-supplied `log_path` is treated as untrusted: the path
+    /// must canonicalize to a child of the gwt logs directory, must exist as
+    /// a file, and must not contain a URL scheme (CodeRabbit review on PR
+    /// #2630). Validation failures are silently dropped — the modal already
+    /// surfaces the in-memory `Reason` so a missing log file is not blocking.
     fn open_update_log_events(
         &self,
         _client_id: &str,
         log_path: Option<String>,
     ) -> Vec<OutboundEvent> {
-        if let Some(path) = log_path {
-            let _ = open_path_with_os_default(&path);
+        if let Some(raw) = log_path {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() || trimmed.contains("://") {
+                return vec![];
+            }
+            // Derive the allowed logs root from the canonical update log
+            // resolver itself. AppRuntime is not allowed to call the legacy
+            // `gwt_logs_dir()` directly (project-scoped resolver test in
+            // main.rs), so we ride on `update_log_path()`'s parent.
+            let logs_root_candidate = match gwt_core::update::update_log_path().parent() {
+                Some(p) => p.to_path_buf(),
+                None => return vec![],
+            };
+            let logs_root = match std::fs::canonicalize(&logs_root_candidate) {
+                Ok(root) => root,
+                Err(_) => return vec![],
+            };
+            let candidate = match std::fs::canonicalize(trimmed) {
+                Ok(p) => p,
+                Err(_) => return vec![],
+            };
+            if !candidate.starts_with(&logs_root) || !candidate.is_file() {
+                return vec![];
+            }
+            let _ = open_path_with_os_default(&candidate.to_string_lossy());
         }
         vec![]
     }

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -296,7 +296,9 @@ body::after {
 .update-modal__details dd {
   margin: 0;
   color: var(--color-text-primary);
-  word-break: break-word;
+  /* `word-break: break-word` is deprecated; modern equivalent
+     for long words is `overflow-wrap: anywhere` (CodeRabbit review). */
+  overflow-wrap: anywhere;
 }
 
 .update-modal__actions {

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -344,10 +344,16 @@ export function createUpdateCtaController({
     modal.appendChild(panel);
   }
 
-  function renderModalFailed({ stage, reason, log_path }) {
+  function renderModalFailed({ stage, reason, log_path, message }) {
     const modal = ensureModal();
     modal.dataset.state = "failed";
     clearChildren(modal);
+
+    // Phase 19 promotes structured `reason`, but `message` is still on the
+    // wire contract for legacy callers (see UpdateApplyError optional fields
+    // in protocol.rs). Fall through so older or partial emitters still
+    // surface a useful failure (CodeRabbit review on PR #2630).
+    const displayReason = reason || message || "Unknown reason";
 
     const dl = el("dl", { className: "update-modal__details" }, [
       el("dt", { text: "Stage" }),
@@ -357,7 +363,7 @@ export function createUpdateCtaController({
       }),
       el("dt", { text: "Reason" }),
       el("dd", {
-        text: reason || "Unknown reason",
+        text: displayReason,
         data: { updateModalReason: "true" },
       }),
       el("dt", { text: "Log" }),

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -158,7 +158,13 @@ export function createUpdateCtaController({
 
   function handleUpdateApplyError(payload) {
     if (!payload) return;
-    if (status === "applying") {
+    // SPEC-2041 Phase 19 (FR-064 follow-up, CodeRabbit review on PR #2635):
+    // Later can fail when commit_update_later_pending detects the persisted
+    // manifest is gone. The CTA was already morphed to `ready` by then, so
+    // surface the failure modal even in the `ready` state — silently dropping
+    // the error would leave the user believing Restart is safe when it isn't.
+    if (status === "applying" || status === "ready") {
+      renderCta("applying", "Applying update...");
       renderModalFailed(payload);
     }
   }

--- a/docs/spec-2041-phase-19-manual-smoke.md
+++ b/docs/spec-2041-phase-19-manual-smoke.md
@@ -30,9 +30,11 @@ Phase 19 (FR-066, SC-014d).
    rm -rf ~/.gwt/pending-update
    ```
 4. Optional — if testing against the local mock server in lieu of a
-   real release:
+   real release. Pass **bare semver** to `--version` (the script prepends
+   `v` itself, so `--version v1.2.3` would emit `vv1.2.3` and the updater's
+   `parse_tag_version` would reject the tag):
    ```sh
-   node scripts/mock-update-server.cjs --port 18080 --version <vN+1> \
+   node scripts/mock-update-server.cjs --port 18080 --version 9.99.0 \
      --asset path/to/real/gwt-macos-arm64.tar.gz
    GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
    ```
@@ -80,9 +82,10 @@ Phase 19 (FR-066, SC-014d).
 
 1. Re-install `vN`.
 2. Launch the mock server with no `--asset` so it returns 32 bytes of
-   garbage:
+   garbage. Pass `--version` as bare semver (e.g. `9.99.0`) — the
+   script prepends `v` itself:
    ```sh
-   node scripts/mock-update-server.cjs --port 18080 --version <vN+1>
+   node scripts/mock-update-server.cjs --port 18080 --version 9.99.0
    GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
    ```
 3. Click the CTA. **Verify**: progress reaches 100 % (32 / 32 bytes)

--- a/scripts/mock-update-server.cjs
+++ b/scripts/mock-update-server.cjs
@@ -72,14 +72,16 @@ Then run gwt with:
 }
 
 let assetBuffer;
-let assetName = pickAssetName(process.platform, process.arch);
+// Always advertise the canonical asset name for this platform so the updater's
+// release-contract matcher (`scripts/release-assets.cjs::releaseAssetName`)
+// finds the asset regardless of the local file the operator points at.
+const assetName = pickAssetName(process.platform, process.arch);
 if (opts.asset) {
   if (!fs.existsSync(opts.asset)) {
     console.error(`[mock] --asset path does not exist: ${opts.asset}`);
     process.exit(1);
   }
   assetBuffer = fs.readFileSync(opts.asset);
-  assetName = path.basename(opts.asset);
 } else {
   // 32 bytes of random payload so the download progress callback fires at
   // least once and the persist path runs. The eventual extract_archive will
@@ -108,8 +110,12 @@ const server = http.createServer((req, res) => {
     url.pathname.endsWith("/releases/latest")
   ) {
     const baseUrl = `http://127.0.0.1:${opts.port}`;
+    // Strip a single leading `v` from --version so passing either `9.26.0` or
+    // `v9.26.0` yields the canonical `vN.N.N` tag the updater's
+    // `parse_tag_version` accepts (it tolerates exactly one `v` prefix).
+    const normalizedVersion = String(opts.version).replace(/^v/, "");
     const release = {
-      tag_name: `v${opts.version}`,
+      tag_name: `v${normalizedVersion}`,
       html_url: `${baseUrl}/release-page`,
       assets: [
         {
@@ -137,10 +143,11 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(opts.port, "127.0.0.1", () => {
+  const advertisedTag = `v${String(opts.version).replace(/^v/, "")}`;
   console.log(
     `[mock] update server listening on http://127.0.0.1:${opts.port}`,
   );
-  console.log(`[mock] advertising tag v${opts.version} (asset: ${assetName})`);
+  console.log(`[mock] advertising tag ${advertisedTag} (asset: ${assetName})`);
   console.log("[mock] run gwt with:");
   console.log(
     `  GWT_UPDATE_API_BASE_URL=http://127.0.0.1:${opts.port} ./target/release/gwt`,


### PR DESCRIPTION
## Summary

- PR #2630 (MERGED) で landed した SPEC-2041 Phase 19 architectural fix に対して CodeRabbit reviewer (+ chatgpt-codex-connector) が指摘した 8 件の不具合を addressing する fix-up PR。
- review thread 8 件はすべて reply + resolve 済み (PR #2630 上で record)。

## Changes

### Backend (Rust)
- `gwt-core/src/update.rs::pending_version_is_newer`: malformed input で string ordering fallback に走らせず常に `false` を返すように修正。`assert!(!pending_version_is_newer("abc", "9.25.0"))` 等 3 件の test case を追加。manifest.version が garbage の場合に bootstrap が誤って apply するのを防ぐ。
- `gwt/src/app_runtime/mod.rs::open_path_with_os_default`: spawn 後に `Child` を drop するだけだったため Unix で zombie が積み上がる問題を修正。detached thread で `wait()` するよう変更。
- `gwt/src/app_runtime/mod.rs::open_update_log_events`: renderer-supplied `log_path` をそのまま OS 開封に渡す security hole を修正。`gwt_core::update::update_log_path().parent()` で得た logs root と canonicalize した candidate を比較し、URL scheme / 範囲外パス / 非ファイルを reject。`logging_initialization_sources_do_not_use_legacy_log_dir` テストの project-scoped resolver 制約に従い、legacy `gwt_logs_dir()` は使わない。
- `gwt/src/app_runtime/mod.rs::cancel_update_download_events`: no-op だった handler が race で manifest が persist された後に Cancel が来た場合に bootstrap が誤って apply するのを防ぐため、defensive に `clear_pending_update_manifest()` を呼ぶように変更。

### Frontend
- `gwt/web/update-cta.js::renderModalFailed`: `BackendEvent::UpdateApplyError.message` (legacy field) の fallback を再導入。`reason || message || "Unknown reason"` の優先順で `Reason` cell に表示。
- `gwt/web/styles/components.css::.update-modal__details dd`: deprecated `word-break: break-word` を `overflow-wrap: anywhere` に変更。

## Testing

- `cargo test -p gwt-core --lib pending_version`: 1/1 GREEN (新 3 case 含む)
- `cargo test -p gwt --bin gwt logging_initialization_sources_do_not_use_legacy_log_dir`: 1/1 GREEN (project-scoped resolver 制約を満たすことを確認)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `npm run test:frontend-unit`: 332/332 GREEN

## Closing Issues

None

## Related Issues

- SPEC-2041 Phase 19 (FR-055 / FR-062 / FR-063 / FR-065)
- PR #2630 (MERGED): review threads `PRRT_kwDOPLof2M6A6WhZ` `PRRT_kwDOPLof2M6A6XWR` `PRRT_kwDOPLof2M6A6XWZ` `PRRT_kwDOPLof2M6A6XWe` `PRRT_kwDOPLof2M6A6XWi` `PRRT_kwDOPLof2M6A6XWl` `PRRT_kwDOPLof2M6A6XWw` `PRRT_kwDOPLof2M6A6XW0` を reply + resolve 済み

## Checklist

- [x] Conventional Commits (`fix(update):`)
- [x] CodeRabbit + chatgpt-codex-connector review threads 全件 addressed (PR #2630 上で resolved)
- [x] cargo / clippy / fmt / frontend-unit GREEN
- [x] project-scoped logs resolver 制約 (`logging_initialization_sources_do_not_use_legacy_log_dir`) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
