### PR TITLE
chore(release): v9.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.30.0] - 2026-05-13
+
+### Bug Fixes
+
+- **resize:** Resize 固着の防御策と計測ログ (SPEC-2014 Phase C1/C2)
+- **gui:** Preserve terminals across project switches
+
+### Features
+
+- **workspace:** SPEC-2359 US-37 Workspace auto-done on completion signals
+- **app-runtime:** SPEC-2359 Phase U-5 Board path title sync (FR-125/126/129)
+- **workspace:** SPEC-2359 US-37 retroactive auto-done current.json fallback
+
+### Miscellaneous Tasks
+
+- **merge:** ProjectTabRuntime テスト構築箇所に main_worktree_root_cache を追加
+
+### Performance
+
+- **launch-wizard:** Wizard cold-open の git spawn を集約 (SPEC-2014 Phase B)
+
 ## [9.29.0] - 2026-05-13
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "axum",
  "base64",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.29.0"
+version = "9.30.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.29.0"
+version = "9.30.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -881,6 +881,168 @@ pub fn record_workspace_work_event_paths(
     Ok(())
 }
 
+/// SPEC-2359 US-37 / FR-117..FR-120: Emit a single Done `WorkspaceWorkEvent`
+/// for `work_item_id` iff no Done event has been recorded for it yet. This is
+/// the canonical write path for auto-done emission from PR merge detection,
+/// user-confirmed cleanup, and startup retroactive migration. Returns
+/// `Ok(true)` when a new Done event was appended, `Ok(false)` when an
+/// existing Done event was found (idempotent noop).
+pub fn emit_workspace_done_event_if_absent_paths(
+    work_items_path: &Path,
+    events_path: &Path,
+    work_item_id: &str,
+    updated_at: DateTime<Utc>,
+) -> Result<bool> {
+    if work_item_has_done_event_in_projection(work_items_path, work_item_id)? {
+        return Ok(false);
+    }
+    let mut event = WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Done, work_item_id, updated_at);
+    event.status_category = Some(WorkspaceStatusCategory::Done);
+    record_workspace_work_event_paths(work_items_path, events_path, event)?;
+    Ok(true)
+}
+
+/// SPEC-2359 US-37 / FR-117..FR-120: Convenience wrapper resolving the
+/// project-scoped work_items and work_events paths from `repo_path` and
+/// invoking [`emit_workspace_done_event_if_absent_paths`].
+pub fn emit_workspace_done_event_if_absent(
+    repo_path: &Path,
+    work_item_id: &str,
+    updated_at: DateTime<Utc>,
+) -> Result<bool> {
+    emit_workspace_done_event_if_absent_paths(
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+        &gwt_workspace_work_events_path_for_repo_path(repo_path),
+        work_item_id,
+        updated_at,
+    )
+}
+
+fn work_item_has_done_event_in_projection(
+    work_items_path: &Path,
+    work_item_id: &str,
+) -> Result<bool> {
+    let Some(projection) = load_workspace_work_items_from_path(work_items_path)? else {
+        return Ok(false);
+    };
+    Ok(projection
+        .work_items
+        .iter()
+        .filter(|item| item.id == work_item_id)
+        .any(|item| {
+            item.events
+                .iter()
+                .any(|event| event.kind == WorkspaceWorkEventKind::Done)
+        }))
+}
+
+/// SPEC-2359 US-37 / FR-119: Scan all WorkItems in `work_items.json` and
+/// emit a Done event for each WorkItem that is still incomplete and whose
+/// execution container indicates a merged `work/*` Start Work branch.
+/// Eligibility requires at least one [`WorkspaceExecutionContainerRef`]
+/// whose `branch` starts with `"work/"` and whose `pr_state` matches
+/// `"merged"` case-insensitively. Emission is delegated to
+/// [`emit_workspace_done_event_if_absent_paths`] so repeated invocations
+/// are idempotent. Returns the number of WorkItems that were newly Done'd.
+pub fn retroactive_auto_done_scan_paths(
+    work_items_path: &Path,
+    events_path: &Path,
+    now: DateTime<Utc>,
+) -> Result<usize> {
+    let Some(projection) = load_workspace_work_items_from_path(work_items_path)? else {
+        return Ok(0);
+    };
+    let candidates: Vec<String> = projection
+        .work_items
+        .iter()
+        .filter(|item| item.is_incomplete())
+        .filter(|item| work_item_is_eligible_for_auto_done(item))
+        .map(|item| item.id.clone())
+        .collect();
+    let mut emitted = 0;
+    for work_item_id in candidates {
+        if emit_workspace_done_event_if_absent_paths(
+            work_items_path,
+            events_path,
+            &work_item_id,
+            now,
+        )? {
+            emitted += 1;
+        }
+    }
+    Ok(emitted)
+}
+
+/// SPEC-2359 US-37 / FR-119: Convenience wrapper resolving the project-scoped
+/// work_items and work_events paths from `repo_path` and invoking
+/// [`retroactive_auto_done_scan_paths`].
+pub fn retroactive_auto_done_scan(repo_path: &Path, now: DateTime<Utc>) -> Result<usize> {
+    retroactive_auto_done_scan_paths(
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+        &gwt_workspace_work_events_path_for_repo_path(repo_path),
+        now,
+    )
+}
+
+fn work_item_is_eligible_for_auto_done(item: &WorkspaceWorkItem) -> bool {
+    item.execution_containers.iter().any(|container| {
+        let branch_starts_with_work = container
+            .branch
+            .as_deref()
+            .is_some_and(|branch| branch.starts_with("work/"));
+        let pr_state_merged = container
+            .pr_state
+            .as_deref()
+            .is_some_and(|state| state.eq_ignore_ascii_case("merged"));
+        branch_starts_with_work && pr_state_merged
+    })
+}
+
+/// SPEC-2359 US-37 / FR-118: Emit a Done WorkspaceWorkEvent for the Workspace
+/// WorkItem currently associated with `branch`. The function loads the current
+/// projection at `current_path` and emits Done iff
+/// `projection.git_details.branch` matches `branch`. Used by user-confirmed
+/// cleanup to mark the matching Workspace as completed before worktree/branch
+/// deletion. Idempotent per `work_item_id` via
+/// [`emit_workspace_done_event_if_absent_paths`].
+pub fn emit_workspace_done_event_for_branch_paths(
+    current_path: &Path,
+    work_items_path: &Path,
+    events_path: &Path,
+    branch: &str,
+    now: DateTime<Utc>,
+) -> Result<bool> {
+    let Some(projection) = load_workspace_projection_from_path(current_path)? else {
+        return Ok(false);
+    };
+    let matches = projection
+        .git_details
+        .as_ref()
+        .and_then(|details| details.branch.as_deref())
+        .is_some_and(|stored_branch| stored_branch == branch);
+    if !matches {
+        return Ok(false);
+    }
+    emit_workspace_done_event_if_absent_paths(work_items_path, events_path, &projection.id, now)
+}
+
+/// SPEC-2359 US-37 / FR-118: Convenience wrapper resolving project-scoped
+/// paths from `repo_path` and invoking
+/// [`emit_workspace_done_event_for_branch_paths`].
+pub fn emit_workspace_done_event_for_branch(
+    repo_path: &Path,
+    branch: &str,
+    now: DateTime<Utc>,
+) -> Result<bool> {
+    emit_workspace_done_event_for_branch_paths(
+        &gwt_workspace_projection_path_for_repo_path(repo_path),
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+        &gwt_workspace_work_events_path_for_repo_path(repo_path),
+        branch,
+        now,
+    )
+}
+
 pub fn load_or_default_workspace_projection_from_path(
     path: &Path,
     project_root: &Path,
@@ -2405,6 +2567,354 @@ mod tests {
         assert_eq!(
             resolve_workspace_id_for_mention(dir.path(), "branch", "feature/x"),
             None
+        );
+    }
+
+    // SPEC-2359 US-37 / T-236..T-239: auto-done emit helper and retroactive migration scanner.
+
+    #[test]
+    fn auto_done_emit_helper_appends_single_done_event_and_marks_work_item_done() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap();
+        let done_at = Utc.with_ymd_and_hms(2026, 5, 13, 2, 0, 0).unwrap();
+
+        let mut start =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, "wi-auto-done", started_at);
+        start.title = Some("Auto-done test work".to_string());
+        start.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event_paths(&work_items_path, &events_path, start)
+            .expect("record start event");
+
+        let emitted = emit_workspace_done_event_if_absent_paths(
+            &work_items_path,
+            &events_path,
+            "wi-auto-done",
+            done_at,
+        )
+        .expect("emit done");
+        assert!(emitted, "first call must append a Done event");
+
+        let projection = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load work items")
+            .expect("work items");
+        assert_eq!(projection.work_items.len(), 1);
+        let item = &projection.work_items[0];
+        assert_eq!(item.id, "wi-auto-done");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(item.completed_at, Some(done_at));
+
+        let events_text = std::fs::read_to_string(&events_path).expect("read events");
+        let done_lines = events_text
+            .lines()
+            .filter(|line| line.contains("\"kind\":\"done\"") && line.contains("wi-auto-done"))
+            .count();
+        assert_eq!(done_lines, 1, "exactly one Done event must be persisted");
+    }
+
+    #[test]
+    fn auto_done_emit_helper_is_idempotent_per_work_item_id() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap();
+        let first_done_at = Utc.with_ymd_and_hms(2026, 5, 13, 2, 0, 0).unwrap();
+        let second_done_at = Utc.with_ymd_and_hms(2026, 5, 13, 3, 0, 0).unwrap();
+
+        let mut start =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, "wi-idempotent", started_at);
+        start.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event_paths(&work_items_path, &events_path, start)
+            .expect("record start event");
+
+        let first = emit_workspace_done_event_if_absent_paths(
+            &work_items_path,
+            &events_path,
+            "wi-idempotent",
+            first_done_at,
+        )
+        .expect("first emit");
+        let second = emit_workspace_done_event_if_absent_paths(
+            &work_items_path,
+            &events_path,
+            "wi-idempotent",
+            second_done_at,
+        )
+        .expect("second emit");
+
+        assert!(first, "first call must append Done");
+        assert!(!second, "second call must be a noop");
+
+        let events_text = std::fs::read_to_string(&events_path).expect("read events");
+        let done_lines = events_text
+            .lines()
+            .filter(|line| line.contains("\"kind\":\"done\"") && line.contains("wi-idempotent"))
+            .count();
+        assert_eq!(done_lines, 1, "Done event must not be duplicated");
+
+        let projection = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load work items")
+            .expect("work items");
+        let item = &projection.work_items[0];
+        assert_eq!(item.completed_at, Some(first_done_at));
+    }
+
+    #[test]
+    fn retroactive_auto_done_scan_marks_eligible_merged_work_branch_workitems() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 13, 9, 0, 0).unwrap();
+
+        let mut eligible =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, "wi-eligible", started_at);
+        eligible.status_category = Some(WorkspaceStatusCategory::Active);
+        eligible.execution_container = Some(WorkspaceExecutionContainerRef {
+            branch: Some("work/20260513-0100".to_string()),
+            worktree_path: None,
+            pr_number: Some(1),
+            pr_url: None,
+            pr_state: Some("merged".to_string()),
+        });
+        record_workspace_work_event_paths(&work_items_path, &events_path, eligible)
+            .expect("record eligible start");
+
+        let mut non_work = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "wi-non-work-branch",
+            started_at,
+        );
+        non_work.status_category = Some(WorkspaceStatusCategory::Active);
+        non_work.execution_container = Some(WorkspaceExecutionContainerRef {
+            branch: Some("feature/manual".to_string()),
+            worktree_path: None,
+            pr_number: Some(2),
+            pr_url: None,
+            pr_state: Some("merged".to_string()),
+        });
+        record_workspace_work_event_paths(&work_items_path, &events_path, non_work)
+            .expect("record non-work start");
+
+        let mut not_merged =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, "wi-not-merged", started_at);
+        not_merged.status_category = Some(WorkspaceStatusCategory::Active);
+        not_merged.execution_container = Some(WorkspaceExecutionContainerRef {
+            branch: Some("work/20260513-0200".to_string()),
+            worktree_path: None,
+            pr_number: Some(3),
+            pr_url: None,
+            pr_state: Some("open".to_string()),
+        });
+        record_workspace_work_event_paths(&work_items_path, &events_path, not_merged)
+            .expect("record not-merged start");
+
+        let count = retroactive_auto_done_scan_paths(&work_items_path, &events_path, now)
+            .expect("retroactive scan");
+        assert_eq!(count, 1, "only the eligible WorkItem must be auto-Done'd");
+
+        let projection = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load work items")
+            .expect("work items");
+        let eligible_item = projection
+            .work_items
+            .iter()
+            .find(|item| item.id == "wi-eligible")
+            .expect("eligible item");
+        assert_eq!(eligible_item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(eligible_item.completed_at, Some(now));
+
+        let non_work_item = projection
+            .work_items
+            .iter()
+            .find(|item| item.id == "wi-non-work-branch")
+            .expect("non-work item");
+        assert_eq!(
+            non_work_item.status_category,
+            WorkspaceStatusCategory::Active,
+            "non-work/ branch must not be auto-Done'd",
+        );
+
+        let not_merged_item = projection
+            .work_items
+            .iter()
+            .find(|item| item.id == "wi-not-merged")
+            .expect("not-merged item");
+        assert_eq!(
+            not_merged_item.status_category,
+            WorkspaceStatusCategory::Active,
+            "WorkItem without merged PR must not be auto-Done'd",
+        );
+    }
+
+    #[test]
+    fn retroactive_auto_done_scan_is_idempotent_across_invocations() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let started_at = Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap();
+        let first_run = Utc.with_ymd_and_hms(2026, 5, 13, 9, 0, 0).unwrap();
+        let second_run = Utc.with_ymd_and_hms(2026, 5, 13, 10, 0, 0).unwrap();
+
+        let mut eligible =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, "wi-twice", started_at);
+        eligible.status_category = Some(WorkspaceStatusCategory::Active);
+        eligible.execution_container = Some(WorkspaceExecutionContainerRef {
+            branch: Some("work/20260513-0100".to_string()),
+            worktree_path: None,
+            pr_number: Some(7),
+            pr_url: None,
+            pr_state: Some("merged".to_string()),
+        });
+        record_workspace_work_event_paths(&work_items_path, &events_path, eligible)
+            .expect("record start");
+
+        let first = retroactive_auto_done_scan_paths(&work_items_path, &events_path, first_run)
+            .expect("first scan");
+        let second = retroactive_auto_done_scan_paths(&work_items_path, &events_path, second_run)
+            .expect("second scan");
+
+        assert_eq!(first, 1, "first scan must emit Done");
+        assert_eq!(second, 0, "second scan must be noop");
+
+        let events_text = std::fs::read_to_string(&events_path).expect("read events");
+        let done_lines = events_text
+            .lines()
+            .filter(|line| line.contains("\"kind\":\"done\"") && line.contains("wi-twice"))
+            .count();
+        assert_eq!(done_lines, 1);
+    }
+
+    // SPEC-2359 US-37 / T-241: cleanup hook auto-done by branch match.
+
+    #[test]
+    fn emit_workspace_done_event_for_branch_emits_done_when_branch_matches() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("workspace/current.json");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let now = Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap();
+        let project_root = temp.path().join("repo");
+        std::fs::create_dir_all(&project_root).expect("create repo");
+
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
+        projection.id = "wi-cleanup-target".to_string();
+        projection.git_details = Some(GitDetails {
+            branch: Some("work/auto-done-branch".to_string()),
+            worktree_path: None,
+            base_branch: Some("origin/develop".to_string()),
+            pr_number: None,
+            pr_state: None,
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: now,
+        });
+        save_workspace_projection_to_path(&current_path, &projection).expect("save projection");
+
+        let mut start = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "wi-cleanup-target",
+            Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap(),
+        );
+        start.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event_paths(&work_items_path, &events_path, start)
+            .expect("seed start");
+
+        let emitted = emit_workspace_done_event_for_branch_paths(
+            &current_path,
+            &work_items_path,
+            &events_path,
+            "work/auto-done-branch",
+            now,
+        )
+        .expect("emit");
+        assert!(emitted, "branch match must trigger Done emit");
+
+        let work_items = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load")
+            .expect("work items");
+        let item = work_items
+            .work_items
+            .iter()
+            .find(|item| item.id == "wi-cleanup-target")
+            .expect("item");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(item.completed_at, Some(now));
+    }
+
+    #[test]
+    fn emit_workspace_done_event_for_branch_is_noop_when_branch_does_not_match() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("workspace/current.json");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let now = Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap();
+        let project_root = temp.path().join("repo");
+        std::fs::create_dir_all(&project_root).expect("create repo");
+
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
+        projection.id = "wi-different-branch".to_string();
+        projection.git_details = Some(GitDetails {
+            branch: Some("work/current-branch".to_string()),
+            worktree_path: None,
+            base_branch: None,
+            pr_number: None,
+            pr_state: None,
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: now,
+        });
+        save_workspace_projection_to_path(&current_path, &projection).expect("save projection");
+
+        let mut start = WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Start,
+            "wi-different-branch",
+            Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap(),
+        );
+        start.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event_paths(&work_items_path, &events_path, start)
+            .expect("seed start");
+
+        let emitted = emit_workspace_done_event_for_branch_paths(
+            &current_path,
+            &work_items_path,
+            &events_path,
+            "work/different-branch",
+            now,
+        )
+        .expect("emit");
+        assert!(!emitted, "non-matching branch must not trigger Done");
+
+        let work_items = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load")
+            .expect("work items");
+        let item = work_items
+            .work_items
+            .iter()
+            .find(|item| item.id == "wi-different-branch")
+            .expect("item");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Active);
+    }
+
+    // SPEC-2359 US-37 / T-242: retroactive migration startup robustness.
+
+    #[test]
+    fn retroactive_auto_done_scan_returns_zero_when_work_items_file_missing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let now = Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap();
+
+        assert!(!work_items_path.exists());
+        let count = retroactive_auto_done_scan_paths(&work_items_path, &events_path, now)
+            .expect("scan with missing work_items file must not error");
+        assert_eq!(count, 0);
+        assert!(
+            !events_path.exists(),
+            "missing work_items must skip without writing events"
         );
     }
 }

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -936,48 +936,76 @@ fn work_item_has_done_event_in_projection(
         }))
 }
 
-/// SPEC-2359 US-37 / FR-119: Scan all WorkItems in `work_items.json` and
-/// emit a Done event for each WorkItem that is still incomplete and whose
-/// execution container indicates a merged `work/*` Start Work branch.
-/// Eligibility requires at least one [`WorkspaceExecutionContainerRef`]
-/// whose `branch` starts with `"work/"` and whose `pr_state` matches
-/// `"merged"` case-insensitively. Emission is delegated to
-/// [`emit_workspace_done_event_if_absent_paths`] so repeated invocations
-/// are idempotent. Returns the number of WorkItems that were newly Done'd.
+/// SPEC-2359 US-37 / FR-119: Scan WorkItems and the current Workspace
+/// projection and emit a Done event for each eligible target that is still
+/// incomplete and not yet recorded as Done.
+///
+/// Two eligibility sources are consulted:
+///
+/// 1. Each WorkItem in `work_items.json`: at least one
+///    [`WorkspaceExecutionContainerRef`] whose `branch` starts with `"work/"`
+///    and whose `pr_state` matches `"merged"` case-insensitively.
+/// 2. The current Workspace projection at `current_path`: `git_details.branch`
+///    starts with `"work/"`, `pr_state` matches `"merged"` case-insensitively,
+///    and `created_by_start_work` is true. This catches the case where an
+///    older gwtd version updated `current.json` after a PR merged but never
+///    emitted a corresponding Done event, which would otherwise leave the
+///    WorkItem stuck outside the Completed column.
+///
+/// Emission is delegated to [`emit_workspace_done_event_if_absent_paths`] so
+/// repeated invocations are idempotent. Returns the number of WorkItems that
+/// were newly Done'd. Missing files (`work_items.json`, `current.json`) skip
+/// silently without surfacing an error.
 pub fn retroactive_auto_done_scan_paths(
+    current_path: &Path,
     work_items_path: &Path,
     events_path: &Path,
     now: DateTime<Utc>,
 ) -> Result<usize> {
-    let Some(projection) = load_workspace_work_items_from_path(work_items_path)? else {
-        return Ok(0);
-    };
-    let candidates: Vec<String> = projection
-        .work_items
-        .iter()
-        .filter(|item| item.is_incomplete())
-        .filter(|item| work_item_is_eligible_for_auto_done(item))
-        .map(|item| item.id.clone())
-        .collect();
     let mut emitted = 0;
-    for work_item_id in candidates {
-        if emit_workspace_done_event_if_absent_paths(
-            work_items_path,
-            events_path,
-            &work_item_id,
-            now,
-        )? {
+
+    if let Some(work_items_projection) = load_workspace_work_items_from_path(work_items_path)? {
+        let candidates: Vec<String> = work_items_projection
+            .work_items
+            .iter()
+            .filter(|item| item.is_incomplete())
+            .filter(|item| work_item_is_eligible_for_auto_done(item))
+            .map(|item| item.id.clone())
+            .collect();
+        for work_item_id in candidates {
+            if emit_workspace_done_event_if_absent_paths(
+                work_items_path,
+                events_path,
+                &work_item_id,
+                now,
+            )? {
+                emitted += 1;
+            }
+        }
+    }
+
+    if let Some(current) = load_workspace_projection_from_path(current_path)? {
+        if workspace_projection_is_eligible_for_auto_done(&current)
+            && emit_workspace_done_event_if_absent_paths(
+                work_items_path,
+                events_path,
+                &current.id,
+                now,
+            )?
+        {
             emitted += 1;
         }
     }
+
     Ok(emitted)
 }
 
 /// SPEC-2359 US-37 / FR-119: Convenience wrapper resolving the project-scoped
-/// work_items and work_events paths from `repo_path` and invoking
+/// current, work_items, and work_events paths from `repo_path` and invoking
 /// [`retroactive_auto_done_scan_paths`].
 pub fn retroactive_auto_done_scan(repo_path: &Path, now: DateTime<Utc>) -> Result<usize> {
     retroactive_auto_done_scan_paths(
+        &gwt_workspace_projection_path_for_repo_path(repo_path),
         &gwt_workspace_work_items_path_for_repo_path(repo_path),
         &gwt_workspace_work_events_path_for_repo_path(repo_path),
         now,
@@ -996,6 +1024,21 @@ fn work_item_is_eligible_for_auto_done(item: &WorkspaceWorkItem) -> bool {
             .is_some_and(|state| state.eq_ignore_ascii_case("merged"));
         branch_starts_with_work && pr_state_merged
     })
+}
+
+fn workspace_projection_is_eligible_for_auto_done(projection: &WorkspaceProjection) -> bool {
+    let Some(details) = projection.git_details.as_ref() else {
+        return false;
+    };
+    let branch_starts_with_work = details
+        .branch
+        .as_deref()
+        .is_some_and(|branch| branch.starts_with("work/"));
+    let pr_state_merged = details
+        .pr_state
+        .as_deref()
+        .is_some_and(|state| state.eq_ignore_ascii_case("merged"));
+    branch_starts_with_work && pr_state_merged && details.created_by_start_work
 }
 
 /// SPEC-2359 US-37 / FR-118: Emit a Done WorkspaceWorkEvent for the Workspace
@@ -2663,6 +2706,7 @@ mod tests {
     #[test]
     fn retroactive_auto_done_scan_marks_eligible_merged_work_branch_workitems() {
         let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("workspace/current.json");
         let work_items_path = temp.path().join("workspace/work_items.json");
         let events_path = temp.path().join("workspace/work_events.jsonl");
         let started_at = Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap();
@@ -2710,8 +2754,9 @@ mod tests {
         record_workspace_work_event_paths(&work_items_path, &events_path, not_merged)
             .expect("record not-merged start");
 
-        let count = retroactive_auto_done_scan_paths(&work_items_path, &events_path, now)
-            .expect("retroactive scan");
+        let count =
+            retroactive_auto_done_scan_paths(&current_path, &work_items_path, &events_path, now)
+                .expect("retroactive scan");
         assert_eq!(count, 1, "only the eligible WorkItem must be auto-Done'd");
 
         let projection = load_workspace_work_items_from_path(&work_items_path)
@@ -2751,6 +2796,7 @@ mod tests {
     #[test]
     fn retroactive_auto_done_scan_is_idempotent_across_invocations() {
         let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("workspace/current.json");
         let work_items_path = temp.path().join("workspace/work_items.json");
         let events_path = temp.path().join("workspace/work_events.jsonl");
         let started_at = Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap();
@@ -2770,10 +2816,20 @@ mod tests {
         record_workspace_work_event_paths(&work_items_path, &events_path, eligible)
             .expect("record start");
 
-        let first = retroactive_auto_done_scan_paths(&work_items_path, &events_path, first_run)
-            .expect("first scan");
-        let second = retroactive_auto_done_scan_paths(&work_items_path, &events_path, second_run)
-            .expect("second scan");
+        let first = retroactive_auto_done_scan_paths(
+            &current_path,
+            &work_items_path,
+            &events_path,
+            first_run,
+        )
+        .expect("first scan");
+        let second = retroactive_auto_done_scan_paths(
+            &current_path,
+            &work_items_path,
+            &events_path,
+            second_run,
+        )
+        .expect("second scan");
 
         assert_eq!(first, 1, "first scan must emit Done");
         assert_eq!(second, 0, "second scan must be noop");
@@ -2904,17 +2960,113 @@ mod tests {
     #[test]
     fn retroactive_auto_done_scan_returns_zero_when_work_items_file_missing() {
         let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("workspace/current.json");
         let work_items_path = temp.path().join("workspace/work_items.json");
         let events_path = temp.path().join("workspace/work_events.jsonl");
         let now = Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap();
 
         assert!(!work_items_path.exists());
-        let count = retroactive_auto_done_scan_paths(&work_items_path, &events_path, now)
-            .expect("scan with missing work_items file must not error");
+        assert!(!current_path.exists());
+        let count =
+            retroactive_auto_done_scan_paths(&current_path, &work_items_path, &events_path, now)
+                .expect("scan with missing files must not error");
         assert_eq!(count, 0);
         assert!(
             !events_path.exists(),
-            "missing work_items must skip without writing events"
+            "missing inputs must skip without writing events"
+        );
+    }
+
+    // SPEC-2359 US-37 / FR-119 current.json fallback (upgrade path).
+
+    #[test]
+    fn retroactive_auto_done_scan_emits_done_from_current_projection_when_work_items_missing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("workspace/current.json");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let now = Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap();
+        let project_root = temp.path().join("repo");
+        std::fs::create_dir_all(&project_root).expect("create repo");
+
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
+        projection.id = "wi-current-merged".to_string();
+        projection.git_details = Some(GitDetails {
+            branch: Some("work/20260513-0100".to_string()),
+            worktree_path: None,
+            base_branch: Some("origin/develop".to_string()),
+            pr_number: Some(42),
+            pr_state: Some("MERGED".to_string()),
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: now,
+        });
+        save_workspace_projection_to_path(&current_path, &projection).expect("save projection");
+
+        let count =
+            retroactive_auto_done_scan_paths(&current_path, &work_items_path, &events_path, now)
+                .expect("scan");
+        assert_eq!(
+            count, 1,
+            "current.json with merged work/* + start_work must trigger one Done emit",
+        );
+
+        let work_items = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load work items")
+            .expect("work items projection created via emit");
+        let item = work_items
+            .work_items
+            .iter()
+            .find(|item| item.id == "wi-current-merged")
+            .expect("WorkItem created from emit");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(item.completed_at, Some(now));
+
+        let second =
+            retroactive_auto_done_scan_paths(&current_path, &work_items_path, &events_path, now)
+                .expect("second scan");
+        assert_eq!(
+            second, 0,
+            "second scan must be noop after Done event exists"
+        );
+    }
+
+    #[test]
+    fn retroactive_auto_done_scan_skips_current_projection_without_start_work_flag() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("workspace/current.json");
+        let work_items_path = temp.path().join("workspace/work_items.json");
+        let events_path = temp.path().join("workspace/work_events.jsonl");
+        let now = Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap();
+        let project_root = temp.path().join("repo");
+        std::fs::create_dir_all(&project_root).expect("create repo");
+
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
+        projection.id = "wi-manual-branch".to_string();
+        projection.git_details = Some(GitDetails {
+            branch: Some("work/20260513-0200".to_string()),
+            worktree_path: None,
+            base_branch: None,
+            pr_number: Some(43),
+            pr_state: Some("merged".to_string()),
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: false,
+            created_at: now,
+        });
+        save_workspace_projection_to_path(&current_path, &projection).expect("save projection");
+
+        let count =
+            retroactive_auto_done_scan_paths(&current_path, &work_items_path, &events_path, now)
+                .expect("scan");
+        assert_eq!(
+            count, 0,
+            "non-start_work workspaces must be excluded from current.json fallback",
+        );
+        assert!(
+            !events_path.exists(),
+            "no work_events should be written for ineligible current projection",
         );
     }
 }

--- a/crates/gwt-git/src/lib.rs
+++ b/crates/gwt-git/src/lib.rs
@@ -9,6 +9,7 @@ pub mod diff;
 pub mod issue;
 pub mod migration;
 pub mod pr_status;
+pub mod refs;
 pub mod repository;
 pub mod worktree;
 
@@ -23,6 +24,7 @@ pub use issue::{Issue, IssueCache};
 pub use pr_status::{
     fetch_pr_list, pr_check_report, CiStatus, MergeStatus, PrCheckReport, PrStatus, ReviewStatus,
 };
+pub use refs::list_existing_refs;
 pub use repository::{
     clone_repo, detect_repo_type, initialize_workspace, install_develop_protection, RepoType,
     Repository,

--- a/crates/gwt-git/src/refs.rs
+++ b/crates/gwt-git/src/refs.rs
@@ -1,0 +1,170 @@
+//! Bulk ref existence lookup helpers.
+//!
+//! `list_existing_refs` checks whether each of the supplied fully-qualified
+//! ref names exists in `repo_path`, using a **single** `git for-each-ref`
+//! invocation. This is the primary tool for collapsing the Launch Wizard
+//! cold-open path on Windows, where every additional `git.exe` spawn pays a
+//! `CreateProcess` + Defender real-time-scan cost of several hundred
+//! milliseconds (SPEC-2014 FR-PERF-001 / FR-PERF-002).
+
+use std::{collections::HashSet, path::Path};
+
+use gwt_core::{GwtError, Result};
+
+/// Return the subset of `candidates` that resolve to existing refs in
+/// `repo_path`.
+///
+/// `candidates` must contain fully-qualified ref names (for example
+/// `refs/remotes/origin/develop` or `refs/heads/work/20260513-0315`).
+/// The function runs `git for-each-ref --format=%(refname) <ref...>` exactly
+/// once and parses the output as the existence set. Non-matching candidates
+/// are silently absent from the returned set.
+///
+/// Returns an empty `HashSet` without spawning git when `candidates` is empty
+/// (a `for-each-ref` with no patterns would otherwise list every ref in the
+/// repository).
+pub fn list_existing_refs(repo_path: &Path, candidates: &[&str]) -> Result<HashSet<String>> {
+    let trimmed: Vec<&str> = candidates
+        .iter()
+        .map(|candidate| candidate.trim())
+        .filter(|candidate| !candidate.is_empty())
+        .collect();
+    if trimmed.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let mut command = gwt_core::process::hidden_command("git");
+    command
+        .arg("for-each-ref")
+        .arg("--format=%(refname)")
+        .args(&trimmed)
+        .current_dir(repo_path);
+    let output = command
+        .output()
+        .map_err(|error| GwtError::Git(format!("for-each-ref: {error}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GwtError::Git(format!("for-each-ref: {stderr}")));
+    }
+
+    let existing: HashSet<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    Ok(existing)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn run(cmd: &mut Command) {
+        let output = cmd.output().expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git command failed: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+        run(Command::new("git")
+            .args(["init", "--initial-branch=main"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(path));
+        dir
+    }
+
+    fn create_branch(repo: &Path, name: &str) {
+        run(Command::new("git").args(["branch", name]).current_dir(repo));
+    }
+
+    fn create_remote_tracking_ref(repo: &Path, refname: &str) {
+        // Forge a remote tracking ref by writing it directly with `git
+        // update-ref` so tests do not need a real remote.
+        run(Command::new("git")
+            .args(["update-ref", refname, "HEAD"])
+            .current_dir(repo));
+    }
+
+    #[test]
+    fn list_existing_refs_handles_empty_input() {
+        let dir = init_repo();
+        let result = list_existing_refs(dir.path(), &[]).expect("empty input must succeed");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn list_existing_refs_skips_blank_candidates() {
+        let dir = init_repo();
+        let result =
+            list_existing_refs(dir.path(), &["", "  ", "\t"]).expect("blank input must succeed");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn list_existing_refs_returns_only_present_refs() {
+        let dir = init_repo();
+        let repo = dir.path();
+        create_branch(repo, "develop");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/develop");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/main");
+
+        let result = list_existing_refs(
+            repo,
+            &[
+                "refs/remotes/origin/develop",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/main",
+                "refs/remotes/origin/master",
+            ],
+        )
+        .expect("for-each-ref must succeed");
+
+        assert!(result.contains("refs/remotes/origin/develop"));
+        assert!(result.contains("refs/remotes/origin/main"));
+        assert!(!result.contains("refs/remotes/origin/HEAD"));
+        assert!(!result.contains("refs/remotes/origin/master"));
+    }
+
+    #[test]
+    fn list_existing_refs_resolves_local_and_remote_in_one_spawn() {
+        let dir = init_repo();
+        let repo = dir.path();
+        create_branch(repo, "work/20260513-0315");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/work/20260513-0315");
+
+        let result = list_existing_refs(
+            repo,
+            &[
+                "refs/heads/work/20260513-0315",
+                "refs/remotes/origin/work/20260513-0315",
+                "refs/heads/feature/never-created",
+                "refs/remotes/origin/feature/never-created",
+            ],
+        )
+        .expect("for-each-ref must succeed");
+
+        assert!(result.contains("refs/heads/work/20260513-0315"));
+        assert!(result.contains("refs/remotes/origin/work/20260513-0315"));
+        assert!(!result.contains("refs/heads/feature/never-created"));
+        assert!(!result.contains("refs/remotes/origin/feature/never-created"));
+    }
+}

--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -174,9 +174,29 @@ impl Pane {
     }
 
     /// Resize the pane (PTY + vt100 parser).
+    ///
+    /// Emits an `info` event at `target = gwt::resize::pane` capturing the
+    /// requested dimensions and total wall time so SPEC-2014 Phase C can tell
+    /// PTY ConPTY stalls (logged at `gwt::resize::pty`) apart from
+    /// `resize_parser_preserving_state` regressions inside the parser.
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<(), TerminalError> {
+        let started = std::time::Instant::now();
         self.pty.resize(cols, rows)?;
+        let pty_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let parser_started = std::time::Instant::now();
         resize_parser_preserving_state(&mut self.parser, rows, cols);
+        let parser_elapsed_ms =
+            u64::try_from(parser_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let total_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        tracing::info!(
+            target: "gwt::resize::pane",
+            cols = cols,
+            rows = rows,
+            pty_elapsed_ms = pty_elapsed_ms,
+            parser_elapsed_ms = parser_elapsed_ms,
+            total_elapsed_ms = total_elapsed_ms,
+            "pane resize completed"
+        );
         Ok(())
     }
 

--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -173,20 +173,58 @@ impl PtyHandle {
     }
 
     /// Resize the PTY window.
+    ///
+    /// Emits an `info` event at `target = gwt::resize::pty` with the resolved
+    /// dimensions and total wall time so SPEC-2014 Phase C diagnostics can
+    /// pinpoint Windows ConPTY stalls from `~/.gwt/logs/` alone. The lock and
+    /// the underlying `MasterPty::resize` are timed separately because the
+    /// lock contention pattern differs on Windows vs Unix.
     pub fn resize(&self, cols: u16, rows: u16) -> Result<(), TerminalError> {
+        let started = Instant::now();
         let master = self.master.lock().map_err(|e| TerminalError::PtyIoError {
             details: format!("lock poisoned: {e}"),
         })?;
-        master
-            .resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| TerminalError::PtyIoError {
-                details: e.to_string(),
-            })
+        let lock_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let resize_started = Instant::now();
+        let outcome = master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+        let resize_elapsed_ms =
+            u64::try_from(resize_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let total_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        match outcome {
+            Ok(()) => {
+                tracing::info!(
+                    target: "gwt::resize::pty",
+                    cols = cols,
+                    rows = rows,
+                    lock_elapsed_ms = lock_elapsed_ms,
+                    resize_elapsed_ms = resize_elapsed_ms,
+                    total_elapsed_ms = total_elapsed_ms,
+                    outcome = "ok",
+                    "PTY resize completed"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                let details = e.to_string();
+                tracing::warn!(
+                    target: "gwt::resize::pty",
+                    cols = cols,
+                    rows = rows,
+                    lock_elapsed_ms = lock_elapsed_ms,
+                    resize_elapsed_ms = resize_elapsed_ms,
+                    total_elapsed_ms = total_elapsed_ms,
+                    outcome = "error",
+                    error = %details,
+                    "PTY resize failed"
+                );
+                Err(TerminalError::PtyIoError { details })
+            }
+        }
     }
 
     /// Terminate the child process and every descendant in its process group.

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -191,11 +191,11 @@ impl AppRuntime {
                     },
                 )];
                 if let Some(entry) = latest_entry.as_ref() {
-                    if let Some(event) =
-                        self.record_workspace_board_milestone_event(&tab_id, &project_root, entry)
-                    {
-                        events.push(event);
-                    }
+                    events.extend(self.record_workspace_board_milestone_event(
+                        &tab_id,
+                        &project_root,
+                        entry,
+                    ));
                 }
                 events
             }
@@ -347,7 +347,8 @@ impl AppRuntime {
         tab_id: &str,
         project_root: &Path,
         entry: &coordination::BoardEntry,
-    ) -> Option<OutboundEvent> {
+    ) -> Vec<OutboundEvent> {
+        let _ = tab_id;
         let mut projection =
             match workspace_projection::load_or_default_workspace_projection(project_root) {
                 Ok(projection) => projection,
@@ -357,11 +358,10 @@ impl AppRuntime {
                         project_root = %project_root.display(),
                         "failed to load workspace projection for board milestone"
                     );
-                    return None;
+                    return Vec::new();
                 }
             };
         projection.record_board_milestone(entry);
-        self.update_agent_window_dynamic_title_for_board_entry(entry);
         if let Err(error) =
             workspace_projection::save_workspace_projection(project_root, &projection)
         {
@@ -370,7 +370,7 @@ impl AppRuntime {
                 project_root = %project_root.display(),
                 "failed to save workspace projection for board milestone"
             );
-            return None;
+            return Vec::new();
         }
         if board_entry_origin_can_record_workspace_work_event(&projection, entry) {
             let work_event =
@@ -386,63 +386,7 @@ impl AppRuntime {
             }
         }
 
-        if self.active_tab_id.as_deref() != Some(tab_id) {
-            return None;
-        }
-        let tab = self.tab(tab_id)?;
-        let projection = self.active_work_projection_for_tab(tab_id, tab)?;
-        Some(OutboundEvent::broadcast(
-            BackendEvent::ActiveWorkProjection {
-                projection: Box::new(projection),
-            },
-        ))
-    }
-
-    fn update_agent_window_dynamic_title_for_board_entry(
-        &mut self,
-        entry: &coordination::BoardEntry,
-    ) -> bool {
-        if !matches!(
-            entry.kind,
-            BoardEntryKind::Claim
-                | BoardEntryKind::Status
-                | BoardEntryKind::Blocked
-                | BoardEntryKind::Handoff
-                | BoardEntryKind::Decision
-                | BoardEntryKind::Next
-        ) {
-            return false;
-        }
-        let Some(origin_session_id) = entry.origin_session_id.as_deref() else {
-            return false;
-        };
-        let Some((window_id, _)) = self
-            .active_agent_sessions
-            .iter()
-            .find(|(_, session)| session.session_id == origin_session_id)
-        else {
-            return false;
-        };
-        let Some(address) = self.window_lookup.get(window_id).cloned() else {
-            return false;
-        };
-        let Some(title_summary) = entry
-            .title_summary
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-        else {
-            return false;
-        };
-        let Some(tab) = self.tab_mut(&address.tab_id) else {
-            return false;
-        };
-        tab.workspace.set_dynamic_title_with_detail(
-            &address.raw_id,
-            Some(title_summary),
-            Some(entry.body.clone()),
-        )
+        self.apply_workspace_projection_title_sync(project_root, &projection)
     }
 }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -11433,6 +11433,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11520,6 +11521,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let tab_mut = runtime.tab_mut("tab-1").expect("tab mut");
@@ -11589,6 +11591,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1800,6 +1800,18 @@ impl AppRuntime {
     }
 
     pub(crate) fn bootstrap(&mut self) {
+        // SPEC-2359 US-37 / FR-119 / FR-123: One-shot retroactive migration to
+        // mark historical merged `work/*` Start Work Workspaces as Done so the
+        // Workspace Overview Completed column reflects past completions on the
+        // first startup after auto-done emission lands. The scan is idempotent
+        // per `work_item_id` and skips silently when journal / work_events
+        // files are missing or unreadable.
+        let now = chrono::Utc::now();
+        for tab in &self.tabs {
+            let _ =
+                gwt_core::workspace_projection::retroactive_auto_done_scan(&tab.project_root, now);
+        }
+
         let windows = self
             .tabs
             .iter()
@@ -3776,6 +3788,15 @@ impl AppRuntime {
                 },
             )];
         };
+
+        // SPEC-2359 US-37 / FR-118: emit Done for the Workspace WorkItem whose
+        // git_details.branch matches the cleanup target before delegating to
+        // worktree/branch deletion. Idempotent per work_item_id.
+        let _ = gwt_core::workspace_projection::emit_workspace_done_event_for_branch(
+            &tab.project_root,
+            branch,
+            chrono::Utc::now(),
+        );
 
         spawn_workspace_cleanup_async(
             self.proxy.clone(),

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3279,11 +3279,11 @@ impl AppRuntime {
                 })
                 .map(|tab| (tab.id.clone(), tab.project_root.clone()))
             {
-                if let Some(event) =
-                    self.record_workspace_board_milestone_event(&tab_id, &project_root, entry)
-                {
-                    events.push(event);
-                }
+                events.extend(self.record_workspace_board_milestone_event(
+                    &tab_id,
+                    &project_root,
+                    entry,
+                ));
             }
         }
         events
@@ -10801,8 +10801,11 @@ exit 0
         .with_origin_agent_id("codex")
         .with_origin_branch("work/20260504-1234");
 
-        let event = runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &blocked);
+        let event = events
+            .iter()
+            .find(|e| matches!(e.event, BackendEvent::ActiveWorkProjection { .. }))
+            .cloned()
             .expect("active projection broadcast");
 
         assert!(matches!(
@@ -10927,9 +10930,7 @@ exit 0
             vec!["SPEC-2359".to_string()],
         )
         .with_origin_session_id("session-1");
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
-            .expect("blocked projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &blocked);
         let status = BoardEntry::new(
             AuthorKind::Agent,
             "Codex",
@@ -10942,8 +10943,11 @@ exit 0
         )
         .with_origin_session_id("session-1");
 
-        let event = runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &status)
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &status);
+        let event = events
+            .iter()
+            .find(|e| matches!(e.event, BackendEvent::ActiveWorkProjection { .. }))
+            .cloned()
             .expect("active projection broadcast");
 
         assert!(matches!(
@@ -11005,9 +11009,7 @@ exit 0
             vec!["SPEC-2359".to_string()],
         )
         .with_origin_session_id("session-1");
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &blocked)
-            .expect("blocked projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &blocked);
         let next = BoardEntry::new(
             AuthorKind::Agent,
             "Codex",
@@ -11020,8 +11022,11 @@ exit 0
         )
         .with_origin_session_id("session-1");
 
-        let event = runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &next)
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &next);
+        let event = events
+            .iter()
+            .find(|e| matches!(e.event, BackendEvent::ActiveWorkProjection { .. }))
+            .cloned()
             .expect("blocked projection broadcast");
 
         assert!(matches!(
@@ -11316,9 +11321,7 @@ exit 0
         .with_origin_session_id("session-1")
         .with_title_summary("Implement dynamic title sync");
 
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &milestone)
-            .expect("projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
 
         let tab = runtime.tab("tab-1").expect("tab");
         assert_eq!(
@@ -11344,6 +11347,256 @@ exit 0
                 .dynamic_title
                 .as_deref(),
             None
+        );
+    }
+
+    /// Phase U-5 (SPEC-2359 US-38, FR-125, FR-126): a Board post that carries
+    /// `title_summary` must broadcast both `WorkspaceState` (so the pane
+    /// heading rehydrates on WS reconnect / GUI reload) and
+    /// `ActiveWorkProjection` (Active Work card) in the same batch. Prior to
+    /// Phase U-5 the Board path mutated `dynamic_title` in memory but
+    /// silently skipped the `WorkspaceState` broadcast, leaving the pane
+    /// heading stale after reconnect.
+    #[test]
+    fn app_runtime_board_milestone_broadcasts_workspace_state_for_title_sync() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        agent.purpose_title = Some("Initial purpose".to_string());
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260513-0343".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.clone(),
+                agent_project_root: repo.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        save_start_work_workspace_projection(
+            &repo,
+            runtime
+                .active_agent_sessions
+                .get(&window_id)
+                .expect("session"),
+            "develop",
+            None,
+            None,
+        )
+        .expect("save projection");
+        let milestone = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "Implementing Phase U-5 Board path title sync hardening",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1")
+        .with_title_summary("Implementing Phase U-5");
+
+        let events = runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "expected WorkspaceState broadcast from Board path so pane heading refreshes on reconnect: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "expected ActiveWorkProjection broadcast from Board path: {events:?}"
+        );
+    }
+
+    /// Phase U-5 (SPEC-2359 US-38, FR-129, FR-130): the WebSocket reconnect
+    /// path goes through `FrontendEvent::FrontendReady` → `frontend_sync_events`.
+    /// The replied `WorkspaceState` must carry each window's `dynamic_title`
+    /// and `dynamic_title_detail` so the frontend's `windowDisplayTitle()` can
+    /// rehydrate the pane heading without waiting for another mutation. This
+    /// test fails if anyone strips `dynamic_title` from the projected
+    /// `WorkspaceView`, regressing the reconnect contract.
+    #[test]
+    fn frontend_sync_events_preserves_window_dynamic_title_for_reconnect_rehydrate() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        agent.purpose_title = Some("Initial purpose".to_string());
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let tab_mut = runtime.tab_mut("tab-1").expect("tab mut");
+        tab_mut.workspace.set_dynamic_title_with_detail(
+            "agent-1",
+            Some("Phase U-5 rehydrate target".to_string()),
+            Some("simulated stale state before reconnect".to_string()),
+        );
+
+        let events = runtime.frontend_sync_events("client-1");
+
+        let workspace_event = events
+            .iter()
+            .find(|event| matches!(event.event, BackendEvent::WorkspaceState { .. }))
+            .expect("WorkspaceState reply for FrontendReady");
+        let workspace = match &workspace_event.event {
+            BackendEvent::WorkspaceState { workspace } => workspace,
+            _ => unreachable!(),
+        };
+        let projected_window = workspace
+            .tabs
+            .iter()
+            .find(|tab| tab.id == "tab-1")
+            .and_then(|tab| {
+                tab.workspace
+                    .windows
+                    .iter()
+                    .find(|window| window.id == combined_window_id("tab-1", "agent-1"))
+            })
+            .expect("agent window in projected WorkspaceState");
+        assert_eq!(
+            projected_window.dynamic_title.as_deref(),
+            Some("Phase U-5 rehydrate target"),
+            "frontend_sync_events must include dynamic_title so reconnect rehydrate restores pane heading"
+        );
+        assert_eq!(
+            projected_window.dynamic_title_detail.as_deref(),
+            Some("simulated stale state before reconnect"),
+            "frontend_sync_events must include dynamic_title_detail so tooltip survives reconnect"
+        );
+    }
+
+    /// Phase U-5: re-asserts the diff gate from
+    /// `apply_workspace_projection_title_sync_skips_workspace_state_when_same_title_resyncs`
+    /// at the Board entrypoint. Re-posting an identical milestone (same
+    /// `title_summary` + same body for `current_focus`) must not emit a
+    /// duplicate `WorkspaceState` broadcast on busy projections.
+    #[test]
+    fn app_runtime_board_milestone_skips_workspace_state_on_identical_resync() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut tab_workspace = empty_workspace_state();
+        let mut agent = sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Running);
+        agent.title = "Codex".to_string();
+        tab_workspace.windows.push(agent);
+        tab_workspace.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(tab_workspace),
+            migration_pending: false,
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260513-0343".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: repo.clone(),
+                agent_project_root: repo.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        save_start_work_workspace_projection(
+            &repo,
+            runtime
+                .active_agent_sessions
+                .get(&window_id)
+                .expect("session"),
+            "develop",
+            None,
+            None,
+        )
+        .expect("save projection");
+        let milestone = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "Stable body for current_focus",
+            None,
+            None,
+            vec!["start-work".to_string()],
+            vec!["SPEC-2359".to_string()],
+        )
+        .with_origin_session_id("session-1")
+        .with_title_summary("Stable title");
+
+        let first = runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
+        assert!(
+            first
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "first Board post should broadcast WorkspaceState: {first:?}"
+        );
+
+        let second = runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
+        assert!(
+            !second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
+            "second Board post with identical title_summary must not duplicate WorkspaceState: {second:?}"
+        );
+        assert!(
+            second
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::ActiveWorkProjection { .. })),
+            "ActiveWorkProjection should still broadcast on identical resync: {second:?}"
         );
     }
 
@@ -11416,9 +11669,7 @@ exit 0
         entry_value["title_summary"] = serde_json::json!("Title summary contract");
         let milestone: BoardEntry = serde_json::from_value(entry_value).expect("milestone");
 
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &milestone)
-            .expect("projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
 
         let tab = runtime.tab("tab-1").expect("tab");
         assert_eq!(
@@ -11502,9 +11753,7 @@ exit 0
         )
         .with_origin_session_id("session-1");
 
-        runtime
-            .record_workspace_board_milestone_event("tab-1", &repo, &milestone)
-            .expect("projection broadcast");
+        runtime.record_workspace_board_milestone_event("tab-1", &repo, &milestone);
 
         let tab = runtime.tab("tab-1").expect("tab");
         assert_eq!(

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1518,6 +1518,30 @@ pub struct ProjectTabRuntime {
     /// [`BackendEvent::MigrationDetected`] until the user picks Migrate /
     /// Skip / Quit. Not persisted: re-detected on every launch.
     pub(crate) migration_pending: bool,
+    /// SPEC-2014 FR-PERF-003: cached `git rev-parse --git-common-dir`
+    /// resolution for this tab. `gwt_git::worktree::main_worktree_root`
+    /// spawns `git.exe`; on Windows every spawn costs several hundred
+    /// milliseconds (`CreateProcess` + Defender real-time scan). The Launch
+    /// Wizard / Start Work / Add Agent / Resume Workspace paths used to call
+    /// it on every open, accounting for the bulk of the cold-open delay.
+    /// We resolve the value on first access and reuse it for the lifetime
+    /// of the tab; the [`Arc`] wrapper keeps `ProjectTabRuntime: Clone`.
+    pub(crate) main_worktree_root_cache: std::sync::Arc<std::sync::OnceLock<PathBuf>>,
+}
+
+impl ProjectTabRuntime {
+    /// Return the cached primary repository root for this tab, lazily
+    /// resolving it on first access (FR-PERF-003). Falls back to
+    /// `project_root` when `git rev-parse --git-common-dir` fails so the
+    /// caller never has to deal with `Result`.
+    pub(crate) fn main_worktree_root(&self) -> PathBuf {
+        self.main_worktree_root_cache
+            .get_or_init(|| {
+                gwt_git::worktree::main_worktree_root(&self.project_root)
+                    .unwrap_or_else(|_| self.project_root.clone())
+            })
+            .clone()
+    }
 }
 
 fn recovery_state_label(recovery: gwt_core::migration::RecoveryState) -> &'static str {
@@ -1730,6 +1754,7 @@ impl ProjectTabRuntime {
             // Re-detected at startup via resolve_project_target; persistence
             // does not carry the flag.
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -2602,6 +2627,7 @@ impl AppRuntime {
                     .map_err(|error| error.to_string())?
             }),
             migration_pending: target.needs_migration,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         });
         self.active_tab_id = Some(tab_id);
         self.remember_recent_project(&target);
@@ -6233,6 +6259,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -6254,6 +6281,7 @@ exit 0
             kind,
             workspace,
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -8244,6 +8272,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
@@ -9776,6 +9805,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
@@ -10329,6 +10359,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let current_window_id = combined_window_id("tab-1", "profile-1");
@@ -11260,6 +11291,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let first_window_id = combined_window_id("tab-1", "agent-1");
@@ -11370,6 +11402,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11462,6 +11495,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11539,6 +11573,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "agent-1");
@@ -11623,6 +11658,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         // Need the path so the temp directory survives until the runtime drops.
         let temp_root = repo.parent().expect("repo has parent").to_path_buf();
@@ -12225,6 +12261,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let all_window_id = combined_window_id("tab-1", "board-all");
@@ -12334,6 +12371,7 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(tab_workspace),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         let other_tab = sample_project_tab_with_window_at(
             "tab-2",
@@ -12378,7 +12416,42 @@ exit 0
             kind: ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(empty_workspace_state()),
             migration_pending: true,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
+    }
+
+    /// SPEC-2014 FR-PERF-003: ProjectTabRuntime caches `main_worktree_root`
+    /// resolution per tab so the Launch Wizard / Start Work paths do not
+    /// re-spawn `git rev-parse --git-common-dir` on every open.
+    #[test]
+    fn project_tab_runtime_main_worktree_root_caches_resolution() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("repo");
+        gwt_core::process::hidden_command("git")
+            .args(["init", repo.to_str().unwrap()])
+            .output()
+            .expect("git init");
+
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        assert!(
+            tab.main_worktree_root_cache.get().is_none(),
+            "cache must start empty"
+        );
+
+        let first = tab.main_worktree_root();
+        let cached = tab
+            .main_worktree_root_cache
+            .get()
+            .expect("cache populated after first access")
+            .clone();
+        assert_eq!(first, cached);
+
+        let second = tab.main_worktree_root();
+        assert_eq!(
+            first, second,
+            "second call must return the cached resolution"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -61,7 +61,7 @@ fn start_work_open_error(client_id: &str, message: impl Into<String>) -> Vec<Out
 }
 
 use super::{
-    branch_worktree_path, build_shell_process_launch, combined_window_id,
+    branch_worktree_path, branch_worktree_path_for, build_shell_process_launch, combined_window_id,
     detect_wizard_docker_context_and_status, knowledge_error_event, knowledge_kind_for_preset,
     list_branch_entries_with_active_sessions, normalize_branch_name, preferred_issue_launch_branch,
     resolve_shell_launch_worktree, synthetic_branch_entry, workspace_projection_for_current_resume,
@@ -166,7 +166,14 @@ impl AppRuntime {
     ) -> Result<(), String> {
         let normalized_branch_name = normalize_branch_name(branch_name);
         let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
-        let worktree_path = branch_worktree_path(project_root, &normalized_branch_name);
+        // SPEC-2014 FR-PERF-003: reuse the project tab's cached
+        // `main_worktree_root` resolution so the Launch Wizard cold-open path
+        // avoids another `git rev-parse --git-common-dir` spawn on Windows.
+        let main_repo_path = self.tab(tab_id).map(|tab| tab.main_worktree_root());
+        let worktree_path = main_repo_path.as_deref().map_or_else(
+            || branch_worktree_path(project_root, &normalized_branch_name),
+            |main_root| branch_worktree_path_for(main_root, &normalized_branch_name),
+        );
         let quick_start_root = worktree_path
             .clone()
             .unwrap_or_else(|| project_root.to_path_buf());
@@ -398,8 +405,15 @@ impl AppRuntime {
         project_root: &Path,
         workspace_resume_context: Option<WorkspaceResumeContext>,
     ) -> Result<(), String> {
-        let base_branch = gwt::start_work::resolve_start_work_base_branch(project_root)
-            .map_err(|error| error.to_string())?;
+        // SPEC-2014 FR-PERF-003: reuse the tab's cached `main_worktree_root`
+        // so Start Work does not spawn another `git rev-parse
+        // --git-common-dir` per open.
+        let git_root = self.tab(tab_id).map(|tab| tab.main_worktree_root());
+        let base_branch = match git_root.as_deref() {
+            Some(root) => gwt::start_work::resolve_start_work_base_branch_in(root),
+            None => gwt::start_work::resolve_start_work_base_branch(project_root),
+        }
+        .map_err(|error| error.to_string())?;
         let work_branch =
             gwt::start_work::reserve_start_work_branch_name_for_project(project_root, Utc::now())
                 .map_err(|error| error.to_string())?;

--- a/crates/gwt/src/cli/pr/mod.rs
+++ b/crates/gwt/src/cli/pr/mod.rs
@@ -200,6 +200,17 @@ fn sync_workspace_pr_metadata<E: CliEnv>(env: &E, pr: &PrStatus, requested_head:
     details.pr_created_at = pr.created_at;
     projection.updated_at = chrono::Utc::now();
     let _ = gwt_core::workspace_projection::save_workspace_projection(env.repo_path(), &projection);
+
+    // SPEC-2359 US-37 / FR-117: auto-emit Done for the linked Workspace WorkItem
+    // when the PR transitions to merged. The helper is idempotent per work_item_id,
+    // so repeated polling does not duplicate Done events.
+    if pr.state.to_string().eq_ignore_ascii_case("merged") {
+        let _ = gwt_core::workspace_projection::emit_workspace_done_event_if_absent(
+            env.repo_path(),
+            &projection.id,
+            chrono::Utc::now(),
+        );
+    }
 }
 
 fn should_sync_workspace_pr_metadata(
@@ -864,5 +875,94 @@ mod tests {
                 .expect("resolved after retry");
             assert_eq!(resolved, 2);
         });
+    }
+
+    // SPEC-2359 US-37 / T-240: PR state polling auto-done on merged
+
+    #[test]
+    fn pr_family_current_emits_workspace_auto_done_when_pr_is_merged() {
+        use crate::cli::test_support::ScopedEnvVar;
+        use chrono::TimeZone;
+
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("home");
+        let repo = home.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let mut env = crate::cli::TestEnv::new(home.path().join("cache"));
+        env.repo_path = repo.clone();
+        env.seed_current_pr(Some(gwt_git::PrStatus {
+            number: 9999,
+            title: "Auto-done PR".to_string(),
+            state: gwt_git::pr_status::PrState::Merged,
+            url: "https://github.com/akiojin/gwt/pull/9999".to_string(),
+            created_at: None,
+            ci_status: "SUCCESS".to_string(),
+            mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
+            review_status: "APPROVED".to_string(),
+        }));
+
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.id = "wi-pr-merge-auto-done".to_string();
+        projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
+            branch: Some("work/20260513-0500".to_string()),
+            worktree_path: Some(repo.join("work/20260513-0500")),
+            base_branch: Some("origin/develop".to_string()),
+            pr_number: None,
+            pr_state: None,
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: chrono::Utc::now(),
+        });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+
+        let mut start = gwt_core::workspace_projection::WorkspaceWorkEvent::new(
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Start,
+            "wi-pr-merge-auto-done",
+            chrono::Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap(),
+        );
+        start.title = Some("Auto-done PR work".to_string());
+        start.status_category =
+            Some(gwt_core::workspace_projection::WorkspaceStatusCategory::Active);
+        gwt_core::workspace_projection::record_workspace_work_event(&repo, start)
+            .expect("seed start event");
+
+        let mut out = String::new();
+        let code = run(&mut env, PrCommand::Current, &mut out).expect("run pr current");
+        assert_eq!(code, 0);
+
+        let projection_after = gwt_core::workspace_projection::load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        assert_eq!(
+            projection_after
+                .git_details
+                .as_ref()
+                .expect("git details")
+                .pr_state
+                .as_deref(),
+            Some("MERGED")
+        );
+
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        let item = work_items
+            .work_items
+            .iter()
+            .find(|item| item.id == "wi-pr-merge-auto-done")
+            .expect("work item");
+        assert_eq!(
+            item.status_category,
+            gwt_core::workspace_projection::WorkspaceStatusCategory::Done,
+            "PR merge must auto-emit Done for the linked Workspace WorkItem",
+        );
     }
 }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -639,6 +639,49 @@ mod tests {
         );
     }
 
+    /// SPEC-2014 Phase C1: Windows WebView2 で pointerup / pointercancel /
+    /// lostpointercapture のいずれも届かないケースで Wizard / Terminal が永久に
+    /// 固まらないよう、resizeState には auto-clear する staleness guard と
+    /// 二重 resize 検知時の forceReset が組み込まれていなければならない。
+    #[test]
+    fn embedded_web_resize_state_guards_against_lost_pointer_end_events() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("function scheduleResizeStalenessGuard(pointerId)"),
+            "expected a staleness guard scheduler that triggers when pointerup/cancel/lostpointercapture all miss"
+        );
+        assert!(
+            html.contains("function cancelResizeStalenessGuard()"),
+            "expected the staleness guard to be cancellable on the normal resize teardown path"
+        );
+        assert!(
+            html.contains("function forceResetResizeState(reason)"),
+            "expected a force-reset helper that clears stale resizeState when a new resize starts"
+        );
+        assert!(
+            html.contains(
+                "forceResetResizeState(\"new resize started before previous one finished\");",
+            ),
+            "expected new pointerdown to force-reset any leaked previous resizeState before opening a new session"
+        );
+        assert!(
+            html.contains("startedAt: performance.now(),"),
+            "expected resizeState to carry a startedAt timestamp so the staleness guard can log elapsed time"
+        );
+        assert!(
+            html.contains("stalenessTimer: scheduleResizeStalenessGuard(event.pointerId),"),
+            "expected the resize start path to schedule the staleness guard"
+        );
+        assert!(
+            html.contains("try {\n              resizeHandle.setPointerCapture(event.pointerId);")
+                && html.contains(
+                    "console.warn(\n                \"[resize] setPointerCapture failed, falling back to window-bound pointer events\"",
+                ),
+            "expected setPointerCapture to be wrapped in try/catch with a warning fallback for WebView2 edge cases"
+        );
+    }
+
     #[test]
     fn embedded_web_terminal_scrolls_refresh_viewport_after_xterm_scroll() {
         let html = frontend_bundle_source();

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -87,13 +87,14 @@ pub(crate) use launch_runtime::{
 };
 pub(crate) use runtime_support::{
     app_state_view_from_parts, attach_parent_console_for_cli, branch_worktree_path,
-    close_window_from_workspace, combined_window_id, current_git_branch, dedupe_recent_projects,
-    fallback_project_target, first_available_worktree_path, front_door_route, geometry_to_pty_size,
-    knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
-    origin_remote_ref, prune_missing_recent_projects, resolve_launch_spec_with_fallback,
-    resolve_project_target, run_cli, same_worktree_path, should_auto_close_agent_window,
-    should_auto_start_restored_window, synthetic_branch_entry, usable_worktree_path_for_branch,
-    workspace_view_for_tab, worktrees_have_stale_branch_entry,
+    branch_worktree_path_for, close_window_from_workspace, combined_window_id, current_git_branch,
+    dedupe_recent_projects, fallback_project_target, first_available_worktree_path,
+    front_door_route, geometry_to_pty_size, knowledge_kind_for_preset, local_branch_exists,
+    normalize_active_tab_id, normalize_branch_name, origin_remote_ref,
+    prune_missing_recent_projects, resolve_launch_spec_with_fallback, resolve_project_target,
+    run_cli, same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
+    synthetic_branch_entry, usable_worktree_path_for_branch, workspace_view_for_tab,
+    worktrees_have_stale_branch_entry,
 };
 #[cfg(test)]
 pub(crate) use runtime_support::{
@@ -1408,6 +1409,7 @@ mod tests {
             kind: gwt::ProjectKind::Git,
             workspace: WorkspaceState::from_persisted(persisted),
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -1443,6 +1445,7 @@ mod tests {
             kind,
             workspace,
             migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -219,16 +219,28 @@ pub fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> 
     }
 }
 
+/// Resolve the on-disk worktree path for `branch_name` (FR-PERF-002).
+///
+/// Earlier revisions probed `git branch --show-current` first as a fast path
+/// when the requested branch happened to be checked out at `repo_path`.
+/// `WorktreeManager::list` is authoritative for that information, so the
+/// extra spawn was pure overhead on Windows (one `CreateProcess` +
+/// Defender scan per Launch Wizard open). The current implementation skips
+/// `current_git_branch` entirely and relies on the worktree list.
 pub fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
-    if current_git_branch(repo_path)
-        .as_ref()
-        .is_ok_and(|current| current == branch_name)
-    {
-        return Some(repo_path.to_path_buf());
-    }
-
     let main_repo_path = gwt_git::worktree::main_worktree_root(repo_path).ok()?;
-    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+    branch_worktree_path_for(&main_repo_path, branch_name)
+}
+
+/// Like [`branch_worktree_path`] but starts from a pre-resolved
+/// `main_repo_path`, so the caller can re-use a cached value across multiple
+/// Launch Wizard / Start Work / Resume Workspace invocations (FR-PERF-003).
+/// Windows pays a hefty `CreateProcess` cost per `git.exe` spawn; reusing the
+/// `git rev-parse --git-common-dir` resolution that `branch_worktree_path`
+/// would otherwise perform halves the cold-open git spawn count for branch
+/// resolution.
+pub fn branch_worktree_path_for(main_repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
+    let manager = gwt_git::WorktreeManager::new(main_repo_path);
     let mut worktrees = manager.list().ok()?;
     if let Some(path) = usable_worktree_path_for_branch(&worktrees, branch_name) {
         return Some(path);
@@ -895,6 +907,101 @@ upstream\tgit@github.com:anthropics/example.git (push)
                 (s("origin"), s("https://github.com/akiojin/gwt")),
                 (s("upstream"), s("git@github.com:anthropics/example.git")),
             ]
+        );
+    }
+
+    fn seed_git_identity(path: &std::path::Path) {
+        for (key, value) in [
+            ("user.email", "tests@example.com"),
+            ("user.name", "Test User"),
+        ] {
+            gwt_core::process::hidden_command("git")
+                .args(["config", key, value])
+                .current_dir(path)
+                .output()
+                .expect("git config");
+        }
+    }
+
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        let status = gwt_core::process::hidden_command("git")
+            .args(args)
+            .current_dir(repo)
+            .status()
+            .expect("git command should run");
+        assert!(
+            status.success(),
+            "git {args:?} failed in {}",
+            repo.display()
+        );
+    }
+
+    /// SPEC-2014 FR-PERF-002: branch_worktree_path must locate the worktree
+    /// path for a non-HEAD branch by consulting the WorktreeManager list
+    /// alone, without first spawning `git branch --show-current`.
+    #[test]
+    fn branch_worktree_path_resolves_linked_worktree_for_target_branch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        run_git(&repo, &["init", "--initial-branch=main"]);
+        seed_git_identity(&repo);
+        run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+        run_git(&repo, &["branch", "feature/alpha"]);
+        let alpha_path = tmp.path().join("alpha");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                alpha_path.to_str().unwrap(),
+                "feature/alpha",
+            ],
+        );
+
+        let resolved = super::branch_worktree_path(&repo, "feature/alpha")
+            .expect("branch worktree path must resolve");
+        assert!(
+            super::same_worktree_path(&resolved, &alpha_path),
+            "expected {} to resolve to {}",
+            resolved.display(),
+            alpha_path.display(),
+        );
+    }
+
+    #[test]
+    fn branch_worktree_path_returns_none_for_unknown_branch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        run_git(&repo, &["init", "--initial-branch=main"]);
+        seed_git_identity(&repo);
+        run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+        assert!(super::branch_worktree_path(&repo, "feature/never-exists").is_none());
+    }
+
+    #[test]
+    fn branch_worktree_path_resolves_head_branch_via_main_worktree_listing() {
+        // SPEC-2014 FR-PERF-002 regression: when the requested branch is the
+        // HEAD of the main worktree, branch_worktree_path must still return
+        // that worktree's path. Earlier revisions short-circuited this case
+        // through `git branch --show-current`; the WorktreeManager list now
+        // owns the resolution alone.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        run_git(&repo, &["init", "--initial-branch=main"]);
+        seed_git_identity(&repo);
+        run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+        let resolved =
+            super::branch_worktree_path(&repo, "main").expect("HEAD branch must resolve");
+        assert!(
+            super::same_worktree_path(&resolved, &repo),
+            "expected {} to resolve to {}",
+            resolved.display(),
+            repo.display(),
         );
     }
 }

--- a/crates/gwt/src/start_work.rs
+++ b/crates/gwt/src/start_work.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use std::{
+    collections::HashSet,
     fs::{self, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
@@ -16,6 +17,7 @@ pub const START_WORK_REMOTE_HEAD_REF: &str = "origin/HEAD";
 pub enum StartWorkError {
     MissingBaseBranch,
     ReservationIo(String),
+    Lookup(String),
 }
 
 impl std::fmt::Display for StartWorkError {
@@ -27,19 +29,35 @@ impl std::fmt::Display for StartWorkError {
             Self::ReservationIo(error) => {
                 write!(f, "Failed to reserve Start Work branch name: {error}")
             }
+            Self::Lookup(error) => {
+                write!(f, "Failed to look up existing Start Work refs: {error}")
+            }
         }
     }
 }
 
 impl std::error::Error for StartWorkError {}
 
+/// Resolve the canonical Start Work base branch (FR-PERF-001).
+///
+/// The closure is invoked **once** with every candidate in
+/// [`START_WORK_BASE_BRANCH_CANDIDATES`] and must return the subset of
+/// candidates that resolve to existing refs (or a `StartWorkError::Lookup`
+/// on failure). The first candidate in the ordered list that appears in the
+/// returned set wins. The wrapper [`resolve_start_work_base_branch`] supplies
+/// a closure backed by [`gwt_git::list_existing_refs`], collapsing the four
+/// historical `git show-ref` invocations into a single
+/// `git for-each-ref`. This is the dominant cold-open cost on Windows where
+/// `CreateProcess` and Defender real-time scanning add several hundred
+/// milliseconds per spawn (SPEC-2014 Phase B).
 pub fn resolve_start_work_base_branch_with(
-    mut remote_branch_exists: impl FnMut(&str) -> bool,
+    remote_branches_existing: impl FnOnce(&[&str]) -> Result<HashSet<String>, StartWorkError>,
 ) -> Result<String, StartWorkError> {
+    let existing = remote_branches_existing(&START_WORK_BASE_BRANCH_CANDIDATES)?;
     START_WORK_BASE_BRANCH_CANDIDATES
         .iter()
         .copied()
-        .find(|candidate| remote_branch_exists(candidate))
+        .find(|candidate| existing.contains(*candidate))
         .map(str::to_string)
         .ok_or(StartWorkError::MissingBaseBranch)
 }
@@ -77,32 +95,62 @@ fn is_start_work_branch_name(branch_name: &str) -> bool {
 pub fn resolve_start_work_base_branch(repo_path: &Path) -> Result<String, StartWorkError> {
     let git_root = gwt_git::worktree::main_worktree_root(repo_path)
         .unwrap_or_else(|_| repo_path.to_path_buf());
-    resolve_start_work_base_branch_with(|candidate| {
-        git_ref_exists(&git_root, &remote_tracking_ref(candidate))
-    })
+    resolve_start_work_base_branch_in(&git_root)
+}
+
+/// Same as [`resolve_start_work_base_branch`] but skips the
+/// `git rev-parse --git-common-dir` spawn by accepting a pre-resolved
+/// `git_root`. Callers should pass the same value they already obtained
+/// from [`gwt_git::worktree::main_worktree_root`] or a tab-level cache
+/// (FR-PERF-003).
+pub fn resolve_start_work_base_branch_in(git_root: &Path) -> Result<String, StartWorkError> {
+    resolve_start_work_base_branch_with(|candidates| lookup_short_refs(git_root, candidates))
+}
+
+/// Wrap [`gwt_git::list_existing_refs`] to translate short candidate names
+/// (for example `origin/develop`) into the fully qualified refs needed by
+/// `for-each-ref`, then translate the existing-set back to short names.
+fn lookup_short_refs(
+    repo_path: &Path,
+    candidates: &[&str],
+) -> Result<HashSet<String>, StartWorkError> {
+    let qualified: Vec<String> = candidates
+        .iter()
+        .map(|candidate| remote_tracking_ref(candidate))
+        .collect();
+    let qualified_refs: Vec<&str> = qualified.iter().map(String::as_str).collect();
+    let existing_full = gwt_git::list_existing_refs(repo_path, &qualified_refs)
+        .map_err(|error| StartWorkError::Lookup(error.to_string()))?;
+    Ok(candidates
+        .iter()
+        .filter(|candidate| existing_full.contains(&remote_tracking_ref(candidate)))
+        .map(|candidate| (*candidate).to_string())
+        .collect())
 }
 
 pub fn reserve_start_work_branch_name_with(
     now: DateTime<Utc>,
-    mut branch_exists: impl FnMut(&str) -> bool,
-) -> String {
+    mut branch_exists: impl FnMut(&str) -> Result<bool, StartWorkError>,
+) -> Result<String, StartWorkError> {
     let base = format!("work/{}", now.format("%Y%m%d-%H%M"));
-    if !branch_exists(&base) {
-        return base;
+    if !branch_exists(&base)? {
+        return Ok(base);
     }
     for suffix in 2usize.. {
         let candidate = format!("{base}-{suffix}");
-        if !branch_exists(&candidate) {
-            return candidate;
+        if !branch_exists(&candidate)? {
+            return Ok(candidate);
         }
     }
     unreachable!("unbounded suffix search should always return")
 }
 
-pub fn reserve_start_work_branch_name(repo_path: &Path, now: DateTime<Utc>) -> String {
+pub fn reserve_start_work_branch_name(
+    repo_path: &Path,
+    now: DateTime<Utc>,
+) -> Result<String, StartWorkError> {
     reserve_start_work_branch_name_with(now, |candidate| {
-        git_ref_exists(repo_path, &format!("refs/heads/{candidate}"))
-            || git_ref_exists(repo_path, &format!("refs/remotes/origin/{candidate}"))
+        local_or_remote_branch_exists(repo_path, candidate)
     })
 }
 
@@ -115,17 +163,14 @@ pub fn reserve_start_work_branch_name_for_project(
         .join("start-work-reservations");
     reserve_start_work_branch_name_with_reservations(
         now,
-        |candidate| {
-            git_ref_exists(repo_path, &format!("refs/heads/{candidate}"))
-                || git_ref_exists(repo_path, &format!("refs/remotes/origin/{candidate}"))
-        },
+        |candidate| local_or_remote_branch_exists(repo_path, candidate),
         &reservations_dir,
     )
 }
 
 pub fn reserve_start_work_branch_name_with_reservations(
     now: DateTime<Utc>,
-    mut branch_exists: impl FnMut(&str) -> bool,
+    mut branch_exists: impl FnMut(&str) -> Result<bool, StartWorkError>,
     reservations_dir: &Path,
 ) -> Result<String, StartWorkError> {
     fs::create_dir_all(reservations_dir)
@@ -137,7 +182,7 @@ pub fn reserve_start_work_branch_name_with_reservations(
         } else {
             format!("{base}-{suffix}")
         };
-        if branch_exists(&candidate) {
+        if branch_exists(&candidate)? {
             continue;
         }
         match create_reservation(reservations_dir, &candidate) {
@@ -147,6 +192,21 @@ pub fn reserve_start_work_branch_name_with_reservations(
         }
     }
     unreachable!("unbounded suffix search should always return")
+}
+
+/// Check whether either `refs/heads/<candidate>` or
+/// `refs/remotes/origin/<candidate>` exists in `repo_path`, using a single
+/// `git for-each-ref` invocation (FR-PERF-001). On Windows this halves the
+/// number of `git.exe` spawns per Start Work candidate from two to one.
+fn local_or_remote_branch_exists(
+    repo_path: &Path,
+    candidate: &str,
+) -> Result<bool, StartWorkError> {
+    let local = format!("refs/heads/{candidate}");
+    let remote = format!("refs/remotes/origin/{candidate}");
+    let existing = gwt_git::list_existing_refs(repo_path, &[local.as_str(), remote.as_str()])
+        .map_err(|error| StartWorkError::Lookup(error.to_string()))?;
+    Ok(!existing.is_empty())
 }
 
 fn create_reservation(reservations_dir: &Path, branch_name: &str) -> std::io::Result<()> {
@@ -167,14 +227,6 @@ fn reservation_path(reservations_dir: &Path, branch_name: &str) -> PathBuf {
         })
 }
 
-fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
-    gwt_core::process::hidden_command("git")
-        .args(["show-ref", "--verify", "--quiet", ref_name])
-        .current_dir(repo_path)
-        .status()
-        .is_ok_and(|status| status.success())
-}
-
 fn remote_tracking_ref(remote_ref: &str) -> String {
     if remote_ref.starts_with("refs/remotes/") {
         remote_ref.to_string()
@@ -185,15 +237,19 @@ fn remote_tracking_ref(remote_ref: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
     use chrono::{TimeZone, Utc};
 
     use super::{
         refallback_start_work_base_branch_with, remote_tracking_ref,
         reserve_start_work_branch_name_with, reserve_start_work_branch_name_with_reservations,
-        resolve_start_work_base_branch_with, StartWorkError,
+        resolve_start_work_base_branch_with, StartWorkError, START_WORK_BASE_BRANCH_CANDIDATES,
     };
+
+    fn ok_existing(existing: &HashSet<String>) -> HashSet<String> {
+        existing.clone()
+    }
 
     #[test]
     fn start_work_base_branch_prefers_develop_before_remote_head() {
@@ -202,9 +258,8 @@ mod tests {
             "origin/develop".to_string(),
             "origin/main".to_string(),
         ]);
-        let resolved =
-            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
-                .expect("resolve base branch");
+        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect("resolve base branch");
 
         assert_eq!(resolved, "origin/develop");
     }
@@ -212,9 +267,8 @@ mod tests {
     #[test]
     fn start_work_base_branch_uses_remote_head_when_develop_is_missing() {
         let existing = HashSet::from(["origin/HEAD".to_string(), "origin/main".to_string()]);
-        let resolved =
-            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
-                .expect("resolve base branch");
+        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect("resolve base branch");
 
         assert_eq!(resolved, "origin/HEAD");
     }
@@ -248,18 +302,56 @@ mod tests {
     #[test]
     fn start_work_base_branch_falls_back_to_develop_main_master_order() {
         let existing = HashSet::from(["origin/main".to_string(), "origin/master".to_string()]);
-        let resolved =
-            resolve_start_work_base_branch_with(|candidate| existing.contains(candidate))
-                .expect("resolve base branch");
+        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect("resolve base branch");
 
         assert_eq!(resolved, "origin/main");
     }
 
     #[test]
     fn start_work_base_branch_reports_recoverable_missing_base() {
-        let error = resolve_start_work_base_branch_with(|_| false).expect_err("missing base");
+        let error =
+            resolve_start_work_base_branch_with(|_| Ok(HashSet::new())).expect_err("missing base");
 
         assert_eq!(error, StartWorkError::MissingBaseBranch);
+    }
+
+    #[test]
+    fn start_work_base_branch_invokes_lookup_only_once_for_all_candidates() {
+        let calls = Rc::new(RefCell::new(0usize));
+        let captured: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let calls_clone = Rc::clone(&calls);
+        let captured_clone = Rc::clone(&captured);
+        let existing = HashSet::from(["origin/develop".to_string()]);
+
+        let resolved = resolve_start_work_base_branch_with(|candidates| {
+            *calls_clone.borrow_mut() += 1;
+            *captured_clone.borrow_mut() = candidates.iter().map(|c| (*c).to_string()).collect();
+            Ok(existing.clone())
+        })
+        .expect("resolve base branch");
+
+        assert_eq!(*calls.borrow(), 1, "bulk lookup must run exactly once");
+        assert_eq!(
+            captured.borrow().as_slice(),
+            START_WORK_BASE_BRANCH_CANDIDATES
+                .iter()
+                .map(|c| (*c).to_string())
+                .collect::<Vec<_>>()
+                .as_slice(),
+            "the closure must receive every Start Work candidate in order"
+        );
+        assert_eq!(resolved, "origin/develop");
+    }
+
+    #[test]
+    fn start_work_base_branch_propagates_lookup_errors() {
+        let error = resolve_start_work_base_branch_with(|_| {
+            Err(StartWorkError::Lookup("git crashed".into()))
+        })
+        .expect_err("must surface lookup failures");
+
+        assert_eq!(error, StartWorkError::Lookup("git crashed".into()));
     }
 
     #[test]
@@ -283,7 +375,8 @@ mod tests {
         ]);
 
         let branch =
-            reserve_start_work_branch_name_with(now, |candidate| existing.contains(candidate));
+            reserve_start_work_branch_name_with(now, |candidate| Ok(existing.contains(candidate)))
+                .expect("reserve");
 
         assert_eq!(branch, "work/20260504-1234-3");
     }
@@ -295,10 +388,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0).unwrap();
 
         let first =
-            reserve_start_work_branch_name_with_reservations(now, |_| false, &reservations_dir)
+            reserve_start_work_branch_name_with_reservations(now, |_| Ok(false), &reservations_dir)
                 .expect("first reservation");
         let second =
-            reserve_start_work_branch_name_with_reservations(now, |_| false, &reservations_dir)
+            reserve_start_work_branch_name_with_reservations(now, |_| Ok(false), &reservations_dir)
                 .expect("second reservation");
 
         assert_eq!(first, "work/20260504-1234");
@@ -307,5 +400,47 @@ mod tests {
             reservations_dir.join("work").join("20260504-1234").exists(),
             "reservation should be stored without creating a Git ref"
         );
+    }
+
+    #[test]
+    fn reserve_branch_invokes_lookup_only_once_per_candidate() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reservations_dir = temp.path().join("reservations");
+        let now = Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0).unwrap();
+        let calls = Rc::new(RefCell::new(0usize));
+        let calls_clone = Rc::clone(&calls);
+
+        let branch = reserve_start_work_branch_name_with_reservations(
+            now,
+            |_candidate| {
+                *calls_clone.borrow_mut() += 1;
+                Ok(false)
+            },
+            &reservations_dir,
+        )
+        .expect("reserve");
+
+        assert_eq!(branch, "work/20260504-1234");
+        assert_eq!(
+            *calls.borrow(),
+            1,
+            "lookup must run exactly once for the first available candidate"
+        );
+    }
+
+    #[test]
+    fn reserve_branch_propagates_lookup_errors() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reservations_dir = temp.path().join("reservations");
+        let now = Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0).unwrap();
+
+        let error = reserve_start_work_branch_name_with_reservations(
+            now,
+            |_| Err(StartWorkError::Lookup("git crashed".into())),
+            &reservations_dir,
+        )
+        .expect_err("must surface lookup failures");
+
+        assert_eq!(error, StartWorkError::Lookup("git crashed".into()));
     }
 }

--- a/crates/gwt/tests/start_work_test.rs
+++ b/crates/gwt/tests/start_work_test.rs
@@ -81,7 +81,8 @@ fn start_work_launch_confirmation_materializes_reserved_work_branch_and_worktree
         Utc.with_ymd_and_hms(2026, 5, 4, 12, 34, 0)
             .single()
             .expect("timestamp"),
-    );
+    )
+    .expect("reserve start work branch name");
     let refs_before = git_output(&repo, &["for-each-ref", "refs/heads/work"]);
     assert!(
         refs_before.is_empty(),

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -17,6 +17,7 @@ import { parseHTML } from "linkedom";
 import {
   applyVisibilityTransition,
   attachHostResizeReflow,
+  classifyProjectWindowVisibility,
   viewportEligibleForRefresh,
 } from "../terminal-viewport-reflow.js";
 
@@ -158,6 +159,26 @@ test("viewportEligibleForRefresh skips display:none and minimised windows (T-186
   );
 });
 
+test("classifyProjectWindowVisibility keeps inactive project terminals hidden, not removed", () => {
+  const result = classifyProjectWindowVisibility({
+    activeWindowIds: ["tab-a::agent-1", "tab-a::board-1"],
+    allProjectWindowIds: [
+      "tab-a::agent-1",
+      "tab-a::board-1",
+      "tab-b::agent-1",
+    ],
+    mountedWindowIds: [
+      "tab-a::agent-1",
+      "tab-b::agent-1",
+      "orphan::agent-1",
+    ],
+  });
+
+  assert.deepEqual(result.visible, ["tab-a::agent-1", "tab-a::board-1"]);
+  assert.deepEqual(result.hidden, ["tab-b::agent-1"]);
+  assert.deepEqual(result.removed, ["orphan::agent-1"]);
+});
+
 test("attachHostResizeReflow throws when given a non-DOM window", () => {
   assert.throws(
     () =>
@@ -194,5 +215,10 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
     appSource,
     /viewportEligibleForRefresh\(\{/,
     "canRefreshTerminalViewport must consult the shared predicate",
+  );
+  assert.match(
+    appSource,
+    /classifyProjectWindowVisibility\(\{/,
+    "project tab switches must classify inactive project windows as hidden instead of disposing their terminal runtimes",
   );
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1379,6 +1379,7 @@
         }
         const runtime = terminalMap.get(resizeState.id);
         cancelTerminalResizeFit();
+        cancelResizeStalenessGuard();
         fitTerminal(resizeState.id, false);
         sendGeometry(
           resizeState.id,
@@ -1390,6 +1391,56 @@
         // SPEC-2356 Phase 9 (T-136): release the hover-reveal peek strip lock
         // so pointer events resume on the screen-edge triggers once resize
         // ends.
+        delete document.documentElement.dataset.opResizeActive;
+      }
+
+      // SPEC-2014 Phase C1: maximum wall time (in ms) a single resize gesture
+      // may stay active before we assume the pointer-end event was lost and
+      // force a teardown. Long enough to cover slow Windows ConPTY resizes
+      // (anecdotally a couple of seconds in the worst case) yet short enough
+      // that the user does not have to restart the app when WebView2 drops
+      // the pointerup.
+      const RESIZE_STALENESS_TIMEOUT_MS = 30_000;
+
+      function scheduleResizeStalenessGuard(pointerId) {
+        return setTimeout(() => {
+          if (!resizeState || resizeState.pointerId !== pointerId) {
+            return;
+          }
+          const elapsed = Math.round(
+            performance.now() - (resizeState.startedAt ?? performance.now()),
+          );
+          console.warn(
+            `[resize] staleness guard fired after ${elapsed}ms; clearing stuck resizeState (pointerId=${pointerId})`,
+          );
+          // Trigger the normal teardown path so xterm fit / sendGeometry /
+          // hover-reveal cleanup all run, then null the state.
+          finishWindowResize(pointerId);
+        }, RESIZE_STALENESS_TIMEOUT_MS);
+      }
+
+      function cancelResizeStalenessGuard() {
+        if (resizeState && resizeState.stalenessTimer != null) {
+          clearTimeout(resizeState.stalenessTimer);
+          resizeState.stalenessTimer = null;
+        }
+      }
+
+      function forceResetResizeState(reason) {
+        if (!resizeState) {
+          return;
+        }
+        const previous = resizeState;
+        console.warn(
+          `[resize] force-reset resizeState (reason=${reason}, previousPointerId=${previous.pointerId}, windowId=${previous.id})`,
+        );
+        if (previous.fitFrame != null) {
+          cancelAnimationFrame(previous.fitFrame);
+        }
+        if (previous.stalenessTimer != null) {
+          clearTimeout(previous.stalenessTimer);
+        }
+        resizeState = null;
         delete document.documentElement.dataset.opResizeActive;
       }
 
@@ -7215,6 +7266,12 @@
 
           resizeHandle.addEventListener("pointerdown", (event) => {
             focusWindowRemotely(windowData.id);
+            // SPEC-2014 Phase C1: Windows WebView2 occasionally fails to
+            // deliver pointerup / pointercancel / lostpointercapture, leaving
+            // the previous resizeState alive when the next gesture starts.
+            // Force-clear the leaked state on every new pointerdown so the
+            // user never has to restart the app to escape a stuck resize.
+            forceResetResizeState("new resize started before previous one finished");
             resizeState = {
               id: windowData.id,
               pointerId: event.pointerId,
@@ -7223,12 +7280,27 @@
               width: parseNumber(element.style.width),
               height: parseNumber(element.style.height),
               fitFrame: null,
+              startedAt: performance.now(),
+              stalenessTimer: scheduleResizeStalenessGuard(event.pointerId),
             };
             // SPEC-2356 Phase 9 (T-136): suppress hover-reveal peek strip
             // hits while resize is active so pointer movements that cross
             // the screen edge do not steal focus mid-resize.
             document.documentElement.dataset.opResizeActive = "true";
-            resizeHandle.setPointerCapture(event.pointerId);
+            try {
+              resizeHandle.setPointerCapture(event.pointerId);
+            } catch (error) {
+              // SPEC-2014 Phase C1: setPointerCapture is best-effort; on
+              // Windows WebView2 it can throw when the pointer has already
+              // been released by the OS between the dispatch and the
+              // callback. We continue without capture so that the
+              // window-bound pointermove / pointerup listeners still
+              // drive the resize.
+              console.warn(
+                "[resize] setPointerCapture failed, falling back to window-bound pointer events",
+                error,
+              );
+            }
           });
           resizeHandle.addEventListener("lostpointercapture", (event) => {
             finishWindowResize(event.pointerId);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -32,6 +32,7 @@
       import {
         applyVisibilityTransition,
         attachHostResizeReflow,
+        classifyProjectWindowVisibility,
         viewportEligibleForRefresh,
       } from "/terminal-viewport-reflow.js";
 
@@ -501,6 +502,16 @@
 
       function activeWorkspace() {
         return activeProjectTab()?.workspace || emptyWorkspace();
+      }
+
+      function allProjectWindowIds() {
+        const ids = [];
+        for (const tab of appState?.tabs || []) {
+          for (const windowData of tab.workspace?.windows || []) {
+            ids.push(windowData.id);
+          }
+        }
+        return ids;
       }
 
       function workspaceWindowById(windowId) {
@@ -7284,11 +7295,25 @@
         };
         applyViewport();
 
-        const ids = new Set(workspace.windows.map((windowData) => windowData.id));
-        for (const [windowId, element] of windowMap.entries()) {
-          if (ids.has(windowId)) {
-            continue;
-          }
+        const activeWindowIds = workspace.windows.map((windowData) => windowData.id);
+        const ids = new Set(activeWindowIds);
+        const visibility = classifyProjectWindowVisibility({
+          activeWindowIds,
+          allProjectWindowIds: allProjectWindowIds(),
+          mountedWindowIds: windowMap.keys(),
+        });
+        for (const windowId of visibility.hidden) {
+          const element = windowMap.get(windowId);
+          applyVisibilityTransition({
+            element,
+            shouldHide: true,
+            hasTerminal: terminalMap.has(windowId),
+            onReveal: () => scheduleTerminalFocusActivation(windowId),
+          });
+        }
+        for (const windowId of visibility.removed) {
+          const element = windowMap.get(windowId);
+          if (!element) continue;
           const runtime = terminalMap.get(windowId);
           if (runtime && runtime.viewportRefreshFrame !== null) {
             cancelAnimationFrame(runtime.viewportRefreshFrame);

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -58,6 +58,48 @@ export function applyVisibilityTransition({
   return false;
 }
 
+function idSet(values) {
+  const set = new Set();
+  for (const value of values || []) {
+    if (value === null || value === undefined) continue;
+    set.add(String(value));
+  }
+  return set;
+}
+
+/**
+ * Classify mounted workspace windows during a project-tab render.
+ *
+ * Active-project windows are visible, windows that still belong to another
+ * project tab stay mounted but hidden, and only windows missing from every
+ * project tab are safe to dispose. This keeps inactive terminal xterm
+ * runtimes alive so returning to a project can reflow instead of recreating
+ * the terminal surface from scratch.
+ */
+export function classifyProjectWindowVisibility({
+  activeWindowIds,
+  allProjectWindowIds,
+  mountedWindowIds,
+}) {
+  const active = idSet(activeWindowIds);
+  const all = idSet(allProjectWindowIds);
+  const visible = Array.from(active);
+  const hidden = [];
+  const removed = [];
+
+  for (const windowId of mountedWindowIds || []) {
+    const id = String(windowId);
+    if (active.has(id)) continue;
+    if (all.has(id)) {
+      hidden.push(id);
+    } else {
+      removed.push(id);
+    }
+  }
+
+  return { visible, hidden, removed };
+}
+
 /**
  * Predicate used by both the host resize fan-out and the existing
  * `fitTerminal` short-circuit. Pulled out so a unit test can pin the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.29.0",
+  "version": "9.30.0",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.30.0 リリース。`develop` を `main` にマージし、GitHub Release / npm publish / cross-platform バイナリを自動生成します。

主要トピック:

- **SPEC-2359 US-37 (Workspace auto-done on completion signals)** — PR merge と user-confirmed cleanup から Workspace Overview の Completed カラムへ自動遷移させる auto-done emit を追加。retroactive scan を起動時に走らせ、過去の merged + `work/*` + start_work Workspace を 1 回だけ Done 化。`current.json` も eligibility source として参照する fallback を追加し、旧 gwtd 版からの upgrade scenario も初回起動で正しく拾える。
- **SPEC-2359 Phase U-5 + U-6 partial (Title Sync + schema)** — Board path → canonical title sync orchestrator 直結、WorkspaceState + ActiveWorkProjection 同一バッチ broadcast。WorkspaceProjection に `created_at` / `creator` / `lifecycle_stage` / `blocked_reason` / `linked_issues` / `linked_prs` / `tags` / `progress_pct` 追加 (#[serde(default)] で後方互換)。
- **SPEC-2014 Phase B/C1/C2 (wizard cold-open perf + resize guards)** — Wizard cold-open の git spawn を集約。Frontend resize state に staleness guard + pointerdown 再初期化。Backend PtyHandle/Pane resize に instrumentation 追加。
- **GUI fix (project tab terminal preservation)** — Inactive project terminals を hidden にし dispose しない。orphan window cleanup は維持。

## Changes

### Features

- **workspace**: SPEC-2359 US-37 Workspace auto-done on completion signals (#2670)
- **app-runtime**: SPEC-2359 Phase U-5 Board path title sync (FR-125/126/129) (#2671)
- **workspace**: SPEC-2359 US-37 retroactive auto-done current.json fallback (#2673)

### Performance

- **launch-wizard**: Wizard cold-open の git spawn を集約 (SPEC-2014 Phase B) (#2672)

### Bug Fixes

- **resize**: Resize 固着の防御策と計測ログ (SPEC-2014 Phase C1/C2) (#2672)
- **gui**: Preserve terminals across project switches (#2669)

### Miscellaneous

- **merge**: ProjectTabRuntime テスト構築箇所に main_worktree_root_cache を追加

## Version

`v9.29.0` → **`v9.30.0`** (minor bump: 3 feat, 2 fix, 0 BREAKING)

## Closing Issues

Closes #2668

## Related Issues / Links

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v9.30.0

* **New Features**
  * Auto-completion of Start Work items when associated pull requests are merged
  * Workspace board titles now synchronize with project paths
  * Improved terminal window visibility management to prevent orphaned resources

* **Bug Fixes**
  * Terminal resize operations are now properly instrumented and logged
  * Enhanced PTY resize error handling with detailed diagnostics
  * Workspace projection fallback handling for auto-done tracking

* **Performance**
  * Optimized wizard cold-open flows through improved branch resolution caching
  * Reduced git operations for branch existence checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2674)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->