### PR TITLE
feat(workspace): add unassigned agent state

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -27,6 +27,17 @@ pub enum WorkspaceStatusCategory {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceAgentAffiliationStatus {
+    Unassigned,
+    Assigned,
+}
+
+fn default_workspace_agent_affiliation_status() -> WorkspaceAgentAffiliationStatus {
+    WorkspaceAgentAffiliationStatus::Assigned
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitDetails {
     pub branch: Option<String>,
@@ -86,7 +97,21 @@ pub struct WorkspaceAgentSummary {
     pub last_board_entry_kind: Option<BoardEntryKind>,
     #[serde(default)]
     pub coordination_scope: Option<String>,
+    #[serde(default = "default_workspace_agent_affiliation_status")]
+    pub affiliation_status: WorkspaceAgentAffiliationStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
     pub updated_at: DateTime<Utc>,
+}
+
+impl WorkspaceAgentSummary {
+    pub fn is_unassigned(&self) -> bool {
+        self.affiliation_status == WorkspaceAgentAffiliationStatus::Unassigned
+    }
+
+    pub fn is_assigned(&self) -> bool {
+        self.affiliation_status == WorkspaceAgentAffiliationStatus::Assigned
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -125,51 +150,81 @@ impl WorkspaceProjection {
     }
 
     pub fn effective_status_category(&self) -> WorkspaceStatusCategory {
-        if self
-            .agents
-            .iter()
-            .any(|agent| agent.status_category == WorkspaceStatusCategory::Blocked)
-        {
+        if self.agents.iter().any(|agent| {
+            agent.is_assigned() && agent.status_category == WorkspaceStatusCategory::Blocked
+        }) {
             return WorkspaceStatusCategory::Blocked;
         }
-        if self
-            .agents
-            .iter()
-            .any(|agent| agent.status_category == WorkspaceStatusCategory::Active)
-        {
+        if self.agents.iter().any(|agent| {
+            agent.is_assigned() && agent.status_category == WorkspaceStatusCategory::Active
+        }) {
             return WorkspaceStatusCategory::Active;
         }
         self.status_category
+    }
+
+    pub fn unassigned_agents(&self) -> impl Iterator<Item = &WorkspaceAgentSummary> {
+        self.agents.iter().filter(|agent| agent.is_unassigned())
+    }
+
+    pub fn assigned_agents(&self) -> impl Iterator<Item = &WorkspaceAgentSummary> {
+        self.agents.iter().filter(|agent| agent.is_assigned())
+    }
+
+    pub fn register_unassigned_agent(&mut self, mut agent: WorkspaceAgentSummary) {
+        agent.affiliation_status = WorkspaceAgentAffiliationStatus::Unassigned;
+        agent.workspace_id = None;
+        if let Some(existing) = self
+            .agents
+            .iter_mut()
+            .find(|existing| existing.session_id == agent.session_id)
+        {
+            *existing = agent;
+        } else {
+            self.agents.push(agent);
+        }
     }
 
     pub fn record_board_milestone(&mut self, entry: &BoardEntry) {
         if !self.board_refs.iter().any(|id| id == &entry.id) {
             self.board_refs.push(entry.id.clone());
         }
-        if let Some(owner) = entry.related_owners.first() {
-            self.owner = Some(owner.clone());
-        }
+        let origin_agent_is_unassigned = entry
+            .origin_session_id
+            .as_deref()
+            .and_then(|session_id| {
+                self.agents
+                    .iter()
+                    .find(|agent| agent.session_id == session_id)
+            })
+            .is_some_and(WorkspaceAgentSummary::is_unassigned);
 
-        match entry.kind {
-            BoardEntryKind::Blocked => {
-                self.status_category = WorkspaceStatusCategory::Blocked;
-                self.status_text = entry.body.clone();
-                self.next_action = Some("Resolve blocker".to_string());
+        if !origin_agent_is_unassigned {
+            if let Some(owner) = entry.related_owners.first() {
+                self.owner = Some(owner.clone());
             }
-            BoardEntryKind::Next => {
-                self.next_action = Some(entry.body.clone());
-                if self.status_category == WorkspaceStatusCategory::Unknown {
-                    self.status_category = WorkspaceStatusCategory::Active;
+
+            match entry.kind {
+                BoardEntryKind::Blocked => {
+                    self.status_category = WorkspaceStatusCategory::Blocked;
+                    self.status_text = entry.body.clone();
+                    self.next_action = Some("Resolve blocker".to_string());
                 }
+                BoardEntryKind::Next => {
+                    self.next_action = Some(entry.body.clone());
+                    if self.status_category == WorkspaceStatusCategory::Unknown {
+                        self.status_category = WorkspaceStatusCategory::Active;
+                    }
+                }
+                BoardEntryKind::Status
+                | BoardEntryKind::Claim
+                | BoardEntryKind::Handoff
+                | BoardEntryKind::Decision => {
+                    self.status_category = WorkspaceStatusCategory::Active;
+                    self.status_text = entry.body.clone();
+                }
+                BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {}
             }
-            BoardEntryKind::Status
-            | BoardEntryKind::Claim
-            | BoardEntryKind::Handoff
-            | BoardEntryKind::Decision => {
-                self.status_category = WorkspaceStatusCategory::Active;
-                self.status_text = entry.body.clone();
-            }
-            BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {}
         }
 
         if let Some(session_id) = entry.origin_session_id.as_deref() {
@@ -315,10 +370,11 @@ impl WorkspaceProjection {
         if removed {
             self.updated_at = updated_at;
             if !self.agents.iter().any(|agent| {
-                matches!(
-                    agent.status_category,
-                    WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
-                )
+                agent.is_assigned()
+                    && matches!(
+                        agent.status_category,
+                        WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
+                    )
             }) {
                 self.status_category = WorkspaceStatusCategory::Idle;
                 self.status_text = "No active work".to_string();
@@ -946,6 +1002,15 @@ fn synthesize_workspace_work_item_from_legacy(
     if projection.is_none() && journal_entries.is_empty() {
         return None;
     }
+    if let Some(projection) = projection {
+        let has_workspace_identity = projection.assigned_agents().next().is_some()
+            || projection.git_details.is_some()
+            || !projection.board_refs.is_empty()
+            || projection.status_category != WorkspaceStatusCategory::Unknown;
+        if journal_entries.is_empty() && !has_workspace_identity {
+            return None;
+        }
+    }
     let first_entry = journal_entries.first();
     let last_entry = journal_entries.last();
     let id = projection
@@ -1000,13 +1065,16 @@ fn synthesize_workspace_work_item_from_legacy(
         events: Vec::new(),
     };
     if let Some(projection) = projection {
-        item.agents
-            .extend(projection.agents.iter().map(|agent| WorkspaceWorkAgentRef {
-                session_id: agent.session_id.clone(),
-                agent_id: Some(agent.agent_id.clone()),
-                display_name: Some(agent.display_name.clone()),
-                updated_at: agent.updated_at,
-            }));
+        item.agents.extend(
+            projection
+                .assigned_agents()
+                .map(|agent| WorkspaceWorkAgentRef {
+                    session_id: agent.session_id.clone(),
+                    agent_id: Some(agent.agent_id.clone()),
+                    display_name: Some(agent.display_name.clone()),
+                    updated_at: agent.updated_at,
+                }),
+        );
         if let Some(details) = projection.git_details.as_ref() {
             item.execution_containers
                 .push(WorkspaceExecutionContainerRef {
@@ -1295,6 +1363,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
 
@@ -1346,6 +1416,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
 
@@ -1517,6 +1589,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut blocked = BoardEntry::new(
@@ -1577,6 +1651,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut entry_value = serde_json::to_value(
@@ -1629,6 +1705,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut blocked = BoardEntry::new(
@@ -1690,6 +1768,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut handoff = BoardEntry::new(
@@ -1958,6 +2038,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at,
         });
 
@@ -1997,6 +2079,61 @@ mod tests {
     }
 
     #[test]
+    fn legacy_workspace_agent_affiliation_defaults_to_assigned() {
+        let payload = serde_json::json!({
+            "session_id": "session-legacy",
+            "window_id": "tab-1:agent-1",
+            "agent_id": "codex",
+            "display_name": "Codex",
+            "status_category": "active",
+            "current_focus": "Implement existing Workspace behavior",
+            "title_summary": "Existing Workspace behavior",
+            "worktree_path": null,
+            "branch": "work/legacy",
+            "last_board_entry_id": null,
+            "updated_at": "2026-05-11T00:00:00Z"
+        });
+
+        let agent: WorkspaceAgentSummary =
+            serde_json::from_value(payload).expect("legacy agent summary");
+
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), None);
+    }
+
+    #[test]
+    fn unassigned_agent_is_not_effective_active_workspace_status() {
+        let mut projection = WorkspaceProjection::default_for_project("/tmp/repo");
+        projection.register_unassigned_agent(WorkspaceAgentSummary {
+            session_id: "session-unassigned".to_string(),
+            window_id: Some("tab-1:agent-1".to_string()),
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            title_summary: None,
+            worktree_path: None,
+            branch: Some("work/20260511-0100".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        });
+
+        assert_eq!(projection.unassigned_agents().count(), 1);
+        assert_eq!(
+            projection.effective_status_category(),
+            WorkspaceStatusCategory::Unknown,
+            "Unassigned Agents must not make a Workspace active"
+        );
+    }
+
+    #[test]
     fn stopped_agent_is_removed_from_current_projection_without_losing_summary() {
         let now = Utc::now();
         let mut projection = WorkspaceProjection::default_for_project("/repo");
@@ -2017,6 +2154,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: now,
         });
 

--- a/crates/gwt-core/tests/workspace_projection.rs
+++ b/crates/gwt-core/tests/workspace_projection.rs
@@ -6,8 +6,8 @@ use gwt_core::{
     repo_hash::compute_repo_hash,
     workspace_projection::{
         load_or_default_workspace_projection_from_path, load_workspace_projection_from_path,
-        save_workspace_projection_to_path, GitDetails, WorkspaceAgentSummary, WorkspaceProjection,
-        WorkspaceStatusCategory,
+        save_workspace_projection_to_path, GitDetails, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
     },
 };
 
@@ -34,6 +34,8 @@ fn projection(project_root: &Path) -> WorkspaceProjection {
             last_board_entry_id: Some("board-1".to_string()),
             last_board_entry_kind: Some(gwt_core::coordination::BoardEntryKind::Status),
             coordination_scope: Some("SPEC-2359 / start-work".to_string()),
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: Some("work-1".to_string()),
             updated_at: Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap(),
         }],
         git_details: Some(GitDetails {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -619,26 +619,23 @@ fn active_work_projection_from_saved(
 fn active_work_projection_from_saved_with_journal(
     projection: gwt_core::workspace_projection::WorkspaceProjection,
     journal_entries: Vec<gwt::WorkspaceJournalEntryView>,
-    work_items: Vec<gwt::WorkspaceWorkItemView>,
+    workspaces: Vec<gwt::WorkspaceHistoryView>,
     cleanup_candidate: Option<gwt::ActiveWorkCleanupCandidateView>,
 ) -> gwt::ActiveWorkProjectionView {
     use gwt_core::workspace_projection::WorkspaceStatusCategory;
 
     let active_agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .filter(|agent| agent.status_category == WorkspaceStatusCategory::Active)
         .count();
     let blocked_agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .filter(|agent| agent.status_category == WorkspaceStatusCategory::Blocked)
         .count();
     let agent_branch = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .find_map(|agent| agent.branch.clone());
-    let agent_worktree = projection.agents.iter().find_map(|agent| {
+    let agent_worktree = projection.assigned_agents().find_map(|agent| {
         agent
             .worktree_path
             .as_ref()
@@ -646,32 +643,41 @@ fn active_work_projection_from_saved_with_journal(
     });
     let status_category =
         workspace_status_category_wire(projection.effective_status_category()).to_string();
-    let git_details = projection.git_details;
-    let (branch, worktree_path, pr_number, pr_url, pr_state, pr_created_at) = match git_details {
-        Some(details) => (
-            details.branch.or(agent_branch),
-            details
-                .worktree_path
-                .map(|path| path.display().to_string())
-                .or(agent_worktree),
-            details.pr_number,
-            details.pr_url,
-            details.pr_state,
-            details
-                .pr_created_at
-                .map(|created_at| created_at.to_rfc3339()),
-        ),
-        None => (agent_branch, agent_worktree, None, None, None, None),
-    };
+    let (branch, worktree_path, pr_number, pr_url, pr_state, pr_created_at) =
+        match projection.git_details.as_ref() {
+            Some(details) => (
+                details.branch.clone().or(agent_branch),
+                details
+                    .worktree_path
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .or(agent_worktree),
+                details.pr_number,
+                details.pr_url.clone(),
+                details.pr_state.clone(),
+                details
+                    .pr_created_at
+                    .map(|created_at| created_at.to_rfc3339()),
+            ),
+            None => (agent_branch, agent_worktree, None, None, None, None),
+        };
     let mut agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .map(active_work_agent_view_from_summary)
         .collect::<Vec<_>>();
     agents.sort_by(|left, right| {
         active_work_agent_priority_rank(left)
             .cmp(&active_work_agent_priority_rank(right))
             .then_with(|| left.display_name.cmp(&right.display_name))
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+    let mut unassigned_agents = projection
+        .unassigned_agents()
+        .map(active_work_agent_view_from_summary)
+        .collect::<Vec<_>>();
+    unassigned_agents.sort_by(|left, right| {
+        left.display_name
+            .cmp(&right.display_name)
             .then_with(|| left.session_id.cmp(&right.session_id))
     });
 
@@ -693,9 +699,10 @@ fn active_work_projection_from_saved_with_journal(
         pr_created_at,
         board_refs: projection.board_refs,
         journal_entries,
-        work_items,
+        workspaces,
         cleanup_candidate,
         agents,
+        unassigned_agents,
     }
 }
 
@@ -721,9 +728,10 @@ fn empty_active_work_projection_view(
         pr_created_at: None,
         board_refs: Vec::new(),
         journal_entries: Vec::new(),
-        work_items: Vec::new(),
+        workspaces: Vec::new(),
         cleanup_candidate: None,
         agents: Vec::new(),
+        unassigned_agents: Vec::new(),
     }
 }
 
@@ -767,8 +775,8 @@ fn workspace_journal_entry_view_from_entry(
 
 fn workspace_work_item_view_from_item(
     item: &gwt_core::workspace_projection::WorkspaceWorkItem,
-) -> gwt::WorkspaceWorkItemView {
-    gwt::WorkspaceWorkItemView {
+) -> gwt::WorkspaceHistoryView {
+    gwt::WorkspaceHistoryView {
         id: item.id.clone(),
         title: item.title.clone(),
         intent: item.intent.clone(),
@@ -795,7 +803,7 @@ fn workspace_work_item_view_from_item(
             .map(workspace_execution_container_view_from_ref)
             .collect(),
         board_refs: item.board_refs.clone(),
-        related_work_item_ids: item.related_work_item_ids.clone(),
+        related_workspace_ids: item.related_work_item_ids.clone(),
         events: item
             .events
             .iter()
@@ -806,8 +814,8 @@ fn workspace_work_item_view_from_item(
 
 fn workspace_work_agent_view_from_ref(
     agent: &gwt_core::workspace_projection::WorkspaceWorkAgentRef,
-) -> gwt::WorkspaceWorkAgentView {
-    gwt::WorkspaceWorkAgentView {
+) -> gwt::WorkspaceHistoryAgentView {
+    gwt::WorkspaceHistoryAgentView {
         session_id: agent.session_id.clone(),
         agent_id: agent.agent_id.clone(),
         display_name: agent.display_name.clone(),
@@ -834,10 +842,10 @@ fn workspace_execution_container_view_from_ref(
 
 fn workspace_work_event_view_from_event(
     event: &gwt_core::workspace_projection::WorkspaceWorkEvent,
-) -> gwt::WorkspaceWorkEventView {
-    gwt::WorkspaceWorkEventView {
+) -> gwt::WorkspaceHistoryEventView {
+    gwt::WorkspaceHistoryEventView {
         id: event.id.clone(),
-        work_item_id: event.work_item_id.clone(),
+        workspace_id: event.work_item_id.clone(),
         kind: workspace_work_event_kind_wire(event.kind).to_string(),
         title: event.title.clone(),
         intent: event.intent.clone(),
@@ -850,7 +858,7 @@ fn workspace_work_event_view_from_event(
         next_action: event.next_action.clone(),
         agent_session_id: event.agent_session_id.clone(),
         board_entry_id: event.board_entry_id.clone(),
-        related_work_item_id: event.related_work_item_id.clone(),
+        related_workspace_id: event.related_work_item_id.clone(),
         updated_at: event
             .updated_at
             .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -1026,11 +1034,17 @@ fn active_work_agent_priority_rank(agent: &gwt::ActiveWorkAgentView) -> u8 {
 fn active_work_agent_view_from_summary(
     agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
 ) -> gwt::ActiveWorkAgentView {
+    let affiliation_status = match agent.affiliation_status {
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned => "unassigned",
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned => "assigned",
+    };
     gwt::ActiveWorkAgentView {
         session_id: agent.session_id.clone(),
         window_id: agent.window_id.clone(),
         agent_id: agent.agent_id.clone(),
         display_name: agent.display_name.clone(),
+        affiliation_status: affiliation_status.to_string(),
+        workspace_id: agent.workspace_id.clone(),
         status_category: workspace_status_category_wire(agent.status_category).to_string(),
         current_focus: agent.current_focus.clone(),
         title_summary: agent.title_summary.clone(),
@@ -1066,8 +1080,22 @@ fn active_agent_summary_from_session(
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
+        affiliation_status:
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+        workspace_id: None,
         updated_at,
     }
+}
+
+fn unassigned_agent_summary_from_session(
+    session: &ActiveAgentSession,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
+    let mut summary = active_agent_summary_from_session(session, updated_at);
+    summary.affiliation_status =
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned;
+    summary.workspace_id = None;
+    summary
 }
 
 fn agent_launch_purpose_title(
@@ -1163,6 +1191,11 @@ fn upsert_workspace_agent(
         if summary.coordination_scope.is_some() {
             existing.coordination_scope = summary.coordination_scope;
         }
+        if summary.title_summary.is_some() {
+            existing.title_summary = summary.title_summary;
+        }
+        existing.affiliation_status = summary.affiliation_status;
+        existing.workspace_id = summary.workspace_id;
         if summary.updated_at > existing.updated_at {
             existing.updated_at = summary.updated_at;
         }
@@ -1177,10 +1210,31 @@ fn merge_active_sessions_into_projection<'a>(
     updated_at: chrono::DateTime<chrono::Utc>,
 ) {
     for session in sessions {
-        upsert_workspace_agent(
-            &mut projection.agents,
-            active_agent_summary_from_session(session, updated_at),
-        );
+        let existing = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.session_id)
+            .or_else(|| {
+                projection
+                    .agents
+                    .iter()
+                    .find(|agent| agent.window_id.as_deref() == Some(session.window_id.as_str()))
+            });
+        let mut summary = active_agent_summary_from_session(session, updated_at);
+        if let Some(existing) = existing {
+            summary.affiliation_status = existing.affiliation_status;
+            summary.workspace_id = existing.workspace_id.clone();
+            summary.title_summary = existing.title_summary.clone();
+            summary.current_focus = existing.current_focus.clone();
+            summary.last_board_entry_id = existing.last_board_entry_id.clone();
+            summary.last_board_entry_kind = existing.last_board_entry_kind.clone();
+            summary.coordination_scope = existing.coordination_scope.clone();
+        } else {
+            summary.affiliation_status =
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned;
+            summary.workspace_id = None;
+        }
+        upsert_workspace_agent(&mut projection.agents, summary);
     }
 }
 
@@ -1197,11 +1251,12 @@ fn retain_live_workspace_agents(
         .agents
         .retain(|agent| live_session_ids.contains(agent.session_id.as_str()));
     if !projection.agents.iter().any(|agent| {
-        matches!(
-            agent.status_category,
-            gwt_core::workspace_projection::WorkspaceStatusCategory::Active
-                | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
-        )
+        agent.is_assigned()
+            && matches!(
+                agent.status_category,
+                gwt_core::workspace_projection::WorkspaceStatusCategory::Active
+                    | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
+            )
     }) {
         projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Idle;
         projection.status_text = "No active work".to_string();
@@ -1214,11 +1269,12 @@ fn workspace_projection_has_current_agents(
     projection: &gwt_core::workspace_projection::WorkspaceProjection,
 ) -> bool {
     projection.agents.iter().any(|agent| {
-        matches!(
-            agent.status_category,
-            gwt_core::workspace_projection::WorkspaceStatusCategory::Active
-                | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
-        )
+        agent.is_assigned()
+            && matches!(
+                agent.status_category,
+                gwt_core::workspace_projection::WorkspaceStatusCategory::Active
+                    | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
+            )
     })
 }
 
@@ -1315,13 +1371,13 @@ fn save_workspace_launch_projection(
     } else if let Some(issue_number) = linked_issue_number {
         projection.owner = Some(format!("Issue #{issue_number}"));
     }
-    upsert_workspace_agent(
-        &mut projection.agents,
-        active_agent_summary_from_session(session, now),
-    );
+    let mut agent = active_agent_summary_from_session(session, now);
+    agent.affiliation_status =
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned;
+    agent.workspace_id = Some(projection.id.clone());
+    upsert_workspace_agent(&mut projection.agents, agent);
     let active_agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .filter(|agent| agent.status_category == WorkspaceStatusCategory::Active)
         .count();
     projection.status_text = if active_agents == 1 {
@@ -1394,17 +1450,35 @@ fn workspace_work_event_from_launch_projection(
     event
 }
 
+fn save_unassigned_workspace_launch_projection(
+    project_root: &Path,
+    session: &ActiveAgentSession,
+) -> Result<(), String> {
+    let now = chrono::Utc::now();
+    let mut projection =
+        gwt_core::workspace_projection::load_or_default_workspace_projection(project_root)
+            .map_err(|error| error.to_string())?;
+    projection.project_root = project_root.to_path_buf();
+    projection.register_unassigned_agent(unassigned_agent_summary_from_session(session, now));
+    projection.updated_at = now;
+    gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
+        .map_err(|error| error.to_string())
+}
+
 fn save_start_work_workspace_projection(
     project_root: &Path,
     session: &ActiveAgentSession,
-    base_branch: &str,
+    _base_branch: &str,
     linked_issue_number: Option<u64>,
     workspace_resume_context: Option<&WorkspaceResumeContext>,
 ) -> Result<(), String> {
+    if workspace_resume_context.is_none() {
+        return save_unassigned_workspace_launch_projection(project_root, session);
+    }
     save_workspace_launch_projection(
         project_root,
         session,
-        Some(base_branch),
+        Some(_base_branch),
         linked_issue_number,
         workspace_resume_context,
         true,
@@ -2388,7 +2462,7 @@ impl AppRuntime {
                 .iter()
                 .map(workspace_journal_entry_view_from_entry)
                 .collect::<Vec<_>>();
-            let work_items =
+            let workspaces =
                 gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(
                     &tab.project_root,
                 )
@@ -2405,7 +2479,7 @@ impl AppRuntime {
             return Some(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
-                work_items,
+                workspaces,
                 cleanup_candidate,
             ));
         }
@@ -2447,9 +2521,10 @@ impl AppRuntime {
             pr_created_at: None,
             board_refs: Vec::new(),
             journal_entries: Vec::new(),
-            work_items: Vec::new(),
+            workspaces: Vec::new(),
             cleanup_candidate: None,
             agents,
+            unassigned_agents: Vec::new(),
         })
     }
 
@@ -3801,7 +3876,7 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
     .iter()
     .map(workspace_journal_entry_view_from_entry)
     .collect::<Vec<_>>();
-    let work_items =
+    let workspaces =
         gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(project_root)
             .unwrap_or_else(
                 |_| gwt_core::workspace_projection::WorkspaceWorkItemsProjection {
@@ -3818,7 +3893,7 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
             projection: Box::new(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
-                work_items,
+                workspaces,
                 None,
             )),
         },
@@ -4163,25 +4238,23 @@ impl AppRuntime {
                                 }
                             }
                         } else if let Some(base_branch) = base_branch.as_deref() {
-                            if active_session.branch_name.starts_with("work/") {
-                                match save_start_work_workspace_projection(
-                                    &project_root,
-                                    active_session,
-                                    base_branch,
-                                    linked_issue_number,
-                                    None,
-                                ) {
-                                    Ok(()) => {
-                                        workspace_projection_updated = true;
-                                    }
-                                    Err(error) => {
-                                        tracing::warn!(
-                                            project_root = %project_root.display(),
-                                            branch = %active_session.branch_name,
-                                            error = %error,
-                                            "workspace projection update skipped after Start Work launch"
-                                        );
-                                    }
+                            match save_start_work_workspace_projection(
+                                &project_root,
+                                active_session,
+                                base_branch,
+                                linked_issue_number,
+                                None,
+                            ) {
+                                Ok(()) => {
+                                    workspace_projection_updated = true;
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        project_root = %project_root.display(),
+                                        branch = %active_session.branch_name,
+                                        error = %error,
+                                        "workspace projection update skipped after Start Work launch"
+                                    );
                                 }
                             }
                         }
@@ -5649,11 +5722,11 @@ mod tests {
 
     use super::{
         active_work_projection_from_saved, dispatch_agent_launch_success,
-        save_start_work_workspace_projection, ActiveAgentSession, AgentLaunchCompletion,
-        AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget, KnowledgeLoadRequest,
-        KnowledgeRefreshTask, KnowledgeSearchRequest, LaunchWizardMemoryCache, LaunchWizardSession,
-        OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent, WindowRuntime,
-        WorkspaceResumeContext,
+        save_start_work_workspace_projection, save_workspace_launch_projection, ActiveAgentSession,
+        AgentLaunchCompletion, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
+        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest,
+        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProcessLaunch,
+        ProjectTabRuntime, UserEvent, WindowRuntime, WorkspaceResumeContext,
     };
     use crate::{combined_window_id, geometry_to_pty_size, same_worktree_path, PtyWriterRegistry};
 
@@ -6101,6 +6174,19 @@ exit 0
             runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
             tab_id: tab_id.to_string(),
         }
+    }
+
+    fn save_assigned_workspace_projection_for_test(
+        repo: &Path,
+        session: &ActiveAgentSession,
+    ) -> Result<(), String> {
+        let context = WorkspaceResumeContext {
+            title: Some("Start Work".to_string()),
+            owner: Some("SPEC-2359".to_string()),
+            summary: Some("Assigned Workspace".to_string()),
+            next_action: Some("Check Board for latest updates".to_string()),
+        };
+        save_workspace_launch_projection(repo, session, Some("develop"), None, Some(&context), true)
     }
 
     #[test]
@@ -7679,7 +7765,7 @@ exit 0
     }
 
     #[test]
-    fn app_runtime_start_work_launch_completion_records_workspace_git_details() {
+    fn app_runtime_start_work_launch_completion_registers_unassigned_agent() {
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
@@ -7738,31 +7824,99 @@ exit 0
         let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
-        let details = projection.git_details.expect("git details");
         assert_eq!(
             projection.status_category,
-            gwt_core::workspace_projection::WorkspaceStatusCategory::Active
+            gwt_core::workspace_projection::WorkspaceStatusCategory::Unknown,
+            "Start Work must not make an unassigned Agent an active Workspace"
         );
-        assert_eq!(details.branch.as_deref(), Some("work/20260504-1234"));
-        assert_eq!(details.base_branch.as_deref(), Some("origin/main"));
-        assert_eq!(details.worktree_path.as_deref(), Some(worktree.as_path()));
-        assert!(details.created_by_start_work);
+        assert!(projection.git_details.is_none());
         assert_eq!(projection.agents.len(), 1);
         assert_eq!(projection.agents[0].session_id, "session-1");
-        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
-            .expect("load work items")
-            .expect("work items");
-        assert_eq!(work_items.work_items.len(), 1);
         assert_eq!(
-            work_items.work_items[0].events[0].kind,
-            gwt_core::workspace_projection::WorkspaceWorkEventKind::Start
+            projection.agents[0].affiliation_status,
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
         );
         assert_eq!(
-            work_items.work_items[0].execution_containers[0]
-                .branch
-                .as_deref(),
+            projection.agents[0].branch.as_deref(),
             Some("work/20260504-1234")
         );
+        assert_eq!(
+            projection.agents[0].worktree_path.as_deref(),
+            Some(worktree.as_path())
+        );
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items");
+        assert!(
+            work_items.is_none(),
+            "Start Work launch must not create Workspace history before explicit assignment"
+        );
+    }
+
+    #[test]
+    fn app_runtime_non_work_launch_registers_unassigned_agent() {
+        let _env_guard = env_test_lock().lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "agent-1",
+            repo.clone(),
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        let (command, args) = if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec![
+                    "/d".to_string(),
+                    "/s".to_string(),
+                    "/c".to_string(),
+                    "exit /b 0".to_string(),
+                ],
+            )
+        } else {
+            (
+                "/bin/sh".to_string(),
+                vec!["-lc".to_string(), "exit 0".to_string()],
+            )
+        };
+
+        let _events = runtime.handle_launch_complete(
+            window_id,
+            Ok((
+                ProcessLaunch {
+                    command,
+                    args,
+                    env: HashMap::new(),
+                    remove_env: Vec::new(),
+                    cwd: Some(repo.clone()),
+                },
+                "session-develop".to_string(),
+                "develop".to_string(),
+                "Codex".to_string(),
+                repo.clone(),
+                gwt_agent::AgentId::Codex,
+                None,
+                Some("origin/develop".to_string()),
+                gwt_agent::LaunchRuntimeTarget::Host,
+                repo.display().to_string(),
+            )),
+        );
+
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        assert_eq!(projection.agents.len(), 1);
+        assert_eq!(projection.agents[0].session_id, "session-develop");
+        assert_eq!(
+            projection.agents[0].affiliation_status,
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
+        );
+        assert_eq!(projection.agents[0].branch.as_deref(), Some("develop"));
     }
 
     #[test]
@@ -7857,7 +8011,7 @@ exit 0
     }
 
     #[test]
-    fn app_runtime_start_work_launch_completion_merges_agents_and_broadcasts_projection() {
+    fn app_runtime_start_work_launch_completion_registers_multiple_unassigned_agents() {
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
@@ -7959,13 +8113,19 @@ exit 0
         assert_eq!(projection.agents.len(), 2);
         assert!(session_ids.contains("session-1"));
         assert!(session_ids.contains("session-2"));
+        assert!(projection
+            .agents
+            .iter()
+            .all(gwt_core::workspace_projection::WorkspaceAgentSummary::is_unassigned));
         assert!(second_events.iter().any(|event| matches!(
             event,
             OutboundEvent {
                 target: DispatchTarget::Broadcast,
                 event: BackendEvent::ActiveWorkProjection { projection },
-            } if projection.active_agents == 2
-                && projection.branch.as_deref() == Some("work/20260504-1235")
+            } if projection.active_agents == 0
+                && projection.agents.is_empty()
+                && projection.unassigned_agents.len() == 2
+                && projection.branch.is_none()
         )));
     }
 
@@ -8069,6 +8229,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
@@ -8133,6 +8296,9 @@ exit 0
                 last_board_entry_id: Some("board-old".to_string()),
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
@@ -8187,6 +8353,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
@@ -10070,7 +10239,7 @@ exit 0
         runtime
             .active_agent_sessions
             .insert(session.window_id.clone(), session.clone());
-        save_start_work_workspace_projection(&repo, &session, "develop", None, None)
+        save_assigned_workspace_projection_for_test(&repo, &session)
             .expect("save initial projection");
         let blocked = BoardEntry::new(
             AuthorKind::Agent,
@@ -10128,6 +10297,9 @@ exit 0
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status:
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: now,
         });
         projection.agents.push(WorkspaceAgentSummary {
@@ -10143,6 +10315,9 @@ exit 0
             last_board_entry_id: Some("board-handoff".to_string()),
             last_board_entry_kind: Some(BoardEntryKind::Handoff),
             coordination_scope: Some("SPEC-2359 / workspace-ux".to_string()),
+            affiliation_status:
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: now,
         });
 
@@ -10193,7 +10368,7 @@ exit 0
         runtime
             .active_agent_sessions
             .insert(session.window_id.clone(), session.clone());
-        save_start_work_workspace_projection(&repo, &session, "develop", None, None)
+        save_assigned_workspace_projection_for_test(&repo, &session)
             .expect("save initial projection");
         let blocked = BoardEntry::new(
             AuthorKind::Agent,
@@ -10271,7 +10446,7 @@ exit 0
         runtime
             .active_agent_sessions
             .insert(session.window_id.clone(), session.clone());
-        save_start_work_workspace_projection(&repo, &session, "develop", None, None)
+        save_assigned_workspace_projection_for_test(&repo, &session)
             .expect("save initial projection");
         let blocked = BoardEntry::new(
             AuthorKind::Agent,
@@ -10857,6 +11032,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -189,6 +189,25 @@ pub enum WorkspaceCommand {
         current_focus: Option<String>,
         title_summary: Option<String>,
     },
+    /// `gwtd workspace candidates --agent-session <id>` — list join candidates.
+    Candidates { agent_session: String },
+    /// `gwtd workspace join --agent-session <id> --workspace <id>`.
+    Join {
+        agent_session: String,
+        workspace_id: String,
+        current_focus: Option<String>,
+        title_summary: Option<String>,
+    },
+    /// `gwtd workspace create --agent-session <id> --title-summary <name> ...`.
+    Create {
+        agent_session: String,
+        title_summary: String,
+        current_focus: Option<String>,
+        spec: Option<u64>,
+        issue: Option<u64>,
+        split_from: Option<String>,
+        boundary: Option<String>,
+    },
 }
 
 /// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).
@@ -418,7 +437,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* | gwtd workspace update [--title-summary <text>] [fields] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -107,15 +107,18 @@ fn agent_title_summary_missing(session: &Session) -> Result<bool, HookError> {
     let Some(projection) =
         gwt_core::workspace_projection::load_workspace_projection(&session.worktree_path)?
     else {
-        return Ok(true);
+        return Ok(false);
     };
     let Some(agent) = projection
         .agents
         .iter()
         .find(|agent| agent.session_id == session.id)
     else {
-        return Ok(true);
+        return Ok(false);
     };
+    if agent.is_unassigned() {
+        return Ok(false);
+    }
     Ok(agent
         .title_summary
         .as_deref()
@@ -304,8 +307,8 @@ mod tests {
         let session = make_session(&repo, "work/title", "Codex");
 
         assert!(
-            agent_title_summary_missing(&session).expect("missing title check"),
-            "new sessions without a saved title_summary must require an update"
+            !agent_title_summary_missing(&session).expect("missing title check"),
+            "sessions without a Workspace projection are Unassigned and must not require a title update"
         );
 
         let mut projection =
@@ -325,6 +328,9 @@ mod tests {
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -199,15 +199,18 @@ fn current_agent_title_summary_missing(worktree_root: &Path) -> Result<bool, Hoo
         worktree_root
     };
     let Some(projection) = load_workspace_projection(projection_root)? else {
-        return Ok(true);
+        return Ok(false);
     };
     let Some(agent) = projection
         .agents
         .iter()
         .find(|agent| agent.session_id == session.id)
     else {
-        return Ok(true);
+        return Ok(false);
     };
+    if agent.is_unassigned() {
+        return Ok(false);
+    }
     Ok(agent
         .title_summary
         .as_deref()
@@ -329,6 +332,7 @@ fn workspace_agent_conflicts(
         .iter()
         .filter(|agent| {
             current_session_id != Some(agent.session_id.as_str())
+                && agent.is_assigned()
                 && matches!(
                     agent.status_category,
                     WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
@@ -378,7 +382,7 @@ fn workspace_work_item_conflicts(
                 let first_agent = item.agents.first();
                 let first_container = item.execution_containers.first();
                 WorkspaceCoordinationConflict {
-                    source_label: "incomplete Workspace WorkItem",
+                    source_label: "incomplete Workspace",
                     title: item.title.clone(),
                     session_id: first_agent.map(|agent| agent.session_id.clone()),
                     branch: first_container.and_then(|container| container.branch.clone()),

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -1,5 +1,10 @@
+use chrono::Utc;
 use gwt_core::workspace_projection::{
-    update_workspace_projection_with_journal, WorkspaceProjectionUpdate, WorkspaceStatusCategory,
+    load_or_default_workspace_projection, load_or_synthesize_workspace_work_items,
+    record_workspace_work_event, save_workspace_projection,
+    update_workspace_projection_with_journal, WorkspaceAgentAffiliationStatus,
+    WorkspaceExecutionContainerRef, WorkspaceProjection, WorkspaceProjectionUpdate,
+    WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind, WorkspaceWorkItem,
 };
 use gwt_github::{ApiError, SpecOpsError};
 
@@ -9,8 +14,21 @@ pub fn parse(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     match head.as_str() {
         "update" => parse_update(rest),
+        "candidates" => parse_candidates(rest),
+        "join" => parse_join(rest),
+        "create" => parse_create(rest),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
     }
+}
+
+fn parse_required_value(
+    args: &[String],
+    index: usize,
+    flag: &'static str,
+) -> Result<String, CliParseError> {
+    args.get(index + 1)
+        .cloned()
+        .ok_or(CliParseError::MissingFlag(flag))
 }
 
 fn parse_update(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
@@ -59,6 +77,111 @@ fn parse_update(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
     })
 }
 
+fn parse_candidates(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    Ok(WorkspaceCommand::Candidates {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+    })
+}
+
+fn parse_join(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut workspace_id = None;
+    let mut current_focus = None;
+    let mut title_summary = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            "--workspace" | "--workspace-id" => {
+                workspace_id = Some(parse_required_value(args, i, "--workspace")?)
+            }
+            "--current-focus" => {
+                current_focus = Some(parse_required_value(args, i, "--current-focus")?)
+            }
+            "--title-summary" => {
+                title_summary = Some(parse_required_value(args, i, "--title-summary")?)
+            }
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    if let Some(value) = title_summary.as_deref() {
+        super::validate_title_summary_work_name("--title-summary", value)?;
+    }
+    Ok(WorkspaceCommand::Join {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+        workspace_id: workspace_id.ok_or(CliParseError::MissingFlag("--workspace"))?,
+        current_focus,
+        title_summary,
+    })
+}
+
+fn parse_create(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut title_summary = None;
+    let mut current_focus = None;
+    let mut spec = None;
+    let mut issue = None;
+    let mut split_from = None;
+    let mut boundary = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            "--title-summary" => {
+                title_summary = Some(parse_required_value(args, i, "--title-summary")?)
+            }
+            "--current-focus" => {
+                current_focus = Some(parse_required_value(args, i, "--current-focus")?)
+            }
+            "--spec" => {
+                spec = Some(
+                    parse_required_value(args, i, "--spec")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--issue" => {
+                issue = Some(
+                    parse_required_value(args, i, "--issue")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--split-from" => split_from = Some(parse_required_value(args, i, "--split-from")?),
+            "--boundary" => boundary = Some(parse_required_value(args, i, "--boundary")?),
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    let title_summary = title_summary.ok_or(CliParseError::MissingFlag("--title-summary"))?;
+    super::validate_title_summary_work_name("--title-summary", &title_summary)?;
+    Ok(WorkspaceCommand::Create {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+        title_summary,
+        current_focus,
+        spec,
+        issue,
+        split_from,
+        boundary,
+    })
+}
+
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
     cmd: WorkspaceCommand,
@@ -97,7 +220,300 @@ pub(super) fn run<E: CliEnv>(
             out.push_str(&format!("workspace updated: {}\n", entry.id));
             Ok(0)
         }
+        WorkspaceCommand::Candidates { agent_session } => {
+            let projection =
+                load_or_synthesize_workspace_work_items(env.repo_path()).map_err(core_error)?;
+            let current_intent = current_agent_intent(env.repo_path(), &agent_session)?;
+            let mut candidates = projection
+                .work_items
+                .iter()
+                .filter(|item| item.is_incomplete())
+                .filter(|item| {
+                    !item
+                        .agents
+                        .iter()
+                        .any(|agent| agent.session_id == agent_session)
+                })
+                .map(|item| {
+                    let score = workspace_similarity_score(
+                        current_intent.as_deref().unwrap_or_default(),
+                        &workspace_item_text(item),
+                    );
+                    (score, item)
+                })
+                .collect::<Vec<_>>();
+            candidates.sort_by(|left, right| {
+                right
+                    .0
+                    .cmp(&left.0)
+                    .then_with(|| right.1.updated_at.cmp(&left.1.updated_at))
+            });
+            if candidates.is_empty() {
+                out.push_str("workspace candidates: none\n");
+            } else {
+                for (score, item) in candidates {
+                    out.push_str(&format!(
+                        "{}\t{}\t{}\tscore={score}\n",
+                        item.id,
+                        status_category_wire(item.status_category),
+                        item.title
+                    ));
+                }
+            }
+            Ok(0)
+        }
+        WorkspaceCommand::Join {
+            agent_session,
+            workspace_id,
+            current_focus,
+            title_summary,
+        } => {
+            let mut projection =
+                load_or_default_workspace_projection(env.repo_path()).map_err(core_error)?;
+            let Some(item) = workspace_item_by_id(env.repo_path(), &workspace_id)? else {
+                return Err(string_error(format!("workspace not found: {workspace_id}")));
+            };
+            assign_agent_to_workspace(
+                &mut projection,
+                &agent_session,
+                &workspace_id,
+                current_focus,
+                title_summary,
+            )?;
+            apply_workspace_item_to_projection(&mut projection, &item);
+            save_workspace_projection(env.repo_path(), &projection).map_err(core_error)?;
+            publish_workspace_change(env.repo_path());
+            out.push_str(&format!("workspace joined: {workspace_id}\n"));
+            Ok(0)
+        }
+        WorkspaceCommand::Create {
+            agent_session,
+            title_summary,
+            current_focus,
+            spec,
+            issue,
+            split_from,
+            boundary,
+        } => {
+            let existing =
+                load_or_synthesize_workspace_work_items(env.repo_path()).map_err(core_error)?;
+            if split_from.is_none()
+                && boundary
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .is_none()
+            {
+                let new_text = [Some(title_summary.as_str()), current_focus.as_deref()]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if let Some(item) = existing.work_items.iter().find(|item| {
+                    item.is_incomplete()
+                        && workspace_similarity_score(&new_text, &workspace_item_text(item)) >= 2
+                }) {
+                    return Err(string_error(format!(
+                        "similar Workspace exists: {} ({})",
+                        item.title, item.id
+                    )));
+                }
+            }
+            let mut projection =
+                load_or_default_workspace_projection(env.repo_path()).map_err(core_error)?;
+            let Some(agent) = projection
+                .agents
+                .iter()
+                .find(|agent| agent.session_id == agent_session)
+            else {
+                return Err(string_error(format!(
+                    "agent session not found: {agent_session}"
+                )));
+            };
+            let workspace_id = format!("workspace-{}", Utc::now().timestamp_millis());
+            let owner = spec
+                .map(|number| format!("SPEC-{number}"))
+                .or_else(|| issue.map(|number| format!("Issue #{number}")));
+            let now = Utc::now();
+            let mut event =
+                WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, workspace_id.clone(), now);
+            event.title = Some(title_summary.clone());
+            event.intent = current_focus.clone();
+            event.summary = current_focus
+                .clone()
+                .or_else(|| Some(title_summary.clone()));
+            event.status_category = Some(WorkspaceStatusCategory::Active);
+            event.owner = owner.clone();
+            event.next_action = Some("Coordinate on Board before implementation".to_string());
+            event.agent_session_id = Some(agent_session.clone());
+            event.agent_id = Some(agent.agent_id.clone());
+            event.display_name = Some(agent.display_name.clone());
+            event.execution_container = Some(WorkspaceExecutionContainerRef {
+                branch: agent.branch.clone(),
+                worktree_path: agent.worktree_path.clone(),
+                pr_number: None,
+                pr_url: None,
+                pr_state: None,
+            });
+            if let Some(split_from) = split_from {
+                event.kind = WorkspaceWorkEventKind::Split;
+                event.related_work_item_id = Some(split_from);
+            }
+            if let Some(boundary) = boundary {
+                event.next_action = Some(format!("Boundary: {boundary}"));
+            }
+            record_workspace_work_event(env.repo_path(), event).map_err(core_error)?;
+            projection.id = workspace_id.clone();
+            projection.title = title_summary.clone();
+            projection.status_category = WorkspaceStatusCategory::Active;
+            projection.status_text = current_focus
+                .clone()
+                .unwrap_or_else(|| "Workspace created".to_string());
+            projection.summary = current_focus.clone();
+            projection.owner = owner;
+            projection.next_action = Some("Coordinate on Board before implementation".to_string());
+            assign_agent_to_workspace(
+                &mut projection,
+                &agent_session,
+                &workspace_id,
+                current_focus,
+                Some(title_summary),
+            )?;
+            projection.updated_at = now;
+            save_workspace_projection(env.repo_path(), &projection).map_err(core_error)?;
+            publish_workspace_change(env.repo_path());
+            out.push_str(&format!("workspace created: {workspace_id}\n"));
+            Ok(0)
+        }
     }
+}
+
+fn core_error(error: gwt_core::error::GwtError) -> SpecOpsError {
+    string_error(error.to_string())
+}
+
+fn status_category_wire(category: WorkspaceStatusCategory) -> &'static str {
+    match category {
+        WorkspaceStatusCategory::Active => "active",
+        WorkspaceStatusCategory::Idle => "idle",
+        WorkspaceStatusCategory::Blocked => "blocked",
+        WorkspaceStatusCategory::Done => "done",
+        WorkspaceStatusCategory::Unknown => "unknown",
+    }
+}
+
+fn current_agent_intent(
+    repo_path: &std::path::Path,
+    agent_session: &str,
+) -> Result<Option<String>, SpecOpsError> {
+    let projection = load_or_default_workspace_projection(repo_path).map_err(core_error)?;
+    Ok(projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == agent_session)
+        .map(|agent| {
+            [
+                agent.title_summary.as_deref(),
+                agent.current_focus.as_deref(),
+                agent.coordination_scope.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join("\n")
+        }))
+}
+
+fn workspace_item_by_id(
+    repo_path: &std::path::Path,
+    workspace_id: &str,
+) -> Result<Option<WorkspaceWorkItem>, SpecOpsError> {
+    Ok(load_or_synthesize_workspace_work_items(repo_path)
+        .map_err(core_error)?
+        .work_items
+        .into_iter()
+        .find(|item| item.id == workspace_id))
+}
+
+fn apply_workspace_item_to_projection(
+    projection: &mut WorkspaceProjection,
+    item: &WorkspaceWorkItem,
+) {
+    projection.id = item.id.clone();
+    projection.title = item.title.clone();
+    projection.status_category = item.status_category;
+    projection.status_text = item
+        .summary
+        .clone()
+        .or_else(|| item.intent.clone())
+        .unwrap_or_else(|| "Workspace selected".to_string());
+    projection.summary = item.summary.clone().or_else(|| item.intent.clone());
+    projection.owner = item.owner.clone();
+    projection.updated_at = Utc::now();
+}
+
+fn assign_agent_to_workspace(
+    projection: &mut WorkspaceProjection,
+    agent_session: &str,
+    workspace_id: &str,
+    current_focus: Option<String>,
+    title_summary: Option<String>,
+) -> Result<(), SpecOpsError> {
+    let Some(agent) = projection
+        .agents
+        .iter_mut()
+        .find(|agent| agent.session_id == agent_session)
+    else {
+        return Err(string_error(format!(
+            "agent session not found: {agent_session}"
+        )));
+    };
+    agent.affiliation_status = WorkspaceAgentAffiliationStatus::Assigned;
+    agent.workspace_id = Some(workspace_id.to_string());
+    agent.status_category = WorkspaceStatusCategory::Active;
+    if current_focus.is_some() {
+        agent.current_focus = current_focus;
+    }
+    if title_summary.is_some() {
+        agent.title_summary = title_summary;
+    }
+    agent.updated_at = Utc::now();
+    Ok(())
+}
+
+fn workspace_item_text(item: &WorkspaceWorkItem) -> String {
+    let mut parts = vec![item.title.as_str()];
+    if let Some(intent) = item.intent.as_deref() {
+        parts.push(intent);
+    }
+    if let Some(summary) = item.summary.as_deref() {
+        parts.push(summary);
+    }
+    if let Some(owner) = item.owner.as_deref() {
+        parts.push(owner);
+    }
+    parts.join("\n")
+}
+
+fn workspace_similarity_score(left: &str, right: &str) -> usize {
+    let left_tokens = workspace_tokens(left);
+    if left_tokens.is_empty() {
+        return 0;
+    }
+    let right_tokens = workspace_tokens(right);
+    left_tokens
+        .iter()
+        .filter(|token| right_tokens.contains(*token))
+        .count()
+}
+
+fn workspace_tokens(value: &str) -> std::collections::BTreeSet<String> {
+    value
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(str::trim)
+        .filter(|token| token.len() >= 3)
+        .map(|token| token.to_lowercase())
+        .collect()
 }
 
 #[cfg(unix)]
@@ -137,9 +553,57 @@ fn string_error(error: String) -> SpecOpsError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::env::TestEnv;
+    use gwt_core::workspace_projection::{
+        load_workspace_projection, load_workspace_work_items, record_workspace_work_event,
+        save_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
+    };
+    use std::ffi::OsString;
 
     fn s(value: &str) -> String {
         value.to_string()
+    }
+
+    struct ScopedHome {
+        previous_home: Option<OsString>,
+    }
+
+    impl ScopedHome {
+        fn set(path: &std::path::Path) -> Self {
+            let previous_home = std::env::var_os("HOME");
+            std::env::set_var("HOME", path);
+            Self { previous_home }
+        }
+    }
+
+    impl Drop for ScopedHome {
+        fn drop(&mut self) {
+            if let Some(previous_home) = self.previous_home.as_ref() {
+                std::env::set_var("HOME", previous_home);
+            } else {
+                std::env::remove_var("HOME");
+            }
+        }
+    }
+
+    fn unassigned_agent(session_id: &str) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Implement Workspace history".to_string()),
+            title_summary: Some("Workspace history".to_string()),
+            worktree_path: None,
+            branch: Some("work/20260511-0100".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        }
     }
 
     #[test]
@@ -232,5 +696,295 @@ mod tests {
         assert!(message.contains("--title-summary"), "{message}");
         assert!(message.contains("work name"), "{message}");
         assert!(message.contains("status"), "{message}");
+    }
+
+    #[test]
+    fn parse_workspace_create_accepts_assignment_fields() {
+        let parsed = parse(&[
+            s("create"),
+            s("--agent-session"),
+            s("session-1"),
+            s("--title-summary"),
+            s("Workspace history"),
+            s("--current-focus"),
+            s("Implementing Workspace history"),
+            s("--spec"),
+            s("2359"),
+            s("--split-from"),
+            s("workspace-existing"),
+            s("--boundary"),
+            s("UI only"),
+        ])
+        .expect("parse");
+
+        assert_eq!(
+            parsed,
+            WorkspaceCommand::Create {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace history".to_string(),
+                current_focus: Some("Implementing Workspace history".to_string()),
+                spec: Some(2359),
+                issue: None,
+                split_from: Some("workspace-existing".to_string()),
+                boundary: Some("UI only".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_workspace_candidates_and_join_commands() {
+        let candidates = parse(&[s("candidates"), s("--agent-session"), s("session-1")])
+            .expect("parse candidates");
+        assert_eq!(
+            candidates,
+            WorkspaceCommand::Candidates {
+                agent_session: "session-1".to_string()
+            }
+        );
+
+        let join = parse(&[
+            s("join"),
+            s("--agent-session"),
+            s("session-1"),
+            s("--workspace"),
+            s("workspace-existing"),
+            s("--current-focus"),
+            s("Continue Workspace history"),
+            s("--title-summary"),
+            s("Workspace history"),
+        ])
+        .expect("parse join");
+        assert_eq!(
+            join,
+            WorkspaceCommand::Join {
+                agent_session: "session-1".to_string(),
+                workspace_id: "workspace-existing".to_string(),
+                current_focus: Some("Continue Workspace history".to_string()),
+                title_summary: Some("Workspace history".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn workspace_update_persists_workspace_status() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Update {
+                title: Some("Workspace coordination".to_string()),
+                status: Some("blocked".to_string()),
+                status_text: Some("Waiting on Board alignment".to_string()),
+                summary: Some("Align Workspace ownership before edits".to_string()),
+                next_action: Some("Post Board request".to_string()),
+                owner: Some("SPEC-2359".to_string()),
+                agent_session: None,
+                current_focus: None,
+                title_summary: None,
+            },
+            &mut out,
+        )
+        .expect("update workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace updated:"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        assert_eq!(saved.title, "Workspace coordination");
+        assert_eq!(saved.status_category, WorkspaceStatusCategory::Blocked);
+        assert_eq!(saved.owner.as_deref(), Some("SPEC-2359"));
+    }
+
+    #[test]
+    fn workspace_join_assigns_unassigned_agent_to_existing_workspace() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace history".to_string());
+        event.summary = Some("Existing Workspace".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Join {
+                agent_session: "session-1".to_string(),
+                workspace_id: "workspace-existing".to_string(),
+                current_focus: Some("Continue Workspace history".to_string()),
+                title_summary: Some("Workspace history".to_string()),
+            },
+            &mut out,
+        )
+        .expect("join workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace joined: workspace-existing"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some("workspace-existing"));
+        assert_eq!(saved.id, "workspace-existing");
+    }
+
+    #[test]
+    fn workspace_create_records_workspace_and_assigns_agent() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Create {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace history".to_string(),
+                current_focus: Some("Implement Workspace history".to_string()),
+                spec: Some(2359),
+                issue: None,
+                split_from: None,
+                boundary: Some("history slice".to_string()),
+            },
+            &mut out,
+        )
+        .expect("create workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace created: workspace-"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let workspace_id = saved.id.clone();
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some(workspace_id.as_str()));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert_eq!(items.work_items.len(), 1);
+        assert_eq!(items.work_items[0].id, workspace_id);
+        assert_eq!(items.work_items[0].title, "Workspace history");
+    }
+
+    #[test]
+    fn workspace_candidates_lists_similar_incomplete_workspaces() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace history".to_string());
+        event.intent = Some("Implement Workspace history with affiliation state".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Candidates {
+                agent_session: "session-1".to_string(),
+            },
+            &mut out,
+        )
+        .expect("list candidates");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace-existing"), "{out}");
+        assert!(out.contains("Workspace history"), "{out}");
+        assert!(out.contains("score="), "{out}");
+    }
+
+    #[test]
+    fn workspace_create_rejects_similar_workspace_without_split_boundary() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace history".to_string());
+        event.intent = Some("Implement Workspace history with affiliation state".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let err = run(
+            &mut env,
+            WorkspaceCommand::Create {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace history".to_string(),
+                current_focus: Some("Implement Workspace history affiliation".to_string()),
+                spec: None,
+                issue: Some(2359),
+                split_from: None,
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect_err("similar Workspace should be rejected");
+
+        assert!(err.to_string().contains("similar Workspace exists"));
     }
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -99,7 +99,8 @@ pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
     ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FocusCycleDirection,
     FrontendEvent, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView,
-    RecentProjectView, WorkspaceExecutionContainerView, WorkspaceJournalEntryView,
+    RecentProjectView, WorkspaceExecutionContainerView, WorkspaceHistoryAgentView,
+    WorkspaceHistoryEventView, WorkspaceHistoryView, WorkspaceJournalEntryView,
     WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView, WorkspaceWorkEventView,
     WorkspaceWorkItemView,
 };

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -411,6 +411,8 @@ pub struct ActiveWorkAgentView {
     pub window_id: Option<String>,
     pub agent_id: String,
     pub display_name: String,
+    pub affiliation_status: String,
+    pub workspace_id: Option<String>,
     pub status_category: String,
     pub current_focus: Option<String>,
     pub title_summary: Option<String>,
@@ -438,12 +440,14 @@ pub struct WorkspaceJournalEntryView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceWorkAgentView {
+pub struct WorkspaceHistoryAgentView {
     pub session_id: String,
     pub agent_id: Option<String>,
     pub display_name: Option<String>,
     pub updated_at: String,
 }
+
+pub type WorkspaceWorkAgentView = WorkspaceHistoryAgentView;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceExecutionContainerView {
@@ -455,9 +459,9 @@ pub struct WorkspaceExecutionContainerView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceWorkEventView {
+pub struct WorkspaceHistoryEventView {
     pub id: String,
-    pub work_item_id: String,
+    pub workspace_id: String,
     pub kind: String,
     pub title: Option<String>,
     pub intent: Option<String>,
@@ -467,12 +471,14 @@ pub struct WorkspaceWorkEventView {
     pub next_action: Option<String>,
     pub agent_session_id: Option<String>,
     pub board_entry_id: Option<String>,
-    pub related_work_item_id: Option<String>,
+    pub related_workspace_id: Option<String>,
     pub updated_at: String,
 }
 
+pub type WorkspaceWorkEventView = WorkspaceHistoryEventView;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceWorkItemView {
+pub struct WorkspaceHistoryView {
     pub id: String,
     pub title: String,
     pub intent: Option<String>,
@@ -482,12 +488,14 @@ pub struct WorkspaceWorkItemView {
     pub created_at: String,
     pub updated_at: String,
     pub completed_at: Option<String>,
-    pub agents: Vec<WorkspaceWorkAgentView>,
+    pub agents: Vec<WorkspaceHistoryAgentView>,
     pub execution_containers: Vec<WorkspaceExecutionContainerView>,
     pub board_refs: Vec<String>,
-    pub related_work_item_ids: Vec<String>,
-    pub events: Vec<WorkspaceWorkEventView>,
+    pub related_workspace_ids: Vec<String>,
+    pub events: Vec<WorkspaceHistoryEventView>,
 }
+
+pub type WorkspaceWorkItemView = WorkspaceHistoryView;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkCleanupCandidateView {
@@ -517,9 +525,12 @@ pub struct ActiveWorkProjectionView {
     pub pr_created_at: Option<String>,
     pub board_refs: Vec<String>,
     pub journal_entries: Vec<WorkspaceJournalEntryView>,
-    pub work_items: Vec<WorkspaceWorkItemView>,
+    #[serde(default, alias = "work_items")]
+    pub workspaces: Vec<WorkspaceHistoryView>,
     pub cleanup_candidate: Option<ActiveWorkCleanupCandidateView>,
     pub agents: Vec<ActiveWorkAgentView>,
+    #[serde(default)]
+    pub unassigned_agents: Vec<ActiveWorkAgentView>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -968,7 +979,7 @@ mod tests {
                     agent_current_focus: Some("Run launch tests".to_string()),
                     agent_title_summary: Some("Launch tests".to_string()),
                 }],
-                work_items: Vec::new(),
+                workspaces: Vec::new(),
                 cleanup_candidate: Some(super::ActiveWorkCleanupCandidateView {
                     branch: "work/20260504-1200".to_string(),
                     worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),
@@ -981,6 +992,8 @@ mod tests {
                     window_id: Some("tab-1::agent-1".to_string()),
                     agent_id: "codex".to_string(),
                     display_name: "Codex".to_string(),
+                    affiliation_status: "assigned".to_string(),
+                    workspace_id: Some("work-1".to_string()),
                     status_category: "active".to_string(),
                     current_focus: Some("Run launch tests".to_string()),
                     title_summary: Some("Launch tests".to_string()),
@@ -991,6 +1004,7 @@ mod tests {
                     coordination_scope: Some("SPEC-2359 / start-work".to_string()),
                     updated_at: "2026-05-04T12:00:00Z".to_string(),
                 }],
+                unassigned_agents: Vec::new(),
             }),
         };
 

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -15,8 +15,9 @@ use gwt_core::{
     paths::gwt_sessions_dir,
     repo_hash::compute_repo_hash,
     workspace_projection::{
-        record_workspace_work_event, save_workspace_projection, WorkspaceAgentSummary,
-        WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
+        record_workspace_work_event, save_workspace_projection, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkEvent,
+        WorkspaceWorkEventKind,
     },
 };
 use gwt_github::{
@@ -189,6 +190,28 @@ fn workspace_agent(
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
+        affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+        workspace_id: Some("workspace-existing".to_string()),
+        updated_at: Utc::now(),
+    }
+}
+
+fn unassigned_workspace_agent(session_id: &str) -> WorkspaceAgentSummary {
+    WorkspaceAgentSummary {
+        session_id: session_id.to_string(),
+        window_id: None,
+        agent_id: "codex".to_string(),
+        display_name: "Codex".to_string(),
+        status_category: WorkspaceStatusCategory::Active,
+        current_focus: None,
+        title_summary: None,
+        worktree_path: None,
+        branch: Some("work/unassigned".to_string()),
+        last_board_entry_id: None,
+        last_board_entry_kind: None,
+        coordination_scope: None,
+        affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+        workspace_id: None,
         updated_at: Utc::now(),
     }
 }
@@ -713,6 +736,68 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
 }
 
 #[test]
+fn unassigned_agent_without_title_summary_is_not_title_blocked() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/unassigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection
+            .agents
+            .push(unassigned_workspace_agent(&session_id));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/lib.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Unassigned Agents must not be blocked as missing title-summary"
+        );
+    });
+}
+
+#[test]
+fn assigned_agent_without_title_summary_remains_title_blocked() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/assigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        let mut agent = workspace_agent(&session_id, "Implement assigned work", "");
+        agent.title_summary = None;
+        projection.agents.push(agent);
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/lib.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::PreToolUsePermission { .. }),
+            "Assigned Agents still need a title-summary before implementation"
+        );
+    });
+}
+
+#[test]
 fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);
@@ -751,7 +836,7 @@ fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
         let HookOutput::PreToolUsePermission { detail, .. } = decision else {
             panic!("expected incomplete WorkItem conflict to block mutation");
         };
-        assert!(detail.contains("incomplete Workspace WorkItem"), "{detail}");
+        assert!(detail.contains("incomplete Workspace"), "{detail}");
         assert!(detail.contains("session-other"), "{detail}");
         assert!(detail.contains("gwtd board post"), "{detail}");
     });

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -148,19 +148,55 @@ test("Workspace Kanban labels the non-current history column as Inactive", () =>
   );
 });
 
-test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", () => {
+test("Workspace Kanban renders Unassigned agents outside Workspace status columns", () => {
+  const fixture = createFixture();
+  const projection = {
+    id: "project-workspace",
+    title: "Project workspace",
+    status_category: "idle",
+    status_text: "No active Workspace selected",
+    journal_entries: [],
+    workspaces: [],
+    unassigned_agents: [
+      {
+        session_id: "session-unassigned",
+        display_name: "Codex",
+        status_category: "active",
+        affiliation_status: "unassigned",
+        branch: "work/20260511-0100",
+      },
+    ],
+  };
+
+  const surface = createSurface(fixture, projection);
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const unassigned = fixture.body.querySelector("[data-role='unassigned-agents']");
+  assert.ok(unassigned, "Unassigned section should be rendered");
+  assert.match(unassigned.textContent, /Unassigned/);
+  assert.match(unassigned.textContent, /No Workspace selected/);
+  assert.match(unassigned.textContent, /Codex/);
+  assert.equal(cardTexts(column(fixture.body, "active")).length, 0);
+  assert.equal(cardTexts(column(fixture.body, "inactive")).length, 1);
+  assert.doesNotMatch(fixture.body.textContent, /WorkItem/);
+});
+
+test("Workspace Kanban renders Workspace history cards with lifecycle timeline detail", () => {
   const fixture = createFixture();
   const projection = {
     id: "current-workspace",
     title: "Legacy current Workspace",
     status_category: "idle",
     status_text: "Idle",
-    work_items: [
+    workspaces: [
       {
-        id: "workitem-history",
-        title: "Workspace WorkItem history",
-        intent: "Group duplicate Workspace work under one WorkItem",
-        summary: "One WorkItem owns the history.",
+        id: "workspace-history",
+        title: "Workspace history",
+        intent: "Group duplicate work under one Workspace",
+        summary: "One Workspace owns the history.",
         status_category: "active",
         owner: "SPEC-2359",
         agents: [
@@ -184,7 +220,7 @@ test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", (
           {
             id: "evt-start",
             kind: "start",
-            title: "Start WorkItem",
+            title: "Start Workspace",
             summary: "Started lifecycle implementation.",
             updated_at: "2026-05-11T01:00:00Z",
             agent_session_id: "session-other",
@@ -217,8 +253,9 @@ test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", (
   });
 
   const cardText = cardTexts(column(fixture.body, "active")).join("\n");
-  assert.match(cardText, /WorkItem/);
-  assert.match(cardText, /Workspace WorkItem history/);
+  assert.match(cardText, /Workspace/);
+  assert.match(cardText, /Workspace history/);
+  assert.doesNotMatch(cardText, /WorkItem/);
   assert.doesNotMatch(cardText, /Legacy duplicate card/);
 
   const detailText = fixture.body

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2316,6 +2316,65 @@ kbd.op-kbd {
   grid-template-columns: repeat(3, minmax(240px, 1fr));
 }
 
+.workspace-unassigned {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: var(--space-3) var(--space-3) 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.workspace-unassigned[hidden] {
+  display: none;
+}
+
+.workspace-unassigned-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--type-xs);
+}
+
+.workspace-unassigned-title {
+  color: var(--color-text-strong);
+  font-size: var(--type-sm);
+  font-weight: 600;
+}
+
+.workspace-unassigned-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-2);
+}
+
+.workspace-unassigned-agent {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-elevated);
+}
+
+.workspace-unassigned-agent-name {
+  color: var(--color-text-strong);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.workspace-unassigned-agent-state {
+  color: var(--color-text-muted);
+  font-size: var(--type-xs);
+}
+
 .kanban-column {
   display: flex;
   flex-direction: column;

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -73,20 +73,30 @@ export function createWorkspaceKanbanSurface({
     const title = projection.title || `${activeWorkspace().title || "Project"} workspace`;
     const branch = projection.branch || "";
     const worktreePath = projection.worktree_path || "";
-    const workItems = Array.isArray(projection.work_items)
-      ? projection.work_items
-      : [];
-    if (workItems.length > 0) {
-      return workItems.map((item) => {
+    const workspaces = Array.isArray(projection.workspaces)
+      ? projection.workspaces
+      : Array.isArray(projection.work_items)
+        ? projection.work_items
+        : [];
+    if (workspaces.length > 0) {
+      return workspaces.map((item) => {
+        const workspaceId = item.id || `workspace-${item.title || "workspace"}`;
+        const workspaceTitle = item.title || item.intent || "Workspace";
+        const workspaceEvents = Array.isArray(item.events) ? item.events : [];
+        const normalizedEvents = workspaceEvents.map((event) => ({
+          ...event,
+          workspace_id: event.workspace_id || event.work_item_id || workspaceId,
+          related_workspace_id: event.related_workspace_id || event.related_work_item_id || "",
+        }));
         const containers = Array.isArray(item.execution_containers)
           ? item.execution_containers
           : [];
         const container = containers[0] || {};
         return {
-          id: item.id || `workitem-${item.title || "workspace"}`,
-          kind: "work_item",
-          label: "WorkItem",
-          title: item.title || item.intent || "Workspace WorkItem",
+          id: workspaceId,
+          kind: "workspace",
+          label: "Workspace",
+          title: workspaceTitle,
           intent: item.intent || "",
           status_category: item.status_category || "idle",
           status_text: item.summary || item.intent || "",
@@ -105,7 +115,7 @@ export function createWorkspaceKanbanSurface({
           updated_at: item.updated_at || "",
           resume_source: "current",
           journal_id: null,
-          events: Array.isArray(item.events) ? item.events : [],
+          events: normalizedEvents,
           column: workspaceColumnForCurrentStatus(item.status_category),
         };
       });
@@ -174,6 +184,70 @@ export function createWorkspaceKanbanSurface({
     }
 
     return cards;
+  }
+
+  function unassignedAgentsFromProjection(projection) {
+    const unassigned = Array.isArray(projection?.unassigned_agents)
+      ? projection.unassigned_agents
+      : [];
+    return unassigned
+      .filter((agent) => String(agent?.affiliation_status || "unassigned") === "unassigned")
+      .map((agent) => ({
+        session_id: agent.session_id || "",
+        display_name: agent.display_name || agent.agent_id || "Agent",
+        agent_id: agent.agent_id || "",
+        branch: agent.branch || "",
+        worktree_path: agent.worktree_path || "",
+        current_focus: agent.current_focus || agent.title_summary || "",
+      }));
+  }
+
+  function renderUnassignedAgents(container, projection) {
+    if (!container) return;
+    container.innerHTML = "";
+    const agents = unassignedAgentsFromProjection(projection);
+    if (agents.length === 0) {
+      container.hidden = true;
+      return;
+    }
+    container.hidden = false;
+    const header = createNode("div", "workspace-unassigned-header");
+    header.appendChild(createNode("div", "workspace-unassigned-title", "Unassigned"));
+    header.appendChild(
+      createNode(
+        "div",
+        "workspace-unassigned-count",
+        agents.length === 1 ? "1 Agent" : `${agents.length} Agents`,
+      ),
+    );
+    container.appendChild(header);
+    const list = createNode("div", "workspace-unassigned-list");
+    for (const agent of agents) {
+      const row = createNode("article", "workspace-unassigned-agent");
+      row.dataset.sessionId = agent.session_id;
+      row.appendChild(createNode("div", "workspace-unassigned-agent-name", agent.display_name));
+      row.appendChild(
+        createNode("div", "workspace-unassigned-agent-state", "No Workspace selected"),
+      );
+      const meta = createNode("div", "kanban-card-meta");
+      appendMeta(meta, agent.branch);
+      appendMeta(meta, agent.current_focus);
+      if (meta.childElementCount > 0) {
+        row.appendChild(meta);
+      }
+      const actions = createNode("div", "workspace-card-actions");
+      const findButton = createNode("button", "wizard-button", "Find Workspace");
+      findButton.type = "button";
+      findButton.disabled = true;
+      const createButton = createNode("button", "wizard-button", "Create Workspace");
+      createButton.type = "button";
+      createButton.disabled = true;
+      actions.appendChild(findButton);
+      actions.appendChild(createButton);
+      row.appendChild(actions);
+      list.appendChild(row);
+    }
+    container.appendChild(list);
   }
 
   function resumeWorkspaceCard(card) {
@@ -380,11 +454,14 @@ export function createWorkspaceKanbanSurface({
     if (!element) return;
     const state = ensureWorkspaceKanbanState(windowId);
     const board = element.querySelector(".workspace-kanban-board");
+    const unassigned = element.querySelector("[data-role='unassigned-agents']");
     const detailPane = element.querySelector(".workspace-kanban-detail-pane");
     const status = element.querySelector(".workspace-kanban-status");
     if (!board || !detailPane || !status) return;
 
-    const cards = workspaceCardsFromProjection(getActiveWorkProjection());
+    const projection = getActiveWorkProjection();
+    const cards = workspaceCardsFromProjection(projection);
+    renderUnassignedAgents(unassigned, projection);
     if (!state.selectedId || !cards.some((card) => card.id === state.selectedId)) {
       state.selectedId = cards[0]?.id || null;
     }
@@ -440,6 +517,7 @@ export function createWorkspaceKanbanSurface({
         <div class="knowledge-status workspace-kanban-status"></div>
         <div class="knowledge-split workspace-split kanban-shell">
           <div class="knowledge-list-pane kanban-list-pane">
+            <section class="workspace-unassigned" data-role="unassigned-agents" hidden></section>
             <div class="kanban-board workspace-kanban-board" role="list" aria-label="Workspace Kanban Board">
               <div class="kanban-column workspace-kanban-column" data-workspace-column="active" aria-label="Active Workspace column">
                 <div class="kanban-column-header">


### PR DESCRIPTION
## Summary

Implements the SPEC-2359 Unassigned Agent / Workspace naming follow-up.

## Changes

- Adds explicit Agent Workspace affiliation state so Start Work and non-work branch launches can appear as Unassigned instead of Active or Inactive Workspace.
- Preserves assigned Workspace behavior and duplicate-work coordination for Agents that have joined a Workspace.
- Renames user-facing Workspace Overview history from WorkItem to Workspace history while preserving local data compatibility.
- Adds `gwtd workspace candidates`, `gwtd workspace join`, and `gwtd workspace create` paths for Agent affiliation.
- Shows Unassigned Agents outside the Workspace status columns in the Workspace Overview UI.

## Testing

- `cargo test -p gwt-core -p gwt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo build -p gwt`
- `pnpm run test:frontend-unit`
- `pnpm run test:frontend-bundle`
- `pnpm run test:frontend-smoke`
- `git push` pre-push checks passed with filtered line coverage 90.45% against the 90.00% threshold.

## Closing Issues

None

## Related Issues

- SPEC-2359

## Checklist

- [x] SPEC tasks updated
- [x] Board handoff posted
- [x] Tests/lint/build completed
- [x] Commit pushed
