### PR TITLE
test(update): SPEC-2041 Phase 19 path validation を pure fn に抽出 + 5 unit tests

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1335,6 +1335,25 @@ fn update_apply_error_failed(stage: &str, reason: &str) -> BackendEvent {
     }
 }
 
+/// SPEC-2041 Phase 19 (FR-065, CodeRabbit review on PR #2630): pure
+/// validator for renderer-supplied update log paths. Returns the canonical
+/// path when (1) the input is non-empty and contains no URL scheme,
+/// (2) it canonicalizes successfully, (3) it is a file, and (4) it
+/// resides within the canonicalized `logs_root`. Returns `None` otherwise so
+/// callers can silently drop the request.
+fn validate_update_log_path(raw: &str, logs_root: &Path) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.contains("://") {
+        return None;
+    }
+    let canonical_root = std::fs::canonicalize(logs_root).ok()?;
+    let candidate = std::fs::canonicalize(trimmed).ok()?;
+    if !candidate.starts_with(&canonical_root) || !candidate.is_file() {
+        return None;
+    }
+    Some(candidate)
+}
+
 /// SPEC-2041 Phase 19 (FR-065): launch the platform default opener
 /// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows). Errors are
 /// silently dropped so the modal does not surface noise; the path is logged
@@ -2061,30 +2080,18 @@ impl AppRuntime {
         log_path: Option<String>,
     ) -> Vec<OutboundEvent> {
         if let Some(raw) = log_path {
-            let trimmed = raw.trim();
-            if trimmed.is_empty() || trimmed.contains("://") {
-                return vec![];
-            }
             // Derive the allowed logs root from the canonical update log
             // resolver itself. AppRuntime is not allowed to call the legacy
             // `gwt_logs_dir()` directly (project-scoped resolver test in
             // main.rs), so we ride on `update_log_path()`'s parent.
-            let logs_root_candidate = match gwt_core::update::update_log_path().parent() {
-                Some(p) => p.to_path_buf(),
-                None => return vec![],
-            };
-            let logs_root = match std::fs::canonicalize(&logs_root_candidate) {
-                Ok(root) => root,
-                Err(_) => return vec![],
-            };
-            let candidate = match std::fs::canonicalize(trimmed) {
-                Ok(p) => p,
-                Err(_) => return vec![],
-            };
-            if !candidate.starts_with(&logs_root) || !candidate.is_file() {
-                return vec![];
+            if let Some(logs_root) = gwt_core::update::update_log_path()
+                .parent()
+                .map(|p| p.to_path_buf())
+            {
+                if let Some(safe) = validate_update_log_path(&raw, &logs_root) {
+                    let _ = open_path_with_os_default(&safe.to_string_lossy());
+                }
             }
-            let _ = open_path_with_os_default(&candidate.to_string_lossy());
         }
         vec![]
     }
@@ -11011,5 +11018,72 @@ exit 0
             )),
             "existing migration backup must be surfaced as a recovery error"
         );
+    }
+
+    // SPEC-2041 Phase 19 (FR-065 / CodeRabbit review on PR #2630): renderer-
+    // supplied log paths must canonicalize into the gwt update logs root.
+    // These tests cover the `validate_update_log_path` pure validator.
+    #[test]
+    fn validate_update_log_path_accepts_file_inside_logs_root() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        let log_file = logs_root.path().join("update-2026-05-10.log");
+        std::fs::write(&log_file, b"{}\n").unwrap();
+
+        let resolved =
+            super::validate_update_log_path(log_file.to_str().unwrap(), logs_root.path());
+        assert!(
+            resolved.is_some(),
+            "expected file inside logs_root to validate"
+        );
+        let resolved = resolved.unwrap();
+        assert!(resolved.is_absolute());
+        assert!(resolved.ends_with("update-2026-05-10.log"));
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_files_outside_logs_root() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("evil.txt");
+        std::fs::write(&outside_file, b"steal me").unwrap();
+
+        let resolved =
+            super::validate_update_log_path(outside_file.to_str().unwrap(), logs_root.path());
+        assert!(resolved.is_none(), "outside-root paths must be rejected");
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_url_schemes_and_empty() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        for raw in [
+            "",
+            "   ",
+            "http://evil.example/log",
+            "https://evil.example/log",
+            "file:///etc/passwd",
+        ] {
+            assert!(
+                super::validate_update_log_path(raw, logs_root.path()).is_none(),
+                "expected `{raw}` to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_directories() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        // Caller passes the logs root itself; a directory must not be opened
+        // as a file.
+        let resolved =
+            super::validate_update_log_path(logs_root.path().to_str().unwrap(), logs_root.path());
+        assert!(resolved.is_none(), "directories must be rejected");
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_missing_files() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        let missing = logs_root.path().join("does-not-exist.log");
+        let resolved = super::validate_update_log_path(missing.to_str().unwrap(), logs_root.path());
+        assert!(resolved.is_none(), "missing files must be rejected");
     }
 }

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -526,6 +526,48 @@ test("phase19: update_apply_pending_persisted morphs CTA directly to ready state
   assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
 });
 
+// SPEC-2041 Phase 19 (FR-064 follow-up, CodeRabbit review on PR #2635):
+// Later -> commit_update_later_pending can detect that the manifest persisted
+// by ApplyUpdateStart's worker thread vanished (external cleanup, disk-full
+// race). In that case backend emits update_apply_error AFTER the CTA has
+// already morphed to "ready". The frontend must surface the failure modal
+// even though status === "ready" so the user is not silently misled.
+test("phase19: update_apply_error in ready state re-opens failed modal", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+
+  // Simulate the post-Later state that the next-launch path lands in.
+  controller.handleUpdateApplyPendingPersisted({ version: "9.26.0" });
+  const ctaBefore = fixture.document.getElementById("update-cta");
+  assert.equal(ctaBefore.dataset.status, "ready");
+
+  // Backend reports the persisted manifest is gone.
+  controller.handleUpdateApplyError({
+    stage: "Persist pending",
+    reason: "Pending update manifest is missing; download did not persist.",
+    log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.ok(modal, "modal must reopen so the failure is visible");
+  assert.equal(modal.dataset.state, "failed");
+  assert.match(
+    modal.querySelector("[data-update-modal-stage]").textContent,
+    /Persist pending/,
+  );
+  assert.match(
+    modal.querySelector("[data-update-modal-reason]").textContent,
+    /manifest is missing/,
+  );
+
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(
+    cta.dataset.status,
+    "applying",
+    "CTA flips to applying so the modal sits visually on top",
+  );
+});
+
 test("phase19: controller exposes the Phase 19 event handlers required by app.js wiring", () => {
   const fixture = createFixture();
   const controller = createUpdateCtaController(fixture.options);


### PR DESCRIPTION
## Summary

- SPEC-2041 Phase 19 (FR-065) の path validation logic を pure function に抽出し、5 件の unit test で security guarantee をロックインする。
- production code の挙動は不変、test coverage の補強のみ。

## Changes

`crates/gwt/src/app_runtime/mod.rs`:

- `validate_update_log_path(raw, logs_root) -> Option<PathBuf>` を新設。pure な function なので tempdir で testable。canonicalize / scope check / URL scheme rejection / file is_file 判定を 1 関数に集約。
- `open_update_log_events` を `validate_update_log_path` 経由に簡素化。元の inline ロジックは削除。
- 新 unit tests (5 件):
  - `validate_update_log_path_accepts_file_inside_logs_root`: 正常パスを accept
  - `validate_update_log_path_rejects_files_outside_logs_root`: traversal を block
  - `validate_update_log_path_rejects_url_schemes_and_empty`: `http://` / `https://` / `file://` / 空文字を block
  - `validate_update_log_path_rejects_directories`: ディレクトリを block
  - `validate_update_log_path_rejects_missing_files`: 存在しないパスを block

## Testing

- `cargo test -p gwt --bin gwt validate_update_log_path`: 5/5 GREEN
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean

## Closing Issues

None

## Related Issues

- SPEC-2041 Phase 19 (FR-065 — `[Open log]` button security)
- PR #2636 (MERGED): renderer-supplied `log_path` 検証の original implementation

## Checklist

- [x] Conventional Commits (`test(update):`)
- [x] production behavior 不変
- [x] cargo test GREEN
- [x] FR-065 path traversal protection が unit test で固定された

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of update log paths to prevent potential errors when opening logs, including checks for non-empty inputs, proper file existence, and safe path handling.
  * Enhanced handling of race conditions during updates when manifest files are missing, ensuring error states are properly communicated to users.

* **Tests**
  * Added test coverage for update log path validation and manifest-missing edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2637)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->