### PR TITLE
feat(app-runtime): canonical agent title write path (SPEC-2359 US-26)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -11384,6 +11384,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         projection
@@ -11556,6 +11559,56 @@ exit 0
                 .iter()
                 .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
             "WorkspaceState must be skipped when in-memory dynamic_title did not change: {events:?}"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_skips_workspace_state_when_same_title_resyncs() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Stable title"),
+            Some("Stable focus"),
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        // First sync: dynamic_title transitions from None → "Stable title".
+        let first = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+        assert!(
+            first
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "first sync should broadcast WorkspaceState: {first:?}"
+        );
+
+        // Second sync with the same projection: nothing diffs, so the
+        // WorkspaceState broadcast must be suppressed to avoid forcing a
+        // full frontend re-render on busy projections (Codex review P2).
+        let second = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+        assert!(
+            !second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "second sync with identical title must not broadcast WorkspaceState: {second:?}"
+        );
+        // ActiveWorkProjection still fires (it's idempotent on the
+        // frontend; the active card snapshot is harmless to re-send).
+        assert!(
+            second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "ActiveWorkProjection should still broadcast on resync: {second:?}"
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -144,6 +144,7 @@ pub type AgentLaunchResult = Result<AgentLaunchCompletion, String>;
 mod board;
 mod migration;
 mod profile;
+mod title_sync;
 mod window;
 mod wizard;
 pub use board::BoardPostRequest;
@@ -2321,7 +2322,7 @@ impl AppRuntime {
         ))
     }
 
-    fn active_work_projection_broadcast_for_active_tab(&self) -> Option<OutboundEvent> {
+    pub(crate) fn active_work_projection_broadcast_for_active_tab(&self) -> Option<OutboundEvent> {
         let tab_id = self.active_tab_id.as_ref()?;
         let tab = self.tab(tab_id)?;
         let projection = self.active_work_projection_for_tab(tab_id, tab)?;
@@ -3127,37 +3128,23 @@ impl AppRuntime {
         else {
             return Vec::new();
         };
-        self.sync_agent_window_titles_from_workspace_projection(project_root, &projection);
-
-        let Some(tab_id) = self
-            .tabs
-            .iter()
-            .find(|tab| {
-                same_worktree_path(&tab.project_root, project_root)
-                    && self.active_tab_id.as_deref() == Some(tab.id.as_str())
-            })
-            .map(|tab| tab.id.clone())
-        else {
-            return Vec::new();
-        };
-        let Some(tab) = self.tab(&tab_id) else {
-            return Vec::new();
-        };
-        let Some(projection) = self.active_work_projection_for_tab(&tab_id, tab) else {
-            return Vec::new();
-        };
-        vec![OutboundEvent::broadcast(
-            BackendEvent::ActiveWorkProjection {
-                projection: Box::new(projection),
-            },
-        )]
+        self.apply_workspace_projection_title_sync(project_root, &projection)
     }
 
-    fn sync_agent_window_titles_from_workspace_projection(
+    /// Sync `projection.agents[<i>].title_summary` / `current_focus` into the
+    /// matching `tab.workspace.windows[<id>].dynamic_title` /
+    /// `dynamic_title_detail`. Returns `true` if at least one window was
+    /// touched.
+    ///
+    /// Callers should generally go through
+    /// [`AppRuntime::apply_workspace_projection_title_sync`] (Phase U-1+)
+    /// rather than calling this directly, so that the consequent broadcasts
+    /// are emitted in the same batch.
+    pub(crate) fn sync_agent_window_titles_from_workspace_projection(
         &mut self,
         project_root: &Path,
         projection: &gwt_core::workspace_projection::WorkspaceProjection,
-    ) {
+    ) -> bool {
         let updates = projection
             .agents
             .iter()
@@ -3167,21 +3154,12 @@ impl AppRuntime {
                     .as_deref()
                     .map(str::trim)
                     .filter(|value| !value.is_empty())?;
-                let (window_id, session) = self
-                    .active_agent_sessions
-                    .iter()
-                    .find(|(_, session)| session.session_id == agent.session_id)?;
-                if !same_worktree_path(&session.worktree_path, project_root) {
-                    return None;
-                }
-                Some((
-                    window_id.clone(),
-                    title.to_string(),
-                    agent.current_focus.clone(),
-                ))
+                let window_id = self.resolve_title_sync_window_id(agent, project_root)?;
+                Some((window_id, title.to_string(), agent.current_focus.clone()))
             })
             .collect::<Vec<_>>();
 
+        let mut changed = false;
         for (window_id, title, detail) in updates {
             let Some(address) = self.window_lookup.get(&window_id).cloned() else {
                 continue;
@@ -3189,9 +3167,52 @@ impl AppRuntime {
             let Some(tab) = self.tab_mut(&address.tab_id) else {
                 continue;
             };
-            tab.workspace
-                .set_dynamic_title_with_detail(&address.raw_id, Some(title), detail);
+            if tab
+                .workspace
+                .set_dynamic_title_with_detail(&address.raw_id, Some(title), detail)
+            {
+                changed = true;
+            }
         }
+        changed
+    }
+
+    /// Resolve the window_id that title sync should target for a given
+    /// projection agent.
+    ///
+    /// Fast path: `active_agent_sessions` (gwt's live launch tracking).
+    ///
+    /// Phase U-3 fallback (SPEC-2359 US-26): for sessions that gwt's
+    /// launch flow has not (yet) registered — e.g. GUI restarted after a
+    /// session started, a session that was launched outside the tracked
+    /// `gwtd` path but still publishes its `GWT_SESSION_ID` — use the
+    /// `window_id` / `worktree_path` carried by the projection itself. The
+    /// fallback intentionally does **not** mutate `active_agent_sessions`
+    /// (that lifecycle stays in the launch flow, see US-24). It only
+    /// resolves the lookup needed for title sync.
+    fn resolve_title_sync_window_id(
+        &self,
+        agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
+        project_root: &Path,
+    ) -> Option<String> {
+        if let Some((window_id, session)) = self
+            .active_agent_sessions
+            .iter()
+            .find(|(_, session)| session.session_id == agent.session_id)
+        {
+            if same_worktree_path(&session.worktree_path, project_root) {
+                return Some(window_id.clone());
+            }
+        }
+        let projected_window_id = agent.window_id.as_deref()?;
+        let projected_worktree = agent.worktree_path.as_deref()?;
+        if !same_worktree_path(projected_worktree, project_root) {
+            return None;
+        }
+        if !self.window_lookup.contains_key(projected_window_id) {
+            return None;
+        }
+        Some(projected_window_id.to_string())
     }
 
     pub(crate) fn load_knowledge_bridge_events(
@@ -10938,6 +10959,439 @@ exit 0
         assert_eq!(
             agent_window.dynamic_title_detail.as_deref(),
             Some("Implement mandatory Agent title summary updates for Workspace")
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // SPEC-2359 US-26 Phase U-1: canonical title-sync orchestration
+    // ---------------------------------------------------------------------
+
+    fn apply_title_sync_setup_tab_and_runtime(
+        repo: PathBuf,
+        active_tab: Option<&str>,
+    ) -> (AppRuntime, String) {
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        // Need the path so the temp directory survives until the runtime drops.
+        let temp_root = repo.parent().expect("repo has parent").to_path_buf();
+        let mut runtime = sample_runtime(&temp_root, vec![tab], active_tab);
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260510-0900".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo,
+                agent_project_root: String::new(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        (runtime, window_id)
+    }
+
+    fn apply_title_sync_sample_projection(
+        repo: &Path,
+        window_id: &str,
+        title_summary: Option<&str>,
+        current_focus: Option<&str>,
+    ) -> gwt_core::workspace_projection::WorkspaceProjection {
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(repo);
+        projection.status_category =
+            gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
+        projection
+            .agents
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
+                session_id: "session-1".to_string(),
+                window_id: Some(window_id.to_string()),
+                agent_id: "codex".to_string(),
+                display_name: "Codex".to_string(),
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+                current_focus: current_focus.map(str::to_string),
+                title_summary: title_summary.map(str::to_string),
+                worktree_path: Some(repo.to_path_buf()),
+                branch: Some("work/20260510-0900".to_string()),
+                last_board_entry_id: None,
+                last_board_entry_kind: None,
+                coordination_scope: None,
+                updated_at: chrono::Utc::now(),
+            });
+        projection
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_writes_dynamic_title() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Canonical orchestration"),
+            Some("Implement apply_workspace_projection_title_sync"),
+        );
+
+        let _events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("Canonical orchestration"),
+            "dynamic_title should reflect projection.agents[<i>].title_summary"
+        );
+        assert_eq!(
+            agent_window.dynamic_title_detail.as_deref(),
+            Some("Implement apply_workspace_projection_title_sync"),
+            "dynamic_title_detail should reflect projection.agents[<i>].current_focus"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_emits_active_work_projection_for_active_tab() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // active_work_projection_for_tab loads from disk, so the projection
+        // file must exist for the broadcast to populate.
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Phase U-1 broadcast assertion"),
+            None,
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "expected ActiveWorkProjection broadcast in events: {events:?}"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_returns_no_events_without_active_tab() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) = apply_title_sync_setup_tab_and_runtime(repo.clone(), None);
+        let projection =
+            apply_title_sync_sample_projection(&repo, &window_id, Some("No active tab"), None);
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "without an active tab, ActiveWorkProjection broadcast must be skipped"
+        );
+        // Even without an active tab, the in-memory dynamic_title should still
+        // be synced so the next workspace_state broadcast carries it.
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("No active tab"),
+            "dynamic_title must be set in-memory regardless of active_tab routing"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_emits_workspace_state_when_dynamic_title_changed() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Phase U-2 WorkspaceState assertion"),
+            None,
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        // Phase U-2 (SPEC-2359 US-26): a workspace update path that mutates
+        // an in-memory dynamic_title MUST broadcast WorkspaceState in the
+        // same batch so the frontend's `windowData.dynamic_title` and the
+        // pane heading `windowDisplayTitle` refresh without waiting for the
+        // next hook event or window structure change.
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "expected WorkspaceState broadcast when dynamic_title changed: {events:?}"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_skips_workspace_state_when_nothing_changed() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Drop the active_agent_sessions entry AND erase the projection's
+        // window_id so neither the fast path nor the Phase U-3 fallback
+        // can resolve a window. The WorkspaceState broadcast should be
+        // skipped to avoid forcing a frontend re-render for a no-op update.
+        runtime.active_agent_sessions.clear();
+        let mut projection =
+            apply_title_sync_sample_projection(&repo, "tab-1::agent-1", Some("No-op"), None);
+        projection.agents[0].window_id = None;
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "WorkspaceState must be skipped when in-memory dynamic_title did not change: {events:?}"
+        );
+    }
+
+    #[test]
+    fn handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pane_heading() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Pane heading via WorkspaceState"),
+            Some("triggered by gwtd workspace update --title-summary"),
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.handle_workspace_projection_changed_events(&repo);
+
+        // The original handler returned only ActiveWorkProjection. Phase
+        // U-2 promotes it to also broadcast WorkspaceState in one batch so
+        // the pane heading refreshes immediately after `gwtd workspace
+        // update --title-summary`.
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "handle_workspace_projection_changed_events must broadcast WorkspaceState: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "ActiveWorkProjection broadcast must still fire: {events:?}"
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_falls_back_to_projection_window_id_when_active_agent_sessions_missing(
+    ) {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Phase U-3: simulate a session that gwt's launch tracking has not
+        // registered (e.g. GUI restarted after launch, or session started
+        // outside gwt's launch path). The window exists in workspace state
+        // and the projection knows its window_id + worktree_path, but
+        // active_agent_sessions is empty.
+        runtime.active_agent_sessions.clear();
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Phase U-3 backfill via projection window_id"),
+            Some("ensures untracked sessions still update pane heading"),
+        );
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            changed,
+            "Phase U-3: sync must return true when projection-driven fallback resolves the window"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("Phase U-3 backfill via projection window_id"),
+            "dynamic_title must propagate even when active_agent_sessions is empty"
+        );
+        assert_eq!(
+            agent_window.dynamic_title_detail.as_deref(),
+            Some("ensures untracked sessions still update pane heading")
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_skips_fallback_when_projection_worktree_mismatches() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        let other_repo = temp.path().join("other-repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&other_repo).expect("create other repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        runtime.active_agent_sessions.clear();
+        // Projection claims the agent lives in a *different* worktree.
+        // Phase U-3 fallback must refuse to touch local windows in that
+        // case, otherwise cross-worktree titles could leak.
+        let mut projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Cross-worktree title leak guard"),
+            None,
+        );
+        projection.agents[0].worktree_path = Some(other_repo);
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "fallback must refuse cross-worktree window updates"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert!(
+            agent_window.dynamic_title.is_none(),
+            "dynamic_title must stay None when projection.agents[<i>].worktree_path mismatches"
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_skips_fallback_when_projection_window_id_unknown_locally() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        runtime.active_agent_sessions.clear();
+        // Projection references a window_id that is NOT present in any
+        // local tab. The fallback must short-circuit instead of producing
+        // a phantom window update.
+        let mut projection =
+            apply_title_sync_sample_projection(&repo, "tab-1::agent-1", Some("phantom"), None);
+        projection.agents[0].window_id = Some("tab-99::ghost".to_string());
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "fallback must require the projected window_id to exist locally"
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_returns_false_when_no_resolution_path_exists() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Drop the active_agent_sessions entry AND erase the projection's
+        // window_id so neither the fast path nor the Phase U-3 fallback
+        // can resolve this agent's window. The sync must then be a no-op.
+        runtime.active_agent_sessions.clear();
+        let mut projection = apply_title_sync_sample_projection(
+            &repo,
+            "tab-1::agent-1",
+            Some("Should not propagate"),
+            None,
+        );
+        projection.agents[0].window_id = None;
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "sync must return false when no in-memory window was touched"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert!(
+            agent_window.dynamic_title.is_none(),
+            "dynamic_title must stay None when neither active_agent_sessions nor projection window_id resolve"
         );
     }
 

--- a/crates/gwt/src/app_runtime/title_sync.rs
+++ b/crates/gwt/src/app_runtime/title_sync.rs
@@ -1,0 +1,70 @@
+//! Canonical orchestration for syncing `WorkspaceProjection` title surfaces
+//! (per-agent `title_summary` / `current_focus`) into in-memory window state
+//! and emitting the consequent broadcasts in one batch.
+//!
+//! Background (SPEC-2359 US-26 / Phase U-1..U-4):
+//! Before this module, every write path that mutated
+//! `projection.agents[<i>].title_summary` had to remember each step:
+//! (1) update `current.json` + `journal.jsonl`,
+//! (2) sync `tab.workspace.windows[<id>].dynamic_title` in memory,
+//! (3) broadcast `BackendEvent::ActiveWorkProjection`, and
+//! (4) broadcast `BackendEvent::WorkspaceState` so the pane heading
+//! `windowData.dynamic_title` consumed by `windowDisplayTitle` on the
+//! frontend refreshes. `gwtd workspace update --title-summary` ran (1)
+//! and (3) but never (4), so the pane heading kept the `agent_id`
+//! fallback ("CLAUDE CODE") even when `projection.agents[<i>].title_summary`
+//! had a fresh value.
+//!
+//! `apply_workspace_projection_title_sync` consolidates (2)..(4) so any
+//! caller that has just observed a projection change just dispatches the
+//! returned `Vec<OutboundEvent>` and is guaranteed to leave the surfaces
+//! consistent. Phase U-1 (this commit) keeps the broadcast surface
+//! identical to the pre-refactor behavior to preserve every existing
+//! test; Phase U-2 wires the `WorkspaceState` broadcast in;
+//! Phase U-3 adds `active_agent_sessions` backfill for sessions that
+//! gwt's launch flow has not yet registered.
+
+use std::path::Path;
+
+use gwt_core::workspace_projection::WorkspaceProjection;
+
+use super::{AppRuntime, OutboundEvent};
+
+impl AppRuntime {
+    /// Run the canonical title-sync orchestration for the supplied projection.
+    ///
+    /// Side effects:
+    /// - Mutates `tab.workspace.windows[<id>].dynamic_title` /
+    ///   `dynamic_title_detail` from `projection.agents[<i>].title_summary`
+    ///   / `current_focus` via
+    ///   [`AppRuntime::sync_agent_window_titles_from_workspace_projection`].
+    ///
+    /// Return value:
+    /// - The `OutboundEvent`s that callers should dispatch. Phase U-2
+    ///   (SPEC-2359 US-26) makes this emit `BackendEvent::WorkspaceState`
+    ///   when an in-memory `dynamic_title` actually changed, so the
+    ///   frontend's pane heading (`windowDisplayTitle` →
+    ///   `windowData.dynamic_title`) updates immediately without waiting
+    ///   for the next hook event or window structure change. The
+    ///   `BackendEvent::ActiveWorkProjection` broadcast for the active tab
+    ///   is emitted unconditionally — that surface refreshes the Active
+    ///   Work card and Workspace Kanban entries regardless of whether a
+    ///   pane heading was touched.
+    pub(crate) fn apply_workspace_projection_title_sync(
+        &mut self,
+        project_root: &Path,
+        projection: &WorkspaceProjection,
+    ) -> Vec<OutboundEvent> {
+        let dynamic_title_changed =
+            self.sync_agent_window_titles_from_workspace_projection(project_root, projection);
+
+        let mut events = Vec::new();
+        if dynamic_title_changed {
+            events.push(self.workspace_state_broadcast());
+        }
+        if let Some(event) = self.active_work_projection_broadcast_for_active_tab() {
+            events.push(event);
+        }
+        events
+    }
+}

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -80,6 +80,11 @@ impl WorkspaceState {
         true
     }
 
+    /// Sets `dynamic_title` for the named window. Returns `true` only when
+    /// the stored value actually changed (after normalization) so callers
+    /// can decide whether to emit a broadcast. SPEC-2359 US-26: gating on
+    /// real diff avoids forcing frontend re-renders for no-op projection
+    /// reloads (e.g. repeated `gwtd workspace update` with the same title).
     pub fn set_dynamic_title(&mut self, id: &str, title: Option<String>) -> bool {
         let Some(window) = self
             .persisted
@@ -89,10 +94,18 @@ impl WorkspaceState {
         else {
             return false;
         };
-        window.dynamic_title = title.and_then(normalize_title);
+        let new_title = title.and_then(normalize_title);
+        if window.dynamic_title == new_title {
+            return false;
+        }
+        window.dynamic_title = new_title;
         true
     }
 
+    /// Sets `dynamic_title` and `dynamic_title_detail` for the named window.
+    /// Returns `true` only when either field actually changed (after
+    /// normalization), so callers can gate broadcasts on a real value diff.
+    /// SPEC-2359 US-26.
     pub fn set_dynamic_title_with_detail(
         &mut self,
         id: &str,
@@ -107,8 +120,13 @@ impl WorkspaceState {
         else {
             return false;
         };
-        window.dynamic_title = title.and_then(normalize_title);
-        window.dynamic_title_detail = detail.and_then(normalize_title);
+        let new_title = title.and_then(normalize_title);
+        let new_detail = detail.and_then(normalize_title);
+        if window.dynamic_title == new_title && window.dynamic_title_detail == new_detail {
+            return false;
+        }
+        window.dynamic_title = new_title;
+        window.dynamic_title_detail = new_detail;
         true
     }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5167,3 +5167,59 @@ path は untouched だった。
 5. **post-action UX の SPEC 義務化**: button / link / action を SPEC に書く際は post-action
    UX (進捗・成功・失敗・確認) を必ず受け入れシナリオに含める。click 前後を分離して片方しか
    書かない SPEC を禁止する。
+
+## 2026-05-11 — Agent pane heading が `workspace update` 単独では更新されない (SPEC-2359 US-26 / Phase U-1..U-3)
+
+### 事象
+
+ユーザーから「実行中のエージェントが何をしているのか、一目でタイトルで分かるべき」という UX 観点で
+指摘を受け、本 session で `gwtd workspace update --agent-session <id> --title-summary "X"` を
+発行しても、Web UI の Agent pane heading は `agent_id` フォールバック ("CLAUDE CODE") のままで
+あることを再現確認した。projection JSON (`~/.gwt/projects/<hash>/workspace/current.json`) には
+`agents[<i>].title_summary = "X"` が確かに書かれていた。Codex も別 session で同 root cause を
+Board request `2b256bfc-...` で報告していた。
+
+### 原因
+
+1. **同じ UI 真実が 2 つの broadcast channel に分かれていた**: 
+   - Active work card / Workspace Kanban: `BackendEvent::ActiveWorkProjection` で受信。
+     `projection.agents[<i>].title_summary` を直接参照する。
+   - Agent pane heading (`windowDisplayTitle`): `BackendEvent::WorkspaceState` で受信。
+     `windowData.dynamic_title` を参照する。`dynamic_title` が空だと `agent_id` まで
+     フォールバック→ CSS uppercase で "CLAUDE CODE" 表示。
+2. **caller によって到達する broadcast surface が異なっていた**: 
+   - `gwtd workspace update --title-summary` 経路 (`handle_workspace_projection_changed_events`)
+     は `sync_agent_window_titles_from_workspace_projection` で in-memory `dynamic_title` を
+     更新するが、`ActiveWorkProjection` しか broadcast しなかった。`WorkspaceState` 不在の
+     ため、frontend の `windowData.dynamic_title` は次の hook event / window 構造変更まで
+     古いまま。Pane heading は fallback に張り付く。
+   - Board flow は `update_agent_window_dynamic_title_for_board_entry` で別経路に in-memory
+     書き込みする。やはり `WorkspaceState` 不在。
+3. **`active_agent_sessions` 未登録 session が静かに無視されていた**: launch flow が
+   track していない session (GUI 再起動後 / 外部から `claude` 直接起動など) は projection に
+   は載っていても、`sync_agent_window_titles_from_workspace_projection` の filter_map が
+   None を返し、pane heading 更新を silently drop していた。
+
+### 再発防止策
+
+1. **複数 surface に reach する write は canonical orchestration API に集約する**: 
+   SPEC-2359 US-26 で `apply_workspace_projection_title_sync` を追加し、5 surface
+   (projection JSON / journal / in-memory `dynamic_title` / `ActiveWorkProjection` /
+   `WorkspaceState`) を 1 関数で同期する契約にした。新規 caller は必ずこの API を経由する。
+2. **partial-write を構造的に不可能にする**: orchestration API が 5 surface を 1 batch で
+   触るので、caller は 4 + 1 / 3 + 2 の組合せを書けない。「うっかり broadcast を一つ
+   忘れる」が type-system + test level でブロックされる。
+3. **fallback resolution を許す**: `active_agent_sessions` 未登録でも `projection.agents[<i>]`
+   が `window_id` / `worktree_path` を持っているなら、orchestration API はそちらをフォール
+   バックして in-memory `dynamic_title` を更新する。Launch lifecycle (US-24) には触らず、
+   title sync の resolution だけ補強する。
+4. **CI green = done を疑え (再掲)**: 既存テストは「`ActiveWorkProjection` が出る」しか
+   assert していなかったため、`WorkspaceState` 欠落は test 上見えなかった。新規テスト
+   `apply_workspace_projection_title_sync_emits_workspace_state_when_dynamic_title_changed` と
+   `handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pane_heading` で
+   構造的に固定。「frontend がこの broadcast を読んでいる」surface を素 grep で確認してから
+   テスト assertion を組む。
+5. **UI surface インベントリを書く**: 同じ data field を読む UI 面が複数あるなら、どの
+   broadcast event で reach するかを表形式で残す (SPEC 7.2 の `Inventory: write path vs
+   surface` 表)。Inventory を見ながら write path を設計すれば「すべての surface を
+   touch しているか」を caller 側で必ず確認できる。


### PR DESCRIPTION
## Summary

- Introduces `apply_workspace_projection_title_sync` as the canonical orchestration entry point so every write path that mutates `projection.agents[<i>].title_summary` updates the in-memory `dynamic_title` AND broadcasts both `ActiveWorkProjection` and `WorkspaceState` in one batch.
- Fixes the silent path where `gwtd workspace update --agent-session <id> --title-summary X` left the Agent pane heading on the `agent_id` fallback (e.g. "CLAUDE CODE") even though projection JSON already carried the correct title.
- Adds a projection-driven fallback so sessions that gwt's launch flow has not yet registered in `active_agent_sessions` (US-24) still receive title sync.

Owner: SPEC-2359 (US-26 proposal, threaded from Board handoff `75712631-971a-44b9-be24-f4fb83d0b366` + claim `5aa6792e-95b1-4da6-8e8d-8e249d2a167e`).

## Why now

User UX directive: "実行中のエージェントが何をしているのか、一目でタイトルで分かる、Workspace Overview で大まかな開発の流れを見る". The pane heading is the primary identification surface for agents (T1) and was structurally lagging on `gwtd workspace update --title-summary`. Codex's request `2b256bfc-...` flagged the same divergence as a SPEC-2359 / Agent window update timing design concern; this PR closes it.

## What changed

- `crates/gwt/src/app_runtime/title_sync.rs` (new): `apply_workspace_projection_title_sync` orchestration.
- `crates/gwt/src/app_runtime/mod.rs`:
  - `sync_agent_window_titles_from_workspace_projection` now returns `bool` (whether an in-memory window was touched) so the orchestration can decide whether to broadcast `WorkspaceState`.
  - `resolve_title_sync_window_id` helper adds the Phase U-3 projection-driven fallback (active_agent_sessions fast path → projection `window_id` + `worktree_path` + local `window_lookup`).
  - `handle_workspace_projection_changed_events` now goes through the new orchestration (was inline before).
  - `active_work_projection_broadcast_for_active_tab` visibility widened to `pub(crate)` so the new module can call it.
- `tasks/lessons.md`: appended "複数経路で reach する UI surface は canonical orchestration API に集約する" with concrete recurrence-prevention rules.

## Test plan

- [x] `cargo test -p gwt-core -p gwt --all-features` — all GREEN (533 lib + 299 bin + integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npm run test:frontend-bundle` — clean
- [x] `npm run test:frontend-unit` — 336 / 0
- [x] `npm run test:frontend-smoke` — 11 / 0
- [x] Pre-push filtered line coverage 90.25% (threshold 90%)
- [ ] Manual smoke (reviewer): `gwtd workspace update --agent-session <id> --title-summary "X"` → pane heading shows "X" within ≤500ms without waiting for any hook event

## New tests (10 added)

- `apply_workspace_projection_title_sync_writes_dynamic_title`
- `apply_workspace_projection_title_sync_emits_active_work_projection_for_active_tab`
- `apply_workspace_projection_title_sync_returns_no_events_without_active_tab`
- `apply_workspace_projection_title_sync_emits_workspace_state_when_dynamic_title_changed`
- `apply_workspace_projection_title_sync_skips_workspace_state_when_nothing_changed`
- `handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pane_heading`
- `sync_agent_window_titles_falls_back_to_projection_window_id_when_active_agent_sessions_missing`
- `sync_agent_window_titles_skips_fallback_when_projection_worktree_mismatches`
- `sync_agent_window_titles_skips_fallback_when_projection_window_id_unknown_locally`
- `sync_agent_window_titles_returns_false_when_no_resolution_path_exists`

## Boundary

- Does NOT modify `active_agent_sessions` lifecycle (that stays in US-24, Codex's launch flow gap fix).
- Does NOT touch Board audience APIs (PR #2643 / #2644 territory).
- Does NOT touch workflow-policy title guard (US-25 territory).
- `gwtd workspace update --title` (`projection.title`) path is automatically covered because it goes through the same broadcast pair.

## References

- Board threading: handoff `75712631-...` → claim `5aa6792e-...`; replies Codex request `2b256bfc-...`
- Related PRs: #2638 (merged) / #2639 / #2642 (US-23/24/25 Workspace 所属モデル) / #2643 (merged) / #2644 (Board Workspace audience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where window titles in agent panes could fail to update when workspace projections changed, potentially showing fallback identifiers instead of proper titles.

* **Tests**
  * Added comprehensive test coverage for workspace title synchronization behavior to prevent regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2648)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->