### PR TITLE
feat(workspace): add work item history

### DIFF
--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -82,6 +82,16 @@ pub fn gwt_workspace_journal_path(repo_hash: &RepoHash) -> PathBuf {
     gwt_project_dir(repo_hash).join("workspace/journal.jsonl")
 }
 
+/// Return the Workspace WorkItem hot projection path for a repository hash.
+pub fn gwt_workspace_work_items_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("workspace/work_items.json")
+}
+
+/// Return the Workspace WorkItem event log path for a repository hash.
+pub fn gwt_workspace_work_events_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("workspace/work_events.jsonl")
+}
+
 /// Return the Workspace current projection path for a repository path.
 pub fn gwt_workspace_projection_path_for_repo_path(repo_path: &Path) -> PathBuf {
     let repo_hash = project_scope_hash(repo_path);
@@ -92,6 +102,18 @@ pub fn gwt_workspace_projection_path_for_repo_path(repo_path: &Path) -> PathBuf 
 pub fn gwt_workspace_journal_path_for_repo_path(repo_path: &Path) -> PathBuf {
     let repo_hash = project_scope_hash(repo_path);
     gwt_workspace_journal_path(&repo_hash)
+}
+
+/// Return the Workspace WorkItem hot projection path for a repository path.
+pub fn gwt_workspace_work_items_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    let repo_hash = project_scope_hash(repo_path);
+    gwt_workspace_work_items_path(&repo_hash)
+}
+
+/// Return the Workspace WorkItem event log path for a repository path.
+pub fn gwt_workspace_work_events_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    let repo_hash = project_scope_hash(repo_path);
+    gwt_workspace_work_events_path(&repo_hash)
 }
 
 /// Return the repo-scoped notes root (`~/.gwt/notes/`).

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -13,6 +13,7 @@ use crate::{
     error::{GwtError, Result},
     paths::{
         gwt_workspace_journal_path_for_repo_path, gwt_workspace_projection_path_for_repo_path,
+        gwt_workspace_work_events_path_for_repo_path, gwt_workspace_work_items_path_for_repo_path,
     },
 };
 
@@ -393,6 +394,248 @@ pub struct WorkspaceJournalEntry {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkAgentRef {
+    pub session_id: String,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceExecutionContainerRef {
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub worktree_path: Option<PathBuf>,
+    #[serde(default)]
+    pub pr_number: Option<u64>,
+    #[serde(default)]
+    pub pr_url: Option<String>,
+    #[serde(default)]
+    pub pr_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceWorkEventKind {
+    Start,
+    Claim,
+    Update,
+    Blocked,
+    Handoff,
+    Resume,
+    Split,
+    Merge,
+    Pr,
+    Done,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkEvent {
+    pub id: String,
+    pub work_item_id: String,
+    pub kind: WorkspaceWorkEventKind,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub intent: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub status_category: Option<WorkspaceStatusCategory>,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub next_action: Option<String>,
+    #[serde(default)]
+    pub agent_session_id: Option<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub board_entry_id: Option<String>,
+    #[serde(default)]
+    pub execution_container: Option<WorkspaceExecutionContainerRef>,
+    #[serde(default)]
+    pub related_work_item_id: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl WorkspaceWorkEvent {
+    pub fn new(
+        kind: WorkspaceWorkEventKind,
+        work_item_id: impl Into<String>,
+        updated_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            work_item_id: work_item_id.into(),
+            kind,
+            title: None,
+            intent: None,
+            summary: None,
+            status_category: None,
+            owner: None,
+            next_action: None,
+            agent_session_id: None,
+            agent_id: None,
+            display_name: None,
+            board_entry_id: None,
+            execution_container: None,
+            related_work_item_id: None,
+            updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkItem {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub intent: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+    pub status_category: WorkspaceStatusCategory,
+    #[serde(default)]
+    pub owner: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub agents: Vec<WorkspaceWorkAgentRef>,
+    #[serde(default)]
+    pub execution_containers: Vec<WorkspaceExecutionContainerRef>,
+    #[serde(default)]
+    pub board_refs: Vec<String>,
+    #[serde(default)]
+    pub related_work_item_ids: Vec<String>,
+    #[serde(default)]
+    pub events: Vec<WorkspaceWorkEvent>,
+}
+
+impl WorkspaceWorkItem {
+    pub fn is_incomplete(&self) -> bool {
+        self.status_category != WorkspaceStatusCategory::Done
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkItemsProjection {
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub work_items: Vec<WorkspaceWorkItem>,
+}
+
+impl WorkspaceWorkItemsProjection {
+    fn empty(updated_at: DateTime<Utc>) -> Self {
+        Self {
+            updated_at,
+            work_items: Vec::new(),
+        }
+    }
+
+    fn apply_event(&mut self, event: WorkspaceWorkEvent) {
+        let index = self
+            .work_items
+            .iter()
+            .position(|item| item.id == event.work_item_id)
+            .unwrap_or_else(|| {
+                self.work_items.push(WorkspaceWorkItem {
+                    id: event.work_item_id.clone(),
+                    title: event
+                        .title
+                        .clone()
+                        .or_else(|| event.intent.clone())
+                        .unwrap_or_else(|| event.work_item_id.clone()),
+                    intent: event.intent.clone(),
+                    summary: event.summary.clone(),
+                    status_category: workspace_work_event_status(&event),
+                    owner: event.owner.clone(),
+                    created_at: event.updated_at,
+                    updated_at: event.updated_at,
+                    completed_at: None,
+                    agents: Vec::new(),
+                    execution_containers: Vec::new(),
+                    board_refs: Vec::new(),
+                    related_work_item_ids: Vec::new(),
+                    events: Vec::new(),
+                });
+                self.work_items.len() - 1
+            });
+
+        let item = &mut self.work_items[index];
+        if let Some(title) = non_empty_clone(event.title.as_deref()) {
+            item.title = title;
+        }
+        if let Some(intent) = non_empty_clone(event.intent.as_deref()) {
+            item.intent = Some(intent);
+        }
+        if let Some(summary) = non_empty_clone(event.summary.as_deref()) {
+            item.summary = Some(summary);
+        }
+        if let Some(owner) = non_empty_clone(event.owner.as_deref()) {
+            item.owner = Some(owner);
+        }
+        item.status_category = workspace_work_event_status(&event);
+        if item.status_category == WorkspaceStatusCategory::Done {
+            item.completed_at = Some(event.updated_at);
+        } else {
+            item.completed_at = None;
+        }
+        item.updated_at = event.updated_at;
+        if item.created_at > event.updated_at {
+            item.created_at = event.updated_at;
+        }
+        if let Some(session_id) = non_empty_clone(event.agent_session_id.as_deref()) {
+            if let Some(agent) = item
+                .agents
+                .iter_mut()
+                .find(|agent| agent.session_id == session_id)
+            {
+                agent.agent_id = event.agent_id.clone().or(agent.agent_id.clone());
+                agent.display_name = event.display_name.clone().or(agent.display_name.clone());
+                agent.updated_at = event.updated_at;
+            } else {
+                item.agents.push(WorkspaceWorkAgentRef {
+                    session_id,
+                    agent_id: event.agent_id.clone(),
+                    display_name: event.display_name.clone(),
+                    updated_at: event.updated_at,
+                });
+            }
+        }
+        if let Some(container) = event.execution_container.clone() {
+            if !item
+                .execution_containers
+                .iter()
+                .any(|existing| workspace_execution_container_same(existing, &container))
+            {
+                item.execution_containers.push(container);
+            }
+        }
+        if let Some(board_entry_id) = non_empty_clone(event.board_entry_id.as_deref()) {
+            push_unique(&mut item.board_refs, board_entry_id);
+        }
+        if let Some(related_work_item_id) = non_empty_clone(event.related_work_item_id.as_deref()) {
+            push_unique(&mut item.related_work_item_ids, related_work_item_id);
+        }
+        let event_updated_at = event.updated_at;
+        item.events.push(event);
+        item.events.sort_by_key(|event| event.updated_at);
+        if event_updated_at > self.updated_at {
+            self.updated_at = event_updated_at;
+        }
+        self.work_items
+            .sort_by_key(|item| std::cmp::Reverse(item.updated_at));
+    }
+}
+
 fn coordination_scope_for_entry(entry: &BoardEntry) -> Option<String> {
     let mut parts = Vec::new();
     if let Some(owner) = entry.related_owners.first() {
@@ -432,12 +675,17 @@ pub fn update_workspace_projection_with_journal(
     repo_path: &Path,
     update: WorkspaceProjectionUpdate,
 ) -> Result<WorkspaceJournalEntry> {
-    update_workspace_projection_with_journal_paths(
+    let entry = update_workspace_projection_with_journal_paths(
         &gwt_workspace_projection_path_for_repo_path(repo_path),
         &gwt_workspace_journal_path_for_repo_path(repo_path),
         repo_path,
         update,
-    )
+    )?;
+    if let Some(projection) = load_workspace_projection(repo_path)? {
+        let event = workspace_work_event_from_journal_entry(&projection, &entry);
+        record_workspace_work_event(repo_path, event)?;
+    }
+    Ok(entry)
 }
 
 pub fn mark_workspace_agent_stopped(
@@ -462,6 +710,75 @@ pub fn load_workspace_projection_from_path(path: &Path) -> Result<Option<Workspa
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error.into()),
     }
+}
+
+pub fn load_workspace_work_items(repo_path: &Path) -> Result<Option<WorkspaceWorkItemsProjection>> {
+    load_workspace_work_items_from_path(&gwt_workspace_work_items_path_for_repo_path(repo_path))
+}
+
+pub fn load_workspace_work_items_from_path(
+    path: &Path,
+) -> Result<Option<WorkspaceWorkItemsProjection>> {
+    match fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|error| GwtError::Other(format!("workspace work items json: {error}"))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn load_or_synthesize_workspace_work_items(
+    repo_path: &Path,
+) -> Result<WorkspaceWorkItemsProjection> {
+    load_or_synthesize_workspace_work_items_from_paths(
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+        &gwt_workspace_projection_path_for_repo_path(repo_path),
+        &gwt_workspace_journal_path_for_repo_path(repo_path),
+        repo_path,
+    )
+}
+
+pub fn load_or_synthesize_workspace_work_items_from_paths(
+    work_items_path: &Path,
+    current_path: &Path,
+    journal_path: &Path,
+    project_root: &Path,
+) -> Result<WorkspaceWorkItemsProjection> {
+    if let Some(projection) = load_workspace_work_items_from_path(work_items_path)? {
+        return Ok(projection);
+    }
+    synthesize_workspace_work_items_from_legacy_paths(current_path, journal_path, project_root)
+}
+
+pub fn save_workspace_work_items_projection_to_path(
+    path: &Path,
+    projection: &WorkspaceWorkItemsProjection,
+) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(projection)
+        .map_err(|error| GwtError::Other(format!("workspace work items json: {error}")))?;
+    write_atomic(path, &bytes)
+}
+
+pub fn record_workspace_work_event(repo_path: &Path, event: WorkspaceWorkEvent) -> Result<()> {
+    record_workspace_work_event_paths(
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+        &gwt_workspace_work_events_path_for_repo_path(repo_path),
+        event,
+    )
+}
+
+pub fn record_workspace_work_event_paths(
+    work_items_path: &Path,
+    events_path: &Path,
+    event: WorkspaceWorkEvent,
+) -> Result<()> {
+    let mut projection = load_workspace_work_items_from_path(work_items_path)?
+        .unwrap_or_else(|| WorkspaceWorkItemsProjection::empty(event.updated_at));
+    projection.apply_event(event.clone());
+    save_workspace_work_items_projection_to_path(work_items_path, &projection)?;
+    append_workspace_work_event_to_path(events_path, &event)?;
+    Ok(())
 }
 
 pub fn load_or_default_workspace_projection_from_path(
@@ -548,6 +865,21 @@ pub fn append_workspace_journal_entry_to_path(
     Ok(())
 }
 
+pub fn append_workspace_work_event_to_path(path: &Path, event: &WorkspaceWorkEvent) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    serde_json::to_writer(&mut file, event)
+        .map_err(|error| GwtError::Other(format!("workspace work event json: {error}")))?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    Ok(())
+}
+
 pub fn load_recent_workspace_journal_entries(
     repo_path: &Path,
     limit: usize,
@@ -577,6 +909,344 @@ pub fn load_recent_workspace_journal_entries_from_path(
     entries.sort_by_key(|entry| std::cmp::Reverse(entry.updated_at));
     entries.truncate(limit);
     Ok(entries)
+}
+
+fn synthesize_workspace_work_items_from_legacy_paths(
+    current_path: &Path,
+    journal_path: &Path,
+    project_root: &Path,
+) -> Result<WorkspaceWorkItemsProjection> {
+    let projection = load_workspace_projection_from_path(current_path)?;
+    let mut journal_entries =
+        load_recent_workspace_journal_entries_from_path(journal_path, usize::MAX)?;
+    journal_entries.sort_by_key(|entry| entry.updated_at);
+    let updated_at = projection
+        .as_ref()
+        .map(|projection| projection.updated_at)
+        .or_else(|| journal_entries.last().map(|entry| entry.updated_at))
+        .unwrap_or_else(Utc::now);
+    let Some(item) = synthesize_workspace_work_item_from_legacy(
+        projection.as_ref(),
+        &journal_entries,
+        project_root,
+    ) else {
+        return Ok(WorkspaceWorkItemsProjection::empty(updated_at));
+    };
+    Ok(WorkspaceWorkItemsProjection {
+        updated_at: item.updated_at,
+        work_items: vec![item],
+    })
+}
+
+fn synthesize_workspace_work_item_from_legacy(
+    projection: Option<&WorkspaceProjection>,
+    journal_entries: &[WorkspaceJournalEntry],
+    _project_root: &Path,
+) -> Option<WorkspaceWorkItem> {
+    if projection.is_none() && journal_entries.is_empty() {
+        return None;
+    }
+    let first_entry = journal_entries.first();
+    let last_entry = journal_entries.last();
+    let id = projection
+        .map(|projection| projection.id.clone())
+        .or_else(|| first_entry.map(|entry| format!("legacy-{}", entry.id)))?;
+    let title = projection
+        .map(|projection| projection.title.clone())
+        .or_else(|| {
+            first_entry.and_then(|entry| {
+                non_empty_clone(entry.title.as_deref())
+                    .or_else(|| non_empty_clone(entry.agent_title_summary.as_deref()))
+                    .or_else(|| non_empty_clone(entry.summary.as_deref()))
+            })
+        })
+        .unwrap_or_else(|| "Workspace history".to_string());
+    let status_category = projection
+        .map(WorkspaceProjection::effective_status_category)
+        .or_else(|| last_entry.and_then(|entry| entry.status_category))
+        .unwrap_or(WorkspaceStatusCategory::Unknown);
+    let summary = projection
+        .and_then(|projection| projection.summary.clone())
+        .or_else(|| last_entry.and_then(|entry| entry.summary.clone()))
+        .or_else(|| last_entry.and_then(|entry| entry.status_text.clone()));
+    let owner = projection
+        .and_then(|projection| projection.owner.clone())
+        .or_else(|| last_entry.and_then(|entry| entry.owner.clone()));
+    let created_at = first_entry
+        .map(|entry| entry.updated_at)
+        .or_else(|| projection.map(|projection| projection.updated_at))
+        .unwrap_or_else(Utc::now);
+    let updated_at = projection
+        .map(|projection| projection.updated_at)
+        .or_else(|| last_entry.map(|entry| entry.updated_at))
+        .unwrap_or(created_at);
+    let completed_at = (status_category == WorkspaceStatusCategory::Done).then_some(updated_at);
+    let mut item = WorkspaceWorkItem {
+        id: id.clone(),
+        title,
+        intent: summary.clone(),
+        summary,
+        status_category,
+        owner,
+        created_at,
+        updated_at,
+        completed_at,
+        agents: Vec::new(),
+        execution_containers: Vec::new(),
+        board_refs: projection
+            .map(|projection| projection.board_refs.clone())
+            .unwrap_or_default(),
+        related_work_item_ids: Vec::new(),
+        events: Vec::new(),
+    };
+    if let Some(projection) = projection {
+        item.agents
+            .extend(projection.agents.iter().map(|agent| WorkspaceWorkAgentRef {
+                session_id: agent.session_id.clone(),
+                agent_id: Some(agent.agent_id.clone()),
+                display_name: Some(agent.display_name.clone()),
+                updated_at: agent.updated_at,
+            }));
+        if let Some(details) = projection.git_details.as_ref() {
+            item.execution_containers
+                .push(WorkspaceExecutionContainerRef {
+                    branch: details.branch.clone(),
+                    worktree_path: details.worktree_path.clone(),
+                    pr_number: details.pr_number,
+                    pr_url: details.pr_url.clone(),
+                    pr_state: details.pr_state.clone(),
+                });
+        }
+    }
+    for (index, entry) in journal_entries.iter().enumerate() {
+        let mut event = WorkspaceWorkEvent::new(
+            workspace_work_event_kind_from_journal(index, entry),
+            id.clone(),
+            entry.updated_at,
+        );
+        event.id = format!("legacy-journal-{}", entry.id);
+        event.title = entry
+            .title
+            .clone()
+            .or_else(|| entry.agent_title_summary.clone());
+        event.intent = entry
+            .agent_current_focus
+            .clone()
+            .or_else(|| entry.summary.clone());
+        event.summary = entry.summary.clone().or_else(|| entry.status_text.clone());
+        event.status_category = entry.status_category;
+        event.owner = entry.owner.clone();
+        event.next_action = entry.next_action.clone();
+        event.agent_session_id = entry.agent_session_id.clone();
+        if let Some(session_id) = non_empty_clone(entry.agent_session_id.as_deref()) {
+            if !item
+                .agents
+                .iter()
+                .any(|agent| agent.session_id == session_id)
+            {
+                item.agents.push(WorkspaceWorkAgentRef {
+                    session_id,
+                    agent_id: None,
+                    display_name: entry.agent_title_summary.clone(),
+                    updated_at: entry.updated_at,
+                });
+            }
+        }
+        item.events.push(event);
+    }
+    if item.events.is_empty() {
+        let mut event = WorkspaceWorkEvent::new(
+            workspace_work_event_kind_from_status(status_category, 0),
+            id,
+            updated_at,
+        );
+        event.title = Some(item.title.clone());
+        event.summary = item.summary.clone();
+        event.status_category = Some(status_category);
+        event.owner = item.owner.clone();
+        item.events.push(event);
+    }
+    item.events.sort_by_key(|event| event.updated_at);
+    Some(item)
+}
+
+fn workspace_work_event_from_journal_entry(
+    projection: &WorkspaceProjection,
+    entry: &WorkspaceJournalEntry,
+) -> WorkspaceWorkEvent {
+    let mut event = WorkspaceWorkEvent::new(
+        workspace_work_event_kind_from_status(
+            entry.status_category.unwrap_or(projection.status_category),
+            1,
+        ),
+        projection.id.clone(),
+        entry.updated_at,
+    );
+    event.title = entry
+        .title
+        .clone()
+        .or_else(|| entry.agent_title_summary.clone())
+        .or_else(|| Some(projection.title.clone()));
+    event.intent = entry
+        .agent_current_focus
+        .clone()
+        .or_else(|| entry.summary.clone())
+        .or_else(|| projection.summary.clone());
+    event.summary = entry.summary.clone().or_else(|| entry.status_text.clone());
+    event.status_category = Some(entry.status_category.unwrap_or(projection.status_category));
+    event.owner = entry.owner.clone().or_else(|| projection.owner.clone());
+    event.next_action = entry.next_action.clone();
+    event.agent_session_id = entry.agent_session_id.clone();
+    if let Some(session_id) = entry.agent_session_id.as_deref() {
+        if let Some(agent) = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session_id)
+        {
+            event.agent_id = Some(agent.agent_id.clone());
+            event.display_name = Some(agent.display_name.clone());
+        }
+    }
+    event.execution_container = workspace_execution_container_from_projection(projection);
+    event
+}
+
+pub fn workspace_work_event_from_board_entry(
+    projection: &WorkspaceProjection,
+    entry: &BoardEntry,
+) -> WorkspaceWorkEvent {
+    let mut event = WorkspaceWorkEvent::new(
+        workspace_work_event_kind_from_board_entry(entry),
+        projection.id.clone(),
+        entry.updated_at,
+    );
+    event.title = entry
+        .title_summary
+        .clone()
+        .or_else(|| first_nonempty_line(&entry.body))
+        .or_else(|| Some(projection.title.clone()));
+    event.intent = entry.title_summary.clone();
+    event.summary = Some(entry.body.clone());
+    event.status_category = Some(match entry.kind {
+        BoardEntryKind::Blocked => WorkspaceStatusCategory::Blocked,
+        BoardEntryKind::Next
+        | BoardEntryKind::Status
+        | BoardEntryKind::Claim
+        | BoardEntryKind::Handoff
+        | BoardEntryKind::Decision => WorkspaceStatusCategory::Active,
+        BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {
+            projection.status_category
+        }
+    });
+    event.owner = entry
+        .related_owners
+        .first()
+        .cloned()
+        .or_else(|| projection.owner.clone());
+    event.agent_session_id = entry.origin_session_id.clone();
+    event.agent_id = entry.origin_agent_id.clone();
+    event.board_entry_id = Some(entry.id.clone());
+    event.execution_container = workspace_execution_container_from_projection(projection);
+    event
+}
+
+fn workspace_work_event_status(event: &WorkspaceWorkEvent) -> WorkspaceStatusCategory {
+    event.status_category.unwrap_or(match event.kind {
+        WorkspaceWorkEventKind::Done => WorkspaceStatusCategory::Done,
+        WorkspaceWorkEventKind::Blocked => WorkspaceStatusCategory::Blocked,
+        WorkspaceWorkEventKind::Start
+        | WorkspaceWorkEventKind::Claim
+        | WorkspaceWorkEventKind::Update
+        | WorkspaceWorkEventKind::Handoff
+        | WorkspaceWorkEventKind::Resume
+        | WorkspaceWorkEventKind::Split
+        | WorkspaceWorkEventKind::Merge
+        | WorkspaceWorkEventKind::Pr => WorkspaceStatusCategory::Active,
+    })
+}
+
+fn workspace_work_event_kind_from_board_entry(entry: &BoardEntry) -> WorkspaceWorkEventKind {
+    match entry.kind {
+        BoardEntryKind::Claim => WorkspaceWorkEventKind::Claim,
+        BoardEntryKind::Blocked => WorkspaceWorkEventKind::Blocked,
+        BoardEntryKind::Handoff => WorkspaceWorkEventKind::Handoff,
+        BoardEntryKind::Next
+        | BoardEntryKind::Status
+        | BoardEntryKind::Decision
+        | BoardEntryKind::Request
+        | BoardEntryKind::Impact
+        | BoardEntryKind::Question => WorkspaceWorkEventKind::Update,
+    }
+}
+
+fn workspace_work_event_kind_from_journal(
+    index: usize,
+    entry: &WorkspaceJournalEntry,
+) -> WorkspaceWorkEventKind {
+    workspace_work_event_kind_from_status(
+        entry
+            .status_category
+            .unwrap_or(WorkspaceStatusCategory::Unknown),
+        index,
+    )
+}
+
+fn workspace_work_event_kind_from_status(
+    status_category: WorkspaceStatusCategory,
+    index: usize,
+) -> WorkspaceWorkEventKind {
+    match status_category {
+        WorkspaceStatusCategory::Done => WorkspaceWorkEventKind::Done,
+        WorkspaceStatusCategory::Blocked => WorkspaceWorkEventKind::Blocked,
+        _ if index == 0 => WorkspaceWorkEventKind::Start,
+        _ => WorkspaceWorkEventKind::Update,
+    }
+}
+
+fn workspace_execution_container_from_projection(
+    projection: &WorkspaceProjection,
+) -> Option<WorkspaceExecutionContainerRef> {
+    projection
+        .git_details
+        .as_ref()
+        .map(|details| WorkspaceExecutionContainerRef {
+            branch: details.branch.clone(),
+            worktree_path: details.worktree_path.clone(),
+            pr_number: details.pr_number,
+            pr_url: details.pr_url.clone(),
+            pr_state: details.pr_state.clone(),
+        })
+}
+
+fn workspace_execution_container_same(
+    left: &WorkspaceExecutionContainerRef,
+    right: &WorkspaceExecutionContainerRef,
+) -> bool {
+    (left.branch.is_some() && left.branch == right.branch)
+        || (left.worktree_path.is_some() && left.worktree_path == right.worktree_path)
+        || (left.pr_number.is_some() && left.pr_number == right.pr_number)
+        || (left.pr_url.is_some() && left.pr_url == right.pr_url)
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn non_empty_clone(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn first_nonempty_line(value: &str) -> Option<String> {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
 }
 
 fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
@@ -1106,6 +1776,168 @@ mod tests {
         assert_eq!(
             journal.agent_current_focus.as_deref(),
             Some("Writing RED tests")
+        );
+    }
+
+    #[test]
+    fn workspace_work_events_build_hot_projection_with_lifecycle_refs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 11, 1, 0, 0).unwrap();
+        let done_at = Utc.with_ymd_and_hms(2026, 5, 11, 1, 30, 0).unwrap();
+
+        let mut start = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workitem-workspace-history",
+            started_at,
+        );
+        start.title = Some("Workspace WorkItem history".to_string());
+        start.intent = Some("Group duplicate Workspace work under one WorkItem".to_string());
+        start.summary = Some("Start the WorkItem lifecycle implementation.".to_string());
+        start.status_category = Some(WorkspaceStatusCategory::Active);
+        start.owner = Some("SPEC-2359".to_string());
+        start.agent_session_id = Some("session-1".to_string());
+        start.agent_id = Some("codex".to_string());
+        start.display_name = Some("Codex".to_string());
+        start.board_entry_id = Some("board-claim-1".to_string());
+        start.execution_container = Some(WorkspaceExecutionContainerRef {
+            branch: Some("work/20260510-2353".to_string()),
+            worktree_path: Some(PathBuf::from("/repo/work/20260510-2353")),
+            pr_number: Some(2638),
+            pr_url: Some("https://github.com/akiojin/gwt/pull/2638".to_string()),
+            pr_state: Some("open".to_string()),
+        });
+        record_workspace_work_event_paths(&work_items_path, &events_path, start)
+            .expect("record start event");
+
+        let mut done = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Done,
+            "workitem-workspace-history",
+            done_at,
+        );
+        done.summary = Some("WorkItem lifecycle history is implemented.".to_string());
+        done.status_category = Some(WorkspaceStatusCategory::Done);
+        done.agent_session_id = Some("session-1".to_string());
+        done.board_entry_id = Some("board-done-1".to_string());
+        record_workspace_work_event_paths(&work_items_path, &events_path, done)
+            .expect("record done event");
+
+        let projection = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(projection.work_items.len(), 1);
+        let item = &projection.work_items[0];
+        assert_eq!(item.id, "workitem-workspace-history");
+        assert_eq!(item.title, "Workspace WorkItem history");
+        assert_eq!(
+            item.intent.as_deref(),
+            Some("Group duplicate Workspace work under one WorkItem")
+        );
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(item.owner.as_deref(), Some("SPEC-2359"));
+        assert_eq!(item.completed_at, Some(done_at));
+        assert_eq!(
+            item.board_refs,
+            vec!["board-claim-1".to_string(), "board-done-1".to_string()]
+        );
+        assert_eq!(item.agents.len(), 1);
+        assert_eq!(item.agents[0].session_id, "session-1");
+        assert_eq!(item.execution_containers.len(), 1);
+        assert_eq!(
+            item.execution_containers[0].branch.as_deref(),
+            Some("work/20260510-2353")
+        );
+        assert_eq!(item.events.len(), 2);
+        assert_eq!(item.events[0].kind, WorkspaceWorkEventKind::Start);
+        assert_eq!(item.events[1].kind, WorkspaceWorkEventKind::Done);
+
+        let event_lines = std::fs::read_to_string(&events_path).expect("event log");
+        assert_eq!(event_lines.lines().count(), 2);
+    }
+
+    #[test]
+    fn workspace_work_items_synthesize_from_legacy_current_and_journal_without_rewrite() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().join("repo");
+        let current_path = temp.path().join("workspace/current.json");
+        let journal_path = temp.path().join("workspace/journal.jsonl");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let first_at = Utc.with_ymd_and_hms(2026, 5, 11, 2, 0, 0).unwrap();
+        let second_at = Utc.with_ymd_and_hms(2026, 5, 11, 2, 5, 0).unwrap();
+
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
+        projection.id = "workspace-current".to_string();
+        projection.title = "Workspace WorkItem history".to_string();
+        projection.status_category = WorkspaceStatusCategory::Active;
+        projection.status_text = "Implementing WorkItem projection".to_string();
+        projection.summary = Some("Legacy current state remains readable.".to_string());
+        projection.owner = Some("SPEC-2359".to_string());
+        projection.board_refs.push("board-legacy-1".to_string());
+        save_workspace_projection_to_path(&current_path, &projection)
+            .expect("save legacy projection");
+
+        append_workspace_journal_entry_to_path(
+            &journal_path,
+            &WorkspaceJournalEntry {
+                id: "journal-start".to_string(),
+                project_root: project_root.clone(),
+                title: Some("Workspace WorkItem history".to_string()),
+                status_category: Some(WorkspaceStatusCategory::Active),
+                status_text: Some("Started".to_string()),
+                owner: Some("SPEC-2359".to_string()),
+                next_action: None,
+                summary: Some("Started from legacy journal.".to_string()),
+                agent_session_id: Some("session-legacy".to_string()),
+                agent_current_focus: Some("Implement lifecycle events".to_string()),
+                agent_title_summary: Some("WorkItem history".to_string()),
+                updated_at: first_at,
+            },
+        )
+        .expect("append first journal");
+        append_workspace_journal_entry_to_path(
+            &journal_path,
+            &WorkspaceJournalEntry {
+                id: "journal-update".to_string(),
+                project_root: project_root.clone(),
+                title: None,
+                status_category: Some(WorkspaceStatusCategory::Blocked),
+                status_text: Some("Waiting for coordination decision".to_string()),
+                owner: Some("SPEC-2359".to_string()),
+                next_action: Some("Post Board handoff".to_string()),
+                summary: Some("Blocked state from legacy journal.".to_string()),
+                agent_session_id: Some("session-legacy".to_string()),
+                agent_current_focus: None,
+                agent_title_summary: Some("WorkItem history".to_string()),
+                updated_at: second_at,
+            },
+        )
+        .expect("append second journal");
+
+        let synthesized = load_or_synthesize_workspace_work_items_from_paths(
+            &work_items_path,
+            &current_path,
+            &journal_path,
+            &project_root,
+        )
+        .expect("synthesize work items");
+
+        assert_eq!(synthesized.work_items.len(), 1);
+        let item = &synthesized.work_items[0];
+        assert_eq!(item.id, "workspace-current");
+        assert_eq!(item.title, "Workspace WorkItem history");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Active);
+        assert_eq!(item.owner.as_deref(), Some("SPEC-2359"));
+        assert_eq!(item.board_refs, vec!["board-legacy-1".to_string()]);
+        assert_eq!(item.events.len(), 2);
+        assert_eq!(
+            item.events[0].summary.as_deref(),
+            Some("Started from legacy journal.")
+        );
+        assert_eq!(item.events[1].kind, WorkspaceWorkEventKind::Blocked);
+        assert!(
+            !work_items_path.exists(),
+            "legacy migration must be read-only until a real WorkItem event is recorded"
         );
     }
 

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -215,6 +215,17 @@ impl AppRuntime {
             );
             return None;
         }
+        let work_event =
+            workspace_projection::workspace_work_event_from_board_entry(&projection, entry);
+        if let Err(error) =
+            workspace_projection::record_workspace_work_event(project_root, work_event)
+        {
+            tracing::warn!(
+                error = %error,
+                project_root = %project_root.display(),
+                "failed to record workspace WorkItem event for board milestone"
+            );
+        }
 
         if self.active_tab_id.as_deref() != Some(tab_id) {
             return None;

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -608,12 +608,18 @@ fn active_work_projection_from_saved(
     let cleanup_candidate = projection
         .cleanup_candidate(false)
         .map(active_work_cleanup_candidate_view_from_candidate);
-    active_work_projection_from_saved_with_journal(projection, Vec::new(), cleanup_candidate)
+    active_work_projection_from_saved_with_journal(
+        projection,
+        Vec::new(),
+        Vec::new(),
+        cleanup_candidate,
+    )
 }
 
 fn active_work_projection_from_saved_with_journal(
     projection: gwt_core::workspace_projection::WorkspaceProjection,
     journal_entries: Vec<gwt::WorkspaceJournalEntryView>,
+    work_items: Vec<gwt::WorkspaceWorkItemView>,
     cleanup_candidate: Option<gwt::ActiveWorkCleanupCandidateView>,
 ) -> gwt::ActiveWorkProjectionView {
     use gwt_core::workspace_projection::WorkspaceStatusCategory;
@@ -687,6 +693,7 @@ fn active_work_projection_from_saved_with_journal(
         pr_created_at,
         board_refs: projection.board_refs,
         journal_entries,
+        work_items,
         cleanup_candidate,
         agents,
     }
@@ -714,6 +721,7 @@ fn empty_active_work_projection_view(
         pr_created_at: None,
         board_refs: Vec::new(),
         journal_entries: Vec::new(),
+        work_items: Vec::new(),
         cleanup_candidate: None,
         agents: Vec::new(),
     }
@@ -754,6 +762,117 @@ fn workspace_journal_entry_view_from_entry(
         agent_session_id: entry.agent_session_id.clone(),
         agent_current_focus: entry.agent_current_focus.clone(),
         agent_title_summary: entry.agent_title_summary.clone(),
+    }
+}
+
+fn workspace_work_item_view_from_item(
+    item: &gwt_core::workspace_projection::WorkspaceWorkItem,
+) -> gwt::WorkspaceWorkItemView {
+    gwt::WorkspaceWorkItemView {
+        id: item.id.clone(),
+        title: item.title.clone(),
+        intent: item.intent.clone(),
+        summary: item.summary.clone(),
+        status_category: workspace_status_category_wire(item.status_category).to_string(),
+        owner: item.owner.clone(),
+        created_at: item
+            .created_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        updated_at: item
+            .updated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        completed_at: item
+            .completed_at
+            .map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        agents: item
+            .agents
+            .iter()
+            .map(workspace_work_agent_view_from_ref)
+            .collect(),
+        execution_containers: item
+            .execution_containers
+            .iter()
+            .map(workspace_execution_container_view_from_ref)
+            .collect(),
+        board_refs: item.board_refs.clone(),
+        related_work_item_ids: item.related_work_item_ids.clone(),
+        events: item
+            .events
+            .iter()
+            .map(workspace_work_event_view_from_event)
+            .collect(),
+    }
+}
+
+fn workspace_work_agent_view_from_ref(
+    agent: &gwt_core::workspace_projection::WorkspaceWorkAgentRef,
+) -> gwt::WorkspaceWorkAgentView {
+    gwt::WorkspaceWorkAgentView {
+        session_id: agent.session_id.clone(),
+        agent_id: agent.agent_id.clone(),
+        display_name: agent.display_name.clone(),
+        updated_at: agent
+            .updated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+    }
+}
+
+fn workspace_execution_container_view_from_ref(
+    container: &gwt_core::workspace_projection::WorkspaceExecutionContainerRef,
+) -> gwt::WorkspaceExecutionContainerView {
+    gwt::WorkspaceExecutionContainerView {
+        branch: container.branch.clone(),
+        worktree_path: container
+            .worktree_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        pr_number: container.pr_number,
+        pr_url: container.pr_url.clone(),
+        pr_state: container.pr_state.clone(),
+    }
+}
+
+fn workspace_work_event_view_from_event(
+    event: &gwt_core::workspace_projection::WorkspaceWorkEvent,
+) -> gwt::WorkspaceWorkEventView {
+    gwt::WorkspaceWorkEventView {
+        id: event.id.clone(),
+        work_item_id: event.work_item_id.clone(),
+        kind: workspace_work_event_kind_wire(event.kind).to_string(),
+        title: event.title.clone(),
+        intent: event.intent.clone(),
+        summary: event.summary.clone(),
+        status_category: event
+            .status_category
+            .map(workspace_status_category_wire)
+            .map(str::to_string),
+        owner: event.owner.clone(),
+        next_action: event.next_action.clone(),
+        agent_session_id: event.agent_session_id.clone(),
+        board_entry_id: event.board_entry_id.clone(),
+        related_work_item_id: event.related_work_item_id.clone(),
+        updated_at: event
+            .updated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+    }
+}
+
+fn workspace_work_event_kind_wire(
+    kind: gwt_core::workspace_projection::WorkspaceWorkEventKind,
+) -> &'static str {
+    use gwt_core::workspace_projection::WorkspaceWorkEventKind;
+
+    match kind {
+        WorkspaceWorkEventKind::Start => "start",
+        WorkspaceWorkEventKind::Claim => "claim",
+        WorkspaceWorkEventKind::Update => "update",
+        WorkspaceWorkEventKind::Blocked => "blocked",
+        WorkspaceWorkEventKind::Handoff => "handoff",
+        WorkspaceWorkEventKind::Resume => "resume",
+        WorkspaceWorkEventKind::Split => "split",
+        WorkspaceWorkEventKind::Merge => "merge",
+        WorkspaceWorkEventKind::Pr => "pr",
+        WorkspaceWorkEventKind::Done => "done",
     }
 }
 
@@ -1228,7 +1347,51 @@ fn save_workspace_launch_projection(
     projection.updated_at = now;
 
     gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
+        .map_err(|error| error.to_string())?;
+    let work_event_kind = if workspace_resume_context.is_some() {
+        gwt_core::workspace_projection::WorkspaceWorkEventKind::Resume
+    } else {
+        gwt_core::workspace_projection::WorkspaceWorkEventKind::Start
+    };
+    let work_event =
+        workspace_work_event_from_launch_projection(&projection, session, work_event_kind, now);
+    gwt_core::workspace_projection::record_workspace_work_event(project_root, work_event)
         .map_err(|error| error.to_string())
+}
+
+fn workspace_work_event_from_launch_projection(
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
+    session: &ActiveAgentSession,
+    kind: gwt_core::workspace_projection::WorkspaceWorkEventKind,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> gwt_core::workspace_projection::WorkspaceWorkEvent {
+    let mut event = gwt_core::workspace_projection::WorkspaceWorkEvent::new(
+        kind,
+        projection.id.clone(),
+        updated_at,
+    );
+    event.title = Some(projection.title.clone());
+    event.intent = projection
+        .summary
+        .clone()
+        .or_else(|| projection.next_action.clone());
+    event.summary = Some(projection.status_text.clone());
+    event.status_category = Some(projection.status_category);
+    event.owner = projection.owner.clone();
+    event.next_action = projection.next_action.clone();
+    event.agent_session_id = Some(session.session_id.clone());
+    event.agent_id = Some(session.agent_id.to_string());
+    event.display_name = Some(session.display_name.clone());
+    event.execution_container = projection.git_details.as_ref().map(|details| {
+        gwt_core::workspace_projection::WorkspaceExecutionContainerRef {
+            branch: details.branch.clone(),
+            worktree_path: details.worktree_path.clone(),
+            pr_number: details.pr_number,
+            pr_url: details.pr_url.clone(),
+            pr_state: details.pr_state.clone(),
+        }
+    });
+    event
 }
 
 fn save_start_work_workspace_projection(
@@ -2225,9 +2388,24 @@ impl AppRuntime {
                 .iter()
                 .map(workspace_journal_entry_view_from_entry)
                 .collect::<Vec<_>>();
+            let work_items =
+                gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(
+                    &tab.project_root,
+                )
+                .unwrap_or_else(
+                    |_| gwt_core::workspace_projection::WorkspaceWorkItemsProjection {
+                        updated_at,
+                        work_items: Vec::new(),
+                    },
+                )
+                .work_items
+                .iter()
+                .map(workspace_work_item_view_from_item)
+                .collect::<Vec<_>>();
             return Some(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
+                work_items,
                 cleanup_candidate,
             ));
         }
@@ -2269,6 +2447,7 @@ impl AppRuntime {
             pr_created_at: None,
             board_refs: Vec::new(),
             journal_entries: Vec::new(),
+            work_items: Vec::new(),
             cleanup_candidate: None,
             agents,
         })
@@ -3622,11 +3801,24 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
     .iter()
     .map(workspace_journal_entry_view_from_entry)
     .collect::<Vec<_>>();
+    let work_items =
+        gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(project_root)
+            .unwrap_or_else(
+                |_| gwt_core::workspace_projection::WorkspaceWorkItemsProjection {
+                    updated_at: projection.updated_at,
+                    work_items: Vec::new(),
+                },
+            )
+            .work_items
+            .iter()
+            .map(workspace_work_item_view_from_item)
+            .collect::<Vec<_>>();
     Some(OutboundEvent::broadcast(
         BackendEvent::ActiveWorkProjection {
             projection: Box::new(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
+                work_items,
                 None,
             )),
         },
@@ -7557,6 +7749,20 @@ exit 0
         assert!(details.created_by_start_work);
         assert_eq!(projection.agents.len(), 1);
         assert_eq!(projection.agents[0].session_id, "session-1");
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(work_items.work_items.len(), 1);
+        assert_eq!(
+            work_items.work_items[0].events[0].kind,
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Start
+        );
+        assert_eq!(
+            work_items.work_items[0].execution_containers[0]
+                .branch
+                .as_deref(),
+            Some("work/20260504-1234")
+        );
     }
 
     #[test]
@@ -7641,6 +7847,13 @@ exit 0
         assert!(details.created_by_start_work);
         assert_eq!(projection.agents.len(), 1);
         assert_eq!(projection.agents[0].session_id, "session-1");
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(
+            work_items.work_items[0].events[0].kind,
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Resume
+        );
     }
 
     #[test]
@@ -9796,6 +10009,17 @@ exit 0
         );
         assert_eq!(projection.owner.as_deref(), Some("SPEC-2359"));
         assert_eq!(projection.board_refs.len(), 1);
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(
+            work_items.work_items[0].board_refs,
+            vec![board_entry_id.clone()]
+        );
+        assert_eq!(
+            work_items.work_items[0].events[0].kind,
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Update
+        );
         let projected_event = events
             .iter()
             .find_map(|event| match event {

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -23,8 +23,8 @@ use gwt_core::{
     coordination::{load_snapshot, BoardEntry, BoardEntryKind, BoardMentionTargetKind},
     paths::{gwt_cache_dir, gwt_sessions_dir},
     workspace_projection::{
-        load_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
-        WorkspaceStatusCategory,
+        load_or_synthesize_workspace_work_items, load_workspace_projection, WorkspaceAgentSummary,
+        WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkItem,
     },
 };
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
@@ -306,6 +306,11 @@ fn workspace_coordination_conflicts(
             current_session_id,
         ));
     }
+    conflicts.extend(workspace_work_item_conflicts(
+        worktree_root,
+        current_intent,
+        current_session_id,
+    )?);
     conflicts.extend(board_claim_conflicts(
         worktree_root,
         current_intent,
@@ -347,6 +352,43 @@ fn workspace_agent_conflicts(
             })
         })
         .collect()
+}
+
+fn workspace_work_item_conflicts(
+    worktree_root: &Path,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
+    let projection = load_or_synthesize_workspace_work_items(worktree_root)?;
+    Ok(projection
+        .work_items
+        .iter()
+        .filter(|item| item.is_incomplete())
+        .filter(|item| {
+            current_session_id.is_none_or(|session_id| {
+                !item
+                    .agents
+                    .iter()
+                    .any(|agent| agent.session_id == session_id)
+            })
+        })
+        .filter_map(|item| {
+            let text = workspace_work_item_text(item);
+            is_similar_work(current_intent, &text).then(|| {
+                let first_agent = item.agents.first();
+                let first_container = item.execution_containers.first();
+                WorkspaceCoordinationConflict {
+                    source_label: "incomplete Workspace WorkItem",
+                    title: item.title.clone(),
+                    session_id: first_agent.map(|agent| agent.session_id.clone()),
+                    branch: first_container.and_then(|container| container.branch.clone()),
+                    agent_id: first_agent.and_then(|agent| agent.agent_id.clone()),
+                    related_owners: item.owner.iter().cloned().collect(),
+                    related_topics: vec![item.id.clone()],
+                }
+            })
+        })
+        .collect())
 }
 
 fn board_claim_conflicts(
@@ -433,6 +475,39 @@ fn workspace_agent_text(agent: &WorkspaceAgentSummary) -> String {
     push_optional(&mut parts, agent.branch.as_deref());
     parts.push(agent.agent_id.as_str());
     parts.push(agent.display_name.as_str());
+    parts.join("\n")
+}
+
+fn workspace_work_item_text(item: &WorkspaceWorkItem) -> String {
+    let mut parts = Vec::new();
+    parts.push(item.title.as_str());
+    push_optional(&mut parts, item.intent.as_deref());
+    push_optional(&mut parts, item.summary.as_deref());
+    push_optional(&mut parts, item.owner.as_deref());
+    parts.extend(item.board_refs.iter().map(String::as_str));
+    for agent in &item.agents {
+        parts.push(agent.session_id.as_str());
+        push_optional(&mut parts, agent.agent_id.as_deref());
+        push_optional(&mut parts, agent.display_name.as_deref());
+    }
+    for container in &item.execution_containers {
+        push_optional(&mut parts, container.branch.as_deref());
+        push_optional(
+            &mut parts,
+            container
+                .worktree_path
+                .as_ref()
+                .and_then(|path| path.to_str()),
+        );
+        push_optional(&mut parts, container.pr_url.as_deref());
+        push_optional(&mut parts, container.pr_state.as_deref());
+    }
+    for event in &item.events {
+        push_optional(&mut parts, event.title.as_deref());
+        push_optional(&mut parts, event.intent.as_deref());
+        push_optional(&mut parts, event.summary.as_deref());
+        push_optional(&mut parts, event.next_action.as_deref());
+    }
     parts.join("\n")
 }
 

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -99,6 +99,8 @@ pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
     ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FocusCycleDirection,
     FrontendEvent, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView,
-    RecentProjectView, WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView,
+    RecentProjectView, WorkspaceExecutionContainerView, WorkspaceJournalEntryView,
+    WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView, WorkspaceWorkEventView,
+    WorkspaceWorkItemView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -438,6 +438,58 @@ pub struct WorkspaceJournalEntryView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceWorkAgentView {
+    pub session_id: String,
+    pub agent_id: Option<String>,
+    pub display_name: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceExecutionContainerView {
+    pub branch: Option<String>,
+    pub worktree_path: Option<String>,
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub pr_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceWorkEventView {
+    pub id: String,
+    pub work_item_id: String,
+    pub kind: String,
+    pub title: Option<String>,
+    pub intent: Option<String>,
+    pub summary: Option<String>,
+    pub status_category: Option<String>,
+    pub owner: Option<String>,
+    pub next_action: Option<String>,
+    pub agent_session_id: Option<String>,
+    pub board_entry_id: Option<String>,
+    pub related_work_item_id: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceWorkItemView {
+    pub id: String,
+    pub title: String,
+    pub intent: Option<String>,
+    pub summary: Option<String>,
+    pub status_category: String,
+    pub owner: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub completed_at: Option<String>,
+    pub agents: Vec<WorkspaceWorkAgentView>,
+    pub execution_containers: Vec<WorkspaceExecutionContainerView>,
+    pub board_refs: Vec<String>,
+    pub related_work_item_ids: Vec<String>,
+    pub events: Vec<WorkspaceWorkEventView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkCleanupCandidateView {
     pub branch: String,
     pub worktree_path: Option<String>,
@@ -465,6 +517,7 @@ pub struct ActiveWorkProjectionView {
     pub pr_created_at: Option<String>,
     pub board_refs: Vec<String>,
     pub journal_entries: Vec<WorkspaceJournalEntryView>,
+    pub work_items: Vec<WorkspaceWorkItemView>,
     pub cleanup_candidate: Option<ActiveWorkCleanupCandidateView>,
     pub agents: Vec<ActiveWorkAgentView>,
 }
@@ -915,6 +968,7 @@ mod tests {
                     agent_current_focus: Some("Run launch tests".to_string()),
                     agent_title_summary: Some("Launch tests".to_string()),
                 }],
+                work_items: Vec::new(),
                 cleanup_candidate: Some(super::ActiveWorkCleanupCandidateView {
                     branch: "work/20260504-1200".to_string(),
                     worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -15,8 +15,8 @@ use gwt_core::{
     paths::gwt_sessions_dir,
     repo_hash::compute_repo_hash,
     workspace_projection::{
-        save_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
-        WorkspaceStatusCategory,
+        record_workspace_work_event, save_workspace_projection, WorkspaceAgentSummary,
+        WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
     },
 };
 use gwt_github::{
@@ -215,6 +215,36 @@ fn seed_workspace_agents(
         other_title,
     ));
     save_workspace_projection(repo_path, &projection).expect("save workspace projection");
+}
+
+fn seed_workspace_current_agent(repo_path: &Path, session_id: &str, title: &str, focus: &str) {
+    let mut projection = WorkspaceProjection::default_for_project(repo_path);
+    projection
+        .agents
+        .push(workspace_agent(session_id, focus, title));
+    save_workspace_projection(repo_path, &projection).expect("save workspace projection");
+}
+
+fn seed_workspace_work_item(
+    repo_path: &Path,
+    work_item_id: &str,
+    kind: WorkspaceWorkEventKind,
+    title: &str,
+    session_id: &str,
+) {
+    let mut event = WorkspaceWorkEvent::new(kind, work_item_id, Utc::now());
+    event.title = Some(title.to_string());
+    event.intent = Some("Implement Workspace WorkItem lifecycle history".to_string());
+    event.summary =
+        Some("Workspace WorkItem history should be joined instead of duplicated.".to_string());
+    event.status_category = Some(match kind {
+        WorkspaceWorkEventKind::Done => WorkspaceStatusCategory::Done,
+        _ => WorkspaceStatusCategory::Active,
+    });
+    event.agent_session_id = Some(session_id.to_string());
+    event.agent_id = Some("codex".to_string());
+    event.display_name = Some("Codex".to_string());
+    record_workspace_work_event(repo_path, event).expect("record workspace work item");
 }
 
 fn seed_issue_linkage(repo_path: &Path, branch: &str, issue_number: u64) {
@@ -679,5 +709,89 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
         };
         assert!(detail.contains("active Board claim"), "{detail}");
         assert!(detail.contains("session-other"), "{detail}");
+    });
+}
+
+#[test]
+fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_current_agent(
+            &repo_path,
+            &session_id,
+            "Workspace WorkItem history",
+            "Implement Workspace WorkItem lifecycle history",
+        );
+        seed_workspace_work_item(
+            &repo_path,
+            "workitem-existing",
+            WorkspaceWorkEventKind::Start,
+            "Workspace WorkItem history duplicate prevention",
+            "session-other",
+        );
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt-core/src/workspace_projection.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected incomplete WorkItem conflict to block mutation");
+        };
+        assert!(detail.contains("incomplete Workspace WorkItem"), "{detail}");
+        assert!(detail.contains("session-other"), "{detail}");
+        assert!(detail.contains("gwtd board post"), "{detail}");
+    });
+}
+
+#[test]
+fn completed_work_item_history_does_not_block_new_related_work() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_current_agent(
+            &repo_path,
+            &session_id,
+            "Workspace WorkItem history",
+            "Implement Workspace WorkItem lifecycle history follow-up",
+        );
+        seed_workspace_work_item(
+            &repo_path,
+            "workitem-completed",
+            WorkspaceWorkEventKind::Done,
+            "Workspace WorkItem history",
+            "session-other",
+        );
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt-core/src/workspace_projection.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "completed WorkItem history must be context only"
+        );
     });
 }

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -148,6 +148,92 @@ test("Workspace Kanban labels the non-current history column as Inactive", () =>
   );
 });
 
+test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", () => {
+  const fixture = createFixture();
+  const projection = {
+    id: "current-workspace",
+    title: "Legacy current Workspace",
+    status_category: "idle",
+    status_text: "Idle",
+    work_items: [
+      {
+        id: "workitem-history",
+        title: "Workspace WorkItem history",
+        intent: "Group duplicate Workspace work under one WorkItem",
+        summary: "One WorkItem owns the history.",
+        status_category: "active",
+        owner: "SPEC-2359",
+        agents: [
+          {
+            session_id: "session-other",
+            display_name: "Codex",
+            status_category: "active",
+          },
+        ],
+        execution_containers: [
+          {
+            branch: "work/20260510-2353",
+            worktree_path: "/repo/work/20260510-2353",
+            pr_number: 2638,
+            pr_url: "https://github.com/akiojin/gwt/pull/2638",
+            pr_state: "open",
+          },
+        ],
+        board_refs: ["board-claim-1"],
+        events: [
+          {
+            id: "evt-start",
+            kind: "start",
+            title: "Start WorkItem",
+            summary: "Started lifecycle implementation.",
+            updated_at: "2026-05-11T01:00:00Z",
+            agent_session_id: "session-other",
+            board_entry_id: "board-claim-1",
+          },
+          {
+            id: "evt-blocked",
+            kind: "blocked",
+            summary: "Waiting for Board coordination.",
+            updated_at: "2026-05-11T01:10:00Z",
+            agent_session_id: "session-other",
+            board_entry_id: "board-blocked-1",
+          },
+        ],
+      },
+    ],
+    journal_entries: [
+      {
+        id: "legacy-journal",
+        status_category: "active",
+        agent_title_summary: "Legacy duplicate card",
+      },
+    ],
+  };
+
+  const surface = createSurface(fixture, projection);
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const cardText = cardTexts(column(fixture.body, "active")).join("\n");
+  assert.match(cardText, /WorkItem/);
+  assert.match(cardText, /Workspace WorkItem history/);
+  assert.doesNotMatch(cardText, /Legacy duplicate card/);
+
+  const detailText = fixture.body
+    .querySelector(".workspace-kanban-detail-pane")
+    .textContent.replace(/\s+/g, " ")
+    .trim();
+  assert.match(detailText, /Lifecycle/);
+  assert.match(detailText, /start/);
+  assert.match(detailText, /Started lifecycle implementation/);
+  assert.match(detailText, /board-claim-1/);
+  assert.match(detailText, /blocked/);
+  assert.match(detailText, /Waiting for Board coordination/);
+  assert.match(detailText, /board-blocked-1/);
+});
+
 function createFixture() {
   const { document } = parseHTML(`
     <div id="workspace-window">

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -73,10 +73,48 @@ export function createWorkspaceKanbanSurface({
     const title = projection.title || `${activeWorkspace().title || "Project"} workspace`;
     const branch = projection.branch || "";
     const worktreePath = projection.worktree_path || "";
+    const workItems = Array.isArray(projection.work_items)
+      ? projection.work_items
+      : [];
+    if (workItems.length > 0) {
+      return workItems.map((item) => {
+        const containers = Array.isArray(item.execution_containers)
+          ? item.execution_containers
+          : [];
+        const container = containers[0] || {};
+        return {
+          id: item.id || `workitem-${item.title || "workspace"}`,
+          kind: "work_item",
+          label: "WorkItem",
+          title: item.title || item.intent || "Workspace WorkItem",
+          intent: item.intent || "",
+          status_category: item.status_category || "idle",
+          status_text: item.summary || item.intent || "",
+          summary: item.summary || item.intent || "",
+          owner: item.owner || "",
+          next_action: "",
+          branch: container.branch || "",
+          worktree_path: container.worktree_path || "",
+          pr_number: container.pr_number || null,
+          pr_url: container.pr_url || "",
+          pr_state: container.pr_state || "",
+          board_refs: Array.isArray(item.board_refs) ? item.board_refs : [],
+          agents: Array.isArray(item.agents) ? item.agents : [],
+          execution_containers: containers,
+          cleanup_candidate: null,
+          updated_at: item.updated_at || "",
+          resume_source: "current",
+          journal_id: null,
+          events: Array.isArray(item.events) ? item.events : [],
+          column: workspaceColumnForCurrentStatus(item.status_category),
+        };
+      });
+    }
     const cards = [
       {
         id: projection.id || "__current_workspace__",
         kind: "current",
+        label: "Current",
         title,
         status_category: projection.status_category || "idle",
         status_text: projection.status_text || "No active work",
@@ -94,6 +132,7 @@ export function createWorkspaceKanbanSurface({
         updated_at: projection.updated_at || "",
         resume_source: "current",
         journal_id: null,
+        events: [],
         column: workspaceColumnForCurrentStatus(projection.status_category),
       },
     ];
@@ -129,6 +168,7 @@ export function createWorkspaceKanbanSurface({
         updated_at: entry.updated_at || "",
         resume_source: "journal",
         journal_id: entry.id || "",
+        events: [],
         column: workspaceColumnForJournalStatus(statusCategory),
       });
     }
@@ -168,7 +208,11 @@ export function createWorkspaceKanbanSurface({
 
     const head = createNode("div", "kanban-card-head");
     head.appendChild(
-      createNode("span", "kanban-card-number", cardData.kind === "current" ? "Current" : "Update"),
+      createNode(
+        "span",
+        "kanban-card-number",
+        cardData.label || (cardData.kind === "current" ? "Current" : "Update"),
+      ),
     );
     head.appendChild(
       createNode(
@@ -279,6 +323,32 @@ export function createWorkspaceKanbanSurface({
       context.appendChild(createNode("div", "knowledge-section-title", "Workspace Context"));
       context.appendChild(createNode("pre", "knowledge-section-body", cardData.worktree_path));
       scroll.appendChild(context);
+    }
+
+    if (cardData.events.length > 0) {
+      const lifecycle = createNode("section", "knowledge-section");
+      lifecycle.appendChild(createNode("div", "knowledge-section-title", "Lifecycle"));
+      lifecycle.appendChild(
+        createNode(
+          "pre",
+          "knowledge-section-body",
+          cardData.events
+            .map((event) =>
+              [
+                event.updated_at || "",
+                event.kind || "update",
+                event.title || event.intent || "",
+                event.summary || "",
+                event.board_entry_id ? `board:${event.board_entry_id}` : "",
+                event.agent_session_id ? `session:${event.agent_session_id}` : "",
+              ]
+                .filter(Boolean)
+                .join(" · "),
+            )
+            .join("\n"),
+        ),
+      );
+      scroll.appendChild(lifecycle);
     }
 
     if (cardData.agents.length > 0) {


### PR DESCRIPTION
## Summary

- Add first-class Workspace WorkItem history so similar work can converge on existing work instead of creating duplicate Workspace entries.
- Record Start, Resume, Board, and Workspace update lifecycle events with execution container and Board references.
- Render WorkItem history in Workspace Overview and block duplicate mutation only while matching WorkItems are incomplete.

## Changes

- `crates/gwt-core/src/workspace_projection.rs`: added WorkItem/WorkEvent data model, event append/projection helpers, legacy current/journal synthesis, and lifecycle tests.
- `crates/gwt-core/src/paths.rs`: added project-scoped WorkItem and WorkEvent storage paths.
- `crates/gwt/src/app_runtime`: records WorkItem events from Start, Resume, Board, and Workspace projection updates and exposes WorkItems in active-work projection responses.
- `crates/gwt/src/protocol.rs`: extends active-work projection DTOs with WorkItem, lifecycle event, agent, and execution-container views.
- `crates/gwt/src/cli/hook/workflow_policy.rs`: checks incomplete WorkItems as duplicate coordination blockers while leaving completed history as context only.
- `crates/gwt/web/workspace-kanban-surface.js`: renders WorkItem cards as the primary Workspace history with lifecycle timeline details and Board/session references.
- `crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs` and `crates/gwt/tests/hook_workflow_policy_test.rs`: added regression coverage for WorkItem rendering and duplicate-blocking behavior.

## Testing

- [x] `cargo test -p gwt-core workspace_work -- --nocapture` — passed.
- [x] `cargo test -p gwt --test hook_workflow_policy_test work_item -- --nocapture` — passed.
- [x] `pnpm exec node --test crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs` — passed.
- [x] `cargo test -p gwt app_runtime_start_work_launch_completion_records_workspace_git_details -- --nocapture` — passed.
- [x] `cargo test -p gwt app_runtime_workspace_resume_launch_completion_carries_context_to_projection -- --nocapture` — passed.
- [x] `cargo test -p gwt app_runtime_post_board_entry_updates_workspace_projection_current_state -- --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `pnpm run test:frontend-unit` — passed.
- [x] `pnpm run test:frontend-bundle` — passed.
- [x] `pnpm run test:frontend-smoke` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `git diff --check` — passed.
- [x] `git push` pre-push checks — passed with filtered line coverage 90.23%.

## Closing Issues

- None

## Related Issues / Links

- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2359 tasks updated)
- [x] Migration/backfill plan included (legacy Workspace current/journal synthesis is read-only)
- [x] CHANGELOG impact considered (feature commit, no breaking change)

## Context

- Workspace coordination needs durable WorkItem history so agents do not repeat similar work and can use Board for communication when an incomplete WorkItem already owns the scope.

## Risk / Impact

- **Affected areas**: Workspace projection storage, Board/Workspace lifecycle recording, workflow-policy duplicate guard, and Workspace Overview rendering.
- **Rollback plan**: Revert the PR; legacy `current.json` and `journal.jsonl` remain readable and are not rewritten by the synthesis path.
