### PR TITLE
fix(skills): skip non-gwt skills and broaden .gwt/ exclude

### DIFF
--- a/crates/gwt-skills/src/distribute.rs
+++ b/crates/gwt-skills/src/distribute.rs
@@ -82,7 +82,7 @@ pub fn distribute_to_worktree_for_targets(
     prune_managed_asset_roots_for_targets(worktree, &tracked_paths, &targets, &mut report)?;
 
     if targets.contains(&ManagedAssetTarget::ClaudeCode) {
-        write_dir_assets(
+        write_gwt_skill_dir_assets(
             &CLAUDE_SKILLS,
             worktree,
             &worktree.join(".claude/skills"),
@@ -99,7 +99,7 @@ pub fn distribute_to_worktree_for_targets(
     }
 
     if targets.contains(&ManagedAssetTarget::Codex) {
-        write_dir_assets(
+        write_gwt_skill_dir_assets(
             &CLAUDE_SKILLS,
             worktree,
             &worktree.join(".codex/skills"),
@@ -150,7 +150,7 @@ fn prune_managed_asset_roots_for_targets(
             worktree,
             &worktree.join(".claude/skills"),
             Some(RootEntryKind::Directories),
-            false,
+            true,
             tracked_paths,
             report,
         )?;
@@ -172,7 +172,7 @@ fn prune_managed_asset_roots_for_targets(
             worktree,
             &worktree.join(".codex/skills"),
             Some(RootEntryKind::Directories),
-            false,
+            true,
             tracked_paths,
             report,
         )?;
@@ -520,6 +520,72 @@ mod tests {
         assert!(
             user_asset.exists(),
             "Hermes distribution must not prune non-gwt skill content"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_skips_non_gwt_claude_skill_for_claude_code() {
+        let dir = tempfile::tempdir().unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::ClaudeCode]).unwrap();
+
+        assert!(
+            !dir.path().join(".claude/skills/tui-design").exists(),
+            "tui-design must not be materialized for ClaudeCode target"
+        );
+        assert!(
+            dir.path()
+                .join(".claude/skills/gwt-manage-pr/SKILL.md")
+                .exists(),
+            "gwt-* skill must still be materialized for ClaudeCode target"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_skips_non_gwt_codex_skill_for_codex() {
+        let dir = tempfile::tempdir().unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Codex]).unwrap();
+
+        assert!(
+            !dir.path().join(".codex/skills/tui-design").exists(),
+            "tui-design must not be materialized for Codex target"
+        );
+        assert!(
+            dir.path()
+                .join(".codex/skills/gwt-manage-pr/SKILL.md")
+                .exists(),
+            "gwt-* skill must still be materialized for Codex target"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_preserves_user_created_non_gwt_claude_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let user_asset = dir.path().join(".claude/skills/my-local-skill/SKILL.md");
+        fs::create_dir_all(user_asset.parent().unwrap()).unwrap();
+        fs::write(&user_asset, "user owned").unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::ClaudeCode]).unwrap();
+
+        assert!(
+            user_asset.exists(),
+            "ClaudeCode distribution must not prune user-created non-gwt skill content"
+        );
+    }
+
+    #[test]
+    fn distribute_for_targets_preserves_user_created_non_gwt_codex_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let user_asset = dir.path().join(".codex/skills/my-local-skill/SKILL.md");
+        fs::create_dir_all(user_asset.parent().unwrap()).unwrap();
+        fs::write(&user_asset, "user owned").unwrap();
+
+        distribute_to_worktree_for_targets(dir.path(), &[ManagedAssetTarget::Codex]).unwrap();
+
+        assert!(
+            user_asset.exists(),
+            "Codex distribution must not prune user-created non-gwt skill content"
         );
     }
 

--- a/crates/gwt-skills/src/git_exclude.rs
+++ b/crates/gwt-skills/src/git_exclude.rs
@@ -189,33 +189,25 @@ fn replace_managed_block_with_patterns(
 
 fn exclude_patterns_for_targets(targets: &[ManagedAssetTarget]) -> Vec<&'static str> {
     let mut patterns = Vec::new();
-    if !targets.is_empty() {
-        push_unique(&mut patterns, ".gwt/discussion.md");
+    if targets.is_empty() {
+        return patterns;
     }
-    for target in ManagedAssetTarget::ALL {
-        if !targets.contains(&target) {
-            continue;
-        }
-        match target {
-            ManagedAssetTarget::ClaudeCode => {
-                push_unique(&mut patterns, ".claude/skills/gwt-*");
-                push_unique(&mut patterns, ".claude/commands/gwt-*");
-                push_unique(&mut patterns, ".claude/settings.local.json");
-            }
-            ManagedAssetTarget::Codex => {
-                push_unique(&mut patterns, ".codex/skills/gwt-*");
-            }
-            ManagedAssetTarget::OpenCode => {
-                push_unique(&mut patterns, ".gwt/opencode/");
-            }
-            ManagedAssetTarget::OpenClaw => {
-                push_unique(&mut patterns, ".gwt/openclaw/");
-            }
-            ManagedAssetTarget::Hermes => {
-                push_unique(&mut patterns, ".gwt/hermes/");
-            }
-        }
+    // project-local `.gwt/` holds only gwt-managed files (project.toml,
+    // discussion.md, agent homes). Exclude it as a broad pattern so any
+    // future gwt-managed path under `.gwt/` is covered without listing
+    // each subpath individually.
+    push_unique(&mut patterns, ".gwt/");
+    if targets.contains(&ManagedAssetTarget::ClaudeCode) {
+        push_unique(&mut patterns, ".claude/skills/gwt-*");
+        push_unique(&mut patterns, ".claude/commands/gwt-*");
+        push_unique(&mut patterns, ".claude/settings.local.json");
     }
+    if targets.contains(&ManagedAssetTarget::Codex) {
+        push_unique(&mut patterns, ".codex/skills/gwt-*");
+    }
+    // OpenCode / OpenClaw / Hermes need no additional pattern: their agent
+    // homes (`.gwt/opencode/`, `.gwt/openclaw/`, `.gwt/hermes/`) are
+    // subsumed by the broad `.gwt/` pattern above.
     patterns
 }
 
@@ -243,11 +235,12 @@ mod tests {
         assert!(result.contains(END_MARKER));
         assert!(result.contains(".claude/skills/gwt-*"));
         assert!(result.contains(".codex/skills/gwt-*"));
-        assert!(result.contains(".gwt/discussion.md"));
-        assert!(result.contains(".gwt/opencode/"));
-        assert!(result.contains(".gwt/openclaw/"));
-        assert!(result.contains(".gwt/hermes/"));
+        assert!(result.contains("\n.gwt/\n"));
         assert!(result.contains("docker-compose.override.yml"));
+        assert!(!result.contains(".gwt/discussion.md"));
+        assert!(!result.contains(".gwt/opencode/"));
+        assert!(!result.contains(".gwt/openclaw/"));
+        assert!(!result.contains(".gwt/hermes/"));
         assert!(!result.contains(".codex/hooks.json"));
         assert!(!result.contains(".codex/hooks/scripts/gwt-*"));
         assert!(!result.contains(".agents/skills/gwt-*"));
@@ -258,12 +251,56 @@ mod tests {
         let result = replace_managed_block_for_targets("", &[ManagedAssetTarget::Hermes]).unwrap();
 
         assert!(result.contains(BEGIN_MARKER));
-        assert!(result.contains(".gwt/hermes/"));
-        assert!(result.contains(".gwt/discussion.md"));
+        assert!(result.contains("\n.gwt/\n"));
         assert!(!result.contains(".claude/skills/gwt-*"));
         assert!(!result.contains(".codex/skills/gwt-*"));
+        assert!(!result.contains(".gwt/discussion.md"));
+        assert!(!result.contains(".gwt/hermes/"));
         assert!(!result.contains(".gwt/opencode/"));
         assert!(!result.contains(".gwt/openclaw/"));
+    }
+
+    #[test]
+    fn adds_broad_gwt_dir_pattern_when_any_target_specified() {
+        let result = replace_managed_block("").unwrap();
+        assert!(
+            result.contains("\n.gwt/\n"),
+            "managed block should contain broad `.gwt/` pattern: {result}"
+        );
+    }
+
+    #[test]
+    fn does_not_emit_individual_gwt_subpaths_when_broad_pattern_included() {
+        let result = replace_managed_block("").unwrap();
+        assert!(
+            !result.contains(".gwt/discussion.md"),
+            "individual .gwt/discussion.md must be subsumed by broad .gwt/ pattern: {result}"
+        );
+        assert!(
+            !result.contains(".gwt/hermes/"),
+            "individual .gwt/hermes/ must be subsumed by broad .gwt/ pattern: {result}"
+        );
+        assert!(
+            !result.contains(".gwt/opencode/"),
+            "individual .gwt/opencode/ must be subsumed by broad .gwt/ pattern: {result}"
+        );
+        assert!(
+            !result.contains(".gwt/openclaw/"),
+            "individual .gwt/openclaw/ must be subsumed by broad .gwt/ pattern: {result}"
+        );
+    }
+
+    #[test]
+    fn broad_gwt_dir_pattern_present_for_single_provider_target() {
+        let result = replace_managed_block_for_targets("", &[ManagedAssetTarget::Codex]).unwrap();
+        assert!(
+            result.contains("\n.gwt/\n"),
+            "single-target managed block should contain broad `.gwt/` pattern: {result}"
+        );
+        assert!(
+            !result.contains(".gwt/discussion.md"),
+            "single-target managed block should not emit .gwt/discussion.md separately: {result}"
+        );
     }
 
     #[test]

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -182,7 +182,10 @@ fn refresh_managed_assets_for_hermes_materializes_hermes_home_skills_only() {
 
     let exclude =
         std::fs::read_to_string(dir.path().join(".git/info/exclude")).expect("read exclude");
-    assert!(exclude.contains(".gwt/hermes/"));
+    // .gwt/hermes/ is subsumed by the broad project-local .gwt/ exclude
+    // emitted for any managed target.
+    assert!(exclude.contains("\n.gwt/\n"));
+    assert!(!exclude.contains(".gwt/hermes/"));
     assert!(!exclude.contains(".claude/skills/gwt-*"));
     assert!(!exclude.contains(".codex/skills/gwt-*"));
 }


### PR DESCRIPTION
## Summary

- ClaudeCode と Codex の skill 配布が prefix filtering 無しで動いており、`tui-design` などの非 gwt skill が他プロジェクトに混入していた。Hermes 経路と同じ `root_gwt_only=true` 統一に揃え、SPEC-1935 US-10 の設計意図を実装に反映する。
- `.git/info/exclude` の gwt-managed block を `.gwt/` broad pattern に集約し、`.gwt/project.toml` を含む project-local gwt 管理 path を一括除外する。

## Changes

- `crates/gwt-skills/src/distribute.rs`: ClaudeCode / Codex の `write_dir_assets` 呼び出しを `write_gwt_skill_dir_assets` (`root_gwt_only=true`) に変更し、`prune_dir_against_source` の `root_gwt_only` 引数も `true` に揃える。これで bundle 側 `tui-design` は配布されず、既に書き込まれた user-created な非 gwt skill ディレクトリは prune ガード (gwt-* 以外スキップ) により保持される。
- `crates/gwt-skills/src/git_exclude.rs`: `exclude_patterns_for_targets` で「target が 1 つ以上指定されている時に `.gwt/` broad pattern を 1 行で push する」形に集約。個別 `.gwt/discussion.md` / `.gwt/hermes/` / `.gwt/opencode/` / `.gwt/openclaw/` の push を撤廃。`.codex/hooks.json` を exclude しない既存挙動は維持。
- `crates/gwt-skills/src/distribute.rs` (tests): tui-design が ClaudeCode / Codex 経路で配布されないこと、user-created 非 gwt skill が pruning でも保持されることを新規 4 テストで assert。
- `crates/gwt-skills/src/git_exclude.rs` (tests): `.gwt/` broad pattern が含まれること、個別 `.gwt/*` subpath が独立して出力されないことを新規 3 テストで assert。既存 `adds_managed_block_to_empty_file` / `adds_only_requested_provider_patterns` を新挙動に追従。

## Testing

- [x] `cargo test -p gwt-skills --lib distribute::` — 25/25 GREEN (新規 4 テスト含む)
- [x] `cargo test -p gwt-skills --lib git_exclude::` — 11/11 GREEN (新規 3 テスト含む)
- [x] `cargo clippy -p gwt-skills --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — pass

## Closing Issues

- Closes #2691

## Related Issues / Links

- #1935 (SPEC-1935 US-10) — prefix なし skill は managed catalog 外、`.git/info/exclude` の gwt-managed block 自動補完の設計が canonical reference

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — n/a, 内部実装の修正のみ
- [ ] Migration/backfill plan included (if schema/data change) — n/a, スキーマ変更なし
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — `fix:` のため patch 扱い、breaking change なし

## Context

- gwt 以外のプロジェクトを gwt で開いた際の挙動を点検したところ、(1) `.claude/skills/` / `.codex/skills/` に `tui-design` などの prefix なし skill が他プロジェクトに混入し、(2) `.git/info/exclude` の gwt-managed block で `.gwt/project.toml` 等が除外漏れになっていた。両方とも SPEC-1935 US-10 の設計意図に沿っていなかったため、最小変更で乖離を修正する。
- 対象プロジェクトの `.gitignore` には書き込まない (AGENTS.md の「gwt の規約を他プロジェクトに押し付けない」方針)。exclude は worktree local の `.git/info/exclude` に閉じる。

## Notes

- 既存テスト 3 件が pre-existing failure として残っている (`settings_local::tests::managed_stop_chain_includes_three_skill_check_handlers_after_board_reminder` は `GWT_BIN_PATH` env 解決の影響、`tests::gwt_arch_review_uses_scope_based_contract` と `tests::public_workflow_chain_uses_current_entrypoints` は `.codex/skills/gwt-arch-review/SKILL.md` がリポジトリに物理的に欠落)。RED 状態 (本 PR の実装変更前) でも同じく失敗していたことを確認しており、本 PR の修正対象 (`distribute.rs` / `git_exclude.rs`) とは無関係。
- 既に配布済みの `tui-design` / `release` ディレクトリは pruning でも保護される (`prune_dir_against_source` の line 330: `name.starts_with("gwt-")` 以外はスキップ)。ユーザーが明示的に削除しない限り残るので、必要なら別 Issue で扱う。
- 実装計画: `/Users/akiojin/.claude/plans/gwt-gwt-info-exclude-gwt-tui-design-mana-purring-truffle.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skill distribution now materializes only gwt-managed subdirectories for specific targets, preventing unwanted non-gwt subfolders.
  * Git exclusion rules simplified to use a broader gwt path, removing redundant provider-specific entries.

* **Tests**
  * Added tests verifying gwt-only materialization, preservation of user-created non-gwt skill content, and updated exclusion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2692)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->