### PR TITLE
chore(release): v9.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.27.0] - 2026-05-11
+
+### Bug Fixes
+
+- Prepend GWT_BIN_PATH dir under existing case-insensitive PATH key
+- Scope managed assets by agent provider
+- **workspace:** Materialize actionable unassigned agents
+
+### Features
+
+- Prepend GWT_BIN_PATH dir to agent PATH
+- Restore launch agent preferences per agent
+
+### Miscellaneous Tasks
+
+- Apply cargo fmt to prepend_dir_to_path test additions
+- Merge origin develop
+
 ## [9.26.0] - 2026-05-11
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "axum",
  "base64",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.26.0"
+version = "9.27.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.26.0"
+version = "9.27.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -2092,15 +2092,10 @@ mod tests {
         // the spawned child process inherits both and command lookup is
         // corrupted. Test values use the platform-native PATH separator so
         // split_paths / join_paths round-trip on the host test runner.
-        let existing = std::env::join_paths([
-            Path::new("/usr/bin"),
-            Path::new("/bin"),
-        ])
-        .expect("join_paths existing entries");
-        let mut env_vars = HashMap::from([(
-            "Path".to_string(),
-            existing.to_string_lossy().into_owned(),
-        )]);
+        let existing = std::env::join_paths([Path::new("/usr/bin"), Path::new("/bin")])
+            .expect("join_paths existing entries");
+        let mut env_vars =
+            HashMap::from([("Path".to_string(), existing.to_string_lossy().into_owned())]);
         let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
         assert!(updated, "PATH must be updated for Windows-style key");
         assert!(
@@ -2122,10 +2117,8 @@ mod tests {
     fn prepend_dir_to_path_preserves_lowercase_path_key() {
         let existing = std::env::join_paths([Path::new("/usr/bin"), Path::new("/bin")])
             .expect("join_paths existing entries");
-        let mut env_vars = HashMap::from([(
-            "path".to_string(),
-            existing.to_string_lossy().into_owned(),
-        )]);
+        let mut env_vars =
+            HashMap::from([("path".to_string(), existing.to_string_lossy().into_owned())]);
         let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
         assert!(updated);
         assert!(
@@ -2142,18 +2135,20 @@ mod tests {
 
     #[test]
     fn prepend_dir_to_path_dedups_case_insensitive_existing_dir() {
-        let existing = std::env::join_paths([
-            Path::new("/opt/gwt/bin"),
-            Path::new("/usr/bin"),
-        ])
-        .expect("join_paths existing entries");
+        let existing = std::env::join_paths([Path::new("/opt/gwt/bin"), Path::new("/usr/bin")])
+            .expect("join_paths existing entries");
         let original_value = existing.to_string_lossy().into_owned();
-        let mut env_vars =
-            HashMap::from([("Path".to_string(), original_value.clone())]);
+        let mut env_vars = HashMap::from([("Path".to_string(), original_value.clone())]);
         let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
-        assert!(!updated, "existing entry must be a no-op regardless of key case");
+        assert!(
+            !updated,
+            "existing entry must be a no-op regardless of key case"
+        );
         assert!(!env_vars.contains_key("PATH"));
-        assert_eq!(env_vars.get("Path").map(String::as_str), Some(original_value.as_str()));
+        assert_eq!(
+            env_vars.get("Path").map(String::as_str),
+            Some(original_value.as_str())
+        );
     }
 
     #[test]

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -450,7 +450,44 @@ pub fn install_launch_gwt_bin_env_with_lookup(
                 .or_insert(gwt_bin);
         }
     }
+    if let Some(resolved) = env_vars.get(GWT_BIN_PATH_ENV).cloned() {
+        if let Some(parent) = Path::new(&resolved).parent() {
+            prepend_dir_to_path(env_vars, parent);
+        }
+    }
     Ok(())
+}
+
+/// Prepend `dir` to `env_vars["PATH"]` unless it is empty or already present.
+///
+/// Returns `true` if PATH was updated, `false` for a no-op (empty `dir`, dir
+/// already on PATH, or `join_paths` failure). PATH parsing uses
+/// [`std::env::split_paths`] / [`std::env::join_paths`] so the `:` / `;`
+/// separator difference between Unix and Windows is handled automatically.
+pub fn prepend_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -> bool {
+    if dir.as_os_str().is_empty() {
+        return false;
+    }
+    let existing_path = env_vars
+        .get("PATH")
+        .map(String::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let mut entries: Vec<PathBuf> = if existing_path.is_empty() {
+        Vec::new()
+    } else {
+        std::env::split_paths(&existing_path).collect()
+    };
+    let dir_buf = dir.to_path_buf();
+    if entries.iter().any(|entry| entry == &dir_buf) {
+        return false;
+    }
+    entries.insert(0, dir_buf);
+    let Ok(joined) = std::env::join_paths(&entries) else {
+        return false;
+    };
+    env_vars.insert("PATH".to_string(), joined.to_string_lossy().into_owned());
+    true
 }
 
 pub fn resolve_public_gwt_bin_with_lookup(
@@ -1886,5 +1923,237 @@ mod tests {
     fn preflight_env_test_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    // SPEC-2077 Phase I1 (US-7 / FR-020 / FR-021 / FR-022 / SC-010):
+    // install_launch_gwt_bin_env_with_lookup must prepend the GWT_BIN_PATH
+    // parent directory to env_vars["PATH"] so agent subshells can resolve
+    // gwtd / gwt directly without the ${GWT_BIN_PATH:-gwtd} indirection.
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_prepends_gwtd_dir_to_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars.get(GWT_BIN_PATH_ENV).map(String::as_str),
+            Some("/Applications/GWT.app/Contents/MacOS/gwtd"),
+        );
+        let path = env_vars.get("PATH").expect("PATH should be set");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/Applications/GWT.app/Contents/MacOS")),
+            "GWT_BIN_PATH parent dir must be prepended; got {path}",
+        );
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_dedups_existing_path_entry() {
+        let mut env_vars = HashMap::from([(
+            "PATH".to_string(),
+            "/Applications/GWT.app/Contents/MacOS:/usr/bin".to_string(),
+        )]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/Applications/GWT.app/Contents/MacOS"),
+                PathBuf::from("/usr/bin"),
+            ],
+            "PATH must not contain duplicate GWT_BIN_PATH parent dir",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_skips_path_update_when_parent_is_empty() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/opt/gwt/bin/gwt");
+        // Lookup returns a bare filename (Path::parent => Some(""))
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("gwtd")),
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars.get(GWT_BIN_PATH_ENV).map(String::as_str),
+            Some("gwtd"),
+        );
+        assert_eq!(
+            env_vars.get("PATH").map(String::as_str),
+            Some("/usr/bin:/bin"),
+            "empty GWT_BIN_PATH parent must be a no-op",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_creates_path_when_absent() {
+        let mut env_vars: HashMap<String, String> = HashMap::new();
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let path = env_vars.get("PATH").expect("PATH should be created");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/Applications/GWT.app/Contents/MacOS")],
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_dedups_when_dir_already_on_path() {
+        let mut env_vars =
+            HashMap::from([("PATH".to_string(), "/usr/local/bin:/usr/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars.get(GWT_BIN_PATH_ENV).map(String::as_str),
+            Some("/usr/local/bin/gwtd"),
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin"),],
+            "Docker dir already on PATH must dedup",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_prepends_when_dir_missing_from_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/usr/local/bin")),
+            "Docker dir not on PATH must be prepended; got entries: {entries:?}",
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_preserves_existing_path_order() {
+        let mut env_vars =
+            HashMap::from([("PATH".to_string(), "/profile/bin:/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/Applications/GWT.app/Contents/MacOS"),
+                PathBuf::from("/profile/bin"),
+                PathBuf::from("/usr/bin"),
+                PathBuf::from("/bin"),
+            ],
+            "existing PATH order must be preserved after prepend",
+        );
+    }
+
+    #[test]
+    fn prepare_agent_launch_host_prepends_gwtd_dir_to_path() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo-feature");
+        let sessions_dir = temp.path().join(".gwt").join("sessions");
+        fs::create_dir_all(&worktree).expect("create worktree");
+
+        let mut config = sample_versioned_launch_config(&worktree);
+        config
+            .env_vars
+            .insert("PATH".to_string(), "/usr/bin:/bin".to_string());
+
+        let mut probe_host_runner =
+            |_command: &str,
+             _args: Vec<String>,
+             _env: &HashMap<String, String>,
+             _remove_env: &[String],
+             _cwd: Option<PathBuf>| true;
+        let lookup_gwt_bin = |_command: &str| Some(PathBuf::from("/opt/gwt/bin/gwtd"));
+
+        let prepared = prepare_agent_launch_with(
+            &worktree,
+            &sessions_dir,
+            config,
+            None,
+            |_path| Ok(()),
+            PrepareLaunchDeps {
+                current_exe: Path::new("/opt/gwt/bin/gwt"),
+                probe_host_runner: &mut probe_host_runner,
+                lookup_gwt_bin: &lookup_gwt_bin,
+            },
+        )
+        .expect("prepare launch");
+
+        assert_eq!(
+            prepared
+                .process_launch
+                .env
+                .get(GWT_BIN_PATH_ENV)
+                .map(String::as_str),
+            Some("/opt/gwt/bin/gwtd"),
+        );
+        let path = prepared
+            .process_launch
+            .env
+            .get("PATH")
+            .expect("PATH should be set after install_launch_gwt_bin_env_with_lookup");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/opt/gwt/bin")),
+            "agent process PATH must start with GWT_BIN_PATH parent dir; got {path}",
+        );
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
     }
 }

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -458,18 +458,28 @@ pub fn install_launch_gwt_bin_env_with_lookup(
     Ok(())
 }
 
-/// Prepend `dir` to `env_vars["PATH"]` unless it is empty or already present.
+/// Prepend `dir` to the PATH-style entry in `env_vars` unless it is empty or
+/// already present.
 ///
-/// Returns `true` if PATH was updated, `false` for a no-op (empty `dir`, dir
-/// already on PATH, or `join_paths` failure). PATH parsing uses
-/// [`std::env::split_paths`] / [`std::env::join_paths`] so the `:` / `;`
-/// separator difference between Unix and Windows is handled automatically.
+/// Returns `true` if the entry was updated, `false` for a no-op (empty `dir`,
+/// dir already on PATH, or `join_paths` failure). Key lookup is
+/// case-insensitive: Windows processes may expose the variable as `Path` or
+/// `path`, and a case-sensitive read would produce a duplicate `PATH` key
+/// alongside the original, corrupting command lookup once the child process
+/// inherits both. PATH parsing uses [`std::env::split_paths`] /
+/// [`std::env::join_paths`] so the `:` / `;` separator difference between
+/// Unix and Windows is handled automatically.
 pub fn prepend_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -> bool {
     if dir.as_os_str().is_empty() {
         return false;
     }
+    let existing_key = env_vars
+        .keys()
+        .find(|key| key.eq_ignore_ascii_case("PATH"))
+        .cloned();
+    let key = existing_key.unwrap_or_else(|| "PATH".to_string());
     let existing_path = env_vars
-        .get("PATH")
+        .get(&key)
         .map(String::as_str)
         .unwrap_or_default()
         .to_string();
@@ -486,7 +496,7 @@ pub fn prepend_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -
     let Ok(joined) = std::env::join_paths(&entries) else {
         return false;
     };
-    env_vars.insert("PATH".to_string(), joined.to_string_lossy().into_owned());
+    env_vars.insert(key, joined.to_string_lossy().into_owned());
     true
 }
 
@@ -2071,6 +2081,79 @@ mod tests {
             Some(Path::new("/usr/local/bin")),
             "Docker dir not on PATH must be prepended; got entries: {entries:?}",
         );
+    }
+
+    #[test]
+    fn prepend_dir_to_path_preserves_windows_style_path_key() {
+        // CodeRabbit P1 regression follow-up: Windows processes may expose
+        // the path variable as "Path" (case-insensitive at OS level).
+        // prepend_dir_to_path must update the existing key in place rather
+        // than creating a duplicate "PATH" entry alongside "Path", otherwise
+        // the spawned child process inherits both and command lookup is
+        // corrupted. Test values use the platform-native PATH separator so
+        // split_paths / join_paths round-trip on the host test runner.
+        let existing = std::env::join_paths([
+            Path::new("/usr/bin"),
+            Path::new("/bin"),
+        ])
+        .expect("join_paths existing entries");
+        let mut env_vars = HashMap::from([(
+            "Path".to_string(),
+            existing.to_string_lossy().into_owned(),
+        )]);
+        let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
+        assert!(updated, "PATH must be updated for Windows-style key");
+        assert!(
+            !env_vars.contains_key("PATH"),
+            "no duplicate uppercase PATH key may be created when Path exists: {env_vars:?}",
+        );
+        let path = env_vars.get("Path").expect("Path key must be preserved");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/opt/gwt/bin")),
+            "prepended dir must lead the Path value; got {path}",
+        );
+        assert!(entries.iter().any(|p| p == Path::new("/usr/bin")));
+        assert!(entries.iter().any(|p| p == Path::new("/bin")));
+    }
+
+    #[test]
+    fn prepend_dir_to_path_preserves_lowercase_path_key() {
+        let existing = std::env::join_paths([Path::new("/usr/bin"), Path::new("/bin")])
+            .expect("join_paths existing entries");
+        let mut env_vars = HashMap::from([(
+            "path".to_string(),
+            existing.to_string_lossy().into_owned(),
+        )]);
+        let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
+        assert!(updated);
+        assert!(
+            !env_vars.contains_key("PATH"),
+            "no duplicate uppercase PATH key may be created when lowercase path exists: {env_vars:?}",
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("path").expect("path key")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/opt/gwt/bin")),
+        );
+    }
+
+    #[test]
+    fn prepend_dir_to_path_dedups_case_insensitive_existing_dir() {
+        let existing = std::env::join_paths([
+            Path::new("/opt/gwt/bin"),
+            Path::new("/usr/bin"),
+        ])
+        .expect("join_paths existing entries");
+        let original_value = existing.to_string_lossy().into_owned();
+        let mut env_vars =
+            HashMap::from([("Path".to_string(), original_value.clone())]);
+        let updated = prepend_dir_to_path(&mut env_vars, Path::new("/opt/gwt/bin"));
+        assert!(!updated, "existing entry must be a no-op regardless of key case");
+        assert!(!env_vars.contains_key("PATH"));
+        assert_eq!(env_vars.get("Path").map(String::as_str), Some(original_value.as_str()));
     }
 
     #[test]

--- a/crates/gwt-skills/src/distribute.rs
+++ b/crates/gwt-skills/src/distribute.rs
@@ -11,7 +11,31 @@ use include_dir::Dir;
 
 use crate::assets::{CLAUDE_COMMANDS, CLAUDE_SKILLS};
 
-const TRACKED_ROOTS: &[&str] = &[".claude/skills", ".claude/commands", ".codex/skills"];
+const TRACKED_ROOTS: &[&str] = &[
+    ".claude/skills",
+    ".claude/commands",
+    ".codex/skills",
+    ".gwt/hermes/skills",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ManagedAssetTarget {
+    ClaudeCode,
+    Codex,
+    OpenCode,
+    OpenClaw,
+    Hermes,
+}
+
+impl ManagedAssetTarget {
+    pub const ALL: [Self; 5] = [
+        Self::ClaudeCode,
+        Self::Codex,
+        Self::OpenCode,
+        Self::OpenClaw,
+        Self::Hermes,
+    ];
+}
 
 /// Result of a distribution operation.
 #[derive(Debug, Default)]
@@ -30,46 +54,69 @@ enum RootEntryKind {
     Files,
 }
 
-/// Write all bundled skill, command, and hook files to the target worktree.
+/// Write bundled skill and command files to the target worktree.
 ///
-/// Distribution targets:
+/// Full distribution targets:
 /// - `.claude/skills/gwt-*/`
 /// - `.claude/commands/gwt-*.md`
 /// - `.codex/skills/gwt-*/`  (same skill content)
+/// - `.gwt/hermes/skills/gwt-*/`  (gwt skill content only)
 ///
-/// Claude and Codex hook execution are now driven only by generated config
-/// (`.claude/settings.local.json` and `.codex/hooks.json`).
+/// Provider hook execution is driven by generated config owned by the
+/// caller (`.claude/settings.local.json`, `.codex/hooks.json`, and
+/// `.gwt/<provider>/...` provider homes).
 /// Retired `hooks/scripts/gwt-*` files are pruned as stale managed
 /// assets instead of being redistributed.
 pub fn distribute_to_worktree(worktree: &Path) -> io::Result<DistributeReport> {
+    distribute_to_worktree_for_targets(worktree, &ManagedAssetTarget::ALL)
+}
+
+pub fn distribute_to_worktree_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<DistributeReport> {
     let mut report = DistributeReport::default();
     let tracked_paths = tracked_gwt_asset_paths(worktree);
+    let targets = normalize_targets(targets);
 
-    prune_managed_asset_roots(worktree, &tracked_paths, &mut report)?;
+    prune_managed_asset_roots_for_targets(worktree, &tracked_paths, &targets, &mut report)?;
 
-    // Claude Code targets
-    write_dir_assets(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".claude/skills"),
-        &tracked_paths,
-        &mut report,
-    )?;
-    write_dir_assets(
-        &CLAUDE_COMMANDS,
-        worktree,
-        &worktree.join(".claude/commands"),
-        &tracked_paths,
-        &mut report,
-    )?;
-    // Codex targets
-    write_dir_assets(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".codex/skills"),
-        &tracked_paths,
-        &mut report,
-    )?;
+    if targets.contains(&ManagedAssetTarget::ClaudeCode) {
+        write_dir_assets(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".claude/skills"),
+            &tracked_paths,
+            &mut report,
+        )?;
+        write_dir_assets(
+            &CLAUDE_COMMANDS,
+            worktree,
+            &worktree.join(".claude/commands"),
+            &tracked_paths,
+            &mut report,
+        )?;
+    }
+
+    if targets.contains(&ManagedAssetTarget::Codex) {
+        write_dir_assets(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".codex/skills"),
+            &tracked_paths,
+            &mut report,
+        )?;
+    }
+
+    if targets.contains(&ManagedAssetTarget::Hermes) {
+        write_gwt_skill_dir_assets(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".gwt/hermes/skills"),
+            &tracked_paths,
+            &mut report,
+        )?;
+    }
 
     Ok(report)
 }
@@ -77,48 +124,84 @@ pub fn distribute_to_worktree(worktree: &Path) -> io::Result<DistributeReport> {
 /// Remove stale gwt-managed asset paths from the target worktree without
 /// materializing the current bundle.
 pub fn prune_stale_gwt_assets(worktree: &Path) -> io::Result<usize> {
+    prune_stale_gwt_assets_for_targets(worktree, &ManagedAssetTarget::ALL)
+}
+
+pub fn prune_stale_gwt_assets_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<usize> {
     let mut report = DistributeReport::default();
     let tracked_paths = tracked_gwt_asset_paths(worktree);
-    prune_managed_asset_roots(worktree, &tracked_paths, &mut report)?;
+    let targets = normalize_targets(targets);
+    prune_managed_asset_roots_for_targets(worktree, &tracked_paths, &targets, &mut report)?;
     Ok(report.paths_removed)
 }
 
-fn prune_managed_asset_roots(
+fn prune_managed_asset_roots_for_targets(
     worktree: &Path,
     tracked_paths: &HashSet<PathBuf>,
+    targets: &[ManagedAssetTarget],
     report: &mut DistributeReport,
 ) -> io::Result<()> {
-    // Claude Code targets
-    prune_dir_against_source(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".claude/skills"),
-        Some(RootEntryKind::Directories),
-        tracked_paths,
-        report,
-    )?;
-    prune_dir_against_source(
-        &CLAUDE_COMMANDS,
-        worktree,
-        &worktree.join(".claude/commands"),
-        Some(RootEntryKind::Files),
-        tracked_paths,
-        report,
-    )?;
-    prune_retired_hook_scripts(&worktree.join(".claude/hooks/scripts"), report)?;
+    if targets.contains(&ManagedAssetTarget::ClaudeCode) {
+        prune_dir_against_source(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".claude/skills"),
+            Some(RootEntryKind::Directories),
+            false,
+            tracked_paths,
+            report,
+        )?;
+        prune_dir_against_source(
+            &CLAUDE_COMMANDS,
+            worktree,
+            &worktree.join(".claude/commands"),
+            Some(RootEntryKind::Files),
+            false,
+            tracked_paths,
+            report,
+        )?;
+        prune_retired_hook_scripts(&worktree.join(".claude/hooks/scripts"), report)?;
+    }
 
-    // Codex targets use the same skill bundle as Claude.
-    prune_dir_against_source(
-        &CLAUDE_SKILLS,
-        worktree,
-        &worktree.join(".codex/skills"),
-        Some(RootEntryKind::Directories),
-        tracked_paths,
-        report,
-    )?;
-    prune_retired_hook_scripts(&worktree.join(".codex/hooks/scripts"), report)?;
+    if targets.contains(&ManagedAssetTarget::Codex) {
+        prune_dir_against_source(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".codex/skills"),
+            Some(RootEntryKind::Directories),
+            false,
+            tracked_paths,
+            report,
+        )?;
+        prune_retired_hook_scripts(&worktree.join(".codex/hooks/scripts"), report)?;
+    }
+
+    if targets.contains(&ManagedAssetTarget::Hermes) {
+        prune_dir_against_source(
+            &CLAUDE_SKILLS,
+            worktree,
+            &worktree.join(".gwt/hermes/skills"),
+            Some(RootEntryKind::Directories),
+            true,
+            tracked_paths,
+            report,
+        )?;
+    }
 
     Ok(())
+}
+
+fn normalize_targets(targets: &[ManagedAssetTarget]) -> Vec<ManagedAssetTarget> {
+    let mut normalized = Vec::new();
+    for target in targets {
+        if !normalized.contains(target) {
+            normalized.push(*target);
+        }
+    }
+    normalized
 }
 
 fn prune_retired_hook_scripts(dest: &Path, report: &mut DistributeReport) -> io::Result<()> {
@@ -158,6 +241,27 @@ fn write_dir_assets(
     tracked_paths: &HashSet<PathBuf>,
     report: &mut DistributeReport,
 ) -> io::Result<()> {
+    write_dir_assets_inner(source, worktree, dest, tracked_paths, false, report)
+}
+
+fn write_gwt_skill_dir_assets(
+    source: &Dir<'_>,
+    worktree: &Path,
+    dest: &Path,
+    tracked_paths: &HashSet<PathBuf>,
+    report: &mut DistributeReport,
+) -> io::Result<()> {
+    write_dir_assets_inner(source, worktree, dest, tracked_paths, true, report)
+}
+
+fn write_dir_assets_inner(
+    source: &Dir<'_>,
+    worktree: &Path,
+    dest: &Path,
+    tracked_paths: &HashSet<PathBuf>,
+    root_gwt_only: bool,
+    report: &mut DistributeReport,
+) -> io::Result<()> {
     for file in source.files() {
         let target = dest.join(file.path().file_name().unwrap_or_default());
         // Preserve existing tracked files so we do not overwrite user-checked-in
@@ -178,6 +282,9 @@ fn write_dir_assets(
 
     for subdir in source.dirs() {
         let subdir_name = subdir.path().file_name().unwrap_or_default();
+        if root_gwt_only && !subdir_name.to_string_lossy().starts_with("gwt-") {
+            continue;
+        }
         write_dir_assets(
             subdir,
             worktree,
@@ -195,6 +302,7 @@ fn prune_dir_against_source(
     worktree: &Path,
     dest: &Path,
     root_kind: Option<RootEntryKind>,
+    root_gwt_only: bool,
     tracked_paths: &HashSet<PathBuf>,
     report: &mut DistributeReport,
 ) -> io::Result<()> {
@@ -210,6 +318,7 @@ fn prune_dir_against_source(
     let desired_dir_names: HashSet<String> = source
         .dirs()
         .filter_map(|dir| dir.path().file_name().and_then(|name| name.to_str()))
+        .filter(|name| !root_gwt_only || name.starts_with("gwt-"))
         .map(str::to_string)
         .collect();
 
@@ -247,11 +356,15 @@ fn prune_dir_against_source(
 
     for subdir in source.dirs() {
         let subdir_name = subdir.path().file_name().unwrap_or_default();
+        if root_gwt_only && !subdir_name.to_string_lossy().starts_with("gwt-") {
+            continue;
+        }
         prune_dir_against_source(
             subdir,
             worktree,
             &dest.join(subdir_name),
             None,
+            false,
             tracked_paths,
             report,
         )?;
@@ -343,6 +456,71 @@ mod tests {
         distribute_to_worktree(dir.path()).unwrap();
         let skill_md = dir.path().join(".codex/skills/gwt-manage-pr/SKILL.md");
         assert!(skill_md.exists(), "expected {}", skill_md.display());
+    }
+
+    #[test]
+    fn distribute_for_targets_only_materializes_requested_agent_assets() {
+        let dir = tempfile::tempdir().unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Codex]).unwrap();
+
+        assert!(dir
+            .path()
+            .join(".codex/skills/gwt-manage-pr/SKILL.md")
+            .exists());
+        assert!(
+            !dir.path()
+                .join(".claude/skills/gwt-manage-pr/SKILL.md")
+                .exists(),
+            "Codex launch must not materialize Claude Code skills"
+        );
+        assert!(
+            !dir.path()
+                .join(".gwt/hermes/skills/gwt-manage-pr/SKILL.md")
+                .exists(),
+            "Codex launch must not materialize Hermes skills"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_materializes_hermes_skills_under_hermes_home() {
+        let dir = tempfile::tempdir().unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Hermes]).unwrap();
+
+        let skill_md = dir
+            .path()
+            .join(".gwt/hermes/skills/gwt-build-spec/SKILL.md");
+        assert!(skill_md.exists(), "expected {}", skill_md.display());
+        assert!(
+            !dir.path()
+                .join(".claude/skills/gwt-build-spec/SKILL.md")
+                .exists(),
+            "Hermes launch must not materialize Claude Code skills"
+        );
+        assert!(
+            !dir.path()
+                .join(".codex/skills/gwt-build-spec/SKILL.md")
+                .exists(),
+            "Hermes launch must not materialize Codex skills"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_preserves_non_gwt_hermes_skill_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let user_asset = dir
+            .path()
+            .join(".gwt/hermes/skills/tui-design/user-note.md");
+        fs::create_dir_all(user_asset.parent().unwrap()).unwrap();
+        fs::write(&user_asset, "user owned").unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Hermes]).unwrap();
+
+        assert!(
+            user_asset.exists(),
+            "Hermes distribution must not prune non-gwt skill content"
+        );
     }
 
     #[test]

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -7,28 +7,12 @@ use std::{
 
 use gwt_core::process::hidden_command;
 
+use crate::distribute::ManagedAssetTarget;
+
 const BEGIN_MARKER: &str = "# gwt-managed-begin";
 const END_MARKER: &str = "# gwt-managed-end";
-
-/// Patterns to exclude gwt-managed assets from git tracking.
-///
-/// `.gwt/discussion.md` is the gwt-discussion skill's working artifact, which
-/// is always created under the active worktree. gwt owns its exclusion via
-/// this managed block rather than `.gitignore`, because a project-level
-/// `.gitignore` cannot assume every worktree using a gwt skill has the same
-/// repo-wide rule (some consumers run gwt without committing to the
-/// repository's `.gitignore`).
-const GWT_EXCLUDE_PATTERNS: &[&str] = &[
-    ".claude/skills/gwt-*",
-    ".claude/commands/gwt-*",
-    ".claude/settings.local.json",
-    ".codex/skills/gwt-*",
-    ".gwt/discussion.md",
-    ".gwt/opencode/",
-    ".gwt/openclaw/",
-    ".gwt/hermes/",
-    "docker-compose.override.yml",
-];
+const LEGACY_BEGIN_MARKER: &str = "# BEGIN gwt managed local assets";
+const LEGACY_END_MARKER: &str = "# END gwt managed local assets";
 
 /// Update `.git/info/exclude` to include gwt-managed asset exclusions.
 ///
@@ -36,6 +20,22 @@ const GWT_EXCLUDE_PATTERNS: &[&str] = &[
 /// `# gwt-managed-begin` / `# gwt-managed-end` markers and replaced on
 /// each call.
 pub fn update_git_exclude(worktree: &Path) -> io::Result<()> {
+    write_git_exclude(worktree, replace_managed_block)
+}
+
+pub fn update_git_exclude_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<()> {
+    write_git_exclude(worktree, |existing| {
+        replace_managed_block_for_targets(existing, targets)
+    })
+}
+
+fn write_git_exclude(
+    worktree: &Path,
+    replace: impl FnOnce(&str) -> io::Result<String>,
+) -> io::Result<()> {
     let exclude_path = resolve_git_exclude_path(worktree)?;
 
     // Create parent directory if needed
@@ -49,7 +49,7 @@ pub fn update_git_exclude(worktree: &Path) -> io::Result<()> {
         String::new()
     };
 
-    let updated = replace_managed_block(&existing)?;
+    let updated = replace(&existing)?;
     fs::write(&exclude_path, updated)?;
 
     Ok(())
@@ -88,8 +88,26 @@ fn resolve_git_exclude_path(worktree: &Path) -> io::Result<PathBuf> {
 }
 
 fn replace_managed_block(content: &str) -> io::Result<String> {
+    let mut patterns = exclude_patterns_for_targets(&ManagedAssetTarget::ALL);
+    push_unique(&mut patterns, "docker-compose.override.yml");
+    replace_managed_block_with_patterns(content, &patterns)
+}
+
+fn replace_managed_block_for_targets(
+    content: &str,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<String> {
+    let patterns = exclude_patterns_for_targets(targets);
+    replace_managed_block_with_patterns(content, &patterns)
+}
+
+fn replace_managed_block_with_patterns(
+    content: &str,
+    patterns: &[&'static str],
+) -> io::Result<String> {
     let mut result = String::new();
     let mut in_managed_block = false;
+    let mut in_legacy_managed_block = false;
 
     for line in content.lines() {
         if line.trim() == BEGIN_MARKER {
@@ -101,6 +119,15 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
             in_managed_block = true;
             continue;
         }
+        if line.trim() == LEGACY_BEGIN_MARKER {
+            if in_legacy_managed_block {
+                return Err(malformed_marker_error(
+                    "nested begin marker in legacy gwt-managed exclude block",
+                ));
+            }
+            in_legacy_managed_block = true;
+            continue;
+        }
         if line.trim() == END_MARKER {
             if !in_managed_block {
                 return Err(malformed_marker_error(
@@ -110,7 +137,16 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
             in_managed_block = false;
             continue;
         }
-        if !in_managed_block {
+        if line.trim() == LEGACY_END_MARKER {
+            if !in_legacy_managed_block {
+                return Err(malformed_marker_error(
+                    "legacy end marker without matching begin marker in gwt-managed exclude block",
+                ));
+            }
+            in_legacy_managed_block = false;
+            continue;
+        }
+        if !in_managed_block && !in_legacy_managed_block {
             result.push_str(line);
             result.push('\n');
         }
@@ -119,6 +155,11 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
     if in_managed_block {
         return Err(malformed_marker_error(
             "unterminated gwt-managed exclude block",
+        ));
+    }
+    if in_legacy_managed_block {
+        return Err(malformed_marker_error(
+            "unterminated legacy gwt-managed exclude block",
         ));
     }
 
@@ -130,18 +171,58 @@ fn replace_managed_block(content: &str) -> io::Result<String> {
         format!("{trimmed}\n")
     };
 
-    // Append managed block
-    final_content.push('\n');
-    final_content.push_str(BEGIN_MARKER);
-    final_content.push('\n');
-    for pattern in GWT_EXCLUDE_PATTERNS {
-        final_content.push_str(pattern);
+    if !patterns.is_empty() {
+        // Append managed block
+        final_content.push('\n');
+        final_content.push_str(BEGIN_MARKER);
+        final_content.push('\n');
+        for pattern in patterns {
+            final_content.push_str(pattern);
+            final_content.push('\n');
+        }
+        final_content.push_str(END_MARKER);
         final_content.push('\n');
     }
-    final_content.push_str(END_MARKER);
-    final_content.push('\n');
 
     Ok(final_content)
+}
+
+fn exclude_patterns_for_targets(targets: &[ManagedAssetTarget]) -> Vec<&'static str> {
+    let mut patterns = Vec::new();
+    if !targets.is_empty() {
+        push_unique(&mut patterns, ".gwt/discussion.md");
+    }
+    for target in ManagedAssetTarget::ALL {
+        if !targets.contains(&target) {
+            continue;
+        }
+        match target {
+            ManagedAssetTarget::ClaudeCode => {
+                push_unique(&mut patterns, ".claude/skills/gwt-*");
+                push_unique(&mut patterns, ".claude/commands/gwt-*");
+                push_unique(&mut patterns, ".claude/settings.local.json");
+            }
+            ManagedAssetTarget::Codex => {
+                push_unique(&mut patterns, ".codex/skills/gwt-*");
+            }
+            ManagedAssetTarget::OpenCode => {
+                push_unique(&mut patterns, ".gwt/opencode/");
+            }
+            ManagedAssetTarget::OpenClaw => {
+                push_unique(&mut patterns, ".gwt/openclaw/");
+            }
+            ManagedAssetTarget::Hermes => {
+                push_unique(&mut patterns, ".gwt/hermes/");
+            }
+        }
+    }
+    patterns
+}
+
+fn push_unique(patterns: &mut Vec<&'static str>, pattern: &'static str) {
+    if !patterns.contains(&pattern) {
+        patterns.push(pattern);
+    }
 }
 
 fn malformed_marker_error(detail: &str) -> io::Error {
@@ -170,6 +251,40 @@ mod tests {
         assert!(!result.contains(".codex/hooks.json"));
         assert!(!result.contains(".codex/hooks/scripts/gwt-*"));
         assert!(!result.contains(".agents/skills/gwt-*"));
+    }
+
+    #[test]
+    fn adds_only_requested_provider_patterns() {
+        let result = replace_managed_block_for_targets("", &[ManagedAssetTarget::Hermes]).unwrap();
+
+        assert!(result.contains(BEGIN_MARKER));
+        assert!(result.contains(".gwt/hermes/"));
+        assert!(result.contains(".gwt/discussion.md"));
+        assert!(!result.contains(".claude/skills/gwt-*"));
+        assert!(!result.contains(".codex/skills/gwt-*"));
+        assert!(!result.contains(".gwt/opencode/"));
+        assert!(!result.contains(".gwt/openclaw/"));
+    }
+
+    #[test]
+    fn replaces_legacy_broad_managed_block_with_scoped_patterns() {
+        let existing = "\
+user-entry
+# BEGIN gwt managed local assets
+/.gwt/
+/.codex/skills/gwt-*/
+/.claude/skills/gwt-*/
+# END gwt managed local assets
+";
+
+        let result =
+            replace_managed_block_for_targets(existing, &[ManagedAssetTarget::Codex]).unwrap();
+
+        assert!(result.contains("user-entry"));
+        assert!(result.contains(".codex/skills/gwt-*"));
+        assert!(!result.contains("/.gwt/"));
+        assert!(!result.contains(".claude/skills/gwt-*"));
+        assert!(!result.contains("# BEGIN gwt managed local assets"));
     }
 
     #[test]

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -9,8 +9,11 @@ pub mod registry;
 pub mod settings_local;
 pub mod validate;
 
-pub use distribute::{distribute_to_worktree, prune_stale_gwt_assets, DistributeReport};
-pub use git_exclude::update_git_exclude;
+pub use distribute::{
+    distribute_to_worktree, distribute_to_worktree_for_targets, prune_stale_gwt_assets,
+    prune_stale_gwt_assets_for_targets, DistributeReport, ManagedAssetTarget,
+};
+pub use git_exclude::{update_git_exclude, update_git_exclude_for_targets};
 pub use hooks::{
     backup_hooks, detect_corruption, is_gwt_managed, merge_hooks, merge_hooks_safe,
     restore_from_backup, Hook, HooksConfig, HooksError,

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -372,16 +372,18 @@ impl AppRuntime {
             );
             return None;
         }
-        let work_event =
-            workspace_projection::workspace_work_event_from_board_entry(&projection, entry);
-        if let Err(error) =
-            workspace_projection::record_workspace_work_event(project_root, work_event)
-        {
-            tracing::warn!(
-                error = %error,
-                project_root = %project_root.display(),
-                "failed to record workspace WorkItem event for board milestone"
-            );
+        if board_entry_origin_can_record_workspace_work_event(&projection, entry) {
+            let work_event =
+                workspace_projection::workspace_work_event_from_board_entry(&projection, entry);
+            if let Err(error) =
+                workspace_projection::record_workspace_work_event(project_root, work_event)
+            {
+                tracing::warn!(
+                    error = %error,
+                    project_root = %project_root.display(),
+                    "failed to record workspace WorkItem event for board milestone"
+                );
+            }
         }
 
         if self.active_tab_id.as_deref() != Some(tab_id) {
@@ -442,6 +444,20 @@ impl AppRuntime {
             Some(entry.body.clone()),
         )
     }
+}
+
+fn board_entry_origin_can_record_workspace_work_event(
+    projection: &workspace_projection::WorkspaceProjection,
+    entry: &coordination::BoardEntry,
+) -> bool {
+    let Some(session_id) = entry.origin_session_id.as_deref() else {
+        return true;
+    };
+    projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+        .is_some_and(|agent| agent.is_assigned())
 }
 
 fn board_error(client_id: &str, id: &str, message: impl Into<String>) -> Vec<OutboundEvent> {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4669,7 +4669,7 @@ impl AppRuntime {
             )?
             .with_project_root(&worktree_path)
             .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
-            refresh_managed_gwt_assets_for_worktree(&worktree_path)
+            refresh_managed_gwt_assets_for_agent(&worktree_path, &config.agent_id)
                 .map_err(|error| error.to_string())?;
 
             if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Host

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -407,8 +407,8 @@ impl LaunchWizardMemoryCache {
         )
     }
 
-    fn previous_profile(&self, repo_path: &Path) -> Option<gwt::LaunchWizardPreviousProfile> {
-        gwt::launch_wizard::previous_launch_profile_from_sessions(repo_path, &self.sessions)
+    fn previous_profiles(&self) -> gwt::LaunchWizardPreviousProfiles {
+        gwt::launch_wizard::previous_launch_profiles_from_sessions(&self.sessions)
     }
 
     fn record_session(&mut self, session: gwt_agent::Session) {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -10673,6 +10673,82 @@ exit 0
     }
 
     #[test]
+    fn app_runtime_board_milestone_from_unassigned_origin_does_not_create_workspace_history() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "board-1",
+            repo.clone(),
+            WindowPreset::Board,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection
+            .agents
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
+                session_id: "session-unassigned".to_string(),
+                window_id: None,
+                agent_id: "codex".to_string(),
+                display_name: "Codex".to_string(),
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
+                current_focus: Some("Investigate Workspace materialization".to_string()),
+                title_summary: Some("Workspace materialization".to_string()),
+                worktree_path: None,
+                branch: Some("work/unassigned".to_string()),
+                last_board_entry_id: None,
+                last_board_entry_kind: None,
+                coordination_scope: None,
+                affiliation_status:
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned,
+                workspace_id: None,
+                updated_at: chrono::Utc::now(),
+            });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Claim,
+            "Unassigned claim without materialization must not pollute current Workspace history.",
+            None,
+            None,
+            vec!["workspace-materialization".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_title_summary("Workspace materialization")
+        .with_origin_session_id("session-unassigned");
+
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &entry);
+
+        let saved = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-unassigned")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
+        );
+        assert!(
+            gwt_core::workspace_projection::load_workspace_work_items(&repo)
+                .expect("load workspace history")
+                .is_none(),
+            "Unassigned origin Board entries must not append to unrelated Workspace history"
+        );
+    }
+
+    #[test]
     fn app_runtime_active_work_projection_preserves_blocked_agent_board_state() {
         let _env_lock = env_test_lock()
             .lock()

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -166,7 +166,7 @@ impl AppRuntime {
         let quick_start_entries = self
             .launch_wizard_cache
             .quick_start_entries(&quick_start_root, &normalized_branch_name);
-        let previous_profile = self.launch_wizard_cache.previous_profile(&quick_start_root);
+        let previous_profiles = self.launch_wizard_cache.previous_profiles();
         let agent_options = self.launch_wizard_cache.agent_options();
         let (docker_context, docker_service_status) =
             detect_wizard_docker_context_and_status(&quick_start_root);
@@ -174,7 +174,7 @@ impl AppRuntime {
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
             wizard_id,
-            wizard: LaunchWizardState::open_with_previous_profile(
+            wizard: LaunchWizardState::open_with_previous_profiles(
                 LaunchWizardContext {
                     selected_branch: synthetic_branch_entry(branch_name),
                     normalized_branch_name,
@@ -188,7 +188,7 @@ impl AppRuntime {
                 },
                 agent_options,
                 quick_start_entries,
-                previous_profile,
+                previous_profiles,
             ),
             workspace_resume_context,
         });
@@ -376,7 +376,7 @@ impl AppRuntime {
         let quick_start_entries = self
             .launch_wizard_cache
             .quick_start_entries(&quick_start_root, &work_branch);
-        let previous_profile = self.launch_wizard_cache.previous_profile(&quick_start_root);
+        let previous_profiles = self.launch_wizard_cache.previous_profiles();
         let agent_options = self.launch_wizard_cache.agent_options();
         let (docker_context, docker_service_status) =
             detect_wizard_docker_context_and_status(&quick_start_root);
@@ -384,7 +384,7 @@ impl AppRuntime {
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
             wizard_id,
-            wizard: LaunchWizardState::open_start_work_with_previous_profile(
+            wizard: LaunchWizardState::open_start_work_with_previous_profiles(
                 LaunchWizardContext {
                     selected_branch: synthetic_branch_entry(&base_branch),
                     normalized_branch_name: work_branch,
@@ -401,7 +401,7 @@ impl AppRuntime {
                 base_branch,
                 agent_options,
                 quick_start_entries,
-                previous_profile,
+                previous_profiles,
             ),
             workspace_resume_context,
         });
@@ -770,7 +770,7 @@ impl AppRuntime {
             docker_service_status: context.docker_service_status,
             agent_options,
             quick_start_entries,
-            previous_profile: None,
+            previous_profiles: None,
         });
     }
 }

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -209,6 +209,16 @@ pub enum WorkspaceCommand {
         split_from: Option<String>,
         boundary: Option<String>,
     },
+    /// `gwtd workspace ensure --agent-session <id> --title-summary <name> ...`.
+    Ensure {
+        agent_session: String,
+        title_summary: String,
+        current_focus: Option<String>,
+        spec: Option<u64>,
+        issue: Option<u64>,
+        topic: Option<String>,
+        boundary: Option<String>,
+    },
 }
 
 /// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).
@@ -414,7 +424,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd workspace ensure --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--topic <t>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|files|files-docs]"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -4,7 +4,7 @@ use gwt_agent::{session::GWT_SESSION_ID_ENV, Session};
 use gwt_core::{
     coordination::{
         load_snapshot, load_snapshot_for_scope, normalize_board_audience, normalize_board_mentions,
-        post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardMention,
+        post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardEntryKind, BoardMention,
     },
     paths::gwt_sessions_dir,
 };
@@ -16,6 +16,8 @@ use crate::{
     },
     cli::{CliEnv, CliParseError},
 };
+
+use super::workspace::{ensure_workspace_for_agent, WorkspaceEnsureInput};
 
 /// SPEC-1942 family enum for `gwtd board ...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -182,6 +184,15 @@ pub(super) fn run<E: CliEnv>(
             if !targets.is_empty() {
                 entry = entry.with_target_owners(targets);
             }
+            let materialized_workspace = if broadcast {
+                None
+            } else {
+                materialize_actionable_unassigned_board_post(
+                    env.repo_path(),
+                    current_session.as_ref(),
+                    &entry,
+                )?
+            };
             let (workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
             let mentions =
                 parse_mentions(&other_mention_args).map_err(gwt_error_to_spec_ops_error)?;
@@ -196,6 +207,9 @@ pub(super) fn run<E: CliEnv>(
                 )
                 .map_err(gwt_error_to_spec_ops_error)?
                 {
+                    audience.push(workspace_id);
+                }
+                if let Some(workspace_id) = materialized_workspace {
                     audience.push(workspace_id);
                 }
                 audience.extend(workspace_audience);
@@ -368,6 +382,108 @@ fn parse_mentions(values: &[String]) -> gwt_core::Result<Vec<BoardMention>> {
         mentions.push(value.parse::<BoardMention>()?);
     }
     Ok(normalize_board_mentions(&mentions))
+}
+
+fn materialize_actionable_unassigned_board_post(
+    repo_path: &std::path::Path,
+    current_session: Option<&Session>,
+    entry: &BoardEntry,
+) -> Result<Option<String>, SpecOpsError> {
+    let Some(session) = current_session else {
+        return Ok(None);
+    };
+    if !board_entry_can_materialize_workspace(entry) {
+        return Ok(None);
+    }
+    let Some(projection) = gwt_core::workspace_projection::load_workspace_projection(repo_path)
+        .map_err(gwt_error_to_spec_ops_error)?
+    else {
+        return Ok(None);
+    };
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session.id)
+    else {
+        return Ok(None);
+    };
+    if !agent.is_unassigned() {
+        return Ok(None);
+    }
+    let (spec, issue) = board_owner_numbers(&entry.related_owners);
+    let result = ensure_workspace_for_agent(
+        repo_path,
+        WorkspaceEnsureInput {
+            agent_session: session.id.clone(),
+            title_summary: entry
+                .title_summary
+                .as_deref()
+                .unwrap_or("Board milestone")
+                .to_string(),
+            current_focus: Some(entry.body.clone()),
+            spec,
+            issue,
+            topic: entry.related_topics.first().cloned(),
+            boundary: boundary_from_board_body(&entry.body),
+        },
+    )?;
+    Ok(Some(result.workspace_id))
+}
+
+fn board_entry_can_materialize_workspace(entry: &BoardEntry) -> bool {
+    matches!(
+        entry.kind,
+        BoardEntryKind::Claim
+            | BoardEntryKind::Status
+            | BoardEntryKind::Blocked
+            | BoardEntryKind::Handoff
+            | BoardEntryKind::Decision
+            | BoardEntryKind::Next
+    ) && entry
+        .title_summary
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+}
+
+fn board_owner_numbers(owners: &[String]) -> (Option<u64>, Option<u64>) {
+    let mut spec = None;
+    let mut issue = None;
+    for owner in owners {
+        let value = owner.trim();
+        if spec.is_none() {
+            if let Some(number) = value
+                .strip_prefix("SPEC-")
+                .or_else(|| value.strip_prefix("spec-"))
+                .and_then(|number| number.parse::<u64>().ok())
+                .or_else(|| value.parse::<u64>().ok())
+            {
+                spec = Some(number);
+                continue;
+            }
+        }
+        if issue.is_none() {
+            let issue_number = value
+                .strip_prefix("Issue #")
+                .or_else(|| value.strip_prefix("issue #"))
+                .or_else(|| value.strip_prefix("issue-"))
+                .and_then(|number| number.parse::<u64>().ok());
+            if let Some(number) = issue_number {
+                issue = Some(number);
+            }
+        }
+    }
+    (spec, issue)
+}
+
+fn boundary_from_board_body(body: &str) -> Option<String> {
+    body.lines().find_map(|line| {
+        line.trim_start()
+            .strip_prefix("Boundary:")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
 }
 
 /// SPEC-2359 FR-096: `--mention workspace:<id>` routes to BoardEntry.audience,
@@ -1192,6 +1308,139 @@ mod tests {
         let snapshot = load_snapshot(&repo).unwrap();
         assert!(snapshot.board.entries[0].audience.is_empty());
         assert!(snapshot.board.entries[1].audience.is_empty());
+    }
+
+    #[test]
+    fn board_family_run_post_materializes_unassigned_actionable_milestone_before_audience() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/workspace-materialization", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        let mut out = String::new();
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "claim".into(),
+                body: Some("Materialize actionable Unassigned Agents before Board audience".into()),
+                file: None,
+                title_summary: Some("Workspace materialization".into()),
+                parent: None,
+                topics: vec!["workspace-materialization".into()],
+                owners: vec!["2359".into()],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: false,
+            })),
+            &mut out,
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        let entry = &snapshot.board.entries[0];
+        assert_eq!(entry.audience.len(), 1, "{entry:?}");
+        let workspace_id = entry.audience[0].clone();
+        assert!(workspace_id.starts_with("workspace-"), "{workspace_id}");
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some(workspace_id.as_str()));
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load workspaces")
+            .expect("workspaces");
+        assert_eq!(work_items.work_items[0].id, workspace_id);
+        assert_eq!(work_items.work_items[0].title, "Workspace materialization");
+    }
+
+    #[test]
+    fn board_family_run_post_broadcast_does_not_materialize_unassigned_actionable_milestone() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", tmp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", tmp.path());
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let sessions_dir = gwt_core::paths::gwt_sessions_dir();
+        let session = Session::new(&repo, "work/workspace-materialization", AgentId::Codex);
+        session.save(&sessions_dir).unwrap();
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+        save_projection(
+            &repo,
+            vec![workspace_agent(
+                &session.id,
+                "codex",
+                None,
+                WorkspaceAgentAffiliationStatus::Unassigned,
+            )],
+        );
+        let mut env = crate::cli::TestEnv::new(repo.clone());
+
+        run(
+            &mut env,
+            BoardCommand::Post(Box::new(BoardPostCommand {
+                kind: "claim".into(),
+                body: Some("Intentional broadcast for cross-workspace coordination".into()),
+                file: None,
+                title_summary: Some("Workspace materialization".into()),
+                parent: None,
+                topics: vec!["workspace-materialization".into()],
+                owners: vec!["2359".into()],
+                targets: vec![],
+                mentions: vec![],
+                broadcast: true,
+            })),
+            &mut String::new(),
+        )
+        .unwrap();
+
+        let snapshot = load_snapshot(&repo).unwrap();
+        assert!(snapshot.board.entries[0].audience.is_empty());
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = projection
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Unassigned
+        );
+        assert!(
+            gwt_core::workspace_projection::load_workspace_work_items(&repo)
+                .expect("load workspace history")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -225,7 +225,7 @@ pub(crate) fn refresh_managed_assets_for_hook_front_door(
     if gwt_git::Repository::discover(project_root).is_err() {
         return Ok(());
     }
-    crate::managed_assets::refresh_managed_gwt_assets_for_worktree(project_root)
+    crate::managed_assets::refresh_existing_managed_gwt_assets_for_worktree(project_root)
         .map_err(|err| err.to_string())
 }
 

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -50,6 +50,7 @@ pub struct WorkflowContext {
     pub has_tasks: bool,
     pub bypass: Option<WorkflowBypass>,
     pub title_summary_missing: bool,
+    pub workspace_materialization_missing: bool,
 }
 
 impl WorkflowContext {
@@ -60,6 +61,7 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: None,
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
@@ -70,6 +72,7 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: None,
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
@@ -80,6 +83,7 @@ impl WorkflowContext {
             has_tasks,
             bypass: None,
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
@@ -90,11 +94,17 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: Some(bypass),
             title_summary_missing: false,
+            workspace_materialization_missing: false,
         }
     }
 
     pub fn with_title_summary_missing(mut self, missing: bool) -> Self {
         self.title_summary_missing = missing;
+        self
+    }
+
+    pub fn with_workspace_materialization_missing(mut self, missing: bool) -> Self {
+        self.workspace_materialization_missing = missing;
         self
     }
 }
@@ -119,12 +129,20 @@ pub fn evaluate_with_context(
     if title_summary != HookOutput::Silent {
         return Ok(title_summary);
     }
+    let materialization =
+        evaluate_workspace_materialization_guard(event, context.workspace_materialization_missing)?;
+    if materialization != HookOutput::Silent {
+        return Ok(materialization);
+    }
     evaluate_workspace_coordination_guard(event, worktree_root)
 }
 
 pub fn evaluate(event: &HookEvent, worktree_root: &Path) -> Result<HookOutput, HookError> {
     let context = resolve_workflow_context(worktree_root)
-        .with_title_summary_missing(current_agent_title_summary_missing(worktree_root)?);
+        .with_title_summary_missing(current_agent_title_summary_missing(worktree_root)?)
+        .with_workspace_materialization_missing(current_agent_workspace_materialization_missing(
+            worktree_root,
+        )?);
     evaluate_with_context(event, worktree_root, &context)
 }
 
@@ -223,6 +241,34 @@ fn current_agent_title_summary_missing(worktree_root: &Path) -> Result<bool, Hoo
         .is_none())
 }
 
+fn current_agent_workspace_materialization_missing(
+    worktree_root: &Path,
+) -> Result<bool, HookError> {
+    let Some(session) = load_session_from_env() else {
+        return Ok(false);
+    };
+    let projection_root = if session.worktree_path.exists() {
+        session.worktree_path.as_path()
+    } else {
+        worktree_root
+    };
+    let Some(projection) = load_workspace_projection(projection_root)? else {
+        return Ok(false);
+    };
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session.id)
+    else {
+        return Ok(false);
+    };
+    if !agent.is_unassigned() {
+        return Ok(false);
+    }
+    Ok(option_has_nonempty_text(agent.title_summary.as_deref())
+        || option_has_nonempty_text(agent.current_focus.as_deref()))
+}
+
 fn evaluate_title_summary_guard(
     event: &HookEvent,
     title_summary_missing: bool,
@@ -244,6 +290,33 @@ Required command shape:\n\
 Good example: --title-summary 'Agent title improvement'\n\
 Bad example: --title-summary 'Agent title improvement complete'\n\n\
 Use the configured narrative language for the title-summary. Keep progress, completion, blocker state, and long detail in --current-focus, --summary, or Board --body.",
+        ));
+    }
+
+    Ok(HookOutput::Silent)
+}
+
+fn evaluate_workspace_materialization_guard(
+    event: &HookEvent,
+    workspace_materialization_missing: bool,
+) -> Result<HookOutput, HookError> {
+    if !workspace_materialization_missing {
+        return Ok(HookOutput::Silent);
+    }
+
+    if is_workspace_materialization_event(event) || is_read_only_exploration_event(event) {
+        return Ok(HookOutput::Silent);
+    }
+
+    if is_title_sensitive_tool(event) {
+        return Ok(HookOutput::pre_tool_use_permission(
+            "Unassigned Agent has actionable Workspace intent",
+            "This Agent already has a title-summary or current focus, but it is still Unassigned. \
+Materialize the work into a Workspace before implementation or verification so title sync, Board audience, and Workspace history stay attached to the same work.\n\n\
+Required command shape:\n\
+  gwtd workspace ensure --agent-session \"$GWT_SESSION_ID\" --title-summary '<short work title>' --current-focus '<current work focus>' [--spec <number>|--issue <number>] [--topic <topic>]\n\n\
+Use `gwtd workspace candidates --agent-session \"$GWT_SESSION_ID\"` first only when you need to inspect choices manually. \
+Use `gwtd board post --kind claim --title-summary '<short work title>' ...` when the intent should be materialized as a Board milestone.",
         ));
     }
 
@@ -537,6 +610,10 @@ fn push_optional<'a>(parts: &mut Vec<&'a str>, value: Option<&'a str>) {
     }
 }
 
+fn option_has_nonempty_text(value: Option<&str>) -> bool {
+    value.map(str::trim).is_some_and(|value| !value.is_empty())
+}
+
 fn board_claim_is_active(entry: &BoardEntry) -> bool {
     !entry.state.as_deref().is_some_and(|state| {
         matches!(
@@ -705,10 +782,45 @@ fn is_workspace_coordination_command(command: &str) -> bool {
             matches!(
                 tokens.as_slice(),
                 [_, "board", "post" | "show", ..]
-                    | [_, "workspace", "update", ..]
+                    | [
+                        _,
+                        "workspace",
+                        "update" | "ensure" | "create" | "join" | "candidates",
+                        ..
+                    ]
                     | [_, "build", "start" | "phase" | "complete" | "abort", ..]
             )
         })
+}
+
+fn is_workspace_materialization_event(event: &HookEvent) -> bool {
+    if event.tool_name.as_deref() != Some("Bash") {
+        return false;
+    }
+    let Some(command) = event.command() else {
+        return false;
+    };
+    let segments = super::segments::split_command_segments(command);
+    !segments.is_empty()
+        && segments
+            .iter()
+            .all(|segment| is_workspace_materialization_segment(segment))
+}
+
+fn is_workspace_materialization_segment(segment: &str) -> bool {
+    let tokens = segment_tokens(segment);
+    let Some(command_name) = tokens.first().map(|token| normalize_command_name(token)) else {
+        return false;
+    };
+    if command_name != "gwtd" {
+        return false;
+    }
+    match tokens.as_slice() {
+        [_, "workspace", "ensure" | "create" | "join" | "candidates", ..] => true,
+        [_, "board", "show", ..] => true,
+        [_, "board", "post", rest @ ..] => rest.contains(&"--title-summary"),
+        _ => false,
+    }
 }
 
 fn is_similar_work(left: &str, right: &str) -> bool {
@@ -825,6 +937,9 @@ fn is_title_summary_update_segment(segment: &str) -> bool {
     }
     match tokens.as_slice() {
         [_, "workspace", "update", rest @ ..] => {
+            rest.contains(&"--agent-session") && rest.contains(&"--title-summary")
+        }
+        [_, "workspace", "ensure", rest @ ..] => {
             rest.contains(&"--agent-session") && rest.contains(&"--title-summary")
         }
         [_, "board", "post", rest @ ..] => rest.contains(&"--title-summary"),

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -3,8 +3,9 @@ use gwt_core::workspace_projection::{
     load_or_default_workspace_projection, load_or_synthesize_workspace_work_items,
     record_workspace_work_event, save_workspace_projection,
     update_workspace_projection_with_journal, WorkspaceAgentAffiliationStatus,
-    WorkspaceExecutionContainerRef, WorkspaceProjection, WorkspaceProjectionUpdate,
-    WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind, WorkspaceWorkItem,
+    WorkspaceAgentSummary, WorkspaceExecutionContainerRef, WorkspaceProjection,
+    WorkspaceProjectionUpdate, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
+    WorkspaceWorkItem,
 };
 use gwt_github::{ApiError, SpecOpsError};
 
@@ -17,6 +18,7 @@ pub fn parse(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
         "candidates" => parse_candidates(rest),
         "join" => parse_join(rest),
         "create" => parse_create(rest),
+        "ensure" => parse_ensure(rest),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
     }
 }
@@ -180,6 +182,93 @@ fn parse_create(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
         split_from,
         boundary,
     })
+}
+
+fn parse_ensure(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut agent_session = None;
+    let mut title_summary = None;
+    let mut current_focus = None;
+    let mut spec = None;
+    let mut issue = None;
+    let mut topic = None;
+    let mut boundary = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--agent-session" => {
+                agent_session = Some(parse_required_value(args, i, "--agent-session")?)
+            }
+            "--title-summary" => {
+                title_summary = Some(parse_required_value(args, i, "--title-summary")?)
+            }
+            "--current-focus" => {
+                current_focus = Some(parse_required_value(args, i, "--current-focus")?)
+            }
+            "--spec" => {
+                spec = Some(
+                    parse_required_value(args, i, "--spec")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--issue" => {
+                issue = Some(
+                    parse_required_value(args, i, "--issue")?
+                        .parse::<u64>()
+                        .map_err(|_| CliParseError::Usage)?,
+                );
+            }
+            "--topic" => topic = Some(parse_required_value(args, i, "--topic")?),
+            "--boundary" => boundary = Some(parse_required_value(args, i, "--boundary")?),
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+    let title_summary = title_summary.ok_or(CliParseError::MissingFlag("--title-summary"))?;
+    super::validate_title_summary_work_name("--title-summary", &title_summary)?;
+    Ok(WorkspaceCommand::Ensure {
+        agent_session: agent_session.ok_or(CliParseError::MissingFlag("--agent-session"))?,
+        title_summary,
+        current_focus,
+        spec,
+        issue,
+        topic,
+        boundary,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WorkspaceEnsureInput {
+    pub agent_session: String,
+    pub title_summary: String,
+    pub current_focus: Option<String>,
+    pub spec: Option<u64>,
+    pub issue: Option<u64>,
+    pub topic: Option<String>,
+    pub boundary: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkspaceEnsureDisposition {
+    AlreadyAssigned,
+    Joined,
+    Created,
+}
+
+impl WorkspaceEnsureDisposition {
+    fn as_str(self) -> &'static str {
+        match self {
+            WorkspaceEnsureDisposition::AlreadyAssigned => "already-assigned",
+            WorkspaceEnsureDisposition::Joined => "joined",
+            WorkspaceEnsureDisposition::Created => "created",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WorkspaceEnsureResult {
+    pub workspace_id: String,
+    pub disposition: WorkspaceEnsureDisposition,
 }
 
 pub(super) fn run<E: CliEnv>(
@@ -385,6 +474,243 @@ pub(super) fn run<E: CliEnv>(
             out.push_str(&format!("workspace created: {workspace_id}\n"));
             Ok(0)
         }
+        WorkspaceCommand::Ensure {
+            agent_session,
+            title_summary,
+            current_focus,
+            spec,
+            issue,
+            topic,
+            boundary,
+        } => {
+            let result = ensure_workspace_for_agent(
+                env.repo_path(),
+                WorkspaceEnsureInput {
+                    agent_session,
+                    title_summary,
+                    current_focus,
+                    spec,
+                    issue,
+                    topic,
+                    boundary,
+                },
+            )?;
+            out.push_str(&format!(
+                "workspace ensured: {} ({})\n",
+                result.workspace_id,
+                result.disposition.as_str()
+            ));
+            Ok(0)
+        }
+    }
+}
+
+pub(super) fn ensure_workspace_for_agent(
+    repo_path: &std::path::Path,
+    input: WorkspaceEnsureInput,
+) -> Result<WorkspaceEnsureResult, SpecOpsError> {
+    let mut projection = load_or_default_workspace_projection(repo_path).map_err(core_error)?;
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == input.agent_session)
+        .cloned()
+    else {
+        return Err(string_error(format!(
+            "agent session not found: {}",
+            input.agent_session
+        )));
+    };
+    let owner = owner_from_spec_or_issue(input.spec, input.issue);
+    if agent.is_assigned() {
+        if let Some(workspace_id) = agent.workspace_id.as_deref() {
+            if let Some(item) = workspace_item_by_id(repo_path, workspace_id)?
+                .filter(WorkspaceWorkItem::is_incomplete)
+            {
+                apply_workspace_item_to_projection(&mut projection, &item);
+            }
+            assign_agent_to_workspace(
+                &mut projection,
+                &input.agent_session,
+                workspace_id,
+                input.current_focus,
+                Some(input.title_summary),
+            )?;
+            save_workspace_projection(repo_path, &projection).map_err(core_error)?;
+            publish_workspace_change(repo_path);
+            return Ok(WorkspaceEnsureResult {
+                workspace_id: workspace_id.to_string(),
+                disposition: WorkspaceEnsureDisposition::AlreadyAssigned,
+            });
+        }
+    }
+
+    let existing = load_or_synthesize_workspace_work_items(repo_path).map_err(core_error)?;
+    let ensure_text = workspace_ensure_text(&input, owner.as_deref());
+    if let Some(item) = best_workspace_candidate(&existing.work_items, &ensure_text) {
+        let workspace_id = item.id.clone();
+        record_workspace_join_event(repo_path, &workspace_id, &input, owner.clone(), &agent)?;
+        assign_agent_to_workspace(
+            &mut projection,
+            &input.agent_session,
+            &workspace_id,
+            input.current_focus,
+            Some(input.title_summary),
+        )?;
+        apply_workspace_item_to_projection(&mut projection, item);
+        save_workspace_projection(repo_path, &projection).map_err(core_error)?;
+        publish_workspace_change(repo_path);
+        return Ok(WorkspaceEnsureResult {
+            workspace_id,
+            disposition: WorkspaceEnsureDisposition::Joined,
+        });
+    }
+
+    let workspace_id =
+        create_workspace_for_agent(repo_path, &mut projection, &input, owner, &agent)?;
+    save_workspace_projection(repo_path, &projection).map_err(core_error)?;
+    publish_workspace_change(repo_path);
+    Ok(WorkspaceEnsureResult {
+        workspace_id,
+        disposition: WorkspaceEnsureDisposition::Created,
+    })
+}
+
+fn owner_from_spec_or_issue(spec: Option<u64>, issue: Option<u64>) -> Option<String> {
+    spec.map(|number| format!("SPEC-{number}"))
+        .or_else(|| issue.map(|number| format!("Issue #{number}")))
+}
+
+fn workspace_ensure_text(input: &WorkspaceEnsureInput, owner: Option<&str>) -> String {
+    [
+        Some(input.title_summary.as_str()),
+        input.current_focus.as_deref(),
+        input.topic.as_deref(),
+        owner,
+        input.boundary.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+fn best_workspace_candidate<'a>(
+    work_items: &'a [WorkspaceWorkItem],
+    ensure_text: &str,
+) -> Option<&'a WorkspaceWorkItem> {
+    work_items
+        .iter()
+        .filter(|item| item.is_incomplete())
+        .map(|item| {
+            let score = workspace_similarity_score(ensure_text, &workspace_item_text(item));
+            (score, item)
+        })
+        .filter(|(score, _)| *score >= 2)
+        .max_by(|(left_score, left), (right_score, right)| {
+            left_score
+                .cmp(right_score)
+                .then_with(|| left.updated_at.cmp(&right.updated_at))
+        })
+        .map(|(_, item)| item)
+}
+
+fn record_workspace_join_event(
+    repo_path: &std::path::Path,
+    workspace_id: &str,
+    input: &WorkspaceEnsureInput,
+    owner: Option<String>,
+    agent: &WorkspaceAgentSummary,
+) -> Result<(), SpecOpsError> {
+    let now = Utc::now();
+    let mut event =
+        WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Claim, workspace_id.to_string(), now);
+    event.intent = input.current_focus.clone();
+    event.summary = Some(format!("Joined Workspace: {}", input.title_summary));
+    event.status_category = Some(WorkspaceStatusCategory::Active);
+    event.owner = owner;
+    event.next_action = input
+        .boundary
+        .as_deref()
+        .map(|boundary| format!("Boundary: {boundary}"));
+    event.agent_session_id = Some(input.agent_session.clone());
+    event.agent_id = Some(agent.agent_id.clone());
+    event.display_name = Some(agent.display_name.clone());
+    event.execution_container = Some(workspace_execution_container_from_agent(agent));
+    record_workspace_work_event(repo_path, event).map_err(core_error)
+}
+
+fn create_workspace_for_agent(
+    repo_path: &std::path::Path,
+    projection: &mut WorkspaceProjection,
+    input: &WorkspaceEnsureInput,
+    owner: Option<String>,
+    agent: &WorkspaceAgentSummary,
+) -> Result<String, SpecOpsError> {
+    let workspace_id = format!("workspace-{}", Utc::now().timestamp_millis());
+    let now = Utc::now();
+    let mut event =
+        WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, workspace_id.clone(), now);
+    event.title = Some(input.title_summary.clone());
+    event.intent = input
+        .current_focus
+        .clone()
+        .or_else(|| Some(input.title_summary.clone()));
+    event.summary = input
+        .current_focus
+        .clone()
+        .or_else(|| Some(input.title_summary.clone()));
+    event.status_category = Some(WorkspaceStatusCategory::Active);
+    event.owner = owner.clone();
+    event.next_action = Some(
+        input
+            .boundary
+            .as_deref()
+            .map(|boundary| format!("Boundary: {boundary}"))
+            .unwrap_or_else(|| "Coordinate on Board before implementation".to_string()),
+    );
+    event.agent_session_id = Some(input.agent_session.clone());
+    event.agent_id = Some(agent.agent_id.clone());
+    event.display_name = Some(agent.display_name.clone());
+    event.execution_container = Some(workspace_execution_container_from_agent(agent));
+    record_workspace_work_event(repo_path, event).map_err(core_error)?;
+
+    projection.id = workspace_id.clone();
+    projection.title = input.title_summary.clone();
+    projection.status_category = WorkspaceStatusCategory::Active;
+    projection.status_text = input
+        .current_focus
+        .clone()
+        .unwrap_or_else(|| "Workspace created".to_string());
+    projection.summary = input.current_focus.clone();
+    projection.owner = owner;
+    projection.next_action = Some(
+        input
+            .boundary
+            .as_deref()
+            .map(|boundary| format!("Boundary: {boundary}"))
+            .unwrap_or_else(|| "Coordinate on Board before implementation".to_string()),
+    );
+    assign_agent_to_workspace(
+        projection,
+        &input.agent_session,
+        &workspace_id,
+        input.current_focus.clone(),
+        Some(input.title_summary.clone()),
+    )?;
+    projection.updated_at = now;
+    Ok(workspace_id)
+}
+
+fn workspace_execution_container_from_agent(
+    agent: &WorkspaceAgentSummary,
+) -> WorkspaceExecutionContainerRef {
+    WorkspaceExecutionContainerRef {
+        branch: agent.branch.clone(),
+        worktree_path: agent.worktree_path.clone(),
+        pr_number: None,
+        pr_url: None,
+        pr_state: None,
     }
 }
 
@@ -766,6 +1092,41 @@ mod tests {
     }
 
     #[test]
+    fn parse_workspace_ensure_accepts_materialization_fields() {
+        let parsed = parse(&[
+            s("ensure"),
+            s("--agent-session"),
+            s("session-1"),
+            s("--title-summary"),
+            s("Workspace materialization"),
+            s("--current-focus"),
+            s("Ensure actionable Unassigned Agents join a Workspace"),
+            s("--spec"),
+            s("2359"),
+            s("--topic"),
+            s("workspace-materialization"),
+            s("--boundary"),
+            s("CLI and Board write path"),
+        ])
+        .expect("parse ensure");
+
+        assert_eq!(
+            parsed,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some(
+                    "Ensure actionable Unassigned Agents join a Workspace".to_string()
+                ),
+                spec: Some(2359),
+                issue: None,
+                topic: Some("workspace-materialization".to_string()),
+                boundary: Some("CLI and Board write path".to_string()),
+            }
+        );
+    }
+
+    #[test]
     fn workspace_update_persists_workspace_status() {
         let _guard = crate::env_test_lock().lock().unwrap();
         let gwt_home = tempfile::tempdir().expect("gwt home");
@@ -986,5 +1347,168 @@ mod tests {
         .expect_err("similar Workspace should be rejected");
 
         assert!(err.to_string().contains("similar Workspace exists"));
+    }
+
+    #[test]
+    fn workspace_ensure_joins_similar_incomplete_workspace() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace materialization".to_string());
+        event.intent = Some("Ensure actionable Unassigned Agents join Workspace".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some(
+                    "Ensure actionable Unassigned Agents join Workspace".to_string(),
+                ),
+                spec: Some(2359),
+                issue: None,
+                topic: Some("workspace-materialization".to_string()),
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect("ensure workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace ensured: workspace-existing (joined)"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(
+            agent.affiliation_status,
+            WorkspaceAgentAffiliationStatus::Assigned
+        );
+        assert_eq!(agent.workspace_id.as_deref(), Some("workspace-existing"));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert!(items.work_items[0]
+            .agents
+            .iter()
+            .any(|agent| agent.session_id == "session-1"));
+    }
+
+    #[test]
+    fn workspace_ensure_creates_workspace_when_no_candidate_matches() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some("Create Workspace from actionable intent".to_string()),
+                spec: Some(2359),
+                issue: None,
+                topic: Some("workspace-materialization".to_string()),
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect("ensure workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace ensured: workspace-"));
+        assert!(out.contains("(created)"));
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let workspace_id = saved.id.clone();
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(agent.workspace_id.as_deref(), Some(workspace_id.as_str()));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert_eq!(items.work_items.len(), 1);
+        assert_eq!(items.work_items[0].title, "Workspace materialization");
+        assert_eq!(items.work_items[0].owner.as_deref(), Some("SPEC-2359"));
+    }
+
+    #[test]
+    fn workspace_ensure_is_idempotent_for_already_assigned_agent() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut agent = unassigned_agent("session-1");
+        agent.affiliation_status = WorkspaceAgentAffiliationStatus::Assigned;
+        agent.workspace_id = Some("workspace-existing".to_string());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.id = "workspace-existing".to_string();
+        projection.agents.push(agent);
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace materialization".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Ensure {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace materialization".to_string(),
+                current_focus: Some("Continue current Workspace".to_string()),
+                spec: Some(2359),
+                issue: None,
+                topic: None,
+                boundary: None,
+            },
+            &mut out,
+        )
+        .expect("ensure workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace ensured: workspace-existing (already-assigned)"));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert_eq!(items.work_items.len(), 1);
     }
 }

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -598,6 +598,11 @@ pub fn install_launch_gwt_bin_env_with_lookup(
                 .or_insert(gwt_bin);
         }
     }
+    if let Some(resolved) = env_vars.get(gwt_agent::session::GWT_BIN_PATH_ENV).cloned() {
+        if let Some(parent) = Path::new(&resolved).parent() {
+            gwt_agent::prepare::prepend_dir_to_path(env_vars, parent);
+        }
+    }
     Ok(())
 }
 
@@ -633,6 +638,151 @@ mod tests {
         assert_eq!(
             interactive_windows_shell_args(gwt_agent::WindowsShellKind::PowerShell7),
             vec!["-NoLogo"]
+        );
+    }
+
+    // SPEC-2077 Phase I1 (US-7 / FR-020 / FR-021 / FR-022 / SC-010):
+    // launch_runtime mirror of install_launch_gwt_bin_env_with_lookup must
+    // prepend dirname(GWT_BIN_PATH) to env_vars["PATH"] with dedup + empty
+    // guard. Mirrors crates/gwt-agent/src/prepare.rs::tests::install_launch_gwt_bin_env_*.
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_prepends_gwtd_dir_to_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars
+                .get(gwt_agent::session::GWT_BIN_PATH_ENV)
+                .map(String::as_str),
+            Some("/Applications/GWT.app/Contents/MacOS/gwtd"),
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/Applications/GWT.app/Contents/MacOS")),
+        );
+        assert!(entries.contains(&PathBuf::from("/usr/bin")));
+        assert!(entries.contains(&PathBuf::from("/bin")));
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_dedups_existing_path_entry() {
+        let mut env_vars = HashMap::from([(
+            "PATH".to_string(),
+            "/Applications/GWT.app/Contents/MacOS:/usr/bin".to_string(),
+        )]);
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/Applications/GWT.app/Contents/MacOS"),
+                PathBuf::from("/usr/bin"),
+            ],
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_skips_path_update_when_parent_is_empty() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let current_exe = PathBuf::from("/opt/gwt/bin/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("gwtd")),
+        )
+        .expect("install");
+
+        // GWT_BIN_PATH may end up as a sibling/managed_assets resolution; we
+        // assert only that PATH is untouched when the resolved binary has no
+        // meaningful parent dir.
+        assert_eq!(
+            env_vars.get("PATH").map(String::as_str),
+            Some("/usr/bin:/bin"),
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_host_creates_path_when_absent() {
+        let mut env_vars: HashMap<String, String> = HashMap::new();
+        let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &current_exe,
+            |_command| Some(PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        )
+        .expect("install");
+
+        let path = env_vars.get("PATH").expect("PATH should be created");
+        let entries: Vec<PathBuf> = std::env::split_paths(path).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/Applications/GWT.app/Contents/MacOS")],
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_prepends_when_dir_missing_from_path() {
+        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        assert_eq!(
+            env_vars
+                .get(gwt_agent::session::GWT_BIN_PATH_ENV)
+                .map(String::as_str),
+            Some("/usr/local/bin/gwtd"),
+        );
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries.first().map(|p| p.as_path()),
+            Some(Path::new("/usr/local/bin")),
+        );
+    }
+
+    #[test]
+    fn install_launch_gwt_bin_env_docker_dedups_when_dir_already_on_path() {
+        let mut env_vars =
+            HashMap::from([("PATH".to_string(), "/usr/local/bin:/usr/bin".to_string())]);
+        install_launch_gwt_bin_env_with_lookup(
+            &mut env_vars,
+            gwt_agent::LaunchRuntimeTarget::Docker,
+            Path::new("/never/used/in/docker"),
+            |_command| None,
+        )
+        .expect("install");
+
+        let entries: Vec<PathBuf> =
+            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        assert_eq!(
+            entries,
+            vec![PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin"),],
         );
     }
 }

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     collections::HashMap,
     path::{Path, PathBuf},
 };
@@ -204,6 +205,34 @@ pub struct LaunchWizardPreviousProfile {
     pub windows_shell: Option<gwt_agent::WindowsShellKind>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LaunchWizardPreviousProfiles {
+    default_agent_id: Option<String>,
+    by_agent: HashMap<String, LaunchWizardPreviousProfile>,
+}
+
+impl LaunchWizardPreviousProfiles {
+    fn from_profile(profile: Option<LaunchWizardPreviousProfile>) -> Self {
+        let Some(profile) = profile else {
+            return Self::default();
+        };
+        let default_agent_id = Some(profile.agent_id.clone());
+        let by_agent = HashMap::from([(profile.agent_id.clone(), profile)]);
+        Self {
+            default_agent_id,
+            by_agent,
+        }
+    }
+
+    fn preferred_agent_id(&self) -> Option<&str> {
+        self.default_agent_id.as_deref()
+    }
+
+    fn profile_for(&self, agent_id: &str) -> Option<&LaunchWizardPreviousProfile> {
+        self.by_agent.get(agent_id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AgentLaunchDraft {
     model: String,
@@ -261,16 +290,13 @@ pub fn load_previous_launch_profile(
     repo_path: &Path,
     sessions_dir: &Path,
 ) -> Option<LaunchWizardPreviousProfile> {
-    let entries = std::fs::read_dir(sessions_dir).ok()?;
-    let sessions = entries
-        .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
-            (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
-        })
-        .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
-        .collect::<Vec<_>>();
+    let sessions = load_launch_sessions(sessions_dir);
     previous_launch_profile_from_sessions(repo_path, &sessions)
+}
+
+pub fn load_previous_launch_profiles(sessions_dir: &Path) -> LaunchWizardPreviousProfiles {
+    let sessions = load_launch_sessions(sessions_dir);
+    previous_launch_profiles_from_sessions(&sessions)
 }
 
 pub fn previous_launch_profile_from_sessions(
@@ -280,14 +306,65 @@ pub fn previous_launch_profile_from_sessions(
     sessions
         .iter()
         .filter(|session| same_launch_profile_repo(repo_path, session))
-        .max_by(|left, right| {
-            left.updated_at
-                .cmp(&right.updated_at)
-                .then_with(|| left.created_at.cmp(&right.created_at))
-                .then_with(|| left.id.cmp(&right.id))
-        })
+        .max_by(|left, right| launch_profile_session_cmp(left, right))
         .cloned()
         .map(previous_profile_from_session)
+}
+
+pub fn previous_launch_profiles_from_sessions(
+    sessions: &[gwt_agent::Session],
+) -> LaunchWizardPreviousProfiles {
+    let mut latest_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
+    let mut default_agent_id = None;
+    let mut latest_session = None::<gwt_agent::Session>;
+
+    for session in sessions {
+        let agent_id = session.agent_id.command().to_string();
+        if latest_by_agent
+            .get(&agent_id)
+            .is_none_or(|existing| launch_profile_session_cmp(session, existing).is_gt())
+        {
+            latest_by_agent.insert(agent_id.clone(), session.clone());
+        }
+        if latest_session
+            .as_ref()
+            .is_none_or(|existing| launch_profile_session_cmp(session, existing).is_gt())
+        {
+            default_agent_id = Some(agent_id);
+            latest_session = Some(session.clone());
+        }
+    }
+
+    let by_agent = latest_by_agent
+        .into_iter()
+        .map(|(agent_id, session)| (agent_id, previous_profile_from_session(session)))
+        .collect();
+
+    LaunchWizardPreviousProfiles {
+        default_agent_id,
+        by_agent,
+    }
+}
+
+fn load_launch_sessions(sessions_dir: &Path) -> Vec<gwt_agent::Session> {
+    let Ok(entries) = std::fs::read_dir(sessions_dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            (path.extension().and_then(|ext| ext.to_str()) == Some("toml")).then_some(path)
+        })
+        .filter_map(|path| gwt_agent::Session::load_and_migrate(&path).ok())
+        .collect()
+}
+
+fn launch_profile_session_cmp(left: &gwt_agent::Session, right: &gwt_agent::Session) -> Ordering {
+    left.updated_at
+        .cmp(&right.updated_at)
+        .then_with(|| left.created_at.cmp(&right.created_at))
+        .then_with(|| left.id.cmp(&right.id))
 }
 
 pub fn quick_start_entries_from_sessions(
@@ -417,7 +494,7 @@ pub struct LaunchWizardHydration {
     pub docker_service_status: gwt_docker::ComposeServiceStatus,
     pub agent_options: Vec<AgentOption>,
     pub quick_start_entries: Vec<QuickStartEntry>,
-    pub previous_profile: Option<LaunchWizardPreviousProfile>,
+    pub previous_profiles: Option<LaunchWizardPreviousProfiles>,
 }
 
 #[derive(Debug, Clone)]
@@ -511,6 +588,7 @@ pub struct LaunchWizardState {
     pub selected: usize,
     pub detected_agents: Vec<AgentOption>,
     pub quick_start_entries: Vec<QuickStartEntry>,
+    previous_profiles: LaunchWizardPreviousProfiles,
     pub is_new_branch: bool,
     pub base_branch_name: Option<String>,
     pub launch_target: LaunchTargetKind,
@@ -559,7 +637,7 @@ impl LaunchWizardState {
         context: LaunchWizardContext,
         agent_options: Vec<AgentOption>,
         mut quick_start_entries: Vec<QuickStartEntry>,
-        previous_profile: Option<LaunchWizardPreviousProfile>,
+        previous_profiles: LaunchWizardPreviousProfiles,
         is_hydrating: bool,
     ) -> Self {
         Self::hydrate_live_window_ids(&context, &mut quick_start_entries);
@@ -588,6 +666,7 @@ impl LaunchWizardState {
             selected: 0,
             detected_agents: agent_options,
             quick_start_entries,
+            previous_profiles,
             is_new_branch: false,
             base_branch_name: None,
             launch_target: LaunchTargetKind::Agent,
@@ -613,12 +692,8 @@ impl LaunchWizardState {
         };
         state.branch_name = state.context.normalized_branch_name.clone();
         state.sync_selected_agent_options();
-        let previous_profile_applied = previous_profile
-            .map(|profile| state.apply_previous_profile(profile))
-            .unwrap_or(false);
-        if !previous_profile_applied {
-            state.sync_docker_lifecycle_default();
-        }
+        state.apply_preferred_agent_profile();
+        state.sync_docker_lifecycle_default();
         state.selected = step_default_selection(state.step, &state);
         state
     }
@@ -628,7 +703,28 @@ impl LaunchWizardState {
         agent_options: Vec<AgentOption>,
         quick_start_entries: Vec<QuickStartEntry>,
     ) -> Self {
-        Self::new_with(context, agent_options, quick_start_entries, None, false)
+        Self::new_with(
+            context,
+            agent_options,
+            quick_start_entries,
+            LaunchWizardPreviousProfiles::default(),
+            false,
+        )
+    }
+
+    pub fn open_with_previous_profiles(
+        context: LaunchWizardContext,
+        agent_options: Vec<AgentOption>,
+        quick_start_entries: Vec<QuickStartEntry>,
+        previous_profiles: LaunchWizardPreviousProfiles,
+    ) -> Self {
+        Self::new_with(
+            context,
+            agent_options,
+            quick_start_entries,
+            previous_profiles,
+            false,
+        )
     }
 
     pub fn open_with_previous_profile(
@@ -637,27 +733,26 @@ impl LaunchWizardState {
         quick_start_entries: Vec<QuickStartEntry>,
         previous_profile: Option<LaunchWizardPreviousProfile>,
     ) -> Self {
-        Self::new_with(
+        Self::open_with_previous_profiles(
             context,
             agent_options,
             quick_start_entries,
-            previous_profile,
-            false,
+            LaunchWizardPreviousProfiles::from_profile(previous_profile),
         )
     }
 
-    pub fn open_start_work_with_previous_profile(
+    pub fn open_start_work_with_previous_profiles(
         context: LaunchWizardContext,
         base_branch_name: String,
         agent_options: Vec<AgentOption>,
         quick_start_entries: Vec<QuickStartEntry>,
-        previous_profile: Option<LaunchWizardPreviousProfile>,
+        previous_profiles: LaunchWizardPreviousProfiles,
     ) -> Self {
         let mut state = Self::new_with(
             context,
             agent_options,
             quick_start_entries,
-            previous_profile,
+            previous_profiles,
             false,
         );
         state.wizard_mode = LaunchWizardMode::StartWork;
@@ -669,8 +764,30 @@ impl LaunchWizardState {
         state
     }
 
+    pub fn open_start_work_with_previous_profile(
+        context: LaunchWizardContext,
+        base_branch_name: String,
+        agent_options: Vec<AgentOption>,
+        quick_start_entries: Vec<QuickStartEntry>,
+        previous_profile: Option<LaunchWizardPreviousProfile>,
+    ) -> Self {
+        Self::open_start_work_with_previous_profiles(
+            context,
+            base_branch_name,
+            agent_options,
+            quick_start_entries,
+            LaunchWizardPreviousProfiles::from_profile(previous_profile),
+        )
+    }
+
     pub fn open_loading(context: LaunchWizardContext, agent_options: Vec<AgentOption>) -> Self {
-        Self::new_with(context, agent_options, Vec::new(), None, true)
+        Self::new_with(
+            context,
+            agent_options,
+            Vec::new(),
+            LaunchWizardPreviousProfiles::default(),
+            true,
+        )
     }
 
     pub fn open(context: LaunchWizardContext, sessions_dir: &Path, cache_path: &Path) -> Self {
@@ -680,13 +797,12 @@ impl LaunchWizardState {
             sessions_dir,
             &context.normalized_branch_name,
         );
-        let previous_profile =
-            load_previous_launch_profile(&context.quick_start_root, sessions_dir);
-        Self::open_with_previous_profile(
+        let previous_profiles = load_previous_launch_profiles(sessions_dir);
+        Self::open_with_previous_profiles(
             context,
             agent_options,
             quick_start_entries,
-            previous_profile,
+            previous_profiles,
         )
     }
 
@@ -765,7 +881,7 @@ impl LaunchWizardState {
             docker_service_status,
             agent_options,
             mut quick_start_entries,
-            previous_profile,
+            previous_profiles,
         } = hydration;
         if let Some(selected_branch) = selected_branch {
             self.context.selected_branch = selected_branch;
@@ -795,12 +911,11 @@ impl LaunchWizardState {
             self.docker_service = None;
         }
         self.sync_selected_agent_options();
-        let previous_profile_applied = previous_profile
-            .map(|profile| self.apply_previous_profile(profile))
-            .unwrap_or(false);
-        if !previous_profile_applied {
-            self.sync_docker_lifecycle_default();
+        if let Some(previous_profiles) = previous_profiles {
+            self.previous_profiles = previous_profiles;
+            self.apply_preferred_agent_profile();
         }
+        self.sync_docker_lifecycle_default();
         self.selected = self
             .selected
             .min(self.current_options().len().saturating_sub(1));
@@ -1248,18 +1363,25 @@ impl LaunchWizardState {
         }
     }
 
-    fn apply_previous_profile(&mut self, profile: LaunchWizardPreviousProfile) -> bool {
-        let saved_agent = self
-            .detected_agents
-            .iter()
-            .find(|candidate| candidate.id == profile.agent_id);
-        let Some(agent) = saved_agent.or_else(|| self.detected_agents.first()) else {
-            return false;
-        };
+    fn apply_preferred_agent_profile(&mut self) -> bool {
+        if let Some(agent_id) = self
+            .previous_profiles
+            .preferred_agent_id()
+            .map(str::to_string)
+        {
+            if self
+                .detected_agents
+                .iter()
+                .any(|agent| agent.id == agent_id)
+            {
+                self.launch_target = LaunchTargetKind::Agent;
+                self.agent_id = agent_id;
+            }
+        }
+        self.restore_agent_draft_or_defaults()
+    }
 
-        self.launch_target = LaunchTargetKind::Agent;
-        self.agent_id = agent.id.clone();
-        self.sync_selected_agent_options();
+    fn apply_previous_agent_preferences(&mut self, profile: LaunchWizardPreviousProfile) {
         self.apply_saved_model(profile.model.as_deref());
         if let Some(reasoning) = profile.reasoning.as_deref() {
             if self
@@ -1284,44 +1406,6 @@ impl LaunchWizardState {
         self.resume_session_id = None;
         self.skip_permissions = profile.skip_permissions;
         self.codex_fast_mode = profile.codex_fast_mode && self.agent_is_codex();
-        self.apply_previous_runtime_profile(
-            profile.runtime_target,
-            profile.docker_service.as_deref(),
-            profile.docker_lifecycle_intent,
-        );
-        if let Some(windows_shell) = profile.windows_shell {
-            self.windows_shell = windows_shell;
-        }
-        true
-    }
-
-    fn apply_previous_runtime_profile(
-        &mut self,
-        runtime_target: gwt_agent::LaunchRuntimeTarget,
-        docker_service: Option<&str>,
-        docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent,
-    ) {
-        if runtime_target != gwt_agent::LaunchRuntimeTarget::Docker || !self.has_docker_workflow() {
-            self.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
-            self.docker_service = None;
-            self.sync_docker_lifecycle_default();
-            return;
-        }
-
-        self.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
-        let services = self.docker_service_options();
-        self.docker_service = docker_service
-            .filter(|service| services.iter().any(|candidate| candidate == service))
-            .map(str::to_string)
-            .or_else(|| {
-                self.context
-                    .docker_context
-                    .as_ref()
-                    .and_then(|ctx| ctx.suggested_service.clone())
-            })
-            .or_else(|| services.first().cloned());
-        self.docker_lifecycle_intent = docker_lifecycle_intent;
-        self.sync_docker_lifecycle_default();
     }
 
     fn focus_existing_session(&mut self, index: usize) {
@@ -1971,14 +2055,21 @@ impl LaunchWizardState {
         );
     }
 
-    fn restore_agent_draft_or_defaults(&mut self) {
+    fn restore_agent_draft_or_defaults(&mut self) -> bool {
         let draft = self.agent_drafts.get(&self.agent_id).cloned();
-        match draft {
-            Some(draft) => self.apply_agent_draft(draft),
-            None => self.reset_agent_draft_defaults(),
-        }
+        let restored = if let Some(draft) = draft {
+            self.apply_agent_draft(draft);
+            true
+        } else if let Some(profile) = self.previous_profiles.profile_for(&self.agent_id).cloned() {
+            self.apply_previous_agent_preferences(profile);
+            true
+        } else {
+            self.reset_agent_draft_defaults();
+            false
+        };
         self.sync_selected_agent_options();
         self.normalize_execution_mode();
+        restored
     }
 
     fn apply_agent_draft(&mut self, draft: AgentLaunchDraft) {
@@ -3614,6 +3705,123 @@ mod tests {
     }
 
     #[test]
+    fn agent_preferences_restore_selected_agent_when_latest_session_is_other_agent() {
+        let current_repo = PathBuf::from("/tmp/current-repo");
+        let codex_repo = PathBuf::from("/tmp/codex-repo");
+        let claude_repo = PathBuf::from("/tmp/claude-repo");
+        let mut codex = sample_session_record(
+            "feature/codex",
+            &codex_repo,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        codex.model = Some("gpt-5.4".to_string());
+        codex.reasoning_level = Some("xhigh".to_string());
+        codex.tool_version = Some("0.110.0".to_string());
+        codex.session_mode = gwt_agent::SessionMode::Continue;
+        codex.skip_permissions = true;
+        codex.codex_fast_mode = true;
+
+        let mut claude = sample_session_record(
+            "feature/claude",
+            &claude_repo,
+            gwt_agent::AgentId::ClaudeCode,
+            Utc.with_ymd_and_hms(2026, 5, 10, 10, 0, 0).unwrap(),
+            None,
+        );
+        claude.model = Some("sonnet".to_string());
+        claude.reasoning_level = Some("low".to_string());
+        claude.skip_permissions = false;
+        claude.codex_fast_mode = false;
+
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.worktree_path = Some(current_repo.clone());
+        ctx.quick_start_root = current_repo.clone();
+        let profiles = previous_launch_profiles_from_sessions(&[codex, claude]);
+        let mut state = LaunchWizardState::open_with_previous_profiles(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            profiles,
+        );
+
+        assert_eq!(state.view().selected_agent_id, "claude");
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "codex".to_string(),
+        });
+        let view = state.view();
+
+        assert_eq!(view.branch_name, "feature/current");
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_reasoning, "xhigh");
+        assert_eq!(view.selected_version, "0.110.0");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.branch.as_deref(), Some("feature/current"));
+        assert_eq!(config.session_mode, gwt_agent::SessionMode::Continue);
+        assert_eq!(config.reasoning_level.as_deref(), Some("xhigh"));
+        assert!(config.codex_fast_mode);
+        assert!(config.skip_permissions);
+        assert_eq!(config.working_dir.as_deref(), Some(current_repo.as_path()));
+    }
+
+    #[test]
+    fn agent_preferences_do_not_restore_project_runtime_settings() {
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.quick_start_root = PathBuf::from("/tmp/current-repo");
+        ctx.worktree_path = Some(PathBuf::from("/tmp/current-repo"));
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string()],
+            suggested_service: Some("api".to_string()),
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Stopped;
+
+        let mut codex = sample_session_record(
+            "feature/codex",
+            Path::new("/tmp/other-repo"),
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        codex.model = Some("gpt-5.4".to_string());
+        codex.reasoning_level = Some("xhigh".to_string());
+        codex.tool_version = Some("0.110.0".to_string());
+        codex.session_mode = gwt_agent::SessionMode::Continue;
+        codex.skip_permissions = true;
+        codex.codex_fast_mode = true;
+        codex.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+        codex.docker_service = Some("worker".to_string());
+        codex.docker_lifecycle_intent = gwt_agent::DockerLifecycleIntent::Restart;
+        codex.windows_shell = Some(gwt_agent::WindowsShellKind::PowerShell7);
+
+        let state = LaunchWizardState::open_with_previous_profiles(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            previous_launch_profiles_from_sessions(&[codex]),
+        );
+        let view = state.view();
+
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_reasoning, "xhigh");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("api"));
+        assert_eq!(view.selected_docker_lifecycle, "start");
+        assert_ne!(view.selected_docker_service.as_deref(), Some("worker"));
+        assert_ne!(view.selected_docker_lifecycle, "restart");
+    }
+
+    #[test]
     fn load_previous_launch_profile_matches_deleted_worktree_by_persisted_repo_hash() {
         let dir = tempdir().expect("tempdir");
         let repo = dir.path().join("repo");
@@ -4009,7 +4217,7 @@ mod tests {
     }
 
     #[test]
-    fn open_with_previous_profile_restores_full_profile_without_reusing_branch() {
+    fn open_with_previous_profile_restores_agent_preferences_without_reusing_branch() {
         let mut ctx = context(branch("feature/current"), "feature/current");
         ctx.docker_context = Some(DockerWizardContext {
             services: vec!["api".to_string(), "gwt".to_string()],
@@ -4043,8 +4251,10 @@ mod tests {
         assert_eq!(view.selected_version, "0.110.0");
         assert_eq!(view.selected_execution_mode, "continue");
         assert_eq!(view.selected_runtime_target, "docker");
-        assert_eq!(view.selected_docker_service.as_deref(), Some("gwt"));
-        assert_eq!(view.selected_docker_lifecycle, "restart");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("api"));
+        assert_eq!(view.selected_docker_lifecycle, "connect");
+        assert_ne!(view.selected_docker_service.as_deref(), Some("gwt"));
+        assert_ne!(view.selected_docker_lifecycle, "restart");
         assert!(view.skip_permissions);
         assert!(view.codex_fast_mode);
 
@@ -4268,25 +4478,76 @@ mod tests {
             docker_service_status: gwt_docker::ComposeServiceStatus::Running,
             agent_options: sample_agent_options(),
             quick_start_entries: Vec::new(),
-            previous_profile: Some(LaunchWizardPreviousProfile {
-                agent_id: "missing-agent".to_string(),
-                model: None,
-                reasoning: None,
-                version: None,
-                session_mode: gwt_agent::SessionMode::Normal,
-                skip_permissions: false,
-                codex_fast_mode: false,
-                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
-                docker_service: None,
-                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::CreateAndStart,
-                windows_shell: None,
-            }),
+            previous_profiles: Some(LaunchWizardPreviousProfiles::from_profile(Some(
+                LaunchWizardPreviousProfile {
+                    agent_id: "missing-agent".to_string(),
+                    model: None,
+                    reasoning: None,
+                    version: None,
+                    session_mode: gwt_agent::SessionMode::Normal,
+                    skip_permissions: false,
+                    codex_fast_mode: false,
+                    runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                    docker_service: None,
+                    docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::CreateAndStart,
+                    windows_shell: None,
+                },
+            ))),
         });
 
         assert_eq!(
             state.docker_lifecycle_intent,
             gwt_agent::DockerLifecycleIntent::Connect
         );
+    }
+
+    #[test]
+    fn hydration_refresh_preserves_open_wizard_agent_settings_without_reapplying_preferences() {
+        let mut codex = sample_session_record(
+            "feature/old",
+            Path::new("/tmp/old-repo"),
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        codex.model = Some("gpt-5.4".to_string());
+        codex.reasoning_level = Some("xhigh".to_string());
+        codex.tool_version = Some("0.110.0".to_string());
+        codex.session_mode = gwt_agent::SessionMode::Continue;
+        codex.skip_permissions = true;
+        codex.codex_fast_mode = true;
+
+        let mut state = LaunchWizardState::open_with_previous_profiles(
+            context(branch("feature/current"), "feature/current"),
+            sample_agent_options(),
+            Vec::new(),
+            previous_launch_profiles_from_sessions(&[codex]),
+        );
+        assert_eq!(state.view().selected_reasoning, "xhigh");
+
+        state.apply(LaunchWizardAction::SetReasoning {
+            reasoning: "medium".to_string(),
+        });
+        state.apply_hydration(LaunchWizardHydration {
+            selected_branch: Some(branch("feature/current")),
+            normalized_branch_name: "feature/current".to_string(),
+            worktree_path: Some(PathBuf::from("/tmp/current-repo")),
+            quick_start_root: PathBuf::from("/tmp/current-repo"),
+            docker_context: None,
+            docker_service_status: gwt_docker::ComposeServiceStatus::Unknown,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: None,
+        });
+
+        let view = state.view();
+        assert_eq!(view.selected_agent_id, "codex");
+        assert_eq!(view.selected_model, "gpt-5.4");
+        assert_eq!(view.selected_reasoning, "medium");
+        assert_eq!(view.selected_version, "0.110.0");
+        assert_eq!(view.selected_execution_mode, "continue");
+        assert!(view.skip_permissions);
+        assert!(view.codex_fast_mode);
     }
 
     #[test]
@@ -5232,7 +5493,7 @@ mod tests {
                 docker_service: None,
                 docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
             }],
-            previous_profile: None,
+            previous_profiles: Some(LaunchWizardPreviousProfiles::default()),
         });
 
         let view = state.view();

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -421,8 +421,7 @@ fn resolve_launch_wizard_hydration(
         sessions_dir,
         &normalized_branch_name,
     );
-    let previous_profile =
-        gwt::launch_wizard::load_previous_launch_profile(&quick_start_root, sessions_dir);
+    let previous_profiles = gwt::launch_wizard::load_previous_launch_profiles(sessions_dir);
     let (docker_context, docker_service_status) =
         detect_wizard_docker_context_and_status(&quick_start_root);
 
@@ -435,6 +434,6 @@ fn resolve_launch_wizard_hydration(
         docker_service_status,
         agent_options,
         quick_start_entries,
-        previous_profile,
+        previous_profiles: Some(previous_profiles),
     })
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -70,9 +70,9 @@ pub use launch_wizard::{
     load_agent_options, AgentOption, DockerWizardContext, LaunchTargetKind, LaunchWizardAction,
     LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchRequest,
     LaunchWizardLiveSessionView, LaunchWizardMode, LaunchWizardOptionView,
-    LaunchWizardPreviousProfile, LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep,
-    LaunchWizardSummaryView, LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry,
-    QuickStartLaunchMode, ShellLaunchConfig,
+    LaunchWizardPreviousProfile, LaunchWizardPreviousProfiles, LaunchWizardQuickStartView,
+    LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView, LaunchWizardView,
+    LinkedIssueKind, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode, ShellLaunchConfig,
 };
 pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
 #[cfg(target_os = "macos")]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -74,7 +74,10 @@ pub use launch_wizard::{
     LaunchWizardSummaryView, LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry,
     QuickStartLaunchMode, ShellLaunchConfig,
 };
-pub use managed_assets::refresh_managed_gwt_assets_for_worktree;
+pub use managed_assets::{
+    refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,
+    refresh_managed_gwt_assets_for_worktree,
+};
 #[cfg(target_os = "macos")]
 pub use native_app::MacosNativeMenu;
 pub use native_app::{

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -15,7 +15,7 @@ use base64::Engine;
 use gwt::{
     cleanup_selected_branches, detect_shell_program, list_branch_entries_with_active_sessions,
     list_directory_entries, load_knowledge_bridge, load_restored_workspace_state,
-    load_session_state, migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_worktree,
+    load_session_state, migrate_legacy_workspace_state, refresh_managed_gwt_assets_for_agent,
     resolve_launch_spec, save_session_state, save_workspace_state, workspace_state_path,
     BackendEvent, BranchEntriesPhase, BranchListEntry, DockerWizardContext, FrontendEvent,
     HookForwardTarget, KnowledgeKind, LaunchWizardState, LiveSessionEntry, ShellLaunchConfig,

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -8,43 +8,140 @@ use crate::cli::gwtd_resolver::{
     GwtdResolutionInputs,
 };
 use crate::native_app::{GUI_FRONT_DOOR_BINARY_NAME, INTERNAL_DAEMON_BINARY_NAME};
+use gwt_agent::AgentId;
 use gwt_skills::{
-    distribute_to_worktree, generate_codex_hooks, generate_hermes_hooks, generate_openclaw_hooks,
-    generate_opencode_hooks, generate_settings_local, update_git_exclude,
+    distribute_to_worktree_for_targets, generate_codex_hooks, generate_hermes_hooks,
+    generate_openclaw_hooks, generate_opencode_hooks, generate_settings_local, update_git_exclude,
+    update_git_exclude_for_targets, ManagedAssetTarget,
 };
 
 pub fn refresh_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()> {
-    distribute_to_worktree(worktree).map_err(|error| {
-        io::Error::other(format!("failed to distribute gwt managed assets: {error}"))
-    })?;
+    materialize_managed_gwt_assets_for_targets(worktree, &ManagedAssetTarget::ALL)?;
     update_git_exclude(worktree).map_err(|error| {
         io::Error::other(format!("failed to update gwt managed excludes: {error}"))
     })?;
-    let _hook_bin_guard = install_hook_bin_override()?;
-    generate_settings_local(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate Claude hook settings: {error}"
-        ))
-    })?;
-    generate_codex_hooks(worktree).map_err(|error| {
-        io::Error::other(format!("failed to regenerate Codex hook settings: {error}"))
-    })?;
-    generate_opencode_hooks(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate OpenCode hook settings: {error}"
-        ))
-    })?;
-    generate_openclaw_hooks(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate OpenClaw hook settings: {error}"
-        ))
-    })?;
-    generate_hermes_hooks(worktree).map_err(|error| {
-        io::Error::other(format!(
-            "failed to regenerate Hermes hook settings: {error}"
-        ))
+    Ok(())
+}
+
+pub fn refresh_managed_gwt_assets_for_agent(worktree: &Path, agent_id: &AgentId) -> io::Result<()> {
+    let targets = managed_targets_for_agent(agent_id)
+        .into_iter()
+        .collect::<Vec<_>>();
+    materialize_managed_gwt_assets_for_targets(worktree, &targets)?;
+    let exclude_targets = detect_existing_managed_asset_targets(worktree);
+    update_git_exclude_for_targets(worktree, &exclude_targets).map_err(|error| {
+        io::Error::other(format!("failed to update gwt managed excludes: {error}"))
     })?;
     Ok(())
+}
+
+pub fn refresh_existing_managed_gwt_assets_for_worktree(worktree: &Path) -> io::Result<()> {
+    let targets = detect_existing_managed_asset_targets(worktree);
+    materialize_managed_gwt_assets_for_targets(worktree, &targets)?;
+    update_git_exclude_for_targets(worktree, &targets).map_err(|error| {
+        io::Error::other(format!("failed to update gwt managed excludes: {error}"))
+    })?;
+    Ok(())
+}
+
+fn materialize_managed_gwt_assets_for_targets(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+) -> io::Result<()> {
+    distribute_to_worktree_for_targets(worktree, targets).map_err(|error| {
+        io::Error::other(format!("failed to distribute gwt managed assets: {error}"))
+    })?;
+    if targets.is_empty() {
+        return Ok(());
+    }
+    let _hook_bin_guard = install_hook_bin_override()?;
+    if targets.contains(&ManagedAssetTarget::ClaudeCode) {
+        generate_settings_local(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate Claude hook settings: {error}"
+            ))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::Codex) {
+        generate_codex_hooks(worktree).map_err(|error| {
+            io::Error::other(format!("failed to regenerate Codex hook settings: {error}"))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::OpenCode) {
+        generate_opencode_hooks(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate OpenCode hook settings: {error}"
+            ))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::OpenClaw) {
+        generate_openclaw_hooks(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate OpenClaw hook settings: {error}"
+            ))
+        })?;
+    }
+    if targets.contains(&ManagedAssetTarget::Hermes) {
+        generate_hermes_hooks(worktree).map_err(|error| {
+            io::Error::other(format!(
+                "failed to regenerate Hermes hook settings: {error}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn managed_targets_for_agent(agent_id: &AgentId) -> Option<ManagedAssetTarget> {
+    match agent_id {
+        AgentId::ClaudeCode => Some(ManagedAssetTarget::ClaudeCode),
+        AgentId::Codex => Some(ManagedAssetTarget::Codex),
+        AgentId::OpenCode => Some(ManagedAssetTarget::OpenCode),
+        AgentId::OpenClaw => Some(ManagedAssetTarget::OpenClaw),
+        AgentId::Hermes => Some(ManagedAssetTarget::Hermes),
+        AgentId::Gemini | AgentId::Copilot | AgentId::Custom(_) => None,
+    }
+}
+
+fn detect_existing_managed_asset_targets(worktree: &Path) -> Vec<ManagedAssetTarget> {
+    let mut targets = Vec::new();
+    push_existing_target(
+        &mut targets,
+        worktree.join(".claude/skills").exists()
+            || worktree.join(".claude/commands").exists()
+            || worktree.join(".claude/settings.local.json").exists(),
+        ManagedAssetTarget::ClaudeCode,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".codex/skills").exists() || worktree.join(".codex/hooks.json").exists(),
+        ManagedAssetTarget::Codex,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".gwt/opencode").exists(),
+        ManagedAssetTarget::OpenCode,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".gwt/openclaw").exists(),
+        ManagedAssetTarget::OpenClaw,
+    );
+    push_existing_target(
+        &mut targets,
+        worktree.join(".gwt/hermes").exists(),
+        ManagedAssetTarget::Hermes,
+    );
+    targets
+}
+
+fn push_existing_target(
+    targets: &mut Vec<ManagedAssetTarget>,
+    exists: bool,
+    target: ManagedAssetTarget,
+) {
+    if exists && !targets.contains(&target) {
+        targets.push(target);
+    }
 }
 
 fn install_hook_bin_override() -> io::Result<EnvVarGuard> {

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -825,6 +825,69 @@ fn unassigned_agent_without_title_summary_is_not_title_blocked() {
 }
 
 #[test]
+fn actionable_unassigned_agent_is_blocked_from_mutation_until_workspace_ensure() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/unassigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        let mut agent = unassigned_workspace_agent(&session_id);
+        agent.title_summary = Some("Workspace materialization".to_string());
+        agent.current_focus = Some("Ensure actionable intent enters a Workspace".to_string());
+        projection.agents.push(agent);
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Edit",
+            json!({
+                "file_path": "crates/gwt/src/cli/workspace.rs",
+                "old_string": "old",
+                "new_string": "new"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
+            panic!("expected actionable Unassigned mutation to be blocked");
+        };
+        assert!(detail.contains("Unassigned"), "{detail}");
+        assert!(detail.contains("gwtd workspace ensure"), "{detail}");
+    });
+}
+
+#[test]
+fn actionable_unassigned_agent_can_run_workspace_ensure_command() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/unassigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        let mut agent = unassigned_workspace_agent(&session_id);
+        agent.title_summary = Some("Workspace materialization".to_string());
+        agent.current_focus = Some("Ensure actionable intent enters a Workspace".to_string());
+        projection.agents.push(agent);
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let event = event(
+            "Bash",
+            json!({
+                "command": "gwtd workspace ensure --agent-session \"$GWT_SESSION_ID\" --title-summary 'Workspace materialization' --current-focus 'Ensure actionable intent enters a Workspace' --spec 2359"
+            }),
+        );
+
+        let decision =
+            workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Workspace ensure must remain allowed so the Agent can repair affiliation"
+        );
+    });
+}
+
+#[test]
 fn assigned_agent_without_title_summary_remains_title_blocked() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -3,7 +3,11 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use gwt::refresh_managed_gwt_assets_for_worktree;
+use gwt::{
+    refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,
+    refresh_managed_gwt_assets_for_worktree,
+};
+use gwt_agent::AgentId;
 use serde_json::Value;
 use tempfile::tempdir;
 
@@ -76,6 +80,105 @@ fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() 
     assert!(exclude.contains(".claude/skills/gwt-*"));
     assert!(exclude.contains(".claude/commands/gwt-*"));
     assert!(exclude.contains(".codex/skills/gwt-*"));
+}
+
+#[test]
+fn refresh_managed_assets_for_codex_only_materializes_codex_assets() {
+    let dir = tempdir().expect("tempdir");
+    run_git(dir.path(), &["init", "-q"]);
+    let _env_guard = env_lock();
+    let cli_bin = dir.path().join("bin/gwtd");
+    std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+    std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+    let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+
+    refresh_managed_gwt_assets_for_agent(dir.path(), &AgentId::Codex)
+        .expect("refresh Codex assets");
+
+    assert!(dir
+        .path()
+        .join(".codex/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(dir.path().join(".codex/hooks.json").exists());
+    assert!(!dir
+        .path()
+        .join(".claude/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir.path().join(".claude/settings.local.json").exists());
+    assert!(!dir.path().join(".gwt/hermes/config.yaml").exists());
+
+    let exclude =
+        std::fs::read_to_string(dir.path().join(".git/info/exclude")).expect("read exclude");
+    assert!(exclude.contains(".codex/skills/gwt-*"));
+    assert!(!exclude.contains(".claude/skills/gwt-*"));
+    assert!(!exclude.contains(".gwt/hermes/"));
+}
+
+#[test]
+fn refresh_managed_assets_for_hermes_materializes_hermes_home_skills_only() {
+    let dir = tempdir().expect("tempdir");
+    run_git(dir.path(), &["init", "-q"]);
+    let _env_guard = env_lock();
+    let cli_bin = dir.path().join("bin/gwtd");
+    std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+    std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+    let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+
+    refresh_managed_gwt_assets_for_agent(dir.path(), &AgentId::Hermes)
+        .expect("refresh Hermes assets");
+
+    assert!(dir.path().join(".gwt/hermes/config.yaml").exists());
+    assert!(dir
+        .path()
+        .join(".gwt/hermes/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir
+        .path()
+        .join(".claude/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir
+        .path()
+        .join(".codex/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir.path().join(".codex/hooks.json").exists());
+
+    let exclude =
+        std::fs::read_to_string(dir.path().join(".git/info/exclude")).expect("read exclude");
+    assert!(exclude.contains(".gwt/hermes/"));
+    assert!(!exclude.contains(".claude/skills/gwt-*"));
+    assert!(!exclude.contains(".codex/skills/gwt-*"));
+}
+
+#[test]
+fn refresh_existing_managed_assets_refreshes_only_present_provider_surfaces() {
+    let dir = tempdir().expect("tempdir");
+    run_git(dir.path(), &["init", "-q"]);
+    let _env_guard = env_lock();
+    let cli_bin = dir.path().join("bin/gwtd");
+    std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+    std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+    let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+    std::fs::create_dir_all(dir.path().join(".codex/skills")).expect("create codex marker");
+
+    refresh_existing_managed_gwt_assets_for_worktree(dir.path())
+        .expect("refresh existing managed assets");
+
+    assert!(dir
+        .path()
+        .join(".codex/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(dir.path().join(".codex/hooks.json").exists());
+    assert!(!dir
+        .path()
+        .join(".claude/skills/gwt-build-spec/SKILL.md")
+        .exists());
+    assert!(!dir.path().join(".gwt/hermes/config.yaml").exists());
+
+    let exclude =
+        std::fs::read_to_string(dir.path().join(".git/info/exclude")).expect("read exclude");
+    assert!(exclude.contains(".codex/skills/gwt-*"));
+    assert!(!exclude.contains(".claude/skills/gwt-*"));
+    assert!(!exclude.contains(".gwt/hermes/"));
 }
 
 #[test]

--- a/crates/gwt/web/__tests__/kanban-structure.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-structure.test.mjs
@@ -159,6 +159,37 @@ test("Kanban shell lets column bodies own vertical scrolling", () => {
   assert.match(columnBodyRule[0], /min-height:\s*0/);
 });
 
+test("Workspace Overview contains Unassigned overflow without clipping columns", () => {
+  const unassignedRule = componentsCss.match(/\.workspace-unassigned\s*\{[^}]+\}/);
+  assert.ok(
+    unassignedRule,
+    "expected .workspace-unassigned rule in components.css",
+  );
+  assert.match(
+    unassignedRule[0],
+    /max-height:/,
+    "Unassigned Agents must have a bounded height inside the Kanban list pane",
+  );
+  assert.match(
+    unassignedRule[0],
+    /overflow-y:\s*auto/,
+    "Unassigned Agents must own their scroll when many Agents are listed",
+  );
+  assert.match(
+    unassignedRule[0],
+    /flex-shrink:\s*0/,
+    "Unassigned section must not collapse the Workspace columns",
+  );
+
+  const detailRule = componentsCss.match(/\.workspace-kanban-detail-pane\s*\{[^}]+\}/);
+  assert.ok(
+    detailRule,
+    "expected .workspace-kanban-detail-pane rule in components.css",
+  );
+  assert.match(detailRule[0], /min-height:\s*0/);
+  assert.match(detailRule[0], /overflow:\s*hidden/);
+});
+
 test("components.css declares column and card classes", () => {
   // Cards and columns need their own selectors so the renderer can style
   // them independently. Without these classes the renderer can't apply

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2316,12 +2316,20 @@ kbd.op-kbd {
   grid-template-columns: repeat(3, minmax(240px, 1fr));
 }
 
+.workspace-kanban-detail-pane {
+  min-height: 0;
+  overflow: hidden;
+}
+
 .workspace-unassigned {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   gap: var(--space-2);
   margin: var(--space-3) var(--space-3) 0;
   padding: var(--space-3);
+  max-height: min(28vh, 260px);
+  overflow-y: auto;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.26.0",
+  "version": "9.27.0",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,36 @@
 # Lessons Learned
 
+## 2026-05-11 — Actionable Unassigned Agents must materialize before mutation
+
+### 事象
+
+Unassigned Agent が `title-summary` 付きの Board milestone や実装作業を
+行っても、Agent window title が更新されず、Workspace Overview では多くの
+Agent が Unassigned のまま残った。さらに Workspace Overview の Unassigned
+領域と detail pane に明示的な scroll containment がなく、表示内容が見切れた。
+
+### 原因
+
+`title-summary` guard は「Assigned Agent の title 欠落」を防いでいたが、
+「作業名や current focus を持つ Unassigned Agent は、まず Workspace に
+materialize しなければならない」という前提を workflow-policy / Board post
+経路で強制していなかった。Board milestone から Workspace history を更新する
+経路も origin Agent の affiliation を確認しておらず、Unassigned 起点の
+milestone が所属修復なしに履歴だけを更新できた。
+
+### 再発防止策
+
+1. Agent title / Board milestone / Workspace history のいずれかを変更する
+   修正では、Unassigned Agent の materialization 経路 (`workspace ensure` /
+   join / create) を必ずテストする。
+2. Board post で milestone kind (`claim` / `status` / `blocked` / `handoff` /
+   `decision` / `next`) を扱う場合、audience 計算より前に Workspace
+   affiliation が確定していることを確認する。意図的な broadcast は例外として
+   明示的に opt-out させる。
+3. Workspace Overview の固定領域を変更する場合は、`min-height: 0` と
+   bounded `overflow` の contract test を追加し、Unassigned / columns /
+   detail pane のどれも到達不能にならないことを確認する。
+
 ## 2026-05-10 — SPEC section edits must preserve section markers and avoid concurrent writes
 
 ### 事象


### PR DESCRIPTION
## Summary

Release v9.27.0 — feat 2件と fix 3件をまとめた minor リリース。Agent PATH 設定とリリースに関する複数の挙動修正を含む。

## Changes

- feat: Restore launch agent preferences per agent
- feat: Prepend GWT_BIN_PATH dir to agent PATH
- fix: Scope managed assets by agent provider
- fix(workspace): Materialize actionable unassigned agents
- fix: Prepend GWT_BIN_PATH dir under existing case-insensitive PATH key
- chore: Apply cargo fmt to prepend_dir_to_path test additions

## Version

v9.26.0 to v9.27.0 (minor)

## Closing Issues

None

## Related Issues / Links

#1935, #2014, #2077, #2653

Note: 上記 Related Issues は PR #2653 / #2654 / #2655 / #2656 の本文で Related Issues / Links セクションにのみ参照されているため、main マージ時に自動クローズされません。auto-close したい場合は Closing Issues に移してください。
