### PR TITLE
feat(coordination): SPEC-2359 Phase 20 audience auto-attach and mention fan-out

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -713,6 +713,50 @@ pub fn load_workspace_projection(repo_path: &Path) -> Result<Option<WorkspacePro
     load_workspace_projection_from_path(&gwt_workspace_projection_path_for_repo_path(repo_path))
 }
 
+/// SPEC-2359 FR-094 / FR-097 / FR-098 / FR-099: resolve the currently
+/// assigned Workspace id for a given session. Returns `Some(id)` when
+/// the agent is assigned to a Workspace and `None` otherwise (Unassigned
+/// agent, missing agent, or load failure). Callers use this for Board
+/// audience auto-attach, reminder injection scoping, and the
+/// duplicate-work coordination gate corpus.
+pub fn resolve_workspace_id_for_session(repo_path: &Path, session_id: &str) -> Option<String> {
+    let projection = load_workspace_projection(repo_path).ok().flatten()?;
+    projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+        .filter(|agent| !agent.is_unassigned())
+        .and_then(|agent| agent.workspace_id.clone())
+}
+
+/// SPEC-2359 FR-097: resolve the currently assigned Workspace id for a
+/// mention target. `target_kind` is `BoardMentionTargetKind::Agent` or
+/// `BoardMentionTargetKind::Session`; the target value is matched
+/// against agent display_name / agent_id (agent) or session_id (session).
+/// Returns `Some(id)` when the matched agent is assigned, `None`
+/// otherwise.
+pub fn resolve_workspace_id_for_mention(
+    repo_path: &Path,
+    target_kind: &str,
+    target_value: &str,
+) -> Option<String> {
+    let projection = load_workspace_projection(repo_path).ok().flatten()?;
+    projection
+        .agents
+        .iter()
+        .find(|agent| match target_kind {
+            "session" => agent.session_id == target_value,
+            "agent" => {
+                agent.agent_id == target_value
+                    || agent.display_name == target_value
+                    || agent.display_name.eq_ignore_ascii_case(target_value)
+            }
+            _ => false,
+        })
+        .filter(|agent| !agent.is_unassigned())
+        .and_then(|agent| agent.workspace_id.clone())
+}
+
 pub fn load_or_default_workspace_projection(repo_path: &Path) -> Result<WorkspaceProjection> {
     load_or_default_workspace_projection_from_path(
         &gwt_workspace_projection_path_for_repo_path(repo_path),
@@ -2223,5 +2267,144 @@ mod tests {
         assert_eq!(recent.len(), 1);
         assert_eq!(recent[0].summary.as_deref(), Some("Second summary"));
         assert_eq!(recent[0].updated_at, second_at);
+    }
+
+    fn assigned_agent(
+        session_id: &str,
+        agent_id: &str,
+        workspace_id: &str,
+    ) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.into(),
+            window_id: None,
+            agent_id: agent_id.into(),
+            display_name: agent_id.into(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            title_summary: None,
+            worktree_path: None,
+            branch: None,
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: Some(workspace_id.into()),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn unassigned_agent(session_id: &str, agent_id: &str) -> WorkspaceAgentSummary {
+        let mut a = assigned_agent(session_id, agent_id, "_unused");
+        a.affiliation_status = WorkspaceAgentAffiliationStatus::Unassigned;
+        a.workspace_id = None;
+        a
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_session_returns_assigned_workspace_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-A", "codex", "ws-1"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_session(dir.path(), "sess-A"),
+            Some("ws-1".into())
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_session_returns_none_for_unassigned_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection.agents.push(unassigned_agent("sess-B", "codex"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(resolve_workspace_id_for_session(dir.path(), "sess-B"), None);
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_session_returns_none_when_session_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let projection = WorkspaceProjection::default_for_project(dir.path());
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_session(dir.path(), "sess-missing"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_session_matches_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-C", "codex", "ws-2"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "session", "sess-C"),
+            Some("ws-2".into())
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_agent_matches_display_or_agent_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-D", "codex", "ws-3"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "agent", "codex"),
+            Some("ws-3".into())
+        );
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "agent", "Codex"),
+            Some("ws-3".into()),
+            "case-insensitive display-name match"
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_returns_none_for_unassigned_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection.agents.push(unassigned_agent("sess-E", "codex"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "session", "sess-E"),
+            None
+        );
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "agent", "codex"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_user_or_branch_kind_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-F", "codex", "ws-4"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "user", "akiojin"),
+            None
+        );
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "branch", "feature/x"),
+            None
+        );
     }
 }

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -141,22 +141,54 @@ pub(super) fn run<E: CliEnv>(
             if !targets.is_empty() {
                 entry = entry.with_target_owners(targets);
             }
-            let (workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
+            let (mut workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
             let mentions =
                 parse_mentions(&other_mention_args).map_err(gwt_error_to_spec_ops_error)?;
+            // SPEC-2359 FR-094/097: unless `--broadcast` is set, auto-attach
+            // the current Agent's assigned Workspace id and fan out the
+            // current Workspace id of each agent/session mention target.
+            // FR-103: legacy entries (Unassigned/missing) leave audience
+            // absent which round-trips as broadcast.
+            if !broadcast {
+                if let Some(session) = current_session.as_ref() {
+                    if let Some(ws_id) =
+                        gwt_core::workspace_projection::resolve_workspace_id_for_session(
+                            env.repo_path(),
+                            &session.id,
+                        )
+                    {
+                        if !workspace_audience.iter().any(|existing| existing == &ws_id) {
+                            workspace_audience.push(ws_id);
+                        }
+                    }
+                }
+                for mention in mentions.iter() {
+                    let kind = mention.target_kind.as_str();
+                    if kind == "user" || kind == "branch" {
+                        continue;
+                    }
+                    if let Some(ws_id) =
+                        gwt_core::workspace_projection::resolve_workspace_id_for_mention(
+                            env.repo_path(),
+                            kind,
+                            &mention.target,
+                        )
+                    {
+                        if !workspace_audience.iter().any(|existing| existing == &ws_id) {
+                            workspace_audience.push(ws_id);
+                        }
+                    }
+                }
+            }
             if !mentions.is_empty() {
                 entry = entry.with_mentions(mentions);
             }
-            // SPEC-2359 FR-093/094/095/096: Workspace audience comes from
-            // explicit `--mention workspace:<id>` flags. `--broadcast`
-            // suppresses any auto-attach (FR-094/097 will fan-out the
-            // current Agent's and mention targets' workspaces once the
-            // Agent affiliation field lands; until then, audience is
-            // only the explicit workspace mentions).
+            // SPEC-2359 FR-093/094/095/096/097: persist the resolved audience
+            // (explicit workspace mentions + auto-attach + fan-out). Empty
+            // serializes as absent (FR-103 broadcast fallback).
             if !workspace_audience.is_empty() {
                 entry = entry.with_audience(workspace_audience);
             }
-            let _ = broadcast;
             let snapshot =
                 post_entry(env.repo_path(), entry).map_err(gwt_error_to_spec_ops_error)?;
             publish_board_change(env.repo_path(), snapshot.board.entries.len());

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -193,7 +193,7 @@ pub fn compute_plan(
         reminders,
         has_recent_own_status,
         language: language.clone(),
-        self_workspace_id: resolve_self_workspace_id(),
+        self_workspace_id: resolve_self_workspace_id(session),
     });
 
     plan.output = append_title_summary_required_context(
@@ -216,15 +216,13 @@ fn resolve_narrative_language() -> String {
 }
 
 /// SPEC-2359 FR-098: resolve the current Agent's assigned Workspace id
-/// for audience-aware reminder filtering. Returns `None` until the Agent
-/// affiliation field (SPEC-2359 FR-088, US-25) is populated, at which
-/// point this resolver should read `WorkspaceAgentSummary` for the
-/// current session and return its assigned `workspace_id`. Returning
-/// `None` is safe: audience-aware filtering then surfaces only
-/// broadcast-audience entries, matching legacy behavior since all
-/// pre-migration entries are broadcast (FR-103).
-fn resolve_self_workspace_id() -> Option<String> {
-    None
+/// for audience-aware reminder filtering. Returns `None` for Unassigned
+/// agents (broadcast-only visibility) and `Some(id)` for assigned agents.
+fn resolve_self_workspace_id(session: &Session) -> Option<String> {
+    gwt_core::workspace_projection::resolve_workspace_id_for_session(
+        &session.worktree_path,
+        &session.id,
+    )
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -314,7 +314,8 @@ fn workspace_coordination_conflicts(
         current_intent,
         current_session_id,
     )?);
-    let current_workspace_id = resolve_current_workspace_audience();
+    let current_workspace_id = current_session_id
+        .and_then(|session_id| resolve_current_workspace_audience(worktree_root, session_id));
     conflicts.extend(board_claim_conflicts(
         worktree_root,
         current_intent,
@@ -325,13 +326,11 @@ fn workspace_coordination_conflicts(
 }
 
 /// SPEC-2359 FR-099: resolve the current Agent's assigned Workspace id for
-/// the duplicate-work coordination gate. Returns `None` until the Agent
-/// affiliation field (SPEC-2359 FR-088, US-25) lands, mirroring the
-/// reminder-injection resolver. With `None`, only broadcast (audience
-/// absent) claims gate the current Agent, matching reminder visibility
-/// for Unassigned Agents.
-fn resolve_current_workspace_audience() -> Option<String> {
-    None
+/// the duplicate-work coordination gate. Returns `None` for Unassigned
+/// agents (broadcast-only gating) and `Some(id)` for assigned agents,
+/// mirroring the reminder-injection resolver.
+fn resolve_current_workspace_audience(worktree_root: &Path, session_id: &str) -> Option<String> {
+    gwt_core::workspace_projection::resolve_workspace_id_for_session(worktree_root, session_id)
 }
 
 fn workspace_agent_conflicts(


### PR DESCRIPTION
## Summary

Wire up the Board audience auto-attach (FR-094) and mention fan-out (FR-097) now that Codex's affiliation field (`WorkspaceAgentSummary.workspace_id` / `affiliation_status`) landed via PR #2642.

- `gwt-core`: new helpers `resolve_workspace_id_for_session` and `resolve_workspace_id_for_mention` provide a single lookup path shared by CLI, reminder hook, and workflow-policy.
- `gwtd board post`: auto-attaches the current Agent's assigned Workspace id and fans out the assigned Workspace id of each `--mention agent:<id>` / `--mention session:<id>` target into `BoardEntry.audience`. `--broadcast` short-circuits both. `--mention user:<id>` / `--mention branch:<id>` never extend audience (FR-097 isolation).
- `board-reminder` hook: `resolve_self_workspace_id` now reads the projection so SessionStart / UserPromptSubmit reminders scope to the current Agent's assigned Workspace + broadcast (FR-098).
- `workflow-policy`: `resolve_current_workspace_audience` now reads the same projection so the duplicate-work coordination gate uses the same audience corpus as the reminder (FR-099). The previous test `does_not_block_when_active_board_claim_is_audienced_to_other_workspace` keeps proving the non-overlap path with the real resolver in place.

## Test plan

- [x] 7 new `gwt-core` resolver tests (assigned / unassigned / missing / session / agent display name + agent_id / case-insensitive / user-branch isolation)
- [x] `cargo test -p gwt-core -p gwt` — 838+ tests pass, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo build -p gwt` — clean
- [ ] CI green
- [ ] Manual smoke (post-merge): assigned-agent `gwtd board post` rounds-trips audience including its workspace_id

## SPEC tracking

- SPEC-2359 tasks.md: T-213 / T-214 now `[x]` (auto-attach + fan-out)
- Remaining: T-211 / T-218 / T-219 (frontend Board pane + final manual smoke) — Codex can pick these up per Board claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)
