### PR TITLE
fix(windows): resize/起動の追加防御策と診断ログ (SPEC-2014 Phase C4-C6)

### DIFF
--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -16,6 +16,14 @@ use tracing::instrument;
 
 use crate::TerminalError;
 
+/// Phase C5 threshold (ms) above which a successful PTY resize is logged at
+/// `warn` instead of `info`. Windows ConPTY's `ResizePseudoConsole` should
+/// complete in single-digit milliseconds; anything north of 250 ms is a
+/// strong signal of OS-level contention (Defender real-time scanning,
+/// stalled child process, etc.) and worth surfacing in `~/.gwt/logs/`
+/// without having to hand-correlate elapsed-time fields.
+pub const SLOW_RESIZE_WARN_MS: u64 = 250;
+
 mod process_group;
 #[cfg(windows)]
 mod windows_spawn;
@@ -179,6 +187,11 @@ impl PtyHandle {
     /// pinpoint Windows ConPTY stalls from `~/.gwt/logs/` alone. The lock and
     /// the underlying `MasterPty::resize` are timed separately because the
     /// lock contention pattern differs on Windows vs Unix.
+    ///
+    /// Phase C5: when `total_elapsed_ms` exceeds [`SLOW_RESIZE_WARN_MS`] the
+    /// `info` event is upgraded to a `warn` so slow-path operators (and
+    /// `~/.gwt/logs/` greps) can flag Windows ConPTY hangs without having to
+    /// hand-correlate the elapsed-time field.
     pub fn resize(&self, cols: u16, rows: u16) -> Result<(), TerminalError> {
         let started = Instant::now();
         let master = self.master.lock().map_err(|e| TerminalError::PtyIoError {
@@ -197,16 +210,30 @@ impl PtyHandle {
         let total_elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
         match outcome {
             Ok(()) => {
-                tracing::info!(
-                    target: "gwt::resize::pty",
-                    cols = cols,
-                    rows = rows,
-                    lock_elapsed_ms = lock_elapsed_ms,
-                    resize_elapsed_ms = resize_elapsed_ms,
-                    total_elapsed_ms = total_elapsed_ms,
-                    outcome = "ok",
-                    "PTY resize completed"
-                );
+                if total_elapsed_ms >= SLOW_RESIZE_WARN_MS {
+                    tracing::warn!(
+                        target: "gwt::resize::pty",
+                        cols = cols,
+                        rows = rows,
+                        lock_elapsed_ms = lock_elapsed_ms,
+                        resize_elapsed_ms = resize_elapsed_ms,
+                        total_elapsed_ms = total_elapsed_ms,
+                        outcome = "slow",
+                        threshold_ms = SLOW_RESIZE_WARN_MS,
+                        "PTY resize completed but exceeded slow-path threshold"
+                    );
+                } else {
+                    tracing::info!(
+                        target: "gwt::resize::pty",
+                        cols = cols,
+                        rows = rows,
+                        lock_elapsed_ms = lock_elapsed_ms,
+                        resize_elapsed_ms = resize_elapsed_ms,
+                        total_elapsed_ms = total_elapsed_ms,
+                        outcome = "ok",
+                        "PTY resize completed"
+                    );
+                }
                 Ok(())
             }
             Err(e) => {

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -639,6 +639,47 @@ mod tests {
         );
     }
 
+    /// SPEC-2014 Phase C4: 高頻度な pointermove を直接 DOM mutation に
+    /// 流し込まず、`requestAnimationFrame` で 1 フレーム 1 回に絞り込んで
+    /// いることを bundle 上で固定する。Windows WebView2 で layout reflow が
+    /// pointermove 速度に追従できず render thread が枯渇する症状を回避するため。
+    #[test]
+    fn embedded_web_resize_pointermove_is_coalesced_via_request_animation_frame() {
+        let html = frontend_bundle_source();
+        let direct_pointermove_width = regex::Regex::new(
+            r"if\s*\(resizeState && resizeState\.pointerId === event\.pointerId\)\s*\{\s*const element = windowMap\.get\(resizeState\.id\)",
+        )
+        .expect("valid regex");
+        assert!(
+            !direct_pointermove_width.is_match(html),
+            "expected pointermove resize handler to stop directly mutating element.style; the coalesced applyResizePointermove path must replace it"
+        );
+        assert!(
+            html.contains("function scheduleResizePointermoveApply()"),
+            "expected a rAF scheduler that coalesces pointermove-driven DOM writes"
+        );
+        assert!(
+            html.contains("function cancelResizePointermoveApply()"),
+            "expected the coalescing scheduler to be cancellable on resize teardown"
+        );
+        assert!(
+            html.contains("function applyResizePointermove(state)"),
+            "expected a pure helper that translates resizeState into element.style.width/height"
+        );
+        assert!(
+            html.contains("resizeState.latestClientX = event.clientX;"),
+            "expected pointermove to store the latest client coordinates on resizeState"
+        );
+        assert!(
+            html.contains("scheduleResizePointermoveApply();"),
+            "expected pointermove to schedule the coalesced apply rather than write to the DOM directly"
+        );
+        assert!(
+            html.contains("applyFrame: null,"),
+            "expected resizeState to carry an applyFrame slot so the rAF handle can be cancelled"
+        );
+    }
+
     /// SPEC-2014 Phase C1: Windows WebView2 で pointerup / pointercancel /
     /// lostpointercapture のいずれも届かないケースで Wizard / Terminal が永久に
     /// 固まらないよう、resizeState には auto-clear する staleness guard と

--- a/crates/gwt/src/gui_single_instance.rs
+++ b/crates/gwt/src/gui_single_instance.rs
@@ -3,9 +3,25 @@ use std::{
     fs::{self, File, OpenOptions},
     path::{Path, PathBuf},
     sync::{Mutex, OnceLock},
+    time::{Duration, SystemTime},
 };
 
 use fs2::FileExt;
+
+/// Environment variable that lets a user force-bypass the GUI single-instance
+/// lock when a previous gwt crash left a stale OS lock on Windows. Set to
+/// `"1"` / `"true"` / `"yes"` (case-insensitive) to skip the lock acquisition
+/// failure path and continue startup. Phase C6 escape hatch for Issue #1764
+/// follow-ups where the lock file cannot be unlocked by normal means
+/// (antivirus / filesystem cache pinning the handle alive after the owning
+/// process exited).
+const FORCE_NEW_INSTANCE_ENV: &str = "GWT_FORCE_NEW_INSTANCE";
+
+/// Phase C6: if the lock file is older than this threshold AND `try_lock_*`
+/// fails, the failure is logged with a recovery hint pointing at the lock
+/// path. Long-lived gwt processes do not refresh the lock file mtime, so
+/// "old file" alone is not enough to drop the lock; we only surface the hint.
+const STALE_LOCK_HINT_AGE: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug)]
 pub struct GuiInstanceLock {
@@ -79,15 +95,29 @@ pub fn acquire_gui_instance_lock(
         source,
     })?;
 
+    let override_active = force_new_instance_requested();
     {
         let mut registry = process_lock_registry()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if registry.contains(&lock_path) {
-            return Err(GuiInstanceLockError::AlreadyRunning {
-                project_root: project_root.to_path_buf(),
-                lock_path,
-            });
+            // Phase C6: the in-process registry guards against double-acquire
+            // within the same gwt process. Honour the override here too so
+            // the env var has uniform semantics: setting it always lets the
+            // current process proceed, regardless of which layer reported
+            // the collision.
+            if override_active {
+                tracing::warn!(
+                    target: "gwt::startup::lock",
+                    lock_path = %lock_path.display(),
+                    "GWT_FORCE_NEW_INSTANCE override bypassed the in-process single-instance registry"
+                );
+            } else {
+                return Err(GuiInstanceLockError::AlreadyRunning {
+                    project_root: project_root.to_path_buf(),
+                    lock_path,
+                });
+            }
         }
         registry.insert(lock_path.clone());
     }
@@ -115,6 +145,23 @@ pub fn acquire_gui_instance_lock(
             file,
         }),
         Err(_) => {
+            // Phase C6 escape hatch: a previous gwt crash on Windows can
+            // leave the OS-level file lock pinned even after the process
+            // exits if security software is holding the file open. Setting
+            // GWT_FORCE_NEW_INSTANCE=1 skips the lock check so the user can
+            // recover without having to delete the lock file by hand.
+            if force_new_instance_requested() {
+                tracing::warn!(
+                    target: "gwt::startup::lock",
+                    lock_path = %lock_path.display(),
+                    "GWT_FORCE_NEW_INSTANCE override bypassed the single-instance lock"
+                );
+                return Ok(GuiInstanceLock {
+                    path: lock_path,
+                    file,
+                });
+            }
+            log_stale_lock_hint(&lock_path);
             unregister_process_lock(&lock_path);
             Err(GuiInstanceLockError::AlreadyRunning {
                 project_root: project_root.to_path_buf(),
@@ -122,6 +169,42 @@ pub fn acquire_gui_instance_lock(
             })
         }
     }
+}
+
+fn force_new_instance_requested() -> bool {
+    match std::env::var(FORCE_NEW_INSTANCE_ENV) {
+        Ok(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        }
+        Err(_) => false,
+    }
+}
+
+fn log_stale_lock_hint(lock_path: &Path) {
+    let age = lock_path
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok());
+    if let Some(age) = age {
+        if age >= STALE_LOCK_HINT_AGE {
+            tracing::warn!(
+                target: "gwt::startup::lock",
+                lock_path = %lock_path.display(),
+                lock_age_secs = age.as_secs(),
+                env_hint = FORCE_NEW_INSTANCE_ENV,
+                "single-instance lock is older than the stale threshold; if no other gwt is running set GWT_FORCE_NEW_INSTANCE=1 to bypass"
+            );
+            return;
+        }
+    }
+    tracing::info!(
+        target: "gwt::startup::lock",
+        lock_path = %lock_path.display(),
+        env_hint = FORCE_NEW_INSTANCE_ENV,
+        "single-instance lock is held; set GWT_FORCE_NEW_INSTANCE=1 only if you are certain no other gwt is running"
+    );
 }
 
 fn unregister_process_lock(path: &Path) {
@@ -134,4 +217,88 @@ fn unregister_process_lock(path: &Path) {
 fn process_lock_registry() -> &'static Mutex<HashSet<PathBuf>> {
     static REGISTRY: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate the `GWT_FORCE_NEW_INSTANCE` env var so
+    /// they do not race when run with `cargo test --test-threads > 1`.
+    static FORCE_ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    fn with_force_env<T, F: FnOnce() -> T>(value: Option<&str>, body: F) -> T {
+        let _guard = FORCE_ENV_GUARD
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var(FORCE_NEW_INSTANCE_ENV).ok();
+        match value {
+            Some(value) => std::env::set_var(FORCE_NEW_INSTANCE_ENV, value),
+            None => std::env::remove_var(FORCE_NEW_INSTANCE_ENV),
+        }
+        let result = body();
+        match previous {
+            Some(value) => std::env::set_var(FORCE_NEW_INSTANCE_ENV, value),
+            None => std::env::remove_var(FORCE_NEW_INSTANCE_ENV),
+        }
+        result
+    }
+
+    #[test]
+    fn force_new_instance_requested_accepts_common_truthy_values() {
+        for value in ["1", "true", "TRUE", "Yes", "on"] {
+            assert!(
+                with_force_env(Some(value), force_new_instance_requested),
+                "expected `{value}` to enable the override"
+            );
+        }
+    }
+
+    #[test]
+    fn force_new_instance_requested_rejects_falsy_and_missing_values() {
+        for value in ["", "0", "false", "no", "off", "garbage"] {
+            assert!(
+                !with_force_env(Some(value), force_new_instance_requested),
+                "expected `{value}` to leave the override disabled"
+            );
+        }
+        assert!(!with_force_env(None, force_new_instance_requested));
+    }
+
+    #[test]
+    fn acquire_gui_instance_lock_force_override_bypasses_taken_lock() {
+        // SPEC-2014 Phase C6: confirm that a fresh acquisition can succeed via
+        // the GWT_FORCE_NEW_INSTANCE override even after another process
+        // grabbed the same lock first.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let gwt_home = temp.path().join("gwt-home");
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project dir");
+
+        let _primary =
+            acquire_gui_instance_lock(&gwt_home, &project_root).expect("first acquire ok");
+
+        with_force_env(Some("1"), || {
+            let secondary = acquire_gui_instance_lock(&gwt_home, &project_root)
+                .expect("override must let the second acquire succeed");
+            drop(secondary);
+        });
+    }
+
+    #[test]
+    fn acquire_gui_instance_lock_without_override_errors_with_taken_lock() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let gwt_home = temp.path().join("gwt-home");
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("project dir");
+
+        let _primary =
+            acquire_gui_instance_lock(&gwt_home, &project_root).expect("first acquire ok");
+
+        let error = with_force_env(None, || {
+            acquire_gui_instance_lock(&gwt_home, &project_root).expect_err("override absent")
+        });
+        assert!(matches!(error, GuiInstanceLockError::AlreadyRunning { .. }));
+    }
 }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1390,7 +1390,12 @@
         }
         const runtime = terminalMap.get(resizeState.id);
         cancelTerminalResizeFit();
+        cancelResizePointermoveApply();
         cancelResizeStalenessGuard();
+        // Flush the last pointer coordinates to the DOM so the final geometry
+        // matches the latest pointermove. fitTerminal + sendGeometry below
+        // observe the up-to-date `element.style.width/height`.
+        applyResizePointermove(resizeState);
         fitTerminal(resizeState.id, false);
         sendGeometry(
           resizeState.id,
@@ -1403,6 +1408,52 @@
         // so pointer events resume on the screen-edge triggers once resize
         // ends.
         delete document.documentElement.dataset.opResizeActive;
+      }
+
+      // SPEC-2014 Phase C4: coalesce pointermove-driven `style.width/height`
+      // writes via requestAnimationFrame. Without this, fast trackpads /
+      // 120Hz pointers can cause Windows WebView2 to spend more time in
+      // layout than in paint, manifesting as the resize freeze.
+      function scheduleResizePointermoveApply() {
+        if (!resizeState || resizeState.applyFrame != null) {
+          return;
+        }
+        const pointerId = resizeState.pointerId;
+        resizeState.applyFrame = requestAnimationFrame(() => {
+          if (!resizeState || resizeState.pointerId !== pointerId) {
+            return;
+          }
+          resizeState.applyFrame = null;
+          applyResizePointermove(resizeState);
+          scheduleTerminalResizeFit(resizeState.id);
+        });
+      }
+
+      function cancelResizePointermoveApply() {
+        if (resizeState && resizeState.applyFrame != null) {
+          cancelAnimationFrame(resizeState.applyFrame);
+          resizeState.applyFrame = null;
+        }
+      }
+
+      function applyResizePointermove(state) {
+        if (!state) {
+          return;
+        }
+        const element = windowMap.get(state.id);
+        if (!element) {
+          return;
+        }
+        const x = state.latestClientX ?? state.startX;
+        const y = state.latestClientY ?? state.startY;
+        element.style.width = `${clamp(
+          state.width + (x - state.startX) / viewport.zoom,
+          420,
+        )}px`;
+        element.style.height = `${clamp(
+          state.height + (y - state.startY) / viewport.zoom,
+          260,
+        )}px`;
       }
 
       // SPEC-2014 Phase C1: maximum wall time (in ms) a single resize gesture
@@ -1447,6 +1498,9 @@
         );
         if (previous.fitFrame != null) {
           cancelAnimationFrame(previous.fitFrame);
+        }
+        if (previous.applyFrame != null) {
+          cancelAnimationFrame(previous.applyFrame);
         }
         if (previous.stalenessTimer != null) {
           clearTimeout(previous.stalenessTimer);
@@ -7288,9 +7342,12 @@
               pointerId: event.pointerId,
               startX: event.clientX,
               startY: event.clientY,
+              latestClientX: event.clientX,
+              latestClientY: event.clientY,
               width: parseNumber(element.style.width),
               height: parseNumber(element.style.height),
               fitFrame: null,
+              applyFrame: null,
               startedAt: performance.now(),
               stalenessTimer: scheduleResizeStalenessGuard(event.pointerId),
             };
@@ -8273,19 +8330,18 @@
         }
 
         if (resizeState && resizeState.pointerId === event.pointerId) {
-          const element = windowMap.get(resizeState.id);
-          if (!element) {
-            return;
-          }
-          element.style.width = `${clamp(
-            resizeState.width + (event.clientX - resizeState.startX) / viewport.zoom,
-            420,
-          )}px`;
-          element.style.height = `${clamp(
-            resizeState.height + (event.clientY - resizeState.startY) / viewport.zoom,
-            260,
-          )}px`;
-          scheduleTerminalResizeFit(resizeState.id);
+          // SPEC-2014 Phase C4: store the latest pointer coordinates and
+          // batch the actual DOM mutation via requestAnimationFrame. The
+          // previous implementation wrote `element.style.width/height` on
+          // every pointermove (potentially 200+ times per second on high
+          // refresh rate displays), triggering layout reflow at the same
+          // rate. On Windows WebView2 this can starve the render thread and
+          // surface as the resize freeze users reported requiring an app
+          // restart. By coalescing to one apply per frame we keep the visual
+          // responsiveness while letting WebView2 paint between updates.
+          resizeState.latestClientX = event.clientX;
+          resizeState.latestClientY = event.clientY;
+          scheduleResizePointermoveApply();
         }
       });
 


### PR DESCRIPTION
## Summary

PR #2672 (Phase B/C1/C2) に続く Windows 不具合の proactive 改善。
今回は Phase C4/C5/C6 を 1 PR にまとめる。

### Phase C4 — pointermove DOM 更新の rAF coalesce

`crates/gwt/web/app.js` の resize pointermove ハンドラは pointer event ごとに
`element.style.width/height` を直接書き換えていた。120Hz pointer + Windows
WebView2 の組合せで layout reflow が pointer 速度に追従できず render thread を
枯渇させる典型パターンで、ユーザー報告「resize で固まる → アプリ再起動が必要」の
直接的な原因仮説の 1 つ。

- `resizeState` に `latestClientX` / `latestClientY` / `applyFrame` を追加
- pointermove は座標保持と `scheduleResizePointermoveApply` の rAF 予約だけ
- 実 DOM mutation と `scheduleTerminalResizeFit` は次フレームで 1 回だけ走る
- finalizer (`finishWindowResize`) と `forceResetResizeState` で applyFrame を
  必ず cancel

### Phase C5 — PTY resize の slow-path threshold warn

`crates/gwt-terminal/src/pty.rs::PtyHandle::resize` で `total_elapsed_ms` が
`SLOW_RESIZE_WARN_MS = 250` を超えた場合に `tracing::info!` ではなく
`tracing::warn!` で記録する。outcome を `slow` とし threshold_ms 付き。
`~/.gwt/logs/` の grep だけで Windows ConPTY 遅延を識別可能にする。

### Phase C6 — Single-instance lock の force bypass

`crates/gwt/src/gui_single_instance.rs::acquire_gui_instance_lock` に
環境変数 `GWT_FORCE_NEW_INSTANCE=1` の escape hatch を追加。Windows で
antivirus / FS cache が前回プロセスの OS lock を pin したまま残る Issue #1764
系で、ユーザーがアプリ再起動なしで強制起動できる。

- 失敗時に lock path と env hint を構造化ログで出す (mtime ≥ 1h は warn)
- in-process registry の重複判定も override 対象に揃えて semantics 一貫化

### Phase C7 — Windows shim contract verification

既存テスト群 (`wraps_cmd_shims_with_comspec` / `resolves_shell_shim_js_entry_to_node`
/ `preserves_script_arg_for_node_exe_shims` / `falls_back_to_node_when_shim_runtime_is_missing`
/ `nodejs_distribution_npx_shim_does_not_collapse_to_node_exe` /
`spawn_succeeds_via_spaced_npx_cmd_path`) で npm shim 正規化 + `.cmd` /d /k
interactive wrapper 契約は網羅済を確認。追加コード/テストなし。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p gwt-terminal -p gwt-core -p gwt-git -p gwt --all-features` 全 GREEN
  (587 lib + 325 binary + integration)
- [x] 新規テスト:
  - `embedded_web::tests::embedded_web_resize_pointermove_is_coalesced_via_request_animation_frame`
  - `gui_single_instance::tests::force_new_instance_requested_accepts_common_truthy_values`
  - `gui_single_instance::tests::force_new_instance_requested_rejects_falsy_and_missing_values`
  - `gui_single_instance::tests::acquire_gui_instance_lock_force_override_bypasses_taken_lock`
  - `gui_single_instance::tests::acquire_gui_instance_lock_without_override_errors_with_taken_lock`
- [x] 既存 finalizer / coalescing / English-only / windows_spawn 契約テストは GREEN を維持
- [ ] Windows 実機 smoke (T-PERF-009 / 追加): resize 動作のなめらかさ、`gwt::resize::pty` の
  warn 行発生有無、`GWT_FORCE_NEW_INSTANCE=1` での復旧経路


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance monitoring for PTY resize operations with enhanced warnings on slow operations (≥250ms threshold)
  * Added recovery option for single-instance GUI locking via environment variable override

* **Bug Fixes**
  * Fixed UI freezing during window resize by batching DOM style updates to animation frames
  * Improved stale lock detection with better recovery messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2675)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->