### PR TITLE
perf(launch-wizard) + fix(resize): Windows Wizard 5s+ 遅延と resize 固着の防御策 (SPEC-2014 Phase B/C)

### DIFF
--- a/crates/gwt-git/src/lib.rs
+++ b/crates/gwt-git/src/lib.rs
@@ -9,6 +9,7 @@ pub mod diff;
 pub mod issue;
 pub mod migration;
 pub mod pr_status;
+pub mod refs;
 pub mod repository;
 pub mod worktree;
 
@@ -23,6 +24,7 @@ pub use issue::{Issue, IssueCache};
 pub use pr_status::{
     fetch_pr_list, pr_check_report, CiStatus, MergeStatus, PrCheckReport, PrStatus, ReviewStatus,
 };
+pub use refs::list_existing_refs;
 pub use repository::{
     clone_repo, detect_repo_type, initialize_workspace, install_develop_protection, RepoType,
     Repository,

--- a/crates/gwt-git/src/refs.rs
+++ b/crates/gwt-git/src/refs.rs
@@ -1,0 +1,170 @@
+//! Bulk ref existence lookup helpers.
+//!
+//! `list_existing_refs` checks whether each of the supplied fully-qualified
+//! ref names exists in `repo_path`, using a **single** `git for-each-ref`
+//! invocation. This is the primary tool for collapsing the Launch Wizard
+//! cold-open path on Windows, where every additional `git.exe` spawn pays a
+//! `CreateProcess` + Defender real-time-scan cost of several hundred
+//! milliseconds (SPEC-2014 FR-PERF-001 / FR-PERF-002).
+
+use std::{collections::HashSet, path::Path};
+
+use gwt_core::{GwtError, Result};
+
+/// Return the subset of `candidates` that resolve to existing refs in
+/// `repo_path`.
+///
+/// `candidates` must contain fully-qualified ref names (for example
+/// `refs/remotes/origin/develop` or `refs/heads/work/20260513-0315`).
+/// The function runs `git for-each-ref --format=%(refname) <ref...>` exactly
+/// once and parses the output as the existence set. Non-matching candidates
+/// are silently absent from the returned set.
+///
+/// Returns an empty `HashSet` without spawning git when `candidates` is empty
+/// (a `for-each-ref` with no patterns would otherwise list every ref in the
+/// repository).
+pub fn list_existing_refs(repo_path: &Path, candidates: &[&str]) -> Result<HashSet<String>> {
+    let trimmed: Vec<&str> = candidates
+        .iter()
+        .map(|candidate| candidate.trim())
+        .filter(|candidate| !candidate.is_empty())
+        .collect();
+    if trimmed.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let mut command = gwt_core::process::hidden_command("git");
+    command
+        .arg("for-each-ref")
+        .arg("--format=%(refname)")
+        .args(&trimmed)
+        .current_dir(repo_path);
+    let output = command
+        .output()
+        .map_err(|error| GwtError::Git(format!("for-each-ref: {error}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GwtError::Git(format!("for-each-ref: {stderr}")));
+    }
+
+    let existing: HashSet<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    Ok(existing)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn run(cmd: &mut Command) {
+        let output = cmd.output().expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git command failed: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+        run(Command::new("git")
+            .args(["init", "--initial-branch=main"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(path));
+        dir
+    }
+
+    fn create_branch(repo: &Path, name: &str) {
+        run(Command::new("git").args(["branch", name]).current_dir(repo));
+    }
+
+    fn create_remote_tracking_ref(repo: &Path, refname: &str) {
+        // Forge a remote tracking ref by writing it directly with `git
+        // update-ref` so tests do not need a real remote.
+        run(Command::new("git")
+            .args(["update-ref", refname, "HEAD"])
+            .current_dir(repo));
+    }
+
+    #[test]
+    fn list_existing_refs_handles_empty_input() {
+        let dir = init_repo();
+        let result = list_existing_refs(dir.path(), &[]).expect("empty input must succeed");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn list_existing_refs_skips_blank_candidates() {
+        let dir = init_repo();
+        let result =
+            list_existing_refs(dir.path(), &["", "  ", "\t"]).expect("blank input must succeed");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn list_existing_refs_returns_only_present_refs() {
+        let dir = init_repo();
+        let repo = dir.path();
+        create_branch(repo, "develop");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/develop");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/main");
+
+        let result = list_existing_refs(
+            repo,
+            &[
+                "refs/remotes/origin/develop",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/main",
+                "refs/remotes/origin/master",
+            ],
+        )
+        .expect("for-each-ref must succeed");
+
+        assert!(result.contains("refs/remotes/origin/develop"));
+        assert!(result.contains("refs/remotes/origin/main"));
+        assert!(!result.contains("refs/remotes/origin/HEAD"));
+        assert!(!result.contains("refs/remotes/origin/master"));
+    }
+
+    #[test]
+    fn list_existing_refs_resolves_local_and_remote_in_one_spawn() {
+        let dir = init_repo();
+        let repo = dir.path();
+        create_branch(repo, "work/20260513-0315");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/work/20260513-0315");
+
+        let result = list_existing_refs(
+            repo,
+            &[
+                "refs/heads/work/20260513-0315",
+                "refs/remotes/origin/work/20260513-0315",
+                "refs/heads/feature/never-created",
+                "refs/remotes/origin/feature/never-created",
+            ],
+        )
+        .expect("for-each-ref must succeed");
+
+        assert!(result.contains("refs/heads/work/20260513-0315"));
+        assert!(result.contains("refs/remotes/origin/work/20260513-0315"));
+        assert!(!result.contains("refs/heads/feature/never-created"));
+        assert!(!result.contains("refs/remotes/origin/feature/never-created"));
+    }
+}

--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -174,9 +174,29 @@ impl Pane {
     }
 
     /// Resize the pane (PTY + vt100 parser).
+    ///
+    /// Emits an `info` event at `target = gwt::resize::pane` capturing the
+    /// requested dimensions and total wall time so SPEC-2014 Phase C can tell
+    /// PTY ConPTY stalls (logged at `gwt::resize::pty`) apart from
+    /// `resize_parser_preserving_state` regressions inside the parser.
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<(), TerminalError> {
+        let started = std::time::Instant::now();
         self.pty.resize(cols, rows)?;
+        let pty_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let parser_started = std::time::Instant::now();
         resize_parser_preserving_state(&mut self.parser, rows, cols);
+        let parser_elapsed_ms =
+            u64::try_from(parser_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let total_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        tracing::info!(
+            target: "gwt::resize::pane",
+            cols = cols,
+            rows = rows,
+            pty_elapsed_ms = pty_elapsed_ms,
+            parser_elapsed_ms = parser_elapsed_ms,
+            total_elapsed_ms = total_elapsed_ms,
+            "pane resize completed"
+        );
         Ok(())
     }
 

--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -173,20 +173,58 @@ impl PtyHandle {
     }
 
     /// Resize the PTY window.
+    ///
+    /// Emits an `info` event at `target = gwt::resize::pty` with the resolved
+    /// dimensions and total wall time so SPEC-2014 Phase C diagnostics can
+    /// pinpoint Windows ConPTY stalls from `~/.gwt/logs/` alone. The lock and
+    /// the underlying `MasterPty::resize` are timed separately because the
+    /// lock contention pattern differs on Windows vs Unix.
     pub fn resize(&self, cols: u16, rows: u16) -> Result<(), TerminalError> {
+        let started = Instant::now();
         let master = self.master.lock().map_err(|e| TerminalError::PtyIoError {
             details: format!("lock poisoned: {e}"),
         })?;
-        master
-            .resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| TerminalError::PtyIoError {
-                details: e.to_string(),
-            })
+        let lock_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let resize_started = Instant::now();
+        let outcome = master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+        let resize_elapsed_ms =
+            u64::try_from(resize_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let total_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        match outcome {
+            Ok(()) => {
+                tracing::info!(
+                    target: "gwt::resize::pty",
+                    cols = cols,
+                    rows = rows,
+                    lock_elapsed_ms = lock_elapsed_ms,
+                    resize_elapsed_ms = resize_elapsed_ms,
+                    total_elapsed_ms = total_elapsed_ms,
+                    outcome = "ok",
+                    "PTY resize completed"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                let details = e.to_string();
+                tracing::warn!(
+                    target: "gwt::resize::pty",
+                    cols = cols,
+                    rows = rows,
+                    lock_elapsed_ms = lock_elapsed_ms,
+                    resize_elapsed_ms = resize_elapsed_ms,
+                    total_elapsed_ms = total_elapsed_ms,
+                    outcome = "error",
+                    error = %details,
+                    "PTY resize failed"
+                );
+                Err(TerminalError::PtyIoError { details })
+            }
+        }
     }
 
     /// Terminate the child process and every descendant in its process group.

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -11433,6 +11433,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11520,6 +11521,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let tab_mut = runtime.tab_mut("tab-1").expect("tab mut");
@@ -11589,6 +11591,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1518,6 +1518,30 @@ pub struct ProjectTabRuntime {
     /// [`BackendEvent::MigrationDetected`] until the user picks Migrate /
     /// Skip / Quit. Not persisted: re-detected on every launch.
     pub(crate) migration_pending: bool,
+    /// SPEC-2014 FR-PERF-003: cached `git rev-parse --git-common-dir`
+    /// resolution for this tab. `gwt_git::worktree::main_worktree_root`
+    /// spawns `git.exe`; on Windows every spawn costs several hundred
+    /// milliseconds (`CreateProcess` + Defender real-time scan). The Launch
+    /// Wizard / Start Work / Add Agent / Resume Workspace paths used to call
+    /// it on every open, accounting for the bulk of the cold-open delay.
+    /// We resolve the value on first access and reuse it for the lifetime
+    /// of the tab; the [`Arc`] wrapper keeps `ProjectTabRuntime: Clone`.
+    pub(crate) main_worktree_root_cache: std::sync::Arc<std::sync::OnceLock<PathBuf>>,
+}
+
+impl ProjectTabRuntime {
+    /// Return the cached primary repository root for this tab, lazily
+    /// resolving it on first access (FR-PERF-003). Falls back to
+    /// `project_root` when `git rev-parse --git-common-dir` fails so the
+    /// caller never has to deal with `Result`.
+    pub(crate) fn main_worktree_root(&self) -> PathBuf {
+        self.main_worktree_root_cache
+            .get_or_init(|| {
+                gwt_git::worktree::main_worktree_root(&self.project_root)
+                    .unwrap_or_else(|_| self.project_root.clone())
+            })
+            .clone()
+    }
 }
 
 fn recovery_state_label(recovery: gwt_core::migration::RecoveryState) -> &'static str {
@@ -1730,6 +1754,7 @@ impl ProjectTabRuntime {
             // Re-detected at startup via resolve_project_target; persistence
             // does not carry the flag.
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -2602,6 +2627,7 @@ impl AppRuntime {
                     .map_err(|error| error.to_string())?
             }),
             migration_pending: target.needs_migration,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         });
         self.active_tab_id = Some(tab_id);
         self.remember_recent_project(&target);
@@ -6233,6 +6259,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -6254,6 +6281,7 @@ exit 0
             kind,
             workspace,
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -8244,6 +8272,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
@@ -9776,6 +9805,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
@@ -10329,6 +10359,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let current_window_id = combined_window_id("tab-1", "profile-1");
@@ -11260,6 +11291,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let first_window_id = combined_window_id("tab-1", "agent-1");
@@ -11370,6 +11402,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11462,6 +11495,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11539,6 +11573,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11623,6 +11658,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         // Need the path so the temp directory survives until the runtime drops.
         let temp_root = repo.parent().expect("repo has parent").to_path_buf();
@@ -12225,6 +12261,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let all_window_id = combined_window_id("tab-1", "board-all");
@@ -12334,6 +12371,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let other_tab = sample_project_tab_with_window_at(
             "tab-2",
@@ -12378,7 +12416,42 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(empty_workspace_state()),
             migration_pending: true,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
+    }
+
+    /// SPEC-2014 FR-PERF-003: ProjectTabRuntime caches `main_worktree_root`
+    /// resolution per tab so the Launch Wizard / Start Work paths do not
+    /// re-spawn `git rev-parse --git-common-dir` on every open.
+    #[test]
+    fn project_tab_runtime_main_worktree_root_caches_resolution() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("repo");
+        gwt_core::process::hidden_command("git")
+            .args(["init", repo.to_str().unwrap()])
+            .output()
+            .expect("git init");
+
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        assert!(
+            tab.main_worktree_root_cache.get().is_none(),
+            "cache must start empty"
+        );
+
+        let first = tab.main_worktree_root();
+        let cached = tab
+            .main_worktree_root_cache
+            .get()
+            .expect("cache populated after first access")
+            .clone();
+        assert_eq!(first, cached);
+
+        let second = tab.main_worktree_root();
+        assert_eq!(
+            first, second,
+            "second call must return the cached resolution"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -61,7 +61,7 @@ fn start_work_open_error(client_id: &str, message: impl Into<String>) -> Vec<Out
 }
 
 use super::{
-    branch_worktree_path, build_shell_process_launch, combined_window_id,
+    branch_worktree_path, branch_worktree_path_for, build_shell_process_launch, combined_window_id,
     detect_wizard_docker_context_and_status, knowledge_error_event, knowledge_kind_for_preset,
     list_branch_entries_with_active_sessions, normalize_branch_name, preferred_issue_launch_branch,
     resolve_shell_launch_worktree, synthetic_branch_entry, workspace_projection_for_current_resume,
@@ -166,7 +166,14 @@ impl AppRuntime {
     ) -> Result<(), String> {
         let normalized_branch_name = normalize_branch_name(branch_name);
         let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
-        let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
+        // SPEC-2014 FR-PERF-003: reuse the project tab's cached
+        // `main_worktree_root` resolution so the Launch Wizard cold-open path
+        // avoids another `git rev-parse --git-common-dir` spawn on Windows.
+        let main_repo_path = self.tab(tab_id).map(|tab| tab.main_worktree_root());
+        let worktree_path = main_repo_path.as_deref().map_or_else(
+            || branch_worktree_path(project_root, &normalized_branch_name),
+            |main_root| branch_worktree_path_for(main_root, &normalized_branch_name),
+        );
         let quick_start_root = worktree_path
             .clone()
             .unwrap_or_else(|| project_root.to_path_buf());
@@ -398,8 +405,15 @@ impl AppRuntime {
         project_root: &Path,
         workspace_resume_context: Option<WorkspaceResumeContext>,
     ) -> Result<(), String> {
-        let base_branch = gwt::start_work::resolve_start_work_base_branch(project_root)
-            .map_err(|error| error.to_string())?;
+        // SPEC-2014 FR-PERF-003: reuse the tab's cached `main_worktree_root`
+        // so Start Work does not spawn another `git rev-parse
+        // --git-common-dir` per open.
+        let git_root = self.tab(tab_id).map(|tab| tab.main_worktree_root());
+        let base_branch = match git_root.as_deref() {
+            Some(root) => gwt::start_work::resolve_start_work_base_branch_in(root),
+            None => gwt::start_work::resolve_start_work_base_branch(project_root),
+        }
+        .map_err(|error| error.to_string())?;
         let work_branch =
             gwt::start_work::reserve_start_work_branch_name_for_project(project_root, Utc::now())
                 .map_err(|error| error.to_string())?;

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -639,6 +639,49 @@ mod tests {
         );
     }
 
+    /// SPEC-2014 Phase C1: Windows WebView2 で pointerup / pointercancel /
+    /// lostpointercapture のいずれも届かないケースで Wizard / Terminal が永久に
+    /// 固まらないよう、resizeState には auto-clear する staleness guard と
+    /// 二重 resize 検知時の forceReset が組み込まれていなければならない。
+    #[test]
+    fn embedded_web_resize_state_guards_against_lost_pointer_end_events() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("function scheduleResizeStalenessGuard(pointerId)"),
+            "expected a staleness guard scheduler that triggers when pointerup/cancel/lostpointercapture all miss"
+        );
+        assert!(
+            html.contains("function cancelResizeStalenessGuard()"),
+            "expected the staleness guard to be cancellable on the normal resize teardown path"
+        );
+        assert!(
+            html.contains("function forceResetResizeState(reason)"),
+            "expected a force-reset helper that clears stale resizeState when a new resize starts"
+        );
+        assert!(
+            html.contains(
+                "forceResetResizeState(\"new resize started before previous one finished\");",
+            ),
+            "expected new pointerdown to force-reset any leaked previous resizeState before opening a new session"
+        );
+        assert!(
+            html.contains("startedAt: performance.now(),"),
+            "expected resizeState to carry a startedAt timestamp so the staleness guard can log elapsed time"
+        );
+        assert!(
+            html.contains("stalenessTimer: scheduleResizeStalenessGuard(event.pointerId),"),
+            "expected the resize start path to schedule the staleness guard"
+        );
+        assert!(
+            html.contains("try {\n              resizeHandle.setPointerCapture(event.pointerId);")
+                && html.contains(
+                    "console.warn(\n                \"[resize] setPointerCapture failed, falling back to window-bound pointer events\"",
+                ),
+            "expected setPointerCapture to be wrapped in try/catch with a warning fallback for WebView2 edge cases"
+        );
+    }
+
     #[test]
     fn embedded_web_terminal_scrolls_refresh_viewport_after_xterm_scroll() {
         let html = frontend_bundle_source();

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -87,13 +87,14 @@ pub(crate) use launch_runtime::{
 };
 pub(crate) use runtime_support::{
     app_state_view_from_parts, attach_parent_console_for_cli, branch_worktree_path,
-    close_window_from_workspace, combined_window_id, current_git_branch, dedupe_recent_projects,
-    fallback_project_target, first_available_worktree_path, front_door_route, geometry_to_pty_size,
-    knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
-    origin_remote_ref, prune_missing_recent_projects, resolve_launch_spec_with_fallback,
-    resolve_project_target, run_cli, same_worktree_path, should_auto_close_agent_window,
-    should_auto_start_restored_window, synthetic_branch_entry, usable_worktree_path_for_branch,
-    workspace_view_for_tab, worktrees_have_stale_branch_entry,
+    branch_worktree_path_for, close_window_from_workspace, combined_window_id, current_git_branch,
+    dedupe_recent_projects, fallback_project_target, first_available_worktree_path,
+    front_door_route, geometry_to_pty_size, knowledge_kind_for_preset, local_branch_exists,
+    normalize_active_tab_id, normalize_branch_name, origin_remote_ref,
+    prune_missing_recent_projects, resolve_launch_spec_with_fallback, resolve_project_target,
+    run_cli, same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
+    synthetic_branch_entry, usable_worktree_path_for_branch, workspace_view_for_tab,
+    worktrees_have_stale_branch_entry,
 };
 #[cfg(test)]
 pub(crate) use runtime_support::{
@@ -1408,6 +1409,7 @@ mod tests {
             kind: gwt::ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -1443,6 +1445,7 @@ mod tests {
             kind,
             workspace,
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -219,16 +219,28 @@ pub fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> 
     }
 }
 
+/// Resolve the on-disk worktree path for `branch_name` (FR-PERF-002).
+///
+/// Earlier revisions probed `git branch --show-current` first as a fast path
+/// when the requested branch happened to be checked out at `repo_path`.
+/// `WorktreeManager::list` is authoritative for that information, so the
+/// extra spawn was pure overhead on Windows (one `CreateProcess` +
+/// Defender scan per Launch Wizard open). The current implementation skips
+/// `current_git_branch` entirely and relies on the worktree list.
 pub fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
-    if current_git_branch(repo_path)
-        .as_ref()
-        .is_ok_and(|current| current == branch_name)
-    {
-        return Some(repo_path.to_path_buf());
-    }
-
     let main_repo_path = gwt_git::worktree::main_worktree_root(repo_path).ok()?;
-    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+    branch_worktree_path_for(&main_repo_path, branch_name)
+}
+
+/// Like [`branch_worktree_path`] but starts from a pre-resolved
+/// `main_repo_path`, so the caller can re-use a cached value across multiple
+/// Launch Wizard / Start Work / Resume Workspace invocations (FR-PERF-003).
+/// Windows pays a hefty `CreateProcess` cost per `git.exe` spawn; reusing the
+/// `git rev-parse --git-common-dir` resolution that `branch_worktree_path`
+/// would otherwise perform halves the cold-open git spawn count for branch
+/// resolution.
+pub fn branch_worktree_path_for(main_repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
+    let manager = gwt_git::WorktreeManager::new(main_repo_path);
     let mut worktrees = manager.list().ok()?;
     if let Some(path) = usable_worktree_path_for_branch(&worktrees, branch_name) {
         return Some(path);
@@ -895,6 +907,101 @@ upstream\tgit@github.com:anthropics/example.git (push)
                 (s("origin"), s("https://github.com/akiojin/gwt")),
                 (s("upstream"), s("git@github.com:anthropics/example.git")),
             ]
+        );
+    }
+
+    fn seed_git_identity(path: &std::path::Path) {
+        for (key, value) in [
+            ("user.email", "tests@example.com"),
+            ("user.name", "Test User"),
+        ] {
+            gwt_core::process::hidden_command("git")
+                .args(["config", key, value])
+                .current_dir(path)
+                .output()
+                .expect("git config");
+        }
+    }
+
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        let status = gwt_core::process::hidden_command("git")
+            .args(args)
+            .current_dir(repo)
+            .status()
+            .expect("git command should run");
+        assert!(
+            status.success(),
+            "git {args:?} failed in {}",
+            repo.display()
+        );
+    }
+
+    /// SPEC-2014 FR-PERF-002: branch_worktree_path must locate the worktree
+    /// path for a non-HEAD branch by consulting the WorktreeManager list
+    /// alone, without first spawning `git branch --show-current`.
+    #[test]
+    fn branch_worktree_path_resolves_linked_worktree_for_target_branch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        run_git(&repo, &["init", "--initial-branch=main"]);
+        seed_git_identity(&repo);
+        run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+        run_git(&repo, &["branch", "feature/alpha"]);
+        let alpha_path = tmp.path().join("alpha");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                alpha_path.to_str().unwrap(),
+                "feature/alpha",
+            ],
+        );
+
+        let resolved = super::branch_worktree_path(&repo, "feature/alpha")
+            .expect("branch worktree path must resolve");
+        assert!(
+            super::same_worktree_path(&resolved, &alpha_path),
+            "expected {} to resolve to {}",
+            resolved.display(),
+            alpha_path.display(),
+        );
+    }
+
+    #[test]
+    fn branch_worktree_path_returns_none_for_unknown_branch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        run_git(&repo, &["init", "--initial-branch=main"]);
+        seed_git_identity(&repo);
+        run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+        assert!(super::branch_worktree_path(&repo, "feature/never-exists").is_none());
+    }
+
+    #[test]
+    fn branch_worktree_path_resolves_head_branch_via_main_worktree_listing() {
+        // SPEC-2014 FR-PERF-002 regression: when the requested branch is the
+        // HEAD of the main worktree, branch_worktree_path must still return
+        // that worktree's path. Earlier revisions short-circuited this case
+        // through `git branch --show-current`; the WorktreeManager list now
+        // owns the resolution alone.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        run_git(&repo, &["init", "--initial-branch=main"]);
+        seed_git_identity(&repo);
+        run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+        let resolved =
+            super::branch_worktree_path(&repo, "main").expect("HEAD branch must resolve");
+        assert!(
+            super::same_worktree_path(&resolved, &repo),
+            "expected {} to resolve to {}",
+            resolved.display(),
+            repo.display(),
         );
     }
 }

--- a/crates/gwt/src/start_work.rs
+++ b/crates/gwt/src/start_work.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use std::{
+    collections::HashSet,
     fs::{self, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
@@ -16,6 +17,7 @@ pub const START_WORK_REMOTE_HEAD_REF: &str = "origin/HEAD";
 pub enum StartWorkError {
     MissingBaseBranch,
     ReservationIo(String),
+    Lookup(String),
 }
 
 impl std::fmt::Display for StartWorkError {
@@ -27,19 +29,35 @@ impl std::fmt::Display for StartWorkError {
             Self::ReservationIo(error) => {
                 write!(f, "Failed to reserve Start Work branch name: {error}")
             }
+            Self::Lookup(error) => {
+                write!(f, "Failed to look up existing Start Work refs: {error}")
+            }
         }
     }
 }
 
 impl std::error::Error for StartWorkError {}
 
+/// Resolve the canonical Start Work base branch (FR-PERF-001).
+///
+/// The closure is invoked **once** with every candidate in
+/// [`START_WORK_BASE_BRANCH_CANDIDATES`] and must return the subset of
+/// candidates that resolve to existing refs (or a `StartWorkError::Lookup`
+/// on failure). The first candidate in the ordered list that appears in the
+/// returned set wins. The wrapper [`resolve_start_work_base_branch`] supplies
+/// a closure backed by [`gwt_git::list_existing_refs`], collapsing the four
+/// historical `git show-ref` invocations into a single
+/// `git for-each-ref`. This is the dominant cold-open cost on Windows where
+/// `CreateProcess` and Defender real-time scanning add several hundred
+/// milliseconds per spawn (SPEC-2014 Phase B).
 pub fn resolve_start_work_base_branch_with(
-    mut remote_branch_exists: impl FnMut(&str) -> bool,
+    remote_branches_existing: impl FnOnce(&[&str]) -> Result<HashSet<String>, StartWorkError>,
 ) -> Result<String, StartWorkError> {
+    let existing = remote_branches_existing(&START_WORK_BASE_BRANCH_CANDIDATES)?;
     START_WORK_BASE_BRANCH_CANDIDATES
         .iter()
         .copied()
-        .find(|candidate| remote_branch_exists(candidate))
+        .find(|candidate| existing.contains(*candidate))
         .map(str::to_string)
         .ok_or(StartWorkError::MissingBaseBranch)
 }
@@ -77,32 +95,62 @@ fn is_start_work_branch_name(branch_name: &str) -> bool {
 pub fn resolve_start_work_base_branch(repo_path: &Path) -> Result<String, StartWorkError> {
     let git_root = gwt_git::worktree::main_worktree_root(repo_path)
         .unwrap_or_else(|_| repo_path.to_path_buf());
-    resolve_start_work_base_branch_with(|candidate| {
-        git_ref_exists(&git_root, &remote_tracking_ref(candidate))
-    })
+    resolve_start_work_base_branch_in(&git_root)
+}
+
+/// Same as [`resolve_start_work_base_branch`] but skips the
+/// `git rev-parse --git-common-dir` spawn by accepting a pre-resolved
+/// `git_root`. Callers should pass the same value they already obtained
+/// from [`gwt_git::worktree::main_worktree_root`] or a tab-level cache
+/// (FR-PERF-003).
+pub fn resolve_start_work_base_branch_in(git_root: &Path) -> Result<String, StartWorkError> {
+    resolve_start_work_base_branch_with(|candidates| lookup_short_refs(git_root, candidates))
+}
+
+/// Wrap [`gwt_git::list_existing_refs`] to translate short candidate names
+/// (for example `origin/develop`) into the fully qualified refs needed by
+/// `for-each-ref`, then translate the existing-set back to short names.
+fn lookup_short_refs(
+    repo_path: &Path,
+    candidates: &[&str],
+) -> Result<HashSet<String>, StartWorkError> {
+    let qualified: Vec<String> = candidates
+        .iter()
+        .map(|candidate| remote_tracking_ref(candidate))
+        .collect();
+    let qualified_refs: Vec<&str> = qualified.iter().map(String::as_str).collect();
+    let existing_full = gwt_git::list_existing_refs(repo_path, &qualified_refs)
+        .map_err(|error| StartWorkError::Lookup(error.to_string()))?;
+    Ok(candidates
+        .iter()
+        .filter(|candidate| existing_full.contains(&remote_tracking_ref(candidate)))
+        .map(|candidate| (*candidate).to_string())
+        .collect())
 }
 
 pub fn reserve_start_work_branch_name_with(
     now: DateTime<Utc>,
-    mut branch_exists: impl FnMut(&str) -> bool,
-) -> String {
+    mut branch_exists: impl FnMut(&str) -> Result<bool, StartWorkError>,
+) -> Result<String, StartWorkError> {
     let base = format!("work/{}", now.format("%Y%m%d-%H%M"));
-    if !branch_exists(&base) {
-        return base;
+    if !branch_exists(&base)? {
+        return Ok(base);
     }
     for suffix in 2usize.. {
         let candidate = format!("{base}-{suffix}");
-        if !branch_exists(&candidate) {
-            return candidate;
+        if !branch_exists(&candidate)? {
+            return Ok(candidate);
         }
     }
     unreachable!("unbounded suffix search should always return")
 }
 
-pub fn reserve_start_work_branch_name(repo_path: &Path, now: DateTime<Utc>) -> String {
+pub fn reserve_start_work_branch_name(
+    repo_path: &Path,
+    now: DateTime<Utc>,
+) -> Result<String, StartWorkError> {
     reserve_start_work_branch_name_with(now, |candidate| {
-        git_ref_exists(repo_path, &format!("refs/heads/{candidate}"))
-            || git_ref_exists(repo_path, &format!("refs/remotes/origin/{candidate}"))
+        local_or_remote_branch_exists(repo_path, candidate)
     })
 }
 
@@ -115,17 +163,14 @@ pub fn reserve_start_work_branch_name_for_project(
         .join("start-work-reservations");
     reserve_start_work_branch_name_with_reservations(
         now,
-        |candidate| {
-            git_ref_exists(repo_path, &format!("refs/heads/{candidate}"))
-                || git_ref_exists(repo_path, &format!("refs/remotes/origin/{candidate}"))
-        },
+        |candidate| local_or_remote_branch_exists(repo_path, candidate),
         &reservations_dir,
     )
 }
 
 pub fn reserve_start_work_branch_name_with_reservations(
     now: DateTime<Utc>,
-    mut branch_exists: impl FnMut(&str) -> bool,
+    mut branch_exists: impl FnMut(&str) -> Result<bool, StartWorkError>,
     reservations_dir: &Path,
 ) -> Result<String, StartWorkError> {
     fs::create_dir_all(reservations_dir)
@@ -137,7 +182,7 @@ pub fn reserve_start_work_branch_name_with_reservations(
         } else {
             format!("{base}-{suffix}")
         };
-        if branch_exists(&candidate) {
+        if branch_exists(&candidate)? {
             continue;
         }
         match create_reservation(reservations_dir, &candidate) {
@@ -147,6 +192,21 @@ pub fn reserve_start_work_branch_name_with_reservations(
         }
     }
     unreachable!("unbounded suffix search should always return")
+}
+
+/// Check whether either `refs/heads/<candidate>` or
+/// `refs/remotes/origin/<candidate>` exists in `repo_path`, using a single
+/// `git for-each-ref` invocation (FR-PERF-001). On Windows this halves the
+/// number of `git.exe` spawns per Start Work candidate from two to one.
+fn local_or_remote_branch_exists(
+    repo_path: &Path,
+    candidate: &str,
+) -> Result<bool, StartWorkError> {
+    let local = format!("refs/heads/{candidate}");
+    let remote = format!("refs/remotes/origin/{candidate}");
+    let existing = gwt_git::list_existing_refs(repo_path, &[local.as_str(), remote.as_str()])
+        .map_err(|error| StartWorkError::Lookup(error.to_string()))?;
+    Ok(!existing.is_empty())
 }
 
 fn create_reservation(reservations_dir: &Path, branch_name: &str) -> std::io::Result<()> {
@@ -167,14 +227,6 @@ fn reservation_path(reservations_dir: &Path, branch_name: &str) -> PathBuf {
         })
 }
 
-fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
-    gwt_core::process::hidden_command("git")
-        .args(["show-ref", "--verify", "--quiet", ref_name])
-        .current_dir(repo_path)
-        .status()
-        .is_ok_and(|status| status.success())
-}
-
 fn remote_tracking_ref(remote_ref: &str) -> String {
     if remote_ref.starts_with("refs/remotes/") {
         remote_ref.to_string()
@@ -185,15 +237,19 @@ fn remote_tracking_ref(remote_ref: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
     use chrono::{TimeZone, Utc};
 
     use super::{
         refallback_start_work_base_branch_with, remote_tracking_ref,
         reserve_start_work_branch_name_with, reserve_start_work_branch_name_with_reservations,
-        resolve_start_work_base_branch_with, StartWorkError,
+        resolve_start_work_base_branch_with, StartWorkError, START_WORK_BASE_BRANCH_CANDIDATES,
     };
+
+    fn ok_existing(existing: &HashSet<String>) -> HashSet<String> {
+        existing.clone()
+    }
 
     #[test]
     fn start_work_base_branch_prefers_develop_before_remote_head() {
@@ -202,9 +258,8 @@ mod tests {
             "origin/develop".to_string(),
             "origin/main".to_string(),
         ]);
-        let resolved =
-            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
-                .expect("resolve base branch");
+        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect("resolve base branch");
 
         assert_eq!(resolved, "origin/develop");
     }
@@ -212,9 +267,8 @@ mod tests {
     #[test]
     fn start_work_base_branch_uses_remote_head_when_develop_is_missing() {
         let existing = HashSet::from(["origin/HEAD".to_string(), "origin/main".to_string()]);
-        let resolved =
-            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
-                .expect("resolve base branch");
+        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect("resolve base branch");
 
         assert_eq!(resolved, "origin/HEAD");
     }
@@ -248,18 +302,56 @@ mod tests {
     #[test]
     fn start_work_base_branch_falls_back_to_develop_main_master_order() {
         let existing = HashSet::from(["origin/main".to_string(), "origin/master".to_string()]);
-        let resolved =
-            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
-                .expect("resolve base branch");
+        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect("resolve base branch");
 
         assert_eq!(resolved, "origin/main");
     }
 
     #[test]
     fn start_work_base_branch_reports_recoverable_missing_base() {
-        let error = resolve_start_work_base_branch_with(|_| false).expect_err("missing base");
+        let error =
+            resolve_start_work_base_branch_with(|_| Ok(HashSet::new())).expect_err("missing base");
 
         assert_eq!(error, StartWorkError::MissingBaseBranch);
+    }
+
+    #[test]
+    fn start_work_base_branch_invokes_lookup_only_once_for_all_candidates() {
+        let calls = Rc::new(RefCell::new(0usize));
+        let captured: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let calls_clone = Rc::clone(&calls);
+        let captured_clone = Rc::clone(&captured);
+        let existing = HashSet::from(["origin/develop".to_string()]);
+
+        let resolved = resolve_start_work_base_branch_with(|candidates| {
+            *calls_clone.borrow_mut() += 1;
+            *captured_clone.borrow_mut() = candidates.iter().map(|c| (*c).to_string()).collect();
+            Ok(existing.clone())
+        })
+        .expect("resolve base branch");
+
+        assert_eq!(*calls.borrow(), 1, "bulk lookup must run exactly once");
+        assert_eq!(
+            captured.borrow().as_slice(),
+            START_WORK_BASE_BRANCH_CANDIDATES
+                .iter()
+                .map(|c| (*c).to_string())
+                .collect::<Vec<_>>()
+                .as_slice(),
+            "the closure must receive every Start Work candidate in order"
+        );
+        assert_eq!(resolved, "origin/develop");
+    }
+
+    #[test]
+    fn start_work_base_branch_propagates_lookup_errors() {
+        let error = resolve_start_work_base_branch_with(|_| {
+            Err(StartWorkError::Lookup("git crashed".into()))
+        })
+        .expect_err("must surface lookup failures");
+
+        assert_eq!(error, StartWorkError::Lookup("git crashed".into()));
     }
 
     #[test]
@@ -283,7 +375,8 @@ mod tests {
         ]);
 
         let branch =
-            reserve_start_work_branch_name_with(now, |candidate| existing.contains(candidate));
+            reserve_start_work_branch_name_with(now, |candidate| Ok(existing.contains(candidate)))
+                .expect("reserve");
 
         assert_eq!(branch, "work/20260504-1234-3");
     }
@@ -295,10 +388,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0).unwrap();
 
         let first =
-            reserve_start_work_branch_name_with_reservations(now, |_| false, &reservations_dir)
+            reserve_start_work_branch_name_with_reservations(now, |_| Ok(false), &reservations_dir)
                 .expect("first reservation");
         let second =
-            reserve_start_work_branch_name_with_reservations(now, |_| false, &reservations_dir)
+            reserve_start_work_branch_name_with_reservations(now, |_| Ok(false), &reservations_dir)
                 .expect("second reservation");
 
         assert_eq!(first, "work/20260504-1234");
@@ -307,5 +400,47 @@ mod tests {
             reservations_dir.join("work").join("20260504-1234").exists(),
             "reservation should be stored without creating a Git ref"
         );
+    }
+
+    #[test]
+    fn reserve_branch_invokes_lookup_only_once_per_candidate() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reservations_dir = temp.path().join("reservations");
+        let now = Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0).unwrap();
+        let calls = Rc::new(RefCell::new(0usize));
+        let calls_clone = Rc::clone(&calls);
+
+        let branch = reserve_start_work_branch_name_with_reservations(
+            now,
+            |_candidate| {
+                *calls_clone.borrow_mut() += 1;
+                Ok(false)
+            },
+            &reservations_dir,
+        )
+        .expect("reserve");
+
+        assert_eq!(branch, "work/20260504-1234");
+        assert_eq!(
+            *calls.borrow(),
+            1,
+            "lookup must run exactly once for the first available candidate"
+        );
+    }
+
+    #[test]
+    fn reserve_branch_propagates_lookup_errors() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reservations_dir = temp.path().join("reservations");
+        let now = Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0).unwrap();
+
+        let error = reserve_start_work_branch_name_with_reservations(
+            now,
+            |_| Err(StartWorkError::Lookup("git crashed".into())),
+            &reservations_dir,
+        )
+        .expect_err("must surface lookup failures");
+
+        assert_eq!(error, StartWorkError::Lookup("git crashed".into()));
     }
 }

--- a/crates/gwt/tests/start_work_test.rs
+++ b/crates/gwt/tests/start_work_test.rs
@@ -81,7 +81,8 @@ fn start_work_launch_confirmation_materializes_reserved_work_branch_and_worktree
         Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0)
             .single()
             .expect("timestamp"),
-    );
+    )
+    .expect("reserve start work branch name");
     let refs_before = git_output(&repo, &["for-each-ref", "refs/heads/work"]);
     assert!(
         refs_before.is_empty(),

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1379,6 +1379,7 @@
         }
         const runtime = terminalMap.get(resizeState.id);
         cancelTerminalResizeFit();
+        cancelResizeStalenessGuard();
         fitTerminal(resizeState.id, false);
         sendGeometry(
           resizeState.id,
@@ -1390,6 +1391,56 @@
         // SPEC-2356 Phase 9 (T-136): release the hover-reveal peek strip lock
         // so pointer events resume on the screen-edge triggers once resize
         // ends.
+        delete document.documentElement.dataset.opResizeActive;
+      }
+
+      // SPEC-2014 Phase C1: maximum wall time (in ms) a single resize gesture
+      // may stay active before we assume the pointer-end event was lost and
+      // force a teardown. Long enough to cover slow Windows ConPTY resizes
+      // (anecdotally a couple of seconds in the worst case) yet short enough
+      // that the user does not have to restart the app when WebView2 drops
+      // the pointerup.
+      const RESIZE_STALENESS_TIMEOUT_MS = 30_000;
+
+      function scheduleResizeStalenessGuard(pointerId) {
+        return setTimeout(() => {
+          if (!resizeState || resizeState.pointerId !== pointerId) {
+            return;
+          }
+          const elapsed = Math.round(
+            performance.now() - (resizeState.startedAt ?? performance.now()),
+          );
+          console.warn(
+            `[resize] staleness guard fired after ${elapsed}ms; clearing stuck resizeState (pointerId=${pointerId})`,
+          );
+          // Trigger the normal teardown path so xterm fit / sendGeometry /
+          // hover-reveal cleanup all run, then null the state.
+          finishWindowResize(pointerId);
+        }, RESIZE_STALENESS_TIMEOUT_MS);
+      }
+
+      function cancelResizeStalenessGuard() {
+        if (resizeState && resizeState.stalenessTimer != null) {
+          clearTimeout(resizeState.stalenessTimer);
+          resizeState.stalenessTimer = null;
+        }
+      }
+
+      function forceResetResizeState(reason) {
+        if (!resizeState) {
+          return;
+        }
+        const previous = resizeState;
+        console.warn(
+          `[resize] force-reset resizeState (reason=${reason}, previousPointerId=${previous.pointerId}, windowId=${previous.id})`,
+        );
+        if (previous.fitFrame != null) {
+          cancelAnimationFrame(previous.fitFrame);
+        }
+        if (previous.stalenessTimer != null) {
+          clearTimeout(previous.stalenessTimer);
+        }
+        resizeState = null;
         delete document.documentElement.dataset.opResizeActive;
       }
 
@@ -7215,6 +7266,12 @@
 
           resizeHandle.addEventListener("pointerdown", (event) => {
             focusWindowRemotely(windowData.id);
+            // SPEC-2014 Phase C1: Windows WebView2 occasionally fails to
+            // deliver pointerup / pointercancel / lostpointercapture, leaving
+            // the previous resizeState alive when the next gesture starts.
+            // Force-clear the leaked state on every new pointerdown so the
+            // user never has to restart the app to escape a stuck resize.
+            forceResetResizeState("new resize started before previous one finished");
             resizeState = {
               id: windowData.id,
               pointerId: event.pointerId,
@@ -7223,12 +7280,27 @@
               width: parseNumber(element.style.width),
               height: parseNumber(element.style.height),
               fitFrame: null,
+              startedAt: performance.now(),
+              stalenessTimer: scheduleResizeStalenessGuard(event.pointerId),
             };
             // SPEC-2356 Phase 9 (T-136): suppress hover-reveal peek strip
             // hits while resize is active so pointer movements that cross
             // the screen edge do not steal focus mid-resize.
             document.documentElement.dataset.opResizeActive = "true";
-            resizeHandle.setPointerCapture(event.pointerId);
+            try {
+              resizeHandle.setPointerCapture(event.pointerId);
+            } catch (error) {
+              // SPEC-2014 Phase C1: setPointerCapture is best-effort; on
+              // Windows WebView2 it can throw when the pointer has already
+              // been released by the OS between the dispatch and the
+              // callback. We continue without capture so that the
+              // window-bound pointermove / pointerup listeners still
+              // drive the resize.
+              console.warn(
+                "[resize] setPointerCapture failed, falling back to window-bound pointer events",
+                error,
+              );
+            }
           });
           resizeHandle.addEventListener("lostpointercapture", (event) => {
             finishWindowResize(event.pointerId);


### PR DESCRIPTION
## Summary

Windows 上の 2 件の不具合を SPEC-2014 配下で修正。Wizard 表示の 5 秒以上の
遅延を解消し、エージェントウィンドウのリサイズ固着で「アプリ再起動が必要」
になる症状に対する防御策と計測ログを追加する。

### Phase B — Launch Wizard cold-open performance (FR-PERF-001..003)

- `crates/gwt-git/src/refs.rs::list_existing_refs` を新設し、複数 ref の
  存在確認を 1 回の `git for-each-ref` invocation で行う bulk lookup
  helper を公開。
- `crates/gwt/src/start_work.rs` を bulk lookup closure に移行。Start Work
  経路の `git show-ref` を **6 spawn → 1〜2 spawn** に圧縮 (4 候補チェック
  と reservation の local+remote 確認をまとめる)。
- `crates/gwt/src/runtime_support.rs::branch_worktree_path` から
  `git branch --show-current` を削除し、`WorktreeManager::list` の結果だけで
  HEAD/linked worktree を解決 (**3 spawn → 2 spawn**)。
- `crates/gwt/src/app_runtime/mod.rs::ProjectTabRuntime` に
  `main_worktree_root_cache: Arc<OnceLock<PathBuf>>` を追加。Launch / Start
  Work / Add Agent / Resume Workspace で再利用し、2 回目以降の Open は
  cache hit でさらに短縮。

Windows 上で `CreateProcess` + Defender real-time scan が 1 spawn 数百 ms
かかるため、本変更でコールドオープン時間が 5+ 秒 → 体感 1 秒以下に改善
される見込み (実機計測は T-PERF-009 として SPEC-2014 tasks に予約済み)。

### Phase C1/C2 — Resize 固着の防御策と計測ログ

- `crates/gwt/web/app.js`: `resizeState` に `startedAt` と `stalenessTimer`
  を追加。30 秒経過しても pointerup / cancel / lostpointercapture のいずれも
  届かない場合は `finishWindowResize` を強制的に呼び teardown する。新
  `pointerdown` 時に既存 state が残っていれば `forceResetResizeState` で
  即時クリア。`setPointerCapture` を try/catch でラップし、WebView2 で
  OS が pointer を先に解放しても window-bound pointermove で継続できる
  ようにする。
- `crates/gwt-terminal/src/pty.rs::PtyHandle::resize` と
  `crates/gwt-terminal/src/pane.rs::Pane::resize` に
  `tracing::info!(target=gwt::resize::pty|pane)` を追加。`cols` / `rows` /
  `lock_elapsed_ms` / `resize_elapsed_ms` / `total_elapsed_ms` / `outcome`
  を構造化出力し、`~/.gwt/logs/` だけで ConPTY 遅延 vs parser 遅延 vs
  lock 遅延を切り分けられるようにする。

根本原因まで踏み込まないのは、Windows 実機ログが取得できない制約下で
defensive guard + 計測点を先に入れ、再現時に切り分けできる土台を作る
ためです (SPEC-2014 plan の Phase C 続編に T-PERF-009 / SC-PERF-004 と
して残してあります)。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p gwt-core -p gwt-git -p gwt --all-features` 全 GREEN
- [x] `cargo test -p gwt-terminal` 全 GREEN
- [x] `cargo build -p gwt --bin gwt --bin gwtd`
- [x] 新規テスト:
  - `gwt-git`: `list_existing_refs_*` × 4
  - `gwt`: `start_work::tests::start_work_base_branch_invokes_lookup_only_once_for_all_candidates`、`reserve_branch_invokes_lookup_only_once_per_candidate`、`*_propagates_lookup_errors`
  - `gwt` (binary): `runtime_support::tests::branch_worktree_path_resolves_linked_worktree_for_target_branch` / `branch_worktree_path_returns_none_for_unknown_branch` / `branch_worktree_path_resolves_head_branch_via_main_worktree_listing`
  - `gwt` (binary): `app_runtime::tests::project_tab_runtime_main_worktree_root_caches_resolution`
  - `gwt` (binary): `embedded_web::tests::embedded_web_resize_state_guards_against_lost_pointer_end_events`
- [x] SPEC-2014 (#2014) spec / plan / tasks に Phase B / Phase C を追記済み
- [ ] Windows 実機 GUI smoke (T-PERF-009): Branch 起点 / Start Work 起点いずれも Wizard 表示が 1 秒以内になることを stopwatch 計測
- [ ] Windows 実機 resize smoke: defensive guard 発火時に `[resize] staleness guard fired after Nms` が WebView2 DevTools console に出ること、`~/.gwt/logs/` に `gwt::resize::pty` / `gwt::resize::pane` info 行が出ることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git refs listing functionality.

* **Bug Fixes**
  * Fixed resize state getting stuck when pointer events drop in WebView2/Windows environments by adding staleness detection.

* **Performance**
  * Optimized branch and start-work resolution using cached worktree paths and bulk ref lookups, reducing unnecessary Git operations.
  * Added resize timing diagnostics to improve performance visibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2672)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->