### PR TITLE
fix(gui): prevent terminal bottom clipping

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -452,7 +452,14 @@ pub fn install_launch_gwt_bin_env_with_lookup(
     }
     if let Some(resolved) = env_vars.get(GWT_BIN_PATH_ENV).cloned() {
         if let Some(parent) = Path::new(&resolved).parent() {
-            prepend_dir_to_path(env_vars, parent);
+            match runtime_target {
+                LaunchRuntimeTarget::Docker => {
+                    prepend_posix_dir_to_path(env_vars, parent);
+                }
+                LaunchRuntimeTarget::Host => {
+                    prepend_dir_to_path(env_vars, parent);
+                }
+            }
         }
     }
     Ok(())
@@ -497,6 +504,38 @@ pub fn prepend_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -
         return false;
     };
     env_vars.insert(key, joined.to_string_lossy().into_owned());
+    true
+}
+
+/// Prepend `dir` to a POSIX PATH value used inside Docker containers.
+pub fn prepend_posix_dir_to_path(env_vars: &mut HashMap<String, String>, dir: &Path) -> bool {
+    if dir.as_os_str().is_empty() {
+        return false;
+    }
+    let existing_key = env_vars
+        .keys()
+        .find(|key| key.eq_ignore_ascii_case("PATH"))
+        .cloned();
+    let key = existing_key.unwrap_or_else(|| "PATH".to_string());
+    let existing_path = env_vars
+        .get(&key)
+        .map(String::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let dir_value = dir.to_string_lossy().into_owned();
+    if dir_value.is_empty() {
+        return false;
+    }
+    let mut entries: Vec<String> = if existing_path.is_empty() {
+        Vec::new()
+    } else {
+        existing_path.split(':').map(str::to_string).collect()
+    };
+    if entries.iter().any(|entry| entry == &dir_value) {
+        return false;
+    }
+    entries.insert(0, dir_value);
+    env_vars.insert(key, entries.join(":"));
     true
 }
 
@@ -1935,6 +1974,17 @@ mod tests {
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
     }
 
+    fn test_path(entries: &[&str]) -> String {
+        std::env::join_paths(entries.iter().map(Path::new))
+            .expect("join test PATH entries")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn posix_path_entries(path: &str) -> Vec<&str> {
+        path.split(':').collect()
+    }
+
     // SPEC-2077 Phase I1 (US-7 / FR-020 / FR-021 / FR-022 / SC-010):
     // install_launch_gwt_bin_env_with_lookup must prepend the GWT_BIN_PATH
     // parent directory to env_vars["PATH"] so agent subshells can resolve
@@ -1942,7 +1992,7 @@ mod tests {
 
     #[test]
     fn install_launch_gwt_bin_env_host_prepends_gwtd_dir_to_path() {
-        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let mut env_vars = HashMap::from([("PATH".to_string(), test_path(&["/usr/bin", "/bin"]))]);
         let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
         install_launch_gwt_bin_env_with_lookup(
             &mut env_vars,
@@ -1971,7 +2021,7 @@ mod tests {
     fn install_launch_gwt_bin_env_host_dedups_existing_path_entry() {
         let mut env_vars = HashMap::from([(
             "PATH".to_string(),
-            "/Applications/GWT.app/Contents/MacOS:/usr/bin".to_string(),
+            test_path(&["/Applications/GWT.app/Contents/MacOS", "/usr/bin"]),
         )]);
         let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
         install_launch_gwt_bin_env_with_lookup(
@@ -1996,7 +2046,8 @@ mod tests {
 
     #[test]
     fn install_launch_gwt_bin_env_host_skips_path_update_when_parent_is_empty() {
-        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let original_path = test_path(&["/usr/bin", "/bin"]);
+        let mut env_vars = HashMap::from([("PATH".to_string(), original_path.clone())]);
         let current_exe = PathBuf::from("/opt/gwt/bin/gwt");
         // Lookup returns a bare filename (Path::parent => Some(""))
         install_launch_gwt_bin_env_with_lookup(
@@ -2013,7 +2064,7 @@ mod tests {
         );
         assert_eq!(
             env_vars.get("PATH").map(String::as_str),
-            Some("/usr/bin:/bin"),
+            Some(original_path.as_str()),
             "empty GWT_BIN_PATH parent must be a no-op",
         );
     }
@@ -2054,11 +2105,10 @@ mod tests {
             env_vars.get(GWT_BIN_PATH_ENV).map(String::as_str),
             Some("/usr/local/bin/gwtd"),
         );
-        let entries: Vec<PathBuf> =
-            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        let entries = posix_path_entries(env_vars.get("PATH").expect("PATH"));
         assert_eq!(
             entries,
-            vec![PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin"),],
+            vec!["/usr/local/bin", "/usr/bin"],
             "Docker dir already on PATH must dedup",
         );
     }
@@ -2074,11 +2124,10 @@ mod tests {
         )
         .expect("install");
 
-        let entries: Vec<PathBuf> =
-            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
+        let entries = posix_path_entries(env_vars.get("PATH").expect("PATH"));
         assert_eq!(
-            entries.first().map(|p| p.as_path()),
-            Some(Path::new("/usr/local/bin")),
+            entries.first().copied(),
+            Some("/usr/local/bin"),
             "Docker dir not on PATH must be prepended; got entries: {entries:?}",
         );
     }
@@ -2153,8 +2202,10 @@ mod tests {
 
     #[test]
     fn install_launch_gwt_bin_env_host_preserves_existing_path_order() {
-        let mut env_vars =
-            HashMap::from([("PATH".to_string(), "/profile/bin:/usr/bin:/bin".to_string())]);
+        let mut env_vars = HashMap::from([(
+            "PATH".to_string(),
+            test_path(&["/profile/bin", "/usr/bin", "/bin"]),
+        )]);
         let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
         install_launch_gwt_bin_env_with_lookup(
             &mut env_vars,
@@ -2188,7 +2239,7 @@ mod tests {
         let mut config = sample_versioned_launch_config(&worktree);
         config
             .env_vars
-            .insert("PATH".to_string(), "/usr/bin:/bin".to_string());
+            .insert("PATH".to_string(), test_path(&["/usr/bin", "/bin"]));
 
         let mut probe_host_runner =
             |_command: &str,

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2046,7 +2046,9 @@ mod tests {
 
         assert!(
             css.contains(".op-active-work[hidden]")
-                && css.contains(".op-active-work[hidden] {\n  display: none;"),
+                && regex::Regex::new(r"\.op-active-work\[hidden\]\s*\{\s*display:\s*none;")
+                    .unwrap()
+                    .is_match(css),
             "Active Work must not render when the hidden attribute is present",
         );
     }

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -600,7 +600,14 @@ pub fn install_launch_gwt_bin_env_with_lookup(
     }
     if let Some(resolved) = env_vars.get(gwt_agent::session::GWT_BIN_PATH_ENV).cloned() {
         if let Some(parent) = Path::new(&resolved).parent() {
-            gwt_agent::prepare::prepend_dir_to_path(env_vars, parent);
+            match runtime_target {
+                gwt_agent::LaunchRuntimeTarget::Docker => {
+                    gwt_agent::prepare::prepend_posix_dir_to_path(env_vars, parent);
+                }
+                gwt_agent::LaunchRuntimeTarget::Host => {
+                    gwt_agent::prepare::prepend_dir_to_path(env_vars, parent);
+                }
+            }
         }
     }
     Ok(())
@@ -609,6 +616,17 @@ pub fn install_launch_gwt_bin_env_with_lookup(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_path(entries: &[&str]) -> String {
+        std::env::join_paths(entries.iter().map(Path::new))
+            .expect("join test PATH entries")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn posix_path_entries(path: &str) -> Vec<&str> {
+        path.split(':').collect()
+    }
 
     #[test]
     fn windows_shell_process_command_maps_all_variants() {
@@ -648,7 +666,7 @@ mod tests {
 
     #[test]
     fn install_launch_gwt_bin_env_host_prepends_gwtd_dir_to_path() {
-        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let mut env_vars = HashMap::from([("PATH".to_string(), test_path(&["/usr/bin", "/bin"]))]);
         let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
         install_launch_gwt_bin_env_with_lookup(
             &mut env_vars,
@@ -678,7 +696,7 @@ mod tests {
     fn install_launch_gwt_bin_env_host_dedups_existing_path_entry() {
         let mut env_vars = HashMap::from([(
             "PATH".to_string(),
-            "/Applications/GWT.app/Contents/MacOS:/usr/bin".to_string(),
+            test_path(&["/Applications/GWT.app/Contents/MacOS", "/usr/bin"]),
         )]);
         let current_exe = PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwt");
         install_launch_gwt_bin_env_with_lookup(
@@ -702,7 +720,8 @@ mod tests {
 
     #[test]
     fn install_launch_gwt_bin_env_host_skips_path_update_when_parent_is_empty() {
-        let mut env_vars = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let original_path = test_path(&["/usr/bin", "/bin"]);
+        let mut env_vars = HashMap::from([("PATH".to_string(), original_path.clone())]);
         let current_exe = PathBuf::from("/opt/gwt/bin/gwt");
         install_launch_gwt_bin_env_with_lookup(
             &mut env_vars,
@@ -717,7 +736,7 @@ mod tests {
         // meaningful parent dir.
         assert_eq!(
             env_vars.get("PATH").map(String::as_str),
-            Some("/usr/bin:/bin"),
+            Some(original_path.as_str()),
         );
     }
 
@@ -758,12 +777,8 @@ mod tests {
                 .map(String::as_str),
             Some("/usr/local/bin/gwtd"),
         );
-        let entries: Vec<PathBuf> =
-            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
-        assert_eq!(
-            entries.first().map(|p| p.as_path()),
-            Some(Path::new("/usr/local/bin")),
-        );
+        let entries = posix_path_entries(env_vars.get("PATH").expect("PATH"));
+        assert_eq!(entries.first().copied(), Some("/usr/local/bin"),);
     }
 
     #[test]
@@ -778,11 +793,7 @@ mod tests {
         )
         .expect("install");
 
-        let entries: Vec<PathBuf> =
-            std::env::split_paths(env_vars.get("PATH").expect("PATH")).collect();
-        assert_eq!(
-            entries,
-            vec![PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin"),],
-        );
+        let entries = posix_path_entries(env_vars.get("PATH").expect("PATH"));
+        assert_eq!(entries, vec!["/usr/local/bin", "/usr/bin"],);
     }
 }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -565,6 +565,13 @@ pub(crate) struct DockerBundleMounts {
 /// are rare (pane create/destroy), so `RwLock` is the natural fit.
 type PtyWriterRegistry = Arc<RwLock<HashMap<String, Arc<PtyHandle>>>>;
 
+#[cfg_attr(
+    windows,
+    allow(
+        dead_code,
+        reason = "daemon-fed events are constructed by Unix subscribers"
+    )
+)]
 #[derive(Debug, Clone)]
 enum UserEvent {
     Frontend {

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1877,6 +1877,45 @@ test("terminal surface body stays on the dark Operator canvas across themes (FR-
   );
 });
 
+test("terminal root spacing stays inside the window body (SPEC-2008 FR-060)", () => {
+  const terminalRootRule = inlineStyle.match(/\.terminal-root\s*\{([^}]*)\}/);
+  assert.ok(terminalRootRule, "expected .terminal-root CSS rule");
+  const body = terminalRootRule[1];
+
+  assert.match(
+    body,
+    /position:\s*absolute/,
+    ".terminal-root must remain absolutely positioned inside .window-body",
+  );
+  assert.match(
+    body,
+    /inset:\s*8px\s+10px\s+10px\s*;/,
+    ".terminal-root must express terminal chrome spacing as inset so its outer box stays inside .window-body",
+  );
+  assert.match(
+    body,
+    /overflow:\s*hidden/,
+    ".terminal-root must clip xterm internals within the in-bounds terminal host box",
+  );
+});
+
+test("terminal root does not combine full inset with padding overflow (SPEC-2008 SC-039)", () => {
+  const terminalRootRule = inlineStyle.match(/\.terminal-root\s*\{([^}]*)\}/);
+  assert.ok(terminalRootRule, "expected .terminal-root CSS rule");
+  const body = terminalRootRule[1];
+
+  assert.doesNotMatch(
+    body,
+    /inset:\s*0\s*;[\s\S]*padding:\s*(?!0\b)[^;]+;/,
+    ".terminal-root must not use inset:0 plus nonzero padding; content-box padding extends past .window-body and clips the bottom prompt",
+  );
+  assert.match(
+    body,
+    /padding:\s*0\s*;/,
+    ".terminal-root padding must stay zero so FitAddon measures the same box xterm can paint into",
+  );
+});
+
 test("non-terminal surface bodies still follow the overall theme (FR-013 boundary)", () => {
   // The Dark fix is scoped to .surface-terminal.  Other surfaces (Board /
   // Logs / File Tree / Branches / Knowledge / Mock / Profile) must

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -908,8 +908,9 @@ body {
 
 .terminal-root {
   position: absolute;
-  inset: 0;
-  padding: 8px 10px 10px;
+  inset: 8px 10px 10px;
+  padding: 0;
+  overflow: hidden;
 }
 
 .terminal-overlay {


### PR DESCRIPTION
## Summary

- Fixes the terminal root spacing model so the xterm host stays inside `.window-body` and the bottom prompt/cursor row is not clipped after resize.
- Adds frontend CSS contract coverage for SPEC-2008 Phase 27 to prevent reintroducing `inset: 0` plus nonzero padding overflow.
- Keeps Windows verification green by preserving POSIX PATH separators for Docker agent launches and hardening platform-sensitive lint/test contracts.

## Changes

- `crates/gwt/web/styles/app.css`: moves terminal chrome spacing from `.terminal-root` padding into `inset` and clips xterm internals within the in-bounds host box.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds regression tests for `.terminal-root` bottom/right bounds and the no-overflow spacing contract.
- `crates/gwt-agent/src/prepare.rs` / `crates/gwt/src/launch_runtime.rs`: preserve `:`-separated container PATH values for Docker while keeping host PATH handling platform-native.
- `crates/gwt/src/embedded_web.rs` / `crates/gwt/src/main.rs`: make Windows verification robust for CRLF CSS matching and Unix-only daemon event construction.

## Testing

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 87 passed.
- [x] `pnpm test:frontend-bundle` — passed.
- [x] `pnpm test:frontend-unit` — 372 passed.
- [x] `cargo test -p gwt-agent install_launch_gwt_bin_env --all-features` — 7 passed.
- [x] `cargo test -p gwt embedded_web --all-features` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx commitlint --from HEAD~3 --to HEAD` — passed.
- [x] Pre-push CI-equivalent checks — passed; filtered line coverage 91.11% against the 90% threshold.

## Closing Issues

None

## Related Issues / Links

- #2008

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation not required: this is a layout regression fix and SPEC-2008 tasks were updated
- [x] Migration/backfill not required: no schema or data changes
- [x] CHANGELOG impact considered: fix commits are patch-level changes

## Context

- The user-provided `ss.mp4` showed the terminal's bottom row being clipped after resize. The root cause was `.terminal-root` using full `inset: 0` plus nonzero padding, which made the content-box overflow the parent `.window-body`.

## Risk / Impact

- **Affected areas**: terminal window layout, Docker agent launch PATH injection on Windows, Windows verification lint behavior.
- **Rollback plan**: revert the three commits in this PR.

## Screenshots

- Not attached. The source report was the local `ss.mp4`; automated CSS contract tests now cover the spacing regression.
