### PR TITLE
fix(managed-assets): scope materialization by provider

### DIFF
--- a/crates/gwt-skills/src/distribute.rs
+++ b/crates/gwt-skills/src/distribute.rs
@@ -11,7 +11,31 @@ use include_dir::Dir;
 
 use crate::assets::{CLAUDE_COMMANDS, CLAUDE_SKILLS};
 
-const TRACKED_ROOTS: &[&str] = &[".claude/skills", ".claude/commands", ".codex/skills"];
+const TRACKED_ROOTS: &[&str] = &[
+    ".claude/skills",
+    ".claude/commands",
+    ".codex/skills",
+    ".gwt/hermes/skills",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ManagedAssetTarget {
+    ClaudeCode,
+    Codex,
+    OpenCode,
+    OpenClaw,
+    Hermes,
+}
+
+impl ManagedAssetTarget {
+    pub const ALL: [Self; 5] = [
+        Self::ClaudeCode,
+        Self::Codex,
+        Self::OpenCode,
+        Self::OpenClaw,
+        Self::Hermes,
+    ];
+}
 
 /// Result of a distribution operation.
 #[derive(Debug, Default)]
@@ -30,46 +54,69 @@ enum RootEntryKind {
     Files,
 }
 
-/// Write all bundled skill, command, and hook files to the target worktree.
+/// Write bundled skill and command files to the target worktree.
 ///
-/// Distribution targets:
+/// Full distribution targets:
 /// - `.claude/skills/gwt-*/`
 /// - `.claude/commands/gwt-*.md`
 /// - `.codex/skills/gwt-*/`  (same skill content)
+/// - `.gwt/hermes/skills/gwt-*/`  (gwt skill content only)
 ///
-/// Claude and Codex hook execution are now driven only by generated config
-/// (`.claude/settings.local.json` and `.codex/hooks.json`).
+/// Provider hook execution is driven by generated config owned by the
+/// caller (`.claude/settings.local.json`, `.codex/hooks.json`, and
+/// `.gwt/<provider>/...` provider homes).
 /// Retired `hooks/scripts/gwt-*` files are pruned as stale managed
 /// assets instead of being redistributed.
 pub fn distribute_to_worktree(worktree: &Path) -> io::Result<DistributeReport> {
+    distribute_to_worktree_for_targets(worktree, &ManagedAssetTarget::ALL)
+}
+
+pub fn distribute_to_worktree_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<DistributeReport> {
     let mut report = DistributeReport::default();
     let tracked_paths = tracked_gwt_asset_paths(worktree);
+    let targets = normalize_targets(targets);
 
-    prune_managed_asset_roots(worktree, &tracked_paths, &mut report)?;
+    prune_managed_asset_roots_for_targets(worktree, &tracked_paths, &targets, &mut report)?;
 
-    // Claude Code targets
-    write_dir_assets(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".claude/skills"),
-        &tracked_paths,
-        &mut report,
-    )?;
-    write_dir_assets(
-        &CLAUDE_COMMANDS,
-        worktree,
-        &worktree.join(".claude/commands"),
-        &tracked_paths,
-        &mut report,
-    )?;
-    // Codex targets
-    write_dir_assets(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".codex/skills"),
-        &tracked_paths,
-        &mut report,
-    )?;
+    if targets.contains(&ManagedAssetTarget::ClaudeCode) {
+        write_dir_assets(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".claude/skills"),
+            &tracked_paths,
+            &mut report,
+        )?;
+        write_dir_assets(
+            &CLAUDE_COMMANDS,
+            worktree,
+            &worktree.join(".claude/commands"),
+            &tracked_paths,
+            &mut report,
+        )?;
+    }
+
+    if targets.contains(&ManagedAssetTarget::Codex) {
+        write_dir_assets(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".codex/skills"),
+            &tracked_paths,
+            &mut report,
+        )?;
+    }
+
+    if targets.contains(&ManagedAssetTarget::Hermes) {
+        write_gwt_skill_dir_assets(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".gwt/hermes/skills"),
+            &tracked_paths,
+            &mut report,
+        )?;
+    }
 
     Ok(report)
 }
@@ -77,48 +124,84 @@ pub fn distribute_to_worktree(worktree: &Path) -> io::Result<DistributeReport> {
 /// Remove stale gwt-managed asset paths from the target worktree without
 /// materializing the current bundle.
 pub fn prune_stale_gwt_assets(worktree: &Path) -> io::Result<usize> {
+    prune_stale_gwt_assets_for_targets(worktree, &ManagedAssetTarget::ALL)
+}
+
+pub fn prune_stale_gwt_assets_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<usize> {
     let mut report = DistributeReport::default();
     let tracked_paths = tracked_gwt_asset_paths(worktree);
-    prune_managed_asset_roots(worktree, &tracked_paths, &mut report)?;
+    let targets = normalize_targets(targets);
+    prune_managed_asset_roots_for_targets(worktree, &tracked_paths, &targets, &mut report)?;
     Ok(report.paths_removed)
 }
 
-fn prune_managed_asset_roots(
+fn prune_managed_asset_roots_for_targets(
     worktree: &Path,
     tracked_paths: &HashSet<PathBuf>,
+    targets: &[ManagedAssetTarget],
     report: &mut DistributeReport,
 ) -> io::Result<()> {
-    // Claude Code targets
-    prune_dir_against_source(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".claude/skills"),
-        Some(RootEntryKind::Directories),
-        tracked_paths,
-        report,
-    )?;
-    prune_dir_against_source(
-        &CLAUDE_COMMANDS,
-        worktree,
-        &worktree.join(".claude/commands"),
-        Some(RootEntryKind::Files),
-        tracked_paths,
-        report,
-    )?;
-    prune_retired_hook_scripts(&worktree.join(".claude/hooks/scripts"), report)?;
+    if targets.contains(&ManagedAssetTarget::ClaudeCode) {
+        prune_dir_against_source(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".claude/skills"),
+            Some(RootEntryKind::Directories),
+            false,
+            tracked_paths,
+            report,
+        )?;
+        prune_dir_against_source(
+            &CLAUDE_COMMANDS,
+            worktree,
+            &worktree.join(".claude/commands"),
+            Some(RootEntryKind::Files),
+            false,
+            tracked_paths,
+            report,
+        )?;
+        prune_retired_hook_scripts(&worktree.join(".claude/hooks/scripts"), report)?;
+    }
 
-    // Codex targets use the same skill bundle as Claude.
-    prune_dir_against_source(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".codex/skills"),
-        Some(RootEntryKind::Directories),
-        tracked_paths,
-        report,
-    )?;
-    prune_retired_hook_scripts(&worktree.join(".codex/hooks/scripts"), report)?;
+    if targets.contains(&ManagedAssetTarget::Codex) {
+        prune_dir_against_source(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".codex/skills"),
+            Some(RootEntryKind::Directories),
+            false,
+            tracked_paths,
+            report,
+        )?;
+        prune_retired_hook_scripts(&worktree.join(".codex/hooks/scripts"), report)?;
+    }
+
+    if targets.contains(&ManagedAssetTarget::Hermes) {
+        prune_dir_against_source(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".gwt/hermes/skills"),
+            Some(RootEntryKind::Directories),
+            true,
+            tracked_paths,
+            report,
+        )?;
+    }
 
     Ok(())
+}
+
+fn normalize_targets(targets: &[ManagedAssetTarget]) -> Vec<ManagedAssetTarget> {
+    let mut normalized = Vec::new();
+    for target in targets {
+        if !normalized.contains(target) {
+            normalized.push(*target);
+        }
+    }
+    normalized
 }
 
 fn prune_retired_hook_scripts(dest: &Path, report: &mut DistributeReport) -> io::Result<()> {
@@ -158,6 +241,27 @@ fn write_dir_assets(
     tracked_paths: &HashSet<PathBuf>,
     report: &mut DistributeReport,
 ) -> io::Result<()> {
+    write_dir_assets_inner(source, worktree, dest, tracked_paths, false, report)
+}
+
+fn write_gwt_skill_dir_assets(
+    source: &Dir<'_>,
+    worktree: &Path,
+    dest: &Path,
+    tracked_paths: &HashSet<PathBuf>,
+    report: &mut DistributeReport,
+) -> io::Result<()> {
+    write_dir_assets_inner(source, worktree, dest, tracked_paths, true, report)
+}
+
+fn write_dir_assets_inner(
+    source: &Dir<'_>,
+    worktree: &Path,
+    dest: &Path,
+    tracked_paths: &HashSet<PathBuf>,
+    root_gwt_only: bool,
+    report: &mut DistributeReport,
+) -> io::Result<()> {
     for file in source.files() {
         let target = dest.join(file.path().file_name().unwrap_or_default());
         // Preserve existing tracked files so we do not overwrite user-checked-in
@@ -178,6 +282,9 @@ fn write_dir_assets(
 
     for subdir in source.dirs() {
         let subdir_name = subdir.path().file_name().unwrap_or_default();
+        if root_gwt_only && !subdir_name.to_string_lossy().starts_with("gwt-") {
+            continue;
+        }
         write_dir_assets(
             subdir,
             worktree,
@@ -195,6 +302,7 @@ fn prune_dir_against_source(
     worktree: &Path,
     dest: &Path,
     root_kind: Option<RootEntryKind>,
+    root_gwt_only: bool,
     tracked_paths: &HashSet<PathBuf>,
     report: &mut DistributeReport,
 ) -> io::Result<()> {
@@ -210,6 +318,7 @@ fn prune_dir_against_source(
     let desired_dir_names: HashSet<String> = source
         .dirs()
         .filter_map(|dir| dir.path().file_name().and_then(|name| name.to_str()))
+        .filter(|name| !root_gwt_only || name.starts_with("gwt-"))
         .map(str::to_string)
         .collect();
 
@@ -247,11 +356,15 @@ fn prune_dir_against_source(
 
     for subdir in source.dirs() {
         let subdir_name = subdir.path().file_name().unwrap_or_default();
+        if root_gwt_only && !subdir_name.to_string_lossy().starts_with("gwt-") {
+            continue;
+        }
         prune_dir_against_source(
             subdir,
             worktree,
             &dest.join(subdir_name),
             None,
+            false,
             tracked_paths,
             report,
         )?;
@@ -343,6 +456,71 @@ mod tests {
         distribute_to_worktree(dir.path()).unwrap();
         let skill_md = dir.path().join(".codex/skills/gwt-manage-pr/SKILL.md");
         assert!(skill_md.exists(), "expected {}", skill_md.display());
+    }
+
+    #[test]
+    fn distribute_for_targets_only_materializes_requested_agent_assets() {
+        let dir = tempfile::tempdir().unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Codex]).unwrap();
+
+        assert!(dir
+            .path()
+            .join(".codex/skills/gwt-manage-pr/SKILL.md")
+            .exists());
+        assert!(
+            !dir.path()
+                .join(".claude/skills/gwt-manage-pr/SKILL.md")
+                .exists(),
+            "Codex launch must not materialize Claude Code skills"
+        );
+        assert!(
+            !dir.path()
+                .join(".gwt/hermes/skills/gwt-manage-pr/SKILL.md")
+                .exists(),
+            "Codex launch must not materialize Hermes skills"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_materializes_hermes_skills_under_hermes_home() {
+        let dir = tempfile::tempdir().unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Hermes]).unwrap();
+
+        let skill_md = dir
+            .path()
+            .join(".gwt/hermes/skills/gwt-build-spec/SKILL.md");
+        assert!(skill_md.exists(), "expected {}", skill_md.display());
+        assert!(
+            !dir.path()
+                .join(".claude/skills/gwt-build-spec/SKILL.md")
+                .exists(),
+            "Hermes launch must not materialize Claude Code skills"
+        );
+        assert!(
+            !dir.path()
+                .join(".codex/skills/gwt-build-spec/SKILL.md")
+                .exists(),
+            "Hermes launch must not materialize Codex skills"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_preserves_non_gwt_hermes_skill_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let user_asset = dir
+            .path()
+            .join(".gwt/hermes/skills/tui-design/user-note.md");
+        fs::create_dir_all(user_asset.parent().unwrap()).unwrap();
+        fs::write(&user_asset, "user owned").unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Hermes]).unwrap();
+
+        assert!(
+            user_asset.exists(),
+            "Hermes distribution must not prune non-gwt skill content"
+        );
     }
 
     #[test]

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -7,28 +7,12 @@ use std::{
 
 use gwt_core::process::hidden_command;
 
+use crate::distribute::ManagedAssetTarget;
+
 const BEGIN_MARKER: &str = "# gwt-managed-begin";
 const END_MARKER: &str = "# gwt-managed-end";
-
-/// Patterns to exclude gwt-managed assets from git tracking.
-///
-/// `.gwt/discussion.md` is the gwt-discussion skill's working artifact, which
-/// is always created under the active worktree. gwt owns its exclusion via
-/// this managed block rather than `.gitignore`, because a project-level
-/// `.gitignore` cannot assume every worktree using a gwt skill has the same
-/// repo-wide rule (some consumers run gwt without committing to the
-/// repository's `.gitignore`).
-const GWT_EXCLUDE_PATTERNS: &[&str] = &[
-    ".claude/skills/gwt-*",
-    ".claude/commands/gwt-*",
-    ".claude/settings.local.json",
-    ".codex/skills/gwt-*",
-    ".gwt/discussion.md",
-    ".gwt/opencode/",
-    ".gwt/openclaw/",
-    ".gwt/hermes/",
-    "docker-compose.override.yml",
-];
+const LEGACY_BEGIN_MARKER: &str = "# BEGIN gwt managed local assets";
+const LEGACY_END_MARKER: &str = "# END gwt managed local assets";
 
 /// Update `.git/info/exclude` to include gwt-managed asset exclusions.
 ///
@@ -36,6 +20,22 @@ const GWT_EXCLUDE_PATTERNS: &[&str] = &[
 /// `# gwt-managed-begin` / `# gwt-managed-end` markers and replaced on
 /// each call.
 pub fn update_git_exclude(worktree: &Path) -> io::Result<()> {
+    write_git_exclude(worktree, replace_managed_block)
+}
+
+pub fn update_git_exclude_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<()> {
+    write_git_exclude(worktree, |existing| {
+        replace_managed_block_for_targets(existing, targets)
+    })
+}
+
+fn write_git_exclude(
+    worktree: &Path,
+    replace: impl FnOnce(&str) -> io::Result<String>,
+) -> io::Result<()> {
     let exclude_path = resolve_git_exclude_path(worktree)?;
 
     // Create parent directory if needed
@@ -49,7 +49,7 @@ pub fn update_git_exclude(worktree: &Path) -> io::Result<()> {
         String::new()
     };
 
-    let updated = replace_managed_block(&existing)?;
+    let updated = replace(&existing)?;
     fs::write(&exclude_path, updated)?;
 
     Ok(())
@@ -88,8 +88,26 @@ fn resolve_git_exclude_path(worktree: &Path) -> io::Result<PathBuf> {
 }
 
 fn replace_managed_block(content: &str) -> io::Result<String> {
+    let mut patterns = exclude_patterns_for_targets(&ManagedAssetTarget::ALL);
+    push_unique(&mut patterns, "docker-compose.override.yml");
+    replace_managed_block_with_patterns(content, &patterns)
+}
+
+fn replace_managed_block_for_targets(
+    content: &str,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<String> {
+    let patterns = exclude_patterns_for_targets(targets);
+    replace_managed_block_with_patterns(content, &patterns)
+}
+
+fn replace_managed_block_with_patterns(
+    content: &str,
+    patterns: &[&'static str],
+) -> io::Result<String> {
     let mut result = String::new();
     let mut in_managed_block = false;
+    let mut in_legacy_managed_block = false;
 
     for line in content.lines() {
         if line.trim() == BEGIN_MARKER {
@@ -101,6 +119,15 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
             in_managed_block = true;
             continue;
         }
+        if line.trim() == LEGACY_BEGIN_MARKER {
+            if in_legacy_managed_block {
+                return Err(malformed_marker_error(
+                    "nested begin marker in legacy gwt-managed exclude block",
+                ));
+            }
+            in_legacy_managed_block = true;
+            continue;
+        }
         if line.trim() == END_MARKER {
             if !in_managed_block {
                 return Err(malformed_marker_error(
@@ -110,7 +137,16 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
             in_managed_block = false;
             continue;
         }
-        if !in_managed_block {
+        if line.trim() == LEGACY_END_MARKER {
+            if !in_legacy_managed_block {
+                return Err(malformed_marker_error(
+                    "legacy end marker without matching begin marker in gwt-managed exclude block",
+                ));
+            }
+            in_legacy_managed_block = false;
+            continue;
+        }
+        if !in_managed_block && !in_legacy_managed_block {
             result.push_str(line);
             result.push('\n');
         }
@@ -119,6 +155,11 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
     if in_managed_block {
         return Err(malformed_marker_error(
             "unterminated gwt-managed exclude block",
+        ));
+    }
+    if in_legacy_managed_block {
+        return Err(malformed_marker_error(
+            "unterminated legacy gwt-managed exclude block",
         ));
     }
 
@@ -130,18 +171,58 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
         format!("{trimmed}\n")
     };
 
-    // Append managed block
-    final_content.push('\n');
-    final_content.push_str(BEGIN_MARKER);
-    final_content.push('\n');
-    for pattern in GWT_EXCLUDE_PATTERNS {
-        final_content.push_str(pattern);
+    if !patterns.is_empty() {
+        // Append managed block
+        final_content.push('\n');
+        final_content.push_str(BEGIN_MARKER);
+        final_content.push('\n');
+        for pattern in patterns {
+            final_content.push_str(pattern);
+            final_content.push('\n');
+        }
+        final_content.push_str(END_MARKER);
         final_content.push('\n');
     }
-    final_content.push_str(END_MARKER);
-    final_content.push('\n');
 
     Ok(final_content)
+}
+
+fn exclude_patterns_for_targets(targets: &[ManagedAssetTarget]) -> Vec<&'static str> {
+    let mut patterns = Vec::new();
+    if !targets.is_empty() {
+        push_unique(&mut patterns, ".gwt/discussion.md");
+    }
+    for target in ManagedAssetTarget::ALL {
+        if !targets.contains(&target) {
+            continue;
+        }
+        match target {
+            ManagedAssetTarget::ClaudeCode => {
+                push_unique(&mut patterns, ".claude/skills/gwt-*");
+                push_unique(&mut patterns, ".claude/commands/gwt-*");
+                push_unique(&mut patterns, ".claude/settings.local.json");
+            }
+            ManagedAssetTarget::Codex => {
+                push_unique(&mut patterns, ".codex/skills/gwt-*");
+            }
+            ManagedAssetTarget::OpenCode => {
+                push_unique(&mut patterns, ".gwt/opencode/");
+            }
+            ManagedAssetTarget::OpenClaw => {
+                push_unique(&mut patterns, ".gwt/openclaw/");
+            }
+            ManagedAssetTarget::Hermes => {
+                push_unique(&mut patterns, ".gwt/hermes/");
+            }
+        }
+    }
+    patterns
+}
+
+fn push_unique(patterns: &mut Vec<&'static str>, pattern: &'static str) {
+    if !patterns.contains(&pattern) {
+        patterns.push(pattern);
+    }
 }
 
 fn malformed_marker_error(detail: &str) -> io::Error {
@@ -170,6 +251,40 @@ mod tests {
         assert!(!result.contains(".codex/hooks.json"));
         assert!(!result.contains(".codex/hooks/scripts/gwt-*"));
         assert!(!result.contains(".agents/skills/gwt-*"));
+    }
+
+    #[test]
+    fn adds_only_requested_provider_patterns() {
+        let result = replace_managed_block_for_targets("", &[ManagedAssetTarget::Hermes]).unwrap();
+
+        assert!(result.contains(BEGIN_MARKER));
+        assert!(result.contains(".gwt/hermes/"));
+        assert!(result.contains(".gwt/discussion.md"));
+        assert!(!result.contains(".claude/skills/gwt-*"));
+        assert!(!result.contains(".codex/skills/gwt-*"));
+        assert!(!result.contains(".gwt/opencode/"));
+        assert!(!result.contains(".gwt/openclaw/"));
+    }
+
+    #[test]
+    fn replaces_legacy_broad_managed_block_with_scoped_patterns() {
+        let existing = "\
+user-entry
+# BEGIN gwt managed local assets
+/.gwt/
+/.codex/skills/gwt-*/
+/.claude/skills/gwt-*/
+# END gwt managed local assets
+";
+
+        let result =
+            replace_managed_block_for_targets(existing, &[ManagedAssetTarget::Codex]).unwrap();
+
+        assert!(result.contains("user-entry"));
+        assert!(result.contains(".codex/skills/gwt-*"));
+        assert!(!result.contains("/.gwt/"));
+        assert!(!result.contains(".claude/skills/gwt-*"));
+        assert!(!result.contains("# BEGIN gwt managed local assets"));
     }
 
     #[test]

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -9,8 +9,11 @@ pub mod registry;
 pub mod settings_local;
 pub mod validate;
 
-pub use distribute::{distribute_to_worktree, prune_stale_gwt_assets, DistributeReport};
-pub use git_exclude::update_git_exclude;
+pub use distribute::{
+    distribute_to_worktree, distribute_to_worktree_for_targets, prune_stale_gwt_assets,
+    prune_stale_gwt_assets_for_targets, DistributeReport, ManagedAssetTarget,
+};
+pub use git_exclude::{update_git_exclude, update_git_exclude_for_targets};
 pub use hooks::{
     backup_hooks, detect_corruption, is_gwt_managed, merge_hooks, merge_hooks_safe,
     restore_from_backup, Hook, HooksConfig, HooksError,

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4669,7 +4669,7 @@ impl AppRuntime {
             )?
             .with_project_root(&worktree_path)
             .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
-            refresh_managed_gwt_assets_for_worktree(&worktree_path)
+            refresh_managed_gwt_assets_for_agent(&worktree_path, &config.agent_id)
                 .map_err(|error| error.to_string())?;
 
             if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Host

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -225,7 +225,7 @@ pub(crate) fn refresh_managed_assets_for_hook_front_door(
     if gwt_git::Repository::discover(project_root).is_err() {
         return Ok(());
     }
-    crate::managed_assets::refresh_managed_gwt_assets_for_worktree(project_root)
+    crate::managed_assets::refresh_existing_managed_gwt_assets_for_worktree(project_root)
         .map_err(|err| err.to_string())
 }
 

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -74,7 +74,10 @@ pub use launch_wizard::{
     LaunchWizardSummaryView, LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry,
     QuickStartLaunchMode, ShellLaunchConfig,
 };
-pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
+pub use managed_assets::{
+    refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,
+    refresh_managed_gwt_assets_for_worktree,
+};
 #[cfg(target_os = "macos")]
 pub use native_app::MacosNativeMenu;
 pub use native_app::{

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -15,7 +15,7 @@ use base64::Engine;
 use gwt::{
     cleanup_selected_branches, detect_shell_program, list_branch_entries_with_active_sessions,
     list_directory_entries, load_knowledge_bridge, load_restored_workspace_state,
-    load_session_state, migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree,
+    load_session_state, migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_agent,
     resolve_launch_spec, save_session_state, save_workspace_state, workspace_state_path,
     BackendEvent, BranchEntriesPhase, BranchListEntry, DockerWizardContext, FrontendEvent,
     HookForwardTarget, KnowledgeKind, LaunchWizardState, LiveSessionEntry, ShellLaunchConfig,

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -8,43 +8,140 @@ use crate::cli::gwtd_resolver::{
     GwtdResolutionInputs,
 };
 use crate::native_app::{GUI_FRONT_DOOR_BINARY_NAME, INTERNAL_DAEMON_BINARY_NAME};
+use gwt_agent::AgentId;
 use gwt_skills::{
-    distribute_to_worktree, generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks,
-    generate_opencode_hooks, generate_settings_local, update_git_exclude,
+    distribute_to_worktree_for_targets, generate_codex_hooks, generate_hermes_hooks,
+    generate_openclaw_hooks, generate_opencode_hooks, generate_settings_local, update_git_exclude,
+    update_git_exclude_for_targets, ManagedAssetTarget,
 };
 
 pub fn refresh_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()> {
-    distribute_to_worktree(worktree).map_err(|error| {
-        io::Error::other(format!("failed to distribute gwt managed assets: {error}"))
-    })?;
+    materialize_managed_gwt_assets_for_targets(worktree, &ManagedAssetTarget::ALL)?;
     update_git_exclude(worktree).map_err(|error| {
         io::Error::other(format!("failed to update gwt managed excludes: {error}"))
     })?;
-    let _hook_bin_guard = install_hook_bin_override()?;
-    generate_settings_local(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate Claude hook settings: {error}"
-        ))
-    })?;
-    generate_codex_hooks(worktree).map_err(|error| {
-        io::Error::other(format!("failed to regenerate Codex hook settings: {error}"))
-    })?;
-    generate_opencode_hooks(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate OpenCode hook settings: {error}"
-        ))
-    })?;
-    generate_openclaw_hooks(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate OpenClaw hook settings: {error}"
-        ))
-    })?;
-    generate_hermes_hooks(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate Hermes hook settings: {error}"
-        ))
+    Ok(())
+}
+
+pub fn refresh_managed_gwt_assets_for_agent(worktree: &Path, agent_id: &AgentId) -> io::Result<()> {
+    let targets = managed_targets_for_agent(agent_id)
+        .into_iter()
+        .collect::<Vec<_>>();
+    materialize_managed_gwt_assets_for_targets(worktree, &targets)?;
+    let exclude_targets = detect_existing_managed_asset_targets(worktree);
+    update_git_exclude_for_targets(worktree, &exclude_targets).map_err(|error| {
+        io::Error::other(format!("failed to update gwt managed excludes: {error}"))
     })?;
     Ok(())
+}
+
+pub fn refresh_existing_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()> {
+    let targets = detect_existing_managed_asset_targets(worktree);
+    materialize_managed_gwt_assets_for_targets(worktree, &targets)?;
+    update_git_exclude_for_targets(worktree, &targets).map_err(|error| {
+        io::Error::other(format!("failed to update gwt managed excludes: {error}"))
+    })?;
+    Ok(())
+}
+
+fn materialize_managed_gwt_assets_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<()> {
+    distribute_to_worktree_for_targets(worktree, targets).map_err(|error| {
+        io::Error::other(format!("failed to distribute gwt managed assets: {error}"))
+    })?;
+    if targets.is_empty() {
+        return Ok(());
+    }
+    let _hook_bin_guard = install_hook_bin_override()?;
+    if targets.contains(&ManagedAssetTarget::ClaudeCode) {
+        generate_settings_local(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate Claude hook settings: {error}"
+            ))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::Codex) {
+        generate_codex_hooks(worktree).map_err(|error| {
+            io::Error::other(format!("failed to regenerate Codex hook settings: {error}"))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::OpenCode) {
+        generate_opencode_hooks(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate OpenCode hook settings: {error}"
+            ))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::OpenClaw) {
+        generate_openclaw_hooks(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate OpenClaw hook settings: {error}"
+            ))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::Hermes) {
+        generate_hermes_hooks(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate Hermes hook settings: {error}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn managed_targets_for_agent(agent_id: &AgentId) -> Option<ManagedAssetTarget> {
+    match agent_id {
+        AgentId::ClaudeCode => Some(ManagedAssetTarget::ClaudeCode),
+        AgentId::Codex => Some(ManagedAssetTarget::Codex),
+        AgentId::OpenCode => Some(ManagedAssetTarget::OpenCode),
+        AgentId::OpenClaw => Some(ManagedAssetTarget::OpenClaw),
+        AgentId::Hermes => Some(ManagedAssetTarget::Hermes),
+        AgentId::Gemini | AgentId::Copilot | AgentId::Custom(_) => None,
+    }
+}
+
+fn detect_existing_managed_asset_targets(worktree: &Path) -> Vec<ManagedAssetTarget> {
+    let mut targets = Vec::new();
+    push_existing_target(
+        &mut targets,
+        worktree.join(".claude/skills").exists()
+            || worktree.join(".claude/commands").exists()
+            || worktree.join(".claude/settings.local.json").exists(),
+        ManagedAssetTarget::ClaudeCode,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".codex/skills").exists() || worktree.join(".codex/hooks.json").exists(),
+        ManagedAssetTarget::Codex,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".gwt/opencode").exists(),
+        ManagedAssetTarget::OpenCode,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".gwt/openclaw").exists(),
+        ManagedAssetTarget::OpenClaw,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".gwt/hermes").exists(),
+        ManagedAssetTarget::Hermes,
+    );
+    targets
+}
+
+fn push_existing_target(
+    targets: &mut Vec<ManagedAssetTarget>,
+    exists: bool,
+    target: ManagedAssetTarget,
+) {
+    if exists && !targets.contains(&target) {
+        targets.push(target);
+    }
 }
 
 fn install_hook_bin_override() -> io::Result<EnvVarGuard> {

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -3,7 +3,11 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use gwt::refresh_managed_gwt_assets_for_worktree;
+use gwt::{
+    refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,
+    refresh_managed_gwt_assets_for_worktree,
+};
+use gwt_agent::AgentId;
 use serde_json::Value;
 use tempfile::tempdir;
 
@@ -76,6 +80,105 @@ fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() 
     assert!(exclude.contains(".claude/skills/gwt-*"));
     assert!(exclude.contains(".claude/commands/gwt-*"));
     assert!(exclude.contains(".codex/skills/gwt-*"));
+}
+
+#[test]
+fn refresh_managed_assets_for_codex_only_materializes_codex_assets() {
+    let dir = tempdir().expect("tempdir");
+    run_git(dir.path(), &["init", "-q"]);
+    let _env_guard = env_lock();
+    let cli_bin = dir.path().join("bin/gwtd");
+    std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+    std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+    let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+
+    refresh_managed_gwt_assets_for_agent(dir.path(), &AgentId::Codex)
+        .expect("refresh Codex assets");
+
+    assert!(dir
+        .path()
+        .join(".codex/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(dir.path().join(".codex/hooks.json").exists());
+    assert!(!dir
+        .path()
+        .join(".claude/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir.path().join(".claude/settings.local.json").exists());
+    assert!(!dir.path().join(".gwt/hermes/config.yaml").exists());
+
+    let exclude =
+        std::fs::read_to_string(dir.path().join(".git/info/exclude")).expect("read exclude");
+    assert!(exclude.contains(".codex/skills/gwt-*"));
+    assert!(!exclude.contains(".claude/skills/gwt-*"));
+    assert!(!exclude.contains(".gwt/hermes/"));
+}
+
+#[test]
+fn refresh_managed_assets_for_hermes_materializes_hermes_home_skills_only() {
+    let dir = tempdir().expect("tempdir");
+    run_git(dir.path(), &["init", "-q"]);
+    let _env_guard = env_lock();
+    let cli_bin = dir.path().join("bin/gwtd");
+    std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+    std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+    let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+
+    refresh_managed_gwt_assets_for_agent(dir.path(), &AgentId::Hermes)
+        .expect("refresh Hermes assets");
+
+    assert!(dir.path().join(".gwt/hermes/config.yaml").exists());
+    assert!(dir
+        .path()
+        .join(".gwt/hermes/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir
+        .path()
+        .join(".claude/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir
+        .path()
+        .join(".codex/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir.path().join(".codex/hooks.json").exists());
+
+    let exclude =
+        std::fs::read_to_string(dir.path().join(".git/info/exclude")).expect("read exclude");
+    assert!(exclude.contains(".gwt/hermes/"));
+    assert!(!exclude.contains(".claude/skills/gwt-*"));
+    assert!(!exclude.contains(".codex/skills/gwt-*"));
+}
+
+#[test]
+fn refresh_existing_managed_assets_refreshes_only_present_provider_surfaces() {
+    let dir = tempdir().expect("tempdir");
+    run_git(dir.path(), &["init", "-q"]);
+    let _env_guard = env_lock();
+    let cli_bin = dir.path().join("bin/gwtd");
+    std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+    std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+    let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+    std::fs::create_dir_all(dir.path().join(".codex/skills")).expect("create codex marker");
+
+    refresh_existing_managed_gwt_assets_for_worktree(dir.path())
+        .expect("refresh existing managed assets");
+
+    assert!(dir
+        .path()
+        .join(".codex/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(dir.path().join(".codex/hooks.json").exists());
+    assert!(!dir
+        .path()
+        .join(".claude/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir.path().join(".gwt/hermes/config.yaml").exists());
+
+    let exclude =
+        std::fs::read_to_string(dir.path().join(".git/info/exclude")).expect("read exclude");
+    assert!(exclude.contains(".codex/skills/gwt-*"));
+    assert!(!exclude.contains(".claude/skills/gwt-*"));
+    assert!(!exclude.contains(".gwt/hermes/"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Scope managed asset materialization to the selected Launch Agent provider so Codex, Claude Code, Hermes, OpenCode, and OpenClaw no longer create each other's local surfaces.
- Add provider-scoped `info/exclude` generation and preserve already-existing provider surfaces for hook front door self-heal.
- Document the provider-scoped materialization contract in SPEC #1935.

## Changes

- `crates/gwt-skills/src/distribute.rs`: adds `ManagedAssetTarget`, scoped distribution/pruning, Hermes `.gwt/hermes/skills/gwt-*` placement, and preservation for non-`gwt-*` Hermes skill dirs.
- `crates/gwt-skills/src/git_exclude.rs`: adds provider-scoped exclude generation and legacy broad managed-block migration.
- `crates/gwt/src/managed_assets.rs`: adds selected-agent refresh and existing-surface refresh, while retaining full refresh for full maintenance flows.
- `crates/gwt/src/app_runtime/mod.rs`: wires Launch Agent materialization to the selected provider.
- `crates/gwt/src/cli/hook/mod.rs`: changes hook front door self-heal to refresh only existing managed provider surfaces.
- `crates/gwt/tests/managed_assets_test.rs`: covers Codex-only, Hermes-only, and existing-surface refresh behavior.

## Testing

- [x] `cargo test -p gwt-skills --lib` — 120 passed.
- [x] `cargo test -p gwt --test managed_assets_test` — 6 passed.
- [x] `cargo test -p gwt-core -p gwt` — all tests passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed with 0 warnings.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #1935

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #1935)
- [x] Migration/backfill plan included (legacy broad `info/exclude` block migration is covered by tests)
- [x] CHANGELOG impact considered (patch fix, no breaking change)

## Context

- The prior Launch Agent path refreshed every managed provider surface, which meant starting Codex could also place Claude Code or Hermes assets. The new path materializes only the selected provider and keeps hook-time self-heal from introducing new provider surfaces.

## Risk / Impact

- **Affected areas**: Launch Agent managed asset placement, hook front door self-heal, `.git/info/exclude` managed blocks.
- **Rollback plan**: Revert this PR to return to full managed-surface materialization during Launch Agent refresh.
