### PR TITLE
feat(gui): SPEC-2359 Board pane Workspace audience filter toggle

### DIFF
--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -7,6 +7,7 @@ import {
   applyBoardMentionNotificationFocus,
   boardEntryAudienceLabels,
   boardEntryMentionsSelf,
+  entryVisibleForWorkspace,
   mentionForReplyParent,
   mentionsForBoardSubmit,
   visibleBoardEntries,
@@ -45,6 +46,12 @@ test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /showBoardMentionNotification/);
   assert.match(appSource, /Jump to original/);
   assert.match(appSource, /state\.audienceFilter\s*=\s*"all"/);
+});
+
+test("Board surface exposes a Workspace audience filter toggle (SPEC-2359 FR-101)", () => {
+  assert.match(appSource, /board-workspace-filter/);
+  assert.match(appSource, /toggle-board-workspace/);
+  assert.match(appSource, /state\.audienceFilter\s*===\s*"workspace"/);
 });
 
 test("Board message body preserves multiline plaintext", () => {
@@ -107,6 +114,64 @@ test("Board reply helpers create reply mentions and filter for-you entries", () 
     visibleBoardEntries(state, ["user:you"]).map((entry) => entry.id),
     ["entry-user"],
   );
+});
+
+test("entryVisibleForWorkspace treats absent or empty audience as broadcast (FR-093/103)", () => {
+  const broadcastA = { id: "a", audience: [] };
+  const broadcastB = { id: "b" };
+  const scopedAB = { id: "ab", audience: ["ws-1", "ws-2"] };
+  const scopedOther = { id: "other", audience: ["ws-2"] };
+
+  assert.equal(entryVisibleForWorkspace(broadcastA, "ws-1"), true);
+  assert.equal(entryVisibleForWorkspace(broadcastB, "ws-1"), true);
+  assert.equal(entryVisibleForWorkspace(broadcastA, null), true);
+  assert.equal(entryVisibleForWorkspace(scopedAB, "ws-1"), true);
+  assert.equal(entryVisibleForWorkspace(scopedAB, "ws-3"), false);
+  assert.equal(entryVisibleForWorkspace(scopedOther, "ws-1"), false);
+  assert.equal(entryVisibleForWorkspace(scopedAB, null), false);
+});
+
+test("visibleBoardEntries 'workspace' filter scopes by current workspace audience plus broadcast (FR-098)", () => {
+  const broadcast = { id: "broadcast", audience: [], mentions: [] };
+  const scopedSelf = { id: "scoped-self", audience: ["ws-1"], mentions: [] };
+  const scopedOther = { id: "scoped-other", audience: ["ws-2"], mentions: [] };
+
+  const state = {
+    entries: [broadcast, scopedSelf, scopedOther],
+    audienceFilter: "workspace",
+    currentWorkspaceId: "ws-1",
+  };
+
+  const visibleIds = visibleBoardEntries(state, []).map((entry) => entry.id);
+  assert.deepEqual(visibleIds, ["broadcast", "scoped-self"]);
+});
+
+test("visibleBoardEntries 'workspace' filter for unassigned agent shows only broadcast", () => {
+  const broadcast = { id: "broadcast", audience: [], mentions: [] };
+  const scoped = { id: "scoped", audience: ["ws-1"], mentions: [] };
+
+  const state = {
+    entries: [broadcast, scoped],
+    audienceFilter: "workspace",
+    currentWorkspaceId: null,
+  };
+
+  const visibleIds = visibleBoardEntries(state, []).map((entry) => entry.id);
+  assert.deepEqual(visibleIds, ["broadcast"]);
+});
+
+test("visibleBoardEntries 'all' filter still bypasses workspace scoping", () => {
+  const broadcast = { id: "broadcast", audience: [], mentions: [] };
+  const scopedOther = { id: "scoped-other", audience: ["ws-2"], mentions: [] };
+
+  const state = {
+    entries: [broadcast, scopedOther],
+    audienceFilter: "all",
+    currentWorkspaceId: "ws-1",
+  };
+
+  const visibleIds = visibleBoardEntries(state, []).map((entry) => entry.id);
+  assert.deepEqual(visibleIds, ["broadcast", "scoped-other"]);
 });
 
 test("Board notification helper prepares focused state for click-through", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3860,6 +3860,7 @@
         const timeline = body.querySelector(".board-timeline");
         const composer = body.querySelector(".board-composer-pane");
         const forYouFilter = body.querySelector("[data-action='toggle-board-for-you']");
+        const workspaceFilter = body.querySelector("[data-action='toggle-board-workspace']");
         if (!status || !timeline || !composer) {
           return;
         }
@@ -3894,6 +3895,11 @@
           forYouFilter.classList.toggle("active", state.audienceFilter === "for_you");
           forYouFilter.textContent =
             state.forYouUnread > 0 ? `For you (${state.forYouUnread})` : "For you";
+        }
+        if (workspaceFilter) {
+          const workspaceActive = state.audienceFilter === "workspace";
+          workspaceFilter.setAttribute("aria-pressed", workspaceActive ? "true" : "false");
+          workspaceFilter.classList.toggle("active", workspaceActive);
         }
 
         // The actual scroll viewport is `.board-timeline-scroll`, the
@@ -6239,6 +6245,7 @@
                 </div>
                 <div class="workspace-toolbar-actions">
                   <button class="text-button board-for-you-filter" data-action="toggle-board-for-you" type="button" aria-pressed="false">For you</button>
+                  <button class="text-button board-workspace-filter" data-action="toggle-board-workspace" type="button" aria-pressed="false">Workspace</button>
                   <button class="icon-button" data-action="refresh-board" aria-label="Refresh board">↻</button>
                 </div>
               </div>
@@ -6274,6 +6281,20 @@
               if (state.audienceFilter === "for_you") {
                 state.forYouUnread = 0;
               }
+              frontendUnits.boardSurface.renderBoard(windowData.id);
+            });
+          // SPEC-2359 FR-101: toggle the Workspace audience filter. The
+          // entry visibility itself is driven by `state.audienceFilter ===
+          // "workspace"` plus `state.currentWorkspaceId` via
+          // `visibleBoardEntries`; the projection wires up the workspace
+          // id separately so unassigned agents see only broadcast.
+          body
+            .querySelector("[data-action='toggle-board-workspace']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);
+              state.audienceFilter =
+                state.audienceFilter === "workspace" ? "all" : "workspace";
               frontendUnits.boardSurface.renderBoard(windowData.id);
             });
           const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);

--- a/crates/gwt/web/board-surface.js
+++ b/crates/gwt/web/board-surface.js
@@ -79,12 +79,27 @@ export function mentionsForBoardSubmit(state) {
   return mention ? [mention] : [];
 }
 
+// SPEC-2359 FR-093/098/103: mirror Rust `entry_visible_for_workspace`.
+// An entry is in-scope for Workspace W when its `audience` is empty
+// (broadcast) or contains W. Unassigned (`null`/`undefined`
+// workspaceId) only sees broadcast entries.
+export function entryVisibleForWorkspace(entry, currentWorkspaceId) {
+  const audience = Array.isArray(entry?.audience) ? entry.audience : [];
+  if (audience.length === 0) return true;
+  if (!currentWorkspaceId) return false;
+  return audience.includes(currentWorkspaceId);
+}
+
 export function visibleBoardEntries(state, selfKeys = []) {
   const entries = state?.entries || [];
-  if (state?.audienceFilter !== "for_you") {
-    return entries;
+  if (state?.audienceFilter === "for_you") {
+    return entries.filter((entry) => boardEntryMentionsSelf(entry, selfKeys));
   }
-  return entries.filter((entry) => boardEntryMentionsSelf(entry, selfKeys));
+  if (state?.audienceFilter === "workspace") {
+    const workspaceId = state?.currentWorkspaceId || null;
+    return entries.filter((entry) => entryVisibleForWorkspace(entry, workspaceId));
+  }
+  return entries;
 }
 
 export function applyBoardMentionNotificationFocus(state, entryId) {


### PR DESCRIPTION
## Summary

Add the frontend half of the Board audience model (SPEC-2359 FR-101).

- `gwt/web/board-surface.js`: export `entryVisibleForWorkspace`, mirroring the Rust `entry_visible_for_workspace` predicate (FR-098/103). Add a `workspace` mode to `visibleBoardEntries` driven by `state.currentWorkspaceId`. Unassigned agents (no workspace id) see only broadcast entries.
- `gwt/web/app.js`: render the Workspace toggle button, wire its aria-pressed/active state, and cycle `state.audienceFilter` between `workspace` and `all` on click.
- 4 new `board-surface.test.mjs` cases + UI affordance assertion.

The workspace id is sourced from the projection in a follow-up; until then the toggle defaults to the unassigned/broadcast view, which is the safe fallback matching FR-103.

## Test plan

- [x] `node --test crates/gwt/web/__tests__/board-surface.test.mjs` — 13/13 pass
- [x] `npm run test:frontend-unit` — 342/342 pass
- [x] `npm run test:frontend-smoke` — 11/11 pass
- [x] `npm run test:frontend-bundle` — clean
- [x] `cargo test -p gwt-core -p gwt` — 838+ pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] CI green
- [ ] Manual smoke: toggle "Workspace" button on Board pane and verify only broadcast entries show when current Agent is Unassigned

## SPEC tracking

- SPEC-2359 tasks.md: T-211, T-218 (workspace-id propagation follow-up still needed for assigned agents)
- T-219 (manual smoke) is the remaining gate before SPEC-2359 audience work is fully closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
