### PR TITLE
fix(gui): split-button menu に roving arrow navigation と empty-state node (#2684 follow-up)

### DIFF
--- a/crates/gwt/playwright/tests/open-project-split-button.spec.ts
+++ b/crates/gwt/playwright/tests/open-project-split-button.spec.ts
@@ -89,10 +89,82 @@ test.describe("Open Project split-button", () => {
     await expect(caret).toHaveAttribute("aria-expanded", "false");
     await expect(caret).toBeFocused();
   });
+
+  test("ArrowDown / ArrowUp / Home / End rotate focus across menu items", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installWorkspaceFixture(page);
+    await page.goto(APP_URL);
+
+    await expect(page.locator(".project-tab")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const caret = page.locator("#open-project-menu-button");
+    await caret.click();
+
+    // Menu opens with focus on Open Project... (the first menuitem).
+    await expect(page.locator("#open-project-menu-open")).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator("#open-project-menu-clone")).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    // Third menuitem is the only Recent row in the fixture.
+    await expect(
+      page.locator("#open-project-menu .split-button-menu-recent-row"),
+    ).toBeFocused();
+
+    // Wrap around: ArrowDown from the last row goes back to the first item.
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator("#open-project-menu-open")).toBeFocused();
+
+    // ArrowUp from the first item wraps to the last.
+    await page.keyboard.press("ArrowUp");
+    await expect(
+      page.locator("#open-project-menu .split-button-menu-recent-row"),
+    ).toBeFocused();
+
+    await page.keyboard.press("Home");
+    await expect(page.locator("#open-project-menu-open")).toBeFocused();
+
+    await page.keyboard.press("End");
+    await expect(
+      page.locator("#open-project-menu .split-button-menu-recent-row"),
+    ).toBeFocused();
+  });
+
+  test("empty Recent state renders an explicit text node", async ({ page }) => {
+    await installEmbeddedRoutes(page);
+    await installWorkspaceFixture(page, { recentProjects: [] });
+    await page.goto(APP_URL);
+
+    await expect(page.locator(".project-tab")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.locator("#open-project-menu-button").click();
+    const empty = page.locator(
+      "#open-project-menu-recent .split-button-menu-empty",
+    );
+    await expect(empty).toBeVisible();
+    await expect(empty).toHaveText("No recent projects");
+    await expect(page.locator("#open-project-menu-recent")).toHaveAttribute(
+      "data-empty",
+      "true",
+    );
+  });
 });
 
-async function installWorkspaceFixture(page: any): Promise<void> {
-  await page.addInitScript(() => {
+async function installWorkspaceFixture(
+  page: any,
+  options: { recentProjects?: Array<{ title: string; path: string; kind: string }> } = {},
+): Promise<void> {
+  const recentProjects = options.recentProjects ?? [
+    { title: "Recent A", path: "/recent/a", kind: "git" },
+  ];
+  await page.addInitScript((fixture: any) => {
     const workspaceState = {
       kind: "workspace_state",
       workspace: {
@@ -110,13 +182,7 @@ async function installWorkspaceFixture(page: any): Promise<void> {
           },
         ],
         active_tab_id: "tab-1",
-        recent_projects: [
-          {
-            title: "Recent A",
-            path: "/recent/a",
-            kind: "git",
-          },
-        ],
+        recent_projects: fixture.recentProjects,
       },
     };
 
@@ -166,5 +232,5 @@ async function installWorkspaceFixture(page: any): Promise<void> {
       configurable: true,
       value: FixtureWebSocket,
     });
-  });
+  }, { recentProjects });
 }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1105,6 +1105,12 @@
         const recentProjects = appState?.recent_projects || [];
         if (recentProjects.length === 0) {
           openProjectMenuRecent.dataset.empty = "true";
+          // Real DOM node beats CSS pseudo-content so screen readers reach it.
+          const empty = document.createElement("div");
+          empty.className = "split-button-menu-empty";
+          empty.setAttribute("role", "presentation");
+          empty.textContent = "No recent projects";
+          openProjectMenuRecent.appendChild(empty);
           return;
         }
         delete openProjectMenuRecent.dataset.empty;
@@ -1182,6 +1188,47 @@
         } else {
           openOpenProjectMenu();
         }
+      }
+
+      // Issue #2684 — roving focus across menu items. Items carry
+      // tabindex="-1" by ARIA APG convention so Tab does not stop on each
+      // individual entry; arrow keys take over once the menu is open.
+      function openProjectMenuItems() {
+        if (!openProjectMenu) {
+          return [];
+        }
+        return Array.from(
+          openProjectMenu.querySelectorAll('[role="menuitem"]'),
+        ).filter((el) => !el.disabled);
+      }
+
+      function focusOpenProjectMenuItemAt(index) {
+        const items = openProjectMenuItems();
+        if (items.length === 0) {
+          return;
+        }
+        const wrapped = ((index % items.length) + items.length) % items.length;
+        try {
+          items[wrapped].focus({ preventScroll: true });
+        } catch {
+          items[wrapped].focus();
+        }
+      }
+
+      function moveOpenProjectMenuFocus(direction) {
+        const items = openProjectMenuItems();
+        if (items.length === 0) {
+          return;
+        }
+        const active = document.activeElement;
+        const currentIndex = items.indexOf(active);
+        const nextIndex =
+          currentIndex === -1
+            ? direction > 0
+              ? 0
+              : items.length - 1
+            : currentIndex + direction;
+        focusOpenProjectMenuItemAt(nextIndex);
       }
 
       function renderProjectPicker() {
@@ -8916,6 +8963,31 @@
           if (event.key === "Escape" && isOpenProjectMenuOpen()) {
             event.preventDefault();
             closeOpenProjectMenu({ restoreFocus: true });
+          }
+        });
+        openProjectMenu.addEventListener("keydown", (event) => {
+          if (!isOpenProjectMenuOpen()) {
+            return;
+          }
+          switch (event.key) {
+            case "ArrowDown":
+              event.preventDefault();
+              moveOpenProjectMenuFocus(1);
+              break;
+            case "ArrowUp":
+              event.preventDefault();
+              moveOpenProjectMenuFocus(-1);
+              break;
+            case "Home":
+              event.preventDefault();
+              focusOpenProjectMenuItemAt(0);
+              break;
+            case "End":
+              event.preventDefault();
+              focusOpenProjectMenuItemAt(-1);
+              break;
+            default:
+              break;
           }
         });
       }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -523,10 +523,9 @@
         gap: 4px;
       }
 
-      .split-button-menu-recent:empty::before,
-      .split-button-menu-recent[data-empty="true"]::before {
-        content: "No recent projects";
-        display: block;
+      /* Empty-state copy is rendered as a real <div> by JS so assistive tech
+         finds it; this rule only styles that node. */
+      .split-button-menu-empty {
         padding: 8px 10px;
         font-family: var(--font-body);
         font-size: var(--type-sm);


### PR DESCRIPTION
## Summary

PR #2685 (Issue #2684、commit `e3d56ac5` で既に develop へマージ済) のレビュー指摘 2 件への a11y フォローアップ。タイミング上 #2685 が先に auto-merge されたため、別 PR として切り出した。

## Background

PR #2685 で追加した top toolbar の Open Project split-button について、merge 後に Codex と CodeRabbit から下記のレビュー指摘が残っていた:

1. **Codex (P1)** — `[role="menuitem"]` 要素が `tabindex="-1"` で sequential nav から外れており、ArrowDown/ArrowUp による roving navigation も実装されていないため、メニューを開いた後にキーボードユーザーが `Clone from GitHub...` や Recent items に到達できない (実質マウス専用になる)
2. **CodeRabbit (Minor)** — 空 Recent 状態が CSS `:empty::before` 依存で、assistive tech がテキストを認識しない

## Changes

### 1. Roving arrow navigation (Codex P1)

- `openProjectMenu` に keydown handler を追加
- `ArrowDown` / `ArrowUp` で `[role="menuitem"]` 要素を wrap-around で巡回
- `Home` / `End` で先頭・末尾へジャンプ
- ARIA APG menu pattern に整合 (Tab はメニュー要素に stop せず、矢印キーが nav を担う)
- `openProjectMenuItems()` / `focusOpenProjectMenuItemAt()` / `moveOpenProjectMenuFocus()` のヘルパを `app.js` に追加

### 2. Empty-state DOM node (CodeRabbit Minor)

- `renderRecentProjectsIntoMenu` が Recent 0 件のときに `<div class="split-button-menu-empty" role="presentation">No recent projects</div>` を実 DOM ノードとして append
- CSS の `:empty::before` ルールを削除し、`.split-button-menu-empty` 単体スタイル定義に置換

### 3. Playwright e2e 追加

- `ArrowDown / ArrowUp / Home / End rotate focus across menu items` — 6 ステップで navigation を検証 (forward / wrap / backward wrap / Home / End)
- `empty Recent state renders an explicit text node` — empty-state div の存在、`data-empty="true"` 属性、テキストを検証

## Test plan

- [x] `cargo test -p gwt-core -p gwt --all-features` clean (embedded HTML smoke 含む)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `pnpm test:frontend-bundle / smoke / unit` (365件) すべて pass
- [x] `npx playwright test open-project-split-button` 10/10 pass (5 テスト × 2 themes)
- [ ] 手動: メニューを開いて ArrowDown でフォーカスが Open → Clone → Recent と移動、wrap-around、Home/End、Esc で caret に focus 戻ること (reviewer 確認用)

## Related

- 親 PR: #2685 (merged `ce67a711`)
- 影響ファイル: `crates/gwt/web/app.js`, `crates/gwt/web/index.html`, `crates/gwt/playwright/tests/open-project-split-button.spec.ts`

Closes #2684


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation to project selection dropdown: use arrow keys (Up/Down) and Home/End to cycle through menu items.

* **Bug Fixes**
  * Improved accessibility: "No recent projects" message now displays properly and is compatible with screen readers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2686)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->