### PR TITLE
feat(migration): SPEC-1934 US-7 で fetch refspec 正規化と Start Work ガードを追加

### DIFF
--- a/crates/gwt-git/src/migration.rs
+++ b/crates/gwt-git/src/migration.rs
@@ -356,6 +356,84 @@ pub fn init_submodules(worktree: &Path) -> Result<()> {
     }
 }
 
+/// Wildcard `fetch` refspec used as the canonical form on `origin` after
+/// migration. This matches what `git clone` (without `--single-branch`)
+/// configures by default and lets Workspace Start Work / Launch Wizard sync
+/// new `work/*` branches into `refs/remotes/origin/*` after pushing them.
+pub const ORIGIN_WILDCARD_FETCH_REFSPEC: &str = "+refs/heads/*:refs/remotes/origin/*";
+
+/// Normalize the `remote.origin.fetch` refspec to the wildcard form (SPEC-1934
+/// FR-033, US-7). GitHub-UI `--single-branch` clones leave a refspec like
+/// `+refs/heads/develop:refs/remotes/origin/develop`, which blocks subsequent
+/// `git fetch origin --prune` from materializing newly pushed `work/*`
+/// branches into `refs/remotes/origin/*`. Migration normalizes the refspec
+/// and runs a follow-up prune-fetch so the local mirror is complete.
+///
+/// Returns the previous refspec value (`Some`) when a rewrite happened so the
+/// caller can record it in the migration backup for rollback, or `None` when
+/// the repository already had the canonical wildcard form (idempotent).
+pub fn normalize_fetch_refspec(repo: &Path) -> Result<Option<String>> {
+    let read = hidden_command("git")
+        .args(["config", "--get", "remote.origin.fetch"])
+        .current_dir(repo)
+        .output()
+        .map_err(|e| {
+            GwtError::Git(format!(
+                "normalize_fetch_refspec: read remote.origin.fetch: {e}"
+            ))
+        })?;
+
+    if !read.status.success() {
+        // No `origin` remote (or no `fetch` configured for it). Migration has
+        // nothing to normalize here; the caller may proceed without rollback
+        // state for this phase.
+        return Ok(None);
+    }
+
+    let current = String::from_utf8_lossy(&read.stdout).trim().to_string();
+    if current.is_empty() || current == ORIGIN_WILDCARD_FETCH_REFSPEC {
+        return Ok(None);
+    }
+
+    let write = hidden_command("git")
+        .args([
+            "config",
+            "remote.origin.fetch",
+            ORIGIN_WILDCARD_FETCH_REFSPEC,
+        ])
+        .current_dir(repo)
+        .output()
+        .map_err(|e| {
+            GwtError::Git(format!(
+                "normalize_fetch_refspec: write remote.origin.fetch: {e}"
+            ))
+        })?;
+    if !write.status.success() {
+        let stderr = String::from_utf8_lossy(&write.stderr).to_string();
+        return Err(GwtError::Git(format!(
+            "normalize_fetch_refspec: write failed: {stderr}"
+        )));
+    }
+
+    let fetch = hidden_command("git")
+        .args(["fetch", "origin", "--prune"])
+        .current_dir(repo)
+        .output()
+        .map_err(|e| {
+            GwtError::Git(format!(
+                "normalize_fetch_refspec: fetch origin --prune: {e}"
+            ))
+        })?;
+    if !fetch.status.success() {
+        let stderr = String::from_utf8_lossy(&fetch.stderr).to_string();
+        return Err(GwtError::Git(format!(
+            "normalize_fetch_refspec: fetch failed: {stderr}"
+        )));
+    }
+
+    Ok(Some(current))
+}
+
 /// Set upstream tracking for `<branch>` to `origin/<branch>` in `worktree`.
 /// FR-026 requires this to succeed silently when `origin/<branch>` is missing
 /// (e.g. local-only branches), so we treat any non-zero git exit as a no-op.

--- a/crates/gwt-git/tests/migration_test.rs
+++ b/crates/gwt-git/tests/migration_test.rs
@@ -6,8 +6,8 @@
 
 use gwt_git::migration::{
     add_worktree_clean, add_worktree_no_checkout, bareify_local, clone_bare_from_normal,
-    copy_hooks_to_bare, evacuate_dirty_files, init_submodules, parse_worktree_list_porcelain,
-    restore_evacuated_files, set_upstream,
+    copy_hooks_to_bare, evacuate_dirty_files, init_submodules, normalize_fetch_refspec,
+    parse_worktree_list_porcelain, restore_evacuated_files, set_upstream,
 };
 use gwt_git::repository::{detect_repo_type, install_develop_protection, RepoType};
 
@@ -343,5 +343,249 @@ fn t042_bareify_local_converts_local_dot_git_when_origin_missing() {
     assert!(
         !String::from_utf8_lossy(&output.stdout).is_empty(),
         "bareified repo must list at least one branch"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SPEC-1934 US-7 / 2026-05-13 Mandatory Migration Hardening
+//
+// FR-033: Migration executor must normalize a single-branch `fetch` refspec
+// (e.g. `+refs/heads/develop:refs/remotes/origin/develop` produced by
+// GitHub-UI `--single-branch` clones) into the wildcard form
+// `+refs/heads/*:refs/remotes/origin/*` so that subsequent Workspace Start
+// Work can pull new `work/*` branches into the local remote-tracking refs.
+// ---------------------------------------------------------------------------
+
+fn read_remote_fetch_refspec(repo: &std::path::Path, remote: &str) -> Option<String> {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["config", "--get", &format!("remote.{remote}.fetch")])
+        .current_dir(repo)
+        .output()
+        .expect("git config --get remote.<remote>.fetch");
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn set_remote_fetch_refspec(repo: &std::path::Path, remote: &str, refspec: &str) {
+    let status = gwt_core::process::hidden_command("git")
+        .args(["config", &format!("remote.{remote}.fetch"), refspec])
+        .current_dir(repo)
+        .status()
+        .expect("git config remote.<remote>.fetch");
+    assert!(
+        status.success(),
+        "git config remote.{remote}.fetch must succeed"
+    );
+}
+
+fn add_remote(repo: &std::path::Path, remote: &str, url: &str) {
+    let status = gwt_core::process::hidden_command("git")
+        .args(["remote", "add", remote, url])
+        .current_dir(repo)
+        .status()
+        .expect("git remote add");
+    assert!(status.success(), "git remote add {remote} must succeed");
+}
+
+#[test]
+fn t148_normalize_fetch_refspec_replaces_single_branch_refspec() {
+    // RED: normalize_fetch_refspec must rewrite a `--single-branch` style
+    // refspec into the wildcard form and return the previous value so the
+    // migration executor can record it in the backup for rollback.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let local = tempfile::tempdir().unwrap();
+    init_normal_repo(local.path());
+    commit_initial(local.path());
+    add_remote(
+        local.path(),
+        "origin",
+        upstream.path().to_str().expect("upstream path"),
+    );
+    set_remote_fetch_refspec(
+        local.path(),
+        "origin",
+        "+refs/heads/develop:refs/remotes/origin/develop",
+    );
+
+    let previous = normalize_fetch_refspec(local.path()).expect("normalize_fetch_refspec");
+
+    assert_eq!(
+        previous.as_deref(),
+        Some("+refs/heads/develop:refs/remotes/origin/develop"),
+        "previous refspec must be returned for rollback"
+    );
+    assert_eq!(
+        read_remote_fetch_refspec(local.path(), "origin").as_deref(),
+        Some("+refs/heads/*:refs/remotes/origin/*"),
+        "origin fetch refspec must be normalized to wildcard form"
+    );
+}
+
+#[test]
+fn t149_normalize_fetch_refspec_is_idempotent_when_already_wildcard() {
+    // RED: when the refspec is already the wildcard form, normalize must be a
+    // no-op and return None so the executor records nothing to roll back.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let local = tempfile::tempdir().unwrap();
+    init_normal_repo(local.path());
+    commit_initial(local.path());
+    add_remote(
+        local.path(),
+        "origin",
+        upstream.path().to_str().expect("upstream path"),
+    );
+    set_remote_fetch_refspec(
+        local.path(),
+        "origin",
+        "+refs/heads/*:refs/remotes/origin/*",
+    );
+
+    let previous = normalize_fetch_refspec(local.path()).expect("normalize_fetch_refspec");
+
+    assert!(
+        previous.is_none(),
+        "no rewrite must report None for idempotency"
+    );
+    assert_eq!(
+        read_remote_fetch_refspec(local.path(), "origin").as_deref(),
+        Some("+refs/heads/*:refs/remotes/origin/*"),
+        "wildcard refspec must remain unchanged"
+    );
+}
+
+#[test]
+fn t150_normalize_fetch_refspec_preserves_other_remotes() {
+    // RED: only the `origin` remote should be touched; user-managed remotes
+    // such as `upstream` must keep whatever refspec the user configured.
+    let upstream_repo = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream_repo.path());
+    commit_initial(upstream_repo.path());
+
+    let other_repo = tempfile::tempdir().unwrap();
+    init_normal_repo(other_repo.path());
+    commit_initial(other_repo.path());
+
+    let local = tempfile::tempdir().unwrap();
+    init_normal_repo(local.path());
+    commit_initial(local.path());
+    add_remote(
+        local.path(),
+        "origin",
+        upstream_repo.path().to_str().expect("upstream path"),
+    );
+    set_remote_fetch_refspec(
+        local.path(),
+        "origin",
+        "+refs/heads/develop:refs/remotes/origin/develop",
+    );
+    add_remote(
+        local.path(),
+        "upstream",
+        other_repo.path().to_str().expect("other path"),
+    );
+    set_remote_fetch_refspec(
+        local.path(),
+        "upstream",
+        "+refs/heads/feature/*:refs/remotes/upstream/feature/*",
+    );
+
+    normalize_fetch_refspec(local.path()).expect("normalize_fetch_refspec");
+
+    assert_eq!(
+        read_remote_fetch_refspec(local.path(), "origin").as_deref(),
+        Some("+refs/heads/*:refs/remotes/origin/*"),
+        "origin must be normalized"
+    );
+    assert_eq!(
+        read_remote_fetch_refspec(local.path(), "upstream").as_deref(),
+        Some("+refs/heads/feature/*:refs/remotes/upstream/feature/*"),
+        "upstream refspec must be preserved verbatim"
+    );
+}
+
+#[test]
+fn t151_normalize_fetch_refspec_runs_fetch_origin_prune_after_rewrite() {
+    // RED: after rewriting the refspec, the function must run
+    // `git fetch origin --prune` so that branches outside the previous
+    // single-branch refspec become available as `refs/remotes/origin/*`.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    // Create an initial commit on `main`, then add an additional branch that
+    // the single-branch refspec would have hidden from the local mirror.
+    commit_initial(upstream.path());
+    let rename_status = gwt_core::process::hidden_command("git")
+        .args(["branch", "-M", "develop"])
+        .current_dir(upstream.path())
+        .status()
+        .expect("git branch -M develop");
+    assert!(rename_status.success(), "rename to develop must succeed");
+    let extra_branch_status = gwt_core::process::hidden_command("git")
+        .args(["branch", "work/20260513-test"])
+        .current_dir(upstream.path())
+        .status()
+        .expect("git branch work/20260513-test");
+    assert!(
+        extra_branch_status.success(),
+        "create extra branch on upstream must succeed"
+    );
+
+    let local = tempfile::tempdir().unwrap();
+    init_normal_repo(local.path());
+    commit_initial(local.path());
+    add_remote(
+        local.path(),
+        "origin",
+        upstream.path().to_str().expect("upstream path"),
+    );
+    set_remote_fetch_refspec(
+        local.path(),
+        "origin",
+        "+refs/heads/develop:refs/remotes/origin/develop",
+    );
+
+    // Sanity: before normalize, the additional branch is not visible locally.
+    let before = gwt_core::process::hidden_command("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/remotes/origin/",
+        ])
+        .current_dir(local.path())
+        .output()
+        .expect("git for-each-ref");
+    let before_refs = String::from_utf8_lossy(&before.stdout).to_string();
+    assert!(
+        !before_refs.contains("refs/remotes/origin/work/20260513-test"),
+        "extra branch must not be visible before normalize: {before_refs}"
+    );
+
+    normalize_fetch_refspec(local.path()).expect("normalize_fetch_refspec");
+
+    let after = gwt_core::process::hidden_command("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/remotes/origin/",
+        ])
+        .current_dir(local.path())
+        .output()
+        .expect("git for-each-ref");
+    let after_refs = String::from_utf8_lossy(&after.stdout).to_string();
+    assert!(
+        after_refs.contains("refs/remotes/origin/work/20260513-test"),
+        "extra branch must be present after normalize + fetch: {after_refs}"
     );
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -12472,6 +12472,35 @@ exit 0
     }
 
     #[test]
+    fn open_start_work_refuses_while_migration_pending() {
+        // SPEC-1934 US-7 / FR-034: Workspace Start Work must not run on a tab
+        // whose Normal → Nested Bare+Worktree migration is still pending.
+        // Without this gate, the launch path tries to fetch
+        // `origin/work/<branch>` on a single-branch refspec and dies with
+        // `fatal: invalid reference: origin/work/<branch>`.
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+
+        let tab = migration_pending_tab("tab-1", project);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events = runtime.open_start_work("client-1");
+
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                OutboundEvent {
+                    target: DispatchTarget::Client(_),
+                    event: BackendEvent::LaunchWizardOpenError { title, message },
+                } if title == "Start Work"
+                    && message == "Complete the project migration before starting work"
+            )),
+            "Start Work on a migration_pending tab must surface a clear error: {events:?}"
+        );
+    }
+
+    #[test]
     fn skip_migration_events_clears_pending_flag_without_broadcast() {
         let temp = tempdir().expect("tempdir");
         let project = temp.path().join("project");

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -115,6 +115,13 @@ impl AppRuntime {
         if window.preset != WindowPreset::Branches {
             return launch_agent_open_error(client_id, "Window is not a branches list");
         }
+        // SPEC-1934 US-7 / FR-034
+        if tab.migration_pending {
+            return launch_agent_open_error(
+                client_id,
+                "Complete the project migration before launching an agent",
+            );
+        }
 
         let project_root = tab.project_root.clone();
         let tab_id = address.tab_id.clone();
@@ -213,6 +220,13 @@ impl AppRuntime {
         if tab.kind != gwt::ProjectKind::Git {
             return launch_agent_open_error(client_id, "Add Agent requires a Git project");
         }
+        // SPEC-1934 US-7 / FR-034
+        if tab.migration_pending {
+            return launch_agent_open_error(
+                client_id,
+                "Complete the project migration before adding an agent",
+            );
+        }
 
         let project_root = tab.project_root.clone();
         match self.open_launch_wizard_for_branch(
@@ -236,6 +250,17 @@ impl AppRuntime {
         };
         if tab.kind != gwt::ProjectKind::Git {
             return start_work_open_error(client_id, "Start Work requires a Git project");
+        }
+        // SPEC-1934 US-7 / FR-034: refuse Start Work on a project whose
+        // Nested Bare+Worktree migration has not completed. Without this
+        // gate, `git fetch origin --prune` on a single-branch refspec leaves
+        // the new `work/*` branch unsynchronized and the launch path dies
+        // with `fatal: invalid reference: origin/work/<branch>`.
+        if tab.migration_pending {
+            return start_work_open_error(
+                client_id,
+                "Complete the project migration before starting work",
+            );
         }
 
         let project_root = tab.project_root.clone();
@@ -264,6 +289,10 @@ impl AppRuntime {
         };
         if tab.kind != gwt::ProjectKind::Git {
             return error_event("Resume Workspace requires a Git project");
+        }
+        // SPEC-1934 US-7 / FR-034
+        if tab.migration_pending {
+            return error_event("Complete the project migration before resuming work");
         }
         let project_root = tab.project_root.clone();
         let tab_title = tab.title.clone();
@@ -455,6 +484,19 @@ impl AppRuntime {
                 ),
             )];
         };
+        // SPEC-1934 US-7 / FR-034
+        if tab.migration_pending {
+            return vec![OutboundEvent::reply(
+                client_id,
+                knowledge_error_event(
+                    id,
+                    KnowledgeKind::Issue,
+                    "Complete the project migration before launching from an Issue",
+                    None,
+                    None,
+                ),
+            )];
+        }
 
         let project_root = tab.project_root.clone();
         let tab_id = address.tab_id.clone();

--- a/crates/gwt/src/migration/executor.rs
+++ b/crates/gwt/src/migration/executor.rs
@@ -118,6 +118,33 @@ fn run_post_backup(
         recovery: RecoveryState::Partial,
     })?;
 
+    // SPEC-1934 US-7 / FR-033: rewrite a `--single-branch` style fetch refspec
+    // on the new bare repo to the canonical `+refs/heads/*:refs/remotes/origin/*`
+    // and refresh remote-tracking refs. Config rewrite is strict (a failure
+    // means the new bare repo cannot serve later Start Work). The follow-up
+    // `git fetch origin --prune` is best-effort: a network or auth failure
+    // here still leaves a correctly-configured repo whose next manual fetch
+    // will succeed, so we swallow that specific failure to avoid forcing
+    // rollback when the bare contents are otherwise complete.
+    match git_migration::normalize_fetch_refspec(&bare_repo_path) {
+        Ok(_) => {}
+        Err(gwt_core::GwtError::Git(msg)) if msg.contains("fetch failed") => {
+            tracing::warn!(
+                bare = %bare_repo_path.display(),
+                error = %msg,
+                "normalize_fetch_refspec: post-rewrite fetch did not succeed; \
+                 continuing because refspec was already normalized",
+            );
+        }
+        Err(e) => {
+            return Err(MigrationError {
+                phase: MigrationPhase::Bareify,
+                message: format!("normalize fetch refspec: {e}"),
+                recovery: RecoveryState::Partial,
+            });
+        }
+    }
+
     progress(MigrationPhase::Worktrees, 0);
     let mut worktrees = migration_worktrees(
         project_root,


### PR DESCRIPTION
## Summary

- `--single-branch` clone (`fetch = +refs/heads/develop:refs/remotes/origin/develop`) の Normal Git layout で Workspace Start Work を実行すると、push 後の `git fetch origin --prune` が新ブランチを `refs/remotes/origin/*` に同期できず、`fatal: invalid reference: origin/work/<branch>` で死ぬ問題 (llmlb 等で再現) を SPEC-1934 US-7 として恒久対応します。
- 本 PR では Phase 1 / Phase 2 / Phase 3 partial: `normalize_fetch_refspec()` の新設、Migration executor の Bareify 直後への組み込み、Workspace Start Work / Launch / Resume / Issue Launch / Add Agent の 5 エントリポイントへの `migration_pending` pre-check を実装します。
- Modal UX 改訂 (Skip / Quit ボタン撤去、FR-032 / SC-024) は別 PR に分けます。本 PR の pre-check により、Skip 経路を残したままでも Start Work は明示エラーで止まります。

## Changes

| ファイル | 変更内容 |
|---|---|
| `crates/gwt-git/src/migration.rs` | `pub const ORIGIN_WILDCARD_FETCH_REFSPEC` / `pub fn normalize_fetch_refspec()` を追加 (FR-033)。冪等で、書き換え発生時は旧値を `Some` で返す。 |
| `crates/gwt-git/tests/migration_test.rs` | RED→GREEN テスト 4 ケース: 単一ブランチ rewrite / idempotent / 他 remote 保持 / fetch-after-rewrite (T-148〜T-151)。 |
| `crates/gwt/src/migration/executor.rs` | Bareify フェーズ直後で `normalize_fetch_refspec` を呼ぶ。config write 失敗は migration を中断、`fetch failed` のみ `tracing::warn` に降格して migration を継続させる。 |
| `crates/gwt/src/app_runtime/wizard.rs` | `open_start_work` / `open_active_work_launch_wizard` / `open_launch_wizard` / `open_issue_launch_wizard_events` / `resume_workspace_events` に `migration_pending` pre-check を追加 (FR-034)。 |
| `crates/gwt/src/app_runtime/mod.rs` | `open_start_work_refuses_while_migration_pending` テストを追加。 |

## SPEC

SPEC-1934 spec/plan/tasks セクションを 2026-05-13 Update / Phase: Mandatory Migration Hardening / T-148〜T-177 で拡張済み (`gwtd issue spec --edit` 経由)。詳細は [Issue #1934](https://github.com/akiojin/gwt/issues/1934) 参照。

## Test plan

- [x] `cargo test -p gwt-core -p gwt-git -p gwt --all-features` (1000+ ケース, 全 GREEN)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (gwt-core / gwt-git / gwt)
- [x] `cargo fmt -- --check`
- [x] `cargo build -p gwt --bin gwt --bin gwtd`
- [x] commitlint (subject 93 chars, conventional `feat(migration):`)
- [ ] Manual smoke: llmlb 同等の `--single-branch` Normal layout fixture を `gwt` GUI で開き、Open Project → Migrate → Workspace Home → Start Work が `fatal: invalid reference` 無しで通ることを確認 (follow-up セッション)

## Follow-up

- SPEC-1934 FR-032 / SC-024 — Migration modal の Skip / Quit ボタン撤去 (`crates/gwt/web/migration-modal.js`, `app.js`, operator-chrome smoke test)
- SPEC-1644 — `GwtError::Git(stderr)` raw 伝搬の総点検 (Start Work / Launch / Materialize / Agent Prepare 直下以外)
- llmlb 個別 hot-fix — GitHub origin 側の `work/20260513-0042` 孤立ブランチ削除 + 手動 config 修正手順を Issue 化 (緊急性に応じ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration safety checks that prevent launching agents, adding agents, starting work, resuming work, and launching from issues while project migration is in progress
  * Enhanced migration process to normalize fetch configuration, ensuring all branches remain visible after migration completes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2665)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->