### PR TITLE
fix(agent): stop forcing Claude no-flicker env

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -573,7 +573,6 @@ impl AgentLaunchBuilder {
     fn build_claude_args(&self, args: &mut Vec<String>, env_vars: &mut HashMap<String, String>) {
         // Claude Code specific env vars
         env_vars.insert("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".into(), "1".into());
-        env_vars.insert("CLAUDE_CODE_NO_FLICKER".into(), "1".into());
 
         // Telemetry/analytics disable
         env_vars.insert("DISABLE_TELEMETRY".into(), "1".into());
@@ -1340,9 +1339,9 @@ mod tests {
     fn build_claude_has_telemetry_disable_vars() {
         let config = AgentLaunchBuilder::new(AgentId::ClaudeCode).build();
 
-        assert_eq!(
-            config.env_vars.get("CLAUDE_CODE_NO_FLICKER"),
-            Some(&"1".to_string())
+        assert!(
+            !config.env_vars.contains_key("CLAUDE_CODE_NO_FLICKER"),
+            "Claude Code launches must not force the legacy no-flicker renderer"
         );
         assert_eq!(
             config.env_vars.get("DISABLE_TELEMETRY"),
@@ -1693,10 +1692,10 @@ mod tests {
     }
 
     #[test]
-    fn custom_agent_env_can_override_claude_builtin_env() {
+    fn custom_agent_env_can_still_export_claude_no_flicker() {
         // If a user somehow applies custom_agent_env to a built-in Claude
-        // launch, the custom value should win over the built-in Claude
-        // defaults. This is consistent with FR-063 "custom wins over Common".
+        // launch, an explicit value should still be forwarded even though gwt
+        // no longer sets the legacy no-flicker flag by default.
         let mut env = HashMap::new();
         env.insert("CLAUDE_CODE_NO_FLICKER".to_string(), "0".to_string());
 
@@ -1710,7 +1709,7 @@ mod tests {
                 .get("CLAUDE_CODE_NO_FLICKER")
                 .map(String::as_str),
             Some("0"),
-            "custom_agent_env must win over agent-specific built-in env"
+            "custom_agent_env must remain able to pass explicit Claude env"
         );
     }
 

--- a/crates/gwt-agent/src/presets.rs
+++ b/crates/gwt-agent/src/presets.rs
@@ -230,7 +230,7 @@ pub fn claude_code_openai_compat_preset(
     let api_key = api_key.into();
     let default_model = default_model.into();
 
-    let mut env = HashMap::with_capacity(13);
+    let mut env = HashMap::with_capacity(12);
     env.insert("ANTHROPIC_API_KEY".to_string(), api_key);
     env.insert("ANTHROPIC_BASE_URL".to_string(), base_url);
     env.insert(
@@ -251,7 +251,6 @@ pub fn claude_code_openai_compat_preset(
         "0".to_string(),
     );
     env.insert("DISABLE_TELEMETRY".to_string(), "1".to_string());
-    env.insert("CLAUDE_CODE_NO_FLICKER".to_string(), "1".to_string());
     env.insert("DISABLE_ERROR_REPORTING".to_string(), "1".to_string());
     env.insert("DISABLE_FEEDBACK_COMMAND".to_string(), "1".to_string());
     env.insert(
@@ -303,12 +302,12 @@ mod tests {
     }
 
     #[test]
-    fn preset_env_contains_thirteen_entries() {
+    fn preset_env_contains_twelve_entries() {
         let preset = claude_code_openai_compat_preset("x", "X", "http://a", "k", "m");
         assert_eq!(
             preset.env.len(),
-            13,
-            "preset must seed exactly 13 env vars (FR-062)"
+            12,
+            "preset must seed exactly 12 env vars and avoid legacy no-flicker defaults"
         );
     }
 
@@ -330,7 +329,6 @@ mod tests {
             "CLAUDE_CODE_SUBAGENT_MODEL",
             "CLAUDE_CODE_ATTRIBUTION_HEADER",
             "DISABLE_TELEMETRY",
-            "CLAUDE_CODE_NO_FLICKER",
             "DISABLE_ERROR_REPORTING",
             "DISABLE_FEEDBACK_COMMAND",
             "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY",
@@ -342,6 +340,10 @@ mod tests {
                 "preset env is missing key {key}"
             );
         }
+        assert!(
+            !preset.env.contains_key("CLAUDE_CODE_NO_FLICKER"),
+            "preset must not force the legacy no-flicker renderer"
+        );
     }
 
     #[test]
@@ -386,7 +388,7 @@ mod tests {
         let preset = claude_code_openai_compat_preset("x", "X", "http://a", "k", "m");
         assert_eq!(preset.env["CLAUDE_CODE_ATTRIBUTION_HEADER"], "0");
         assert_eq!(preset.env["DISABLE_TELEMETRY"], "1");
-        assert_eq!(preset.env["CLAUDE_CODE_NO_FLICKER"], "1");
+        assert!(!preset.env.contains_key("CLAUDE_CODE_NO_FLICKER"));
         assert_eq!(preset.env["DISABLE_ERROR_REPORTING"], "1");
         assert_eq!(preset.env["DISABLE_FEEDBACK_COMMAND"], "1");
         assert_eq!(preset.env["CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY"], "1");
@@ -419,7 +421,7 @@ mod tests {
 
         assert_eq!(preset.id, "claude-code-openai");
         assert_eq!(preset.command, "@anthropic-ai/claude-code@latest");
-        assert_eq!(preset.env.len(), 13);
+        assert_eq!(preset.env.len(), 12);
         assert_eq!(
             preset.env["ANTHROPIC_BASE_URL"],
             "https://proxy.example.com"

--- a/crates/gwt-agent/src/store.rs
+++ b/crates/gwt-agent/src/store.rs
@@ -464,7 +464,7 @@ default = { id = "default", label = "Default", arg = "" }
     }
 
     #[test]
-    fn preset_roundtrip_preserves_all_thirteen_env_entries() {
+    fn preset_roundtrip_preserves_all_twelve_env_entries() {
         let dir = tempfile::tempdir().expect("temp config dir");
         let config_path = dir.path().join("config.toml");
 
@@ -490,9 +490,10 @@ default = { id = "default", label = "Default", arg = "" }
         );
         assert_eq!(
             agent.env.len(),
-            13,
-            "all 13 preset env entries survive TOML round-trip"
+            12,
+            "all 12 preset env entries survive TOML round-trip"
         );
+        assert!(!agent.env.contains_key("CLAUDE_CODE_NO_FLICKER"));
         assert_eq!(
             agent.env.get("ANTHROPIC_API_KEY").map(String::as_str),
             Some("sk-test-key")

--- a/crates/gwt/src/custom_agents_service.rs
+++ b/crates/gwt/src/custom_agents_service.rs
@@ -229,13 +229,15 @@ mod tests {
         let agent = add_sample_from_preset(&path, &input).expect("save");
 
         assert_eq!(agent.id, input.id);
-        assert_eq!(agent.env.len(), 13);
+        assert_eq!(agent.env.len(), 12);
+        assert!(!agent.env.contains_key("CLAUDE_CODE_NO_FLICKER"));
         assert_eq!(agent.env["ANTHROPIC_API_KEY"], input.api_key);
         assert_eq!(agent.env["ANTHROPIC_BASE_URL"], input.base_url);
 
         let reloaded = list_custom_agents(&path).unwrap();
         assert_eq!(reloaded.len(), 1);
-        assert_eq!(reloaded[0].env.len(), 13);
+        assert_eq!(reloaded[0].env.len(), 12);
+        assert!(!reloaded[0].env.contains_key("CLAUDE_CODE_NO_FLICKER"));
         assert_eq!(
             reloaded[0].env["ANTHROPIC_DEFAULT_OPUS_MODEL"],
             input.default_model
@@ -253,7 +255,8 @@ mod tests {
             add_from_preset(&path, PresetId::ClaudeCodeOpenaiCompat, &payload).expect("save");
 
         assert_eq!(agent.id, input.id);
-        assert_eq!(agent.env.len(), 13);
+        assert_eq!(agent.env.len(), 12);
+        assert!(!agent.env.contains_key("CLAUDE_CODE_NO_FLICKER"));
         assert_eq!(agent.env["ANTHROPIC_API_KEY"], input.api_key);
         assert_eq!(agent.env["ANTHROPIC_BASE_URL"], input.base_url);
 


### PR DESCRIPTION
## Summary

- Stop forcing `CLAUDE_CODE_NO_FLICKER=1` for built-in Claude Code launches because the legacy renderer override is the first identified gwt-only Windows Enter-send regression suspect.
- Align the Claude Code OpenAI-compatible preset and persistence tests with the same launch-env contract while preserving explicit user/custom env overrides.
- Update SPEC-1921 so the documented Claude launch-env contract matches the implementation.

## Changes

- `crates/gwt-agent/src/launch.rs`: remove the built-in `CLAUDE_CODE_NO_FLICKER` default and add coverage that explicit custom env can still pass the variable.
- `crates/gwt-agent/src/presets.rs`: remove `CLAUDE_CODE_NO_FLICKER` from the OpenAI-compatible Claude Code preset and update required-env tests to 12 entries.
- `crates/gwt-agent/src/store.rs`: update preset TOML round-trip coverage for the 12-entry env set and assert the no-flicker flag stays absent.
- `crates/gwt/src/custom_agents_service.rs`: update add-from-preset persistence tests to the current 12-entry env contract.
- SPEC-1921: document that `CLAUDE_CODE_NO_FLICKER` is not set by default and is only user opt-in through profile/custom env.

## Testing

- [x] `cargo test -p gwt-agent build_claude_has_telemetry_disable_vars -- --nocapture` — RED before implementation: failed because default Claude Code launch still forced `CLAUDE_CODE_NO_FLICKER`.
- [x] `cargo test -p gwt-agent preset_env_contains_thirteen_entries -- --nocapture` — RED before implementation: failed because the preset still had 13 env entries.
- [x] `cargo test -p gwt-agent --lib` — 215 passed.
- [x] `cargo test -p gwt creates_entry_and_persists_all_env -- --nocapture` — 2 passed.
- [x] `cargo test -p gwt-agent -p gwt-terminal -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [ ] Windows manual smoke — not run in this macOS worktree; verify gwt-launched Windows Claude Code accepts `hello` + Enter and `gwt_input_trace` has `onData -> ws_recv -> fast_path_write` without `fast_path_write_err`.

## Closing Issues

- Closes #2678

## Related Issues / Links

- #1921
- #1919
- #2008
- #2149
- #2513

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-1921)
- [x] Migration/backfill plan included (not applicable: no schema/data change)
- [x] CHANGELOG impact considered (patch fix, no breaking change)

## Context

- The user confirmed direct Windows `claude` works and the failure occurs only inside gwt: text appears in the Claude Code prompt, but Enter clears it without sending a response.
- Prior related fixes covered Windows shim input loss (#2149) and resize/focus freezes (#2513), but this issue is scoped to default Claude Code launch env first; Windows host-shell wrapper remains the fallback investigation path if manual smoke disproves the env hypothesis.

## Risk / Impact

- **Affected areas**: Claude Code built-in launches and the Claude Code OpenAI-compatible preset env defaults.
- **Rollback plan**: Revert this commit to restore the previous default env injection; users who need the legacy renderer override can already opt in through profile/custom env.

## Notes

- PR is draft until Windows manual smoke confirms the gwt-launched Claude Code Enter path on an affected Windows host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Claude Code launch environment configuration by removing the legacy `CLAUDE_CODE_NO_FLICKER` environment variable from default settings. This change reduces default environment overhead. The variable can still be explicitly set through custom environment configurations if needed for specific use cases or compatibility with existing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2679)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->