### PR TITLE
fix(workspace): limit coordination to explicit affiliation

### DIFF
--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -4,7 +4,7 @@ use gwt_agent::{session::GWT_SESSION_ID_ENV, Session};
 use gwt_core::{
     coordination::{
         load_snapshot, load_snapshot_for_scope, normalize_board_audience, normalize_board_mentions,
-        post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardEntryKind, BoardMention,
+        post_entry, AuthorKind, BoardAudienceScope, BoardEntry, BoardMention,
     },
     paths::gwt_sessions_dir,
 };
@@ -16,8 +16,6 @@ use crate::{
     },
     cli::{CliEnv, CliParseError},
 };
-
-use super::workspace::{ensure_workspace_for_agent, WorkspaceEnsureInput};
 
 /// SPEC-1942 family enum for `gwtd board ...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -184,15 +182,6 @@ pub(super) fn run<E: CliEnv>(
             if !targets.is_empty() {
                 entry = entry.with_target_owners(targets);
             }
-            let materialized_workspace = if broadcast {
-                None
-            } else {
-                materialize_actionable_unassigned_board_post(
-                    env.repo_path(),
-                    current_session.as_ref(),
-                    &entry,
-                )?
-            };
             let (workspace_audience, other_mention_args) = split_workspace_mentions(&mentions);
             let mentions =
                 parse_mentions(&other_mention_args).map_err(gwt_error_to_spec_ops_error)?;
@@ -207,9 +196,6 @@ pub(super) fn run<E: CliEnv>(
                 )
                 .map_err(gwt_error_to_spec_ops_error)?
                 {
-                    audience.push(workspace_id);
-                }
-                if let Some(workspace_id) = materialized_workspace {
                     audience.push(workspace_id);
                 }
                 audience.extend(workspace_audience);
@@ -382,108 +368,6 @@ fn parse_mentions(values: &[String]) -> gwt_core::Result<Vec<BoardMention>> {
         mentions.push(value.parse::<BoardMention>()?);
     }
     Ok(normalize_board_mentions(&mentions))
-}
-
-fn materialize_actionable_unassigned_board_post(
-    repo_path: &std::path::Path,
-    current_session: Option<&Session>,
-    entry: &BoardEntry,
-) -> Result<Option<String>, SpecOpsError> {
-    let Some(session) = current_session else {
-        return Ok(None);
-    };
-    if !board_entry_can_materialize_workspace(entry) {
-        return Ok(None);
-    }
-    let Some(projection) = gwt_core::workspace_projection::load_workspace_projection(repo_path)
-        .map_err(gwt_error_to_spec_ops_error)?
-    else {
-        return Ok(None);
-    };
-    let Some(agent) = projection
-        .agents
-        .iter()
-        .find(|agent| agent.session_id == session.id)
-    else {
-        return Ok(None);
-    };
-    if !agent.is_unassigned() {
-        return Ok(None);
-    }
-    let (spec, issue) = board_owner_numbers(&entry.related_owners);
-    let result = ensure_workspace_for_agent(
-        repo_path,
-        WorkspaceEnsureInput {
-            agent_session: session.id.clone(),
-            title_summary: entry
-                .title_summary
-                .as_deref()
-                .unwrap_or("Board milestone")
-                .to_string(),
-            current_focus: Some(entry.body.clone()),
-            spec,
-            issue,
-            topic: entry.related_topics.first().cloned(),
-            boundary: boundary_from_board_body(&entry.body),
-        },
-    )?;
-    Ok(Some(result.workspace_id))
-}
-
-fn board_entry_can_materialize_workspace(entry: &BoardEntry) -> bool {
-    matches!(
-        entry.kind,
-        BoardEntryKind::Claim
-            | BoardEntryKind::Status
-            | BoardEntryKind::Blocked
-            | BoardEntryKind::Handoff
-            | BoardEntryKind::Decision
-            | BoardEntryKind::Next
-    ) && entry
-        .title_summary
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty())
-}
-
-fn board_owner_numbers(owners: &[String]) -> (Option<u64>, Option<u64>) {
-    let mut spec = None;
-    let mut issue = None;
-    for owner in owners {
-        let value = owner.trim();
-        if spec.is_none() {
-            if let Some(number) = value
-                .strip_prefix("SPEC-")
-                .or_else(|| value.strip_prefix("spec-"))
-                .and_then(|number| number.parse::<u64>().ok())
-                .or_else(|| value.parse::<u64>().ok())
-            {
-                spec = Some(number);
-                continue;
-            }
-        }
-        if issue.is_none() {
-            let issue_number = value
-                .strip_prefix("Issue #")
-                .or_else(|| value.strip_prefix("issue #"))
-                .or_else(|| value.strip_prefix("issue-"))
-                .and_then(|number| number.parse::<u64>().ok());
-            if let Some(number) = issue_number {
-                issue = Some(number);
-            }
-        }
-    }
-    (spec, issue)
-}
-
-fn boundary_from_board_body(body: &str) -> Option<String> {
-    body.lines().find_map(|line| {
-        line.trim_start()
-            .strip_prefix("Boundary:")
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-    })
 }
 
 /// SPEC-2359 FR-096: `--mention workspace:<id>` routes to BoardEntry.audience,
@@ -1311,7 +1195,7 @@ mod tests {
     }
 
     #[test]
-    fn board_family_run_post_materializes_unassigned_actionable_milestone_before_audience() {
+    fn board_family_run_post_keeps_unassigned_actionable_milestone_unscoped() {
         let _env_lock = crate::env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -1356,9 +1240,10 @@ mod tests {
 
         let snapshot = load_snapshot(&repo).unwrap();
         let entry = &snapshot.board.entries[0];
-        assert_eq!(entry.audience.len(), 1, "{entry:?}");
-        let workspace_id = entry.audience[0].clone();
-        assert!(workspace_id.starts_with("workspace-"), "{workspace_id}");
+        assert!(
+            entry.audience.is_empty(),
+            "Unassigned Board posts should not auto-materialize a Workspace or audience: {entry:?}"
+        );
         let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
@@ -1369,14 +1254,14 @@ mod tests {
             .expect("agent");
         assert_eq!(
             agent.affiliation_status,
-            WorkspaceAgentAffiliationStatus::Assigned
+            WorkspaceAgentAffiliationStatus::Unassigned
         );
-        assert_eq!(agent.workspace_id.as_deref(), Some(workspace_id.as_str()));
-        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
-            .expect("load workspaces")
-            .expect("workspaces");
-        assert_eq!(work_items.work_items[0].id, workspace_id);
-        assert_eq!(work_items.work_items[0].title, "Workspace materialization");
+        assert!(agent.workspace_id.is_none());
+        assert!(
+            gwt_core::workspace_projection::load_workspace_work_items(&repo)
+                .expect("load workspace history")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -9,32 +9,20 @@
 //! - allow transport operations such as `git push` and worktree-internal edits
 //!   without an owner gate
 
-use std::{
-    collections::{HashMap, HashSet},
-    io::Read,
-    path::Path,
-};
+use std::{collections::HashMap, io::Read, path::Path};
 
 use gwt_agent::{
     session::{Session, GWT_SESSION_ID_ENV},
     types::WorkflowBypass,
 };
 use gwt_core::{
-    coordination::{
-        board_entry_visible_for_scope, load_snapshot, BoardEntry, BoardEntryKind,
-        BoardMentionTargetKind,
-    },
     paths::{gwt_cache_dir, gwt_sessions_dir},
-    workspace_projection::{
-        load_or_synthesize_workspace_work_items, load_workspace_projection, WorkspaceAgentSummary,
-        WorkspaceProjection, WorkspaceStatusCategory, WorkspaceWorkItem,
-    },
+    workspace_projection::load_workspace_projection,
 };
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;
 
 use super::{block_bash_policy, HookError, HookEvent, HookOutput};
-use crate::board_audience::current_session_board_scope;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkflowOwner {
@@ -50,7 +38,6 @@ pub struct WorkflowContext {
     pub has_tasks: bool,
     pub bypass: Option<WorkflowBypass>,
     pub title_summary_missing: bool,
-    pub workspace_materialization_missing: bool,
 }
 
 impl WorkflowContext {
@@ -61,7 +48,6 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: None,
             title_summary_missing: false,
-            workspace_materialization_missing: false,
         }
     }
 
@@ -72,7 +58,6 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: None,
             title_summary_missing: false,
-            workspace_materialization_missing: false,
         }
     }
 
@@ -83,7 +68,6 @@ impl WorkflowContext {
             has_tasks,
             bypass: None,
             title_summary_missing: false,
-            workspace_materialization_missing: false,
         }
     }
 
@@ -94,17 +78,11 @@ impl WorkflowContext {
             has_tasks: false,
             bypass: Some(bypass),
             title_summary_missing: false,
-            workspace_materialization_missing: false,
         }
     }
 
     pub fn with_title_summary_missing(mut self, missing: bool) -> Self {
         self.title_summary_missing = missing;
-        self
-    }
-
-    pub fn with_workspace_materialization_missing(mut self, missing: bool) -> Self {
-        self.workspace_materialization_missing = missing;
         self
     }
 }
@@ -129,20 +107,12 @@ pub fn evaluate_with_context(
     if title_summary != HookOutput::Silent {
         return Ok(title_summary);
     }
-    let materialization =
-        evaluate_workspace_materialization_guard(event, context.workspace_materialization_missing)?;
-    if materialization != HookOutput::Silent {
-        return Ok(materialization);
-    }
-    evaluate_workspace_coordination_guard(event, worktree_root)
+    Ok(HookOutput::Silent)
 }
 
 pub fn evaluate(event: &HookEvent, worktree_root: &Path) -> Result<HookOutput, HookError> {
     let context = resolve_workflow_context(worktree_root)
-        .with_title_summary_missing(current_agent_title_summary_missing(worktree_root)?)
-        .with_workspace_materialization_missing(current_agent_workspace_materialization_missing(
-            worktree_root,
-        )?);
+        .with_title_summary_missing(current_agent_title_summary_missing(worktree_root)?);
     evaluate_with_context(event, worktree_root, &context)
 }
 
@@ -241,34 +211,6 @@ fn current_agent_title_summary_missing(worktree_root: &Path) -> Result<bool, Hoo
         .is_none())
 }
 
-fn current_agent_workspace_materialization_missing(
-    worktree_root: &Path,
-) -> Result<bool, HookError> {
-    let Some(session) = load_session_from_env() else {
-        return Ok(false);
-    };
-    let projection_root = if session.worktree_path.exists() {
-        session.worktree_path.as_path()
-    } else {
-        worktree_root
-    };
-    let Some(projection) = load_workspace_projection(projection_root)? else {
-        return Ok(false);
-    };
-    let Some(agent) = projection
-        .agents
-        .iter()
-        .find(|agent| agent.session_id == session.id)
-    else {
-        return Ok(false);
-    };
-    if !agent.is_unassigned() {
-        return Ok(false);
-    }
-    Ok(option_has_nonempty_text(agent.title_summary.as_deref())
-        || option_has_nonempty_text(agent.current_focus.as_deref()))
-}
-
 fn evaluate_title_summary_guard(
     event: &HookEvent,
     title_summary_missing: bool,
@@ -294,615 +236,6 @@ Use the configured narrative language for the title-summary. Keep progress, comp
     }
 
     Ok(HookOutput::Silent)
-}
-
-fn evaluate_workspace_materialization_guard(
-    event: &HookEvent,
-    workspace_materialization_missing: bool,
-) -> Result<HookOutput, HookError> {
-    if !workspace_materialization_missing {
-        return Ok(HookOutput::Silent);
-    }
-
-    if is_workspace_materialization_event(event) || is_read_only_exploration_event(event) {
-        return Ok(HookOutput::Silent);
-    }
-
-    if is_title_sensitive_tool(event) {
-        return Ok(HookOutput::pre_tool_use_permission(
-            "Unassigned Agent has actionable Workspace intent",
-            "This Agent already has a title-summary or current focus, but it is still Unassigned. \
-Materialize the work into a Workspace before implementation or verification so title sync, Board audience, and Workspace history stay attached to the same work.\n\n\
-Required command shape:\n\
-  gwtd workspace ensure --agent-session \"$GWT_SESSION_ID\" --title-summary '<short work title>' --current-focus '<current work focus>' [--spec <number>|--issue <number>] [--topic <topic>]\n\n\
-Use `gwtd workspace candidates --agent-session \"$GWT_SESSION_ID\"` first only when you need to inspect choices manually. \
-Use `gwtd board post --kind claim --title-summary '<short work title>' ...` when the intent should be materialized as a Board milestone.",
-        ));
-    }
-
-    Ok(HookOutput::Silent)
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct WorkspaceCoordinationConflict {
-    source_label: &'static str,
-    title: String,
-    session_id: Option<String>,
-    branch: Option<String>,
-    agent_id: Option<String>,
-    related_owners: Vec<String>,
-    related_topics: Vec<String>,
-}
-
-fn evaluate_workspace_coordination_guard(
-    event: &HookEvent,
-    worktree_root: &Path,
-) -> Result<HookOutput, HookError> {
-    if !is_workspace_coordination_sensitive_event(event) {
-        return Ok(HookOutput::Silent);
-    }
-
-    let session = load_session_from_env();
-    let current_session_id = session.as_ref().map(|session| session.id.as_str());
-    let projection = load_workspace_projection(worktree_root)?;
-    let current_intent = workspace_current_intent(event, projection.as_ref(), current_session_id);
-    if current_intent.trim().is_empty() {
-        return Ok(HookOutput::Silent);
-    }
-
-    let conflicts = workspace_coordination_conflicts(
-        worktree_root,
-        projection.as_ref(),
-        &current_intent,
-        current_session_id,
-    )?;
-    let Some(conflict) = conflicts.into_iter().next() else {
-        return Ok(HookOutput::Silent);
-    };
-
-    if has_matching_split_claim(
-        worktree_root,
-        current_session_id,
-        &current_intent,
-        &conflict,
-    )? {
-        return Ok(HookOutput::Silent);
-    }
-
-    Ok(workspace_coordination_block_decision(&conflict))
-}
-
-fn workspace_coordination_conflicts(
-    worktree_root: &Path,
-    projection: Option<&WorkspaceProjection>,
-    current_intent: &str,
-    current_session_id: Option<&str>,
-) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
-    let mut conflicts = Vec::new();
-    if let Some(projection) = projection {
-        conflicts.extend(workspace_agent_conflicts(
-            projection,
-            current_intent,
-            current_session_id,
-        ));
-    }
-    conflicts.extend(workspace_work_item_conflicts(
-        worktree_root,
-        current_intent,
-        current_session_id,
-    )?);
-    conflicts.extend(board_claim_conflicts(
-        worktree_root,
-        current_intent,
-        current_session_id,
-    )?);
-    Ok(conflicts)
-}
-
-fn workspace_agent_conflicts(
-    projection: &WorkspaceProjection,
-    current_intent: &str,
-    current_session_id: Option<&str>,
-) -> Vec<WorkspaceCoordinationConflict> {
-    projection
-        .agents
-        .iter()
-        .filter(|agent| {
-            current_session_id != Some(agent.session_id.as_str())
-                && agent.is_assigned()
-                && matches!(
-                    agent.status_category,
-                    WorkspaceStatusCategory::Active | WorkspaceStatusCategory::Blocked
-                )
-        })
-        .filter_map(|agent| {
-            let text = workspace_agent_text(agent);
-            is_similar_work(current_intent, &text).then(|| WorkspaceCoordinationConflict {
-                source_label: "similar active Workspace",
-                title: agent
-                    .title_summary
-                    .as_deref()
-                    .or(agent.current_focus.as_deref())
-                    .unwrap_or("active Workspace agent")
-                    .to_string(),
-                session_id: Some(agent.session_id.clone()),
-                branch: agent.branch.clone(),
-                agent_id: Some(agent.agent_id.clone()),
-                related_owners: Vec::new(),
-                related_topics: agent.coordination_scope.iter().cloned().collect(),
-            })
-        })
-        .collect()
-}
-
-fn workspace_work_item_conflicts(
-    worktree_root: &Path,
-    current_intent: &str,
-    current_session_id: Option<&str>,
-) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
-    let projection = load_or_synthesize_workspace_work_items(worktree_root)?;
-    Ok(projection
-        .work_items
-        .iter()
-        .filter(|item| item.is_incomplete())
-        .filter(|item| {
-            current_session_id.is_none_or(|session_id| {
-                !item
-                    .agents
-                    .iter()
-                    .any(|agent| agent.session_id == session_id)
-            })
-        })
-        .filter_map(|item| {
-            let text = workspace_work_item_text(item);
-            is_similar_work(current_intent, &text).then(|| {
-                let first_agent = item.agents.first();
-                let first_container = item.execution_containers.first();
-                WorkspaceCoordinationConflict {
-                    source_label: "incomplete Workspace",
-                    title: item.title.clone(),
-                    session_id: first_agent.map(|agent| agent.session_id.clone()),
-                    branch: first_container.and_then(|container| container.branch.clone()),
-                    agent_id: first_agent.and_then(|agent| agent.agent_id.clone()),
-                    related_owners: item.owner.iter().cloned().collect(),
-                    related_topics: vec![item.id.clone()],
-                }
-            })
-        })
-        .collect())
-}
-
-fn board_claim_conflicts(
-    worktree_root: &Path,
-    current_intent: &str,
-    current_session_id: Option<&str>,
-) -> Result<Vec<WorkspaceCoordinationConflict>, HookError> {
-    let snapshot = load_snapshot(worktree_root)?;
-    let audience_scope = current_session_board_scope(worktree_root, current_session_id)?;
-    Ok(snapshot
-        .board
-        .entries
-        .iter()
-        .rev()
-        .filter(|entry| {
-            entry.kind == BoardEntryKind::Claim
-                && board_claim_is_active(entry)
-                && current_session_id != entry.origin_session_id.as_deref()
-                && board_entry_visible_for_scope(entry, &audience_scope)
-        })
-        .filter_map(|entry| {
-            let text = board_entry_text(entry);
-            is_similar_work(current_intent, &text).then(|| WorkspaceCoordinationConflict {
-                source_label: "active Board claim",
-                title: entry
-                    .title_summary
-                    .as_deref()
-                    .or_else(|| entry.body.lines().find(|line| !line.trim().is_empty()))
-                    .unwrap_or("active Board claim")
-                    .trim()
-                    .to_string(),
-                session_id: entry.origin_session_id.clone(),
-                branch: entry.origin_branch.clone(),
-                agent_id: entry.origin_agent_id.clone(),
-                related_owners: entry.related_owners.clone(),
-                related_topics: entry.related_topics.clone(),
-            })
-        })
-        .collect())
-}
-
-fn workspace_current_intent(
-    event: &HookEvent,
-    projection: Option<&WorkspaceProjection>,
-    current_session_id: Option<&str>,
-) -> String {
-    let mut parts = Vec::new();
-    if let (Some(projection), Some(current_session_id)) = (projection, current_session_id) {
-        if let Some(agent) = projection
-            .agents
-            .iter()
-            .find(|agent| agent.session_id == current_session_id)
-        {
-            push_optional(&mut parts, agent.title_summary.as_deref());
-            push_optional(&mut parts, agent.current_focus.as_deref());
-            push_optional(&mut parts, agent.coordination_scope.as_deref());
-        }
-    }
-    if parts.is_empty() {
-        if let Some(projection) = projection {
-            parts.push(projection.title.as_str());
-            push_optional(&mut parts, projection.summary.as_deref());
-            push_optional(&mut parts, projection.next_action.as_deref());
-            push_optional(&mut parts, projection.owner.as_deref());
-        }
-    }
-    if parts.is_empty() {
-        push_optional(&mut parts, event.command());
-        if let Some(tool_input) = event.tool_input.as_ref() {
-            push_optional(
-                &mut parts,
-                tool_input
-                    .get("file_path")
-                    .and_then(serde_json::Value::as_str),
-            );
-        }
-    }
-    parts.join("\n")
-}
-
-fn workspace_agent_text(agent: &WorkspaceAgentSummary) -> String {
-    let mut parts = Vec::new();
-    push_optional(&mut parts, agent.title_summary.as_deref());
-    push_optional(&mut parts, agent.current_focus.as_deref());
-    push_optional(&mut parts, agent.coordination_scope.as_deref());
-    push_optional(&mut parts, agent.branch.as_deref());
-    parts.push(agent.agent_id.as_str());
-    parts.push(agent.display_name.as_str());
-    parts.join("\n")
-}
-
-fn workspace_work_item_text(item: &WorkspaceWorkItem) -> String {
-    let mut parts = Vec::new();
-    parts.push(item.title.as_str());
-    push_optional(&mut parts, item.intent.as_deref());
-    push_optional(&mut parts, item.summary.as_deref());
-    push_optional(&mut parts, item.owner.as_deref());
-    parts.extend(item.board_refs.iter().map(String::as_str));
-    for agent in &item.agents {
-        parts.push(agent.session_id.as_str());
-        push_optional(&mut parts, agent.agent_id.as_deref());
-        push_optional(&mut parts, agent.display_name.as_deref());
-    }
-    for container in &item.execution_containers {
-        push_optional(&mut parts, container.branch.as_deref());
-        push_optional(
-            &mut parts,
-            container
-                .worktree_path
-                .as_ref()
-                .and_then(|path| path.to_str()),
-        );
-        push_optional(&mut parts, container.pr_url.as_deref());
-        push_optional(&mut parts, container.pr_state.as_deref());
-    }
-    for event in &item.events {
-        push_optional(&mut parts, event.title.as_deref());
-        push_optional(&mut parts, event.intent.as_deref());
-        push_optional(&mut parts, event.summary.as_deref());
-        push_optional(&mut parts, event.next_action.as_deref());
-    }
-    parts.join("\n")
-}
-
-fn board_entry_text(entry: &BoardEntry) -> String {
-    let mut parts = Vec::new();
-    push_optional(&mut parts, entry.title_summary.as_deref());
-    parts.push(entry.body.as_str());
-    parts.extend(entry.related_topics.iter().map(String::as_str));
-    parts.extend(entry.related_owners.iter().map(String::as_str));
-    parts.extend(entry.target_owners.iter().map(String::as_str));
-    parts.join("\n")
-}
-
-fn push_optional<'a>(parts: &mut Vec<&'a str>, value: Option<&'a str>) {
-    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
-        parts.push(value);
-    }
-}
-
-fn option_has_nonempty_text(value: Option<&str>) -> bool {
-    value.map(str::trim).is_some_and(|value| !value.is_empty())
-}
-
-fn board_claim_is_active(entry: &BoardEntry) -> bool {
-    !entry.state.as_deref().is_some_and(|state| {
-        matches!(
-            state.trim().to_ascii_lowercase().as_str(),
-            "done" | "closed" | "resolved" | "cancelled" | "canceled" | "inactive"
-        )
-    })
-}
-
-fn has_matching_split_claim(
-    worktree_root: &Path,
-    current_session_id: Option<&str>,
-    current_intent: &str,
-    conflict: &WorkspaceCoordinationConflict,
-) -> Result<bool, HookError> {
-    let Some(current_session_id) = current_session_id else {
-        return Ok(false);
-    };
-    let snapshot = load_snapshot(worktree_root)?;
-    let audience_scope = current_session_board_scope(worktree_root, Some(current_session_id))?;
-    Ok(snapshot.board.entries.iter().rev().any(|entry| {
-        entry.kind == BoardEntryKind::Claim
-            && entry.origin_session_id.as_deref() == Some(current_session_id)
-            && board_claim_is_active(entry)
-            && board_entry_visible_for_scope(entry, &audience_scope)
-            && board_entry_has_boundary(entry)
-            && board_entry_targets_conflict(entry, conflict)
-            && split_claim_matches_current_work(entry, current_intent)
-    }))
-}
-
-fn split_claim_matches_current_work(entry: &BoardEntry, current_intent: &str) -> bool {
-    is_similar_work(current_intent, &board_entry_text(entry))
-        || entry
-            .title_summary
-            .as_deref()
-            .is_some_and(|title| is_similar_work(current_intent, title))
-        || entry
-            .related_topics
-            .iter()
-            .any(|topic| is_similar_work(current_intent, topic))
-}
-
-fn board_entry_has_boundary(entry: &BoardEntry) -> bool {
-    entry.body.lines().any(|line| {
-        line.trim_start()
-            .to_ascii_lowercase()
-            .starts_with("boundary:")
-    })
-}
-
-fn board_entry_targets_conflict(
-    entry: &BoardEntry,
-    conflict: &WorkspaceCoordinationConflict,
-) -> bool {
-    let mut keys = Vec::new();
-    if let Some(session_id) = conflict.session_id.as_deref() {
-        keys.push(session_id.to_string());
-        keys.push(format!("session:{session_id}"));
-    }
-    if let Some(branch) = conflict.branch.as_deref() {
-        keys.push(branch.to_string());
-        keys.push(format!("branch:{branch}"));
-    }
-    if let Some(agent_id) = conflict.agent_id.as_deref() {
-        keys.push(agent_id.to_string());
-        keys.push(format!("agent:{agent_id}"));
-    }
-    keys.extend(conflict.related_owners.iter().cloned());
-
-    entry
-        .target_owners
-        .iter()
-        .any(|target| keys.iter().any(|key| key == target))
-        || entry
-            .mentions
-            .iter()
-            .map(|mention| match mention.target_kind {
-                BoardMentionTargetKind::Session => format!("session:{}", mention.target),
-                BoardMentionTargetKind::Branch => format!("branch:{}", mention.target),
-                BoardMentionTargetKind::Agent => format!("agent:{}", mention.target),
-                BoardMentionTargetKind::User => format!("user:{}", mention.target),
-                BoardMentionTargetKind::Workspace => format!("workspace:{}", mention.target),
-            })
-            .any(|typed_key| keys.iter().any(|key| key == &typed_key))
-}
-
-fn workspace_coordination_block_decision(conflict: &WorkspaceCoordinationConflict) -> HookOutput {
-    let mut detail = format!(
-        "A {source} is already in progress and appears to cover the same work.\n\n\
-Conflict title: {title}\n",
-        source = conflict.source_label,
-        title = conflict.title
-    );
-    if let Some(session_id) = conflict.session_id.as_deref() {
-        detail.push_str(&format!("Session: {session_id}\n"));
-    }
-    if let Some(branch) = conflict.branch.as_deref() {
-        detail.push_str(&format!("Branch: {branch}\n"));
-    }
-    if !conflict.related_topics.is_empty() {
-        detail.push_str(&format!("Topics: {}\n", conflict.related_topics.join(", ")));
-    }
-    detail.push_str(
-        "\nDo not continue implementation/editing for duplicate work in a new Workspace. \
-Coordinate on the shared Board with the active agent first.\n\n\
-To coordinate or hand off:\n\
-  gwtd board post --kind request --target <session-or-branch> --body '<question or handoff request>'\n\n\
-To split intentionally, post a claim that targets/mentions the active agent and includes a Boundary line:\n\
-  gwtd board post --kind claim --target <session-or-branch> --topic <topic> --body 'Split accepted.\\n\\nBoundary: <owned files/modules and non-overlap>'",
-    );
-    HookOutput::pre_tool_use_permission("Similar active Workspace already exists", &detail)
-}
-
-fn is_workspace_coordination_sensitive_event(event: &HookEvent) -> bool {
-    match event.tool_name.as_deref() {
-        Some("Edit" | "MultiEdit" | "Write" | "NotebookEdit" | "apply_patch") => true,
-        Some("Bash") => event
-            .command()
-            .is_some_and(is_workspace_coordination_sensitive_bash),
-        _ => false,
-    }
-}
-
-fn is_workspace_coordination_sensitive_bash(command: &str) -> bool {
-    if is_workspace_coordination_command(command) {
-        return false;
-    }
-    if command.contains('>') || command.contains(" tee ") || command.contains("|tee ") {
-        return true;
-    }
-    let segments = super::segments::split_command_segments(command);
-    segments.iter().any(|segment| {
-        let tokens = segment_tokens(segment);
-        let Some(command_name) = tokens.first().map(|token| normalize_command_name(token)) else {
-            return false;
-        };
-        match command_name.as_str() {
-            "cp" | "mkdir" | "mv" | "rm" | "rmdir" | "touch" => true,
-            "sed" => tokens
-                .iter()
-                .any(|token| *token == "--in-place" || token.starts_with("-i")),
-            "cargo" => tokens
-                .get(1)
-                .is_some_and(|subcommand| matches!(*subcommand, "fmt" | "fix")),
-            "git" => tokens
-                .get(1)
-                .is_some_and(|subcommand| matches!(*subcommand, "add" | "commit")),
-            _ => false,
-        }
-    })
-}
-
-fn is_workspace_coordination_command(command: &str) -> bool {
-    let segments = super::segments::split_command_segments(command);
-    !segments.is_empty()
-        && segments.iter().all(|segment| {
-            let tokens = segment_tokens(segment);
-            let Some(command_name) = tokens.first().map(|token| normalize_command_name(token))
-            else {
-                return false;
-            };
-            if command_name != "gwtd" {
-                return false;
-            }
-            matches!(
-                tokens.as_slice(),
-                [_, "board", "post" | "show", ..]
-                    | [
-                        _,
-                        "workspace",
-                        "update" | "ensure" | "create" | "join" | "candidates",
-                        ..
-                    ]
-                    | [_, "build", "start" | "phase" | "complete" | "abort", ..]
-            )
-        })
-}
-
-fn is_workspace_materialization_event(event: &HookEvent) -> bool {
-    if event.tool_name.as_deref() != Some("Bash") {
-        return false;
-    }
-    let Some(command) = event.command() else {
-        return false;
-    };
-    let segments = super::segments::split_command_segments(command);
-    !segments.is_empty()
-        && segments
-            .iter()
-            .all(|segment| is_workspace_materialization_segment(segment))
-}
-
-fn is_workspace_materialization_segment(segment: &str) -> bool {
-    let tokens = segment_tokens(segment);
-    let Some(command_name) = tokens.first().map(|token| normalize_command_name(token)) else {
-        return false;
-    };
-    if command_name != "gwtd" {
-        return false;
-    }
-    match tokens.as_slice() {
-        [_, "workspace", "ensure" | "create" | "join" | "candidates", ..] => true,
-        [_, "board", "show", ..] => true,
-        [_, "board", "post", rest @ ..] => rest.contains(&"--title-summary"),
-        _ => false,
-    }
-}
-
-fn is_similar_work(left: &str, right: &str) -> bool {
-    let left_compact = compact_for_similarity(left);
-    let right_compact = compact_for_similarity(right);
-    if left_compact.len() >= 16
-        && right_compact.len() >= 16
-        && (left_compact.contains(&right_compact) || right_compact.contains(&left_compact))
-    {
-        return true;
-    }
-
-    let left_tokens = similarity_tokens(left);
-    let right_tokens = similarity_tokens(right);
-    if left_tokens.is_empty() || right_tokens.is_empty() {
-        return false;
-    }
-    let overlap = left_tokens.intersection(&right_tokens).count();
-    if overlap < 3 {
-        return false;
-    }
-    let left_coverage = overlap as f32 / left_tokens.len() as f32;
-    let right_coverage = overlap as f32 / right_tokens.len() as f32;
-    let dice = (2 * overlap) as f32 / (left_tokens.len() + right_tokens.len()) as f32;
-
-    (overlap >= 4 && left_coverage >= 0.45 && dice >= 0.35)
-        || (left_coverage >= 0.60 && right_coverage >= 0.45)
-}
-
-fn compact_for_similarity(value: &str) -> String {
-    value
-        .chars()
-        .filter(|ch| ch.is_alphanumeric())
-        .flat_map(char::to_lowercase)
-        .collect()
-}
-
-fn similarity_tokens(value: &str) -> HashSet<String> {
-    let mut tokens = HashSet::new();
-    for raw in value
-        .split(|ch: char| !ch.is_alphanumeric())
-        .map(str::trim)
-        .filter(|token| !token.is_empty())
-    {
-        let lower = raw.to_ascii_lowercase();
-        if raw.is_ascii() {
-            if lower.len() >= 3 && !is_similarity_stopword(&lower) {
-                tokens.insert(lower);
-            }
-            continue;
-        }
-        let chars = raw.chars().collect::<Vec<_>>();
-        for size in [2, 3] {
-            if chars.len() >= size {
-                for window in chars.windows(size) {
-                    tokens.insert(window.iter().collect());
-                }
-            }
-        }
-    }
-    tokens
-}
-
-fn is_similarity_stopword(token: &str) -> bool {
-    matches!(
-        token,
-        "add"
-            | "and"
-            | "body"
-            | "for"
-            | "from"
-            | "gate"
-            | "new"
-            | "old"
-            | "only"
-            | "the"
-            | "this"
-            | "update"
-            | "with"
-            | "work"
-            | "works"
-    )
 }
 
 fn is_title_sensitive_tool(event: &HookEvent) -> bool {

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -1350,6 +1350,66 @@ mod tests {
     }
 
     #[test]
+    fn workspace_create_allows_explicit_split_boundary_for_similar_workspace() {
+        let _guard = crate::env_test_lock().lock().unwrap();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let mut env = TestEnv::new(repo.clone());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(unassigned_agent("session-1"));
+        save_workspace_projection(&repo, &projection).expect("save projection");
+        let mut event = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "workspace-existing",
+            Utc::now(),
+        );
+        event.title = Some("Workspace history".to_string());
+        event.intent = Some("Implement Workspace history with affiliation state".to_string());
+        event.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(&repo, event).expect("record workspace");
+
+        let mut out = String::new();
+        let code = run(
+            &mut env,
+            WorkspaceCommand::Create {
+                agent_session: "session-1".to_string(),
+                title_summary: "Workspace history".to_string(),
+                current_focus: Some("Implement Workspace history affiliation".to_string()),
+                spec: None,
+                issue: Some(2359),
+                split_from: Some("workspace-existing".to_string()),
+                boundary: Some("new affiliation state tests only".to_string()),
+            },
+            &mut out,
+        )
+        .expect("explicit split boundary should create a new Workspace");
+
+        assert_eq!(code, 0);
+        assert!(out.contains("workspace created: workspace-"), "{out}");
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        assert_ne!(saved.id, "workspace-existing");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == "session-1")
+            .expect("agent");
+        assert_eq!(agent.workspace_id.as_deref(), Some(saved.id.as_str()));
+        let items = load_workspace_work_items(&repo)
+            .expect("load workspace history")
+            .expect("workspace history");
+        assert!(items
+            .work_items
+            .iter()
+            .any(|item| item.id == "workspace-existing"));
+        assert!(items.work_items.iter().any(|item| item.id == saved.id));
+    }
+
+    #[test]
     fn workspace_ensure_joins_similar_incomplete_workspace() {
         let _guard = crate::env_test_lock().lock().unwrap();
         let gwt_home = tempfile::tempdir().expect("gwt home");

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -595,7 +595,7 @@ fn evaluate_falls_back_to_issue_linkage_store_for_plain_issue_owner() {
 }
 
 #[test]
-fn blocks_mutation_when_another_active_workspace_matches_current_title() {
+fn similar_active_workspace_does_not_hard_block_mutation() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/current", None);
@@ -624,13 +624,10 @@ fn blocks_mutation_when_another_active_workspace_matches_current_title() {
         )
         .expect("workflow evaluation succeeds");
 
-        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
-            panic!("expected active Workspace conflict to block mutation");
-        };
-        assert!(detail.contains("similar active Workspace"), "{detail}");
-        assert!(detail.contains("session-other"), "{detail}");
-        assert!(detail.contains("gwtd board post"), "{detail}");
-        assert!(detail.contains("Boundary:"), "{detail}");
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "active Workspace similarity is coordination context; duplicate prevention belongs to explicit workspace affiliation"
+        );
     });
 }
 
@@ -689,7 +686,7 @@ fn allows_mutation_after_split_claim_targets_matching_workspace_agent() {
 }
 
 #[test]
-fn blocks_mutation_when_active_board_claim_matches_current_title() {
+fn active_board_claim_does_not_hard_block_mutation() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/current", None);
@@ -727,11 +724,57 @@ fn blocks_mutation_when_active_board_claim_matches_current_title() {
         )
         .expect("workflow evaluation succeeds");
 
-        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
-            panic!("expected active Board claim conflict to block mutation");
-        };
-        assert!(detail.contains("active Board claim"), "{detail}");
-        assert!(detail.contains("session-other"), "{detail}");
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "active Board claims should coordinate duplicate risk without blocking unrelated tool execution"
+        );
+    });
+}
+
+#[test]
+fn unassigned_agent_does_not_inherit_projection_title_for_duplicate_gate() {
+    with_temp_home(|home| {
+        let repo_path = init_repo(home);
+        let session_id = save_session(&repo_path, "work/unassigned", None);
+        std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
+        projection.title = "Workspace affiliation fix".to_string();
+        projection.summary = Some("Stale project-level workspace title".to_string());
+        projection.status_category = WorkspaceStatusCategory::Active;
+        projection
+            .agents
+            .push(unassigned_workspace_agent(&session_id));
+        save_workspace_projection(&repo_path, &projection).expect("save workspace projection");
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Other Codex",
+            BoardEntryKind::Claim,
+            "Workspace affiliation fix is in progress on another branch.",
+            None,
+            None,
+            vec!["workspace-materialization".to_string()],
+            vec!["2359".to_string()],
+        )
+        .with_origin_session_id("session-other");
+        post_entry(&repo_path, entry).expect("post stale active claim");
+
+        let event = event(
+            "Write",
+            json!({ "file_path": "crates/gwt/src/cli/hook/workflow_policy.rs", "content": "x" }),
+        );
+
+        let decision = workflow_policy::evaluate_with_context(
+            &event,
+            &repo_path,
+            &workflow_policy::WorkflowContext::unknown(),
+        )
+        .expect("workflow evaluation succeeds");
+
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Unassigned Agents must not inherit stale projection-level title as duplicate-gate intent"
+        );
     });
 }
 
@@ -825,7 +868,7 @@ fn unassigned_agent_without_title_summary_is_not_title_blocked() {
 }
 
 #[test]
-fn actionable_unassigned_agent_is_blocked_from_mutation_until_workspace_ensure() {
+fn actionable_unassigned_agent_can_mutate_without_forced_workspace_affiliation() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/unassigned", None);
@@ -849,11 +892,10 @@ fn actionable_unassigned_agent_is_blocked_from_mutation_until_workspace_ensure()
         let decision =
             workflow_policy::evaluate(&event, &repo_path).expect("workflow evaluation succeeds");
 
-        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
-            panic!("expected actionable Unassigned mutation to be blocked");
-        };
-        assert!(detail.contains("Unassigned"), "{detail}");
-        assert!(detail.contains("gwtd workspace ensure"), "{detail}");
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "Unassigned is a valid coordination state; affiliation is explicit and optional"
+        );
     });
 }
 
@@ -919,7 +961,7 @@ fn assigned_agent_without_title_summary_remains_title_blocked() {
 }
 
 #[test]
-fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
+fn incomplete_work_item_history_does_not_hard_block_mutation() {
     with_temp_home(|home| {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/current", None);
@@ -954,12 +996,10 @@ fn blocks_mutation_when_incomplete_work_item_matches_current_title() {
         )
         .expect("workflow evaluation succeeds");
 
-        let HookOutput::PreToolUsePermission { detail, .. } = decision else {
-            panic!("expected incomplete WorkItem conflict to block mutation");
-        };
-        assert!(detail.contains("incomplete Workspace"), "{detail}");
-        assert!(detail.contains("session-other"), "{detail}");
-        assert!(detail.contains("gwtd board post"), "{detail}");
+        assert!(
+            matches!(decision, HookOutput::Silent),
+            "incomplete Workspace history is context; explicit workspace join/create owns duplicate prevention"
+        );
     });
 }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,33 @@
 # Lessons Learned
 
+## 2026-05-12 — Workspace coordination must not become a global tool lock
+
+### 事象
+
+`Similar active Workspace already exists` が Claude Code hooks で発生し、複数の
+gwt-* skill / agent が unrelated work でも実装・編集を継続できなくなった。
+特に stale な project-level Workspace title や active Board claim が、現在の
+Agent の実作業 intent として扱われ、広範囲の PreToolUse denial に波及した。
+
+### 原因
+
+Workspace / Board は duplicate work を避けるための coordination surface だが、
+workflow-policy が active Workspace / Board claim / incomplete work item の
+semantic similarity を tool 実行前の hard block として扱っていた。さらに
+Unassigned Agent の actionable title/focus を mutation 前に強制 materialize
+する設計により、Workspace 所属が任意状態ではなく実行前提になっていた。
+
+### 再発防止策
+
+1. duplicate prevention は `gwtd workspace candidates` / `join` / `create` /
+   `ensure` の explicit affiliation boundary で扱い、PreToolUse hook では
+   Board/Workspace similarity を理由に mutation を hard block しない。
+2. Unassigned は正常な affiliation state として扱う。Board post や通常 mutation
+   から暗黙に Workspace を create/join しない。
+3. coordination policy を変更する場合は、stale projection title、active Board
+   claim、incomplete work item、Unassigned actionable intent の各ケースを
+   hook tests で固定してから実装する。
+
 ## 2026-05-11 — Actionable Unassigned Agents must materialize before mutation
 
 ### 事象


### PR DESCRIPTION
## Summary

- Removes the Workspace similarity PreToolUse hard block so Board and Workspace remain coordination context instead of a global implementation lock.
- Keeps Unassigned as a valid Agent state by removing implicit Workspace materialization from Board posts.
- Preserves duplicate prevention on explicit Workspace affiliation commands such as candidates, join, create, and ensure.

## Changes

- `crates/gwt/src/cli/hook/workflow_policy.rs`: removes the `Similar active Workspace already exists` duplicate gate and the forced Unassigned materialization gate while preserving Bash safety checks and assigned-agent title-summary checks.
- `crates/gwt/src/cli/board.rs`: stops `gwtd board post` from auto-creating or joining a Workspace for Unassigned Agents; Assigned Agents still attach their current Workspace audience.
- `crates/gwt/src/cli/workspace.rs`: adds coverage for intentional split-boundary creation when a similar incomplete Workspace already exists.
- `crates/gwt/tests/hook_workflow_policy_test.rs`: adds regression coverage for stale projection titles, active Board claims, incomplete work history, and actionable Unassigned Agents.
- `tasks/lessons.md`: records the coordination-scope failure mode and prevention rule.

## Testing

- [x] `cargo fmt -- --check` — formatting check passed.
- [x] `cargo build -p gwt` — gwt build passed.
- [x] `cargo test -p gwt-core -p gwt` — full Rust test suite for gwt-core and gwt passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clippy passed with warnings denied.
- [x] `bunx commitlint --from HEAD~2 --to HEAD` — branch commits pass commitlint after syncing with `origin/develop`.
- [x] Hook reproduction payload through `gwtd hook workflow-policy` exits silently instead of returning `Similar active Workspace already exists`.

## Closing Issues

None

## Related Issues / Links

- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Agents reported that stale active Workspace state and Board claims were preventing unrelated gwt-* workflows from continuing. This PR narrows Workspace duplicate prevention to explicit affiliation actions and leaves normal implementation hooks fail-open for coordination similarity.

## Risk / Impact

- **Affected areas**: Claude Code workflow-policy hooks, `gwtd board post` audience/materialization behavior, Workspace affiliation tests.
- **Rollback plan**: Revert this PR to restore the previous hard-block and Board post materialization behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed auto-materialization of workspaces for unassigned agent posts, simplifying audience assignment logic.
  * Simplified workflow policy enforcement to bash safety guardrails and title-summary requirements, preventing overly restrictive workspace coordination blocking.

* **Tests**
  * Added test coverage for explicit workspace creation with split boundaries.
  * Updated policy hook tests to reflect new coordination behavior expectations.

* **Documentation**
  * Added lessons documenting workspace coordination improvements and preventing unintended tool locks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2660)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->