### PR TITLE
feat(board): scope board entries by workspace

### DIFF
--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -90,6 +90,7 @@ pub enum BoardMentionTargetKind {
     Agent,
     Session,
     Branch,
+    Workspace,
 }
 
 impl std::str::FromStr for BoardMentionTargetKind {
@@ -101,6 +102,7 @@ impl std::str::FromStr for BoardMentionTargetKind {
             "agent" => Ok(Self::Agent),
             "session" => Ok(Self::Session),
             "branch" => Ok(Self::Branch),
+            "workspace" => Ok(Self::Workspace),
             other => Err(GwtError::Other(format!(
                 "unknown board mention target kind: {other}"
             ))),
@@ -115,6 +117,7 @@ impl BoardMentionTargetKind {
             Self::Agent => "agent",
             Self::Session => "session",
             Self::Branch => "branch",
+            Self::Workspace => "workspace",
         }
     }
 }
@@ -192,6 +195,69 @@ pub fn normalize_board_mentions(values: &[BoardMention]) -> Vec<BoardMention> {
     normalized
 }
 
+pub fn normalize_board_audience(values: Option<Vec<String>>) -> Option<Vec<String>> {
+    let mut normalized = Vec::new();
+    for value in values.unwrap_or_default() {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if normalized.iter().any(|item| item == value) {
+            continue;
+        }
+        normalized.push(value.to_string());
+    }
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn board_audience_is_absent(value: &Option<Vec<String>>) -> bool {
+    value
+        .as_ref()
+        .map(|items| items.iter().all(|item| item.trim().is_empty()))
+        .unwrap_or(true)
+}
+
+fn deserialize_board_audience<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Vec<String>>::deserialize(deserializer)?;
+    Ok(normalize_board_audience(value))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardAudienceScope {
+    All,
+    Broadcast,
+    Workspace(String),
+}
+
+pub fn board_entry_visible_for_scope(entry: &BoardEntry, scope: &BoardAudienceScope) -> bool {
+    let Some(audience) = normalize_board_audience(entry.audience.clone()) else {
+        return true;
+    };
+    match scope {
+        BoardAudienceScope::All => true,
+        BoardAudienceScope::Broadcast => false,
+        BoardAudienceScope::Workspace(workspace_id) => {
+            let workspace_id = workspace_id.trim();
+            !workspace_id.is_empty() && audience.iter().any(|item| item == workspace_id)
+        }
+    }
+}
+
+pub fn filter_board_entries_for_scope(
+    entries: Vec<BoardEntry>,
+    scope: &BoardAudienceScope,
+) -> Vec<BoardEntry> {
+    entries
+        .into_iter()
+        .filter(|entry| board_entry_visible_for_scope(entry, scope))
+        .collect()
+}
+
 pub fn board_entry_targets_self(entry: &BoardEntry, match_keys: &[String]) -> bool {
     entry
         .target_owners
@@ -232,6 +298,12 @@ pub struct BoardEntry {
     pub target_owners: Vec<String>,
     #[serde(default)]
     pub mentions: Vec<BoardMention>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_board_audience",
+        skip_serializing_if = "board_audience_is_absent"
+    )]
+    pub audience: Option<Vec<String>>,
 }
 
 impl BoardEntry {
@@ -276,6 +348,16 @@ impl BoardEntry {
         self
     }
 
+    pub fn with_audience(mut self, values: Vec<impl Into<String>>) -> Self {
+        self.audience =
+            normalize_board_audience(Some(values.into_iter().map(Into::into).collect::<Vec<_>>()));
+        self
+    }
+
+    pub fn normalize_audience(&mut self) {
+        self.audience = normalize_board_audience(self.audience.take());
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         author_kind: AuthorKind,
@@ -306,6 +388,7 @@ impl BoardEntry {
             origin_agent_id: None,
             target_owners: Vec::new(),
             mentions: Vec::new(),
+            audience: None,
         }
     }
 }
@@ -440,8 +523,9 @@ pub fn ensure_repo_local_files(worktree_root: &Path) -> Result<()> {
 pub fn load_snapshot(worktree_root: &Path) -> Result<CoordinationSnapshot> {
     ensure_repo_local_files(worktree_root)?;
     let coordination_root = coordination_dir(worktree_root);
-    let projection: BoardProjection =
+    let mut projection: BoardProjection =
         load_json_or_default(&coordination_board_projection_path(worktree_root))?;
+    normalize_board_projection(&mut projection);
     let manifest = load_event_manifest_from_dir(&coordination_root)?;
     if legacy_event_log_needs_import(&coordination_root)?
         || projection_needs_rebuild(&projection, &manifest)
@@ -452,6 +536,8 @@ pub fn load_snapshot(worktree_root: &Path) -> Result<CoordinationSnapshot> {
 }
 
 pub fn post_entry(worktree_root: &Path, entry: BoardEntry) -> Result<CoordinationSnapshot> {
+    let mut entry = entry;
+    entry.normalize_audience();
     append_event(worktree_root, &CoordinationEvent::MessageAppended { entry })
 }
 
@@ -572,6 +658,9 @@ fn build_hot_projection(
     mut entries: Vec<BoardEntry>,
     updated_at: DateTime<Utc>,
 ) -> BoardProjection {
+    for entry in &mut entries {
+        entry.normalize_audience();
+    }
     entries.sort_by_key(|entry| entry.created_at);
     let total_entries = entries.len();
     let has_more_before = total_entries > HOT_PROJECTION_ENTRY_LIMIT;
@@ -589,6 +678,26 @@ fn build_hot_projection(
         total_entries,
         updated_at,
     }
+}
+
+fn normalize_board_projection(projection: &mut BoardProjection) {
+    for entry in &mut projection.entries {
+        entry.normalize_audience();
+    }
+}
+
+pub fn load_snapshot_for_scope(
+    worktree_root: &Path,
+    scope: &BoardAudienceScope,
+) -> Result<CoordinationSnapshot> {
+    if *scope == BoardAudienceScope::All {
+        return load_snapshot(worktree_root);
+    }
+    ensure_repo_local_files(worktree_root)?;
+    let entries = load_board_entries_from_segments_root(&coordination_dir(worktree_root))?;
+    Ok(CoordinationSnapshot {
+        board: build_hot_projection(filter_board_entries_for_scope(entries, scope), Utc::now()),
+    })
 }
 
 fn load_json_or_default<T>(path: &Path) -> Result<T>
@@ -1121,7 +1230,9 @@ fn load_events_from_path(path: &Path) -> Result<Vec<CoordinationEvent>> {
         if trimmed.is_empty() {
             continue;
         }
-        events.push(serde_json::from_str(trimmed).map_err(json_error)?);
+        let mut event: CoordinationEvent = serde_json::from_str(trimmed).map_err(json_error)?;
+        normalize_coordination_event(&mut event);
+        events.push(event);
     }
     Ok(events)
 }
@@ -1146,12 +1257,21 @@ fn load_legacy_board_events_from_path(path: &Path) -> Result<Vec<CoordinationEve
             .unwrap_or_default();
         match event_type {
             "message_appended" | "board_post" => {
-                events.push(serde_json::from_value(value).map_err(json_error)?);
+                let mut event: CoordinationEvent =
+                    serde_json::from_value(value).map_err(json_error)?;
+                normalize_coordination_event(&mut event);
+                events.push(event);
             }
             _ => continue,
         }
     }
     Ok(events)
+}
+
+fn normalize_coordination_event(event: &mut CoordinationEvent) {
+    match event {
+        CoordinationEvent::MessageAppended { entry } => entry.normalize_audience(),
+    }
 }
 
 fn write_events_to_path(path: &Path, events: &[CoordinationEvent]) -> Result<()> {
@@ -1335,6 +1455,15 @@ pub fn load_entries_since(worktree_root: &Path, since: DateTime<Utc>) -> Result<
     Ok(entries)
 }
 
+pub fn load_entries_since_for_scope(
+    worktree_root: &Path,
+    since: DateTime<Utc>,
+    scope: &BoardAudienceScope,
+) -> Result<Vec<BoardEntry>> {
+    let entries = load_entries_since(worktree_root, since)?;
+    Ok(filter_board_entries_for_scope(entries, scope))
+}
+
 /// Check whether `author` has posted a message of the given `kind` within the
 /// trailing `within` duration. Used by `board-reminder` for redundancy
 /// suppression.
@@ -1395,6 +1524,36 @@ pub fn load_entries_before(
     })
 }
 
+pub fn load_entries_before_for_scope(
+    worktree_root: &Path,
+    before_entry_id: Option<&str>,
+    limit: usize,
+    scope: &BoardAudienceScope,
+) -> Result<BoardHistoryPage> {
+    if *scope == BoardAudienceScope::All {
+        return load_entries_before(worktree_root, before_entry_id, limit);
+    }
+    ensure_repo_local_files(worktree_root)?;
+    if limit == 0 {
+        return Ok(BoardHistoryPage::default());
+    }
+
+    let entries = filter_board_entries_for_scope(
+        load_board_entries_from_segments_root(&coordination_dir(worktree_root))?,
+        scope,
+    );
+    let cutoff = before_entry_id
+        .and_then(|id| entries.iter().position(|entry| entry.id == id))
+        .unwrap_or(entries.len());
+    let older = &entries[..cutoff];
+    let has_more_before = older.len() > limit;
+    let start = older.len().saturating_sub(limit);
+    Ok(BoardHistoryPage {
+        entries: older[start..].to_vec(),
+        has_more_before,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::{str::FromStr, sync::Arc, thread};
@@ -1435,6 +1594,179 @@ mod tests {
         let entry: BoardEntry = serde_json::from_value(legacy).unwrap();
 
         assert!(entry.mentions.is_empty());
+    }
+
+    #[test]
+    fn board_entry_audience_round_trips_and_legacy_absence_is_broadcast() {
+        let legacy = serde_json::json!({
+            "id": "entry-1",
+            "author_kind": "agent",
+            "author": "Codex",
+            "kind": "status",
+            "body": "legacy entry",
+            "created_at": "2026-05-07T00:00:00Z",
+            "updated_at": "2026-05-07T00:00:00Z"
+        });
+
+        let legacy_entry: BoardEntry = serde_json::from_value(legacy).unwrap();
+        assert_eq!(legacy_entry.audience, None);
+        assert!(board_entry_visible_for_scope(
+            &legacy_entry,
+            &BoardAudienceScope::Workspace("workspace-a".to_string())
+        ));
+        assert!(board_entry_visible_for_scope(
+            &legacy_entry,
+            &BoardAudienceScope::Broadcast
+        ));
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Question,
+            "Can workspace-a see this?",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(vec![" workspace-a ", "workspace-a", "workspace-b"]);
+
+        let encoded = serde_json::to_value(&entry).unwrap();
+        assert_eq!(encoded["audience"][0], "workspace-a");
+        assert_eq!(encoded["audience"][1], "workspace-b");
+
+        let decoded: BoardEntry = serde_json::from_value(encoded).unwrap();
+        assert_eq!(
+            decoded.audience,
+            Some(vec!["workspace-a".to_string(), "workspace-b".to_string()])
+        );
+        assert!(board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::Workspace("workspace-a".to_string())
+        ));
+        assert!(!board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::Workspace("workspace-c".to_string())
+        ));
+        assert!(!board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::Broadcast
+        ));
+        assert!(board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::All
+        ));
+    }
+
+    #[test]
+    fn board_entry_empty_audience_normalizes_to_absent() {
+        let empty_audience = serde_json::json!({
+            "id": "entry-1",
+            "author_kind": "agent",
+            "author": "Codex",
+            "kind": "status",
+            "body": "empty audience",
+            "audience": [],
+            "created_at": "2026-05-07T00:00:00Z",
+            "updated_at": "2026-05-07T00:00:00Z"
+        });
+
+        let entry: BoardEntry = serde_json::from_value(empty_audience).unwrap();
+        assert_eq!(entry.audience, None);
+
+        let mut explicit_empty = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "explicit empty",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        explicit_empty.audience = Some(Vec::new());
+        let encoded = serde_json::to_value(&explicit_empty).unwrap();
+        assert!(encoded.get("audience").is_none());
+    }
+
+    #[test]
+    fn board_audience_round_trips_through_hot_projection_and_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let scoped = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Claim,
+            "workspace scoped",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(vec!["workspace-a"]);
+        let broadcast = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "broadcast",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        let empty = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "empty audience",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(Vec::<String>::new());
+
+        post_entry(dir.path(), scoped).unwrap();
+        post_entry(dir.path(), broadcast).unwrap();
+        post_entry(dir.path(), empty).unwrap();
+
+        let snapshot = load_snapshot(dir.path()).unwrap();
+        assert_eq!(snapshot.board.entries.len(), 3);
+        assert_eq!(
+            snapshot.board.entries[0].audience,
+            Some(vec!["workspace-a".to_string()])
+        );
+        assert_eq!(snapshot.board.entries[1].audience, None);
+        assert_eq!(snapshot.board.entries[2].audience, None);
+
+        let scoped_snapshot = load_snapshot_for_scope(
+            dir.path(),
+            &BoardAudienceScope::Workspace("workspace-a".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            scoped_snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["workspace scoped", "broadcast", "empty audience"]
+        );
+
+        let other_snapshot = load_snapshot_for_scope(
+            dir.path(),
+            &BoardAudienceScope::Workspace("workspace-b".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            other_snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["broadcast", "empty audience"]
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -22,7 +22,15 @@ use gwt_core::{
     workspace_projection,
 };
 
+use gwt::board_audience::{gui_default_board_scope, post_audience_for_gui};
+
 use super::{AppRuntime, BackendEvent, OutboundEvent, WindowPreset};
+
+pub(super) fn gui_default_board_scope_for_project(
+    project_root: &Path,
+) -> gwt_core::Result<coordination::BoardAudienceScope> {
+    gui_default_board_scope(project_root)
+}
 
 #[derive(Debug, Clone)]
 pub struct BoardPostRequest {
@@ -153,6 +161,21 @@ impl AppRuntime {
         }
         if !mentions.is_empty() {
             entry = entry.with_mentions(mentions);
+        }
+        let audience = match post_audience_for_gui(&tab.project_root, &entry.mentions) {
+            Ok(audience) => audience,
+            Err(error) => {
+                return vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BoardError {
+                        id,
+                        message: error.to_string(),
+                    },
+                )];
+            }
+        };
+        if let Some(audience) = audience {
+            entry = entry.with_audience(audience);
         }
         match coordination::post_entry(&tab.project_root, entry) {
             Ok(snapshot) => {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1881,12 +1881,19 @@ impl AppRuntime {
                 )]
             }
             FrontendEvent::LoadBranches { id } => self.load_branches_events(&client_id, &id),
-            FrontendEvent::LoadBoard { id } => self.load_board_events(&client_id, &id),
+            FrontendEvent::LoadBoard { id, all } => self.load_board_events(&client_id, &id, all),
             FrontendEvent::LoadBoardHistory {
                 id,
                 before_entry_id,
                 limit,
-            } => self.load_board_history_events(&client_id, &id, before_entry_id.as_deref(), limit),
+                all,
+            } => self.load_board_history_events(
+                &client_id,
+                &id,
+                before_entry_id.as_deref(),
+                limit,
+                all,
+            ),
             FrontendEvent::LoadProfile { id } => self.load_profile_events(&client_id, &id),
             FrontendEvent::LoadLogs { id } => self.load_logs_events(&client_id, &id),
             FrontendEvent::LoadKnowledgeBridge {
@@ -2971,69 +2978,11 @@ impl AppRuntime {
         Vec::new()
     }
 
-    pub(crate) fn load_board_events(&self, client_id: &str, id: &str) -> Vec<OutboundEvent> {
-        let Some(address) = self.window_lookup.get(id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        let Some(tab) = self.tab(&address.tab_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Project tab not found".to_string(),
-                },
-            )];
-        };
-        let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        if window.preset != WindowPreset::Board {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Window is not a Board surface".to_string(),
-                },
-            )];
-        }
-
-        match gwt_core::coordination::load_snapshot(&tab.project_root) {
-            Ok(snapshot) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardEntries {
-                    id: id.to_string(),
-                    entries: snapshot.board.entries,
-                    has_more_before: snapshot.board.has_more_before,
-                },
-            )],
-            Err(error) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: error.to_string(),
-                },
-            )],
-        }
-    }
-
-    pub(crate) fn load_board_history_events(
+    pub(crate) fn load_board_events(
         &self,
         client_id: &str,
         id: &str,
-        before_entry_id: Option<&str>,
-        limit: usize,
+        all: bool,
     ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id) else {
             return vec![OutboundEvent::reply(
@@ -3072,8 +3021,118 @@ impl AppRuntime {
             )];
         }
 
-        match gwt_core::coordination::load_entries_before(&tab.project_root, before_entry_id, limit)
-        {
+        let scope = if all {
+            gwt_core::coordination::BoardAudienceScope::All
+        } else {
+            match board::gui_default_board_scope_for_project(&tab.project_root) {
+                Ok(scope) => scope,
+                Err(error) => {
+                    return vec![OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::BoardError {
+                            id: id.to_string(),
+                            message: error.to_string(),
+                        },
+                    )];
+                }
+            }
+        };
+        let snapshot_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
+            gwt_core::coordination::load_snapshot(&tab.project_root)
+        } else {
+            gwt_core::coordination::load_snapshot_for_scope(&tab.project_root, &scope)
+        };
+        match snapshot_result {
+            Ok(snapshot) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardEntries {
+                    id: id.to_string(),
+                    entries: snapshot.board.entries,
+                    has_more_before: snapshot.board.has_more_before,
+                },
+            )],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: error.to_string(),
+                },
+            )],
+        }
+    }
+
+    pub(crate) fn load_board_history_events(
+        &self,
+        client_id: &str,
+        id: &str,
+        before_entry_id: Option<&str>,
+        limit: usize,
+        all: bool,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        if window.preset != WindowPreset::Board {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window is not a Board surface".to_string(),
+                },
+            )];
+        }
+
+        let scope = if all {
+            gwt_core::coordination::BoardAudienceScope::All
+        } else {
+            match board::gui_default_board_scope_for_project(&tab.project_root) {
+                Ok(scope) => scope,
+                Err(error) => {
+                    return vec![OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::BoardError {
+                            id: id.to_string(),
+                            message: error.to_string(),
+                        },
+                    )];
+                }
+            }
+        };
+        let page_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
+            gwt_core::coordination::load_entries_before(&tab.project_root, before_entry_id, limit)
+        } else {
+            gwt_core::coordination::load_entries_before_for_scope(
+                &tab.project_root,
+                before_entry_id,
+                limit,
+                &scope,
+            )
+        };
+        match page_result {
             Ok(page) => vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::BoardHistoryPage {
@@ -3166,10 +3225,19 @@ impl AppRuntime {
                 if window.preset != WindowPreset::Board {
                     continue;
                 }
+                let scope = board::gui_default_board_scope_for_project(&tab.project_root)
+                    .unwrap_or(gwt_core::coordination::BoardAudienceScope::All);
+                let board = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
+                    snapshot.board.clone()
+                } else {
+                    gwt_core::coordination::load_snapshot_for_scope(&tab.project_root, &scope)
+                        .map(|snapshot| snapshot.board)
+                        .unwrap_or_else(|_| snapshot.board.clone())
+                };
                 events.push(OutboundEvent::broadcast(BackendEvent::BoardEntries {
                     id: combined_window_id(&tab.id, &window.id),
-                    entries: snapshot.board.entries.clone(),
-                    has_more_before: snapshot.board.has_more_before,
+                    entries: board.entries,
+                    has_more_before: board.has_more_before,
                 }));
             }
         }
@@ -9223,6 +9291,7 @@ exit 0
             "client-1".to_string(),
             FrontendEvent::LoadBoard {
                 id: window_id.clone(),
+                all: false,
             },
         );
 
@@ -9235,6 +9304,113 @@ exit 0
                 && id == &window_id
                 && entries.len() == 1
                 && entries[0].body == "Need review"
+        ));
+    }
+
+    #[test]
+    fn app_runtime_load_board_defaults_to_current_workspace_audience() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-current".to_string();
+        projection
+            .agents
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
+                session_id: "session-current".to_string(),
+                window_id: None,
+                agent_id: "codex".to_string(),
+                display_name: "Codex".to_string(),
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+                current_focus: Some("Board audience".to_string()),
+                title_summary: Some("Board audience".to_string()),
+                worktree_path: Some(repo.clone()),
+                branch: Some("work/board-audience".to_string()),
+                last_board_entry_id: None,
+                last_board_entry_kind: None,
+                coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: Some("workspace-current".to_string()),
+                updated_at: chrono::Utc::now(),
+            });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "broadcast entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            ),
+        )
+        .expect("seed broadcast");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "current workspace entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-current"]),
+        )
+        .expect("seed current");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "other workspace entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-other"]),
+        )
+        .expect("seed other");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo,
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "board-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LoadBoard {
+                id: window_id.clone(),
+                all: false,
+            },
+        );
+
+        assert!(matches!(
+            &events[..],
+            [OutboundEvent {
+                event: BackendEvent::BoardEntries { entries, .. },
+                ..
+            }] if entries.iter().map(|entry| entry.body.as_str()).collect::<Vec<_>>()
+                == vec!["broadcast entry", "current workspace entry"]
         ));
     }
 
@@ -9280,6 +9456,7 @@ exit 0
                 id: window_id.clone(),
                 before_entry_id: Some("entry-3".to_string()),
                 limit: 2,
+                all: false,
             },
         );
 

--- a/crates/gwt/src/board_audience.rs
+++ b/crates/gwt/src/board_audience.rs
@@ -1,0 +1,177 @@
+use std::path::Path;
+
+use gwt_core::{
+    coordination::{
+        normalize_board_audience, BoardAudienceScope, BoardMention, BoardMentionTargetKind,
+    },
+    workspace_projection::{load_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection},
+};
+
+fn non_empty_string(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn workspace_id_for_agent(
+    projection: &WorkspaceProjection,
+    agent: &WorkspaceAgentSummary,
+) -> Option<String> {
+    if !agent.is_assigned() {
+        return None;
+    }
+    agent
+        .workspace_id
+        .as_deref()
+        .and_then(non_empty_string)
+        .or_else(|| non_empty_string(&projection.id))
+}
+
+fn push_unique(values: &mut Vec<String>, value: impl Into<String>) {
+    let value = value.into();
+    if value.trim().is_empty() || values.iter().any(|item| item == &value) {
+        return;
+    }
+    values.push(value);
+}
+
+fn push_workspace_for_session(
+    values: &mut Vec<String>,
+    projection: &WorkspaceProjection,
+    session_id: &str,
+) -> bool {
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+    else {
+        return false;
+    };
+    if let Some(workspace_id) = workspace_id_for_agent(projection, agent) {
+        push_unique(values, workspace_id);
+    }
+    true
+}
+
+fn push_workspace_for_agent(
+    values: &mut Vec<String>,
+    projection: &WorkspaceProjection,
+    target: &str,
+) {
+    let target = target.trim();
+    if target.is_empty() {
+        return;
+    }
+    for agent in &projection.agents {
+        let agent_matches = agent.agent_id.eq_ignore_ascii_case(target)
+            || agent.display_name.eq_ignore_ascii_case(target);
+        if !agent_matches {
+            continue;
+        }
+        if let Some(workspace_id) = workspace_id_for_agent(projection, agent) {
+            push_unique(values, workspace_id);
+        }
+    }
+}
+
+pub fn current_session_board_scope(
+    repo_path: &Path,
+    session_id: Option<&str>,
+) -> gwt_core::Result<BoardAudienceScope> {
+    let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(BoardAudienceScope::All);
+    };
+    let Some(projection) = load_workspace_projection(repo_path)? else {
+        return Ok(BoardAudienceScope::All);
+    };
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+    else {
+        return Ok(BoardAudienceScope::All);
+    };
+    if agent.is_unassigned() {
+        return Ok(BoardAudienceScope::Broadcast);
+    }
+    Ok(workspace_id_for_agent(&projection, agent)
+        .map(BoardAudienceScope::Workspace)
+        .unwrap_or(BoardAudienceScope::All))
+}
+
+pub fn gui_default_board_scope(repo_path: &Path) -> gwt_core::Result<BoardAudienceScope> {
+    let Some(projection) = load_workspace_projection(repo_path)? else {
+        return Ok(BoardAudienceScope::All);
+    };
+    if let Some(workspace_id) = projection
+        .assigned_agents()
+        .find_map(|agent| workspace_id_for_agent(&projection, agent))
+    {
+        return Ok(BoardAudienceScope::Workspace(workspace_id));
+    }
+    if projection.unassigned_agents().next().is_some() {
+        return Ok(BoardAudienceScope::Broadcast);
+    }
+    Ok(BoardAudienceScope::All)
+}
+
+pub fn post_audience_for_session(
+    repo_path: &Path,
+    session_id: Option<&str>,
+    mentions: &[BoardMention],
+    broadcast: bool,
+) -> gwt_core::Result<Option<Vec<String>>> {
+    if broadcast {
+        return Ok(None);
+    }
+    let projection = load_workspace_projection(repo_path)?;
+    let mut audience = Vec::new();
+    if let (Some(projection), Some(session_id)) = (
+        projection.as_ref(),
+        session_id.map(str::trim).filter(|value| !value.is_empty()),
+    ) {
+        push_workspace_for_session(&mut audience, projection, session_id);
+    }
+    collect_mention_audience(&mut audience, projection.as_ref(), mentions);
+    Ok(normalize_board_audience(Some(audience)))
+}
+
+pub fn post_audience_for_gui(
+    repo_path: &Path,
+    mentions: &[BoardMention],
+) -> gwt_core::Result<Option<Vec<String>>> {
+    let projection = load_workspace_projection(repo_path)?;
+    let mut audience = Vec::new();
+    if let Some(projection) = projection.as_ref() {
+        if let Some(workspace_id) = projection
+            .assigned_agents()
+            .find_map(|agent| workspace_id_for_agent(projection, agent))
+        {
+            push_unique(&mut audience, workspace_id);
+        }
+    }
+    collect_mention_audience(&mut audience, projection.as_ref(), mentions);
+    Ok(normalize_board_audience(Some(audience)))
+}
+
+fn collect_mention_audience(
+    audience: &mut Vec<String>,
+    projection: Option<&WorkspaceProjection>,
+    mentions: &[BoardMention],
+) {
+    for mention in mentions {
+        match mention.target_kind {
+            BoardMentionTargetKind::Workspace => push_unique(audience, mention.target.clone()),
+            BoardMentionTargetKind::Session => {
+                if let Some(projection) = projection {
+                    push_workspace_for_session(audience, projection, &mention.target);
+                }
+            }
+            BoardMentionTargetKind::Agent => {
+                if let Some(projection) = projection {
+                    push_workspace_for_agent(audience, projection, &mention.target);
+                }
+            }
+            BoardMentionTargetKind::User | BoardMentionTargetKind::Branch => {}
+        }
+    }
+}

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -41,6 +41,7 @@ mod workspace;
 
 use std::io::{self};
 
+pub use board::{BoardCommand, BoardPostCommand};
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
 use gwt_github::{ApiError, SpecOpsError};
@@ -315,30 +316,6 @@ pub enum ActionsCommand {
     JobLogs { job_id: u64 },
 }
 
-/// SPEC-1942 family enum for `gwtd board ...`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BoardCommand {
-    /// `gwtd board show [--json]`.
-    Show { json: bool },
-    /// `gwtd board post --kind <kind> (--body <text> | -f <file>)
-    /// [--title-summary <text>] [--parent <id>] [--topic <t>]*
-    /// [--owner <n>]* [--target <id>]* [--mention <kind:id>]*`.
-    Post(Box<BoardPostCommand>),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BoardPostCommand {
-    pub kind: String,
-    pub body: Option<String>,
-    pub file: Option<String>,
-    pub title_summary: Option<String>,
-    pub parent: Option<String>,
-    pub topics: Vec<String>,
-    pub owners: Vec<String>,
-    pub targets: Vec<String>,
-    pub mentions: Vec<String>,
-}
-
 /// SPEC-1942 family enum for `gwtd index ...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IndexCommand {
@@ -437,7 +414,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -3,26 +3,76 @@ use std::io;
 use gwt_agent::{session::GWT_SESSION_ID_ENV, Session};
 use gwt_core::{
     coordination::{
-        load_snapshot, normalize_board_mentions, post_entry, AuthorKind, BoardEntry, BoardMention,
+        load_snapshot, load_snapshot_for_scope, normalize_board_mentions, post_entry, AuthorKind,
+        BoardAudienceScope, BoardEntry, BoardMention,
     },
     paths::gwt_sessions_dir,
 };
 use gwt_github::SpecOpsError;
 
-use crate::cli::{BoardCommand, BoardPostCommand, CliEnv, CliParseError};
+use crate::{
+    board_audience::{current_session_board_scope, post_audience_for_session},
+    cli::{CliEnv, CliParseError},
+};
+
+/// SPEC-1942 family enum for `gwtd board ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardCommand {
+    /// `gwtd board show [--json] [--workspace <id>|--all]`.
+    Show {
+        json: bool,
+        workspace: Option<String>,
+        all: bool,
+    },
+    /// `gwtd board post --kind <kind> (--body <text> | -f <file>)
+    /// [--title-summary <text>] [--parent <id>] [--topic <t>]*
+    /// [--owner <n>]* [--target <id>]* [--mention <kind:id>]*`.
+    Post(Box<BoardPostCommand>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoardPostCommand {
+    pub kind: String,
+    pub body: Option<String>,
+    pub file: Option<String>,
+    pub title_summary: Option<String>,
+    pub parent: Option<String>,
+    pub topics: Vec<String>,
+    pub owners: Vec<String>,
+    pub targets: Vec<String>,
+    pub mentions: Vec<String>,
+    pub broadcast: bool,
+}
 
 pub fn parse(args: &[String]) -> Result<BoardCommand, CliParseError> {
     let mut it = args.iter().peekable();
     match it.next().map(String::as_str) {
         Some("show") => {
             let mut json = false;
-            for arg in it {
-                match arg.as_str() {
+            let mut workspace = None;
+            let mut all = false;
+            let args = it.collect::<Vec<_>>();
+            let mut i = 0;
+            while i < args.len() {
+                match args[i].as_str() {
                     "--json" => json = true,
+                    "--workspace" => {
+                        i += 1;
+                        if i >= args.len() {
+                            return Err(CliParseError::MissingFlag("--workspace"));
+                        }
+                        workspace = Some(args[i].clone());
+                    }
+                    "--all" => all = true,
                     other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
                 }
+                i += 1;
             }
-            Ok(BoardCommand::Show { json })
+            Ok(BoardCommand::Show {
+                json,
+                workspace,
+                all,
+            })
         }
         Some("post") => parse_post_args(it.collect::<Vec<_>>().as_slice()),
         Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
@@ -36,8 +86,29 @@ pub(super) fn run<E: CliEnv>(
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     let code = match cmd {
-        BoardCommand::Show { json } => {
-            let snapshot = load_snapshot(env.repo_path()).map_err(gwt_error_to_spec_ops_error)?;
+        BoardCommand::Show {
+            json,
+            workspace,
+            all,
+        } => {
+            let current_session = current_session_from_env().ok().flatten();
+            let scope = if all {
+                BoardAudienceScope::All
+            } else if let Some(workspace_id) = workspace {
+                BoardAudienceScope::Workspace(workspace_id)
+            } else {
+                current_session_board_scope(
+                    env.repo_path(),
+                    current_session.as_ref().map(|session| session.id.as_str()),
+                )
+                .map_err(gwt_error_to_spec_ops_error)?
+            };
+            let snapshot = if matches!(scope, BoardAudienceScope::All) {
+                load_snapshot(env.repo_path()).map_err(gwt_error_to_spec_ops_error)?
+            } else {
+                load_snapshot_for_scope(env.repo_path(), &scope)
+                    .map_err(gwt_error_to_spec_ops_error)?
+            };
             if json {
                 let rendered = serde_json::to_string_pretty(&snapshot)
                     .map_err(|err| io_as_spec_ops_error(io::Error::other(err.to_string())))?;
@@ -59,6 +130,7 @@ pub(super) fn run<E: CliEnv>(
                 owners,
                 targets,
                 mentions,
+                broadcast,
             } = *command;
             let body = match (body, file) {
                 (Some(body), None) => body,
@@ -110,6 +182,16 @@ pub(super) fn run<E: CliEnv>(
             let mentions = parse_mentions(&mentions).map_err(gwt_error_to_spec_ops_error)?;
             if !mentions.is_empty() {
                 entry = entry.with_mentions(mentions);
+            }
+            let audience = post_audience_for_session(
+                env.repo_path(),
+                current_session.as_ref().map(|session| session.id.as_str()),
+                &entry.mentions,
+                broadcast,
+            )
+            .map_err(gwt_error_to_spec_ops_error)?;
+            if let Some(audience) = audience {
+                entry = entry.with_audience(audience);
             }
             let snapshot =
                 post_entry(env.repo_path(), entry).map_err(gwt_error_to_spec_ops_error)?;
@@ -171,6 +253,7 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
     let mut owners = Vec::new();
     let mut targets = Vec::new();
     let mut mentions = Vec::new();
+    let mut broadcast = false;
     let mut i = 0;
 
     while i < args.len() {
@@ -238,6 +321,9 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
                 }
                 mentions.push(args[i].clone());
             }
+            "--broadcast" => {
+                broadcast = true;
+            }
             other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
         }
         i += 1;
@@ -256,6 +342,7 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
         owners,
         targets,
         mentions,
+        broadcast,
     })))
 }
 
@@ -339,7 +426,13 @@ fn gwt_error_to_spec_ops_error(err: gwt_core::GwtError) -> SpecOpsError {
 #[cfg(test)]
 mod tests {
     use gwt_agent::{AgentId, Session, GWT_SESSION_ID_ENV};
-    use gwt_core::coordination::BoardEntryKind;
+    use gwt_core::{
+        coordination::BoardEntryKind,
+        workspace_projection::{
+            save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+            WorkspaceProjection, WorkspaceStatusCategory,
+        },
+    };
 
     use crate::cli::test_support::{fake_gh_test_lock, ScopedEnvVar};
 
@@ -349,10 +442,49 @@ mod tests {
         value.to_string()
     }
 
+    fn workspace_agent(
+        session_id: &str,
+        agent_id: &str,
+        workspace_id: Option<&str>,
+        affiliation_status: WorkspaceAgentAffiliationStatus,
+    ) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: agent_id.to_string(),
+            display_name: agent_id.to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Board audience".to_string()),
+            title_summary: Some("Board audience".to_string()),
+            worktree_path: None,
+            branch: Some("work/board-audience".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status,
+            workspace_id: workspace_id.map(str::to_string),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn save_projection(repo: &std::path::Path, agents: Vec<WorkspaceAgentSummary>) {
+        let mut projection = WorkspaceProjection::default_for_project(repo);
+        projection.id = "workspace-current".to_string();
+        projection.agents = agents;
+        save_workspace_projection(repo, &projection).expect("save workspace projection");
+    }
+
     #[test]
     fn board_family_parse_show_json() {
         let cmd = parse(&[s("show"), s("--json")]).unwrap();
-        assert_eq!(cmd, BoardCommand::Show { json: true });
+        assert_eq!(
+            cmd,
+            BoardCommand::Show {
+                json: true,
+                workspace: None,
+                all: false,
+            }
+        );
     }
 
     #[test]
@@ -379,6 +511,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -409,6 +542,7 @@ mod tests {
                 owners: vec![],
                 targets: vec!["sess-a3f2".into(), "feature/foo".into()],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -440,6 +574,66 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec!["user:akiojin".into(), "agent:codex".into()],
+                broadcast: false,
+            }))
+        );
+    }
+
+    #[test]
+    fn board_family_parse_show_workspace_and_all() {
+        let workspace = parse(&[s("show"), s("--workspace"), s("workspace-a")]).unwrap();
+        assert_eq!(
+            workspace,
+            BoardCommand::Show {
+                json: false,
+                workspace: Some("workspace-a".into()),
+                all: false,
+            }
+        );
+
+        let all = parse(&[s("show"), s("--all"), s("--json")]).unwrap();
+        assert_eq!(
+            all,
+            BoardCommand::Show {
+                json: true,
+                workspace: None,
+                all: true,
+            }
+        );
+    }
+
+    #[test]
+    fn board_family_parse_post_collects_workspace_mentions_and_broadcast() {
+        let cmd = parse(&[
+            s("post"),
+            s("--kind"),
+            s("status"),
+            s("--body"),
+            s("cross-workspace update"),
+            s("--mention"),
+            s("workspace:workspace-a"),
+            s("--mention"),
+            s("workspace:workspace-b"),
+            s("--broadcast"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cmd,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("cross-workspace update".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![
+                    "workspace:workspace-a".into(),
+                    "workspace:workspace-b".into()
+                ],
+                broadcast: true,
             }))
         );
     }
@@ -471,6 +665,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -512,6 +707,7 @@ mod tests {
                 owners: vec![],
                 targets: vec!["sess-a3f2".into(), "feature/x".into()],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -544,6 +740,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec!["user:akiojin".into(), "agent:codex".into()],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -565,7 +762,7 @@ mod tests {
 
     #[test]
     fn board_family_run_post_attaches_current_session_origin_metadata() {
-        let _env_lock = fake_gh_test_lock()
+        let _env_lock = crate::env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmp = tempfile::tempdir().unwrap();
@@ -590,6 +787,7 @@ mod tests {
                 owners: vec!["2359".into()],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -610,6 +808,214 @@ mod tests {
         );
         assert_eq!(entry.origin_branch.as_deref(), Some("work/20260506-1706"));
         assert_eq!(entry.origin_agent_id.as_deref(), Some("Codex"));
+    }
+
+    #[test]
+    fn board_family_run_post_auto_attaches_current_assigned_workspace() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        let mut out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("current workspace update".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: false,
+            })),
+            &mut out,
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert_eq!(
+            snapshot.board.entries[0].audience,
+            Some(vec!["workspace-current".to_string()])
+        );
+    }
+
+    #[test]
+    fn board_family_run_post_leaves_unassigned_and_broadcast_posts_unscoped() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("unassigned broadcast".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: false,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("forced broadcast".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: true,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert_eq!(snapshot.board.entries[0].audience, None);
+        assert_eq!(snapshot.board.entries[1].audience, None);
+    }
+
+    #[test]
+    fn board_family_run_post_fans_out_workspace_audience_from_mentions() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![
+                workspace_agent(
+                    &session.id,
+                    "codex",
+                    Some("workspace-current"),
+                    WorkspaceAgentAffiliationStatus::Assigned,
+                ),
+                workspace_agent(
+                    "session-target",
+                    "reviewer",
+                    Some("workspace-target"),
+                    WorkspaceAgentAffiliationStatus::Assigned,
+                ),
+                workspace_agent(
+                    "session-unassigned",
+                    "observer",
+                    None,
+                    WorkspaceAgentAffiliationStatus::Unassigned,
+                ),
+            ],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "handoff".into(),
+                body: Some("handoff across workspaces".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![
+                    "workspace:workspace-explicit".into(),
+                    "session:session-target".into(),
+                    "agent:reviewer".into(),
+                    "agent:observer".into(),
+                    "user:akiojin".into(),
+                ],
+                broadcast: false,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                "session-target",
+                "reviewer",
+                Some("workspace-later"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert_eq!(
+            snapshot.board.entries[0].audience,
+            Some(vec![
+                "workspace-current".to_string(),
+                "workspace-explicit".to_string(),
+                "workspace-target".to_string(),
+            ])
+        );
     }
 
     #[test]
@@ -646,6 +1052,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -691,6 +1098,7 @@ mod tests {
                 owners: vec!["1974".into()],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -701,6 +1109,163 @@ mod tests {
         assert_eq!(snapshot.board.entries.len(), 1);
         assert_eq!(snapshot.board.entries[0].body, "Need a board");
         assert!(out.contains("board entries: 1"));
+    }
+
+    #[test]
+    fn board_family_run_show_scopes_workspace_and_all_timelines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "broadcast entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            ),
+        )
+        .unwrap();
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "workspace a entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-a"]),
+        )
+        .unwrap();
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "workspace b entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-b"]),
+        )
+        .unwrap();
+
+        let mut workspace_out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: Some("workspace-a".into()),
+                all: false,
+            },
+            &mut workspace_out,
+        )
+        .unwrap();
+        assert!(workspace_out.contains("broadcast entry"), "{workspace_out}");
+        assert!(
+            workspace_out.contains("workspace a entry"),
+            "{workspace_out}"
+        );
+        assert!(
+            !workspace_out.contains("workspace b entry"),
+            "{workspace_out}"
+        );
+
+        let mut all_out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: true,
+            },
+            &mut all_out,
+        )
+        .unwrap();
+        assert!(all_out.contains("workspace b entry"), "{all_out}");
+    }
+
+    #[test]
+    fn board_family_run_show_defaults_to_current_workspace_when_session_is_assigned() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "current entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-current"]),
+        )
+        .unwrap();
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "other entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-other"]),
+        )
+        .unwrap();
+        let mut env = crate::cli::TestEnv::new(repo);
+
+        let mut out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+
+        assert!(out.contains("current entry"), "{out}");
+        assert!(!out.contains("other entry"), "{out}");
     }
 
     #[test]
@@ -725,7 +1290,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(
@@ -754,7 +1328,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("- [request] user ("));
@@ -783,7 +1366,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("== Chat =="));
@@ -814,7 +1406,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(

--- a/crates/gwt/src/cli/family_split_tests.rs
+++ b/crates/gwt/src/cli/family_split_tests.rs
@@ -53,7 +53,14 @@ fn cli_command_family_split_round_trip_parses() {
 
     // gwtd board show --json
     let cmd = parse_board_args(&[s("show"), s("--json")]).expect("parse board show");
-    assert_eq!(cmd, CliCommand::Board(BoardCommand::Show { json: true }));
+    assert_eq!(
+        cmd,
+        CliCommand::Board(BoardCommand::Show {
+            json: true,
+            workspace: None,
+            all: false,
+        })
+    );
 
     // gwtd board post --kind status --body x
     let cmd = parse_board_args(&[s("post"), s("--kind"), s("status"), s("--body"), s("x")])
@@ -65,6 +72,7 @@ fn cli_command_family_split_round_trip_parses() {
     assert_eq!(command.body.as_deref(), Some("x"));
     assert_eq!(command.file, None);
     assert_eq!(command.title_summary, None);
+    assert!(!command.broadcast);
 
     // gwtd index status / rebuild
     let cmd = parse_index_args(&[s("status")]).expect("parse index status");

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -30,11 +30,12 @@ use std::{
 use chrono::{DateTime, Utc};
 use gwt_agent::{Session, GWT_SESSION_ID_ENV};
 use gwt_core::coordination::{
-    has_recent_post_by, load_entries_since, load_reminders_state, write_reminders_state,
+    has_recent_post_by, load_entries_since_for_scope, load_reminders_state, write_reminders_state,
     BoardEntryKind,
 };
 
 use super::{HookError, HookEvent, HookOutput, IntentBoundaryEvent};
+use crate::board_audience::current_session_board_scope;
 
 pub use plan::{plan_reminder, ReminderInputs, ReminderPlan};
 
@@ -158,17 +159,18 @@ pub fn compute_plan(
     };
 
     let reminders = load_reminders_state(&session.worktree_path, &session.id)?;
+    let audience_scope = current_session_board_scope(&session.worktree_path, Some(&session.id))?;
 
     let recent_entries = match intent_event {
         IntentBoundaryEvent::SessionStart => {
             let threshold = now - session_start_window();
-            load_entries_since(&session.worktree_path, threshold)?
+            load_entries_since_for_scope(&session.worktree_path, threshold, &audience_scope)?
         }
         IntentBoundaryEvent::UserPromptSubmit => {
             let since = reminders
                 .last_injected_at
                 .unwrap_or(now - session_start_window());
-            load_entries_since(&session.worktree_path, since)?
+            load_entries_since_for_scope(&session.worktree_path, since, &audience_scope)?
         }
         IntentBoundaryEvent::Stop => Vec::new(),
     };
@@ -216,9 +218,16 @@ fn resolve_narrative_language() -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::cli::test_support::ScopedEnvVar;
     use chrono::TimeZone;
     use gwt_agent::AgentId;
-    use gwt_core::coordination::{post_entry, AuthorKind, BoardEntry, BoardEntryKind};
+    use gwt_core::{
+        coordination::{post_entry, AuthorKind, BoardEntry, BoardEntryKind},
+        workspace_projection::{
+            save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+            WorkspaceProjection, WorkspaceStatusCategory,
+        },
+    };
 
     use super::*;
 
@@ -226,6 +235,37 @@ mod tests {
         let mut session = Session::new(dir, branch, AgentId::Codex);
         session.display_name = display_name.to_string();
         session
+    }
+
+    fn workspace_agent(
+        session_id: &str,
+        workspace_id: Option<&str>,
+        affiliation_status: WorkspaceAgentAffiliationStatus,
+    ) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Board audience".to_string()),
+            title_summary: Some("Board audience".to_string()),
+            worktree_path: None,
+            branch: Some("work/board-audience".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status,
+            workspace_id: workspace_id.map(str::to_string),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn save_projection(repo: &Path, agents: Vec<WorkspaceAgentSummary>) {
+        let mut projection = WorkspaceProjection::default_for_project(repo);
+        projection.id = "workspace-current".to_string();
+        projection.agents = agents;
+        save_workspace_projection(repo, &projection).expect("save workspace projection");
     }
 
     fn entry(
@@ -479,6 +519,117 @@ mod tests {
         assert!(!text.contains("old post before last inject"));
         assert!(text.contains("brand new post"));
         assert_eq!(plan.next_reminders.last_injected_at, Some(now));
+    }
+
+    #[test]
+    fn compute_plan_session_start_filters_entries_to_current_workspace_audience() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", dir.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", dir.path());
+        let session = make_session(dir.path(), "feature/me", "Codex");
+        save_projection(
+            dir.path(),
+            vec![workspace_agent(
+                &session.id,
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        let now = Utc.with_ymd_and_hms(2026, 5, 11, 12, 0, 0).unwrap();
+        let broadcast = entry(
+            "Other",
+            BoardEntryKind::Status,
+            "broadcast update",
+            "work/other",
+            "session-other",
+            now - chrono::Duration::minutes(5),
+        );
+        let current = entry(
+            "Other",
+            BoardEntryKind::Status,
+            "current workspace update",
+            "work/other",
+            "session-other",
+            now - chrono::Duration::minutes(4),
+        )
+        .with_audience(vec!["workspace-current"]);
+        let other = entry(
+            "Other",
+            BoardEntryKind::Status,
+            "other workspace update",
+            "work/other",
+            "session-other",
+            now - chrono::Duration::minutes(3),
+        )
+        .with_audience(vec!["workspace-other"]);
+        post_entry(dir.path(), broadcast).unwrap();
+        post_entry(dir.path(), current).unwrap();
+        post_entry(dir.path(), other).unwrap();
+
+        let plan = compute_plan("SessionStart", &session, now)
+            .unwrap()
+            .unwrap();
+        let text = additional_context(&plan.output);
+
+        assert!(text.contains("broadcast update"), "{text}");
+        assert!(text.contains("current workspace update"), "{text}");
+        assert!(!text.contains("other workspace update"), "{text}");
+    }
+
+    #[test]
+    fn compute_plan_unassigned_agent_only_reads_broadcast_board_entries() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", dir.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", dir.path());
+        let session = make_session(dir.path(), "feature/me", "Codex");
+        save_projection(
+            dir.path(),
+            vec![workspace_agent(
+                &session.id,
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let now = Utc.with_ymd_and_hms(2026, 5, 11, 12, 0, 0).unwrap();
+        post_entry(
+            dir.path(),
+            entry(
+                "Other",
+                BoardEntryKind::Status,
+                "broadcast update",
+                "work/other",
+                "session-other",
+                now - chrono::Duration::minutes(5),
+            ),
+        )
+        .unwrap();
+        post_entry(
+            dir.path(),
+            entry(
+                "Other",
+                BoardEntryKind::Status,
+                "workspace-only update",
+                "work/other",
+                "session-other",
+                now - chrono::Duration::minutes(4),
+            )
+            .with_audience(vec!["workspace-current"]),
+        )
+        .unwrap();
+
+        let plan = compute_plan("SessionStart", &session, now)
+            .unwrap()
+            .unwrap();
+        let text = additional_context(&plan.output);
+
+        assert!(text.contains("broadcast update"), "{text}");
+        assert!(!text.contains("workspace-only update"), "{text}");
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -20,7 +20,10 @@ use gwt_agent::{
     types::WorkflowBypass,
 };
 use gwt_core::{
-    coordination::{load_snapshot, BoardEntry, BoardEntryKind, BoardMentionTargetKind},
+    coordination::{
+        board_entry_visible_for_scope, load_snapshot, BoardEntry, BoardEntryKind,
+        BoardMentionTargetKind,
+    },
     paths::{gwt_cache_dir, gwt_sessions_dir},
     workspace_projection::{
         load_or_synthesize_workspace_work_items, load_workspace_projection, WorkspaceAgentSummary,
@@ -31,6 +34,7 @@ use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;
 
 use super::{block_bash_policy, HookError, HookEvent, HookOutput};
+use crate::board_audience::current_session_board_scope;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkflowOwner {
@@ -401,6 +405,7 @@ fn board_claim_conflicts(
     current_session_id: Option<&str>,
 ) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
     let snapshot = load_snapshot(worktree_root)?;
+    let audience_scope = current_session_board_scope(worktree_root, current_session_id)?;
     Ok(snapshot
         .board
         .entries
@@ -410,6 +415,7 @@ fn board_claim_conflicts(
             entry.kind == BoardEntryKind::Claim
                 && board_claim_is_active(entry)
                 && current_session_id != entry.origin_session_id.as_deref()
+                && board_entry_visible_for_scope(entry, &audience_scope)
         })
         .filter_map(|entry| {
             let text = board_entry_text(entry);
@@ -550,10 +556,12 @@ fn has_matching_split_claim(
         return Ok(false);
     };
     let snapshot = load_snapshot(worktree_root)?;
+    let audience_scope = current_session_board_scope(worktree_root, Some(current_session_id))?;
     Ok(snapshot.board.entries.iter().rev().any(|entry| {
         entry.kind == BoardEntryKind::Claim
             && entry.origin_session_id.as_deref() == Some(current_session_id)
             && board_claim_is_active(entry)
+            && board_entry_visible_for_scope(entry, &audience_scope)
             && board_entry_has_boundary(entry)
             && board_entry_targets_conflict(entry, conflict)
             && split_claim_matches_current_work(entry, current_intent)
@@ -611,6 +619,7 @@ fn board_entry_targets_conflict(
                 BoardMentionTargetKind::Branch => format!("branch:{}", mention.target),
                 BoardMentionTargetKind::Agent => format!("agent:{}", mention.target),
                 BoardMentionTargetKind::User => format!("user:{}", mention.target),
+                BoardMentionTargetKind::Workspace => format!("workspace:{}", mention.target),
             })
             .any(|typed_key| keys.iter().any(|key| key == &typed_key))
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod board_audience;
 pub mod branch_cleanup;
 pub mod branch_list;
 pub mod cli;

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -130,12 +130,16 @@ pub enum FrontendEvent {
     },
     LoadBoard {
         id: String,
+        #[serde(default)]
+        all: bool,
     },
     LoadBoardHistory {
         id: String,
         before_entry_id: Option<String>,
         #[serde(default = "default_board_history_limit")]
         limit: usize,
+        #[serde(default)]
+        all: bool,
     },
     LoadProfile {
         id: String,
@@ -1293,6 +1297,21 @@ mod tests {
     }
 
     #[test]
+    fn load_board_deserializes_all_view_opt_in() {
+        let frontend: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "load_board",
+            "id": "board-1",
+            "all": true
+        }))
+        .expect("deserialize load board all");
+
+        assert!(matches!(
+            frontend,
+            FrontendEvent::LoadBoard { id, all } if id == "board-1" && all
+        ));
+    }
+
+    #[test]
     fn board_history_page_serializes_cursor_contract() {
         let frontend: FrontendEvent = serde_json::from_value(serde_json::json!({
             "kind": "load_board_history",
@@ -1306,8 +1325,9 @@ mod tests {
             FrontendEvent::LoadBoardHistory {
                 id,
                 before_entry_id: Some(before_entry_id),
-                limit
-            } if id == "board-1" && before_entry_id == "entry-3" && limit == 50
+                limit,
+                all
+            } if id == "board-1" && before_entry_id == "entry-3" && limit == 50 && !all
         ));
 
         let backend = BackendEvent::BoardHistoryPage {

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -736,6 +736,53 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
 }
 
 #[test]
+fn allows_mutation_when_active_board_claim_is_scoped_to_other_workspace() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection.agents.push(workspace_agent(
+            &session_id,
+            "Implement Workspace semantic coordination gate",
+            "Workspace semantic coordination gate",
+        ));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Other Codex",
+            BoardEntryKind::Claim,
+            "Implement Workspace semantic coordination duplicate guard for active agents.",
+            None,
+            None,
+            vec!["workspace-semantic-coordination".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id("session-other")
+        .with_audience(vec!["workspace-other"]);
+        post_entry(&repo_path, entry).expect("post other-workspace claim");
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "other-Workspace Board claims must not block this Workspace"
+        );
+    });
+}
+
+#[test]
 fn unassigned_agent_without_title_summary_is_not_title_blocked() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -38,6 +38,7 @@ test("Board surface follows external posts only when already near bottom", () =>
 
 test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /board-for-you-filter/);
+  assert.match(appSource, /board-all-filter/);
   assert.match(appSource, /board-audience-badge/);
   assert.match(appSource, /board-reply-button/);
   assert.match(appSource, /board-reply-banner/);
@@ -45,6 +46,7 @@ test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /showBoardMentionNotification/);
   assert.match(appSource, /Jump to original/);
   assert.match(appSource, /state\.audienceFilter\s*=\s*"all"/);
+  assert.match(appSource, /all:\s*state\.audienceFilter\s*===\s*"all"/);
 });
 
 test("Board message body preserves multiline plaintext", () => {
@@ -106,6 +108,30 @@ test("Board reply helpers create reply mentions and filter for-you entries", () 
   assert.deepEqual(
     visibleBoardEntries(state, ["user:you"]).map((entry) => entry.id),
     ["entry-user"],
+  );
+});
+
+test("Board workspace audience filter shows current workspace plus broadcast by default", () => {
+  const state = {
+    audienceFilter: "workspace",
+    currentWorkspaceId: "workspace-a",
+    entries: [
+      { id: "broadcast", body: "legacy broadcast" },
+      { id: "workspace-a", audience: ["workspace-a"], body: "current workspace" },
+      { id: "workspace-b", audience: ["workspace-b"], body: "other workspace" },
+      { id: "empty", audience: [], body: "empty is broadcast" },
+    ],
+  };
+
+  assert.deepEqual(
+    visibleBoardEntries(state).map((entry) => entry.id),
+    ["broadcast", "workspace-a", "empty"],
+  );
+
+  state.audienceFilter = "all";
+  assert.deepEqual(
+    visibleBoardEntries(state).map((entry) => entry.id),
+    ["broadcast", "workspace-a", "workspace-b", "empty"],
   );
 });
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2710,7 +2710,8 @@
             newEntriesAvailable: false,
             focusEntryId: null,
             pendingFocusScroll: false,
-            audienceFilter: "all",
+            audienceFilter: "workspace",
+            currentWorkspaceId: "",
             forYouUnread: 0,
             lastNotifiedMentionEntryId: null,
           });
@@ -2779,6 +2780,7 @@
         send({
           kind: "load_board",
           id: windowId,
+          all: state.audienceFilter === "all",
         });
       }
 
@@ -2798,6 +2800,7 @@
           id: windowId,
           before_entry_id: beforeEntryId,
           limit: 50,
+          all: state.audienceFilter === "all",
         });
       }
 
@@ -3859,6 +3862,7 @@
         const status = body.querySelector(".board-status");
         const timeline = body.querySelector(".board-timeline");
         const composer = body.querySelector(".board-composer-pane");
+        const allFilter = body.querySelector("[data-action='toggle-board-all']");
         const forYouFilter = body.querySelector("[data-action='toggle-board-for-you']");
         if (!status || !timeline || !composer) {
           return;
@@ -3867,6 +3871,10 @@
           state.focusEntryId = pendingBoardEntryFocusId;
           state.pendingFocusScroll = true;
         }
+        state.currentWorkspaceId =
+          activeWorkProjection && (activeWorkProjection.agents || []).length > 0
+            ? activeWorkProjection.id || ""
+            : "";
 
         const entryCountLabel = `${state.entries.length} entr${state.entries.length === 1 ? "y" : "ies"}`;
         status.textContent = state.error
@@ -3885,6 +3893,13 @@
           status.classList.add("error");
         } else if (state.loading) {
           status.classList.add("info");
+        }
+        if (allFilter) {
+          allFilter.setAttribute(
+            "aria-pressed",
+            state.audienceFilter === "all" ? "true" : "false",
+          );
+          allFilter.classList.toggle("active", state.audienceFilter === "all");
         }
         if (forYouFilter) {
           forYouFilter.setAttribute(
@@ -3949,6 +3964,8 @@
               "board-empty workspace-empty-state",
               state.audienceFilter === "for_you"
                 ? "No posts addressed to you."
+                : state.audienceFilter === "workspace"
+                  ? "No posts in this Workspace."
                 : "No coordination entries yet.",
             ),
           );
@@ -6238,6 +6255,7 @@
                   <div class="board-status"></div>
                 </div>
                 <div class="workspace-toolbar-actions">
+                  <button class="text-button board-all-filter" data-action="toggle-board-all" type="button" aria-pressed="false">All</button>
                   <button class="text-button board-for-you-filter" data-action="toggle-board-for-you" type="button" aria-pressed="false">For you</button>
                   <button class="icon-button" data-action="refresh-board" aria-label="Refresh board">↻</button>
                 </div>
@@ -6270,10 +6288,21 @@
             .addEventListener("click", (event) => {
               event.stopPropagation();
               const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);
-              state.audienceFilter = state.audienceFilter === "for_you" ? "all" : "for_you";
+              state.audienceFilter =
+                state.audienceFilter === "for_you" ? "workspace" : "for_you";
               if (state.audienceFilter === "for_you") {
                 state.forYouUnread = 0;
               }
+              frontendUnits.boardSurface.renderBoard(windowData.id);
+            });
+          body
+            .querySelector("[data-action='toggle-board-all']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);
+              state.audienceFilter = state.audienceFilter === "all" ? "workspace" : "all";
+              state.error = "";
+              frontendUnits.boardSurface.requestBoard(windowData.id);
               frontendUnits.boardSurface.renderBoard(windowData.id);
             });
           const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);

--- a/crates/gwt/web/board-surface.js
+++ b/crates/gwt/web/board-surface.js
@@ -25,6 +25,10 @@ export function boardEntryMentionsSelf(entry, selfKeys = []) {
 }
 
 export function boardEntryAudienceLabels(entry, selfKeys = []) {
+  const workspaceAudience = normalizedBoardWorkspaceAudience(entry);
+  if (workspaceAudience.length > 0) {
+    return workspaceAudience.map((workspaceId) => `Workspace: ${workspaceId}`);
+  }
   const mentions = entry?.mentions || [];
   const keySet = new Set((selfKeys || []).map((key) => String(key).trim()).filter(Boolean));
   if (mentions.length > 0) {
@@ -38,6 +42,7 @@ export function boardEntryAudienceLabels(entry, selfKeys = []) {
       if (kind === "agent") return `To: ${label}`;
       if (kind === "session") return `Session: ${label}`;
       if (kind === "branch") return `Branch: ${label}`;
+      if (kind === "workspace") return `Workspace: ${label}`;
       return `To: ${label}`;
     });
   }
@@ -46,6 +51,24 @@ export function boardEntryAudienceLabels(entry, selfKeys = []) {
     return targets.map((target) => `To: ${target}`);
   }
   return ["Broadcast"];
+}
+
+export function normalizedBoardWorkspaceAudience(entry) {
+  const audience = Array.isArray(entry?.audience) ? entry.audience : [];
+  const normalized = [];
+  for (const value of audience) {
+    const workspaceId = String(value || "").trim();
+    if (!workspaceId || normalized.includes(workspaceId)) continue;
+    normalized.push(workspaceId);
+  }
+  return normalized;
+}
+
+export function boardEntryVisibleForWorkspace(entry, workspaceId) {
+  const audience = normalizedBoardWorkspaceAudience(entry);
+  if (audience.length === 0) return true;
+  const current = String(workspaceId || "").trim();
+  return Boolean(current) && audience.includes(current);
 }
 
 export function boardEntryPreview(entry) {
@@ -81,8 +104,13 @@ export function mentionsForBoardSubmit(state) {
 
 export function visibleBoardEntries(state, selfKeys = []) {
   const entries = state?.entries || [];
-  if (state?.audienceFilter !== "for_you") {
+  if (state?.audienceFilter === "all") {
     return entries;
+  }
+  if (state?.audienceFilter === "workspace") {
+    return entries.filter((entry) =>
+      boardEntryVisibleForWorkspace(entry, state?.currentWorkspaceId),
+    );
   }
   return entries.filter((entry) => boardEntryMentionsSelf(entry, selfKeys));
 }


### PR DESCRIPTION
## Summary
- Scope Board timeline reads by current Workspace audience, while keeping broadcast entries visible.
- Route `--mention workspace:<id>` into Board entry audience and fan out agent/session mentions to their assigned Workspace.
- Apply the same audience filter to Board reminder injection, workflow-policy duplicate claim checks, runtime Board loads, and frontend Board filters.

## Verification
- cargo test -p gwt-core -p gwt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build -p gwt
- pnpm run test:frontend-unit
- pnpm run test:frontend-bundle
- pnpm run test:frontend-smoke
- cargo fmt -- --check
- git diff --check
- bunx commitlint --from HEAD~1 --to HEAD
- git push pre-push checks: passed, coverage 90.65%
