### PR TITLE
feat(launch-wizard): persist Host/Docker runtime per repo (SPEC-2014)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -407,8 +407,11 @@ impl LaunchWizardMemoryCache {
         )
     }
 
-    fn previous_profiles(&self) -> gwt::LaunchWizardPreviousProfiles {
-        gwt::launch_wizard::previous_launch_profiles_from_sessions(&self.sessions)
+    fn previous_profiles(&self, repo_path: &Path) -> gwt::LaunchWizardPreviousProfiles {
+        gwt::launch_wizard::previous_launch_profiles_for_repo_from_sessions(
+            repo_path,
+            &self.sessions,
+        )
     }
 
     fn record_session(&mut self, session: gwt_agent::Session) {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -166,7 +166,9 @@ impl AppRuntime {
         let quick_start_entries = self
             .launch_wizard_cache
             .quick_start_entries(&quick_start_root, &normalized_branch_name);
-        let previous_profiles = self.launch_wizard_cache.previous_profiles();
+        let previous_profiles = self
+            .launch_wizard_cache
+            .previous_profiles(&quick_start_root);
         let agent_options = self.launch_wizard_cache.agent_options();
         let (docker_context, docker_service_status) =
             detect_wizard_docker_context_and_status(&quick_start_root);
@@ -376,7 +378,9 @@ impl AppRuntime {
         let quick_start_entries = self
             .launch_wizard_cache
             .quick_start_entries(&quick_start_root, &work_branch);
-        let previous_profiles = self.launch_wizard_cache.previous_profiles();
+        let previous_profiles = self
+            .launch_wizard_cache
+            .previous_profiles(&quick_start_root);
         let agent_options = self.launch_wizard_cache.agent_options();
         let (docker_context, docker_service_status) =
             detect_wizard_docker_context_and_status(&quick_start_root);

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -209,6 +209,11 @@ pub struct LaunchWizardPreviousProfile {
 pub struct LaunchWizardPreviousProfiles {
     default_agent_id: Option<String>,
     by_agent: HashMap<String, LaunchWizardPreviousProfile>,
+    /// SPEC-2014 FR-032/FR-035: repo-local 最新 successful session から得られる
+    /// runtime_target / docker_service / docker_lifecycle_intent の復元元。
+    /// agent 識別系 (by_agent) は cross-repo の global preference を表すのに対し、
+    /// repo_local は per-repo の runtime/Docker 永続化を担う。
+    repo_local: Option<LaunchWizardPreviousProfile>,
 }
 
 impl LaunchWizardPreviousProfiles {
@@ -217,11 +222,19 @@ impl LaunchWizardPreviousProfiles {
             return Self::default();
         };
         let default_agent_id = Some(profile.agent_id.clone());
-        let by_agent = HashMap::from([(profile.agent_id.clone(), profile)]);
+        let by_agent = HashMap::from([(profile.agent_id.clone(), profile.clone())]);
         Self {
             default_agent_id,
             by_agent,
+            repo_local: Some(profile),
         }
+    }
+
+    /// SPEC-2014 FR-032: repo-local previous profile を別途差し込む。
+    /// テスト・production 双方で agent map とは独立に runtime 復元元を構成できる。
+    pub fn with_repo_local(mut self, profile: Option<LaunchWizardPreviousProfile>) -> Self {
+        self.repo_local = profile;
+        self
     }
 
     fn preferred_agent_id(&self) -> Option<&str> {
@@ -230,6 +243,11 @@ impl LaunchWizardPreviousProfiles {
 
     fn profile_for(&self, agent_id: &str) -> Option<&LaunchWizardPreviousProfile> {
         self.by_agent.get(agent_id)
+    }
+
+    /// SPEC-2014 FR-032/FR-035: repo-local previous profile を返す。
+    fn repo_local(&self) -> Option<&LaunchWizardPreviousProfile> {
+        self.repo_local.as_ref()
     }
 }
 
@@ -343,7 +361,20 @@ pub fn previous_launch_profiles_from_sessions(
     LaunchWizardPreviousProfiles {
         default_agent_id,
         by_agent,
+        repo_local: None,
     }
+}
+
+/// SPEC-2014 FR-032/FR-035: per-agent global preference に加え、repo-local
+/// 最新 successful session profile を `repo_local` 経路として併せ持つ
+/// `LaunchWizardPreviousProfiles` を構築する。
+pub fn previous_launch_profiles_for_repo_from_sessions(
+    repo_path: &Path,
+    sessions: &[gwt_agent::Session],
+) -> LaunchWizardPreviousProfiles {
+    let mut profiles = previous_launch_profiles_from_sessions(sessions);
+    profiles.repo_local = previous_launch_profile_from_sessions(repo_path, sessions);
+    profiles
 }
 
 fn load_launch_sessions(sessions_dir: &Path) -> Vec<gwt_agent::Session> {
@@ -641,17 +672,12 @@ impl LaunchWizardState {
         is_hydrating: bool,
     ) -> Self {
         Self::hydrate_live_window_ids(&context, &mut quick_start_entries);
-        let runtime_target = if context.docker_context.is_some() {
-            gwt_agent::LaunchRuntimeTarget::Docker
-        } else {
-            gwt_agent::LaunchRuntimeTarget::Host
-        };
-        let docker_service = context
-            .docker_context
-            .as_ref()
-            .and_then(|ctx| ctx.suggested_service.clone());
-        let docker_lifecycle_intent =
-            default_docker_lifecycle_intent(context.docker_service_status);
+        // SPEC-2014 FR-032..FR-035: 初期 runtime_target / docker_service / docker_lifecycle_intent は
+        // open Wizard draft (= 開いた直後はまだ無い) → repo-local previous session → context default
+        // の順で決定する。runtime/Docker の復元は agent map ではなく `repo_local` 経路に閉じ込め、
+        // global agent preference path (apply_previous_agent_preferences) は触れない。
+        let (runtime_target, docker_service, docker_lifecycle_intent) =
+            resolve_initial_runtime_selection(&context, previous_profiles.repo_local());
         let has_quick_start = !quick_start_entries.is_empty() || !context.live_sessions.is_empty();
         let step = if has_quick_start {
             LaunchWizardStep::QuickStart
@@ -2682,6 +2708,82 @@ fn default_docker_lifecycle_intent(
     }
 }
 
+/// SPEC-2014 FR-032..FR-035:
+/// Launch Wizard 初期 `runtime_target` / `docker_service` /
+/// `docker_lifecycle_intent` を、現在の Docker context と repo-local previous
+/// profile から決定する。優先順は
+/// `repo-local previous session` → `docker context default` で、open Wizard
+/// draft は wizard 起動直後には存在しないので呼び出し側で考慮する必要は無い。
+fn resolve_initial_runtime_selection(
+    context: &LaunchWizardContext,
+    repo_local_previous: Option<&LaunchWizardPreviousProfile>,
+) -> (
+    gwt_agent::LaunchRuntimeTarget,
+    Option<String>,
+    gwt_agent::DockerLifecycleIntent,
+) {
+    let context_default_target = if context.docker_context.is_some() {
+        gwt_agent::LaunchRuntimeTarget::Docker
+    } else {
+        gwt_agent::LaunchRuntimeTarget::Host
+    };
+    let context_default_service = context
+        .docker_context
+        .as_ref()
+        .and_then(|ctx| ctx.suggested_service.clone());
+    let context_default_lifecycle = default_docker_lifecycle_intent(context.docker_service_status);
+
+    let Some(saved) = repo_local_previous else {
+        return (
+            context_default_target,
+            context_default_service,
+            context_default_lifecycle,
+        );
+    };
+
+    match saved.runtime_target {
+        gwt_agent::LaunchRuntimeTarget::Host => {
+            // FR-033: saved=Host は Docker context の有無に関わらず Host を維持し、
+            // service/lifecycle UI も表示しない。
+            (
+                gwt_agent::LaunchRuntimeTarget::Host,
+                None,
+                default_docker_lifecycle_intent(context.docker_service_status),
+            )
+        }
+        gwt_agent::LaunchRuntimeTarget::Docker => match context.docker_context.as_ref() {
+            // FR-034: saved=Docker かつ context 無し → Host に fallback。
+            None => (
+                gwt_agent::LaunchRuntimeTarget::Host,
+                None,
+                default_docker_lifecycle_intent(context.docker_service_status),
+            ),
+            // FR-034: saved service が現在の services にあれば session の値を採用。
+            // 無ければ既存 FR-013 の正規化 (suggested → first → 既定) を経由する。
+            Some(docker_context) => {
+                let saved_service_in_context = saved
+                    .docker_service
+                    .as_ref()
+                    .filter(|name| docker_context.services.iter().any(|svc| svc == *name))
+                    .cloned();
+                if let Some(service) = saved_service_in_context {
+                    (
+                        gwt_agent::LaunchRuntimeTarget::Docker,
+                        Some(service),
+                        saved.docker_lifecycle_intent,
+                    )
+                } else {
+                    (
+                        gwt_agent::LaunchRuntimeTarget::Docker,
+                        context_default_service,
+                        context_default_lifecycle,
+                    )
+                }
+            }
+        },
+    }
+}
+
 struct LaunchWizardFlow<'a> {
     state: &'a LaunchWizardState,
 }
@@ -4251,10 +4353,9 @@ mod tests {
         assert_eq!(view.selected_version, "0.110.0");
         assert_eq!(view.selected_execution_mode, "continue");
         assert_eq!(view.selected_runtime_target, "docker");
-        assert_eq!(view.selected_docker_service.as_deref(), Some("api"));
-        assert_eq!(view.selected_docker_lifecycle, "connect");
-        assert_ne!(view.selected_docker_service.as_deref(), Some("gwt"));
-        assert_ne!(view.selected_docker_lifecycle, "restart");
+        // SPEC-2014 FR-034: saved docker_service が現 context にあれば saved を採用する。
+        assert_eq!(view.selected_docker_service.as_deref(), Some("gwt"));
+        assert_eq!(view.selected_docker_lifecycle, "restart");
         assert!(view.skip_permissions);
         assert!(view.codex_fast_mode);
 
@@ -4263,6 +4364,76 @@ mod tests {
         assert_eq!(config.session_mode, gwt_agent::SessionMode::Continue);
         assert!(config.resume_session_id.is_none());
         assert_eq!(config.linked_issue_number, None);
+    }
+
+    #[test]
+    fn previous_profile_runtime_target_restores_host_with_docker_context_available() {
+        // SPEC-2014 SC-018: saved=Host のとき、Docker context が検出されていても Host を初期値にする。
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string(), "gwt".to_string()],
+            suggested_service: Some("api".to_string()),
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Running;
+        let state = LaunchWizardState::open_with_previous_profile(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                session_mode: gwt_agent::SessionMode::Normal,
+                skip_permissions: false,
+                codex_fast_mode: false,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+                windows_shell: None,
+            }),
+        );
+
+        let view = state.view();
+        assert_eq!(view.selected_runtime_target, "host");
+        assert!(!view.show_docker_service);
+        assert!(!view.show_docker_lifecycle);
+    }
+
+    #[test]
+    fn previous_profile_docker_service_and_lifecycle_restore_when_service_present_in_current_context(
+    ) {
+        // SPEC-2014 SC-019: saved=Docker + saved docker_service が現在 context にあれば、
+        // runtime_target / docker_service / docker_lifecycle_intent を session の値で復元する。
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["api".to_string(), "worker".to_string()],
+            suggested_service: Some("api".to_string()),
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Running;
+        let state = LaunchWizardState::open_with_previous_profile(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                reasoning: Some("high".to_string()),
+                version: Some("0.110.0".to_string()),
+                session_mode: gwt_agent::SessionMode::Normal,
+                skip_permissions: false,
+                codex_fast_mode: false,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Docker,
+                docker_service: Some("worker".to_string()),
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Restart,
+                windows_shell: None,
+            }),
+        );
+
+        let view = state.view();
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("worker"));
+        assert_eq!(view.selected_docker_lifecycle, "restart");
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -927,18 +927,21 @@ impl LaunchWizardState {
         } else {
             self.context.normalized_branch_name.clone()
         };
-        if self.has_docker_workflow() {
-            self.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
-            if self.docker_service.is_none() {
-                self.docker_service = self.preferred_docker_service().map(str::to_string);
-            }
-        } else {
-            self.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
-            self.docker_service = None;
-        }
-        self.sync_selected_agent_options();
+        // SPEC-2014 FR-032..FR-035: hydration 経路でも初期化と同じ runtime resolver を使い、
+        // open_loading -> hydration の間に repo-local Host/Docker 選好が失われないようにする。
+        let refreshed_previous_profiles = previous_profiles.is_some();
         if let Some(previous_profiles) = previous_profiles {
             self.previous_profiles = previous_profiles;
+        }
+        let (resolved_target, resolved_service, resolved_lifecycle) =
+            resolve_initial_runtime_selection(&self.context, self.previous_profiles.repo_local());
+        self.runtime_target = resolved_target;
+        self.docker_service = resolved_service;
+        self.docker_lifecycle_intent = resolved_lifecycle;
+        self.sync_selected_agent_options();
+        // Agent preference の再適用は previous_profiles が refresh されたときのみ。
+        // 現 wizard 内で user が編集した draft (model / reasoning など) を上書きしない。
+        if refreshed_previous_profiles {
             self.apply_preferred_agent_profile();
         }
         self.sync_docker_lifecycle_default();
@@ -2722,15 +2725,19 @@ fn resolve_initial_runtime_selection(
     Option<String>,
     gwt_agent::DockerLifecycleIntent,
 ) {
-    let context_default_target = if context.docker_context.is_some() {
+    // SPEC-2014 FR-013: 既存正規化チェーン (suggested -> first -> Host fallback)。
+    // docker_context があっても services が空、または stale saved service で
+    // 全ての候補が消えた場合は Host に落とす。
+    let context_default_service = context.docker_context.as_ref().and_then(|ctx| {
+        ctx.suggested_service
+            .clone()
+            .or_else(|| ctx.services.first().cloned())
+    });
+    let context_default_target = if context_default_service.is_some() {
         gwt_agent::LaunchRuntimeTarget::Docker
     } else {
         gwt_agent::LaunchRuntimeTarget::Host
     };
-    let context_default_service = context
-        .docker_context
-        .as_ref()
-        .and_then(|ctx| ctx.suggested_service.clone());
     let context_default_lifecycle = default_docker_lifecycle_intent(context.docker_service_status);
 
     let Some(saved) = repo_local_previous else {
@@ -4364,6 +4371,83 @@ mod tests {
         assert_eq!(config.session_mode, gwt_agent::SessionMode::Continue);
         assert!(config.resume_session_id.is_none());
         assert_eq!(config.linked_issue_number, None);
+    }
+
+    #[test]
+    fn apply_hydration_preserves_repo_local_host_preference_when_docker_context_appears() {
+        // CodeRabbit PR #2661 B2: open_loading -> hydration の途中で apply_hydration が
+        // raw Docker context のみで runtime_target を上書きしないこと。
+        let initial_ctx = context(branch("feature/current"), "feature/current");
+        let mut state = LaunchWizardState::open_with_previous_profile(
+            initial_ctx,
+            sample_agent_options(),
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: None,
+                reasoning: None,
+                version: None,
+                session_mode: gwt_agent::SessionMode::Normal,
+                skip_permissions: false,
+                codex_fast_mode: false,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                docker_service: None,
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+                windows_shell: None,
+            }),
+        );
+        assert_eq!(state.view().selected_runtime_target, "host");
+        state.apply_hydration(LaunchWizardHydration {
+            selected_branch: None,
+            normalized_branch_name: "feature/current".to_string(),
+            worktree_path: None,
+            quick_start_root: PathBuf::from("/tmp/quick_start_root"),
+            docker_context: Some(DockerWizardContext {
+                services: vec!["api".to_string()],
+                suggested_service: Some("api".to_string()),
+            }),
+            docker_service_status: gwt_docker::ComposeServiceStatus::Running,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: None,
+        });
+        let view = state.view();
+        assert_eq!(view.selected_runtime_target, "host");
+        assert!(view.selected_docker_service.is_none());
+    }
+
+    #[test]
+    fn previous_profile_docker_service_falls_back_to_first_service_when_no_suggestion() {
+        // CodeRabbit PR #2661 B3: saved docker_service が stale で context に
+        // suggested_service が無い場合、services の最初の要素を採用する。
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["only".to_string()],
+            suggested_service: None,
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Running;
+        let state = LaunchWizardState::open_with_previous_profile(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            Some(LaunchWizardPreviousProfile {
+                agent_id: "codex".to_string(),
+                model: None,
+                reasoning: None,
+                version: None,
+                session_mode: gwt_agent::SessionMode::Normal,
+                skip_permissions: false,
+                codex_fast_mode: false,
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Docker,
+                docker_service: Some("missing".to_string()),
+                docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Restart,
+                windows_shell: None,
+            }),
+        );
+
+        let view = state.view();
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("only"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Launch Agent の Host/Docker / Docker service / Docker lifecycle を repo-local 最新 successful session から復元するようにし、Docker compose が存在する repo でも明示的に `Host` を選んでいれば次回 open でも `Host` が初期値になるようにした。
- `LaunchWizardPreviousProfiles` に `repo_local` 経路を追加し、global agent preference (FR-024) と切り離して `runtime_target` / `docker_service` / `docker_lifecycle_intent` を担当する。
- SPEC-2014 に US-18 / FR-032..FR-035 / SC-018..SC-019 / 2026-05-11 FR-026 の修正を追記し、plan.md / tasks.md にも 2026-05-12 セクションを追加した。

## Behavior

- Saved=`Host` の場合、Docker context があっても `Host` を維持する (FR-033)。
- Saved=`Docker` で context 無し → `Host` に fallback (FR-034)。
- Saved=`Docker` + saved `docker_service` が現 context にあれば session の service と lifecycle を採用、無ければ既存 FR-013 の正規化 (suggested → first → Host) に従う。
- Cross-repo / global agent preference path は agent 識別系 (model / reasoning / version / fast mode) のみを扱い、runtime / Docker 系には作用しない。

## Owner

- SPEC: #2014 (SPEC-2014 Launch Wizard)

## Test plan

- [x] `cargo test -p gwt --lib launch_wizard::tests::previous_profile_runtime_target_restores_host_with_docker_context_available -- --nocapture`
- [x] `cargo test -p gwt --lib launch_wizard::tests::previous_profile_docker_service_and_lifecycle_restore_when_service_present_in_current_context -- --nocapture`
- [x] `cargo test -p gwt --lib launch_wizard::tests::previous_profile_docker_runtime_falls_back_to_host_without_context -- --nocapture`
- [x] `cargo test -p gwt --lib launch_wizard::tests::previous_profile_docker_service_falls_back_to_current_suggestion -- --nocapture`
- [x] `cargo test -p gwt --lib launch_wizard::tests::open_with_previous_profile_restores_agent_preferences_without_reusing_branch -- --nocapture` (updated to assert saved service/lifecycle restoration)
- [x] `cargo test -p gwt --lib launch_wizard::tests` (67 passed)
- [x] `cargo test -p gwt-core -p gwt` (1471 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo build -p gwt`
- [x] `cargo llvm-cov ...` + `node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90` (90.81%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wizard now restores previous settings scoped to the repository, preserving repo-local host and Docker choices when switching projects.
  * Hydration reliably retains saved runtime selection and avoids overwriting repo-local preferences when context changes.
  * Docker service/lifecycle restoration improved with smarter fallbacks when prior suggestions are absent.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2661)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->