### PR TITLE
fix(workspace): materialize actionable unassigned agents

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -372,16 +372,18 @@ impl AppRuntime {
             );
             return None;
         }
-        let work_event =
-            workspace_projection::workspace_work_event_from_board_entry(&projection, entry);
-        if let Err(error) =
-            workspace_projection::record_workspace_work_event(project_root, work_event)
-        {
-            tracing::warn!(
-                error = %error,
-                project_root = %project_root.display(),
-                "failed to record workspace WorkItem event for board milestone"
-            );
+        if board_entry_origin_can_record_workspace_work_event(&projection, entry) {
+            let work_event =
+                workspace_projection::workspace_work_event_from_board_entry(&projection, entry);
+            if let Err(error) =
+                workspace_projection::record_workspace_work_event(project_root, work_event)
+            {
+                tracing::warn!(
+                    error = %error,
+                    project_root = %project_root.display(),
+                    "failed to record workspace WorkItem event for board milestone"
+                );
+            }
         }
 
         if self.active_tab_id.as_deref() != Some(tab_id) {
@@ -442,6 +444,20 @@ impl AppRuntime {
             Some(entry.body.clone()),
         )
     }
+}
+
+fn board_entry_origin_can_record_workspace_work_event(
+    projection: &workspace_projection::WorkspaceProjection,
+    entry: &coordination::BoardEntry,
+) -> bool {
+    let Some(session_id) = entry.origin_session_id.as_deref() else {
+        return true;
+    };
+    projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+        .is_some_and(|agent| agent.is_assigned())
 }
 
 fn board_error(client_id: &str, id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -10673,6 +10673,82 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_board_milestone_from_unassigned_origin_does_not_create_workspace_history() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo.clone(),
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection
+            .agents
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
+                session_id: "session-unassigned".to_string(),
+                window_id: None,
+                agent_id: "codex".to_string(),
+                display_name: "Codex".to_string(),
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+                current_focus: Some("Investigate Workspace materialization".to_string()),
+                title_summary: Some("Workspace materialization".to_string()),
+                worktree_path: None,
+                branch: Some("work/unassigned".to_string()),
+                last_board_entry_id: None,
+                last_board_entry_kind: None,
+                coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned,
+                workspace_id: None,
+                updated_at: chrono::Utc::now(),
+            });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Claim,
+            "Unassigned claim without materialization must not pollute current Workspace history.",
+            None,
+            None,
+            vec!["workspace-materialization".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_title_summary("Workspace materialization")
+        .with_origin_session_id("session-unassigned");
+
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &entry);
+
+        let saved = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-unassigned")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
+        );
+        assert!(
+            gwt_core::workspace_projection::load_workspace_work_items(&repo)
+                .expect("load workspace history")
+                .is_none(),
+            "Unassigned origin Board entries must not append to unrelated Workspace history"
+        );
+    }
+
+    #[test]
     fn app_runtime_active_work_projection_preserves_blocked_agent_board_state() {
         let _env_lock = env_test_lock()
             .lock()

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -209,6 +209,16 @@ pub enum WorkspaceCommand {
         split_from: Option<String>,
         boundary: Option<String>,
     },
+    /// `gwtd workspace ensure --agent-session <id> --title-summary <name> ...`.
+    Ensure {
+        agent_session: String,
+        title_summary: String,
+        current_focus: Option<String>,
+        spec: Option<u64>,
+        issue: Option<u64>,
+        topic: Option<String>,
+        boundary: Option<String>,
+    },
 }
 
 /// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).
@@ -414,7 +424,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd workspace ensure --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--topic <t>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -4,7 +4,7 @@ use gwt_agent::{session::GWT_SESSION_ID_ENV, Session};
 use gwt_core::{
     coordination::{
         load_snapshot, load_snapshot_for_scope, normalize_board_audience, normalize_board_mentions,
-        post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardMention,
+        post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardEntryKind, BoardMention,
     },
     paths::gwt_sessions_dir,
 };
@@ -16,6 +16,8 @@ use crate::{
     },
     cli::{CliEnv, CliParseError},
 };
+
+use super::workspace::{ensure_workspace_for_agent, WorkspaceEnsureInput};
 
 /// SPEC-1942 family enum for `gwtd board ...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -182,6 +184,15 @@ pub(super) fn run<E: CliEnv>(
             if !targets.is_empty() {
                 entry = entry.with_target_owners(targets);
             }
+            let materialized_workspace = if broadcast {
+                None
+            } else {
+                materialize_actionable_unassigned_board_post(
+                    env.repo_path(),
+                    current_session.as_ref(),
+                    &entry,
+                )?
+            };
             let (workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
             let mentions =
                 parse_mentions(&other_mention_args).map_err(gwt_error_to_spec_ops_error)?;
@@ -196,6 +207,9 @@ pub(super) fn run<E: CliEnv>(
                 )
                 .map_err(gwt_error_to_spec_ops_error)?
                 {
+                    audience.push(workspace_id);
+                }
+                if let Some(workspace_id) = materialized_workspace {
                     audience.push(workspace_id);
                 }
                 audience.extend(workspace_audience);
@@ -368,6 +382,108 @@ fn parse_mentions(values: &[String]) -> gwt_core::Result<Vec<BoardMention>> {
         mentions.push(value.parse::<BoardMention>()?);
     }
     Ok(normalize_board_mentions(&mentions))
+}
+
+fn materialize_actionable_unassigned_board_post(
+    repo_path: &std::path::Path,
+    current_session: Option<&Session>,
+    entry: &BoardEntry,
+) -> Result<Option<String>, SpecOpsError> {
+    let Some(session) = current_session else {
+        return Ok(None);
+    };
+    if !board_entry_can_materialize_workspace(entry) {
+        return Ok(None);
+    }
+    let Some(projection) = gwt_core::workspace_projection::load_workspace_projection(repo_path)
+        .map_err(gwt_error_to_spec_ops_error)?
+    else {
+        return Ok(None);
+    };
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session.id)
+    else {
+        return Ok(None);
+    };
+    if !agent.is_unassigned() {
+        return Ok(None);
+    }
+    let (spec, issue) = board_owner_numbers(&entry.related_owners);
+    let result = ensure_workspace_for_agent(
+        repo_path,
+        WorkspaceEnsureInput {
+            agent_session: session.id.clone(),
+            title_summary: entry
+                .title_summary
+                .as_deref()
+                .unwrap_or("Board milestone")
+                .to_string(),
+            current_focus: Some(entry.body.clone()),
+            spec,
+            issue,
+            topic: entry.related_topics.first().cloned(),
+            boundary: boundary_from_board_body(&entry.body),
+        },
+    )?;
+    Ok(Some(result.workspace_id))
+}
+
+fn board_entry_can_materialize_workspace(entry: &BoardEntry) -> bool {
+    matches!(
+        entry.kind,
+        BoardEntryKind::Claim
+            | BoardEntryKind::Status
+            | BoardEntryKind::Blocked
+            | BoardEntryKind::Handoff
+            | BoardEntryKind::Decision
+            | BoardEntryKind::Next
+    ) && entry
+        .title_summary
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+}
+
+fn board_owner_numbers(owners: &[String]) -> (Option<u64>, Option<u64>) {
+    let mut spec = None;
+    let mut issue = None;
+    for owner in owners {
+        let value = owner.trim();
+        if spec.is_none() {
+            if let Some(number) = value
+                .strip_prefix("SPEC-")
+                .or_else(|| value.strip_prefix("spec-"))
+                .and_then(|number| number.parse::<u64>().ok())
+                .or_else(|| value.parse::<u64>().ok())
+            {
+                spec = Some(number);
+                continue;
+            }
+        }
+        if issue.is_none() {
+            let issue_number = value
+                .strip_prefix("Issue #")
+                .or_else(|| value.strip_prefix("issue #"))
+                .or_else(|| value.strip_prefix("issue-"))
+                .and_then(|number| number.parse::<u64>().ok());
+            if let Some(number) = issue_number {
+                issue = Some(number);
+            }
+        }
+    }
+    (spec, issue)
+}
+
+fn boundary_from_board_body(body: &str) -> Option<String> {
+    body.lines().find_map(|line| {
+        line.trim_start()
+            .strip_prefix("Boundary:")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
 }
 
 /// SPEC-2359 FR-096: `--mention workspace:<id>` routes to BoardEntry.audience,
@@ -1192,6 +1308,139 @@ mod tests {
         let snapshot = load_snapshot(&repo).unwrap();
         assert!(snapshot.board.entries[0].audience.is_empty());
         assert!(snapshot.board.entries[1].audience.is_empty());
+    }
+
+    #[test]
+    fn board_family_run_post_materializes_unassigned_actionable_milestone_before_audience() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/workspace-materialization", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        let mut out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "claim".into(),
+                body: Some("Materialize actionable Unassigned Agents before Board audience".into()),
+                file: None,
+                title_summary: Some("Workspace materialization".into()),
+                parent: None,
+                topics: vec!["workspace-materialization".into()],
+                owners: vec!["2359".into()],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: false,
+            })),
+            &mut out,
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        let entry = &snapshot.board.entries[0];
+        assert_eq!(entry.audience.len(), 1, "{entry:?}");
+        let workspace_id = entry.audience[0].clone();
+        assert!(workspace_id.starts_with("workspace-"), "{workspace_id}");
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some(workspace_id.as_str()));
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load workspaces")
+            .expect("workspaces");
+        assert_eq!(work_items.work_items[0].id, workspace_id);
+        assert_eq!(work_items.work_items[0].title, "Workspace materialization");
+    }
+
+    #[test]
+    fn board_family_run_post_broadcast_does_not_materialize_unassigned_actionable_milestone() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/workspace-materialization", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "claim".into(),
+                body: Some("Intentional broadcast for cross-workspace coordination".into()),
+                file: None,
+                title_summary: Some("Workspace materialization".into()),
+                parent: None,
+                topics: vec!["workspace-materialization".into()],
+                owners: vec!["2359".into()],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: true,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert!(snapshot.board.entries[0].audience.is_empty());
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Unassigned
+        );
+        assert!(
+            gwt_core::workspace_projection::load_workspace_work_items(&repo)
+                .expect("load workspace history")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -50,6 +50,7 @@ pub struct WorkflowContext {
     pub has_tasks: bool,
     pub bypass: Option<WorkflowBypass>,
     pub title_summary_missing: bool,
+    pub workspace_materialization_missing: bool,
 }
 
 impl WorkflowContext {
@@ -60,6 +61,7 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: None,
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
@@ -70,6 +72,7 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: None,
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
@@ -80,6 +83,7 @@ impl WorkflowContext {
             has_tasks,
             bypass: None,
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
@@ -90,11 +94,17 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: Some(bypass),
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
     pub fn with_title_summary_missing(mut self, missing: bool) -> Self {
         self.title_summary_missing = missing;
+        self
+    }
+
+    pub fn with_workspace_materialization_missing(mut self, missing: bool) -> Self {
+        self.workspace_materialization_missing = missing;
         self
     }
 }
@@ -119,12 +129,20 @@ pub fn evaluate_with_context(
     if title_summary != HookOutput::Silent {
         return Ok(title_summary);
     }
+    let materialization =
+        evaluate_workspace_materialization_guard(event, context.workspace_materialization_missing)?;
+    if materialization != HookOutput::Silent {
+        return Ok(materialization);
+    }
     evaluate_workspace_coordination_guard(event, worktree_root)
 }
 
 pub fn evaluate(event: &HookEvent, worktree_root: &Path) -> Result<HookOutput, HookError> {
     let context = resolve_workflow_context(worktree_root)
-        .with_title_summary_missing(current_agent_title_summary_missing(worktree_root)?);
+        .with_title_summary_missing(current_agent_title_summary_missing(worktree_root)?)
+        .with_workspace_materialization_missing(current_agent_workspace_materialization_missing(
+            worktree_root,
+        )?);
     evaluate_with_context(event, worktree_root, &context)
 }
 
@@ -223,6 +241,34 @@ fn current_agent_title_summary_missing(worktree_root: &Path) -> Result<bool, Hoo
         .is_none())
 }
 
+fn current_agent_workspace_materialization_missing(
+    worktree_root: &Path,
+) -> Result<bool, HookError> {
+    let Some(session) = load_session_from_env() else {
+        return Ok(false);
+    };
+    let projection_root = if session.worktree_path.exists() {
+        session.worktree_path.as_path()
+    } else {
+        worktree_root
+    };
+    let Some(projection) = load_workspace_projection(projection_root)? else {
+        return Ok(false);
+    };
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session.id)
+    else {
+        return Ok(false);
+    };
+    if !agent.is_unassigned() {
+        return Ok(false);
+    }
+    Ok(option_has_nonempty_text(agent.title_summary.as_deref())
+        || option_has_nonempty_text(agent.current_focus.as_deref()))
+}
+
 fn evaluate_title_summary_guard(
     event: &HookEvent,
     title_summary_missing: bool,
@@ -244,6 +290,33 @@ Required command shape:\n\
 Good example: --title-summary 'Agent title improvement'\n\
 Bad example: --title-summary 'Agent title improvement complete'\n\n\
 Use the configured narrative language for the title-summary. Keep progress, completion, blocker state, and long detail in --current-focus, --summary, or Board --body.",
+        ));
+    }
+
+    Ok(HookOutput::Silent)
+}
+
+fn evaluate_workspace_materialization_guard(
+    event: &HookEvent,
+    workspace_materialization_missing: bool,
+) -> Result<HookOutput, HookError> {
+    if !workspace_materialization_missing {
+        return Ok(HookOutput::Silent);
+    }
+
+    if is_workspace_materialization_event(event) || is_read_only_exploration_event(event) {
+        return Ok(HookOutput::Silent);
+    }
+
+    if is_title_sensitive_tool(event) {
+        return Ok(HookOutput::pre_tool_use_permission(
+            "Unassigned Agent has actionable Workspace intent",
+            "This Agent already has a title-summary or current focus, but it is still Unassigned. \
+Materialize the work into a Workspace before implementation or verification so title sync, Board audience, and Workspace history stay attached to the same work.\n\n\
+Required command shape:\n\
+  gwtd workspace ensure --agent-session \"$GWT_SESSION_ID\" --title-summary '<short work title>' --current-focus '<current work focus>' [--spec <number>|--issue <number>] [--topic <topic>]\n\n\
+Use `gwtd workspace candidates --agent-session \"$GWT_SESSION_ID\"` first only when you need to inspect choices manually. \
+Use `gwtd board post --kind claim --title-summary '<short work title>' ...` when the intent should be materialized as a Board milestone.",
         ));
     }
 
@@ -537,6 +610,10 @@ fn push_optional<'a>(parts: &mut Vec<&'a str>, value: Option<&'a str>) {
     }
 }
 
+fn option_has_nonempty_text(value: Option<&str>) -> bool {
+    value.map(str::trim).is_some_and(|value| !value.is_empty())
+}
+
 fn board_claim_is_active(entry: &BoardEntry) -> bool {
     !entry.state.as_deref().is_some_and(|state| {
         matches!(
@@ -705,10 +782,45 @@ fn is_workspace_coordination_command(command: &str) -> bool {
             matches!(
                 tokens.as_slice(),
                 [_, "board", "post" | "show", ..]
-                    | [_, "workspace", "update", ..]
+                    | [
+                        _,
+                        "workspace",
+                        "update" | "ensure" | "create" | "join" | "candidates",
+                        ..
+                    ]
                     | [_, "build", "start" | "phase" | "complete" | "abort", ..]
             )
         })
+}
+
+fn is_workspace_materialization_event(event: &HookEvent) -> bool {
+    if event.tool_name.as_deref() != Some("Bash") {
+        return false;
+    }
+    let Some(command) = event.command() else {
+        return false;
+    };
+    let segments = super::segments::split_command_segments(command);
+    !segments.is_empty()
+        && segments
+            .iter()
+            .all(|segment| is_workspace_materialization_segment(segment))
+}
+
+fn is_workspace_materialization_segment(segment: &str) -> bool {
+    let tokens = segment_tokens(segment);
+    let Some(command_name) = tokens.first().map(|token| normalize_command_name(token)) else {
+        return false;
+    };
+    if command_name != "gwtd" {
+        return false;
+    }
+    match tokens.as_slice() {
+        [_, "workspace", "ensure" | "create" | "join" | "candidates", ..] => true,
+        [_, "board", "show", ..] => true,
+        [_, "board", "post", rest @ ..] => rest.contains(&"--title-summary"),
+        _ => false,
+    }
 }
 
 fn is_similar_work(left: &str, right: &str) -> bool {
@@ -825,6 +937,9 @@ fn is_title_summary_update_segment(segment: &str) -> bool {
     }
     match tokens.as_slice() {
         [_, "workspace", "update", rest @ ..] => {
+            rest.contains(&"--agent-session") && rest.contains(&"--title-summary")
+        }
+        [_, "workspace", "ensure", rest @ ..] => {
             rest.contains(&"--agent-session") && rest.contains(&"--title-summary")
         }
         [_, "board", "post", rest @ ..] => rest.contains(&"--title-summary"),

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -3,8 +3,9 @@ use gwt_core::workspace_projection::{
     load_or_default_workspace_projection, load_or_synthesize_workspace_work_items,
     record_workspace_work_event, save_workspace_projection,
     update_workspace_projection_with_journal, WorkspaceAgentAffiliationStatus,
-    WorkspaceExecutionContainerRef, WorkspaceProjection, WorkspaceProjectionUpdate,
-    WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind, WorkspaceWorkItem,
+    WorkspaceAgentSummary, WorkspaceExecutionContainerRef, WorkspaceProjection,
+    WorkspaceProjectionUpdate, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
+    WorkspaceWorkItem,
 };
 use gwt_github::{ApiError, SpecOpsError};
 
@@ -17,6 +18,7 @@ pub fn parse(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
         "candidates" => parse_candidates(rest),
         "join" => parse_join(rest),
         "create" => parse_create(rest),
+        "ensure" => parse_ensure(rest),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
     }
 }
@@ -180,6 +182,93 @@ fn parse_create(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
         split_from,
         boundary,
     })
+}
+
+fn parse_ensure(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut title_summary = None;
+    let mut current_focus = None;
+    let mut spec = None;
+    let mut issue = None;
+    let mut topic = None;
+    let mut boundary = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            "--title-summary" => {
+                title_summary = Some(parse_required_value(args, i, "--title-summary")?)
+            }
+            "--current-focus" => {
+                current_focus = Some(parse_required_value(args, i, "--current-focus")?)
+            }
+            "--spec" => {
+                spec = Some(
+                    parse_required_value(args, i, "--spec")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--issue" => {
+                issue = Some(
+                    parse_required_value(args, i, "--issue")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--topic" => topic = Some(parse_required_value(args, i, "--topic")?),
+            "--boundary" => boundary = Some(parse_required_value(args, i, "--boundary")?),
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    let title_summary = title_summary.ok_or(CliParseError::MissingFlag("--title-summary"))?;
+    super::validate_title_summary_work_name("--title-summary", &title_summary)?;
+    Ok(WorkspaceCommand::Ensure {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+        title_summary,
+        current_focus,
+        spec,
+        issue,
+        topic,
+        boundary,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WorkspaceEnsureInput {
+    pub agent_session: String,
+    pub title_summary: String,
+    pub current_focus: Option<String>,
+    pub spec: Option<u64>,
+    pub issue: Option<u64>,
+    pub topic: Option<String>,
+    pub boundary: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkspaceEnsureDisposition {
+    AlreadyAssigned,
+    Joined,
+    Created,
+}
+
+impl WorkspaceEnsureDisposition {
+    fn as_str(self) -> &'static str {
+        match self {
+            WorkspaceEnsureDisposition::AlreadyAssigned => "already-assigned",
+            WorkspaceEnsureDisposition::Joined => "joined",
+            WorkspaceEnsureDisposition::Created => "created",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WorkspaceEnsureResult {
+    pub workspace_id: String,
+    pub disposition: WorkspaceEnsureDisposition,
 }
 
 pub(super) fn run<E: CliEnv>(
@@ -385,6 +474,243 @@ pub(super) fn run<E: CliEnv>(
             out.push_str(&format!("workspace created: {workspace_id}\n"));
             Ok(0)
         }
+        WorkspaceCommand::Ensure {
+            agent_session,
+            title_summary,
+            current_focus,
+            spec,
+            issue,
+            topic,
+            boundary,
+        } => {
+            let result = ensure_workspace_for_agent(
+                env.repo_path(),
+                WorkspaceEnsureInput {
+                    agent_session,
+                    title_summary,
+                    current_focus,
+                    spec,
+                    issue,
+                    topic,
+                    boundary,
+                },
+            )?;
+            out.push_str(&format!(
+                "workspace ensured: {} ({})\n",
+                result.workspace_id,
+                result.disposition.as_str()
+            ));
+            Ok(0)
+        }
+    }
+}
+
+pub(super) fn ensure_workspace_for_agent(
+    repo_path: &std::path::Path,
+    input: WorkspaceEnsureInput,
+) -> Result<WorkspaceEnsureResult, SpecOpsError> {
+    let mut projection = load_or_default_workspace_projection(repo_path).map_err(core_error)?;
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == input.agent_session)
+        .cloned()
+    else {
+        return Err(string_error(format!(
+            "agent session not found: {}",
+            input.agent_session
+        )));
+    };
+    let owner = owner_from_spec_or_issue(input.spec, input.issue);
+    if agent.is_assigned() {
+        if let Some(workspace_id) = agent.workspace_id.as_deref() {
+            if let Some(item) = workspace_item_by_id(repo_path, workspace_id)?
+                .filter(WorkspaceWorkItem::is_incomplete)
+            {
+                apply_workspace_item_to_projection(&mut projection, &item);
+            }
+            assign_agent_to_workspace(
+                &mut projection,
+                &input.agent_session,
+                workspace_id,
+                input.current_focus,
+                Some(input.title_summary),
+            )?;
+            save_workspace_projection(repo_path, &projection).map_err(core_error)?;
+            publish_workspace_change(repo_path);
+            return Ok(WorkspaceEnsureResult {
+                workspace_id: workspace_id.to_string(),
+                disposition: WorkspaceEnsureDisposition::AlreadyAssigned,
+            });
+        }
+    }
+
+    let existing = load_or_synthesize_workspace_work_items(repo_path).map_err(core_error)?;
+    let ensure_text = workspace_ensure_text(&input, owner.as_deref());
+    if let Some(item) = best_workspace_candidate(&existing.work_items, &ensure_text) {
+        let workspace_id = item.id.clone();
+        record_workspace_join_event(repo_path, &workspace_id, &input, owner.clone(), &agent)?;
+        assign_agent_to_workspace(
+            &mut projection,
+            &input.agent_session,
+            &workspace_id,
+            input.current_focus,
+            Some(input.title_summary),
+        )?;
+        apply_workspace_item_to_projection(&mut projection, item);
+        save_workspace_projection(repo_path, &projection).map_err(core_error)?;
+        publish_workspace_change(repo_path);
+        return Ok(WorkspaceEnsureResult {
+            workspace_id,
+            disposition: WorkspaceEnsureDisposition::Joined,
+        });
+    }
+
+    let workspace_id =
+        create_workspace_for_agent(repo_path, &mut projection, &input, owner, &agent)?;
+    save_workspace_projection(repo_path, &projection).map_err(core_error)?;
+    publish_workspace_change(repo_path);
+    Ok(WorkspaceEnsureResult {
+        workspace_id,
+        disposition: WorkspaceEnsureDisposition::Created,
+    })
+}
+
+fn owner_from_spec_or_issue(spec: Option<u64>, issue: Option<u64>) -> Option<String> {
+    spec.map(|number| format!("SPEC-{number}"))
+        .or_else(|| issue.map(|number| format!("Issue #{number}")))
+}
+
+fn workspace_ensure_text(input: &WorkspaceEnsureInput, owner: Option<&str>) -> String {
+    [
+        Some(input.title_summary.as_str()),
+        input.current_focus.as_deref(),
+        input.topic.as_deref(),
+        owner,
+        input.boundary.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+fn best_workspace_candidate<'a>(
+    work_items: &'a [WorkspaceWorkItem],
+    ensure_text: &str,
+) -> Option<&'a WorkspaceWorkItem> {
+    work_items
+        .iter()
+        .filter(|item| item.is_incomplete())
+        .map(|item| {
+            let score = workspace_similarity_score(ensure_text, &workspace_item_text(item));
+            (score, item)
+        })
+        .filter(|(score, _)| *score >= 2)
+        .max_by(|(left_score, left), (right_score, right)| {
+            left_score
+                .cmp(right_score)
+                .then_with(|| left.updated_at.cmp(&right.updated_at))
+        })
+        .map(|(_, item)| item)
+}
+
+fn record_workspace_join_event(
+    repo_path: &std::path::Path,
+    workspace_id: &str,
+    input: &WorkspaceEnsureInput,
+    owner: Option<String>,
+    agent: &WorkspaceAgentSummary,
+) -> Result<(), SpecOpsError> {
+    let now = Utc::now();
+    let mut event =
+        WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Claim, workspace_id.to_string(), now);
+    event.intent = input.current_focus.clone();
+    event.summary = Some(format!("Joined Workspace: {}", input.title_summary));
+    event.status_category = Some(WorkspaceStatusCategory::Active);
+    event.owner = owner;
+    event.next_action = input
+        .boundary
+        .as_deref()
+        .map(|boundary| format!("Boundary: {boundary}"));
+    event.agent_session_id = Some(input.agent_session.clone());
+    event.agent_id = Some(agent.agent_id.clone());
+    event.display_name = Some(agent.display_name.clone());
+    event.execution_container = Some(workspace_execution_container_from_agent(agent));
+    record_workspace_work_event(repo_path, event).map_err(core_error)
+}
+
+fn create_workspace_for_agent(
+    repo_path: &std::path::Path,
+    projection: &mut WorkspaceProjection,
+    input: &WorkspaceEnsureInput,
+    owner: Option<String>,
+    agent: &WorkspaceAgentSummary,
+) -> Result<String, SpecOpsError> {
+    let workspace_id = format!("workspace-{}", Utc::now().timestamp_millis());
+    let now = Utc::now();
+    let mut event =
+        WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, workspace_id.clone(), now);
+    event.title = Some(input.title_summary.clone());
+    event.intent = input
+        .current_focus
+        .clone()
+        .or_else(|| Some(input.title_summary.clone()));
+    event.summary = input
+        .current_focus
+        .clone()
+        .or_else(|| Some(input.title_summary.clone()));
+    event.status_category = Some(WorkspaceStatusCategory::Active);
+    event.owner = owner.clone();
+    event.next_action = Some(
+        input
+            .boundary
+            .as_deref()
+            .map(|boundary| format!("Boundary: {boundary}"))
+            .unwrap_or_else(|| "Coordinate on Board before implementation".to_string()),
+    );
+    event.agent_session_id = Some(input.agent_session.clone());
+    event.agent_id = Some(agent.agent_id.clone());
+    event.display_name = Some(agent.display_name.clone());
+    event.execution_container = Some(workspace_execution_container_from_agent(agent));
+    record_workspace_work_event(repo_path, event).map_err(core_error)?;
+
+    projection.id = workspace_id.clone();
+    projection.title = input.title_summary.clone();
+    projection.status_category = WorkspaceStatusCategory::Active;
+    projection.status_text = input
+        .current_focus
+        .clone()
+        .unwrap_or_else(|| "Workspace created".to_string());
+    projection.summary = input.current_focus.clone();
+    projection.owner = owner;
+    projection.next_action = Some(
+        input
+            .boundary
+            .as_deref()
+            .map(|boundary| format!("Boundary: {boundary}"))
+            .unwrap_or_else(|| "Coordinate on Board before implementation".to_string()),
+    );
+    assign_agent_to_workspace(
+        projection,
+        &input.agent_session,
+        &workspace_id,
+        input.current_focus.clone(),
+        Some(input.title_summary.clone()),
+    )?;
+    projection.updated_at = now;
+    Ok(workspace_id)
+}
+
+fn workspace_execution_container_from_agent(
+    agent: &WorkspaceAgentSummary,
+) -> WorkspaceExecutionContainerRef {
+    WorkspaceExecutionContainerRef {
+        branch: agent.branch.clone(),
+        worktree_path: agent.worktree_path.clone(),
+        pr_number: None,
+        pr_url: None,
+        pr_state: None,
     }
 }
 
@@ -766,6 +1092,41 @@ mod tests {
     }
 
     #[test]
+    fn parse_workspace_ensure_accepts_materialization_fields() {
+        let parsed = parse(&[
+            s("ensure"),
+            s("--agent-session"),
+            s("session-1"),
+            s("--title-summary"),
+            s("Workspace materialization"),
+            s("--current-focus"),
+            s("Ensure actionable Unassigned Agents join a Workspace"),
+            s("--spec"),
+            s("2359"),
+            s("--topic"),
+            s("workspace-materialization"),
+            s("--boundary"),
+            s("CLI and Board write path"),
+        ])
+        .expect("parse ensure");
+
+        assert_eq!(
+            parsed,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some(
+                    "Ensure actionable Unassigned Agents join a Workspace".to_string()
+                ),
+                spec: Some(2359),
+                issue: None,
+                topic: Some("workspace-materialization".to_string()),
+                boundary: Some("CLI and Board write path".to_string()),
+            }
+        );
+    }
+
+    #[test]
     fn workspace_update_persists_workspace_status() {
         let _guard = crate::env_test_lock().lock().unwrap();
         let gwt_home = tempfile::tempdir().expect("gwt home");
@@ -986,5 +1347,168 @@ mod tests {
         .expect_err("similar Workspace should be rejected");
 
         assert!(err.to_string().contains("similar Workspace exists"));
+    }
+
+    #[test]
+    fn workspace_ensure_joins_similar_incomplete_workspace() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace materialization".to_string());
+        event.intent = Some("Ensure actionable Unassigned Agents join Workspace".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some(
+                    "Ensure actionable Unassigned Agents join Workspace".to_string(),
+                ),
+                spec: Some(2359),
+                issue: None,
+                topic: Some("workspace-materialization".to_string()),
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect("ensure workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace ensured: workspace-existing (joined)"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some("workspace-existing"));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert!(items.work_items[0]
+            .agents
+            .iter()
+            .any(|agent| agent.session_id == "session-1"));
+    }
+
+    #[test]
+    fn workspace_ensure_creates_workspace_when_no_candidate_matches() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some("Create Workspace from actionable intent".to_string()),
+                spec: Some(2359),
+                issue: None,
+                topic: Some("workspace-materialization".to_string()),
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect("ensure workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace ensured: workspace-"));
+        assert!(out.contains("(created)"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let workspace_id = saved.id.clone();
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(agent.workspace_id.as_deref(), Some(workspace_id.as_str()));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert_eq!(items.work_items.len(), 1);
+        assert_eq!(items.work_items[0].title, "Workspace materialization");
+        assert_eq!(items.work_items[0].owner.as_deref(), Some("SPEC-2359"));
+    }
+
+    #[test]
+    fn workspace_ensure_is_idempotent_for_already_assigned_agent() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut agent = unassigned_agent("session-1");
+        agent.affiliation_status = WorkspaceAgentAffiliationStatus::Assigned;
+        agent.workspace_id = Some("workspace-existing".to_string());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-existing".to_string();
+        projection.agents.push(agent);
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace materialization".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some("Continue current Workspace".to_string()),
+                spec: Some(2359),
+                issue: None,
+                topic: None,
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect("ensure workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace ensured: workspace-existing (already-assigned)"));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert_eq!(items.work_items.len(), 1);
     }
 }

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -825,6 +825,69 @@ fn unassigned_agent_without_title_summary_is_not_title_blocked() {
 }
 
 #[test]
+fn actionable_unassigned_agent_is_blocked_from_mutation_until_workspace_ensure() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/unassigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        let mut agent = unassigned_workspace_agent(&session_id);
+        agent.title_summary = Some("Workspace materialization".to_string());
+        agent.current_focus = Some("Ensure actionable intent enters a Workspace".to_string());
+        projection.agents.push(agent);
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/cli/workspace.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected actionable Unassigned mutation to be blocked");
+        };
+        assert!(detail.contains("Unassigned"), "{detail}");
+        assert!(detail.contains("gwtd workspace ensure"), "{detail}");
+    });
+}
+
+#[test]
+fn actionable_unassigned_agent_can_run_workspace_ensure_command() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/unassigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        let mut agent = unassigned_workspace_agent(&session_id);
+        agent.title_summary = Some("Workspace materialization".to_string());
+        agent.current_focus = Some("Ensure actionable intent enters a Workspace".to_string());
+        projection.agents.push(agent);
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Bash",
+            json!({
+                "command": "gwtd workspace ensure --agent-session \"$GWT_SESSION_ID\" --title-summary 'Workspace materialization' --current-focus 'Ensure actionable intent enters a Workspace' --spec 2359"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Workspace ensure must remain allowed so the Agent can repair affiliation"
+        );
+    });
+}
+
+#[test]
 fn assigned_agent_without_title_summary_remains_title_blocked() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);

--- a/crates/gwt/web/__tests__/kanban-structure.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-structure.test.mjs
@@ -159,6 +159,37 @@ test("Kanban shell lets column bodies own vertical scrolling", () => {
   assert.match(columnBodyRule[0], /min-height:\s*0/);
 });
 
+test("Workspace Overview contains Unassigned overflow without clipping columns", () => {
+  const unassignedRule = componentsCss.match(/\.workspace-unassigned\s*\{[^}]+\}/);
+  assert.ok(
+    unassignedRule,
+    "expected .workspace-unassigned rule in components.css",
+  );
+  assert.match(
+    unassignedRule[0],
+    /max-height:/,
+    "Unassigned Agents must have a bounded height inside the Kanban list pane",
+  );
+  assert.match(
+    unassignedRule[0],
+    /overflow-y:\s*auto/,
+    "Unassigned Agents must own their scroll when many Agents are listed",
+  );
+  assert.match(
+    unassignedRule[0],
+    /flex-shrink:\s*0/,
+    "Unassigned section must not collapse the Workspace columns",
+  );
+
+  const detailRule = componentsCss.match(/\.workspace-kanban-detail-pane\s*\{[^}]+\}/);
+  assert.ok(
+    detailRule,
+    "expected .workspace-kanban-detail-pane rule in components.css",
+  );
+  assert.match(detailRule[0], /min-height:\s*0/);
+  assert.match(detailRule[0], /overflow:\s*hidden/);
+});
+
 test("components.css declares column and card classes", () => {
   // Cards and columns need their own selectors so the renderer can style
   // them independently. Without these classes the renderer can't apply

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2316,12 +2316,20 @@ kbd.op-kbd {
   grid-template-columns: repeat(3, minmax(240px, 1fr));
 }
 
+.workspace-kanban-detail-pane {
+  min-height: 0;
+  overflow: hidden;
+}
+
 .workspace-unassigned {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   gap: var(--space-2);
   margin: var(--space-3) var(--space-3) 0;
   padding: var(--space-3);
+  max-height: min(28vh, 260px);
+  overflow-y: auto;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface);

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,36 @@
 # Lessons Learned
 
+## 2026-05-11 — Actionable Unassigned Agents must materialize before mutation
+
+### 事象
+
+Unassigned Agent が `title-summary` 付きの Board milestone や実装作業を
+行っても、Agent window title が更新されず、Workspace Overview では多くの
+Agent が Unassigned のまま残った。さらに Workspace Overview の Unassigned
+領域と detail pane に明示的な scroll containment がなく、表示内容が見切れた。
+
+### 原因
+
+`title-summary` guard は「Assigned Agent の title 欠落」を防いでいたが、
+「作業名や current focus を持つ Unassigned Agent は、まず Workspace に
+materialize しなければならない」という前提を workflow-policy / Board post
+経路で強制していなかった。Board milestone から Workspace history を更新する
+経路も origin Agent の affiliation を確認しておらず、Unassigned 起点の
+milestone が所属修復なしに履歴だけを更新できた。
+
+### 再発防止策
+
+1. Agent title / Board milestone / Workspace history のいずれかを変更する
+   修正では、Unassigned Agent の materialization 経路 (`workspace ensure` /
+   join / create) を必ずテストする。
+2. Board post で milestone kind (`claim` / `status` / `blocked` / `handoff` /
+   `decision` / `next`) を扱う場合、audience 計算より前に Workspace
+   affiliation が確定していることを確認する。意図的な broadcast は例外として
+   明示的に opt-out させる。
+3. Workspace Overview の固定領域を変更する場合は、`min-height: 0` と
+   bounded `overflow` の contract test を追加し、Unassigned / columns /
+   detail pane のどれも到達不能にならないことを確認する。
+
 ## 2026-05-10 — SPEC section edits must preserve section markers and avoid concurrent writes
 
 ### 事象


### PR DESCRIPTION
## Summary

Fixes the Workspace materialization gap for actionable Unassigned Agents so Agent window titles, Board audience, and Workspace history stay attached to the same work.

## Changes

- Adds `gwtd workspace ensure` as the shared repair path for joining a similar incomplete Workspace, creating a new Workspace, or refreshing an already assigned Agent.
- Materializes actionable Unassigned Board milestone posts before Board audience calculation, while keeping `--broadcast` as an explicit opt-out.
- Blocks mutation/verification from Unassigned Agents that already have actionable focus until they materialize or coordinate.
- Guards runtime Workspace history writes from Unassigned Board origins.
- Fixes Workspace Overview overflow so Unassigned Agents and detail content remain reachable.
- Records a local lesson for this class of Workspace/title/audience regression.

## Testing

- `cargo test -p gwt-core -p gwt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt`
- `cargo fmt -- --check`
- `git diff --check`
- `pnpm run test:frontend-unit`
- `pnpm run test:frontend-bundle`
- `pnpm run test:frontend-smoke`
- `pnpm dlx markdownlint-cli@0.44.0 tasks/lessons.md`
- `bunx commitlint --from origin/develop --to HEAD`
- `git push` pre-push coverage gate: 90.79% filtered line coverage, threshold 90.00%

## Closing Issues

None

## Related Issues

- SPEC #2359

## Checklist

- [x] SPEC/tasks updated
- [x] Focused RED/GREEN tests added
- [x] Full Rust verification passed
- [x] Frontend verification passed
- [x] Static checks passed
- [x] Commitlint passed
- [x] Branch pushed
