### PR TITLE
fix(board): preserve all-view live updates

### DIFF
--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -3185,7 +3185,7 @@ mod tests {
     fn has_recent_post_by_checks_segment_history_beyond_hot_projection() {
         let dir = tempfile::tempdir().unwrap();
 
-        let base = chrono::Utc::now() - chrono::Duration::minutes(9);
+        let base = chrono::Utc::now() - chrono::Duration::minutes(1);
         let mut events = Vec::with_capacity(HOT_PROJECTION_ENTRY_LIMIT + 1);
         let mut target = BoardEntry::new(
             AuthorKind::Agent,

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1692,6 +1692,7 @@ pub struct AppRuntime {
     pub(crate) runtimes: HashMap<String, WindowRuntime>,
     pub(crate) window_details: HashMap<String, String>,
     pub(crate) window_lookup: HashMap<String, WindowAddress>,
+    pub(crate) board_all_view_windows: HashSet<String>,
     pub(crate) session_state_path: PathBuf,
     pub(crate) log_dir: PathBuf,
     pub(crate) proxy: AppEventProxy,
@@ -1771,6 +1772,7 @@ impl AppRuntime {
             runtimes: HashMap::new(),
             window_details: HashMap::new(),
             window_lookup: HashMap::new(),
+            board_all_view_windows: HashSet::new(),
             session_state_path,
             log_dir,
             proxy: AppEventProxy::new(proxy),
@@ -2979,7 +2981,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn load_board_events(
-        &self,
+        &mut self,
         client_id: &str,
         id: &str,
         all: bool,
@@ -3020,11 +3022,17 @@ impl AppRuntime {
                 },
             )];
         }
+        let project_root = tab.project_root.clone();
+        if all {
+            self.board_all_view_windows.insert(id.to_string());
+        } else {
+            self.board_all_view_windows.remove(id);
+        }
 
         let scope = if all {
             gwt_core::coordination::BoardAudienceScope::All
         } else {
-            match board::gui_default_board_scope_for_project(&tab.project_root) {
+            match board::gui_default_board_scope_for_project(&project_root) {
                 Ok(scope) => scope,
                 Err(error) => {
                     return vec![OutboundEvent::reply(
@@ -3038,9 +3046,9 @@ impl AppRuntime {
             }
         };
         let snapshot_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
-            gwt_core::coordination::load_snapshot(&tab.project_root)
+            gwt_core::coordination::load_snapshot(&project_root)
         } else {
-            gwt_core::coordination::load_snapshot_for_scope(&tab.project_root, &scope)
+            gwt_core::coordination::load_snapshot_for_scope(&project_root, &scope)
         };
         match snapshot_result {
             Ok(snapshot) => vec![OutboundEvent::reply(
@@ -3062,7 +3070,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn load_board_history_events(
-        &self,
+        &mut self,
         client_id: &str,
         id: &str,
         before_entry_id: Option<&str>,
@@ -3105,11 +3113,17 @@ impl AppRuntime {
                 },
             )];
         }
+        let project_root = tab.project_root.clone();
+        if all {
+            self.board_all_view_windows.insert(id.to_string());
+        } else {
+            self.board_all_view_windows.remove(id);
+        }
 
         let scope = if all {
             gwt_core::coordination::BoardAudienceScope::All
         } else {
-            match board::gui_default_board_scope_for_project(&tab.project_root) {
+            match board::gui_default_board_scope_for_project(&project_root) {
                 Ok(scope) => scope,
                 Err(error) => {
                     return vec![OutboundEvent::reply(
@@ -3123,10 +3137,10 @@ impl AppRuntime {
             }
         };
         let page_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
-            gwt_core::coordination::load_entries_before(&tab.project_root, before_entry_id, limit)
+            gwt_core::coordination::load_entries_before(&project_root, before_entry_id, limit)
         } else {
             gwt_core::coordination::load_entries_before_for_scope(
-                &tab.project_root,
+                &project_root,
                 before_entry_id,
                 limit,
                 &scope,
@@ -3225,8 +3239,13 @@ impl AppRuntime {
                 if window.preset != WindowPreset::Board {
                     continue;
                 }
-                let scope = board::gui_default_board_scope_for_project(&tab.project_root)
-                    .unwrap_or(gwt_core::coordination::BoardAudienceScope::All);
+                let window_id = combined_window_id(&tab.id, &window.id);
+                let scope = if self.board_all_view_windows.contains(&window_id) {
+                    gwt_core::coordination::BoardAudienceScope::All
+                } else {
+                    board::gui_default_board_scope_for_project(&tab.project_root)
+                        .unwrap_or(gwt_core::coordination::BoardAudienceScope::All)
+                };
                 let board = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
                     snapshot.board.clone()
                 } else {
@@ -3235,7 +3254,7 @@ impl AppRuntime {
                         .unwrap_or_else(|_| snapshot.board.clone())
                 };
                 events.push(OutboundEvent::broadcast(BackendEvent::BoardEntries {
-                    id: combined_window_id(&tab.id, &window.id),
+                    id: window_id,
                     entries: board.entries,
                     has_more_before: board.has_more_before,
                 }));
@@ -5239,6 +5258,7 @@ impl AppRuntime {
     fn remove_window_state_tracking(&mut self, window_id: &str) {
         self.window_pty_statuses.remove(window_id);
         self.window_hook_states.remove(window_id);
+        self.board_all_view_windows.remove(window_id);
     }
 
     fn tracked_window_exists(&self, window_id: &str) -> bool {
@@ -5774,8 +5794,8 @@ mod tests {
     use gwt_config::{Profile, Settings};
     use gwt_core::{
         coordination::{
-            load_snapshot, post_entry, AuthorKind, BoardEntry, BoardEntryKind, BoardMention,
-            BoardMentionTargetKind,
+            load_snapshot, post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardEntryKind,
+            BoardMention, BoardMentionTargetKind,
         },
         logging::{current_log_file, LogEvent, LogLevel},
         paths::gwt_cache_dir,
@@ -6257,6 +6277,30 @@ exit 0
         save_workspace_launch_projection(repo, session, Some("develop"), None, Some(&context), true)
     }
 
+    fn workspace_agent_summary_for_test(
+        session_id: &str,
+        workspace_id: Option<&str>,
+    ) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
+        gwt_core::workspace_projection::WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+            current_focus: Some("Board audience follow-up".to_string()),
+            title_summary: Some("Board audience follow-up".to_string()),
+            worktree_path: None,
+            branch: Some("work/test".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status:
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: workspace_id.map(str::to_string),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
     #[test]
     fn image_paste_prepare_uses_host_absolute_path_reference() {
         let temp = tempdir().expect("tempdir");
@@ -6490,6 +6534,7 @@ exit 0
             runtimes: HashMap::new(),
             window_details: HashMap::new(),
             window_lookup: HashMap::new(),
+            board_all_view_windows: std::collections::HashSet::new(),
             session_state_path: temp_root.join("session-state.json"),
             log_dir,
             proxy,
@@ -11327,6 +11372,152 @@ exit 0
                 .dynamic_title
                 .as_deref(),
             Some("Board milestone focus")
+        );
+    }
+
+    #[test]
+    fn app_runtime_gui_board_scope_uses_active_workspace_id_not_first_agent_workspace() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-active".to_string();
+        projection.agents.push(workspace_agent_summary_for_test(
+            "session-other",
+            Some("workspace-other"),
+        ));
+        projection
+            .agents
+            .push(workspace_agent_summary_for_test("session-active", None));
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let scope = super::board::gui_default_board_scope_for_project(&repo)
+            .expect("resolve GUI board scope");
+        let post_audience =
+            gwt::board_audience::post_audience_for_gui(&repo, &[]).expect("resolve post audience");
+
+        assert_eq!(
+            scope,
+            BoardAudienceScope::Workspace("workspace-active".to_string())
+        );
+        assert_eq!(post_audience, Some(vec!["workspace-active".to_string()]));
+    }
+
+    #[test]
+    fn app_runtime_board_projection_change_preserves_all_view_for_live_updates() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-a".to_string();
+        projection
+            .agents
+            .push(workspace_agent_summary_for_test("session-a", None));
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "Workspace A update",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-a"]),
+        )
+        .expect("seed workspace A update");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "Workspace B update",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-b"]),
+        )
+        .expect("seed workspace B update");
+
+        let mut tab_workspace = empty_workspace_state();
+        tab_workspace.windows.push(sample_window(
+            "board-all",
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        ));
+        tab_workspace.windows.push(sample_window(
+            "board-workspace",
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        ));
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let all_window_id = combined_window_id("tab-1", "board-all");
+        let workspace_window_id = combined_window_id("tab-1", "board-workspace");
+        let _ = runtime.load_board_events("client-1", &all_window_id, true);
+        let _ = runtime.load_board_events("client-1", &workspace_window_id, false);
+
+        let events = runtime.handle_board_projection_changed_events(&repo);
+
+        let all_entries = events
+            .iter()
+            .find_map(|event| match event {
+                OutboundEvent {
+                    event: BackendEvent::BoardEntries { id, entries, .. },
+                    ..
+                } if id == &all_window_id => Some(entries),
+                _ => None,
+            })
+            .expect("all view board entries");
+        let workspace_entries = events
+            .iter()
+            .find_map(|event| match event {
+                OutboundEvent {
+                    event: BackendEvent::BoardEntries { id, entries, .. },
+                    ..
+                } if id == &workspace_window_id => Some(entries),
+                _ => None,
+            })
+            .expect("workspace view board entries");
+
+        assert!(
+            all_entries
+                .iter()
+                .any(|entry| entry.body == "Workspace B update"),
+            "All view live update must include other Workspace entries"
+        );
+        assert!(
+            !workspace_entries
+                .iter()
+                .any(|entry| entry.body == "Workspace B update"),
+            "Workspace view live update must stay scoped"
         );
     }
 

--- a/crates/gwt/src/board_audience.rs
+++ b/crates/gwt/src/board_audience.rs
@@ -26,6 +26,19 @@ fn workspace_id_for_agent(
         .or_else(|| non_empty_string(&projection.id))
 }
 
+fn active_workspace_id(projection: &WorkspaceProjection) -> Option<String> {
+    non_empty_string(&projection.id)
+}
+
+fn gui_workspace_id(projection: &WorkspaceProjection) -> Option<String> {
+    projection.assigned_agents().next()?;
+    active_workspace_id(projection).or_else(|| {
+        projection
+            .assigned_agents()
+            .find_map(|agent| workspace_id_for_agent(projection, agent))
+    })
+}
+
 fn push_unique(values: &mut Vec<String>, value: impl Into<String>) {
     let value = value.into();
     if value.trim().is_empty() || values.iter().any(|item| item == &value) {
@@ -102,10 +115,7 @@ pub fn gui_default_board_scope(repo_path: &Path) -> gwt_core::Result<BoardAudien
     let Some(projection) = load_workspace_projection(repo_path)? else {
         return Ok(BoardAudienceScope::All);
     };
-    if let Some(workspace_id) = projection
-        .assigned_agents()
-        .find_map(|agent| workspace_id_for_agent(&projection, agent))
-    {
+    if let Some(workspace_id) = gui_workspace_id(&projection) {
         return Ok(BoardAudienceScope::Workspace(workspace_id));
     }
     if projection.unassigned_agents().next().is_some() {
@@ -143,10 +153,7 @@ pub fn post_audience_for_gui(
     let projection = load_workspace_projection(repo_path)?;
     let mut audience = Vec::new();
     if let Some(projection) = projection.as_ref() {
-        if let Some(workspace_id) = projection
-            .assigned_agents()
-            .find_map(|agent| workspace_id_for_agent(projection, agent))
-        {
+        if let Some(workspace_id) = gui_workspace_id(projection) {
             push_unique(&mut audience, workspace_id);
         }
     }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1471,6 +1471,7 @@ mod tests {
             runtimes: HashMap::new(),
             window_details: HashMap::new(),
             window_lookup: HashMap::new(),
+            board_all_view_windows: std::collections::HashSet::new(),
             session_state_path: temp_root.join("session-state.json"),
             log_dir,
             proxy,


### PR DESCRIPTION
## Summary

- Fixes the Board review follow-up from #2645 so windows that selected All keep receiving unfiltered live Board updates.
- Anchors the GUI Board default Workspace scope and GUI post audience to the active Workspace projection id instead of the first assigned agent workspace id.
- Stabilizes the recent-post history regression test that failed under coverage by avoiding a narrow clock boundary unrelated to the assertion.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: Tracks per-window Board All view state and uses it when broadcasting live Board projection updates.
- `crates/gwt/src/board_audience.rs`: Resolves GUI default scope and GUI post audience from the active Workspace projection id when assigned agents exist.
- `crates/gwt/src/main.rs`: Initializes the Board All view tracking state in test runtime construction.
- `crates/gwt-core/src/coordination.rs`: Widens timing headroom in the segment-history recent-post test.

## Testing

- [x] `cargo test -p gwt app_runtime_gui_board_scope_uses_active_workspace_id_not_first_agent_workspace -- --nocapture` — passed.
- [x] `cargo test -p gwt app_runtime_board_projection_change_preserves_all_view_for_live_updates -- --nocapture` — passed.
- [x] `cargo test -p gwt-core has_recent_post_by_checks_segment_history_beyond_hot_projection -- --nocapture` — passed.
- [x] `cargo test --tests --manifest-path Cargo.toml --target-dir target/llvm-cov-target -p gwt-core --all-features has_recent_post_by_checks_segment_history_beyond_hot_projection -- --test-threads=1 --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `git push origin work/20260510-2353` — pre-push checks passed, including filtered coverage 90.69%.

## Closing Issues

- None

## Related Issues / Links

- #2645
- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not user-facing)
- [x] Migration/backfill plan included (no schema/data change)
- [x] CHANGELOG impact considered (patch fix, no breaking change)

## Context

- #2645 was already merged, but Codex review threads on that PR identified two follow-up defects in Board live updates and GUI Workspace scope resolution.

## Risk / Impact

- **Affected areas**: GUI Board live updates, GUI Board default Workspace scoping, GUI Board post audience.
- **Rollback plan**: Revert this PR to restore the previous Board live update and GUI scope behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Board audience preferences are now tracked per-window, ensuring consistent viewing behavior across multiple board windows.
  * Live board updates now respect per-window audience scope settings.

* **Improvements**
  * Workspace selection for board scoping improved to prioritize active workspace context.

* **Tests**
  * Extended test coverage for board audience scoping behavior during live updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2649)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->