### PR TITLE
feat(agent): support OpenCode OpenClaw and Hermes hooks

### DIFF
--- a/crates/gwt-agent/src/detect.rs
+++ b/crates/gwt-agent/src/detect.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use tracing::debug;
 
-use crate::types::AgentId;
+use crate::types::{builtin_agent_descriptor_for_command, builtin_agent_descriptors, AgentId};
 
 /// Result of detecting a single agent on the system.
 #[derive(Debug, Clone)]
@@ -25,50 +25,15 @@ struct AgentProbe {
 
 /// All builtin agents we attempt to detect.
 fn builtin_probes() -> Vec<AgentProbe> {
-    vec![
-        AgentProbe {
-            id: AgentId::ClaudeCode,
-            command: "claude",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Codex,
-            command: "codex",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Gemini,
-            command: "gemini",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::OpenCode,
-            command: "opencode",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::OpenClaw,
-            command: "openclaw",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Hermes,
-            command: "hermes",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Copilot,
-            command: "gh",
-            version_flag: "--version",
-            prefix_args: &["copilot"],
-        },
-    ]
+    builtin_agent_descriptors()
+        .iter()
+        .map(|descriptor| AgentProbe {
+            id: descriptor.id.clone(),
+            command: descriptor.command,
+            version_flag: descriptor.version_flag,
+            prefix_args: descriptor.version_prefix_args,
+        })
+        .collect()
 }
 
 /// Detects installed coding agents.
@@ -89,18 +54,19 @@ impl AgentDetector {
     /// Detect a single agent by its command name.
     pub fn detect_by_command(command: &str) -> Option<DetectedAgent> {
         let path = which::which(command).ok()?;
-        let version = Self::fetch_version(command, "--version", &[]);
-        // Map known commands to AgentIds, fall back to Custom
-        let agent_id = match command {
-            "claude" => AgentId::ClaudeCode,
-            "codex" => AgentId::Codex,
-            "gemini" => AgentId::Gemini,
-            "opencode" => AgentId::OpenCode,
-            "openclaw" => AgentId::OpenClaw,
-            "hermes" => AgentId::Hermes,
-            "gh" => AgentId::Copilot,
-            other => AgentId::Custom(other.to_string()),
+        let descriptor = builtin_agent_descriptor_for_command(command);
+        let version = match descriptor {
+            Some(descriptor) => Self::fetch_version(
+                command,
+                descriptor.version_flag,
+                descriptor.version_prefix_args,
+            ),
+            None => Self::fetch_version(command, "--version", &[]),
         };
+        // Map known commands to AgentIds, fall back to Custom
+        let agent_id = descriptor
+            .map(|descriptor| descriptor.id.clone())
+            .unwrap_or_else(|| AgentId::Custom(command.to_string()));
         Some(DetectedAgent {
             agent_id,
             version,

--- a/crates/gwt-agent/src/detect.rs
+++ b/crates/gwt-agent/src/detect.rs
@@ -51,6 +51,18 @@ fn builtin_probes() -> Vec<AgentProbe> {
             prefix_args: &[],
         },
         AgentProbe {
+            id: AgentId::OpenClaw,
+            command: "openclaw",
+            version_flag: "--version",
+            prefix_args: &[],
+        },
+        AgentProbe {
+            id: AgentId::Hermes,
+            command: "hermes",
+            version_flag: "--version",
+            prefix_args: &[],
+        },
+        AgentProbe {
             id: AgentId::Copilot,
             command: "gh",
             version_flag: "--version",
@@ -84,6 +96,8 @@ impl AgentDetector {
             "codex" => AgentId::Codex,
             "gemini" => AgentId::Gemini,
             "opencode" => AgentId::OpenCode,
+            "openclaw" => AgentId::OpenClaw,
+            "hermes" => AgentId::Hermes,
             "gh" => AgentId::Copilot,
             other => AgentId::Custom(other.to_string()),
         };
@@ -159,12 +173,14 @@ mod tests {
     #[test]
     fn builtin_probes_cover_all_variants() {
         let probes = builtin_probes();
-        assert_eq!(probes.len(), 5);
+        assert_eq!(probes.len(), 7);
         let ids: Vec<_> = probes.iter().map(|p| &p.id).collect();
         assert!(ids.contains(&&AgentId::ClaudeCode));
         assert!(ids.contains(&&AgentId::Codex));
         assert!(ids.contains(&&AgentId::Gemini));
         assert!(ids.contains(&&AgentId::OpenCode));
+        assert!(ids.contains(&&AgentId::OpenClaw));
+        assert!(ids.contains(&&AgentId::Hermes));
         assert!(ids.contains(&&AgentId::Copilot));
     }
 

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -100,6 +100,8 @@ pub fn canonical_launch_args(agent: &AgentId) -> Vec<String> {
         AgentId::ClaudeCode
         | AgentId::Gemini
         | AgentId::OpenCode
+        | AgentId::OpenClaw
+        | AgentId::Hermes
         | AgentId::Copilot
         | AgentId::Custom(_) => Vec::new(),
     }
@@ -493,7 +495,13 @@ impl AgentLaunchBuilder {
                 self.build_gemini_args(&mut args);
             }
             AgentId::OpenCode => {
-                self.build_opencode_args(&mut args);
+                self.build_opencode_args(&mut args, &mut env_vars);
+            }
+            AgentId::OpenClaw => {
+                self.build_openclaw_args(&mut args, &mut env_vars);
+            }
+            AgentId::Hermes => {
+                self.build_hermes_args(&mut args, &mut env_vars);
             }
             AgentId::Copilot => {
                 self.build_copilot_args(&mut args);
@@ -720,8 +728,92 @@ impl AgentLaunchBuilder {
         }
     }
 
-    fn build_opencode_args(&self, _args: &mut Vec<String>) {
-        // OpenCode has minimal CLI flags
+    fn build_opencode_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
+        if let Some(ref dir) = self.working_dir {
+            env_vars.insert(
+                "OPENCODE_CONFIG_DIR".to_string(),
+                dir.join(".gwt/opencode").to_string_lossy().into_owned(),
+            );
+        }
+        match self.session_mode {
+            SessionMode::Continue => args.push("--continue".to_string()),
+            SessionMode::Resume => {
+                if let Some(ref id) = self.resume_session_id {
+                    args.push("--session".to_string());
+                    args.push(id.clone());
+                } else {
+                    args.push("--continue".to_string());
+                }
+            }
+            SessionMode::Normal => {}
+        }
+        if let Some(ref model) = self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+    }
+
+    fn build_openclaw_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
+        args.push("tui".to_string());
+        args.push("--local".to_string());
+        if let Some(ref dir) = self.working_dir {
+            env_vars.insert(
+                "OPENCLAW_CONFIG_PATH".to_string(),
+                dir.join(".gwt/openclaw/openclaw.json")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+            env_vars.insert(
+                "OPENCLAW_INCLUDE_ROOTS".to_string(),
+                dir.join(".gwt/openclaw").to_string_lossy().into_owned(),
+            );
+        }
+        match self.session_mode {
+            SessionMode::Continue => {}
+            SessionMode::Resume => {
+                if let Some(ref id) = self.resume_session_id {
+                    args.push("--session".to_string());
+                    args.push(id.clone());
+                }
+            }
+            SessionMode::Normal => {}
+        }
+        if let Some(ref level) = self.reasoning_level {
+            if level != "auto" {
+                args.push("--thinking".to_string());
+                args.push(level.clone());
+            }
+        }
+    }
+
+    fn build_hermes_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
+        args.push("chat".to_string());
+        args.push("--accept-hooks".to_string());
+        args.push("--pass-session-id".to_string());
+        if let Some(ref dir) = self.working_dir {
+            env_vars.insert(
+                "HERMES_HOME".to_string(),
+                dir.join(".gwt/hermes").to_string_lossy().into_owned(),
+            );
+        }
+        env_vars.insert("HERMES_ACCEPT_HOOKS".to_string(), "1".to_string());
+        match self.session_mode {
+            SessionMode::Continue => args.push("--continue".to_string()),
+            SessionMode::Resume => {
+                args.push("--resume".to_string());
+                if let Some(ref id) = self.resume_session_id {
+                    args.push(id.clone());
+                }
+            }
+            SessionMode::Normal => {}
+        }
+        if let Some(ref model) = self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+        if self.skip_permissions {
+            args.push("--yolo".to_string());
+        }
     }
 
     fn build_copilot_args(&self, args: &mut Vec<String>) {
@@ -763,6 +855,8 @@ mod tests {
         assert!(canonical_launch_args(&AgentId::ClaudeCode).is_empty());
         assert!(canonical_launch_args(&AgentId::Gemini).is_empty());
         assert!(canonical_launch_args(&AgentId::OpenCode).is_empty());
+        assert!(canonical_launch_args(&AgentId::OpenClaw).is_empty());
+        assert!(canonical_launch_args(&AgentId::Hermes).is_empty());
         assert!(canonical_launch_args(&AgentId::Copilot).is_empty());
         assert!(canonical_launch_args(&AgentId::Custom("aider".into())).is_empty());
     }
@@ -1099,6 +1193,8 @@ mod tests {
             AgentId::ClaudeCode,
             AgentId::Gemini,
             AgentId::OpenCode,
+            AgentId::OpenClaw,
+            AgentId::Hermes,
             AgentId::Copilot,
             AgentId::Custom("custom".into()),
         ] {
@@ -1304,6 +1400,81 @@ mod tests {
         let runner = resolve_runner(&AgentId::OpenCode, "latest");
         assert_eq!(runner.executable, "opencode");
         assert!(runner.base_args.is_empty());
+    }
+
+    #[test]
+    fn build_opencode_sets_model_and_project_config_dir() {
+        let config = AgentLaunchBuilder::new(AgentId::OpenCode)
+            .working_dir("/tmp/project")
+            .model("anthropic/claude-sonnet-4-5")
+            .build();
+
+        assert_eq!(config.command, "opencode");
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--model" && pair[1] == "anthropic/claude-sonnet-4-5"));
+        assert_eq!(
+            config.env_vars.get("OPENCODE_CONFIG_DIR"),
+            Some(&"/tmp/project/.gwt/opencode".to_string())
+        );
+    }
+
+    #[test]
+    fn build_openclaw_uses_local_tui_and_gwt_config_path() {
+        let config = AgentLaunchBuilder::new(AgentId::OpenClaw)
+            .working_dir("/tmp/project")
+            .reasoning_level("high")
+            .session_mode(SessionMode::Resume)
+            .resume_session_id("session-123")
+            .build();
+
+        assert_eq!(config.command, "openclaw");
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "tui" && pair[1] == "--local"));
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--session" && pair[1] == "session-123"));
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--thinking" && pair[1] == "high"));
+        assert_eq!(
+            config.env_vars.get("OPENCLAW_CONFIG_PATH"),
+            Some(&"/tmp/project/.gwt/openclaw/openclaw.json".to_string())
+        );
+    }
+
+    #[test]
+    fn build_hermes_accepts_hooks_and_maps_launch_controls() {
+        let config = AgentLaunchBuilder::new(AgentId::Hermes)
+            .working_dir("/tmp/project")
+            .model("openrouter/anthropic/claude-sonnet-4")
+            .skip_permissions(true)
+            .session_mode(SessionMode::Continue)
+            .build();
+
+        assert_eq!(config.command, "hermes");
+        assert!(config.args.contains(&"chat".to_string()));
+        assert!(config.args.contains(&"--accept-hooks".to_string()));
+        assert!(config.args.contains(&"--pass-session-id".to_string()));
+        assert!(config.args.contains(&"--continue".to_string()));
+        assert!(config.args.contains(&"--yolo".to_string()));
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--model" && pair[1] == "openrouter/anthropic/claude-sonnet-4"));
+        assert_eq!(
+            config.env_vars.get("HERMES_HOME"),
+            Some(&"/tmp/project/.gwt/hermes".to_string())
+        );
+        assert_eq!(
+            config.env_vars.get("HERMES_ACCEPT_HOOKS"),
+            Some(&"1".to_string())
+        );
     }
 
     #[cfg(windows)]

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -51,7 +51,8 @@ pub use store::{
     save_stored_custom_agents_to_path, StoredCustomAgent, DISABLE_GLOBAL_CUSTOM_AGENTS_ENV,
 };
 pub use types::{
-    resolve_agent_id, AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent,
+    builtin_agent_descriptor_for_command, builtin_agent_descriptors, resolve_agent_id, AgentColor,
+    AgentId, AgentInfo, AgentStatus, BuiltinAgentDescriptor, DockerLifecycleIntent,
     LaunchRuntimeTarget, SessionMode, WindowsShellKind, WorkflowBypass,
 };
 pub use version_cache::{build_version_options, VersionCache, VersionOption};

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -10,6 +10,8 @@ pub enum AgentId {
     Codex,
     Gemini,
     OpenCode,
+    OpenClaw,
+    Hermes,
     Copilot,
     Custom(String),
 }
@@ -22,6 +24,8 @@ impl AgentId {
             Self::Codex => "codex",
             Self::Gemini => "gemini",
             Self::OpenCode => "opencode",
+            Self::OpenClaw => "openclaw",
+            Self::Hermes => "hermes",
             Self::Copilot => "gh",
             Self::Custom(name) => name,
         }
@@ -34,6 +38,8 @@ impl AgentId {
             Self::Codex => "Codex",
             Self::Gemini => "Gemini CLI",
             Self::OpenCode => "OpenCode",
+            Self::OpenClaw => "OpenClaw",
+            Self::Hermes => "Hermes Agent",
             Self::Copilot => "GitHub Copilot",
             Self::Custom(name) => name,
         }
@@ -46,6 +52,8 @@ impl AgentId {
             Self::Codex => Some("@openai/codex"),
             Self::Gemini => Some("@anthropic-ai/gemini-cli"),
             Self::OpenCode => None,
+            Self::OpenClaw => None,
+            Self::Hermes => None,
             Self::Copilot => None,
             Self::Custom(_) => None,
         }
@@ -58,6 +66,8 @@ impl AgentId {
             Self::Codex => AgentColor::Cyan,
             Self::Gemini => AgentColor::Magenta,
             Self::OpenCode => AgentColor::Green,
+            Self::OpenClaw => AgentColor::Blue,
+            Self::Hermes => AgentColor::Magenta,
             Self::Copilot => AgentColor::Blue,
             Self::Custom(_) => AgentColor::Gray,
         }
@@ -90,6 +100,8 @@ pub fn resolve_agent_id(raw: &str) -> Option<AgentId> {
         "codex" => Some(AgentId::Codex),
         "gemini" | "gemini cli" | "gemini-cli" => Some(AgentId::Gemini),
         "opencode" | "open-code" => Some(AgentId::OpenCode),
+        "openclaw" | "open-claw" => Some(AgentId::OpenClaw),
+        "hermes" | "hermes agent" | "hermes-agent" => Some(AgentId::Hermes),
         "gh" | "copilot" | "github copilot" | "github-copilot" => Some(AgentId::Copilot),
         _ => Some(AgentId::Custom(trimmed.to_string())),
     }
@@ -209,6 +221,8 @@ mod tests {
         assert_eq!(AgentId::Codex.command(), "codex");
         assert_eq!(AgentId::Gemini.command(), "gemini");
         assert_eq!(AgentId::OpenCode.command(), "opencode");
+        assert_eq!(AgentId::OpenClaw.command(), "openclaw");
+        assert_eq!(AgentId::Hermes.command(), "hermes");
         assert_eq!(AgentId::Copilot.command(), "gh");
         assert_eq!(AgentId::Custom("aider".into()).command(), "aider");
     }
@@ -216,6 +230,9 @@ mod tests {
     #[test]
     fn agent_id_display_name_returns_expected() {
         assert_eq!(AgentId::ClaudeCode.display_name(), "Claude Code");
+        assert_eq!(AgentId::OpenCode.display_name(), "OpenCode");
+        assert_eq!(AgentId::OpenClaw.display_name(), "OpenClaw");
+        assert_eq!(AgentId::Hermes.display_name(), "Hermes Agent");
         assert_eq!(AgentId::Copilot.display_name(), "GitHub Copilot");
         assert_eq!(AgentId::Custom("aider".into()).display_name(), "aider");
     }
@@ -227,6 +244,8 @@ mod tests {
             Some("@anthropic-ai/claude-code")
         );
         assert_eq!(AgentId::OpenCode.package_name(), None);
+        assert_eq!(AgentId::OpenClaw.package_name(), None);
+        assert_eq!(AgentId::Hermes.package_name(), None);
         assert_eq!(AgentId::Custom("x".into()).package_name(), None);
     }
 
@@ -235,6 +254,9 @@ mod tests {
         assert_eq!(AgentId::ClaudeCode.default_color(), AgentColor::Yellow);
         assert_eq!(AgentId::Codex.default_color(), AgentColor::Cyan);
         assert_eq!(AgentId::Gemini.default_color(), AgentColor::Magenta);
+        assert_eq!(AgentId::OpenCode.default_color(), AgentColor::Green);
+        assert_eq!(AgentId::OpenClaw.default_color(), AgentColor::Blue);
+        assert_eq!(AgentId::Hermes.default_color(), AgentColor::Magenta);
         assert_eq!(
             AgentId::Custom("x".into()).default_color(),
             AgentColor::Gray
@@ -295,6 +317,12 @@ mod tests {
         assert_eq!(resolve_agent_id("opencode"), Some(AgentId::OpenCode));
         assert_eq!(resolve_agent_id("OpenCode"), Some(AgentId::OpenCode));
         assert_eq!(resolve_agent_id("open-code"), Some(AgentId::OpenCode));
+        assert_eq!(resolve_agent_id("openclaw"), Some(AgentId::OpenClaw));
+        assert_eq!(resolve_agent_id("OpenClaw"), Some(AgentId::OpenClaw));
+        assert_eq!(resolve_agent_id("open-claw"), Some(AgentId::OpenClaw));
+        assert_eq!(resolve_agent_id("hermes"), Some(AgentId::Hermes));
+        assert_eq!(resolve_agent_id("Hermes Agent"), Some(AgentId::Hermes));
+        assert_eq!(resolve_agent_id("hermes-agent"), Some(AgentId::Hermes));
         assert_eq!(resolve_agent_id("gh"), Some(AgentId::Copilot));
         assert_eq!(resolve_agent_id("copilot"), Some(AgentId::Copilot));
         assert_eq!(resolve_agent_id("GitHub Copilot"), Some(AgentId::Copilot));
@@ -331,6 +359,8 @@ mod tests {
             "codex-wrapper",
             "gemini-helper",
             "opencode-mentor",
+            "openclaw-mentor",
+            "hermes-helper",
             "copilot-mentor",
             "github-copilot-wrapper",
         ];
@@ -351,6 +381,8 @@ mod tests {
             ("codex", AgentColor::Cyan),
             ("gemini", AgentColor::Magenta),
             ("opencode", AgentColor::Green),
+            ("openclaw", AgentColor::Blue),
+            ("hermes", AgentColor::Magenta),
             ("gh", AgentColor::Blue),
             ("my-custom", AgentColor::Gray),
         ];
@@ -367,6 +399,11 @@ mod tests {
         let ids = vec![
             AgentId::ClaudeCode,
             AgentId::Codex,
+            AgentId::Gemini,
+            AgentId::OpenCode,
+            AgentId::OpenClaw,
+            AgentId::Hermes,
+            AgentId::Copilot,
             AgentId::Custom("test".into()),
         ];
         for id in ids {

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -19,58 +19,41 @@ pub enum AgentId {
 impl AgentId {
     /// Canonical command name used to invoke this agent.
     pub fn command(&self) -> &str {
-        match self {
-            Self::ClaudeCode => "claude",
-            Self::Codex => "codex",
-            Self::Gemini => "gemini",
-            Self::OpenCode => "opencode",
-            Self::OpenClaw => "openclaw",
-            Self::Hermes => "hermes",
-            Self::Copilot => "gh",
-            Self::Custom(name) => name,
-        }
+        self.builtin_descriptor()
+            .map(|descriptor| descriptor.command)
+            .unwrap_or_else(|| match self {
+                Self::Custom(name) => name,
+                _ => unreachable!("all non-custom agents must have descriptors"),
+            })
     }
 
     /// Human-readable display name.
     pub fn display_name(&self) -> &str {
-        match self {
-            Self::ClaudeCode => "Claude Code",
-            Self::Codex => "Codex",
-            Self::Gemini => "Gemini CLI",
-            Self::OpenCode => "OpenCode",
-            Self::OpenClaw => "OpenClaw",
-            Self::Hermes => "Hermes Agent",
-            Self::Copilot => "GitHub Copilot",
-            Self::Custom(name) => name,
-        }
+        self.builtin_descriptor()
+            .map(|descriptor| descriptor.display_name)
+            .unwrap_or_else(|| match self {
+                Self::Custom(name) => name,
+                _ => unreachable!("all non-custom agents must have descriptors"),
+            })
     }
 
     /// npm package name (if distributed via npm).
     pub fn package_name(&self) -> Option<&str> {
-        match self {
-            Self::ClaudeCode => Some("@anthropic-ai/claude-code"),
-            Self::Codex => Some("@openai/codex"),
-            Self::Gemini => Some("@anthropic-ai/gemini-cli"),
-            Self::OpenCode => None,
-            Self::OpenClaw => None,
-            Self::Hermes => None,
-            Self::Copilot => None,
-            Self::Custom(_) => None,
-        }
+        self.builtin_descriptor()
+            .and_then(|descriptor| descriptor.package_name)
     }
 
     /// Default UI color for this agent.
     pub fn default_color(&self) -> AgentColor {
-        match self {
-            Self::ClaudeCode => AgentColor::Yellow,
-            Self::Codex => AgentColor::Cyan,
-            Self::Gemini => AgentColor::Magenta,
-            Self::OpenCode => AgentColor::Green,
-            Self::OpenClaw => AgentColor::Blue,
-            Self::Hermes => AgentColor::Magenta,
-            Self::Copilot => AgentColor::Blue,
-            Self::Custom(_) => AgentColor::Gray,
-        }
+        self.builtin_descriptor()
+            .map(|descriptor| descriptor.color)
+            .unwrap_or(AgentColor::Gray)
+    }
+
+    pub fn builtin_descriptor(&self) -> Option<&'static BuiltinAgentDescriptor> {
+        builtin_agent_descriptors()
+            .iter()
+            .find(|descriptor| descriptor.id == *self)
     }
 }
 
@@ -78,6 +61,116 @@ impl std::fmt::Display for AgentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_name())
     }
+}
+
+/// Metadata for a built-in coding agent.
+///
+/// Keep agent identity, presentation, detection, and cache keys in this
+/// descriptor so new built-ins do not require synchronized table edits across
+/// every consumer.
+#[derive(Debug, Clone)]
+pub struct BuiltinAgentDescriptor {
+    pub id: AgentId,
+    pub command: &'static str,
+    pub display_name: &'static str,
+    pub package_name: Option<&'static str>,
+    pub color: AgentColor,
+    pub aliases: &'static [&'static str],
+    pub cache_key: &'static str,
+    pub version_flag: &'static str,
+    pub version_prefix_args: &'static [&'static str],
+}
+
+const BUILTIN_AGENT_DESCRIPTORS: &[BuiltinAgentDescriptor] = &[
+    BuiltinAgentDescriptor {
+        id: AgentId::ClaudeCode,
+        command: "claude",
+        display_name: "Claude Code",
+        package_name: Some("@anthropic-ai/claude-code"),
+        color: AgentColor::Yellow,
+        aliases: &["claude", "claudecode", "claude-code", "claude code"],
+        cache_key: "claude-code",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Codex,
+        command: "codex",
+        display_name: "Codex",
+        package_name: Some("@openai/codex"),
+        color: AgentColor::Cyan,
+        aliases: &["codex"],
+        cache_key: "codex",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Gemini,
+        command: "gemini",
+        display_name: "Gemini CLI",
+        package_name: Some("@anthropic-ai/gemini-cli"),
+        color: AgentColor::Magenta,
+        aliases: &["gemini", "gemini cli", "gemini-cli"],
+        cache_key: "gemini",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::OpenCode,
+        command: "opencode",
+        display_name: "OpenCode",
+        package_name: None,
+        color: AgentColor::Green,
+        aliases: &["opencode", "open-code"],
+        cache_key: "opencode",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::OpenClaw,
+        command: "openclaw",
+        display_name: "OpenClaw",
+        package_name: None,
+        color: AgentColor::Blue,
+        aliases: &["openclaw", "open-claw"],
+        cache_key: "openclaw",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Hermes,
+        command: "hermes",
+        display_name: "Hermes Agent",
+        package_name: None,
+        color: AgentColor::Magenta,
+        aliases: &["hermes", "hermes agent", "hermes-agent"],
+        cache_key: "hermes",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Copilot,
+        command: "gh",
+        display_name: "GitHub Copilot",
+        package_name: None,
+        color: AgentColor::Blue,
+        aliases: &["gh", "copilot", "github copilot", "github-copilot"],
+        cache_key: "copilot",
+        version_flag: "--version",
+        version_prefix_args: &["copilot"],
+    },
+];
+
+pub fn builtin_agent_descriptors() -> &'static [BuiltinAgentDescriptor] {
+    BUILTIN_AGENT_DESCRIPTORS
+}
+
+pub fn builtin_agent_descriptor_for_command(
+    command: &str,
+) -> Option<&'static BuiltinAgentDescriptor> {
+    builtin_agent_descriptors()
+        .iter()
+        .find(|descriptor| descriptor.command == command)
 }
 
 /// Normalize a raw agent identifier string (command name, display name, or
@@ -95,15 +188,14 @@ pub fn resolve_agent_id(raw: &str) -> Option<AgentId> {
         return None;
     }
     let lower = trimmed.to_ascii_lowercase();
-    match lower.as_str() {
-        "claude" | "claudecode" | "claude-code" | "claude code" => Some(AgentId::ClaudeCode),
-        "codex" => Some(AgentId::Codex),
-        "gemini" | "gemini cli" | "gemini-cli" => Some(AgentId::Gemini),
-        "opencode" | "open-code" => Some(AgentId::OpenCode),
-        "openclaw" | "open-claw" => Some(AgentId::OpenClaw),
-        "hermes" | "hermes agent" | "hermes-agent" => Some(AgentId::Hermes),
-        "gh" | "copilot" | "github copilot" | "github-copilot" => Some(AgentId::Copilot),
-        _ => Some(AgentId::Custom(trimmed.to_string())),
+    if let Some(descriptor) = builtin_agent_descriptors().iter().find(|descriptor| {
+        descriptor.aliases.iter().any(|alias| *alias == lower)
+            || descriptor.command == lower
+            || descriptor.display_name.eq_ignore_ascii_case(trimmed)
+    }) {
+        Some(descriptor.id.clone())
+    } else {
+        Some(AgentId::Custom(trimmed.to_string()))
     }
 }
 
@@ -270,6 +362,30 @@ mod tests {
         assert_eq!(info.command, "claude");
         assert_eq!(info.color, AgentColor::Yellow);
         assert_eq!(info.package_name, Some("@anthropic-ai/claude-code".into()));
+    }
+
+    #[test]
+    fn builtin_agent_descriptors_drive_agent_info_contract() {
+        let descriptors = builtin_agent_descriptors();
+        assert_eq!(descriptors.len(), 7);
+
+        for descriptor in descriptors {
+            let info = AgentInfo::from_id(descriptor.id.clone());
+            assert_eq!(info.command, descriptor.command, "{:?}", descriptor.id);
+            assert_eq!(
+                info.display_name, descriptor.display_name,
+                "{:?}",
+                descriptor.id
+            );
+            assert_eq!(info.package_name.as_deref(), descriptor.package_name);
+            assert_eq!(info.color, descriptor.color);
+            assert_eq!(
+                resolve_agent_id(descriptor.command),
+                Some(descriptor.id.clone()),
+                "{} must resolve through the same descriptor registry",
+                descriptor.command
+            );
+        }
     }
 
     #[test]

--- a/crates/gwt-agent/src/version_cache.rs
+++ b/crates/gwt-agent/src/version_cache.rs
@@ -222,6 +222,8 @@ impl VersionCache {
             AgentId::Codex => "codex".to_string(),
             AgentId::Gemini => "gemini".to_string(),
             AgentId::OpenCode => "opencode".to_string(),
+            AgentId::OpenClaw => "openclaw".to_string(),
+            AgentId::Hermes => "hermes".to_string(),
             AgentId::Copilot => "copilot".to_string(),
             AgentId::Custom(name) => format!("custom-{name}"),
         }
@@ -393,6 +395,11 @@ mod tests {
     fn agent_key_mapping() {
         assert_eq!(VersionCache::agent_key(&AgentId::ClaudeCode), "claude-code");
         assert_eq!(VersionCache::agent_key(&AgentId::Codex), "codex");
+        assert_eq!(VersionCache::agent_key(&AgentId::Gemini), "gemini");
+        assert_eq!(VersionCache::agent_key(&AgentId::OpenCode), "opencode");
+        assert_eq!(VersionCache::agent_key(&AgentId::OpenClaw), "openclaw");
+        assert_eq!(VersionCache::agent_key(&AgentId::Hermes), "hermes");
+        assert_eq!(VersionCache::agent_key(&AgentId::Copilot), "copilot");
         assert_eq!(
             VersionCache::agent_key(&AgentId::Custom("aider".into())),
             "custom-aider"

--- a/crates/gwt-agent/src/version_cache.rs
+++ b/crates/gwt-agent/src/version_cache.rs
@@ -217,15 +217,13 @@ impl VersionCache {
     }
 
     fn agent_key(agent_id: &AgentId) -> String {
-        match agent_id {
-            AgentId::ClaudeCode => "claude-code".to_string(),
-            AgentId::Codex => "codex".to_string(),
-            AgentId::Gemini => "gemini".to_string(),
-            AgentId::OpenCode => "opencode".to_string(),
-            AgentId::OpenClaw => "openclaw".to_string(),
-            AgentId::Hermes => "hermes".to_string(),
-            AgentId::Copilot => "copilot".to_string(),
-            AgentId::Custom(name) => format!("custom-{name}"),
+        if let Some(descriptor) = agent_id.builtin_descriptor() {
+            descriptor.cache_key.to_string()
+        } else {
+            match agent_id {
+                AgentId::Custom(name) => format!("custom-{name}"),
+                _ => unreachable!("all non-custom agents must have descriptors"),
+            }
         }
     }
 

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -24,6 +24,9 @@ const GWT_EXCLUDE_PATTERNS: &[&str] = &[
     ".claude/settings.local.json",
     ".codex/skills/gwt-*",
     ".gwt/discussion.md",
+    ".gwt/opencode/",
+    ".gwt/openclaw/",
+    ".gwt/hermes/",
     "docker-compose.override.yml",
 ];
 
@@ -160,6 +163,9 @@ mod tests {
         assert!(result.contains(".claude/skills/gwt-*"));
         assert!(result.contains(".codex/skills/gwt-*"));
         assert!(result.contains(".gwt/discussion.md"));
+        assert!(result.contains(".gwt/opencode/"));
+        assert!(result.contains(".gwt/openclaw/"));
+        assert!(result.contains(".gwt/hermes/"));
         assert!(result.contains("docker-compose.override.yml"));
         assert!(!result.contains(".codex/hooks.json"));
         assert!(!result.contains(".codex/hooks/scripts/gwt-*"));

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -4,6 +4,7 @@ pub mod assets;
 pub mod distribute;
 pub mod git_exclude;
 pub mod hooks;
+pub mod provider_hooks;
 pub mod registry;
 pub mod settings_local;
 pub mod validate;
@@ -14,11 +15,9 @@ pub use hooks::{
     backup_hooks, detect_corruption, is_gwt_managed, merge_hooks, merge_hooks_safe,
     restore_from_backup, Hook, HooksConfig, HooksError,
 };
+pub use provider_hooks::{generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks};
 pub use registry::{EmbeddedSkill, RegistryError, SkillRegistry};
-pub use settings_local::{
-    generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks,
-    generate_settings_local,
-};
+pub use settings_local::{generate_codex_hooks, generate_settings_local};
 
 #[cfg(test)]
 mod tests {

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -15,7 +15,10 @@ pub use hooks::{
     restore_from_backup, Hook, HooksConfig, HooksError,
 };
 pub use registry::{EmbeddedSkill, RegistryError, SkillRegistry};
-pub use settings_local::{generate_codex_hooks, generate_settings_local};
+pub use settings_local::{
+    generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks,
+    generate_settings_local,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/gwt-skills/src/provider_hooks.rs
+++ b/crates/gwt-skills/src/provider_hooks.rs
@@ -1,0 +1,294 @@
+//! Worktree-local hook bridge assets for providers without Claude/Codex-style hooks.
+
+use std::{io, path::Path};
+
+use serde_json::{json, Value};
+
+use crate::settings_local::{
+    gwt_hook_bin_path, posix_shell_quote, set_executable, write_settings_atomically,
+    write_text_atomically,
+};
+
+/// Generate OpenCode project-local hook bridge assets under `.gwt/opencode`.
+pub fn generate_opencode_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/opencode");
+    let plugin_path = config_dir.join("plugins/gwt-hooks.js");
+    let config_path = config_dir.join("opencode.json");
+    let plugin_content = opencode_plugin_content(&gwt_hook_bin_path());
+    let config = json!({
+        "plugin": ["./plugins/gwt-hooks.js"],
+    });
+
+    write_text_atomically(&plugin_path, &plugin_content)?;
+    write_settings_atomically(&config_path, &config)
+}
+
+/// Generate Hermes Agent project-local hook config under `.gwt/hermes`.
+pub fn generate_hermes_hooks(worktree: &Path) -> io::Result<()> {
+    let home = worktree.join(".gwt/hermes");
+    let config_path = home.join("config.yaml");
+    let script_path = home.join("agent-hooks/gwt-hook.sh");
+
+    write_text_atomically(
+        &script_path,
+        &hermes_hook_script_content(&gwt_hook_bin_path()),
+    )?;
+    set_executable(&script_path)?;
+    write_text_atomically(&config_path, &hermes_config_content(&script_path))
+}
+
+/// Generate OpenClaw project-local hook bridge assets under `.gwt/openclaw`.
+pub fn generate_openclaw_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/openclaw");
+    let plugin_dir = config_dir.join("plugins/gwt-hook-bridge");
+    let config_path = config_dir.join("openclaw.json");
+
+    write_settings_atomically(&config_path, &openclaw_config(&plugin_dir))?;
+    write_text_atomically(
+        &plugin_dir.join("package.json"),
+        &openclaw_package_content(),
+    )?;
+    write_settings_atomically(
+        &plugin_dir.join("openclaw.plugin.json"),
+        &openclaw_manifest(),
+    )?;
+    write_text_atomically(
+        &plugin_dir.join("plugin.ts"),
+        &openclaw_plugin_content(&gwt_hook_bin_path()),
+    )
+}
+
+fn js_string_literal(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"gwtd\"".to_string())
+}
+
+fn opencode_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+
+const GWT_HOOK_BIN = {bin};
+
+function canonicalPayload(nativeEvent, input = {{}}, output = {{}}, context = {{}}) {{
+  const toolName = input.tool ?? input.toolName ?? output.tool ?? output.toolName ?? input.name;
+  const toolInput = output.args ?? input.args ?? output.params ?? input.params ?? output.input ?? input.input ?? {{}};
+  return {{
+    provider: "opencode",
+    native_event: nativeEvent,
+    tool_name: toolName,
+    tool_input: toolInput,
+    session_id: input.sessionID ?? input.sessionId ?? input.session_id ?? context.sessionID ?? context.sessionId,
+    cwd: input.cwd ?? context.directory ?? context.worktree ?? context.project?.root,
+    input,
+    output,
+  }};
+}}
+
+function dispatch(nativeEvent, input, output, context) {{
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "opencode", nativeEvent],
+    {{
+      input: JSON.stringify(canonicalPayload(nativeEvent, input, output, context)),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockReason(result) {{
+  return result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+}}
+
+export const GwtHooks = async (context) => ({{
+  "session.created": async (input, output) => dispatch("session.created", input, output, context),
+  "message.updated": async (input, output) => dispatch("message.updated", input, output, context),
+  "tool.execute.before": async (input, output) => {{
+    const reason = blockReason(dispatch("tool.execute.before", input, output, context));
+    if (reason) throw new Error(reason);
+  }},
+  "tool.execute.after": async (input, output) => dispatch("tool.execute.after", input, output, context),
+  "session.idle": async (input, output) => dispatch("session.idle", input, output, context),
+}});
+"#
+    )
+}
+
+fn hermes_hook_command(script_path: &Path, event: &str) -> String {
+    js_string_literal(&format!(
+        "{} {event}",
+        posix_shell_quote(script_path.to_string_lossy().as_ref())
+    ))
+}
+
+fn hermes_config_content(script_path: &Path) -> String {
+    let on_session_start = hermes_hook_command(script_path, "on_session_start");
+    let pre_llm_call = hermes_hook_command(script_path, "pre_llm_call");
+    let pre_tool_call = hermes_hook_command(script_path, "pre_tool_call");
+    let post_tool_call = hermes_hook_command(script_path, "post_tool_call");
+    let on_session_end = hermes_hook_command(script_path, "on_session_end");
+    format!(
+        r#"hooks:
+  on_session_start:
+    - command: {on_session_start}
+      timeout: 10
+  pre_llm_call:
+    - command: {pre_llm_call}
+      timeout: 10
+  pre_tool_call:
+    - matcher: ".*"
+      command: {pre_tool_call}
+      timeout: 10
+  post_tool_call:
+    - matcher: ".*"
+      command: {post_tool_call}
+      timeout: 10
+  on_session_end:
+    - command: {on_session_end}
+      timeout: 10
+hooks_auto_accept: true
+"#
+    )
+}
+
+fn hermes_hook_script_content(bin: &str) -> String {
+    let bin = posix_shell_quote(bin);
+    r#"#!/bin/sh
+set -eu
+
+event="${1:-}"
+if [ -z "$event" ]; then
+  exit 0
+fi
+
+payload="$(cat)"
+set +e
+output="$(printf '%s' "$payload" | __GWT_HOOK_BIN__ hook provider-event hermes "$event")"
+set -e
+if [ -n "$output" ]; then
+  printf '%s\n' "$output"
+fi
+exit 0
+"#
+    .replace("__GWT_HOOK_BIN__", &bin)
+}
+
+fn openclaw_config(plugin_dir: &Path) -> Value {
+    json!({
+        "commands": {
+            "native": "auto",
+            "nativeSkills": "auto",
+            "restart": true,
+            "ownerDisplay": "raw",
+        },
+        "plugins": {
+            "enabled": true,
+            "load": {
+                "paths": [plugin_dir.to_string_lossy().to_string()],
+            },
+            "entries": {
+                "gwt-hook-bridge": {
+                    "enabled": true,
+                    "hooks": {
+                        "allowPromptInjection": true,
+                        "allowConversationAccess": false,
+                    },
+                },
+            },
+        },
+    })
+}
+
+fn openclaw_manifest() -> Value {
+    json!({
+        "id": "gwt-hook-bridge",
+        "name": "gwt Hook Bridge",
+        "description": "Routes OpenClaw plugin hook events into gwtd hook provider-event.",
+        "configSchema": {
+            "type": "object",
+            "additionalProperties": false,
+        },
+    })
+}
+
+fn openclaw_package_content() -> String {
+    r#"{
+  "name": "gwt-hook-bridge",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "openclaw": {
+    "extensions": ["./plugin.ts"]
+  }
+}
+"#
+    .to_string()
+}
+
+fn openclaw_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
+
+const GWT_HOOK_BIN = {bin};
+
+function dispatch(nativeEvent, event = {{}}, ctx = {{}}) {{
+  const payload = {{
+    provider: "openclaw",
+    native_event: nativeEvent,
+    tool_name: event.toolName ?? event.tool_name,
+    tool_input: event.params ?? event.args ?? event.toolInput ?? event.tool_input ?? {{}},
+    session_id: event.sessionId ?? event.session_id ?? ctx.sessionId ?? ctx.sessionKey,
+    cwd: event.cwd ?? ctx.cwd ?? ctx.workspaceRoot,
+    event,
+    ctx,
+  }};
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "openclaw", nativeEvent],
+    {{
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockResult(result) {{
+  const reason = result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+  if (!reason) return undefined;
+  return {{ block: true, blockReason: reason }};
+}}
+
+function promptContextResult(result) {{
+  const text = result.hookSpecificOutput?.additionalContext ?? result.context;
+  if (!text) return undefined;
+  return {{ prependContext: text }};
+}}
+
+export default definePluginEntry({{
+  id: "gwt-hook-bridge",
+  name: "gwt Hook Bridge",
+  description: "Routes OpenClaw hook events into gwtd.",
+  register(api) {{
+    api.on("session_start", async (event, ctx) => dispatch("session_start", event, ctx));
+    api.on("before_prompt_build", async (event, ctx) => promptContextResult(dispatch("before_prompt_build", event, ctx)));
+    api.on("before_tool_call", async (event, ctx) => blockResult(dispatch("before_tool_call", event, ctx)));
+    api.on("after_tool_call", async (event, ctx) => dispatch("after_tool_call", event, ctx));
+    api.on("session_end", async (event, ctx) => dispatch("session_end", event, ctx));
+  }},
+}});
+"#
+    )
+}

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -19,6 +19,7 @@ const LEGACY_GWT_HOOK_SCRIPT_SEGMENT: &str = "hooks/scripts/gwt-";
 /// like `gwt_skills-abc123def` during unit tests.
 const MANAGED_HOOK_SUBCMD_SUFFIXES: &[&str] = &[
     " hook event ",
+    " hook provider-event ",
     " hook runtime-state ",
     " hook coordination-event ",
     " hook board-reminder ",
@@ -80,6 +81,65 @@ pub fn generate_codex_hooks(worktree: &Path) -> io::Result<()> {
     generate_hook_config(worktree, ManagedHookTarget::Codex)
 }
 
+/// Generate OpenCode project-local hook bridge assets under `.gwt/opencode`.
+///
+/// The launcher sets `OPENCODE_CONFIG_DIR=<worktree>/.gwt/opencode`, so the
+/// generated `opencode.json` and plugin stay scoped to this gwt worktree.
+pub fn generate_opencode_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/opencode");
+    let plugin_path = config_dir.join("plugins/gwt-hooks.js");
+    let config_path = config_dir.join("opencode.json");
+    let plugin_content = opencode_plugin_content(&gwt_hook_bin_path());
+    let config = json!({
+        "plugin": ["./plugins/gwt-hooks.js"],
+    });
+
+    write_text_atomically(&plugin_path, &plugin_content)?;
+    write_settings_atomically(&config_path, &config)
+}
+
+/// Generate Hermes Agent project-local hook config under `.gwt/hermes`.
+///
+/// The launcher sets `HERMES_HOME=<worktree>/.gwt/hermes`, which makes this
+/// config and its shell-hook allowlist independent from the user's global
+/// Hermes home.
+pub fn generate_hermes_hooks(worktree: &Path) -> io::Result<()> {
+    let home = worktree.join(".gwt/hermes");
+    let config_path = home.join("config.yaml");
+    let script_path = home.join("agent-hooks/gwt-hook.sh");
+
+    write_text_atomically(
+        &script_path,
+        &hermes_hook_script_content(&gwt_hook_bin_path()),
+    )?;
+    set_executable(&script_path)?;
+    write_text_atomically(&config_path, &hermes_config_content(&script_path))
+}
+
+/// Generate OpenClaw project-local hook bridge assets under `.gwt/openclaw`.
+///
+/// The launcher sets `OPENCLAW_CONFIG_PATH=<worktree>/.gwt/openclaw/openclaw.json`,
+/// so plugin loading is limited to gwt-managed files in this worktree.
+pub fn generate_openclaw_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/openclaw");
+    let plugin_dir = config_dir.join("plugins/gwt-hook-bridge");
+    let config_path = config_dir.join("openclaw.json");
+
+    write_settings_atomically(&config_path, &openclaw_config(&plugin_dir))?;
+    write_text_atomically(
+        &plugin_dir.join("package.json"),
+        &openclaw_package_content(),
+    )?;
+    write_settings_atomically(
+        &plugin_dir.join("openclaw.plugin.json"),
+        &openclaw_manifest(),
+    )?;
+    write_text_atomically(
+        &plugin_dir.join("plugin.ts"),
+        &openclaw_plugin_content(&gwt_hook_bin_path()),
+    )
+}
+
 fn generate_hook_config(worktree: &Path, target: ManagedHookTarget) -> io::Result<()> {
     let settings_path = target.config_path(worktree);
 
@@ -121,6 +181,7 @@ fn read_existing_settings(path: &Path) -> io::Result<Map<String, Value>> {
 
 fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(dir)?;
     let tmp_path = dir.join(format!(
         ".{}.tmp-{}",
         path.file_name()
@@ -142,6 +203,49 @@ fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
         fs::remove_file(path)?;
     }
     fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(dir)?;
+    let tmp_path = dir.join(format!(
+        ".{}.tmp-{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("gwt-managed"),
+        std::process::id()
+    ));
+
+    {
+        let mut tmp = fs::File::create(&tmp_path)?;
+        tmp.write_all(content.as_bytes())?;
+        if !content.ends_with('\n') {
+            tmp.write_all(b"\n")?;
+        }
+        tmp.sync_all()?;
+    }
+
+    if cfg!(windows) && path.exists() {
+        fs::remove_file(path)?;
+    }
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn set_executable(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
     Ok(())
 }
 
@@ -379,6 +483,230 @@ fn powershell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "''"))
 }
 
+fn js_string_literal(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"gwtd\"".to_string())
+}
+
+fn opencode_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+
+const GWT_HOOK_BIN = {bin};
+
+function canonicalPayload(nativeEvent, input = {{}}, output = {{}}, context = {{}}) {{
+  const toolName = input.tool ?? input.toolName ?? output.tool ?? output.toolName ?? input.name;
+  const toolInput = output.args ?? input.args ?? output.params ?? input.params ?? output.input ?? input.input ?? {{}};
+  return {{
+    provider: "opencode",
+    native_event: nativeEvent,
+    tool_name: toolName,
+    tool_input: toolInput,
+    session_id: input.sessionID ?? input.sessionId ?? input.session_id ?? context.sessionID ?? context.sessionId,
+    cwd: input.cwd ?? context.directory ?? context.worktree ?? context.project?.root,
+    input,
+    output,
+  }};
+}}
+
+function dispatch(nativeEvent, input, output, context) {{
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "opencode", nativeEvent],
+    {{
+      input: JSON.stringify(canonicalPayload(nativeEvent, input, output, context)),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockReason(result) {{
+  return result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+}}
+
+export const GwtHooks = async (context) => ({{
+  "session.created": async (input, output) => dispatch("session.created", input, output, context),
+  "message.updated": async (input, output) => dispatch("message.updated", input, output, context),
+  "tool.execute.before": async (input, output) => {{
+    const reason = blockReason(dispatch("tool.execute.before", input, output, context));
+    if (reason) throw new Error(reason);
+  }},
+  "tool.execute.after": async (input, output) => dispatch("tool.execute.after", input, output, context),
+  "session.idle": async (input, output) => dispatch("session.idle", input, output, context),
+}});
+"#
+    )
+}
+
+fn hermes_config_content(script_path: &Path) -> String {
+    let script = js_string_literal(script_path.to_string_lossy().as_ref());
+    format!(
+        r#"hooks:
+  on_session_start:
+    - command: {script}
+      timeout: 10
+  pre_llm_call:
+    - command: {script}
+      timeout: 10
+  pre_tool_call:
+    - matcher: ".*"
+      command: {script}
+      timeout: 10
+  post_tool_call:
+    - matcher: ".*"
+      command: {script}
+      timeout: 10
+  on_session_end:
+    - command: {script}
+      timeout: 10
+hooks_auto_accept: true
+"#
+    )
+}
+
+fn hermes_hook_script_content(bin: &str) -> String {
+    let bin = posix_shell_quote(bin);
+    r#"#!/bin/sh
+set -eu
+
+payload="$(cat)"
+event="$(printf '%s' "$payload" | sed -n 's/.*"hook_event_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+if [ -z "$event" ]; then
+  event="${1:-pre_tool_call}"
+fi
+
+set +e
+output="$(printf '%s' "$payload" | __GWT_HOOK_BIN__ hook provider-event hermes "$event")"
+set -e
+if [ -n "$output" ]; then
+  printf '%s\n' "$output"
+fi
+exit 0
+"#
+    .replace("__GWT_HOOK_BIN__", &bin)
+}
+
+fn openclaw_config(plugin_dir: &Path) -> Value {
+    json!({
+        "commands": {
+            "native": "auto",
+            "nativeSkills": "auto",
+            "restart": true,
+            "ownerDisplay": "raw",
+        },
+        "plugins": {
+            "enabled": true,
+            "load": {
+                "paths": [plugin_dir.to_string_lossy().to_string()],
+            },
+            "entries": {
+                "gwt-hook-bridge": {
+                    "enabled": true,
+                    "hooks": {
+                        "allowPromptInjection": true,
+                        "allowConversationAccess": false,
+                    },
+                },
+            },
+        },
+    })
+}
+
+fn openclaw_manifest() -> Value {
+    json!({
+        "id": "gwt-hook-bridge",
+        "name": "gwt Hook Bridge",
+        "description": "Routes OpenClaw plugin hook events into gwtd hook provider-event.",
+        "configSchema": {
+            "type": "object",
+            "additionalProperties": false,
+        },
+    })
+}
+
+fn openclaw_package_content() -> String {
+    r#"{
+  "name": "gwt-hook-bridge",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "openclaw": {
+    "extensions": ["./plugin.ts"]
+  }
+}
+"#
+    .to_string()
+}
+
+fn openclaw_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
+
+const GWT_HOOK_BIN = {bin};
+
+function dispatch(nativeEvent, event = {{}}, ctx = {{}}) {{
+  const payload = {{
+    provider: "openclaw",
+    native_event: nativeEvent,
+    tool_name: event.toolName ?? event.tool_name,
+    tool_input: event.params ?? event.args ?? event.toolInput ?? event.tool_input ?? {{}},
+    session_id: event.sessionId ?? event.session_id ?? ctx.sessionId ?? ctx.sessionKey,
+    cwd: event.cwd ?? ctx.cwd ?? ctx.workspaceRoot,
+    event,
+    ctx,
+  }};
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "openclaw", nativeEvent],
+    {{
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockResult(result) {{
+  const reason = result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+  if (!reason) return undefined;
+  return {{ block: true, blockReason: reason }};
+}}
+
+function promptContextResult(result) {{
+  const text = result.hookSpecificOutput?.additionalContext ?? result.context;
+  if (!text) return undefined;
+  return {{ prependContext: text }};
+}}
+
+export default definePluginEntry({{
+  id: "gwt-hook-bridge",
+  name: "gwt Hook Bridge",
+  description: "Routes OpenClaw hook events into gwtd.",
+  register(api) {{
+    api.on("session_start", async (event, ctx) => dispatch("session_start", event, ctx));
+    api.on("before_prompt_build", async (event, ctx) => promptContextResult(dispatch("before_prompt_build", event, ctx)));
+    api.on("before_tool_call", async (event, ctx) => blockResult(dispatch("before_tool_call", event, ctx)));
+    api.on("after_tool_call", async (event, ctx) => dispatch("after_tool_call", event, ctx));
+    api.on("session_end", async (event, ctx) => dispatch("session_end", event, ctx));
+  }},
+}});
+"#
+    )
+}
+
 fn managed_hook_shell() -> HookShell {
     if cfg!(windows) {
         HookShell::PowerShell
@@ -542,6 +870,74 @@ mod tests {
                 commands[0]
             );
         }
+    }
+
+    #[test]
+    fn generate_opencode_hooks_creates_project_plugin_bridge() {
+        let dir = tempfile::tempdir().unwrap();
+
+        generate_opencode_hooks(dir.path()).unwrap();
+
+        let plugin_path = dir.path().join(".gwt/opencode/plugins/gwt-hooks.js");
+        assert!(plugin_path.exists());
+        let content = fs::read_to_string(plugin_path).unwrap();
+        assert!(content.contains("provider-event"));
+        assert!(content.contains("opencode"));
+        assert!(content.contains("tool.execute.before"));
+        assert!(content.contains("tool.execute.after"));
+        assert!(content.contains("session.created"));
+        assert!(content.contains("session.idle"));
+        assert!(content.contains("permissionDecisionReason"));
+        assert!(content.contains("throw new Error"));
+    }
+
+    #[test]
+    fn generate_hermes_hooks_creates_isolated_home_config_and_script() {
+        let dir = tempfile::tempdir().unwrap();
+
+        generate_hermes_hooks(dir.path()).unwrap();
+
+        let config_path = dir.path().join(".gwt/hermes/config.yaml");
+        let script_path = dir.path().join(".gwt/hermes/agent-hooks/gwt-hook.sh");
+        assert!(config_path.exists());
+        assert!(script_path.exists());
+        let config = fs::read_to_string(config_path).unwrap();
+        assert!(config.contains("hooks_auto_accept: true"));
+        assert!(config.contains("on_session_start"));
+        assert!(config.contains("pre_llm_call"));
+        assert!(config.contains("pre_tool_call"));
+        assert!(config.contains("post_tool_call"));
+        assert!(config.contains("on_session_end"));
+        let script = fs::read_to_string(script_path).unwrap();
+        assert!(script.contains("provider-event"));
+        assert!(script.contains("hermes"));
+        assert!(script.contains("exit 0"));
+    }
+
+    #[test]
+    fn generate_openclaw_hooks_creates_isolated_config_and_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+
+        generate_openclaw_hooks(dir.path()).unwrap();
+
+        let config_path = dir.path().join(".gwt/openclaw/openclaw.json");
+        let plugin_path = dir
+            .path()
+            .join(".gwt/openclaw/plugins/gwt-hook-bridge/plugin.ts");
+        assert!(config_path.exists());
+        assert!(plugin_path.exists());
+        let config = fs::read_to_string(config_path).unwrap();
+        assert!(config.contains("gwt-hook-bridge"));
+        let plugin = fs::read_to_string(plugin_path).unwrap();
+        assert!(plugin.contains("before_tool_call"));
+        assert!(plugin.contains("after_tool_call"));
+        assert!(plugin.contains("before_prompt_build"));
+        assert!(plugin.contains("session_start"));
+        assert!(plugin.contains("session_end"));
+        assert!(plugin.contains("provider-event"));
+        assert!(plugin.contains("openclaw"));
+        assert!(plugin.contains("blockReason"));
+        assert!(plugin.contains("prependContext"));
     }
 
     #[test]

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -81,65 +81,6 @@ pub fn generate_codex_hooks(worktree: &Path) -> io::Result<()> {
     generate_hook_config(worktree, ManagedHookTarget::Codex)
 }
 
-/// Generate OpenCode project-local hook bridge assets under `.gwt/opencode`.
-///
-/// The launcher sets `OPENCODE_CONFIG_DIR=<worktree>/.gwt/opencode`, so the
-/// generated `opencode.json` and plugin stay scoped to this gwt worktree.
-pub fn generate_opencode_hooks(worktree: &Path) -> io::Result<()> {
-    let config_dir = worktree.join(".gwt/opencode");
-    let plugin_path = config_dir.join("plugins/gwt-hooks.js");
-    let config_path = config_dir.join("opencode.json");
-    let plugin_content = opencode_plugin_content(&gwt_hook_bin_path());
-    let config = json!({
-        "plugin": ["./plugins/gwt-hooks.js"],
-    });
-
-    write_text_atomically(&plugin_path, &plugin_content)?;
-    write_settings_atomically(&config_path, &config)
-}
-
-/// Generate Hermes Agent project-local hook config under `.gwt/hermes`.
-///
-/// The launcher sets `HERMES_HOME=<worktree>/.gwt/hermes`, which makes this
-/// config and its shell-hook allowlist independent from the user's global
-/// Hermes home.
-pub fn generate_hermes_hooks(worktree: &Path) -> io::Result<()> {
-    let home = worktree.join(".gwt/hermes");
-    let config_path = home.join("config.yaml");
-    let script_path = home.join("agent-hooks/gwt-hook.sh");
-
-    write_text_atomically(
-        &script_path,
-        &hermes_hook_script_content(&gwt_hook_bin_path()),
-    )?;
-    set_executable(&script_path)?;
-    write_text_atomically(&config_path, &hermes_config_content(&script_path))
-}
-
-/// Generate OpenClaw project-local hook bridge assets under `.gwt/openclaw`.
-///
-/// The launcher sets `OPENCLAW_CONFIG_PATH=<worktree>/.gwt/openclaw/openclaw.json`,
-/// so plugin loading is limited to gwt-managed files in this worktree.
-pub fn generate_openclaw_hooks(worktree: &Path) -> io::Result<()> {
-    let config_dir = worktree.join(".gwt/openclaw");
-    let plugin_dir = config_dir.join("plugins/gwt-hook-bridge");
-    let config_path = config_dir.join("openclaw.json");
-
-    write_settings_atomically(&config_path, &openclaw_config(&plugin_dir))?;
-    write_text_atomically(
-        &plugin_dir.join("package.json"),
-        &openclaw_package_content(),
-    )?;
-    write_settings_atomically(
-        &plugin_dir.join("openclaw.plugin.json"),
-        &openclaw_manifest(),
-    )?;
-    write_text_atomically(
-        &plugin_dir.join("plugin.ts"),
-        &openclaw_plugin_content(&gwt_hook_bin_path()),
-    )
-}
-
 fn generate_hook_config(worktree: &Path, target: ManagedHookTarget) -> io::Result<()> {
     let settings_path = target.config_path(worktree);
 
@@ -179,7 +120,7 @@ fn read_existing_settings(path: &Path) -> io::Result<Map<String, Value>> {
     }
 }
 
-fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
+pub(crate) fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(dir)?;
     let tmp_path = dir.join(format!(
@@ -206,7 +147,7 @@ fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
     Ok(())
 }
 
-fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
+pub(crate) fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(dir)?;
     let tmp_path = dir.join(format!(
@@ -233,7 +174,7 @@ fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn set_executable(path: &Path) -> io::Result<()> {
+pub(crate) fn set_executable(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -411,7 +352,7 @@ const GWT_HOOK_BIN_ENV: &str = "GWT_HOOK_BIN";
 /// - Linux: `/proc/self/exe` resolves to the real binary, which may
 ///   land inside bun's per-version cache. The generator is re-run on
 ///   every gwt startup so staleness self-heals on the next launch.
-fn gwt_hook_bin_path() -> String {
+pub(crate) fn gwt_hook_bin_path() -> String {
     if let Ok(v) = std::env::var(GWT_HOOK_BIN_ENV) {
         if !v.is_empty() {
             return v;
@@ -473,7 +414,7 @@ fn path_lookup(command: &str) -> Option<PathBuf> {
 
 /// POSIX shell single-quote quoting. An embedded single quote becomes
 /// `'\''` (close, literal, reopen).
-fn posix_shell_quote(s: &str) -> String {
+pub(crate) fn posix_shell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', r"'\''"))
 }
 
@@ -481,230 +422,6 @@ fn posix_shell_quote(s: &str) -> String {
 /// escaped by doubling it.
 fn powershell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "''"))
-}
-
-fn js_string_literal(value: &str) -> String {
-    serde_json::to_string(value).unwrap_or_else(|_| "\"gwtd\"".to_string())
-}
-
-fn opencode_plugin_content(bin: &str) -> String {
-    let bin = js_string_literal(bin);
-    format!(
-        r#"import {{ spawnSync }} from "node:child_process";
-
-const GWT_HOOK_BIN = {bin};
-
-function canonicalPayload(nativeEvent, input = {{}}, output = {{}}, context = {{}}) {{
-  const toolName = input.tool ?? input.toolName ?? output.tool ?? output.toolName ?? input.name;
-  const toolInput = output.args ?? input.args ?? output.params ?? input.params ?? output.input ?? input.input ?? {{}};
-  return {{
-    provider: "opencode",
-    native_event: nativeEvent,
-    tool_name: toolName,
-    tool_input: toolInput,
-    session_id: input.sessionID ?? input.sessionId ?? input.session_id ?? context.sessionID ?? context.sessionId,
-    cwd: input.cwd ?? context.directory ?? context.worktree ?? context.project?.root,
-    input,
-    output,
-  }};
-}}
-
-function dispatch(nativeEvent, input, output, context) {{
-  const result = spawnSync(
-    GWT_HOOK_BIN,
-    ["hook", "provider-event", "opencode", nativeEvent],
-    {{
-      input: JSON.stringify(canonicalPayload(nativeEvent, input, output, context)),
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "ignore"],
-    }},
-  );
-  try {{
-    return result.stdout ? JSON.parse(result.stdout) : {{}};
-  }} catch {{
-    return {{}};
-  }}
-}}
-
-function blockReason(result) {{
-  return result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
-}}
-
-export const GwtHooks = async (context) => ({{
-  "session.created": async (input, output) => dispatch("session.created", input, output, context),
-  "message.updated": async (input, output) => dispatch("message.updated", input, output, context),
-  "tool.execute.before": async (input, output) => {{
-    const reason = blockReason(dispatch("tool.execute.before", input, output, context));
-    if (reason) throw new Error(reason);
-  }},
-  "tool.execute.after": async (input, output) => dispatch("tool.execute.after", input, output, context),
-  "session.idle": async (input, output) => dispatch("session.idle", input, output, context),
-}});
-"#
-    )
-}
-
-fn hermes_config_content(script_path: &Path) -> String {
-    let script = js_string_literal(script_path.to_string_lossy().as_ref());
-    format!(
-        r#"hooks:
-  on_session_start:
-    - command: {script}
-      timeout: 10
-  pre_llm_call:
-    - command: {script}
-      timeout: 10
-  pre_tool_call:
-    - matcher: ".*"
-      command: {script}
-      timeout: 10
-  post_tool_call:
-    - matcher: ".*"
-      command: {script}
-      timeout: 10
-  on_session_end:
-    - command: {script}
-      timeout: 10
-hooks_auto_accept: true
-"#
-    )
-}
-
-fn hermes_hook_script_content(bin: &str) -> String {
-    let bin = posix_shell_quote(bin);
-    r#"#!/bin/sh
-set -eu
-
-payload="$(cat)"
-event="$(printf '%s' "$payload" | sed -n 's/.*"hook_event_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
-if [ -z "$event" ]; then
-  event="${1:-pre_tool_call}"
-fi
-
-set +e
-output="$(printf '%s' "$payload" | __GWT_HOOK_BIN__ hook provider-event hermes "$event")"
-set -e
-if [ -n "$output" ]; then
-  printf '%s\n' "$output"
-fi
-exit 0
-"#
-    .replace("__GWT_HOOK_BIN__", &bin)
-}
-
-fn openclaw_config(plugin_dir: &Path) -> Value {
-    json!({
-        "commands": {
-            "native": "auto",
-            "nativeSkills": "auto",
-            "restart": true,
-            "ownerDisplay": "raw",
-        },
-        "plugins": {
-            "enabled": true,
-            "load": {
-                "paths": [plugin_dir.to_string_lossy().to_string()],
-            },
-            "entries": {
-                "gwt-hook-bridge": {
-                    "enabled": true,
-                    "hooks": {
-                        "allowPromptInjection": true,
-                        "allowConversationAccess": false,
-                    },
-                },
-            },
-        },
-    })
-}
-
-fn openclaw_manifest() -> Value {
-    json!({
-        "id": "gwt-hook-bridge",
-        "name": "gwt Hook Bridge",
-        "description": "Routes OpenClaw plugin hook events into gwtd hook provider-event.",
-        "configSchema": {
-            "type": "object",
-            "additionalProperties": false,
-        },
-    })
-}
-
-fn openclaw_package_content() -> String {
-    r#"{
-  "name": "gwt-hook-bridge",
-  "version": "0.0.0",
-  "type": "module",
-  "private": true,
-  "openclaw": {
-    "extensions": ["./plugin.ts"]
-  }
-}
-"#
-    .to_string()
-}
-
-fn openclaw_plugin_content(bin: &str) -> String {
-    let bin = js_string_literal(bin);
-    format!(
-        r#"import {{ spawnSync }} from "node:child_process";
-import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
-
-const GWT_HOOK_BIN = {bin};
-
-function dispatch(nativeEvent, event = {{}}, ctx = {{}}) {{
-  const payload = {{
-    provider: "openclaw",
-    native_event: nativeEvent,
-    tool_name: event.toolName ?? event.tool_name,
-    tool_input: event.params ?? event.args ?? event.toolInput ?? event.tool_input ?? {{}},
-    session_id: event.sessionId ?? event.session_id ?? ctx.sessionId ?? ctx.sessionKey,
-    cwd: event.cwd ?? ctx.cwd ?? ctx.workspaceRoot,
-    event,
-    ctx,
-  }};
-  const result = spawnSync(
-    GWT_HOOK_BIN,
-    ["hook", "provider-event", "openclaw", nativeEvent],
-    {{
-      input: JSON.stringify(payload),
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "ignore"],
-    }},
-  );
-  try {{
-    return result.stdout ? JSON.parse(result.stdout) : {{}};
-  }} catch {{
-    return {{}};
-  }}
-}}
-
-function blockResult(result) {{
-  const reason = result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
-  if (!reason) return undefined;
-  return {{ block: true, blockReason: reason }};
-}}
-
-function promptContextResult(result) {{
-  const text = result.hookSpecificOutput?.additionalContext ?? result.context;
-  if (!text) return undefined;
-  return {{ prependContext: text }};
-}}
-
-export default definePluginEntry({{
-  id: "gwt-hook-bridge",
-  name: "gwt Hook Bridge",
-  description: "Routes OpenClaw hook events into gwtd.",
-  register(api) {{
-    api.on("session_start", async (event, ctx) => dispatch("session_start", event, ctx));
-    api.on("before_prompt_build", async (event, ctx) => promptContextResult(dispatch("before_prompt_build", event, ctx)));
-    api.on("before_tool_call", async (event, ctx) => blockResult(dispatch("before_tool_call", event, ctx)));
-    api.on("after_tool_call", async (event, ctx) => dispatch("after_tool_call", event, ctx));
-    api.on("session_end", async (event, ctx) => dispatch("session_end", event, ctx));
-  }},
-}});
-"#
-    )
 }
 
 fn managed_hook_shell() -> HookShell {
@@ -832,6 +549,10 @@ fn powershell_coordination_hook_command(event: &str) -> String {
 mod tests {
     use std::process::Command;
 
+    use crate::provider_hooks::{
+        generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks,
+    };
+
     use super::*;
 
     fn commands_for_event<'a>(value: &'a Value, event: &str) -> Vec<&'a str> {
@@ -908,10 +629,22 @@ mod tests {
         assert!(config.contains("pre_tool_call"));
         assert!(config.contains("post_tool_call"));
         assert!(config.contains("on_session_end"));
-        let script = fs::read_to_string(script_path).unwrap();
+        assert!(config.contains("gwt-hook.sh' on_session_start"));
+        assert!(config.contains("gwt-hook.sh' pre_tool_call"));
+        let script = fs::read_to_string(&script_path).unwrap();
         assert!(script.contains("provider-event"));
         assert!(script.contains("hermes"));
+        assert!(!script.contains("pre_tool_call}\""));
+        assert!(!script.contains("sed -n"));
         assert!(script.contains("exit 0"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = fs::metadata(script_path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "Hermes hook script must be executable");
+        }
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -5947,8 +5947,7 @@ mod tests {
     }
 
     fn env_test_lock() -> &'static Mutex<()> {
-        static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        crate::env_test_lock()
     }
 
     fn fake_gh_test_lock() -> &'static Mutex<()> {

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -23,6 +23,7 @@ pub mod envelope;
 pub mod event_dispatcher;
 pub mod forward;
 mod identity;
+pub mod provider_event;
 pub mod runtime_state;
 pub mod segments;
 pub mod skill_build_spec_stop_check;
@@ -47,6 +48,7 @@ pub(crate) use identity::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookKind {
     Event,
+    ProviderEvent,
     RuntimeState,
     CoordinationEvent,
     BoardReminder,
@@ -66,6 +68,7 @@ impl HookKind {
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "event" => Some(Self::Event),
+            "provider-event" => Some(Self::ProviderEvent),
             "runtime-state" => Some(Self::RuntimeState),
             "coordination-event" => Some(Self::CoordinationEvent),
             "board-reminder" => Some(Self::BoardReminder),
@@ -232,7 +235,7 @@ pub fn run_daemon_hook<E: CliEnv>(
     rest: &[String],
 ) -> Result<i32, SpecOpsError> {
     use crate::cli::hook::{
-        block_bash_policy, event_dispatcher, skill_build_spec_stop_check,
+        block_bash_policy, event_dispatcher, provider_event, skill_build_spec_stop_check,
         skill_discussion_stop_check, skill_plan_spec_stop_check, workflow_policy, HookKind,
         HookOutput,
     };
@@ -267,6 +270,34 @@ pub fn run_daemon_hook<E: CliEnv>(
             let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
             match event_dispatcher::handle_with_input(
                 event,
+                &stdin,
+                &cwd,
+                current_session.as_deref(),
+            ) {
+                Ok(output) => Ok(emit_hook_output(env, &output)),
+                Err(err) => Ok(emit_hook_error(env, name, err)),
+            }
+        }
+        HookKind::ProviderEvent => {
+            let Some(provider) = rest.first() else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook provider-event: missing <provider> argument"
+                );
+                return Ok(2);
+            };
+            let Some(native_event) = rest.get(1) else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook provider-event: missing <native-event> argument"
+                );
+                return Ok(2);
+            };
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            match provider_event::handle_with_input(
+                provider,
+                native_event,
                 &stdin,
                 &cwd,
                 current_session.as_deref(),
@@ -484,5 +515,39 @@ mod tests {
             !content.contains("/tmp/bunx-old"),
             "stale temporary hook binary path must be removed, got: {content}"
         );
+    }
+
+    #[test]
+    fn provider_event_normalizes_hermes_hook_payloads_to_canonical_events() {
+        let normalized = provider_event::normalize_provider_payload(
+            "hermes",
+            "pre_tool_call",
+            r#"{"tool_name":"terminal","tool_input":{"command":"git status"},"session_id":"h-1","cwd":"/repo"}"#,
+        )
+        .expect("normalize hermes pre_tool_call");
+
+        assert_eq!(normalized.event, "PreToolUse");
+        assert_eq!(normalized.payload["tool_name"], "terminal");
+        assert_eq!(normalized.payload["tool_input"]["command"], "git status");
+        assert_eq!(normalized.payload["session_id"], "h-1");
+        assert_eq!(normalized.payload["cwd"], "/repo");
+    }
+
+    #[test]
+    fn provider_event_maps_prompt_and_stop_boundaries() {
+        let cases = [
+            ("opencode", "message.updated", "UserPromptSubmit"),
+            ("opencode", "session.idle", "Stop"),
+            ("openclaw", "before_prompt_build", "UserPromptSubmit"),
+            ("openclaw", "session_end", "Stop"),
+            ("hermes", "pre_llm_call", "UserPromptSubmit"),
+            ("hermes", "on_session_end", "Stop"),
+        ];
+
+        for (provider, native, expected) in cases {
+            let normalized = provider_event::normalize_provider_payload(provider, native, "{}")
+                .unwrap_or_else(|err| panic!("{provider}:{native}: {err}"));
+            assert_eq!(normalized.event, expected, "{provider}:{native}");
+        }
     }
 }

--- a/crates/gwt/src/cli/hook/provider_event.rs
+++ b/crates/gwt/src/cli/hook/provider_event.rs
@@ -1,0 +1,200 @@
+//! Provider-owned hook adapters for non-Claude/Codex agents.
+//!
+//! OpenCode, OpenClaw, and Hermes expose different native hook names and
+//! payload shapes. This adapter normalizes those native events into gwt's
+//! canonical hook vocabulary, then delegates to the existing event dispatcher.
+
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use super::{event_dispatcher, HookError, HookOutput};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizedProviderEvent {
+    pub event: String,
+    pub payload: Value,
+}
+
+pub fn handle_with_input(
+    provider: &str,
+    native_event: &str,
+    input: &str,
+    worktree_root: &Path,
+    current_session: Option<&str>,
+) -> Result<HookOutput, HookError> {
+    let normalized = normalize_provider_payload(provider, native_event, input)?;
+    let payload = serde_json::to_string(&normalized.payload)?;
+    event_dispatcher::handle_with_input(&normalized.event, &payload, worktree_root, current_session)
+}
+
+pub fn normalize_provider_payload(
+    provider: &str,
+    native_event: &str,
+    input: &str,
+) -> Result<NormalizedProviderEvent, HookError> {
+    let event = canonical_event(provider, native_event)
+        .ok_or_else(|| HookError::InvalidEvent(format!("{provider}:{native_event}")))?;
+    let raw = parse_input(input)?;
+    let payload = normalize_payload(provider, native_event, raw);
+
+    Ok(NormalizedProviderEvent {
+        event: event.to_string(),
+        payload,
+    })
+}
+
+fn canonical_event(provider: &str, native_event: &str) -> Option<&'static str> {
+    let provider = provider.trim().to_ascii_lowercase();
+    match (provider.as_str(), native_event.trim()) {
+        ("opencode", "session.created") => Some("SessionStart"),
+        ("opencode", "message.updated") => Some("UserPromptSubmit"),
+        ("opencode", "tool.execute.before") => Some("PreToolUse"),
+        ("opencode", "tool.execute.after") => Some("PostToolUse"),
+        ("opencode", "session.idle") => Some("Stop"),
+        ("openclaw", "session_start") => Some("SessionStart"),
+        ("openclaw", "before_prompt_build") => Some("UserPromptSubmit"),
+        ("openclaw", "before_tool_call") => Some("PreToolUse"),
+        ("openclaw", "after_tool_call") => Some("PostToolUse"),
+        ("openclaw", "session_end") => Some("Stop"),
+        ("hermes", "on_session_start") => Some("SessionStart"),
+        ("hermes", "pre_llm_call") => Some("UserPromptSubmit"),
+        ("hermes", "pre_tool_call") => Some("PreToolUse"),
+        ("hermes", "post_tool_call") => Some("PostToolUse"),
+        ("hermes", "on_session_end") => Some("Stop"),
+        _ => None,
+    }
+}
+
+fn parse_input(input: &str) -> Result<Value, HookError> {
+    if input.trim().is_empty() {
+        return Ok(Value::Object(Map::new()));
+    }
+    Ok(serde_json::from_str(input)?)
+}
+
+fn normalize_payload(provider: &str, native_event: &str, raw: Value) -> Value {
+    let mut out = raw.as_object().cloned().unwrap_or_else(|| {
+        let mut map = Map::new();
+        map.insert("raw".to_string(), raw.clone());
+        map
+    });
+
+    insert_string_if_missing(&mut out, "provider", Some(provider));
+    insert_string_if_missing(&mut out, "native_event", Some(native_event));
+    insert_string_if_missing(&mut out, "tool_name", tool_name(&raw).as_deref());
+    insert_value_if_missing(&mut out, "tool_input", tool_input(&raw));
+    insert_string_if_missing(&mut out, "session_id", session_id(&raw).as_deref());
+    insert_string_if_missing(&mut out, "cwd", cwd(&raw).as_deref());
+    insert_string_if_missing(
+        &mut out,
+        "transcript_path",
+        string_at_any(&raw, &[&["transcript_path"], &["transcriptPath"]]).as_deref(),
+    );
+
+    Value::Object(out)
+}
+
+fn insert_string_if_missing(map: &mut Map<String, Value>, key: &str, value: Option<&str>) {
+    if map.contains_key(key) {
+        return;
+    }
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    map.insert(key.to_string(), Value::String(value.to_string()));
+}
+
+fn insert_value_if_missing(map: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if map.contains_key(key) {
+        return;
+    }
+    if let Some(value) = value {
+        map.insert(key.to_string(), value);
+    }
+}
+
+fn tool_name(raw: &Value) -> Option<String> {
+    string_at_any(
+        raw,
+        &[
+            &["tool_name"],
+            &["toolName"],
+            &["tool", "name"],
+            &["toolName"],
+            &["name"],
+        ],
+    )
+    .or_else(|| string_at_any(raw, &[&["tool"]]))
+}
+
+fn tool_input(raw: &Value) -> Option<Value> {
+    value_at_any(
+        raw,
+        &[
+            &["tool_input"],
+            &["toolInput"],
+            &["input"],
+            &["args"],
+            &["arguments"],
+            &["params"],
+            &["tool", "input"],
+            &["tool", "args"],
+            &["tool", "arguments"],
+            &["tool", "params"],
+        ],
+    )
+    .cloned()
+}
+
+fn session_id(raw: &Value) -> Option<String> {
+    string_at_any(
+        raw,
+        &[
+            &["session_id"],
+            &["sessionId"],
+            &["sessionID"],
+            &["session", "id"],
+            &["session", "session_id"],
+            &["ctx", "sessionId"],
+            &["context", "sessionId"],
+        ],
+    )
+}
+
+fn cwd(raw: &Value) -> Option<String> {
+    string_at_any(
+        raw,
+        &[
+            &["cwd"],
+            &["working_directory"],
+            &["workingDirectory"],
+            &["directory"],
+            &["project", "root"],
+            &["workspace", "root"],
+            &["session", "cwd"],
+        ],
+    )
+}
+
+fn string_at_any(raw: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| value_at(raw, path))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn value_at_any<'a>(raw: &'a Value, paths: &[&[&str]]) -> Option<&'a Value> {
+    paths.iter().find_map(|path| value_at(raw, path))
+}
+
+fn value_at<'a>(raw: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = raw;
+    for key in path {
+        current = current.as_object()?.get(*key)?;
+    }
+    Some(current)
+}

--- a/crates/gwt/src/cli/hook/provider_event.rs
+++ b/crates/gwt/src/cli/hook/provider_event.rs
@@ -33,10 +33,13 @@ pub fn normalize_provider_payload(
     native_event: &str,
     input: &str,
 ) -> Result<NormalizedProviderEvent, HookError> {
-    let event = canonical_event(provider, native_event)
+    let provider_kind = ProviderKind::parse(provider)
+        .ok_or_else(|| HookError::InvalidEvent(format!("{provider}:{native_event}")))?;
+    let event = provider_kind
+        .canonical_event(native_event)
         .ok_or_else(|| HookError::InvalidEvent(format!("{provider}:{native_event}")))?;
     let raw = parse_input(input)?;
-    let payload = normalize_payload(provider, native_event, raw);
+    let payload = normalize_payload(provider_kind, native_event, raw);
 
     Ok(NormalizedProviderEvent {
         event: event.to_string(),
@@ -44,25 +47,50 @@ pub fn normalize_provider_payload(
     })
 }
 
-fn canonical_event(provider: &str, native_event: &str) -> Option<&'static str> {
-    let provider = provider.trim().to_ascii_lowercase();
-    match (provider.as_str(), native_event.trim()) {
-        ("opencode", "session.created") => Some("SessionStart"),
-        ("opencode", "message.updated") => Some("UserPromptSubmit"),
-        ("opencode", "tool.execute.before") => Some("PreToolUse"),
-        ("opencode", "tool.execute.after") => Some("PostToolUse"),
-        ("opencode", "session.idle") => Some("Stop"),
-        ("openclaw", "session_start") => Some("SessionStart"),
-        ("openclaw", "before_prompt_build") => Some("UserPromptSubmit"),
-        ("openclaw", "before_tool_call") => Some("PreToolUse"),
-        ("openclaw", "after_tool_call") => Some("PostToolUse"),
-        ("openclaw", "session_end") => Some("Stop"),
-        ("hermes", "on_session_start") => Some("SessionStart"),
-        ("hermes", "pre_llm_call") => Some("UserPromptSubmit"),
-        ("hermes", "pre_tool_call") => Some("PreToolUse"),
-        ("hermes", "post_tool_call") => Some("PostToolUse"),
-        ("hermes", "on_session_end") => Some("Stop"),
-        _ => None,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderKind {
+    OpenCode,
+    OpenClaw,
+    Hermes,
+}
+
+impl ProviderKind {
+    fn parse(provider: &str) -> Option<Self> {
+        match provider.trim().to_ascii_lowercase().as_str() {
+            "opencode" => Some(Self::OpenCode),
+            "openclaw" => Some(Self::OpenClaw),
+            "hermes" => Some(Self::Hermes),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenCode => "opencode",
+            Self::OpenClaw => "openclaw",
+            Self::Hermes => "hermes",
+        }
+    }
+
+    fn canonical_event(self, native_event: &str) -> Option<&'static str> {
+        match (self, native_event.trim()) {
+            (Self::OpenCode, "session.created") => Some("SessionStart"),
+            (Self::OpenCode, "message.updated") => Some("UserPromptSubmit"),
+            (Self::OpenCode, "tool.execute.before") => Some("PreToolUse"),
+            (Self::OpenCode, "tool.execute.after") => Some("PostToolUse"),
+            (Self::OpenCode, "session.idle") => Some("Stop"),
+            (Self::OpenClaw, "session_start") => Some("SessionStart"),
+            (Self::OpenClaw, "before_prompt_build") => Some("UserPromptSubmit"),
+            (Self::OpenClaw, "before_tool_call") => Some("PreToolUse"),
+            (Self::OpenClaw, "after_tool_call") => Some("PostToolUse"),
+            (Self::OpenClaw, "session_end") => Some("Stop"),
+            (Self::Hermes, "on_session_start") => Some("SessionStart"),
+            (Self::Hermes, "pre_llm_call") => Some("UserPromptSubmit"),
+            (Self::Hermes, "pre_tool_call") => Some("PreToolUse"),
+            (Self::Hermes, "post_tool_call") => Some("PostToolUse"),
+            (Self::Hermes, "on_session_end") => Some("Stop"),
+            _ => None,
+        }
     }
 }
 
@@ -73,19 +101,23 @@ fn parse_input(input: &str) -> Result<Value, HookError> {
     Ok(serde_json::from_str(input)?)
 }
 
-fn normalize_payload(provider: &str, native_event: &str, raw: Value) -> Value {
+fn normalize_payload(provider: ProviderKind, native_event: &str, raw: Value) -> Value {
     let mut out = raw.as_object().cloned().unwrap_or_else(|| {
         let mut map = Map::new();
         map.insert("raw".to_string(), raw.clone());
         map
     });
 
-    insert_string_if_missing(&mut out, "provider", Some(provider));
+    insert_string_if_missing(&mut out, "provider", Some(provider.as_str()));
     insert_string_if_missing(&mut out, "native_event", Some(native_event));
-    insert_string_if_missing(&mut out, "tool_name", tool_name(&raw).as_deref());
-    insert_value_if_missing(&mut out, "tool_input", tool_input(&raw));
-    insert_string_if_missing(&mut out, "session_id", session_id(&raw).as_deref());
-    insert_string_if_missing(&mut out, "cwd", cwd(&raw).as_deref());
+    insert_string_if_missing(&mut out, "tool_name", tool_name(provider, &raw).as_deref());
+    insert_value_if_missing(&mut out, "tool_input", tool_input(provider, &raw));
+    insert_string_if_missing(
+        &mut out,
+        "session_id",
+        session_id(provider, &raw).as_deref(),
+    );
+    insert_string_if_missing(&mut out, "cwd", cwd(provider, &raw).as_deref());
     insert_string_if_missing(
         &mut out,
         "transcript_path",
@@ -114,67 +146,184 @@ fn insert_value_if_missing(map: &mut Map<String, Value>, key: &str, value: Optio
     }
 }
 
-fn tool_name(raw: &Value) -> Option<String> {
-    string_at_any(
-        raw,
-        &[
-            &["tool_name"],
-            &["toolName"],
-            &["tool", "name"],
-            &["toolName"],
-            &["name"],
-        ],
-    )
-    .or_else(|| string_at_any(raw, &[&["tool"]]))
+fn tool_name(provider: ProviderKind, raw: &Value) -> Option<String> {
+    match provider {
+        ProviderKind::OpenCode => string_at_any(
+            raw,
+            &[
+                &["tool_name"],
+                &["toolName"],
+                &["tool", "name"],
+                &["name"],
+                &["input", "tool"],
+                &["input", "toolName"],
+                &["output", "tool"],
+                &["output", "toolName"],
+            ],
+        ),
+        ProviderKind::OpenClaw => string_at_any(
+            raw,
+            &[
+                &["tool_name"],
+                &["toolName"],
+                &["tool", "name"],
+                &["event", "toolName"],
+                &["event", "tool_name"],
+            ],
+        ),
+        ProviderKind::Hermes => string_at_any(
+            raw,
+            &[
+                &["tool_name"],
+                &["toolName"],
+                &["tool", "name"],
+                &["name"],
+                &["tool"],
+            ],
+        ),
+    }
 }
 
-fn tool_input(raw: &Value) -> Option<Value> {
-    value_at_any(
-        raw,
-        &[
-            &["tool_input"],
-            &["toolInput"],
-            &["input"],
-            &["args"],
-            &["arguments"],
-            &["params"],
-            &["tool", "input"],
-            &["tool", "args"],
-            &["tool", "arguments"],
-            &["tool", "params"],
-        ],
-    )
+fn tool_input(provider: ProviderKind, raw: &Value) -> Option<Value> {
+    match provider {
+        ProviderKind::OpenCode => value_at_any(
+            raw,
+            &[
+                &["tool_input"],
+                &["toolInput"],
+                &["output", "args"],
+                &["input", "args"],
+                &["output", "params"],
+                &["input", "params"],
+                &["output", "input"],
+                &["input", "input"],
+                &["args"],
+                &["arguments"],
+                &["params"],
+                &["tool", "input"],
+                &["tool", "args"],
+                &["tool", "arguments"],
+                &["tool", "params"],
+            ],
+        ),
+        ProviderKind::OpenClaw => value_at_any(
+            raw,
+            &[
+                &["tool_input"],
+                &["toolInput"],
+                &["event", "params"],
+                &["event", "args"],
+                &["event", "toolInput"],
+                &["event", "tool_input"],
+                &["params"],
+                &["args"],
+                &["tool", "input"],
+            ],
+        ),
+        ProviderKind::Hermes => value_at_any(
+            raw,
+            &[
+                &["tool_input"],
+                &["toolInput"],
+                &["input"],
+                &["args"],
+                &["arguments"],
+                &["params"],
+                &["tool", "input"],
+                &["tool", "args"],
+                &["tool", "arguments"],
+                &["tool", "params"],
+            ],
+        ),
+    }
     .cloned()
 }
 
-fn session_id(raw: &Value) -> Option<String> {
-    string_at_any(
-        raw,
-        &[
-            &["session_id"],
-            &["sessionId"],
-            &["sessionID"],
-            &["session", "id"],
-            &["session", "session_id"],
-            &["ctx", "sessionId"],
-            &["context", "sessionId"],
-        ],
-    )
+fn session_id(provider: ProviderKind, raw: &Value) -> Option<String> {
+    match provider {
+        ProviderKind::OpenCode => string_at_any(
+            raw,
+            &[
+                &["session_id"],
+                &["sessionId"],
+                &["sessionID"],
+                &["session", "id"],
+                &["session", "session_id"],
+                &["input", "sessionID"],
+                &["input", "sessionId"],
+                &["input", "session_id"],
+                &["context", "sessionID"],
+                &["context", "sessionId"],
+            ],
+        ),
+        ProviderKind::OpenClaw => string_at_any(
+            raw,
+            &[
+                &["session_id"],
+                &["sessionId"],
+                &["sessionID"],
+                &["session", "id"],
+                &["event", "sessionId"],
+                &["event", "session_id"],
+                &["ctx", "sessionId"],
+                &["ctx", "sessionKey"],
+            ],
+        ),
+        ProviderKind::Hermes => string_at_any(
+            raw,
+            &[
+                &["session_id"],
+                &["sessionId"],
+                &["sessionID"],
+                &["session", "id"],
+                &["session", "session_id"],
+                &["ctx", "sessionId"],
+                &["context", "sessionId"],
+            ],
+        ),
+    }
 }
 
-fn cwd(raw: &Value) -> Option<String> {
-    string_at_any(
-        raw,
-        &[
-            &["cwd"],
-            &["working_directory"],
-            &["workingDirectory"],
-            &["directory"],
-            &["project", "root"],
-            &["workspace", "root"],
-            &["session", "cwd"],
-        ],
-    )
+fn cwd(provider: ProviderKind, raw: &Value) -> Option<String> {
+    match provider {
+        ProviderKind::OpenCode => string_at_any(
+            raw,
+            &[
+                &["cwd"],
+                &["working_directory"],
+                &["workingDirectory"],
+                &["directory"],
+                &["input", "cwd"],
+                &["context", "directory"],
+                &["context", "worktree"],
+                &["context", "project", "root"],
+            ],
+        ),
+        ProviderKind::OpenClaw => string_at_any(
+            raw,
+            &[
+                &["cwd"],
+                &["working_directory"],
+                &["workingDirectory"],
+                &["directory"],
+                &["event", "cwd"],
+                &["ctx", "cwd"],
+                &["ctx", "workspaceRoot"],
+            ],
+        ),
+        ProviderKind::Hermes => string_at_any(
+            raw,
+            &[
+                &["cwd"],
+                &["working_directory"],
+                &["workingDirectory"],
+                &["directory"],
+                &["project", "root"],
+                &["workspace", "root"],
+                &["session", "cwd"],
+            ],
+        ),
+    }
 }
 
 fn string_at_any(raw: &Value, paths: &[&[&str]]) -> Option<String> {
@@ -197,4 +346,59 @@ fn value_at<'a>(raw: &'a Value, path: &[&str]) -> Option<&'a Value> {
         current = current.as_object()?.get(*key)?;
     }
     Some(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opencode_native_payload_shape_promotes_tool_and_workspace_fields() {
+        let normalized = normalize_provider_payload(
+            "opencode",
+            "tool.execute.before",
+            r#"{
+              "input": {
+                "tool": "Bash",
+                "args": { "command": "pwd" },
+                "sessionID": "oc-1"
+              },
+              "context": {
+                "directory": "/repo"
+              }
+            }"#,
+        )
+        .expect("normalize opencode native-like payload");
+
+        assert_eq!(normalized.event, "PreToolUse");
+        assert_eq!(normalized.payload["tool_name"], "Bash");
+        assert_eq!(normalized.payload["tool_input"]["command"], "pwd");
+        assert_eq!(normalized.payload["session_id"], "oc-1");
+        assert_eq!(normalized.payload["cwd"], "/repo");
+    }
+
+    #[test]
+    fn openclaw_native_payload_shape_promotes_event_and_context_fields() {
+        let normalized = normalize_provider_payload(
+            "openclaw",
+            "before_tool_call",
+            r#"{
+              "event": {
+                "toolName": "Bash",
+                "params": { "command": "git status" },
+                "sessionId": "claw-1"
+              },
+              "ctx": {
+                "workspaceRoot": "/repo"
+              }
+            }"#,
+        )
+        .expect("normalize openclaw native-like payload");
+
+        assert_eq!(normalized.event, "PreToolUse");
+        assert_eq!(normalized.payload["tool_name"], "Bash");
+        assert_eq!(normalized.payload["tool_input"]["command"], "git status");
+        assert_eq!(normalized.payload["session_id"], "claw-1");
+        assert_eq!(normalized.payload["cwd"], "/repo");
+    }
 }

--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -123,6 +123,9 @@ mod tests {
 
     #[test]
     fn publish_returns_error_when_no_daemon_registered() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Use a tempdir for the project root and a tempdir for $HOME so
         // the resolver looks for the endpoint inside an empty
         // `~/.gwt/projects/.../runtime/daemon/` tree and finds nothing.

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1632,6 +1632,9 @@ Extra context.
 
     #[test]
     fn update_knowledge_phase_rejects_unknown_target() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3103,6 +3103,9 @@ fn agent_id_from_key(agent_id: &str) -> gwt_agent::AgentId {
         "claude" => gwt_agent::AgentId::ClaudeCode,
         "codex" => gwt_agent::AgentId::Codex,
         "gemini" => gwt_agent::AgentId::Gemini,
+        "opencode" => gwt_agent::AgentId::OpenCode,
+        "openclaw" => gwt_agent::AgentId::OpenClaw,
+        "hermes" => gwt_agent::AgentId::Hermes,
         "gh" => gwt_agent::AgentId::Copilot,
         other => gwt_agent::AgentId::Custom(other.to_string()),
     }
@@ -3160,10 +3163,13 @@ pub fn build_builtin_agent_options(
     detected_agents: Vec<gwt_agent::DetectedAgent>,
     cache: &gwt_agent::VersionCache,
 ) -> Vec<AgentOption> {
-    const BUILTIN: [gwt_agent::AgentId; 4] = [
+    const BUILTIN: [gwt_agent::AgentId; 7] = [
         gwt_agent::AgentId::ClaudeCode,
         gwt_agent::AgentId::Codex,
         gwt_agent::AgentId::Gemini,
+        gwt_agent::AgentId::OpenCode,
+        gwt_agent::AgentId::OpenClaw,
+        gwt_agent::AgentId::Hermes,
         gwt_agent::AgentId::Copilot,
     ];
 
@@ -3258,6 +3264,14 @@ mod tests {
             agent_option_color("opencode"),
             Some(gwt_agent::AgentColor::Green)
         );
+        assert_eq!(
+            agent_option_color("openclaw"),
+            Some(gwt_agent::AgentColor::Blue)
+        );
+        assert_eq!(
+            agent_option_color("hermes"),
+            Some(gwt_agent::AgentColor::Magenta)
+        );
         assert_eq!(agent_option_color("gh"), Some(gwt_agent::AgentColor::Blue));
         assert_eq!(
             agent_option_color("my-custom"),
@@ -3313,6 +3327,20 @@ mod tests {
             options[missing].available,
             "configured custom agents must stay selectable; runtime preparation validates execution"
         );
+    }
+
+    #[test]
+    fn build_builtin_agent_options_includes_hook_parity_agents() {
+        let options = build_builtin_agent_options(Vec::new(), &gwt_agent::VersionCache::new());
+        let ids: Vec<&str> = options.iter().map(|option| option.id.as_str()).collect();
+
+        assert_eq!(
+            ids,
+            vec!["claude", "codex", "gemini", "opencode", "openclaw", "hermes", "gh"]
+        );
+        assert!(options.iter().any(|option| option.name == "OpenCode"));
+        assert!(options.iter().any(|option| option.name == "OpenClaw"));
+        assert!(options.iter().any(|option| option.name == "Hermes Agent"));
     }
 
     fn branch(name: &str) -> BranchListEntry {
@@ -5025,8 +5053,14 @@ mod tests {
         assert!(is_explicit_model_selection("gpt-5.5"));
         assert!(!is_explicit_model_selection("Default (Installed)"));
         assert!(agent_has_npm_package("codex"));
+        assert!(!agent_has_npm_package("opencode"));
+        assert!(!agent_has_npm_package("openclaw"));
+        assert!(!agent_has_npm_package("hermes"));
         assert!(!agent_has_npm_package("custom"));
         assert_eq!(agent_id_from_key("gh"), gwt_agent::AgentId::Copilot);
+        assert_eq!(agent_id_from_key("opencode"), gwt_agent::AgentId::OpenCode);
+        assert_eq!(agent_id_from_key("openclaw"), gwt_agent::AgentId::OpenClaw);
+        assert_eq!(agent_id_from_key("hermes"), gwt_agent::AgentId::Hermes);
         assert_eq!(
             agent_id_from_key("custom"),
             gwt_agent::AgentId::Custom("custom".to_string())

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3095,20 +3095,13 @@ fn is_explicit_model_selection(model: &str) -> bool {
 }
 
 fn agent_has_npm_package(agent_id: &str) -> bool {
-    matches!(agent_id, "claude" | "codex" | "gemini")
+    agent_id_from_key(agent_id).package_name().is_some()
 }
 
 fn agent_id_from_key(agent_id: &str) -> gwt_agent::AgentId {
-    match agent_id {
-        "claude" => gwt_agent::AgentId::ClaudeCode,
-        "codex" => gwt_agent::AgentId::Codex,
-        "gemini" => gwt_agent::AgentId::Gemini,
-        "opencode" => gwt_agent::AgentId::OpenCode,
-        "openclaw" => gwt_agent::AgentId::OpenClaw,
-        "hermes" => gwt_agent::AgentId::Hermes,
-        "gh" => gwt_agent::AgentId::Copilot,
-        other => gwt_agent::AgentId::Custom(other.to_string()),
-    }
+    gwt_agent::builtin_agent_descriptor_for_command(agent_id)
+        .map(|descriptor| descriptor.id.clone())
+        .unwrap_or_else(|| gwt_agent::AgentId::Custom(agent_id.to_string()))
 }
 
 fn agent_description(agent: &AgentOption) -> String {
@@ -3163,19 +3156,10 @@ pub fn build_builtin_agent_options(
     detected_agents: Vec<gwt_agent::DetectedAgent>,
     cache: &gwt_agent::VersionCache,
 ) -> Vec<AgentOption> {
-    const BUILTIN: [gwt_agent::AgentId; 7] = [
-        gwt_agent::AgentId::ClaudeCode,
-        gwt_agent::AgentId::Codex,
-        gwt_agent::AgentId::Gemini,
-        gwt_agent::AgentId::OpenCode,
-        gwt_agent::AgentId::OpenClaw,
-        gwt_agent::AgentId::Hermes,
-        gwt_agent::AgentId::Copilot,
-    ];
-
-    BUILTIN
-        .into_iter()
-        .map(|agent_id| {
+    gwt_agent::builtin_agent_descriptors()
+        .iter()
+        .map(|descriptor| {
+            let agent_id = descriptor.id.clone();
             let detected = detected_agents
                 .iter()
                 .find(|detected| detected.agent_id == agent_id);

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -42,6 +42,12 @@ mod runtime_support;
 mod update_front_door;
 
 #[cfg(test)]
+pub(crate) fn env_test_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[cfg(test)]
 pub(crate) use app_runtime::LaunchWizardMemoryCache;
 #[cfg(test)]
 pub(crate) use app_runtime::{

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -9,7 +9,8 @@ use crate::cli::gwtd_resolver::{
 };
 use crate::native_app::{GUI_FRONT_DOOR_BINARY_NAME, INTERNAL_DAEMON_BINARY_NAME};
 use gwt_skills::{
-    distribute_to_worktree, generate_codex_hooks, generate_settings_local, update_git_exclude,
+    distribute_to_worktree, generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks,
+    generate_opencode_hooks, generate_settings_local, update_git_exclude,
 };
 
 pub fn refresh_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()> {
@@ -27,6 +28,21 @@ pub fn refresh_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()
     })?;
     generate_codex_hooks(worktree).map_err(|error| {
         io::Error::other(format!("failed to regenerate Codex hook settings: {error}"))
+    })?;
+    generate_opencode_hooks(worktree).map_err(|error| {
+        io::Error::other(format!(
+            "failed to regenerate OpenCode hook settings: {error}"
+        ))
+    })?;
+    generate_openclaw_hooks(worktree).map_err(|error| {
+        io::Error::other(format!(
+            "failed to regenerate OpenClaw hook settings: {error}"
+        ))
+    })?;
+    generate_hermes_hooks(worktree).map_err(|error| {
+        io::Error::other(format!(
+            "failed to regenerate Hermes hook settings: {error}"
+        ))
     })?;
     Ok(())
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5223,3 +5223,25 @@ Board request `2b256bfc-...` で報告していた。
    broadcast event で reach するかを表形式で残す (SPEC 7.2 の `Inventory: write path vs
    surface` 表)。Inventory を見ながら write path を設計すれば「すべての surface を
    touch しているか」を caller 側で必ず確認できる。
+
+## 2026-05-11 — Test-only HOME mutation は crate-wide lock に統一する
+
+### 事象
+
+`cargo test -p gwt-core -p gwt` の並列実行で Board/Workspace 系テストが intermittent に失敗した。
+単独実行では通り、失敗時は `GWT_SESSION_ID` から保存済み session を読めず、current workspace
+audience が欠落していた。
+
+### 原因
+
+`app_runtime` test module と一部 helper test が `HOME` / `USERPROFILE` を module-local lock
+または lock なしで変更していた。CLI Board/Workspace tests は crate-wide `env_test_lock` を
+使っていたため、同じ process 内で別 test が HOME を差し替え、session path resolution が
+別 tempdir を参照した。
+
+### 再発防止策
+
+1. `HOME` / `USERPROFILE` / `GWT_SESSION_ID` など process-global env を触る test は、
+   module-local lock を作らず crate-wide `env_test_lock` に寄せる。
+2. 単独 test green で満足せず、env mutation を伴う修正後は default parallelism の
+   `cargo test -p gwt-core -p gwt` を必ず 1 回通す。


### PR DESCRIPTION
## Summary

- Adds OpenCode, OpenClaw, and Hermes Agent as first-class coding agent launch options with hook-aware runtime metadata.
- Generates provider-specific hook assets so Board, workspace, workflow policy, and runtime state events keep working outside Codex and Claude.
- Stabilizes merge-time CI by serializing HOME-mutating gwt tests through the shared test env lock.

## Changes

- `crates/gwt-agent`: adds built-in provider identities, detection, version cache mapping, launch arguments, model/config flags, and hook support metadata for OpenCode, OpenClaw, and Hermes.
- `crates/gwt-skills`: adds provider hook asset generation, `.git/info/exclude` coverage, and settings materialization for OpenCode/OpenClaw/Hermes.
- `crates/gwt/src/cli/hook`: adds provider event normalization and routes non-Codex provider hooks into the existing coordination/runtime hook pipeline.
- `crates/gwt/src/launch_wizard.rs`: exposes the new hook parity agents in launch selection with the existing launch controls.
- `crates/gwt/src/app_runtime/mod.rs`, `crates/gwt/src/daemon_publisher.rs`, `crates/gwt/src/knowledge_bridge.rs`, `crates/gwt/src/main.rs`: aligns test-only HOME mutation with the crate-wide env lock.
- `tasks/lessons.md`: records the parallel-test env mutation lesson.

## Testing

- [x] `cargo test -p gwt-agent --lib` — passed, 204 tests.
- [x] `cargo test -p gwt-skills --lib` — passed, 115 tests.
- [x] `cargo test -p gwt --lib provider_event -- --nocapture` — passed, 4 tests.
- [x] `cargo test -p gwt --lib launch_wizard -- --nocapture` — passed, 69 tests.
- [x] `cargo test -p gwt-core -p gwt` — passed after the test env lock fix.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx markdownlint-cli tasks/lessons.md` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## Closing Issues

- None

## Related Issues / Links

- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (internal lessons; no README change required)
- [x] Migration/backfill plan included (not applicable: no schema/data migration)
- [x] CHANGELOG impact considered (feature and fix commits, no breaking change)

## Context

- This PR completes the provider hook parity slice discussed for SPEC-1921 and keeps the existing managed hook contract as the canonical integration point.

## Risk / Impact

- **Affected areas**: agent detection/launch, managed skills materialization, hook event normalization, Launch Wizard agent choices, and test isolation for HOME-dependent gwt tests.
- **Rollback plan**: revert this PR; generated provider hook assets are project-local and regenerated from the managed assets pipeline.
