### PR TITLE
fix(gui): scope launch wizard open errors to client

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1943,7 +1943,7 @@ impl AppRuntime {
             FrontendEvent::OpenIssueLaunchWizard { id, issue_number } => {
                 self.open_issue_launch_wizard_events(&client_id, &id, issue_number)
             }
-            FrontendEvent::OpenStartWork => self.open_start_work(),
+            FrontendEvent::OpenStartWork => self.open_start_work(&client_id),
             FrontendEvent::ResumeWorkspace { source, journal_id } => {
                 self.resume_workspace_events(source, journal_id)
             }
@@ -1951,11 +1951,11 @@ impl AppRuntime {
                 id,
                 branch_name,
                 linked_issue_number,
-            } => self.open_launch_wizard(&id, &branch_name, linked_issue_number),
+            } => self.open_launch_wizard(&client_id, &id, &branch_name, linked_issue_number),
             FrontendEvent::OpenActiveWorkLaunchWizard {
                 branch_name,
                 linked_issue_number,
-            } => self.open_active_work_launch_wizard(&branch_name, linked_issue_number),
+            } => self.open_active_work_launch_wizard(&client_id, &branch_name, linked_issue_number),
             FrontendEvent::LaunchWizardAction { action, bounds } => {
                 self.handle_launch_wizard_action(action, bounds)
             }
@@ -7521,6 +7521,10 @@ exit 0
 
         assert!(runtime.launch_wizard.is_none());
         assert!(matches!(
+            events.first().map(|event| &event.target),
+            Some(DispatchTarget::Client(client_id)) if client_id == "client-1"
+        ));
+        assert!(matches!(
             events.first().map(|event| &event.event),
             Some(BackendEvent::LaunchWizardOpenError { title, message })
                 if title == "Start Work" && !message.is_empty()
@@ -7549,6 +7553,10 @@ exit 0
         );
 
         assert!(runtime.launch_wizard.is_none());
+        assert!(matches!(
+            events.first().map(|event| &event.target),
+            Some(DispatchTarget::Client(client_id)) if client_id == "client-1"
+        ));
         assert!(matches!(
             events.first().map(|event| &event.event),
             Some(BackendEvent::LaunchWizardOpenError { title, message })

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -38,19 +38,26 @@ fn linked_issue_kind_from_knowledge(kind: KnowledgeKind) -> Option<LinkedIssueKi
     }
 }
 
-fn launch_wizard_open_error(title: &str, message: impl Into<String>) -> OutboundEvent {
-    OutboundEvent::broadcast(BackendEvent::LaunchWizardOpenError {
-        title: title.to_string(),
-        message: message.into(),
-    })
+fn launch_wizard_open_error(
+    client_id: &str,
+    title: &str,
+    message: impl Into<String>,
+) -> OutboundEvent {
+    OutboundEvent::reply(
+        client_id.to_string(),
+        BackendEvent::LaunchWizardOpenError {
+            title: title.to_string(),
+            message: message.into(),
+        },
+    )
 }
 
-fn launch_agent_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
-    vec![launch_wizard_open_error("Launch Agent", message)]
+fn launch_agent_open_error(client_id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error(client_id, "Launch Agent", message)]
 }
 
-fn start_work_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
-    vec![launch_wizard_open_error("Start Work", message)]
+fn start_work_open_error(client_id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error(client_id, "Start Work", message)]
 }
 
 use super::{
@@ -90,22 +97,23 @@ impl AppRuntime {
 
     pub(crate) fn open_launch_wizard(
         &mut self,
+        client_id: &str,
         id: &str,
         branch_name: &str,
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id).cloned() else {
-            return launch_agent_open_error("Window not found");
+            return launch_agent_open_error(client_id, "Window not found");
         };
         let Some(tab) = self.tab(&address.tab_id) else {
-            return launch_agent_open_error("Project tab not found");
+            return launch_agent_open_error(client_id, "Project tab not found");
         };
         let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return launch_agent_open_error("Window not found");
+            return launch_agent_open_error(client_id, "Window not found");
         };
 
         if window.preset != WindowPreset::Branches {
-            return launch_agent_open_error("Window is not a branches list");
+            return launch_agent_open_error(client_id, "Window is not a branches list");
         }
 
         let project_root = tab.project_root.clone();
@@ -118,7 +126,7 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => launch_agent_open_error(error),
+            Err(error) => launch_agent_open_error(client_id, error),
         }
     }
 
@@ -190,17 +198,18 @@ impl AppRuntime {
 
     pub(crate) fn open_active_work_launch_wizard(
         &mut self,
+        client_id: &str,
         branch_name: &str,
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return launch_agent_open_error("Open a project before adding an agent");
+            return launch_agent_open_error(client_id, "Open a project before adding an agent");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return launch_agent_open_error("Project tab not found");
+            return launch_agent_open_error(client_id, "Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return launch_agent_open_error("Add Agent requires a Git project");
+            return launch_agent_open_error(client_id, "Add Agent requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
@@ -212,25 +221,25 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => launch_agent_open_error(error),
+            Err(error) => launch_agent_open_error(client_id, error),
         }
     }
 
-    pub(crate) fn open_start_work(&mut self) -> Vec<OutboundEvent> {
+    pub(crate) fn open_start_work(&mut self, client_id: &str) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return start_work_open_error("Open a project before starting work");
+            return start_work_open_error(client_id, "Open a project before starting work");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return start_work_open_error("Project tab not found");
+            return start_work_open_error(client_id, "Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return start_work_open_error("Start Work requires a Git project");
+            return start_work_open_error(client_id, "Start Work requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
         match self.open_start_work_for_project(&tab_id, &project_root) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => start_work_open_error(error),
+            Err(error) => start_work_open_error(client_id, error),
         }
     }
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2236,7 +2236,8 @@ mod tests {
                 if message == "Window is not a branches list"
         ));
 
-        let wizard_missing = runtime.open_launch_wizard("missing", "feature/demo", None);
+        let wizard_missing =
+            runtime.open_launch_wizard("client-1", "missing", "feature/demo", None);
         assert_eq!(wizard_missing.len(), 1);
         assert!(matches!(
             wizard_missing[0].event,
@@ -2244,7 +2245,8 @@ mod tests {
                 if title == "Launch Agent" && message == "Window not found"
         ));
 
-        let wizard_wrong = runtime.open_launch_wizard(&file_tree_id, "feature/demo", None);
+        let wizard_wrong =
+            runtime.open_launch_wizard("client-1", &file_tree_id, "feature/demo", None);
         assert_eq!(wizard_wrong.len(), 1);
         assert!(matches!(
             wizard_wrong[0].event,
@@ -2534,7 +2536,8 @@ mod tests {
             })
         });
 
-        let wizard_events = runtime.open_launch_wizard(&branches_id, "feature/demo", Some(42));
+        let wizard_events =
+            runtime.open_launch_wizard("client-1", &branches_id, "feature/demo", Some(42));
         assert_eq!(wizard_events.len(), 1);
         assert!(matches!(
             wizard_events[0].event,


### PR DESCRIPTION
## Summary

- Scope Launch Wizard open error events to the requesting client so one operator's failed Start Work or Launch Agent attempt does not open an error modal for every connected client.

## Changes

- `crates/gwt/src/app_runtime/wizard.rs`: Changed `LaunchWizardOpenError` construction to use `OutboundEvent::reply` with the initiating client ID.
- `crates/gwt/src/app_runtime/mod.rs`: Passed the frontend `client_id` through Start Work, Branches Launch Agent, and Active Work Launch Agent open paths.
- `crates/gwt/src/main.rs`: Updated Wizard entrypoint tests for the new client-aware signature.

## Testing

- [x] `cargo test -p gwt launch_wizard_open_error -- --nocapture` — failed before implementation because open errors were broadcast; passed after the fix.
- [x] `cargo test -p gwt loaders_and_wizard_entrypoints_cover_success_and_error_paths -- --nocapture` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git push` — passed; pre-push hook ran CI-equivalent checks, Rust coverage, skill frontmatter validation, and coverage threshold.

## Closing Issues

- None

## Related Issues / Links

- #2014
- #2640

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not required: internal bugfix with no README-facing workflow change)
- [ ] Migration/backfill plan included (not required: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- Follow-up for Codex review on #2640: the initial `launch_wizard_open_error` event was broadcast globally, which could show one client's open failure modal to every connected browser client.

## Risk / Impact

- **Affected areas**: Launch Wizard open failure routing for Start Work, Branches Launch Agent, and Active Work Launch Agent.
- **Rollback plan**: Revert this PR to restore global broadcast behavior for Wizard open errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for wizard operations. Launch wizard, active work wizard, and start work operation errors are now properly directed to the specific client that triggered the action, rather than being broadcast to all connected users. This ensures users only see notifications relevant to their own actions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2641)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->