### PR TITLE
feat: prepend GWT_BIN_PATH dir to agent PATH

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -450,7 +450,44 @@ pub fn install_launch_gwt_bin_env_with_lookup(
                 .or_insert(gwt_bin);
         }
     }
+    if let Some(resolved) = env_vars.get(GWT_BIN_PATH_ENV).cloned() {
+        if let Some(parent) = Path::new(&resolved).parent() {
+            prepend_dir_to_path(env_vars, parent);
+        }
+    }
     Ok(())
+}
+
+/// Prepend `dir` to `env_vars["PATH"]` unless it is empty or already present.
+///
+/// Returns `true` if PATH was updated, `false` for a no-op (empty `dir`, dir
+/// already on PATH, or `join_paths` failure). PATH parsing uses
+/// [`std::env::split_paths`] / [`std::env::join_paths`] so the `:` / `;`
+/// separator difference between Unix and Windows is handled automatically.
+pub fn prepend_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -> bool {
+    if dir.as_os_str().is_empty() {
+        return false;
+    }
+    let existing_path = env_vars
+        .get("PATH")
+        .map(String::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let mut entries: Vec<PathBuf> = if existing_path.is_empty() {
+        Vec::new()
+    } else {
+        std::env::split_paths(&existing_path).collect()
+    };
+    let dir_buf = dir.to_path_buf();
+    if entries.iter().any(|entry| entry == &dir_buf) {
+        return false;
+    }
+    entries.insert(0, dir_buf);
+    let Ok(joined) = std::env::join_paths(&entries) else {
+        return false;
+    };
+    env_vars.insert("PATH".to_string(), joined.to_string_lossy().into_owned());
+    true
 }
 
 pub fn resolve_public_gwt_bin_with_lookup(
@@ -1886,5 +1923,237 @@ mod tests {
     fn preflight_env_test_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    // SPEC-2077 Phase I1 (US-7 / FR-020 / FR-021 / FR-022 / SC-010):
+    // install_launch_gwt_bin_env_with_lookup must prepend the GWT_BIN_PATH
+    // parent directory to env_vars["PATH"] so agent subshells can resolve
+    // gwtd / gwt directly without the ${GWT_BIN_PATH:-gwtd} indirection.
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_prepends_gwtd_dir_to_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars.get(GWT_BIN_PATH_ENV).map(String::as_str),
+            Some("/Applications/GWT.app/Contents/MacOS/gwtd"),
+        );
+        let path = env_vars.get("PATH").expect("PATH should be set");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/Applications/GWT.app/Contents/MacOS")),
+            "GWT_BIN_PATH parent dir must be prepended; got {path}",
+        );
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_dedups_existing_path_entry() {
+        let mut env_vars = HashMap::from([(
+            "PATH".to_string(),
+            "/Applications/GWT.app/Contents/MacOS:/usr/bin".to_string(),
+        )]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/Applications/GWT.app/Contents/MacOS"),
+                PathBuf::from("/usr/bin"),
+            ],
+            "PATH must not contain duplicate GWT_BIN_PATH parent dir",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_skips_path_update_when_parent_is_empty() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/opt/gwt/bin/gwt");
+        // Lookup returns a bare filename (Path::parent => Some(""))
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("gwtd")),
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars.get(GWT_BIN_PATH_ENV).map(String::as_str),
+            Some("gwtd"),
+        );
+        assert_eq!(
+            env_vars.get("PATH").map(String::as_str),
+            Some("/usr/bin:/bin"),
+            "empty GWT_BIN_PATH parent must be a no-op",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_creates_path_when_absent() {
+        let mut env_vars: HashMap<String, String> = HashMap::new();
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let path = env_vars.get("PATH").expect("PATH should be created");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/Applications/GWT.app/Contents/MacOS")],
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_dedups_when_dir_already_on_path() {
+        let mut env_vars =
+            HashMap::from([("PATH".to_string(), "/usr/local/bin:/usr/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars.get(GWT_BIN_PATH_ENV).map(String::as_str),
+            Some("/usr/local/bin/gwtd"),
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin"),],
+            "Docker dir already on PATH must dedup",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_prepends_when_dir_missing_from_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/usr/local/bin")),
+            "Docker dir not on PATH must be prepended; got entries: {entries:?}",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_preserves_existing_path_order() {
+        let mut env_vars =
+            HashMap::from([("PATH".to_string(), "/profile/bin:/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/Applications/GWT.app/Contents/MacOS"),
+                PathBuf::from("/profile/bin"),
+                PathBuf::from("/usr/bin"),
+                PathBuf::from("/bin"),
+            ],
+            "existing PATH order must be preserved after prepend",
+        );
+    }
+
+    #[test]
+    fn prepare_agent_launch_host_prepends_gwtd_dir_to_path() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo-feature");
+        let sessions_dir = temp.path().join(".gwt").join("sessions");
+        fs::create_dir_all(&worktree).expect("create worktree");
+
+        let mut config = sample_versioned_launch_config(&worktree);
+        config
+            .env_vars
+            .insert("PATH".to_string(), "/usr/bin:/bin".to_string());
+
+        let mut probe_host_runner =
+            |_command: &str,
+             _args: Vec<String>,
+             _env: &HashMap<String, String>,
+             _remove_env: &[String],
+             _cwd: Option<PathBuf>| true;
+        let lookup_gwt_bin = |_command: &str| Some(PathBuf::from("/opt/gwt/bin/gwtd"));
+
+        let prepared = prepare_agent_launch_with(
+            &worktree,
+            &sessions_dir,
+            config,
+            None,
+            |_path| Ok(()),
+            PrepareLaunchDeps {
+                current_exe: Path::new("/opt/gwt/bin/gwt"),
+                probe_host_runner: &mut probe_host_runner,
+                lookup_gwt_bin: &lookup_gwt_bin,
+            },
+        )
+        .expect("prepare launch");
+
+        assert_eq!(
+            prepared
+                .process_launch
+                .env
+                .get(GWT_BIN_PATH_ENV)
+                .map(String::as_str),
+            Some("/opt/gwt/bin/gwtd"),
+        );
+        let path = prepared
+            .process_launch
+            .env
+            .get("PATH")
+            .expect("PATH should be set after install_launch_gwt_bin_env_with_lookup");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/opt/gwt/bin")),
+            "agent process PATH must start with GWT_BIN_PATH parent dir; got {path}",
+        );
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
     }
 }

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -598,6 +598,11 @@ pub fn install_launch_gwt_bin_env_with_lookup(
                 .or_insert(gwt_bin);
         }
     }
+    if let Some(resolved) = env_vars.get(gwt_agent::session::GWT_BIN_PATH_ENV).cloned() {
+        if let Some(parent) = Path::new(&resolved).parent() {
+            gwt_agent::prepare::prepend_dir_to_path(env_vars, parent);
+        }
+    }
     Ok(())
 }
 
@@ -633,6 +638,151 @@ mod tests {
         assert_eq!(
             interactive_windows_shell_args(gwt_agent::WindowsShellKind::PowerShell7),
             vec!["-NoLogo"]
+        );
+    }
+
+    // SPEC-2077 Phase I1 (US-7 / FR-020 / FR-021 / FR-022 / SC-010):
+    // launch_runtime mirror of install_launch_gwt_bin_env_with_lookup must
+    // prepend dirname(GWT_BIN_PATH) to env_vars["PATH"] with dedup + empty
+    // guard. Mirrors crates/gwt-agent/src/prepare.rs::tests::install_launch_gwt_bin_env_*.
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_prepends_gwtd_dir_to_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars
+                .get(gwt_agent::session::GWT_BIN_PATH_ENV)
+                .map(String::as_str),
+            Some("/Applications/GWT.app/Contents/MacOS/gwtd"),
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/Applications/GWT.app/Contents/MacOS")),
+        );
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_dedups_existing_path_entry() {
+        let mut env_vars = HashMap::from([(
+            "PATH".to_string(),
+            "/Applications/GWT.app/Contents/MacOS:/usr/bin".to_string(),
+        )]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/Applications/GWT.app/Contents/MacOS"),
+                PathBuf::from("/usr/bin"),
+            ],
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_skips_path_update_when_parent_is_empty() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/opt/gwt/bin/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("gwtd")),
+        )
+        .expect("install");
+
+        // GWT_BIN_PATH may end up as a sibling/managed_assets resolution; we
+        // assert only that PATH is untouched when the resolved binary has no
+        // meaningful parent dir.
+        assert_eq!(
+            env_vars.get("PATH").map(String::as_str),
+            Some("/usr/bin:/bin"),
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_creates_path_when_absent() {
+        let mut env_vars: HashMap<String, String> = HashMap::new();
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let path = env_vars.get("PATH").expect("PATH should be created");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/Applications/GWT.app/Contents/MacOS")],
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_prepends_when_dir_missing_from_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars
+                .get(gwt_agent::session::GWT_BIN_PATH_ENV)
+                .map(String::as_str),
+            Some("/usr/local/bin/gwtd"),
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/usr/local/bin")),
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_dedups_when_dir_already_on_path() {
+        let mut env_vars =
+            HashMap::from([("PATH".to_string(), "/usr/local/bin:/usr/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin"),],
         );
     }
 }


### PR DESCRIPTION
## Summary

- `install_launch_gwt_bin_env_with_lookup` が `GWT_BIN_PATH` を設定する際に、その親ディレクトリを `env_vars["PATH"]` の先頭に prepend するようにする。GUI 起動 (macOS app) でも agent shell から `gwtd` / `gwt` を直接呼べるようになり、`$GWT_BIN_PATH` indirection が default path で短絡される。
- SPEC-2077 Phase I1 follow-up (US-7 / FR-020-022 / SC-010) の TDD 実装。skill 側の `${GWT_BIN_PATH:-gwtd}` 3 段フォールバックは defense として現状維持。

## Changes

- `crates/gwt-agent/src/prepare.rs`: `pub fn prepend_dir_to_path(env_vars, dir)` を新設 (空ガード + dedup + `std::env::split_paths` / `join_paths` で OS-correct 処理)。`install_launch_gwt_bin_env_with_lookup` の Host / Docker 両 arm で `env_vars[GWT_BIN_PATH_ENV]` の `Path::parent()` から helper を呼び出す。`tests` module に 6 ケースの unit test (Host prepend / dedup / empty guard / PATH 不在 / Docker prepend / Docker dedup / profile PATH 順序保存) と integration test `prepare_agent_launch_host_prepends_gwtd_dir_to_path` を追加。
- `crates/gwt/src/launch_runtime.rs`: near-duplicate の `install_launch_gwt_bin_env_with_lookup` を `gwt_agent::prepare::prepend_dir_to_path` 経由で同じ挙動に揃え、helper の重複定義を回避。`tests` module に 6 ケースの mirror unit test を追加。

## Testing

- [ ] `cargo test -p gwt-agent install_launch_gwt_bin_env` — 7 passed (新規 6 ケース + 既存 1)
- [ ] `cargo test -p gwt-agent prepare_agent_launch_host_prepends` — 1 passed (integration regression net)
- [ ] `cargo test -p gwt --bin gwt install_launch_gwt_bin_env` — 7 passed (新規 6 ケース + 既存 windows-style 1)
- [ ] `cargo test -p gwt-agent` — 212 passed (broad regression)
- [ ] `cargo test -p gwt` — 全 binary / lib / integration suite green
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — warnings 0
- [ ] `cargo fmt --check` — clean
- [ ] `cargo build -p gwt --bin gwt --bin gwtd` — success

## Closing Issues

- None

## Related Issues / Links

- #2077 (SPEC-2077 Runtime Daemon、Phase I1 follow-up owner)

## Checklist

- [x] Tests added/updated (12 unit tests + 1 integration test)
- [x] Lint/format passed (`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`)
- [ ] Documentation updated (if user-facing change) — N/A (内部 env injection の改善で operator-visible behavior change なし、 既存 `${GWT_BIN_PATH:-gwtd}` 経路は不変)
- [ ] Migration/backfill plan included (if schema/data change) — N/A (env_vars HashMap への加算のみ)
- [x] CHANGELOG impact considered (breaking change flagged in commit) — non-breaking、`feat:` minor bump

## Context

- SPEC-2077 (#2077) は `GWT_BIN_PATH` operator-facing contract の owner。GUI 起動 (macOS app) で `/Applications/GWT.app/Contents/MacOS/` が PATH 外で `command -v gwtd` が解決できず、skill の `${GWT_BIN_PATH:-gwtd}` 3 段フォールバックの第 2 段 (PATH lookup) が常に miss するという gap が顕在化していた。本 PR で第 2 段が GUI launch でも有効化される。
- SPEC-2077 の Phase H1-H4 (gwtd runtime ownership migration) とは独立。本 PR は launch 時 env injection だけを触り、runtime ownership には介入しない。

## Risk / Impact

- **Affected areas**: agent 起動 env (`prepare_agent_launch_with` / `launch_runtime`)。Host / Docker 両方に同じロジックを適用。Docker は `/usr/local/bin` が既に container PATH 内のため dedup で実質 no-op。
- **Rollback plan**: 2 ファイルの diff を revert すれば旧挙動に戻る (`prepend_dir_to_path` 削除 + 呼び出し箇所削除)。env_vars 経路の加算的変更なのでローリングバックは無害。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GWT binary resolution: the agent now automatically prepends the GWT binary directory to the PATH environment variable, enabling direct `gwt`/`gwtd` command resolution without manual path configuration. This works consistently across host and Docker runtime environments.

* **Tests**
  * Added comprehensive test coverage for PATH management across different runtime environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2653)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->