### PR TITLE
feat(workspace): SPEC-2359 Phase U-5/U-6/U-7 Title Sync + Workspace Content Coherence

### DIFF
--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -191,11 +191,11 @@ impl AppRuntime {
                     },
                 )];
                 if let Some(entry) = latest_entry.as_ref() {
-                    if let Some(event) =
-                        self.record_workspace_board_milestone_event(&tab_id, &project_root, entry)
-                    {
-                        events.push(event);
-                    }
+                    events.extend(self.record_workspace_board_milestone_event(
+                        &tab_id,
+                        &project_root,
+                        entry,
+                    ));
                 }
                 events
             }
@@ -347,7 +347,8 @@ impl AppRuntime {
         tab_id: &str,
         project_root: &Path,
         entry: &coordination::BoardEntry,
-    ) -> Option<OutboundEvent> {
+    ) -> Vec<OutboundEvent> {
+        let _ = tab_id;
         let mut projection =
             match workspace_projection::load_or_default_workspace_projection(project_root) {
                 Ok(projection) => projection,
@@ -357,11 +358,10 @@ impl AppRuntime {
                         project_root = %project_root.display(),
                         "failed to load workspace projection for board milestone"
                     );
-                    return None;
+                    return Vec::new();
                 }
             };
         projection.record_board_milestone(entry);
-        self.update_agent_window_dynamic_title_for_board_entry(entry);
         if let Err(error) =
             workspace_projection::save_workspace_projection(project_root, &projection)
         {
@@ -370,7 +370,7 @@ impl AppRuntime {
                 project_root = %project_root.display(),
                 "failed to save workspace projection for board milestone"
             );
-            return None;
+            return Vec::new();
         }
         if board_entry_origin_can_record_workspace_work_event(&projection, entry) {
             let work_event =
@@ -386,63 +386,7 @@ impl AppRuntime {
             }
         }
 
-        if self.active_tab_id.as_deref() != Some(tab_id) {
-            return None;
-        }
-        let tab = self.tab(tab_id)?;
-        let projection = self.active_work_projection_for_tab(tab_id, tab)?;
-        Some(OutboundEvent::broadcast(
-            BackendEvent::ActiveWorkProjection {
-                projection: Box::new(projection),
-            },
-        ))
-    }
-
-    fn update_agent_window_dynamic_title_for_board_entry(
-        &mut self,
-        entry: &coordination::BoardEntry,
-    ) -> bool {
-        if !matches!(
-            entry.kind,
-            BoardEntryKind::Claim
-                | BoardEntryKind::Status
-                | BoardEntryKind::Blocked
-                | BoardEntryKind::Handoff
-                | BoardEntryKind::Decision
-                | BoardEntryKind::Next
-        ) {
-            return false;
-        }
-        let Some(origin_session_id) = entry.origin_session_id.as_deref() else {
-            return false;
-        };
-        let Some((window_id, _)) = self
-            .active_agent_sessions
-            .iter()
-            .find(|(_, session)| session.session_id == origin_session_id)
-        else {
-            return false;
-        };
-        let Some(address) = self.window_lookup.get(window_id).cloned() else {
-            return false;
-        };
-        let Some(title_summary) = entry
-            .title_summary
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-        else {
-            return false;
-        };
-        let Some(tab) = self.tab_mut(&address.tab_id) else {
-            return false;
-        };
-        tab.workspace.set_dynamic_title_with_detail(
-            &address.raw_id,
-            Some(title_summary),
-            Some(entry.body.clone()),
-        )
+        self.apply_workspace_projection_title_sync(project_root, &projection)
     }
 }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3279,11 +3279,11 @@ impl AppRuntime {
                 })
                 .map(|tab| (tab.id.clone(), tab.project_root.clone()))
             {
-                if let Some(event) =
-                    self.record_workspace_board_milestone_event(&tab_id, &project_root, entry)
-                {
-                    events.push(event);
-                }
+                events.extend(self.record_workspace_board_milestone_event(
+                    &tab_id,
+                    &project_root,
+                    entry,
+                ));
             }
         }
         events
@@ -10801,8 +10801,11 @@ exit 0
         .with_origin_agent_id("codex")
         .with_origin_branch("work/20260504-1234");
 
-        let event = runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &blocked);
+        let event = events
+            .iter()
+            .find(|e| matches!(e.event, BackendEvent::ActiveWorkProjection { .. }))
+            .cloned()
             .expect("active projection broadcast");
 
         assert!(matches!(
@@ -10927,9 +10930,7 @@ exit 0
             vec!["SPEC-2359".to_string()],
         )
         .with_origin_session_id("session-1");
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
-            .expect("blocked projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &blocked);
         let status = BoardEntry::new(
             AuthorKind::Agent,
             "Codex",
@@ -10942,8 +10943,11 @@ exit 0
         )
         .with_origin_session_id("session-1");
 
-        let event = runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &status)
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &status);
+        let event = events
+            .iter()
+            .find(|e| matches!(e.event, BackendEvent::ActiveWorkProjection { .. }))
+            .cloned()
             .expect("active projection broadcast");
 
         assert!(matches!(
@@ -11005,9 +11009,7 @@ exit 0
             vec!["SPEC-2359".to_string()],
         )
         .with_origin_session_id("session-1");
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
-            .expect("blocked projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &blocked);
         let next = BoardEntry::new(
             AuthorKind::Agent,
             "Codex",
@@ -11020,8 +11022,11 @@ exit 0
         )
         .with_origin_session_id("session-1");
 
-        let event = runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &next)
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &next);
+        let event = events
+            .iter()
+            .find(|e| matches!(e.event, BackendEvent::ActiveWorkProjection { .. }))
+            .cloned()
             .expect("blocked projection broadcast");
 
         assert!(matches!(
@@ -11316,9 +11321,7 @@ exit 0
         .with_origin_session_id("session-1")
         .with_title_summary("Implement dynamic title sync");
 
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &milestone)
-            .expect("projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
 
         let tab = runtime.tab("tab-1").expect("tab");
         assert_eq!(
@@ -11344,6 +11347,256 @@ exit 0
                 .dynamic_title
                 .as_deref(),
             None
+        );
+    }
+
+    /// Phase U-5 (SPEC-2359 US-38, FR-125, FR-126): a Board post that carries
+    /// `title_summary` must broadcast both `WorkspaceState` (so the pane
+    /// heading rehydrates on WS reconnect / GUI reload) and
+    /// `ActiveWorkProjection` (Active Work card) in the same batch. Prior to
+    /// Phase U-5 the Board path mutated `dynamic_title` in memory but
+    /// silently skipped the `WorkspaceState` broadcast, leaving the pane
+    /// heading stale after reconnect.
+    #[test]
+    fn app_runtime_board_milestone_broadcasts_workspace_state_for_title_sync() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        agent.purpose_title = Some("Initial purpose".to_string());
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260513-0343".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.clone(),
+                agent_project_root: repo.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        save_start_work_workspace_projection(
+            &repo,
+            runtime
+                .active_agent_sessions
+                .get(&window_id)
+                .expect("session"),
+            "develop",
+            None,
+            None,
+        )
+        .expect("save projection");
+        let milestone = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "Implementing Phase U-5 Board path title sync hardening",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1")
+        .with_title_summary("Implementing Phase U-5");
+
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "expected WorkspaceState broadcast from Board path so pane heading refreshes on reconnect: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "expected ActiveWorkProjection broadcast from Board path: {events:?}"
+        );
+    }
+
+    /// Phase U-5 (SPEC-2359 US-38, FR-129, FR-130): the WebSocket reconnect
+    /// path goes through `FrontendEvent::FrontendReady` → `frontend_sync_events`.
+    /// The replied `WorkspaceState` must carry each window's `dynamic_title`
+    /// and `dynamic_title_detail` so the frontend's `windowDisplayTitle()` can
+    /// rehydrate the pane heading without waiting for another mutation. This
+    /// test fails if anyone strips `dynamic_title` from the projected
+    /// `WorkspaceView`, regressing the reconnect contract.
+    #[test]
+    fn frontend_sync_events_preserves_window_dynamic_title_for_reconnect_rehydrate() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        agent.purpose_title = Some("Initial purpose".to_string());
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let tab_mut = runtime.tab_mut("tab-1").expect("tab mut");
+        tab_mut.workspace.set_dynamic_title_with_detail(
+            "agent-1",
+            Some("Phase U-5 rehydrate target".to_string()),
+            Some("simulated stale state before reconnect".to_string()),
+        );
+
+        let events = runtime.frontend_sync_events("client-1");
+
+        let workspace_event = events
+            .iter()
+            .find(|event| matches!(event.event, BackendEvent::WorkspaceState { .. }))
+            .expect("WorkspaceState reply for FrontendReady");
+        let workspace = match &workspace_event.event {
+            BackendEvent::WorkspaceState { workspace } => workspace,
+            _ => unreachable!(),
+        };
+        let projected_window = workspace
+            .tabs
+            .iter()
+            .find(|tab| tab.id == "tab-1")
+            .and_then(|tab| {
+                tab.workspace
+                    .windows
+                    .iter()
+                    .find(|window| window.id == combined_window_id("tab-1", "agent-1"))
+            })
+            .expect("agent window in projected WorkspaceState");
+        assert_eq!(
+            projected_window.dynamic_title.as_deref(),
+            Some("Phase U-5 rehydrate target"),
+            "frontend_sync_events must include dynamic_title so reconnect rehydrate restores pane heading"
+        );
+        assert_eq!(
+            projected_window.dynamic_title_detail.as_deref(),
+            Some("simulated stale state before reconnect"),
+            "frontend_sync_events must include dynamic_title_detail so tooltip survives reconnect"
+        );
+    }
+
+    /// Phase U-5: re-asserts the diff gate from
+    /// `apply_workspace_projection_title_sync_skips_workspace_state_when_same_title_resyncs`
+    /// at the Board entrypoint. Re-posting an identical milestone (same
+    /// `title_summary` + same body for `current_focus`) must not emit a
+    /// duplicate `WorkspaceState` broadcast on busy projections.
+    #[test]
+    fn app_runtime_board_milestone_skips_workspace_state_on_identical_resync() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260513-0343".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.clone(),
+                agent_project_root: repo.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        save_start_work_workspace_projection(
+            &repo,
+            runtime
+                .active_agent_sessions
+                .get(&window_id)
+                .expect("session"),
+            "develop",
+            None,
+            None,
+        )
+        .expect("save projection");
+        let milestone = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "Stable body for current_focus",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1")
+        .with_title_summary("Stable title");
+
+        let first = runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
+        assert!(
+            first
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "first Board post should broadcast WorkspaceState: {first:?}"
+        );
+
+        let second = runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
+        assert!(
+            !second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "second Board post with identical title_summary must not duplicate WorkspaceState: {second:?}"
+        );
+        assert!(
+            second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "ActiveWorkProjection should still broadcast on identical resync: {second:?}"
         );
     }
 
@@ -11416,9 +11669,7 @@ exit 0
         entry_value["title_summary"] = serde_json::json!("Title summary contract");
         let milestone: BoardEntry = serde_json::from_value(entry_value).expect("milestone");
 
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &milestone)
-            .expect("projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
 
         let tab = runtime.tab("tab-1").expect("tab");
         assert_eq!(
@@ -11502,9 +11753,7 @@ exit 0
         )
         .with_origin_session_id("session-1");
 
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &milestone)
-            .expect("projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
 
         let tab = runtime.tab("tab-1").expect("tab");
         assert_eq!(


### PR DESCRIPTION
## Summary

SPEC-2359 Phase U-5 / U-6 / U-7 を 1 PR にまとめて、ユーザー報告 2 不具合
(エージェントウィンドウのタイトル非更新 / Workspace の Summary・Lifecycle が空)
を新規 Workspace 含めて解消する。

## Phase U-5: Title Sync Hardening (FR-125..130 / SC-047..049)

- `record_workspace_board_milestone_event` から
  `update_agent_window_dynamic_title_for_board_entry` の直接呼び出しを削除し、
  `apply_workspace_projection_title_sync` orchestrator に title sync を
  一本化。`WorkspaceState` + `ActiveWorkProjection` の両 broadcast を同一
  バッチで dispatch し、WebSocket 再接続 / GUI リロード後の silent stale を
  解消。
- 戻り値を `Option<OutboundEvent>` → `Vec<OutboundEvent>` に変更。
  既存 8 件の test caller を Vec 受け取りに追従。
- `workspace update --title-summary` (FR-127) は既存
  `daemon_publisher::publish_event` 経由で daemon → orchestrator が動作。
  既存テスト
  `handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pane_heading`
  で回帰防止済み。
- Frontend reconnect (FR-129) は既存 `frontend_ready` →
  `frontend_sync_events` が WorkspaceState に dynamic_title /
  dynamic_title_detail を含めて返す経路で対応済み。新規回帰テストで
  contract を固定。

## Phase U-6: Schema + Auto-populate + Migration (FR-131..145)

- `WorkspaceProjection` に新フィールドを追加 (FR-131): `created_at`,
  `creator`, `lifecycle_stage`, `blocked_reason`, `linked_issues`,
  `linked_prs`, `tags`, `progress_pct`。全 `#[serde(default)]` で legacy
  JSON と後方互換。
- `WorkspaceLifecycleStage` enum (FR-132) と `WorkspaceIssueLink` /
  `WorkspacePrLink` struct (FR-133) を追加。
- `gwtd workspace create` の auto-populate (FR-134, FR-135): `--current-focus`
  省略時に `summary` を `title_summary` で自動補完。`created_at`,
  `creator`, `lifecycle_stage = Active` も初期化。WorkspaceWorkEvent
  `kind: Start` の Day-0 Lifecycle 起点は既存実装で出ていた (FR-136)。
- `record_board_milestone` (FR-140, FR-141): Status/Claim/Handoff/Decision
  entry で `summary` 空時に entry body を backfill。Blocked entry で
  `blocked_reason` を `status_text` と独立に populate。
- 新規モジュール `workspace_projection_migration.rs` (FR-142..145):
  起動時に既存 `workspace.json` を Phase U-6 schema へ整合させる。`summary`
  ← title (legacy default 以外)、`created_at` ← updated_at (sentinel
  detect)、`lifecycle_stage` ← status_category 由来、`creator` ← 最初の
  agent.agent_id か `"system"`。`workspace.migration.json` marker で
  exactly-once、missing/unreadable files は silent skip。
- daemon startup への wire-up は peer agent PR #2670 (US-37 auto-done
  retroactive scan) との bootstrap conflict を避けるため、PR #2670 merge 後の
  follow-up commit に延期 (helper module はビルド可能で test 4 件 GREEN)。

## Phase U-7: Card UI partial (FR-141 / FR-147)

- Detail pane Summary fallback message を解決導線付きに変更
  ("Summary not set — add one with `gwtd workspace update --summary X`")。
- Detail pane に Blocked Reason 専用 section を追加 (FR-141 / FR-147)。
  Summary の直後、Next Action の前に描画。
- Detail pane Lifecycle section を常時表示化 (FR-147)。events 空時は
  "Workspace created — no lifecycle events yet. Activity will appear after
  the next Board post." の informative placeholder。
- `workspaceCardsFromProjection` で新 Phase U-6 フィールド全てを cardData
  に propagate (古い daemon / pre-migration payload には fallback)。

## Out of scope (follow-up PRs)

- Phase U-6 残り: `recompute_lifecycle_stage` helper (events → lifecycle 派生)、
  `workspace update` / `workspace join` への新 CLI flag (FR-137..139)、daemon
  startup migration wire-up (PR #2670 merge 後)。
- Phase U-7 残り: Card preview の lifecycle chip / created-ago / agent count、
  linked Issues/PRs / tags chip、progress bar、SPEC-2356 design token 整合の
  CSS リファクタ、Active Work card の `activeWorkDisplayTitle()` 更新
  (FR-146 / FR-148 / FR-149 / FR-150)。

## SPEC reference

- Issue: #2359 (reopen 済み、`phase/implementation` label 付与済み)
- `spec` US-38..US-40 / FR-125..150 / SC-047..056
- `plan` Title Sync Hardening + Workspace Content Coherence + Card UI Redesign
- `tasks` T-248..280

## Test plan

- [x] `cargo test -p gwt-core -p gwt --all-targets` (231 + 579 + 319 + ...
  全 GREEN)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `npm run test:frontend-bundle`
- [x] `npm run test:frontend-unit` (348 passed)
- [x] Pre-push coverage: 90.85% (threshold 90.00%)
- [x] 新規 RED→GREEN テスト 14 件:
  - app_runtime: Board orchestrator wire / diff gate / frontend rehydrate (3 件)
  - gwt-core workspace_projection: serde legacy / round-trip / board milestone
    backfill × 3 (5 件)
  - gwt-core workspace_projection_migration: backfill / idempotent / missing /
    no-backfill (4 件)
  - cli/workspace: workspace_create auto-populate (1 件)
  - (上記 Phase U-7 detail pane は既存 snapshot で間接カバー、明示 test は
    follow-up)
- [ ] Manual GUI smoke (PR レビュー後):
  - `gwtd board post --kind status --title-summary X` で agent window
    ヘッダーが X に更新、リロードでも残る (Phase U-5)
  - `gwtd workspace create --title-summary "Test"` (current-focus 無し) で
    Workspace Detail pane の Summary に "Test" が表示、Lifecycle に
    "Workspace created" entry が出る (Phase U-6 + U-7)
  - 既存 Workspace で `workspace_projection_migration` を呼ぶと
    summary 等が backfill される (Phase U-6 helper; 起動時 wire-up は別 PR)

## Related issues

- #2359 (SPEC-2359)
- #2670 (peer SPEC-2359 US-37 auto-done; workspace_projection.rs で関数単位
  boundary 分離済み、両 PR は並列マージ可能)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
