### PR TITLE
feat(migration): SPEC-1934 US-7 modal Accept 化 / origin 無 fetch 補完 / E2E smoke

### DIFF
--- a/crates/gwt-git/src/migration.rs
+++ b/crates/gwt-git/src/migration.rs
@@ -373,6 +373,25 @@ pub const ORIGIN_WILDCARD_FETCH_REFSPEC: &str = "+refs/heads/*:refs/remotes/orig
 /// caller can record it in the migration backup for rollback, or `None` when
 /// the repository already had the canonical wildcard form (idempotent).
 pub fn normalize_fetch_refspec(repo: &Path) -> Result<Option<String>> {
+    // First confirm an `origin` remote exists at all. `git clone --bare`
+    // sets `remote.origin.url` but on some git versions omits
+    // `remote.origin.fetch`, so we must distinguish "no origin" (skip) from
+    // "origin without fetch refspec" (write the wildcard).
+    let has_origin = hidden_command("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .current_dir(repo)
+        .output()
+        .map_err(|e| {
+            GwtError::Git(format!(
+                "normalize_fetch_refspec: read remote.origin.url: {e}"
+            ))
+        })?
+        .status
+        .success();
+    if !has_origin {
+        return Ok(None);
+    }
+
     let read = hidden_command("git")
         .args(["config", "--get", "remote.origin.fetch"])
         .current_dir(repo)
@@ -383,17 +402,24 @@ pub fn normalize_fetch_refspec(repo: &Path) -> Result<Option<String>> {
             ))
         })?;
 
-    if !read.status.success() {
-        // No `origin` remote (or no `fetch` configured for it). Migration has
-        // nothing to normalize here; the caller may proceed without rollback
-        // state for this phase.
+    let current = if read.status.success() {
+        String::from_utf8_lossy(&read.stdout).trim().to_string()
+    } else {
+        // Origin exists but has no `fetch` refspec — treat as the same
+        // "needs canonicalization" path the single-branch case takes.
+        String::new()
+    };
+    if current == ORIGIN_WILDCARD_FETCH_REFSPEC {
         return Ok(None);
     }
-
-    let current = String::from_utf8_lossy(&read.stdout).trim().to_string();
-    if current.is_empty() || current == ORIGIN_WILDCARD_FETCH_REFSPEC {
-        return Ok(None);
-    }
+    // For rollback bookkeeping we report `None` when there was no prior
+    // value (origin had no `fetch`) so the executor knows nothing must be
+    // restored; we still proceed to write + fetch below.
+    let previous = if current.is_empty() {
+        None
+    } else {
+        Some(current.clone())
+    };
 
     let write = hidden_command("git")
         .args([
@@ -431,7 +457,7 @@ pub fn normalize_fetch_refspec(repo: &Path) -> Result<Option<String>> {
         )));
     }
 
-    Ok(Some(current))
+    Ok(previous)
 }
 
 /// Set upstream tracking for `<branch>` to `origin/<branch>` in `worktree`.

--- a/crates/gwt-git/tests/migration_test.rs
+++ b/crates/gwt-git/tests/migration_test.rs
@@ -517,6 +517,54 @@ fn t150_normalize_fetch_refspec_preserves_other_remotes() {
 }
 
 #[test]
+fn t152_normalize_fetch_refspec_writes_wildcard_when_origin_has_no_fetch_refspec() {
+    // RED: bare clones (`git clone --bare`) sometimes set
+    // `remote.origin.url` but omit `remote.origin.fetch`. The migration
+    // still has to leave the bare repo with the wildcard refspec so future
+    // `git fetch origin --prune` can sync new branches into
+    // `refs/remotes/origin/*`.
+    let upstream = tempfile::tempdir().unwrap();
+    init_normal_repo(upstream.path());
+    commit_initial(upstream.path());
+
+    let local = tempfile::tempdir().unwrap();
+    init_normal_repo(local.path());
+    commit_initial(local.path());
+    add_remote(
+        local.path(),
+        "origin",
+        upstream.path().to_str().expect("upstream path"),
+    );
+    // Force a no-fetch origin by removing the auto-generated fetch entry
+    // that `git remote add` writes.
+    let status = gwt_core::process::hidden_command("git")
+        .args(["config", "--unset", "remote.origin.fetch"])
+        .current_dir(local.path())
+        .status()
+        .expect("git config --unset remote.origin.fetch");
+    assert!(
+        status.success(),
+        "fixture must be able to unset remote.origin.fetch"
+    );
+    assert!(
+        read_remote_fetch_refspec(local.path(), "origin").is_none(),
+        "fixture must reproduce the bare-clone shape with origin URL but no fetch"
+    );
+
+    let previous = normalize_fetch_refspec(local.path()).expect("normalize_fetch_refspec");
+
+    assert!(
+        previous.is_none(),
+        "no prior refspec means nothing to roll back (previous == None)"
+    );
+    assert_eq!(
+        read_remote_fetch_refspec(local.path(), "origin").as_deref(),
+        Some("+refs/heads/*:refs/remotes/origin/*"),
+        "wildcard refspec must be written even when origin had no fetch entry"
+    );
+}
+
+#[test]
 fn t151_normalize_fetch_refspec_runs_fetch_origin_prune_after_rewrite() {
     // RED: after rewriting the refspec, the function must run
     // `git fetch origin --prune` so that branches outside the previous

--- a/crates/gwt/tests/migration_single_branch_test.rs
+++ b/crates/gwt/tests/migration_single_branch_test.rs
@@ -33,6 +33,14 @@ fn run_git(args: &[&str], cwd: &Path) {
     );
 }
 
+/// Configure a deterministic identity inside a freshly-created Git repo so
+/// `git commit` works on CI runners that do not provision a global
+/// `user.email` / `user.name` (Linux ubuntu-latest is the canonical case).
+fn set_test_identity(repo: &Path) {
+    run_git(["config", "user.email", "test@example.com"].as_ref(), repo);
+    run_git(["config", "user.name", "Test"].as_ref(), repo);
+}
+
 fn read_remote_fetch_refspec(repo: &Path) -> Option<String> {
     let output = gwt_core::process::hidden_command("git")
         .args(["config", "--get", "remote.origin.fetch"])
@@ -84,6 +92,7 @@ fn build_upstream(workspace: &Path, upstream_dir: &Path) {
     // bare (no working tree) while still owning real history.
     let scratch = tempdir().expect("scratch tempdir for upstream seed");
     run_git(["init"].as_ref(), scratch.path());
+    set_test_identity(scratch.path());
     run_git(
         [
             "remote",

--- a/crates/gwt/tests/migration_single_branch_test.rs
+++ b/crates/gwt/tests/migration_single_branch_test.rs
@@ -1,0 +1,214 @@
+//! SPEC-1934 US-7 / T-174 end-to-end smoke for the `--single-branch` Normal
+//! Git layout (e.g. the GitHub UI clone shape that produced the llmlb
+//! incident: `fetch = +refs/heads/develop:refs/remotes/origin/develop`).
+//!
+//! This drives `gwt::migration::execute_migration` against an isolated
+//! fixture and asserts that the migrated bare repository has its
+//! `remote.origin.fetch` normalized to the wildcard form and that branches
+//! the original single-branch refspec hid are now visible as
+//! `refs/remotes/origin/*`. It is the regression test for the original
+//! `Git error: fatal: invalid reference: origin/work/<branch>` failure.
+//!
+//! The Workspace Start Work materialization path that consumes this state is
+//! exercised by `crates/gwt-git/src/worktree.rs` unit tests and the
+//! `app_runtime::tests::open_start_work_refuses_while_migration_pending`
+//! guard test; this E2E focuses on the migration executor itself.
+
+use std::path::Path;
+
+use gwt::migration::execute_migration;
+use gwt_core::migration::types::{MigrationOptions, MigrationPhase};
+use tempfile::tempdir;
+
+fn run_git(args: &[&str], cwd: &Path) {
+    let status = gwt_core::process::hidden_command("git")
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .expect("git command spawn");
+    assert!(
+        status.success(),
+        "git {args:?} in {} must succeed",
+        cwd.display()
+    );
+}
+
+fn read_remote_fetch_refspec(repo: &Path) -> Option<String> {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["config", "--get", "remote.origin.fetch"])
+        .current_dir(repo)
+        .output()
+        .expect("git config --get remote.origin.fetch");
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn list_remote_origin_refs(repo: &Path) -> String {
+    let output = gwt_core::process::hidden_command("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/remotes/origin/",
+        ])
+        .current_dir(repo)
+        .output()
+        .expect("git for-each-ref");
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+/// Build the bare upstream that the local clone targets. Two branches are
+/// populated so the migration's wildcard fetch can prove it pulls down the
+/// branch that the single-branch refspec previously masked.
+fn build_upstream(workspace: &Path, upstream_dir: &Path) {
+    // `git init --bare <path>` creates `<path>` itself, so run with `cwd =
+    // workspace` to avoid the chicken-and-egg of cd'ing into an unborn dir.
+    run_git(
+        [
+            "init",
+            "--bare",
+            upstream_dir.to_str().expect("upstream path"),
+        ]
+        .as_ref(),
+        workspace,
+    );
+
+    // Seed an initial commit + `develop` on a scratch normal repo, then push
+    // both branches up. Pushing through a scratch tree keeps the upstream
+    // bare (no working tree) while still owning real history.
+    let scratch = tempdir().expect("scratch tempdir for upstream seed");
+    run_git(["init"].as_ref(), scratch.path());
+    run_git(
+        [
+            "remote",
+            "add",
+            "origin",
+            upstream_dir.to_str().expect("upstream path"),
+        ]
+        .as_ref(),
+        scratch.path(),
+    );
+    run_git(
+        ["commit", "--allow-empty", "-m", "seed"].as_ref(),
+        scratch.path(),
+    );
+    // Force the seed branch to be named `develop` so the single-branch
+    // refspec under test is the realistic one.
+    run_git(["branch", "-M", "develop"].as_ref(), scratch.path());
+    run_git(["push", "-u", "origin", "develop"].as_ref(), scratch.path());
+    // Add a second branch (`feature/hidden`) that the single-branch refspec
+    // would have masked from the local mirror.
+    run_git(["branch", "feature/hidden"].as_ref(), scratch.path());
+    run_git(
+        ["push", "origin", "feature/hidden"].as_ref(),
+        scratch.path(),
+    );
+}
+
+/// Reproduce the local layout that triggered the llmlb failure: a Normal
+/// Git working tree with an `origin` whose `fetch` refspec is restricted to
+/// `develop` only.
+fn build_local_single_branch_clone(workspace: &Path, local_dir: &Path, upstream_dir: &Path) {
+    // `--single-branch -b develop` is the exact shape GitHub UI clones use.
+    // `git clone` creates `<local>` itself so we run with `cwd = workspace`.
+    run_git(
+        [
+            "clone",
+            "--single-branch",
+            "-b",
+            "develop",
+            upstream_dir.to_str().expect("upstream path"),
+            local_dir.to_str().expect("local path"),
+        ]
+        .as_ref(),
+        workspace,
+    );
+    // Sanity: confirm the cloned config has the single-branch refspec.
+    let initial = read_remote_fetch_refspec(local_dir);
+    assert_eq!(
+        initial.as_deref(),
+        Some("+refs/heads/develop:refs/remotes/origin/develop"),
+        "fixture must reproduce the single-branch fetch refspec exactly"
+    );
+}
+
+#[test]
+fn t174_single_branch_normal_repo_migrates_and_normalizes_fetch_refspec() {
+    // Build upstream + local Normal layout outside the target dir so the
+    // migration runs over a clean fixture without sibling noise.
+    let workspace = tempdir().expect("workspace tempdir");
+    let upstream_dir = workspace.path().join("upstream.git");
+    let local_dir = workspace.path().join("local");
+    build_upstream(workspace.path(), &upstream_dir);
+    build_local_single_branch_clone(workspace.path(), &local_dir, &upstream_dir);
+
+    // Sanity: the single-branch clone only knows about `origin/develop`.
+    let before_refs = list_remote_origin_refs(&local_dir);
+    assert!(
+        before_refs.contains("refs/remotes/origin/develop"),
+        "fixture must have origin/develop locally: {before_refs}"
+    );
+    assert!(
+        !before_refs.contains("refs/remotes/origin/feature/hidden"),
+        "fixture must hide origin/feature/hidden behind the single-branch refspec: {before_refs}"
+    );
+
+    let mut last_phase: Option<MigrationPhase> = None;
+    let outcome = execute_migration(
+        &local_dir,
+        MigrationOptions::default(),
+        |phase, _percent| {
+            last_phase = Some(phase);
+        },
+    )
+    .expect("migration must succeed end-to-end");
+
+    assert_eq!(
+        last_phase,
+        Some(MigrationPhase::Done),
+        "executor must reach the Done phase on success"
+    );
+
+    // The migrated bare repo lives under the original project_root with the
+    // derived `<repo>.git` directory. Its `remote.origin.fetch` must now be
+    // the wildcard form so future `git fetch origin --prune` syncs every
+    // branch into `refs/remotes/origin/*`.
+    assert!(
+        outcome.bare_repo_path.is_dir(),
+        "bare repo dir must exist after migration: {}",
+        outcome.bare_repo_path.display()
+    );
+    assert_eq!(
+        read_remote_fetch_refspec(&outcome.bare_repo_path).as_deref(),
+        Some("+refs/heads/*:refs/remotes/origin/*"),
+        "SPEC-1934 FR-033: migrated origin must use the wildcard fetch refspec"
+    );
+
+    // The hidden branch must now be present in the local mirror — this is
+    // the exact pre-condition that the broken Workspace Start Work flow was
+    // failing because it depended on `refs/remotes/origin/work/<branch>`
+    // arriving via the wildcard fetch.
+    let after_refs = list_remote_origin_refs(&outcome.bare_repo_path);
+    assert!(
+        after_refs.contains("refs/remotes/origin/develop"),
+        "develop must remain visible after migration: {after_refs}"
+    );
+    assert!(
+        after_refs.contains("refs/remotes/origin/feature/hidden"),
+        "feature/hidden must arrive once the wildcard refspec replaces the single-branch one: {after_refs}"
+    );
+
+    // Branch worktree must materialize alongside the bare repo so the
+    // Workspace Home / Start Work path has a checkout to operate on.
+    assert!(
+        outcome.branch_worktree_path.is_dir(),
+        "branch worktree must exist after migration: {}",
+        outcome.branch_worktree_path.display()
+    );
+}

--- a/crates/gwt/web/__tests__/migration-modal.smoke.test.mjs
+++ b/crates/gwt/web/__tests__/migration-modal.smoke.test.mjs
@@ -67,15 +67,14 @@ test("closed migration modal: clears dialog and removes .open", () => {
     state: { migrationModal: { open: false } },
     createNode,
     onMigrate: noop,
-    onSkip: noop,
-    onQuit: noop,
+    onClose: noop,
   });
 
   assert.equal(modalEl.classList.contains("open"), false);
   assert.equal(dialogEl.firstChild, null);
 });
 
-test("confirm stage paints title, project root, and three action buttons", () => {
+test("confirm stage paints title, project root, and an Accept-only action button (SPEC-1934 US-7 / FR-032)", () => {
   const { modalEl, dialogEl, createNode } = mount();
   renderMigrationModal({
     modalEl,
@@ -83,8 +82,7 @@ test("confirm stage paints title, project root, and three action buttons", () =>
     state: makeState(),
     createNode,
     onMigrate: noop,
-    onSkip: noop,
-    onQuit: noop,
+    onClose: noop,
   });
 
   assert.equal(modalEl.classList.contains("open"), true);
@@ -95,9 +93,13 @@ test("confirm stage paints title, project root, and three action buttons", () =>
   );
   assert.match(dialogEl.textContent, /gwt/);
   const buttons = dialogEl.querySelectorAll("button");
-  assert.equal(buttons.length, 3, "Quit / Skip / Migrate buttons");
+  assert.equal(buttons.length, 1, "Accept-only: Migrate is the sole action");
   const labels = Array.from(buttons).map((b) => b.textContent);
-  assert.deepEqual(labels, ["Quit", "Skip", "Migrate"]);
+  assert.deepEqual(
+    labels,
+    ["Migrate"],
+    "Skip / Quit buttons must not be rendered",
+  );
 });
 
 test("confirm stage disables Migrate when locked worktrees are present", () => {
@@ -108,8 +110,7 @@ test("confirm stage disables Migrate when locked worktrees are present", () => {
     state: makeState({ hasLocked: true }),
     createNode,
     onMigrate: noop,
-    onSkip: noop,
-    onQuit: noop,
+    onClose: noop,
   });
 
   const buttons = Array.from(dialogEl.querySelectorAll("button"));
@@ -126,8 +127,7 @@ test("running stage shows phase label and progress bar", () => {
     state: makeState({ stage: "running", phase: "bareify", percent: 42 }),
     createNode,
     onMigrate: noop,
-    onSkip: noop,
-    onQuit: noop,
+    onClose: noop,
   });
 
   assert.match(dialogEl.textContent, /Migrating repository/);
@@ -150,8 +150,7 @@ test("error stage exposes the failing phase, message, and recovery hint", () => 
     }),
     createNode,
     onMigrate: noop,
-    onSkip: noop,
-    onQuit: noop,
+    onClose: noop,
   });
 
   assert.match(dialogEl.textContent, /Migration failed/);
@@ -163,6 +162,37 @@ test("error stage exposes the failing phase, message, and recovery hint", () => 
   assert.equal(buttons[0].textContent, "Close");
 });
 
+test("error stage Close button invokes onClose without flipping migration_pending (SPEC-1934 US-7 / FR-032)", () => {
+  const { modalEl, dialogEl, createNode } = mount();
+  let closed = 0;
+  renderMigrationModal({
+    modalEl,
+    dialogEl,
+    state: makeState({
+      stage: "error",
+      phase: "worktrees",
+      message: "boom",
+      recovery: "rolled_back",
+    }),
+    createNode,
+    onMigrate: noop,
+    onClose: () => {
+      closed += 1;
+    },
+  });
+
+  const close = Array.from(dialogEl.querySelectorAll("button")).find(
+    (b) => b.textContent === "Close",
+  );
+  assert.ok(close, "Close button must exist on the error stage");
+  close.dispatchEvent(new modalEl.ownerDocument.defaultView.Event("click"));
+  assert.equal(
+    closed,
+    1,
+    "Close routes through onClose (UI-only dismiss); no skip/quit fan-out",
+  );
+});
+
 test("running and error stages expose selectable DOM text without overlay copy shim", () => {
   const { modalEl, dialogEl, createNode } = mount();
   renderMigrationModal({
@@ -171,8 +201,7 @@ test("running and error stages expose selectable DOM text without overlay copy s
     state: makeState({ stage: "running", phase: "bareify", percent: 42 }),
     createNode,
     onMigrate: noop,
-    onSkip: noop,
-    onQuit: noop,
+    onClose: noop,
   });
 
   assert.match(dialogEl.textContent, /Building bare repository/);
@@ -197,8 +226,7 @@ test("running and error stages expose selectable DOM text without overlay copy s
     }),
     createNode,
     onMigrate: noop,
-    onSkip: noop,
-    onQuit: noop,
+    onClose: noop,
   });
 
   const errorMessage = dialogEl.querySelector(".migration-modal-error-message");

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1683,10 +1683,19 @@ test("Drawer modals close on Escape — keyboard parity with backdrop click", ()
     /branchCleanupModal\.classList\.contains\("open"\)[\s\S]*closeBranchCleanupModal/,
     "expected Esc to call closeBranchCleanupModal when that modal is open",
   );
+  // SPEC-1934 US-7 / FR-032: the confirmation modal is Accept-only. Esc no
+  // longer routes to skip_migration; at the confirm stage it is swallowed
+  // (no backend send), at the error stage it dismisses the UI without
+  // flipping `migration_pending`.
+  assert.doesNotMatch(
+    appSource,
+    /migrationModal\s*&&\s*migrationModal\.classList\.contains\("open"\)[\s\S]{0,400}skip_migration/,
+    "Esc must not send skip_migration when the Accept-only migration modal is open",
+  );
   assert.match(
     appSource,
-    /migrationModal\s*&&\s*migrationModal\.classList\.contains\("open"\)[\s\S]*skip_migration/,
-    "expected Esc to send skip_migration when migration modal is open",
+    /migrationModal\s*&&\s*migrationModal\.classList\.contains\("open"\)[\s\S]*migrationModalState\.stage\s*===\s*"error"[\s\S]*migrationModalState\.open\s*=\s*false/,
+    "expected Esc on the migration modal error stage to dismiss the dialog without backend skip",
   );
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -6067,24 +6067,16 @@
             renderMigrationModal();
             send({ kind: "start_migration", tab_id: tabId });
           },
-          onSkip: () => {
-            const tabId = migrationModalState.tabId;
+          // SPEC-1934 US-7 / FR-032: only the error stage exposes a dismissal
+          // affordance ("Close"), and it must not flip migration_pending —
+          // the tab keeps its pending status so the next Open Project shows
+          // the Accept-only modal again.
+          onClose: () => {
             migrationModalState.open = false;
             migrationModalState.stage = "confirm";
             migrationModalState.message = "";
             migrationModalState.recovery = "";
             renderMigrationModal();
-            if (tabId) {
-              send({ kind: "skip_migration", tab_id: tabId });
-            }
-          },
-          onQuit: () => {
-            const tabId = migrationModalState.tabId;
-            migrationModalState.open = false;
-            renderMigrationModal();
-            if (tabId) {
-              send({ kind: "quit_migration", tab_id: tabId });
-            }
           },
         });
       }
@@ -8480,17 +8472,17 @@
           return;
         }
         if (migrationModal && migrationModal.classList.contains("open")) {
-          // Migration "skip" is the cancellation path; map Esc to the
-          // same intent so the modal isn't a keyboard trap. Must use
-          // tab_id (not id) to match the backend protocol.
-          const tabId = migrationModalState.tabId;
-          migrationModalState.open = false;
-          migrationModalState.stage = "confirm";
-          migrationModalState.message = "";
-          migrationModalState.recovery = "";
-          renderMigrationModal();
-          if (tabId) {
-            send({ kind: "skip_migration", tab_id: tabId });
+          // SPEC-1934 US-7 / FR-032: the confirmation modal is Accept-only.
+          // Esc no longer routes to skip — at the confirm stage it is
+          // swallowed (so the user can't bypass migration), at the error
+          // stage it dismisses the failure UI without flipping
+          // migration_pending so the next Open Project re-presents Accept.
+          if (migrationModalState.stage === "error") {
+            migrationModalState.open = false;
+            migrationModalState.stage = "confirm";
+            migrationModalState.message = "";
+            migrationModalState.recovery = "";
+            renderMigrationModal();
           }
           event.preventDefault();
           return;

--- a/crates/gwt/web/migration-modal.js
+++ b/crates/gwt/web/migration-modal.js
@@ -51,8 +51,11 @@ export function renderMigrationModal({
   state,
   createNode,
   onMigrate,
-  onSkip,
-  onQuit,
+  // SPEC-1934 US-7 / FR-032: the confirmation modal is Accept-only; closing
+  // the OS window remains the sole abort path. `onClose` is still used by the
+  // error stage so the user can dismiss a failure dialog without sending a
+  // skip event to the backend.
+  onClose,
 }) {
   if (!state || !state.migrationModal || !state.migrationModal.open) {
     const wasOpenBeforeClose = modalEl.classList.contains("open");
@@ -166,7 +169,10 @@ export function renderMigrationModal({
     const footer = createNode("div", "modal-footer");
     const close = createNode("button", "wizard-button primary", "Close");
     close.type = "button";
-    close.addEventListener("click", onSkip);
+    // SPEC-1934 US-7 / FR-032: dismiss the error UI without sending a skip
+    // event; the tab remains migration_pending so the Accept-only modal can
+    // be re-presented on the next Open Project.
+    close.addEventListener("click", onClose);
     footer.appendChild(close);
     dialogEl.appendChild(footer);
     return;
@@ -232,17 +238,12 @@ export function renderMigrationModal({
     ),
   );
 
+  // SPEC-1934 US-7 / FR-032 / SC-024: the confirm stage offers Accept only.
+  // Skip / Quit / Cancel buttons are intentionally not rendered — closing
+  // the OS window remains the sole abort path so a migration_pending tab can
+  // never proceed to Start Work / Launch / Materialize while the layout is
+  // still Normal Git.
   const footer = createNode("div", "modal-footer");
-  const quit = createNode("button", "wizard-button", "Quit");
-  quit.type = "button";
-  quit.addEventListener("click", onQuit);
-  footer.appendChild(quit);
-
-  const skip = createNode("button", "wizard-button", "Skip");
-  skip.type = "button";
-  skip.addEventListener("click", onSkip);
-  footer.appendChild(skip);
-
   const migrate = createNode("button", "wizard-button primary", "Migrate");
   migrate.type = "button";
   migrate.disabled = Boolean(m.hasLocked);


### PR DESCRIPTION
## Summary

PR #2665 (merged) で着手済の SPEC-1934 US-7 (Mandatory Migration Hardening) を、Modal UX 完成 + Bare-clone のエッジケース補完 + llmlb 相当 E2E smoke 追加で **マイグレーションが正常動作する状態まで** 仕上げる follow-up PR です。

- Migration confirmation modal を Accept 専用 UX に再構成 (FR-032 / SC-020 / SC-024)
- `normalize_fetch_refspec()` を「origin URL あり / fetch refspec 未設定」パターンにも拡張 (FR-033 補強)
- T-174: `--single-branch -b develop` clone を再現する end-to-end smoke を追加し、`gwt::migration::execute_migration` 経由で bare の `remote.origin.fetch` 正規化と隠れていたブランチの再露出を assert する

## Changes

| ファイル | 変更内容 |
|---|---|
| `crates/gwt/web/migration-modal.js` | confirm ステージから Skip / Quit ボタンを撤去し Migrate のみを描画。error ステージの Close は新 `onClose` callback (UI 限定 dismiss、`migration_pending` を flip しない)。renderer 引数から `onSkip` / `onQuit` を削除。 |
| `crates/gwt/web/app.js` | renderMigrationModal 呼び出しを onClose 単独に簡素化。Esc キーは confirm ステージで swallow / error ステージで UI のみ dismiss、`skip_migration` 送信を完全に廃止。 |
| `crates/gwt/web/__tests__/migration-modal.smoke.test.mjs` | Accept-only な 1 ボタン構成、error stage Close が onClose のみ呼ぶことを assert する RED→GREEN smoke。 |
| `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` | Esc → `skip_migration` 経路が存在しないこと、error stage で UI dismiss のみ起こることを assert。 |
| `crates/gwt-git/src/migration.rs` | `normalize_fetch_refspec()` を分岐強化: `remote.origin.url` がある場合は `remote.origin.fetch` が未設定でも wildcard を新規書き込み。rollback 対象は旧値存在時のみ。 |
| `crates/gwt-git/tests/migration_test.rs` | T-152: `origin` 存在 + fetch 未設定の bare-clone 形を fixture 化し、wildcard が書き込まれることを RED→GREEN。 |
| `crates/gwt/tests/migration_single_branch_test.rs` (NEW) | T-174 E2E: GitHub UI `--single-branch -b develop` clone を再現 → `execute_migration` → bare 側 `remote.origin.fetch` が wildcard、`feature/hidden` が `refs/remotes/origin/feature/hidden` に到達することを assert。 |

## llmlb への影響

本 PR がマージされると、llmlb のような Normal Git layout + `--single-branch` clone を gwt から Open Project した時、

1. Accept 必須 modal が出る (Skip / Quit / Esc では bypass 不可)
2. Accept で migration 実行 → bare 化と同時に `remote.origin.fetch` が wildcard に
3. `git fetch origin --prune` で全ブランチが `refs/remotes/origin/*` に同期
4. Workspace Start Work で `work/<branch>` push 後の fetch も成功し、`git worktree add -b ... origin/work/<branch>` が `fatal: invalid reference` を出さない

という end-to-end 動作が新規 E2E smoke で機械的に検証されます。

## Test plan

- [x] `cargo test -p gwt-core -p gwt-git -p gwt --all-features` (全 GREEN)
- [x] `cargo test -p gwt --test migration_single_branch_test` (T-174 GREEN)
- [x] `cargo test -p gwt-git --test migration_test normalize_fetch_refspec` (T-148〜T-152 全 5 ケース GREEN)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo build -p gwt --bin gwt --bin gwtd`
- [x] `pnpm test:frontend-bundle` (14 JS syntax checks)
- [x] `pnpm test:frontend-smoke` (12 smoke tests)
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` (85 tests)

## Follow-up

- SPEC-1644: raw `GwtError::Git(stderr)` 伝搬総点検 (Start Work 系以外の call site)
- llmlb 個別: origin 側に残った `work/20260513-0042` 孤立ブランチ削除 (緊急性に応じ Issue 化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration now normalizes remote fetch settings even when a repo's origin had no prior fetch refspec, ensuring hidden branches become visible after migration.

* **New Features**
  * Migration confirmation simplified to an accept-only flow with a single primary action.

* **Chores**
  * Escape key behavior adjusted: Esc closes the modal in error state and returns UI to confirmation without triggering skip/quit.

* **Tests**
  * Added integration and end-to-end tests validating fetch normalization and modal behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2666)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->