### PR TITLE
feat(workspace): block duplicate active workspace edits

### DIFF
--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -9,15 +9,23 @@
 //! - allow transport operations such as `git push` and worktree-internal edits
 //!   without an owner gate
 
-use std::{collections::HashMap, io::Read, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Read,
+    path::Path,
+};
 
 use gwt_agent::{
     session::{Session, GWT_SESSION_ID_ENV},
     types::WorkflowBypass,
 };
 use gwt_core::{
+    coordination::{load_snapshot, BoardEntry, BoardEntryKind, BoardMentionTargetKind},
     paths::{gwt_cache_dir, gwt_sessions_dir},
-    workspace_projection::load_workspace_projection,
+    workspace_projection::{
+        load_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
+        WorkspaceStatusCategory,
+    },
 };
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;
@@ -103,7 +111,11 @@ pub fn evaluate_with_context(
     if safety != HookOutput::Silent {
         return Ok(safety);
     }
-    evaluate_title_summary_guard(event, context.title_summary_missing)
+    let title_summary = evaluate_title_summary_guard(event, context.title_summary_missing)?;
+    if title_summary != HookOutput::Silent {
+        return Ok(title_summary);
+    }
+    evaluate_workspace_coordination_guard(event, worktree_root)
 }
 
 pub fn evaluate(event: &HookEvent, worktree_root: &Path) -> Result<HookOutput, HookError> {
@@ -229,6 +241,468 @@ Use the configured narrative language for the title-summary. Keep progress, comp
     }
 
     Ok(HookOutput::Silent)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkspaceCoordinationConflict {
+    source_label: &'static str,
+    title: String,
+    session_id: Option<String>,
+    branch: Option<String>,
+    agent_id: Option<String>,
+    related_owners: Vec<String>,
+    related_topics: Vec<String>,
+}
+
+fn evaluate_workspace_coordination_guard(
+    event: &HookEvent,
+    worktree_root: &Path,
+) -> Result<HookOutput, HookError> {
+    if !is_workspace_coordination_sensitive_event(event) {
+        return Ok(HookOutput::Silent);
+    }
+
+    let session = load_session_from_env();
+    let current_session_id = session.as_ref().map(|session| session.id.as_str());
+    let projection = load_workspace_projection(worktree_root)?;
+    let current_intent = workspace_current_intent(event, projection.as_ref(), current_session_id);
+    if current_intent.trim().is_empty() {
+        return Ok(HookOutput::Silent);
+    }
+
+    let conflicts = workspace_coordination_conflicts(
+        worktree_root,
+        projection.as_ref(),
+        &current_intent,
+        current_session_id,
+    )?;
+    let Some(conflict) = conflicts.into_iter().next() else {
+        return Ok(HookOutput::Silent);
+    };
+
+    if has_matching_split_claim(
+        worktree_root,
+        current_session_id,
+        &current_intent,
+        &conflict,
+    )? {
+        return Ok(HookOutput::Silent);
+    }
+
+    Ok(workspace_coordination_block_decision(&conflict))
+}
+
+fn workspace_coordination_conflicts(
+    worktree_root: &Path,
+    projection: Option<&WorkspaceProjection>,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
+    let mut conflicts = Vec::new();
+    if let Some(projection) = projection {
+        conflicts.extend(workspace_agent_conflicts(
+            projection,
+            current_intent,
+            current_session_id,
+        ));
+    }
+    conflicts.extend(board_claim_conflicts(
+        worktree_root,
+        current_intent,
+        current_session_id,
+    )?);
+    Ok(conflicts)
+}
+
+fn workspace_agent_conflicts(
+    projection: &WorkspaceProjection,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Vec<WorkspaceCoordinationConflict> {
+    projection
+        .agents
+        .iter()
+        .filter(|agent| {
+            current_session_id != Some(agent.session_id.as_str())
+                && matches!(
+                    agent.status_category,
+                    WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
+                )
+        })
+        .filter_map(|agent| {
+            let text = workspace_agent_text(agent);
+            is_similar_work(current_intent, &text).then(|| WorkspaceCoordinationConflict {
+                source_label: "similar active Workspace",
+                title: agent
+                    .title_summary
+                    .as_deref()
+                    .or(agent.current_focus.as_deref())
+                    .unwrap_or("active Workspace agent")
+                    .to_string(),
+                session_id: Some(agent.session_id.clone()),
+                branch: agent.branch.clone(),
+                agent_id: Some(agent.agent_id.clone()),
+                related_owners: Vec::new(),
+                related_topics: agent.coordination_scope.iter().cloned().collect(),
+            })
+        })
+        .collect()
+}
+
+fn board_claim_conflicts(
+    worktree_root: &Path,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
+    let snapshot = load_snapshot(worktree_root)?;
+    Ok(snapshot
+        .board
+        .entries
+        .iter()
+        .rev()
+        .filter(|entry| {
+            entry.kind == BoardEntryKind::Claim
+                && board_claim_is_active(entry)
+                && current_session_id != entry.origin_session_id.as_deref()
+        })
+        .filter_map(|entry| {
+            let text = board_entry_text(entry);
+            is_similar_work(current_intent, &text).then(|| WorkspaceCoordinationConflict {
+                source_label: "active Board claim",
+                title: entry
+                    .title_summary
+                    .as_deref()
+                    .or_else(|| entry.body.lines().find(|line| !line.trim().is_empty()))
+                    .unwrap_or("active Board claim")
+                    .trim()
+                    .to_string(),
+                session_id: entry.origin_session_id.clone(),
+                branch: entry.origin_branch.clone(),
+                agent_id: entry.origin_agent_id.clone(),
+                related_owners: entry.related_owners.clone(),
+                related_topics: entry.related_topics.clone(),
+            })
+        })
+        .collect())
+}
+
+fn workspace_current_intent(
+    event: &HookEvent,
+    projection: Option<&WorkspaceProjection>,
+    current_session_id: Option<&str>,
+) -> String {
+    let mut parts = Vec::new();
+    if let (Some(projection), Some(current_session_id)) = (projection, current_session_id) {
+        if let Some(agent) = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == current_session_id)
+        {
+            push_optional(&mut parts, agent.title_summary.as_deref());
+            push_optional(&mut parts, agent.current_focus.as_deref());
+            push_optional(&mut parts, agent.coordination_scope.as_deref());
+        }
+    }
+    if parts.is_empty() {
+        if let Some(projection) = projection {
+            parts.push(projection.title.as_str());
+            push_optional(&mut parts, projection.summary.as_deref());
+            push_optional(&mut parts, projection.next_action.as_deref());
+            push_optional(&mut parts, projection.owner.as_deref());
+        }
+    }
+    if parts.is_empty() {
+        push_optional(&mut parts, event.command());
+        if let Some(tool_input) = event.tool_input.as_ref() {
+            push_optional(
+                &mut parts,
+                tool_input
+                    .get("file_path")
+                    .and_then(serde_json::Value::as_str),
+            );
+        }
+    }
+    parts.join("\n")
+}
+
+fn workspace_agent_text(agent: &WorkspaceAgentSummary) -> String {
+    let mut parts = Vec::new();
+    push_optional(&mut parts, agent.title_summary.as_deref());
+    push_optional(&mut parts, agent.current_focus.as_deref());
+    push_optional(&mut parts, agent.coordination_scope.as_deref());
+    push_optional(&mut parts, agent.branch.as_deref());
+    parts.push(agent.agent_id.as_str());
+    parts.push(agent.display_name.as_str());
+    parts.join("\n")
+}
+
+fn board_entry_text(entry: &BoardEntry) -> String {
+    let mut parts = Vec::new();
+    push_optional(&mut parts, entry.title_summary.as_deref());
+    parts.push(entry.body.as_str());
+    parts.extend(entry.related_topics.iter().map(String::as_str));
+    parts.extend(entry.related_owners.iter().map(String::as_str));
+    parts.extend(entry.target_owners.iter().map(String::as_str));
+    parts.join("\n")
+}
+
+fn push_optional<'a>(parts: &mut Vec<&'a str>, value: Option<&'a str>) {
+    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+        parts.push(value);
+    }
+}
+
+fn board_claim_is_active(entry: &BoardEntry) -> bool {
+    !entry.state.as_deref().is_some_and(|state| {
+        matches!(
+            state.trim().to_ascii_lowercase().as_str(),
+            "done" | "closed" | "resolved" | "cancelled" | "canceled" | "inactive"
+        )
+    })
+}
+
+fn has_matching_split_claim(
+    worktree_root: &Path,
+    current_session_id: Option<&str>,
+    current_intent: &str,
+    conflict: &WorkspaceCoordinationConflict,
+) -> Result<bool, HookError> {
+    let Some(current_session_id) = current_session_id else {
+        return Ok(false);
+    };
+    let snapshot = load_snapshot(worktree_root)?;
+    Ok(snapshot.board.entries.iter().rev().any(|entry| {
+        entry.kind == BoardEntryKind::Claim
+            && entry.origin_session_id.as_deref() == Some(current_session_id)
+            && board_claim_is_active(entry)
+            && board_entry_has_boundary(entry)
+            && board_entry_targets_conflict(entry, conflict)
+            && split_claim_matches_current_work(entry, current_intent)
+    }))
+}
+
+fn split_claim_matches_current_work(entry: &BoardEntry, current_intent: &str) -> bool {
+    is_similar_work(current_intent, &board_entry_text(entry))
+        || entry
+            .title_summary
+            .as_deref()
+            .is_some_and(|title| is_similar_work(current_intent, title))
+        || entry
+            .related_topics
+            .iter()
+            .any(|topic| is_similar_work(current_intent, topic))
+}
+
+fn board_entry_has_boundary(entry: &BoardEntry) -> bool {
+    entry.body.lines().any(|line| {
+        line.trim_start()
+            .to_ascii_lowercase()
+            .starts_with("boundary:")
+    })
+}
+
+fn board_entry_targets_conflict(
+    entry: &BoardEntry,
+    conflict: &WorkspaceCoordinationConflict,
+) -> bool {
+    let mut keys = Vec::new();
+    if let Some(session_id) = conflict.session_id.as_deref() {
+        keys.push(session_id.to_string());
+        keys.push(format!("session:{session_id}"));
+    }
+    if let Some(branch) = conflict.branch.as_deref() {
+        keys.push(branch.to_string());
+        keys.push(format!("branch:{branch}"));
+    }
+    if let Some(agent_id) = conflict.agent_id.as_deref() {
+        keys.push(agent_id.to_string());
+        keys.push(format!("agent:{agent_id}"));
+    }
+    keys.extend(conflict.related_owners.iter().cloned());
+
+    entry
+        .target_owners
+        .iter()
+        .any(|target| keys.iter().any(|key| key == target))
+        || entry
+            .mentions
+            .iter()
+            .map(|mention| match mention.target_kind {
+                BoardMentionTargetKind::Session => format!("session:{}", mention.target),
+                BoardMentionTargetKind::Branch => format!("branch:{}", mention.target),
+                BoardMentionTargetKind::Agent => format!("agent:{}", mention.target),
+                BoardMentionTargetKind::User => format!("user:{}", mention.target),
+            })
+            .any(|typed_key| keys.iter().any(|key| key == &typed_key))
+}
+
+fn workspace_coordination_block_decision(conflict: &WorkspaceCoordinationConflict) -> HookOutput {
+    let mut detail = format!(
+        "A {source} is already in progress and appears to cover the same work.\n\n\
+Conflict title: {title}\n",
+        source = conflict.source_label,
+        title = conflict.title
+    );
+    if let Some(session_id) = conflict.session_id.as_deref() {
+        detail.push_str(&format!("Session: {session_id}\n"));
+    }
+    if let Some(branch) = conflict.branch.as_deref() {
+        detail.push_str(&format!("Branch: {branch}\n"));
+    }
+    if !conflict.related_topics.is_empty() {
+        detail.push_str(&format!("Topics: {}\n", conflict.related_topics.join(", ")));
+    }
+    detail.push_str(
+        "\nDo not continue implementation/editing for duplicate work in a new Workspace. \
+Coordinate on the shared Board with the active agent first.\n\n\
+To coordinate or hand off:\n\
+  gwtd board post --kind request --target <session-or-branch> --body '<question or handoff request>'\n\n\
+To split intentionally, post a claim that targets/mentions the active agent and includes a Boundary line:\n\
+  gwtd board post --kind claim --target <session-or-branch> --topic <topic> --body 'Split accepted.\\n\\nBoundary: <owned files/modules and non-overlap>'",
+    );
+    HookOutput::pre_tool_use_permission("Similar active Workspace already exists", &detail)
+}
+
+fn is_workspace_coordination_sensitive_event(event: &HookEvent) -> bool {
+    match event.tool_name.as_deref() {
+        Some("Edit" | "MultiEdit" | "Write" | "NotebookEdit" | "apply_patch") => true,
+        Some("Bash") => event
+            .command()
+            .is_some_and(is_workspace_coordination_sensitive_bash),
+        _ => false,
+    }
+}
+
+fn is_workspace_coordination_sensitive_bash(command: &str) -> bool {
+    if is_workspace_coordination_command(command) {
+        return false;
+    }
+    if command.contains('>') || command.contains(" tee ") || command.contains("|tee ") {
+        return true;
+    }
+    let segments = super::segments::split_command_segments(command);
+    segments.iter().any(|segment| {
+        let tokens = segment_tokens(segment);
+        let Some(command_name) = tokens.first().map(|token| normalize_command_name(token)) else {
+            return false;
+        };
+        match command_name.as_str() {
+            "cp" | "mkdir" | "mv" | "rm" | "rmdir" | "touch" => true,
+            "sed" => tokens
+                .iter()
+                .any(|token| *token == "--in-place" || token.starts_with("-i")),
+            "cargo" => tokens
+                .get(1)
+                .is_some_and(|subcommand| matches!(*subcommand, "fmt" | "fix")),
+            "git" => tokens
+                .get(1)
+                .is_some_and(|subcommand| matches!(*subcommand, "add" | "commit")),
+            _ => false,
+        }
+    })
+}
+
+fn is_workspace_coordination_command(command: &str) -> bool {
+    let segments = super::segments::split_command_segments(command);
+    !segments.is_empty()
+        && segments.iter().all(|segment| {
+            let tokens = segment_tokens(segment);
+            let Some(command_name) = tokens.first().map(|token| normalize_command_name(token))
+            else {
+                return false;
+            };
+            if command_name != "gwtd" {
+                return false;
+            }
+            matches!(
+                tokens.as_slice(),
+                [_, "board", "post" | "show", ..]
+                    | [_, "workspace", "update", ..]
+                    | [_, "build", "start" | "phase" | "complete" | "abort", ..]
+            )
+        })
+}
+
+fn is_similar_work(left: &str, right: &str) -> bool {
+    let left_compact = compact_for_similarity(left);
+    let right_compact = compact_for_similarity(right);
+    if left_compact.len() >= 16
+        && right_compact.len() >= 16
+        && (left_compact.contains(&right_compact) || right_compact.contains(&left_compact))
+    {
+        return true;
+    }
+
+    let left_tokens = similarity_tokens(left);
+    let right_tokens = similarity_tokens(right);
+    if left_tokens.is_empty() || right_tokens.is_empty() {
+        return false;
+    }
+    let overlap = left_tokens.intersection(&right_tokens).count();
+    if overlap < 3 {
+        return false;
+    }
+    let left_coverage = overlap as f32 / left_tokens.len() as f32;
+    let right_coverage = overlap as f32 / right_tokens.len() as f32;
+    let dice = (2 * overlap) as f32 / (left_tokens.len() + right_tokens.len()) as f32;
+
+    (overlap >= 4 && left_coverage >= 0.45 && dice >= 0.35)
+        || (left_coverage >= 0.60 && right_coverage >= 0.45)
+}
+
+fn compact_for_similarity(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn similarity_tokens(value: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    for raw in value
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    {
+        let lower = raw.to_ascii_lowercase();
+        if raw.is_ascii() {
+            if lower.len() >= 3 && !is_similarity_stopword(&lower) {
+                tokens.insert(lower);
+            }
+            continue;
+        }
+        let chars = raw.chars().collect::<Vec<_>>();
+        for size in [2, 3] {
+            if chars.len() >= size {
+                for window in chars.windows(size) {
+                    tokens.insert(window.iter().collect());
+                }
+            }
+        }
+    }
+    tokens
+}
+
+fn is_similarity_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "add"
+            | "and"
+            | "body"
+            | "for"
+            | "from"
+            | "gate"
+            | "new"
+            | "old"
+            | "only"
+            | "the"
+            | "this"
+            | "update"
+            | "with"
+            | "work"
+            | "works"
+    )
 }
 
 fn is_title_sensitive_tool(event: &HookEvent) -> bool {

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -9,6 +9,9 @@ use chrono::Utc;
 use gwt::cli::hook::{workflow_policy, HookEvent, HookOutput};
 use gwt_agent::{session::GWT_SESSION_ID_ENV, AgentId, Session};
 use gwt_core::{
+    coordination::{
+        post_entry, AuthorKind, BoardEntry, BoardEntryKind, BoardMention, BoardMentionTargetKind,
+    },
     paths::gwt_sessions_dir,
     repo_hash::compute_repo_hash,
     workspace_projection::{
@@ -160,21 +163,57 @@ fn save_session(repo_path: &Path, branch: &str, linked_issue_number: Option<u64>
 
 fn seed_workspace_agent_title(repo_path: &Path, session_id: &str) {
     let mut projection = WorkspaceProjection::default_for_project(repo_path);
-    projection.agents.push(WorkspaceAgentSummary {
+    projection.agents.push(workspace_agent(
+        session_id,
+        "Testing workflow policy",
+        "Workflow policy test",
+    ));
+    save_workspace_projection(repo_path, &projection).expect("save workspace projection");
+}
+
+fn workspace_agent(
+    session_id: &str,
+    current_focus: &str,
+    title_summary: &str,
+) -> WorkspaceAgentSummary {
+    WorkspaceAgentSummary {
         session_id: session_id.to_string(),
         window_id: None,
         agent_id: "codex".to_string(),
         display_name: "Codex".to_string(),
         status_category: WorkspaceStatusCategory::Active,
-        current_focus: Some("Testing workflow policy".to_string()),
-        title_summary: Some("Workflow policy test".to_string()),
-        worktree_path: Some(repo_path.to_path_buf()),
+        current_focus: Some(current_focus.to_string()),
+        title_summary: Some(title_summary.to_string()),
+        worktree_path: None,
         branch: Some("feature/workflow".to_string()),
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
         updated_at: Utc::now(),
-    });
+    }
+}
+
+fn seed_workspace_agents(
+    repo_path: &Path,
+    current_session_id: &str,
+    current_title: &str,
+    other_session_id: &str,
+    other_title: &str,
+) {
+    let mut projection = WorkspaceProjection::default_for_project(repo_path);
+    projection.title = "Workspace semantic coordination".to_string();
+    projection.status_category = WorkspaceStatusCategory::Active;
+    projection.summary = Some("Coordinate same-work detection across agents".to_string());
+    projection.agents.push(workspace_agent(
+        current_session_id,
+        "Implement Workspace semantic coordination gate",
+        current_title,
+    ));
+    projection.agents.push(workspace_agent(
+        other_session_id,
+        "Implement duplicate Workspace semantic coordination protection",
+        other_title,
+    ));
     save_workspace_projection(repo_path, &projection).expect("save workspace projection");
 }
 
@@ -499,5 +538,146 @@ fn evaluate_falls_back_to_issue_linkage_store_for_plain_issue_owner() {
             matches!(decision, HookOutput::Silent),
             "plain issue owner from linkage store should allow implementation"
         );
+    });
+}
+
+#[test]
+fn blocks_mutation_when_another_active_workspace_matches_current_title() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_agents(
+            &repo_path,
+            &session_id,
+            "Workspace semantic coordination gate",
+            "session-other",
+            "Workspace semantic coordination duplicate guard",
+        );
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected active Workspace conflict to block mutation");
+        };
+        assert!(detail.contains("similar active Workspace"), "{detail}");
+        assert!(detail.contains("session-other"), "{detail}");
+        assert!(detail.contains("gwtd board post"), "{detail}");
+        assert!(detail.contains("Boundary:"), "{detail}");
+    });
+}
+
+#[test]
+fn allows_mutation_after_split_claim_targets_matching_workspace_agent() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_agents(
+            &repo_path,
+            &session_id,
+            "Workspace semantic coordination gate",
+            "session-other",
+            "Workspace semantic coordination duplicate guard",
+        );
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Claim,
+            "Split accepted for same Workspace work.\n\nBoundary: current session owns workflow-policy tests and policy gate only.",
+            None,
+            None,
+            vec!["workspace-semantic-coordination".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id(session_id.clone())
+        .with_mention(BoardMention::new(
+            BoardMentionTargetKind::Session,
+            "session-other",
+        ));
+        post_entry(&repo_path, entry).expect("post split claim");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Boundary-targeted split claim should allow disjoint implementation"
+        );
+    });
+}
+
+#[test]
+fn blocks_mutation_when_active_board_claim_matches_current_title() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection.agents.push(workspace_agent(
+            &session_id,
+            "Implement Workspace semantic coordination gate",
+            "Workspace semantic coordination gate",
+        ));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Other Codex",
+            BoardEntryKind::Claim,
+            "Implement Workspace semantic coordination duplicate guard for active agents.",
+            None,
+            None,
+            vec!["workspace-semantic-coordination".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id("session-other");
+        post_entry(&repo_path, entry).expect("post active claim");
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected active Board claim conflict to block mutation");
+        };
+        assert!(detail.contains("active Board claim"), "{detail}");
+        assert!(detail.contains("session-other"), "{detail}");
     });
 }


### PR DESCRIPTION
## Summary

- Adds a workflow-policy gate that blocks implementation/editing when similar active Workspace work is already claimed by another agent.
- Keeps Board/Workspace coordination commands available, and permits intentional split work only after a Boundary-targeted Board claim.

## Changes

- `crates/gwt/src/cli/hook/workflow_policy.rs`: adds active-only Workspace/Board claim conflict detection, conservative work-intent matching, split-claim validation, and coordination command exemptions.
- `crates/gwt/tests/hook_workflow_policy_test.rs`: adds regression coverage for active Workspace conflicts, active Board claim conflicts, and Boundary-targeted split claims.
- `SPEC-2359`: updated spec, plan, and tasks sections with the Workspace semantic coordination gate follow-up and verification evidence.

## Testing

- [x] `cargo test -p gwt --test hook_workflow_policy_test blocks_mutation_when_another_active_workspace_matches_current_title` — passed after RED failure before implementation.
- [x] `cargo test -p gwt --test hook_workflow_policy_test workspace` — passed.
- [x] `cargo test -p gwt --test hook_workflow_policy_test active_board_claim` — passed.
- [x] `cargo test -p gwt --test hook_workflow_policy_test` — passed, 27/27.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` and `git diff --cached --check` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2359)
- [x] Migration/backfill plan included (not applicable: no schema/data migration)
- [x] CHANGELOG impact considered (feature, non-breaking)

## Context

- Workspace should represent the work item and should not let agents perform the same implementation in parallel without communicating on Board first.

## Risk / Impact

- **Affected areas**: `gwtd hook workflow-policy` for Edit/Write/apply_patch and clearly file-mutating Bash commands.
- **Rollback plan**: revert this PR; no data migration is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added workspace coordination guard to detect and prevent overlapping work between agents
* Introduced conflict detection when multiple agents target similar tasks
* Added support for explicit split claims to allow authorized coordinated work

## Tests
* Added comprehensive tests for workspace conflict scenarios and mutation-gating behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2638)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->