### PR TITLE
fix: handle Windows case-insensitive PATH key in prepend_dir_to_path

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -2092,15 +2092,10 @@ mod tests {
         // the spawned child process inherits both and command lookup is
         // corrupted. Test values use the platform-native PATH separator so
         // split_paths / join_paths round-trip on the host test runner.
-        let existing = std::env::join_paths([
-            Path::new("/usr/bin"),
-            Path::new("/bin"),
-        ])
-        .expect("join_paths existing entries");
-        let mut env_vars = HashMap::from([(
-            "Path".to_string(),
-            existing.to_string_lossy().into_owned(),
-        )]);
+        let existing = std::env::join_paths([Path::new("/usr/bin"), Path::new("/bin")])
+            .expect("join_paths existing entries");
+        let mut env_vars =
+            HashMap::from([("Path".to_string(), existing.to_string_lossy().into_owned())]);
         let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
         assert!(updated, "PATH must be updated for Windows-style key");
         assert!(
@@ -2122,10 +2117,8 @@ mod tests {
     fn prepend_dir_to_path_preserves_lowercase_path_key() {
         let existing = std::env::join_paths([Path::new("/usr/bin"), Path::new("/bin")])
             .expect("join_paths existing entries");
-        let mut env_vars = HashMap::from([(
-            "path".to_string(),
-            existing.to_string_lossy().into_owned(),
-        )]);
+        let mut env_vars =
+            HashMap::from([("path".to_string(), existing.to_string_lossy().into_owned())]);
         let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
         assert!(updated);
         assert!(
@@ -2142,18 +2135,20 @@ mod tests {
 
     #[test]
     fn prepend_dir_to_path_dedups_case_insensitive_existing_dir() {
-        let existing = std::env::join_paths([
-            Path::new("/opt/gwt/bin"),
-            Path::new("/usr/bin"),
-        ])
-        .expect("join_paths existing entries");
+        let existing = std::env::join_paths([Path::new("/opt/gwt/bin"), Path::new("/usr/bin")])
+            .expect("join_paths existing entries");
         let original_value = existing.to_string_lossy().into_owned();
-        let mut env_vars =
-            HashMap::from([("Path".to_string(), original_value.clone())]);
+        let mut env_vars = HashMap::from([("Path".to_string(), original_value.clone())]);
         let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
-        assert!(!updated, "existing entry must be a no-op regardless of key case");
+        assert!(
+            !updated,
+            "existing entry must be a no-op regardless of key case"
+        );
         assert!(!env_vars.contains_key("PATH"));
-        assert_eq!(env_vars.get("Path").map(String::as_str), Some(original_value.as_str()));
+        assert_eq!(
+            env_vars.get("Path").map(String::as_str),
+            Some(original_value.as_str())
+        );
     }
 
     #[test]

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -458,18 +458,28 @@ pub fn install_launch_gwt_bin_env_with_lookup(
     Ok(())
 }
 
-/// Prepend `dir` to `env_vars["PATH"]` unless it is empty or already present.
+/// Prepend `dir` to the PATH-style entry in `env_vars` unless it is empty or
+/// already present.
 ///
-/// Returns `true` if PATH was updated, `false` for a no-op (empty `dir`, dir
-/// already on PATH, or `join_paths` failure). PATH parsing uses
-/// [`std::env::split_paths`] / [`std::env::join_paths`] so the `:` / `;`
-/// separator difference between Unix and Windows is handled automatically.
+/// Returns `true` if the entry was updated, `false` for a no-op (empty `dir`,
+/// dir already on PATH, or `join_paths` failure). Key lookup is
+/// case-insensitive: Windows processes may expose the variable as `Path` or
+/// `path`, and a case-sensitive read would produce a duplicate `PATH` key
+/// alongside the original, corrupting command lookup once the child process
+/// inherits both. PATH parsing uses [`std::env::split_paths`] /
+/// [`std::env::join_paths`] so the `:` / `;` separator difference between
+/// Unix and Windows is handled automatically.
 pub fn prepend_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -> bool {
     if dir.as_os_str().is_empty() {
         return false;
     }
+    let existing_key = env_vars
+        .keys()
+        .find(|key| key.eq_ignore_ascii_case("PATH"))
+        .cloned();
+    let key = existing_key.unwrap_or_else(|| "PATH".to_string());
     let existing_path = env_vars
-        .get("PATH")
+        .get(&key)
         .map(String::as_str)
         .unwrap_or_default()
         .to_string();
@@ -486,7 +496,7 @@ pub fn prepend_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -
     let Ok(joined) = std::env::join_paths(&entries) else {
         return false;
     };
-    env_vars.insert("PATH".to_string(), joined.to_string_lossy().into_owned());
+    env_vars.insert(key, joined.to_string_lossy().into_owned());
     true
 }
 
@@ -2071,6 +2081,79 @@ mod tests {
             Some(Path::new("/usr/local/bin")),
             "Docker dir not on PATH must be prepended; got entries: {entries:?}",
         );
+    }
+
+    #[test]
+    fn prepend_dir_to_path_preserves_windows_style_path_key() {
+        // CodeRabbit P1 regression follow-up: Windows processes may expose
+        // the path variable as "Path" (case-insensitive at OS level).
+        // prepend_dir_to_path must update the existing key in place rather
+        // than creating a duplicate "PATH" entry alongside "Path", otherwise
+        // the spawned child process inherits both and command lookup is
+        // corrupted. Test values use the platform-native PATH separator so
+        // split_paths / join_paths round-trip on the host test runner.
+        let existing = std::env::join_paths([
+            Path::new("/usr/bin"),
+            Path::new("/bin"),
+        ])
+        .expect("join_paths existing entries");
+        let mut env_vars = HashMap::from([(
+            "Path".to_string(),
+            existing.to_string_lossy().into_owned(),
+        )]);
+        let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
+        assert!(updated, "PATH must be updated for Windows-style key");
+        assert!(
+            !env_vars.contains_key("PATH"),
+            "no duplicate uppercase PATH key may be created when Path exists: {env_vars:?}",
+        );
+        let path = env_vars.get("Path").expect("Path key must be preserved");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/opt/gwt/bin")),
+            "prepended dir must lead the Path value; got {path}",
+        );
+        assert!(entries.iter().any(|p| p == Path::new("/usr/bin")));
+        assert!(entries.iter().any(|p| p == Path::new("/bin")));
+    }
+
+    #[test]
+    fn prepend_dir_to_path_preserves_lowercase_path_key() {
+        let existing = std::env::join_paths([Path::new("/usr/bin"), Path::new("/bin")])
+            .expect("join_paths existing entries");
+        let mut env_vars = HashMap::from([(
+            "path".to_string(),
+            existing.to_string_lossy().into_owned(),
+        )]);
+        let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
+        assert!(updated);
+        assert!(
+            !env_vars.contains_key("PATH"),
+            "no duplicate uppercase PATH key may be created when lowercase path exists: {env_vars:?}",
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("path").expect("path key")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/opt/gwt/bin")),
+        );
+    }
+
+    #[test]
+    fn prepend_dir_to_path_dedups_case_insensitive_existing_dir() {
+        let existing = std::env::join_paths([
+            Path::new("/opt/gwt/bin"),
+            Path::new("/usr/bin"),
+        ])
+        .expect("join_paths existing entries");
+        let original_value = existing.to_string_lossy().into_owned();
+        let mut env_vars =
+            HashMap::from([("Path".to_string(), original_value.clone())]);
+        let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
+        assert!(!updated, "existing entry must be a no-op regardless of key case");
+        assert!(!env_vars.contains_key("PATH"));
+        assert_eq!(env_vars.get("Path").map(String::as_str), Some(original_value.as_str()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- PR #2653 で導入した `prepend_dir_to_path` が Windows の case-insensitive な PATH キー (`Path` / `path`) を扱えず、 既存 `Path` を放置して新規 `PATH` キーを併設してしまう regression を修正する。 child process は両方のキーを継承して PATH 解決が壊れる P1 バグ。
- CodeRabbit (chatgpt-codex-connector) からの post-merge review コメントへの follow-up。 case-insensitive lookup に切り替え、 hit したキーをそのまま使って値を更新する。

## Changes

- `crates/gwt-agent/src/prepare.rs`: `prepend_dir_to_path` の PATH キー検索を `env_vars.keys().find(|k| k.eq_ignore_ascii_case("PATH"))` で case-insensitive に変更。 hit すれば元のキー (`Path` / `path` / `PATH`) を保持したまま値を更新、 miss すれば従来通り `"PATH"` を新規作成。 `tests` module に 3 ケース追加 (`Path` 維持 / `path` 維持 / case-insensitive dedup) し、 既存 10 unit tests + 1 integration test の挙動は不変。 `launch_runtime.rs` 側は helper を再利用しているので変更不要 (mirror tests 7 ケースも GREEN を維持)。

## Testing

- [ ] `cargo test -p gwt-agent prepend_dir_to_path` — 3 passed (3 new cases)
- [ ] `cargo test -p gwt-agent install_launch_gwt_bin_env` — 7 passed (既存)
- [ ] `cargo test -p gwt-agent` — 215 passed (212 + 3 new)
- [ ] `cargo test -p gwt --bin gwt install_launch_gwt_bin_env` — 7 passed (mirror)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- [ ] `cargo fmt --check` — clean

## Closing Issues

- None

## Related Issues / Links

- #2077 (SPEC-2077 Runtime Daemon、Phase I1 follow-up owner)
- #2653 (前段の `feat: prepend GWT_BIN_PATH dir to agent PATH`、 本 PR で残 P1 regression を解消)

## Checklist

- [x] Tests added/updated (3 new unit tests; 既存 17 tests 全部 GREEN)
- [x] Lint/format passed (`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`)
- [ ] Documentation updated — N/A (内部 env injection、 user-visible behavior は変わらず)
- [ ] Migration/backfill plan included — N/A (env_vars HashMap への加算的 fix)
- [x] CHANGELOG impact considered — `fix:` patch bump

## Context

- PR #2653 (merged at f5f1e7ff) で `prepend_dir_to_path` を新設し GWT_BIN_PATH 親 dir を agent PATH に prepend する SPEC-2077 Phase I1 を入れた。
- CodeRabbit のコメント (PR #2653 thread `PRRT_kwDOPLof2M6BERaq`) が Windows 環境変数の case-insensitive 性質に起因する regression を P1 として指摘:
  > `prepend_dir_to_path` only reads/writes the exact key `"PATH"`, but Windows environment variable names are case-insensitive and many processes provide the path as `"Path"`. In that case this new code treats PATH as missing, creates a new `PATH` value containing only the prepended gwtd directory, and leaves `Path` untouched; when both are later passed to the child process, effective command lookup can be corrupted (or become non-deterministic), causing agent shells to fail to find standard tools.
- 本 PR は Phase I1 を Windows 環境でも安全に成立させる post-merge regression fix。

## Risk / Impact

- **Affected areas**: `prepend_dir_to_path` の lookup ロジック。 Unix runner は従来通り `"PATH"` のみ存在するため挙動変化なし、 Windows runner で `Path` が渡された際にのみ新挙動が観測される。 `launch_runtime.rs` mirror は helper を再利用しているので追加変更不要。
- **Rollback plan**: 単一関数の `find().cloned()` 行と `key` パラメータ化を revert すれば旧挙動に戻る。 ただし戻すと Windows regression が再発するため non-rollback 推奨。
