### PR TITLE
feat(board): focus origin agents

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -455,20 +455,17 @@ fn board_error(client_id: &str, id: &str, message: impl Into<String>) -> Vec<Out
 }
 
 fn agent_option_matches_session(option: &gwt::AgentOption, agent_id: &AgentId) -> bool {
+    let command_matches = option.id == agent_id.command();
     match agent_id {
-        AgentId::ClaudeCode => option.id == "claude",
-        AgentId::Codex => option.id == "codex",
-        AgentId::Gemini => option.id == "gemini",
-        AgentId::OpenCode => option.id == "opencode",
-        AgentId::Copilot => option.id == "gh",
         AgentId::Custom(id) => {
-            option.id == *id
+            command_matches
                 || option
                     .custom_agent
                     .as_ref()
                     .map(|agent| agent.id == *id)
                     .unwrap_or(false)
         }
+        _ => command_matches,
     }
 }
 

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -17,12 +17,13 @@
 
 use std::path::Path;
 
+use gwt_agent::{AgentId, AgentLaunchBuilder, LaunchConfig, SessionMode};
 use gwt_core::{
     coordination::{self, BoardEntryKind, BoardMention},
     workspace_projection,
 };
 
-use super::{AppRuntime, BackendEvent, OutboundEvent, WindowPreset};
+use super::{AppRuntime, BackendEvent, OutboundEvent, WindowGeometry, WindowPreset};
 
 #[derive(Debug, Clone)]
 pub struct BoardPostRequest {
@@ -185,6 +186,139 @@ impl AppRuntime {
         }
     }
 
+    pub(crate) fn open_board_origin_agent_events(
+        &mut self,
+        client_id: &str,
+        id: &str,
+        origin_session_id: &str,
+        bounds: Option<WindowGeometry>,
+    ) -> Vec<OutboundEvent> {
+        let (tab_id, board_geometry) = match self.board_surface_context(id) {
+            Ok(context) => context,
+            Err(message) => return board_error(client_id, id, message),
+        };
+        let origin_session_id = origin_session_id.trim();
+        if origin_session_id.is_empty() {
+            return board_error(client_id, id, "Board origin session is unavailable");
+        }
+
+        let live_window_id = self
+            .active_agent_sessions
+            .iter()
+            .find(|(_, session)| session.session_id == origin_session_id)
+            .map(|(window_id, _)| window_id.clone());
+        if let Some(window_id) = live_window_id {
+            let mut events = self.restore_window_events(&window_id);
+            events.extend(self.focus_window_events(&window_id, bounds));
+            return if events.is_empty() {
+                board_error(
+                    client_id,
+                    id,
+                    format!("Board origin Agent window not found for {origin_session_id}"),
+                )
+            } else {
+                events
+            };
+        }
+
+        let config = match self.board_origin_agent_resume_config(origin_session_id) {
+            Ok(config) => config,
+            Err(message) => return board_error(client_id, id, message),
+        };
+        match self.spawn_agent_window(&tab_id, config, bounds.unwrap_or(board_geometry), None) {
+            Ok(events) => events,
+            Err(message) => board_error(client_id, id, message),
+        }
+    }
+
+    pub(crate) fn board_origin_agent_resume_config(
+        &self,
+        origin_session_id: &str,
+    ) -> Result<LaunchConfig, String> {
+        let origin_session_id = origin_session_id.trim();
+        if origin_session_id.is_empty() {
+            return Err("Board origin session is unavailable".to_string());
+        }
+        let session_path = self.sessions_dir.join(format!("{origin_session_id}.toml"));
+        let session = gwt_agent::Session::load_and_migrate(&session_path).map_err(|error| {
+            format!("Board origin session {origin_session_id} could not be loaded: {error}")
+        })?;
+        let resume_session_id = session
+            .agent_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                format!("Board origin session {origin_session_id} has no agent session id")
+            })?;
+
+        let mut builder = AgentLaunchBuilder::new(session.agent_id.clone())
+            .working_dir(session.worktree_path.clone())
+            .branch(session.branch.clone())
+            .session_mode(SessionMode::Resume)
+            .resume_session_id(resume_session_id.to_string())
+            .runtime_target(session.runtime_target)
+            .docker_lifecycle_intent(session.docker_lifecycle_intent);
+
+        if let Some(custom_agent) = self
+            .launch_wizard_cache
+            .agent_options()
+            .into_iter()
+            .find(|option| agent_option_matches_session(option, &session.agent_id))
+            .and_then(|option| option.custom_agent)
+        {
+            builder = builder.custom_agent(custom_agent);
+        }
+        if let Some(model) = non_empty(session.model.as_deref()) {
+            builder = builder.model(model.to_string());
+        }
+        if let Some(tool_version) = non_empty(session.tool_version.as_deref()) {
+            builder = builder.version(tool_version.to_string());
+        }
+        if let Some(reasoning_level) = non_empty(session.reasoning_level.as_deref()) {
+            builder = builder.reasoning_level(reasoning_level.to_string());
+        }
+        if session.skip_permissions {
+            builder = builder.skip_permissions(true);
+        }
+        if session.codex_fast_mode {
+            builder = builder.fast_mode(true);
+        }
+        if let Some(docker_service) = non_empty(session.docker_service.as_deref()) {
+            builder = builder.docker_service(docker_service.to_string());
+        }
+        if let Some(linked_issue_number) = session.linked_issue_number {
+            builder = builder.linked_issue_number(linked_issue_number);
+        }
+        if let Some(windows_shell) = session.windows_shell {
+            builder = builder.windows_shell(windows_shell);
+        }
+
+        let mut config = builder.build();
+        if !session.display_name.trim().is_empty() {
+            config.display_name = session.display_name;
+        }
+        Ok(config)
+    }
+
+    fn board_surface_context(&self, id: &str) -> Result<(String, WindowGeometry), String> {
+        let address = self
+            .window_lookup
+            .get(id)
+            .ok_or_else(|| "Window not found".to_string())?;
+        let tab = self
+            .tab(&address.tab_id)
+            .ok_or_else(|| "Project tab not found".to_string())?;
+        let window = tab
+            .workspace
+            .window(&address.raw_id)
+            .ok_or_else(|| "Window not found".to_string())?;
+        if window.preset != WindowPreset::Board {
+            return Err("Window is not a Board surface".to_string());
+        }
+        Ok((address.tab_id.clone(), window.geometry.clone()))
+    }
+
     pub(crate) fn record_workspace_board_milestone_event(
         &mut self,
         tab_id: &str,
@@ -285,6 +419,38 @@ impl AppRuntime {
             Some(entry.body.clone()),
         )
     }
+}
+
+fn board_error(client_id: &str, id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![OutboundEvent::reply(
+        client_id,
+        BackendEvent::BoardError {
+            id: id.to_string(),
+            message: message.into(),
+        },
+    )]
+}
+
+fn agent_option_matches_session(option: &gwt::AgentOption, agent_id: &AgentId) -> bool {
+    match agent_id {
+        AgentId::ClaudeCode => option.id == "claude",
+        AgentId::Codex => option.id == "codex",
+        AgentId::Gemini => option.id == "gemini",
+        AgentId::OpenCode => option.id == "opencode",
+        AgentId::Copilot => option.id == "gh",
+        AgentId::Custom(id) => {
+            option.id == *id
+                || option
+                    .custom_agent
+                    .as_ref()
+                    .map(|agent| agent.id == *id)
+                    .unwrap_or(false)
+        }
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 /// Best-effort fan-out of a Board projection change to other gwt

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9638,6 +9638,38 @@ exit 0
     }
 
     #[test]
+    fn board_origin_agent_resume_config_supports_builtin_agent_descriptors() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let runtime = sample_runtime(temp.path(), Vec::new(), None);
+
+        for agent_id in [gwt_agent::AgentId::OpenClaw, gwt_agent::AgentId::Hermes] {
+            let session_id = format!("session-{}", agent_id.command());
+            let resume_id = format!("resume-{}", agent_id.command());
+            let mut session = gwt_agent::Session::new(
+                &repo,
+                format!("work/{}", agent_id.command()),
+                agent_id.clone(),
+            );
+            session.id = session_id.clone();
+            session.agent_session_id = Some(resume_id.clone());
+            session.save(&runtime.sessions_dir).expect("save session");
+
+            let config = runtime
+                .board_origin_agent_resume_config(&session_id)
+                .expect("resume config");
+
+            assert_eq!(config.agent_id, agent_id);
+            assert_eq!(
+                config.resume_session_id.as_deref(),
+                Some(resume_id.as_str())
+            );
+            assert_eq!(config.session_mode, gwt_agent::SessionMode::Resume);
+        }
+    }
+
+    #[test]
     fn app_runtime_open_board_origin_agent_rejects_missing_exact_resume_session() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1984,6 +1984,11 @@ impl AppRuntime {
                     mentions,
                 },
             ),
+            FrontendEvent::OpenBoardOriginAgent {
+                id,
+                origin_session_id,
+                bounds,
+            } => self.open_board_origin_agent_events(&client_id, &id, &origin_session_id, bounds),
             FrontendEvent::SelectProfile { id, profile_name } => {
                 self.select_profile_events(&client_id, &id, &profile_name)
             }
@@ -9296,6 +9301,132 @@ exit 0
                 && id == &window_id
                 && entries.iter().map(|entry| entry.body.as_str()).collect::<Vec<_>>() == vec!["entry-1", "entry-2"]
                 && *has_more_before
+        ));
+    }
+
+    #[test]
+    fn app_runtime_open_board_origin_agent_focuses_live_origin_session_window() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let board_raw_id = tab
+            .workspace
+            .add_window(WindowPreset::Board, canvas_bounds())
+            .id;
+        let agent_raw_id = tab
+            .workspace
+            .add_window(WindowPreset::Agent, canvas_bounds())
+            .id;
+        let board_window_id = combined_window_id("tab-1", &board_raw_id);
+        let agent_window_id = combined_window_id("tab-1", &agent_raw_id);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.active_agent_sessions.insert(
+            agent_window_id.clone(),
+            ActiveAgentSession {
+                window_id: agent_window_id.clone(),
+                session_id: "session-origin".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/board-origin".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.clone(),
+                agent_project_root: repo.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenBoardOriginAgent {
+                id: board_window_id,
+                origin_session_id: "session-origin".to_string(),
+                bounds: Some(canvas_bounds()),
+            },
+        );
+
+        let workspace = runtime.tab("tab-1").expect("tab").workspace.persisted();
+        let focused = workspace
+            .windows
+            .iter()
+            .max_by_key(|window| window.z_index)
+            .expect("focused window");
+        assert_eq!(focused.id, agent_raw_id);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            OutboundEvent {
+                event: BackendEvent::WorkspaceState { .. },
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn board_origin_agent_resume_config_uses_exact_saved_session() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let runtime = sample_runtime(temp.path(), Vec::new(), None);
+        let mut session =
+            gwt_agent::Session::new(&repo, "work/board-origin", gwt_agent::AgentId::Codex);
+        session.id = "session-origin".to_string();
+        session.agent_session_id = Some("codex-resume-123".to_string());
+        session.model = Some("gpt-5.4".to_string());
+        session.reasoning_level = Some("high".to_string());
+        session.tool_version = Some("latest".to_string());
+        session.skip_permissions = true;
+        session.codex_fast_mode = true;
+        session.save(&runtime.sessions_dir).expect("save session");
+
+        let config = runtime
+            .board_origin_agent_resume_config("session-origin")
+            .expect("resume config");
+
+        assert_eq!(config.branch.as_deref(), Some("work/board-origin"));
+        assert_eq!(config.working_dir.as_deref(), Some(repo.as_path()));
+        assert_eq!(
+            config.resume_session_id.as_deref(),
+            Some("codex-resume-123")
+        );
+        assert_eq!(config.session_mode, gwt_agent::SessionMode::Resume);
+        assert_eq!(config.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(config.reasoning_level.as_deref(), Some("high"));
+        assert!(config.skip_permissions);
+        assert!(config.codex_fast_mode);
+    }
+
+    #[test]
+    fn app_runtime_open_board_origin_agent_rejects_missing_exact_resume_session() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo,
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let board_window_id = combined_window_id("tab-1", "board-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenBoardOriginAgent {
+                id: board_window_id.clone(),
+                origin_session_id: "missing-session".to_string(),
+                bounds: Some(canvas_bounds()),
+            },
+        );
+
+        assert!(matches!(
+            &events[..],
+            [OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::BoardError { id, message },
+            }] if client_id == "client-1"
+                && id == &board_window_id
+                && message.contains("missing-session")
         ));
     }
 

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -176,15 +176,16 @@ pub fn handle(event: &str) -> Result<(), HookError> {
 }
 
 pub fn handle_with_input(event: &str, input: &str) -> Result<(), HookError> {
-    if std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV).is_none() {
+    let Some(runtime_path) = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV) else {
         return Ok(());
-    }
+    };
+    let runtime_path = PathBuf::from(runtime_path);
     let hook_event = if input.trim().is_empty() {
         None
     } else {
         RawHookEvent::read_from_str(input)?
     };
-    let sessions_dir = sessions_dir_for_current_runtime();
+    let sessions_dir = sessions_dir_for_runtime_path(&runtime_path);
     let gwt_session_id = GwtSessionId::required_from_env(event)?;
     let session = current_session_for_id(&sessions_dir, &gwt_session_id)?;
     let agent_session_id = validated_hook_agent_session_id(
@@ -197,19 +198,16 @@ pub fn handle_with_input(event: &str, input: &str) -> Result<(), HookError> {
         sync_agent_session_id(&sessions_dir, &gwt_session_id, agent_session_id)?;
     }
 
-    let Some(path) = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV) else {
-        return Ok(());
-    };
-    let path = PathBuf::from(path);
-    write_for_event(&path, event)
+    let pending_discussion = session.as_ref().and_then(|session| {
+        pending_discussion_for_session(&sessions_dir, &session.id)
+            .ok()
+            .flatten()
+    });
+    write_for_event_with_pending_discussion(&runtime_path, event, pending_discussion)
 }
 
-fn sessions_dir_for_current_runtime() -> PathBuf {
-    let Some(runtime_path) = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV) else {
-        return gwt_core::paths::gwt_sessions_dir();
-    };
-    let runtime_path = PathBuf::from(runtime_path);
-    gwt_agent::sessions_dir_from_runtime_path(&runtime_path)
+fn sessions_dir_for_runtime_path(runtime_path: &Path) -> PathBuf {
+    gwt_agent::sessions_dir_from_runtime_path(runtime_path)
         .unwrap_or_else(gwt_core::paths::gwt_sessions_dir)
 }
 

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -210,6 +210,11 @@ pub enum FrontendEvent {
         #[serde(default)]
         mentions: Vec<gwt_core::coordination::BoardMention>,
     },
+    OpenBoardOriginAgent {
+        id: String,
+        origin_session_id: String,
+        bounds: Option<WindowGeometry>,
+    },
     SelectProfile {
         id: String,
         profile_name: String,
@@ -1262,6 +1267,33 @@ mod tests {
         assert_eq!(value["entries"][0]["mentions"][0]["target_kind"], "user");
         assert_eq!(value["entries"][0]["mentions"][0]["target"], "akiojin");
         assert_eq!(value["entries"][0]["mentions"][0]["label"], "Akio");
+    }
+
+    #[test]
+    fn open_board_origin_agent_deserializes_frontend_event_contract() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "open_board_origin_agent",
+            "id": "tab-1::board-1",
+            "origin_session_id": "session-origin",
+            "bounds": {
+                "x": 0.0,
+                "y": 0.0,
+                "width": 1200.0,
+                "height": 800.0
+            }
+        }))
+        .expect("deserialize open board origin agent event");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::OpenBoardOriginAgent {
+                id,
+                origin_session_id,
+                bounds,
+            } if id == "tab-1::board-1"
+                && origin_session_id == "session-origin"
+                && bounds.as_ref().is_some_and(|bounds| bounds.width == 1200.0)
+        ));
     }
 
     #[test]

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -5,6 +5,9 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import {
   applyBoardMentionNotificationFocus,
+  boardEntryOriginActionLabel,
+  boardEntryOriginLabel,
+  boardEntryOriginSessionId,
   boardEntryAudienceLabels,
   boardEntryMentionsSelf,
   entryVisibleForWorkspace,
@@ -46,6 +49,13 @@ test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /showBoardMentionNotification/);
   assert.match(appSource, /Jump to original/);
   assert.match(appSource, /state\.audienceFilter\s*=\s*"all"/);
+});
+
+test("Board surface exposes origin Agent focus and resume affordances", () => {
+  assert.match(appSource, /open_board_origin_agent/);
+  assert.match(appSource, /board-origin-badge/);
+  assert.match(appSource, /board-origin-button/);
+  assert.match(appSource, /visibleBounds\(\)/);
 });
 
 test("Board surface exposes a Workspace audience filter toggle (SPEC-2359 FR-101)", () => {
@@ -188,4 +198,29 @@ test("Board notification helper prepares focused state for click-through", () =>
   assert.equal(state.forYouUnread, 0);
   assert.equal(state.focusEntryId, "entry-target");
   assert.equal(state.pendingFocusScroll, true);
+});
+
+test("Board origin helpers label live focus versus exact resume actions", () => {
+  const entry = {
+    author_kind: "agent",
+    author: "Codex",
+    origin_agent_id: "Codex",
+    origin_branch: "work/20260511-0327",
+    origin_session_id: "12345678-90ab-cdef-1234-567890abcdef",
+  };
+  const liveAgents = [
+    {
+      session_id: "12345678-90ab-cdef-1234-567890abcdef",
+      window_id: "tab-1::agent-1",
+    },
+  ];
+
+  assert.equal(
+    boardEntryOriginSessionId(entry),
+    "12345678-90ab-cdef-1234-567890abcdef",
+  );
+  assert.match(boardEntryOriginLabel(entry), /^From Codex · work\/20260511-0327 · 12345678$/);
+  assert.equal(boardEntryOriginActionLabel(entry, liveAgents), "Focus Agent");
+  assert.equal(boardEntryOriginActionLabel(entry, []), "Resume Agent");
+  assert.equal(boardEntryOriginActionLabel({ author_kind: "user" }, liveAgents), "");
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -15,6 +15,9 @@
         applyBoardMentionNotificationFocus,
         boardEntryAudienceLabels,
         boardEntryMentionsSelf,
+        boardEntryOriginActionLabel,
+        boardEntryOriginLabel,
+        boardEntryOriginSessionId,
         boardEntryPreview,
         findBoardEntry,
         mentionsForBoardSubmit,
@@ -3040,6 +3043,29 @@
         });
       }
 
+      function boardOriginActiveAgents() {
+        const assigned = Array.isArray(activeWorkProjection?.agents)
+          ? activeWorkProjection.agents
+          : [];
+        const unassigned = Array.isArray(activeWorkProjection?.unassigned_agents)
+          ? activeWorkProjection.unassigned_agents
+          : [];
+        return assigned.concat(unassigned);
+      }
+
+      function openBoardOriginAgent(windowId, entry) {
+        const originSessionId = boardEntryOriginSessionId(entry);
+        if (!originSessionId) {
+          return;
+        }
+        send({
+          kind: "open_board_origin_agent",
+          id: windowId,
+          origin_session_id: originSessionId,
+          bounds: visibleBounds(),
+        });
+      }
+
       function logMatchesQuery(entry, query) {
         if (!query) {
           return true;
@@ -4004,6 +4030,10 @@
             }
             meta.appendChild(badge);
           }
+          const originLabel = boardEntryOriginLabel(entry);
+          if (originLabel) {
+            meta.appendChild(createNode("span", "board-origin-badge", originLabel));
+          }
           card.appendChild(meta);
           if (entry.parent_id) {
             const parent = findBoardEntry(state, entry.parent_id);
@@ -4029,6 +4059,16 @@
             input?.focus();
           });
           messageActions.appendChild(replyButton);
+          const originActionLabel = boardEntryOriginActionLabel(
+            entry,
+            boardOriginActiveAgents(),
+          );
+          if (originActionLabel) {
+            const originButton = createNode("button", "board-origin-button", originActionLabel);
+            originButton.type = "button";
+            originButton.addEventListener("click", () => openBoardOriginAgent(windowId, entry));
+            messageActions.appendChild(originButton);
+          }
           card.appendChild(messageActions);
           timeline.appendChild(card);
         }

--- a/crates/gwt/web/board-surface.js
+++ b/crates/gwt/web/board-surface.js
@@ -48,6 +48,31 @@ export function boardEntryAudienceLabels(entry, selfKeys = []) {
   return ["Broadcast"];
 }
 
+export function boardEntryOriginSessionId(entry) {
+  const authorKind = String(entry?.author_kind || "").toLowerCase();
+  const sessionId = String(entry?.origin_session_id || "").trim();
+  return authorKind === "agent" ? sessionId : "";
+}
+
+export function boardEntryOriginLabel(entry) {
+  const sessionId = boardEntryOriginSessionId(entry);
+  if (!sessionId) return "";
+  const agent = String(entry?.origin_agent_id || entry?.author || "").trim();
+  const branch = String(entry?.origin_branch || "").trim();
+  const shortSession = sessionId.slice(0, 8);
+  const parts = [agent, branch, shortSession].filter(Boolean);
+  return parts.length > 0 ? `From ${parts.join(" · ")}` : "";
+}
+
+export function boardEntryOriginActionLabel(entry, activeAgents = []) {
+  const sessionId = boardEntryOriginSessionId(entry);
+  if (!sessionId) return "";
+  const live = (activeAgents || []).some(
+    (agent) => String(agent?.session_id || "").trim() === sessionId && agent?.window_id,
+  );
+  return live ? "Focus Agent" : "Resume Agent";
+}
+
 export function boardEntryPreview(entry) {
   const body = String(entry?.body || "").replace(/\s+/g, " ").trim();
   if (!body) return "Empty entry";

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1672,6 +1672,20 @@
         background: color-mix(in oklab, var(--color-state-active) 18%, var(--color-surface-elevated));
       }
 
+      .board-origin-badge {
+        display: inline-flex;
+        align-items: center;
+        min-height: 18px;
+        padding: 2px 6px;
+        border: 1px solid color-mix(in oklab, var(--color-state-warning) 52%, var(--color-border));
+        border-radius: var(--radius-sm);
+        background: color-mix(in oklab, var(--color-state-warning) 12%, var(--color-surface));
+        color: var(--color-text);
+        font-family: var(--font-mono);
+        font-size: var(--type-2xs);
+        letter-spacing: var(--tracking-mono);
+      }
+
       .board-reply-quote {
         width: 100%;
         border: 1px solid var(--color-border);
@@ -1702,10 +1716,13 @@
 
       .board-message-actions {
         display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
         justify-content: flex-end;
       }
 
-      .board-reply-button {
+      .board-reply-button,
+      .board-origin-button {
         min-height: 26px;
         padding: 4px 8px;
         border: 1px solid var(--color-border);
@@ -1717,7 +1734,14 @@
         cursor: pointer;
       }
 
-      .board-reply-button:hover {
+      .board-origin-button {
+        border-color: color-mix(in oklab, var(--color-state-warning) 48%, var(--color-border));
+        color: var(--color-text);
+        background: color-mix(in oklab, var(--color-state-warning) 10%, var(--color-surface));
+      }
+
+      .board-reply-button:hover,
+      .board-origin-button:hover {
         color: var(--color-text);
         border-color: var(--color-focus-ring);
       }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5245,3 +5245,26 @@ audience が欠落していた。
    module-local lock を作らず crate-wide `env_test_lock` に寄せる。
 2. 単独 test green で満足せず、env mutation を伴う修正後は default parallelism の
    `cargo test -p gwt-core -p gwt` を必ず 1 回通す。
+
+## 2026-05-11 — Built-in AgentId を consumer 側の個別表で持たない
+
+### 事象
+
+develop 取り込み後、Board origin focus の `agent_option_matches_session` が `AgentId::OpenClaw`
+と `AgentId::Hermes` を網羅しておらず、`cargo test -p gwt-core -p gwt` が compile error で
+停止した。
+
+### 原因
+
+`gwt-agent` は built-in agent descriptor (`command`, `display_name`, `color` など) を持っているが、
+Board 側で `AgentId` variant ごとの `option.id` 対応表を別途 match していた。新しい built-in
+agent が追加されたとき、descriptor は更新されても Board 側の表が同期されなかった。
+
+### 再発防止策
+
+1. built-in `AgentId` の表示名・command・色・cache key は `AgentId` / descriptor API を使い、
+   consumer 側に variant 別の重複表を作らない。
+2. custom agent だけは `custom_agent.id` の互換判定が必要なので、built-in と custom の差分だけを
+   consumer 側に残す。
+3. 新規 AgentId 追加後は、Agent 起動だけでなく Board / Workspace / UI projection の resume 経路も
+   focused test で通す。


### PR DESCRIPTION
## Summary

- Board posts now show the source Agent identity and expose a Focus or Resume action so users can trace who posted each message.
- The backend resolves Board origin sessions to live Agent windows or exact saved resume sessions, avoiding ambiguous latest-session fallback.
- Hook runtime-state handling now snapshots the runtime path once per event so parallel tests and hooks do not race process-wide environment changes.

## Changes

- `crates/gwt/src/protocol.rs`: Adds the `open_board_origin_agent` frontend event contract.
- `crates/gwt/src/app_runtime/board.rs`: Validates Board windows, focuses live origin Agent windows, resumes exact saved sessions, and uses built-in Agent descriptors for resume option matching.
- `crates/gwt/src/app_runtime/mod.rs`: Adds Rust coverage for live focus, exact resume, missing-session errors, and new built-in Agent descriptors.
- `crates/gwt/web/board-surface.js`, `crates/gwt/web/app.js`, `crates/gwt/web/index.html`: Renders origin badges and wires Focus Agent / Resume Agent actions from Board entries.
- `crates/gwt/web/__tests__/board-surface.test.mjs`: Adds frontend coverage for origin labels and action routing.
- `crates/gwt/src/cli/hook/runtime_state.rs`: Avoids re-reading mutable runtime-path environment state during hook handling.
- `tasks/lessons.md`: Records the AgentId descriptor lesson from the latest develop merge.

## Testing

- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt board_origin_agent_resume_config -- --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `pnpm run test:frontend-bundle` — passed.
- [x] `pnpm run test:frontend-unit` — passed.
- [x] `pnpm exec commitlint --from origin/develop --to HEAD` — passed.

## Closing Issues

- Closes #2018

## Related Issues / Links

- #2018

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2018 and `tasks/lessons.md`)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (feature commit uses `feat:`)

## Context

- SPEC-2018 requested a Board workflow where users can identify the Agent that posted a message and focus that Agent directly from the Board post.
- The implementation intentionally resumes only the exact persisted origin session when the Agent is not live, so Board posts do not jump to an unrelated latest session.

## Risk / Impact

- **Affected areas**: Board surface rendering, frontend event routing, Agent window focus/resume flow, managed hook runtime-state handling.
- **Rollback plan**: Revert this PR; Board posts will return to display-only origin metadata without focus/resume actions.

## Screenshots

| Before | After |
|--------|-------|
| Not captured in this headless run. | Not captured in this headless run; frontend behavior is covered by `board-surface` unit tests. |
