### PR TITLE
feat(gui): SPEC-2359 wire current project workspace id into Board filter

### DIFF
--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -54,6 +54,13 @@ test("Board surface exposes a Workspace audience filter toggle (SPEC-2359 FR-101
   assert.match(appSource, /state\.audienceFilter\s*===\s*"workspace"/);
 });
 
+test("Board surface wires Workspace projection's primary assigned agent into currentWorkspaceId (SPEC-2359 FR-098)", () => {
+  assert.match(appSource, /deriveCurrentProjectWorkspaceId/);
+  assert.match(appSource, /refreshBoardCurrentWorkspaceId/);
+  assert.match(appSource, /affiliation_status[\s\S]{0,60}assigned/);
+  assert.match(appSource, /currentWorkspaceId:\s*currentProjectWorkspaceId/);
+});
+
 test("Board message body preserves multiline plaintext", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -972,6 +972,11 @@
         const tab = activeProjectTab();
         renderProjectOnboarding(tab);
         renderWorkspace(tab?.workspace || emptyWorkspace());
+        const nextWorkspaceId = deriveCurrentProjectWorkspaceId(tab?.workspace || {});
+        if (nextWorkspaceId !== currentProjectWorkspaceId) {
+          currentProjectWorkspaceId = nextWorkspaceId;
+          refreshBoardCurrentWorkspaceId();
+        }
         renderWindowList();
         renderActiveWorkOverview();
       }
@@ -2713,9 +2718,35 @@
             audienceFilter: "all",
             forYouUnread: 0,
             lastNotifiedMentionEntryId: null,
+            currentWorkspaceId: currentProjectWorkspaceId,
           });
         }
         return boardStateMap.get(windowId);
+      }
+
+      // SPEC-2359 FR-098/101: track the project's "primary" assigned
+      // workspace id for the Board Workspace filter. Picks the first
+      // assigned agent's workspace_id from the workspace state event.
+      // When no agent in the project is assigned (all Unassigned), the
+      // filter degrades to broadcast-only via FR-103. Multi-workspace
+      // selection UX is a follow-up.
+      let currentProjectWorkspaceId = null;
+      function deriveCurrentProjectWorkspaceId(workspaceState) {
+        const agents = workspaceState?.workspace?.agents
+          || workspaceState?.agents
+          || [];
+        const assigned = agents.find(
+          (agent) =>
+            String(agent?.affiliation_status || "").toLowerCase() === "assigned"
+            && typeof agent?.workspace_id === "string"
+            && agent.workspace_id.length > 0,
+        );
+        return assigned ? assigned.workspace_id : null;
+      }
+      function refreshBoardCurrentWorkspaceId() {
+        for (const state of boardStateMap.values()) {
+          state.currentWorkspaceId = currentProjectWorkspaceId;
+        }
       }
 
       function normalizeLogSeverity(severity) {


### PR DESCRIPTION
## Summary

Wire the Board pane's `state.currentWorkspaceId` to the first assigned agent in the workspace projection so the "Workspace" audience toggle from PR #2646 actually scopes to the project's workspace.

- `gwt/web/app.js`: derive `currentProjectWorkspaceId` from the workspace state event's first assigned agent and propagate to every Board state when it changes. New Board states inherit the current value.
- `gwt/web/__tests__/board-surface.test.mjs`: wire-up assertion.

Behavior:
- All agents in the project Unassigned → toggle stays in "broadcast only" mode (FR-103).
- One Workspace assigned → toggle shows that workspace + broadcast.
- Multiple Workspaces in a project → picks the first assigned agent (heuristic). Multi-workspace selection UX is a follow-up.

## Test plan

- [x] `node --test crates/gwt/web/__tests__/board-surface.test.mjs` — 14/14 pass
- [x] `npm run test:frontend-unit` — 342/342 pass
- [x] `cargo test -p gwt-core -p gwt` — 838+ pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] CI green
- [ ] Manual smoke: assigned agent post visible under "Workspace" filter; other Workspaces hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)
