### PR TITLE
fix(gui): clamp and scroll terminal-overlay to keep window operable

### DIFF
--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -830,9 +830,7 @@
 
       .terminal-overlay {
         position: absolute;
-        left: 12px;
-        right: 12px;
-        bottom: 12px;
+        inset: 12px;
         padding: 10px 12px;
         border-radius: var(--radius-md);
         background: color-mix(in oklab, var(--color-canvas) 82%, transparent);
@@ -849,9 +847,9 @@
       .terminal-overlay.visible {
         display: flex;
         flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        gap: 12px;
+        align-items: stretch;
+        justify-content: flex-start;
+        gap: 8px;
         background: color-mix(in oklab, var(--color-canvas) 95%, transparent);
         pointer-events: auto;
         user-select: text;
@@ -870,6 +868,10 @@
         font-size: var(--type-sm);
         color: var(--color-text);
         max-width: 100%;
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: 100%;
+        overflow-y: auto;
         overflow-wrap: anywhere;
         white-space: pre-wrap;
         user-select: text;
@@ -877,6 +879,8 @@
 
       .overlay-copy-button {
         align-self: flex-end;
+        position: sticky;
+        top: 0;
         min-width: 56px;
         height: 26px;
         border: 1px solid var(--color-border-strong);


### PR DESCRIPTION
## Summary

- Agent window 内 `.terminal-overlay` を `inset: 12px` で window body 内に拘束し、長文 stderr (Docker 起動失敗時の複数行エラーなど) でも window タイトル領域を侵食しないようにした
- `.overlay-message` に `flex: 1 1 auto; min-height: 0; overflow-y: auto` を加え、overlay 内部で stderr をスクロール可能にした
- `.overlay-copy-button` を `position: sticky; top: 0` に変更し、スクロール中も Copy 操作を維持できるようにした

## Changes

- `crates/gwt/web/index.html`: 4 セレクタの CSS を更新。`.terminal-overlay` を `inset: 12px` 化、`.terminal-overlay.visible` を `stretch` / `flex-start` / `gap: 8px` に、`.overlay-message` に flex + scroll を追加、`.overlay-copy-button` を sticky に。Rust / JS 側 (`crates/gwt/web/app.js` の `applyStatus` ほか) は無変更。

## Testing

- [x] `cargo fmt -- --check` — 差分なし
- [x] `cargo clippy -p gwt --all-targets --all-features -- -D warnings` — warning なし
- [x] `cargo build -p gwt` — success
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — pass
- [ ] 手動回帰: 任意の agent pane を `runtime === "error"` 状態にして 1000+ 文字の `detail` を渡し、(a) window タイトル領域が overlay に被さらず close/minimize/maximize/focus が操作可能、(b) overlay 内部で stderr が縦スクロール可能、(c) Copy ボタンがスクロール中も上部固定で押下可能、を確認

## Closing Issues

- None

## Related Issues / Links

- None

## Checklist

- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — CSS のみの修正のため、ユーザー向けドキュメント変更は不要
- [x] Migration/backfill plan included (if schema/data change) — N/A (CSS のみ)
- [x] CHANGELOG impact considered (breaking change flagged in commit) — `fix` (patch) のみで breaking change なし
- [ ] Tests added/updated — WebView の CSS computed value を assert する自動テスト基盤が無い領域のため、手動回帰のみで対応

## Notes

- Docker port 衝突 (今回の起点 bug のもう半分) と関連クリーンアップ (`docker-compose.gwt.override.yml` ファイル名統一、`version: '3.8'` 削除) は本 PR の対象外。container-per-session を維持しつつ host-container 通信を TCP host port から Unix domain socket (Windows は named pipe) に置換する設計の P2 SPEC で別途扱う。
- `runtime === "running"` 時の spinner は `align-items: stretch` 化の影響で左寄せになるが、視認性は許容範囲。中央維持が必要になれば spinner 単体に `align-self: center` を後追いで付与する。
- PreToolUse hook (workspace-policy / unassigned-agent) の誤検知問題は別 Issue として登録予定 (本 PR 完了後)。本 PR 作業中も該当フックの誤発火に遭遇したが、Board claim を `--title-summary` 付きで投稿することで unblock した。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined terminal overlay layout with improved spacing and alignment for better visual presentation
  * Enhanced message scrolling behavior with a sticky copy button that remains visible while navigating through content
  * Optimized content containment and wrapping within the overlay message area

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2659)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->