### PR TITLE
fix(gui): preserve terminals across project switches

### DIFF
--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -17,6 +17,7 @@ import { parseHTML } from "linkedom";
 import {
   applyVisibilityTransition,
   attachHostResizeReflow,
+  classifyProjectWindowVisibility,
   viewportEligibleForRefresh,
 } from "../terminal-viewport-reflow.js";
 
@@ -158,6 +159,26 @@ test("viewportEligibleForRefresh skips display:none and minimised windows (T-186
   );
 });
 
+test("classifyProjectWindowVisibility keeps inactive project terminals hidden, not removed", () => {
+  const result = classifyProjectWindowVisibility({
+    activeWindowIds: ["tab-a::agent-1", "tab-a::board-1"],
+    allProjectWindowIds: [
+      "tab-a::agent-1",
+      "tab-a::board-1",
+      "tab-b::agent-1",
+    ],
+    mountedWindowIds: [
+      "tab-a::agent-1",
+      "tab-b::agent-1",
+      "orphan::agent-1",
+    ],
+  });
+
+  assert.deepEqual(result.visible, ["tab-a::agent-1", "tab-a::board-1"]);
+  assert.deepEqual(result.hidden, ["tab-b::agent-1"]);
+  assert.deepEqual(result.removed, ["orphan::agent-1"]);
+});
+
 test("attachHostResizeReflow throws when given a non-DOM window", () => {
   assert.throws(
     () =>
@@ -194,5 +215,10 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
     appSource,
     /viewportEligibleForRefresh\(\{/,
     "canRefreshTerminalViewport must consult the shared predicate",
+  );
+  assert.match(
+    appSource,
+    /classifyProjectWindowVisibility\(\{/,
+    "project tab switches must classify inactive project windows as hidden instead of disposing their terminal runtimes",
   );
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -32,6 +32,7 @@
       import {
         applyVisibilityTransition,
         attachHostResizeReflow,
+        classifyProjectWindowVisibility,
         viewportEligibleForRefresh,
       } from "/terminal-viewport-reflow.js";
 
@@ -501,6 +502,16 @@
 
       function activeWorkspace() {
         return activeProjectTab()?.workspace || emptyWorkspace();
+      }
+
+      function allProjectWindowIds() {
+        const ids = [];
+        for (const tab of appState?.tabs || []) {
+          for (const windowData of tab.workspace?.windows || []) {
+            ids.push(windowData.id);
+          }
+        }
+        return ids;
       }
 
       function workspaceWindowById(windowId) {
@@ -7284,11 +7295,25 @@
         };
         applyViewport();
 
-        const ids = new Set(workspace.windows.map((windowData) => windowData.id));
-        for (const [windowId, element] of windowMap.entries()) {
-          if (ids.has(windowId)) {
-            continue;
-          }
+        const activeWindowIds = workspace.windows.map((windowData) => windowData.id);
+        const ids = new Set(activeWindowIds);
+        const visibility = classifyProjectWindowVisibility({
+          activeWindowIds,
+          allProjectWindowIds: allProjectWindowIds(),
+          mountedWindowIds: windowMap.keys(),
+        });
+        for (const windowId of visibility.hidden) {
+          const element = windowMap.get(windowId);
+          applyVisibilityTransition({
+            element,
+            shouldHide: true,
+            hasTerminal: terminalMap.has(windowId),
+            onReveal: () => scheduleTerminalFocusActivation(windowId),
+          });
+        }
+        for (const windowId of visibility.removed) {
+          const element = windowMap.get(windowId);
+          if (!element) continue;
           const runtime = terminalMap.get(windowId);
           if (runtime && runtime.viewportRefreshFrame !== null) {
             cancelAnimationFrame(runtime.viewportRefreshFrame);

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -58,6 +58,48 @@ export function applyVisibilityTransition({
   return false;
 }
 
+function idSet(values) {
+  const set = new Set();
+  for (const value of values || []) {
+    if (value === null || value === undefined) continue;
+    set.add(String(value));
+  }
+  return set;
+}
+
+/**
+ * Classify mounted workspace windows during a project-tab render.
+ *
+ * Active-project windows are visible, windows that still belong to another
+ * project tab stay mounted but hidden, and only windows missing from every
+ * project tab are safe to dispose. This keeps inactive terminal xterm
+ * runtimes alive so returning to a project can reflow instead of recreating
+ * the terminal surface from scratch.
+ */
+export function classifyProjectWindowVisibility({
+  activeWindowIds,
+  allProjectWindowIds,
+  mountedWindowIds,
+}) {
+  const active = idSet(activeWindowIds);
+  const all = idSet(allProjectWindowIds);
+  const visible = Array.from(active);
+  const hidden = [];
+  const removed = [];
+
+  for (const windowId of mountedWindowIds || []) {
+    const id = String(windowId);
+    if (active.has(id)) continue;
+    if (all.has(id)) {
+      hidden.push(id);
+    } else {
+      removed.push(id);
+    }
+  }
+
+  return { visible, hidden, removed };
+}
+
 /**
  * Predicate used by both the host resize fan-out and the existing
  * `fitTerminal` short-circuit. Pulled out so a unit test can pin the


### PR DESCRIPTION
## Summary

- Preserve agent terminal rendering across project tab switches by keeping inactive project windows mounted instead of tearing down their terminal runtimes.
- Keep cleanup scoped to orphaned windows so closed windows still release runtime state.

## Changes

- `crates/gwt/web/terminal-viewport-reflow.js`: adds project-window visibility classification for active, hidden inactive, and removed orphan windows.
- `crates/gwt/web/app.js`: hides inactive project-tab windows during workspace render and disposes only windows no longer owned by any project tab.
- `crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs`: adds behavior coverage for inactive project terminals and source wiring coverage for the classifier.

## Testing

- [x] `node --test crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs` — passed, 6 tests.
- [x] `node --check crates/gwt/web/app.js && node --check crates/gwt/web/terminal-viewport-reflow.js` — passed.
- [x] `cargo test -p gwt embedded_web_tab_visibility_transition_triggers_terminal_focus_activation --all-features` — passed.
- [x] `pnpm test:frontend-bundle` — passed.
- [x] `pnpm test:frontend-unit` — passed, 348 tests.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] Pre-push CI-equivalent checks — passed, filtered line coverage 90.85% with 90.00% threshold met.

## Closing Issues

- Closes #2668

## Related Issues / Links

- SPEC-2008
- SPEC-2013

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated — Not applicable: this is a runtime rendering bug fix with no user-facing command or workflow documentation change.
- [ ] Migration/backfill plan included — Not applicable: no schema or persisted data changes.
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- Project switching previously removed every mounted window outside the active project workspace. Agent terminal windows were recreated when returning to the project, which left a rendering corruption path after tab switches.

## Risk / Impact

- **Affected areas**: WebView project tabs, workspace window rendering, xterm terminal runtime lifecycle.
- **Rollback plan**: Revert `34ca1f48` to restore the previous dispose-on-switch behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of inactive project terminals—windows now transition smoothly rather than being immediately removed, with automatic focus activation when revealed.

* **Tests**
  * Added test coverage for window visibility classification logic and workspace rendering integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2669)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->