### PR TITLE
fix(gui): surface launch wizard open errors

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -7311,6 +7311,60 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_open_start_work_failure_surfaces_launch_wizard_open_error() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo,
+            ProjectKind::Git,
+            &[WindowPreset::Board],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::OpenStartWork);
+
+        assert!(runtime.launch_wizard.is_none());
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::LaunchWizardOpenError { title, message })
+                if title == "Start Work" && !message.is_empty()
+        ));
+    }
+
+    #[test]
+    fn app_runtime_open_launch_wizard_failure_surfaces_launch_wizard_open_error() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenLaunchWizard {
+                id: "missing-window".to_string(),
+                branch_name: "main".to_string(),
+                linked_issue_number: None,
+            },
+        );
+
+        assert!(runtime.launch_wizard.is_none());
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::LaunchWizardOpenError { title, message })
+                if title == "Launch Agent" && message == "Window not found"
+        ));
+    }
+
+    #[test]
     fn app_runtime_custom_agent_cache_refresh_rebroadcasts_open_wizard_state() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -38,6 +38,21 @@ fn linked_issue_kind_from_knowledge(kind: KnowledgeKind) -> Option<LinkedIssueKi
     }
 }
 
+fn launch_wizard_open_error(title: &str, message: impl Into<String>) -> OutboundEvent {
+    OutboundEvent::broadcast(BackendEvent::LaunchWizardOpenError {
+        title: title.to_string(),
+        message: message.into(),
+    })
+}
+
+fn launch_agent_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error("Launch Agent", message)]
+}
+
+fn start_work_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error("Start Work", message)]
+}
+
 use super::{
     branch_worktree_path, build_shell_process_launch, combined_window_id,
     detect_wizard_docker_context_and_status, knowledge_error_event, knowledge_kind_for_preset,
@@ -80,29 +95,17 @@ impl AppRuntime {
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id).cloned() else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            })];
+            return launch_agent_open_error("Window not found");
         };
         let Some(tab) = self.tab(&address.tab_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Project tab not found".to_string(),
-            })];
+            return launch_agent_open_error("Project tab not found");
         };
         let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            })];
+            return launch_agent_open_error("Window not found");
         };
 
         if window.preset != WindowPreset::Branches {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window is not a branches list".to_string(),
-            })];
+            return launch_agent_open_error("Window is not a branches list");
         }
 
         let project_root = tab.project_root.clone();
@@ -115,10 +118,7 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: error,
-            })],
+            Err(error) => launch_agent_open_error(error),
         }
     }
 
@@ -194,19 +194,13 @@ impl AppRuntime {
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Open a project before adding an agent".to_string(),
-            })];
+            return launch_agent_open_error("Open a project before adding an agent");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Project tab not found".to_string(),
-            })];
+            return launch_agent_open_error("Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Add Agent requires a Git project".to_string(),
-            })];
+            return launch_agent_open_error("Add Agent requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
@@ -218,35 +212,25 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: error,
-            })],
+            Err(error) => launch_agent_open_error(error),
         }
     }
 
     pub(crate) fn open_start_work(&mut self) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Open a project before starting work".to_string(),
-            })];
+            return start_work_open_error("Open a project before starting work");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Project tab not found".to_string(),
-            })];
+            return start_work_open_error("Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Start Work requires a Git project".to_string(),
-            })];
+            return start_work_open_error("Start Work requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
         match self.open_start_work_for_project(&tab_id, &project_root) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: error,
-            })],
+            Err(error) => start_work_open_error(error),
         }
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1975,11 +1975,11 @@ mod tests {
         )
         .expect("valid regex");
         let close_controls = regex::Regex::new(
-            r#"wizardCloseButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"cancel"\s*\}\);\s*\}\);\s*wizardCancelButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"cancel"\s*\}\);\s*\}\);"#,
+            r#"wizardCloseButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\);\s*wizardCancelButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\);"#,
         )
         .expect("valid regex");
         let submit_button = regex::Regex::new(
-            r#"wizardSubmitButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*(?:flushWizardBranchDraft|frontendUnits\.launchWizardSurface\.flushBranchDraft)\(\);\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"submit"\s*\}\);\s*\}\);"#,
+            r#"wizardSubmitButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*if\s*\(\s*launchWizardOpenError\s*\)\s*\{\s*return;\s*\}\s*(?:flushWizardBranchDraft|frontendUnits\.launchWizardSurface\.flushBranchDraft)\(\);\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"submit"\s*\}\);\s*\}\);"#,
         )
         .expect("valid regex");
 
@@ -1998,22 +1998,28 @@ mod tests {
         );
         assert!(
             close_controls.is_match(html),
-            "expected both close controls to route cancel through sendWizardAction",
+            "expected both close controls to share the wizard close helper",
+        );
+        assert!(
+            html.contains("function closeLaunchWizardFromChrome()")
+                && html.contains("closeLaunchWizardLocal();")
+                && html.contains("frontendUnits.launchWizardSurface.sendAction({ kind: \"cancel\" });"),
+            "expected close helper to local-close error-only state and send cancel for normal wizard state",
         );
         assert!(
             submit_button.is_match(html),
-            "expected submit control to flush branch draft before dispatching submit",
+            "expected submit control to ignore error-only state and flush branch draft before dispatching submit",
         );
         let backdrop_cancel = regex::Regex::new(
-            r#"if\s*\(\s*event\.target === wizardModal\s*\)\s*\{\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"cancel"\s*\}\);\s*\}"#,
+            r#"if\s*\(\s*event\.target === wizardModal\s*\)\s*\{\s*closeLaunchWizardFromChrome\(\);\s*\}"#,
         )
         .expect("valid regex");
         assert!(
             backdrop_cancel.is_match(html),
-            "expected backdrop dismissal to share the same wizard cancel transport",
+            "expected backdrop dismissal to share the same wizard close helper",
         );
         let wizard_state = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*launchWizardOpenError\s*=\s*null;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
         )
         .expect("valid regex");
         assert!(
@@ -2120,7 +2126,11 @@ mod tests {
         )
         .expect("valid regex");
         let wizard_event = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*launchWizardOpenError\s*=\s*null;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
+        )
+        .expect("valid regex");
+        let wizard_open_error_event = regex::Regex::new(
+            r#"case\s*"launch_wizard_open_error":\s*launchWizard\s*=\s*null;[\s\S]*?launchWizardOpenError\s*=\s*\{[\s\S]*?frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
         )
         .expect("valid regex");
 
@@ -2143,6 +2153,10 @@ mod tests {
         assert!(
             wizard_event.is_match(html),
             "expected launch wizard state events to render through the wizard surface unit",
+        );
+        assert!(
+            wizard_open_error_event.is_match(html),
+            "expected launch wizard open errors to render through the wizard surface unit",
         );
     }
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2240,15 +2240,16 @@ mod tests {
         assert_eq!(wizard_missing.len(), 1);
         assert!(matches!(
             wizard_missing[0].event,
-            BackendEvent::BranchError { ref message, .. } if message == "Window not found"
+            BackendEvent::LaunchWizardOpenError { ref title, ref message }
+                if title == "Launch Agent" && message == "Window not found"
         ));
 
         let wizard_wrong = runtime.open_launch_wizard(&file_tree_id, "feature/demo", None);
         assert_eq!(wizard_wrong.len(), 1);
         assert!(matches!(
             wizard_wrong[0].event,
-            BackendEvent::BranchError { ref message, .. }
-                if message == "Window is not a branches list"
+            BackendEvent::LaunchWizardOpenError { ref title, ref message }
+                if title == "Launch Agent" && message == "Window is not a branches list"
         ));
 
         let issue_missing = runtime.open_issue_launch_wizard_events("client-1", "missing", 7);

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -605,6 +605,10 @@ pub enum BackendEvent {
     ProjectOpenError {
         message: String,
     },
+    LaunchWizardOpenError {
+        title: String,
+        message: String,
+    },
     LaunchWizardState {
         wizard: Option<Box<LaunchWizardView>>,
     },
@@ -1007,6 +1011,29 @@ mod tests {
         assert!(
             matches!(event, FrontendEvent::OpenStartWork),
             "Start Work must be a global command, not a Branches window event"
+        );
+    }
+
+    #[test]
+    fn launch_wizard_open_error_serializes_modal_error_contract() {
+        let event = BackendEvent::LaunchWizardOpenError {
+            title: "Start Work".to_string(),
+            message: "Default base branch not found".to_string(),
+        };
+
+        let value = serde_json::to_value(&event).expect("serialize launch wizard open error");
+
+        assert_eq!(
+            value.get("kind"),
+            Some(&Value::String("launch_wizard_open_error".to_string()))
+        );
+        assert_eq!(
+            value.get("title"),
+            Some(&Value::String("Start Work".to_string()))
+        );
+        assert_eq!(
+            value.get("message"),
+            Some(&Value::String("Default base branch not found".to_string()))
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1176,6 +1176,19 @@ test("Branch rows are keyboard-navigable with click + dblclick parity", () => {
   );
 });
 
+test("Branches toolbar exposes explicit Launch Agent action for selected branch", () => {
+  assert.match(
+    appSource,
+    /data-action="open-branch-launch"/,
+    "expected Branches toolbar to include an explicit Launch Agent action",
+  );
+  assert.match(
+    appSource,
+    /selectedBranchName[\s\S]{0,300}?kind:\s*"open_launch_wizard"|kind:\s*"open_launch_wizard"[\s\S]{0,300}?selectedBranchName/,
+    "expected Branches toolbar Launch Agent action to send selectedBranchName",
+  );
+});
+
 test("Keyboard-navigable rows have :focus-visible outlines", () => {
   // After PRs #2464/#2465 made file-tree-row and branch-row keyboard-
   // navigable, the rows could receive focus but had no visible outline
@@ -1192,6 +1205,29 @@ test("Keyboard-navigable rows have :focus-visible outlines", () => {
       `expected ${selector} to be in the unified focus-visible group`,
     );
   }
+});
+
+test("Launch wizard open errors render in wizard modal and close locally", () => {
+  assert.match(
+    appSource,
+    /let\s+launchWizardOpenError\s*=\s*null/,
+    "expected frontend to track launch wizard open errors separately from project_open_error",
+  );
+  assert.match(
+    appSource,
+    /case\s+"launch_wizard_open_error":[\s\S]{0,300}?launchWizardOpenError\s*=/,
+    "expected launch_wizard_open_error events to populate wizard error state",
+  );
+  assert.match(
+    appSource,
+    /function\s+closeLaunchWizardLocal\(\)[\s\S]{0,300}?launchWizardOpenError\s*=\s*null/,
+    "expected a local close path for error-only wizard state",
+  );
+  assert.match(
+    appSource,
+    /wizardModal\.classList\.contains\("open"\)[\s\S]{0,500}?closeLaunchWizardLocal\(\)[\s\S]{0,500}?sendAction\(\{\s*kind:\s*"cancel"/,
+    "expected Esc/backdrop/close to locally dismiss error-only wizard state before sending backend cancel",
+  );
 });
 
 test("File tree rows are keyboard-navigable (tabindex + role + keydown)", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -205,12 +205,14 @@
           owner: "launch-wizard-surface",
           state: Object.freeze([
             "launchWizard",
+            "launchWizardOpenError",
             "wizardWasOpen",
             "wizardBranchDraft",
             "wizardBranchBackendValue",
           ]),
           mutatedBy: Object.freeze([
             "openIssueLaunchWizard",
+            "closeLaunchWizardLocal",
             "sendWizardAction",
             "renderLaunchWizard",
             "flushWizardBranchDraft",
@@ -261,6 +263,7 @@
       let viewport = { x: 0, y: 0, zoom: 1 };
       let viewportRasterTimer = null;
       let launchWizard = null;
+      let launchWizardOpenError = null;
       let activeWorkProjection = null;
       let pendingBoardEntryFocusId = null;
       let wizardWasOpen = false;
@@ -4304,8 +4307,22 @@
       let wizardFocusReturn = null;
       let wizardFocusTrapRelease = null;
 
+      function closeLaunchWizardLocal() {
+        launchWizard = null;
+        launchWizardOpenError = null;
+        renderLaunchWizard();
+      }
+
+      function closeLaunchWizardFromChrome() {
+        if (launchWizardOpenError) {
+          closeLaunchWizardLocal();
+          return;
+        }
+        frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+      }
+
       function renderLaunchWizard() {
-        if (!launchWizard) {
+        if (!launchWizard && !launchWizardOpenError) {
           const wasOpenBeforeClose = wizardModal.classList.contains("open");
           wizardModal.classList.remove("open");
           // SPEC-2356 — keep aria-hidden in lockstep with .open so screen
@@ -4333,13 +4350,17 @@
           if (wizardTitle) wizardTitle.textContent = "Launch Agent";
           wizardSubmitButton.textContent = "Launch";
           wizardSubmitButton.disabled = false;
+          wizardSubmitButton.hidden = false;
+          wizardCancelButton.textContent = "Cancel";
           syncWizardDraftState();
           return;
         }
 
         syncWizardDraftState();
         closeModal();
-        const isStartWorkMode = launchWizard.show_branch_controls === false;
+        const isStartWorkMode =
+          launchWizard?.show_branch_controls === false ||
+          launchWizardOpenError?.title === "Start Work";
         wizardModal.classList.toggle("is-drawer", isStartWorkMode);
         wizardDialog?.classList.toggle("is-drawer-shell", isStartWorkMode);
         const wasOpenWizard = wizardModal.classList.contains("open");
@@ -4361,6 +4382,28 @@
           // keyboard users can't escape into background content.
           wizardFocusTrapRelease = createFocusTrap(wizardDialog, { document });
         }
+
+        if (launchWizardOpenError) {
+          if (wizardTitle) {
+            wizardTitle.textContent = launchWizardOpenError.title || "Launch Agent";
+          }
+          wizardMeta.textContent =
+            launchWizardOpenError.title === "Start Work"
+              ? "Workspace launch"
+              : "Launch Agent";
+          wizardSubmitButton.hidden = true;
+          wizardSubmitButton.disabled = true;
+          wizardCancelButton.textContent = "Close";
+          wizardError.hidden = false;
+          wizardError.textContent =
+            launchWizardOpenError.message || "Unable to open Launch Wizard";
+          wizardSummary.innerHTML = "";
+          wizardBody.innerHTML = "";
+          return;
+        }
+
+        wizardSubmitButton.hidden = false;
+        wizardCancelButton.textContent = "Cancel";
         if (wizardTitle) wizardTitle.textContent = launchWizard.title || "Launch Agent";
         wizardMeta.textContent = launchWizard.show_branch_controls === false
           ? "Workspace launch"
@@ -5136,6 +5179,7 @@
         syncBranchSelectionState(state);
         const list = element.querySelector(".branch-list");
         const notice = element.querySelector(".branch-notice");
+        const launchButton = element.querySelector("[data-action='open-branch-launch']");
         const cleanupButton = element.querySelector("[data-action='open-branch-cleanup']");
         if (!list) {
           return;
@@ -5143,6 +5187,9 @@
 
         for (const button of element.querySelectorAll("[data-branch-filter]")) {
           button.classList.toggle("active", button.dataset.branchFilter === state.filter);
+        }
+        if (launchButton) {
+          launchButton.disabled = !state.selectedBranchName;
         }
         if (cleanupButton) {
           const selectedCount = selectedBranchCleanupEntries(windowId).length;
@@ -6063,6 +6110,7 @@
                   </div>
                 </div>
                 <div class="branch-toolbar-actions workspace-toolbar-actions">
+                  <button class="wizard-button primary branch-launch-trigger" type="button" data-action="open-branch-launch" disabled>Launch Agent</button>
                   <button class="wizard-button branch-cleanup-trigger" type="button" data-action="open-branch-cleanup">Clean Up</button>
                   <button class="icon-button" data-action="refresh-branches" aria-label="Refresh branches">↻</button>
                 </div>
@@ -6099,6 +6147,22 @@
               frontendUnits.branchesFileTreeSurface.renderBranches(windowData.id);
             });
           }
+          body
+            .querySelector("[data-action='open-branch-launch']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = frontendUnits.branchesFileTreeSurface.ensureBranchListState(
+                windowData.id,
+              );
+              if (!state.selectedBranchName) {
+                return;
+              }
+              send({
+                kind: "open_launch_wizard",
+                id: windowData.id,
+                branch_name: state.selectedBranchName,
+              });
+            });
           body
             .querySelector("[data-action='open-branch-cleanup']")
             .addEventListener("click", (event) => {
@@ -7789,8 +7853,17 @@
               frontendUnits.projectWorkspaceShell.activeProjectTab(),
             );
             break;
+          case "launch_wizard_open_error":
+            launchWizard = null;
+            launchWizardOpenError = {
+              title: event.title || "Launch Agent",
+              message: event.message || "Unable to open Launch Wizard",
+            };
+            frontendUnits.launchWizardSurface.render();
+            break;
           case "launch_wizard_state":
             launchWizard = event.wizard;
+            launchWizardOpenError = null;
             frontendUnits.launchWizardSurface.render();
             break;
           case "runtime_hook_event":
@@ -8212,19 +8285,18 @@
           closeModal();
         }
       });
-      wizardCloseButton.addEventListener("click", () => {
-        frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
-      });
-      wizardCancelButton.addEventListener("click", () => {
-        frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
-      });
+      wizardCloseButton.addEventListener("click", closeLaunchWizardFromChrome);
+      wizardCancelButton.addEventListener("click", closeLaunchWizardFromChrome);
       wizardSubmitButton.addEventListener("click", () => {
+        if (launchWizardOpenError) {
+          return;
+        }
         frontendUnits.launchWizardSurface.flushBranchDraft();
         frontendUnits.launchWizardSurface.sendAction({ kind: "submit" });
       });
       wizardModal.addEventListener("click", (event) => {
         if (event.target === wizardModal) {
-          frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+          closeLaunchWizardFromChrome();
         }
       });
       branchCleanupModal.addEventListener("click", (event) => {
@@ -8268,7 +8340,11 @@
         if (wizardModal.classList.contains("open")) {
           // Wizard cancel is the explicit cancellation path; map Esc to
           // the same action so the modal isn't a keyboard trap.
-          frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+          if (launchWizardOpenError) {
+            closeLaunchWizardLocal();
+          } else {
+            frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+          }
           event.preventDefault();
           return;
         }


### PR DESCRIPTION
## Summary

- Surface Launch Wizard open failures through a dedicated backend event so Start Work and Branches Launch Agent errors are visible in the Wizard modal instead of being routed to hidden project/branch error surfaces.
- Add an explicit Branches toolbar Launch Agent button that opens the selected branch in the Launch Wizard.

## Changes

- `crates/gwt/src/protocol.rs`: Added the `launch_wizard_open_error` backend event contract and serialization coverage.
- `crates/gwt/src/app_runtime/wizard.rs`: Routed Start Work and Branches Launch Wizard open precondition failures to `LaunchWizardOpenError` without changing Project Picker `project_open_error` behavior.
- `crates/gwt/web/app.js`: Added error-only Launch Wizard rendering, local modal close behavior, and the Branches toolbar Launch Agent action.
- `crates/gwt/src/app_runtime/mod.rs`, `crates/gwt/src/embedded_web.rs`, `crates/gwt/src/main.rs`, `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: Added and updated Rust/frontend contract tests for the new event, modal state, and toolbar wiring.

## Testing

- [x] `cargo test -p gwt launch_wizard_open_error -- --nocapture` — passed after the base sync merge.
- [x] `bunx commitlint --from origin/work/20260511-0043 --to HEAD` — passed before pushing the merge.
- [x] `git push` — passed; pre-push hook ran CI-equivalent checks, Rust coverage, skill frontmatter validation, and coverage threshold.
- [x] Pre-push coverage gate — passed with filtered line coverage 90.25%.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not required: bugfix behavior is tracked in SPEC-2014 and README-facing workflow text did not change)
- [ ] Migration/backfill plan included (not required: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- This PR addresses the Windows Launch Agent / Start Work Wizard failure mode where opening the Wizard could fail but the error was not visible to the user in the active Wizard surface.

## Risk / Impact

- **Affected areas**: Launch Wizard open flow, Branches toolbar, frontend modal close handling, backend/frontend event protocol.
- **Rollback plan**: Revert this PR to restore the previous `project_open_error` / `branch_error` routing and remove the explicit Branches toolbar action.

## Screenshots

- Not captured; the changed UI state is an error precondition modal driven by backend event handling and is covered by frontend DOM contract tests.
