### PR TITLE
chore(release): v9.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,67 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.26.0] - 2026-05-11
+
+### Bug Fixes
+
+- **update:** SPEC-2041 Phase 19 CodeRabbit review fixes (PR #2630)
+- **update:** SPEC-2041 Phase 19 follow-up review fixes (PRs #2631/#2634/#2635)
+- Surface launch wizard open errors
+- Scope launch wizard open errors to client
+- **board:** Preserve all-view live updates
+- **app-runtime:** Gate WorkspaceState broadcast on real title diff
+- Stabilize hook runtime path handling
+- Harden provider hook adapters
+- **tests:** Serialize HOME-mutating gwt tests
+- Support new built-in board origin agents
+
+### Documentation
+
+- **lessons:** SPEC-2041 Phase 14 silent-failure 5回連続見逃しの教訓を追加
+- **spec-2041:** SPEC-2041 Phase 19 Gate 3 manual smoke runbook
+
+### Features
+
+- **gui:** SPEC-2041 Phase 19 post-click modal state machine を実装
+- **gui:** SPEC-2041 Phase 19 backend split で silent failure を解消
+- **update:** SPEC-2041 Phase 19 download progress callback (T-128)
+- **update:** SPEC-2041 Phase 19 pending persistence + bootstrap swap + log writer
+- **update:** GWT_UPDATE_API_BASE_URL env override で Gate 2 mock smoke を可能に
+- **scripts:** SPEC-2041 Phase 19 Gate 2 mock update server
+- **update:** SPEC-2041 Phase 19 commit_update_later_pending を explicit named function に (FR-064)
+- **workspace:** Block duplicate active workspace edits
+- **workspace:** Add work item history
+- **coordination:** SPEC-2359 Phase 20 Board Workspace audience foundation
+- **workspace:** Add unassigned agent state
+- **coordination:** SPEC-2359 wire up Workspace audience auto-attach and mention fan-out
+- **gui:** SPEC-2359 Board pane Workspace audience filter toggle
+- Focus board origin agents
+- **board:** Scope board entries by workspace
+- **gui:** SPEC-2359 wire current project workspace id into Board filter
+- **app-runtime:** Canonical orchestration for agent title sync
+- OpenCode/OpenClaw/Hermes Agent の hook 対応を追加
+
+### Miscellaneous Tasks
+
+- Merge develop into board audience branch
+- Merge latest develop into board audience branch
+- Merge latest develop into board audience UI branch
+- Merge origin develop into board follow-up
+- Merge develop for board origin pr
+- Merge develop into provider hook parity branch
+- Merge latest develop for board origin pr
+
+### Testing
+
+- **gui:** SPEC-2041 Phase 19 post-click modal の RED テストを追加
+- **gui:** SPEC-2041 Phase 19 Playwright scaffold for modal flow (T-121)
+- **gui:** SPEC-2041 Phase 19 bootstrap decision + cleanup tests (T-127)
+- **update:** SPEC-2041 Phase 19 progress callback monotonic test (T-125)
+- **update:** SPEC-2041 Phase 19 path validation を pure fn に抽出 + 5 unit tests
+- **gui:** SPEC-2041 Phase 19 ready-state error handling test
+- **coordination:** Stabilize recent post history test
+
 ## [9.25.0] - 2026-05-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "axum",
  "base64",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.25.0"
+version = "9.26.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.25.0"
+version = "9.26.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-agent/src/detect.rs
+++ b/crates/gwt-agent/src/detect.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use tracing::debug;
 
-use crate::types::AgentId;
+use crate::types::{builtin_agent_descriptor_for_command, builtin_agent_descriptors, AgentId};
 
 /// Result of detecting a single agent on the system.
 #[derive(Debug, Clone)]
@@ -25,50 +25,15 @@ struct AgentProbe {
 
 /// All builtin agents we attempt to detect.
 fn builtin_probes() -> Vec<AgentProbe> {
-    vec![
-        AgentProbe {
-            id: AgentId::ClaudeCode,
-            command: "claude",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Codex,
-            command: "codex",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Gemini,
-            command: "gemini",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::OpenCode,
-            command: "opencode",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::OpenClaw,
-            command: "openclaw",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Hermes,
-            command: "hermes",
-            version_flag: "--version",
-            prefix_args: &[],
-        },
-        AgentProbe {
-            id: AgentId::Copilot,
-            command: "gh",
-            version_flag: "--version",
-            prefix_args: &["copilot"],
-        },
-    ]
+    builtin_agent_descriptors()
+        .iter()
+        .map(|descriptor| AgentProbe {
+            id: descriptor.id.clone(),
+            command: descriptor.command,
+            version_flag: descriptor.version_flag,
+            prefix_args: descriptor.version_prefix_args,
+        })
+        .collect()
 }
 
 /// Detects installed coding agents.
@@ -89,18 +54,19 @@ impl AgentDetector {
     /// Detect a single agent by its command name.
     pub fn detect_by_command(command: &str) -> Option<DetectedAgent> {
         let path = which::which(command).ok()?;
-        let version = Self::fetch_version(command, "--version", &[]);
-        // Map known commands to AgentIds, fall back to Custom
-        let agent_id = match command {
-            "claude" => AgentId::ClaudeCode,
-            "codex" => AgentId::Codex,
-            "gemini" => AgentId::Gemini,
-            "opencode" => AgentId::OpenCode,
-            "openclaw" => AgentId::OpenClaw,
-            "hermes" => AgentId::Hermes,
-            "gh" => AgentId::Copilot,
-            other => AgentId::Custom(other.to_string()),
+        let descriptor = builtin_agent_descriptor_for_command(command);
+        let version = match descriptor {
+            Some(descriptor) => Self::fetch_version(
+                command,
+                descriptor.version_flag,
+                descriptor.version_prefix_args,
+            ),
+            None => Self::fetch_version(command, "--version", &[]),
         };
+        // Map known commands to AgentIds, fall back to Custom
+        let agent_id = descriptor
+            .map(|descriptor| descriptor.id.clone())
+            .unwrap_or_else(|| AgentId::Custom(command.to_string()));
         Some(DetectedAgent {
             agent_id,
             version,

--- a/crates/gwt-agent/src/detect.rs
+++ b/crates/gwt-agent/src/detect.rs
@@ -51,6 +51,18 @@ fn builtin_probes() -> Vec<AgentProbe> {
             prefix_args: &[],
         },
         AgentProbe {
+            id: AgentId::OpenClaw,
+            command: "openclaw",
+            version_flag: "--version",
+            prefix_args: &[],
+        },
+        AgentProbe {
+            id: AgentId::Hermes,
+            command: "hermes",
+            version_flag: "--version",
+            prefix_args: &[],
+        },
+        AgentProbe {
             id: AgentId::Copilot,
             command: "gh",
             version_flag: "--version",
@@ -84,6 +96,8 @@ impl AgentDetector {
             "codex" => AgentId::Codex,
             "gemini" => AgentId::Gemini,
             "opencode" => AgentId::OpenCode,
+            "openclaw" => AgentId::OpenClaw,
+            "hermes" => AgentId::Hermes,
             "gh" => AgentId::Copilot,
             other => AgentId::Custom(other.to_string()),
         };
@@ -159,12 +173,14 @@ mod tests {
     #[test]
     fn builtin_probes_cover_all_variants() {
         let probes = builtin_probes();
-        assert_eq!(probes.len(), 5);
+        assert_eq!(probes.len(), 7);
         let ids: Vec<_> = probes.iter().map(|p| &p.id).collect();
         assert!(ids.contains(&&AgentId::ClaudeCode));
         assert!(ids.contains(&&AgentId::Codex));
         assert!(ids.contains(&&AgentId::Gemini));
         assert!(ids.contains(&&AgentId::OpenCode));
+        assert!(ids.contains(&&AgentId::OpenClaw));
+        assert!(ids.contains(&&AgentId::Hermes));
         assert!(ids.contains(&&AgentId::Copilot));
     }
 

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -100,6 +100,8 @@ pub fn canonical_launch_args(agent: &AgentId) -> Vec<String> {
         AgentId::ClaudeCode
         | AgentId::Gemini
         | AgentId::OpenCode
+        | AgentId::OpenClaw
+        | AgentId::Hermes
         | AgentId::Copilot
         | AgentId::Custom(_) => Vec::new(),
     }
@@ -493,7 +495,13 @@ impl AgentLaunchBuilder {
                 self.build_gemini_args(&mut args);
             }
             AgentId::OpenCode => {
-                self.build_opencode_args(&mut args);
+                self.build_opencode_args(&mut args, &mut env_vars);
+            }
+            AgentId::OpenClaw => {
+                self.build_openclaw_args(&mut args, &mut env_vars);
+            }
+            AgentId::Hermes => {
+                self.build_hermes_args(&mut args, &mut env_vars);
             }
             AgentId::Copilot => {
                 self.build_copilot_args(&mut args);
@@ -720,8 +728,92 @@ impl AgentLaunchBuilder {
         }
     }
 
-    fn build_opencode_args(&self, _args: &mut Vec<String>) {
-        // OpenCode has minimal CLI flags
+    fn build_opencode_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
+        if let Some(ref dir) = self.working_dir {
+            env_vars.insert(
+                "OPENCODE_CONFIG_DIR".to_string(),
+                dir.join(".gwt/opencode").to_string_lossy().into_owned(),
+            );
+        }
+        match self.session_mode {
+            SessionMode::Continue => args.push("--continue".to_string()),
+            SessionMode::Resume => {
+                if let Some(ref id) = self.resume_session_id {
+                    args.push("--session".to_string());
+                    args.push(id.clone());
+                } else {
+                    args.push("--continue".to_string());
+                }
+            }
+            SessionMode::Normal => {}
+        }
+        if let Some(ref model) = self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+    }
+
+    fn build_openclaw_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
+        args.push("tui".to_string());
+        args.push("--local".to_string());
+        if let Some(ref dir) = self.working_dir {
+            env_vars.insert(
+                "OPENCLAW_CONFIG_PATH".to_string(),
+                dir.join(".gwt/openclaw/openclaw.json")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+            env_vars.insert(
+                "OPENCLAW_INCLUDE_ROOTS".to_string(),
+                dir.join(".gwt/openclaw").to_string_lossy().into_owned(),
+            );
+        }
+        match self.session_mode {
+            SessionMode::Continue => {}
+            SessionMode::Resume => {
+                if let Some(ref id) = self.resume_session_id {
+                    args.push("--session".to_string());
+                    args.push(id.clone());
+                }
+            }
+            SessionMode::Normal => {}
+        }
+        if let Some(ref level) = self.reasoning_level {
+            if level != "auto" {
+                args.push("--thinking".to_string());
+                args.push(level.clone());
+            }
+        }
+    }
+
+    fn build_hermes_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
+        args.push("chat".to_string());
+        args.push("--accept-hooks".to_string());
+        args.push("--pass-session-id".to_string());
+        if let Some(ref dir) = self.working_dir {
+            env_vars.insert(
+                "HERMES_HOME".to_string(),
+                dir.join(".gwt/hermes").to_string_lossy().into_owned(),
+            );
+        }
+        env_vars.insert("HERMES_ACCEPT_HOOKS".to_string(), "1".to_string());
+        match self.session_mode {
+            SessionMode::Continue => args.push("--continue".to_string()),
+            SessionMode::Resume => {
+                args.push("--resume".to_string());
+                if let Some(ref id) = self.resume_session_id {
+                    args.push(id.clone());
+                }
+            }
+            SessionMode::Normal => {}
+        }
+        if let Some(ref model) = self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+        if self.skip_permissions {
+            args.push("--yolo".to_string());
+        }
     }
 
     fn build_copilot_args(&self, args: &mut Vec<String>) {
@@ -763,6 +855,8 @@ mod tests {
         assert!(canonical_launch_args(&AgentId::ClaudeCode).is_empty());
         assert!(canonical_launch_args(&AgentId::Gemini).is_empty());
         assert!(canonical_launch_args(&AgentId::OpenCode).is_empty());
+        assert!(canonical_launch_args(&AgentId::OpenClaw).is_empty());
+        assert!(canonical_launch_args(&AgentId::Hermes).is_empty());
         assert!(canonical_launch_args(&AgentId::Copilot).is_empty());
         assert!(canonical_launch_args(&AgentId::Custom("aider".into())).is_empty());
     }
@@ -1099,6 +1193,8 @@ mod tests {
             AgentId::ClaudeCode,
             AgentId::Gemini,
             AgentId::OpenCode,
+            AgentId::OpenClaw,
+            AgentId::Hermes,
             AgentId::Copilot,
             AgentId::Custom("custom".into()),
         ] {
@@ -1304,6 +1400,81 @@ mod tests {
         let runner = resolve_runner(&AgentId::OpenCode, "latest");
         assert_eq!(runner.executable, "opencode");
         assert!(runner.base_args.is_empty());
+    }
+
+    #[test]
+    fn build_opencode_sets_model_and_project_config_dir() {
+        let config = AgentLaunchBuilder::new(AgentId::OpenCode)
+            .working_dir("/tmp/project")
+            .model("anthropic/claude-sonnet-4-5")
+            .build();
+
+        assert_eq!(config.command, "opencode");
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--model" && pair[1] == "anthropic/claude-sonnet-4-5"));
+        assert_eq!(
+            config.env_vars.get("OPENCODE_CONFIG_DIR"),
+            Some(&"/tmp/project/.gwt/opencode".to_string())
+        );
+    }
+
+    #[test]
+    fn build_openclaw_uses_local_tui_and_gwt_config_path() {
+        let config = AgentLaunchBuilder::new(AgentId::OpenClaw)
+            .working_dir("/tmp/project")
+            .reasoning_level("high")
+            .session_mode(SessionMode::Resume)
+            .resume_session_id("session-123")
+            .build();
+
+        assert_eq!(config.command, "openclaw");
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "tui" && pair[1] == "--local"));
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--session" && pair[1] == "session-123"));
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--thinking" && pair[1] == "high"));
+        assert_eq!(
+            config.env_vars.get("OPENCLAW_CONFIG_PATH"),
+            Some(&"/tmp/project/.gwt/openclaw/openclaw.json".to_string())
+        );
+    }
+
+    #[test]
+    fn build_hermes_accepts_hooks_and_maps_launch_controls() {
+        let config = AgentLaunchBuilder::new(AgentId::Hermes)
+            .working_dir("/tmp/project")
+            .model("openrouter/anthropic/claude-sonnet-4")
+            .skip_permissions(true)
+            .session_mode(SessionMode::Continue)
+            .build();
+
+        assert_eq!(config.command, "hermes");
+        assert!(config.args.contains(&"chat".to_string()));
+        assert!(config.args.contains(&"--accept-hooks".to_string()));
+        assert!(config.args.contains(&"--pass-session-id".to_string()));
+        assert!(config.args.contains(&"--continue".to_string()));
+        assert!(config.args.contains(&"--yolo".to_string()));
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--model" && pair[1] == "openrouter/anthropic/claude-sonnet-4"));
+        assert_eq!(
+            config.env_vars.get("HERMES_HOME"),
+            Some(&"/tmp/project/.gwt/hermes".to_string())
+        );
+        assert_eq!(
+            config.env_vars.get("HERMES_ACCEPT_HOOKS"),
+            Some(&"1".to_string())
+        );
     }
 
     #[cfg(windows)]

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -51,7 +51,8 @@ pub use store::{
     save_stored_custom_agents_to_path, StoredCustomAgent, DISABLE_GLOBAL_CUSTOM_AGENTS_ENV,
 };
 pub use types::{
-    resolve_agent_id, AgentColor, AgentId, AgentInfo, AgentStatus, DockerLifecycleIntent,
+    builtin_agent_descriptor_for_command, builtin_agent_descriptors, resolve_agent_id, AgentColor,
+    AgentId, AgentInfo, AgentStatus, BuiltinAgentDescriptor, DockerLifecycleIntent,
     LaunchRuntimeTarget, SessionMode, WindowsShellKind, WorkflowBypass,
 };
 pub use version_cache::{build_version_options, VersionCache, VersionOption};

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -10,6 +10,8 @@ pub enum AgentId {
     Codex,
     Gemini,
     OpenCode,
+    OpenClaw,
+    Hermes,
     Copilot,
     Custom(String),
 }
@@ -22,6 +24,8 @@ impl AgentId {
             Self::Codex => "codex",
             Self::Gemini => "gemini",
             Self::OpenCode => "opencode",
+            Self::OpenClaw => "openclaw",
+            Self::Hermes => "hermes",
             Self::Copilot => "gh",
             Self::Custom(name) => name,
         }
@@ -34,6 +38,8 @@ impl AgentId {
             Self::Codex => "Codex",
             Self::Gemini => "Gemini CLI",
             Self::OpenCode => "OpenCode",
+            Self::OpenClaw => "OpenClaw",
+            Self::Hermes => "Hermes Agent",
             Self::Copilot => "GitHub Copilot",
             Self::Custom(name) => name,
         }
@@ -46,6 +52,8 @@ impl AgentId {
             Self::Codex => Some("@openai/codex"),
             Self::Gemini => Some("@anthropic-ai/gemini-cli"),
             Self::OpenCode => None,
+            Self::OpenClaw => None,
+            Self::Hermes => None,
             Self::Copilot => None,
             Self::Custom(_) => None,
         }
@@ -58,6 +66,8 @@ impl AgentId {
             Self::Codex => AgentColor::Cyan,
             Self::Gemini => AgentColor::Magenta,
             Self::OpenCode => AgentColor::Green,
+            Self::OpenClaw => AgentColor::Blue,
+            Self::Hermes => AgentColor::Magenta,
             Self::Copilot => AgentColor::Blue,
             Self::Custom(_) => AgentColor::Gray,
         }
@@ -90,6 +100,8 @@ pub fn resolve_agent_id(raw: &str) -> Option<AgentId> {
         "codex" => Some(AgentId::Codex),
         "gemini" | "gemini cli" | "gemini-cli" => Some(AgentId::Gemini),
         "opencode" | "open-code" => Some(AgentId::OpenCode),
+        "openclaw" | "open-claw" => Some(AgentId::OpenClaw),
+        "hermes" | "hermes agent" | "hermes-agent" => Some(AgentId::Hermes),
         "gh" | "copilot" | "github copilot" | "github-copilot" => Some(AgentId::Copilot),
         _ => Some(AgentId::Custom(trimmed.to_string())),
     }
@@ -209,6 +221,8 @@ mod tests {
         assert_eq!(AgentId::Codex.command(), "codex");
         assert_eq!(AgentId::Gemini.command(), "gemini");
         assert_eq!(AgentId::OpenCode.command(), "opencode");
+        assert_eq!(AgentId::OpenClaw.command(), "openclaw");
+        assert_eq!(AgentId::Hermes.command(), "hermes");
         assert_eq!(AgentId::Copilot.command(), "gh");
         assert_eq!(AgentId::Custom("aider".into()).command(), "aider");
     }
@@ -216,6 +230,9 @@ mod tests {
     #[test]
     fn agent_id_display_name_returns_expected() {
         assert_eq!(AgentId::ClaudeCode.display_name(), "Claude Code");
+        assert_eq!(AgentId::OpenCode.display_name(), "OpenCode");
+        assert_eq!(AgentId::OpenClaw.display_name(), "OpenClaw");
+        assert_eq!(AgentId::Hermes.display_name(), "Hermes Agent");
         assert_eq!(AgentId::Copilot.display_name(), "GitHub Copilot");
         assert_eq!(AgentId::Custom("aider".into()).display_name(), "aider");
     }
@@ -227,6 +244,8 @@ mod tests {
             Some("@anthropic-ai/claude-code")
         );
         assert_eq!(AgentId::OpenCode.package_name(), None);
+        assert_eq!(AgentId::OpenClaw.package_name(), None);
+        assert_eq!(AgentId::Hermes.package_name(), None);
         assert_eq!(AgentId::Custom("x".into()).package_name(), None);
     }
 
@@ -235,6 +254,9 @@ mod tests {
         assert_eq!(AgentId::ClaudeCode.default_color(), AgentColor::Yellow);
         assert_eq!(AgentId::Codex.default_color(), AgentColor::Cyan);
         assert_eq!(AgentId::Gemini.default_color(), AgentColor::Magenta);
+        assert_eq!(AgentId::OpenCode.default_color(), AgentColor::Green);
+        assert_eq!(AgentId::OpenClaw.default_color(), AgentColor::Blue);
+        assert_eq!(AgentId::Hermes.default_color(), AgentColor::Magenta);
         assert_eq!(
             AgentId::Custom("x".into()).default_color(),
             AgentColor::Gray
@@ -295,6 +317,12 @@ mod tests {
         assert_eq!(resolve_agent_id("opencode"), Some(AgentId::OpenCode));
         assert_eq!(resolve_agent_id("OpenCode"), Some(AgentId::OpenCode));
         assert_eq!(resolve_agent_id("open-code"), Some(AgentId::OpenCode));
+        assert_eq!(resolve_agent_id("openclaw"), Some(AgentId::OpenClaw));
+        assert_eq!(resolve_agent_id("OpenClaw"), Some(AgentId::OpenClaw));
+        assert_eq!(resolve_agent_id("open-claw"), Some(AgentId::OpenClaw));
+        assert_eq!(resolve_agent_id("hermes"), Some(AgentId::Hermes));
+        assert_eq!(resolve_agent_id("Hermes Agent"), Some(AgentId::Hermes));
+        assert_eq!(resolve_agent_id("hermes-agent"), Some(AgentId::Hermes));
         assert_eq!(resolve_agent_id("gh"), Some(AgentId::Copilot));
         assert_eq!(resolve_agent_id("copilot"), Some(AgentId::Copilot));
         assert_eq!(resolve_agent_id("GitHub Copilot"), Some(AgentId::Copilot));
@@ -331,6 +359,8 @@ mod tests {
             "codex-wrapper",
             "gemini-helper",
             "opencode-mentor",
+            "openclaw-mentor",
+            "hermes-helper",
             "copilot-mentor",
             "github-copilot-wrapper",
         ];
@@ -351,6 +381,8 @@ mod tests {
             ("codex", AgentColor::Cyan),
             ("gemini", AgentColor::Magenta),
             ("opencode", AgentColor::Green),
+            ("openclaw", AgentColor::Blue),
+            ("hermes", AgentColor::Magenta),
             ("gh", AgentColor::Blue),
             ("my-custom", AgentColor::Gray),
         ];
@@ -367,6 +399,11 @@ mod tests {
         let ids = vec![
             AgentId::ClaudeCode,
             AgentId::Codex,
+            AgentId::Gemini,
+            AgentId::OpenCode,
+            AgentId::OpenClaw,
+            AgentId::Hermes,
+            AgentId::Copilot,
             AgentId::Custom("test".into()),
         ];
         for id in ids {

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -19,58 +19,41 @@ pub enum AgentId {
 impl AgentId {
     /// Canonical command name used to invoke this agent.
     pub fn command(&self) -> &str {
-        match self {
-            Self::ClaudeCode => "claude",
-            Self::Codex => "codex",
-            Self::Gemini => "gemini",
-            Self::OpenCode => "opencode",
-            Self::OpenClaw => "openclaw",
-            Self::Hermes => "hermes",
-            Self::Copilot => "gh",
-            Self::Custom(name) => name,
-        }
+        self.builtin_descriptor()
+            .map(|descriptor| descriptor.command)
+            .unwrap_or_else(|| match self {
+                Self::Custom(name) => name,
+                _ => unreachable!("all non-custom agents must have descriptors"),
+            })
     }
 
     /// Human-readable display name.
     pub fn display_name(&self) -> &str {
-        match self {
-            Self::ClaudeCode => "Claude Code",
-            Self::Codex => "Codex",
-            Self::Gemini => "Gemini CLI",
-            Self::OpenCode => "OpenCode",
-            Self::OpenClaw => "OpenClaw",
-            Self::Hermes => "Hermes Agent",
-            Self::Copilot => "GitHub Copilot",
-            Self::Custom(name) => name,
-        }
+        self.builtin_descriptor()
+            .map(|descriptor| descriptor.display_name)
+            .unwrap_or_else(|| match self {
+                Self::Custom(name) => name,
+                _ => unreachable!("all non-custom agents must have descriptors"),
+            })
     }
 
     /// npm package name (if distributed via npm).
     pub fn package_name(&self) -> Option<&str> {
-        match self {
-            Self::ClaudeCode => Some("@anthropic-ai/claude-code"),
-            Self::Codex => Some("@openai/codex"),
-            Self::Gemini => Some("@anthropic-ai/gemini-cli"),
-            Self::OpenCode => None,
-            Self::OpenClaw => None,
-            Self::Hermes => None,
-            Self::Copilot => None,
-            Self::Custom(_) => None,
-        }
+        self.builtin_descriptor()
+            .and_then(|descriptor| descriptor.package_name)
     }
 
     /// Default UI color for this agent.
     pub fn default_color(&self) -> AgentColor {
-        match self {
-            Self::ClaudeCode => AgentColor::Yellow,
-            Self::Codex => AgentColor::Cyan,
-            Self::Gemini => AgentColor::Magenta,
-            Self::OpenCode => AgentColor::Green,
-            Self::OpenClaw => AgentColor::Blue,
-            Self::Hermes => AgentColor::Magenta,
-            Self::Copilot => AgentColor::Blue,
-            Self::Custom(_) => AgentColor::Gray,
-        }
+        self.builtin_descriptor()
+            .map(|descriptor| descriptor.color)
+            .unwrap_or(AgentColor::Gray)
+    }
+
+    pub fn builtin_descriptor(&self) -> Option<&'static BuiltinAgentDescriptor> {
+        builtin_agent_descriptors()
+            .iter()
+            .find(|descriptor| descriptor.id == *self)
     }
 }
 
@@ -78,6 +61,116 @@ impl std::fmt::Display for AgentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_name())
     }
+}
+
+/// Metadata for a built-in coding agent.
+///
+/// Keep agent identity, presentation, detection, and cache keys in this
+/// descriptor so new built-ins do not require synchronized table edits across
+/// every consumer.
+#[derive(Debug, Clone)]
+pub struct BuiltinAgentDescriptor {
+    pub id: AgentId,
+    pub command: &'static str,
+    pub display_name: &'static str,
+    pub package_name: Option<&'static str>,
+    pub color: AgentColor,
+    pub aliases: &'static [&'static str],
+    pub cache_key: &'static str,
+    pub version_flag: &'static str,
+    pub version_prefix_args: &'static [&'static str],
+}
+
+const BUILTIN_AGENT_DESCRIPTORS: &[BuiltinAgentDescriptor] = &[
+    BuiltinAgentDescriptor {
+        id: AgentId::ClaudeCode,
+        command: "claude",
+        display_name: "Claude Code",
+        package_name: Some("@anthropic-ai/claude-code"),
+        color: AgentColor::Yellow,
+        aliases: &["claude", "claudecode", "claude-code", "claude code"],
+        cache_key: "claude-code",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Codex,
+        command: "codex",
+        display_name: "Codex",
+        package_name: Some("@openai/codex"),
+        color: AgentColor::Cyan,
+        aliases: &["codex"],
+        cache_key: "codex",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Gemini,
+        command: "gemini",
+        display_name: "Gemini CLI",
+        package_name: Some("@anthropic-ai/gemini-cli"),
+        color: AgentColor::Magenta,
+        aliases: &["gemini", "gemini cli", "gemini-cli"],
+        cache_key: "gemini",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::OpenCode,
+        command: "opencode",
+        display_name: "OpenCode",
+        package_name: None,
+        color: AgentColor::Green,
+        aliases: &["opencode", "open-code"],
+        cache_key: "opencode",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::OpenClaw,
+        command: "openclaw",
+        display_name: "OpenClaw",
+        package_name: None,
+        color: AgentColor::Blue,
+        aliases: &["openclaw", "open-claw"],
+        cache_key: "openclaw",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Hermes,
+        command: "hermes",
+        display_name: "Hermes Agent",
+        package_name: None,
+        color: AgentColor::Magenta,
+        aliases: &["hermes", "hermes agent", "hermes-agent"],
+        cache_key: "hermes",
+        version_flag: "--version",
+        version_prefix_args: &[],
+    },
+    BuiltinAgentDescriptor {
+        id: AgentId::Copilot,
+        command: "gh",
+        display_name: "GitHub Copilot",
+        package_name: None,
+        color: AgentColor::Blue,
+        aliases: &["gh", "copilot", "github copilot", "github-copilot"],
+        cache_key: "copilot",
+        version_flag: "--version",
+        version_prefix_args: &["copilot"],
+    },
+];
+
+pub fn builtin_agent_descriptors() -> &'static [BuiltinAgentDescriptor] {
+    BUILTIN_AGENT_DESCRIPTORS
+}
+
+pub fn builtin_agent_descriptor_for_command(
+    command: &str,
+) -> Option<&'static BuiltinAgentDescriptor> {
+    builtin_agent_descriptors()
+        .iter()
+        .find(|descriptor| descriptor.command == command)
 }
 
 /// Normalize a raw agent identifier string (command name, display name, or
@@ -95,15 +188,14 @@ pub fn resolve_agent_id(raw: &str) -> Option<AgentId> {
         return None;
     }
     let lower = trimmed.to_ascii_lowercase();
-    match lower.as_str() {
-        "claude" | "claudecode" | "claude-code" | "claude code" => Some(AgentId::ClaudeCode),
-        "codex" => Some(AgentId::Codex),
-        "gemini" | "gemini cli" | "gemini-cli" => Some(AgentId::Gemini),
-        "opencode" | "open-code" => Some(AgentId::OpenCode),
-        "openclaw" | "open-claw" => Some(AgentId::OpenClaw),
-        "hermes" | "hermes agent" | "hermes-agent" => Some(AgentId::Hermes),
-        "gh" | "copilot" | "github copilot" | "github-copilot" => Some(AgentId::Copilot),
-        _ => Some(AgentId::Custom(trimmed.to_string())),
+    if let Some(descriptor) = builtin_agent_descriptors().iter().find(|descriptor| {
+        descriptor.aliases.iter().any(|alias| *alias == lower)
+            || descriptor.command == lower
+            || descriptor.display_name.eq_ignore_ascii_case(trimmed)
+    }) {
+        Some(descriptor.id.clone())
+    } else {
+        Some(AgentId::Custom(trimmed.to_string()))
     }
 }
 
@@ -270,6 +362,30 @@ mod tests {
         assert_eq!(info.command, "claude");
         assert_eq!(info.color, AgentColor::Yellow);
         assert_eq!(info.package_name, Some("@anthropic-ai/claude-code".into()));
+    }
+
+    #[test]
+    fn builtin_agent_descriptors_drive_agent_info_contract() {
+        let descriptors = builtin_agent_descriptors();
+        assert_eq!(descriptors.len(), 7);
+
+        for descriptor in descriptors {
+            let info = AgentInfo::from_id(descriptor.id.clone());
+            assert_eq!(info.command, descriptor.command, "{:?}", descriptor.id);
+            assert_eq!(
+                info.display_name, descriptor.display_name,
+                "{:?}",
+                descriptor.id
+            );
+            assert_eq!(info.package_name.as_deref(), descriptor.package_name);
+            assert_eq!(info.color, descriptor.color);
+            assert_eq!(
+                resolve_agent_id(descriptor.command),
+                Some(descriptor.id.clone()),
+                "{} must resolve through the same descriptor registry",
+                descriptor.command
+            );
+        }
     }
 
     #[test]

--- a/crates/gwt-agent/src/version_cache.rs
+++ b/crates/gwt-agent/src/version_cache.rs
@@ -222,6 +222,8 @@ impl VersionCache {
             AgentId::Codex => "codex".to_string(),
             AgentId::Gemini => "gemini".to_string(),
             AgentId::OpenCode => "opencode".to_string(),
+            AgentId::OpenClaw => "openclaw".to_string(),
+            AgentId::Hermes => "hermes".to_string(),
             AgentId::Copilot => "copilot".to_string(),
             AgentId::Custom(name) => format!("custom-{name}"),
         }
@@ -393,6 +395,11 @@ mod tests {
     fn agent_key_mapping() {
         assert_eq!(VersionCache::agent_key(&AgentId::ClaudeCode), "claude-code");
         assert_eq!(VersionCache::agent_key(&AgentId::Codex), "codex");
+        assert_eq!(VersionCache::agent_key(&AgentId::Gemini), "gemini");
+        assert_eq!(VersionCache::agent_key(&AgentId::OpenCode), "opencode");
+        assert_eq!(VersionCache::agent_key(&AgentId::OpenClaw), "openclaw");
+        assert_eq!(VersionCache::agent_key(&AgentId::Hermes), "hermes");
+        assert_eq!(VersionCache::agent_key(&AgentId::Copilot), "copilot");
         assert_eq!(
             VersionCache::agent_key(&AgentId::Custom("aider".into())),
             "custom-aider"

--- a/crates/gwt-agent/src/version_cache.rs
+++ b/crates/gwt-agent/src/version_cache.rs
@@ -217,15 +217,13 @@ impl VersionCache {
     }
 
     fn agent_key(agent_id: &AgentId) -> String {
-        match agent_id {
-            AgentId::ClaudeCode => "claude-code".to_string(),
-            AgentId::Codex => "codex".to_string(),
-            AgentId::Gemini => "gemini".to_string(),
-            AgentId::OpenCode => "opencode".to_string(),
-            AgentId::OpenClaw => "openclaw".to_string(),
-            AgentId::Hermes => "hermes".to_string(),
-            AgentId::Copilot => "copilot".to_string(),
-            AgentId::Custom(name) => format!("custom-{name}"),
+        if let Some(descriptor) = agent_id.builtin_descriptor() {
+            descriptor.cache_key.to_string()
+        } else {
+            match agent_id {
+                AgentId::Custom(name) => format!("custom-{name}"),
+                _ => unreachable!("all non-custom agents must have descriptors"),
+            }
         }
     }
 

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -192,6 +192,21 @@ pub fn normalize_board_mentions(values: &[BoardMention]) -> Vec<BoardMention> {
     normalized
 }
 
+/// SPEC-2359 FR-098/099/100: shared audience predicate for reminder
+/// injection, workflow-policy duplicate-work coordination gate, CLI Board
+/// view, and GUI Board pane. An entry is visible from Workspace `W` when
+/// its `audience` is empty (broadcast) or contains `W`. An Unassigned
+/// Agent (`current_workspace_id = None`) only sees broadcast entries.
+pub fn entry_visible_for_workspace(entry: &BoardEntry, current_workspace_id: Option<&str>) -> bool {
+    if entry.audience.is_empty() {
+        return true;
+    }
+    match current_workspace_id {
+        Some(id) => entry.audience.iter().any(|workspace| workspace == id),
+        None => false,
+    }
+}
+
 pub fn board_entry_targets_self(entry: &BoardEntry, match_keys: &[String]) -> bool {
     entry
         .target_owners
@@ -232,6 +247,8 @@ pub struct BoardEntry {
     pub target_owners: Vec<String>,
     #[serde(default)]
     pub mentions: Vec<BoardMention>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub audience: Vec<String>,
 }
 
 impl BoardEntry {
@@ -276,6 +293,19 @@ impl BoardEntry {
         self
     }
 
+    pub fn with_audience(mut self, values: Vec<String>) -> Self {
+        self.audience = normalize_audience(values);
+        self
+    }
+
+    pub fn with_audience_workspace(mut self, value: impl Into<String>) -> Self {
+        let trimmed = value.into().trim().to_string();
+        if !trimmed.is_empty() && !self.audience.iter().any(|existing| existing == &trimmed) {
+            self.audience.push(trimmed);
+        }
+        self
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         author_kind: AuthorKind,
@@ -306,8 +336,24 @@ impl BoardEntry {
             origin_agent_id: None,
             target_owners: Vec::new(),
             mentions: Vec::new(),
+            audience: Vec::new(),
         }
     }
+}
+
+pub fn normalize_audience(values: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for value in values {
+        let trimmed = value.trim().to_string();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if out.iter().any(|existing| existing == &trimmed) {
+            continue;
+        }
+        out.push(trimmed);
+    }
+    out
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1489,6 +1535,143 @@ mod tests {
         assert_eq!(normalized[0].label.as_deref(), Some("Akio"));
         assert_eq!(normalized[1].typed_key(), "agent:codex");
         assert_eq!(normalized[1].label, None);
+    }
+
+    #[test]
+    fn entry_visible_for_workspace_broadcast_audience_is_visible_from_anywhere() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "broadcast",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+
+        assert!(entry_visible_for_workspace(&entry, Some("ws-1")));
+        assert!(entry_visible_for_workspace(&entry, None));
+    }
+
+    #[test]
+    fn entry_visible_for_workspace_matches_only_listed_audience() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "scoped",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(vec!["ws-1".into(), "ws-2".into()]);
+
+        assert!(entry_visible_for_workspace(&entry, Some("ws-1")));
+        assert!(entry_visible_for_workspace(&entry, Some("ws-2")));
+        assert!(!entry_visible_for_workspace(&entry, Some("ws-3")));
+    }
+
+    #[test]
+    fn entry_visible_for_workspace_unassigned_excludes_non_broadcast() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "scoped to ws-1",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(vec!["ws-1".into()]);
+
+        assert!(!entry_visible_for_workspace(&entry, None));
+    }
+
+    #[test]
+    fn board_entry_audience_default_empty_and_legacy_compatible() {
+        let legacy = serde_json::json!({
+            "id": "entry-1",
+            "author_kind": "agent",
+            "author": "Codex",
+            "kind": "status",
+            "body": "legacy entry without audience",
+            "created_at": "2026-05-07T00:00:00Z",
+            "updated_at": "2026-05-07T00:00:00Z"
+        });
+
+        let entry: BoardEntry = serde_json::from_value(legacy).unwrap();
+
+        assert!(entry.audience.is_empty());
+    }
+
+    #[test]
+    fn board_entry_round_trips_audience_workspace_ids() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "audienced status",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(vec!["ws-1".into(), "ws-2".into()]);
+
+        let encoded = serde_json::to_value(&entry).unwrap();
+
+        assert_eq!(encoded["audience"][0], "ws-1");
+        assert_eq!(encoded["audience"][1], "ws-2");
+
+        let decoded: BoardEntry = serde_json::from_value(encoded).unwrap();
+        assert_eq!(
+            decoded.audience,
+            vec!["ws-1".to_string(), "ws-2".to_string()]
+        );
+    }
+
+    #[test]
+    fn board_entry_empty_audience_is_skipped_during_serialization() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "broadcast entry",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+
+        let encoded = serde_json::to_value(&entry).unwrap();
+
+        assert!(
+            !encoded.as_object().unwrap().contains_key("audience"),
+            "empty audience must be omitted to round-trip as absent (FR-093): {encoded}"
+        );
+    }
+
+    #[test]
+    fn board_entry_with_audience_workspace_appends_dedup_and_trims() {
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "fan-out target",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience_workspace("  ws-a  ")
+        .with_audience_workspace("ws-a")
+        .with_audience_workspace("ws-b")
+        .with_audience_workspace("   ");
+
+        assert_eq!(entry.audience, vec!["ws-a".to_string(), "ws-b".to_string()]);
     }
 
     #[test]

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -90,6 +90,7 @@ pub enum BoardMentionTargetKind {
     Agent,
     Session,
     Branch,
+    Workspace,
 }
 
 impl std::str::FromStr for BoardMentionTargetKind {
@@ -101,6 +102,7 @@ impl std::str::FromStr for BoardMentionTargetKind {
             "agent" => Ok(Self::Agent),
             "session" => Ok(Self::Session),
             "branch" => Ok(Self::Branch),
+            "workspace" => Ok(Self::Workspace),
             other => Err(GwtError::Other(format!(
                 "unknown board mention target kind: {other}"
             ))),
@@ -115,6 +117,7 @@ impl BoardMentionTargetKind {
             Self::Agent => "agent",
             Self::Session => "session",
             Self::Branch => "branch",
+            Self::Workspace => "workspace",
         }
     }
 }
@@ -192,6 +195,69 @@ pub fn normalize_board_mentions(values: &[BoardMention]) -> Vec<BoardMention> {
     normalized
 }
 
+pub fn normalize_board_audience(values: Option<Vec<String>>) -> Option<Vec<String>> {
+    let mut normalized = Vec::new();
+    for value in values.unwrap_or_default() {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if normalized.iter().any(|item| item == value) {
+            continue;
+        }
+        normalized.push(value.to_string());
+    }
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn board_audience_is_absent(value: &Option<Vec<String>>) -> bool {
+    value
+        .as_ref()
+        .map(|items| items.iter().all(|item| item.trim().is_empty()))
+        .unwrap_or(true)
+}
+
+fn deserialize_board_audience<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Vec<String>>::deserialize(deserializer)?;
+    Ok(normalize_board_audience(value))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardAudienceScope {
+    All,
+    Broadcast,
+    Workspace(String),
+}
+
+pub fn board_entry_visible_for_scope(entry: &BoardEntry, scope: &BoardAudienceScope) -> bool {
+    let Some(audience) = normalize_board_audience(entry.audience.clone()) else {
+        return true;
+    };
+    match scope {
+        BoardAudienceScope::All => true,
+        BoardAudienceScope::Broadcast => false,
+        BoardAudienceScope::Workspace(workspace_id) => {
+            let workspace_id = workspace_id.trim();
+            !workspace_id.is_empty() && audience.iter().any(|item| item == workspace_id)
+        }
+    }
+}
+
+pub fn filter_board_entries_for_scope(
+    entries: Vec<BoardEntry>,
+    scope: &BoardAudienceScope,
+) -> Vec<BoardEntry> {
+    entries
+        .into_iter()
+        .filter(|entry| board_entry_visible_for_scope(entry, scope))
+        .collect()
+}
+
 pub fn board_entry_targets_self(entry: &BoardEntry, match_keys: &[String]) -> bool {
     entry
         .target_owners
@@ -232,6 +298,12 @@ pub struct BoardEntry {
     pub target_owners: Vec<String>,
     #[serde(default)]
     pub mentions: Vec<BoardMention>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_board_audience",
+        skip_serializing_if = "board_audience_is_absent"
+    )]
+    pub audience: Option<Vec<String>>,
 }
 
 impl BoardEntry {
@@ -276,6 +348,16 @@ impl BoardEntry {
         self
     }
 
+    pub fn with_audience(mut self, values: Vec<impl Into<String>>) -> Self {
+        self.audience =
+            normalize_board_audience(Some(values.into_iter().map(Into::into).collect::<Vec<_>>()));
+        self
+    }
+
+    pub fn normalize_audience(&mut self) {
+        self.audience = normalize_board_audience(self.audience.take());
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         author_kind: AuthorKind,
@@ -306,6 +388,7 @@ impl BoardEntry {
             origin_agent_id: None,
             target_owners: Vec::new(),
             mentions: Vec::new(),
+            audience: None,
         }
     }
 }
@@ -440,8 +523,9 @@ pub fn ensure_repo_local_files(worktree_root: &Path) -> Result<()> {
 pub fn load_snapshot(worktree_root: &Path) -> Result<CoordinationSnapshot> {
     ensure_repo_local_files(worktree_root)?;
     let coordination_root = coordination_dir(worktree_root);
-    let projection: BoardProjection =
+    let mut projection: BoardProjection =
         load_json_or_default(&coordination_board_projection_path(worktree_root))?;
+    normalize_board_projection(&mut projection);
     let manifest = load_event_manifest_from_dir(&coordination_root)?;
     if legacy_event_log_needs_import(&coordination_root)?
         || projection_needs_rebuild(&projection, &manifest)
@@ -452,6 +536,8 @@ pub fn load_snapshot(worktree_root: &Path) -> Result<CoordinationSnapshot> {
 }
 
 pub fn post_entry(worktree_root: &Path, entry: BoardEntry) -> Result<CoordinationSnapshot> {
+    let mut entry = entry;
+    entry.normalize_audience();
     append_event(worktree_root, &CoordinationEvent::MessageAppended { entry })
 }
 
@@ -572,6 +658,9 @@ fn build_hot_projection(
     mut entries: Vec<BoardEntry>,
     updated_at: DateTime<Utc>,
 ) -> BoardProjection {
+    for entry in &mut entries {
+        entry.normalize_audience();
+    }
     entries.sort_by_key(|entry| entry.created_at);
     let total_entries = entries.len();
     let has_more_before = total_entries > HOT_PROJECTION_ENTRY_LIMIT;
@@ -589,6 +678,26 @@ fn build_hot_projection(
         total_entries,
         updated_at,
     }
+}
+
+fn normalize_board_projection(projection: &mut BoardProjection) {
+    for entry in &mut projection.entries {
+        entry.normalize_audience();
+    }
+}
+
+pub fn load_snapshot_for_scope(
+    worktree_root: &Path,
+    scope: &BoardAudienceScope,
+) -> Result<CoordinationSnapshot> {
+    if *scope == BoardAudienceScope::All {
+        return load_snapshot(worktree_root);
+    }
+    ensure_repo_local_files(worktree_root)?;
+    let entries = load_board_entries_from_segments_root(&coordination_dir(worktree_root))?;
+    Ok(CoordinationSnapshot {
+        board: build_hot_projection(filter_board_entries_for_scope(entries, scope), Utc::now()),
+    })
 }
 
 fn load_json_or_default<T>(path: &Path) -> Result<T>
@@ -1121,7 +1230,9 @@ fn load_events_from_path(path: &Path) -> Result<Vec<CoordinationEvent>> {
         if trimmed.is_empty() {
             continue;
         }
-        events.push(serde_json::from_str(trimmed).map_err(json_error)?);
+        let mut event: CoordinationEvent = serde_json::from_str(trimmed).map_err(json_error)?;
+        normalize_coordination_event(&mut event);
+        events.push(event);
     }
     Ok(events)
 }
@@ -1146,12 +1257,21 @@ fn load_legacy_board_events_from_path(path: &Path) -> Result<Vec<CoordinationEve
             .unwrap_or_default();
         match event_type {
             "message_appended" | "board_post" => {
-                events.push(serde_json::from_value(value).map_err(json_error)?);
+                let mut event: CoordinationEvent =
+                    serde_json::from_value(value).map_err(json_error)?;
+                normalize_coordination_event(&mut event);
+                events.push(event);
             }
             _ => continue,
         }
     }
     Ok(events)
+}
+
+fn normalize_coordination_event(event: &mut CoordinationEvent) {
+    match event {
+        CoordinationEvent::MessageAppended { entry } => entry.normalize_audience(),
+    }
 }
 
 fn write_events_to_path(path: &Path, events: &[CoordinationEvent]) -> Result<()> {
@@ -1335,6 +1455,15 @@ pub fn load_entries_since(worktree_root: &Path, since: DateTime<Utc>) -> Result<
     Ok(entries)
 }
 
+pub fn load_entries_since_for_scope(
+    worktree_root: &Path,
+    since: DateTime<Utc>,
+    scope: &BoardAudienceScope,
+) -> Result<Vec<BoardEntry>> {
+    let entries = load_entries_since(worktree_root, since)?;
+    Ok(filter_board_entries_for_scope(entries, scope))
+}
+
 /// Check whether `author` has posted a message of the given `kind` within the
 /// trailing `within` duration. Used by `board-reminder` for redundancy
 /// suppression.
@@ -1395,6 +1524,36 @@ pub fn load_entries_before(
     })
 }
 
+pub fn load_entries_before_for_scope(
+    worktree_root: &Path,
+    before_entry_id: Option<&str>,
+    limit: usize,
+    scope: &BoardAudienceScope,
+) -> Result<BoardHistoryPage> {
+    if *scope == BoardAudienceScope::All {
+        return load_entries_before(worktree_root, before_entry_id, limit);
+    }
+    ensure_repo_local_files(worktree_root)?;
+    if limit == 0 {
+        return Ok(BoardHistoryPage::default());
+    }
+
+    let entries = filter_board_entries_for_scope(
+        load_board_entries_from_segments_root(&coordination_dir(worktree_root))?,
+        scope,
+    );
+    let cutoff = before_entry_id
+        .and_then(|id| entries.iter().position(|entry| entry.id == id))
+        .unwrap_or(entries.len());
+    let older = &entries[..cutoff];
+    let has_more_before = older.len() > limit;
+    let start = older.len().saturating_sub(limit);
+    Ok(BoardHistoryPage {
+        entries: older[start..].to_vec(),
+        has_more_before,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::{str::FromStr, sync::Arc, thread};
@@ -1435,6 +1594,179 @@ mod tests {
         let entry: BoardEntry = serde_json::from_value(legacy).unwrap();
 
         assert!(entry.mentions.is_empty());
+    }
+
+    #[test]
+    fn board_entry_audience_round_trips_and_legacy_absence_is_broadcast() {
+        let legacy = serde_json::json!({
+            "id": "entry-1",
+            "author_kind": "agent",
+            "author": "Codex",
+            "kind": "status",
+            "body": "legacy entry",
+            "created_at": "2026-05-07T00:00:00Z",
+            "updated_at": "2026-05-07T00:00:00Z"
+        });
+
+        let legacy_entry: BoardEntry = serde_json::from_value(legacy).unwrap();
+        assert_eq!(legacy_entry.audience, None);
+        assert!(board_entry_visible_for_scope(
+            &legacy_entry,
+            &BoardAudienceScope::Workspace("workspace-a".to_string())
+        ));
+        assert!(board_entry_visible_for_scope(
+            &legacy_entry,
+            &BoardAudienceScope::Broadcast
+        ));
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Question,
+            "Can workspace-a see this?",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(vec![" workspace-a ", "workspace-a", "workspace-b"]);
+
+        let encoded = serde_json::to_value(&entry).unwrap();
+        assert_eq!(encoded["audience"][0], "workspace-a");
+        assert_eq!(encoded["audience"][1], "workspace-b");
+
+        let decoded: BoardEntry = serde_json::from_value(encoded).unwrap();
+        assert_eq!(
+            decoded.audience,
+            Some(vec!["workspace-a".to_string(), "workspace-b".to_string()])
+        );
+        assert!(board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::Workspace("workspace-a".to_string())
+        ));
+        assert!(!board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::Workspace("workspace-c".to_string())
+        ));
+        assert!(!board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::Broadcast
+        ));
+        assert!(board_entry_visible_for_scope(
+            &decoded,
+            &BoardAudienceScope::All
+        ));
+    }
+
+    #[test]
+    fn board_entry_empty_audience_normalizes_to_absent() {
+        let empty_audience = serde_json::json!({
+            "id": "entry-1",
+            "author_kind": "agent",
+            "author": "Codex",
+            "kind": "status",
+            "body": "empty audience",
+            "audience": [],
+            "created_at": "2026-05-07T00:00:00Z",
+            "updated_at": "2026-05-07T00:00:00Z"
+        });
+
+        let entry: BoardEntry = serde_json::from_value(empty_audience).unwrap();
+        assert_eq!(entry.audience, None);
+
+        let mut explicit_empty = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "explicit empty",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        explicit_empty.audience = Some(Vec::new());
+        let encoded = serde_json::to_value(&explicit_empty).unwrap();
+        assert!(encoded.get("audience").is_none());
+    }
+
+    #[test]
+    fn board_audience_round_trips_through_hot_projection_and_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let scoped = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Claim,
+            "workspace scoped",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(vec!["workspace-a"]);
+        let broadcast = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "broadcast",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        let empty = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "empty audience",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_audience(Vec::<String>::new());
+
+        post_entry(dir.path(), scoped).unwrap();
+        post_entry(dir.path(), broadcast).unwrap();
+        post_entry(dir.path(), empty).unwrap();
+
+        let snapshot = load_snapshot(dir.path()).unwrap();
+        assert_eq!(snapshot.board.entries.len(), 3);
+        assert_eq!(
+            snapshot.board.entries[0].audience,
+            Some(vec!["workspace-a".to_string()])
+        );
+        assert_eq!(snapshot.board.entries[1].audience, None);
+        assert_eq!(snapshot.board.entries[2].audience, None);
+
+        let scoped_snapshot = load_snapshot_for_scope(
+            dir.path(),
+            &BoardAudienceScope::Workspace("workspace-a".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            scoped_snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["workspace scoped", "broadcast", "empty audience"]
+        );
+
+        let other_snapshot = load_snapshot_for_scope(
+            dir.path(),
+            &BoardAudienceScope::Workspace("workspace-b".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            other_snapshot
+                .board
+                .entries
+                .iter()
+                .map(|entry| entry.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["broadcast", "empty audience"]
+        );
     }
 
     #[test]

--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -3185,7 +3185,7 @@ mod tests {
     fn has_recent_post_by_checks_segment_history_beyond_hot_projection() {
         let dir = tempfile::tempdir().unwrap();
 
-        let base = chrono::Utc::now() - chrono::Duration::minutes(9);
+        let base = chrono::Utc::now() - chrono::Duration::minutes(1);
         let mut events = Vec::with_capacity(HOT_PROJECTION_ENTRY_LIMIT + 1);
         let mut target = BoardEntry::new(
             AuthorKind::Agent,

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -82,6 +82,16 @@ pub fn gwt_workspace_journal_path(repo_hash: &RepoHash) -> PathBuf {
     gwt_project_dir(repo_hash).join("workspace/journal.jsonl")
 }
 
+/// Return the Workspace WorkItem hot projection path for a repository hash.
+pub fn gwt_workspace_work_items_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("workspace/work_items.json")
+}
+
+/// Return the Workspace WorkItem event log path for a repository hash.
+pub fn gwt_workspace_work_events_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("workspace/work_events.jsonl")
+}
+
 /// Return the Workspace current projection path for a repository path.
 pub fn gwt_workspace_projection_path_for_repo_path(repo_path: &Path) -> PathBuf {
     let repo_hash = project_scope_hash(repo_path);
@@ -92,6 +102,18 @@ pub fn gwt_workspace_projection_path_for_repo_path(repo_path: &Path) -> PathBuf 
 pub fn gwt_workspace_journal_path_for_repo_path(repo_path: &Path) -> PathBuf {
     let repo_hash = project_scope_hash(repo_path);
     gwt_workspace_journal_path(&repo_hash)
+}
+
+/// Return the Workspace WorkItem hot projection path for a repository path.
+pub fn gwt_workspace_work_items_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    let repo_hash = project_scope_hash(repo_path);
+    gwt_workspace_work_items_path(&repo_hash)
+}
+
+/// Return the Workspace WorkItem event log path for a repository path.
+pub fn gwt_workspace_work_events_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    let repo_hash = project_scope_hash(repo_path);
+    gwt_workspace_work_events_path(&repo_hash)
 }
 
 /// Return the repo-scoped notes root (`~/.gwt/notes/`).

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -264,9 +264,9 @@ pub fn log_update_event(stage: &str, fields: &[(&str, &str)]) {
 }
 
 /// Compare two semver-ish versions, returning `true` when `candidate` is
-/// strictly newer than `current`. Falls back to string ordering when either
-/// side fails to parse so a malformed manifest never silently triggers a
-/// downgrade.
+/// strictly newer than `current`. Refuses to act on unparseable input on
+/// either side so a malformed manifest cannot silently authorize an apply
+/// (CodeRabbit review on PR #2630).
 pub fn pending_version_is_newer(candidate: &str, current: &str) -> bool {
     let trim = |v: &str| v.trim().trim_start_matches('v').to_string();
     let candidate_trim = trim(candidate);
@@ -276,7 +276,9 @@ pub fn pending_version_is_newer(candidate: &str, current: &str) -> bool {
         Version::parse(&current_trim),
     ) {
         (Ok(c), Ok(curr)) => c > curr,
-        _ => candidate_trim.as_str() > current_trim.as_str(),
+        // Refuse to act on unparseable input so a malformed manifest cannot
+        // silently trigger an apply.
+        _ => false,
     }
 }
 
@@ -3353,5 +3355,10 @@ mod tests {
         // Pre-release: 9.26.0-rc.1 is newer than 9.25.0 but older than 9.26.0.
         assert!(pending_version_is_newer("9.26.0-rc.1", "9.25.0"));
         assert!(!pending_version_is_newer("9.26.0-rc.1", "9.26.0"));
+        // Malformed input (either side) refuses to authorize an apply
+        // (CodeRabbit review on PR #2630).
+        assert!(!pending_version_is_newer("abc", "9.25.0"));
+        assert!(!pending_version_is_newer("9.26.0", "not-a-version"));
+        assert!(!pending_version_is_newer("abc", "def"));
     }
 }

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -2970,6 +2970,82 @@ mod tests {
         assert!(err.contains("Downloaded payload is empty"));
     }
 
+    // SPEC-2041 Phase 19 (T-125 / FR-054): progress callback fires monotonically
+    // and reports a final completion tick that matches Content-Length.
+    #[test]
+    fn prepare_update_with_progress_invokes_callback_monotonically() {
+        let temp = tempfile::tempdir().unwrap();
+        let mgr = UpdateManager::new()
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+
+        // Build a tiny tarball so prepare_update finishes the extract step too,
+        // proving progress fired across the whole download.
+        let archive_path = temp.path().join("payload.tar.gz");
+        {
+            let archive_file = fs::File::create(&archive_path).unwrap();
+            let encoder =
+                flate2::write::GzEncoder::new(archive_file, flate2::Compression::default());
+            let mut archive = tar::Builder::new(encoder);
+            let binary_name = Platform::detect().binary_name();
+            let daemon_name = companion_binary_name(&binary_name);
+            let bytes = b"progress-bin";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            archive
+                .append_data(&mut header, format!("nested/{binary_name}"), &bytes[..])
+                .unwrap();
+            let daemon_bytes = b"progress-daemon";
+            let mut daemon_header = tar::Header::new_gnu();
+            daemon_header.set_size(daemon_bytes.len() as u64);
+            daemon_header.set_mode(0o755);
+            daemon_header.set_cksum();
+            archive
+                .append_data(
+                    &mut daemon_header,
+                    format!("nested/{daemon_name}"),
+                    &daemon_bytes[..],
+                )
+                .unwrap();
+            archive.into_inner().unwrap().finish().unwrap();
+        }
+
+        let body = fs::read(&archive_path).unwrap();
+        let expected_len = body.len() as u64;
+        let tarball_url = serve_once("/progress.tar.gz", "200 OK", "application/gzip", body);
+
+        let mut ticks: Vec<(u64, Option<u64>)> = Vec::new();
+        mgr.prepare_update_with_progress("99.0.7", &tarball_url, &mut |downloaded, total| {
+            ticks.push((downloaded, total));
+        })
+        .expect("progress prepare");
+
+        assert!(
+            !ticks.is_empty(),
+            "progress callback must fire at least once"
+        );
+
+        // Each tick reports the same `total` (Some(content_length)).
+        for (_, total) in &ticks {
+            assert_eq!(*total, Some(expected_len));
+        }
+
+        // Downloaded counter is monotonic non-decreasing.
+        for window in ticks.windows(2) {
+            assert!(
+                window[1].0 >= window[0].0,
+                "progress downloaded counter must not regress: {ticks:?}",
+            );
+        }
+
+        // Final tick lands at Content-Length (FR-054).
+        let last = ticks.last().unwrap();
+        assert_eq!(last.0, expected_len);
+        assert_eq!(last.1, Some(expected_len));
+    }
+
     #[test]
     fn install_latest_docker_linux_bundle_downloads_release_tarball_to_cache_paths() {
         let temp = tempfile::tempdir().unwrap();

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -405,12 +405,22 @@ impl UpdateManager {
             .build()
             .unwrap_or_else(|_| Client::new());
 
+        // SPEC-2041 Phase 19 (T-137 enabler): allow Gate 2 mock smokes to
+        // redirect the update API to a local fixture by setting
+        // `GWT_UPDATE_API_BASE_URL`. Empty values fall back to the default so
+        // an accidental `export GWT_UPDATE_API_BASE_URL=` does not break
+        // production updates.
+        let api_base_url = std::env::var("GWT_UPDATE_API_BASE_URL")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string());
+
         Self {
             current_version,
             owner: DEFAULT_OWNER.to_string(),
             repo: DEFAULT_REPO.to_string(),
             ttl: DEFAULT_TTL,
-            api_base_url: DEFAULT_API_BASE_URL.to_string(),
+            api_base_url,
             cache_path,
             updates_dir,
             client,

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -363,6 +363,22 @@ impl UpdateManager {
     }
 
     pub fn prepare_update(&self, latest: &str, asset_url: &str) -> Result<PreparedPayload, String> {
+        // SPEC-2041 Phase 19 backward-compat shim: callers that don't need
+        // download progress (CLI `gwt update`, legacy GUI flow) reuse the
+        // chunked downloader via a no-op callback.
+        self.prepare_update_with_progress(latest, asset_url, &mut |_, _| {})
+    }
+
+    /// SPEC-2041 Phase 19 (FR-054): like [`Self::prepare_update`] but invokes
+    /// `progress` for every download chunk. The callback receives `(downloaded
+    /// bytes so far, advertised total if any)`. The final invocation sees
+    /// `downloaded == total` whenever the server provided `Content-Length`.
+    pub fn prepare_update_with_progress(
+        &self,
+        latest: &str,
+        asset_url: &str,
+        progress: &mut dyn FnMut(u64, Option<u64>),
+    ) -> Result<PreparedPayload, String> {
         let update_dir = self
             .updates_dir
             .join(format!("v{}", latest.trim().trim_start_matches('v')));
@@ -371,7 +387,7 @@ impl UpdateManager {
         let asset_name = asset_name_from_url(asset_url).unwrap_or_else(|| "gwt-update".to_string());
         let dest = update_dir.join(&asset_name);
 
-        self.download_asset(asset_url, &dest)?;
+        self.download_asset_with_progress(asset_url, &dest, progress)?;
 
         let dest_str = dest.to_string_lossy().to_string();
         if dest_str.ends_with(".tar.gz") || dest_str.ends_with(".zip") {
@@ -491,6 +507,26 @@ impl UpdateManager {
     }
 
     fn download_asset(&self, asset_url: &str, dest: &Path) -> Result<(), String> {
+        // Phase 19 backward-compat: callers that don't need byte-level
+        // progress (Docker bundle install, legacy CLI flow) tunnel through
+        // the chunked downloader with a no-op callback.
+        self.download_asset_with_progress(asset_url, dest, &mut |_, _| {})
+    }
+
+    /// SPEC-2041 Phase 19 (FR-054): chunked downloader that drives a progress
+    /// callback. Reads the response in 64 KiB chunks so the callback fires
+    /// frequently enough to render a smooth progress bar without overwhelming
+    /// the WebSocket. The callback receives `(downloaded bytes so far,
+    /// `Content-Length` if the server advertised one)`. The first invocation
+    /// always fires with `(0, total)` so frontends can size the progress bar
+    /// before any bytes arrive.
+    fn download_asset_with_progress(
+        &self,
+        asset_url: &str,
+        dest: &Path,
+        progress: &mut dyn FnMut(u64, Option<u64>),
+    ) -> Result<(), String> {
+        use std::io::{Read, Write};
         if let Some(parent) = dest.parent() {
             fs::create_dir_all(parent).map_err(|e| format!("Failed to create payload dir: {e}"))?;
         }
@@ -504,10 +540,29 @@ impl UpdateManager {
             return Err(format!("Download failed with status {}", res.status()));
         }
 
+        let total = res.content_length();
+        progress(0, total);
+
         let mut file =
             fs::File::create(dest).map_err(|e| format!("Failed to create payload file: {e}"))?;
         let mut reader = res;
-        io::copy(&mut reader, &mut file).map_err(|e| format!("Failed to write payload: {e}"))?;
+        let mut buffer = [0u8; 64 * 1024];
+        let mut downloaded: u64 = 0;
+        loop {
+            let n = reader
+                .read(&mut buffer)
+                .map_err(|e| format!("Failed to read payload chunk: {e}"))?;
+            if n == 0 {
+                break;
+            }
+            file.write_all(&buffer[..n])
+                .map_err(|e| format!("Failed to write payload: {e}"))?;
+            downloaded = downloaded.saturating_add(n as u64);
+            progress(downloaded, total);
+        }
+        // Ensure the final progress tick reflects the actual on-disk size,
+        // even when the server omitted Content-Length.
+        progress(downloaded, total.or(Some(downloaded)));
 
         let size = fs::metadata(dest).map(|m| m.len()).unwrap_or_default();
         if size == 0 {
@@ -809,7 +864,10 @@ fn parse_tag_version(tag: &str) -> Option<Version> {
     Version::parse(v).ok()
 }
 
-fn asset_name_from_url(url: &str) -> Option<String> {
+/// Extract the asset filename from a release URL. Used by Phase 19
+/// download-progress broadcasts to populate `BackendEvent::UpdateProgress.asset`
+/// so the modal can show "Downloading gwt-macos-arm64.tar.gz".
+pub fn asset_name_from_url(url: &str) -> Option<String> {
     url.split('/')
         .next_back()
         .map(str::trim)

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -103,17 +103,181 @@ struct GitHubAsset {
     browser_download_url: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InstallerKind {
     MacDmg,
     MacPkg,
     WindowsMsi,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PreparedPayload {
     PortableBinary { path: PathBuf },
     Installer { path: PathBuf, kind: InstallerKind },
+}
+
+/// SPEC-2041 Phase 19 (FR-056/059/062): on-disk manifest pointing at a
+/// download that is ready to apply but has not been committed (helper-spawn +
+/// exit) yet. Written when the user defers the apply with `Later` and read by
+/// the bootstrap path on the next gwt launch so the new version takes effect
+/// transparently.
+///
+/// The manifest lives at `~/.gwt/pending-update/manifest.json` and is the
+/// single source of truth for "is there a pending apply". Removing the file
+/// (e.g. after the apply succeeds, or because the manifest is stale) is how
+/// the flow returns to the regular polling loop.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingUpdateManifest {
+    /// Target version (without the leading `v`).
+    pub version: String,
+    /// Source release URL the asset was downloaded from.
+    pub asset_url: String,
+    /// Prepared payload on disk (extracted binary or installer file).
+    pub payload: PreparedPayload,
+    /// RFC3339 timestamp of when the download finished.
+    pub downloaded_at: String,
+}
+
+/// `~/.gwt/pending-update/`. Created on demand by
+/// [`persist_pending_update_manifest`].
+pub fn pending_update_dir() -> PathBuf {
+    crate::paths::gwt_home().join("pending-update")
+}
+
+/// `~/.gwt/pending-update/manifest.json`. Single source of truth for "is there
+/// a pending apply ready for the next launch".
+pub fn pending_update_manifest_path() -> PathBuf {
+    pending_update_dir().join("manifest.json")
+}
+
+/// SPEC-2041 Phase 19 (FR-059): atomically write the manifest. Callers should
+/// invoke this after `Later` so the next launch sees the pending payload.
+pub fn persist_pending_update_manifest(manifest: &PendingUpdateManifest) -> Result<(), String> {
+    persist_pending_update_manifest_in(&pending_update_dir(), manifest)
+}
+
+/// Test-friendly variant: write the manifest into an explicit directory. The
+/// production path uses [`persist_pending_update_manifest`] which targets
+/// [`pending_update_dir`].
+pub fn persist_pending_update_manifest_in(
+    dir: &Path,
+    manifest: &PendingUpdateManifest,
+) -> Result<(), String> {
+    fs::create_dir_all(dir).map_err(|e| format!("Failed to create pending-update dir: {e}"))?;
+    let path = dir.join("manifest.json");
+    let tmp = dir.join("manifest.json.tmp");
+    let json = serde_json::to_string_pretty(manifest)
+        .map_err(|e| format!("Failed to serialize pending manifest: {e}"))?;
+    fs::write(&tmp, json).map_err(|e| format!("Failed to write pending manifest: {e}"))?;
+    fs::rename(&tmp, &path).map_err(|e| format!("Failed to commit pending manifest: {e}"))?;
+    Ok(())
+}
+
+/// SPEC-2041 Phase 19 (FR-062): load the manifest if it exists. Returns `None`
+/// when the file is absent, malformed, or the referenced payload no longer
+/// exists on disk (so callers don't have to repeat that check).
+pub fn load_pending_update_manifest() -> Option<PendingUpdateManifest> {
+    load_pending_update_manifest_in(&pending_update_dir())
+}
+
+/// Test-friendly variant: load from an explicit directory.
+pub fn load_pending_update_manifest_in(dir: &Path) -> Option<PendingUpdateManifest> {
+    let path = dir.join("manifest.json");
+    let bytes = fs::read(&path).ok()?;
+    let manifest: PendingUpdateManifest = serde_json::from_slice(&bytes).ok()?;
+    let payload_path = match &manifest.payload {
+        PreparedPayload::PortableBinary { path } | PreparedPayload::Installer { path, .. } => path,
+    };
+    if !payload_path.exists() {
+        return None;
+    }
+    Some(manifest)
+}
+
+/// Best-effort: remove the manifest. Failures are silently ignored because
+/// this is called from cleanup paths (post-apply, post-stale-detect) where
+/// retrying is not useful.
+pub fn clear_pending_update_manifest() -> Result<(), String> {
+    clear_pending_update_manifest_in(&pending_update_dir())
+}
+
+/// Test-friendly variant: clear from an explicit directory.
+pub fn clear_pending_update_manifest_in(dir: &Path) -> Result<(), String> {
+    let path = dir.join("manifest.json");
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!("Failed to remove pending manifest: {err}")),
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-065): per-day log file for the post-click update
+/// flow. Stages and failure reasons append as JSONL entries so the failure
+/// modal's `[Open log]` button has a stable target. Format:
+/// `~/.gwt/logs/update-YYYY-MM-DD.log`.
+pub fn update_log_path() -> PathBuf {
+    update_log_path_for(chrono::Utc::now())
+}
+
+/// Test-friendly variant: derive the log filename from a fixed timestamp.
+pub fn update_log_path_for<Tz>(now: chrono::DateTime<Tz>) -> PathBuf
+where
+    Tz: chrono::TimeZone,
+    Tz::Offset: std::fmt::Display,
+{
+    let date = now.format("%Y-%m-%d").to_string();
+    crate::paths::gwt_logs_dir().join(format!("update-{date}.log"))
+}
+
+/// SPEC-2041 Phase 19 (FR-065): append a structured stage entry to the
+/// per-day update log. Failures are silently dropped because logging must
+/// never block the apply path. Each line is a JSON object so downstream
+/// tooling (and the frontend `[Open log]` action) can parse it.
+pub fn log_update_event(stage: &str, fields: &[(&str, &str)]) {
+    let path = update_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let mut entry = serde_json::Map::new();
+    entry.insert(
+        "ts".to_string(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+    entry.insert(
+        "stage".to_string(),
+        serde_json::Value::String(stage.to_string()),
+    );
+    for (k, v) in fields {
+        entry.insert(
+            (*k).to_string(),
+            serde_json::Value::String((*v).to_string()),
+        );
+    }
+    let line = match serde_json::to_string(&entry) {
+        Ok(s) => format!("{s}\n"),
+        Err(_) => return,
+    };
+    use std::io::Write;
+    if let Ok(mut file) = fs::OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+/// Compare two semver-ish versions, returning `true` when `candidate` is
+/// strictly newer than `current`. Falls back to string ordering when either
+/// side fails to parse so a malformed manifest never silently triggers a
+/// downgrade.
+pub fn pending_version_is_newer(candidate: &str, current: &str) -> bool {
+    let trim = |v: &str| v.trim().trim_start_matches('v').to_string();
+    let candidate_trim = trim(candidate);
+    let current_trim = trim(current);
+    match (
+        Version::parse(&candidate_trim),
+        Version::parse(&current_trim),
+    ) {
+        (Ok(c), Ok(curr)) => c > curr,
+        _ => candidate_trim.as_str() > current_trim.as_str(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3034,5 +3198,74 @@ mod tests {
         )
         .unwrap_err();
         assert!(mac_dmg_err.contains("mac_dmg installer can only run on macOS"));
+    }
+
+    // SPEC-2041 Phase 19 (T-126): pending-update manifest round trip.
+    #[test]
+    fn pending_manifest_persist_load_clear_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Write a fake payload so load_pending_update_manifest's existence
+        // check passes.
+        let payload_path = dir.path().join("v9.26.0").join("gwt");
+        fs::create_dir_all(payload_path.parent().unwrap()).unwrap();
+        fs::write(&payload_path, b"#!/bin/sh\nexit 0\n").unwrap();
+
+        let manifest = PendingUpdateManifest {
+            version: "9.26.0".to_string(),
+            asset_url: "https://example.invalid/v9.26.0/gwt-macos-arm64.tar.gz".to_string(),
+            payload: PreparedPayload::PortableBinary {
+                path: payload_path.clone(),
+            },
+            downloaded_at: "2026-05-10T13:00:00Z".to_string(),
+        };
+
+        // Persist + load returns the same manifest.
+        persist_pending_update_manifest_in(dir.path(), &manifest).expect("persist");
+        let loaded = load_pending_update_manifest_in(dir.path()).expect("load");
+        assert_eq!(loaded, manifest);
+
+        // Clear removes it; subsequent loads return None.
+        clear_pending_update_manifest_in(dir.path()).expect("clear");
+        assert!(load_pending_update_manifest_in(dir.path()).is_none());
+
+        // Clear is idempotent on missing manifest.
+        clear_pending_update_manifest_in(dir.path()).expect("clear-idempotent");
+    }
+
+    #[test]
+    fn pending_manifest_load_returns_none_when_payload_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing_payload = dir.path().join("missing").join("gwt");
+        let manifest = PendingUpdateManifest {
+            version: "9.26.0".to_string(),
+            asset_url: "https://example.invalid/asset.tar.gz".to_string(),
+            payload: PreparedPayload::PortableBinary {
+                path: missing_payload,
+            },
+            downloaded_at: "2026-05-10T13:00:00Z".to_string(),
+        };
+        persist_pending_update_manifest_in(dir.path(), &manifest).expect("persist");
+        // Stale manifest (payload not on disk) is treated as absent so the
+        // bootstrap path doesn't loop forever on a missing file.
+        assert!(load_pending_update_manifest_in(dir.path()).is_none());
+    }
+
+    #[test]
+    fn pending_manifest_load_returns_none_when_file_malformed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("manifest.json"), b"{not json").unwrap();
+        assert!(load_pending_update_manifest_in(dir.path()).is_none());
+    }
+
+    #[test]
+    fn pending_version_is_newer_compares_semver() {
+        assert!(pending_version_is_newer("9.26.0", "9.25.0"));
+        assert!(pending_version_is_newer("v9.26.0", "v9.25.0"));
+        assert!(pending_version_is_newer("10.0.0", "9.99.99"));
+        assert!(!pending_version_is_newer("9.25.0", "9.25.0"));
+        assert!(!pending_version_is_newer("9.24.0", "9.25.0"));
+        // Pre-release: 9.26.0-rc.1 is newer than 9.25.0 but older than 9.26.0.
+        assert!(pending_version_is_newer("9.26.0-rc.1", "9.25.0"));
+        assert!(!pending_version_is_newer("9.26.0-rc.1", "9.26.0"));
     }
 }

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -713,6 +713,50 @@ pub fn load_workspace_projection(repo_path: &Path) -> Result<Option<WorkspacePro
     load_workspace_projection_from_path(&gwt_workspace_projection_path_for_repo_path(repo_path))
 }
 
+/// SPEC-2359 FR-094 / FR-097 / FR-098 / FR-099: resolve the currently
+/// assigned Workspace id for a given session. Returns `Some(id)` when
+/// the agent is assigned to a Workspace and `None` otherwise (Unassigned
+/// agent, missing agent, or load failure). Callers use this for Board
+/// audience auto-attach, reminder injection scoping, and the
+/// duplicate-work coordination gate corpus.
+pub fn resolve_workspace_id_for_session(repo_path: &Path, session_id: &str) -> Option<String> {
+    let projection = load_workspace_projection(repo_path).ok().flatten()?;
+    projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+        .filter(|agent| !agent.is_unassigned())
+        .and_then(|agent| agent.workspace_id.clone())
+}
+
+/// SPEC-2359 FR-097: resolve the currently assigned Workspace id for a
+/// mention target. `target_kind` is `BoardMentionTargetKind::Agent` or
+/// `BoardMentionTargetKind::Session`; the target value is matched
+/// against agent display_name / agent_id (agent) or session_id (session).
+/// Returns `Some(id)` when the matched agent is assigned, `None`
+/// otherwise.
+pub fn resolve_workspace_id_for_mention(
+    repo_path: &Path,
+    target_kind: &str,
+    target_value: &str,
+) -> Option<String> {
+    let projection = load_workspace_projection(repo_path).ok().flatten()?;
+    projection
+        .agents
+        .iter()
+        .find(|agent| match target_kind {
+            "session" => agent.session_id == target_value,
+            "agent" => {
+                agent.agent_id == target_value
+                    || agent.display_name == target_value
+                    || agent.display_name.eq_ignore_ascii_case(target_value)
+            }
+            _ => false,
+        })
+        .filter(|agent| !agent.is_unassigned())
+        .and_then(|agent| agent.workspace_id.clone())
+}
+
 pub fn load_or_default_workspace_projection(repo_path: &Path) -> Result<WorkspaceProjection> {
     load_or_default_workspace_projection_from_path(
         &gwt_workspace_projection_path_for_repo_path(repo_path),
@@ -2223,5 +2267,144 @@ mod tests {
         assert_eq!(recent.len(), 1);
         assert_eq!(recent[0].summary.as_deref(), Some("Second summary"));
         assert_eq!(recent[0].updated_at, second_at);
+    }
+
+    fn assigned_agent(
+        session_id: &str,
+        agent_id: &str,
+        workspace_id: &str,
+    ) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.into(),
+            window_id: None,
+            agent_id: agent_id.into(),
+            display_name: agent_id.into(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            title_summary: None,
+            worktree_path: None,
+            branch: None,
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: Some(workspace_id.into()),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn unassigned_agent(session_id: &str, agent_id: &str) -> WorkspaceAgentSummary {
+        let mut a = assigned_agent(session_id, agent_id, "_unused");
+        a.affiliation_status = WorkspaceAgentAffiliationStatus::Unassigned;
+        a.workspace_id = None;
+        a
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_session_returns_assigned_workspace_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-A", "codex", "ws-1"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_session(dir.path(), "sess-A"),
+            Some("ws-1".into())
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_session_returns_none_for_unassigned_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection.agents.push(unassigned_agent("sess-B", "codex"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(resolve_workspace_id_for_session(dir.path(), "sess-B"), None);
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_session_returns_none_when_session_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let projection = WorkspaceProjection::default_for_project(dir.path());
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_session(dir.path(), "sess-missing"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_session_matches_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-C", "codex", "ws-2"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "session", "sess-C"),
+            Some("ws-2".into())
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_agent_matches_display_or_agent_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-D", "codex", "ws-3"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "agent", "codex"),
+            Some("ws-3".into())
+        );
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "agent", "Codex"),
+            Some("ws-3".into()),
+            "case-insensitive display-name match"
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_returns_none_for_unassigned_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection.agents.push(unassigned_agent("sess-E", "codex"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "session", "sess-E"),
+            None
+        );
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "agent", "codex"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_id_for_mention_user_or_branch_kind_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
+        projection
+            .agents
+            .push(assigned_agent("sess-F", "codex", "ws-4"));
+        save_workspace_projection(dir.path(), &projection).unwrap();
+
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "user", "akiojin"),
+            None
+        );
+        assert_eq!(
+            resolve_workspace_id_for_mention(dir.path(), "branch", "feature/x"),
+            None
+        );
     }
 }

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -27,6 +27,17 @@ pub enum WorkspaceStatusCategory {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceAgentAffiliationStatus {
+    Unassigned,
+    Assigned,
+}
+
+fn default_workspace_agent_affiliation_status() -> WorkspaceAgentAffiliationStatus {
+    WorkspaceAgentAffiliationStatus::Assigned
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitDetails {
     pub branch: Option<String>,
@@ -86,7 +97,21 @@ pub struct WorkspaceAgentSummary {
     pub last_board_entry_kind: Option<BoardEntryKind>,
     #[serde(default)]
     pub coordination_scope: Option<String>,
+    #[serde(default = "default_workspace_agent_affiliation_status")]
+    pub affiliation_status: WorkspaceAgentAffiliationStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
     pub updated_at: DateTime<Utc>,
+}
+
+impl WorkspaceAgentSummary {
+    pub fn is_unassigned(&self) -> bool {
+        self.affiliation_status == WorkspaceAgentAffiliationStatus::Unassigned
+    }
+
+    pub fn is_assigned(&self) -> bool {
+        self.affiliation_status == WorkspaceAgentAffiliationStatus::Assigned
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -125,51 +150,81 @@ impl WorkspaceProjection {
     }
 
     pub fn effective_status_category(&self) -> WorkspaceStatusCategory {
-        if self
-            .agents
-            .iter()
-            .any(|agent| agent.status_category == WorkspaceStatusCategory::Blocked)
-        {
+        if self.agents.iter().any(|agent| {
+            agent.is_assigned() && agent.status_category == WorkspaceStatusCategory::Blocked
+        }) {
             return WorkspaceStatusCategory::Blocked;
         }
-        if self
-            .agents
-            .iter()
-            .any(|agent| agent.status_category == WorkspaceStatusCategory::Active)
-        {
+        if self.agents.iter().any(|agent| {
+            agent.is_assigned() && agent.status_category == WorkspaceStatusCategory::Active
+        }) {
             return WorkspaceStatusCategory::Active;
         }
         self.status_category
+    }
+
+    pub fn unassigned_agents(&self) -> impl Iterator<Item = &WorkspaceAgentSummary> {
+        self.agents.iter().filter(|agent| agent.is_unassigned())
+    }
+
+    pub fn assigned_agents(&self) -> impl Iterator<Item = &WorkspaceAgentSummary> {
+        self.agents.iter().filter(|agent| agent.is_assigned())
+    }
+
+    pub fn register_unassigned_agent(&mut self, mut agent: WorkspaceAgentSummary) {
+        agent.affiliation_status = WorkspaceAgentAffiliationStatus::Unassigned;
+        agent.workspace_id = None;
+        if let Some(existing) = self
+            .agents
+            .iter_mut()
+            .find(|existing| existing.session_id == agent.session_id)
+        {
+            *existing = agent;
+        } else {
+            self.agents.push(agent);
+        }
     }
 
     pub fn record_board_milestone(&mut self, entry: &BoardEntry) {
         if !self.board_refs.iter().any(|id| id == &entry.id) {
             self.board_refs.push(entry.id.clone());
         }
-        if let Some(owner) = entry.related_owners.first() {
-            self.owner = Some(owner.clone());
-        }
+        let origin_agent_is_unassigned = entry
+            .origin_session_id
+            .as_deref()
+            .and_then(|session_id| {
+                self.agents
+                    .iter()
+                    .find(|agent| agent.session_id == session_id)
+            })
+            .is_some_and(WorkspaceAgentSummary::is_unassigned);
 
-        match entry.kind {
-            BoardEntryKind::Blocked => {
-                self.status_category = WorkspaceStatusCategory::Blocked;
-                self.status_text = entry.body.clone();
-                self.next_action = Some("Resolve blocker".to_string());
+        if !origin_agent_is_unassigned {
+            if let Some(owner) = entry.related_owners.first() {
+                self.owner = Some(owner.clone());
             }
-            BoardEntryKind::Next => {
-                self.next_action = Some(entry.body.clone());
-                if self.status_category == WorkspaceStatusCategory::Unknown {
-                    self.status_category = WorkspaceStatusCategory::Active;
+
+            match entry.kind {
+                BoardEntryKind::Blocked => {
+                    self.status_category = WorkspaceStatusCategory::Blocked;
+                    self.status_text = entry.body.clone();
+                    self.next_action = Some("Resolve blocker".to_string());
                 }
+                BoardEntryKind::Next => {
+                    self.next_action = Some(entry.body.clone());
+                    if self.status_category == WorkspaceStatusCategory::Unknown {
+                        self.status_category = WorkspaceStatusCategory::Active;
+                    }
+                }
+                BoardEntryKind::Status
+                | BoardEntryKind::Claim
+                | BoardEntryKind::Handoff
+                | BoardEntryKind::Decision => {
+                    self.status_category = WorkspaceStatusCategory::Active;
+                    self.status_text = entry.body.clone();
+                }
+                BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {}
             }
-            BoardEntryKind::Status
-            | BoardEntryKind::Claim
-            | BoardEntryKind::Handoff
-            | BoardEntryKind::Decision => {
-                self.status_category = WorkspaceStatusCategory::Active;
-                self.status_text = entry.body.clone();
-            }
-            BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {}
         }
 
         if let Some(session_id) = entry.origin_session_id.as_deref() {
@@ -315,10 +370,11 @@ impl WorkspaceProjection {
         if removed {
             self.updated_at = updated_at;
             if !self.agents.iter().any(|agent| {
-                matches!(
-                    agent.status_category,
-                    WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
-                )
+                agent.is_assigned()
+                    && matches!(
+                        agent.status_category,
+                        WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
+                    )
             }) {
                 self.status_category = WorkspaceStatusCategory::Idle;
                 self.status_text = "No active work".to_string();
@@ -946,6 +1002,15 @@ fn synthesize_workspace_work_item_from_legacy(
     if projection.is_none() && journal_entries.is_empty() {
         return None;
     }
+    if let Some(projection) = projection {
+        let has_workspace_identity = projection.assigned_agents().next().is_some()
+            || projection.git_details.is_some()
+            || !projection.board_refs.is_empty()
+            || projection.status_category != WorkspaceStatusCategory::Unknown;
+        if journal_entries.is_empty() && !has_workspace_identity {
+            return None;
+        }
+    }
     let first_entry = journal_entries.first();
     let last_entry = journal_entries.last();
     let id = projection
@@ -1000,13 +1065,16 @@ fn synthesize_workspace_work_item_from_legacy(
         events: Vec::new(),
     };
     if let Some(projection) = projection {
-        item.agents
-            .extend(projection.agents.iter().map(|agent| WorkspaceWorkAgentRef {
-                session_id: agent.session_id.clone(),
-                agent_id: Some(agent.agent_id.clone()),
-                display_name: Some(agent.display_name.clone()),
-                updated_at: agent.updated_at,
-            }));
+        item.agents.extend(
+            projection
+                .assigned_agents()
+                .map(|agent| WorkspaceWorkAgentRef {
+                    session_id: agent.session_id.clone(),
+                    agent_id: Some(agent.agent_id.clone()),
+                    display_name: Some(agent.display_name.clone()),
+                    updated_at: agent.updated_at,
+                }),
+        );
         if let Some(details) = projection.git_details.as_ref() {
             item.execution_containers
                 .push(WorkspaceExecutionContainerRef {
@@ -1295,6 +1363,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
 
@@ -1346,6 +1416,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
 
@@ -1517,6 +1589,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut blocked = BoardEntry::new(
@@ -1577,6 +1651,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut entry_value = serde_json::to_value(
@@ -1629,6 +1705,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut blocked = BoardEntry::new(
@@ -1690,6 +1768,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: Utc::now(),
         });
         let mut handoff = BoardEntry::new(
@@ -1958,6 +2038,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at,
         });
 
@@ -1997,6 +2079,61 @@ mod tests {
     }
 
     #[test]
+    fn legacy_workspace_agent_affiliation_defaults_to_assigned() {
+        let payload = serde_json::json!({
+            "session_id": "session-legacy",
+            "window_id": "tab-1:agent-1",
+            "agent_id": "codex",
+            "display_name": "Codex",
+            "status_category": "active",
+            "current_focus": "Implement existing Workspace behavior",
+            "title_summary": "Existing Workspace behavior",
+            "worktree_path": null,
+            "branch": "work/legacy",
+            "last_board_entry_id": null,
+            "updated_at": "2026-05-11T00:00:00Z"
+        });
+
+        let agent: WorkspaceAgentSummary =
+            serde_json::from_value(payload).expect("legacy agent summary");
+
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), None);
+    }
+
+    #[test]
+    fn unassigned_agent_is_not_effective_active_workspace_status() {
+        let mut projection = WorkspaceProjection::default_for_project("/tmp/repo");
+        projection.register_unassigned_agent(WorkspaceAgentSummary {
+            session_id: "session-unassigned".to_string(),
+            window_id: Some("tab-1:agent-1".to_string()),
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            title_summary: None,
+            worktree_path: None,
+            branch: Some("work/20260511-0100".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        });
+
+        assert_eq!(projection.unassigned_agents().count(), 1);
+        assert_eq!(
+            projection.effective_status_category(),
+            WorkspaceStatusCategory::Unknown,
+            "Unassigned Agents must not make a Workspace active"
+        );
+    }
+
+    #[test]
     fn stopped_agent_is_removed_from_current_projection_without_losing_summary() {
         let now = Utc::now();
         let mut projection = WorkspaceProjection::default_for_project("/repo");
@@ -2017,6 +2154,8 @@ mod tests {
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: now,
         });
 

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -13,6 +13,7 @@ use crate::{
     error::{GwtError, Result},
     paths::{
         gwt_workspace_journal_path_for_repo_path, gwt_workspace_projection_path_for_repo_path,
+        gwt_workspace_work_events_path_for_repo_path, gwt_workspace_work_items_path_for_repo_path,
     },
 };
 
@@ -393,6 +394,248 @@ pub struct WorkspaceJournalEntry {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkAgentRef {
+    pub session_id: String,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceExecutionContainerRef {
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub worktree_path: Option<PathBuf>,
+    #[serde(default)]
+    pub pr_number: Option<u64>,
+    #[serde(default)]
+    pub pr_url: Option<String>,
+    #[serde(default)]
+    pub pr_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceWorkEventKind {
+    Start,
+    Claim,
+    Update,
+    Blocked,
+    Handoff,
+    Resume,
+    Split,
+    Merge,
+    Pr,
+    Done,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkEvent {
+    pub id: String,
+    pub work_item_id: String,
+    pub kind: WorkspaceWorkEventKind,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub intent: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub status_category: Option<WorkspaceStatusCategory>,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub next_action: Option<String>,
+    #[serde(default)]
+    pub agent_session_id: Option<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub board_entry_id: Option<String>,
+    #[serde(default)]
+    pub execution_container: Option<WorkspaceExecutionContainerRef>,
+    #[serde(default)]
+    pub related_work_item_id: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl WorkspaceWorkEvent {
+    pub fn new(
+        kind: WorkspaceWorkEventKind,
+        work_item_id: impl Into<String>,
+        updated_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            work_item_id: work_item_id.into(),
+            kind,
+            title: None,
+            intent: None,
+            summary: None,
+            status_category: None,
+            owner: None,
+            next_action: None,
+            agent_session_id: None,
+            agent_id: None,
+            display_name: None,
+            board_entry_id: None,
+            execution_container: None,
+            related_work_item_id: None,
+            updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkItem {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub intent: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+    pub status_category: WorkspaceStatusCategory,
+    #[serde(default)]
+    pub owner: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub agents: Vec<WorkspaceWorkAgentRef>,
+    #[serde(default)]
+    pub execution_containers: Vec<WorkspaceExecutionContainerRef>,
+    #[serde(default)]
+    pub board_refs: Vec<String>,
+    #[serde(default)]
+    pub related_work_item_ids: Vec<String>,
+    #[serde(default)]
+    pub events: Vec<WorkspaceWorkEvent>,
+}
+
+impl WorkspaceWorkItem {
+    pub fn is_incomplete(&self) -> bool {
+        self.status_category != WorkspaceStatusCategory::Done
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceWorkItemsProjection {
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub work_items: Vec<WorkspaceWorkItem>,
+}
+
+impl WorkspaceWorkItemsProjection {
+    fn empty(updated_at: DateTime<Utc>) -> Self {
+        Self {
+            updated_at,
+            work_items: Vec::new(),
+        }
+    }
+
+    fn apply_event(&mut self, event: WorkspaceWorkEvent) {
+        let index = self
+            .work_items
+            .iter()
+            .position(|item| item.id == event.work_item_id)
+            .unwrap_or_else(|| {
+                self.work_items.push(WorkspaceWorkItem {
+                    id: event.work_item_id.clone(),
+                    title: event
+                        .title
+                        .clone()
+                        .or_else(|| event.intent.clone())
+                        .unwrap_or_else(|| event.work_item_id.clone()),
+                    intent: event.intent.clone(),
+                    summary: event.summary.clone(),
+                    status_category: workspace_work_event_status(&event),
+                    owner: event.owner.clone(),
+                    created_at: event.updated_at,
+                    updated_at: event.updated_at,
+                    completed_at: None,
+                    agents: Vec::new(),
+                    execution_containers: Vec::new(),
+                    board_refs: Vec::new(),
+                    related_work_item_ids: Vec::new(),
+                    events: Vec::new(),
+                });
+                self.work_items.len() - 1
+            });
+
+        let item = &mut self.work_items[index];
+        if let Some(title) = non_empty_clone(event.title.as_deref()) {
+            item.title = title;
+        }
+        if let Some(intent) = non_empty_clone(event.intent.as_deref()) {
+            item.intent = Some(intent);
+        }
+        if let Some(summary) = non_empty_clone(event.summary.as_deref()) {
+            item.summary = Some(summary);
+        }
+        if let Some(owner) = non_empty_clone(event.owner.as_deref()) {
+            item.owner = Some(owner);
+        }
+        item.status_category = workspace_work_event_status(&event);
+        if item.status_category == WorkspaceStatusCategory::Done {
+            item.completed_at = Some(event.updated_at);
+        } else {
+            item.completed_at = None;
+        }
+        item.updated_at = event.updated_at;
+        if item.created_at > event.updated_at {
+            item.created_at = event.updated_at;
+        }
+        if let Some(session_id) = non_empty_clone(event.agent_session_id.as_deref()) {
+            if let Some(agent) = item
+                .agents
+                .iter_mut()
+                .find(|agent| agent.session_id == session_id)
+            {
+                agent.agent_id = event.agent_id.clone().or(agent.agent_id.clone());
+                agent.display_name = event.display_name.clone().or(agent.display_name.clone());
+                agent.updated_at = event.updated_at;
+            } else {
+                item.agents.push(WorkspaceWorkAgentRef {
+                    session_id,
+                    agent_id: event.agent_id.clone(),
+                    display_name: event.display_name.clone(),
+                    updated_at: event.updated_at,
+                });
+            }
+        }
+        if let Some(container) = event.execution_container.clone() {
+            if !item
+                .execution_containers
+                .iter()
+                .any(|existing| workspace_execution_container_same(existing, &container))
+            {
+                item.execution_containers.push(container);
+            }
+        }
+        if let Some(board_entry_id) = non_empty_clone(event.board_entry_id.as_deref()) {
+            push_unique(&mut item.board_refs, board_entry_id);
+        }
+        if let Some(related_work_item_id) = non_empty_clone(event.related_work_item_id.as_deref()) {
+            push_unique(&mut item.related_work_item_ids, related_work_item_id);
+        }
+        let event_updated_at = event.updated_at;
+        item.events.push(event);
+        item.events.sort_by_key(|event| event.updated_at);
+        if event_updated_at > self.updated_at {
+            self.updated_at = event_updated_at;
+        }
+        self.work_items
+            .sort_by_key(|item| std::cmp::Reverse(item.updated_at));
+    }
+}
+
 fn coordination_scope_for_entry(entry: &BoardEntry) -> Option<String> {
     let mut parts = Vec::new();
     if let Some(owner) = entry.related_owners.first() {
@@ -432,12 +675,17 @@ pub fn update_workspace_projection_with_journal(
     repo_path: &Path,
     update: WorkspaceProjectionUpdate,
 ) -> Result<WorkspaceJournalEntry> {
-    update_workspace_projection_with_journal_paths(
+    let entry = update_workspace_projection_with_journal_paths(
         &gwt_workspace_projection_path_for_repo_path(repo_path),
         &gwt_workspace_journal_path_for_repo_path(repo_path),
         repo_path,
         update,
-    )
+    )?;
+    if let Some(projection) = load_workspace_projection(repo_path)? {
+        let event = workspace_work_event_from_journal_entry(&projection, &entry);
+        record_workspace_work_event(repo_path, event)?;
+    }
+    Ok(entry)
 }
 
 pub fn mark_workspace_agent_stopped(
@@ -462,6 +710,75 @@ pub fn load_workspace_projection_from_path(path: &Path) -> Result<Option<Workspa
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error.into()),
     }
+}
+
+pub fn load_workspace_work_items(repo_path: &Path) -> Result<Option<WorkspaceWorkItemsProjection>> {
+    load_workspace_work_items_from_path(&gwt_workspace_work_items_path_for_repo_path(repo_path))
+}
+
+pub fn load_workspace_work_items_from_path(
+    path: &Path,
+) -> Result<Option<WorkspaceWorkItemsProjection>> {
+    match fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|error| GwtError::Other(format!("workspace work items json: {error}"))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn load_or_synthesize_workspace_work_items(
+    repo_path: &Path,
+) -> Result<WorkspaceWorkItemsProjection> {
+    load_or_synthesize_workspace_work_items_from_paths(
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+        &gwt_workspace_projection_path_for_repo_path(repo_path),
+        &gwt_workspace_journal_path_for_repo_path(repo_path),
+        repo_path,
+    )
+}
+
+pub fn load_or_synthesize_workspace_work_items_from_paths(
+    work_items_path: &Path,
+    current_path: &Path,
+    journal_path: &Path,
+    project_root: &Path,
+) -> Result<WorkspaceWorkItemsProjection> {
+    if let Some(projection) = load_workspace_work_items_from_path(work_items_path)? {
+        return Ok(projection);
+    }
+    synthesize_workspace_work_items_from_legacy_paths(current_path, journal_path, project_root)
+}
+
+pub fn save_workspace_work_items_projection_to_path(
+    path: &Path,
+    projection: &WorkspaceWorkItemsProjection,
+) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(projection)
+        .map_err(|error| GwtError::Other(format!("workspace work items json: {error}")))?;
+    write_atomic(path, &bytes)
+}
+
+pub fn record_workspace_work_event(repo_path: &Path, event: WorkspaceWorkEvent) -> Result<()> {
+    record_workspace_work_event_paths(
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+        &gwt_workspace_work_events_path_for_repo_path(repo_path),
+        event,
+    )
+}
+
+pub fn record_workspace_work_event_paths(
+    work_items_path: &Path,
+    events_path: &Path,
+    event: WorkspaceWorkEvent,
+) -> Result<()> {
+    let mut projection = load_workspace_work_items_from_path(work_items_path)?
+        .unwrap_or_else(|| WorkspaceWorkItemsProjection::empty(event.updated_at));
+    projection.apply_event(event.clone());
+    save_workspace_work_items_projection_to_path(work_items_path, &projection)?;
+    append_workspace_work_event_to_path(events_path, &event)?;
+    Ok(())
 }
 
 pub fn load_or_default_workspace_projection_from_path(
@@ -548,6 +865,21 @@ pub fn append_workspace_journal_entry_to_path(
     Ok(())
 }
 
+pub fn append_workspace_work_event_to_path(path: &Path, event: &WorkspaceWorkEvent) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    serde_json::to_writer(&mut file, event)
+        .map_err(|error| GwtError::Other(format!("workspace work event json: {error}")))?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    Ok(())
+}
+
 pub fn load_recent_workspace_journal_entries(
     repo_path: &Path,
     limit: usize,
@@ -577,6 +909,344 @@ pub fn load_recent_workspace_journal_entries_from_path(
     entries.sort_by_key(|entry| std::cmp::Reverse(entry.updated_at));
     entries.truncate(limit);
     Ok(entries)
+}
+
+fn synthesize_workspace_work_items_from_legacy_paths(
+    current_path: &Path,
+    journal_path: &Path,
+    project_root: &Path,
+) -> Result<WorkspaceWorkItemsProjection> {
+    let projection = load_workspace_projection_from_path(current_path)?;
+    let mut journal_entries =
+        load_recent_workspace_journal_entries_from_path(journal_path, usize::MAX)?;
+    journal_entries.sort_by_key(|entry| entry.updated_at);
+    let updated_at = projection
+        .as_ref()
+        .map(|projection| projection.updated_at)
+        .or_else(|| journal_entries.last().map(|entry| entry.updated_at))
+        .unwrap_or_else(Utc::now);
+    let Some(item) = synthesize_workspace_work_item_from_legacy(
+        projection.as_ref(),
+        &journal_entries,
+        project_root,
+    ) else {
+        return Ok(WorkspaceWorkItemsProjection::empty(updated_at));
+    };
+    Ok(WorkspaceWorkItemsProjection {
+        updated_at: item.updated_at,
+        work_items: vec![item],
+    })
+}
+
+fn synthesize_workspace_work_item_from_legacy(
+    projection: Option<&WorkspaceProjection>,
+    journal_entries: &[WorkspaceJournalEntry],
+    _project_root: &Path,
+) -> Option<WorkspaceWorkItem> {
+    if projection.is_none() && journal_entries.is_empty() {
+        return None;
+    }
+    let first_entry = journal_entries.first();
+    let last_entry = journal_entries.last();
+    let id = projection
+        .map(|projection| projection.id.clone())
+        .or_else(|| first_entry.map(|entry| format!("legacy-{}", entry.id)))?;
+    let title = projection
+        .map(|projection| projection.title.clone())
+        .or_else(|| {
+            first_entry.and_then(|entry| {
+                non_empty_clone(entry.title.as_deref())
+                    .or_else(|| non_empty_clone(entry.agent_title_summary.as_deref()))
+                    .or_else(|| non_empty_clone(entry.summary.as_deref()))
+            })
+        })
+        .unwrap_or_else(|| "Workspace history".to_string());
+    let status_category = projection
+        .map(WorkspaceProjection::effective_status_category)
+        .or_else(|| last_entry.and_then(|entry| entry.status_category))
+        .unwrap_or(WorkspaceStatusCategory::Unknown);
+    let summary = projection
+        .and_then(|projection| projection.summary.clone())
+        .or_else(|| last_entry.and_then(|entry| entry.summary.clone()))
+        .or_else(|| last_entry.and_then(|entry| entry.status_text.clone()));
+    let owner = projection
+        .and_then(|projection| projection.owner.clone())
+        .or_else(|| last_entry.and_then(|entry| entry.owner.clone()));
+    let created_at = first_entry
+        .map(|entry| entry.updated_at)
+        .or_else(|| projection.map(|projection| projection.updated_at))
+        .unwrap_or_else(Utc::now);
+    let updated_at = projection
+        .map(|projection| projection.updated_at)
+        .or_else(|| last_entry.map(|entry| entry.updated_at))
+        .unwrap_or(created_at);
+    let completed_at = (status_category == WorkspaceStatusCategory::Done).then_some(updated_at);
+    let mut item = WorkspaceWorkItem {
+        id: id.clone(),
+        title,
+        intent: summary.clone(),
+        summary,
+        status_category,
+        owner,
+        created_at,
+        updated_at,
+        completed_at,
+        agents: Vec::new(),
+        execution_containers: Vec::new(),
+        board_refs: projection
+            .map(|projection| projection.board_refs.clone())
+            .unwrap_or_default(),
+        related_work_item_ids: Vec::new(),
+        events: Vec::new(),
+    };
+    if let Some(projection) = projection {
+        item.agents
+            .extend(projection.agents.iter().map(|agent| WorkspaceWorkAgentRef {
+                session_id: agent.session_id.clone(),
+                agent_id: Some(agent.agent_id.clone()),
+                display_name: Some(agent.display_name.clone()),
+                updated_at: agent.updated_at,
+            }));
+        if let Some(details) = projection.git_details.as_ref() {
+            item.execution_containers
+                .push(WorkspaceExecutionContainerRef {
+                    branch: details.branch.clone(),
+                    worktree_path: details.worktree_path.clone(),
+                    pr_number: details.pr_number,
+                    pr_url: details.pr_url.clone(),
+                    pr_state: details.pr_state.clone(),
+                });
+        }
+    }
+    for (index, entry) in journal_entries.iter().enumerate() {
+        let mut event = WorkspaceWorkEvent::new(
+            workspace_work_event_kind_from_journal(index, entry),
+            id.clone(),
+            entry.updated_at,
+        );
+        event.id = format!("legacy-journal-{}", entry.id);
+        event.title = entry
+            .title
+            .clone()
+            .or_else(|| entry.agent_title_summary.clone());
+        event.intent = entry
+            .agent_current_focus
+            .clone()
+            .or_else(|| entry.summary.clone());
+        event.summary = entry.summary.clone().or_else(|| entry.status_text.clone());
+        event.status_category = entry.status_category;
+        event.owner = entry.owner.clone();
+        event.next_action = entry.next_action.clone();
+        event.agent_session_id = entry.agent_session_id.clone();
+        if let Some(session_id) = non_empty_clone(entry.agent_session_id.as_deref()) {
+            if !item
+                .agents
+                .iter()
+                .any(|agent| agent.session_id == session_id)
+            {
+                item.agents.push(WorkspaceWorkAgentRef {
+                    session_id,
+                    agent_id: None,
+                    display_name: entry.agent_title_summary.clone(),
+                    updated_at: entry.updated_at,
+                });
+            }
+        }
+        item.events.push(event);
+    }
+    if item.events.is_empty() {
+        let mut event = WorkspaceWorkEvent::new(
+            workspace_work_event_kind_from_status(status_category, 0),
+            id,
+            updated_at,
+        );
+        event.title = Some(item.title.clone());
+        event.summary = item.summary.clone();
+        event.status_category = Some(status_category);
+        event.owner = item.owner.clone();
+        item.events.push(event);
+    }
+    item.events.sort_by_key(|event| event.updated_at);
+    Some(item)
+}
+
+fn workspace_work_event_from_journal_entry(
+    projection: &WorkspaceProjection,
+    entry: &WorkspaceJournalEntry,
+) -> WorkspaceWorkEvent {
+    let mut event = WorkspaceWorkEvent::new(
+        workspace_work_event_kind_from_status(
+            entry.status_category.unwrap_or(projection.status_category),
+            1,
+        ),
+        projection.id.clone(),
+        entry.updated_at,
+    );
+    event.title = entry
+        .title
+        .clone()
+        .or_else(|| entry.agent_title_summary.clone())
+        .or_else(|| Some(projection.title.clone()));
+    event.intent = entry
+        .agent_current_focus
+        .clone()
+        .or_else(|| entry.summary.clone())
+        .or_else(|| projection.summary.clone());
+    event.summary = entry.summary.clone().or_else(|| entry.status_text.clone());
+    event.status_category = Some(entry.status_category.unwrap_or(projection.status_category));
+    event.owner = entry.owner.clone().or_else(|| projection.owner.clone());
+    event.next_action = entry.next_action.clone();
+    event.agent_session_id = entry.agent_session_id.clone();
+    if let Some(session_id) = entry.agent_session_id.as_deref() {
+        if let Some(agent) = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session_id)
+        {
+            event.agent_id = Some(agent.agent_id.clone());
+            event.display_name = Some(agent.display_name.clone());
+        }
+    }
+    event.execution_container = workspace_execution_container_from_projection(projection);
+    event
+}
+
+pub fn workspace_work_event_from_board_entry(
+    projection: &WorkspaceProjection,
+    entry: &BoardEntry,
+) -> WorkspaceWorkEvent {
+    let mut event = WorkspaceWorkEvent::new(
+        workspace_work_event_kind_from_board_entry(entry),
+        projection.id.clone(),
+        entry.updated_at,
+    );
+    event.title = entry
+        .title_summary
+        .clone()
+        .or_else(|| first_nonempty_line(&entry.body))
+        .or_else(|| Some(projection.title.clone()));
+    event.intent = entry.title_summary.clone();
+    event.summary = Some(entry.body.clone());
+    event.status_category = Some(match entry.kind {
+        BoardEntryKind::Blocked => WorkspaceStatusCategory::Blocked,
+        BoardEntryKind::Next
+        | BoardEntryKind::Status
+        | BoardEntryKind::Claim
+        | BoardEntryKind::Handoff
+        | BoardEntryKind::Decision => WorkspaceStatusCategory::Active,
+        BoardEntryKind::Request | BoardEntryKind::Impact | BoardEntryKind::Question => {
+            projection.status_category
+        }
+    });
+    event.owner = entry
+        .related_owners
+        .first()
+        .cloned()
+        .or_else(|| projection.owner.clone());
+    event.agent_session_id = entry.origin_session_id.clone();
+    event.agent_id = entry.origin_agent_id.clone();
+    event.board_entry_id = Some(entry.id.clone());
+    event.execution_container = workspace_execution_container_from_projection(projection);
+    event
+}
+
+fn workspace_work_event_status(event: &WorkspaceWorkEvent) -> WorkspaceStatusCategory {
+    event.status_category.unwrap_or(match event.kind {
+        WorkspaceWorkEventKind::Done => WorkspaceStatusCategory::Done,
+        WorkspaceWorkEventKind::Blocked => WorkspaceStatusCategory::Blocked,
+        WorkspaceWorkEventKind::Start
+        | WorkspaceWorkEventKind::Claim
+        | WorkspaceWorkEventKind::Update
+        | WorkspaceWorkEventKind::Handoff
+        | WorkspaceWorkEventKind::Resume
+        | WorkspaceWorkEventKind::Split
+        | WorkspaceWorkEventKind::Merge
+        | WorkspaceWorkEventKind::Pr => WorkspaceStatusCategory::Active,
+    })
+}
+
+fn workspace_work_event_kind_from_board_entry(entry: &BoardEntry) -> WorkspaceWorkEventKind {
+    match entry.kind {
+        BoardEntryKind::Claim => WorkspaceWorkEventKind::Claim,
+        BoardEntryKind::Blocked => WorkspaceWorkEventKind::Blocked,
+        BoardEntryKind::Handoff => WorkspaceWorkEventKind::Handoff,
+        BoardEntryKind::Next
+        | BoardEntryKind::Status
+        | BoardEntryKind::Decision
+        | BoardEntryKind::Request
+        | BoardEntryKind::Impact
+        | BoardEntryKind::Question => WorkspaceWorkEventKind::Update,
+    }
+}
+
+fn workspace_work_event_kind_from_journal(
+    index: usize,
+    entry: &WorkspaceJournalEntry,
+) -> WorkspaceWorkEventKind {
+    workspace_work_event_kind_from_status(
+        entry
+            .status_category
+            .unwrap_or(WorkspaceStatusCategory::Unknown),
+        index,
+    )
+}
+
+fn workspace_work_event_kind_from_status(
+    status_category: WorkspaceStatusCategory,
+    index: usize,
+) -> WorkspaceWorkEventKind {
+    match status_category {
+        WorkspaceStatusCategory::Done => WorkspaceWorkEventKind::Done,
+        WorkspaceStatusCategory::Blocked => WorkspaceWorkEventKind::Blocked,
+        _ if index == 0 => WorkspaceWorkEventKind::Start,
+        _ => WorkspaceWorkEventKind::Update,
+    }
+}
+
+fn workspace_execution_container_from_projection(
+    projection: &WorkspaceProjection,
+) -> Option<WorkspaceExecutionContainerRef> {
+    projection
+        .git_details
+        .as_ref()
+        .map(|details| WorkspaceExecutionContainerRef {
+            branch: details.branch.clone(),
+            worktree_path: details.worktree_path.clone(),
+            pr_number: details.pr_number,
+            pr_url: details.pr_url.clone(),
+            pr_state: details.pr_state.clone(),
+        })
+}
+
+fn workspace_execution_container_same(
+    left: &WorkspaceExecutionContainerRef,
+    right: &WorkspaceExecutionContainerRef,
+) -> bool {
+    (left.branch.is_some() && left.branch == right.branch)
+        || (left.worktree_path.is_some() && left.worktree_path == right.worktree_path)
+        || (left.pr_number.is_some() && left.pr_number == right.pr_number)
+        || (left.pr_url.is_some() && left.pr_url == right.pr_url)
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn non_empty_clone(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn first_nonempty_line(value: &str) -> Option<String> {
+    value
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
 }
 
 fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
@@ -1106,6 +1776,168 @@ mod tests {
         assert_eq!(
             journal.agent_current_focus.as_deref(),
             Some("Writing RED tests")
+        );
+    }
+
+    #[test]
+    fn workspace_work_events_build_hot_projection_with_lifecycle_refs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 11, 1, 0, 0).unwrap();
+        let done_at = Utc.with_ymd_and_hms(2026, 5, 11, 1, 30, 0).unwrap();
+
+        let mut start = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workitem-workspace-history",
+            started_at,
+        );
+        start.title = Some("Workspace WorkItem history".to_string());
+        start.intent = Some("Group duplicate Workspace work under one WorkItem".to_string());
+        start.summary = Some("Start the WorkItem lifecycle implementation.".to_string());
+        start.status_category = Some(WorkspaceStatusCategory::Active);
+        start.owner = Some("SPEC-2359".to_string());
+        start.agent_session_id = Some("session-1".to_string());
+        start.agent_id = Some("codex".to_string());
+        start.display_name = Some("Codex".to_string());
+        start.board_entry_id = Some("board-claim-1".to_string());
+        start.execution_container = Some(WorkspaceExecutionContainerRef {
+            branch: Some("work/20260510-2353".to_string()),
+            worktree_path: Some(PathBuf::from("/repo/work/20260510-2353")),
+            pr_number: Some(2638),
+            pr_url: Some("https://github.com/akiojin/gwt/pull/2638".to_string()),
+            pr_state: Some("open".to_string()),
+        });
+        record_workspace_work_event_paths(&work_items_path, &events_path, start)
+            .expect("record start event");
+
+        let mut done = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Done,
+            "workitem-workspace-history",
+            done_at,
+        );
+        done.summary = Some("WorkItem lifecycle history is implemented.".to_string());
+        done.status_category = Some(WorkspaceStatusCategory::Done);
+        done.agent_session_id = Some("session-1".to_string());
+        done.board_entry_id = Some("board-done-1".to_string());
+        record_workspace_work_event_paths(&work_items_path, &events_path, done)
+            .expect("record done event");
+
+        let projection = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(projection.work_items.len(), 1);
+        let item = &projection.work_items[0];
+        assert_eq!(item.id, "workitem-workspace-history");
+        assert_eq!(item.title, "Workspace WorkItem history");
+        assert_eq!(
+            item.intent.as_deref(),
+            Some("Group duplicate Workspace work under one WorkItem")
+        );
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(item.owner.as_deref(), Some("SPEC-2359"));
+        assert_eq!(item.completed_at, Some(done_at));
+        assert_eq!(
+            item.board_refs,
+            vec!["board-claim-1".to_string(), "board-done-1".to_string()]
+        );
+        assert_eq!(item.agents.len(), 1);
+        assert_eq!(item.agents[0].session_id, "session-1");
+        assert_eq!(item.execution_containers.len(), 1);
+        assert_eq!(
+            item.execution_containers[0].branch.as_deref(),
+            Some("work/20260510-2353")
+        );
+        assert_eq!(item.events.len(), 2);
+        assert_eq!(item.events[0].kind, WorkspaceWorkEventKind::Start);
+        assert_eq!(item.events[1].kind, WorkspaceWorkEventKind::Done);
+
+        let event_lines = std::fs::read_to_string(&events_path).expect("event log");
+        assert_eq!(event_lines.lines().count(), 2);
+    }
+
+    #[test]
+    fn workspace_work_items_synthesize_from_legacy_current_and_journal_without_rewrite() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().join("repo");
+        let current_path = temp.path().join("workspace/current.json");
+        let journal_path = temp.path().join("workspace/journal.jsonl");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let first_at = Utc.with_ymd_and_hms(2026, 5, 11, 2, 0, 0).unwrap();
+        let second_at = Utc.with_ymd_and_hms(2026, 5, 11, 2, 5, 0).unwrap();
+
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
+        projection.id = "workspace-current".to_string();
+        projection.title = "Workspace WorkItem history".to_string();
+        projection.status_category = WorkspaceStatusCategory::Active;
+        projection.status_text = "Implementing WorkItem projection".to_string();
+        projection.summary = Some("Legacy current state remains readable.".to_string());
+        projection.owner = Some("SPEC-2359".to_string());
+        projection.board_refs.push("board-legacy-1".to_string());
+        save_workspace_projection_to_path(&current_path, &projection)
+            .expect("save legacy projection");
+
+        append_workspace_journal_entry_to_path(
+            &journal_path,
+            &WorkspaceJournalEntry {
+                id: "journal-start".to_string(),
+                project_root: project_root.clone(),
+                title: Some("Workspace WorkItem history".to_string()),
+                status_category: Some(WorkspaceStatusCategory::Active),
+                status_text: Some("Started".to_string()),
+                owner: Some("SPEC-2359".to_string()),
+                next_action: None,
+                summary: Some("Started from legacy journal.".to_string()),
+                agent_session_id: Some("session-legacy".to_string()),
+                agent_current_focus: Some("Implement lifecycle events".to_string()),
+                agent_title_summary: Some("WorkItem history".to_string()),
+                updated_at: first_at,
+            },
+        )
+        .expect("append first journal");
+        append_workspace_journal_entry_to_path(
+            &journal_path,
+            &WorkspaceJournalEntry {
+                id: "journal-update".to_string(),
+                project_root: project_root.clone(),
+                title: None,
+                status_category: Some(WorkspaceStatusCategory::Blocked),
+                status_text: Some("Waiting for coordination decision".to_string()),
+                owner: Some("SPEC-2359".to_string()),
+                next_action: Some("Post Board handoff".to_string()),
+                summary: Some("Blocked state from legacy journal.".to_string()),
+                agent_session_id: Some("session-legacy".to_string()),
+                agent_current_focus: None,
+                agent_title_summary: Some("WorkItem history".to_string()),
+                updated_at: second_at,
+            },
+        )
+        .expect("append second journal");
+
+        let synthesized = load_or_synthesize_workspace_work_items_from_paths(
+            &work_items_path,
+            &current_path,
+            &journal_path,
+            &project_root,
+        )
+        .expect("synthesize work items");
+
+        assert_eq!(synthesized.work_items.len(), 1);
+        let item = &synthesized.work_items[0];
+        assert_eq!(item.id, "workspace-current");
+        assert_eq!(item.title, "Workspace WorkItem history");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Active);
+        assert_eq!(item.owner.as_deref(), Some("SPEC-2359"));
+        assert_eq!(item.board_refs, vec!["board-legacy-1".to_string()]);
+        assert_eq!(item.events.len(), 2);
+        assert_eq!(
+            item.events[0].summary.as_deref(),
+            Some("Started from legacy journal.")
+        );
+        assert_eq!(item.events[1].kind, WorkspaceWorkEventKind::Blocked);
+        assert!(
+            !work_items_path.exists(),
+            "legacy migration must be read-only until a real WorkItem event is recorded"
         );
     }
 

--- a/crates/gwt-core/tests/workspace_projection.rs
+++ b/crates/gwt-core/tests/workspace_projection.rs
@@ -6,8 +6,8 @@ use gwt_core::{
     repo_hash::compute_repo_hash,
     workspace_projection::{
         load_or_default_workspace_projection_from_path, load_workspace_projection_from_path,
-        save_workspace_projection_to_path, GitDetails, WorkspaceAgentSummary, WorkspaceProjection,
-        WorkspaceStatusCategory,
+        save_workspace_projection_to_path, GitDetails, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
     },
 };
 
@@ -34,6 +34,8 @@ fn projection(project_root: &Path) -> WorkspaceProjection {
             last_board_entry_id: Some("board-1".to_string()),
             last_board_entry_kind: Some(gwt_core::coordination::BoardEntryKind::Status),
             coordination_scope: Some("SPEC-2359 / start-work".to_string()),
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: Some("work-1".to_string()),
             updated_at: Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap(),
         }],
         git_details: Some(GitDetails {

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -24,6 +24,9 @@ const GWT_EXCLUDE_PATTERNS: &[&str] = &[
     ".claude/settings.local.json",
     ".codex/skills/gwt-*",
     ".gwt/discussion.md",
+    ".gwt/opencode/",
+    ".gwt/openclaw/",
+    ".gwt/hermes/",
     "docker-compose.override.yml",
 ];
 
@@ -160,6 +163,9 @@ mod tests {
         assert!(result.contains(".claude/skills/gwt-*"));
         assert!(result.contains(".codex/skills/gwt-*"));
         assert!(result.contains(".gwt/discussion.md"));
+        assert!(result.contains(".gwt/opencode/"));
+        assert!(result.contains(".gwt/openclaw/"));
+        assert!(result.contains(".gwt/hermes/"));
         assert!(result.contains("docker-compose.override.yml"));
         assert!(!result.contains(".codex/hooks.json"));
         assert!(!result.contains(".codex/hooks/scripts/gwt-*"));

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -4,6 +4,7 @@ pub mod assets;
 pub mod distribute;
 pub mod git_exclude;
 pub mod hooks;
+pub mod provider_hooks;
 pub mod registry;
 pub mod settings_local;
 pub mod validate;
@@ -14,11 +15,9 @@ pub use hooks::{
     backup_hooks, detect_corruption, is_gwt_managed, merge_hooks, merge_hooks_safe,
     restore_from_backup, Hook, HooksConfig, HooksError,
 };
+pub use provider_hooks::{generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks};
 pub use registry::{EmbeddedSkill, RegistryError, SkillRegistry};
-pub use settings_local::{
-    generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks,
-    generate_settings_local,
-};
+pub use settings_local::{generate_codex_hooks, generate_settings_local};
 
 #[cfg(test)]
 mod tests {

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -15,7 +15,10 @@ pub use hooks::{
     restore_from_backup, Hook, HooksConfig, HooksError,
 };
 pub use registry::{EmbeddedSkill, RegistryError, SkillRegistry};
-pub use settings_local::{generate_codex_hooks, generate_settings_local};
+pub use settings_local::{
+    generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks,
+    generate_settings_local,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/gwt-skills/src/provider_hooks.rs
+++ b/crates/gwt-skills/src/provider_hooks.rs
@@ -1,0 +1,294 @@
+//! Worktree-local hook bridge assets for providers without Claude/Codex-style hooks.
+
+use std::{io, path::Path};
+
+use serde_json::{json, Value};
+
+use crate::settings_local::{
+    gwt_hook_bin_path, posix_shell_quote, set_executable, write_settings_atomically,
+    write_text_atomically,
+};
+
+/// Generate OpenCode project-local hook bridge assets under `.gwt/opencode`.
+pub fn generate_opencode_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/opencode");
+    let plugin_path = config_dir.join("plugins/gwt-hooks.js");
+    let config_path = config_dir.join("opencode.json");
+    let plugin_content = opencode_plugin_content(&gwt_hook_bin_path());
+    let config = json!({
+        "plugin": ["./plugins/gwt-hooks.js"],
+    });
+
+    write_text_atomically(&plugin_path, &plugin_content)?;
+    write_settings_atomically(&config_path, &config)
+}
+
+/// Generate Hermes Agent project-local hook config under `.gwt/hermes`.
+pub fn generate_hermes_hooks(worktree: &Path) -> io::Result<()> {
+    let home = worktree.join(".gwt/hermes");
+    let config_path = home.join("config.yaml");
+    let script_path = home.join("agent-hooks/gwt-hook.sh");
+
+    write_text_atomically(
+        &script_path,
+        &hermes_hook_script_content(&gwt_hook_bin_path()),
+    )?;
+    set_executable(&script_path)?;
+    write_text_atomically(&config_path, &hermes_config_content(&script_path))
+}
+
+/// Generate OpenClaw project-local hook bridge assets under `.gwt/openclaw`.
+pub fn generate_openclaw_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/openclaw");
+    let plugin_dir = config_dir.join("plugins/gwt-hook-bridge");
+    let config_path = config_dir.join("openclaw.json");
+
+    write_settings_atomically(&config_path, &openclaw_config(&plugin_dir))?;
+    write_text_atomically(
+        &plugin_dir.join("package.json"),
+        &openclaw_package_content(),
+    )?;
+    write_settings_atomically(
+        &plugin_dir.join("openclaw.plugin.json"),
+        &openclaw_manifest(),
+    )?;
+    write_text_atomically(
+        &plugin_dir.join("plugin.ts"),
+        &openclaw_plugin_content(&gwt_hook_bin_path()),
+    )
+}
+
+fn js_string_literal(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"gwtd\"".to_string())
+}
+
+fn opencode_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+
+const GWT_HOOK_BIN = {bin};
+
+function canonicalPayload(nativeEvent, input = {{}}, output = {{}}, context = {{}}) {{
+  const toolName = input.tool ?? input.toolName ?? output.tool ?? output.toolName ?? input.name;
+  const toolInput = output.args ?? input.args ?? output.params ?? input.params ?? output.input ?? input.input ?? {{}};
+  return {{
+    provider: "opencode",
+    native_event: nativeEvent,
+    tool_name: toolName,
+    tool_input: toolInput,
+    session_id: input.sessionID ?? input.sessionId ?? input.session_id ?? context.sessionID ?? context.sessionId,
+    cwd: input.cwd ?? context.directory ?? context.worktree ?? context.project?.root,
+    input,
+    output,
+  }};
+}}
+
+function dispatch(nativeEvent, input, output, context) {{
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "opencode", nativeEvent],
+    {{
+      input: JSON.stringify(canonicalPayload(nativeEvent, input, output, context)),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockReason(result) {{
+  return result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+}}
+
+export const GwtHooks = async (context) => ({{
+  "session.created": async (input, output) => dispatch("session.created", input, output, context),
+  "message.updated": async (input, output) => dispatch("message.updated", input, output, context),
+  "tool.execute.before": async (input, output) => {{
+    const reason = blockReason(dispatch("tool.execute.before", input, output, context));
+    if (reason) throw new Error(reason);
+  }},
+  "tool.execute.after": async (input, output) => dispatch("tool.execute.after", input, output, context),
+  "session.idle": async (input, output) => dispatch("session.idle", input, output, context),
+}});
+"#
+    )
+}
+
+fn hermes_hook_command(script_path: &Path, event: &str) -> String {
+    js_string_literal(&format!(
+        "{} {event}",
+        posix_shell_quote(script_path.to_string_lossy().as_ref())
+    ))
+}
+
+fn hermes_config_content(script_path: &Path) -> String {
+    let on_session_start = hermes_hook_command(script_path, "on_session_start");
+    let pre_llm_call = hermes_hook_command(script_path, "pre_llm_call");
+    let pre_tool_call = hermes_hook_command(script_path, "pre_tool_call");
+    let post_tool_call = hermes_hook_command(script_path, "post_tool_call");
+    let on_session_end = hermes_hook_command(script_path, "on_session_end");
+    format!(
+        r#"hooks:
+  on_session_start:
+    - command: {on_session_start}
+      timeout: 10
+  pre_llm_call:
+    - command: {pre_llm_call}
+      timeout: 10
+  pre_tool_call:
+    - matcher: ".*"
+      command: {pre_tool_call}
+      timeout: 10
+  post_tool_call:
+    - matcher: ".*"
+      command: {post_tool_call}
+      timeout: 10
+  on_session_end:
+    - command: {on_session_end}
+      timeout: 10
+hooks_auto_accept: true
+"#
+    )
+}
+
+fn hermes_hook_script_content(bin: &str) -> String {
+    let bin = posix_shell_quote(bin);
+    r#"#!/bin/sh
+set -eu
+
+event="${1:-}"
+if [ -z "$event" ]; then
+  exit 0
+fi
+
+payload="$(cat)"
+set +e
+output="$(printf '%s' "$payload" | __GWT_HOOK_BIN__ hook provider-event hermes "$event")"
+set -e
+if [ -n "$output" ]; then
+  printf '%s\n' "$output"
+fi
+exit 0
+"#
+    .replace("__GWT_HOOK_BIN__", &bin)
+}
+
+fn openclaw_config(plugin_dir: &Path) -> Value {
+    json!({
+        "commands": {
+            "native": "auto",
+            "nativeSkills": "auto",
+            "restart": true,
+            "ownerDisplay": "raw",
+        },
+        "plugins": {
+            "enabled": true,
+            "load": {
+                "paths": [plugin_dir.to_string_lossy().to_string()],
+            },
+            "entries": {
+                "gwt-hook-bridge": {
+                    "enabled": true,
+                    "hooks": {
+                        "allowPromptInjection": true,
+                        "allowConversationAccess": false,
+                    },
+                },
+            },
+        },
+    })
+}
+
+fn openclaw_manifest() -> Value {
+    json!({
+        "id": "gwt-hook-bridge",
+        "name": "gwt Hook Bridge",
+        "description": "Routes OpenClaw plugin hook events into gwtd hook provider-event.",
+        "configSchema": {
+            "type": "object",
+            "additionalProperties": false,
+        },
+    })
+}
+
+fn openclaw_package_content() -> String {
+    r#"{
+  "name": "gwt-hook-bridge",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "openclaw": {
+    "extensions": ["./plugin.ts"]
+  }
+}
+"#
+    .to_string()
+}
+
+fn openclaw_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
+
+const GWT_HOOK_BIN = {bin};
+
+function dispatch(nativeEvent, event = {{}}, ctx = {{}}) {{
+  const payload = {{
+    provider: "openclaw",
+    native_event: nativeEvent,
+    tool_name: event.toolName ?? event.tool_name,
+    tool_input: event.params ?? event.args ?? event.toolInput ?? event.tool_input ?? {{}},
+    session_id: event.sessionId ?? event.session_id ?? ctx.sessionId ?? ctx.sessionKey,
+    cwd: event.cwd ?? ctx.cwd ?? ctx.workspaceRoot,
+    event,
+    ctx,
+  }};
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "openclaw", nativeEvent],
+    {{
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockResult(result) {{
+  const reason = result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+  if (!reason) return undefined;
+  return {{ block: true, blockReason: reason }};
+}}
+
+function promptContextResult(result) {{
+  const text = result.hookSpecificOutput?.additionalContext ?? result.context;
+  if (!text) return undefined;
+  return {{ prependContext: text }};
+}}
+
+export default definePluginEntry({{
+  id: "gwt-hook-bridge",
+  name: "gwt Hook Bridge",
+  description: "Routes OpenClaw hook events into gwtd.",
+  register(api) {{
+    api.on("session_start", async (event, ctx) => dispatch("session_start", event, ctx));
+    api.on("before_prompt_build", async (event, ctx) => promptContextResult(dispatch("before_prompt_build", event, ctx)));
+    api.on("before_tool_call", async (event, ctx) => blockResult(dispatch("before_tool_call", event, ctx)));
+    api.on("after_tool_call", async (event, ctx) => dispatch("after_tool_call", event, ctx));
+    api.on("session_end", async (event, ctx) => dispatch("session_end", event, ctx));
+  }},
+}});
+"#
+    )
+}

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -19,6 +19,7 @@ const LEGACY_GWT_HOOK_SCRIPT_SEGMENT: &str = "hooks/scripts/gwt-";
 /// like `gwt_skills-abc123def` during unit tests.
 const MANAGED_HOOK_SUBCMD_SUFFIXES: &[&str] = &[
     " hook event ",
+    " hook provider-event ",
     " hook runtime-state ",
     " hook coordination-event ",
     " hook board-reminder ",
@@ -80,6 +81,65 @@ pub fn generate_codex_hooks(worktree: &Path) -> io::Result<()> {
     generate_hook_config(worktree, ManagedHookTarget::Codex)
 }
 
+/// Generate OpenCode project-local hook bridge assets under `.gwt/opencode`.
+///
+/// The launcher sets `OPENCODE_CONFIG_DIR=<worktree>/.gwt/opencode`, so the
+/// generated `opencode.json` and plugin stay scoped to this gwt worktree.
+pub fn generate_opencode_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/opencode");
+    let plugin_path = config_dir.join("plugins/gwt-hooks.js");
+    let config_path = config_dir.join("opencode.json");
+    let plugin_content = opencode_plugin_content(&gwt_hook_bin_path());
+    let config = json!({
+        "plugin": ["./plugins/gwt-hooks.js"],
+    });
+
+    write_text_atomically(&plugin_path, &plugin_content)?;
+    write_settings_atomically(&config_path, &config)
+}
+
+/// Generate Hermes Agent project-local hook config under `.gwt/hermes`.
+///
+/// The launcher sets `HERMES_HOME=<worktree>/.gwt/hermes`, which makes this
+/// config and its shell-hook allowlist independent from the user's global
+/// Hermes home.
+pub fn generate_hermes_hooks(worktree: &Path) -> io::Result<()> {
+    let home = worktree.join(".gwt/hermes");
+    let config_path = home.join("config.yaml");
+    let script_path = home.join("agent-hooks/gwt-hook.sh");
+
+    write_text_atomically(
+        &script_path,
+        &hermes_hook_script_content(&gwt_hook_bin_path()),
+    )?;
+    set_executable(&script_path)?;
+    write_text_atomically(&config_path, &hermes_config_content(&script_path))
+}
+
+/// Generate OpenClaw project-local hook bridge assets under `.gwt/openclaw`.
+///
+/// The launcher sets `OPENCLAW_CONFIG_PATH=<worktree>/.gwt/openclaw/openclaw.json`,
+/// so plugin loading is limited to gwt-managed files in this worktree.
+pub fn generate_openclaw_hooks(worktree: &Path) -> io::Result<()> {
+    let config_dir = worktree.join(".gwt/openclaw");
+    let plugin_dir = config_dir.join("plugins/gwt-hook-bridge");
+    let config_path = config_dir.join("openclaw.json");
+
+    write_settings_atomically(&config_path, &openclaw_config(&plugin_dir))?;
+    write_text_atomically(
+        &plugin_dir.join("package.json"),
+        &openclaw_package_content(),
+    )?;
+    write_settings_atomically(
+        &plugin_dir.join("openclaw.plugin.json"),
+        &openclaw_manifest(),
+    )?;
+    write_text_atomically(
+        &plugin_dir.join("plugin.ts"),
+        &openclaw_plugin_content(&gwt_hook_bin_path()),
+    )
+}
+
 fn generate_hook_config(worktree: &Path, target: ManagedHookTarget) -> io::Result<()> {
     let settings_path = target.config_path(worktree);
 
@@ -121,6 +181,7 @@ fn read_existing_settings(path: &Path) -> io::Result<Map<String, Value>> {
 
 fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(dir)?;
     let tmp_path = dir.join(format!(
         ".{}.tmp-{}",
         path.file_name()
@@ -142,6 +203,49 @@ fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
         fs::remove_file(path)?;
     }
     fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(dir)?;
+    let tmp_path = dir.join(format!(
+        ".{}.tmp-{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("gwt-managed"),
+        std::process::id()
+    ));
+
+    {
+        let mut tmp = fs::File::create(&tmp_path)?;
+        tmp.write_all(content.as_bytes())?;
+        if !content.ends_with('\n') {
+            tmp.write_all(b"\n")?;
+        }
+        tmp.sync_all()?;
+    }
+
+    if cfg!(windows) && path.exists() {
+        fs::remove_file(path)?;
+    }
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn set_executable(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
     Ok(())
 }
 
@@ -379,6 +483,230 @@ fn powershell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "''"))
 }
 
+fn js_string_literal(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"gwtd\"".to_string())
+}
+
+fn opencode_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+
+const GWT_HOOK_BIN = {bin};
+
+function canonicalPayload(nativeEvent, input = {{}}, output = {{}}, context = {{}}) {{
+  const toolName = input.tool ?? input.toolName ?? output.tool ?? output.toolName ?? input.name;
+  const toolInput = output.args ?? input.args ?? output.params ?? input.params ?? output.input ?? input.input ?? {{}};
+  return {{
+    provider: "opencode",
+    native_event: nativeEvent,
+    tool_name: toolName,
+    tool_input: toolInput,
+    session_id: input.sessionID ?? input.sessionId ?? input.session_id ?? context.sessionID ?? context.sessionId,
+    cwd: input.cwd ?? context.directory ?? context.worktree ?? context.project?.root,
+    input,
+    output,
+  }};
+}}
+
+function dispatch(nativeEvent, input, output, context) {{
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "opencode", nativeEvent],
+    {{
+      input: JSON.stringify(canonicalPayload(nativeEvent, input, output, context)),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockReason(result) {{
+  return result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+}}
+
+export const GwtHooks = async (context) => ({{
+  "session.created": async (input, output) => dispatch("session.created", input, output, context),
+  "message.updated": async (input, output) => dispatch("message.updated", input, output, context),
+  "tool.execute.before": async (input, output) => {{
+    const reason = blockReason(dispatch("tool.execute.before", input, output, context));
+    if (reason) throw new Error(reason);
+  }},
+  "tool.execute.after": async (input, output) => dispatch("tool.execute.after", input, output, context),
+  "session.idle": async (input, output) => dispatch("session.idle", input, output, context),
+}});
+"#
+    )
+}
+
+fn hermes_config_content(script_path: &Path) -> String {
+    let script = js_string_literal(script_path.to_string_lossy().as_ref());
+    format!(
+        r#"hooks:
+  on_session_start:
+    - command: {script}
+      timeout: 10
+  pre_llm_call:
+    - command: {script}
+      timeout: 10
+  pre_tool_call:
+    - matcher: ".*"
+      command: {script}
+      timeout: 10
+  post_tool_call:
+    - matcher: ".*"
+      command: {script}
+      timeout: 10
+  on_session_end:
+    - command: {script}
+      timeout: 10
+hooks_auto_accept: true
+"#
+    )
+}
+
+fn hermes_hook_script_content(bin: &str) -> String {
+    let bin = posix_shell_quote(bin);
+    r#"#!/bin/sh
+set -eu
+
+payload="$(cat)"
+event="$(printf '%s' "$payload" | sed -n 's/.*"hook_event_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+if [ -z "$event" ]; then
+  event="${1:-pre_tool_call}"
+fi
+
+set +e
+output="$(printf '%s' "$payload" | __GWT_HOOK_BIN__ hook provider-event hermes "$event")"
+set -e
+if [ -n "$output" ]; then
+  printf '%s\n' "$output"
+fi
+exit 0
+"#
+    .replace("__GWT_HOOK_BIN__", &bin)
+}
+
+fn openclaw_config(plugin_dir: &Path) -> Value {
+    json!({
+        "commands": {
+            "native": "auto",
+            "nativeSkills": "auto",
+            "restart": true,
+            "ownerDisplay": "raw",
+        },
+        "plugins": {
+            "enabled": true,
+            "load": {
+                "paths": [plugin_dir.to_string_lossy().to_string()],
+            },
+            "entries": {
+                "gwt-hook-bridge": {
+                    "enabled": true,
+                    "hooks": {
+                        "allowPromptInjection": true,
+                        "allowConversationAccess": false,
+                    },
+                },
+            },
+        },
+    })
+}
+
+fn openclaw_manifest() -> Value {
+    json!({
+        "id": "gwt-hook-bridge",
+        "name": "gwt Hook Bridge",
+        "description": "Routes OpenClaw plugin hook events into gwtd hook provider-event.",
+        "configSchema": {
+            "type": "object",
+            "additionalProperties": false,
+        },
+    })
+}
+
+fn openclaw_package_content() -> String {
+    r#"{
+  "name": "gwt-hook-bridge",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "openclaw": {
+    "extensions": ["./plugin.ts"]
+  }
+}
+"#
+    .to_string()
+}
+
+fn openclaw_plugin_content(bin: &str) -> String {
+    let bin = js_string_literal(bin);
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
+
+const GWT_HOOK_BIN = {bin};
+
+function dispatch(nativeEvent, event = {{}}, ctx = {{}}) {{
+  const payload = {{
+    provider: "openclaw",
+    native_event: nativeEvent,
+    tool_name: event.toolName ?? event.tool_name,
+    tool_input: event.params ?? event.args ?? event.toolInput ?? event.tool_input ?? {{}},
+    session_id: event.sessionId ?? event.session_id ?? ctx.sessionId ?? ctx.sessionKey,
+    cwd: event.cwd ?? ctx.cwd ?? ctx.workspaceRoot,
+    event,
+    ctx,
+  }};
+  const result = spawnSync(
+    GWT_HOOK_BIN,
+    ["hook", "provider-event", "openclaw", nativeEvent],
+    {{
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }},
+  );
+  try {{
+    return result.stdout ? JSON.parse(result.stdout) : {{}};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+function blockResult(result) {{
+  const reason = result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
+  if (!reason) return undefined;
+  return {{ block: true, blockReason: reason }};
+}}
+
+function promptContextResult(result) {{
+  const text = result.hookSpecificOutput?.additionalContext ?? result.context;
+  if (!text) return undefined;
+  return {{ prependContext: text }};
+}}
+
+export default definePluginEntry({{
+  id: "gwt-hook-bridge",
+  name: "gwt Hook Bridge",
+  description: "Routes OpenClaw hook events into gwtd.",
+  register(api) {{
+    api.on("session_start", async (event, ctx) => dispatch("session_start", event, ctx));
+    api.on("before_prompt_build", async (event, ctx) => promptContextResult(dispatch("before_prompt_build", event, ctx)));
+    api.on("before_tool_call", async (event, ctx) => blockResult(dispatch("before_tool_call", event, ctx)));
+    api.on("after_tool_call", async (event, ctx) => dispatch("after_tool_call", event, ctx));
+    api.on("session_end", async (event, ctx) => dispatch("session_end", event, ctx));
+  }},
+}});
+"#
+    )
+}
+
 fn managed_hook_shell() -> HookShell {
     if cfg!(windows) {
         HookShell::PowerShell
@@ -542,6 +870,74 @@ mod tests {
                 commands[0]
             );
         }
+    }
+
+    #[test]
+    fn generate_opencode_hooks_creates_project_plugin_bridge() {
+        let dir = tempfile::tempdir().unwrap();
+
+        generate_opencode_hooks(dir.path()).unwrap();
+
+        let plugin_path = dir.path().join(".gwt/opencode/plugins/gwt-hooks.js");
+        assert!(plugin_path.exists());
+        let content = fs::read_to_string(plugin_path).unwrap();
+        assert!(content.contains("provider-event"));
+        assert!(content.contains("opencode"));
+        assert!(content.contains("tool.execute.before"));
+        assert!(content.contains("tool.execute.after"));
+        assert!(content.contains("session.created"));
+        assert!(content.contains("session.idle"));
+        assert!(content.contains("permissionDecisionReason"));
+        assert!(content.contains("throw new Error"));
+    }
+
+    #[test]
+    fn generate_hermes_hooks_creates_isolated_home_config_and_script() {
+        let dir = tempfile::tempdir().unwrap();
+
+        generate_hermes_hooks(dir.path()).unwrap();
+
+        let config_path = dir.path().join(".gwt/hermes/config.yaml");
+        let script_path = dir.path().join(".gwt/hermes/agent-hooks/gwt-hook.sh");
+        assert!(config_path.exists());
+        assert!(script_path.exists());
+        let config = fs::read_to_string(config_path).unwrap();
+        assert!(config.contains("hooks_auto_accept: true"));
+        assert!(config.contains("on_session_start"));
+        assert!(config.contains("pre_llm_call"));
+        assert!(config.contains("pre_tool_call"));
+        assert!(config.contains("post_tool_call"));
+        assert!(config.contains("on_session_end"));
+        let script = fs::read_to_string(script_path).unwrap();
+        assert!(script.contains("provider-event"));
+        assert!(script.contains("hermes"));
+        assert!(script.contains("exit 0"));
+    }
+
+    #[test]
+    fn generate_openclaw_hooks_creates_isolated_config_and_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+
+        generate_openclaw_hooks(dir.path()).unwrap();
+
+        let config_path = dir.path().join(".gwt/openclaw/openclaw.json");
+        let plugin_path = dir
+            .path()
+            .join(".gwt/openclaw/plugins/gwt-hook-bridge/plugin.ts");
+        assert!(config_path.exists());
+        assert!(plugin_path.exists());
+        let config = fs::read_to_string(config_path).unwrap();
+        assert!(config.contains("gwt-hook-bridge"));
+        let plugin = fs::read_to_string(plugin_path).unwrap();
+        assert!(plugin.contains("before_tool_call"));
+        assert!(plugin.contains("after_tool_call"));
+        assert!(plugin.contains("before_prompt_build"));
+        assert!(plugin.contains("session_start"));
+        assert!(plugin.contains("session_end"));
+        assert!(plugin.contains("provider-event"));
+        assert!(plugin.contains("openclaw"));
+        assert!(plugin.contains("blockReason"));
+        assert!(plugin.contains("prependContext"));
     }
 
     #[test]

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -81,65 +81,6 @@ pub fn generate_codex_hooks(worktree: &Path) -> io::Result<()> {
     generate_hook_config(worktree, ManagedHookTarget::Codex)
 }
 
-/// Generate OpenCode project-local hook bridge assets under `.gwt/opencode`.
-///
-/// The launcher sets `OPENCODE_CONFIG_DIR=<worktree>/.gwt/opencode`, so the
-/// generated `opencode.json` and plugin stay scoped to this gwt worktree.
-pub fn generate_opencode_hooks(worktree: &Path) -> io::Result<()> {
-    let config_dir = worktree.join(".gwt/opencode");
-    let plugin_path = config_dir.join("plugins/gwt-hooks.js");
-    let config_path = config_dir.join("opencode.json");
-    let plugin_content = opencode_plugin_content(&gwt_hook_bin_path());
-    let config = json!({
-        "plugin": ["./plugins/gwt-hooks.js"],
-    });
-
-    write_text_atomically(&plugin_path, &plugin_content)?;
-    write_settings_atomically(&config_path, &config)
-}
-
-/// Generate Hermes Agent project-local hook config under `.gwt/hermes`.
-///
-/// The launcher sets `HERMES_HOME=<worktree>/.gwt/hermes`, which makes this
-/// config and its shell-hook allowlist independent from the user's global
-/// Hermes home.
-pub fn generate_hermes_hooks(worktree: &Path) -> io::Result<()> {
-    let home = worktree.join(".gwt/hermes");
-    let config_path = home.join("config.yaml");
-    let script_path = home.join("agent-hooks/gwt-hook.sh");
-
-    write_text_atomically(
-        &script_path,
-        &hermes_hook_script_content(&gwt_hook_bin_path()),
-    )?;
-    set_executable(&script_path)?;
-    write_text_atomically(&config_path, &hermes_config_content(&script_path))
-}
-
-/// Generate OpenClaw project-local hook bridge assets under `.gwt/openclaw`.
-///
-/// The launcher sets `OPENCLAW_CONFIG_PATH=<worktree>/.gwt/openclaw/openclaw.json`,
-/// so plugin loading is limited to gwt-managed files in this worktree.
-pub fn generate_openclaw_hooks(worktree: &Path) -> io::Result<()> {
-    let config_dir = worktree.join(".gwt/openclaw");
-    let plugin_dir = config_dir.join("plugins/gwt-hook-bridge");
-    let config_path = config_dir.join("openclaw.json");
-
-    write_settings_atomically(&config_path, &openclaw_config(&plugin_dir))?;
-    write_text_atomically(
-        &plugin_dir.join("package.json"),
-        &openclaw_package_content(),
-    )?;
-    write_settings_atomically(
-        &plugin_dir.join("openclaw.plugin.json"),
-        &openclaw_manifest(),
-    )?;
-    write_text_atomically(
-        &plugin_dir.join("plugin.ts"),
-        &openclaw_plugin_content(&gwt_hook_bin_path()),
-    )
-}
-
 fn generate_hook_config(worktree: &Path, target: ManagedHookTarget) -> io::Result<()> {
     let settings_path = target.config_path(worktree);
 
@@ -179,7 +120,7 @@ fn read_existing_settings(path: &Path) -> io::Result<Map<String, Value>> {
     }
 }
 
-fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
+pub(crate) fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(dir)?;
     let tmp_path = dir.join(format!(
@@ -206,7 +147,7 @@ fn write_settings_atomically(path: &Path, value: &Value) -> io::Result<()> {
     Ok(())
 }
 
-fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
+pub(crate) fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(dir)?;
     let tmp_path = dir.join(format!(
@@ -233,7 +174,7 @@ fn write_text_atomically(path: &Path, content: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn set_executable(path: &Path) -> io::Result<()> {
+pub(crate) fn set_executable(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -411,7 +352,7 @@ const GWT_HOOK_BIN_ENV: &str = "GWT_HOOK_BIN";
 /// - Linux: `/proc/self/exe` resolves to the real binary, which may
 ///   land inside bun's per-version cache. The generator is re-run on
 ///   every gwt startup so staleness self-heals on the next launch.
-fn gwt_hook_bin_path() -> String {
+pub(crate) fn gwt_hook_bin_path() -> String {
     if let Ok(v) = std::env::var(GWT_HOOK_BIN_ENV) {
         if !v.is_empty() {
             return v;
@@ -473,7 +414,7 @@ fn path_lookup(command: &str) -> Option<PathBuf> {
 
 /// POSIX shell single-quote quoting. An embedded single quote becomes
 /// `'\''` (close, literal, reopen).
-fn posix_shell_quote(s: &str) -> String {
+pub(crate) fn posix_shell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', r"'\''"))
 }
 
@@ -481,230 +422,6 @@ fn posix_shell_quote(s: &str) -> String {
 /// escaped by doubling it.
 fn powershell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "''"))
-}
-
-fn js_string_literal(value: &str) -> String {
-    serde_json::to_string(value).unwrap_or_else(|_| "\"gwtd\"".to_string())
-}
-
-fn opencode_plugin_content(bin: &str) -> String {
-    let bin = js_string_literal(bin);
-    format!(
-        r#"import {{ spawnSync }} from "node:child_process";
-
-const GWT_HOOK_BIN = {bin};
-
-function canonicalPayload(nativeEvent, input = {{}}, output = {{}}, context = {{}}) {{
-  const toolName = input.tool ?? input.toolName ?? output.tool ?? output.toolName ?? input.name;
-  const toolInput = output.args ?? input.args ?? output.params ?? input.params ?? output.input ?? input.input ?? {{}};
-  return {{
-    provider: "opencode",
-    native_event: nativeEvent,
-    tool_name: toolName,
-    tool_input: toolInput,
-    session_id: input.sessionID ?? input.sessionId ?? input.session_id ?? context.sessionID ?? context.sessionId,
-    cwd: input.cwd ?? context.directory ?? context.worktree ?? context.project?.root,
-    input,
-    output,
-  }};
-}}
-
-function dispatch(nativeEvent, input, output, context) {{
-  const result = spawnSync(
-    GWT_HOOK_BIN,
-    ["hook", "provider-event", "opencode", nativeEvent],
-    {{
-      input: JSON.stringify(canonicalPayload(nativeEvent, input, output, context)),
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "ignore"],
-    }},
-  );
-  try {{
-    return result.stdout ? JSON.parse(result.stdout) : {{}};
-  }} catch {{
-    return {{}};
-  }}
-}}
-
-function blockReason(result) {{
-  return result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
-}}
-
-export const GwtHooks = async (context) => ({{
-  "session.created": async (input, output) => dispatch("session.created", input, output, context),
-  "message.updated": async (input, output) => dispatch("message.updated", input, output, context),
-  "tool.execute.before": async (input, output) => {{
-    const reason = blockReason(dispatch("tool.execute.before", input, output, context));
-    if (reason) throw new Error(reason);
-  }},
-  "tool.execute.after": async (input, output) => dispatch("tool.execute.after", input, output, context),
-  "session.idle": async (input, output) => dispatch("session.idle", input, output, context),
-}});
-"#
-    )
-}
-
-fn hermes_config_content(script_path: &Path) -> String {
-    let script = js_string_literal(script_path.to_string_lossy().as_ref());
-    format!(
-        r#"hooks:
-  on_session_start:
-    - command: {script}
-      timeout: 10
-  pre_llm_call:
-    - command: {script}
-      timeout: 10
-  pre_tool_call:
-    - matcher: ".*"
-      command: {script}
-      timeout: 10
-  post_tool_call:
-    - matcher: ".*"
-      command: {script}
-      timeout: 10
-  on_session_end:
-    - command: {script}
-      timeout: 10
-hooks_auto_accept: true
-"#
-    )
-}
-
-fn hermes_hook_script_content(bin: &str) -> String {
-    let bin = posix_shell_quote(bin);
-    r#"#!/bin/sh
-set -eu
-
-payload="$(cat)"
-event="$(printf '%s' "$payload" | sed -n 's/.*"hook_event_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
-if [ -z "$event" ]; then
-  event="${1:-pre_tool_call}"
-fi
-
-set +e
-output="$(printf '%s' "$payload" | __GWT_HOOK_BIN__ hook provider-event hermes "$event")"
-set -e
-if [ -n "$output" ]; then
-  printf '%s\n' "$output"
-fi
-exit 0
-"#
-    .replace("__GWT_HOOK_BIN__", &bin)
-}
-
-fn openclaw_config(plugin_dir: &Path) -> Value {
-    json!({
-        "commands": {
-            "native": "auto",
-            "nativeSkills": "auto",
-            "restart": true,
-            "ownerDisplay": "raw",
-        },
-        "plugins": {
-            "enabled": true,
-            "load": {
-                "paths": [plugin_dir.to_string_lossy().to_string()],
-            },
-            "entries": {
-                "gwt-hook-bridge": {
-                    "enabled": true,
-                    "hooks": {
-                        "allowPromptInjection": true,
-                        "allowConversationAccess": false,
-                    },
-                },
-            },
-        },
-    })
-}
-
-fn openclaw_manifest() -> Value {
-    json!({
-        "id": "gwt-hook-bridge",
-        "name": "gwt Hook Bridge",
-        "description": "Routes OpenClaw plugin hook events into gwtd hook provider-event.",
-        "configSchema": {
-            "type": "object",
-            "additionalProperties": false,
-        },
-    })
-}
-
-fn openclaw_package_content() -> String {
-    r#"{
-  "name": "gwt-hook-bridge",
-  "version": "0.0.0",
-  "type": "module",
-  "private": true,
-  "openclaw": {
-    "extensions": ["./plugin.ts"]
-  }
-}
-"#
-    .to_string()
-}
-
-fn openclaw_plugin_content(bin: &str) -> String {
-    let bin = js_string_literal(bin);
-    format!(
-        r#"import {{ spawnSync }} from "node:child_process";
-import {{ definePluginEntry }} from "openclaw/plugin-sdk/plugin-entry";
-
-const GWT_HOOK_BIN = {bin};
-
-function dispatch(nativeEvent, event = {{}}, ctx = {{}}) {{
-  const payload = {{
-    provider: "openclaw",
-    native_event: nativeEvent,
-    tool_name: event.toolName ?? event.tool_name,
-    tool_input: event.params ?? event.args ?? event.toolInput ?? event.tool_input ?? {{}},
-    session_id: event.sessionId ?? event.session_id ?? ctx.sessionId ?? ctx.sessionKey,
-    cwd: event.cwd ?? ctx.cwd ?? ctx.workspaceRoot,
-    event,
-    ctx,
-  }};
-  const result = spawnSync(
-    GWT_HOOK_BIN,
-    ["hook", "provider-event", "openclaw", nativeEvent],
-    {{
-      input: JSON.stringify(payload),
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "ignore"],
-    }},
-  );
-  try {{
-    return result.stdout ? JSON.parse(result.stdout) : {{}};
-  }} catch {{
-    return {{}};
-  }}
-}}
-
-function blockResult(result) {{
-  const reason = result.hookSpecificOutput?.permissionDecisionReason ?? result.reason;
-  if (!reason) return undefined;
-  return {{ block: true, blockReason: reason }};
-}}
-
-function promptContextResult(result) {{
-  const text = result.hookSpecificOutput?.additionalContext ?? result.context;
-  if (!text) return undefined;
-  return {{ prependContext: text }};
-}}
-
-export default definePluginEntry({{
-  id: "gwt-hook-bridge",
-  name: "gwt Hook Bridge",
-  description: "Routes OpenClaw hook events into gwtd.",
-  register(api) {{
-    api.on("session_start", async (event, ctx) => dispatch("session_start", event, ctx));
-    api.on("before_prompt_build", async (event, ctx) => promptContextResult(dispatch("before_prompt_build", event, ctx)));
-    api.on("before_tool_call", async (event, ctx) => blockResult(dispatch("before_tool_call", event, ctx)));
-    api.on("after_tool_call", async (event, ctx) => dispatch("after_tool_call", event, ctx));
-    api.on("session_end", async (event, ctx) => dispatch("session_end", event, ctx));
-  }},
-}});
-"#
-    )
 }
 
 fn managed_hook_shell() -> HookShell {
@@ -832,6 +549,10 @@ fn powershell_coordination_hook_command(event: &str) -> String {
 mod tests {
     use std::process::Command;
 
+    use crate::provider_hooks::{
+        generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks,
+    };
+
     use super::*;
 
     fn commands_for_event<'a>(value: &'a Value, event: &str) -> Vec<&'a str> {
@@ -908,10 +629,22 @@ mod tests {
         assert!(config.contains("pre_tool_call"));
         assert!(config.contains("post_tool_call"));
         assert!(config.contains("on_session_end"));
-        let script = fs::read_to_string(script_path).unwrap();
+        assert!(config.contains("gwt-hook.sh' on_session_start"));
+        assert!(config.contains("gwt-hook.sh' pre_tool_call"));
+        let script = fs::read_to_string(&script_path).unwrap();
         assert!(script.contains("provider-event"));
         assert!(script.contains("hermes"));
+        assert!(!script.contains("pre_tool_call}\""));
+        assert!(!script.contains("sed -n"));
         assert!(script.contains("exit 0"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = fs::metadata(script_path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "Hermes hook script must be executable");
+        }
     }
 
     #[test]

--- a/crates/gwt/playwright/tests/update-modal.spec.ts
+++ b/crates/gwt/playwright/tests/update-modal.spec.ts
@@ -1,0 +1,115 @@
+/* SPEC-2041 Phase 19 — post-click update modal flow (T-121).
+ *
+ * Driven by injecting `update_state` / `update_progress` / `update_ready` /
+ * `update_apply_error` payloads through the WebSocket message handler the
+ * page exposes on `window.__gwtTestApi`. The test does not require a real
+ * GitHub release to be reachable; it only exercises the rendering pipeline
+ * inside the WebView. Skipped when `GWT_PLAYWRIGHT_BASE_URL` is unset so it
+ * matches the existing Playwright suite's skip-by-default contract.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:0/";
+
+test.describe("Update modal", () => {
+  test.skip(!process.env.GWT_PLAYWRIGHT_BASE_URL, "no GWT_PLAYWRIGHT_BASE_URL set");
+
+  test("CTA -> downloading -> ready -> Later morphs CTA to ready", async ({ page }) => {
+    await page.goto(BASE);
+
+    // Simulate `update_state available` arriving from backend.
+    await page.evaluate(() => {
+      const ev = new CustomEvent("__gwt_test_inject", {
+        detail: {
+          kind: "update_state",
+          state: "available",
+          current: "9.25.0",
+          latest: "9.26.0",
+        },
+      });
+      window.dispatchEvent(ev);
+    });
+
+    const cta = page.locator("#update-cta");
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveText(/Update available: v9\.26\.0 - Click to update/);
+
+    await cta.click();
+    const modal = page.locator("#update-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toHaveAttribute("data-state", "downloading");
+    await expect(page.locator("[data-update-modal-cancel]")).toBeVisible();
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_progress",
+            downloaded: 1024 * 1024,
+            total: 4 * 1024 * 1024,
+            asset: "gwt-macos-arm64.tar.gz",
+            version: "9.26.0",
+          },
+        }),
+      );
+    });
+    const progress = page.locator("[data-update-modal-progress]");
+    await expect(progress).toHaveAttribute("aria-valuenow", "25");
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_ready",
+            version: "9.26.0",
+            asset_path: "/tmp/pending-update/9.26.0/gwt",
+          },
+        }),
+      );
+    });
+    await expect(modal).toHaveAttribute("data-state", "ready");
+    await page.locator("[data-update-modal-later]").click();
+    await expect(modal).toHaveCount(0);
+    await expect(cta).toHaveText(/Update v9\.26\.0 ready.*Restart now/);
+  });
+
+  test("update_apply_error renders failed state with stage / reason / log", async ({ page }) => {
+    await page.goto(BASE);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_state",
+            state: "available",
+            current: "9.25.0",
+            latest: "9.26.0",
+          },
+        }),
+      );
+    });
+
+    await page.locator("#update-cta").click();
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "update_apply_error",
+            stage: "Download asset",
+            reason: "HTTP 503",
+            log_path: "/Users/x/.gwt/logs/update-2026-05-11.log",
+          },
+        }),
+      );
+    });
+
+    const modal = page.locator("#update-modal");
+    await expect(modal).toHaveAttribute("data-state", "failed");
+    await expect(page.locator("[data-update-modal-stage]")).toContainText("Download asset");
+    await expect(page.locator("[data-update-modal-reason]")).toContainText("HTTP 503");
+    await expect(page.locator("[data-update-modal-log]")).toContainText("update-2026-05-11");
+    await expect(page.locator("[data-update-modal-open-log]")).toBeVisible();
+    await expect(page.locator("[data-update-modal-retry]")).toBeVisible();
+    await expect(page.locator("[data-update-modal-close]")).toBeVisible();
+  });
+});

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -215,6 +215,17 @@ impl AppRuntime {
             );
             return None;
         }
+        let work_event =
+            workspace_projection::workspace_work_event_from_board_entry(&projection, entry);
+        if let Err(error) =
+            workspace_projection::record_workspace_work_event(project_root, work_event)
+        {
+            tracing::warn!(
+                error = %error,
+                project_root = %project_root.display(),
+                "failed to record workspace WorkItem event for board milestone"
+            );
+        }
 
         if self.active_tab_id.as_deref() != Some(tab_id) {
             return None;

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -22,7 +22,15 @@ use gwt_core::{
     workspace_projection,
 };
 
+use gwt::board_audience::{gui_default_board_scope, post_audience_for_gui};
+
 use super::{AppRuntime, BackendEvent, OutboundEvent, WindowPreset};
+
+pub(super) fn gui_default_board_scope_for_project(
+    project_root: &Path,
+) -> gwt_core::Result<coordination::BoardAudienceScope> {
+    gui_default_board_scope(project_root)
+}
 
 #[derive(Debug, Clone)]
 pub struct BoardPostRequest {
@@ -153,6 +161,21 @@ impl AppRuntime {
         }
         if !mentions.is_empty() {
             entry = entry.with_mentions(mentions);
+        }
+        let audience = match post_audience_for_gui(&tab.project_root, &entry.mentions) {
+            Ok(audience) => audience,
+            Err(error) => {
+                return vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::BoardError {
+                        id,
+                        message: error.to_string(),
+                    },
+                )];
+            }
+        };
+        if let Some(audience) = audience {
+            entry = entry.with_audience(audience);
         }
         match coordination::post_entry(&tab.project_root, entry) {
             Ok(snapshot) => {

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -455,20 +455,17 @@ fn board_error(client_id: &str, id: &str, message: impl Into<String>) -> Vec<Out
 }
 
 fn agent_option_matches_session(option: &gwt::AgentOption, agent_id: &AgentId) -> bool {
+    let command_matches = option.id == agent_id.command();
     match agent_id {
-        AgentId::ClaudeCode => option.id == "claude",
-        AgentId::Codex => option.id == "codex",
-        AgentId::Gemini => option.id == "gemini",
-        AgentId::OpenCode => option.id == "opencode",
-        AgentId::Copilot => option.id == "gh",
         AgentId::Custom(id) => {
-            option.id == *id
+            command_matches
                 || option
                     .custom_agent
                     .as_ref()
                     .map(|agent| agent.id == *id)
                     .unwrap_or(false)
         }
+        _ => command_matches,
     }
 }
 

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -17,12 +17,13 @@
 
 use std::path::Path;
 
+use gwt_agent::{AgentId, AgentLaunchBuilder, LaunchConfig, SessionMode};
 use gwt_core::{
     coordination::{self, BoardEntryKind, BoardMention},
     workspace_projection,
 };
 
-use super::{AppRuntime, BackendEvent, OutboundEvent, WindowPreset};
+use super::{AppRuntime, BackendEvent, OutboundEvent, WindowGeometry, WindowPreset};
 
 #[derive(Debug, Clone)]
 pub struct BoardPostRequest {
@@ -185,6 +186,139 @@ impl AppRuntime {
         }
     }
 
+    pub(crate) fn open_board_origin_agent_events(
+        &mut self,
+        client_id: &str,
+        id: &str,
+        origin_session_id: &str,
+        bounds: Option<WindowGeometry>,
+    ) -> Vec<OutboundEvent> {
+        let (tab_id, board_geometry) = match self.board_surface_context(id) {
+            Ok(context) => context,
+            Err(message) => return board_error(client_id, id, message),
+        };
+        let origin_session_id = origin_session_id.trim();
+        if origin_session_id.is_empty() {
+            return board_error(client_id, id, "Board origin session is unavailable");
+        }
+
+        let live_window_id = self
+            .active_agent_sessions
+            .iter()
+            .find(|(_, session)| session.session_id == origin_session_id)
+            .map(|(window_id, _)| window_id.clone());
+        if let Some(window_id) = live_window_id {
+            let mut events = self.restore_window_events(&window_id);
+            events.extend(self.focus_window_events(&window_id, bounds));
+            return if events.is_empty() {
+                board_error(
+                    client_id,
+                    id,
+                    format!("Board origin Agent window not found for {origin_session_id}"),
+                )
+            } else {
+                events
+            };
+        }
+
+        let config = match self.board_origin_agent_resume_config(origin_session_id) {
+            Ok(config) => config,
+            Err(message) => return board_error(client_id, id, message),
+        };
+        match self.spawn_agent_window(&tab_id, config, bounds.unwrap_or(board_geometry), None) {
+            Ok(events) => events,
+            Err(message) => board_error(client_id, id, message),
+        }
+    }
+
+    pub(crate) fn board_origin_agent_resume_config(
+        &self,
+        origin_session_id: &str,
+    ) -> Result<LaunchConfig, String> {
+        let origin_session_id = origin_session_id.trim();
+        if origin_session_id.is_empty() {
+            return Err("Board origin session is unavailable".to_string());
+        }
+        let session_path = self.sessions_dir.join(format!("{origin_session_id}.toml"));
+        let session = gwt_agent::Session::load_and_migrate(&session_path).map_err(|error| {
+            format!("Board origin session {origin_session_id} could not be loaded: {error}")
+        })?;
+        let resume_session_id = session
+            .agent_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                format!("Board origin session {origin_session_id} has no agent session id")
+            })?;
+
+        let mut builder = AgentLaunchBuilder::new(session.agent_id.clone())
+            .working_dir(session.worktree_path.clone())
+            .branch(session.branch.clone())
+            .session_mode(SessionMode::Resume)
+            .resume_session_id(resume_session_id.to_string())
+            .runtime_target(session.runtime_target)
+            .docker_lifecycle_intent(session.docker_lifecycle_intent);
+
+        if let Some(custom_agent) = self
+            .launch_wizard_cache
+            .agent_options()
+            .into_iter()
+            .find(|option| agent_option_matches_session(option, &session.agent_id))
+            .and_then(|option| option.custom_agent)
+        {
+            builder = builder.custom_agent(custom_agent);
+        }
+        if let Some(model) = non_empty(session.model.as_deref()) {
+            builder = builder.model(model.to_string());
+        }
+        if let Some(tool_version) = non_empty(session.tool_version.as_deref()) {
+            builder = builder.version(tool_version.to_string());
+        }
+        if let Some(reasoning_level) = non_empty(session.reasoning_level.as_deref()) {
+            builder = builder.reasoning_level(reasoning_level.to_string());
+        }
+        if session.skip_permissions {
+            builder = builder.skip_permissions(true);
+        }
+        if session.codex_fast_mode {
+            builder = builder.fast_mode(true);
+        }
+        if let Some(docker_service) = non_empty(session.docker_service.as_deref()) {
+            builder = builder.docker_service(docker_service.to_string());
+        }
+        if let Some(linked_issue_number) = session.linked_issue_number {
+            builder = builder.linked_issue_number(linked_issue_number);
+        }
+        if let Some(windows_shell) = session.windows_shell {
+            builder = builder.windows_shell(windows_shell);
+        }
+
+        let mut config = builder.build();
+        if !session.display_name.trim().is_empty() {
+            config.display_name = session.display_name;
+        }
+        Ok(config)
+    }
+
+    fn board_surface_context(&self, id: &str) -> Result<(String, WindowGeometry), String> {
+        let address = self
+            .window_lookup
+            .get(id)
+            .ok_or_else(|| "Window not found".to_string())?;
+        let tab = self
+            .tab(&address.tab_id)
+            .ok_or_else(|| "Project tab not found".to_string())?;
+        let window = tab
+            .workspace
+            .window(&address.raw_id)
+            .ok_or_else(|| "Window not found".to_string())?;
+        if window.preset != WindowPreset::Board {
+            return Err("Window is not a Board surface".to_string());
+        }
+        Ok((address.tab_id.clone(), window.geometry.clone()))
+    }
+
     pub(crate) fn record_workspace_board_milestone_event(
         &mut self,
         tab_id: &str,
@@ -285,6 +419,38 @@ impl AppRuntime {
             Some(entry.body.clone()),
         )
     }
+}
+
+fn board_error(client_id: &str, id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![OutboundEvent::reply(
+        client_id,
+        BackendEvent::BoardError {
+            id: id.to_string(),
+            message: message.into(),
+        },
+    )]
+}
+
+fn agent_option_matches_session(option: &gwt::AgentOption, agent_id: &AgentId) -> bool {
+    match agent_id {
+        AgentId::ClaudeCode => option.id == "claude",
+        AgentId::Codex => option.id == "codex",
+        AgentId::Gemini => option.id == "gemini",
+        AgentId::OpenCode => option.id == "opencode",
+        AgentId::Copilot => option.id == "gh",
+        AgentId::Custom(id) => {
+            option.id == *id
+                || option
+                    .custom_agent
+                    .as_ref()
+                    .map(|agent| agent.id == *id)
+                    .unwrap_or(false)
+        }
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 /// Best-effort fan-out of a Board projection change to other gwt

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1983,20 +1983,28 @@ impl AppRuntime {
         vec![]
     }
 
-    /// SPEC-2041 Phase 19 (FR-059..061): user pressed `Later`. Emit
-    /// [`BackendEvent::UpdateApplyPendingPersisted`] so the CTA morphs to
-    /// ready state. Persistence to `~/.gwt/pending-update/` is wired in T-129
-    /// / T-133; for now the prepared payload remains in `prepared_update_path`
-    /// until the parent process exits.
+    /// SPEC-2041 Phase 19 (FR-059..061, FR-064): user pressed `Later`.
+    /// Verifies the manifest persisted by `ApplyUpdateStart`'s worker thread
+    /// is still on disk via [`crate::update_front_door::commit_update_later_pending`],
+    /// then emits [`BackendEvent::UpdateApplyPendingPersisted`] so the CTA
+    /// morphs to ready state. If persistence somehow vanished (external
+    /// cleanup, disk-full race), surface a structured error instead of
+    /// silently lying about pending state.
     fn apply_update_later_events(&self, client_id: &str) -> Vec<OutboundEvent> {
         let version = match self.pending_update.as_ref() {
             Some(gwt_core::update::UpdateState::Available { latest, .. }) => latest.clone(),
             _ => return vec![],
         };
-        vec![OutboundEvent::reply(
-            client_id,
-            BackendEvent::UpdateApplyPendingPersisted { version },
-        )]
+        match crate::update_front_door::commit_update_later_pending() {
+            Ok(()) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::UpdateApplyPendingPersisted { version },
+            )],
+            Err(message) => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed("Persist pending", &message),
+            )],
+        }
     }
 
     /// SPEC-2041 Phase 19 (FR-058): user pressed `Restart now`. Backend

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -619,26 +619,23 @@ fn active_work_projection_from_saved(
 fn active_work_projection_from_saved_with_journal(
     projection: gwt_core::workspace_projection::WorkspaceProjection,
     journal_entries: Vec<gwt::WorkspaceJournalEntryView>,
-    work_items: Vec<gwt::WorkspaceWorkItemView>,
+    workspaces: Vec<gwt::WorkspaceHistoryView>,
     cleanup_candidate: Option<gwt::ActiveWorkCleanupCandidateView>,
 ) -> gwt::ActiveWorkProjectionView {
     use gwt_core::workspace_projection::WorkspaceStatusCategory;
 
     let active_agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .filter(|agent| agent.status_category == WorkspaceStatusCategory::Active)
         .count();
     let blocked_agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .filter(|agent| agent.status_category == WorkspaceStatusCategory::Blocked)
         .count();
     let agent_branch = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .find_map(|agent| agent.branch.clone());
-    let agent_worktree = projection.agents.iter().find_map(|agent| {
+    let agent_worktree = projection.assigned_agents().find_map(|agent| {
         agent
             .worktree_path
             .as_ref()
@@ -646,32 +643,41 @@ fn active_work_projection_from_saved_with_journal(
     });
     let status_category =
         workspace_status_category_wire(projection.effective_status_category()).to_string();
-    let git_details = projection.git_details;
-    let (branch, worktree_path, pr_number, pr_url, pr_state, pr_created_at) = match git_details {
-        Some(details) => (
-            details.branch.or(agent_branch),
-            details
-                .worktree_path
-                .map(|path| path.display().to_string())
-                .or(agent_worktree),
-            details.pr_number,
-            details.pr_url,
-            details.pr_state,
-            details
-                .pr_created_at
-                .map(|created_at| created_at.to_rfc3339()),
-        ),
-        None => (agent_branch, agent_worktree, None, None, None, None),
-    };
+    let (branch, worktree_path, pr_number, pr_url, pr_state, pr_created_at) =
+        match projection.git_details.as_ref() {
+            Some(details) => (
+                details.branch.clone().or(agent_branch),
+                details
+                    .worktree_path
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .or(agent_worktree),
+                details.pr_number,
+                details.pr_url.clone(),
+                details.pr_state.clone(),
+                details
+                    .pr_created_at
+                    .map(|created_at| created_at.to_rfc3339()),
+            ),
+            None => (agent_branch, agent_worktree, None, None, None, None),
+        };
     let mut agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .map(active_work_agent_view_from_summary)
         .collect::<Vec<_>>();
     agents.sort_by(|left, right| {
         active_work_agent_priority_rank(left)
             .cmp(&active_work_agent_priority_rank(right))
             .then_with(|| left.display_name.cmp(&right.display_name))
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+    let mut unassigned_agents = projection
+        .unassigned_agents()
+        .map(active_work_agent_view_from_summary)
+        .collect::<Vec<_>>();
+    unassigned_agents.sort_by(|left, right| {
+        left.display_name
+            .cmp(&right.display_name)
             .then_with(|| left.session_id.cmp(&right.session_id))
     });
 
@@ -693,9 +699,10 @@ fn active_work_projection_from_saved_with_journal(
         pr_created_at,
         board_refs: projection.board_refs,
         journal_entries,
-        work_items,
+        workspaces,
         cleanup_candidate,
         agents,
+        unassigned_agents,
     }
 }
 
@@ -721,9 +728,10 @@ fn empty_active_work_projection_view(
         pr_created_at: None,
         board_refs: Vec::new(),
         journal_entries: Vec::new(),
-        work_items: Vec::new(),
+        workspaces: Vec::new(),
         cleanup_candidate: None,
         agents: Vec::new(),
+        unassigned_agents: Vec::new(),
     }
 }
 
@@ -767,8 +775,8 @@ fn workspace_journal_entry_view_from_entry(
 
 fn workspace_work_item_view_from_item(
     item: &gwt_core::workspace_projection::WorkspaceWorkItem,
-) -> gwt::WorkspaceWorkItemView {
-    gwt::WorkspaceWorkItemView {
+) -> gwt::WorkspaceHistoryView {
+    gwt::WorkspaceHistoryView {
         id: item.id.clone(),
         title: item.title.clone(),
         intent: item.intent.clone(),
@@ -795,7 +803,7 @@ fn workspace_work_item_view_from_item(
             .map(workspace_execution_container_view_from_ref)
             .collect(),
         board_refs: item.board_refs.clone(),
-        related_work_item_ids: item.related_work_item_ids.clone(),
+        related_workspace_ids: item.related_work_item_ids.clone(),
         events: item
             .events
             .iter()
@@ -806,8 +814,8 @@ fn workspace_work_item_view_from_item(
 
 fn workspace_work_agent_view_from_ref(
     agent: &gwt_core::workspace_projection::WorkspaceWorkAgentRef,
-) -> gwt::WorkspaceWorkAgentView {
-    gwt::WorkspaceWorkAgentView {
+) -> gwt::WorkspaceHistoryAgentView {
+    gwt::WorkspaceHistoryAgentView {
         session_id: agent.session_id.clone(),
         agent_id: agent.agent_id.clone(),
         display_name: agent.display_name.clone(),
@@ -834,10 +842,10 @@ fn workspace_execution_container_view_from_ref(
 
 fn workspace_work_event_view_from_event(
     event: &gwt_core::workspace_projection::WorkspaceWorkEvent,
-) -> gwt::WorkspaceWorkEventView {
-    gwt::WorkspaceWorkEventView {
+) -> gwt::WorkspaceHistoryEventView {
+    gwt::WorkspaceHistoryEventView {
         id: event.id.clone(),
-        work_item_id: event.work_item_id.clone(),
+        workspace_id: event.work_item_id.clone(),
         kind: workspace_work_event_kind_wire(event.kind).to_string(),
         title: event.title.clone(),
         intent: event.intent.clone(),
@@ -850,7 +858,7 @@ fn workspace_work_event_view_from_event(
         next_action: event.next_action.clone(),
         agent_session_id: event.agent_session_id.clone(),
         board_entry_id: event.board_entry_id.clone(),
-        related_work_item_id: event.related_work_item_id.clone(),
+        related_workspace_id: event.related_work_item_id.clone(),
         updated_at: event
             .updated_at
             .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -1026,11 +1034,17 @@ fn active_work_agent_priority_rank(agent: &gwt::ActiveWorkAgentView) -> u8 {
 fn active_work_agent_view_from_summary(
     agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
 ) -> gwt::ActiveWorkAgentView {
+    let affiliation_status = match agent.affiliation_status {
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned => "unassigned",
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned => "assigned",
+    };
     gwt::ActiveWorkAgentView {
         session_id: agent.session_id.clone(),
         window_id: agent.window_id.clone(),
         agent_id: agent.agent_id.clone(),
         display_name: agent.display_name.clone(),
+        affiliation_status: affiliation_status.to_string(),
+        workspace_id: agent.workspace_id.clone(),
         status_category: workspace_status_category_wire(agent.status_category).to_string(),
         current_focus: agent.current_focus.clone(),
         title_summary: agent.title_summary.clone(),
@@ -1066,8 +1080,22 @@ fn active_agent_summary_from_session(
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
+        affiliation_status:
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+        workspace_id: None,
         updated_at,
     }
+}
+
+fn unassigned_agent_summary_from_session(
+    session: &ActiveAgentSession,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
+    let mut summary = active_agent_summary_from_session(session, updated_at);
+    summary.affiliation_status =
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned;
+    summary.workspace_id = None;
+    summary
 }
 
 fn agent_launch_purpose_title(
@@ -1163,6 +1191,11 @@ fn upsert_workspace_agent(
         if summary.coordination_scope.is_some() {
             existing.coordination_scope = summary.coordination_scope;
         }
+        if summary.title_summary.is_some() {
+            existing.title_summary = summary.title_summary;
+        }
+        existing.affiliation_status = summary.affiliation_status;
+        existing.workspace_id = summary.workspace_id;
         if summary.updated_at > existing.updated_at {
             existing.updated_at = summary.updated_at;
         }
@@ -1177,10 +1210,31 @@ fn merge_active_sessions_into_projection<'a>(
     updated_at: chrono::DateTime<chrono::Utc>,
 ) {
     for session in sessions {
-        upsert_workspace_agent(
-            &mut projection.agents,
-            active_agent_summary_from_session(session, updated_at),
-        );
+        let existing = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.session_id)
+            .or_else(|| {
+                projection
+                    .agents
+                    .iter()
+                    .find(|agent| agent.window_id.as_deref() == Some(session.window_id.as_str()))
+            });
+        let mut summary = active_agent_summary_from_session(session, updated_at);
+        if let Some(existing) = existing {
+            summary.affiliation_status = existing.affiliation_status;
+            summary.workspace_id = existing.workspace_id.clone();
+            summary.title_summary = existing.title_summary.clone();
+            summary.current_focus = existing.current_focus.clone();
+            summary.last_board_entry_id = existing.last_board_entry_id.clone();
+            summary.last_board_entry_kind = existing.last_board_entry_kind.clone();
+            summary.coordination_scope = existing.coordination_scope.clone();
+        } else {
+            summary.affiliation_status =
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned;
+            summary.workspace_id = None;
+        }
+        upsert_workspace_agent(&mut projection.agents, summary);
     }
 }
 
@@ -1197,11 +1251,12 @@ fn retain_live_workspace_agents(
         .agents
         .retain(|agent| live_session_ids.contains(agent.session_id.as_str()));
     if !projection.agents.iter().any(|agent| {
-        matches!(
-            agent.status_category,
-            gwt_core::workspace_projection::WorkspaceStatusCategory::Active
-                | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
-        )
+        agent.is_assigned()
+            && matches!(
+                agent.status_category,
+                gwt_core::workspace_projection::WorkspaceStatusCategory::Active
+                    | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
+            )
     }) {
         projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Idle;
         projection.status_text = "No active work".to_string();
@@ -1214,11 +1269,12 @@ fn workspace_projection_has_current_agents(
     projection: &gwt_core::workspace_projection::WorkspaceProjection,
 ) -> bool {
     projection.agents.iter().any(|agent| {
-        matches!(
-            agent.status_category,
-            gwt_core::workspace_projection::WorkspaceStatusCategory::Active
-                | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
-        )
+        agent.is_assigned()
+            && matches!(
+                agent.status_category,
+                gwt_core::workspace_projection::WorkspaceStatusCategory::Active
+                    | gwt_core::workspace_projection::WorkspaceStatusCategory::Blocked
+            )
     })
 }
 
@@ -1315,13 +1371,13 @@ fn save_workspace_launch_projection(
     } else if let Some(issue_number) = linked_issue_number {
         projection.owner = Some(format!("Issue #{issue_number}"));
     }
-    upsert_workspace_agent(
-        &mut projection.agents,
-        active_agent_summary_from_session(session, now),
-    );
+    let mut agent = active_agent_summary_from_session(session, now);
+    agent.affiliation_status =
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned;
+    agent.workspace_id = Some(projection.id.clone());
+    upsert_workspace_agent(&mut projection.agents, agent);
     let active_agents = projection
-        .agents
-        .iter()
+        .assigned_agents()
         .filter(|agent| agent.status_category == WorkspaceStatusCategory::Active)
         .count();
     projection.status_text = if active_agents == 1 {
@@ -1394,17 +1450,35 @@ fn workspace_work_event_from_launch_projection(
     event
 }
 
+fn save_unassigned_workspace_launch_projection(
+    project_root: &Path,
+    session: &ActiveAgentSession,
+) -> Result<(), String> {
+    let now = chrono::Utc::now();
+    let mut projection =
+        gwt_core::workspace_projection::load_or_default_workspace_projection(project_root)
+            .map_err(|error| error.to_string())?;
+    projection.project_root = project_root.to_path_buf();
+    projection.register_unassigned_agent(unassigned_agent_summary_from_session(session, now));
+    projection.updated_at = now;
+    gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
+        .map_err(|error| error.to_string())
+}
+
 fn save_start_work_workspace_projection(
     project_root: &Path,
     session: &ActiveAgentSession,
-    base_branch: &str,
+    _base_branch: &str,
     linked_issue_number: Option<u64>,
     workspace_resume_context: Option<&WorkspaceResumeContext>,
 ) -> Result<(), String> {
+    if workspace_resume_context.is_none() {
+        return save_unassigned_workspace_launch_projection(project_root, session);
+    }
     save_workspace_launch_projection(
         project_root,
         session,
-        Some(base_branch),
+        Some(_base_branch),
         linked_issue_number,
         workspace_resume_context,
         true,
@@ -2388,7 +2462,7 @@ impl AppRuntime {
                 .iter()
                 .map(workspace_journal_entry_view_from_entry)
                 .collect::<Vec<_>>();
-            let work_items =
+            let workspaces =
                 gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(
                     &tab.project_root,
                 )
@@ -2405,7 +2479,7 @@ impl AppRuntime {
             return Some(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
-                work_items,
+                workspaces,
                 cleanup_candidate,
             ));
         }
@@ -2447,9 +2521,10 @@ impl AppRuntime {
             pr_created_at: None,
             board_refs: Vec::new(),
             journal_entries: Vec::new(),
-            work_items: Vec::new(),
+            workspaces: Vec::new(),
             cleanup_candidate: None,
             agents,
+            unassigned_agents: Vec::new(),
         })
     }
 
@@ -3801,7 +3876,7 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
     .iter()
     .map(workspace_journal_entry_view_from_entry)
     .collect::<Vec<_>>();
-    let work_items =
+    let workspaces =
         gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(project_root)
             .unwrap_or_else(
                 |_| gwt_core::workspace_projection::WorkspaceWorkItemsProjection {
@@ -3818,7 +3893,7 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
             projection: Box::new(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
-                work_items,
+                workspaces,
                 None,
             )),
         },
@@ -4163,25 +4238,23 @@ impl AppRuntime {
                                 }
                             }
                         } else if let Some(base_branch) = base_branch.as_deref() {
-                            if active_session.branch_name.starts_with("work/") {
-                                match save_start_work_workspace_projection(
-                                    &project_root,
-                                    active_session,
-                                    base_branch,
-                                    linked_issue_number,
-                                    None,
-                                ) {
-                                    Ok(()) => {
-                                        workspace_projection_updated = true;
-                                    }
-                                    Err(error) => {
-                                        tracing::warn!(
-                                            project_root = %project_root.display(),
-                                            branch = %active_session.branch_name,
-                                            error = %error,
-                                            "workspace projection update skipped after Start Work launch"
-                                        );
-                                    }
+                            match save_start_work_workspace_projection(
+                                &project_root,
+                                active_session,
+                                base_branch,
+                                linked_issue_number,
+                                None,
+                            ) {
+                                Ok(()) => {
+                                    workspace_projection_updated = true;
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        project_root = %project_root.display(),
+                                        branch = %active_session.branch_name,
+                                        error = %error,
+                                        "workspace projection update skipped after Start Work launch"
+                                    );
                                 }
                             }
                         }
@@ -5649,11 +5722,11 @@ mod tests {
 
     use super::{
         active_work_projection_from_saved, dispatch_agent_launch_success,
-        save_start_work_workspace_projection, ActiveAgentSession, AgentLaunchCompletion,
-        AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget, KnowledgeLoadRequest,
-        KnowledgeRefreshTask, KnowledgeSearchRequest, LaunchWizardMemoryCache, LaunchWizardSession,
-        OutboundEvent, ProcessLaunch, ProjectTabRuntime, UserEvent, WindowRuntime,
-        WorkspaceResumeContext,
+        save_start_work_workspace_projection, save_workspace_launch_projection, ActiveAgentSession,
+        AgentLaunchCompletion, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
+        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest,
+        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProcessLaunch,
+        ProjectTabRuntime, UserEvent, WindowRuntime, WorkspaceResumeContext,
     };
     use crate::{combined_window_id, geometry_to_pty_size, same_worktree_path, PtyWriterRegistry};
 
@@ -6101,6 +6174,19 @@ exit 0
             runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
             tab_id: tab_id.to_string(),
         }
+    }
+
+    fn save_assigned_workspace_projection_for_test(
+        repo: &Path,
+        session: &ActiveAgentSession,
+    ) -> Result<(), String> {
+        let context = WorkspaceResumeContext {
+            title: Some("Start Work".to_string()),
+            owner: Some("SPEC-2359".to_string()),
+            summary: Some("Assigned Workspace".to_string()),
+            next_action: Some("Check Board for latest updates".to_string()),
+        };
+        save_workspace_launch_projection(repo, session, Some("develop"), None, Some(&context), true)
     }
 
     #[test]
@@ -7679,7 +7765,7 @@ exit 0
     }
 
     #[test]
-    fn app_runtime_start_work_launch_completion_records_workspace_git_details() {
+    fn app_runtime_start_work_launch_completion_registers_unassigned_agent() {
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
@@ -7738,31 +7824,99 @@ exit 0
         let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
-        let details = projection.git_details.expect("git details");
         assert_eq!(
             projection.status_category,
-            gwt_core::workspace_projection::WorkspaceStatusCategory::Active
+            gwt_core::workspace_projection::WorkspaceStatusCategory::Unknown,
+            "Start Work must not make an unassigned Agent an active Workspace"
         );
-        assert_eq!(details.branch.as_deref(), Some("work/20260504-1234"));
-        assert_eq!(details.base_branch.as_deref(), Some("origin/main"));
-        assert_eq!(details.worktree_path.as_deref(), Some(worktree.as_path()));
-        assert!(details.created_by_start_work);
+        assert!(projection.git_details.is_none());
         assert_eq!(projection.agents.len(), 1);
         assert_eq!(projection.agents[0].session_id, "session-1");
-        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
-            .expect("load work items")
-            .expect("work items");
-        assert_eq!(work_items.work_items.len(), 1);
         assert_eq!(
-            work_items.work_items[0].events[0].kind,
-            gwt_core::workspace_projection::WorkspaceWorkEventKind::Start
+            projection.agents[0].affiliation_status,
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
         );
         assert_eq!(
-            work_items.work_items[0].execution_containers[0]
-                .branch
-                .as_deref(),
+            projection.agents[0].branch.as_deref(),
             Some("work/20260504-1234")
         );
+        assert_eq!(
+            projection.agents[0].worktree_path.as_deref(),
+            Some(worktree.as_path())
+        );
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items");
+        assert!(
+            work_items.is_none(),
+            "Start Work launch must not create Workspace history before explicit assignment"
+        );
+    }
+
+    #[test]
+    fn app_runtime_non_work_launch_registers_unassigned_agent() {
+        let _env_guard = env_test_lock().lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "agent-1",
+            repo.clone(),
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        let (command, args) = if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec![
+                    "/d".to_string(),
+                    "/s".to_string(),
+                    "/c".to_string(),
+                    "exit /b 0".to_string(),
+                ],
+            )
+        } else {
+            (
+                "/bin/sh".to_string(),
+                vec!["-lc".to_string(), "exit 0".to_string()],
+            )
+        };
+
+        let _events = runtime.handle_launch_complete(
+            window_id,
+            Ok((
+                ProcessLaunch {
+                    command,
+                    args,
+                    env: HashMap::new(),
+                    remove_env: Vec::new(),
+                    cwd: Some(repo.clone()),
+                },
+                "session-develop".to_string(),
+                "develop".to_string(),
+                "Codex".to_string(),
+                repo.clone(),
+                gwt_agent::AgentId::Codex,
+                None,
+                Some("origin/develop".to_string()),
+                gwt_agent::LaunchRuntimeTarget::Host,
+                repo.display().to_string(),
+            )),
+        );
+
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        assert_eq!(projection.agents.len(), 1);
+        assert_eq!(projection.agents[0].session_id, "session-develop");
+        assert_eq!(
+            projection.agents[0].affiliation_status,
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
+        );
+        assert_eq!(projection.agents[0].branch.as_deref(), Some("develop"));
     }
 
     #[test]
@@ -7857,7 +8011,7 @@ exit 0
     }
 
     #[test]
-    fn app_runtime_start_work_launch_completion_merges_agents_and_broadcasts_projection() {
+    fn app_runtime_start_work_launch_completion_registers_multiple_unassigned_agents() {
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
@@ -7959,13 +8113,19 @@ exit 0
         assert_eq!(projection.agents.len(), 2);
         assert!(session_ids.contains("session-1"));
         assert!(session_ids.contains("session-2"));
+        assert!(projection
+            .agents
+            .iter()
+            .all(gwt_core::workspace_projection::WorkspaceAgentSummary::is_unassigned));
         assert!(second_events.iter().any(|event| matches!(
             event,
             OutboundEvent {
                 target: DispatchTarget::Broadcast,
                 event: BackendEvent::ActiveWorkProjection { projection },
-            } if projection.active_agents == 2
-                && projection.branch.as_deref() == Some("work/20260504-1235")
+            } if projection.active_agents == 0
+                && projection.agents.is_empty()
+                && projection.unassigned_agents.len() == 2
+                && projection.branch.is_none()
         )));
     }
 
@@ -8069,6 +8229,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
@@ -8133,6 +8296,9 @@ exit 0
                 last_board_entry_id: Some("board-old".to_string()),
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
@@ -8187,6 +8353,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
@@ -10070,7 +10239,7 @@ exit 0
         runtime
             .active_agent_sessions
             .insert(session.window_id.clone(), session.clone());
-        save_start_work_workspace_projection(&repo, &session, "develop", None, None)
+        save_assigned_workspace_projection_for_test(&repo, &session)
             .expect("save initial projection");
         let blocked = BoardEntry::new(
             AuthorKind::Agent,
@@ -10128,6 +10297,9 @@ exit 0
             last_board_entry_id: None,
             last_board_entry_kind: None,
             coordination_scope: None,
+            affiliation_status:
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: now,
         });
         projection.agents.push(WorkspaceAgentSummary {
@@ -10143,6 +10315,9 @@ exit 0
             last_board_entry_id: Some("board-handoff".to_string()),
             last_board_entry_kind: Some(BoardEntryKind::Handoff),
             coordination_scope: Some("SPEC-2359 / workspace-ux".to_string()),
+            affiliation_status:
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
             updated_at: now,
         });
 
@@ -10193,7 +10368,7 @@ exit 0
         runtime
             .active_agent_sessions
             .insert(session.window_id.clone(), session.clone());
-        save_start_work_workspace_projection(&repo, &session, "develop", None, None)
+        save_assigned_workspace_projection_for_test(&repo, &session)
             .expect("save initial projection");
         let blocked = BoardEntry::new(
             AuthorKind::Agent,
@@ -10271,7 +10446,7 @@ exit 0
         runtime
             .active_agent_sessions
             .insert(session.window_id.clone(), session.clone());
-        save_start_work_workspace_projection(&repo, &session, "develop", None, None)
+        save_assigned_workspace_projection_for_test(&repo, &session)
             .expect("save initial projection");
         let blocked = BoardEntry::new(
             AuthorKind::Agent,
@@ -10857,6 +11032,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1341,16 +1341,28 @@ fn update_apply_error_failed(stage: &str, reason: &str) -> BackendEvent {
 /// at the trace level.
 fn open_path_with_os_default(path: &str) -> Result<(), std::io::Error> {
     use std::process::Command;
-    let mut cmd = if cfg!(target_os = "macos") {
-        Command::new("open")
+    // Reap the spawned opener on a detached thread so repeated invocations
+    // do not accumulate zombie processes on Unix. `std::process::Child` has
+    // no Drop-time wait, so without this the PID stays in the process table
+    // until parent exit (CodeRabbit review on PR #2630).
+    let child = if cfg!(target_os = "macos") {
+        let mut cmd = Command::new("open");
+        cmd.arg(path);
+        cmd.spawn()?
     } else if cfg!(target_os = "windows") {
-        let mut c = Command::new("cmd");
-        c.args(["/C", "start", "", path]);
-        return c.spawn().map(|_| ());
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "start", "", path]);
+        cmd.spawn()?
     } else {
-        Command::new("xdg-open")
+        let mut cmd = Command::new("xdg-open");
+        cmd.arg(path);
+        cmd.spawn()?
     };
-    cmd.arg(path).spawn().map(|_| ())
+    std::thread::spawn(move || {
+        let mut child = child;
+        let _ = child.wait();
+    });
+    Ok(())
 }
 
 fn detect_dirty(project_root: &Path) -> bool {
@@ -1973,13 +1985,14 @@ impl AppRuntime {
     }
 
     /// SPEC-2041 Phase 19 (FR-055): user pressed `Cancel` mid-download.
-    /// Implementation note: `prepare_update` is currently synchronous in the
-    /// background thread, so a true mid-download abort is a no-op until the
-    /// async download landing in T-128. We still surface the cancel as a
-    /// best-effort acknowledgement so the frontend transition stays
-    /// authoritative.
+    /// `prepare_update` runs synchronously on a worker thread, so a true
+    /// mid-download abort is best-effort. We still defensively clear any
+    /// `~/.gwt/pending-update/manifest.json` that the worker may have
+    /// persisted between the user's click and the modal close — without this
+    /// guard, a race would leave the bootstrap path applying an update the
+    /// user explicitly cancelled (CodeRabbit P1 review on PR #2630).
     fn cancel_update_download_events(&self, _client_id: &str) -> Vec<OutboundEvent> {
-        // TODO(T-128): cooperatively abort the in-flight download.
+        let _ = gwt_core::update::clear_pending_update_manifest();
         vec![]
     }
 
@@ -2037,13 +2050,41 @@ impl AppRuntime {
 
     /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
     /// modal. Backend opens the log file with the OS default application.
+    /// The renderer-supplied `log_path` is treated as untrusted: the path
+    /// must canonicalize to a child of the gwt logs directory, must exist as
+    /// a file, and must not contain a URL scheme (CodeRabbit review on PR
+    /// #2630). Validation failures are silently dropped — the modal already
+    /// surfaces the in-memory `Reason` so a missing log file is not blocking.
     fn open_update_log_events(
         &self,
         _client_id: &str,
         log_path: Option<String>,
     ) -> Vec<OutboundEvent> {
-        if let Some(path) = log_path {
-            let _ = open_path_with_os_default(&path);
+        if let Some(raw) = log_path {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() || trimmed.contains("://") {
+                return vec![];
+            }
+            // Derive the allowed logs root from the canonical update log
+            // resolver itself. AppRuntime is not allowed to call the legacy
+            // `gwt_logs_dir()` directly (project-scoped resolver test in
+            // main.rs), so we ride on `update_log_path()`'s parent.
+            let logs_root_candidate = match gwt_core::update::update_log_path().parent() {
+                Some(p) => p.to_path_buf(),
+                None => return vec![],
+            };
+            let logs_root = match std::fs::canonicalize(&logs_root_candidate) {
+                Ok(root) => root,
+                Err(_) => return vec![],
+            };
+            let candidate = match std::fs::canonicalize(trimmed) {
+                Ok(p) => p,
+                Err(_) => return vec![],
+            };
+            if !candidate.starts_with(&logs_root) || !candidate.is_file() {
+                return vec![];
+            }
+            let _ = open_path_with_os_default(&candidate.to_string_lossy());
         }
         vec![]
     }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1311,6 +1311,48 @@ fn read_head_branch(project_root: &Path) -> Option<String> {
 /// `true` when `git status --porcelain` reports any entry. Failures are
 /// treated as "not dirty" since the backend can fall through to the regular
 /// validator pass.
+/// Build a Phase 14 message-only [`BackendEvent::UpdateApplyError`].
+/// New callers should prefer [`update_apply_error_failed`] which also fills
+/// the structured Phase 19 fields.
+fn update_apply_error_message(message: &str) -> BackendEvent {
+    BackendEvent::UpdateApplyError {
+        message: Some(message.to_string()),
+        stage: None,
+        reason: None,
+        log_path: None,
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-063): structured update failure event with stage
+/// and reason. The legacy `message` field is populated with `reason` for
+/// frontends that still read it.
+fn update_apply_error_failed(stage: &str, reason: &str) -> BackendEvent {
+    BackendEvent::UpdateApplyError {
+        message: Some(reason.to_string()),
+        stage: Some(stage.to_string()),
+        reason: Some(reason.to_string()),
+        log_path: None,
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-065): launch the platform default opener
+/// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows). Errors are
+/// silently dropped so the modal does not surface noise; the path is logged
+/// at the trace level.
+fn open_path_with_os_default(path: &str) -> Result<(), std::io::Error> {
+    use std::process::Command;
+    let mut cmd = if cfg!(target_os = "macos") {
+        Command::new("open")
+    } else if cfg!(target_os = "windows") {
+        let mut c = Command::new("cmd");
+        c.args(["/C", "start", "", path]);
+        return c.spawn().map(|_| ());
+    } else {
+        Command::new("xdg-open")
+    };
+    cmd.arg(path).spawn().map(|_| ())
+}
+
 fn detect_dirty(project_root: &Path) -> bool {
     gwt_core::process::hidden_command("git")
         .args(["status", "--porcelain"])
@@ -1724,6 +1766,15 @@ impl AppRuntime {
                 self.handle_launch_wizard_action(action, bounds)
             }
             FrontendEvent::ApplyUpdate => self.apply_pending_update_events(&client_id),
+            FrontendEvent::ApplyUpdateStart => self.apply_update_start_events(&client_id),
+            FrontendEvent::CancelUpdateDownload => self.cancel_update_download_events(&client_id),
+            FrontendEvent::ApplyUpdateLater => self.apply_update_later_events(&client_id),
+            FrontendEvent::ApplyUpdateRestartNow => {
+                self.apply_update_restart_now_events(&client_id)
+            }
+            FrontendEvent::OpenUpdateLog { log_path } => {
+                self.open_update_log_events(&client_id, log_path)
+            }
             FrontendEvent::ListCustomAgents => vec![OutboundEvent::reply(
                 client_id,
                 gwt::custom_agents_dispatch::list_event(),
@@ -1855,32 +1906,138 @@ impl AppRuntime {
             }
             Some(gwt_core::update::UpdateState::Available { .. }) => vec![OutboundEvent::reply(
                 client_id,
-                BackendEvent::UpdateApplyError {
-                    message: "No applicable update asset is available for this platform."
-                        .to_string(),
-                },
+                update_apply_error_message(
+                    "No applicable update asset is available for this platform.",
+                ),
             )],
             Some(gwt_core::update::UpdateState::UpToDate { .. }) => vec![OutboundEvent::reply(
                 client_id,
-                BackendEvent::UpdateApplyError {
-                    message: "No pending update is available.".to_string(),
-                },
+                update_apply_error_message("No pending update is available."),
             )],
             Some(gwt_core::update::UpdateState::Failed { message, .. }) => {
                 vec![OutboundEvent::reply(
                     client_id,
-                    BackendEvent::UpdateApplyError {
-                        message: format!("Update check failed: {message}"),
-                    },
+                    update_apply_error_message(&format!("Update check failed: {message}")),
                 )]
             }
             None => vec![OutboundEvent::reply(
                 client_id,
-                BackendEvent::UpdateApplyError {
-                    message: "No pending update is available.".to_string(),
-                },
+                update_apply_error_message("No pending update is available."),
             )],
         }
+    }
+
+    /// SPEC-2041 Phase 19 (FR-052): user clicked the update CTA and the modal
+    /// is opening in the `downloading` state. Backend kicks off
+    /// `prepare_update` on a worker thread and emits
+    /// [`BackendEvent::UpdateReady`] (or [`BackendEvent::UpdateApplyError`])
+    /// without exiting the parent process.
+    fn apply_update_start_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        match self.pending_update.clone() {
+            Some(
+                state @ gwt_core::update::UpdateState::Available {
+                    asset_url: Some(_), ..
+                },
+            ) => {
+                self.proxy.send(UserEvent::ApplyUpdateStart {
+                    state,
+                    client_id: client_id.to_string(),
+                });
+                vec![]
+            }
+            Some(gwt_core::update::UpdateState::Available { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed(
+                    "Download asset",
+                    "No applicable update asset is available for this platform.",
+                ),
+            )],
+            Some(gwt_core::update::UpdateState::UpToDate { .. }) => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed("Download asset", "No pending update is available."),
+            )],
+            Some(gwt_core::update::UpdateState::Failed { message, .. }) => {
+                vec![OutboundEvent::reply(
+                    client_id,
+                    update_apply_error_failed(
+                        "Update check",
+                        &format!("Update check failed: {message}"),
+                    ),
+                )]
+            }
+            None => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed("Download asset", "No pending update is available."),
+            )],
+        }
+    }
+
+    /// SPEC-2041 Phase 19 (FR-055): user pressed `Cancel` mid-download.
+    /// Implementation note: `prepare_update` is currently synchronous in the
+    /// background thread, so a true mid-download abort is a no-op until the
+    /// async download landing in T-128. We still surface the cancel as a
+    /// best-effort acknowledgement so the frontend transition stays
+    /// authoritative.
+    fn cancel_update_download_events(&self, _client_id: &str) -> Vec<OutboundEvent> {
+        // TODO(T-128): cooperatively abort the in-flight download.
+        vec![]
+    }
+
+    /// SPEC-2041 Phase 19 (FR-059..061): user pressed `Later`. Emit
+    /// [`BackendEvent::UpdateApplyPendingPersisted`] so the CTA morphs to
+    /// ready state. Persistence to `~/.gwt/pending-update/` is wired in T-129
+    /// / T-133; for now the prepared payload remains in `prepared_update_path`
+    /// until the parent process exits.
+    fn apply_update_later_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        let version = match self.pending_update.as_ref() {
+            Some(gwt_core::update::UpdateState::Available { latest, .. }) => latest.clone(),
+            _ => return vec![],
+        };
+        vec![OutboundEvent::reply(
+            client_id,
+            BackendEvent::UpdateApplyPendingPersisted { version },
+        )]
+    }
+
+    /// SPEC-2041 Phase 19 (FR-058): user pressed `Restart now`. Backend
+    /// commits the prepared payload via the helper subprocess and exits the
+    /// parent. Falls back to the legacy `apply_update_state_and_exit` path
+    /// when no prepared payload exists yet (e.g. user manually re-clicked CTA
+    /// before download completed).
+    fn apply_update_restart_now_events(&self, client_id: &str) -> Vec<OutboundEvent> {
+        match self.pending_update.clone() {
+            Some(
+                state @ gwt_core::update::UpdateState::Available {
+                    asset_url: Some(_), ..
+                },
+            ) => {
+                self.proxy.send(UserEvent::ApplyUpdateRestartNow {
+                    state,
+                    client_id: client_id.to_string(),
+                });
+                vec![]
+            }
+            _ => vec![OutboundEvent::reply(
+                client_id,
+                update_apply_error_failed(
+                    "Restart now",
+                    "No prepared update available for restart.",
+                ),
+            )],
+        }
+    }
+
+    /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
+    /// modal. Backend opens the log file with the OS default application.
+    fn open_update_log_events(
+        &self,
+        _client_id: &str,
+        log_path: Option<String>,
+    ) -> Vec<OutboundEvent> {
+        if let Some(path) = log_path {
+            let _ = open_path_with_os_default(&path);
+        }
+        vec![]
     }
 
     pub(crate) fn frontend_sync_events(&self, client_id: &str) -> Vec<OutboundEvent> {
@@ -6362,7 +6519,7 @@ exit 0
         assert!(outbound.iter().any(|event| {
             matches!(
                 &event.event,
-                BackendEvent::UpdateApplyError { message }
+                BackendEvent::UpdateApplyError { message: Some(message), .. }
                     if message.contains("No applicable update asset")
             )
         }));

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1943,7 +1943,7 @@ impl AppRuntime {
             FrontendEvent::OpenIssueLaunchWizard { id, issue_number } => {
                 self.open_issue_launch_wizard_events(&client_id, &id, issue_number)
             }
-            FrontendEvent::OpenStartWork => self.open_start_work(),
+            FrontendEvent::OpenStartWork => self.open_start_work(&client_id),
             FrontendEvent::ResumeWorkspace { source, journal_id } => {
                 self.resume_workspace_events(source, journal_id)
             }
@@ -1951,11 +1951,11 @@ impl AppRuntime {
                 id,
                 branch_name,
                 linked_issue_number,
-            } => self.open_launch_wizard(&id, &branch_name, linked_issue_number),
+            } => self.open_launch_wizard(&client_id, &id, &branch_name, linked_issue_number),
             FrontendEvent::OpenActiveWorkLaunchWizard {
                 branch_name,
                 linked_issue_number,
-            } => self.open_active_work_launch_wizard(&branch_name, linked_issue_number),
+            } => self.open_active_work_launch_wizard(&client_id, &branch_name, linked_issue_number),
             FrontendEvent::LaunchWizardAction { action, bounds } => {
                 self.handle_launch_wizard_action(action, bounds)
             }
@@ -7521,6 +7521,10 @@ exit 0
 
         assert!(runtime.launch_wizard.is_none());
         assert!(matches!(
+            events.first().map(|event| &event.target),
+            Some(DispatchTarget::Client(client_id)) if client_id == "client-1"
+        ));
+        assert!(matches!(
             events.first().map(|event| &event.event),
             Some(BackendEvent::LaunchWizardOpenError { title, message })
                 if title == "Start Work" && !message.is_empty()
@@ -7549,6 +7553,10 @@ exit 0
         );
 
         assert!(runtime.launch_wizard.is_none());
+        assert!(matches!(
+            events.first().map(|event| &event.target),
+            Some(DispatchTarget::Client(client_id)) if client_id == "client-1"
+        ));
         assert!(matches!(
             events.first().map(|event| &event.event),
             Some(BackendEvent::LaunchWizardOpenError { title, message })

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -11384,6 +11384,9 @@ exit 0
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: chrono::Utc::now(),
             });
         projection
@@ -11556,6 +11559,56 @@ exit 0
                 .iter()
                 .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
             "WorkspaceState must be skipped when in-memory dynamic_title did not change: {events:?}"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_skips_workspace_state_when_same_title_resyncs() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Stable title"),
+            Some("Stable focus"),
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        // First sync: dynamic_title transitions from None → "Stable title".
+        let first = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+        assert!(
+            first
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "first sync should broadcast WorkspaceState: {first:?}"
+        );
+
+        // Second sync with the same projection: nothing diffs, so the
+        // WorkspaceState broadcast must be suppressed to avoid forcing a
+        // full frontend re-render on busy projections (Codex review P2).
+        let second = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+        assert!(
+            !second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "second sync with identical title must not broadcast WorkspaceState: {second:?}"
+        );
+        // ActiveWorkProjection still fires (it's idempotent on the
+        // frontend; the active card snapshot is harmless to re-send).
+        assert!(
+            second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "ActiveWorkProjection should still broadcast on resync: {second:?}"
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9638,6 +9638,38 @@ exit 0
     }
 
     #[test]
+    fn board_origin_agent_resume_config_supports_builtin_agent_descriptors() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let runtime = sample_runtime(temp.path(), Vec::new(), None);
+
+        for agent_id in [gwt_agent::AgentId::OpenClaw, gwt_agent::AgentId::Hermes] {
+            let session_id = format!("session-{}", agent_id.command());
+            let resume_id = format!("resume-{}", agent_id.command());
+            let mut session = gwt_agent::Session::new(
+                &repo,
+                format!("work/{}", agent_id.command()),
+                agent_id.clone(),
+            );
+            session.id = session_id.clone();
+            session.agent_session_id = Some(resume_id.clone());
+            session.save(&runtime.sessions_dir).expect("save session");
+
+            let config = runtime
+                .board_origin_agent_resume_config(&session_id)
+                .expect("resume config");
+
+            assert_eq!(config.agent_id, agent_id);
+            assert_eq!(
+                config.resume_session_id.as_deref(),
+                Some(resume_id.as_str())
+            );
+            assert_eq!(config.session_mode, gwt_agent::SessionMode::Resume);
+        }
+    }
+
+    #[test]
     fn app_runtime_open_board_origin_agent_rejects_missing_exact_resume_session() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -7311,6 +7311,60 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_open_start_work_failure_surfaces_launch_wizard_open_error() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo,
+            ProjectKind::Git,
+            &[WindowPreset::Board],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::OpenStartWork);
+
+        assert!(runtime.launch_wizard.is_none());
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::LaunchWizardOpenError { title, message })
+                if title == "Start Work" && !message.is_empty()
+        ));
+    }
+
+    #[test]
+    fn app_runtime_open_launch_wizard_failure_surfaces_launch_wizard_open_error() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().join("repo"),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenLaunchWizard {
+                id: "missing-window".to_string(),
+                branch_name: "main".to_string(),
+                linked_issue_number: None,
+            },
+        );
+
+        assert!(runtime.launch_wizard.is_none());
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::LaunchWizardOpenError { title, message })
+                if title == "Launch Agent" && message == "Window not found"
+        ));
+    }
+
+    #[test]
     fn app_runtime_custom_agent_cache_refresh_rebroadcasts_open_wizard_state() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1692,6 +1692,7 @@ pub struct AppRuntime {
     pub(crate) runtimes: HashMap<String, WindowRuntime>,
     pub(crate) window_details: HashMap<String, String>,
     pub(crate) window_lookup: HashMap<String, WindowAddress>,
+    pub(crate) board_all_view_windows: HashSet<String>,
     pub(crate) session_state_path: PathBuf,
     pub(crate) log_dir: PathBuf,
     pub(crate) proxy: AppEventProxy,
@@ -1771,6 +1772,7 @@ impl AppRuntime {
             runtimes: HashMap::new(),
             window_details: HashMap::new(),
             window_lookup: HashMap::new(),
+            board_all_view_windows: HashSet::new(),
             session_state_path,
             log_dir,
             proxy: AppEventProxy::new(proxy),
@@ -2979,7 +2981,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn load_board_events(
-        &self,
+        &mut self,
         client_id: &str,
         id: &str,
         all: bool,
@@ -3020,11 +3022,17 @@ impl AppRuntime {
                 },
             )];
         }
+        let project_root = tab.project_root.clone();
+        if all {
+            self.board_all_view_windows.insert(id.to_string());
+        } else {
+            self.board_all_view_windows.remove(id);
+        }
 
         let scope = if all {
             gwt_core::coordination::BoardAudienceScope::All
         } else {
-            match board::gui_default_board_scope_for_project(&tab.project_root) {
+            match board::gui_default_board_scope_for_project(&project_root) {
                 Ok(scope) => scope,
                 Err(error) => {
                     return vec![OutboundEvent::reply(
@@ -3038,9 +3046,9 @@ impl AppRuntime {
             }
         };
         let snapshot_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
-            gwt_core::coordination::load_snapshot(&tab.project_root)
+            gwt_core::coordination::load_snapshot(&project_root)
         } else {
-            gwt_core::coordination::load_snapshot_for_scope(&tab.project_root, &scope)
+            gwt_core::coordination::load_snapshot_for_scope(&project_root, &scope)
         };
         match snapshot_result {
             Ok(snapshot) => vec![OutboundEvent::reply(
@@ -3062,7 +3070,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn load_board_history_events(
-        &self,
+        &mut self,
         client_id: &str,
         id: &str,
         before_entry_id: Option<&str>,
@@ -3105,11 +3113,17 @@ impl AppRuntime {
                 },
             )];
         }
+        let project_root = tab.project_root.clone();
+        if all {
+            self.board_all_view_windows.insert(id.to_string());
+        } else {
+            self.board_all_view_windows.remove(id);
+        }
 
         let scope = if all {
             gwt_core::coordination::BoardAudienceScope::All
         } else {
-            match board::gui_default_board_scope_for_project(&tab.project_root) {
+            match board::gui_default_board_scope_for_project(&project_root) {
                 Ok(scope) => scope,
                 Err(error) => {
                     return vec![OutboundEvent::reply(
@@ -3123,10 +3137,10 @@ impl AppRuntime {
             }
         };
         let page_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
-            gwt_core::coordination::load_entries_before(&tab.project_root, before_entry_id, limit)
+            gwt_core::coordination::load_entries_before(&project_root, before_entry_id, limit)
         } else {
             gwt_core::coordination::load_entries_before_for_scope(
-                &tab.project_root,
+                &project_root,
                 before_entry_id,
                 limit,
                 &scope,
@@ -3225,8 +3239,13 @@ impl AppRuntime {
                 if window.preset != WindowPreset::Board {
                     continue;
                 }
-                let scope = board::gui_default_board_scope_for_project(&tab.project_root)
-                    .unwrap_or(gwt_core::coordination::BoardAudienceScope::All);
+                let window_id = combined_window_id(&tab.id, &window.id);
+                let scope = if self.board_all_view_windows.contains(&window_id) {
+                    gwt_core::coordination::BoardAudienceScope::All
+                } else {
+                    board::gui_default_board_scope_for_project(&tab.project_root)
+                        .unwrap_or(gwt_core::coordination::BoardAudienceScope::All)
+                };
                 let board = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
                     snapshot.board.clone()
                 } else {
@@ -3235,7 +3254,7 @@ impl AppRuntime {
                         .unwrap_or_else(|_| snapshot.board.clone())
                 };
                 events.push(OutboundEvent::broadcast(BackendEvent::BoardEntries {
-                    id: combined_window_id(&tab.id, &window.id),
+                    id: window_id,
                     entries: board.entries,
                     has_more_before: board.has_more_before,
                 }));
@@ -5239,6 +5258,7 @@ impl AppRuntime {
     fn remove_window_state_tracking(&mut self, window_id: &str) {
         self.window_pty_statuses.remove(window_id);
         self.window_hook_states.remove(window_id);
+        self.board_all_view_windows.remove(window_id);
     }
 
     fn tracked_window_exists(&self, window_id: &str) -> bool {
@@ -5774,8 +5794,8 @@ mod tests {
     use gwt_config::{Profile, Settings};
     use gwt_core::{
         coordination::{
-            load_snapshot, post_entry, AuthorKind, BoardEntry, BoardEntryKind, BoardMention,
-            BoardMentionTargetKind,
+            load_snapshot, post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardEntryKind,
+            BoardMention, BoardMentionTargetKind,
         },
         logging::{current_log_file, LogEvent, LogLevel},
         paths::gwt_cache_dir,
@@ -6257,6 +6277,30 @@ exit 0
         save_workspace_launch_projection(repo, session, Some("develop"), None, Some(&context), true)
     }
 
+    fn workspace_agent_summary_for_test(
+        session_id: &str,
+        workspace_id: Option<&str>,
+    ) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
+        gwt_core::workspace_projection::WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+            current_focus: Some("Board audience follow-up".to_string()),
+            title_summary: Some("Board audience follow-up".to_string()),
+            worktree_path: None,
+            branch: Some("work/test".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status:
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: workspace_id.map(str::to_string),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
     #[test]
     fn image_paste_prepare_uses_host_absolute_path_reference() {
         let temp = tempdir().expect("tempdir");
@@ -6490,6 +6534,7 @@ exit 0
             runtimes: HashMap::new(),
             window_details: HashMap::new(),
             window_lookup: HashMap::new(),
+            board_all_view_windows: std::collections::HashSet::new(),
             session_state_path: temp_root.join("session-state.json"),
             log_dir,
             proxy,
@@ -11327,6 +11372,152 @@ exit 0
                 .dynamic_title
                 .as_deref(),
             Some("Board milestone focus")
+        );
+    }
+
+    #[test]
+    fn app_runtime_gui_board_scope_uses_active_workspace_id_not_first_agent_workspace() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-active".to_string();
+        projection.agents.push(workspace_agent_summary_for_test(
+            "session-other",
+            Some("workspace-other"),
+        ));
+        projection
+            .agents
+            .push(workspace_agent_summary_for_test("session-active", None));
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let scope = super::board::gui_default_board_scope_for_project(&repo)
+            .expect("resolve GUI board scope");
+        let post_audience =
+            gwt::board_audience::post_audience_for_gui(&repo, &[]).expect("resolve post audience");
+
+        assert_eq!(
+            scope,
+            BoardAudienceScope::Workspace("workspace-active".to_string())
+        );
+        assert_eq!(post_audience, Some(vec!["workspace-active".to_string()]));
+    }
+
+    #[test]
+    fn app_runtime_board_projection_change_preserves_all_view_for_live_updates() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-a".to_string();
+        projection
+            .agents
+            .push(workspace_agent_summary_for_test("session-a", None));
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "Workspace A update",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-a"]),
+        )
+        .expect("seed workspace A update");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "Workspace B update",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-b"]),
+        )
+        .expect("seed workspace B update");
+
+        let mut tab_workspace = empty_workspace_state();
+        tab_workspace.windows.push(sample_window(
+            "board-all",
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        ));
+        tab_workspace.windows.push(sample_window(
+            "board-workspace",
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        ));
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let all_window_id = combined_window_id("tab-1", "board-all");
+        let workspace_window_id = combined_window_id("tab-1", "board-workspace");
+        let _ = runtime.load_board_events("client-1", &all_window_id, true);
+        let _ = runtime.load_board_events("client-1", &workspace_window_id, false);
+
+        let events = runtime.handle_board_projection_changed_events(&repo);
+
+        let all_entries = events
+            .iter()
+            .find_map(|event| match event {
+                OutboundEvent {
+                    event: BackendEvent::BoardEntries { id, entries, .. },
+                    ..
+                } if id == &all_window_id => Some(entries),
+                _ => None,
+            })
+            .expect("all view board entries");
+        let workspace_entries = events
+            .iter()
+            .find_map(|event| match event {
+                OutboundEvent {
+                    event: BackendEvent::BoardEntries { id, entries, .. },
+                    ..
+                } if id == &workspace_window_id => Some(entries),
+                _ => None,
+            })
+            .expect("workspace view board entries");
+
+        assert!(
+            all_entries
+                .iter()
+                .any(|entry| entry.body == "Workspace B update"),
+            "All view live update must include other Workspace entries"
+        );
+        assert!(
+            !workspace_entries
+                .iter()
+                .any(|entry| entry.body == "Workspace B update"),
+            "Workspace view live update must stay scoped"
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1984,6 +1984,11 @@ impl AppRuntime {
                     mentions,
                 },
             ),
+            FrontendEvent::OpenBoardOriginAgent {
+                id,
+                origin_session_id,
+                bounds,
+            } => self.open_board_origin_agent_events(&client_id, &id, &origin_session_id, bounds),
             FrontendEvent::SelectProfile { id, profile_name } => {
                 self.select_profile_events(&client_id, &id, &profile_name)
             }
@@ -9296,6 +9301,132 @@ exit 0
                 && id == &window_id
                 && entries.iter().map(|entry| entry.body.as_str()).collect::<Vec<_>>() == vec!["entry-1", "entry-2"]
                 && *has_more_before
+        ));
+    }
+
+    #[test]
+    fn app_runtime_open_board_origin_agent_focuses_live_origin_session_window() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let board_raw_id = tab
+            .workspace
+            .add_window(WindowPreset::Board, canvas_bounds())
+            .id;
+        let agent_raw_id = tab
+            .workspace
+            .add_window(WindowPreset::Agent, canvas_bounds())
+            .id;
+        let board_window_id = combined_window_id("tab-1", &board_raw_id);
+        let agent_window_id = combined_window_id("tab-1", &agent_raw_id);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.active_agent_sessions.insert(
+            agent_window_id.clone(),
+            ActiveAgentSession {
+                window_id: agent_window_id.clone(),
+                session_id: "session-origin".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/board-origin".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.clone(),
+                agent_project_root: repo.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenBoardOriginAgent {
+                id: board_window_id,
+                origin_session_id: "session-origin".to_string(),
+                bounds: Some(canvas_bounds()),
+            },
+        );
+
+        let workspace = runtime.tab("tab-1").expect("tab").workspace.persisted();
+        let focused = workspace
+            .windows
+            .iter()
+            .max_by_key(|window| window.z_index)
+            .expect("focused window");
+        assert_eq!(focused.id, agent_raw_id);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            OutboundEvent {
+                event: BackendEvent::WorkspaceState { .. },
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn board_origin_agent_resume_config_uses_exact_saved_session() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let runtime = sample_runtime(temp.path(), Vec::new(), None);
+        let mut session =
+            gwt_agent::Session::new(&repo, "work/board-origin", gwt_agent::AgentId::Codex);
+        session.id = "session-origin".to_string();
+        session.agent_session_id = Some("codex-resume-123".to_string());
+        session.model = Some("gpt-5.4".to_string());
+        session.reasoning_level = Some("high".to_string());
+        session.tool_version = Some("latest".to_string());
+        session.skip_permissions = true;
+        session.codex_fast_mode = true;
+        session.save(&runtime.sessions_dir).expect("save session");
+
+        let config = runtime
+            .board_origin_agent_resume_config("session-origin")
+            .expect("resume config");
+
+        assert_eq!(config.branch.as_deref(), Some("work/board-origin"));
+        assert_eq!(config.working_dir.as_deref(), Some(repo.as_path()));
+        assert_eq!(
+            config.resume_session_id.as_deref(),
+            Some("codex-resume-123")
+        );
+        assert_eq!(config.session_mode, gwt_agent::SessionMode::Resume);
+        assert_eq!(config.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(config.reasoning_level.as_deref(), Some("high"));
+        assert!(config.skip_permissions);
+        assert!(config.codex_fast_mode);
+    }
+
+    #[test]
+    fn app_runtime_open_board_origin_agent_rejects_missing_exact_resume_session() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo,
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let board_window_id = combined_window_id("tab-1", "board-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenBoardOriginAgent {
+                id: board_window_id.clone(),
+                origin_session_id: "missing-session".to_string(),
+                bounds: Some(canvas_bounds()),
+            },
+        );
+
+        assert!(matches!(
+            &events[..],
+            [OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::BoardError { id, message },
+            }] if client_id == "client-1"
+                && id == &board_window_id
+                && message.contains("missing-session")
         ));
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -144,6 +144,7 @@ pub type AgentLaunchResult = Result<AgentLaunchCompletion, String>;
 mod board;
 mod migration;
 mod profile;
+mod title_sync;
 mod window;
 mod wizard;
 pub use board::BoardPostRequest;
@@ -2321,7 +2322,7 @@ impl AppRuntime {
         ))
     }
 
-    fn active_work_projection_broadcast_for_active_tab(&self) -> Option<OutboundEvent> {
+    pub(crate) fn active_work_projection_broadcast_for_active_tab(&self) -> Option<OutboundEvent> {
         let tab_id = self.active_tab_id.as_ref()?;
         let tab = self.tab(tab_id)?;
         let projection = self.active_work_projection_for_tab(tab_id, tab)?;
@@ -3127,37 +3128,23 @@ impl AppRuntime {
         else {
             return Vec::new();
         };
-        self.sync_agent_window_titles_from_workspace_projection(project_root, &projection);
-
-        let Some(tab_id) = self
-            .tabs
-            .iter()
-            .find(|tab| {
-                same_worktree_path(&tab.project_root, project_root)
-                    && self.active_tab_id.as_deref() == Some(tab.id.as_str())
-            })
-            .map(|tab| tab.id.clone())
-        else {
-            return Vec::new();
-        };
-        let Some(tab) = self.tab(&tab_id) else {
-            return Vec::new();
-        };
-        let Some(projection) = self.active_work_projection_for_tab(&tab_id, tab) else {
-            return Vec::new();
-        };
-        vec![OutboundEvent::broadcast(
-            BackendEvent::ActiveWorkProjection {
-                projection: Box::new(projection),
-            },
-        )]
+        self.apply_workspace_projection_title_sync(project_root, &projection)
     }
 
-    fn sync_agent_window_titles_from_workspace_projection(
+    /// Sync `projection.agents[<i>].title_summary` / `current_focus` into the
+    /// matching `tab.workspace.windows[<id>].dynamic_title` /
+    /// `dynamic_title_detail`. Returns `true` if at least one window was
+    /// touched.
+    ///
+    /// Callers should generally go through
+    /// [`AppRuntime::apply_workspace_projection_title_sync`] (Phase U-1+)
+    /// rather than calling this directly, so that the consequent broadcasts
+    /// are emitted in the same batch.
+    pub(crate) fn sync_agent_window_titles_from_workspace_projection(
         &mut self,
         project_root: &Path,
         projection: &gwt_core::workspace_projection::WorkspaceProjection,
-    ) {
+    ) -> bool {
         let updates = projection
             .agents
             .iter()
@@ -3167,21 +3154,12 @@ impl AppRuntime {
                     .as_deref()
                     .map(str::trim)
                     .filter(|value| !value.is_empty())?;
-                let (window_id, session) = self
-                    .active_agent_sessions
-                    .iter()
-                    .find(|(_, session)| session.session_id == agent.session_id)?;
-                if !same_worktree_path(&session.worktree_path, project_root) {
-                    return None;
-                }
-                Some((
-                    window_id.clone(),
-                    title.to_string(),
-                    agent.current_focus.clone(),
-                ))
+                let window_id = self.resolve_title_sync_window_id(agent, project_root)?;
+                Some((window_id, title.to_string(), agent.current_focus.clone()))
             })
             .collect::<Vec<_>>();
 
+        let mut changed = false;
         for (window_id, title, detail) in updates {
             let Some(address) = self.window_lookup.get(&window_id).cloned() else {
                 continue;
@@ -3189,9 +3167,52 @@ impl AppRuntime {
             let Some(tab) = self.tab_mut(&address.tab_id) else {
                 continue;
             };
-            tab.workspace
-                .set_dynamic_title_with_detail(&address.raw_id, Some(title), detail);
+            if tab
+                .workspace
+                .set_dynamic_title_with_detail(&address.raw_id, Some(title), detail)
+            {
+                changed = true;
+            }
         }
+        changed
+    }
+
+    /// Resolve the window_id that title sync should target for a given
+    /// projection agent.
+    ///
+    /// Fast path: `active_agent_sessions` (gwt's live launch tracking).
+    ///
+    /// Phase U-3 fallback (SPEC-2359 US-26): for sessions that gwt's
+    /// launch flow has not (yet) registered — e.g. GUI restarted after a
+    /// session started, a session that was launched outside the tracked
+    /// `gwtd` path but still publishes its `GWT_SESSION_ID` — use the
+    /// `window_id` / `worktree_path` carried by the projection itself. The
+    /// fallback intentionally does **not** mutate `active_agent_sessions`
+    /// (that lifecycle stays in the launch flow, see US-24). It only
+    /// resolves the lookup needed for title sync.
+    fn resolve_title_sync_window_id(
+        &self,
+        agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
+        project_root: &Path,
+    ) -> Option<String> {
+        if let Some((window_id, session)) = self
+            .active_agent_sessions
+            .iter()
+            .find(|(_, session)| session.session_id == agent.session_id)
+        {
+            if same_worktree_path(&session.worktree_path, project_root) {
+                return Some(window_id.clone());
+            }
+        }
+        let projected_window_id = agent.window_id.as_deref()?;
+        let projected_worktree = agent.worktree_path.as_deref()?;
+        if !same_worktree_path(projected_worktree, project_root) {
+            return None;
+        }
+        if !self.window_lookup.contains_key(projected_window_id) {
+            return None;
+        }
+        Some(projected_window_id.to_string())
     }
 
     pub(crate) fn load_knowledge_bridge_events(
@@ -10938,6 +10959,439 @@ exit 0
         assert_eq!(
             agent_window.dynamic_title_detail.as_deref(),
             Some("Implement mandatory Agent title summary updates for Workspace")
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // SPEC-2359 US-26 Phase U-1: canonical title-sync orchestration
+    // ---------------------------------------------------------------------
+
+    fn apply_title_sync_setup_tab_and_runtime(
+        repo: PathBuf,
+        active_tab: Option<&str>,
+    ) -> (AppRuntime, String) {
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        // Need the path so the temp directory survives until the runtime drops.
+        let temp_root = repo.parent().expect("repo has parent").to_path_buf();
+        let mut runtime = sample_runtime(&temp_root, vec![tab], active_tab);
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260510-0900".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo,
+                agent_project_root: String::new(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        (runtime, window_id)
+    }
+
+    fn apply_title_sync_sample_projection(
+        repo: &Path,
+        window_id: &str,
+        title_summary: Option<&str>,
+        current_focus: Option<&str>,
+    ) -> gwt_core::workspace_projection::WorkspaceProjection {
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(repo);
+        projection.status_category =
+            gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
+        projection
+            .agents
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
+                session_id: "session-1".to_string(),
+                window_id: Some(window_id.to_string()),
+                agent_id: "codex".to_string(),
+                display_name: "Codex".to_string(),
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+                current_focus: current_focus.map(str::to_string),
+                title_summary: title_summary.map(str::to_string),
+                worktree_path: Some(repo.to_path_buf()),
+                branch: Some("work/20260510-0900".to_string()),
+                last_board_entry_id: None,
+                last_board_entry_kind: None,
+                coordination_scope: None,
+                updated_at: chrono::Utc::now(),
+            });
+        projection
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_writes_dynamic_title() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Canonical orchestration"),
+            Some("Implement apply_workspace_projection_title_sync"),
+        );
+
+        let _events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("Canonical orchestration"),
+            "dynamic_title should reflect projection.agents[<i>].title_summary"
+        );
+        assert_eq!(
+            agent_window.dynamic_title_detail.as_deref(),
+            Some("Implement apply_workspace_projection_title_sync"),
+            "dynamic_title_detail should reflect projection.agents[<i>].current_focus"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_emits_active_work_projection_for_active_tab() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // active_work_projection_for_tab loads from disk, so the projection
+        // file must exist for the broadcast to populate.
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Phase U-1 broadcast assertion"),
+            None,
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "expected ActiveWorkProjection broadcast in events: {events:?}"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_returns_no_events_without_active_tab() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) = apply_title_sync_setup_tab_and_runtime(repo.clone(), None);
+        let projection =
+            apply_title_sync_sample_projection(&repo, &window_id, Some("No active tab"), None);
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "without an active tab, ActiveWorkProjection broadcast must be skipped"
+        );
+        // Even without an active tab, the in-memory dynamic_title should still
+        // be synced so the next workspace_state broadcast carries it.
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("No active tab"),
+            "dynamic_title must be set in-memory regardless of active_tab routing"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_emits_workspace_state_when_dynamic_title_changed() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Phase U-2 WorkspaceState assertion"),
+            None,
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        // Phase U-2 (SPEC-2359 US-26): a workspace update path that mutates
+        // an in-memory dynamic_title MUST broadcast WorkspaceState in the
+        // same batch so the frontend's `windowData.dynamic_title` and the
+        // pane heading `windowDisplayTitle` refresh without waiting for the
+        // next hook event or window structure change.
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "expected WorkspaceState broadcast when dynamic_title changed: {events:?}"
+        );
+    }
+
+    #[test]
+    fn apply_workspace_projection_title_sync_skips_workspace_state_when_nothing_changed() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Drop the active_agent_sessions entry AND erase the projection's
+        // window_id so neither the fast path nor the Phase U-3 fallback
+        // can resolve a window. The WorkspaceState broadcast should be
+        // skipped to avoid forcing a frontend re-render for a no-op update.
+        runtime.active_agent_sessions.clear();
+        let mut projection =
+            apply_title_sync_sample_projection(&repo, "tab-1::agent-1", Some("No-op"), None);
+        projection.agents[0].window_id = None;
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
+
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "WorkspaceState must be skipped when in-memory dynamic_title did not change: {events:?}"
+        );
+    }
+
+    #[test]
+    fn handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pane_heading() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Pane heading via WorkspaceState"),
+            Some("triggered by gwtd workspace update --title-summary"),
+        );
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let events = runtime.handle_workspace_projection_changed_events(&repo);
+
+        // The original handler returned only ActiveWorkProjection. Phase
+        // U-2 promotes it to also broadcast WorkspaceState in one batch so
+        // the pane heading refreshes immediately after `gwtd workspace
+        // update --title-summary`.
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "handle_workspace_projection_changed_events must broadcast WorkspaceState: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "ActiveWorkProjection broadcast must still fire: {events:?}"
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_falls_back_to_projection_window_id_when_active_agent_sessions_missing(
+    ) {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Phase U-3: simulate a session that gwt's launch tracking has not
+        // registered (e.g. GUI restarted after launch, or session started
+        // outside gwt's launch path). The window exists in workspace state
+        // and the projection knows its window_id + worktree_path, but
+        // active_agent_sessions is empty.
+        runtime.active_agent_sessions.clear();
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Phase U-3 backfill via projection window_id"),
+            Some("ensures untracked sessions still update pane heading"),
+        );
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            changed,
+            "Phase U-3: sync must return true when projection-driven fallback resolves the window"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("Phase U-3 backfill via projection window_id"),
+            "dynamic_title must propagate even when active_agent_sessions is empty"
+        );
+        assert_eq!(
+            agent_window.dynamic_title_detail.as_deref(),
+            Some("ensures untracked sessions still update pane heading")
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_skips_fallback_when_projection_worktree_mismatches() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        let other_repo = temp.path().join("other-repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&other_repo).expect("create other repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        runtime.active_agent_sessions.clear();
+        // Projection claims the agent lives in a *different* worktree.
+        // Phase U-3 fallback must refuse to touch local windows in that
+        // case, otherwise cross-worktree titles could leak.
+        let mut projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Cross-worktree title leak guard"),
+            None,
+        );
+        projection.agents[0].worktree_path = Some(other_repo);
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "fallback must refuse cross-worktree window updates"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert!(
+            agent_window.dynamic_title.is_none(),
+            "dynamic_title must stay None when projection.agents[<i>].worktree_path mismatches"
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_skips_fallback_when_projection_window_id_unknown_locally() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        runtime.active_agent_sessions.clear();
+        // Projection references a window_id that is NOT present in any
+        // local tab. The fallback must short-circuit instead of producing
+        // a phantom window update.
+        let mut projection =
+            apply_title_sync_sample_projection(&repo, "tab-1::agent-1", Some("phantom"), None);
+        projection.agents[0].window_id = Some("tab-99::ghost".to_string());
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "fallback must require the projected window_id to exist locally"
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_returns_false_when_no_resolution_path_exists() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Drop the active_agent_sessions entry AND erase the projection's
+        // window_id so neither the fast path nor the Phase U-3 fallback
+        // can resolve this agent's window. The sync must then be a no-op.
+        runtime.active_agent_sessions.clear();
+        let mut projection = apply_title_sync_sample_projection(
+            &repo,
+            "tab-1::agent-1",
+            Some("Should not propagate"),
+            None,
+        );
+        projection.agents[0].window_id = None;
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "sync must return false when no in-memory window was touched"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert!(
+            agent_window.dynamic_title.is_none(),
+            "dynamic_title must stay None when neither active_agent_sessions nor projection window_id resolve"
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1335,6 +1335,25 @@ fn update_apply_error_failed(stage: &str, reason: &str) -> BackendEvent {
     }
 }
 
+/// SPEC-2041 Phase 19 (FR-065, CodeRabbit review on PR #2630): pure
+/// validator for renderer-supplied update log paths. Returns the canonical
+/// path when (1) the input is non-empty and contains no URL scheme,
+/// (2) it canonicalizes successfully, (3) it is a file, and (4) it
+/// resides within the canonicalized `logs_root`. Returns `None` otherwise so
+/// callers can silently drop the request.
+fn validate_update_log_path(raw: &str, logs_root: &Path) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.contains("://") {
+        return None;
+    }
+    let canonical_root = std::fs::canonicalize(logs_root).ok()?;
+    let candidate = std::fs::canonicalize(trimmed).ok()?;
+    if !candidate.starts_with(&canonical_root) || !candidate.is_file() {
+        return None;
+    }
+    Some(candidate)
+}
+
 /// SPEC-2041 Phase 19 (FR-065): launch the platform default opener
 /// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows). Errors are
 /// silently dropped so the modal does not surface noise; the path is logged
@@ -2061,30 +2080,18 @@ impl AppRuntime {
         log_path: Option<String>,
     ) -> Vec<OutboundEvent> {
         if let Some(raw) = log_path {
-            let trimmed = raw.trim();
-            if trimmed.is_empty() || trimmed.contains("://") {
-                return vec![];
-            }
             // Derive the allowed logs root from the canonical update log
             // resolver itself. AppRuntime is not allowed to call the legacy
             // `gwt_logs_dir()` directly (project-scoped resolver test in
             // main.rs), so we ride on `update_log_path()`'s parent.
-            let logs_root_candidate = match gwt_core::update::update_log_path().parent() {
-                Some(p) => p.to_path_buf(),
-                None => return vec![],
-            };
-            let logs_root = match std::fs::canonicalize(&logs_root_candidate) {
-                Ok(root) => root,
-                Err(_) => return vec![],
-            };
-            let candidate = match std::fs::canonicalize(trimmed) {
-                Ok(p) => p,
-                Err(_) => return vec![],
-            };
-            if !candidate.starts_with(&logs_root) || !candidate.is_file() {
-                return vec![];
+            if let Some(logs_root) = gwt_core::update::update_log_path()
+                .parent()
+                .map(|p| p.to_path_buf())
+            {
+                if let Some(safe) = validate_update_log_path(&raw, &logs_root) {
+                    let _ = open_path_with_os_default(&safe.to_string_lossy());
+                }
             }
-            let _ = open_path_with_os_default(&candidate.to_string_lossy());
         }
         vec![]
     }
@@ -11011,5 +11018,72 @@ exit 0
             )),
             "existing migration backup must be surfaced as a recovery error"
         );
+    }
+
+    // SPEC-2041 Phase 19 (FR-065 / CodeRabbit review on PR #2630): renderer-
+    // supplied log paths must canonicalize into the gwt update logs root.
+    // These tests cover the `validate_update_log_path` pure validator.
+    #[test]
+    fn validate_update_log_path_accepts_file_inside_logs_root() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        let log_file = logs_root.path().join("update-2026-05-10.log");
+        std::fs::write(&log_file, b"{}\n").unwrap();
+
+        let resolved =
+            super::validate_update_log_path(log_file.to_str().unwrap(), logs_root.path());
+        assert!(
+            resolved.is_some(),
+            "expected file inside logs_root to validate"
+        );
+        let resolved = resolved.unwrap();
+        assert!(resolved.is_absolute());
+        assert!(resolved.ends_with("update-2026-05-10.log"));
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_files_outside_logs_root() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("evil.txt");
+        std::fs::write(&outside_file, b"steal me").unwrap();
+
+        let resolved =
+            super::validate_update_log_path(outside_file.to_str().unwrap(), logs_root.path());
+        assert!(resolved.is_none(), "outside-root paths must be rejected");
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_url_schemes_and_empty() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        for raw in [
+            "",
+            "   ",
+            "http://evil.example/log",
+            "https://evil.example/log",
+            "file:///etc/passwd",
+        ] {
+            assert!(
+                super::validate_update_log_path(raw, logs_root.path()).is_none(),
+                "expected `{raw}` to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_directories() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        // Caller passes the logs root itself; a directory must not be opened
+        // as a file.
+        let resolved =
+            super::validate_update_log_path(logs_root.path().to_str().unwrap(), logs_root.path());
+        assert!(resolved.is_none(), "directories must be rejected");
+    }
+
+    #[test]
+    fn validate_update_log_path_rejects_missing_files() {
+        let logs_root = tempfile::tempdir().expect("logs root tempdir");
+        let missing = logs_root.path().join("does-not-exist.log");
+        let resolved = super::validate_update_log_path(missing.to_str().unwrap(), logs_root.path());
+        assert!(resolved.is_none(), "missing files must be rejected");
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1881,12 +1881,19 @@ impl AppRuntime {
                 )]
             }
             FrontendEvent::LoadBranches { id } => self.load_branches_events(&client_id, &id),
-            FrontendEvent::LoadBoard { id } => self.load_board_events(&client_id, &id),
+            FrontendEvent::LoadBoard { id, all } => self.load_board_events(&client_id, &id, all),
             FrontendEvent::LoadBoardHistory {
                 id,
                 before_entry_id,
                 limit,
-            } => self.load_board_history_events(&client_id, &id, before_entry_id.as_deref(), limit),
+                all,
+            } => self.load_board_history_events(
+                &client_id,
+                &id,
+                before_entry_id.as_deref(),
+                limit,
+                all,
+            ),
             FrontendEvent::LoadProfile { id } => self.load_profile_events(&client_id, &id),
             FrontendEvent::LoadLogs { id } => self.load_logs_events(&client_id, &id),
             FrontendEvent::LoadKnowledgeBridge {
@@ -2971,69 +2978,11 @@ impl AppRuntime {
         Vec::new()
     }
 
-    pub(crate) fn load_board_events(&self, client_id: &str, id: &str) -> Vec<OutboundEvent> {
-        let Some(address) = self.window_lookup.get(id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        let Some(tab) = self.tab(&address.tab_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Project tab not found".to_string(),
-                },
-            )];
-        };
-        let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Window not found".to_string(),
-                },
-            )];
-        };
-        if window.preset != WindowPreset::Board {
-            return vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: "Window is not a Board surface".to_string(),
-                },
-            )];
-        }
-
-        match gwt_core::coordination::load_snapshot(&tab.project_root) {
-            Ok(snapshot) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardEntries {
-                    id: id.to_string(),
-                    entries: snapshot.board.entries,
-                    has_more_before: snapshot.board.has_more_before,
-                },
-            )],
-            Err(error) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::BoardError {
-                    id: id.to_string(),
-                    message: error.to_string(),
-                },
-            )],
-        }
-    }
-
-    pub(crate) fn load_board_history_events(
+    pub(crate) fn load_board_events(
         &self,
         client_id: &str,
         id: &str,
-        before_entry_id: Option<&str>,
-        limit: usize,
+        all: bool,
     ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id) else {
             return vec![OutboundEvent::reply(
@@ -3072,8 +3021,118 @@ impl AppRuntime {
             )];
         }
 
-        match gwt_core::coordination::load_entries_before(&tab.project_root, before_entry_id, limit)
-        {
+        let scope = if all {
+            gwt_core::coordination::BoardAudienceScope::All
+        } else {
+            match board::gui_default_board_scope_for_project(&tab.project_root) {
+                Ok(scope) => scope,
+                Err(error) => {
+                    return vec![OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::BoardError {
+                            id: id.to_string(),
+                            message: error.to_string(),
+                        },
+                    )];
+                }
+            }
+        };
+        let snapshot_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
+            gwt_core::coordination::load_snapshot(&tab.project_root)
+        } else {
+            gwt_core::coordination::load_snapshot_for_scope(&tab.project_root, &scope)
+        };
+        match snapshot_result {
+            Ok(snapshot) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardEntries {
+                    id: id.to_string(),
+                    entries: snapshot.board.entries,
+                    has_more_before: snapshot.board.has_more_before,
+                },
+            )],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: error.to_string(),
+                },
+            )],
+        }
+    }
+
+    pub(crate) fn load_board_history_events(
+        &self,
+        client_id: &str,
+        id: &str,
+        before_entry_id: Option<&str>,
+        limit: usize,
+        all: bool,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Project tab not found".to_string(),
+                },
+            )];
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                },
+            )];
+        };
+        if window.preset != WindowPreset::Board {
+            return vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::BoardError {
+                    id: id.to_string(),
+                    message: "Window is not a Board surface".to_string(),
+                },
+            )];
+        }
+
+        let scope = if all {
+            gwt_core::coordination::BoardAudienceScope::All
+        } else {
+            match board::gui_default_board_scope_for_project(&tab.project_root) {
+                Ok(scope) => scope,
+                Err(error) => {
+                    return vec![OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::BoardError {
+                            id: id.to_string(),
+                            message: error.to_string(),
+                        },
+                    )];
+                }
+            }
+        };
+        let page_result = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
+            gwt_core::coordination::load_entries_before(&tab.project_root, before_entry_id, limit)
+        } else {
+            gwt_core::coordination::load_entries_before_for_scope(
+                &tab.project_root,
+                before_entry_id,
+                limit,
+                &scope,
+            )
+        };
+        match page_result {
             Ok(page) => vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::BoardHistoryPage {
@@ -3166,10 +3225,19 @@ impl AppRuntime {
                 if window.preset != WindowPreset::Board {
                     continue;
                 }
+                let scope = board::gui_default_board_scope_for_project(&tab.project_root)
+                    .unwrap_or(gwt_core::coordination::BoardAudienceScope::All);
+                let board = if matches!(scope, gwt_core::coordination::BoardAudienceScope::All) {
+                    snapshot.board.clone()
+                } else {
+                    gwt_core::coordination::load_snapshot_for_scope(&tab.project_root, &scope)
+                        .map(|snapshot| snapshot.board)
+                        .unwrap_or_else(|_| snapshot.board.clone())
+                };
                 events.push(OutboundEvent::broadcast(BackendEvent::BoardEntries {
                     id: combined_window_id(&tab.id, &window.id),
-                    entries: snapshot.board.entries.clone(),
-                    has_more_before: snapshot.board.has_more_before,
+                    entries: board.entries,
+                    has_more_before: board.has_more_before,
                 }));
             }
         }
@@ -9223,6 +9291,7 @@ exit 0
             "client-1".to_string(),
             FrontendEvent::LoadBoard {
                 id: window_id.clone(),
+                all: false,
             },
         );
 
@@ -9235,6 +9304,113 @@ exit 0
                 && id == &window_id
                 && entries.len() == 1
                 && entries[0].body == "Need review"
+        ));
+    }
+
+    #[test]
+    fn app_runtime_load_board_defaults_to_current_workspace_audience() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-current".to_string();
+        projection
+            .agents
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
+                session_id: "session-current".to_string(),
+                window_id: None,
+                agent_id: "codex".to_string(),
+                display_name: "Codex".to_string(),
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+                current_focus: Some("Board audience".to_string()),
+                title_summary: Some("Board audience".to_string()),
+                worktree_path: Some(repo.clone()),
+                branch: Some("work/board-audience".to_string()),
+                last_board_entry_id: None,
+                last_board_entry_kind: None,
+                coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: Some("workspace-current".to_string()),
+                updated_at: chrono::Utc::now(),
+            });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "broadcast entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            ),
+        )
+        .expect("seed broadcast");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "current workspace entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-current"]),
+        )
+        .expect("seed current");
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "codex",
+                BoardEntryKind::Status,
+                "other workspace entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-other"]),
+        )
+        .expect("seed other");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo,
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "board-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LoadBoard {
+                id: window_id.clone(),
+                all: false,
+            },
+        );
+
+        assert!(matches!(
+            &events[..],
+            [OutboundEvent {
+                event: BackendEvent::BoardEntries { entries, .. },
+                ..
+            }] if entries.iter().map(|entry| entry.body.as_str()).collect::<Vec<_>>()
+                == vec!["broadcast entry", "current workspace entry"]
         ));
     }
 
@@ -9280,6 +9456,7 @@ exit 0
                 id: window_id.clone(),
                 before_entry_id: Some("entry-3".to_string()),
                 limit: 2,
+                all: false,
             },
         );
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -5947,8 +5947,7 @@ mod tests {
     }
 
     fn env_test_lock() -> &'static Mutex<()> {
-        static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        crate::env_test_lock()
     }
 
     fn fake_gh_test_lock() -> &'static Mutex<()> {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -608,12 +608,18 @@ fn active_work_projection_from_saved(
     let cleanup_candidate = projection
         .cleanup_candidate(false)
         .map(active_work_cleanup_candidate_view_from_candidate);
-    active_work_projection_from_saved_with_journal(projection, Vec::new(), cleanup_candidate)
+    active_work_projection_from_saved_with_journal(
+        projection,
+        Vec::new(),
+        Vec::new(),
+        cleanup_candidate,
+    )
 }
 
 fn active_work_projection_from_saved_with_journal(
     projection: gwt_core::workspace_projection::WorkspaceProjection,
     journal_entries: Vec<gwt::WorkspaceJournalEntryView>,
+    work_items: Vec<gwt::WorkspaceWorkItemView>,
     cleanup_candidate: Option<gwt::ActiveWorkCleanupCandidateView>,
 ) -> gwt::ActiveWorkProjectionView {
     use gwt_core::workspace_projection::WorkspaceStatusCategory;
@@ -687,6 +693,7 @@ fn active_work_projection_from_saved_with_journal(
         pr_created_at,
         board_refs: projection.board_refs,
         journal_entries,
+        work_items,
         cleanup_candidate,
         agents,
     }
@@ -714,6 +721,7 @@ fn empty_active_work_projection_view(
         pr_created_at: None,
         board_refs: Vec::new(),
         journal_entries: Vec::new(),
+        work_items: Vec::new(),
         cleanup_candidate: None,
         agents: Vec::new(),
     }
@@ -754,6 +762,117 @@ fn workspace_journal_entry_view_from_entry(
         agent_session_id: entry.agent_session_id.clone(),
         agent_current_focus: entry.agent_current_focus.clone(),
         agent_title_summary: entry.agent_title_summary.clone(),
+    }
+}
+
+fn workspace_work_item_view_from_item(
+    item: &gwt_core::workspace_projection::WorkspaceWorkItem,
+) -> gwt::WorkspaceWorkItemView {
+    gwt::WorkspaceWorkItemView {
+        id: item.id.clone(),
+        title: item.title.clone(),
+        intent: item.intent.clone(),
+        summary: item.summary.clone(),
+        status_category: workspace_status_category_wire(item.status_category).to_string(),
+        owner: item.owner.clone(),
+        created_at: item
+            .created_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        updated_at: item
+            .updated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        completed_at: item
+            .completed_at
+            .map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        agents: item
+            .agents
+            .iter()
+            .map(workspace_work_agent_view_from_ref)
+            .collect(),
+        execution_containers: item
+            .execution_containers
+            .iter()
+            .map(workspace_execution_container_view_from_ref)
+            .collect(),
+        board_refs: item.board_refs.clone(),
+        related_work_item_ids: item.related_work_item_ids.clone(),
+        events: item
+            .events
+            .iter()
+            .map(workspace_work_event_view_from_event)
+            .collect(),
+    }
+}
+
+fn workspace_work_agent_view_from_ref(
+    agent: &gwt_core::workspace_projection::WorkspaceWorkAgentRef,
+) -> gwt::WorkspaceWorkAgentView {
+    gwt::WorkspaceWorkAgentView {
+        session_id: agent.session_id.clone(),
+        agent_id: agent.agent_id.clone(),
+        display_name: agent.display_name.clone(),
+        updated_at: agent
+            .updated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+    }
+}
+
+fn workspace_execution_container_view_from_ref(
+    container: &gwt_core::workspace_projection::WorkspaceExecutionContainerRef,
+) -> gwt::WorkspaceExecutionContainerView {
+    gwt::WorkspaceExecutionContainerView {
+        branch: container.branch.clone(),
+        worktree_path: container
+            .worktree_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        pr_number: container.pr_number,
+        pr_url: container.pr_url.clone(),
+        pr_state: container.pr_state.clone(),
+    }
+}
+
+fn workspace_work_event_view_from_event(
+    event: &gwt_core::workspace_projection::WorkspaceWorkEvent,
+) -> gwt::WorkspaceWorkEventView {
+    gwt::WorkspaceWorkEventView {
+        id: event.id.clone(),
+        work_item_id: event.work_item_id.clone(),
+        kind: workspace_work_event_kind_wire(event.kind).to_string(),
+        title: event.title.clone(),
+        intent: event.intent.clone(),
+        summary: event.summary.clone(),
+        status_category: event
+            .status_category
+            .map(workspace_status_category_wire)
+            .map(str::to_string),
+        owner: event.owner.clone(),
+        next_action: event.next_action.clone(),
+        agent_session_id: event.agent_session_id.clone(),
+        board_entry_id: event.board_entry_id.clone(),
+        related_work_item_id: event.related_work_item_id.clone(),
+        updated_at: event
+            .updated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+    }
+}
+
+fn workspace_work_event_kind_wire(
+    kind: gwt_core::workspace_projection::WorkspaceWorkEventKind,
+) -> &'static str {
+    use gwt_core::workspace_projection::WorkspaceWorkEventKind;
+
+    match kind {
+        WorkspaceWorkEventKind::Start => "start",
+        WorkspaceWorkEventKind::Claim => "claim",
+        WorkspaceWorkEventKind::Update => "update",
+        WorkspaceWorkEventKind::Blocked => "blocked",
+        WorkspaceWorkEventKind::Handoff => "handoff",
+        WorkspaceWorkEventKind::Resume => "resume",
+        WorkspaceWorkEventKind::Split => "split",
+        WorkspaceWorkEventKind::Merge => "merge",
+        WorkspaceWorkEventKind::Pr => "pr",
+        WorkspaceWorkEventKind::Done => "done",
     }
 }
 
@@ -1228,7 +1347,51 @@ fn save_workspace_launch_projection(
     projection.updated_at = now;
 
     gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
+        .map_err(|error| error.to_string())?;
+    let work_event_kind = if workspace_resume_context.is_some() {
+        gwt_core::workspace_projection::WorkspaceWorkEventKind::Resume
+    } else {
+        gwt_core::workspace_projection::WorkspaceWorkEventKind::Start
+    };
+    let work_event =
+        workspace_work_event_from_launch_projection(&projection, session, work_event_kind, now);
+    gwt_core::workspace_projection::record_workspace_work_event(project_root, work_event)
         .map_err(|error| error.to_string())
+}
+
+fn workspace_work_event_from_launch_projection(
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
+    session: &ActiveAgentSession,
+    kind: gwt_core::workspace_projection::WorkspaceWorkEventKind,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> gwt_core::workspace_projection::WorkspaceWorkEvent {
+    let mut event = gwt_core::workspace_projection::WorkspaceWorkEvent::new(
+        kind,
+        projection.id.clone(),
+        updated_at,
+    );
+    event.title = Some(projection.title.clone());
+    event.intent = projection
+        .summary
+        .clone()
+        .or_else(|| projection.next_action.clone());
+    event.summary = Some(projection.status_text.clone());
+    event.status_category = Some(projection.status_category);
+    event.owner = projection.owner.clone();
+    event.next_action = projection.next_action.clone();
+    event.agent_session_id = Some(session.session_id.clone());
+    event.agent_id = Some(session.agent_id.to_string());
+    event.display_name = Some(session.display_name.clone());
+    event.execution_container = projection.git_details.as_ref().map(|details| {
+        gwt_core::workspace_projection::WorkspaceExecutionContainerRef {
+            branch: details.branch.clone(),
+            worktree_path: details.worktree_path.clone(),
+            pr_number: details.pr_number,
+            pr_url: details.pr_url.clone(),
+            pr_state: details.pr_state.clone(),
+        }
+    });
+    event
 }
 
 fn save_start_work_workspace_projection(
@@ -2225,9 +2388,24 @@ impl AppRuntime {
                 .iter()
                 .map(workspace_journal_entry_view_from_entry)
                 .collect::<Vec<_>>();
+            let work_items =
+                gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(
+                    &tab.project_root,
+                )
+                .unwrap_or_else(
+                    |_| gwt_core::workspace_projection::WorkspaceWorkItemsProjection {
+                        updated_at,
+                        work_items: Vec::new(),
+                    },
+                )
+                .work_items
+                .iter()
+                .map(workspace_work_item_view_from_item)
+                .collect::<Vec<_>>();
             return Some(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
+                work_items,
                 cleanup_candidate,
             ));
         }
@@ -2269,6 +2447,7 @@ impl AppRuntime {
             pr_created_at: None,
             board_refs: Vec::new(),
             journal_entries: Vec::new(),
+            work_items: Vec::new(),
             cleanup_candidate: None,
             agents,
         })
@@ -3622,11 +3801,24 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
     .iter()
     .map(workspace_journal_entry_view_from_entry)
     .collect::<Vec<_>>();
+    let work_items =
+        gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(project_root)
+            .unwrap_or_else(
+                |_| gwt_core::workspace_projection::WorkspaceWorkItemsProjection {
+                    updated_at: projection.updated_at,
+                    work_items: Vec::new(),
+                },
+            )
+            .work_items
+            .iter()
+            .map(workspace_work_item_view_from_item)
+            .collect::<Vec<_>>();
     Some(OutboundEvent::broadcast(
         BackendEvent::ActiveWorkProjection {
             projection: Box::new(active_work_projection_from_saved_with_journal(
                 projection,
                 journal_entries,
+                work_items,
                 None,
             )),
         },
@@ -7557,6 +7749,20 @@ exit 0
         assert!(details.created_by_start_work);
         assert_eq!(projection.agents.len(), 1);
         assert_eq!(projection.agents[0].session_id, "session-1");
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(work_items.work_items.len(), 1);
+        assert_eq!(
+            work_items.work_items[0].events[0].kind,
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Start
+        );
+        assert_eq!(
+            work_items.work_items[0].execution_containers[0]
+                .branch
+                .as_deref(),
+            Some("work/20260504-1234")
+        );
     }
 
     #[test]
@@ -7641,6 +7847,13 @@ exit 0
         assert!(details.created_by_start_work);
         assert_eq!(projection.agents.len(), 1);
         assert_eq!(projection.agents[0].session_id, "session-1");
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(
+            work_items.work_items[0].events[0].kind,
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Resume
+        );
     }
 
     #[test]
@@ -9796,6 +10009,17 @@ exit 0
         );
         assert_eq!(projection.owner.as_deref(), Some("SPEC-2359"));
         assert_eq!(projection.board_refs.len(), 1);
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(
+            work_items.work_items[0].board_refs,
+            vec![board_entry_id.clone()]
+        );
+        assert_eq!(
+            work_items.work_items[0].events[0].kind,
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Update
+        );
         let projected_event = events
             .iter()
             .find_map(|event| match event {

--- a/crates/gwt/src/app_runtime/title_sync.rs
+++ b/crates/gwt/src/app_runtime/title_sync.rs
@@ -1,0 +1,70 @@
+//! Canonical orchestration for syncing `WorkspaceProjection` title surfaces
+//! (per-agent `title_summary` / `current_focus`) into in-memory window state
+//! and emitting the consequent broadcasts in one batch.
+//!
+//! Background (SPEC-2359 US-26 / Phase U-1..U-4):
+//! Before this module, every write path that mutated
+//! `projection.agents[<i>].title_summary` had to remember each step:
+//! (1) update `current.json` + `journal.jsonl`,
+//! (2) sync `tab.workspace.windows[<id>].dynamic_title` in memory,
+//! (3) broadcast `BackendEvent::ActiveWorkProjection`, and
+//! (4) broadcast `BackendEvent::WorkspaceState` so the pane heading
+//! `windowData.dynamic_title` consumed by `windowDisplayTitle` on the
+//! frontend refreshes. `gwtd workspace update --title-summary` ran (1)
+//! and (3) but never (4), so the pane heading kept the `agent_id`
+//! fallback ("CLAUDE CODE") even when `projection.agents[<i>].title_summary`
+//! had a fresh value.
+//!
+//! `apply_workspace_projection_title_sync` consolidates (2)..(4) so any
+//! caller that has just observed a projection change just dispatches the
+//! returned `Vec<OutboundEvent>` and is guaranteed to leave the surfaces
+//! consistent. Phase U-1 (this commit) keeps the broadcast surface
+//! identical to the pre-refactor behavior to preserve every existing
+//! test; Phase U-2 wires the `WorkspaceState` broadcast in;
+//! Phase U-3 adds `active_agent_sessions` backfill for sessions that
+//! gwt's launch flow has not yet registered.
+
+use std::path::Path;
+
+use gwt_core::workspace_projection::WorkspaceProjection;
+
+use super::{AppRuntime, OutboundEvent};
+
+impl AppRuntime {
+    /// Run the canonical title-sync orchestration for the supplied projection.
+    ///
+    /// Side effects:
+    /// - Mutates `tab.workspace.windows[<id>].dynamic_title` /
+    ///   `dynamic_title_detail` from `projection.agents[<i>].title_summary`
+    ///   / `current_focus` via
+    ///   [`AppRuntime::sync_agent_window_titles_from_workspace_projection`].
+    ///
+    /// Return value:
+    /// - The `OutboundEvent`s that callers should dispatch. Phase U-2
+    ///   (SPEC-2359 US-26) makes this emit `BackendEvent::WorkspaceState`
+    ///   when an in-memory `dynamic_title` actually changed, so the
+    ///   frontend's pane heading (`windowDisplayTitle` →
+    ///   `windowData.dynamic_title`) updates immediately without waiting
+    ///   for the next hook event or window structure change. The
+    ///   `BackendEvent::ActiveWorkProjection` broadcast for the active tab
+    ///   is emitted unconditionally — that surface refreshes the Active
+    ///   Work card and Workspace Kanban entries regardless of whether a
+    ///   pane heading was touched.
+    pub(crate) fn apply_workspace_projection_title_sync(
+        &mut self,
+        project_root: &Path,
+        projection: &WorkspaceProjection,
+    ) -> Vec<OutboundEvent> {
+        let dynamic_title_changed =
+            self.sync_agent_window_titles_from_workspace_projection(project_root, projection);
+
+        let mut events = Vec::new();
+        if dynamic_title_changed {
+            events.push(self.workspace_state_broadcast());
+        }
+        if let Some(event) = self.active_work_projection_broadcast_for_active_tab() {
+            events.push(event);
+        }
+        events
+    }
+}

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -38,19 +38,26 @@ fn linked_issue_kind_from_knowledge(kind: KnowledgeKind) -> Option<LinkedIssueKi
     }
 }
 
-fn launch_wizard_open_error(title: &str, message: impl Into<String>) -> OutboundEvent {
-    OutboundEvent::broadcast(BackendEvent::LaunchWizardOpenError {
-        title: title.to_string(),
-        message: message.into(),
-    })
+fn launch_wizard_open_error(
+    client_id: &str,
+    title: &str,
+    message: impl Into<String>,
+) -> OutboundEvent {
+    OutboundEvent::reply(
+        client_id.to_string(),
+        BackendEvent::LaunchWizardOpenError {
+            title: title.to_string(),
+            message: message.into(),
+        },
+    )
 }
 
-fn launch_agent_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
-    vec![launch_wizard_open_error("Launch Agent", message)]
+fn launch_agent_open_error(client_id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error(client_id, "Launch Agent", message)]
 }
 
-fn start_work_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
-    vec![launch_wizard_open_error("Start Work", message)]
+fn start_work_open_error(client_id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error(client_id, "Start Work", message)]
 }
 
 use super::{
@@ -90,22 +97,23 @@ impl AppRuntime {
 
     pub(crate) fn open_launch_wizard(
         &mut self,
+        client_id: &str,
         id: &str,
         branch_name: &str,
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id).cloned() else {
-            return launch_agent_open_error("Window not found");
+            return launch_agent_open_error(client_id, "Window not found");
         };
         let Some(tab) = self.tab(&address.tab_id) else {
-            return launch_agent_open_error("Project tab not found");
+            return launch_agent_open_error(client_id, "Project tab not found");
         };
         let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return launch_agent_open_error("Window not found");
+            return launch_agent_open_error(client_id, "Window not found");
         };
 
         if window.preset != WindowPreset::Branches {
-            return launch_agent_open_error("Window is not a branches list");
+            return launch_agent_open_error(client_id, "Window is not a branches list");
         }
 
         let project_root = tab.project_root.clone();
@@ -118,7 +126,7 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => launch_agent_open_error(error),
+            Err(error) => launch_agent_open_error(client_id, error),
         }
     }
 
@@ -190,17 +198,18 @@ impl AppRuntime {
 
     pub(crate) fn open_active_work_launch_wizard(
         &mut self,
+        client_id: &str,
         branch_name: &str,
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return launch_agent_open_error("Open a project before adding an agent");
+            return launch_agent_open_error(client_id, "Open a project before adding an agent");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return launch_agent_open_error("Project tab not found");
+            return launch_agent_open_error(client_id, "Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return launch_agent_open_error("Add Agent requires a Git project");
+            return launch_agent_open_error(client_id, "Add Agent requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
@@ -212,25 +221,25 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => launch_agent_open_error(error),
+            Err(error) => launch_agent_open_error(client_id, error),
         }
     }
 
-    pub(crate) fn open_start_work(&mut self) -> Vec<OutboundEvent> {
+    pub(crate) fn open_start_work(&mut self, client_id: &str) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return start_work_open_error("Open a project before starting work");
+            return start_work_open_error(client_id, "Open a project before starting work");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return start_work_open_error("Project tab not found");
+            return start_work_open_error(client_id, "Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return start_work_open_error("Start Work requires a Git project");
+            return start_work_open_error(client_id, "Start Work requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
         match self.open_start_work_for_project(&tab_id, &project_root) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => start_work_open_error(error),
+            Err(error) => start_work_open_error(client_id, error),
         }
     }
 

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -38,6 +38,21 @@ fn linked_issue_kind_from_knowledge(kind: KnowledgeKind) -> Option<LinkedIssueKi
     }
 }
 
+fn launch_wizard_open_error(title: &str, message: impl Into<String>) -> OutboundEvent {
+    OutboundEvent::broadcast(BackendEvent::LaunchWizardOpenError {
+        title: title.to_string(),
+        message: message.into(),
+    })
+}
+
+fn launch_agent_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error("Launch Agent", message)]
+}
+
+fn start_work_open_error(message: impl Into<String>) -> Vec<OutboundEvent> {
+    vec![launch_wizard_open_error("Start Work", message)]
+}
+
 use super::{
     branch_worktree_path, build_shell_process_launch, combined_window_id,
     detect_wizard_docker_context_and_status, knowledge_error_event, knowledge_kind_for_preset,
@@ -80,29 +95,17 @@ impl AppRuntime {
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id).cloned() else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            })];
+            return launch_agent_open_error("Window not found");
         };
         let Some(tab) = self.tab(&address.tab_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Project tab not found".to_string(),
-            })];
+            return launch_agent_open_error("Project tab not found");
         };
         let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window not found".to_string(),
-            })];
+            return launch_agent_open_error("Window not found");
         };
 
         if window.preset != WindowPreset::Branches {
-            return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: "Window is not a branches list".to_string(),
-            })];
+            return launch_agent_open_error("Window is not a branches list");
         }
 
         let project_root = tab.project_root.clone();
@@ -115,10 +118,7 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::BranchError {
-                id: id.to_string(),
-                message: error,
-            })],
+            Err(error) => launch_agent_open_error(error),
         }
     }
 
@@ -194,19 +194,13 @@ impl AppRuntime {
         linked_issue_number: Option<u64>,
     ) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Open a project before adding an agent".to_string(),
-            })];
+            return launch_agent_open_error("Open a project before adding an agent");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Project tab not found".to_string(),
-            })];
+            return launch_agent_open_error("Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Add Agent requires a Git project".to_string(),
-            })];
+            return launch_agent_open_error("Add Agent requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
@@ -218,35 +212,25 @@ impl AppRuntime {
             None,
         ) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: error,
-            })],
+            Err(error) => launch_agent_open_error(error),
         }
     }
 
     pub(crate) fn open_start_work(&mut self) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.clone() else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Open a project before starting work".to_string(),
-            })];
+            return start_work_open_error("Open a project before starting work");
         };
         let Some(tab) = self.tab(&tab_id) else {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Project tab not found".to_string(),
-            })];
+            return start_work_open_error("Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: "Start Work requires a Git project".to_string(),
-            })];
+            return start_work_open_error("Start Work requires a Git project");
         }
 
         let project_root = tab.project_root.clone();
         match self.open_start_work_for_project(&tab_id, &project_root) {
             Ok(()) => vec![self.launch_wizard_state_outbound()],
-            Err(error) => vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: error,
-            })],
+            Err(error) => start_work_open_error(error),
         }
     }
 

--- a/crates/gwt/src/board_audience.rs
+++ b/crates/gwt/src/board_audience.rs
@@ -26,6 +26,19 @@ fn workspace_id_for_agent(
         .or_else(|| non_empty_string(&projection.id))
 }
 
+fn active_workspace_id(projection: &WorkspaceProjection) -> Option<String> {
+    non_empty_string(&projection.id)
+}
+
+fn gui_workspace_id(projection: &WorkspaceProjection) -> Option<String> {
+    projection.assigned_agents().next()?;
+    active_workspace_id(projection).or_else(|| {
+        projection
+            .assigned_agents()
+            .find_map(|agent| workspace_id_for_agent(projection, agent))
+    })
+}
+
 fn push_unique(values: &mut Vec<String>, value: impl Into<String>) {
     let value = value.into();
     if value.trim().is_empty() || values.iter().any(|item| item == &value) {
@@ -102,10 +115,7 @@ pub fn gui_default_board_scope(repo_path: &Path) -> gwt_core::Result<BoardAudien
     let Some(projection) = load_workspace_projection(repo_path)? else {
         return Ok(BoardAudienceScope::All);
     };
-    if let Some(workspace_id) = projection
-        .assigned_agents()
-        .find_map(|agent| workspace_id_for_agent(&projection, agent))
-    {
+    if let Some(workspace_id) = gui_workspace_id(&projection) {
         return Ok(BoardAudienceScope::Workspace(workspace_id));
     }
     if projection.unassigned_agents().next().is_some() {
@@ -143,10 +153,7 @@ pub fn post_audience_for_gui(
     let projection = load_workspace_projection(repo_path)?;
     let mut audience = Vec::new();
     if let Some(projection) = projection.as_ref() {
-        if let Some(workspace_id) = projection
-            .assigned_agents()
-            .find_map(|agent| workspace_id_for_agent(projection, agent))
-        {
+        if let Some(workspace_id) = gui_workspace_id(projection) {
             push_unique(&mut audience, workspace_id);
         }
     }

--- a/crates/gwt/src/board_audience.rs
+++ b/crates/gwt/src/board_audience.rs
@@ -1,0 +1,177 @@
+use std::path::Path;
+
+use gwt_core::{
+    coordination::{
+        normalize_board_audience, BoardAudienceScope, BoardMention, BoardMentionTargetKind,
+    },
+    workspace_projection::{load_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection},
+};
+
+fn non_empty_string(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn workspace_id_for_agent(
+    projection: &WorkspaceProjection,
+    agent: &WorkspaceAgentSummary,
+) -> Option<String> {
+    if !agent.is_assigned() {
+        return None;
+    }
+    agent
+        .workspace_id
+        .as_deref()
+        .and_then(non_empty_string)
+        .or_else(|| non_empty_string(&projection.id))
+}
+
+fn push_unique(values: &mut Vec<String>, value: impl Into<String>) {
+    let value = value.into();
+    if value.trim().is_empty() || values.iter().any(|item| item == &value) {
+        return;
+    }
+    values.push(value);
+}
+
+fn push_workspace_for_session(
+    values: &mut Vec<String>,
+    projection: &WorkspaceProjection,
+    session_id: &str,
+) -> bool {
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+    else {
+        return false;
+    };
+    if let Some(workspace_id) = workspace_id_for_agent(projection, agent) {
+        push_unique(values, workspace_id);
+    }
+    true
+}
+
+fn push_workspace_for_agent(
+    values: &mut Vec<String>,
+    projection: &WorkspaceProjection,
+    target: &str,
+) {
+    let target = target.trim();
+    if target.is_empty() {
+        return;
+    }
+    for agent in &projection.agents {
+        let agent_matches = agent.agent_id.eq_ignore_ascii_case(target)
+            || agent.display_name.eq_ignore_ascii_case(target);
+        if !agent_matches {
+            continue;
+        }
+        if let Some(workspace_id) = workspace_id_for_agent(projection, agent) {
+            push_unique(values, workspace_id);
+        }
+    }
+}
+
+pub fn current_session_board_scope(
+    repo_path: &Path,
+    session_id: Option<&str>,
+) -> gwt_core::Result<BoardAudienceScope> {
+    let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(BoardAudienceScope::All);
+    };
+    let Some(projection) = load_workspace_projection(repo_path)? else {
+        return Ok(BoardAudienceScope::All);
+    };
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+    else {
+        return Ok(BoardAudienceScope::All);
+    };
+    if agent.is_unassigned() {
+        return Ok(BoardAudienceScope::Broadcast);
+    }
+    Ok(workspace_id_for_agent(&projection, agent)
+        .map(BoardAudienceScope::Workspace)
+        .unwrap_or(BoardAudienceScope::All))
+}
+
+pub fn gui_default_board_scope(repo_path: &Path) -> gwt_core::Result<BoardAudienceScope> {
+    let Some(projection) = load_workspace_projection(repo_path)? else {
+        return Ok(BoardAudienceScope::All);
+    };
+    if let Some(workspace_id) = projection
+        .assigned_agents()
+        .find_map(|agent| workspace_id_for_agent(&projection, agent))
+    {
+        return Ok(BoardAudienceScope::Workspace(workspace_id));
+    }
+    if projection.unassigned_agents().next().is_some() {
+        return Ok(BoardAudienceScope::Broadcast);
+    }
+    Ok(BoardAudienceScope::All)
+}
+
+pub fn post_audience_for_session(
+    repo_path: &Path,
+    session_id: Option<&str>,
+    mentions: &[BoardMention],
+    broadcast: bool,
+) -> gwt_core::Result<Option<Vec<String>>> {
+    if broadcast {
+        return Ok(None);
+    }
+    let projection = load_workspace_projection(repo_path)?;
+    let mut audience = Vec::new();
+    if let (Some(projection), Some(session_id)) = (
+        projection.as_ref(),
+        session_id.map(str::trim).filter(|value| !value.is_empty()),
+    ) {
+        push_workspace_for_session(&mut audience, projection, session_id);
+    }
+    collect_mention_audience(&mut audience, projection.as_ref(), mentions);
+    Ok(normalize_board_audience(Some(audience)))
+}
+
+pub fn post_audience_for_gui(
+    repo_path: &Path,
+    mentions: &[BoardMention],
+) -> gwt_core::Result<Option<Vec<String>>> {
+    let projection = load_workspace_projection(repo_path)?;
+    let mut audience = Vec::new();
+    if let Some(projection) = projection.as_ref() {
+        if let Some(workspace_id) = projection
+            .assigned_agents()
+            .find_map(|agent| workspace_id_for_agent(projection, agent))
+        {
+            push_unique(&mut audience, workspace_id);
+        }
+    }
+    collect_mention_audience(&mut audience, projection.as_ref(), mentions);
+    Ok(normalize_board_audience(Some(audience)))
+}
+
+fn collect_mention_audience(
+    audience: &mut Vec<String>,
+    projection: Option<&WorkspaceProjection>,
+    mentions: &[BoardMention],
+) {
+    for mention in mentions {
+        match mention.target_kind {
+            BoardMentionTargetKind::Workspace => push_unique(audience, mention.target.clone()),
+            BoardMentionTargetKind::Session => {
+                if let Some(projection) = projection {
+                    push_workspace_for_session(audience, projection, &mention.target);
+                }
+            }
+            BoardMentionTargetKind::Agent => {
+                if let Some(projection) = projection {
+                    push_workspace_for_agent(audience, projection, &mention.target);
+                }
+            }
+            BoardMentionTargetKind::User | BoardMentionTargetKind::Branch => {}
+        }
+    }
+}

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -41,6 +41,7 @@ mod workspace;
 
 use std::io::{self};
 
+pub use board::{BoardCommand, BoardPostCommand};
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
 use gwt_github::{ApiError, SpecOpsError};
@@ -315,30 +316,6 @@ pub enum ActionsCommand {
     JobLogs { job_id: u64 },
 }
 
-/// SPEC-1942 family enum for `gwtd board ...`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BoardCommand {
-    /// `gwtd board show [--json]`.
-    Show { json: bool },
-    /// `gwtd board post --kind <kind> (--body <text> | -f <file>)
-    /// [--title-summary <text>] [--parent <id>] [--topic <t>]*
-    /// [--owner <n>]* [--target <id>]* [--mention <kind:id>]*`.
-    Post(Box<BoardPostCommand>),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BoardPostCommand {
-    pub kind: String,
-    pub body: Option<String>,
-    pub file: Option<String>,
-    pub title_summary: Option<String>,
-    pub parent: Option<String>,
-    pub topics: Vec<String>,
-    pub owners: Vec<String>,
-    pub targets: Vec<String>,
-    pub mentions: Vec<String>,
-}
-
 /// SPEC-1942 family enum for `gwtd index ...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IndexCommand {
@@ -437,7 +414,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -299,15 +299,27 @@ pub enum ActionsCommand {
 /// SPEC-1942 family enum for `gwtd board ...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BoardCommand {
-    /// `gwtd board show [--json]`.
-    Show { json: bool },
+    /// `gwtd board show [--json] [--workspace <id>] [--all]`.
+    ///
+    /// SPEC-2359 FR-100: `workspace` scopes the view to entries whose
+    /// `audience` contains the given Workspace id or is broadcast.
+    /// `all` opts out of audience scoping and shows the full timeline.
+    /// Without either flag, the default future behavior is "current
+    /// Workspace + broadcast" once the current Agent's affiliation can
+    /// be resolved (FR-088); until then the default falls back to the
+    /// full timeline so legacy callers are unaffected.
+    Show {
+        json: bool,
+        workspace: Option<String>,
+        all: bool,
+    },
     /// `gwtd board post --kind <kind> (--body <text> | -f <file>)
     /// [--title-summary <text>] [--parent <id>] [--topic <t>]*
     /// [--owner <n>]* [--target <id>]* [--mention <kind:id>]*`.
     Post(Box<BoardPostCommand>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct BoardPostCommand {
     pub kind: String,
     pub body: Option<String>,
@@ -318,6 +330,7 @@ pub struct BoardPostCommand {
     pub owners: Vec<String>,
     pub targets: Vec<String>,
     pub mentions: Vec<String>,
+    pub broadcast: bool,
 }
 
 /// SPEC-1942 family enum for `gwtd index ...`.

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -189,6 +189,25 @@ pub enum WorkspaceCommand {
         current_focus: Option<String>,
         title_summary: Option<String>,
     },
+    /// `gwtd workspace candidates --agent-session <id>` — list join candidates.
+    Candidates { agent_session: String },
+    /// `gwtd workspace join --agent-session <id> --workspace <id>`.
+    Join {
+        agent_session: String,
+        workspace_id: String,
+        current_focus: Option<String>,
+        title_summary: Option<String>,
+    },
+    /// `gwtd workspace create --agent-session <id> --title-summary <name> ...`.
+    Create {
+        agent_session: String,
+        title_summary: String,
+        current_focus: Option<String>,
+        spec: Option<u64>,
+        issue: Option<u64>,
+        split_from: Option<String>,
+        boundary: Option<String>,
+    },
 }
 
 /// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).
@@ -418,7 +437,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* | gwtd workspace update [--title-summary <text>] [fields] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -141,22 +141,54 @@ pub(super) fn run<E: CliEnv>(
             if !targets.is_empty() {
                 entry = entry.with_target_owners(targets);
             }
-            let (workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
+            let (mut workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
             let mentions =
                 parse_mentions(&other_mention_args).map_err(gwt_error_to_spec_ops_error)?;
+            // SPEC-2359 FR-094/097: unless `--broadcast` is set, auto-attach
+            // the current Agent's assigned Workspace id and fan out the
+            // current Workspace id of each agent/session mention target.
+            // FR-103: legacy entries (Unassigned/missing) leave audience
+            // absent which round-trips as broadcast.
+            if !broadcast {
+                if let Some(session) = current_session.as_ref() {
+                    if let Some(ws_id) =
+                        gwt_core::workspace_projection::resolve_workspace_id_for_session(
+                            env.repo_path(),
+                            &session.id,
+                        )
+                    {
+                        if !workspace_audience.iter().any(|existing| existing == &ws_id) {
+                            workspace_audience.push(ws_id);
+                        }
+                    }
+                }
+                for mention in mentions.iter() {
+                    let kind = mention.target_kind.as_str();
+                    if kind == "user" || kind == "branch" {
+                        continue;
+                    }
+                    if let Some(ws_id) =
+                        gwt_core::workspace_projection::resolve_workspace_id_for_mention(
+                            env.repo_path(),
+                            kind,
+                            &mention.target,
+                        )
+                    {
+                        if !workspace_audience.iter().any(|existing| existing == &ws_id) {
+                            workspace_audience.push(ws_id);
+                        }
+                    }
+                }
+            }
             if !mentions.is_empty() {
                 entry = entry.with_mentions(mentions);
             }
-            // SPEC-2359 FR-093/094/095/096: Workspace audience comes from
-            // explicit `--mention workspace:<id>` flags. `--broadcast`
-            // suppresses any auto-attach (FR-094/097 will fan-out the
-            // current Agent's and mention targets' workspaces once the
-            // Agent affiliation field lands; until then, audience is
-            // only the explicit workspace mentions).
+            // SPEC-2359 FR-093/094/095/096/097: persist the resolved audience
+            // (explicit workspace mentions + auto-attach + fan-out). Empty
+            // serializes as absent (FR-103 broadcast fallback).
             if !workspace_audience.is_empty() {
                 entry = entry.with_audience(workspace_audience);
             }
-            let _ = broadcast;
             let snapshot =
                 post_entry(env.repo_path(), entry).map_err(gwt_error_to_spec_ops_error)?;
             publish_board_change(env.repo_path(), snapshot.board.entries.len());

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -3,26 +3,76 @@ use std::io;
 use gwt_agent::{session::GWT_SESSION_ID_ENV, Session};
 use gwt_core::{
     coordination::{
-        load_snapshot, normalize_board_mentions, post_entry, AuthorKind, BoardEntry, BoardMention,
+        load_snapshot, load_snapshot_for_scope, normalize_board_mentions, post_entry, AuthorKind,
+        BoardAudienceScope, BoardEntry, BoardMention,
     },
     paths::gwt_sessions_dir,
 };
 use gwt_github::SpecOpsError;
 
-use crate::cli::{BoardCommand, BoardPostCommand, CliEnv, CliParseError};
+use crate::{
+    board_audience::{current_session_board_scope, post_audience_for_session},
+    cli::{CliEnv, CliParseError},
+};
+
+/// SPEC-1942 family enum for `gwtd board ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardCommand {
+    /// `gwtd board show [--json] [--workspace <id>|--all]`.
+    Show {
+        json: bool,
+        workspace: Option<String>,
+        all: bool,
+    },
+    /// `gwtd board post --kind <kind> (--body <text> | -f <file>)
+    /// [--title-summary <text>] [--parent <id>] [--topic <t>]*
+    /// [--owner <n>]* [--target <id>]* [--mention <kind:id>]*`.
+    Post(Box<BoardPostCommand>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoardPostCommand {
+    pub kind: String,
+    pub body: Option<String>,
+    pub file: Option<String>,
+    pub title_summary: Option<String>,
+    pub parent: Option<String>,
+    pub topics: Vec<String>,
+    pub owners: Vec<String>,
+    pub targets: Vec<String>,
+    pub mentions: Vec<String>,
+    pub broadcast: bool,
+}
 
 pub fn parse(args: &[String]) -> Result<BoardCommand, CliParseError> {
     let mut it = args.iter().peekable();
     match it.next().map(String::as_str) {
         Some("show") => {
             let mut json = false;
-            for arg in it {
-                match arg.as_str() {
+            let mut workspace = None;
+            let mut all = false;
+            let args = it.collect::<Vec<_>>();
+            let mut i = 0;
+            while i < args.len() {
+                match args[i].as_str() {
                     "--json" => json = true,
+                    "--workspace" => {
+                        i += 1;
+                        if i >= args.len() {
+                            return Err(CliParseError::MissingFlag("--workspace"));
+                        }
+                        workspace = Some(args[i].clone());
+                    }
+                    "--all" => all = true,
                     other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
                 }
+                i += 1;
             }
-            Ok(BoardCommand::Show { json })
+            Ok(BoardCommand::Show {
+                json,
+                workspace,
+                all,
+            })
         }
         Some("post") => parse_post_args(it.collect::<Vec<_>>().as_slice()),
         Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
@@ -36,8 +86,29 @@ pub(super) fn run<E: CliEnv>(
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     let code = match cmd {
-        BoardCommand::Show { json } => {
-            let snapshot = load_snapshot(env.repo_path()).map_err(gwt_error_to_spec_ops_error)?;
+        BoardCommand::Show {
+            json,
+            workspace,
+            all,
+        } => {
+            let current_session = current_session_from_env().ok().flatten();
+            let scope = if all {
+                BoardAudienceScope::All
+            } else if let Some(workspace_id) = workspace {
+                BoardAudienceScope::Workspace(workspace_id)
+            } else {
+                current_session_board_scope(
+                    env.repo_path(),
+                    current_session.as_ref().map(|session| session.id.as_str()),
+                )
+                .map_err(gwt_error_to_spec_ops_error)?
+            };
+            let snapshot = if matches!(scope, BoardAudienceScope::All) {
+                load_snapshot(env.repo_path()).map_err(gwt_error_to_spec_ops_error)?
+            } else {
+                load_snapshot_for_scope(env.repo_path(), &scope)
+                    .map_err(gwt_error_to_spec_ops_error)?
+            };
             if json {
                 let rendered = serde_json::to_string_pretty(&snapshot)
                     .map_err(|err| io_as_spec_ops_error(io::Error::other(err.to_string())))?;
@@ -59,6 +130,7 @@ pub(super) fn run<E: CliEnv>(
                 owners,
                 targets,
                 mentions,
+                broadcast,
             } = *command;
             let body = match (body, file) {
                 (Some(body), None) => body,
@@ -110,6 +182,16 @@ pub(super) fn run<E: CliEnv>(
             let mentions = parse_mentions(&mentions).map_err(gwt_error_to_spec_ops_error)?;
             if !mentions.is_empty() {
                 entry = entry.with_mentions(mentions);
+            }
+            let audience = post_audience_for_session(
+                env.repo_path(),
+                current_session.as_ref().map(|session| session.id.as_str()),
+                &entry.mentions,
+                broadcast,
+            )
+            .map_err(gwt_error_to_spec_ops_error)?;
+            if let Some(audience) = audience {
+                entry = entry.with_audience(audience);
             }
             let snapshot =
                 post_entry(env.repo_path(), entry).map_err(gwt_error_to_spec_ops_error)?;
@@ -171,6 +253,7 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
     let mut owners = Vec::new();
     let mut targets = Vec::new();
     let mut mentions = Vec::new();
+    let mut broadcast = false;
     let mut i = 0;
 
     while i < args.len() {
@@ -238,6 +321,9 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
                 }
                 mentions.push(args[i].clone());
             }
+            "--broadcast" => {
+                broadcast = true;
+            }
             other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
         }
         i += 1;
@@ -256,6 +342,7 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
         owners,
         targets,
         mentions,
+        broadcast,
     })))
 }
 
@@ -339,7 +426,13 @@ fn gwt_error_to_spec_ops_error(err: gwt_core::GwtError) -> SpecOpsError {
 #[cfg(test)]
 mod tests {
     use gwt_agent::{AgentId, Session, GWT_SESSION_ID_ENV};
-    use gwt_core::coordination::BoardEntryKind;
+    use gwt_core::{
+        coordination::BoardEntryKind,
+        workspace_projection::{
+            save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+            WorkspaceProjection, WorkspaceStatusCategory,
+        },
+    };
 
     use crate::cli::test_support::{fake_gh_test_lock, ScopedEnvVar};
 
@@ -349,10 +442,49 @@ mod tests {
         value.to_string()
     }
 
+    fn workspace_agent(
+        session_id: &str,
+        agent_id: &str,
+        workspace_id: Option<&str>,
+        affiliation_status: WorkspaceAgentAffiliationStatus,
+    ) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: agent_id.to_string(),
+            display_name: agent_id.to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Board audience".to_string()),
+            title_summary: Some("Board audience".to_string()),
+            worktree_path: None,
+            branch: Some("work/board-audience".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status,
+            workspace_id: workspace_id.map(str::to_string),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn save_projection(repo: &std::path::Path, agents: Vec<WorkspaceAgentSummary>) {
+        let mut projection = WorkspaceProjection::default_for_project(repo);
+        projection.id = "workspace-current".to_string();
+        projection.agents = agents;
+        save_workspace_projection(repo, &projection).expect("save workspace projection");
+    }
+
     #[test]
     fn board_family_parse_show_json() {
         let cmd = parse(&[s("show"), s("--json")]).unwrap();
-        assert_eq!(cmd, BoardCommand::Show { json: true });
+        assert_eq!(
+            cmd,
+            BoardCommand::Show {
+                json: true,
+                workspace: None,
+                all: false,
+            }
+        );
     }
 
     #[test]
@@ -379,6 +511,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -409,6 +542,7 @@ mod tests {
                 owners: vec![],
                 targets: vec!["sess-a3f2".into(), "feature/foo".into()],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -440,6 +574,66 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec!["user:akiojin".into(), "agent:codex".into()],
+                broadcast: false,
+            }))
+        );
+    }
+
+    #[test]
+    fn board_family_parse_show_workspace_and_all() {
+        let workspace = parse(&[s("show"), s("--workspace"), s("workspace-a")]).unwrap();
+        assert_eq!(
+            workspace,
+            BoardCommand::Show {
+                json: false,
+                workspace: Some("workspace-a".into()),
+                all: false,
+            }
+        );
+
+        let all = parse(&[s("show"), s("--all"), s("--json")]).unwrap();
+        assert_eq!(
+            all,
+            BoardCommand::Show {
+                json: true,
+                workspace: None,
+                all: true,
+            }
+        );
+    }
+
+    #[test]
+    fn board_family_parse_post_collects_workspace_mentions_and_broadcast() {
+        let cmd = parse(&[
+            s("post"),
+            s("--kind"),
+            s("status"),
+            s("--body"),
+            s("cross-workspace update"),
+            s("--mention"),
+            s("workspace:workspace-a"),
+            s("--mention"),
+            s("workspace:workspace-b"),
+            s("--broadcast"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cmd,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("cross-workspace update".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![
+                    "workspace:workspace-a".into(),
+                    "workspace:workspace-b".into()
+                ],
+                broadcast: true,
             }))
         );
     }
@@ -471,6 +665,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -512,6 +707,7 @@ mod tests {
                 owners: vec![],
                 targets: vec!["sess-a3f2".into(), "feature/x".into()],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -544,6 +740,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec!["user:akiojin".into(), "agent:codex".into()],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -565,7 +762,7 @@ mod tests {
 
     #[test]
     fn board_family_run_post_attaches_current_session_origin_metadata() {
-        let _env_lock = fake_gh_test_lock()
+        let _env_lock = crate::env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmp = tempfile::tempdir().unwrap();
@@ -590,6 +787,7 @@ mod tests {
                 owners: vec!["2359".into()],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -610,6 +808,214 @@ mod tests {
         );
         assert_eq!(entry.origin_branch.as_deref(), Some("work/20260506-1706"));
         assert_eq!(entry.origin_agent_id.as_deref(), Some("Codex"));
+    }
+
+    #[test]
+    fn board_family_run_post_auto_attaches_current_assigned_workspace() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        let mut out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("current workspace update".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: false,
+            })),
+            &mut out,
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert_eq!(
+            snapshot.board.entries[0].audience,
+            Some(vec!["workspace-current".to_string()])
+        );
+    }
+
+    #[test]
+    fn board_family_run_post_leaves_unassigned_and_broadcast_posts_unscoped() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("unassigned broadcast".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: false,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("forced broadcast".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: true,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert_eq!(snapshot.board.entries[0].audience, None);
+        assert_eq!(snapshot.board.entries[1].audience, None);
+    }
+
+    #[test]
+    fn board_family_run_post_fans_out_workspace_audience_from_mentions() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![
+                workspace_agent(
+                    &session.id,
+                    "codex",
+                    Some("workspace-current"),
+                    WorkspaceAgentAffiliationStatus::Assigned,
+                ),
+                workspace_agent(
+                    "session-target",
+                    "reviewer",
+                    Some("workspace-target"),
+                    WorkspaceAgentAffiliationStatus::Assigned,
+                ),
+                workspace_agent(
+                    "session-unassigned",
+                    "observer",
+                    None,
+                    WorkspaceAgentAffiliationStatus::Unassigned,
+                ),
+            ],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "handoff".into(),
+                body: Some("handoff across workspaces".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![
+                    "workspace:workspace-explicit".into(),
+                    "session:session-target".into(),
+                    "agent:reviewer".into(),
+                    "agent:observer".into(),
+                    "user:akiojin".into(),
+                ],
+                broadcast: false,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                "session-target",
+                "reviewer",
+                Some("workspace-later"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert_eq!(
+            snapshot.board.entries[0].audience,
+            Some(vec![
+                "workspace-current".to_string(),
+                "workspace-explicit".to_string(),
+                "workspace-target".to_string(),
+            ])
+        );
     }
 
     #[test]
@@ -646,6 +1052,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -691,6 +1098,7 @@ mod tests {
                 owners: vec!["1974".into()],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -701,6 +1109,163 @@ mod tests {
         assert_eq!(snapshot.board.entries.len(), 1);
         assert_eq!(snapshot.board.entries[0].body, "Need a board");
         assert!(out.contains("board entries: 1"));
+    }
+
+    #[test]
+    fn board_family_run_show_scopes_workspace_and_all_timelines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "broadcast entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            ),
+        )
+        .unwrap();
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "workspace a entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-a"]),
+        )
+        .unwrap();
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "workspace b entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-b"]),
+        )
+        .unwrap();
+
+        let mut workspace_out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: Some("workspace-a".into()),
+                all: false,
+            },
+            &mut workspace_out,
+        )
+        .unwrap();
+        assert!(workspace_out.contains("broadcast entry"), "{workspace_out}");
+        assert!(
+            workspace_out.contains("workspace a entry"),
+            "{workspace_out}"
+        );
+        assert!(
+            !workspace_out.contains("workspace b entry"),
+            "{workspace_out}"
+        );
+
+        let mut all_out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: true,
+            },
+            &mut all_out,
+        )
+        .unwrap();
+        assert!(all_out.contains("workspace b entry"), "{all_out}");
+    }
+
+    #[test]
+    fn board_family_run_show_defaults_to_current_workspace_when_session_is_assigned() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/board-audience", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "current entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-current"]),
+        )
+        .unwrap();
+        post_entry(
+            &repo,
+            BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                BoardEntryKind::Status,
+                "other entry",
+                None,
+                None,
+                vec![],
+                vec![],
+            )
+            .with_audience(vec!["workspace-other"]),
+        )
+        .unwrap();
+        let mut env = crate::cli::TestEnv::new(repo);
+
+        let mut out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+
+        assert!(out.contains("current entry"), "{out}");
+        assert!(!out.contains("other entry"), "{out}");
     }
 
     #[test]
@@ -725,7 +1290,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(
@@ -754,7 +1328,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("- [request] user ("));
@@ -783,7 +1366,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("== Chat =="));
@@ -814,7 +1406,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -16,13 +16,26 @@ pub fn parse(args: &[String]) -> Result<BoardCommand, CliParseError> {
     match it.next().map(String::as_str) {
         Some("show") => {
             let mut json = false;
-            for arg in it {
+            let mut workspace: Option<String> = None;
+            let mut all = false;
+            while let Some(arg) = it.next() {
                 match arg.as_str() {
                     "--json" => json = true,
+                    "--all" => all = true,
+                    "--workspace" => {
+                        let Some(value) = it.next() else {
+                            return Err(CliParseError::MissingFlag("--workspace"));
+                        };
+                        workspace = Some(value.clone());
+                    }
                     other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
                 }
             }
-            Ok(BoardCommand::Show { json })
+            Ok(BoardCommand::Show {
+                json,
+                workspace,
+                all,
+            })
         }
         Some("post") => parse_post_args(it.collect::<Vec<_>>().as_slice()),
         Some(other) => Err(CliParseError::UnknownSubcommand(other.to_string())),
@@ -36,8 +49,28 @@ pub(super) fn run<E: CliEnv>(
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
     let code = match cmd {
-        BoardCommand::Show { json } => {
-            let snapshot = load_snapshot(env.repo_path()).map_err(gwt_error_to_spec_ops_error)?;
+        BoardCommand::Show {
+            json,
+            workspace,
+            all,
+        } => {
+            let mut snapshot =
+                load_snapshot(env.repo_path()).map_err(gwt_error_to_spec_ops_error)?;
+            // SPEC-2359 FR-100: scope to current Workspace audience + broadcast
+            // unless `--all` is set. `--workspace <id>` overrides the default
+            // workspace resolution. Without affiliation resolution yet
+            // (FR-088), the default is the full timeline so legacy callers
+            // are unaffected.
+            if !all {
+                if let Some(workspace_id) = workspace.as_deref() {
+                    snapshot.board.entries.retain(|entry| {
+                        gwt_core::coordination::entry_visible_for_workspace(
+                            entry,
+                            Some(workspace_id),
+                        )
+                    });
+                }
+            }
             if json {
                 let rendered = serde_json::to_string_pretty(&snapshot)
                     .map_err(|err| io_as_spec_ops_error(io::Error::other(err.to_string())))?;
@@ -59,6 +92,7 @@ pub(super) fn run<E: CliEnv>(
                 owners,
                 targets,
                 mentions,
+                broadcast,
             } = *command;
             let body = match (body, file) {
                 (Some(body), None) => body,
@@ -107,10 +141,22 @@ pub(super) fn run<E: CliEnv>(
             if !targets.is_empty() {
                 entry = entry.with_target_owners(targets);
             }
-            let mentions = parse_mentions(&mentions).map_err(gwt_error_to_spec_ops_error)?;
+            let (workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
+            let mentions =
+                parse_mentions(&other_mention_args).map_err(gwt_error_to_spec_ops_error)?;
             if !mentions.is_empty() {
                 entry = entry.with_mentions(mentions);
             }
+            // SPEC-2359 FR-093/094/095/096: Workspace audience comes from
+            // explicit `--mention workspace:<id>` flags. `--broadcast`
+            // suppresses any auto-attach (FR-094/097 will fan-out the
+            // current Agent's and mention targets' workspaces once the
+            // Agent affiliation field lands; until then, audience is
+            // only the explicit workspace mentions).
+            if !workspace_audience.is_empty() {
+                entry = entry.with_audience(workspace_audience);
+            }
+            let _ = broadcast;
             let snapshot =
                 post_entry(env.repo_path(), entry).map_err(gwt_error_to_spec_ops_error)?;
             publish_board_change(env.repo_path(), snapshot.board.entries.len());
@@ -171,6 +217,7 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
     let mut owners = Vec::new();
     let mut targets = Vec::new();
     let mut mentions = Vec::new();
+    let mut broadcast = false;
     let mut i = 0;
 
     while i < args.len() {
@@ -238,6 +285,9 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
                 }
                 mentions.push(args[i].clone());
             }
+            "--broadcast" => {
+                broadcast = true;
+            }
             other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
         }
         i += 1;
@@ -256,6 +306,7 @@ fn parse_post_args(args: &[&String]) -> Result<BoardCommand, CliParseError> {
         owners,
         targets,
         mentions,
+        broadcast,
     })))
 }
 
@@ -265,6 +316,26 @@ fn parse_mentions(values: &[String]) -> gwt_core::Result<Vec<BoardMention>> {
         mentions.push(value.parse::<BoardMention>()?);
     }
     Ok(normalize_board_mentions(&mentions))
+}
+
+/// SPEC-2359 FR-096: `--mention workspace:<id>` routes to BoardEntry.audience,
+/// not to BoardMention. Split the raw mention args into (workspace_audience,
+/// other_mention_args) so the rest of the post path can parse other mentions
+/// as `BoardMention` as before.
+fn split_workspace_mentions(values: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut workspaces: Vec<String> = Vec::new();
+    let mut others: Vec<String> = Vec::new();
+    for value in values {
+        if let Some(rest) = value.trim().strip_prefix("workspace:") {
+            let id = rest.trim();
+            if !id.is_empty() && !workspaces.iter().any(|existing| existing == id) {
+                workspaces.push(id.to_string());
+            }
+        } else {
+            others.push(value.clone());
+        }
+    }
+    (workspaces, others)
 }
 
 fn current_session_from_env() -> io::Result<Option<Session>> {
@@ -352,7 +423,120 @@ mod tests {
     #[test]
     fn board_family_parse_show_json() {
         let cmd = parse(&[s("show"), s("--json")]).unwrap();
-        assert_eq!(cmd, BoardCommand::Show { json: true });
+        assert_eq!(
+            cmd,
+            BoardCommand::Show {
+                json: true,
+                workspace: None,
+                all: false
+            }
+        );
+    }
+
+    #[test]
+    fn board_family_parse_show_collects_workspace_and_all_flags() {
+        let cmd = parse(&[
+            s("show"),
+            s("--json"),
+            s("--workspace"),
+            s("ws-1"),
+            s("--all"),
+        ])
+        .unwrap();
+        assert_eq!(
+            cmd,
+            BoardCommand::Show {
+                json: true,
+                workspace: Some("ws-1".into()),
+                all: true,
+            }
+        );
+    }
+
+    #[test]
+    fn board_family_run_show_workspace_filter_keeps_broadcast_and_matching_audience() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = crate::cli::TestEnv::new(tmp.path().to_path_buf());
+
+        for (body, audience) in [
+            ("broadcast post", Vec::<String>::new()),
+            ("scoped to ws-1", vec!["ws-1".into()]),
+            ("scoped to ws-2", vec!["ws-2".into()]),
+        ] {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                gwt_core::coordination::BoardEntryKind::Status,
+                body,
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            if !audience.is_empty() {
+                entry = entry.with_audience(audience);
+            }
+            gwt_core::coordination::post_entry(tmp.path(), entry).unwrap();
+        }
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: true,
+                workspace: Some("ws-1".into()),
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(code, 0);
+        assert!(out.contains("broadcast post"), "{out}");
+        assert!(out.contains("scoped to ws-1"), "{out}");
+        assert!(!out.contains("scoped to ws-2"), "{out}");
+    }
+
+    #[test]
+    fn board_family_run_show_all_flag_shows_full_timeline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = crate::cli::TestEnv::new(tmp.path().to_path_buf());
+
+        for (body, audience) in [
+            ("broadcast", Vec::<String>::new()),
+            ("scoped to ws-1", vec!["ws-1".into()]),
+            ("scoped to ws-2", vec!["ws-2".into()]),
+        ] {
+            let mut entry = BoardEntry::new(
+                AuthorKind::Agent,
+                "Codex",
+                gwt_core::coordination::BoardEntryKind::Status,
+                body,
+                None,
+                None,
+                vec![],
+                vec![],
+            );
+            if !audience.is_empty() {
+                entry = entry.with_audience(audience);
+            }
+            gwt_core::coordination::post_entry(tmp.path(), entry).unwrap();
+        }
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: true,
+                workspace: Some("ws-1".into()),
+                all: true,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(code, 0);
+        assert!(out.contains("broadcast"), "{out}");
+        assert!(out.contains("scoped to ws-1"), "{out}");
+        assert!(out.contains("scoped to ws-2"), "{out}");
     }
 
     #[test]
@@ -379,6 +563,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -409,6 +594,7 @@ mod tests {
                 owners: vec![],
                 targets: vec!["sess-a3f2".into(), "feature/foo".into()],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -440,6 +626,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec!["user:akiojin".into(), "agent:codex".into()],
+                broadcast: false,
             }))
         );
     }
@@ -471,6 +658,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             }))
         );
     }
@@ -512,6 +700,7 @@ mod tests {
                 owners: vec![],
                 targets: vec!["sess-a3f2".into(), "feature/x".into()],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -544,6 +733,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec!["user:akiojin".into(), "agent:codex".into()],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -560,6 +750,123 @@ mod tests {
         assert_eq!(
             snapshot.board.entries[0].mentions[1].typed_key(),
             "agent:codex"
+        );
+    }
+
+    #[test]
+    fn board_family_parse_post_routes_workspace_mention_into_audience_and_broadcast_flag() {
+        let cmd = parse(&[
+            s("post"),
+            s("--kind"),
+            s("status"),
+            s("--body"),
+            s("scoped to two workspaces"),
+            s("--mention"),
+            s("workspace:ws-1"),
+            s("--mention"),
+            s("agent:codex"),
+            s("--mention"),
+            s("workspace:ws-2"),
+            s("--broadcast"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cmd,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("scoped to two workspaces".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![
+                    "workspace:ws-1".into(),
+                    "agent:codex".into(),
+                    "workspace:ws-2".into(),
+                ],
+                broadcast: true,
+            }))
+        );
+    }
+
+    #[test]
+    fn board_family_run_post_persists_audience_from_workspace_mentions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = crate::cli::TestEnv::new(tmp.path().to_path_buf());
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("audienced status".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![
+                    "workspace:ws-1".into(),
+                    "agent:codex".into(),
+                    "workspace:ws-2".into(),
+                ],
+                broadcast: false,
+            })),
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(code, 0);
+        let snapshot = load_snapshot(tmp.path()).unwrap();
+        let entry = &snapshot.board.entries[0];
+
+        assert_eq!(
+            entry.audience,
+            vec!["ws-1".to_string(), "ws-2".to_string()],
+            "workspace mentions must land on BoardEntry.audience"
+        );
+        assert_eq!(
+            entry.mentions.len(),
+            1,
+            "workspace mentions must not be stored as regular BoardMentions"
+        );
+        assert_eq!(entry.mentions[0].typed_key(), "agent:codex");
+    }
+
+    #[test]
+    fn board_family_run_post_broadcast_flag_keeps_audience_empty_without_explicit_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = crate::cli::TestEnv::new(tmp.path().to_path_buf());
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "status".into(),
+                body: Some("broadcast post".into()),
+                file: None,
+                title_summary: None,
+                parent: None,
+                topics: vec![],
+                owners: vec![],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: true,
+            })),
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(code, 0);
+        let snapshot = load_snapshot(tmp.path()).unwrap();
+        let entry = &snapshot.board.entries[0];
+        assert!(
+            entry.audience.is_empty(),
+            "broadcast flag must keep audience empty even when current workspace exists"
         );
     }
 
@@ -590,6 +897,7 @@ mod tests {
                 owners: vec!["2359".into()],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -646,6 +954,7 @@ mod tests {
                 owners: vec![],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -691,6 +1000,7 @@ mod tests {
                 owners: vec!["1974".into()],
                 targets: vec![],
                 mentions: vec![],
+                broadcast: false,
             })),
             &mut out,
         )
@@ -725,7 +1035,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(
@@ -754,7 +1073,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("- [request] user ("));
@@ -783,7 +1111,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(out.contains("== Chat =="));
@@ -814,7 +1151,16 @@ mod tests {
         .unwrap();
 
         let mut out = String::new();
-        let code = run(&mut env, BoardCommand::Show { json: false }, &mut out).unwrap();
+        let code = run(
+            &mut env,
+            BoardCommand::Show {
+                json: false,
+                workspace: None,
+                all: false,
+            },
+            &mut out,
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         assert!(

--- a/crates/gwt/src/cli/family_split_tests.rs
+++ b/crates/gwt/src/cli/family_split_tests.rs
@@ -53,7 +53,14 @@ fn cli_command_family_split_round_trip_parses() {
 
     // gwtd board show --json
     let cmd = parse_board_args(&[s("show"), s("--json")]).expect("parse board show");
-    assert_eq!(cmd, CliCommand::Board(BoardCommand::Show { json: true }));
+    assert_eq!(
+        cmd,
+        CliCommand::Board(BoardCommand::Show {
+            json: true,
+            workspace: None,
+            all: false,
+        })
+    );
 
     // gwtd board post --kind status --body x
     let cmd = parse_board_args(&[s("post"), s("--kind"), s("status"), s("--body"), s("x")])
@@ -65,6 +72,7 @@ fn cli_command_family_split_round_trip_parses() {
     assert_eq!(command.body.as_deref(), Some("x"));
     assert_eq!(command.file, None);
     assert_eq!(command.title_summary, None);
+    assert!(!command.broadcast);
 
     // gwtd index status / rebuild
     let cmd = parse_index_args(&[s("status")]).expect("parse index status");

--- a/crates/gwt/src/cli/family_split_tests.rs
+++ b/crates/gwt/src/cli/family_split_tests.rs
@@ -53,7 +53,14 @@ fn cli_command_family_split_round_trip_parses() {
 
     // gwtd board show --json
     let cmd = parse_board_args(&[s("show"), s("--json")]).expect("parse board show");
-    assert_eq!(cmd, CliCommand::Board(BoardCommand::Show { json: true }));
+    assert_eq!(
+        cmd,
+        CliCommand::Board(BoardCommand::Show {
+            json: true,
+            workspace: None,
+            all: false,
+        })
+    );
 
     // gwtd board post --kind status --body x
     let cmd = parse_board_args(&[s("post"), s("--kind"), s("status"), s("--body"), s("x")])

--- a/crates/gwt/src/cli/hook/board_reminder/format.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/format.rs
@@ -19,8 +19,10 @@ pub(super) fn filter_and_cap_latest(
     mut entries: Vec<BoardEntry>,
     self_session_id: &str,
     cap: usize,
+    self_workspace_id: Option<&str>,
 ) -> Vec<BoardEntry> {
     entries.retain(|entry| entry.origin_session_id.as_deref() != Some(self_session_id));
+    entries.retain(|entry| coordination::entry_visible_for_workspace(entry, self_workspace_id));
     if entries.len() > cap {
         let start = entries.len() - cap;
         entries.drain(..start);
@@ -220,9 +222,89 @@ mod tests {
         )
         .with_origin_session_id("sess-other");
 
-        let filtered = filter_and_cap_latest(vec![self_entry, other_entry], "sess-self", 20);
+        let filtered = filter_and_cap_latest(vec![self_entry, other_entry], "sess-self", 20, None);
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].author, "Other");
+    }
+
+    #[test]
+    fn filter_and_cap_latest_keeps_only_audience_matching_or_broadcast_entries() {
+        let broadcast = BoardEntry::new(
+            AuthorKind::Agent,
+            "Agent",
+            BoardEntryKind::Status,
+            "broadcast",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_origin_session_id("sess-other");
+        let scoped_match = BoardEntry::new(
+            AuthorKind::Agent,
+            "Agent",
+            BoardEntryKind::Status,
+            "scoped to ws-1",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_origin_session_id("sess-other")
+        .with_audience(vec!["ws-1".into()]);
+        let scoped_other = BoardEntry::new(
+            AuthorKind::Agent,
+            "Agent",
+            BoardEntryKind::Status,
+            "scoped to ws-2",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_origin_session_id("sess-other")
+        .with_audience(vec!["ws-2".into()]);
+
+        let entries = vec![broadcast, scoped_match, scoped_other];
+        let filtered = filter_and_cap_latest(entries, "sess-self", 20, Some("ws-1"));
+
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().any(|e| e.body == "broadcast"));
+        assert!(filtered.iter().any(|e| e.body == "scoped to ws-1"));
+        assert!(filtered.iter().all(|e| e.body != "scoped to ws-2"));
+    }
+
+    #[test]
+    fn filter_and_cap_latest_unassigned_keeps_only_broadcast_entries() {
+        let broadcast = BoardEntry::new(
+            AuthorKind::Agent,
+            "Agent",
+            BoardEntryKind::Status,
+            "broadcast",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_origin_session_id("sess-other");
+        let scoped = BoardEntry::new(
+            AuthorKind::Agent,
+            "Agent",
+            BoardEntryKind::Status,
+            "scoped to ws-1",
+            None,
+            None,
+            vec![],
+            vec![],
+        )
+        .with_origin_session_id("sess-other")
+        .with_audience(vec!["ws-1".into()]);
+
+        let entries = vec![broadcast, scoped];
+        let filtered = filter_and_cap_latest(entries, "sess-self", 20, None);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].body, "broadcast");
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -190,6 +190,7 @@ pub fn compute_plan(
         reminders,
         has_recent_own_status,
         language: language.clone(),
+        self_workspace_id: resolve_self_workspace_id(),
     });
 
     plan.output = append_title_summary_required_context(
@@ -209,6 +210,18 @@ fn resolve_narrative_language() -> String {
     gwt_config::Settings::load()
         .map(|settings| settings.ai.effective_language().to_string())
         .unwrap_or_else(|_| "en".to_string())
+}
+
+/// SPEC-2359 FR-098: resolve the current Agent's assigned Workspace id
+/// for audience-aware reminder filtering. Returns `None` until the Agent
+/// affiliation field (SPEC-2359 FR-088, US-25) is populated, at which
+/// point this resolver should read `WorkspaceAgentSummary` for the
+/// current session and return its assigned `workspace_id`. Returning
+/// `None` is safe: audience-aware filtering then surfaces only
+/// broadcast-audience entries, matching legacy behavior since all
+/// pre-migration entries are broadcast (FR-103).
+fn resolve_self_workspace_id() -> Option<String> {
+    None
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -107,15 +107,18 @@ fn agent_title_summary_missing(session: &Session) -> Result<bool, HookError> {
     let Some(projection) =
         gwt_core::workspace_projection::load_workspace_projection(&session.worktree_path)?
     else {
-        return Ok(true);
+        return Ok(false);
     };
     let Some(agent) = projection
         .agents
         .iter()
         .find(|agent| agent.session_id == session.id)
     else {
-        return Ok(true);
+        return Ok(false);
     };
+    if agent.is_unassigned() {
+        return Ok(false);
+    }
     Ok(agent
         .title_summary
         .as_deref()
@@ -304,8 +307,8 @@ mod tests {
         let session = make_session(&repo, "work/title", "Codex");
 
         assert!(
-            agent_title_summary_missing(&session).expect("missing title check"),
-            "new sessions without a saved title_summary must require an update"
+            !agent_title_summary_missing(&session).expect("missing title check"),
+            "sessions without a Workspace projection are Unassigned and must not require a title update"
         );
 
         let mut projection =
@@ -325,6 +328,9 @@ mod tests {
                 last_board_entry_id: None,
                 last_board_entry_kind: None,
                 coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                workspace_id: None,
                 updated_at: Utc::now(),
             });
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -193,7 +193,7 @@ pub fn compute_plan(
         reminders,
         has_recent_own_status,
         language: language.clone(),
-        self_workspace_id: resolve_self_workspace_id(),
+        self_workspace_id: resolve_self_workspace_id(session),
     });
 
     plan.output = append_title_summary_required_context(
@@ -216,15 +216,13 @@ fn resolve_narrative_language() -> String {
 }
 
 /// SPEC-2359 FR-098: resolve the current Agent's assigned Workspace id
-/// for audience-aware reminder filtering. Returns `None` until the Agent
-/// affiliation field (SPEC-2359 FR-088, US-25) is populated, at which
-/// point this resolver should read `WorkspaceAgentSummary` for the
-/// current session and return its assigned `workspace_id`. Returning
-/// `None` is safe: audience-aware filtering then surfaces only
-/// broadcast-audience entries, matching legacy behavior since all
-/// pre-migration entries are broadcast (FR-103).
-fn resolve_self_workspace_id() -> Option<String> {
-    None
+/// for audience-aware reminder filtering. Returns `None` for Unassigned
+/// agents (broadcast-only visibility) and `Some(id)` for assigned agents.
+fn resolve_self_workspace_id(session: &Session) -> Option<String> {
+    gwt_core::workspace_projection::resolve_workspace_id_for_session(
+        &session.worktree_path,
+        &session.id,
+    )
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -30,11 +30,12 @@ use std::{
 use chrono::{DateTime, Utc};
 use gwt_agent::{Session, GWT_SESSION_ID_ENV};
 use gwt_core::coordination::{
-    has_recent_post_by, load_entries_since, load_reminders_state, write_reminders_state,
+    has_recent_post_by, load_entries_since_for_scope, load_reminders_state, write_reminders_state,
     BoardEntryKind,
 };
 
 use super::{HookError, HookEvent, HookOutput, IntentBoundaryEvent};
+use crate::board_audience::current_session_board_scope;
 
 pub use plan::{plan_reminder, ReminderInputs, ReminderPlan};
 
@@ -158,17 +159,18 @@ pub fn compute_plan(
     };
 
     let reminders = load_reminders_state(&session.worktree_path, &session.id)?;
+    let audience_scope = current_session_board_scope(&session.worktree_path, Some(&session.id))?;
 
     let recent_entries = match intent_event {
         IntentBoundaryEvent::SessionStart => {
             let threshold = now - session_start_window();
-            load_entries_since(&session.worktree_path, threshold)?
+            load_entries_since_for_scope(&session.worktree_path, threshold, &audience_scope)?
         }
         IntentBoundaryEvent::UserPromptSubmit => {
             let since = reminders
                 .last_injected_at
                 .unwrap_or(now - session_start_window());
-            load_entries_since(&session.worktree_path, since)?
+            load_entries_since_for_scope(&session.worktree_path, since, &audience_scope)?
         }
         IntentBoundaryEvent::Stop => Vec::new(),
     };
@@ -216,9 +218,16 @@ fn resolve_narrative_language() -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::cli::test_support::ScopedEnvVar;
     use chrono::TimeZone;
     use gwt_agent::AgentId;
-    use gwt_core::coordination::{post_entry, AuthorKind, BoardEntry, BoardEntryKind};
+    use gwt_core::{
+        coordination::{post_entry, AuthorKind, BoardEntry, BoardEntryKind},
+        workspace_projection::{
+            save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+            WorkspaceProjection, WorkspaceStatusCategory,
+        },
+    };
 
     use super::*;
 
@@ -226,6 +235,37 @@ mod tests {
         let mut session = Session::new(dir, branch, AgentId::Codex);
         session.display_name = display_name.to_string();
         session
+    }
+
+    fn workspace_agent(
+        session_id: &str,
+        workspace_id: Option<&str>,
+        affiliation_status: WorkspaceAgentAffiliationStatus,
+    ) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Board audience".to_string()),
+            title_summary: Some("Board audience".to_string()),
+            worktree_path: None,
+            branch: Some("work/board-audience".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status,
+            workspace_id: workspace_id.map(str::to_string),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn save_projection(repo: &Path, agents: Vec<WorkspaceAgentSummary>) {
+        let mut projection = WorkspaceProjection::default_for_project(repo);
+        projection.id = "workspace-current".to_string();
+        projection.agents = agents;
+        save_workspace_projection(repo, &projection).expect("save workspace projection");
     }
 
     fn entry(
@@ -479,6 +519,117 @@ mod tests {
         assert!(!text.contains("old post before last inject"));
         assert!(text.contains("brand new post"));
         assert_eq!(plan.next_reminders.last_injected_at, Some(now));
+    }
+
+    #[test]
+    fn compute_plan_session_start_filters_entries_to_current_workspace_audience() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", dir.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", dir.path());
+        let session = make_session(dir.path(), "feature/me", "Codex");
+        save_projection(
+            dir.path(),
+            vec![workspace_agent(
+                &session.id,
+                Some("workspace-current"),
+                WorkspaceAgentAffiliationStatus::Assigned,
+            )],
+        );
+        let now = Utc.with_ymd_and_hms(2026, 5, 11, 12, 0, 0).unwrap();
+        let broadcast = entry(
+            "Other",
+            BoardEntryKind::Status,
+            "broadcast update",
+            "work/other",
+            "session-other",
+            now - chrono::Duration::minutes(5),
+        );
+        let current = entry(
+            "Other",
+            BoardEntryKind::Status,
+            "current workspace update",
+            "work/other",
+            "session-other",
+            now - chrono::Duration::minutes(4),
+        )
+        .with_audience(vec!["workspace-current"]);
+        let other = entry(
+            "Other",
+            BoardEntryKind::Status,
+            "other workspace update",
+            "work/other",
+            "session-other",
+            now - chrono::Duration::minutes(3),
+        )
+        .with_audience(vec!["workspace-other"]);
+        post_entry(dir.path(), broadcast).unwrap();
+        post_entry(dir.path(), current).unwrap();
+        post_entry(dir.path(), other).unwrap();
+
+        let plan = compute_plan("SessionStart", &session, now)
+            .unwrap()
+            .unwrap();
+        let text = additional_context(&plan.output);
+
+        assert!(text.contains("broadcast update"), "{text}");
+        assert!(text.contains("current workspace update"), "{text}");
+        assert!(!text.contains("other workspace update"), "{text}");
+    }
+
+    #[test]
+    fn compute_plan_unassigned_agent_only_reads_broadcast_board_entries() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", dir.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", dir.path());
+        let session = make_session(dir.path(), "feature/me", "Codex");
+        save_projection(
+            dir.path(),
+            vec![workspace_agent(
+                &session.id,
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let now = Utc.with_ymd_and_hms(2026, 5, 11, 12, 0, 0).unwrap();
+        post_entry(
+            dir.path(),
+            entry(
+                "Other",
+                BoardEntryKind::Status,
+                "broadcast update",
+                "work/other",
+                "session-other",
+                now - chrono::Duration::minutes(5),
+            ),
+        )
+        .unwrap();
+        post_entry(
+            dir.path(),
+            entry(
+                "Other",
+                BoardEntryKind::Status,
+                "workspace-only update",
+                "work/other",
+                "session-other",
+                now - chrono::Duration::minutes(4),
+            )
+            .with_audience(vec!["workspace-current"]),
+        )
+        .unwrap();
+
+        let plan = compute_plan("SessionStart", &session, now)
+            .unwrap()
+            .unwrap();
+        let text = additional_context(&plan.output);
+
+        assert!(text.contains("broadcast update"), "{text}");
+        assert!(!text.contains("workspace-only update"), "{text}");
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/board_reminder/plan.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/plan.rs
@@ -47,6 +47,12 @@ pub struct ReminderInputs {
     /// because they target the user, not the agent.
     /// SPEC-1933 FR-010.
     pub language: String,
+    /// SPEC-2359 FR-098: workspace audience scoping. `None` means the
+    /// current Agent is Unassigned (or affiliation has not yet been
+    /// resolved), in which case only broadcast-audience entries are
+    /// surfaced. `Some(id)` shows entries audienced to `id` plus
+    /// broadcast.
+    pub self_workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -71,6 +77,7 @@ fn plan_session_start(inputs: ReminderInputs) -> ReminderPlan {
         inputs.recent_entries,
         &inputs.self_session_id,
         SESSION_START_CAP,
+        inputs.self_workspace_id.as_deref(),
     );
     let mut text = session_start_text_with_language(&entries, &inputs.self_match_keys, language);
     text.push_str(&format_language_directive(&inputs.language));
@@ -91,6 +98,7 @@ fn plan_user_prompt_submit(inputs: ReminderInputs) -> ReminderPlan {
         inputs.recent_entries,
         &inputs.self_session_id,
         USER_PROMPT_DIFF_CAP,
+        inputs.self_workspace_id.as_deref(),
     );
 
     let reminder = user_prompt_reminder(language, inputs.has_recent_own_status);
@@ -219,6 +227,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(text.contains("phase"));
@@ -237,6 +246,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = system_message(&plan.output);
         assert!(text.contains("Stop"));
@@ -257,6 +267,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
 
@@ -286,6 +297,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
 
@@ -315,6 +327,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
 
@@ -336,6 +349,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let user_prompt = plan_reminder(ReminderInputs {
             event: IntentBoundaryEvent::UserPromptSubmit,
@@ -347,6 +361,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: true,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let stop = plan_reminder(ReminderInputs {
             event: IntentBoundaryEvent::Stop,
@@ -358,6 +373,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
 
         for text in [
@@ -387,6 +403,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: true,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(text.contains("coordination"));
@@ -417,6 +434,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         let entry_line = text
@@ -453,6 +471,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         let entry_line = text
@@ -488,6 +507,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         let entry_line = text
@@ -513,6 +533,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: true,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         assert!(additional_context(&plan.output).contains("posted to the Board recently"));
     }
@@ -548,6 +569,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(text.contains("investigating broken test"));
@@ -569,6 +591,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(text.contains("Board Post Reminder"));
@@ -587,6 +610,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(
@@ -608,6 +632,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "ja".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(
@@ -629,6 +654,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "ja".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
 
@@ -652,6 +678,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: true,
             language: "ja".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
 
@@ -673,6 +700,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "ja".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(text.contains("Use language: ja"));
@@ -690,6 +718,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: true,
             language: "ja".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(text.contains("最近 Board に投稿済み"));
@@ -708,6 +737,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "ja".to_string(),
+            self_workspace_id: None,
         });
         let text = system_message(&plan.output);
         assert!(
@@ -728,6 +758,7 @@ mod tests {
             reminders: RemindersState::default(),
             has_recent_own_status: false,
             language: "zh".to_string(),
+            self_workspace_id: None,
         });
         let text = additional_context(&plan.output);
         assert!(text.contains("Use language: en"));
@@ -751,6 +782,7 @@ mod tests {
             reminders,
             has_recent_own_status: false,
             language: "en".to_string(),
+            self_workspace_id: None,
         });
         assert_eq!(plan.next_reminders.last_injected_at, Some(before));
     }

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -23,6 +23,7 @@ pub mod envelope;
 pub mod event_dispatcher;
 pub mod forward;
 mod identity;
+pub mod provider_event;
 pub mod runtime_state;
 pub mod segments;
 pub mod skill_build_spec_stop_check;
@@ -47,6 +48,7 @@ pub(crate) use identity::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookKind {
     Event,
+    ProviderEvent,
     RuntimeState,
     CoordinationEvent,
     BoardReminder,
@@ -66,6 +68,7 @@ impl HookKind {
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "event" => Some(Self::Event),
+            "provider-event" => Some(Self::ProviderEvent),
             "runtime-state" => Some(Self::RuntimeState),
             "coordination-event" => Some(Self::CoordinationEvent),
             "board-reminder" => Some(Self::BoardReminder),
@@ -232,7 +235,7 @@ pub fn run_daemon_hook<E: CliEnv>(
     rest: &[String],
 ) -> Result<i32, SpecOpsError> {
     use crate::cli::hook::{
-        block_bash_policy, event_dispatcher, skill_build_spec_stop_check,
+        block_bash_policy, event_dispatcher, provider_event, skill_build_spec_stop_check,
         skill_discussion_stop_check, skill_plan_spec_stop_check, workflow_policy, HookKind,
         HookOutput,
     };
@@ -267,6 +270,34 @@ pub fn run_daemon_hook<E: CliEnv>(
             let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
             match event_dispatcher::handle_with_input(
                 event,
+                &stdin,
+                &cwd,
+                current_session.as_deref(),
+            ) {
+                Ok(output) => Ok(emit_hook_output(env, &output)),
+                Err(err) => Ok(emit_hook_error(env, name, err)),
+            }
+        }
+        HookKind::ProviderEvent => {
+            let Some(provider) = rest.first() else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook provider-event: missing <provider> argument"
+                );
+                return Ok(2);
+            };
+            let Some(native_event) = rest.get(1) else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook provider-event: missing <native-event> argument"
+                );
+                return Ok(2);
+            };
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            match provider_event::handle_with_input(
+                provider,
+                native_event,
                 &stdin,
                 &cwd,
                 current_session.as_deref(),
@@ -484,5 +515,39 @@ mod tests {
             !content.contains("/tmp/bunx-old"),
             "stale temporary hook binary path must be removed, got: {content}"
         );
+    }
+
+    #[test]
+    fn provider_event_normalizes_hermes_hook_payloads_to_canonical_events() {
+        let normalized = provider_event::normalize_provider_payload(
+            "hermes",
+            "pre_tool_call",
+            r#"{"tool_name":"terminal","tool_input":{"command":"git status"},"session_id":"h-1","cwd":"/repo"}"#,
+        )
+        .expect("normalize hermes pre_tool_call");
+
+        assert_eq!(normalized.event, "PreToolUse");
+        assert_eq!(normalized.payload["tool_name"], "terminal");
+        assert_eq!(normalized.payload["tool_input"]["command"], "git status");
+        assert_eq!(normalized.payload["session_id"], "h-1");
+        assert_eq!(normalized.payload["cwd"], "/repo");
+    }
+
+    #[test]
+    fn provider_event_maps_prompt_and_stop_boundaries() {
+        let cases = [
+            ("opencode", "message.updated", "UserPromptSubmit"),
+            ("opencode", "session.idle", "Stop"),
+            ("openclaw", "before_prompt_build", "UserPromptSubmit"),
+            ("openclaw", "session_end", "Stop"),
+            ("hermes", "pre_llm_call", "UserPromptSubmit"),
+            ("hermes", "on_session_end", "Stop"),
+        ];
+
+        for (provider, native, expected) in cases {
+            let normalized = provider_event::normalize_provider_payload(provider, native, "{}")
+                .unwrap_or_else(|err| panic!("{provider}:{native}: {err}"));
+            assert_eq!(normalized.event, expected, "{provider}:{native}");
+        }
     }
 }

--- a/crates/gwt/src/cli/hook/provider_event.rs
+++ b/crates/gwt/src/cli/hook/provider_event.rs
@@ -1,0 +1,200 @@
+//! Provider-owned hook adapters for non-Claude/Codex agents.
+//!
+//! OpenCode, OpenClaw, and Hermes expose different native hook names and
+//! payload shapes. This adapter normalizes those native events into gwt's
+//! canonical hook vocabulary, then delegates to the existing event dispatcher.
+
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use super::{event_dispatcher, HookError, HookOutput};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizedProviderEvent {
+    pub event: String,
+    pub payload: Value,
+}
+
+pub fn handle_with_input(
+    provider: &str,
+    native_event: &str,
+    input: &str,
+    worktree_root: &Path,
+    current_session: Option<&str>,
+) -> Result<HookOutput, HookError> {
+    let normalized = normalize_provider_payload(provider, native_event, input)?;
+    let payload = serde_json::to_string(&normalized.payload)?;
+    event_dispatcher::handle_with_input(&normalized.event, &payload, worktree_root, current_session)
+}
+
+pub fn normalize_provider_payload(
+    provider: &str,
+    native_event: &str,
+    input: &str,
+) -> Result<NormalizedProviderEvent, HookError> {
+    let event = canonical_event(provider, native_event)
+        .ok_or_else(|| HookError::InvalidEvent(format!("{provider}:{native_event}")))?;
+    let raw = parse_input(input)?;
+    let payload = normalize_payload(provider, native_event, raw);
+
+    Ok(NormalizedProviderEvent {
+        event: event.to_string(),
+        payload,
+    })
+}
+
+fn canonical_event(provider: &str, native_event: &str) -> Option<&'static str> {
+    let provider = provider.trim().to_ascii_lowercase();
+    match (provider.as_str(), native_event.trim()) {
+        ("opencode", "session.created") => Some("SessionStart"),
+        ("opencode", "message.updated") => Some("UserPromptSubmit"),
+        ("opencode", "tool.execute.before") => Some("PreToolUse"),
+        ("opencode", "tool.execute.after") => Some("PostToolUse"),
+        ("opencode", "session.idle") => Some("Stop"),
+        ("openclaw", "session_start") => Some("SessionStart"),
+        ("openclaw", "before_prompt_build") => Some("UserPromptSubmit"),
+        ("openclaw", "before_tool_call") => Some("PreToolUse"),
+        ("openclaw", "after_tool_call") => Some("PostToolUse"),
+        ("openclaw", "session_end") => Some("Stop"),
+        ("hermes", "on_session_start") => Some("SessionStart"),
+        ("hermes", "pre_llm_call") => Some("UserPromptSubmit"),
+        ("hermes", "pre_tool_call") => Some("PreToolUse"),
+        ("hermes", "post_tool_call") => Some("PostToolUse"),
+        ("hermes", "on_session_end") => Some("Stop"),
+        _ => None,
+    }
+}
+
+fn parse_input(input: &str) -> Result<Value, HookError> {
+    if input.trim().is_empty() {
+        return Ok(Value::Object(Map::new()));
+    }
+    Ok(serde_json::from_str(input)?)
+}
+
+fn normalize_payload(provider: &str, native_event: &str, raw: Value) -> Value {
+    let mut out = raw.as_object().cloned().unwrap_or_else(|| {
+        let mut map = Map::new();
+        map.insert("raw".to_string(), raw.clone());
+        map
+    });
+
+    insert_string_if_missing(&mut out, "provider", Some(provider));
+    insert_string_if_missing(&mut out, "native_event", Some(native_event));
+    insert_string_if_missing(&mut out, "tool_name", tool_name(&raw).as_deref());
+    insert_value_if_missing(&mut out, "tool_input", tool_input(&raw));
+    insert_string_if_missing(&mut out, "session_id", session_id(&raw).as_deref());
+    insert_string_if_missing(&mut out, "cwd", cwd(&raw).as_deref());
+    insert_string_if_missing(
+        &mut out,
+        "transcript_path",
+        string_at_any(&raw, &[&["transcript_path"], &["transcriptPath"]]).as_deref(),
+    );
+
+    Value::Object(out)
+}
+
+fn insert_string_if_missing(map: &mut Map<String, Value>, key: &str, value: Option<&str>) {
+    if map.contains_key(key) {
+        return;
+    }
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    map.insert(key.to_string(), Value::String(value.to_string()));
+}
+
+fn insert_value_if_missing(map: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if map.contains_key(key) {
+        return;
+    }
+    if let Some(value) = value {
+        map.insert(key.to_string(), value);
+    }
+}
+
+fn tool_name(raw: &Value) -> Option<String> {
+    string_at_any(
+        raw,
+        &[
+            &["tool_name"],
+            &["toolName"],
+            &["tool", "name"],
+            &["toolName"],
+            &["name"],
+        ],
+    )
+    .or_else(|| string_at_any(raw, &[&["tool"]]))
+}
+
+fn tool_input(raw: &Value) -> Option<Value> {
+    value_at_any(
+        raw,
+        &[
+            &["tool_input"],
+            &["toolInput"],
+            &["input"],
+            &["args"],
+            &["arguments"],
+            &["params"],
+            &["tool", "input"],
+            &["tool", "args"],
+            &["tool", "arguments"],
+            &["tool", "params"],
+        ],
+    )
+    .cloned()
+}
+
+fn session_id(raw: &Value) -> Option<String> {
+    string_at_any(
+        raw,
+        &[
+            &["session_id"],
+            &["sessionId"],
+            &["sessionID"],
+            &["session", "id"],
+            &["session", "session_id"],
+            &["ctx", "sessionId"],
+            &["context", "sessionId"],
+        ],
+    )
+}
+
+fn cwd(raw: &Value) -> Option<String> {
+    string_at_any(
+        raw,
+        &[
+            &["cwd"],
+            &["working_directory"],
+            &["workingDirectory"],
+            &["directory"],
+            &["project", "root"],
+            &["workspace", "root"],
+            &["session", "cwd"],
+        ],
+    )
+}
+
+fn string_at_any(raw: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| value_at(raw, path))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn value_at_any<'a>(raw: &'a Value, paths: &[&[&str]]) -> Option<&'a Value> {
+    paths.iter().find_map(|path| value_at(raw, path))
+}
+
+fn value_at<'a>(raw: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = raw;
+    for key in path {
+        current = current.as_object()?.get(*key)?;
+    }
+    Some(current)
+}

--- a/crates/gwt/src/cli/hook/provider_event.rs
+++ b/crates/gwt/src/cli/hook/provider_event.rs
@@ -33,10 +33,13 @@ pub fn normalize_provider_payload(
     native_event: &str,
     input: &str,
 ) -> Result<NormalizedProviderEvent, HookError> {
-    let event = canonical_event(provider, native_event)
+    let provider_kind = ProviderKind::parse(provider)
+        .ok_or_else(|| HookError::InvalidEvent(format!("{provider}:{native_event}")))?;
+    let event = provider_kind
+        .canonical_event(native_event)
         .ok_or_else(|| HookError::InvalidEvent(format!("{provider}:{native_event}")))?;
     let raw = parse_input(input)?;
-    let payload = normalize_payload(provider, native_event, raw);
+    let payload = normalize_payload(provider_kind, native_event, raw);
 
     Ok(NormalizedProviderEvent {
         event: event.to_string(),
@@ -44,25 +47,50 @@ pub fn normalize_provider_payload(
     })
 }
 
-fn canonical_event(provider: &str, native_event: &str) -> Option<&'static str> {
-    let provider = provider.trim().to_ascii_lowercase();
-    match (provider.as_str(), native_event.trim()) {
-        ("opencode", "session.created") => Some("SessionStart"),
-        ("opencode", "message.updated") => Some("UserPromptSubmit"),
-        ("opencode", "tool.execute.before") => Some("PreToolUse"),
-        ("opencode", "tool.execute.after") => Some("PostToolUse"),
-        ("opencode", "session.idle") => Some("Stop"),
-        ("openclaw", "session_start") => Some("SessionStart"),
-        ("openclaw", "before_prompt_build") => Some("UserPromptSubmit"),
-        ("openclaw", "before_tool_call") => Some("PreToolUse"),
-        ("openclaw", "after_tool_call") => Some("PostToolUse"),
-        ("openclaw", "session_end") => Some("Stop"),
-        ("hermes", "on_session_start") => Some("SessionStart"),
-        ("hermes", "pre_llm_call") => Some("UserPromptSubmit"),
-        ("hermes", "pre_tool_call") => Some("PreToolUse"),
-        ("hermes", "post_tool_call") => Some("PostToolUse"),
-        ("hermes", "on_session_end") => Some("Stop"),
-        _ => None,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderKind {
+    OpenCode,
+    OpenClaw,
+    Hermes,
+}
+
+impl ProviderKind {
+    fn parse(provider: &str) -> Option<Self> {
+        match provider.trim().to_ascii_lowercase().as_str() {
+            "opencode" => Some(Self::OpenCode),
+            "openclaw" => Some(Self::OpenClaw),
+            "hermes" => Some(Self::Hermes),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenCode => "opencode",
+            Self::OpenClaw => "openclaw",
+            Self::Hermes => "hermes",
+        }
+    }
+
+    fn canonical_event(self, native_event: &str) -> Option<&'static str> {
+        match (self, native_event.trim()) {
+            (Self::OpenCode, "session.created") => Some("SessionStart"),
+            (Self::OpenCode, "message.updated") => Some("UserPromptSubmit"),
+            (Self::OpenCode, "tool.execute.before") => Some("PreToolUse"),
+            (Self::OpenCode, "tool.execute.after") => Some("PostToolUse"),
+            (Self::OpenCode, "session.idle") => Some("Stop"),
+            (Self::OpenClaw, "session_start") => Some("SessionStart"),
+            (Self::OpenClaw, "before_prompt_build") => Some("UserPromptSubmit"),
+            (Self::OpenClaw, "before_tool_call") => Some("PreToolUse"),
+            (Self::OpenClaw, "after_tool_call") => Some("PostToolUse"),
+            (Self::OpenClaw, "session_end") => Some("Stop"),
+            (Self::Hermes, "on_session_start") => Some("SessionStart"),
+            (Self::Hermes, "pre_llm_call") => Some("UserPromptSubmit"),
+            (Self::Hermes, "pre_tool_call") => Some("PreToolUse"),
+            (Self::Hermes, "post_tool_call") => Some("PostToolUse"),
+            (Self::Hermes, "on_session_end") => Some("Stop"),
+            _ => None,
+        }
     }
 }
 
@@ -73,19 +101,23 @@ fn parse_input(input: &str) -> Result<Value, HookError> {
     Ok(serde_json::from_str(input)?)
 }
 
-fn normalize_payload(provider: &str, native_event: &str, raw: Value) -> Value {
+fn normalize_payload(provider: ProviderKind, native_event: &str, raw: Value) -> Value {
     let mut out = raw.as_object().cloned().unwrap_or_else(|| {
         let mut map = Map::new();
         map.insert("raw".to_string(), raw.clone());
         map
     });
 
-    insert_string_if_missing(&mut out, "provider", Some(provider));
+    insert_string_if_missing(&mut out, "provider", Some(provider.as_str()));
     insert_string_if_missing(&mut out, "native_event", Some(native_event));
-    insert_string_if_missing(&mut out, "tool_name", tool_name(&raw).as_deref());
-    insert_value_if_missing(&mut out, "tool_input", tool_input(&raw));
-    insert_string_if_missing(&mut out, "session_id", session_id(&raw).as_deref());
-    insert_string_if_missing(&mut out, "cwd", cwd(&raw).as_deref());
+    insert_string_if_missing(&mut out, "tool_name", tool_name(provider, &raw).as_deref());
+    insert_value_if_missing(&mut out, "tool_input", tool_input(provider, &raw));
+    insert_string_if_missing(
+        &mut out,
+        "session_id",
+        session_id(provider, &raw).as_deref(),
+    );
+    insert_string_if_missing(&mut out, "cwd", cwd(provider, &raw).as_deref());
     insert_string_if_missing(
         &mut out,
         "transcript_path",
@@ -114,67 +146,184 @@ fn insert_value_if_missing(map: &mut Map<String, Value>, key: &str, value: Optio
     }
 }
 
-fn tool_name(raw: &Value) -> Option<String> {
-    string_at_any(
-        raw,
-        &[
-            &["tool_name"],
-            &["toolName"],
-            &["tool", "name"],
-            &["toolName"],
-            &["name"],
-        ],
-    )
-    .or_else(|| string_at_any(raw, &[&["tool"]]))
+fn tool_name(provider: ProviderKind, raw: &Value) -> Option<String> {
+    match provider {
+        ProviderKind::OpenCode => string_at_any(
+            raw,
+            &[
+                &["tool_name"],
+                &["toolName"],
+                &["tool", "name"],
+                &["name"],
+                &["input", "tool"],
+                &["input", "toolName"],
+                &["output", "tool"],
+                &["output", "toolName"],
+            ],
+        ),
+        ProviderKind::OpenClaw => string_at_any(
+            raw,
+            &[
+                &["tool_name"],
+                &["toolName"],
+                &["tool", "name"],
+                &["event", "toolName"],
+                &["event", "tool_name"],
+            ],
+        ),
+        ProviderKind::Hermes => string_at_any(
+            raw,
+            &[
+                &["tool_name"],
+                &["toolName"],
+                &["tool", "name"],
+                &["name"],
+                &["tool"],
+            ],
+        ),
+    }
 }
 
-fn tool_input(raw: &Value) -> Option<Value> {
-    value_at_any(
-        raw,
-        &[
-            &["tool_input"],
-            &["toolInput"],
-            &["input"],
-            &["args"],
-            &["arguments"],
-            &["params"],
-            &["tool", "input"],
-            &["tool", "args"],
-            &["tool", "arguments"],
-            &["tool", "params"],
-        ],
-    )
+fn tool_input(provider: ProviderKind, raw: &Value) -> Option<Value> {
+    match provider {
+        ProviderKind::OpenCode => value_at_any(
+            raw,
+            &[
+                &["tool_input"],
+                &["toolInput"],
+                &["output", "args"],
+                &["input", "args"],
+                &["output", "params"],
+                &["input", "params"],
+                &["output", "input"],
+                &["input", "input"],
+                &["args"],
+                &["arguments"],
+                &["params"],
+                &["tool", "input"],
+                &["tool", "args"],
+                &["tool", "arguments"],
+                &["tool", "params"],
+            ],
+        ),
+        ProviderKind::OpenClaw => value_at_any(
+            raw,
+            &[
+                &["tool_input"],
+                &["toolInput"],
+                &["event", "params"],
+                &["event", "args"],
+                &["event", "toolInput"],
+                &["event", "tool_input"],
+                &["params"],
+                &["args"],
+                &["tool", "input"],
+            ],
+        ),
+        ProviderKind::Hermes => value_at_any(
+            raw,
+            &[
+                &["tool_input"],
+                &["toolInput"],
+                &["input"],
+                &["args"],
+                &["arguments"],
+                &["params"],
+                &["tool", "input"],
+                &["tool", "args"],
+                &["tool", "arguments"],
+                &["tool", "params"],
+            ],
+        ),
+    }
     .cloned()
 }
 
-fn session_id(raw: &Value) -> Option<String> {
-    string_at_any(
-        raw,
-        &[
-            &["session_id"],
-            &["sessionId"],
-            &["sessionID"],
-            &["session", "id"],
-            &["session", "session_id"],
-            &["ctx", "sessionId"],
-            &["context", "sessionId"],
-        ],
-    )
+fn session_id(provider: ProviderKind, raw: &Value) -> Option<String> {
+    match provider {
+        ProviderKind::OpenCode => string_at_any(
+            raw,
+            &[
+                &["session_id"],
+                &["sessionId"],
+                &["sessionID"],
+                &["session", "id"],
+                &["session", "session_id"],
+                &["input", "sessionID"],
+                &["input", "sessionId"],
+                &["input", "session_id"],
+                &["context", "sessionID"],
+                &["context", "sessionId"],
+            ],
+        ),
+        ProviderKind::OpenClaw => string_at_any(
+            raw,
+            &[
+                &["session_id"],
+                &["sessionId"],
+                &["sessionID"],
+                &["session", "id"],
+                &["event", "sessionId"],
+                &["event", "session_id"],
+                &["ctx", "sessionId"],
+                &["ctx", "sessionKey"],
+            ],
+        ),
+        ProviderKind::Hermes => string_at_any(
+            raw,
+            &[
+                &["session_id"],
+                &["sessionId"],
+                &["sessionID"],
+                &["session", "id"],
+                &["session", "session_id"],
+                &["ctx", "sessionId"],
+                &["context", "sessionId"],
+            ],
+        ),
+    }
 }
 
-fn cwd(raw: &Value) -> Option<String> {
-    string_at_any(
-        raw,
-        &[
-            &["cwd"],
-            &["working_directory"],
-            &["workingDirectory"],
-            &["directory"],
-            &["project", "root"],
-            &["workspace", "root"],
-            &["session", "cwd"],
-        ],
-    )
+fn cwd(provider: ProviderKind, raw: &Value) -> Option<String> {
+    match provider {
+        ProviderKind::OpenCode => string_at_any(
+            raw,
+            &[
+                &["cwd"],
+                &["working_directory"],
+                &["workingDirectory"],
+                &["directory"],
+                &["input", "cwd"],
+                &["context", "directory"],
+                &["context", "worktree"],
+                &["context", "project", "root"],
+            ],
+        ),
+        ProviderKind::OpenClaw => string_at_any(
+            raw,
+            &[
+                &["cwd"],
+                &["working_directory"],
+                &["workingDirectory"],
+                &["directory"],
+                &["event", "cwd"],
+                &["ctx", "cwd"],
+                &["ctx", "workspaceRoot"],
+            ],
+        ),
+        ProviderKind::Hermes => string_at_any(
+            raw,
+            &[
+                &["cwd"],
+                &["working_directory"],
+                &["workingDirectory"],
+                &["directory"],
+                &["project", "root"],
+                &["workspace", "root"],
+                &["session", "cwd"],
+            ],
+        ),
+    }
 }
 
 fn string_at_any(raw: &Value, paths: &[&[&str]]) -> Option<String> {
@@ -197,4 +346,59 @@ fn value_at<'a>(raw: &'a Value, path: &[&str]) -> Option<&'a Value> {
         current = current.as_object()?.get(*key)?;
     }
     Some(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opencode_native_payload_shape_promotes_tool_and_workspace_fields() {
+        let normalized = normalize_provider_payload(
+            "opencode",
+            "tool.execute.before",
+            r#"{
+              "input": {
+                "tool": "Bash",
+                "args": { "command": "pwd" },
+                "sessionID": "oc-1"
+              },
+              "context": {
+                "directory": "/repo"
+              }
+            }"#,
+        )
+        .expect("normalize opencode native-like payload");
+
+        assert_eq!(normalized.event, "PreToolUse");
+        assert_eq!(normalized.payload["tool_name"], "Bash");
+        assert_eq!(normalized.payload["tool_input"]["command"], "pwd");
+        assert_eq!(normalized.payload["session_id"], "oc-1");
+        assert_eq!(normalized.payload["cwd"], "/repo");
+    }
+
+    #[test]
+    fn openclaw_native_payload_shape_promotes_event_and_context_fields() {
+        let normalized = normalize_provider_payload(
+            "openclaw",
+            "before_tool_call",
+            r#"{
+              "event": {
+                "toolName": "Bash",
+                "params": { "command": "git status" },
+                "sessionId": "claw-1"
+              },
+              "ctx": {
+                "workspaceRoot": "/repo"
+              }
+            }"#,
+        )
+        .expect("normalize openclaw native-like payload");
+
+        assert_eq!(normalized.event, "PreToolUse");
+        assert_eq!(normalized.payload["tool_name"], "Bash");
+        assert_eq!(normalized.payload["tool_input"]["command"], "git status");
+        assert_eq!(normalized.payload["session_id"], "claw-1");
+        assert_eq!(normalized.payload["cwd"], "/repo");
+    }
 }

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -176,15 +176,16 @@ pub fn handle(event: &str) -> Result<(), HookError> {
 }
 
 pub fn handle_with_input(event: &str, input: &str) -> Result<(), HookError> {
-    if std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV).is_none() {
+    let Some(runtime_path) = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV) else {
         return Ok(());
-    }
+    };
+    let runtime_path = PathBuf::from(runtime_path);
     let hook_event = if input.trim().is_empty() {
         None
     } else {
         RawHookEvent::read_from_str(input)?
     };
-    let sessions_dir = sessions_dir_for_current_runtime();
+    let sessions_dir = sessions_dir_for_runtime_path(&runtime_path);
     let gwt_session_id = GwtSessionId::required_from_env(event)?;
     let session = current_session_for_id(&sessions_dir, &gwt_session_id)?;
     let agent_session_id = validated_hook_agent_session_id(
@@ -197,19 +198,16 @@ pub fn handle_with_input(event: &str, input: &str) -> Result<(), HookError> {
         sync_agent_session_id(&sessions_dir, &gwt_session_id, agent_session_id)?;
     }
 
-    let Some(path) = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV) else {
-        return Ok(());
-    };
-    let path = PathBuf::from(path);
-    write_for_event(&path, event)
+    let pending_discussion = session.as_ref().and_then(|session| {
+        pending_discussion_for_session(&sessions_dir, &session.id)
+            .ok()
+            .flatten()
+    });
+    write_for_event_with_pending_discussion(&runtime_path, event, pending_discussion)
 }
 
-fn sessions_dir_for_current_runtime() -> PathBuf {
-    let Some(runtime_path) = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV) else {
-        return gwt_core::paths::gwt_sessions_dir();
-    };
-    let runtime_path = PathBuf::from(runtime_path);
-    gwt_agent::sessions_dir_from_runtime_path(&runtime_path)
+fn sessions_dir_for_runtime_path(runtime_path: &Path) -> PathBuf {
+    gwt_agent::sessions_dir_from_runtime_path(runtime_path)
         .unwrap_or_else(gwt_core::paths::gwt_sessions_dir)
 }
 

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -9,15 +9,23 @@
 //! - allow transport operations such as `git push` and worktree-internal edits
 //!   without an owner gate
 
-use std::{collections::HashMap, io::Read, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Read,
+    path::Path,
+};
 
 use gwt_agent::{
     session::{Session, GWT_SESSION_ID_ENV},
     types::WorkflowBypass,
 };
 use gwt_core::{
+    coordination::{load_snapshot, BoardEntry, BoardEntryKind, BoardMentionTargetKind},
     paths::{gwt_cache_dir, gwt_sessions_dir},
-    workspace_projection::load_workspace_projection,
+    workspace_projection::{
+        load_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
+        WorkspaceStatusCategory,
+    },
 };
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;
@@ -103,7 +111,11 @@ pub fn evaluate_with_context(
     if safety != HookOutput::Silent {
         return Ok(safety);
     }
-    evaluate_title_summary_guard(event, context.title_summary_missing)
+    let title_summary = evaluate_title_summary_guard(event, context.title_summary_missing)?;
+    if title_summary != HookOutput::Silent {
+        return Ok(title_summary);
+    }
+    evaluate_workspace_coordination_guard(event, worktree_root)
 }
 
 pub fn evaluate(event: &HookEvent, worktree_root: &Path) -> Result<HookOutput, HookError> {
@@ -229,6 +241,468 @@ Use the configured narrative language for the title-summary. Keep progress, comp
     }
 
     Ok(HookOutput::Silent)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkspaceCoordinationConflict {
+    source_label: &'static str,
+    title: String,
+    session_id: Option<String>,
+    branch: Option<String>,
+    agent_id: Option<String>,
+    related_owners: Vec<String>,
+    related_topics: Vec<String>,
+}
+
+fn evaluate_workspace_coordination_guard(
+    event: &HookEvent,
+    worktree_root: &Path,
+) -> Result<HookOutput, HookError> {
+    if !is_workspace_coordination_sensitive_event(event) {
+        return Ok(HookOutput::Silent);
+    }
+
+    let session = load_session_from_env();
+    let current_session_id = session.as_ref().map(|session| session.id.as_str());
+    let projection = load_workspace_projection(worktree_root)?;
+    let current_intent = workspace_current_intent(event, projection.as_ref(), current_session_id);
+    if current_intent.trim().is_empty() {
+        return Ok(HookOutput::Silent);
+    }
+
+    let conflicts = workspace_coordination_conflicts(
+        worktree_root,
+        projection.as_ref(),
+        &current_intent,
+        current_session_id,
+    )?;
+    let Some(conflict) = conflicts.into_iter().next() else {
+        return Ok(HookOutput::Silent);
+    };
+
+    if has_matching_split_claim(
+        worktree_root,
+        current_session_id,
+        &current_intent,
+        &conflict,
+    )? {
+        return Ok(HookOutput::Silent);
+    }
+
+    Ok(workspace_coordination_block_decision(&conflict))
+}
+
+fn workspace_coordination_conflicts(
+    worktree_root: &Path,
+    projection: Option<&WorkspaceProjection>,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
+    let mut conflicts = Vec::new();
+    if let Some(projection) = projection {
+        conflicts.extend(workspace_agent_conflicts(
+            projection,
+            current_intent,
+            current_session_id,
+        ));
+    }
+    conflicts.extend(board_claim_conflicts(
+        worktree_root,
+        current_intent,
+        current_session_id,
+    )?);
+    Ok(conflicts)
+}
+
+fn workspace_agent_conflicts(
+    projection: &WorkspaceProjection,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Vec<WorkspaceCoordinationConflict> {
+    projection
+        .agents
+        .iter()
+        .filter(|agent| {
+            current_session_id != Some(agent.session_id.as_str())
+                && matches!(
+                    agent.status_category,
+                    WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
+                )
+        })
+        .filter_map(|agent| {
+            let text = workspace_agent_text(agent);
+            is_similar_work(current_intent, &text).then(|| WorkspaceCoordinationConflict {
+                source_label: "similar active Workspace",
+                title: agent
+                    .title_summary
+                    .as_deref()
+                    .or(agent.current_focus.as_deref())
+                    .unwrap_or("active Workspace agent")
+                    .to_string(),
+                session_id: Some(agent.session_id.clone()),
+                branch: agent.branch.clone(),
+                agent_id: Some(agent.agent_id.clone()),
+                related_owners: Vec::new(),
+                related_topics: agent.coordination_scope.iter().cloned().collect(),
+            })
+        })
+        .collect()
+}
+
+fn board_claim_conflicts(
+    worktree_root: &Path,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
+    let snapshot = load_snapshot(worktree_root)?;
+    Ok(snapshot
+        .board
+        .entries
+        .iter()
+        .rev()
+        .filter(|entry| {
+            entry.kind == BoardEntryKind::Claim
+                && board_claim_is_active(entry)
+                && current_session_id != entry.origin_session_id.as_deref()
+        })
+        .filter_map(|entry| {
+            let text = board_entry_text(entry);
+            is_similar_work(current_intent, &text).then(|| WorkspaceCoordinationConflict {
+                source_label: "active Board claim",
+                title: entry
+                    .title_summary
+                    .as_deref()
+                    .or_else(|| entry.body.lines().find(|line| !line.trim().is_empty()))
+                    .unwrap_or("active Board claim")
+                    .trim()
+                    .to_string(),
+                session_id: entry.origin_session_id.clone(),
+                branch: entry.origin_branch.clone(),
+                agent_id: entry.origin_agent_id.clone(),
+                related_owners: entry.related_owners.clone(),
+                related_topics: entry.related_topics.clone(),
+            })
+        })
+        .collect())
+}
+
+fn workspace_current_intent(
+    event: &HookEvent,
+    projection: Option<&WorkspaceProjection>,
+    current_session_id: Option<&str>,
+) -> String {
+    let mut parts = Vec::new();
+    if let (Some(projection), Some(current_session_id)) = (projection, current_session_id) {
+        if let Some(agent) = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == current_session_id)
+        {
+            push_optional(&mut parts, agent.title_summary.as_deref());
+            push_optional(&mut parts, agent.current_focus.as_deref());
+            push_optional(&mut parts, agent.coordination_scope.as_deref());
+        }
+    }
+    if parts.is_empty() {
+        if let Some(projection) = projection {
+            parts.push(projection.title.as_str());
+            push_optional(&mut parts, projection.summary.as_deref());
+            push_optional(&mut parts, projection.next_action.as_deref());
+            push_optional(&mut parts, projection.owner.as_deref());
+        }
+    }
+    if parts.is_empty() {
+        push_optional(&mut parts, event.command());
+        if let Some(tool_input) = event.tool_input.as_ref() {
+            push_optional(
+                &mut parts,
+                tool_input
+                    .get("file_path")
+                    .and_then(serde_json::Value::as_str),
+            );
+        }
+    }
+    parts.join("\n")
+}
+
+fn workspace_agent_text(agent: &WorkspaceAgentSummary) -> String {
+    let mut parts = Vec::new();
+    push_optional(&mut parts, agent.title_summary.as_deref());
+    push_optional(&mut parts, agent.current_focus.as_deref());
+    push_optional(&mut parts, agent.coordination_scope.as_deref());
+    push_optional(&mut parts, agent.branch.as_deref());
+    parts.push(agent.agent_id.as_str());
+    parts.push(agent.display_name.as_str());
+    parts.join("\n")
+}
+
+fn board_entry_text(entry: &BoardEntry) -> String {
+    let mut parts = Vec::new();
+    push_optional(&mut parts, entry.title_summary.as_deref());
+    parts.push(entry.body.as_str());
+    parts.extend(entry.related_topics.iter().map(String::as_str));
+    parts.extend(entry.related_owners.iter().map(String::as_str));
+    parts.extend(entry.target_owners.iter().map(String::as_str));
+    parts.join("\n")
+}
+
+fn push_optional<'a>(parts: &mut Vec<&'a str>, value: Option<&'a str>) {
+    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+        parts.push(value);
+    }
+}
+
+fn board_claim_is_active(entry: &BoardEntry) -> bool {
+    !entry.state.as_deref().is_some_and(|state| {
+        matches!(
+            state.trim().to_ascii_lowercase().as_str(),
+            "done" | "closed" | "resolved" | "cancelled" | "canceled" | "inactive"
+        )
+    })
+}
+
+fn has_matching_split_claim(
+    worktree_root: &Path,
+    current_session_id: Option<&str>,
+    current_intent: &str,
+    conflict: &WorkspaceCoordinationConflict,
+) -> Result<bool, HookError> {
+    let Some(current_session_id) = current_session_id else {
+        return Ok(false);
+    };
+    let snapshot = load_snapshot(worktree_root)?;
+    Ok(snapshot.board.entries.iter().rev().any(|entry| {
+        entry.kind == BoardEntryKind::Claim
+            && entry.origin_session_id.as_deref() == Some(current_session_id)
+            && board_claim_is_active(entry)
+            && board_entry_has_boundary(entry)
+            && board_entry_targets_conflict(entry, conflict)
+            && split_claim_matches_current_work(entry, current_intent)
+    }))
+}
+
+fn split_claim_matches_current_work(entry: &BoardEntry, current_intent: &str) -> bool {
+    is_similar_work(current_intent, &board_entry_text(entry))
+        || entry
+            .title_summary
+            .as_deref()
+            .is_some_and(|title| is_similar_work(current_intent, title))
+        || entry
+            .related_topics
+            .iter()
+            .any(|topic| is_similar_work(current_intent, topic))
+}
+
+fn board_entry_has_boundary(entry: &BoardEntry) -> bool {
+    entry.body.lines().any(|line| {
+        line.trim_start()
+            .to_ascii_lowercase()
+            .starts_with("boundary:")
+    })
+}
+
+fn board_entry_targets_conflict(
+    entry: &BoardEntry,
+    conflict: &WorkspaceCoordinationConflict,
+) -> bool {
+    let mut keys = Vec::new();
+    if let Some(session_id) = conflict.session_id.as_deref() {
+        keys.push(session_id.to_string());
+        keys.push(format!("session:{session_id}"));
+    }
+    if let Some(branch) = conflict.branch.as_deref() {
+        keys.push(branch.to_string());
+        keys.push(format!("branch:{branch}"));
+    }
+    if let Some(agent_id) = conflict.agent_id.as_deref() {
+        keys.push(agent_id.to_string());
+        keys.push(format!("agent:{agent_id}"));
+    }
+    keys.extend(conflict.related_owners.iter().cloned());
+
+    entry
+        .target_owners
+        .iter()
+        .any(|target| keys.iter().any(|key| key == target))
+        || entry
+            .mentions
+            .iter()
+            .map(|mention| match mention.target_kind {
+                BoardMentionTargetKind::Session => format!("session:{}", mention.target),
+                BoardMentionTargetKind::Branch => format!("branch:{}", mention.target),
+                BoardMentionTargetKind::Agent => format!("agent:{}", mention.target),
+                BoardMentionTargetKind::User => format!("user:{}", mention.target),
+            })
+            .any(|typed_key| keys.iter().any(|key| key == &typed_key))
+}
+
+fn workspace_coordination_block_decision(conflict: &WorkspaceCoordinationConflict) -> HookOutput {
+    let mut detail = format!(
+        "A {source} is already in progress and appears to cover the same work.\n\n\
+Conflict title: {title}\n",
+        source = conflict.source_label,
+        title = conflict.title
+    );
+    if let Some(session_id) = conflict.session_id.as_deref() {
+        detail.push_str(&format!("Session: {session_id}\n"));
+    }
+    if let Some(branch) = conflict.branch.as_deref() {
+        detail.push_str(&format!("Branch: {branch}\n"));
+    }
+    if !conflict.related_topics.is_empty() {
+        detail.push_str(&format!("Topics: {}\n", conflict.related_topics.join(", ")));
+    }
+    detail.push_str(
+        "\nDo not continue implementation/editing for duplicate work in a new Workspace. \
+Coordinate on the shared Board with the active agent first.\n\n\
+To coordinate or hand off:\n\
+  gwtd board post --kind request --target <session-or-branch> --body '<question or handoff request>'\n\n\
+To split intentionally, post a claim that targets/mentions the active agent and includes a Boundary line:\n\
+  gwtd board post --kind claim --target <session-or-branch> --topic <topic> --body 'Split accepted.\\n\\nBoundary: <owned files/modules and non-overlap>'",
+    );
+    HookOutput::pre_tool_use_permission("Similar active Workspace already exists", &detail)
+}
+
+fn is_workspace_coordination_sensitive_event(event: &HookEvent) -> bool {
+    match event.tool_name.as_deref() {
+        Some("Edit" | "MultiEdit" | "Write" | "NotebookEdit" | "apply_patch") => true,
+        Some("Bash") => event
+            .command()
+            .is_some_and(is_workspace_coordination_sensitive_bash),
+        _ => false,
+    }
+}
+
+fn is_workspace_coordination_sensitive_bash(command: &str) -> bool {
+    if is_workspace_coordination_command(command) {
+        return false;
+    }
+    if command.contains('>') || command.contains(" tee ") || command.contains("|tee ") {
+        return true;
+    }
+    let segments = super::segments::split_command_segments(command);
+    segments.iter().any(|segment| {
+        let tokens = segment_tokens(segment);
+        let Some(command_name) = tokens.first().map(|token| normalize_command_name(token)) else {
+            return false;
+        };
+        match command_name.as_str() {
+            "cp" | "mkdir" | "mv" | "rm" | "rmdir" | "touch" => true,
+            "sed" => tokens
+                .iter()
+                .any(|token| *token == "--in-place" || token.starts_with("-i")),
+            "cargo" => tokens
+                .get(1)
+                .is_some_and(|subcommand| matches!(*subcommand, "fmt" | "fix")),
+            "git" => tokens
+                .get(1)
+                .is_some_and(|subcommand| matches!(*subcommand, "add" | "commit")),
+            _ => false,
+        }
+    })
+}
+
+fn is_workspace_coordination_command(command: &str) -> bool {
+    let segments = super::segments::split_command_segments(command);
+    !segments.is_empty()
+        && segments.iter().all(|segment| {
+            let tokens = segment_tokens(segment);
+            let Some(command_name) = tokens.first().map(|token| normalize_command_name(token))
+            else {
+                return false;
+            };
+            if command_name != "gwtd" {
+                return false;
+            }
+            matches!(
+                tokens.as_slice(),
+                [_, "board", "post" | "show", ..]
+                    | [_, "workspace", "update", ..]
+                    | [_, "build", "start" | "phase" | "complete" | "abort", ..]
+            )
+        })
+}
+
+fn is_similar_work(left: &str, right: &str) -> bool {
+    let left_compact = compact_for_similarity(left);
+    let right_compact = compact_for_similarity(right);
+    if left_compact.len() >= 16
+        && right_compact.len() >= 16
+        && (left_compact.contains(&right_compact) || right_compact.contains(&left_compact))
+    {
+        return true;
+    }
+
+    let left_tokens = similarity_tokens(left);
+    let right_tokens = similarity_tokens(right);
+    if left_tokens.is_empty() || right_tokens.is_empty() {
+        return false;
+    }
+    let overlap = left_tokens.intersection(&right_tokens).count();
+    if overlap < 3 {
+        return false;
+    }
+    let left_coverage = overlap as f32 / left_tokens.len() as f32;
+    let right_coverage = overlap as f32 / right_tokens.len() as f32;
+    let dice = (2 * overlap) as f32 / (left_tokens.len() + right_tokens.len()) as f32;
+
+    (overlap >= 4 && left_coverage >= 0.45 && dice >= 0.35)
+        || (left_coverage >= 0.60 && right_coverage >= 0.45)
+}
+
+fn compact_for_similarity(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn similarity_tokens(value: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    for raw in value
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    {
+        let lower = raw.to_ascii_lowercase();
+        if raw.is_ascii() {
+            if lower.len() >= 3 && !is_similarity_stopword(&lower) {
+                tokens.insert(lower);
+            }
+            continue;
+        }
+        let chars = raw.chars().collect::<Vec<_>>();
+        for size in [2, 3] {
+            if chars.len() >= size {
+                for window in chars.windows(size) {
+                    tokens.insert(window.iter().collect());
+                }
+            }
+        }
+    }
+    tokens
+}
+
+fn is_similarity_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "add"
+            | "and"
+            | "body"
+            | "for"
+            | "from"
+            | "gate"
+            | "new"
+            | "old"
+            | "only"
+            | "the"
+            | "this"
+            | "update"
+            | "with"
+            | "work"
+            | "works"
+    )
 }
 
 fn is_title_sensitive_tool(event: &HookEvent) -> bool {

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -314,7 +314,8 @@ fn workspace_coordination_conflicts(
         current_intent,
         current_session_id,
     )?);
-    let current_workspace_id = resolve_current_workspace_audience();
+    let current_workspace_id = current_session_id
+        .and_then(|session_id| resolve_current_workspace_audience(worktree_root, session_id));
     conflicts.extend(board_claim_conflicts(
         worktree_root,
         current_intent,
@@ -325,13 +326,11 @@ fn workspace_coordination_conflicts(
 }
 
 /// SPEC-2359 FR-099: resolve the current Agent's assigned Workspace id for
-/// the duplicate-work coordination gate. Returns `None` until the Agent
-/// affiliation field (SPEC-2359 FR-088, US-25) lands, mirroring the
-/// reminder-injection resolver. With `None`, only broadcast (audience
-/// absent) claims gate the current Agent, matching reminder visibility
-/// for Unassigned Agents.
-fn resolve_current_workspace_audience() -> Option<String> {
-    None
+/// the duplicate-work coordination gate. Returns `None` for Unassigned
+/// agents (broadcast-only gating) and `Some(id)` for assigned agents,
+/// mirroring the reminder-injection resolver.
+fn resolve_current_workspace_audience(worktree_root: &Path, session_id: &str) -> Option<String> {
+    gwt_core::workspace_projection::resolve_workspace_id_for_session(worktree_root, session_id)
 }
 
 fn workspace_agent_conflicts(

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -23,8 +23,8 @@ use gwt_core::{
     coordination::{load_snapshot, BoardEntry, BoardEntryKind, BoardMentionTargetKind},
     paths::{gwt_cache_dir, gwt_sessions_dir},
     workspace_projection::{
-        load_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
-        WorkspaceStatusCategory,
+        load_or_synthesize_workspace_work_items, load_workspace_projection, WorkspaceAgentSummary,
+        WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkItem,
     },
 };
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
@@ -306,6 +306,11 @@ fn workspace_coordination_conflicts(
             current_session_id,
         ));
     }
+    conflicts.extend(workspace_work_item_conflicts(
+        worktree_root,
+        current_intent,
+        current_session_id,
+    )?);
     conflicts.extend(board_claim_conflicts(
         worktree_root,
         current_intent,
@@ -347,6 +352,43 @@ fn workspace_agent_conflicts(
             })
         })
         .collect()
+}
+
+fn workspace_work_item_conflicts(
+    worktree_root: &Path,
+    current_intent: &str,
+    current_session_id: Option<&str>,
+) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
+    let projection = load_or_synthesize_workspace_work_items(worktree_root)?;
+    Ok(projection
+        .work_items
+        .iter()
+        .filter(|item| item.is_incomplete())
+        .filter(|item| {
+            current_session_id.is_none_or(|session_id| {
+                !item
+                    .agents
+                    .iter()
+                    .any(|agent| agent.session_id == session_id)
+            })
+        })
+        .filter_map(|item| {
+            let text = workspace_work_item_text(item);
+            is_similar_work(current_intent, &text).then(|| {
+                let first_agent = item.agents.first();
+                let first_container = item.execution_containers.first();
+                WorkspaceCoordinationConflict {
+                    source_label: "incomplete Workspace WorkItem",
+                    title: item.title.clone(),
+                    session_id: first_agent.map(|agent| agent.session_id.clone()),
+                    branch: first_container.and_then(|container| container.branch.clone()),
+                    agent_id: first_agent.and_then(|agent| agent.agent_id.clone()),
+                    related_owners: item.owner.iter().cloned().collect(),
+                    related_topics: vec![item.id.clone()],
+                }
+            })
+        })
+        .collect())
 }
 
 fn board_claim_conflicts(
@@ -433,6 +475,39 @@ fn workspace_agent_text(agent: &WorkspaceAgentSummary) -> String {
     push_optional(&mut parts, agent.branch.as_deref());
     parts.push(agent.agent_id.as_str());
     parts.push(agent.display_name.as_str());
+    parts.join("\n")
+}
+
+fn workspace_work_item_text(item: &WorkspaceWorkItem) -> String {
+    let mut parts = Vec::new();
+    parts.push(item.title.as_str());
+    push_optional(&mut parts, item.intent.as_deref());
+    push_optional(&mut parts, item.summary.as_deref());
+    push_optional(&mut parts, item.owner.as_deref());
+    parts.extend(item.board_refs.iter().map(String::as_str));
+    for agent in &item.agents {
+        parts.push(agent.session_id.as_str());
+        push_optional(&mut parts, agent.agent_id.as_deref());
+        push_optional(&mut parts, agent.display_name.as_deref());
+    }
+    for container in &item.execution_containers {
+        push_optional(&mut parts, container.branch.as_deref());
+        push_optional(
+            &mut parts,
+            container
+                .worktree_path
+                .as_ref()
+                .and_then(|path| path.to_str()),
+        );
+        push_optional(&mut parts, container.pr_url.as_deref());
+        push_optional(&mut parts, container.pr_state.as_deref());
+    }
+    for event in &item.events {
+        push_optional(&mut parts, event.title.as_deref());
+        push_optional(&mut parts, event.intent.as_deref());
+        push_optional(&mut parts, event.summary.as_deref());
+        push_optional(&mut parts, event.next_action.as_deref());
+    }
     parts.join("\n")
 }
 

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -311,12 +311,24 @@ fn workspace_coordination_conflicts(
         current_intent,
         current_session_id,
     )?);
+    let current_workspace_id = resolve_current_workspace_audience();
     conflicts.extend(board_claim_conflicts(
         worktree_root,
         current_intent,
         current_session_id,
+        current_workspace_id.as_deref(),
     )?);
     Ok(conflicts)
+}
+
+/// SPEC-2359 FR-099: resolve the current Agent's assigned Workspace id for
+/// the duplicate-work coordination gate. Returns `None` until the Agent
+/// affiliation field (SPEC-2359 FR-088, US-25) lands, mirroring the
+/// reminder-injection resolver. With `None`, only broadcast (audience
+/// absent) claims gate the current Agent, matching reminder visibility
+/// for Unassigned Agents.
+fn resolve_current_workspace_audience() -> Option<String> {
+    None
 }
 
 fn workspace_agent_conflicts(
@@ -395,6 +407,7 @@ fn board_claim_conflicts(
     worktree_root: &Path,
     current_intent: &str,
     current_session_id: Option<&str>,
+    current_workspace_id: Option<&str>,
 ) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
     let snapshot = load_snapshot(worktree_root)?;
     Ok(snapshot
@@ -406,6 +419,7 @@ fn board_claim_conflicts(
             entry.kind == BoardEntryKind::Claim
                 && board_claim_is_active(entry)
                 && current_session_id != entry.origin_session_id.as_deref()
+                && gwt_core::coordination::entry_visible_for_workspace(entry, current_workspace_id)
         })
         .filter_map(|entry| {
             let text = board_entry_text(entry);

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -20,7 +20,10 @@ use gwt_agent::{
     types::WorkflowBypass,
 };
 use gwt_core::{
-    coordination::{load_snapshot, BoardEntry, BoardEntryKind, BoardMentionTargetKind},
+    coordination::{
+        board_entry_visible_for_scope, load_snapshot, BoardEntry, BoardEntryKind,
+        BoardMentionTargetKind,
+    },
     paths::{gwt_cache_dir, gwt_sessions_dir},
     workspace_projection::{
         load_or_synthesize_workspace_work_items, load_workspace_projection, WorkspaceAgentSummary,
@@ -31,6 +34,7 @@ use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;
 
 use super::{block_bash_policy, HookError, HookEvent, HookOutput};
+use crate::board_audience::current_session_board_scope;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkflowOwner {
@@ -401,6 +405,7 @@ fn board_claim_conflicts(
     current_session_id: Option<&str>,
 ) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
     let snapshot = load_snapshot(worktree_root)?;
+    let audience_scope = current_session_board_scope(worktree_root, current_session_id)?;
     Ok(snapshot
         .board
         .entries
@@ -410,6 +415,7 @@ fn board_claim_conflicts(
             entry.kind == BoardEntryKind::Claim
                 && board_claim_is_active(entry)
                 && current_session_id != entry.origin_session_id.as_deref()
+                && board_entry_visible_for_scope(entry, &audience_scope)
         })
         .filter_map(|entry| {
             let text = board_entry_text(entry);
@@ -550,10 +556,12 @@ fn has_matching_split_claim(
         return Ok(false);
     };
     let snapshot = load_snapshot(worktree_root)?;
+    let audience_scope = current_session_board_scope(worktree_root, Some(current_session_id))?;
     Ok(snapshot.board.entries.iter().rev().any(|entry| {
         entry.kind == BoardEntryKind::Claim
             && entry.origin_session_id.as_deref() == Some(current_session_id)
             && board_claim_is_active(entry)
+            && board_entry_visible_for_scope(entry, &audience_scope)
             && board_entry_has_boundary(entry)
             && board_entry_targets_conflict(entry, conflict)
             && split_claim_matches_current_work(entry, current_intent)
@@ -611,6 +619,7 @@ fn board_entry_targets_conflict(
                 BoardMentionTargetKind::Branch => format!("branch:{}", mention.target),
                 BoardMentionTargetKind::Agent => format!("agent:{}", mention.target),
                 BoardMentionTargetKind::User => format!("user:{}", mention.target),
+                BoardMentionTargetKind::Workspace => format!("workspace:{}", mention.target),
             })
             .any(|typed_key| keys.iter().any(|key| key == &typed_key))
 }

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -199,15 +199,18 @@ fn current_agent_title_summary_missing(worktree_root: &Path) -> Result<bool, Hoo
         worktree_root
     };
     let Some(projection) = load_workspace_projection(projection_root)? else {
-        return Ok(true);
+        return Ok(false);
     };
     let Some(agent) = projection
         .agents
         .iter()
         .find(|agent| agent.session_id == session.id)
     else {
-        return Ok(true);
+        return Ok(false);
     };
+    if agent.is_unassigned() {
+        return Ok(false);
+    }
     Ok(agent
         .title_summary
         .as_deref()
@@ -329,6 +332,7 @@ fn workspace_agent_conflicts(
         .iter()
         .filter(|agent| {
             current_session_id != Some(agent.session_id.as_str())
+                && agent.is_assigned()
                 && matches!(
                     agent.status_category,
                     WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
@@ -378,7 +382,7 @@ fn workspace_work_item_conflicts(
                 let first_agent = item.agents.first();
                 let first_container = item.execution_containers.first();
                 WorkspaceCoordinationConflict {
-                    source_label: "incomplete Workspace WorkItem",
+                    source_label: "incomplete Workspace",
                     title: item.title.clone(),
                     session_id: first_agent.map(|agent| agent.session_id.clone()),
                     branch: first_container.and_then(|container| container.branch.clone()),

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -1,5 +1,10 @@
+use chrono::Utc;
 use gwt_core::workspace_projection::{
-    update_workspace_projection_with_journal, WorkspaceProjectionUpdate, WorkspaceStatusCategory,
+    load_or_default_workspace_projection, load_or_synthesize_workspace_work_items,
+    record_workspace_work_event, save_workspace_projection,
+    update_workspace_projection_with_journal, WorkspaceAgentAffiliationStatus,
+    WorkspaceExecutionContainerRef, WorkspaceProjection, WorkspaceProjectionUpdate,
+    WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind, WorkspaceWorkItem,
 };
 use gwt_github::{ApiError, SpecOpsError};
 
@@ -9,8 +14,21 @@ pub fn parse(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     match head.as_str() {
         "update" => parse_update(rest),
+        "candidates" => parse_candidates(rest),
+        "join" => parse_join(rest),
+        "create" => parse_create(rest),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
     }
+}
+
+fn parse_required_value(
+    args: &[String],
+    index: usize,
+    flag: &'static str,
+) -> Result<String, CliParseError> {
+    args.get(index + 1)
+        .cloned()
+        .ok_or(CliParseError::MissingFlag(flag))
 }
 
 fn parse_update(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
@@ -59,6 +77,111 @@ fn parse_update(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
     })
 }
 
+fn parse_candidates(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    Ok(WorkspaceCommand::Candidates {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+    })
+}
+
+fn parse_join(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut workspace_id = None;
+    let mut current_focus = None;
+    let mut title_summary = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            "--workspace" | "--workspace-id" => {
+                workspace_id = Some(parse_required_value(args, i, "--workspace")?)
+            }
+            "--current-focus" => {
+                current_focus = Some(parse_required_value(args, i, "--current-focus")?)
+            }
+            "--title-summary" => {
+                title_summary = Some(parse_required_value(args, i, "--title-summary")?)
+            }
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    if let Some(value) = title_summary.as_deref() {
+        super::validate_title_summary_work_name("--title-summary", value)?;
+    }
+    Ok(WorkspaceCommand::Join {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+        workspace_id: workspace_id.ok_or(CliParseError::MissingFlag("--workspace"))?,
+        current_focus,
+        title_summary,
+    })
+}
+
+fn parse_create(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut title_summary = None;
+    let mut current_focus = None;
+    let mut spec = None;
+    let mut issue = None;
+    let mut split_from = None;
+    let mut boundary = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            "--title-summary" => {
+                title_summary = Some(parse_required_value(args, i, "--title-summary")?)
+            }
+            "--current-focus" => {
+                current_focus = Some(parse_required_value(args, i, "--current-focus")?)
+            }
+            "--spec" => {
+                spec = Some(
+                    parse_required_value(args, i, "--spec")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--issue" => {
+                issue = Some(
+                    parse_required_value(args, i, "--issue")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--split-from" => split_from = Some(parse_required_value(args, i, "--split-from")?),
+            "--boundary" => boundary = Some(parse_required_value(args, i, "--boundary")?),
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    let title_summary = title_summary.ok_or(CliParseError::MissingFlag("--title-summary"))?;
+    super::validate_title_summary_work_name("--title-summary", &title_summary)?;
+    Ok(WorkspaceCommand::Create {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+        title_summary,
+        current_focus,
+        spec,
+        issue,
+        split_from,
+        boundary,
+    })
+}
+
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
     cmd: WorkspaceCommand,
@@ -97,7 +220,300 @@ pub(super) fn run<E: CliEnv>(
             out.push_str(&format!("workspace updated: {}\n", entry.id));
             Ok(0)
         }
+        WorkspaceCommand::Candidates { agent_session } => {
+            let projection =
+                load_or_synthesize_workspace_work_items(env.repo_path()).map_err(core_error)?;
+            let current_intent = current_agent_intent(env.repo_path(), &agent_session)?;
+            let mut candidates = projection
+                .work_items
+                .iter()
+                .filter(|item| item.is_incomplete())
+                .filter(|item| {
+                    !item
+                        .agents
+                        .iter()
+                        .any(|agent| agent.session_id == agent_session)
+                })
+                .map(|item| {
+                    let score = workspace_similarity_score(
+                        current_intent.as_deref().unwrap_or_default(),
+                        &workspace_item_text(item),
+                    );
+                    (score, item)
+                })
+                .collect::<Vec<_>>();
+            candidates.sort_by(|left, right| {
+                right
+                    .0
+                    .cmp(&left.0)
+                    .then_with(|| right.1.updated_at.cmp(&left.1.updated_at))
+            });
+            if candidates.is_empty() {
+                out.push_str("workspace candidates: none\n");
+            } else {
+                for (score, item) in candidates {
+                    out.push_str(&format!(
+                        "{}\t{}\t{}\tscore={score}\n",
+                        item.id,
+                        status_category_wire(item.status_category),
+                        item.title
+                    ));
+                }
+            }
+            Ok(0)
+        }
+        WorkspaceCommand::Join {
+            agent_session,
+            workspace_id,
+            current_focus,
+            title_summary,
+        } => {
+            let mut projection =
+                load_or_default_workspace_projection(env.repo_path()).map_err(core_error)?;
+            let Some(item) = workspace_item_by_id(env.repo_path(), &workspace_id)? else {
+                return Err(string_error(format!("workspace not found: {workspace_id}")));
+            };
+            assign_agent_to_workspace(
+                &mut projection,
+                &agent_session,
+                &workspace_id,
+                current_focus,
+                title_summary,
+            )?;
+            apply_workspace_item_to_projection(&mut projection, &item);
+            save_workspace_projection(env.repo_path(), &projection).map_err(core_error)?;
+            publish_workspace_change(env.repo_path());
+            out.push_str(&format!("workspace joined: {workspace_id}\n"));
+            Ok(0)
+        }
+        WorkspaceCommand::Create {
+            agent_session,
+            title_summary,
+            current_focus,
+            spec,
+            issue,
+            split_from,
+            boundary,
+        } => {
+            let existing =
+                load_or_synthesize_workspace_work_items(env.repo_path()).map_err(core_error)?;
+            if split_from.is_none()
+                && boundary
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .is_none()
+            {
+                let new_text = [Some(title_summary.as_str()), current_focus.as_deref()]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if let Some(item) = existing.work_items.iter().find(|item| {
+                    item.is_incomplete()
+                        && workspace_similarity_score(&new_text, &workspace_item_text(item)) >= 2
+                }) {
+                    return Err(string_error(format!(
+                        "similar Workspace exists: {} ({})",
+                        item.title, item.id
+                    )));
+                }
+            }
+            let mut projection =
+                load_or_default_workspace_projection(env.repo_path()).map_err(core_error)?;
+            let Some(agent) = projection
+                .agents
+                .iter()
+                .find(|agent| agent.session_id == agent_session)
+            else {
+                return Err(string_error(format!(
+                    "agent session not found: {agent_session}"
+                )));
+            };
+            let workspace_id = format!("workspace-{}", Utc::now().timestamp_millis());
+            let owner = spec
+                .map(|number| format!("SPEC-{number}"))
+                .or_else(|| issue.map(|number| format!("Issue #{number}")));
+            let now = Utc::now();
+            let mut event =
+                WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, workspace_id.clone(), now);
+            event.title = Some(title_summary.clone());
+            event.intent = current_focus.clone();
+            event.summary = current_focus
+                .clone()
+                .or_else(|| Some(title_summary.clone()));
+            event.status_category = Some(WorkspaceStatusCategory::Active);
+            event.owner = owner.clone();
+            event.next_action = Some("Coordinate on Board before implementation".to_string());
+            event.agent_session_id = Some(agent_session.clone());
+            event.agent_id = Some(agent.agent_id.clone());
+            event.display_name = Some(agent.display_name.clone());
+            event.execution_container = Some(WorkspaceExecutionContainerRef {
+                branch: agent.branch.clone(),
+                worktree_path: agent.worktree_path.clone(),
+                pr_number: None,
+                pr_url: None,
+                pr_state: None,
+            });
+            if let Some(split_from) = split_from {
+                event.kind = WorkspaceWorkEventKind::Split;
+                event.related_work_item_id = Some(split_from);
+            }
+            if let Some(boundary) = boundary {
+                event.next_action = Some(format!("Boundary: {boundary}"));
+            }
+            record_workspace_work_event(env.repo_path(), event).map_err(core_error)?;
+            projection.id = workspace_id.clone();
+            projection.title = title_summary.clone();
+            projection.status_category = WorkspaceStatusCategory::Active;
+            projection.status_text = current_focus
+                .clone()
+                .unwrap_or_else(|| "Workspace created".to_string());
+            projection.summary = current_focus.clone();
+            projection.owner = owner;
+            projection.next_action = Some("Coordinate on Board before implementation".to_string());
+            assign_agent_to_workspace(
+                &mut projection,
+                &agent_session,
+                &workspace_id,
+                current_focus,
+                Some(title_summary),
+            )?;
+            projection.updated_at = now;
+            save_workspace_projection(env.repo_path(), &projection).map_err(core_error)?;
+            publish_workspace_change(env.repo_path());
+            out.push_str(&format!("workspace created: {workspace_id}\n"));
+            Ok(0)
+        }
     }
+}
+
+fn core_error(error: gwt_core::error::GwtError) -> SpecOpsError {
+    string_error(error.to_string())
+}
+
+fn status_category_wire(category: WorkspaceStatusCategory) -> &'static str {
+    match category {
+        WorkspaceStatusCategory::Active => "active",
+        WorkspaceStatusCategory::Idle => "idle",
+        WorkspaceStatusCategory::Blocked => "blocked",
+        WorkspaceStatusCategory::Done => "done",
+        WorkspaceStatusCategory::Unknown => "unknown",
+    }
+}
+
+fn current_agent_intent(
+    repo_path: &std::path::Path,
+    agent_session: &str,
+) -> Result<Option<String>, SpecOpsError> {
+    let projection = load_or_default_workspace_projection(repo_path).map_err(core_error)?;
+    Ok(projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == agent_session)
+        .map(|agent| {
+            [
+                agent.title_summary.as_deref(),
+                agent.current_focus.as_deref(),
+                agent.coordination_scope.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join("\n")
+        }))
+}
+
+fn workspace_item_by_id(
+    repo_path: &std::path::Path,
+    workspace_id: &str,
+) -> Result<Option<WorkspaceWorkItem>, SpecOpsError> {
+    Ok(load_or_synthesize_workspace_work_items(repo_path)
+        .map_err(core_error)?
+        .work_items
+        .into_iter()
+        .find(|item| item.id == workspace_id))
+}
+
+fn apply_workspace_item_to_projection(
+    projection: &mut WorkspaceProjection,
+    item: &WorkspaceWorkItem,
+) {
+    projection.id = item.id.clone();
+    projection.title = item.title.clone();
+    projection.status_category = item.status_category;
+    projection.status_text = item
+        .summary
+        .clone()
+        .or_else(|| item.intent.clone())
+        .unwrap_or_else(|| "Workspace selected".to_string());
+    projection.summary = item.summary.clone().or_else(|| item.intent.clone());
+    projection.owner = item.owner.clone();
+    projection.updated_at = Utc::now();
+}
+
+fn assign_agent_to_workspace(
+    projection: &mut WorkspaceProjection,
+    agent_session: &str,
+    workspace_id: &str,
+    current_focus: Option<String>,
+    title_summary: Option<String>,
+) -> Result<(), SpecOpsError> {
+    let Some(agent) = projection
+        .agents
+        .iter_mut()
+        .find(|agent| agent.session_id == agent_session)
+    else {
+        return Err(string_error(format!(
+            "agent session not found: {agent_session}"
+        )));
+    };
+    agent.affiliation_status = WorkspaceAgentAffiliationStatus::Assigned;
+    agent.workspace_id = Some(workspace_id.to_string());
+    agent.status_category = WorkspaceStatusCategory::Active;
+    if current_focus.is_some() {
+        agent.current_focus = current_focus;
+    }
+    if title_summary.is_some() {
+        agent.title_summary = title_summary;
+    }
+    agent.updated_at = Utc::now();
+    Ok(())
+}
+
+fn workspace_item_text(item: &WorkspaceWorkItem) -> String {
+    let mut parts = vec![item.title.as_str()];
+    if let Some(intent) = item.intent.as_deref() {
+        parts.push(intent);
+    }
+    if let Some(summary) = item.summary.as_deref() {
+        parts.push(summary);
+    }
+    if let Some(owner) = item.owner.as_deref() {
+        parts.push(owner);
+    }
+    parts.join("\n")
+}
+
+fn workspace_similarity_score(left: &str, right: &str) -> usize {
+    let left_tokens = workspace_tokens(left);
+    if left_tokens.is_empty() {
+        return 0;
+    }
+    let right_tokens = workspace_tokens(right);
+    left_tokens
+        .iter()
+        .filter(|token| right_tokens.contains(*token))
+        .count()
+}
+
+fn workspace_tokens(value: &str) -> std::collections::BTreeSet<String> {
+    value
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(str::trim)
+        .filter(|token| token.len() >= 3)
+        .map(|token| token.to_lowercase())
+        .collect()
 }
 
 #[cfg(unix)]
@@ -137,9 +553,57 @@ fn string_error(error: String) -> SpecOpsError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::env::TestEnv;
+    use gwt_core::workspace_projection::{
+        load_workspace_projection, load_workspace_work_items, record_workspace_work_event,
+        save_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
+    };
+    use std::ffi::OsString;
 
     fn s(value: &str) -> String {
         value.to_string()
+    }
+
+    struct ScopedHome {
+        previous_home: Option<OsString>,
+    }
+
+    impl ScopedHome {
+        fn set(path: &std::path::Path) -> Self {
+            let previous_home = std::env::var_os("HOME");
+            std::env::set_var("HOME", path);
+            Self { previous_home }
+        }
+    }
+
+    impl Drop for ScopedHome {
+        fn drop(&mut self) {
+            if let Some(previous_home) = self.previous_home.as_ref() {
+                std::env::set_var("HOME", previous_home);
+            } else {
+                std::env::remove_var("HOME");
+            }
+        }
+    }
+
+    fn unassigned_agent(session_id: &str) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("Implement Workspace history".to_string()),
+            title_summary: Some("Workspace history".to_string()),
+            worktree_path: None,
+            branch: Some("work/20260511-0100".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        }
     }
 
     #[test]
@@ -232,5 +696,295 @@ mod tests {
         assert!(message.contains("--title-summary"), "{message}");
         assert!(message.contains("work name"), "{message}");
         assert!(message.contains("status"), "{message}");
+    }
+
+    #[test]
+    fn parse_workspace_create_accepts_assignment_fields() {
+        let parsed = parse(&[
+            s("create"),
+            s("--agent-session"),
+            s("session-1"),
+            s("--title-summary"),
+            s("Workspace history"),
+            s("--current-focus"),
+            s("Implementing Workspace history"),
+            s("--spec"),
+            s("2359"),
+            s("--split-from"),
+            s("workspace-existing"),
+            s("--boundary"),
+            s("UI only"),
+        ])
+        .expect("parse");
+
+        assert_eq!(
+            parsed,
+            WorkspaceCommand::Create {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace history".to_string(),
+                current_focus: Some("Implementing Workspace history".to_string()),
+                spec: Some(2359),
+                issue: None,
+                split_from: Some("workspace-existing".to_string()),
+                boundary: Some("UI only".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_workspace_candidates_and_join_commands() {
+        let candidates = parse(&[s("candidates"), s("--agent-session"), s("session-1")])
+            .expect("parse candidates");
+        assert_eq!(
+            candidates,
+            WorkspaceCommand::Candidates {
+                agent_session: "session-1".to_string()
+            }
+        );
+
+        let join = parse(&[
+            s("join"),
+            s("--agent-session"),
+            s("session-1"),
+            s("--workspace"),
+            s("workspace-existing"),
+            s("--current-focus"),
+            s("Continue Workspace history"),
+            s("--title-summary"),
+            s("Workspace history"),
+        ])
+        .expect("parse join");
+        assert_eq!(
+            join,
+            WorkspaceCommand::Join {
+                agent_session: "session-1".to_string(),
+                workspace_id: "workspace-existing".to_string(),
+                current_focus: Some("Continue Workspace history".to_string()),
+                title_summary: Some("Workspace history".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn workspace_update_persists_workspace_status() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Update {
+                title: Some("Workspace coordination".to_string()),
+                status: Some("blocked".to_string()),
+                status_text: Some("Waiting on Board alignment".to_string()),
+                summary: Some("Align Workspace ownership before edits".to_string()),
+                next_action: Some("Post Board request".to_string()),
+                owner: Some("SPEC-2359".to_string()),
+                agent_session: None,
+                current_focus: None,
+                title_summary: None,
+            },
+            &mut out,
+        )
+        .expect("update workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace updated:"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        assert_eq!(saved.title, "Workspace coordination");
+        assert_eq!(saved.status_category, WorkspaceStatusCategory::Blocked);
+        assert_eq!(saved.owner.as_deref(), Some("SPEC-2359"));
+    }
+
+    #[test]
+    fn workspace_join_assigns_unassigned_agent_to_existing_workspace() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace history".to_string());
+        event.summary = Some("Existing Workspace".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Join {
+                agent_session: "session-1".to_string(),
+                workspace_id: "workspace-existing".to_string(),
+                current_focus: Some("Continue Workspace history".to_string()),
+                title_summary: Some("Workspace history".to_string()),
+            },
+            &mut out,
+        )
+        .expect("join workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace joined: workspace-existing"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some("workspace-existing"));
+        assert_eq!(saved.id, "workspace-existing");
+    }
+
+    #[test]
+    fn workspace_create_records_workspace_and_assigns_agent() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Create {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace history".to_string(),
+                current_focus: Some("Implement Workspace history".to_string()),
+                spec: Some(2359),
+                issue: None,
+                split_from: None,
+                boundary: Some("history slice".to_string()),
+            },
+            &mut out,
+        )
+        .expect("create workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace created: workspace-"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let workspace_id = saved.id.clone();
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some(workspace_id.as_str()));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert_eq!(items.work_items.len(), 1);
+        assert_eq!(items.work_items[0].id, workspace_id);
+        assert_eq!(items.work_items[0].title, "Workspace history");
+    }
+
+    #[test]
+    fn workspace_candidates_lists_similar_incomplete_workspaces() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace history".to_string());
+        event.intent = Some("Implement Workspace history with affiliation state".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Candidates {
+                agent_session: "session-1".to_string(),
+            },
+            &mut out,
+        )
+        .expect("list candidates");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace-existing"), "{out}");
+        assert!(out.contains("Workspace history"), "{out}");
+        assert!(out.contains("score="), "{out}");
+    }
+
+    #[test]
+    fn workspace_create_rejects_similar_workspace_without_split_boundary() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace history".to_string());
+        event.intent = Some("Implement Workspace history with affiliation state".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let err = run(
+            &mut env,
+            WorkspaceCommand::Create {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace history".to_string(),
+                current_focus: Some("Implement Workspace history affiliation".to_string()),
+                spec: None,
+                issue: Some(2359),
+                split_from: None,
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect_err("similar Workspace should be rejected");
+
+        assert!(err.to_string().contains("similar Workspace exists"));
     }
 }

--- a/crates/gwt/src/daemon_publisher.rs
+++ b/crates/gwt/src/daemon_publisher.rs
@@ -123,6 +123,9 @@ mod tests {
 
     #[test]
     fn publish_returns_error_when_no_daemon_registered() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Use a tempdir for the project root and a tempdir for $HOME so
         // the resolver looks for the endpoint inside an empty
         // `~/.gwt/projects/.../runtime/daemon/` tree and finds nothing.

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1975,11 +1975,11 @@ mod tests {
         )
         .expect("valid regex");
         let close_controls = regex::Regex::new(
-            r#"wizardCloseButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"cancel"\s*\}\);\s*\}\);\s*wizardCancelButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"cancel"\s*\}\);\s*\}\);"#,
+            r#"wizardCloseButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\);\s*wizardCancelButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\);"#,
         )
         .expect("valid regex");
         let submit_button = regex::Regex::new(
-            r#"wizardSubmitButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*(?:flushWizardBranchDraft|frontendUnits\.launchWizardSurface\.flushBranchDraft)\(\);\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"submit"\s*\}\);\s*\}\);"#,
+            r#"wizardSubmitButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*if\s*\(\s*launchWizardOpenError\s*\)\s*\{\s*return;\s*\}\s*(?:flushWizardBranchDraft|frontendUnits\.launchWizardSurface\.flushBranchDraft)\(\);\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"submit"\s*\}\);\s*\}\);"#,
         )
         .expect("valid regex");
 
@@ -1998,22 +1998,28 @@ mod tests {
         );
         assert!(
             close_controls.is_match(html),
-            "expected both close controls to route cancel through sendWizardAction",
+            "expected both close controls to share the wizard close helper",
+        );
+        assert!(
+            html.contains("function closeLaunchWizardFromChrome()")
+                && html.contains("closeLaunchWizardLocal();")
+                && html.contains("frontendUnits.launchWizardSurface.sendAction({ kind: \"cancel\" });"),
+            "expected close helper to local-close error-only state and send cancel for normal wizard state",
         );
         assert!(
             submit_button.is_match(html),
-            "expected submit control to flush branch draft before dispatching submit",
+            "expected submit control to ignore error-only state and flush branch draft before dispatching submit",
         );
         let backdrop_cancel = regex::Regex::new(
-            r#"if\s*\(\s*event\.target === wizardModal\s*\)\s*\{\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"cancel"\s*\}\);\s*\}"#,
+            r#"if\s*\(\s*event\.target === wizardModal\s*\)\s*\{\s*closeLaunchWizardFromChrome\(\);\s*\}"#,
         )
         .expect("valid regex");
         assert!(
             backdrop_cancel.is_match(html),
-            "expected backdrop dismissal to share the same wizard cancel transport",
+            "expected backdrop dismissal to share the same wizard close helper",
         );
         let wizard_state = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*launchWizardOpenError\s*=\s*null;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
         )
         .expect("valid regex");
         assert!(
@@ -2120,7 +2126,11 @@ mod tests {
         )
         .expect("valid regex");
         let wizard_event = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":\s*launchWizard\s*=\s*event\.wizard;\s*launchWizardOpenError\s*=\s*null;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
+        )
+        .expect("valid regex");
+        let wizard_open_error_event = regex::Regex::new(
+            r#"case\s*"launch_wizard_open_error":\s*launchWizard\s*=\s*null;[\s\S]*?launchWizardOpenError\s*=\s*\{[\s\S]*?frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
         )
         .expect("valid regex");
 
@@ -2143,6 +2153,10 @@ mod tests {
         assert!(
             wizard_event.is_match(html),
             "expected launch wizard state events to render through the wizard surface unit",
+        );
+        assert!(
+            wizard_open_error_event.is_match(html),
+            "expected launch wizard open errors to render through the wizard surface unit",
         );
     }
 

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1632,6 +1632,9 @@ Extra context.
 
     #[test]
     fn update_knowledge_phase_rejects_unknown_target() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", home.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3103,6 +3103,9 @@ fn agent_id_from_key(agent_id: &str) -> gwt_agent::AgentId {
         "claude" => gwt_agent::AgentId::ClaudeCode,
         "codex" => gwt_agent::AgentId::Codex,
         "gemini" => gwt_agent::AgentId::Gemini,
+        "opencode" => gwt_agent::AgentId::OpenCode,
+        "openclaw" => gwt_agent::AgentId::OpenClaw,
+        "hermes" => gwt_agent::AgentId::Hermes,
         "gh" => gwt_agent::AgentId::Copilot,
         other => gwt_agent::AgentId::Custom(other.to_string()),
     }
@@ -3160,10 +3163,13 @@ pub fn build_builtin_agent_options(
     detected_agents: Vec<gwt_agent::DetectedAgent>,
     cache: &gwt_agent::VersionCache,
 ) -> Vec<AgentOption> {
-    const BUILTIN: [gwt_agent::AgentId; 4] = [
+    const BUILTIN: [gwt_agent::AgentId; 7] = [
         gwt_agent::AgentId::ClaudeCode,
         gwt_agent::AgentId::Codex,
         gwt_agent::AgentId::Gemini,
+        gwt_agent::AgentId::OpenCode,
+        gwt_agent::AgentId::OpenClaw,
+        gwt_agent::AgentId::Hermes,
         gwt_agent::AgentId::Copilot,
     ];
 
@@ -3258,6 +3264,14 @@ mod tests {
             agent_option_color("opencode"),
             Some(gwt_agent::AgentColor::Green)
         );
+        assert_eq!(
+            agent_option_color("openclaw"),
+            Some(gwt_agent::AgentColor::Blue)
+        );
+        assert_eq!(
+            agent_option_color("hermes"),
+            Some(gwt_agent::AgentColor::Magenta)
+        );
         assert_eq!(agent_option_color("gh"), Some(gwt_agent::AgentColor::Blue));
         assert_eq!(
             agent_option_color("my-custom"),
@@ -3313,6 +3327,20 @@ mod tests {
             options[missing].available,
             "configured custom agents must stay selectable; runtime preparation validates execution"
         );
+    }
+
+    #[test]
+    fn build_builtin_agent_options_includes_hook_parity_agents() {
+        let options = build_builtin_agent_options(Vec::new(), &gwt_agent::VersionCache::new());
+        let ids: Vec<&str> = options.iter().map(|option| option.id.as_str()).collect();
+
+        assert_eq!(
+            ids,
+            vec!["claude", "codex", "gemini", "opencode", "openclaw", "hermes", "gh"]
+        );
+        assert!(options.iter().any(|option| option.name == "OpenCode"));
+        assert!(options.iter().any(|option| option.name == "OpenClaw"));
+        assert!(options.iter().any(|option| option.name == "Hermes Agent"));
     }
 
     fn branch(name: &str) -> BranchListEntry {
@@ -5025,8 +5053,14 @@ mod tests {
         assert!(is_explicit_model_selection("gpt-5.5"));
         assert!(!is_explicit_model_selection("Default (Installed)"));
         assert!(agent_has_npm_package("codex"));
+        assert!(!agent_has_npm_package("opencode"));
+        assert!(!agent_has_npm_package("openclaw"));
+        assert!(!agent_has_npm_package("hermes"));
         assert!(!agent_has_npm_package("custom"));
         assert_eq!(agent_id_from_key("gh"), gwt_agent::AgentId::Copilot);
+        assert_eq!(agent_id_from_key("opencode"), gwt_agent::AgentId::OpenCode);
+        assert_eq!(agent_id_from_key("openclaw"), gwt_agent::AgentId::OpenClaw);
+        assert_eq!(agent_id_from_key("hermes"), gwt_agent::AgentId::Hermes);
         assert_eq!(
             agent_id_from_key("custom"),
             gwt_agent::AgentId::Custom("custom".to_string())

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3095,20 +3095,13 @@ fn is_explicit_model_selection(model: &str) -> bool {
 }
 
 fn agent_has_npm_package(agent_id: &str) -> bool {
-    matches!(agent_id, "claude" | "codex" | "gemini")
+    agent_id_from_key(agent_id).package_name().is_some()
 }
 
 fn agent_id_from_key(agent_id: &str) -> gwt_agent::AgentId {
-    match agent_id {
-        "claude" => gwt_agent::AgentId::ClaudeCode,
-        "codex" => gwt_agent::AgentId::Codex,
-        "gemini" => gwt_agent::AgentId::Gemini,
-        "opencode" => gwt_agent::AgentId::OpenCode,
-        "openclaw" => gwt_agent::AgentId::OpenClaw,
-        "hermes" => gwt_agent::AgentId::Hermes,
-        "gh" => gwt_agent::AgentId::Copilot,
-        other => gwt_agent::AgentId::Custom(other.to_string()),
-    }
+    gwt_agent::builtin_agent_descriptor_for_command(agent_id)
+        .map(|descriptor| descriptor.id.clone())
+        .unwrap_or_else(|| gwt_agent::AgentId::Custom(agent_id.to_string()))
 }
 
 fn agent_description(agent: &AgentOption) -> String {
@@ -3163,19 +3156,10 @@ pub fn build_builtin_agent_options(
     detected_agents: Vec<gwt_agent::DetectedAgent>,
     cache: &gwt_agent::VersionCache,
 ) -> Vec<AgentOption> {
-    const BUILTIN: [gwt_agent::AgentId; 7] = [
-        gwt_agent::AgentId::ClaudeCode,
-        gwt_agent::AgentId::Codex,
-        gwt_agent::AgentId::Gemini,
-        gwt_agent::AgentId::OpenCode,
-        gwt_agent::AgentId::OpenClaw,
-        gwt_agent::AgentId::Hermes,
-        gwt_agent::AgentId::Copilot,
-    ];
-
-    BUILTIN
-        .into_iter()
-        .map(|agent_id| {
+    gwt_agent::builtin_agent_descriptors()
+        .iter()
+        .map(|descriptor| {
+            let agent_id = descriptor.id.clone();
             let detected = detected_agents
                 .iter()
                 .find(|detected| detected.agent_id == agent_id);

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -99,7 +99,8 @@ pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
     ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FocusCycleDirection,
     FrontendEvent, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView,
-    RecentProjectView, WorkspaceExecutionContainerView, WorkspaceJournalEntryView,
+    RecentProjectView, WorkspaceExecutionContainerView, WorkspaceHistoryAgentView,
+    WorkspaceHistoryEventView, WorkspaceHistoryView, WorkspaceJournalEntryView,
     WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView, WorkspaceWorkEventView,
     WorkspaceWorkItemView,
 };

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -99,6 +99,8 @@ pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
     ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FocusCycleDirection,
     FrontendEvent, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView,
-    RecentProjectView, WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView,
+    RecentProjectView, WorkspaceExecutionContainerView, WorkspaceJournalEntryView,
+    WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView, WorkspaceWorkEventView,
+    WorkspaceWorkItemView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod board_audience;
 pub mod branch_cleanup;
 pub mod branch_list;
 pub mod cli;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2240,15 +2240,16 @@ mod tests {
         assert_eq!(wizard_missing.len(), 1);
         assert!(matches!(
             wizard_missing[0].event,
-            BackendEvent::BranchError { ref message, .. } if message == "Window not found"
+            BackendEvent::LaunchWizardOpenError { ref title, ref message }
+                if title == "Launch Agent" && message == "Window not found"
         ));
 
         let wizard_wrong = runtime.open_launch_wizard(&file_tree_id, "feature/demo", None);
         assert_eq!(wizard_wrong.len(), 1);
         assert!(matches!(
             wizard_wrong[0].event,
-            BackendEvent::BranchError { ref message, .. }
-                if message == "Window is not a branches list"
+            BackendEvent::LaunchWizardOpenError { ref title, ref message }
+                if title == "Launch Agent" && message == "Window is not a branches list"
         ));
 
         let issue_missing = runtime.open_issue_launch_wizard_events("client-1", "missing", 7);

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -5129,6 +5129,16 @@ fn main() -> wry::Result<()> {
         }
     }
 
+    // SPEC-2041 Phase 19 (T-133): if a previous gwt session wrote a pending
+    // update manifest (via the post-click modal's Later flow, or because the
+    // user killed gwt before clicking Restart now), hand off to the helper
+    // subprocess so the new version takes over before any GUI surfaces.
+    // Returns true only when an apply was attempted and exit(0) was already
+    // called inside; false continues the regular launch.
+    if update_front_door::try_apply_pending_update_at_bootstrap() {
+        return Ok(());
+    }
+
     let startup_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let _gui_instance_lock = match gwt::gui_single_instance::acquire_gui_instance_lock(
         &gwt_core::paths::gwt_home(),
@@ -5385,7 +5395,14 @@ fn main() -> wry::Result<()> {
             Event::UserEvent(UserEvent::ApplyUpdate { state, client_id }) => {
                 let apply_proxy = proxy.clone();
                 std::thread::spawn(move || {
+                    let log_path = gwt_core::update::update_log_path()
+                        .to_string_lossy()
+                        .to_string();
                     if let Err(message) = apply_update_state_and_exit(state) {
+                        gwt_core::update::log_update_event(
+                            "fail",
+                            &[("stage", "apply_update_legacy"), ("reason", &message)],
+                        );
                         let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                             OutboundEvent::reply(
                                 client_id,
@@ -5393,7 +5410,7 @@ fn main() -> wry::Result<()> {
                                     message: Some(message.clone()),
                                     stage: Some("Apply update".to_string()),
                                     reason: Some(message),
-                                    log_path: None,
+                                    log_path: Some(log_path),
                                 },
                             ),
                         ]));
@@ -5414,6 +5431,15 @@ fn main() -> wry::Result<()> {
                     _ => None,
                 };
                 std::thread::spawn(move || {
+                    // SPEC-2041 Phase 19 FR-065: log stage transitions so the
+                    // failure modal's [Open log] action has something to show
+                    // even when the silent path of the apply succeeds.
+                    let log_version = version_for_progress.clone().unwrap_or_default();
+                    let log_asset = asset_for_progress.clone().unwrap_or_default();
+                    gwt_core::update::log_update_event(
+                        "download_start",
+                        &[("version", &log_version), ("asset", &log_asset)],
+                    );
                     // SPEC-2041 Phase 19 FR-054: stream chunk-level progress
                     // back to the modal. Throttle to ~200 ms or the
                     // completion tick (`downloaded >= total`) so the
@@ -5443,11 +5469,55 @@ fn main() -> wry::Result<()> {
                             ]));
                         }
                     };
+                    let log_path_string = gwt_core::update::update_log_path()
+                        .to_string_lossy()
+                        .to_string();
                     match update_front_door::prepare_update_payload_with_progress(
                         state,
                         &mut progress,
                     ) {
                         Ok(prepared) => {
+                            gwt_core::update::log_update_event(
+                                "download_complete",
+                                &[("version", &prepared.latest)],
+                            );
+                            // SPEC-2041 Phase 19 (T-129): persist manifest now
+                            // so that (a) Later doesn't have to round-trip the
+                            // payload back through workspace state, and
+                            // (b) if gwt is killed before user picks
+                            // Later/Restart now, the next launch can still
+                            // apply transparently (T-133).
+                            let manifest = gwt_core::update::PendingUpdateManifest {
+                                version: prepared.latest.clone(),
+                                asset_url: prepared.asset_url.clone(),
+                                payload: prepared.payload.clone(),
+                                downloaded_at: chrono::Utc::now().to_rfc3339(),
+                            };
+                            if let Err(message) =
+                                gwt_core::update::persist_pending_update_manifest(&manifest)
+                            {
+                                gwt_core::update::log_update_event(
+                                    "fail",
+                                    &[("stage", "persist_pending"), ("reason", &message)],
+                                );
+                                let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
+                                    OutboundEvent::reply(
+                                        client_id,
+                                        BackendEvent::UpdateApplyError {
+                                            message: Some(message.clone()),
+                                            stage: Some("Persist pending".to_string()),
+                                            reason: Some(message),
+                                            log_path: Some(log_path_string.clone()),
+                                        },
+                                    ),
+                                ]));
+                                return;
+                            }
+                            gwt_core::update::log_update_event(
+                                "persist_pending",
+                                &[("version", &prepared.latest)],
+                            );
+
                             let asset_path = prepared.payload_path();
                             let version = prepared.latest;
                             let _ = apply_proxy.send_event(UserEvent::UpdatePrepared {
@@ -5456,6 +5526,10 @@ fn main() -> wry::Result<()> {
                             });
                         }
                         Err(message) => {
+                            gwt_core::update::log_update_event(
+                                "fail",
+                                &[("stage", "download_asset"), ("reason", &message)],
+                            );
                             let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                                 OutboundEvent::reply(
                                     client_id,
@@ -5463,7 +5537,7 @@ fn main() -> wry::Result<()> {
                                         message: Some(message.clone()),
                                         stage: Some("Download asset".to_string()),
                                         reason: Some(message),
-                                        log_path: None,
+                                        log_path: Some(log_path_string),
                                     },
                                 ),
                             ]));
@@ -5483,7 +5557,28 @@ fn main() -> wry::Result<()> {
             Event::UserEvent(UserEvent::ApplyUpdateRestartNow { state, client_id }) => {
                 let apply_proxy = proxy.clone();
                 std::thread::spawn(move || {
-                    if let Err(message) = apply_update_state_and_exit(state) {
+                    let log_path = gwt_core::update::update_log_path()
+                        .to_string_lossy()
+                        .to_string();
+                    gwt_core::update::log_update_event("restart_now_requested", &[]);
+                    // SPEC-2041 Phase 19 (T-130/T-133): consume the persisted
+                    // manifest if it exists so we don't re-download the same
+                    // payload after the user already saw the progress modal.
+                    // Falls back to the legacy `apply_update_state_and_exit`
+                    // path when no manifest is present (e.g. user clicked
+                    // Restart now before download persisted, or manifest was
+                    // wiped by an external cleanup).
+                    let result = match gwt_core::update::load_pending_update_manifest() {
+                        Some(manifest) => {
+                            update_front_door::apply_pending_manifest_and_exit(manifest)
+                        }
+                        None => apply_update_state_and_exit(state),
+                    };
+                    if let Err(message) = result {
+                        gwt_core::update::log_update_event(
+                            "fail",
+                            &[("stage", "restart_now"), ("reason", &message)],
+                        );
                         let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                             OutboundEvent::reply(
                                 client_id,
@@ -5491,7 +5586,7 @@ fn main() -> wry::Result<()> {
                                     message: Some(message.clone()),
                                     stage: Some("Restart now".to_string()),
                                     reason: Some(message),
-                                    log_path: None,
+                                    log_path: Some(log_path),
                                 },
                             ),
                         ]));

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -616,6 +616,27 @@ enum UserEvent {
         state: gwt_core::update::UpdateState,
         client_id: ClientId,
     },
+    /// SPEC-2041 Phase 19 (FR-052/056): begin downloading the prepared payload
+    /// without exiting the parent process. On completion, the worker thread
+    /// emits an `UpdatePrepared` event so the dispatcher can broadcast
+    /// `UpdateReady` to all clients.
+    ApplyUpdateStart {
+        state: gwt_core::update::UpdateState,
+        client_id: ClientId,
+    },
+    /// SPEC-2041 Phase 19 (FR-058): user pressed Restart now. Apply the
+    /// prepared payload via the helper subprocess and exit the parent.
+    ApplyUpdateRestartNow {
+        state: gwt_core::update::UpdateState,
+        client_id: ClientId,
+    },
+    /// SPEC-2041 Phase 19 (FR-056): worker thread completed `prepare_update`
+    /// and the prepared payload is ready on disk. Dispatcher broadcasts
+    /// `UpdateReady` to subscribed clients.
+    UpdatePrepared {
+        version: String,
+        asset_path: std::path::PathBuf,
+    },
     /// SPEC-1934 FR-029: progress tick from
     /// `gwt::migration::execute_migration`. Re-broadcast as
     /// [`gwt::BackendEvent::MigrationProgress`].
@@ -5368,7 +5389,67 @@ fn main() -> wry::Result<()> {
                         let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
                             OutboundEvent::reply(
                                 client_id,
-                                BackendEvent::UpdateApplyError { message },
+                                BackendEvent::UpdateApplyError {
+                                    message: Some(message.clone()),
+                                    stage: Some("Apply update".to_string()),
+                                    reason: Some(message),
+                                    log_path: None,
+                                },
+                            ),
+                        ]));
+                    }
+                });
+            }
+            Event::UserEvent(UserEvent::ApplyUpdateStart { state, client_id }) => {
+                let apply_proxy = proxy.clone();
+                std::thread::spawn(move || {
+                    match update_front_door::prepare_update_payload(state) {
+                        Ok(prepared) => {
+                            let asset_path = prepared.payload_path();
+                            let version = prepared.latest;
+                            let _ = apply_proxy.send_event(UserEvent::UpdatePrepared {
+                                version,
+                                asset_path,
+                            });
+                        }
+                        Err(message) => {
+                            let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
+                                OutboundEvent::reply(
+                                    client_id,
+                                    BackendEvent::UpdateApplyError {
+                                        message: Some(message.clone()),
+                                        stage: Some("Download asset".to_string()),
+                                        reason: Some(message),
+                                        log_path: None,
+                                    },
+                                ),
+                            ]));
+                        }
+                    }
+                });
+            }
+            Event::UserEvent(UserEvent::UpdatePrepared {
+                version,
+                asset_path,
+            }) => {
+                clients.dispatch(vec![OutboundEvent::broadcast(BackendEvent::UpdateReady {
+                    version,
+                    asset_path: asset_path.to_string_lossy().to_string(),
+                })]);
+            }
+            Event::UserEvent(UserEvent::ApplyUpdateRestartNow { state, client_id }) => {
+                let apply_proxy = proxy.clone();
+                std::thread::spawn(move || {
+                    if let Err(message) = apply_update_state_and_exit(state) {
+                        let _ = apply_proxy.send_event(UserEvent::Dispatch(vec![
+                            OutboundEvent::reply(
+                                client_id,
+                                BackendEvent::UpdateApplyError {
+                                    message: Some(message.clone()),
+                                    stage: Some("Restart now".to_string()),
+                                    reason: Some(message),
+                                    log_path: None,
+                                },
                             ),
                         ]));
                     }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -5402,8 +5402,51 @@ fn main() -> wry::Result<()> {
             }
             Event::UserEvent(UserEvent::ApplyUpdateStart { state, client_id }) => {
                 let apply_proxy = proxy.clone();
+                let version_for_progress = match &state {
+                    gwt_core::update::UpdateState::Available { latest, .. } => Some(latest.clone()),
+                    _ => None,
+                };
+                let asset_for_progress = match &state {
+                    gwt_core::update::UpdateState::Available {
+                        asset_url: Some(url),
+                        ..
+                    } => gwt_core::update::asset_name_from_url(url),
+                    _ => None,
+                };
                 std::thread::spawn(move || {
-                    match update_front_door::prepare_update_payload(state) {
+                    // SPEC-2041 Phase 19 FR-054: stream chunk-level progress
+                    // back to the modal. Throttle to ~200 ms or the
+                    // completion tick (`downloaded >= total`) so the
+                    // WebSocket does not see one event per 64 KiB.
+                    let throttle_interval = std::time::Duration::from_millis(200);
+                    let progress_proxy = apply_proxy.clone();
+                    let version_for_closure = version_for_progress.clone();
+                    let asset_for_closure = asset_for_progress.clone();
+                    let mut last_emit = std::time::Instant::now();
+                    let mut emitted_first = false;
+                    let mut progress = move |downloaded: u64, total: Option<u64>| {
+                        let is_complete = total.map(|t| downloaded >= t).unwrap_or(false);
+                        let now = std::time::Instant::now();
+                        let should_emit = !emitted_first
+                            || is_complete
+                            || now.duration_since(last_emit) >= throttle_interval;
+                        if should_emit {
+                            emitted_first = true;
+                            last_emit = now;
+                            let _ = progress_proxy.send_event(UserEvent::Dispatch(vec![
+                                OutboundEvent::broadcast(BackendEvent::UpdateProgress {
+                                    downloaded,
+                                    total,
+                                    asset: asset_for_closure.clone(),
+                                    version: version_for_closure.clone(),
+                                }),
+                            ]));
+                        }
+                    };
+                    match update_front_door::prepare_update_payload_with_progress(
+                        state,
+                        &mut progress,
+                    ) {
                         Ok(prepared) => {
                             let asset_path = prepared.payload_path();
                             let version = prepared.latest;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1471,6 +1471,7 @@ mod tests {
             runtimes: HashMap::new(),
             window_details: HashMap::new(),
             window_lookup: HashMap::new(),
+            board_all_view_windows: std::collections::HashSet::new(),
             session_state_path: temp_root.join("session-state.json"),
             log_dir,
             proxy,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -42,6 +42,12 @@ mod runtime_support;
 mod update_front_door;
 
 #[cfg(test)]
+pub(crate) fn env_test_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[cfg(test)]
 pub(crate) use app_runtime::LaunchWizardMemoryCache;
 #[cfg(test)]
 pub(crate) use app_runtime::{

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2236,7 +2236,8 @@ mod tests {
                 if message == "Window is not a branches list"
         ));
 
-        let wizard_missing = runtime.open_launch_wizard("missing", "feature/demo", None);
+        let wizard_missing =
+            runtime.open_launch_wizard("client-1", "missing", "feature/demo", None);
         assert_eq!(wizard_missing.len(), 1);
         assert!(matches!(
             wizard_missing[0].event,
@@ -2244,7 +2245,8 @@ mod tests {
                 if title == "Launch Agent" && message == "Window not found"
         ));
 
-        let wizard_wrong = runtime.open_launch_wizard(&file_tree_id, "feature/demo", None);
+        let wizard_wrong =
+            runtime.open_launch_wizard("client-1", &file_tree_id, "feature/demo", None);
         assert_eq!(wizard_wrong.len(), 1);
         assert!(matches!(
             wizard_wrong[0].event,
@@ -2534,7 +2536,8 @@ mod tests {
             })
         });
 
-        let wizard_events = runtime.open_launch_wizard(&branches_id, "feature/demo", Some(42));
+        let wizard_events =
+            runtime.open_launch_wizard("client-1", &branches_id, "feature/demo", Some(42));
         assert_eq!(wizard_events.len(), 1);
         assert!(matches!(
             wizard_events[0].event,

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -9,7 +9,8 @@ use crate::cli::gwtd_resolver::{
 };
 use crate::native_app::{GUI_FRONT_DOOR_BINARY_NAME, INTERNAL_DAEMON_BINARY_NAME};
 use gwt_skills::{
-    distribute_to_worktree, generate_codex_hooks, generate_settings_local, update_git_exclude,
+    distribute_to_worktree, generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks,
+    generate_opencode_hooks, generate_settings_local, update_git_exclude,
 };
 
 pub fn refresh_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()> {
@@ -27,6 +28,21 @@ pub fn refresh_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()
     })?;
     generate_codex_hooks(worktree).map_err(|error| {
         io::Error::other(format!("failed to regenerate Codex hook settings: {error}"))
+    })?;
+    generate_opencode_hooks(worktree).map_err(|error| {
+        io::Error::other(format!(
+            "failed to regenerate OpenCode hook settings: {error}"
+        ))
+    })?;
+    generate_openclaw_hooks(worktree).map_err(|error| {
+        io::Error::other(format!(
+            "failed to regenerate OpenClaw hook settings: {error}"
+        ))
+    })?;
+    generate_hermes_hooks(worktree).map_err(|error| {
+        io::Error::other(format!(
+            "failed to regenerate Hermes hook settings: {error}"
+        ))
     })?;
     Ok(())
 }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -438,6 +438,58 @@ pub struct WorkspaceJournalEntryView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceWorkAgentView {
+    pub session_id: String,
+    pub agent_id: Option<String>,
+    pub display_name: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceExecutionContainerView {
+    pub branch: Option<String>,
+    pub worktree_path: Option<String>,
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub pr_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceWorkEventView {
+    pub id: String,
+    pub work_item_id: String,
+    pub kind: String,
+    pub title: Option<String>,
+    pub intent: Option<String>,
+    pub summary: Option<String>,
+    pub status_category: Option<String>,
+    pub owner: Option<String>,
+    pub next_action: Option<String>,
+    pub agent_session_id: Option<String>,
+    pub board_entry_id: Option<String>,
+    pub related_work_item_id: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceWorkItemView {
+    pub id: String,
+    pub title: String,
+    pub intent: Option<String>,
+    pub summary: Option<String>,
+    pub status_category: String,
+    pub owner: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub completed_at: Option<String>,
+    pub agents: Vec<WorkspaceWorkAgentView>,
+    pub execution_containers: Vec<WorkspaceExecutionContainerView>,
+    pub board_refs: Vec<String>,
+    pub related_work_item_ids: Vec<String>,
+    pub events: Vec<WorkspaceWorkEventView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkCleanupCandidateView {
     pub branch: String,
     pub worktree_path: Option<String>,
@@ -465,6 +517,7 @@ pub struct ActiveWorkProjectionView {
     pub pr_created_at: Option<String>,
     pub board_refs: Vec<String>,
     pub journal_entries: Vec<WorkspaceJournalEntryView>,
+    pub work_items: Vec<WorkspaceWorkItemView>,
     pub cleanup_candidate: Option<ActiveWorkCleanupCandidateView>,
     pub agents: Vec<ActiveWorkAgentView>,
 }
@@ -915,6 +968,7 @@ mod tests {
                     agent_current_focus: Some("Run launch tests".to_string()),
                     agent_title_summary: Some("Launch tests".to_string()),
                 }],
+                work_items: Vec::new(),
                 cleanup_candidate: Some(super::ActiveWorkCleanupCandidateView {
                     branch: "work/20260504-1200".to_string(),
                     worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -130,12 +130,16 @@ pub enum FrontendEvent {
     },
     LoadBoard {
         id: String,
+        #[serde(default)]
+        all: bool,
     },
     LoadBoardHistory {
         id: String,
         before_entry_id: Option<String>,
         #[serde(default = "default_board_history_limit")]
         limit: usize,
+        #[serde(default)]
+        all: bool,
     },
     LoadProfile {
         id: String,
@@ -1293,6 +1297,21 @@ mod tests {
     }
 
     #[test]
+    fn load_board_deserializes_all_view_opt_in() {
+        let frontend: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "load_board",
+            "id": "board-1",
+            "all": true
+        }))
+        .expect("deserialize load board all");
+
+        assert!(matches!(
+            frontend,
+            FrontendEvent::LoadBoard { id, all } if id == "board-1" && all
+        ));
+    }
+
+    #[test]
     fn board_history_page_serializes_cursor_contract() {
         let frontend: FrontendEvent = serde_json::from_value(serde_json::json!({
             "kind": "load_board_history",
@@ -1306,8 +1325,9 @@ mod tests {
             FrontendEvent::LoadBoardHistory {
                 id,
                 before_entry_id: Some(before_entry_id),
-                limit
-            } if id == "board-1" && before_entry_id == "entry-3" && limit == 50
+                limit,
+                all
+            } if id == "board-1" && before_entry_id == "entry-3" && limit == 50 && !all
         ));
 
         let backend = BackendEvent::BoardHistoryPage {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -411,6 +411,8 @@ pub struct ActiveWorkAgentView {
     pub window_id: Option<String>,
     pub agent_id: String,
     pub display_name: String,
+    pub affiliation_status: String,
+    pub workspace_id: Option<String>,
     pub status_category: String,
     pub current_focus: Option<String>,
     pub title_summary: Option<String>,
@@ -438,12 +440,14 @@ pub struct WorkspaceJournalEntryView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceWorkAgentView {
+pub struct WorkspaceHistoryAgentView {
     pub session_id: String,
     pub agent_id: Option<String>,
     pub display_name: Option<String>,
     pub updated_at: String,
 }
+
+pub type WorkspaceWorkAgentView = WorkspaceHistoryAgentView;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceExecutionContainerView {
@@ -455,9 +459,9 @@ pub struct WorkspaceExecutionContainerView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceWorkEventView {
+pub struct WorkspaceHistoryEventView {
     pub id: String,
-    pub work_item_id: String,
+    pub workspace_id: String,
     pub kind: String,
     pub title: Option<String>,
     pub intent: Option<String>,
@@ -467,12 +471,14 @@ pub struct WorkspaceWorkEventView {
     pub next_action: Option<String>,
     pub agent_session_id: Option<String>,
     pub board_entry_id: Option<String>,
-    pub related_work_item_id: Option<String>,
+    pub related_workspace_id: Option<String>,
     pub updated_at: String,
 }
 
+pub type WorkspaceWorkEventView = WorkspaceHistoryEventView;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkspaceWorkItemView {
+pub struct WorkspaceHistoryView {
     pub id: String,
     pub title: String,
     pub intent: Option<String>,
@@ -482,12 +488,14 @@ pub struct WorkspaceWorkItemView {
     pub created_at: String,
     pub updated_at: String,
     pub completed_at: Option<String>,
-    pub agents: Vec<WorkspaceWorkAgentView>,
+    pub agents: Vec<WorkspaceHistoryAgentView>,
     pub execution_containers: Vec<WorkspaceExecutionContainerView>,
     pub board_refs: Vec<String>,
-    pub related_work_item_ids: Vec<String>,
-    pub events: Vec<WorkspaceWorkEventView>,
+    pub related_workspace_ids: Vec<String>,
+    pub events: Vec<WorkspaceHistoryEventView>,
 }
+
+pub type WorkspaceWorkItemView = WorkspaceHistoryView;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkCleanupCandidateView {
@@ -517,9 +525,12 @@ pub struct ActiveWorkProjectionView {
     pub pr_created_at: Option<String>,
     pub board_refs: Vec<String>,
     pub journal_entries: Vec<WorkspaceJournalEntryView>,
-    pub work_items: Vec<WorkspaceWorkItemView>,
+    #[serde(default, alias = "work_items")]
+    pub workspaces: Vec<WorkspaceHistoryView>,
     pub cleanup_candidate: Option<ActiveWorkCleanupCandidateView>,
     pub agents: Vec<ActiveWorkAgentView>,
+    #[serde(default)]
+    pub unassigned_agents: Vec<ActiveWorkAgentView>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -968,7 +979,7 @@ mod tests {
                     agent_current_focus: Some("Run launch tests".to_string()),
                     agent_title_summary: Some("Launch tests".to_string()),
                 }],
-                work_items: Vec::new(),
+                workspaces: Vec::new(),
                 cleanup_candidate: Some(super::ActiveWorkCleanupCandidateView {
                     branch: "work/20260504-1200".to_string(),
                     worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),
@@ -981,6 +992,8 @@ mod tests {
                     window_id: Some("tab-1::agent-1".to_string()),
                     agent_id: "codex".to_string(),
                     display_name: "Codex".to_string(),
+                    affiliation_status: "assigned".to_string(),
+                    workspace_id: Some("work-1".to_string()),
                     status_category: "active".to_string(),
                     current_focus: Some("Run launch tests".to_string()),
                     title_summary: Some("Launch tests".to_string()),
@@ -991,6 +1004,7 @@ mod tests {
                     coordination_scope: Some("SPEC-2359 / start-work".to_string()),
                     updated_at: "2026-05-04T12:00:00Z".to_string(),
                 }],
+                unassigned_agents: Vec::new(),
             }),
         };
 

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -257,7 +257,33 @@ pub enum FrontendEvent {
         action: LaunchWizardAction,
         bounds: Option<WindowGeometry>,
     },
+    /// Legacy Phase 14 entry point. Frontend now sends
+    /// [`FrontendEvent::ApplyUpdateStart`] / [`FrontendEvent::ApplyUpdateRestartNow`]
+    /// instead. Kept so older clients and unit tests that still drive
+    /// `apply_update` continue to work; routes to the same backend behavior as
+    /// `ApplyUpdateRestartNow` (download → spawn helper → exit).
     ApplyUpdate,
+    /// SPEC-2041 Phase 19 (FR-052..057): user clicked the update CTA. Backend
+    /// downloads/prepares the asset and emits [`BackendEvent::UpdateProgress`]
+    /// during the transfer plus [`BackendEvent::UpdateReady`] on completion,
+    /// without exiting the parent process.
+    ApplyUpdateStart,
+    /// SPEC-2041 Phase 19 (FR-055): user pressed Cancel on the downloading
+    /// modal. Backend aborts the in-flight download and removes any partial
+    /// payload. Currently a best-effort no-op until async download lands.
+    CancelUpdateDownload,
+    /// SPEC-2041 Phase 19 (FR-059..061): user pressed `Later`. Binary stays
+    /// preserved; backend emits [`BackendEvent::UpdateApplyPendingPersisted`]
+    /// so the CTA morphs to ready state and same-session polling stops.
+    ApplyUpdateLater,
+    /// SPEC-2041 Phase 19 (FR-058): user pressed `Restart now`. Backend swaps
+    /// the prepared binary via the helper subprocess and exits the parent.
+    ApplyUpdateRestartNow,
+    /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
+    /// modal. Backend opens the log file in the OS default application.
+    OpenUpdateLog {
+        log_path: Option<String>,
+    },
     /// Settings > Custom Agents: list every stored custom agent. Response is
     /// [`BackendEvent::CustomAgentList`].
     ListCustomAgents,
@@ -594,8 +620,47 @@ pub enum BackendEvent {
         event: RuntimeHookEvent,
     },
     UpdateState(gwt_core::update::UpdateState),
+    /// SPEC-2041 Phase 19 (FR-054): download progress for the current update.
+    /// Emitted from `Backend` while a download is active; the `#update-modal`
+    /// uses these to drive the progress bar and byte counter.
+    UpdateProgress {
+        /// Bytes already received.
+        downloaded: u64,
+        /// Expected total bytes (when the server advertises Content-Length).
+        total: Option<u64>,
+        /// Asset filename (e.g. `gwt-macos-arm64.tar.gz`).
+        asset: Option<String>,
+        /// Target version (without the `v` prefix).
+        version: Option<String>,
+    },
+    /// SPEC-2041 Phase 19 (FR-056): download completed and the prepared payload
+    /// lives on disk. Frontend transitions the modal to the `ready` state.
+    UpdateReady {
+        version: String,
+        /// On-disk path to the prepared payload (extracted binary or installer).
+        asset_path: String,
+    },
+    /// SPEC-2041 Phase 19 (FR-059): `Later` was confirmed. The downloaded
+    /// binary is preserved (in-memory today; persistent across restarts once
+    /// the bootstrap path lands in T-133). Frontend morphs the CTA to ready.
+    UpdateApplyPendingPersisted {
+        version: String,
+    },
     UpdateApplyError {
-        message: String,
+        /// Phase 14 free-form message. Still emitted for backward compat.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+        /// Phase 19 (FR-063): structured failure stage
+        /// (e.g. `"Download asset"`, `"Replace binary"`).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        stage: Option<String>,
+        /// Phase 19 (FR-063): human-readable reason.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        /// Phase 19 (FR-065): path to the per-day update log so the modal can
+        /// surface `[Open log]`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        log_path: Option<String>,
     },
     /// Response to [`FrontendEvent::ListCustomAgents`].
     CustomAgentList {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -605,6 +605,10 @@ pub enum BackendEvent {
     ProjectOpenError {
         message: String,
     },
+    LaunchWizardOpenError {
+        title: String,
+        message: String,
+    },
     LaunchWizardState {
         wizard: Option<Box<LaunchWizardView>>,
     },
@@ -1007,6 +1011,29 @@ mod tests {
         assert!(
             matches!(event, FrontendEvent::OpenStartWork),
             "Start Work must be a global command, not a Branches window event"
+        );
+    }
+
+    #[test]
+    fn launch_wizard_open_error_serializes_modal_error_contract() {
+        let event = BackendEvent::LaunchWizardOpenError {
+            title: "Start Work".to_string(),
+            message: "Default base branch not found".to_string(),
+        };
+
+        let value = serde_json::to_value(&event).expect("serialize launch wizard open error");
+
+        assert_eq!(
+            value.get("kind"),
+            Some(&Value::String("launch_wizard_open_error".to_string()))
+        );
+        assert_eq!(
+            value.get("title"),
+            Some(&Value::String("Start Work".to_string()))
+        );
+        assert_eq!(
+            value.get("message"),
+            Some(&Value::String("Default base branch not found".to_string()))
         );
     }
 

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -210,6 +210,11 @@ pub enum FrontendEvent {
         #[serde(default)]
         mentions: Vec<gwt_core::coordination::BoardMention>,
     },
+    OpenBoardOriginAgent {
+        id: String,
+        origin_session_id: String,
+        bounds: Option<WindowGeometry>,
+    },
     SelectProfile {
         id: String,
         profile_name: String,
@@ -1262,6 +1267,33 @@ mod tests {
         assert_eq!(value["entries"][0]["mentions"][0]["target_kind"], "user");
         assert_eq!(value["entries"][0]["mentions"][0]["target"], "akiojin");
         assert_eq!(value["entries"][0]["mentions"][0]["label"], "Akio");
+    }
+
+    #[test]
+    fn open_board_origin_agent_deserializes_frontend_event_contract() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "open_board_origin_agent",
+            "id": "tab-1::board-1",
+            "origin_session_id": "session-origin",
+            "bounds": {
+                "x": 0.0,
+                "y": 0.0,
+                "width": 1200.0,
+                "height": 800.0
+            }
+        }))
+        .expect("deserialize open board origin agent event");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::OpenBoardOriginAgent {
+                id,
+                origin_session_id,
+                bounds,
+            } if id == "tab-1::board-1"
+                && origin_session_id == "session-origin"
+                && bounds.as_ref().is_some_and(|bounds| bounds.width == 1200.0)
+        ));
     }
 
     #[test]

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -509,7 +509,7 @@ pub fn try_apply_pending_update_at_bootstrap() -> bool {
         None => return false,
     };
     let current_version = env!("CARGO_PKG_VERSION");
-    if !gwt_core::update::pending_version_is_newer(&manifest.version, current_version) {
+    if !should_apply_pending_at_bootstrap(&manifest.version, current_version) {
         // The pending payload is for our current (or older) version. Drop it
         // so we don't loop forever.
         let _ = gwt_core::update::clear_pending_update_manifest();
@@ -526,6 +526,14 @@ pub fn try_apply_pending_update_at_bootstrap() -> bool {
             false
         }
     }
+}
+
+/// SPEC-2041 Phase 19 (T-127 / FR-062): pure decision predicate the bootstrap
+/// path uses to decide whether to swap. Lifted out of
+/// [`try_apply_pending_update_at_bootstrap`] so unit tests can exercise it
+/// without touching `~/.gwt/pending-update/` or invoking `exit(0)`.
+fn should_apply_pending_at_bootstrap(pending_version: &str, current_version: &str) -> bool {
+    gwt_core::update::pending_version_is_newer(pending_version, current_version)
 }
 
 #[cfg(test)]
@@ -757,5 +765,54 @@ mod poll_state_tests {
         assert!(ops.wrote_restart_args);
         assert!(ops.spawned_portable);
         assert!(!ops.spawned_installer);
+    }
+
+    // SPEC-2041 Phase 19 (T-127): bootstrap pending-update decision tests.
+    //
+    // The full bootstrap path ends in `exit(0)` so it cannot be unit-tested
+    // directly. We instead exercise the pure decision predicate
+    // (`should_apply_pending_at_bootstrap`) and the manifest cleanup helper
+    // contract that the bootstrap path relies on.
+
+    #[test]
+    fn bootstrap_decision_swaps_only_when_pending_is_newer() {
+        use super::should_apply_pending_at_bootstrap;
+        assert!(should_apply_pending_at_bootstrap("9.26.0", "9.25.0"));
+        assert!(should_apply_pending_at_bootstrap("v9.26.0", "v9.25.0"));
+        assert!(!should_apply_pending_at_bootstrap("9.25.0", "9.25.0"));
+        assert!(!should_apply_pending_at_bootstrap("9.24.0", "9.25.0"));
+    }
+
+    #[test]
+    fn bootstrap_clears_stale_manifest_in_tempdir() {
+        // Stage a stale manifest pointing at a real on-disk payload so
+        // load_pending_update_manifest_in returns Some, then verify the
+        // cleanup helper wipes it. This exercises the same cleanup contract
+        // the bootstrap path uses for "pending version <= current".
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let payload = tempdir.path().join("v9.20.0").join("gwt");
+        std::fs::create_dir_all(payload.parent().unwrap()).unwrap();
+        std::fs::write(&payload, b"#!/bin/sh\nexit 0\n").unwrap();
+
+        let manifest = gwt_core::update::PendingUpdateManifest {
+            version: "9.20.0".to_string(),
+            asset_url: "https://example.invalid/v9.20.0.tar.gz".to_string(),
+            payload: gwt_core::update::PreparedPayload::PortableBinary { path: payload },
+            downloaded_at: "2026-05-10T12:00:00Z".to_string(),
+        };
+        gwt_core::update::persist_pending_update_manifest_in(tempdir.path(), &manifest)
+            .expect("persist");
+        assert!(
+            gwt_core::update::load_pending_update_manifest_in(tempdir.path()).is_some(),
+            "manifest must be discoverable before cleanup",
+        );
+
+        // Bootstrap would call clear_pending_update_manifest_in when the
+        // pending version is not newer than current.
+        gwt_core::update::clear_pending_update_manifest_in(tempdir.path()).expect("clear succeeds");
+        assert!(
+            gwt_core::update::load_pending_update_manifest_in(tempdir.path()).is_none(),
+            "manifest must be gone after cleanup",
+        );
     }
 }

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -465,11 +465,29 @@ fn apply_prepared_payload_with_ops(
     }
 }
 
+/// SPEC-2041 Phase 19 (FR-059..062): explicit no-op named after the SPEC's
+/// `commit_update_later_pending` so the post-click flow has the named seam
+/// FR-064 prescribes even though persistence happens earlier (in
+/// `UserEvent::ApplyUpdateStart`'s worker thread). Runs a sanity check that
+/// the manifest the bootstrap path will rely on actually exists, returning
+/// an error so callers can surface it via `update_apply_error`.
+pub fn commit_update_later_pending() -> Result<(), String> {
+    match gwt_core::update::load_pending_update_manifest() {
+        Some(_) => Ok(()),
+        None => Err("Pending update manifest is missing; download did not persist.".to_string()),
+    }
+}
+
 /// SPEC-2041 Phase 19 (FR-058/062): consume an already-persisted manifest.
 /// Used both by `Restart now` (when the user clicked through the modal) and
 /// by the bootstrap path (when a previous run wrote the manifest via
 /// `Later`). After the helper subprocess is spawned the manifest is removed
 /// so a future launch does not re-apply the same payload.
+///
+/// This is the function FR-064 names `commit_update_restart_now`. Kept under
+/// the implementation-evolved name `apply_pending_manifest_and_exit` because
+/// renaming would force a much larger diff across tests; the SPEC contract is
+/// satisfied by the function's behavior, not its identifier.
 pub fn apply_pending_manifest_and_exit(
     manifest: gwt_core::update::PendingUpdateManifest,
 ) -> Result<(), String> {

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -306,8 +306,23 @@ impl PreparedUpdate {
 /// helper, and never mutates the running binary. T-130 will eventually replace
 /// `apply_update_state_and_exit` entirely with this + a separate
 /// `commit_update_restart_now` once Phase 19 stabilizes.
+/// Convenience wrapper that drops download-progress events. Kept on the
+/// public API for future non-streaming callers (CLI, automated tests) so the
+/// progress-aware variant does not have to be re-discovered.
+#[allow(dead_code)]
 pub fn prepare_update_payload(
     state: gwt_core::update::UpdateState,
+) -> Result<PreparedUpdate, String> {
+    prepare_update_payload_with_progress(state, &mut |_, _| {})
+}
+
+/// SPEC-2041 Phase 19 (FR-054): like [`prepare_update_payload`] but routes
+/// download chunk progress to `progress`. The closure must be cheap because
+/// it fires once per 64 KiB of payload; callers that broadcast progress over
+/// WebSocket should throttle inside the closure (e.g. by `Instant::elapsed`).
+pub fn prepare_update_payload_with_progress(
+    state: gwt_core::update::UpdateState,
+    progress: &mut dyn FnMut(u64, Option<u64>),
 ) -> Result<PreparedUpdate, String> {
     let (latest, asset_url) = match state {
         gwt_core::update::UpdateState::Available {
@@ -325,9 +340,9 @@ pub fn prepare_update_payload(
             return Err(format!("Update check failed: {message}"));
         }
     };
-    let mut ops = RealUpdateApplyOps::default();
-    let payload = ops
-        .prepare_update(&latest, &asset_url)
+    let mgr = gwt_core::update::UpdateManager::new();
+    let payload = mgr
+        .prepare_update_with_progress(&latest, &asset_url, progress)
         .map_err(|err| format!("Failed to prepare update payload: {err}"))?;
     Ok(PreparedUpdate {
         latest,

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -269,6 +269,73 @@ impl UpdateApplyOps for RealUpdateApplyOps {
     }
 }
 
+/// SPEC-2041 Phase 19 (T-130): a download that has been completed but not yet
+/// committed via the helper subprocess. Constructed by
+/// [`prepare_update_payload`] from a verified `UpdateState::Available`, then
+/// reused by `apply_update_state_and_exit` (which performs the helper spawn +
+/// `exit(0)`). The struct intentionally owns the on-disk path so the apply
+/// path does not have to re-derive it from the asset URL.
+#[derive(Debug, Clone)]
+pub struct PreparedUpdate {
+    pub latest: String,
+    /// Source URL the asset was downloaded from. Retained for diagnostics
+    /// (logs, retry telemetry) so future Phase 19 work can correlate ready
+    /// payloads back to the upstream release without re-walking the cache.
+    #[allow(dead_code)]
+    pub asset_url: String,
+    pub payload: gwt_core::update::PreparedPayload,
+}
+
+impl PreparedUpdate {
+    /// Filesystem path of the prepared payload (binary or installer).
+    pub fn payload_path(&self) -> PathBuf {
+        match &self.payload {
+            gwt_core::update::PreparedPayload::PortableBinary { path }
+            | gwt_core::update::PreparedPayload::Installer { path, .. } => path.clone(),
+        }
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-052/056): download and stage the update payload
+/// without spawning the helper subprocess. The caller (typically the
+/// `UserEvent::ApplyUpdateStart` worker thread in `main.rs`) broadcasts
+/// [`crate::BackendEvent::UpdateReady`] when this returns `Ok`.
+///
+/// This is the explicit no-side-effects half of the legacy
+/// [`apply_update_state_and_exit`]: it never calls `exit(0)`, never spawns the
+/// helper, and never mutates the running binary. T-130 will eventually replace
+/// `apply_update_state_and_exit` entirely with this + a separate
+/// `commit_update_restart_now` once Phase 19 stabilizes.
+pub fn prepare_update_payload(
+    state: gwt_core::update::UpdateState,
+) -> Result<PreparedUpdate, String> {
+    let (latest, asset_url) = match state {
+        gwt_core::update::UpdateState::Available {
+            latest,
+            asset_url: Some(asset_url),
+            ..
+        } => (latest, asset_url),
+        gwt_core::update::UpdateState::Available { .. } => {
+            return Err("No applicable update asset is available for this platform.".to_string());
+        }
+        gwt_core::update::UpdateState::UpToDate { .. } => {
+            return Err("No pending update is available.".to_string());
+        }
+        gwt_core::update::UpdateState::Failed { message, .. } => {
+            return Err(format!("Update check failed: {message}"));
+        }
+    };
+    let mut ops = RealUpdateApplyOps::default();
+    let payload = ops
+        .prepare_update(&latest, &asset_url)
+        .map_err(|err| format!("Failed to prepare update payload: {err}"))?;
+    Ok(PreparedUpdate {
+        latest,
+        asset_url,
+        payload,
+    })
+}
+
 /// Apply an already-detected update state from the GUI notification path.
 ///
 /// The startup poll has already selected the platform-specific asset. Reusing

--- a/crates/gwt/src/update_front_door.rs
+++ b/crates/gwt/src/update_front_door.rs
@@ -171,7 +171,7 @@ fn handle_poll_outcome(
                 _ => return state.on_success_uptodate(),
             };
             let (should_publish, next) = state.on_success_available(&latest);
-            if should_publish {
+            if should_publish && !pending_manifest_covers(&latest) {
                 let _ = update_proxy.send_event(UserEvent::UpdateAvailable(outcome));
             }
             next
@@ -179,6 +179,16 @@ fn handle_poll_outcome(
         StartupUpdateAction::Stop => state.on_success_uptodate(),
         StartupUpdateAction::Retry => state.on_failure(),
     }
+}
+
+/// SPEC-2041 Phase 19 (T-134): suppress polling broadcasts for versions the
+/// user has already deferred via `Later`. Without this guard the same release
+/// would re-pop the CTA every 5 minutes even though the binary is already
+/// staged in `~/.gwt/pending-update/`.
+fn pending_manifest_covers(latest: &str) -> bool {
+    gwt_core::update::load_pending_update_manifest()
+        .map(|m| m.version == latest)
+        .unwrap_or(false)
 }
 
 trait UpdateApplyOps {
@@ -399,6 +409,30 @@ fn start_update_apply_with_ops(
     let payload = ops
         .prepare_update(&latest, &asset_url)
         .map_err(|err| format!("Failed to prepare update payload: {err}"))?;
+    apply_prepared_payload_with_ops(
+        ops,
+        &latest,
+        payload,
+        current_exe,
+        restart_args,
+        old_pid,
+        use_helper_copy,
+    )
+}
+
+/// SPEC-2041 Phase 19 (T-130): commit an already-prepared update by writing
+/// the restart-args file, optionally creating a helper copy on Windows, and
+/// spawning the helper subprocess. Caller is responsible for `exit(0)` once
+/// this returns `Ok` so the helper sees the parent close.
+fn apply_prepared_payload_with_ops(
+    ops: &mut impl UpdateApplyOps,
+    latest: &str,
+    payload: gwt_core::update::PreparedPayload,
+    current_exe: &Path,
+    restart_args: Vec<String>,
+    old_pid: u32,
+    use_helper_copy: bool,
+) -> Result<(), String> {
     let args_file = (match &payload {
         gwt_core::update::PreparedPayload::PortableBinary { path }
         | gwt_core::update::PreparedPayload::Installer { path, .. } => {
@@ -409,7 +443,7 @@ fn start_update_apply_with_ops(
     ops.write_restart_args_file(&args_file, restart_args)
         .map_err(|err| format!("Failed to write update restart args: {err}"))?;
     let helper_exe = if use_helper_copy {
-        ops.make_helper_copy(current_exe, &latest)
+        ops.make_helper_copy(current_exe, latest)
             .map_err(|err| format!("Failed to prepare update helper: {err}"))?
     } else {
         current_exe.to_path_buf()
@@ -428,6 +462,69 @@ fn start_update_apply_with_ops(
                 &args_file,
             )
             .map_err(|err| format!("Failed to start update installer: {err}")),
+    }
+}
+
+/// SPEC-2041 Phase 19 (FR-058/062): consume an already-persisted manifest.
+/// Used both by `Restart now` (when the user clicked through the modal) and
+/// by the bootstrap path (when a previous run wrote the manifest via
+/// `Later`). After the helper subprocess is spawned the manifest is removed
+/// so a future launch does not re-apply the same payload.
+pub fn apply_pending_manifest_and_exit(
+    manifest: gwt_core::update::PendingUpdateManifest,
+) -> Result<(), String> {
+    let current_exe = std::env::current_exe()
+        .map_err(|err| format!("Failed to resolve current executable: {err}"))?;
+    let restart_args: Vec<String> = std::env::args().skip(1).collect();
+    let latest = manifest.version.clone();
+    let payload = manifest.payload.clone();
+    let mut ops = RealUpdateApplyOps::default();
+    apply_prepared_payload_with_ops(
+        &mut ops,
+        &latest,
+        payload,
+        &current_exe,
+        restart_args,
+        std::process::id(),
+        cfg!(windows),
+    )?;
+    // Best-effort cleanup so the next launch starts from a clean state. The
+    // helper has already been spawned so failures here are not fatal.
+    let _ = gwt_core::update::clear_pending_update_manifest();
+    std::process::exit(0);
+}
+
+/// SPEC-2041 Phase 19 (T-133): bootstrap-time swap. Returns `true` when a
+/// pending manifest was found, applied, and the parent process is about to
+/// `exit(0)` (caller should not return). Returns `false` when there is no
+/// applicable pending update so the caller continues normal startup.
+///
+/// Intentionally `pub` so `crates/gwt/src/main.rs` can call this before
+/// any window setup. Stale manifests (older than the running binary, or
+/// pointing at a missing payload) are quietly cleared so they don't keep
+/// rewinding launches.
+pub fn try_apply_pending_update_at_bootstrap() -> bool {
+    let manifest = match gwt_core::update::load_pending_update_manifest() {
+        Some(m) => m,
+        None => return false,
+    };
+    let current_version = env!("CARGO_PKG_VERSION");
+    if !gwt_core::update::pending_version_is_newer(&manifest.version, current_version) {
+        // The pending payload is for our current (or older) version. Drop it
+        // so we don't loop forever.
+        let _ = gwt_core::update::clear_pending_update_manifest();
+        return false;
+    }
+    match apply_pending_manifest_and_exit(manifest) {
+        Ok(()) => true, // unreachable: apply_pending_manifest_and_exit calls exit(0)
+        Err(err) => {
+            // Apply failed before exit. Clear the manifest so we don't loop.
+            // Tracing isn't initialized this early in main(), so log via stderr
+            // for post-mortem inspection.
+            eprintln!("gwt bootstrap pending-update apply failed: {err}");
+            let _ = gwt_core::update::clear_pending_update_manifest();
+            false
+        }
     }
 }
 

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -80,6 +80,11 @@ impl WorkspaceState {
         true
     }
 
+    /// Sets `dynamic_title` for the named window. Returns `true` only when
+    /// the stored value actually changed (after normalization) so callers
+    /// can decide whether to emit a broadcast. SPEC-2359 US-26: gating on
+    /// real diff avoids forcing frontend re-renders for no-op projection
+    /// reloads (e.g. repeated `gwtd workspace update` with the same title).
     pub fn set_dynamic_title(&mut self, id: &str, title: Option<String>) -> bool {
         let Some(window) = self
             .persisted
@@ -89,10 +94,18 @@ impl WorkspaceState {
         else {
             return false;
         };
-        window.dynamic_title = title.and_then(normalize_title);
+        let new_title = title.and_then(normalize_title);
+        if window.dynamic_title == new_title {
+            return false;
+        }
+        window.dynamic_title = new_title;
         true
     }
 
+    /// Sets `dynamic_title` and `dynamic_title_detail` for the named window.
+    /// Returns `true` only when either field actually changed (after
+    /// normalization), so callers can gate broadcasts on a real value diff.
+    /// SPEC-2359 US-26.
     pub fn set_dynamic_title_with_detail(
         &mut self,
         id: &str,
@@ -107,8 +120,13 @@ impl WorkspaceState {
         else {
             return false;
         };
-        window.dynamic_title = title.and_then(normalize_title);
-        window.dynamic_title_detail = detail.and_then(normalize_title);
+        let new_title = title.and_then(normalize_title);
+        let new_detail = detail.and_then(normalize_title);
+        if window.dynamic_title == new_title && window.dynamic_title_detail == new_detail {
+            return false;
+        }
+        window.dynamic_title = new_title;
+        window.dynamic_title_detail = new_detail;
         true
     }
 

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -9,6 +9,9 @@ use chrono::Utc;
 use gwt::cli::hook::{workflow_policy, HookEvent, HookOutput};
 use gwt_agent::{session::GWT_SESSION_ID_ENV, AgentId, Session};
 use gwt_core::{
+    coordination::{
+        post_entry, AuthorKind, BoardEntry, BoardEntryKind, BoardMention, BoardMentionTargetKind,
+    },
     paths::gwt_sessions_dir,
     repo_hash::compute_repo_hash,
     workspace_projection::{
@@ -160,21 +163,57 @@ fn save_session(repo_path: &Path, branch: &str, linked_issue_number: Option<u64>
 
 fn seed_workspace_agent_title(repo_path: &Path, session_id: &str) {
     let mut projection = WorkspaceProjection::default_for_project(repo_path);
-    projection.agents.push(WorkspaceAgentSummary {
+    projection.agents.push(workspace_agent(
+        session_id,
+        "Testing workflow policy",
+        "Workflow policy test",
+    ));
+    save_workspace_projection(repo_path, &projection).expect("save workspace projection");
+}
+
+fn workspace_agent(
+    session_id: &str,
+    current_focus: &str,
+    title_summary: &str,
+) -> WorkspaceAgentSummary {
+    WorkspaceAgentSummary {
         session_id: session_id.to_string(),
         window_id: None,
         agent_id: "codex".to_string(),
         display_name: "Codex".to_string(),
         status_category: WorkspaceStatusCategory::Active,
-        current_focus: Some("Testing workflow policy".to_string()),
-        title_summary: Some("Workflow policy test".to_string()),
-        worktree_path: Some(repo_path.to_path_buf()),
+        current_focus: Some(current_focus.to_string()),
+        title_summary: Some(title_summary.to_string()),
+        worktree_path: None,
         branch: Some("feature/workflow".to_string()),
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
         updated_at: Utc::now(),
-    });
+    }
+}
+
+fn seed_workspace_agents(
+    repo_path: &Path,
+    current_session_id: &str,
+    current_title: &str,
+    other_session_id: &str,
+    other_title: &str,
+) {
+    let mut projection = WorkspaceProjection::default_for_project(repo_path);
+    projection.title = "Workspace semantic coordination".to_string();
+    projection.status_category = WorkspaceStatusCategory::Active;
+    projection.summary = Some("Coordinate same-work detection across agents".to_string());
+    projection.agents.push(workspace_agent(
+        current_session_id,
+        "Implement Workspace semantic coordination gate",
+        current_title,
+    ));
+    projection.agents.push(workspace_agent(
+        other_session_id,
+        "Implement duplicate Workspace semantic coordination protection",
+        other_title,
+    ));
     save_workspace_projection(repo_path, &projection).expect("save workspace projection");
 }
 
@@ -499,5 +538,146 @@ fn evaluate_falls_back_to_issue_linkage_store_for_plain_issue_owner() {
             matches!(decision, HookOutput::Silent),
             "plain issue owner from linkage store should allow implementation"
         );
+    });
+}
+
+#[test]
+fn blocks_mutation_when_another_active_workspace_matches_current_title() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_agents(
+            &repo_path,
+            &session_id,
+            "Workspace semantic coordination gate",
+            "session-other",
+            "Workspace semantic coordination duplicate guard",
+        );
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected active Workspace conflict to block mutation");
+        };
+        assert!(detail.contains("similar active Workspace"), "{detail}");
+        assert!(detail.contains("session-other"), "{detail}");
+        assert!(detail.contains("gwtd board post"), "{detail}");
+        assert!(detail.contains("Boundary:"), "{detail}");
+    });
+}
+
+#[test]
+fn allows_mutation_after_split_claim_targets_matching_workspace_agent() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_agents(
+            &repo_path,
+            &session_id,
+            "Workspace semantic coordination gate",
+            "session-other",
+            "Workspace semantic coordination duplicate guard",
+        );
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Claim,
+            "Split accepted for same Workspace work.\n\nBoundary: current session owns workflow-policy tests and policy gate only.",
+            None,
+            None,
+            vec!["workspace-semantic-coordination".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id(session_id.clone())
+        .with_mention(BoardMention::new(
+            BoardMentionTargetKind::Session,
+            "session-other",
+        ));
+        post_entry(&repo_path, entry).expect("post split claim");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Boundary-targeted split claim should allow disjoint implementation"
+        );
+    });
+}
+
+#[test]
+fn blocks_mutation_when_active_board_claim_matches_current_title() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection.agents.push(workspace_agent(
+            &session_id,
+            "Implement Workspace semantic coordination gate",
+            "Workspace semantic coordination gate",
+        ));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Other Codex",
+            BoardEntryKind::Claim,
+            "Implement Workspace semantic coordination duplicate guard for active agents.",
+            None,
+            None,
+            vec!["workspace-semantic-coordination".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id("session-other");
+        post_entry(&repo_path, entry).expect("post active claim");
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected active Board claim conflict to block mutation");
+        };
+        assert!(detail.contains("active Board claim"), "{detail}");
+        assert!(detail.contains("session-other"), "{detail}");
     });
 }

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -15,8 +15,8 @@ use gwt_core::{
     paths::gwt_sessions_dir,
     repo_hash::compute_repo_hash,
     workspace_projection::{
-        save_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection,
-        WorkspaceStatusCategory,
+        record_workspace_work_event, save_workspace_projection, WorkspaceAgentSummary,
+        WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
     },
 };
 use gwt_github::{
@@ -215,6 +215,36 @@ fn seed_workspace_agents(
         other_title,
     ));
     save_workspace_projection(repo_path, &projection).expect("save workspace projection");
+}
+
+fn seed_workspace_current_agent(repo_path: &Path, session_id: &str, title: &str, focus: &str) {
+    let mut projection = WorkspaceProjection::default_for_project(repo_path);
+    projection
+        .agents
+        .push(workspace_agent(session_id, focus, title));
+    save_workspace_projection(repo_path, &projection).expect("save workspace projection");
+}
+
+fn seed_workspace_work_item(
+    repo_path: &Path,
+    work_item_id: &str,
+    kind: WorkspaceWorkEventKind,
+    title: &str,
+    session_id: &str,
+) {
+    let mut event = WorkspaceWorkEvent::new(kind, work_item_id, Utc::now());
+    event.title = Some(title.to_string());
+    event.intent = Some("Implement Workspace WorkItem lifecycle history".to_string());
+    event.summary =
+        Some("Workspace WorkItem history should be joined instead of duplicated.".to_string());
+    event.status_category = Some(match kind {
+        WorkspaceWorkEventKind::Done => WorkspaceStatusCategory::Done,
+        _ => WorkspaceStatusCategory::Active,
+    });
+    event.agent_session_id = Some(session_id.to_string());
+    event.agent_id = Some("codex".to_string());
+    event.display_name = Some("Codex".to_string());
+    record_workspace_work_event(repo_path, event).expect("record workspace work item");
 }
 
 fn seed_issue_linkage(repo_path: &Path, branch: &str, issue_number: u64) {
@@ -679,5 +709,89 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
         };
         assert!(detail.contains("active Board claim"), "{detail}");
         assert!(detail.contains("session-other"), "{detail}");
+    });
+}
+
+#[test]
+fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_current_agent(
+            &repo_path,
+            &session_id,
+            "Workspace WorkItem history",
+            "Implement Workspace WorkItem lifecycle history",
+        );
+        seed_workspace_work_item(
+            &repo_path,
+            "workitem-existing",
+            WorkspaceWorkEventKind::Start,
+            "Workspace WorkItem history duplicate prevention",
+            "session-other",
+        );
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt-core/src/workspace_projection.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected incomplete WorkItem conflict to block mutation");
+        };
+        assert!(detail.contains("incomplete Workspace WorkItem"), "{detail}");
+        assert!(detail.contains("session-other"), "{detail}");
+        assert!(detail.contains("gwtd board post"), "{detail}");
+    });
+}
+
+#[test]
+fn completed_work_item_history_does_not_block_new_related_work() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        seed_workspace_current_agent(
+            &repo_path,
+            &session_id,
+            "Workspace WorkItem history",
+            "Implement Workspace WorkItem lifecycle history follow-up",
+        );
+        seed_workspace_work_item(
+            &repo_path,
+            "workitem-completed",
+            WorkspaceWorkEventKind::Done,
+            "Workspace WorkItem history",
+            "session-other",
+        );
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt-core/src/workspace_projection.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "completed WorkItem history must be context only"
+        );
     });
 }

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -736,6 +736,53 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
 }
 
 #[test]
+fn allows_mutation_when_active_board_claim_is_scoped_to_other_workspace() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection.agents.push(workspace_agent(
+            &session_id,
+            "Implement Workspace semantic coordination gate",
+            "Workspace semantic coordination gate",
+        ));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Other Codex",
+            BoardEntryKind::Claim,
+            "Implement Workspace semantic coordination duplicate guard for active agents.",
+            None,
+            None,
+            vec!["workspace-semantic-coordination".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id("session-other")
+        .with_audience(vec!["workspace-other"]);
+        post_entry(&repo_path, entry).expect("post other-workspace claim");
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "other-Workspace Board claims must not block this Workspace"
+        );
+    });
+}
+
+#[test]
 fn unassigned_agent_without_title_summary_is_not_title_blocked() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -713,6 +713,62 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
 }
 
 #[test]
+fn does_not_block_when_active_board_claim_is_audienced_to_other_workspace() {
+    // SPEC-2359 FR-099 / SC-031: a claim audienced only to a different
+    // Workspace must not gate the current Agent. Until the affiliation
+    // field lands, the current Agent is treated as Unassigned and only
+    // broadcast claims should reach the gate.
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/current", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection.agents.push(workspace_agent(
+            &session_id,
+            "Implement Workspace audience scoped gate",
+            "Workspace audience scoped gate",
+        ));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Other Codex",
+            BoardEntryKind::Claim,
+            "Implement Workspace audience scoped gate for active agents.",
+            None,
+            None,
+            vec!["workspace-audience".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id("session-other")
+        .with_audience(vec!["ws-other-only".to_string()]);
+        post_entry(&repo_path, entry).expect("post audienced claim");
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        match decision {
+            HookOutput::PreToolUsePermission { detail, .. } => {
+                panic!(
+                    "audience-only claim must not block the current Agent until affiliation lands: {detail}"
+                );
+            }
+            HookOutput::Silent => {}
+            other => panic!("expected silent allow, got {other:?}"),
+        }
+    });
+}
+
+#[test]
 fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -15,8 +15,9 @@ use gwt_core::{
     paths::gwt_sessions_dir,
     repo_hash::compute_repo_hash,
     workspace_projection::{
-        record_workspace_work_event, save_workspace_projection, WorkspaceAgentSummary,
-        WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
+        record_workspace_work_event, save_workspace_projection, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkEvent,
+        WorkspaceWorkEventKind,
     },
 };
 use gwt_github::{
@@ -189,6 +190,28 @@ fn workspace_agent(
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
+        affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+        workspace_id: Some("workspace-existing".to_string()),
+        updated_at: Utc::now(),
+    }
+}
+
+fn unassigned_workspace_agent(session_id: &str) -> WorkspaceAgentSummary {
+    WorkspaceAgentSummary {
+        session_id: session_id.to_string(),
+        window_id: None,
+        agent_id: "codex".to_string(),
+        display_name: "Codex".to_string(),
+        status_category: WorkspaceStatusCategory::Active,
+        current_focus: None,
+        title_summary: None,
+        worktree_path: None,
+        branch: Some("work/unassigned".to_string()),
+        last_board_entry_id: None,
+        last_board_entry_kind: None,
+        coordination_scope: None,
+        affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+        workspace_id: None,
         updated_at: Utc::now(),
     }
 }
@@ -713,6 +736,68 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
 }
 
 #[test]
+fn unassigned_agent_without_title_summary_is_not_title_blocked() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/unassigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection
+            .agents
+            .push(unassigned_workspace_agent(&session_id));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/lib.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Unassigned Agents must not be blocked as missing title-summary"
+        );
+    });
+}
+
+#[test]
+fn assigned_agent_without_title_summary_remains_title_blocked() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/assigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        let mut agent = workspace_agent(&session_id, "Implement assigned work", "");
+        agent.title_summary = None;
+        projection.agents.push(agent);
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/lib.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::PreToolUsePermission { .. }),
+            "Assigned Agents still need a title-summary before implementation"
+        );
+    });
+}
+
+#[test]
 fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);
@@ -751,7 +836,7 @@ fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
         let HookOutput::PreToolUsePermission { detail, .. } = decision else {
             panic!("expected incomplete WorkItem conflict to block mutation");
         };
-        assert!(detail.contains("incomplete Workspace WorkItem"), "{detail}");
+        assert!(detail.contains("incomplete Workspace"), "{detail}");
         assert!(detail.contains("session-other"), "{detail}");
         assert!(detail.contains("gwtd board post"), "{detail}");
     });

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -54,6 +54,13 @@ test("Board surface exposes a Workspace audience filter toggle (SPEC-2359 FR-101
   assert.match(appSource, /state\.audienceFilter\s*===\s*"workspace"/);
 });
 
+test("Board surface wires Workspace projection's primary assigned agent into currentWorkspaceId (SPEC-2359 FR-098)", () => {
+  assert.match(appSource, /deriveCurrentProjectWorkspaceId/);
+  assert.match(appSource, /refreshBoardCurrentWorkspaceId/);
+  assert.match(appSource, /affiliation_status[\s\S]{0,60}assigned/);
+  assert.match(appSource, /currentWorkspaceId:\s*currentProjectWorkspaceId/);
+});
+
 test("Board message body preserves multiline plaintext", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -5,6 +5,9 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import {
   applyBoardMentionNotificationFocus,
+  boardEntryOriginActionLabel,
+  boardEntryOriginLabel,
+  boardEntryOriginSessionId,
   boardEntryAudienceLabels,
   boardEntryMentionsSelf,
   entryVisibleForWorkspace,
@@ -46,6 +49,13 @@ test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /showBoardMentionNotification/);
   assert.match(appSource, /Jump to original/);
   assert.match(appSource, /state\.audienceFilter\s*=\s*"all"/);
+});
+
+test("Board surface exposes origin Agent focus and resume affordances", () => {
+  assert.match(appSource, /open_board_origin_agent/);
+  assert.match(appSource, /board-origin-badge/);
+  assert.match(appSource, /board-origin-button/);
+  assert.match(appSource, /visibleBounds\(\)/);
 });
 
 test("Board surface exposes a Workspace audience filter toggle (SPEC-2359 FR-101)", () => {
@@ -188,4 +198,29 @@ test("Board notification helper prepares focused state for click-through", () =>
   assert.equal(state.forYouUnread, 0);
   assert.equal(state.focusEntryId, "entry-target");
   assert.equal(state.pendingFocusScroll, true);
+});
+
+test("Board origin helpers label live focus versus exact resume actions", () => {
+  const entry = {
+    author_kind: "agent",
+    author: "Codex",
+    origin_agent_id: "Codex",
+    origin_branch: "work/20260511-0327",
+    origin_session_id: "12345678-90ab-cdef-1234-567890abcdef",
+  };
+  const liveAgents = [
+    {
+      session_id: "12345678-90ab-cdef-1234-567890abcdef",
+      window_id: "tab-1::agent-1",
+    },
+  ];
+
+  assert.equal(
+    boardEntryOriginSessionId(entry),
+    "12345678-90ab-cdef-1234-567890abcdef",
+  );
+  assert.match(boardEntryOriginLabel(entry), /^From Codex · work\/20260511-0327 · 12345678$/);
+  assert.equal(boardEntryOriginActionLabel(entry, liveAgents), "Focus Agent");
+  assert.equal(boardEntryOriginActionLabel(entry, []), "Resume Agent");
+  assert.equal(boardEntryOriginActionLabel({ author_kind: "user" }, liveAgents), "");
 });

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -38,6 +38,7 @@ test("Board surface follows external posts only when already near bottom", () =>
 
 test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /board-for-you-filter/);
+  assert.match(appSource, /board-all-filter/);
   assert.match(appSource, /board-audience-badge/);
   assert.match(appSource, /board-reply-button/);
   assert.match(appSource, /board-reply-banner/);
@@ -45,6 +46,7 @@ test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /showBoardMentionNotification/);
   assert.match(appSource, /Jump to original/);
   assert.match(appSource, /state\.audienceFilter\s*=\s*"all"/);
+  assert.match(appSource, /all:\s*state\.audienceFilter\s*===\s*"all"/);
 });
 
 test("Board message body preserves multiline plaintext", () => {
@@ -106,6 +108,30 @@ test("Board reply helpers create reply mentions and filter for-you entries", () 
   assert.deepEqual(
     visibleBoardEntries(state, ["user:you"]).map((entry) => entry.id),
     ["entry-user"],
+  );
+});
+
+test("Board workspace audience filter shows current workspace plus broadcast by default", () => {
+  const state = {
+    audienceFilter: "workspace",
+    currentWorkspaceId: "workspace-a",
+    entries: [
+      { id: "broadcast", body: "legacy broadcast" },
+      { id: "workspace-a", audience: ["workspace-a"], body: "current workspace" },
+      { id: "workspace-b", audience: ["workspace-b"], body: "other workspace" },
+      { id: "empty", audience: [], body: "empty is broadcast" },
+    ],
+  };
+
+  assert.deepEqual(
+    visibleBoardEntries(state).map((entry) => entry.id),
+    ["broadcast", "workspace-a", "empty"],
+  );
+
+  state.audienceFilter = "all";
+  assert.deepEqual(
+    visibleBoardEntries(state).map((entry) => entry.id),
+    ["broadcast", "workspace-a", "workspace-b", "empty"],
   );
 });
 

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -7,6 +7,7 @@ import {
   applyBoardMentionNotificationFocus,
   boardEntryAudienceLabels,
   boardEntryMentionsSelf,
+  entryVisibleForWorkspace,
   mentionForReplyParent,
   mentionsForBoardSubmit,
   visibleBoardEntries,
@@ -45,6 +46,12 @@ test("Board surface exposes clear audience and reply affordances", () => {
   assert.match(appSource, /showBoardMentionNotification/);
   assert.match(appSource, /Jump to original/);
   assert.match(appSource, /state\.audienceFilter\s*=\s*"all"/);
+});
+
+test("Board surface exposes a Workspace audience filter toggle (SPEC-2359 FR-101)", () => {
+  assert.match(appSource, /board-workspace-filter/);
+  assert.match(appSource, /toggle-board-workspace/);
+  assert.match(appSource, /state\.audienceFilter\s*===\s*"workspace"/);
 });
 
 test("Board message body preserves multiline plaintext", () => {
@@ -107,6 +114,64 @@ test("Board reply helpers create reply mentions and filter for-you entries", () 
     visibleBoardEntries(state, ["user:you"]).map((entry) => entry.id),
     ["entry-user"],
   );
+});
+
+test("entryVisibleForWorkspace treats absent or empty audience as broadcast (FR-093/103)", () => {
+  const broadcastA = { id: "a", audience: [] };
+  const broadcastB = { id: "b" };
+  const scopedAB = { id: "ab", audience: ["ws-1", "ws-2"] };
+  const scopedOther = { id: "other", audience: ["ws-2"] };
+
+  assert.equal(entryVisibleForWorkspace(broadcastA, "ws-1"), true);
+  assert.equal(entryVisibleForWorkspace(broadcastB, "ws-1"), true);
+  assert.equal(entryVisibleForWorkspace(broadcastA, null), true);
+  assert.equal(entryVisibleForWorkspace(scopedAB, "ws-1"), true);
+  assert.equal(entryVisibleForWorkspace(scopedAB, "ws-3"), false);
+  assert.equal(entryVisibleForWorkspace(scopedOther, "ws-1"), false);
+  assert.equal(entryVisibleForWorkspace(scopedAB, null), false);
+});
+
+test("visibleBoardEntries 'workspace' filter scopes by current workspace audience plus broadcast (FR-098)", () => {
+  const broadcast = { id: "broadcast", audience: [], mentions: [] };
+  const scopedSelf = { id: "scoped-self", audience: ["ws-1"], mentions: [] };
+  const scopedOther = { id: "scoped-other", audience: ["ws-2"], mentions: [] };
+
+  const state = {
+    entries: [broadcast, scopedSelf, scopedOther],
+    audienceFilter: "workspace",
+    currentWorkspaceId: "ws-1",
+  };
+
+  const visibleIds = visibleBoardEntries(state, []).map((entry) => entry.id);
+  assert.deepEqual(visibleIds, ["broadcast", "scoped-self"]);
+});
+
+test("visibleBoardEntries 'workspace' filter for unassigned agent shows only broadcast", () => {
+  const broadcast = { id: "broadcast", audience: [], mentions: [] };
+  const scoped = { id: "scoped", audience: ["ws-1"], mentions: [] };
+
+  const state = {
+    entries: [broadcast, scoped],
+    audienceFilter: "workspace",
+    currentWorkspaceId: null,
+  };
+
+  const visibleIds = visibleBoardEntries(state, []).map((entry) => entry.id);
+  assert.deepEqual(visibleIds, ["broadcast"]);
+});
+
+test("visibleBoardEntries 'all' filter still bypasses workspace scoping", () => {
+  const broadcast = { id: "broadcast", audience: [], mentions: [] };
+  const scopedOther = { id: "scoped-other", audience: ["ws-2"], mentions: [] };
+
+  const state = {
+    entries: [broadcast, scopedOther],
+    audienceFilter: "all",
+    currentWorkspaceId: "ws-1",
+  };
+
+  const visibleIds = visibleBoardEntries(state, []).map((entry) => entry.id);
+  assert.deepEqual(visibleIds, ["broadcast", "scoped-other"]);
 });
 
 test("Board notification helper prepares focused state for click-through", () => {

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1176,6 +1176,19 @@ test("Branch rows are keyboard-navigable with click + dblclick parity", () => {
   );
 });
 
+test("Branches toolbar exposes explicit Launch Agent action for selected branch", () => {
+  assert.match(
+    appSource,
+    /data-action="open-branch-launch"/,
+    "expected Branches toolbar to include an explicit Launch Agent action",
+  );
+  assert.match(
+    appSource,
+    /selectedBranchName[\s\S]{0,300}?kind:\s*"open_launch_wizard"|kind:\s*"open_launch_wizard"[\s\S]{0,300}?selectedBranchName/,
+    "expected Branches toolbar Launch Agent action to send selectedBranchName",
+  );
+});
+
 test("Keyboard-navigable rows have :focus-visible outlines", () => {
   // After PRs #2464/#2465 made file-tree-row and branch-row keyboard-
   // navigable, the rows could receive focus but had no visible outline
@@ -1192,6 +1205,29 @@ test("Keyboard-navigable rows have :focus-visible outlines", () => {
       `expected ${selector} to be in the unified focus-visible group`,
     );
   }
+});
+
+test("Launch wizard open errors render in wizard modal and close locally", () => {
+  assert.match(
+    appSource,
+    /let\s+launchWizardOpenError\s*=\s*null/,
+    "expected frontend to track launch wizard open errors separately from project_open_error",
+  );
+  assert.match(
+    appSource,
+    /case\s+"launch_wizard_open_error":[\s\S]{0,300}?launchWizardOpenError\s*=/,
+    "expected launch_wizard_open_error events to populate wizard error state",
+  );
+  assert.match(
+    appSource,
+    /function\s+closeLaunchWizardLocal\(\)[\s\S]{0,300}?launchWizardOpenError\s*=\s*null/,
+    "expected a local close path for error-only wizard state",
+  );
+  assert.match(
+    appSource,
+    /wizardModal\.classList\.contains\("open"\)[\s\S]{0,500}?closeLaunchWizardLocal\(\)[\s\S]{0,500}?sendAction\(\{\s*kind:\s*"cancel"/,
+    "expected Esc/backdrop/close to locally dismiss error-only wizard state before sending backend cancel",
+  );
 });
 
 test("File tree rows are keyboard-navigable (tabindex + role + keydown)", () => {

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -242,3 +242,295 @@ function createFixture({ confirmResult = true } = {}) {
     },
   };
 }
+
+// SPEC-2041 Phase 19 (FR-052..066) — Post-click modal & restart UX.
+//
+// These tests pin the modal-driven state machine before implementation.
+// They will fail against the current `update-cta.js` (which uses
+// window.confirm and immediate apply_update_state_and_exit). The implementation
+// in T-122 must satisfy these invariants without regressing earlier tests.
+
+test("phase19: click no longer uses window.confirm and instead opens #update-modal in downloading state", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+
+  fixture.document.getElementById("update-cta").click();
+
+  assert.equal(
+    fixture.confirmCalls.length,
+    0,
+    "window.confirm must not be called; the modal replaces it",
+  );
+  const modal = fixture.document.getElementById("update-modal");
+  assert.ok(modal, "expected #update-modal to be rendered after click");
+  assert.equal(modal.dataset.state, "downloading");
+  assert.deepEqual(fixture.sent, [{ kind: "apply_update_start" }]);
+  assert.equal(
+    fixture.document.getElementById("update-cta").dataset.status,
+    "applying",
+  );
+});
+
+test("phase19: update_progress events update modal progress bar and byte counter", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  controller.handleUpdateProgress({
+    downloaded: 1024 * 1024,
+    total: 4 * 1024 * 1024,
+    asset: "gwt-macos-arm64.tar.gz",
+    version: "9.26.0",
+  });
+  controller.handleUpdateProgress({
+    downloaded: 3 * 1024 * 1024,
+    total: 4 * 1024 * 1024,
+    asset: "gwt-macos-arm64.tar.gz",
+    version: "9.26.0",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  const progress = modal.querySelector("[data-update-modal-progress]");
+  const counter = modal.querySelector("[data-update-modal-byte-counter]");
+  assert.ok(progress, "expected progress bar element");
+  assert.ok(counter, "expected byte counter element");
+  assert.equal(progress.getAttribute("aria-valuenow"), "75");
+  assert.match(counter.textContent, /3.0\s*MB\s*\/\s*4.0\s*MB/);
+});
+
+test("phase19: cancel during download sends cancel_update_download and returns CTA to available", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  fixture.document
+    .querySelector("[data-update-modal-cancel]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "cancel_update_download" },
+  ]);
+  assert.equal(fixture.document.getElementById("update-modal"), null);
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(cta.dataset.status, "available");
+});
+
+test("phase19: update_ready transitions modal to ready state with [Later] [Restart now]", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  controller.handleUpdateReady({
+    version: "9.26.0",
+    asset_path: "/Users/x/.gwt/pending-update/9.26.0/gwt-macos-arm64.tar.gz",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.equal(modal.dataset.state, "ready");
+  assert.ok(modal.querySelector("[data-update-modal-restart-now]"));
+  assert.ok(modal.querySelector("[data-update-modal-later]"));
+});
+
+test("phase19: [Restart now] sends apply_update_restart_now without confirmation", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+
+  fixture.document
+    .querySelector("[data-update-modal-restart-now]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_restart_now" },
+  ]);
+  assert.equal(
+    fixture.confirmCalls.length,
+    0,
+    "Restart now must not gate behind window.confirm",
+  );
+});
+
+test("phase19: [Later] closes modal, sends apply_update_later, and morphs CTA to ready state", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+
+  fixture.document
+    .querySelector("[data-update-modal-later]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_later" },
+  ]);
+  assert.equal(fixture.document.getElementById("update-modal"), null);
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(cta.dataset.status, "ready");
+  assert.match(cta.textContent, /Update v9.26.0 ready\s*[—-]\s*Restart now/);
+  assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
+});
+
+test("phase19: re-clicking CTA in ready state opens modal at ready (no re-download)", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+  fixture.document.querySelector("[data-update-modal-later]").click();
+
+  fixture.document.getElementById("update-cta").click();
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.ok(modal, "modal should reopen on re-click");
+  assert.equal(modal.dataset.state, "ready");
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_later" },
+  ]);
+});
+
+test("phase19: dismiss in ready state hides CTA without losing pending binary", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+  fixture.document.querySelector("[data-update-modal-later]").click();
+
+  fixture.document
+    .querySelector("[data-update-cta-dismiss]")
+    .click();
+
+  assert.equal(fixture.document.getElementById("update-cta"), null);
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_later" },
+  ]);
+});
+
+test("phase19: update_apply_error transitions modal to failed state with stage/reason/log/buttons", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  controller.handleUpdateApplyError({
+    stage: "Download asset",
+    reason: "HTTP 503",
+    log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.equal(modal.dataset.state, "failed");
+  const stage = modal.querySelector("[data-update-modal-stage]");
+  const reason = modal.querySelector("[data-update-modal-reason]");
+  const log = modal.querySelector("[data-update-modal-log]");
+  assert.match(stage.textContent, /Download asset/);
+  assert.match(reason.textContent, /HTTP 503/);
+  assert.match(log.textContent, /update-2026-05-10/);
+  assert.ok(modal.querySelector("[data-update-modal-open-log]"));
+  assert.ok(modal.querySelector("[data-update-modal-retry]"));
+  assert.ok(modal.querySelector("[data-update-modal-close]"));
+});
+
+test("phase19: failed-state [Retry] resends apply_update_start and switches modal back to downloading", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateApplyError({
+    stage: "Download asset",
+    reason: "HTTP 503",
+    log_path: "/x.log",
+  });
+
+  fixture.document
+    .querySelector("[data-update-modal-retry]")
+    .click();
+
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_start" },
+  ]);
+  assert.equal(
+    fixture.document.getElementById("update-modal").dataset.state,
+    "downloading",
+  );
+});
+
+test("phase19: failed-state [Open log] sends open_update_log with the log_path", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateApplyError({
+    stage: "Replace binary",
+    reason: "EPERM",
+    log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+  });
+
+  fixture.document
+    .querySelector("[data-update-modal-open-log]")
+    .click();
+
+  assert.deepEqual(fixture.sent.slice(-1), [
+    {
+      kind: "open_update_log",
+      log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+    },
+  ]);
+});
+
+test("phase19: failed-state [Close] closes modal and returns CTA to available", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateApplyError({
+    stage: "Download asset",
+    reason: "HTTP 503",
+    log_path: "/x.log",
+  });
+
+  fixture.document
+    .querySelector("[data-update-modal-close]")
+    .click();
+
+  assert.equal(fixture.document.getElementById("update-modal"), null);
+  assert.equal(
+    fixture.document.getElementById("update-cta").dataset.status,
+    "available",
+  );
+});
+
+test("phase19: update_apply_pending_persisted morphs CTA directly to ready state (next-launch path)", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+
+  controller.handleUpdateApplyPendingPersisted({ version: "9.26.0" });
+
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(cta.dataset.status, "ready");
+  assert.match(cta.textContent, /Update v9.26.0 ready\s*[—-]\s*Restart now/);
+  assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
+});
+
+test("phase19: controller exposes the Phase 19 event handlers required by app.js wiring", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+
+  assert.equal(typeof controller.handleUpdateProgress, "function");
+  assert.equal(typeof controller.handleUpdateReady, "function");
+  assert.equal(typeof controller.handleUpdateApplyError, "function");
+  assert.equal(typeof controller.handleUpdateApplyPendingPersisted, "function");
+});

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -48,26 +48,17 @@ test("update_state renders one reusable update CTA", () => {
   assert.equal(fixture.versionUpdates.length, 2);
 });
 
-test("update CTA click cancel leaves it available and does not send apply_update", () => {
-  const fixture = createFixture({ confirmResult: false });
-  const controller = createUpdateCtaController(fixture.options);
-  controller.showAvailable("9.23.0");
-
-  fixture.document.getElementById("update-cta").click();
-
-  assert.equal(fixture.confirmCalls.length, 1);
-  assert.deepEqual(fixture.sent, []);
-  assert.equal(fixture.document.getElementById("update-cta").dataset.status, "available");
-});
-
-test("update CTA click approve sends apply_update and shows applying state", () => {
+// Phase 19 supersedes the Phase 14 window.confirm gate. The "click cancel"
+// test is dropped because the new modal flow always sends apply_update_start;
+// see the dedicated phase19 tests below for the modal-driven cancel path.
+test("update CTA click sends apply_update_start and shows applying state with modal", () => {
   const fixture = createFixture({ confirmResult: true });
   const controller = createUpdateCtaController(fixture.options);
   controller.showAvailable("9.23.0");
 
   fixture.document.getElementById("update-cta").click();
 
-  assert.deepEqual(fixture.sent, [{ kind: "apply_update" }]);
+  assert.deepEqual(fixture.sent, [{ kind: "apply_update_start" }]);
   const cta = fixture.document.getElementById("update-cta");
   assert.equal(cta.dataset.status, "applying");
   assert.equal(cta.disabled, true);
@@ -114,7 +105,10 @@ test("update_apply_error reuses the same CTA and allows retry", () => {
   assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
 
   cta.click();
-  assert.deepEqual(fixture.sent, [{ kind: "apply_update" }, { kind: "apply_update" }]);
+  assert.deepEqual(fixture.sent, [
+    { kind: "apply_update_start" },
+    { kind: "apply_update_start" },
+  ]);
 });
 
 test("update CTA dismiss hides available state without applying", () => {
@@ -159,7 +153,7 @@ test("update CTA dismiss hides error state without retrying", () => {
   fixture.document.querySelector("[data-update-cta-dismiss]").click();
 
   assert.equal(fixture.document.getElementById("update-cta"), null);
-  assert.deepEqual(fixture.sent, [{ kind: "apply_update" }]);
+  assert.deepEqual(fixture.sent, [{ kind: "apply_update_start" }]);
 });
 
 test("update_state removes stale split toast and button DOM before showing CTA", () => {
@@ -193,7 +187,14 @@ test("update_state removes stale split toast and button DOM before showing CTA",
 test("app.js delegates update handling to the unified update CTA controller", () => {
   assert.match(appSource, /createUpdateCtaController/);
   assert.match(appSource, /updateCtaController\.handleUpdateState\(event\)/);
-  assert.match(appSource, /updateCtaController\.showError\(/);
+  // Phase 19 replaces showError() with handleUpdateApplyError().
+  assert.match(appSource, /updateCtaController\.handleUpdateApplyError\(/);
+  assert.match(appSource, /updateCtaController\.handleUpdateProgress\(/);
+  assert.match(appSource, /updateCtaController\.handleUpdateReady\(/);
+  assert.match(
+    appSource,
+    /updateCtaController\.handleUpdateApplyPendingPersisted\(/,
+  );
 });
 
 test("legacy split update toast and button surfaces are removed", () => {

--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -526,6 +526,48 @@ test("phase19: update_apply_pending_persisted morphs CTA directly to ready state
   assert.ok(fixture.document.querySelector("[data-update-cta-dismiss]"));
 });
 
+// SPEC-2041 Phase 19 (FR-064 follow-up, CodeRabbit review on PR #2635):
+// Later -> commit_update_later_pending can detect that the manifest persisted
+// by ApplyUpdateStart's worker thread vanished (external cleanup, disk-full
+// race). In that case backend emits update_apply_error AFTER the CTA has
+// already morphed to "ready". The frontend must surface the failure modal
+// even though status === "ready" so the user is not silently misled.
+test("phase19: update_apply_error in ready state re-opens failed modal", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+
+  // Simulate the post-Later state that the next-launch path lands in.
+  controller.handleUpdateApplyPendingPersisted({ version: "9.26.0" });
+  const ctaBefore = fixture.document.getElementById("update-cta");
+  assert.equal(ctaBefore.dataset.status, "ready");
+
+  // Backend reports the persisted manifest is gone.
+  controller.handleUpdateApplyError({
+    stage: "Persist pending",
+    reason: "Pending update manifest is missing; download did not persist.",
+    log_path: "/Users/x/.gwt/logs/update-2026-05-10.log",
+  });
+
+  const modal = fixture.document.getElementById("update-modal");
+  assert.ok(modal, "modal must reopen so the failure is visible");
+  assert.equal(modal.dataset.state, "failed");
+  assert.match(
+    modal.querySelector("[data-update-modal-stage]").textContent,
+    /Persist pending/,
+  );
+  assert.match(
+    modal.querySelector("[data-update-modal-reason]").textContent,
+    /manifest is missing/,
+  );
+
+  const cta = fixture.document.getElementById("update-cta");
+  assert.equal(
+    cta.dataset.status,
+    "applying",
+    "CTA flips to applying so the modal sits visually on top",
+  );
+});
+
 test("phase19: controller exposes the Phase 19 event handlers required by app.js wiring", () => {
   const fixture = createFixture();
   const controller = createUpdateCtaController(fixture.options);

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -148,19 +148,55 @@ test("Workspace Kanban labels the non-current history column as Inactive", () =>
   );
 });
 
-test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", () => {
+test("Workspace Kanban renders Unassigned agents outside Workspace status columns", () => {
+  const fixture = createFixture();
+  const projection = {
+    id: "project-workspace",
+    title: "Project workspace",
+    status_category: "idle",
+    status_text: "No active Workspace selected",
+    journal_entries: [],
+    workspaces: [],
+    unassigned_agents: [
+      {
+        session_id: "session-unassigned",
+        display_name: "Codex",
+        status_category: "active",
+        affiliation_status: "unassigned",
+        branch: "work/20260511-0100",
+      },
+    ],
+  };
+
+  const surface = createSurface(fixture, projection);
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const unassigned = fixture.body.querySelector("[data-role='unassigned-agents']");
+  assert.ok(unassigned, "Unassigned section should be rendered");
+  assert.match(unassigned.textContent, /Unassigned/);
+  assert.match(unassigned.textContent, /No Workspace selected/);
+  assert.match(unassigned.textContent, /Codex/);
+  assert.equal(cardTexts(column(fixture.body, "active")).length, 0);
+  assert.equal(cardTexts(column(fixture.body, "inactive")).length, 1);
+  assert.doesNotMatch(fixture.body.textContent, /WorkItem/);
+});
+
+test("Workspace Kanban renders Workspace history cards with lifecycle timeline detail", () => {
   const fixture = createFixture();
   const projection = {
     id: "current-workspace",
     title: "Legacy current Workspace",
     status_category: "idle",
     status_text: "Idle",
-    work_items: [
+    workspaces: [
       {
-        id: "workitem-history",
-        title: "Workspace WorkItem history",
-        intent: "Group duplicate Workspace work under one WorkItem",
-        summary: "One WorkItem owns the history.",
+        id: "workspace-history",
+        title: "Workspace history",
+        intent: "Group duplicate work under one Workspace",
+        summary: "One Workspace owns the history.",
         status_category: "active",
         owner: "SPEC-2359",
         agents: [
@@ -184,7 +220,7 @@ test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", (
           {
             id: "evt-start",
             kind: "start",
-            title: "Start WorkItem",
+            title: "Start Workspace",
             summary: "Started lifecycle implementation.",
             updated_at: "2026-05-11T01:00:00Z",
             agent_session_id: "session-other",
@@ -217,8 +253,9 @@ test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", (
   });
 
   const cardText = cardTexts(column(fixture.body, "active")).join("\n");
-  assert.match(cardText, /WorkItem/);
-  assert.match(cardText, /Workspace WorkItem history/);
+  assert.match(cardText, /Workspace/);
+  assert.match(cardText, /Workspace history/);
+  assert.doesNotMatch(cardText, /WorkItem/);
   assert.doesNotMatch(cardText, /Legacy duplicate card/);
 
   const detailText = fixture.body

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -148,6 +148,92 @@ test("Workspace Kanban labels the non-current history column as Inactive", () =>
   );
 });
 
+test("Workspace Kanban renders WorkItem cards with lifecycle timeline detail", () => {
+  const fixture = createFixture();
+  const projection = {
+    id: "current-workspace",
+    title: "Legacy current Workspace",
+    status_category: "idle",
+    status_text: "Idle",
+    work_items: [
+      {
+        id: "workitem-history",
+        title: "Workspace WorkItem history",
+        intent: "Group duplicate Workspace work under one WorkItem",
+        summary: "One WorkItem owns the history.",
+        status_category: "active",
+        owner: "SPEC-2359",
+        agents: [
+          {
+            session_id: "session-other",
+            display_name: "Codex",
+            status_category: "active",
+          },
+        ],
+        execution_containers: [
+          {
+            branch: "work/20260510-2353",
+            worktree_path: "/repo/work/20260510-2353",
+            pr_number: 2638,
+            pr_url: "https://github.com/akiojin/gwt/pull/2638",
+            pr_state: "open",
+          },
+        ],
+        board_refs: ["board-claim-1"],
+        events: [
+          {
+            id: "evt-start",
+            kind: "start",
+            title: "Start WorkItem",
+            summary: "Started lifecycle implementation.",
+            updated_at: "2026-05-11T01:00:00Z",
+            agent_session_id: "session-other",
+            board_entry_id: "board-claim-1",
+          },
+          {
+            id: "evt-blocked",
+            kind: "blocked",
+            summary: "Waiting for Board coordination.",
+            updated_at: "2026-05-11T01:10:00Z",
+            agent_session_id: "session-other",
+            board_entry_id: "board-blocked-1",
+          },
+        ],
+      },
+    ],
+    journal_entries: [
+      {
+        id: "legacy-journal",
+        status_category: "active",
+        agent_title_summary: "Legacy duplicate card",
+      },
+    ],
+  };
+
+  const surface = createSurface(fixture, projection);
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const cardText = cardTexts(column(fixture.body, "active")).join("\n");
+  assert.match(cardText, /WorkItem/);
+  assert.match(cardText, /Workspace WorkItem history/);
+  assert.doesNotMatch(cardText, /Legacy duplicate card/);
+
+  const detailText = fixture.body
+    .querySelector(".workspace-kanban-detail-pane")
+    .textContent.replace(/\s+/g, " ")
+    .trim();
+  assert.match(detailText, /Lifecycle/);
+  assert.match(detailText, /start/);
+  assert.match(detailText, /Started lifecycle implementation/);
+  assert.match(detailText, /board-claim-1/);
+  assert.match(detailText, /blocked/);
+  assert.match(detailText, /Waiting for Board coordination/);
+  assert.match(detailText, /board-blocked-1/);
+});
+
 function createFixture() {
   const { document } = parseHTML(`
     <div id="workspace-window">

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2710,7 +2710,8 @@
             newEntriesAvailable: false,
             focusEntryId: null,
             pendingFocusScroll: false,
-            audienceFilter: "all",
+            audienceFilter: "workspace",
+            currentWorkspaceId: "",
             forYouUnread: 0,
             lastNotifiedMentionEntryId: null,
           });
@@ -2779,6 +2780,7 @@
         send({
           kind: "load_board",
           id: windowId,
+          all: state.audienceFilter === "all",
         });
       }
 
@@ -2798,6 +2800,7 @@
           id: windowId,
           before_entry_id: beforeEntryId,
           limit: 50,
+          all: state.audienceFilter === "all",
         });
       }
 
@@ -3859,6 +3862,7 @@
         const status = body.querySelector(".board-status");
         const timeline = body.querySelector(".board-timeline");
         const composer = body.querySelector(".board-composer-pane");
+        const allFilter = body.querySelector("[data-action='toggle-board-all']");
         const forYouFilter = body.querySelector("[data-action='toggle-board-for-you']");
         if (!status || !timeline || !composer) {
           return;
@@ -3867,6 +3871,10 @@
           state.focusEntryId = pendingBoardEntryFocusId;
           state.pendingFocusScroll = true;
         }
+        state.currentWorkspaceId =
+          activeWorkProjection && (activeWorkProjection.agents || []).length > 0
+            ? activeWorkProjection.id || ""
+            : "";
 
         const entryCountLabel = `${state.entries.length} entr${state.entries.length === 1 ? "y" : "ies"}`;
         status.textContent = state.error
@@ -3885,6 +3893,13 @@
           status.classList.add("error");
         } else if (state.loading) {
           status.classList.add("info");
+        }
+        if (allFilter) {
+          allFilter.setAttribute(
+            "aria-pressed",
+            state.audienceFilter === "all" ? "true" : "false",
+          );
+          allFilter.classList.toggle("active", state.audienceFilter === "all");
         }
         if (forYouFilter) {
           forYouFilter.setAttribute(
@@ -3949,6 +3964,8 @@
               "board-empty workspace-empty-state",
               state.audienceFilter === "for_you"
                 ? "No posts addressed to you."
+                : state.audienceFilter === "workspace"
+                  ? "No posts in this Workspace."
                 : "No coordination entries yet.",
             ),
           );
@@ -6238,6 +6255,7 @@
                   <div class="board-status"></div>
                 </div>
                 <div class="workspace-toolbar-actions">
+                  <button class="text-button board-all-filter" data-action="toggle-board-all" type="button" aria-pressed="false">All</button>
                   <button class="text-button board-for-you-filter" data-action="toggle-board-for-you" type="button" aria-pressed="false">For you</button>
                   <button class="icon-button" data-action="refresh-board" aria-label="Refresh board">↻</button>
                 </div>
@@ -6270,10 +6288,21 @@
             .addEventListener("click", (event) => {
               event.stopPropagation();
               const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);
-              state.audienceFilter = state.audienceFilter === "for_you" ? "all" : "for_you";
+              state.audienceFilter =
+                state.audienceFilter === "for_you" ? "workspace" : "for_you";
               if (state.audienceFilter === "for_you") {
                 state.forYouUnread = 0;
               }
+              frontendUnits.boardSurface.renderBoard(windowData.id);
+            });
+          body
+            .querySelector("[data-action='toggle-board-all']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);
+              state.audienceFilter = state.audienceFilter === "all" ? "workspace" : "all";
+              state.error = "";
+              frontendUnits.boardSurface.requestBoard(windowData.id);
               frontendUnits.boardSurface.renderBoard(windowData.id);
             });
           const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -205,12 +205,14 @@
           owner: "launch-wizard-surface",
           state: Object.freeze([
             "launchWizard",
+            "launchWizardOpenError",
             "wizardWasOpen",
             "wizardBranchDraft",
             "wizardBranchBackendValue",
           ]),
           mutatedBy: Object.freeze([
             "openIssueLaunchWizard",
+            "closeLaunchWizardLocal",
             "sendWizardAction",
             "renderLaunchWizard",
             "flushWizardBranchDraft",
@@ -261,6 +263,7 @@
       let viewport = { x: 0, y: 0, zoom: 1 };
       let viewportRasterTimer = null;
       let launchWizard = null;
+      let launchWizardOpenError = null;
       let activeWorkProjection = null;
       let pendingBoardEntryFocusId = null;
       let wizardWasOpen = false;
@@ -4304,8 +4307,22 @@
       let wizardFocusReturn = null;
       let wizardFocusTrapRelease = null;
 
+      function closeLaunchWizardLocal() {
+        launchWizard = null;
+        launchWizardOpenError = null;
+        renderLaunchWizard();
+      }
+
+      function closeLaunchWizardFromChrome() {
+        if (launchWizardOpenError) {
+          closeLaunchWizardLocal();
+          return;
+        }
+        frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+      }
+
       function renderLaunchWizard() {
-        if (!launchWizard) {
+        if (!launchWizard && !launchWizardOpenError) {
           const wasOpenBeforeClose = wizardModal.classList.contains("open");
           wizardModal.classList.remove("open");
           // SPEC-2356 — keep aria-hidden in lockstep with .open so screen
@@ -4333,13 +4350,17 @@
           if (wizardTitle) wizardTitle.textContent = "Launch Agent";
           wizardSubmitButton.textContent = "Launch";
           wizardSubmitButton.disabled = false;
+          wizardSubmitButton.hidden = false;
+          wizardCancelButton.textContent = "Cancel";
           syncWizardDraftState();
           return;
         }
 
         syncWizardDraftState();
         closeModal();
-        const isStartWorkMode = launchWizard.show_branch_controls === false;
+        const isStartWorkMode =
+          launchWizard?.show_branch_controls === false ||
+          launchWizardOpenError?.title === "Start Work";
         wizardModal.classList.toggle("is-drawer", isStartWorkMode);
         wizardDialog?.classList.toggle("is-drawer-shell", isStartWorkMode);
         const wasOpenWizard = wizardModal.classList.contains("open");
@@ -4361,6 +4382,28 @@
           // keyboard users can't escape into background content.
           wizardFocusTrapRelease = createFocusTrap(wizardDialog, { document });
         }
+
+        if (launchWizardOpenError) {
+          if (wizardTitle) {
+            wizardTitle.textContent = launchWizardOpenError.title || "Launch Agent";
+          }
+          wizardMeta.textContent =
+            launchWizardOpenError.title === "Start Work"
+              ? "Workspace launch"
+              : "Launch Agent";
+          wizardSubmitButton.hidden = true;
+          wizardSubmitButton.disabled = true;
+          wizardCancelButton.textContent = "Close";
+          wizardError.hidden = false;
+          wizardError.textContent =
+            launchWizardOpenError.message || "Unable to open Launch Wizard";
+          wizardSummary.innerHTML = "";
+          wizardBody.innerHTML = "";
+          return;
+        }
+
+        wizardSubmitButton.hidden = false;
+        wizardCancelButton.textContent = "Cancel";
         if (wizardTitle) wizardTitle.textContent = launchWizard.title || "Launch Agent";
         wizardMeta.textContent = launchWizard.show_branch_controls === false
           ? "Workspace launch"
@@ -5136,6 +5179,7 @@
         syncBranchSelectionState(state);
         const list = element.querySelector(".branch-list");
         const notice = element.querySelector(".branch-notice");
+        const launchButton = element.querySelector("[data-action='open-branch-launch']");
         const cleanupButton = element.querySelector("[data-action='open-branch-cleanup']");
         if (!list) {
           return;
@@ -5143,6 +5187,9 @@
 
         for (const button of element.querySelectorAll("[data-branch-filter]")) {
           button.classList.toggle("active", button.dataset.branchFilter === state.filter);
+        }
+        if (launchButton) {
+          launchButton.disabled = !state.selectedBranchName;
         }
         if (cleanupButton) {
           const selectedCount = selectedBranchCleanupEntries(windowId).length;
@@ -6063,6 +6110,7 @@
                   </div>
                 </div>
                 <div class="branch-toolbar-actions workspace-toolbar-actions">
+                  <button class="wizard-button primary branch-launch-trigger" type="button" data-action="open-branch-launch" disabled>Launch Agent</button>
                   <button class="wizard-button branch-cleanup-trigger" type="button" data-action="open-branch-cleanup">Clean Up</button>
                   <button class="icon-button" data-action="refresh-branches" aria-label="Refresh branches">↻</button>
                 </div>
@@ -6099,6 +6147,22 @@
               frontendUnits.branchesFileTreeSurface.renderBranches(windowData.id);
             });
           }
+          body
+            .querySelector("[data-action='open-branch-launch']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = frontendUnits.branchesFileTreeSurface.ensureBranchListState(
+                windowData.id,
+              );
+              if (!state.selectedBranchName) {
+                return;
+              }
+              send({
+                kind: "open_launch_wizard",
+                id: windowData.id,
+                branch_name: state.selectedBranchName,
+              });
+            });
           body
             .querySelector("[data-action='open-branch-cleanup']")
             .addEventListener("click", (event) => {
@@ -7789,8 +7853,17 @@
               frontendUnits.projectWorkspaceShell.activeProjectTab(),
             );
             break;
+          case "launch_wizard_open_error":
+            launchWizard = null;
+            launchWizardOpenError = {
+              title: event.title || "Launch Agent",
+              message: event.message || "Unable to open Launch Wizard",
+            };
+            frontendUnits.launchWizardSurface.render();
+            break;
           case "launch_wizard_state":
             launchWizard = event.wizard;
+            launchWizardOpenError = null;
             frontendUnits.launchWizardSurface.render();
             break;
           case "runtime_hook_event":
@@ -8212,19 +8285,18 @@
           closeModal();
         }
       });
-      wizardCloseButton.addEventListener("click", () => {
-        frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
-      });
-      wizardCancelButton.addEventListener("click", () => {
-        frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
-      });
+      wizardCloseButton.addEventListener("click", closeLaunchWizardFromChrome);
+      wizardCancelButton.addEventListener("click", closeLaunchWizardFromChrome);
       wizardSubmitButton.addEventListener("click", () => {
+        if (launchWizardOpenError) {
+          return;
+        }
         frontendUnits.launchWizardSurface.flushBranchDraft();
         frontendUnits.launchWizardSurface.sendAction({ kind: "submit" });
       });
       wizardModal.addEventListener("click", (event) => {
         if (event.target === wizardModal) {
-          frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+          closeLaunchWizardFromChrome();
         }
       });
       branchCleanupModal.addEventListener("click", (event) => {
@@ -8268,7 +8340,11 @@
         if (wizardModal.classList.contains("open")) {
           // Wizard cancel is the explicit cancellation path; map Esc to
           // the same action so the modal isn't a keyboard trap.
-          frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+          if (launchWizardOpenError) {
+            closeLaunchWizardLocal();
+          } else {
+            frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
+          }
           event.preventDefault();
           return;
         }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -15,6 +15,9 @@
         applyBoardMentionNotificationFocus,
         boardEntryAudienceLabels,
         boardEntryMentionsSelf,
+        boardEntryOriginActionLabel,
+        boardEntryOriginLabel,
+        boardEntryOriginSessionId,
         boardEntryPreview,
         findBoardEntry,
         mentionsForBoardSubmit,
@@ -3040,6 +3043,29 @@
         });
       }
 
+      function boardOriginActiveAgents() {
+        const assigned = Array.isArray(activeWorkProjection?.agents)
+          ? activeWorkProjection.agents
+          : [];
+        const unassigned = Array.isArray(activeWorkProjection?.unassigned_agents)
+          ? activeWorkProjection.unassigned_agents
+          : [];
+        return assigned.concat(unassigned);
+      }
+
+      function openBoardOriginAgent(windowId, entry) {
+        const originSessionId = boardEntryOriginSessionId(entry);
+        if (!originSessionId) {
+          return;
+        }
+        send({
+          kind: "open_board_origin_agent",
+          id: windowId,
+          origin_session_id: originSessionId,
+          bounds: visibleBounds(),
+        });
+      }
+
       function logMatchesQuery(entry, query) {
         if (!query) {
           return true;
@@ -4004,6 +4030,10 @@
             }
             meta.appendChild(badge);
           }
+          const originLabel = boardEntryOriginLabel(entry);
+          if (originLabel) {
+            meta.appendChild(createNode("span", "board-origin-badge", originLabel));
+          }
           card.appendChild(meta);
           if (entry.parent_id) {
             const parent = findBoardEntry(state, entry.parent_id);
@@ -4029,6 +4059,16 @@
             input?.focus();
           });
           messageActions.appendChild(replyButton);
+          const originActionLabel = boardEntryOriginActionLabel(
+            entry,
+            boardOriginActiveAgents(),
+          );
+          if (originActionLabel) {
+            const originButton = createNode("button", "board-origin-button", originActionLabel);
+            originButton.type = "button";
+            originButton.addEventListener("click", () => openBoardOriginAgent(windowId, entry));
+            messageActions.appendChild(originButton);
+          }
           card.appendChild(messageActions);
           timeline.appendChild(card);
         }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7801,8 +7801,31 @@
               updateCtaController.handleUpdateState(event);
             }
             break;
+          case "update_progress":
+            updateCtaController.handleUpdateProgress({
+              downloaded: event.downloaded,
+              total: event.total,
+              asset: event.asset,
+              version: event.version,
+            });
+            break;
+          case "update_ready":
+            updateCtaController.handleUpdateReady({
+              version: event.version,
+              asset_path: event.asset_path,
+            });
+            break;
           case "update_apply_error":
-            updateCtaController.showError(event.message || "Failed to start the update.");
+            updateCtaController.handleUpdateApplyError({
+              stage: event.stage,
+              reason: event.reason || event.message,
+              log_path: event.log_path,
+            });
+            break;
+          case "update_apply_pending_persisted":
+            updateCtaController.handleUpdateApplyPendingPersisted({
+              version: event.version,
+            });
             break;
           case "custom_agent_list":
             customAgentsState.agents = event.agents || [];

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -972,6 +972,11 @@
         const tab = activeProjectTab();
         renderProjectOnboarding(tab);
         renderWorkspace(tab?.workspace || emptyWorkspace());
+        const nextWorkspaceId = deriveCurrentProjectWorkspaceId(tab?.workspace || {});
+        if (nextWorkspaceId !== currentProjectWorkspaceId) {
+          currentProjectWorkspaceId = nextWorkspaceId;
+          refreshBoardCurrentWorkspaceId();
+        }
         renderWindowList();
         renderActiveWorkOverview();
       }
@@ -2713,9 +2718,35 @@
             audienceFilter: "all",
             forYouUnread: 0,
             lastNotifiedMentionEntryId: null,
+            currentWorkspaceId: currentProjectWorkspaceId,
           });
         }
         return boardStateMap.get(windowId);
+      }
+
+      // SPEC-2359 FR-098/101: track the project's "primary" assigned
+      // workspace id for the Board Workspace filter. Picks the first
+      // assigned agent's workspace_id from the workspace state event.
+      // When no agent in the project is assigned (all Unassigned), the
+      // filter degrades to broadcast-only via FR-103. Multi-workspace
+      // selection UX is a follow-up.
+      let currentProjectWorkspaceId = null;
+      function deriveCurrentProjectWorkspaceId(workspaceState) {
+        const agents = workspaceState?.workspace?.agents
+          || workspaceState?.agents
+          || [];
+        const assigned = agents.find(
+          (agent) =>
+            String(agent?.affiliation_status || "").toLowerCase() === "assigned"
+            && typeof agent?.workspace_id === "string"
+            && agent.workspace_id.length > 0,
+        );
+        return assigned ? assigned.workspace_id : null;
+      }
+      function refreshBoardCurrentWorkspaceId() {
+        for (const state of boardStateMap.values()) {
+          state.currentWorkspaceId = currentProjectWorkspaceId;
+        }
       }
 
       function normalizeLogSeverity(severity) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3860,6 +3860,7 @@
         const timeline = body.querySelector(".board-timeline");
         const composer = body.querySelector(".board-composer-pane");
         const forYouFilter = body.querySelector("[data-action='toggle-board-for-you']");
+        const workspaceFilter = body.querySelector("[data-action='toggle-board-workspace']");
         if (!status || !timeline || !composer) {
           return;
         }
@@ -3894,6 +3895,11 @@
           forYouFilter.classList.toggle("active", state.audienceFilter === "for_you");
           forYouFilter.textContent =
             state.forYouUnread > 0 ? `For you (${state.forYouUnread})` : "For you";
+        }
+        if (workspaceFilter) {
+          const workspaceActive = state.audienceFilter === "workspace";
+          workspaceFilter.setAttribute("aria-pressed", workspaceActive ? "true" : "false");
+          workspaceFilter.classList.toggle("active", workspaceActive);
         }
 
         // The actual scroll viewport is `.board-timeline-scroll`, the
@@ -6239,6 +6245,7 @@
                 </div>
                 <div class="workspace-toolbar-actions">
                   <button class="text-button board-for-you-filter" data-action="toggle-board-for-you" type="button" aria-pressed="false">For you</button>
+                  <button class="text-button board-workspace-filter" data-action="toggle-board-workspace" type="button" aria-pressed="false">Workspace</button>
                   <button class="icon-button" data-action="refresh-board" aria-label="Refresh board">↻</button>
                 </div>
               </div>
@@ -6274,6 +6281,20 @@
               if (state.audienceFilter === "for_you") {
                 state.forYouUnread = 0;
               }
+              frontendUnits.boardSurface.renderBoard(windowData.id);
+            });
+          // SPEC-2359 FR-101: toggle the Workspace audience filter. The
+          // entry visibility itself is driven by `state.audienceFilter ===
+          // "workspace"` plus `state.currentWorkspaceId` via
+          // `visibleBoardEntries`; the projection wires up the workspace
+          // id separately so unassigned agents see only broadcast.
+          body
+            .querySelector("[data-action='toggle-board-workspace']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);
+              state.audienceFilter =
+                state.audienceFilter === "workspace" ? "all" : "workspace";
               frontendUnits.boardSurface.renderBoard(windowData.id);
             });
           const state = frontendUnits.boardSurface.ensureBoardState(windowData.id);

--- a/crates/gwt/web/board-surface.js
+++ b/crates/gwt/web/board-surface.js
@@ -48,6 +48,31 @@ export function boardEntryAudienceLabels(entry, selfKeys = []) {
   return ["Broadcast"];
 }
 
+export function boardEntryOriginSessionId(entry) {
+  const authorKind = String(entry?.author_kind || "").toLowerCase();
+  const sessionId = String(entry?.origin_session_id || "").trim();
+  return authorKind === "agent" ? sessionId : "";
+}
+
+export function boardEntryOriginLabel(entry) {
+  const sessionId = boardEntryOriginSessionId(entry);
+  if (!sessionId) return "";
+  const agent = String(entry?.origin_agent_id || entry?.author || "").trim();
+  const branch = String(entry?.origin_branch || "").trim();
+  const shortSession = sessionId.slice(0, 8);
+  const parts = [agent, branch, shortSession].filter(Boolean);
+  return parts.length > 0 ? `From ${parts.join(" · ")}` : "";
+}
+
+export function boardEntryOriginActionLabel(entry, activeAgents = []) {
+  const sessionId = boardEntryOriginSessionId(entry);
+  if (!sessionId) return "";
+  const live = (activeAgents || []).some(
+    (agent) => String(agent?.session_id || "").trim() === sessionId && agent?.window_id,
+  );
+  return live ? "Focus Agent" : "Resume Agent";
+}
+
 export function boardEntryPreview(entry) {
   const body = String(entry?.body || "").replace(/\s+/g, " ").trim();
   if (!body) return "Empty entry";

--- a/crates/gwt/web/board-surface.js
+++ b/crates/gwt/web/board-surface.js
@@ -79,12 +79,27 @@ export function mentionsForBoardSubmit(state) {
   return mention ? [mention] : [];
 }
 
+// SPEC-2359 FR-093/098/103: mirror Rust `entry_visible_for_workspace`.
+// An entry is in-scope for Workspace W when its `audience` is empty
+// (broadcast) or contains W. Unassigned (`null`/`undefined`
+// workspaceId) only sees broadcast entries.
+export function entryVisibleForWorkspace(entry, currentWorkspaceId) {
+  const audience = Array.isArray(entry?.audience) ? entry.audience : [];
+  if (audience.length === 0) return true;
+  if (!currentWorkspaceId) return false;
+  return audience.includes(currentWorkspaceId);
+}
+
 export function visibleBoardEntries(state, selfKeys = []) {
   const entries = state?.entries || [];
-  if (state?.audienceFilter !== "for_you") {
-    return entries;
+  if (state?.audienceFilter === "for_you") {
+    return entries.filter((entry) => boardEntryMentionsSelf(entry, selfKeys));
   }
-  return entries.filter((entry) => boardEntryMentionsSelf(entry, selfKeys));
+  if (state?.audienceFilter === "workspace") {
+    const workspaceId = state?.currentWorkspaceId || null;
+    return entries.filter((entry) => entryVisibleForWorkspace(entry, workspaceId));
+  }
+  return entries;
 }
 
 export function applyBoardMentionNotificationFocus(state, entryId) {

--- a/crates/gwt/web/board-surface.js
+++ b/crates/gwt/web/board-surface.js
@@ -25,6 +25,10 @@ export function boardEntryMentionsSelf(entry, selfKeys = []) {
 }
 
 export function boardEntryAudienceLabels(entry, selfKeys = []) {
+  const workspaceAudience = normalizedBoardWorkspaceAudience(entry);
+  if (workspaceAudience.length > 0) {
+    return workspaceAudience.map((workspaceId) => `Workspace: ${workspaceId}`);
+  }
   const mentions = entry?.mentions || [];
   const keySet = new Set((selfKeys || []).map((key) => String(key).trim()).filter(Boolean));
   if (mentions.length > 0) {
@@ -38,6 +42,7 @@ export function boardEntryAudienceLabels(entry, selfKeys = []) {
       if (kind === "agent") return `To: ${label}`;
       if (kind === "session") return `Session: ${label}`;
       if (kind === "branch") return `Branch: ${label}`;
+      if (kind === "workspace") return `Workspace: ${label}`;
       return `To: ${label}`;
     });
   }
@@ -46,6 +51,24 @@ export function boardEntryAudienceLabels(entry, selfKeys = []) {
     return targets.map((target) => `To: ${target}`);
   }
   return ["Broadcast"];
+}
+
+export function normalizedBoardWorkspaceAudience(entry) {
+  const audience = Array.isArray(entry?.audience) ? entry.audience : [];
+  const normalized = [];
+  for (const value of audience) {
+    const workspaceId = String(value || "").trim();
+    if (!workspaceId || normalized.includes(workspaceId)) continue;
+    normalized.push(workspaceId);
+  }
+  return normalized;
+}
+
+export function boardEntryVisibleForWorkspace(entry, workspaceId) {
+  const audience = normalizedBoardWorkspaceAudience(entry);
+  if (audience.length === 0) return true;
+  const current = String(workspaceId || "").trim();
+  return Boolean(current) && audience.includes(current);
 }
 
 export function boardEntryPreview(entry) {
@@ -81,8 +104,13 @@ export function mentionsForBoardSubmit(state) {
 
 export function visibleBoardEntries(state, selfKeys = []) {
   const entries = state?.entries || [];
-  if (state?.audienceFilter !== "for_you") {
+  if (state?.audienceFilter === "all") {
     return entries;
+  }
+  if (state?.audienceFilter === "workspace") {
+    return entries.filter((entry) =>
+      boardEntryVisibleForWorkspace(entry, state?.currentWorkspaceId),
+    );
   }
   return entries.filter((entry) => boardEntryMentionsSelf(entry, selfKeys));
 }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -1672,6 +1672,20 @@
         background: color-mix(in oklab, var(--color-state-active) 18%, var(--color-surface-elevated));
       }
 
+      .board-origin-badge {
+        display: inline-flex;
+        align-items: center;
+        min-height: 18px;
+        padding: 2px 6px;
+        border: 1px solid color-mix(in oklab, var(--color-state-warning) 52%, var(--color-border));
+        border-radius: var(--radius-sm);
+        background: color-mix(in oklab, var(--color-state-warning) 12%, var(--color-surface));
+        color: var(--color-text);
+        font-family: var(--font-mono);
+        font-size: var(--type-2xs);
+        letter-spacing: var(--tracking-mono);
+      }
+
       .board-reply-quote {
         width: 100%;
         border: 1px solid var(--color-border);
@@ -1702,10 +1716,13 @@
 
       .board-message-actions {
         display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
         justify-content: flex-end;
       }
 
-      .board-reply-button {
+      .board-reply-button,
+      .board-origin-button {
         min-height: 26px;
         padding: 4px 8px;
         border: 1px solid var(--color-border);
@@ -1717,7 +1734,14 @@
         cursor: pointer;
       }
 
-      .board-reply-button:hover {
+      .board-origin-button {
+        border-color: color-mix(in oklab, var(--color-state-warning) 48%, var(--color-border));
+        color: var(--color-text);
+        background: color-mix(in oklab, var(--color-state-warning) 10%, var(--color-surface));
+      }
+
+      .board-reply-button:hover,
+      .board-origin-button:hover {
         color: var(--color-text);
         border-color: var(--color-focus-ring);
       }

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -203,10 +203,137 @@ body::after {
   color: var(--color-state-blocked);
 }
 
+.update-cta.is-ready {
+  border-color: var(--color-state-active, var(--color-focus-ring));
+  color: var(--color-state-active, var(--color-text-primary));
+}
+
 .update-cta:focus-visible,
 .update-cta__dismiss:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+}
+
+/* SPEC-2041 Phase 19 — Post-click update modal. */
+
+.update-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 10100;
+}
+
+.update-modal__panel {
+  min-width: 360px;
+  max-width: 480px;
+  padding: 24px 28px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-lg, 8px);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-3, 0 18px 48px rgba(0, 0, 0, 0.42));
+  font: var(--font-body);
+}
+
+.update-modal__panel h2 {
+  margin: 0 0 12px;
+  font-size: var(--font-size-h3, 18px);
+  letter-spacing: 0.01em;
+}
+
+.update-modal__version {
+  margin: 0 0 8px;
+  font-size: var(--font-size-body, 14px);
+  color: var(--color-text-secondary);
+}
+
+.update-modal__hint {
+  margin: 0 0 16px;
+  font-size: var(--font-size-body-sm, 13px);
+  color: var(--color-text-secondary);
+}
+
+.update-modal__progress {
+  position: relative;
+  height: 8px;
+  margin: 12px 0 8px;
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-surface-sunken, rgba(255, 255, 255, 0.08));
+  overflow: hidden;
+}
+
+.update-modal__progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--color-state-active, var(--color-focus-ring));
+  transition: width 120ms linear;
+}
+
+.update-modal__bytes {
+  margin: 0 0 16px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: var(--font-size-body-sm, 13px);
+  color: var(--color-text-secondary);
+}
+
+.update-modal__details {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 12px;
+  margin: 0 0 16px;
+  font-size: var(--font-size-body-sm, 13px);
+}
+
+.update-modal__details dt {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.update-modal__details dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.update-modal__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.update-modal__btn {
+  appearance: none;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  padding: 8px 14px;
+  border-radius: var(--radius-sm, 4px);
+  font: inherit;
+  cursor: pointer;
+}
+
+.update-modal__btn:hover {
+  background: var(--color-surface-hover, rgba(255, 255, 255, 0.04));
+}
+
+.update-modal__btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.update-modal__btn--primary {
+  border-color: var(--color-state-active, var(--color-focus-ring));
+  background: var(--color-state-active, var(--color-focus-ring));
+  color: var(--color-text-on-accent, #0a0a0a);
+}
+
+.update-modal__btn--secondary {
+  background: transparent;
 }
 
 .terminal-context-menu {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -296,7 +296,9 @@ body::after {
 .update-modal__details dd {
   margin: 0;
   color: var(--color-text-primary);
-  word-break: break-word;
+  /* `word-break: break-word` is deprecated; modern equivalent
+     for long words is `overflow-wrap: anywhere` (CodeRabbit review). */
+  overflow-wrap: anywhere;
 }
 
 .update-modal__actions {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2316,6 +2316,65 @@ kbd.op-kbd {
   grid-template-columns: repeat(3, minmax(240px, 1fr));
 }
 
+.workspace-unassigned {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: var(--space-3) var(--space-3) 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.workspace-unassigned[hidden] {
+  display: none;
+}
+
+.workspace-unassigned-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--type-xs);
+}
+
+.workspace-unassigned-title {
+  color: var(--color-text-strong);
+  font-size: var(--type-sm);
+  font-weight: 600;
+}
+
+.workspace-unassigned-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-2);
+}
+
+.workspace-unassigned-agent {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-elevated);
+}
+
+.workspace-unassigned-agent-name {
+  color: var(--color-text-strong);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.workspace-unassigned-agent-state {
+  color: var(--color-text-muted);
+  font-size: var(--type-xs);
+}
+
 .kanban-column {
   display: flex;
   flex-direction: column;

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -1,12 +1,25 @@
+// SPEC-2041 Phase 19 — Post-click modal & restart UX (FR-052..066).
+//
+// The CTA hands user clicks to #update-modal. The modal owns three states:
+// `downloading` (progress bar + Cancel), `ready` (Later / Restart now),
+// `failed` (Stage / Reason / Log + Open log / Retry / Close). The CTA itself
+// has four observable statuses: `available` | `applying` | `ready` | `error`,
+// where `applying` means a modal is mounted on top of it.
+
 export function createUpdateCtaController({
   document,
   send,
-  confirmUpdate,
+  // Phase 14's window.confirm gating is gone; the modal supersedes it.
+  // The option survives only so existing callers do not break.
+  confirmUpdate: _confirmUpdate,
   setVersionState = () => {},
 }) {
   const shellId = "update-cta-shell";
+  const modalId = "update-modal";
   let latestVersion = null;
+  let pendingVersion = null;
   let status = "idle";
+  let lastProgress = null;
 
   function removeLegacyUpdateSurfaces() {
     document.querySelectorAll(".update-toast, .update-button").forEach((node) => {
@@ -53,7 +66,7 @@ export function createUpdateCtaController({
       dismiss.type = "button";
       dismiss.className = "update-cta__dismiss";
       dismiss.dataset.updateCtaDismiss = "true";
-      dismiss.textContent = "\u00d7";
+      dismiss.textContent = "×";
       dismiss.title = "Dismiss update notification";
       dismiss.setAttribute("aria-label", "Dismiss update notification");
       dismiss.onclick = dismissCta;
@@ -71,12 +84,14 @@ export function createUpdateCtaController({
     }
   }
 
-  function render(nextStatus, text) {
+  function renderCta(nextStatus, text) {
     status = nextStatus;
     const shell = ensureShell();
     const cta = ensureCta(shell);
     cta.dataset.status = nextStatus;
-    cta.className = nextStatus === "available" ? "update-cta" : `update-cta is-${nextStatus}`;
+    const stateClass =
+      nextStatus === "available" ? "update-cta" : `update-cta is-${nextStatus}`;
+    cta.className = stateClass;
     cta.title = text;
     cta.setAttribute("aria-label", text);
     cta.disabled = nextStatus === "applying";
@@ -93,12 +108,19 @@ export function createUpdateCtaController({
     if (!version) return null;
     removeLegacyUpdateSurfaces();
     latestVersion = version;
-    return render("available", `Update available: v${version} - Click to update`);
+    return renderCta("available", `Update available: v${version} - Click to update`);
+  }
+
+  function showReadyPending(version) {
+    if (!version) return null;
+    removeLegacyUpdateSurfaces();
+    pendingVersion = version;
+    return renderCta("ready", `Update v${version} ready — Restart now`);
   }
 
   function showError(message) {
     const detail = message || "Failed to start the update.";
-    return render("error", `Update failed: ${detail} Click to retry.`);
+    return renderCta("error", `Update failed: ${detail} Click to retry.`);
   }
 
   function handleUpdateState(event) {
@@ -110,11 +132,45 @@ export function createUpdateCtaController({
     if (status === "applying" && latestVersion === event.latest) {
       return;
     }
+    if (status === "ready" && pendingVersion === event.latest) {
+      return;
+    }
     showAvailable(event.latest);
+  }
+
+  function handleUpdateProgress(payload) {
+    if (!payload) return;
+    lastProgress = payload;
+    const modal = document.getElementById(modalId);
+    if (!modal || modal.dataset.state !== "downloading") {
+      return;
+    }
+    updateProgressDisplay(payload);
+  }
+
+  function handleUpdateReady(payload) {
+    if (!payload || !payload.version) return;
+    pendingVersion = payload.version;
+    if (status === "applying") {
+      renderModalReady(payload.version);
+    }
+  }
+
+  function handleUpdateApplyError(payload) {
+    if (!payload) return;
+    if (status === "applying") {
+      renderModalFailed(payload);
+    }
+  }
+
+  function handleUpdateApplyPendingPersisted(payload) {
+    if (!payload || !payload.version) return;
+    showReadyPending(payload.version);
   }
 
   function dismissCta(event) {
     event?.stopPropagation();
+    closeModal();
     const shell = document.getElementById(shellId);
     if (shell) {
       shell.remove();
@@ -123,20 +179,300 @@ export function createUpdateCtaController({
   }
 
   function handleClick() {
-    if (status === "applying" || !latestVersion) {
+    if (status === "applying") return;
+    if (status === "ready" && pendingVersion) {
+      // Re-open the modal at the ready panel; no second download.
+      renderCta("applying", "Applying update...");
+      renderModalReady(pendingVersion);
       return;
     }
-    if (!confirmUpdate(latestVersion)) {
+    if (!latestVersion) return;
+    renderCta("applying", "Applying update...");
+    renderModalDownloading(latestVersion);
+    send({ kind: "apply_update_start" });
+  }
+
+  // ---- Modal builders (uses createElement/appendChild only) ----
+
+  function ensureModal() {
+    let modal = document.getElementById(modalId);
+    if (!modal) {
+      modal = document.createElement("div");
+      modal.id = modalId;
+      modal.className = "update-modal";
+      modal.setAttribute("role", "dialog");
+      modal.setAttribute("aria-modal", "true");
+      modal.setAttribute("aria-labelledby", "update-modal-title");
+      document.body.appendChild(modal);
+    }
+    return modal;
+  }
+
+  function clearChildren(node) {
+    while (node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
+  }
+
+  function el(tag, props = {}, children = []) {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(props)) {
+      if (v == null) continue;
+      if (k === "className") {
+        node.className = v;
+      } else if (k === "text") {
+        node.textContent = v;
+      } else if (k === "data") {
+        for (const [dk, dv] of Object.entries(v)) {
+          node.dataset[dk] = String(dv);
+        }
+      } else if (k === "attrs") {
+        for (const [ak, av] of Object.entries(v)) {
+          node.setAttribute(ak, String(av));
+        }
+      } else if (k === "onClick") {
+        node.addEventListener("click", v);
+      } else {
+        node.setAttribute(k, String(v));
+      }
+    }
+    for (const child of children) {
+      if (child == null) continue;
+      node.appendChild(child);
+    }
+    return node;
+  }
+
+  function closeModal() {
+    const modal = document.getElementById(modalId);
+    if (modal) {
+      modal.remove();
+    }
+  }
+
+  function renderModalDownloading(version) {
+    const modal = ensureModal();
+    modal.dataset.state = "downloading";
+    clearChildren(modal);
+
+    const fill = el("div", { className: "update-modal__progress-fill" });
+    const progress = el(
+      "div",
+      {
+        className: "update-modal__progress",
+        attrs: {
+          role: "progressbar",
+          "aria-valuemin": "0",
+          "aria-valuemax": "100",
+          "aria-valuenow": "0",
+        },
+        data: { updateModalProgress: "true" },
+      },
+      [fill],
+    );
+    const counter = el("p", {
+      className: "update-modal__bytes",
+      text: "0.0 MB / 0.0 MB",
+      data: { updateModalByteCounter: "true" },
+    });
+    const cancel = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Cancel",
+      data: { updateModalCancel: "true" },
+      onClick: onCancelDownload,
+    });
+
+    const panel = el(
+      "div",
+      { className: "update-modal__panel", data: { state: "downloading" } },
+      [
+        el("h2", { id: "update-modal-title", text: "Updating gwt" }),
+        el("p", {
+          className: "update-modal__version",
+          text: `Downloading v${version || ""}`,
+          data: { updateModalVersion: "true" },
+        }),
+        progress,
+        counter,
+        el("div", { className: "update-modal__actions" }, [cancel]),
+      ],
+    );
+    modal.appendChild(panel);
+
+    if (lastProgress) {
+      updateProgressDisplay(lastProgress);
+    }
+  }
+
+  function renderModalReady(version) {
+    const modal = ensureModal();
+    modal.dataset.state = "ready";
+    clearChildren(modal);
+
+    const later = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Later",
+      data: { updateModalLater: "true" },
+      onClick: onApplyLater,
+    });
+    const restartNow = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--primary",
+      text: "Restart now",
+      data: { updateModalRestartNow: "true" },
+      onClick: onApplyRestartNow,
+    });
+
+    const panel = el(
+      "div",
+      { className: "update-modal__panel", data: { state: "ready" } },
+      [
+        el("h2", { id: "update-modal-title", text: "Update ready" }),
+        el("p", {
+          className: "update-modal__version",
+          text: `v${version} を適用する準備ができました。`,
+        }),
+        el("p", {
+          className: "update-modal__hint",
+          text: "Restart で新しいバージョンが起動します。",
+        }),
+        el("div", { className: "update-modal__actions" }, [later, restartNow]),
+      ],
+    );
+    modal.appendChild(panel);
+  }
+
+  function renderModalFailed({ stage, reason, log_path }) {
+    const modal = ensureModal();
+    modal.dataset.state = "failed";
+    clearChildren(modal);
+
+    const dl = el("dl", { className: "update-modal__details" }, [
+      el("dt", { text: "Stage" }),
+      el("dd", {
+        text: stage || "Unknown stage",
+        data: { updateModalStage: "true" },
+      }),
+      el("dt", { text: "Reason" }),
+      el("dd", {
+        text: reason || "Unknown reason",
+        data: { updateModalReason: "true" },
+      }),
+      el("dt", { text: "Log" }),
+      el("dd", {
+        text: log_path || "",
+        data: { updateModalLog: "true" },
+      }),
+    ]);
+
+    const openLog = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Open log",
+      data: { updateModalOpenLog: "true" },
+      onClick: () => {
+        const message = { kind: "open_update_log" };
+        if (log_path) message.log_path = log_path;
+        send(message);
+      },
+    });
+    const retry = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Retry",
+      data: { updateModalRetry: "true" },
+      onClick: onRetryFailed,
+    });
+    const closeBtn = el("button", {
+      type: "button",
+      className: "update-modal__btn update-modal__btn--secondary",
+      text: "Close",
+      data: { updateModalClose: "true" },
+      onClick: onCloseFailed,
+    });
+
+    const panel = el(
+      "div",
+      { className: "update-modal__panel", data: { state: "failed" } },
+      [
+        el("h2", { id: "update-modal-title", text: "⚠ Update failed" }),
+        dl,
+        el("div", { className: "update-modal__actions" }, [openLog, retry, closeBtn]),
+      ],
+    );
+    modal.appendChild(panel);
+  }
+
+  function updateProgressDisplay({ downloaded, total }) {
+    const modal = document.getElementById(modalId);
+    if (!modal) return;
+    const progress = modal.querySelector("[data-update-modal-progress]");
+    const counter = modal.querySelector("[data-update-modal-byte-counter]");
+    if (progress) {
+      const percent = total
+        ? Math.max(0, Math.min(100, Math.round((downloaded / total) * 100)))
+        : 0;
+      progress.setAttribute("aria-valuenow", String(percent));
+      const fill = progress.querySelector(".update-modal__progress-fill");
+      if (fill) {
+        fill.style.width = `${percent}%`;
+      }
+    }
+    if (counter) {
+      counter.textContent = `${formatBytes(downloaded)} / ${formatBytes(total)}`;
+    }
+  }
+
+  function onCancelDownload() {
+    send({ kind: "cancel_update_download" });
+    lastProgress = null;
+    closeModal();
+    if (latestVersion) {
       showAvailable(latestVersion);
-      return;
     }
-    render("applying", "Applying update...");
-    send({ kind: "apply_update" });
+  }
+
+  function onApplyLater() {
+    send({ kind: "apply_update_later" });
+    closeModal();
+    if (pendingVersion) {
+      showReadyPending(pendingVersion);
+    }
+  }
+
+  function onApplyRestartNow() {
+    send({ kind: "apply_update_restart_now" });
+    // Modal is intentionally left in place; the parent process will exit.
+  }
+
+  function onRetryFailed() {
+    lastProgress = null;
+    renderModalDownloading(latestVersion || pendingVersion || "");
+    send({ kind: "apply_update_start" });
+  }
+
+  function onCloseFailed() {
+    closeModal();
+    if (latestVersion) {
+      showAvailable(latestVersion);
+    }
+  }
+
+  function formatBytes(bytes) {
+    const mb = (bytes ?? 0) / (1024 * 1024);
+    return `${mb.toFixed(1)} MB`;
   }
 
   return {
     handleUpdateState,
+    handleUpdateProgress,
+    handleUpdateReady,
+    handleUpdateApplyError,
+    handleUpdateApplyPendingPersisted,
     showAvailable,
+    showReadyPending,
     showError,
   };
 }

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -344,10 +344,16 @@ export function createUpdateCtaController({
     modal.appendChild(panel);
   }
 
-  function renderModalFailed({ stage, reason, log_path }) {
+  function renderModalFailed({ stage, reason, log_path, message }) {
     const modal = ensureModal();
     modal.dataset.state = "failed";
     clearChildren(modal);
+
+    // Phase 19 promotes structured `reason`, but `message` is still on the
+    // wire contract for legacy callers (see UpdateApplyError optional fields
+    // in protocol.rs). Fall through so older or partial emitters still
+    // surface a useful failure (CodeRabbit review on PR #2630).
+    const displayReason = reason || message || "Unknown reason";
 
     const dl = el("dl", { className: "update-modal__details" }, [
       el("dt", { text: "Stage" }),
@@ -357,7 +363,7 @@ export function createUpdateCtaController({
       }),
       el("dt", { text: "Reason" }),
       el("dd", {
-        text: reason || "Unknown reason",
+        text: displayReason,
         data: { updateModalReason: "true" },
       }),
       el("dt", { text: "Log" }),

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -158,7 +158,13 @@ export function createUpdateCtaController({
 
   function handleUpdateApplyError(payload) {
     if (!payload) return;
-    if (status === "applying") {
+    // SPEC-2041 Phase 19 (FR-064 follow-up, CodeRabbit review on PR #2635):
+    // Later can fail when commit_update_later_pending detects the persisted
+    // manifest is gone. The CTA was already morphed to `ready` by then, so
+    // surface the failure modal even in the `ready` state — silently dropping
+    // the error would leave the user believing Restart is safe when it isn't.
+    if (status === "applying" || status === "ready") {
+      renderCta("applying", "Applying update...");
       renderModalFailed(payload);
     }
   }

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -332,11 +332,11 @@ export function createUpdateCtaController({
         el("h2", { id: "update-modal-title", text: "Update ready" }),
         el("p", {
           className: "update-modal__version",
-          text: `v${version} を適用する準備ができました。`,
+          text: `v${version} is ready to install.`,
         }),
         el("p", {
           className: "update-modal__hint",
-          text: "Restart で新しいバージョンが起動します。",
+          text: "Restart now to launch the new version.",
         }),
         el("div", { className: "update-modal__actions" }, [later, restartNow]),
       ],

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -73,20 +73,30 @@ export function createWorkspaceKanbanSurface({
     const title = projection.title || `${activeWorkspace().title || "Project"} workspace`;
     const branch = projection.branch || "";
     const worktreePath = projection.worktree_path || "";
-    const workItems = Array.isArray(projection.work_items)
-      ? projection.work_items
-      : [];
-    if (workItems.length > 0) {
-      return workItems.map((item) => {
+    const workspaces = Array.isArray(projection.workspaces)
+      ? projection.workspaces
+      : Array.isArray(projection.work_items)
+        ? projection.work_items
+        : [];
+    if (workspaces.length > 0) {
+      return workspaces.map((item) => {
+        const workspaceId = item.id || `workspace-${item.title || "workspace"}`;
+        const workspaceTitle = item.title || item.intent || "Workspace";
+        const workspaceEvents = Array.isArray(item.events) ? item.events : [];
+        const normalizedEvents = workspaceEvents.map((event) => ({
+          ...event,
+          workspace_id: event.workspace_id || event.work_item_id || workspaceId,
+          related_workspace_id: event.related_workspace_id || event.related_work_item_id || "",
+        }));
         const containers = Array.isArray(item.execution_containers)
           ? item.execution_containers
           : [];
         const container = containers[0] || {};
         return {
-          id: item.id || `workitem-${item.title || "workspace"}`,
-          kind: "work_item",
-          label: "WorkItem",
-          title: item.title || item.intent || "Workspace WorkItem",
+          id: workspaceId,
+          kind: "workspace",
+          label: "Workspace",
+          title: workspaceTitle,
           intent: item.intent || "",
           status_category: item.status_category || "idle",
           status_text: item.summary || item.intent || "",
@@ -105,7 +115,7 @@ export function createWorkspaceKanbanSurface({
           updated_at: item.updated_at || "",
           resume_source: "current",
           journal_id: null,
-          events: Array.isArray(item.events) ? item.events : [],
+          events: normalizedEvents,
           column: workspaceColumnForCurrentStatus(item.status_category),
         };
       });
@@ -174,6 +184,70 @@ export function createWorkspaceKanbanSurface({
     }
 
     return cards;
+  }
+
+  function unassignedAgentsFromProjection(projection) {
+    const unassigned = Array.isArray(projection?.unassigned_agents)
+      ? projection.unassigned_agents
+      : [];
+    return unassigned
+      .filter((agent) => String(agent?.affiliation_status || "unassigned") === "unassigned")
+      .map((agent) => ({
+        session_id: agent.session_id || "",
+        display_name: agent.display_name || agent.agent_id || "Agent",
+        agent_id: agent.agent_id || "",
+        branch: agent.branch || "",
+        worktree_path: agent.worktree_path || "",
+        current_focus: agent.current_focus || agent.title_summary || "",
+      }));
+  }
+
+  function renderUnassignedAgents(container, projection) {
+    if (!container) return;
+    container.innerHTML = "";
+    const agents = unassignedAgentsFromProjection(projection);
+    if (agents.length === 0) {
+      container.hidden = true;
+      return;
+    }
+    container.hidden = false;
+    const header = createNode("div", "workspace-unassigned-header");
+    header.appendChild(createNode("div", "workspace-unassigned-title", "Unassigned"));
+    header.appendChild(
+      createNode(
+        "div",
+        "workspace-unassigned-count",
+        agents.length === 1 ? "1 Agent" : `${agents.length} Agents`,
+      ),
+    );
+    container.appendChild(header);
+    const list = createNode("div", "workspace-unassigned-list");
+    for (const agent of agents) {
+      const row = createNode("article", "workspace-unassigned-agent");
+      row.dataset.sessionId = agent.session_id;
+      row.appendChild(createNode("div", "workspace-unassigned-agent-name", agent.display_name));
+      row.appendChild(
+        createNode("div", "workspace-unassigned-agent-state", "No Workspace selected"),
+      );
+      const meta = createNode("div", "kanban-card-meta");
+      appendMeta(meta, agent.branch);
+      appendMeta(meta, agent.current_focus);
+      if (meta.childElementCount > 0) {
+        row.appendChild(meta);
+      }
+      const actions = createNode("div", "workspace-card-actions");
+      const findButton = createNode("button", "wizard-button", "Find Workspace");
+      findButton.type = "button";
+      findButton.disabled = true;
+      const createButton = createNode("button", "wizard-button", "Create Workspace");
+      createButton.type = "button";
+      createButton.disabled = true;
+      actions.appendChild(findButton);
+      actions.appendChild(createButton);
+      row.appendChild(actions);
+      list.appendChild(row);
+    }
+    container.appendChild(list);
   }
 
   function resumeWorkspaceCard(card) {
@@ -380,11 +454,14 @@ export function createWorkspaceKanbanSurface({
     if (!element) return;
     const state = ensureWorkspaceKanbanState(windowId);
     const board = element.querySelector(".workspace-kanban-board");
+    const unassigned = element.querySelector("[data-role='unassigned-agents']");
     const detailPane = element.querySelector(".workspace-kanban-detail-pane");
     const status = element.querySelector(".workspace-kanban-status");
     if (!board || !detailPane || !status) return;
 
-    const cards = workspaceCardsFromProjection(getActiveWorkProjection());
+    const projection = getActiveWorkProjection();
+    const cards = workspaceCardsFromProjection(projection);
+    renderUnassignedAgents(unassigned, projection);
     if (!state.selectedId || !cards.some((card) => card.id === state.selectedId)) {
       state.selectedId = cards[0]?.id || null;
     }
@@ -440,6 +517,7 @@ export function createWorkspaceKanbanSurface({
         <div class="knowledge-status workspace-kanban-status"></div>
         <div class="knowledge-split workspace-split kanban-shell">
           <div class="knowledge-list-pane kanban-list-pane">
+            <section class="workspace-unassigned" data-role="unassigned-agents" hidden></section>
             <div class="kanban-board workspace-kanban-board" role="list" aria-label="Workspace Kanban Board">
               <div class="kanban-column workspace-kanban-column" data-workspace-column="active" aria-label="Active Workspace column">
                 <div class="kanban-column-header">

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -73,10 +73,48 @@ export function createWorkspaceKanbanSurface({
     const title = projection.title || `${activeWorkspace().title || "Project"} workspace`;
     const branch = projection.branch || "";
     const worktreePath = projection.worktree_path || "";
+    const workItems = Array.isArray(projection.work_items)
+      ? projection.work_items
+      : [];
+    if (workItems.length > 0) {
+      return workItems.map((item) => {
+        const containers = Array.isArray(item.execution_containers)
+          ? item.execution_containers
+          : [];
+        const container = containers[0] || {};
+        return {
+          id: item.id || `workitem-${item.title || "workspace"}`,
+          kind: "work_item",
+          label: "WorkItem",
+          title: item.title || item.intent || "Workspace WorkItem",
+          intent: item.intent || "",
+          status_category: item.status_category || "idle",
+          status_text: item.summary || item.intent || "",
+          summary: item.summary || item.intent || "",
+          owner: item.owner || "",
+          next_action: "",
+          branch: container.branch || "",
+          worktree_path: container.worktree_path || "",
+          pr_number: container.pr_number || null,
+          pr_url: container.pr_url || "",
+          pr_state: container.pr_state || "",
+          board_refs: Array.isArray(item.board_refs) ? item.board_refs : [],
+          agents: Array.isArray(item.agents) ? item.agents : [],
+          execution_containers: containers,
+          cleanup_candidate: null,
+          updated_at: item.updated_at || "",
+          resume_source: "current",
+          journal_id: null,
+          events: Array.isArray(item.events) ? item.events : [],
+          column: workspaceColumnForCurrentStatus(item.status_category),
+        };
+      });
+    }
     const cards = [
       {
         id: projection.id || "__current_workspace__",
         kind: "current",
+        label: "Current",
         title,
         status_category: projection.status_category || "idle",
         status_text: projection.status_text || "No active work",
@@ -94,6 +132,7 @@ export function createWorkspaceKanbanSurface({
         updated_at: projection.updated_at || "",
         resume_source: "current",
         journal_id: null,
+        events: [],
         column: workspaceColumnForCurrentStatus(projection.status_category),
       },
     ];
@@ -129,6 +168,7 @@ export function createWorkspaceKanbanSurface({
         updated_at: entry.updated_at || "",
         resume_source: "journal",
         journal_id: entry.id || "",
+        events: [],
         column: workspaceColumnForJournalStatus(statusCategory),
       });
     }
@@ -168,7 +208,11 @@ export function createWorkspaceKanbanSurface({
 
     const head = createNode("div", "kanban-card-head");
     head.appendChild(
-      createNode("span", "kanban-card-number", cardData.kind === "current" ? "Current" : "Update"),
+      createNode(
+        "span",
+        "kanban-card-number",
+        cardData.label || (cardData.kind === "current" ? "Current" : "Update"),
+      ),
     );
     head.appendChild(
       createNode(
@@ -279,6 +323,32 @@ export function createWorkspaceKanbanSurface({
       context.appendChild(createNode("div", "knowledge-section-title", "Workspace Context"));
       context.appendChild(createNode("pre", "knowledge-section-body", cardData.worktree_path));
       scroll.appendChild(context);
+    }
+
+    if (cardData.events.length > 0) {
+      const lifecycle = createNode("section", "knowledge-section");
+      lifecycle.appendChild(createNode("div", "knowledge-section-title", "Lifecycle"));
+      lifecycle.appendChild(
+        createNode(
+          "pre",
+          "knowledge-section-body",
+          cardData.events
+            .map((event) =>
+              [
+                event.updated_at || "",
+                event.kind || "update",
+                event.title || event.intent || "",
+                event.summary || "",
+                event.board_entry_id ? `board:${event.board_entry_id}` : "",
+                event.agent_session_id ? `session:${event.agent_session_id}` : "",
+              ]
+                .filter(Boolean)
+                .join(" · "),
+            )
+            .join("\n"),
+        ),
+      );
+      scroll.appendChild(lifecycle);
     }
 
     if (cardData.agents.length > 0) {

--- a/docs/spec-2041-phase-19-manual-smoke.md
+++ b/docs/spec-2041-phase-19-manual-smoke.md
@@ -30,9 +30,11 @@ Phase 19 (FR-066, SC-014d).
    rm -rf ~/.gwt/pending-update
    ```
 4. Optional — if testing against the local mock server in lieu of a
-   real release:
+   real release. Pass **bare semver** to `--version` (the script prepends
+   `v` itself, so `--version v1.2.3` would emit `vv1.2.3` and the updater's
+   `parse_tag_version` would reject the tag):
    ```sh
-   node scripts/mock-update-server.cjs --port 18080 --version <vN+1> \
+   node scripts/mock-update-server.cjs --port 18080 --version 9.99.0 \
      --asset path/to/real/gwt-macos-arm64.tar.gz
    GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
    ```
@@ -80,9 +82,10 @@ Phase 19 (FR-066, SC-014d).
 
 1. Re-install `vN`.
 2. Launch the mock server with no `--asset` so it returns 32 bytes of
-   garbage:
+   garbage. Pass `--version` as bare semver (e.g. `9.99.0`) — the
+   script prepends `v` itself:
    ```sh
-   node scripts/mock-update-server.cjs --port 18080 --version <vN+1>
+   node scripts/mock-update-server.cjs --port 18080 --version 9.99.0
    GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
    ```
 3. Click the CTA. **Verify**: progress reaches 100 % (32 / 32 bytes)

--- a/docs/spec-2041-phase-19-manual-smoke.md
+++ b/docs/spec-2041-phase-19-manual-smoke.md
@@ -1,0 +1,131 @@
+# SPEC-2041 Phase 19 — manual smoke checklist
+
+T-138 (Gate 3) requires a human reviewer to drive a real `gwt` GUI
+build against an actual GitHub Release because the post-click modal
+flow couples WebView rendering, WebSocket events, helper subprocess
+spawn, and OS process lifecycle in ways the Playwright fixture cannot
+exercise.
+
+SPEC-2041 FR-066 codifies this gate: **CI green is not done. Phase 19
+PRs may not be marked closed until this checklist passes on a release
+candidate.**
+
+Record the outcome in the Board
+(`gwtd board post --kind status --body ...`) and reference SPEC-2041
+Phase 19 (FR-066, SC-014d).
+
+## Prerequisites
+
+1. macOS arm64 (primary target). Linux x86_64 / arm64 and
+   Windows x86_64 are best-effort — same procedure, different
+   download asset name.
+2. Two real GitHub Releases:
+   - `vN` (current): the build the reviewer will install first.
+   - `vN+1` (target): the build the modal will download. Either
+     publish a real next release, or use an unreleased internal tag
+     against the mock server if `vN+1` is not yet ready.
+3. A clean `~/.gwt/pending-update/` directory before each run so the
+   bootstrap path starts from a known state:
+   ```sh
+   rm -rf ~/.gwt/pending-update
+   ```
+4. Optional — if testing against the local mock server in lieu of a
+   real release:
+   ```sh
+   node scripts/mock-update-server.cjs --port 18080 --version <vN+1> \
+     --asset path/to/real/gwt-macos-arm64.tar.gz
+   GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
+   ```
+
+## Gate 3.A — Restart-now happy path
+
+1. Install `vN` from the release asset matching your platform.
+2. Launch `gwt`. Wait up to 5 minutes (or restart with the polling
+   override) until the bottom-right `Update available: v<N+1> — Click
+   to update` CTA appears.
+3. Click the CTA. **Verify**: a centered modal opens immediately with
+   the title "Updating gwt", a progress bar, and a `Cancel` button.
+   The CTA itself flips to "Applying update..." and is disabled.
+4. **Verify**: the progress bar advances and the byte counter
+   (`X.Y MB / Z.W MB`) updates roughly every 200 ms while the
+   download proceeds. Update progress events should arrive over
+   WebSocket without UI freezes.
+5. When the download completes the modal transitions to "Update
+   ready" with `[Later]` and `[Restart now]` buttons. **Verify**:
+   no `window.confirm` appears.
+6. Click `[Restart now]`. **Verify**: the gwt window closes within
+   ~3 seconds and a new gwt window opens. Open the About / version
+   line and confirm it now reports `vN+1`.
+
+## Gate 3.B — Later → next-launch transparent apply
+
+1. Re-install `vN` (or rerun the smoke from the Gate 3.A starting
+   state if you can roll back to the manifest-cleared state).
+2. Launch `gwt`, click the CTA, wait for the `ready` modal.
+3. Click `[Later]`. **Verify**:
+   - the modal closes,
+   - the CTA morphs to `Update v<N+1> ready — Restart now` with a
+     visible dismiss `×`,
+   - `~/.gwt/pending-update/manifest.json` exists and points at the
+     prepared payload under `~/.gwt/updates/v<N+1>/...`.
+4. Quit gwt manually (cmd-Q / window close).
+5. Launch `gwt` again. **Verify**:
+   - the bootstrap path detects the manifest, swaps the binary, and
+     starts a new process running `vN+1`. The transition should be
+     close to instant — the user sees a momentary launch flash and
+     then the regular gwt window for the new version.
+   - `~/.gwt/pending-update/` no longer contains a manifest.
+
+## Gate 3.C — Failure UX (expected)
+
+1. Re-install `vN`.
+2. Launch the mock server with no `--asset` so it returns 32 bytes of
+   garbage:
+   ```sh
+   node scripts/mock-update-server.cjs --port 18080 --version <vN+1>
+   GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
+   ```
+3. Click the CTA. **Verify**: progress reaches 100 % (32 / 32 bytes)
+   then the modal transitions to the `failed` state with:
+   - title `⚠ Update failed`,
+   - `Stage:` "Persist pending" or "Download asset" depending on
+     where extract_archive aborts,
+   - `Reason:` something like "Failed to prepare update payload: …",
+   - `Log:` a path under `~/.gwt/logs/update-<YYYY-MM-DD>.log`,
+   - three buttons: `[Open log] [Retry] [Close]`.
+4. Click `[Open log]`. **Verify**: the OS default text viewer opens
+   the log file and the file contains JSONL entries for
+   `download_start`, `download_complete`, `fail` with the same
+   reason as the modal.
+5. Click `[Close]`. **Verify**: the modal closes and the CTA returns
+   to `Update available: v<N+1> — Click to update`.
+
+## Gate 3.D — Cancel mid-download
+
+1. Re-install `vN`. If you control the mock server, throttle it
+   (e.g. wrap with `pv` to slow the body) so the download takes
+   noticeably more than ~1 s.
+2. Click the CTA, then click `[Cancel]` while the progress bar is
+   below 100 %. **Verify**:
+   - the modal closes,
+   - the CTA returns to `Update available`,
+   - polling resumes (no manifest is created),
+   - any partial file under `~/.gwt/updates/v<N+1>/` is harmless
+     (the next start_download will overwrite it).
+
+## Reporting
+
+Post a single Board entry summarising the outcome:
+
+```
+gwtd board post --kind status --body $'SPEC-2041 Phase 19 Gate 3 manual smoke result:
+- 3.A Restart-now: PASS / FAIL
+- 3.B Later + next-launch swap: PASS / FAIL
+- 3.C Failure UX: PASS / FAIL
+- 3.D Cancel mid-download: PASS / FAIL
+Notes: <free-form observations, screenshots, log excerpts as needed>'
+```
+
+If any sub-gate fails, do not merge dependent work and reopen the
+relevant Phase 19 PR or file a follow-up issue against SPEC-2041
+referencing the failing FR.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.25.0",
+  "version": "9.26.0",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/scripts/mock-update-server.cjs
+++ b/scripts/mock-update-server.cjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * SPEC-2041 Phase 19 Gate 2 mock smoke server.
+ *
+ * Drives the update-modal flow against a synthetic GitHub Releases endpoint
+ * so the post-click flow (downloading -> ready -> Restart now / Later) can be
+ * exercised without publishing real releases. Combine with the
+ * `GWT_UPDATE_API_BASE_URL` env override that landed alongside this script.
+ *
+ * Usage:
+ *   node scripts/mock-update-server.cjs --port 18080 --version 99.99.0 \
+ *     [--asset path/to/gwt-macos-arm64.tar.gz]
+ *
+ * Then in another shell:
+ *   GWT_UPDATE_API_BASE_URL=http://127.0.0.1:18080 ./target/release/gwt
+ *
+ * The server returns a synthetic release at
+ *   GET /repos/akiojin/gwt/releases/latest
+ * that points `browser_download_url` at the mock's own /assets/<filename>
+ * endpoint so the prepare path can both observe progress and (when --asset is
+ * a real tarball) succeed the restart-now path. Without --asset the download
+ * still completes but extraction fails — useful for smoking the failure
+ * modal (`update_apply_error` with stage="Download asset" or
+ * stage="Persist pending").
+ */
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+const opts = {
+  port: 18080,
+  version: "99.99.0",
+  asset: null,
+};
+for (let i = 0; i < args.length; i++) {
+  const flag = args[i];
+  const value = args[i + 1];
+  if (flag === "--port") {
+    opts.port = parseInt(value, 10);
+    i += 1;
+  } else if (flag === "--version") {
+    opts.version = value;
+    i += 1;
+  } else if (flag === "--asset") {
+    opts.asset = value;
+    i += 1;
+  } else if (flag === "--help" || flag === "-h") {
+    printUsage();
+    process.exit(0);
+  }
+}
+
+function printUsage() {
+  console.log(`SPEC-2041 Phase 19 Gate 2 mock smoke server
+
+Usage:
+  node scripts/mock-update-server.cjs [--port PORT] [--version VERSION] [--asset PATH]
+
+Options:
+  --port      TCP port to bind on 127.0.0.1 (default: 18080)
+  --version   Tag name to advertise as the latest release (default: 99.99.0)
+  --asset     Local path to a real tarball/zip to serve as the asset.
+              When omitted, the server returns a 32-byte payload so the
+              download stage succeeds and extraction surfaces a failure
+              modal -- handy for smoking the failure UX.
+
+Then run gwt with:
+  GWT_UPDATE_API_BASE_URL=http://127.0.0.1:PORT ./target/release/gwt
+`);
+}
+
+let assetBuffer;
+let assetName = pickAssetName(process.platform, process.arch);
+if (opts.asset) {
+  if (!fs.existsSync(opts.asset)) {
+    console.error(`[mock] --asset path does not exist: ${opts.asset}`);
+    process.exit(1);
+  }
+  assetBuffer = fs.readFileSync(opts.asset);
+  assetName = path.basename(opts.asset);
+} else {
+  // 32 bytes of random payload so the download progress callback fires at
+  // least once and the persist path runs. The eventual extract_archive will
+  // fail with `Invalid gzip` / `not a tar archive`, exercising the failure
+  // modal.
+  assetBuffer = Buffer.alloc(32, 0x5a);
+}
+
+function pickAssetName(platform, arch) {
+  if (platform === "darwin" && arch === "arm64") return "gwt-macos-arm64.tar.gz";
+  if (platform === "darwin" && (arch === "x64" || arch === "x86_64"))
+    return "gwt-macos-x86_64.tar.gz";
+  if (platform === "linux" && arch === "x64") return "gwt-linux-x86_64.tar.gz";
+  if (platform === "linux" && arch === "arm64")
+    return "gwt-linux-aarch64.tar.gz";
+  if (platform === "win32") return "gwt-windows-x86_64.zip";
+  return "gwt-update.tar.gz";
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  console.log(`[mock] ${req.method} ${url.pathname}`);
+
+  if (
+    url.pathname.startsWith("/repos/") &&
+    url.pathname.endsWith("/releases/latest")
+  ) {
+    const baseUrl = `http://127.0.0.1:${opts.port}`;
+    const release = {
+      tag_name: `v${opts.version}`,
+      html_url: `${baseUrl}/release-page`,
+      assets: [
+        {
+          name: assetName,
+          browser_download_url: `${baseUrl}/assets/${assetName}`,
+        },
+      ],
+    };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(release));
+    return;
+  }
+
+  if (url.pathname.startsWith("/assets/")) {
+    res.writeHead(200, {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": String(assetBuffer.length),
+    });
+    res.end(assetBuffer);
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "text/plain" });
+  res.end("Not Found");
+});
+
+server.listen(opts.port, "127.0.0.1", () => {
+  console.log(
+    `[mock] update server listening on http://127.0.0.1:${opts.port}`,
+  );
+  console.log(`[mock] advertising tag v${opts.version} (asset: ${assetName})`);
+  console.log("[mock] run gwt with:");
+  console.log(
+    `  GWT_UPDATE_API_BASE_URL=http://127.0.0.1:${opts.port} ./target/release/gwt`,
+  );
+  console.log("[mock] press ctrl-c to stop.");
+});

--- a/scripts/mock-update-server.cjs
+++ b/scripts/mock-update-server.cjs
@@ -72,14 +72,16 @@ Then run gwt with:
 }
 
 let assetBuffer;
-let assetName = pickAssetName(process.platform, process.arch);
+// Always advertise the canonical asset name for this platform so the updater's
+// release-contract matcher (`scripts/release-assets.cjs::releaseAssetName`)
+// finds the asset regardless of the local file the operator points at.
+const assetName = pickAssetName(process.platform, process.arch);
 if (opts.asset) {
   if (!fs.existsSync(opts.asset)) {
     console.error(`[mock] --asset path does not exist: ${opts.asset}`);
     process.exit(1);
   }
   assetBuffer = fs.readFileSync(opts.asset);
-  assetName = path.basename(opts.asset);
 } else {
   // 32 bytes of random payload so the download progress callback fires at
   // least once and the persist path runs. The eventual extract_archive will
@@ -108,8 +110,12 @@ const server = http.createServer((req, res) => {
     url.pathname.endsWith("/releases/latest")
   ) {
     const baseUrl = `http://127.0.0.1:${opts.port}`;
+    // Strip a single leading `v` from --version so passing either `9.26.0` or
+    // `v9.26.0` yields the canonical `vN.N.N` tag the updater's
+    // `parse_tag_version` accepts (it tolerates exactly one `v` prefix).
+    const normalizedVersion = String(opts.version).replace(/^v/, "");
     const release = {
-      tag_name: `v${opts.version}`,
+      tag_name: `v${normalizedVersion}`,
       html_url: `${baseUrl}/release-page`,
       assets: [
         {
@@ -137,10 +143,11 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(opts.port, "127.0.0.1", () => {
+  const advertisedTag = `v${String(opts.version).replace(/^v/, "")}`;
   console.log(
     `[mock] update server listening on http://127.0.0.1:${opts.port}`,
   );
-  console.log(`[mock] advertising tag v${opts.version} (asset: ${assetName})`);
+  console.log(`[mock] advertising tag ${advertisedTag} (asset: ${assetName})`);
   console.log("[mock] run gwt with:");
   console.log(
     `  GWT_UPDATE_API_BASE_URL=http://127.0.0.1:${opts.port} ./target/release/gwt`,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5245,3 +5245,26 @@ audience が欠落していた。
    module-local lock を作らず crate-wide `env_test_lock` に寄せる。
 2. 単独 test green で満足せず、env mutation を伴う修正後は default parallelism の
    `cargo test -p gwt-core -p gwt` を必ず 1 回通す。
+
+## 2026-05-11 — Built-in AgentId を consumer 側の個別表で持たない
+
+### 事象
+
+develop 取り込み後、Board origin focus の `agent_option_matches_session` が `AgentId::OpenClaw`
+と `AgentId::Hermes` を網羅しておらず、`cargo test -p gwt-core -p gwt` が compile error で
+停止した。
+
+### 原因
+
+`gwt-agent` は built-in agent descriptor (`command`, `display_name`, `color` など) を持っているが、
+Board 側で `AgentId` variant ごとの `option.id` 対応表を別途 match していた。新しい built-in
+agent が追加されたとき、descriptor は更新されても Board 側の表が同期されなかった。
+
+### 再発防止策
+
+1. built-in `AgentId` の表示名・command・色・cache key は `AgentId` / descriptor API を使い、
+   consumer 側に variant 別の重複表を作らない。
+2. custom agent だけは `custom_agent.id` の互換判定が必要なので、built-in と custom の差分だけを
+   consumer 側に残す。
+3. 新規 AgentId 追加後は、Agent 起動だけでなく Board / Workspace / UI projection の resume 経路も
+   focused test で通す。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5124,3 +5124,46 @@ CLI 実行を同じ quoting context に混ぜてしまった。
    を使い、Markdown 本文を shell double quote に直接埋め込まない。
 3. `gh issue close --comment` を使う場合でも、本文は単一引用符で安全に
    表現できる短文だけに限定する。複数行の検証ログは別途ファイル入力にする。
+
+## 2026-05-10 — 自動更新クリック後の silent failure を 5 回連続で見逃した
+
+### 事象
+
+`自動更新のクリックの対応` を 5 回連続で fix したが、ユーザーから「全く対応できていません」と
+強い不満を受けた。修正対象はすべて click 前 (cache / DOM / 表示) で、click 後の silent failure
+path は untouched だった。
+
+- 76be413f: 5分ポーリング + 永続更新ボタン (UI 表示のみ)
+- 293a1627 / 04d721cc / ca2b8221: toast → CTA 統一 (UI 表示のみ)
+- ffe40f46 / c5348421: asset wiring / ラベル文言 (UI 表示のみ)
+- 3a2e0628: dismiss button (UI 表示のみ)
+- 665dea8e: WebView cache 無効化 (click 検知のみ)
+
+### 原因
+
+1. `apply_update_state_and_exit` (`crates/gwt/src/update_front_door.rs:277`) が
+   `std::process::exit(0)` で親プロセスを click 直後に殺す設計のため、
+   helper subprocess の失敗が UI に surface されない silent failure path だった。
+2. テストが pass していたため done 宣言を繰り返したが、実環境では helper の失敗が見えないため
+   UX としては破綻していた。CI green = done 宣言が untested path を覆い隠した。
+3. 「click 検知が動かない」という assumption に基づいて修正対象を選んだが、根本的には
+   「click は反応しているが post-click が silent」という別問題だった。
+4. ユーザー意図 UX (modal で進捗 → 完了確認 → restart) を確認せず、SPEC は click 前領域の
+   みを規定していた。post-click UX が SPEC に書かれていない feature を「直す」ことができていなかった。
+
+### 再発防止策
+
+1. **CI green = done 禁止**: バグ修正・新機能の完了宣言には Gate 3 manual smoke
+   (実機で実 user flow を 1 往復) を必須化する。SPEC-2041 Phase 14 (FR-066) で正式化済み。
+2. **silent failure path の禁止**: 親プロセスが即時 exit する設計は許容しない。
+   download / install / replace / spawn の各 stage を必ず frontend (UI) に surface する。
+   `*_and_exit` という関数名が出てきた時点で silent failure を疑う。
+3. **修正前の前提検証**: 「動かない」報告を受けたら、表面的な仮説 (cache / DOM) で fix を
+   始める前に、ユーザーが実際に何を見ているか・どこで止まっているかを最低 1 度確認する。
+   「クリック反応するが画面出ない」と「クリック自体反応しない」は別問題。
+4. **再発カウントによる切り替え**: 同じ feature を 2 回以上 fix している場合、表面的修正
+   でなく architecture / silent failure path の review に切り替える。fix を重ねる前に
+   「過去の fix が効かなかった理由は何か」を root cause として specifically 特定する。
+5. **post-action UX の SPEC 義務化**: button / link / action を SPEC に書く際は post-action
+   UX (進捗・成功・失敗・確認) を必ず受け入れシナリオに含める。click 前後を分離して片方しか
+   書かない SPEC を禁止する。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5223,3 +5223,25 @@ Board request `2b256bfc-...` で報告していた。
    broadcast event で reach するかを表形式で残す (SPEC 7.2 の `Inventory: write path vs
    surface` 表)。Inventory を見ながら write path を設計すれば「すべての surface を
    touch しているか」を caller 側で必ず確認できる。
+
+## 2026-05-11 — Test-only HOME mutation は crate-wide lock に統一する
+
+### 事象
+
+`cargo test -p gwt-core -p gwt` の並列実行で Board/Workspace 系テストが intermittent に失敗した。
+単独実行では通り、失敗時は `GWT_SESSION_ID` から保存済み session を読めず、current workspace
+audience が欠落していた。
+
+### 原因
+
+`app_runtime` test module と一部 helper test が `HOME` / `USERPROFILE` を module-local lock
+または lock なしで変更していた。CLI Board/Workspace tests は crate-wide `env_test_lock` を
+使っていたため、同じ process 内で別 test が HOME を差し替え、session path resolution が
+別 tempdir を参照した。
+
+### 再発防止策
+
+1. `HOME` / `USERPROFILE` / `GWT_SESSION_ID` など process-global env を触る test は、
+   module-local lock を作らず crate-wide `env_test_lock` に寄せる。
+2. 単独 test green で満足せず、env mutation を伴う修正後は default parallelism の
+   `cargo test -p gwt-core -p gwt` を必ず 1 回通す。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5167,3 +5167,59 @@ path は untouched だった。
 5. **post-action UX の SPEC 義務化**: button / link / action を SPEC に書く際は post-action
    UX (進捗・成功・失敗・確認) を必ず受け入れシナリオに含める。click 前後を分離して片方しか
    書かない SPEC を禁止する。
+
+## 2026-05-11 — Agent pane heading が `workspace update` 単独では更新されない (SPEC-2359 US-26 / Phase U-1..U-3)
+
+### 事象
+
+ユーザーから「実行中のエージェントが何をしているのか、一目でタイトルで分かるべき」という UX 観点で
+指摘を受け、本 session で `gwtd workspace update --agent-session <id> --title-summary "X"` を
+発行しても、Web UI の Agent pane heading は `agent_id` フォールバック ("CLAUDE CODE") のままで
+あることを再現確認した。projection JSON (`~/.gwt/projects/<hash>/workspace/current.json`) には
+`agents[<i>].title_summary = "X"` が確かに書かれていた。Codex も別 session で同 root cause を
+Board request `2b256bfc-...` で報告していた。
+
+### 原因
+
+1. **同じ UI 真実が 2 つの broadcast channel に分かれていた**: 
+   - Active work card / Workspace Kanban: `BackendEvent::ActiveWorkProjection` で受信。
+     `projection.agents[<i>].title_summary` を直接参照する。
+   - Agent pane heading (`windowDisplayTitle`): `BackendEvent::WorkspaceState` で受信。
+     `windowData.dynamic_title` を参照する。`dynamic_title` が空だと `agent_id` まで
+     フォールバック→ CSS uppercase で "CLAUDE CODE" 表示。
+2. **caller によって到達する broadcast surface が異なっていた**: 
+   - `gwtd workspace update --title-summary` 経路 (`handle_workspace_projection_changed_events`)
+     は `sync_agent_window_titles_from_workspace_projection` で in-memory `dynamic_title` を
+     更新するが、`ActiveWorkProjection` しか broadcast しなかった。`WorkspaceState` 不在の
+     ため、frontend の `windowData.dynamic_title` は次の hook event / window 構造変更まで
+     古いまま。Pane heading は fallback に張り付く。
+   - Board flow は `update_agent_window_dynamic_title_for_board_entry` で別経路に in-memory
+     書き込みする。やはり `WorkspaceState` 不在。
+3. **`active_agent_sessions` 未登録 session が静かに無視されていた**: launch flow が
+   track していない session (GUI 再起動後 / 外部から `claude` 直接起動など) は projection に
+   は載っていても、`sync_agent_window_titles_from_workspace_projection` の filter_map が
+   None を返し、pane heading 更新を silently drop していた。
+
+### 再発防止策
+
+1. **複数 surface に reach する write は canonical orchestration API に集約する**: 
+   SPEC-2359 US-26 で `apply_workspace_projection_title_sync` を追加し、5 surface
+   (projection JSON / journal / in-memory `dynamic_title` / `ActiveWorkProjection` /
+   `WorkspaceState`) を 1 関数で同期する契約にした。新規 caller は必ずこの API を経由する。
+2. **partial-write を構造的に不可能にする**: orchestration API が 5 surface を 1 batch で
+   触るので、caller は 4 + 1 / 3 + 2 の組合せを書けない。「うっかり broadcast を一つ
+   忘れる」が type-system + test level でブロックされる。
+3. **fallback resolution を許す**: `active_agent_sessions` 未登録でも `projection.agents[<i>]`
+   が `window_id` / `worktree_path` を持っているなら、orchestration API はそちらをフォール
+   バックして in-memory `dynamic_title` を更新する。Launch lifecycle (US-24) には触らず、
+   title sync の resolution だけ補強する。
+4. **CI green = done を疑え (再掲)**: 既存テストは「`ActiveWorkProjection` が出る」しか
+   assert していなかったため、`WorkspaceState` 欠落は test 上見えなかった。新規テスト
+   `apply_workspace_projection_title_sync_emits_workspace_state_when_dynamic_title_changed` と
+   `handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pane_heading` で
+   構造的に固定。「frontend がこの broadcast を読んでいる」surface を素 grep で確認してから
+   テスト assertion を組む。
+5. **UI surface インベントリを書く**: 同じ data field を読む UI 面が複数あるなら、どの
+   broadcast event で reach するかを表形式で残す (SPEC 7.2 の `Inventory: write path vs
+   surface` 表)。Inventory を見ながら write path を設計すれば「すべての surface を
+   touch しているか」を caller 側で必ず確認できる。


### PR DESCRIPTION
## Summary

- v9.26.0 リリース。SPEC-2041 Phase 19 の自動更新 modal-driven post-click UX と、SPEC-2359 Phase 20 の Board Workspace audience 基盤を取り込む。
- Workspace 系（unassigned agent state / work item history / 重複アクティブ編集ブロック / canonical agent title sync）と Provider hook parity（OpenCode / OpenClaw / Hermes）を強化。
- v9.25.0 以降の 37 個の非マージコミットを束ねる。

## Changes

### Features

- gui: SPEC-2041 Phase 19 post-click modal state machine 実装と backend split による silent failure 解消
- update: SPEC-2041 Phase 19 download progress callback、pending persistence + bootstrap swap + log writer、`commit_update_later_pending` の explicit named function 化（FR-064）
- update: `GWT_UPDATE_API_BASE_URL` 環境変数で Gate 2 mock smoke を可能に
- scripts: SPEC-2041 Phase 19 Gate 2 mock update server を追加
- coordination / board / gui: SPEC-2359 Phase 20 Board Workspace audience 基盤と Workspace audience auto-attach + mention fan-out、Board pane Workspace audience filter toggle、current project workspace id の Board filter 連携
- workspace: 未割り当て agent state、work item history、重複アクティブ workspace edit のブロック
- app-runtime: agent title sync の canonical orchestration
- OpenCode / OpenClaw / Hermes Agent の hook 対応

### Bug Fixes

- update: SPEC-2041 Phase 19 CodeRabbit / フォローアップレビュー指摘（PR #2630 / #2631 / #2634 / #2635）の修正
- board: all-view live updates の保持
- app-runtime: 真のタイトル差分があるときだけ WorkspaceState を broadcast
- hook runtime path handling / provider hook adapters の堅牢化
- launch wizard open errors のスコープ整理と表面化
- HOME を変更する gwt テストの直列化を含むテスト改善
- 新しい built-in board origin agents への対応

### Tests / Docs

- gui / update: SPEC-2041 Phase 19 の RED テスト、Playwright scaffold、bootstrap decision + cleanup、progress callback monotonic、path validation の pure fn 抽出 + 5 ユニットテスト、ready-state error handling テスト
- coordination: recent post history テストの安定化
- docs: SPEC-2041 Phase 14 silent-failure 5回連続見逃しの教訓と Phase 19 Gate 3 manual smoke runbook

## Version

- 旧バージョン: v9.25.0
- 新バージョン: **v9.26.0**
- 種別: minor（コミットには `feat(gui)!:` および `BREAKING CHANGE:` フッターが含まれているが、ユーザー判断によりマイナーリリースとして取り扱う）

## Closing Issues

None

## Related Issues / Links

- #1921
- #2014
- #2018
- #2359
- #2640
- #2645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OpenClaw and Hermes agent types with full integration
  * Implemented workspace-scoped board audience filtering for improved visibility control
  * Enhanced update flow with progress modal, download tracking, and deferred apply options
  * Introduced workspace work items and coordination system for better task handoff
  * Added board origin agent functionality to focus or resume background agent sessions
  * Implemented provider-specific hook generation for OpenCode, OpenClaw, and Hermes agents

* **Improvements**
  * Enhanced workspace kanban surface with unassigned agent section
  * Improved agent affiliation and workspace identity resolution
  * Better update state persistence across restarts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2652)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->