### PR TITLE
feat(launch): restore agent preferences per agent

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -407,8 +407,8 @@ impl LaunchWizardMemoryCache {
         )
     }
 
-    fn previous_profile(&self, repo_path: &Path) -> Option<gwt::LaunchWizardPreviousProfile> {
-        gwt::launch_wizard::previous_launch_profile_from_sessions(repo_path, &self.sessions)
+    fn previous_profiles(&self) -> gwt::LaunchWizardPreviousProfiles {
+        gwt::launch_wizard::previous_launch_profiles_from_sessions(&self.sessions)
     }
 
     fn record_session(&mut self, session: gwt_agent::Session) {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -166,7 +166,7 @@ impl AppRuntime {
         let quick_start_entries = self
             .launch_wizard_cache
             .quick_start_entries(&quick_start_root, &normalized_branch_name);
-        let previous_profile = self.launch_wizard_cache.previous_profile(&quick_start_root);
+        let previous_profiles = self.launch_wizard_cache.previous_profiles();
         let agent_options = self.launch_wizard_cache.agent_options();
         let (docker_context, docker_service_status) =
             detect_wizard_docker_context_and_status(&quick_start_root);
@@ -174,7 +174,7 @@ impl AppRuntime {
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
             wizard_id,
-            wizard: LaunchWizardState::open_with_previous_profile(
+            wizard: LaunchWizardState::open_with_previous_profiles(
                 LaunchWizardContext {
                     selected_branch: synthetic_branch_entry(branch_name),
                     normalized_branch_name,
@@ -188,7 +188,7 @@ impl AppRuntime {
                 },
                 agent_options,
                 quick_start_entries,
-                previous_profile,
+                previous_profiles,
             ),
             workspace_resume_context,
         });
@@ -376,7 +376,7 @@ impl AppRuntime {
         let quick_start_entries = self
             .launch_wizard_cache
             .quick_start_entries(&quick_start_root, &work_branch);
-        let previous_profile = self.launch_wizard_cache.previous_profile(&quick_start_root);
+        let previous_profiles = self.launch_wizard_cache.previous_profiles();
         let agent_options = self.launch_wizard_cache.agent_options();
         let (docker_context, docker_service_status) =
             detect_wizard_docker_context_and_status(&quick_start_root);
@@ -384,7 +384,7 @@ impl AppRuntime {
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
             wizard_id,
-            wizard: LaunchWizardState::open_start_work_with_previous_profile(
+            wizard: LaunchWizardState::open_start_work_with_previous_profiles(
                 LaunchWizardContext {
                     selected_branch: synthetic_branch_entry(&base_branch),
                     normalized_branch_name: work_branch,
@@ -401,7 +401,7 @@ impl AppRuntime {
                 base_branch,
                 agent_options,
                 quick_start_entries,
-                previous_profile,
+                previous_profiles,
             ),
             workspace_resume_context,
         });
@@ -770,7 +770,7 @@ impl AppRuntime {
             docker_service_status: context.docker_service_status,
             agent_options,
             quick_start_entries,
-            previous_profile: None,
+            previous_profiles: None,
         });
     }
 }

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     collections::HashMap,
     path::{Path, PathBuf},
 };
@@ -204,6 +205,34 @@ pub struct LaunchWizardPreviousProfile {
     pub windows_shell: Option<gwt_agent::WindowsShellKind>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LaunchWizardPreviousProfiles {
+    default_agent_id: Option<String>,
+    by_agent: HashMap<String, LaunchWizardPreviousProfile>,
+}
+
+impl LaunchWizardPreviousProfiles {
+    fn from_profile(profile: Option<LaunchWizardPreviousProfile>) -> Self {
+        let Some(profile) = profile else {
+            return Self::default();
+        };
+        let default_agent_id = Some(profile.agent_id.clone());
+        let by_agent = HashMap::from([(profile.agent_id.clone(), profile)]);
+        Self {
+            default_agent_id,
+            by_agent,
+        }
+    }
+
+    fn preferred_agent_id(&self) -> Option<&str> {
+        self.default_agent_id.as_deref()
+    }
+
+    fn profile_for(&self, agent_id: &str) -> Option<&LaunchWizardPreviousProfile> {
+        self.by_agent.get(agent_id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AgentLaunchDraft {
     model: String,
@@ -261,16 +290,13 @@ pub fn load_previous_launch_profile(
     repo_path: &Path,
     sessions_dir: &Path,
 ) -> Option<LaunchWizardPreviousProfile> {
-    let entries = std::fs::read_dir(sessions_dir).ok()?;
-    let sessions = entries
-        .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
-            (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
-        })
-        .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
-        .collect::<Vec<_>>();
+    let sessions = load_launch_sessions(sessions_dir);
     previous_launch_profile_from_sessions(repo_path, &sessions)
+}
+
+pub fn load_previous_launch_profiles(sessions_dir: &Path) -> LaunchWizardPreviousProfiles {
+    let sessions = load_launch_sessions(sessions_dir);
+    previous_launch_profiles_from_sessions(&sessions)
 }
 
 pub fn previous_launch_profile_from_sessions(
@@ -280,14 +306,65 @@ pub fn previous_launch_profile_from_sessions(
     sessions
         .iter()
         .filter(|session| same_launch_profile_repo(repo_path, session))
-        .max_by(|left, right| {
-            left.updated_at
-                .cmp(&right.updated_at)
-                .then_with(|| left.created_at.cmp(&right.created_at))
-                .then_with(|| left.id.cmp(&right.id))
-        })
+        .max_by(|left, right| launch_profile_session_cmp(left, right))
         .cloned()
         .map(previous_profile_from_session)
+}
+
+pub fn previous_launch_profiles_from_sessions(
+    sessions: &[gwt_agent::Session],
+) -> LaunchWizardPreviousProfiles {
+    let mut latest_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
+    let mut default_agent_id = None;
+    let mut latest_session = None::<gwt_agent::Session>;
+
+    for session in sessions {
+        let agent_id = session.agent_id.command().to_string();
+        if latest_by_agent
+            .get(&agent_id)
+            .is_none_or(|existing| launch_profile_session_cmp(session, existing).is_gt())
+        {
+            latest_by_agent.insert(agent_id.clone(), session.clone());
+        }
+        if latest_session
+            .as_ref()
+            .is_none_or(|existing| launch_profile_session_cmp(session, existing).is_gt())
+        {
+            default_agent_id = Some(agent_id);
+            latest_session = Some(session.clone());
+        }
+    }
+
+    let by_agent = latest_by_agent
+        .into_iter()
+        .map(|(agent_id, session)| (agent_id, previous_profile_from_session(session)))
+        .collect();
+
+    LaunchWizardPreviousProfiles {
+        default_agent_id,
+        by_agent,
+    }
+}
+
+fn load_launch_sessions(sessions_dir: &Path) -> Vec<gwt_agent::Session> {
+    let Ok(entries) = std::fs::read_dir(sessions_dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
+        })
+        .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
+        .collect()
+}
+
+fn launch_profile_session_cmp(left: &gwt_agent::Session, right: &gwt_agent::Session) -> Ordering {
+    left.updated_at
+        .cmp(&right.updated_at)
+        .then_with(|| left.created_at.cmp(&right.created_at))
+        .then_with(|| left.id.cmp(&right.id))
 }
 
 pub fn quick_start_entries_from_sessions(
@@ -417,7 +494,7 @@ pub struct LaunchWizardHydration {
     pub docker_service_status: gwt_docker::ComposeServiceStatus,
     pub agent_options: Vec<AgentOption>,
     pub quick_start_entries: Vec<QuickStartEntry>,
-    pub previous_profile: Option<LaunchWizardPreviousProfile>,
+    pub previous_profiles: Option<LaunchWizardPreviousProfiles>,
 }
 
 #[derive(Debug, Clone)]
@@ -511,6 +588,7 @@ pub struct LaunchWizardState {
     pub selected: usize,
     pub detected_agents: Vec<AgentOption>,
     pub quick_start_entries: Vec<QuickStartEntry>,
+    previous_profiles: LaunchWizardPreviousProfiles,
     pub is_new_branch: bool,
     pub base_branch_name: Option<String>,
     pub launch_target: LaunchTargetKind,
@@ -559,7 +637,7 @@ impl LaunchWizardState {
         context: LaunchWizardContext,
         agent_options: Vec<AgentOption>,
         mut quick_start_entries: Vec<QuickStartEntry>,
-        previous_profile: Option<LaunchWizardPreviousProfile>,
+        previous_profiles: LaunchWizardPreviousProfiles,
         is_hydrating: bool,
     ) -> Self {
         Self::hydrate_live_window_ids(&context, &mut quick_start_entries);
@@ -588,6 +666,7 @@ impl LaunchWizardState {
             selected: 0,
             detected_agents: agent_options,
             quick_start_entries,
+            previous_profiles,
             is_new_branch: false,
             base_branch_name: None,
             launch_target: LaunchTargetKind::Agent,
@@ -613,12 +692,8 @@ impl LaunchWizardState {
         };
         state.branch_name = state.context.normalized_branch_name.clone();
         state.sync_selected_agent_options();
-        let previous_profile_applied = previous_profile
-            .map(|profile| state.apply_previous_profile(profile))
-            .unwrap_or(false);
-        if !previous_profile_applied {
-            state.sync_docker_lifecycle_default();
-        }
+        state.apply_preferred_agent_profile();
+        state.sync_docker_lifecycle_default();
         state.selected = step_default_selection(state.step, &state);
         state
     }
@@ -628,7 +703,28 @@ impl LaunchWizardState {
         agent_options: Vec<AgentOption>,
         quick_start_entries: Vec<QuickStartEntry>,
     ) -> Self {
-        Self::new_with(context, agent_options, quick_start_entries, None, false)
+        Self::new_with(
+            context,
+            agent_options,
+            quick_start_entries,
+            LaunchWizardPreviousProfiles::default(),
+            false,
+        )
+    }
+
+    pub fn open_with_previous_profiles(
+        context: LaunchWizardContext,
+        agent_options: Vec<AgentOption>,
+        quick_start_entries: Vec<QuickStartEntry>,
+        previous_profiles: LaunchWizardPreviousProfiles,
+    ) -> Self {
+        Self::new_with(
+            context,
+            agent_options,
+            quick_start_entries,
+            previous_profiles,
+            false,
+        )
     }
 
     pub fn open_with_previous_profile(
@@ -637,27 +733,26 @@ impl LaunchWizardState {
         quick_start_entries: Vec<QuickStartEntry>,
         previous_profile: Option<LaunchWizardPreviousProfile>,
     ) -> Self {
-        Self::new_with(
+        Self::open_with_previous_profiles(
             context,
             agent_options,
             quick_start_entries,
-            previous_profile,
-            false,
+            LaunchWizardPreviousProfiles::from_profile(previous_profile),
         )
     }
 
-    pub fn open_start_work_with_previous_profile(
+    pub fn open_start_work_with_previous_profiles(
         context: LaunchWizardContext,
         base_branch_name: String,
         agent_options: Vec<AgentOption>,
         quick_start_entries: Vec<QuickStartEntry>,
-        previous_profile: Option<LaunchWizardPreviousProfile>,
+        previous_profiles: LaunchWizardPreviousProfiles,
     ) -> Self {
         let mut state = Self::new_with(
             context,
             agent_options,
             quick_start_entries,
-            previous_profile,
+            previous_profiles,
             false,
         );
         state.wizard_mode = LaunchWizardMode::StartWork;
@@ -669,8 +764,30 @@ impl LaunchWizardState {
         state
     }
 
+    pub fn open_start_work_with_previous_profile(
+        context: LaunchWizardContext,
+        base_branch_name: String,
+        agent_options: Vec<AgentOption>,
+        quick_start_entries: Vec<QuickStartEntry>,
+        previous_profile: Option<LaunchWizardPreviousProfile>,
+    ) -> Self {
+        Self::open_start_work_with_previous_profiles(
+            context,
+            base_branch_name,
+            agent_options,
+            quick_start_entries,
+            LaunchWizardPreviousProfiles::from_profile(previous_profile),
+        )
+    }
+
     pub fn open_loading(context: LaunchWizardContext, agent_options: Vec<AgentOption>) -> Self {
-        Self::new_with(context, agent_options, Vec::new(), None, true)
+        Self::new_with(
+            context,
+            agent_options,
+            Vec::new(),
+            LaunchWizardPreviousProfiles::default(),
+            true,
+        )
     }
 
     pub fn open(context: LaunchWizardContext, sessions_dir: &Path, cache_path: &Path) -> Self {
@@ -680,13 +797,12 @@ impl LaunchWizardState {
             sessions_dir,
             &context.normalized_branch_name,
         );
-        let previous_profile =
-            load_previous_launch_profile(&context.quick_start_root, sessions_dir);
-        Self::open_with_previous_profile(
+        let previous_profiles = load_previous_launch_profiles(sessions_dir);
+        Self::open_with_previous_profiles(
             context,
             agent_options,
             quick_start_entries,
-            previous_profile,
+            previous_profiles,
         )
     }
 
@@ -765,7 +881,7 @@ impl LaunchWizardState {
             docker_service_status,
             agent_options,
             mut quick_start_entries,
-            previous_profile,
+            previous_profiles,
         } = hydration;
         if let Some(selected_branch) = selected_branch {
             self.context.selected_branch = selected_branch;
@@ -795,12 +911,11 @@ impl LaunchWizardState {
             self.docker_service = None;
         }
         self.sync_selected_agent_options();
-        let previous_profile_applied = previous_profile
-            .map(|profile| self.apply_previous_profile(profile))
-            .unwrap_or(false);
-        if !previous_profile_applied {
-            self.sync_docker_lifecycle_default();
+        if let Some(previous_profiles) = previous_profiles {
+            self.previous_profiles = previous_profiles;
+            self.apply_preferred_agent_profile();
         }
+        self.sync_docker_lifecycle_default();
         self.selected = self
             .selected
             .min(self.current_options().len().saturating_sub(1));
@@ -1248,18 +1363,25 @@ impl LaunchWizardState {
         }
     }
 
-    fn apply_previous_profile(&mut self, profile: LaunchWizardPreviousProfile) -> bool {
-        let saved_agent = self
-            .detected_agents
-            .iter()
-            .find(|candidate| candidate.id == profile.agent_id);
-        let Some(agent) = saved_agent.or_else(|| self.detected_agents.first()) else {
-            return false;
-        };
+    fn apply_preferred_agent_profile(&mut self) -> bool {
+        if let Some(agent_id) = self
+            .previous_profiles
+            .preferred_agent_id()
+            .map(str::to_string)
+        {
+            if self
+                .detected_agents
+                .iter()
+                .any(|agent| agent.id == agent_id)
+            {
+                self.launch_target = LaunchTargetKind::Agent;
+                self.agent_id = agent_id;
+            }
+        }
+        self.restore_agent_draft_or_defaults()
+    }
 
-        self.launch_target = LaunchTargetKind::Agent;
-        self.agent_id = agent.id.clone();
-        self.sync_selected_agent_options();
+    fn apply_previous_agent_preferences(&mut self, profile: LaunchWizardPreviousProfile) {
         self.apply_saved_model(profile.model.as_deref());
         if let Some(reasoning) = profile.reasoning.as_deref() {
             if self
@@ -1284,44 +1406,6 @@ impl LaunchWizardState {
         self.resume_session_id = None;
         self.skip_permissions = profile.skip_permissions;
         self.codex_fast_mode = profile.codex_fast_mode && self.agent_is_codex();
-        self.apply_previous_runtime_profile(
-            profile.runtime_target,
-            profile.docker_service.as_deref(),
-            profile.docker_lifecycle_intent,
-        );
-        if let Some(windows_shell) = profile.windows_shell {
-            self.windows_shell = windows_shell;
-        }
-        true
-    }
-
-    fn apply_previous_runtime_profile(
-        &mut self,
-        runtime_target: gwt_agent::LaunchRuntimeTarget,
-        docker_service: Option<&str>,
-        docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
-    ) {
-        if runtime_target != gwt_agent::LaunchRuntimeTarget::Docker || !self.has_docker_workflow() {
-            self.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
-            self.docker_service = None;
-            self.sync_docker_lifecycle_default();
-            return;
-        }
-
-        self.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
-        let services = self.docker_service_options();
-        self.docker_service = docker_service
-            .filter(|service| services.iter().any(|candidate| candidate == service))
-            .map(str::to_string)
-            .or_else(|| {
-                self.context
-                    .docker_context
-                    .as_ref()
-                    .and_then(|ctx| ctx.suggested_service.clone())
-            })
-            .or_else(|| services.first().cloned());
-        self.docker_lifecycle_intent = docker_lifecycle_intent;
-        self.sync_docker_lifecycle_default();
     }
 
     fn focus_existing_session(&mut self, index: usize) {
@@ -1971,14 +2055,21 @@ impl LaunchWizardState {
         );
     }
 
-    fn restore_agent_draft_or_defaults(&mut self) {
+    fn restore_agent_draft_or_defaults(&mut self) -> bool {
         let draft = self.agent_drafts.get(&self.agent_id).cloned();
-        match draft {
-            Some(draft) => self.apply_agent_draft(draft),
-            None => self.reset_agent_draft_defaults(),
-        }
+        let restored = if let Some(draft) = draft {
+            self.apply_agent_draft(draft);
+            true
+        } else if let Some(profile) = self.previous_profiles.profile_for(&self.agent_id).cloned() {
+            self.apply_previous_agent_preferences(profile);
+            true
+        } else {
+            self.reset_agent_draft_defaults();
+            false
+        };
         self.sync_selected_agent_options();
         self.normalize_execution_mode();
+        restored
     }
 
     fn apply_agent_draft(&mut self, draft: AgentLaunchDraft) {
@@ -3614,6 +3705,123 @@ mod tests {
     }
 
     #[test]
+    fn agent_preferences_restore_selected_agent_when_latest_session_is_other_agent() {
+        let current_repo = PathBuf::from("/tmp/current-repo");
+        let codex_repo = PathBuf::from("/tmp/codex-repo");
+        let claude_repo = PathBuf::from("/tmp/claude-repo");
+        let mut codex = sample_session_record(
+            "feature/codex",
+            &codex_repo,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        codex.model = Some("gpt-5.4".to_string());
+        codex.reasoning_level = Some("xhigh".to_string());
+        codex.tool_version = Some("0.110.0".to_string());
+        codex.session_mode = gwt_agent::SessionMode::Continue;
+        codex.skip_permissions = true;
+        codex.codex_fast_mode = true;
+
+        let mut claude = sample_session_record(
+            "feature/claude",
+            &claude_repo,
+            gwt_agent::AgentId::ClaudeCode,
+            Utc.with_ymd_and_hms(2026, 5, 10, 10, 0, 0).unwrap(),
+            None,
+        );
+        claude.model = Some("sonnet".to_string());
+        claude.reasoning_level = Some("low".to_string());
+        claude.skip_permissions = false;
+        claude.codex_fast_mode = false;
+
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.worktree_path = Some(current_repo.clone());
+        ctx.quick_start_root = current_repo.clone();
+        let profiles = previous_launch_profiles_from_sessions(&[codex, claude]);
+        let mut state = LaunchWizardState::open_with_previous_profiles(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            profiles,
+        );
+
+        assert_eq!(state.view().selected_agent_id, "claude");
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "codex".to_string(),
+        });
+        let view = state.view();
+
+        assert_eq!(view.branch_name, "feature/current");
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_reasoning, "xhigh");
+        assert_eq!(view.selected_version, "0.110.0");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.branch.as_deref(), Some("feature/current"));
+        assert_eq!(config.session_mode, gwt_agent::SessionMode::Continue);
+        assert_eq!(config.reasoning_level.as_deref(), Some("xhigh"));
+        assert!(config.codex_fast_mode);
+        assert!(config.skip_permissions);
+        assert_eq!(config.working_dir.as_deref(), Some(current_repo.as_path()));
+    }
+
+    #[test]
+    fn agent_preferences_do_not_restore_project_runtime_settings() {
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.quick_start_root = PathBuf::from("/tmp/current-repo");
+        ctx.worktree_path = Some(PathBuf::from("/tmp/current-repo"));
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string()],
+            suggested_service: Some("api".to_string()),
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Stopped;
+
+        let mut codex = sample_session_record(
+            "feature/codex",
+            Path::new("/tmp/other-repo"),
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        codex.model = Some("gpt-5.4".to_string());
+        codex.reasoning_level = Some("xhigh".to_string());
+        codex.tool_version = Some("0.110.0".to_string());
+        codex.session_mode = gwt_agent::SessionMode::Continue;
+        codex.skip_permissions = true;
+        codex.codex_fast_mode = true;
+        codex.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+        codex.docker_service = Some("worker".to_string());
+        codex.docker_lifecycle_intent = gwt_agent::DockerLifecycleIntent::Restart;
+        codex.windows_shell = Some(gwt_agent::WindowsShellKind::PowerShell7);
+
+        let state = LaunchWizardState::open_with_previous_profiles(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            previous_launch_profiles_from_sessions(&[codex]),
+        );
+        let view = state.view();
+
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_reasoning, "xhigh");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("api"));
+        assert_eq!(view.selected_docker_lifecycle, "start");
+        assert_ne!(view.selected_docker_service.as_deref(), Some("worker"));
+        assert_ne!(view.selected_docker_lifecycle, "restart");
+    }
+
+    #[test]
     fn load_previous_launch_profile_matches_deleted_worktree_by_persisted_repo_hash() {
         let dir = tempdir().expect("tempdir");
         let repo = dir.path().join("repo");
@@ -4009,7 +4217,7 @@ mod tests {
     }
 
     #[test]
-    fn open_with_previous_profile_restores_full_profile_without_reusing_branch() {
+    fn open_with_previous_profile_restores_agent_preferences_without_reusing_branch() {
         let mut ctx = context(branch("feature/current"), "feature/current");
         ctx.docker_context = Some(DockerWizardContext {
             services: vec!["api".to_string(), "gwt".to_string()],
@@ -4043,8 +4251,10 @@ mod tests {
         assert_eq!(view.selected_version, "0.110.0");
         assert_eq!(view.selected_execution_mode, "continue");
         assert_eq!(view.selected_runtime_target, "docker");
-        assert_eq!(view.selected_docker_service.as_deref(), Some("gwt"));
-        assert_eq!(view.selected_docker_lifecycle, "restart");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("api"));
+        assert_eq!(view.selected_docker_lifecycle, "connect");
+        assert_ne!(view.selected_docker_service.as_deref(), Some("gwt"));
+        assert_ne!(view.selected_docker_lifecycle, "restart");
         assert!(view.skip_permissions);
         assert!(view.codex_fast_mode);
 
@@ -4268,25 +4478,76 @@ mod tests {
             docker_service_status: gwt_docker::ComposeServiceStatus::Running,
             agent_options: sample_agent_options(),
             quick_start_entries: Vec::new(),
-            previous_profile: Some(LaunchWizardPreviousProfile {
-                agent_id: "missing-agent".to_string(),
-                model: None,
-                reasoning: None,
-                version: None,
-                session_mode: gwt_agent::SessionMode::Normal,
-                skip_permissions: false,
-                codex_fast_mode: false,
-                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
-                docker_service: None,
-                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::CreateAndStart,
-                windows_shell: None,
-            }),
+            previous_profiles: Some(LaunchWizardPreviousProfiles::from_profile(Some(
+                LaunchWizardPreviousProfile {
+                    agent_id: "missing-agent".to_string(),
+                    model: None,
+                    reasoning: None,
+                    version: None,
+                    session_mode: gwt_agent::SessionMode::Normal,
+                    skip_permissions: false,
+                    codex_fast_mode: false,
+                    runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                    docker_service: None,
+                    docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::CreateAndStart,
+                    windows_shell: None,
+                },
+            ))),
         });
 
         assert_eq!(
             state.docker_lifecycle_intent,
             gwt_agent::DockerLifecycleIntent::Connect
         );
+    }
+
+    #[test]
+    fn hydration_refresh_preserves_open_wizard_agent_settings_without_reapplying_preferences() {
+        let mut codex = sample_session_record(
+            "feature/old",
+            Path::new("/tmp/old-repo"),
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        codex.model = Some("gpt-5.4".to_string());
+        codex.reasoning_level = Some("xhigh".to_string());
+        codex.tool_version = Some("0.110.0".to_string());
+        codex.session_mode = gwt_agent::SessionMode::Continue;
+        codex.skip_permissions = true;
+        codex.codex_fast_mode = true;
+
+        let mut state = LaunchWizardState::open_with_previous_profiles(
+            context(branch("feature/current"), "feature/current"),
+            sample_agent_options(),
+            Vec::new(),
+            previous_launch_profiles_from_sessions(&[codex]),
+        );
+        assert_eq!(state.view().selected_reasoning, "xhigh");
+
+        state.apply(LaunchWizardAction::SetReasoning {
+            reasoning: "medium".to_string(),
+        });
+        state.apply_hydration(LaunchWizardHydration {
+            selected_branch: Some(branch("feature/current")),
+            normalized_branch_name: "feature/current".to_string(),
+            worktree_path: Some(PathBuf::from("/tmp/current-repo")),
+            quick_start_root: PathBuf::from("/tmp/current-repo"),
+            docker_context: None,
+            docker_service_status: gwt_docker::ComposeServiceStatus::Unknown,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: None,
+        });
+
+        let view = state.view();
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_reasoning, "medium");
+        assert_eq!(view.selected_version, "0.110.0");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
     }
 
     #[test]
@@ -5232,7 +5493,7 @@ mod tests {
                 docker_service: None,
                 docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
             }],
-            previous_profile: None,
+            previous_profiles: Some(LaunchWizardPreviousProfiles::default()),
         });
 
         let view = state.view();

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -421,8 +421,7 @@ fn resolve_launch_wizard_hydration(
         sessions_dir,
         &normalized_branch_name,
     );
-    let previous_profile =
-        gwt::launch_wizard::load_previous_launch_profile(&quick_start_root, sessions_dir);
+    let previous_profiles = gwt::launch_wizard::load_previous_launch_profiles(sessions_dir);
     let (docker_context, docker_service_status) =
         detect_wizard_docker_context_and_status(&quick_start_root);
 
@@ -435,6 +434,6 @@ fn resolve_launch_wizard_hydration(
         docker_service_status,
         agent_options,
         quick_start_entries,
-        previous_profile,
+        previous_profiles: Some(previous_profiles),
     })
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -70,9 +70,9 @@ pub use launch_wizard::{
     load_agent_options, AgentOption, DockerWizardContext, LaunchTargetKind, LaunchWizardAction,
     LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest,
     LaunchWizardLiveSessionView, LaunchWizardMode, LaunchWizardOptionView,
-    LaunchWizardPreviousProfile, LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep,
-    LaunchWizardSummaryView, LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry,
-    QuickStartLaunchMode, ShellLaunchConfig,
+    LaunchWizardPreviousProfile, LaunchWizardPreviousProfiles, LaunchWizardQuickStartView,
+    LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView, LaunchWizardView,
+    LinkedIssueKind, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode, ShellLaunchConfig,
 };
 pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- Restore Launch Agent settings as local user preferences per agent so Codex, Claude, and other agents keep independent launch parameters across projects.
- Keep project-specific runtime choices out of preference restoration so Docker service, lifecycle, runtime target, and Windows shell remain tied to the current project context.
- Preserve open Wizard edits during cache refresh instead of reapplying saved preferences over in-progress user input.

## Changes

- `crates/gwt/src/launch_wizard.rs`: adds `LaunchWizardPreviousProfiles`, groups persisted sessions by agent, and applies preferences through `draft -> preference -> defaults`.
- `crates/gwt/src/launch_wizard.rs`: stops restoring runtime / Docker / Windows shell fields from prior sessions and adds regression coverage for cross-repo preferences and hydration refresh.
- `crates/gwt/src/app_runtime/mod.rs`: changes the Launch Wizard memory cache from a single repo-scoped previous profile to a local user agent preference map.
- `crates/gwt/src/app_runtime/wizard.rs`: wires branch and Start Work Launch Wizard opening through the new preference map while leaving refresh hydration non-destructive.
- `crates/gwt/src/launch_wizard_runtime.rs` and `crates/gwt/src/lib.rs`: update the legacy hydration path and public exports for the new preference map type.

## Testing

- [x] `cargo test -p gwt --lib agent_preferences -- --nocapture` -- passed.
- [x] `cargo test -p gwt --lib hydration_refresh_preserves_open_wizard_agent_settings_without_reapplying_preferences -- --nocapture` -- passed.
- [x] `cargo test -p gwt --lib launch_wizard::tests -- --nocapture` -- passed.
- [x] `cargo test -p gwt app_runtime_open_launch_wizard_uses_cached_previous_profile_without_hydrating -- --nocapture` -- passed.
- [x] `cargo fmt -- --check` -- passed.
- [x] `cargo test -p gwt-core -p gwt -- --test-threads=1` -- passed after merging `origin/develop`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- passed.
- [x] `cargo build -p gwt` -- passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` -- passed.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- SPEC-2014 Launch Wizard previously reused one repo-scoped previous profile, which mixed developer preference fields with project runtime fields. This PR splits those concerns so agent launch parameters follow the local user while runtime choices remain project scoped.

## Risk / Impact

- **Affected areas**: Launch Agent wizard initialization, Start Work wizard initialization, persisted session preference lookup, and hydration refresh behavior.
- **Rollback plan**: Revert this PR to restore the previous single previous-profile behavior.
