### PR TITLE
feat(workspace): add Workspace projection retention pruner (US-41 Phase 8a)

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -171,6 +171,52 @@ pub struct WorkspaceCleanupCandidate {
     pub remote_delete_available: bool,
 }
 
+/// SPEC-2359 US-41 (FR-151): why a saved Workspace projection is treated as
+/// stale by [`workspace_projection_stale_reason`]. `WorktreeMissing` and
+/// `PrClosed` come from inspecting `git_details` / `linked_prs`;
+/// `TimeThreshold` comes from `updated_at` exceeding
+/// [`WorkspaceRetentionConfig::archive_after_days`]; `Compound` is returned
+/// when two or more of those conditions hold simultaneously, so callers can
+/// surface the strongest evidence without losing information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StaleReason {
+    WorktreeMissing,
+    PrClosed,
+    TimeThreshold,
+    Compound,
+}
+
+impl StaleReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WorktreeMissing => "worktree_missing",
+            Self::PrClosed => "pr_closed",
+            Self::TimeThreshold => "time_threshold",
+            Self::Compound => "compound",
+        }
+    }
+}
+
+/// SPEC-2359 US-41 (FR-152): retention thresholds for the Workspace
+/// projection pruner. `archive_after_days` triggers the `Active → Archived`
+/// transition; `delete_after_archive_days` triggers the
+/// `Archived → physical delete` transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceRetentionConfig {
+    pub archive_after_days: u32,
+    pub delete_after_archive_days: u32,
+}
+
+impl Default for WorkspaceRetentionConfig {
+    fn default() -> Self {
+        Self {
+            archive_after_days: 30,
+            delete_after_archive_days: 60,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceAgentSummary {
     pub session_id: String,
@@ -1760,6 +1806,240 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// SPEC-2359 US-41 (FR-151): classify a Workspace projection as stale based
+/// on Git side-effect signals (worktree existence, linked PR state) and a
+/// time threshold (`now - updated_at` > `config.archive_after_days`).
+///
+/// Returns `None` when no stale signal applies; returns the single matching
+/// [`StaleReason`] when exactly one applies; returns [`StaleReason::Compound`]
+/// when more than one applies so callers can prioritize compound evidence.
+///
+/// Network-free: PR state is read from `projection.linked_prs[].state` and
+/// `git_details.pr_state`, which are populated by the existing GitHub Issue
+/// cache via `gh` API (the caller keeps that cache fresh).
+pub fn workspace_projection_stale_reason(
+    projection: &WorkspaceProjection,
+    config: &WorkspaceRetentionConfig,
+    now: DateTime<Utc>,
+) -> Option<StaleReason> {
+    let mut reasons: Vec<StaleReason> = Vec::with_capacity(3);
+
+    if let Some(git) = &projection.git_details {
+        if let Some(worktree_path) = &git.worktree_path {
+            if !worktree_path.exists() {
+                reasons.push(StaleReason::WorktreeMissing);
+            }
+        }
+    }
+
+    let mut pr_closed = projection
+        .git_details
+        .as_ref()
+        .and_then(|git| git.pr_state.as_deref())
+        .map(pr_state_is_closed)
+        .unwrap_or(false);
+    if !pr_closed {
+        pr_closed = projection
+            .linked_prs
+            .iter()
+            .any(|pr| pr.state.as_deref().map(pr_state_is_closed).unwrap_or(false));
+    }
+    if pr_closed {
+        reasons.push(StaleReason::PrClosed);
+    }
+
+    let threshold = chrono::Duration::days(config.archive_after_days as i64);
+    if now.signed_duration_since(projection.updated_at) > threshold {
+        reasons.push(StaleReason::TimeThreshold);
+    }
+
+    match reasons.len() {
+        0 => None,
+        1 => Some(reasons[0]),
+        _ => Some(StaleReason::Compound),
+    }
+}
+
+fn pr_state_is_closed(state: &str) -> bool {
+    matches!(state.to_ascii_lowercase().as_str(), "merged" | "closed")
+}
+
+/// SPEC-2359 US-41 (FR-155): why a Workspace projection is left untouched by
+/// the pruner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PruneSkipReason {
+    /// `workspace_projection_stale_reason()` returned `None`.
+    NotStale,
+    /// One or more agents on this Workspace are still affiliated or have a
+    /// live window (FR-155).
+    ActiveAgent,
+    /// `lifecycle_stage = Archived` but `delete_after_archive_days` has not
+    /// elapsed yet.
+    ArchivedTooSoon,
+}
+
+/// SPEC-2359 US-41 (FR-154): action the pruner intends to take on a single
+/// Workspace projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum PruneAction {
+    /// Leave the projection untouched.
+    Skip { reason: PruneSkipReason },
+    /// Transition `lifecycle_stage` from `Active` (or any non-Archived stage)
+    /// to `Archived` and persist the change. The directory is preserved so
+    /// users can recover it manually.
+    Archive,
+    /// Physically remove `~/.gwt/projects/<repo-hash>/workspace/` after the
+    /// archive grace period.
+    Delete,
+}
+
+/// SPEC-2359 US-41: a single Workspace projection classified by
+/// [`classify_workspace_projections`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClassifiedProjection {
+    pub workspace_id: String,
+    pub project_root: PathBuf,
+    pub workspace_dir: PathBuf,
+    pub lifecycle_stage: WorkspaceLifecycleStage,
+    pub updated_at: DateTime<Utc>,
+    pub stale_reason: Option<StaleReason>,
+    pub action: PruneAction,
+}
+
+/// SPEC-2359 US-41 (FR-153): aggregate counts returned by [`apply_prune_plan`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PruneSummary {
+    pub skipped: usize,
+    pub archived: usize,
+    pub deleted: usize,
+}
+
+/// SPEC-2359 US-41 (FR-153, FR-154, FR-155): walk `scan_root` (typically
+/// `~/.gwt/projects/`), load each Workspace projection, and classify it as
+/// `Skip` / `Archive` / `Delete`.
+///
+/// `is_active_session` lets the caller bridge in the live-window registry or
+/// agent affiliation state held outside this crate, so the pruner stays
+/// network-free and registry-free at the core layer.
+pub fn classify_workspace_projections<F>(
+    scan_root: &Path,
+    config: &WorkspaceRetentionConfig,
+    now: DateTime<Utc>,
+    is_active_session: F,
+) -> Vec<ClassifiedProjection>
+where
+    F: Fn(&WorkspaceProjection) -> bool,
+{
+    let mut results = Vec::new();
+
+    let entries = match fs::read_dir(scan_root) {
+        Ok(entries) => entries,
+        Err(_) => return results,
+    };
+
+    for entry in entries.flatten() {
+        let project_dir = entry.path();
+        if !project_dir.is_dir() {
+            continue;
+        }
+        let workspace_dir = project_dir.join("workspace");
+        let current_json = workspace_dir.join("current.json");
+        if !current_json.is_file() {
+            continue;
+        }
+        let projection = match load_workspace_projection_from_path(&current_json) {
+            Ok(Some(p)) => p,
+            _ => continue,
+        };
+
+        let stale_reason = workspace_projection_stale_reason(&projection, config, now);
+
+        let action = if is_active_session(&projection) {
+            PruneAction::Skip {
+                reason: PruneSkipReason::ActiveAgent,
+            }
+        } else {
+            match projection.lifecycle_stage {
+                WorkspaceLifecycleStage::Archived => {
+                    let elapsed = now.signed_duration_since(projection.updated_at);
+                    let threshold = chrono::Duration::days(config.delete_after_archive_days as i64);
+                    if elapsed > threshold {
+                        PruneAction::Delete
+                    } else {
+                        PruneAction::Skip {
+                            reason: PruneSkipReason::ArchivedTooSoon,
+                        }
+                    }
+                }
+                _ => match stale_reason {
+                    Some(_) => PruneAction::Archive,
+                    None => PruneAction::Skip {
+                        reason: PruneSkipReason::NotStale,
+                    },
+                },
+            }
+        };
+
+        results.push(ClassifiedProjection {
+            workspace_id: projection.id.clone(),
+            project_root: projection.project_root.clone(),
+            workspace_dir,
+            lifecycle_stage: projection.lifecycle_stage,
+            updated_at: projection.updated_at,
+            stale_reason,
+            action,
+        });
+    }
+
+    results
+}
+
+/// SPEC-2359 US-41 (FR-153, FR-154): apply a previously-classified plan.
+///
+/// When `dry_run` is `true`, the function counts the actions without touching
+/// the filesystem so callers can preview the outcome. When `dry_run` is
+/// `false`, `Archive` entries are persisted via `save_workspace_projection_to_path`
+/// and `Delete` entries are removed via `fs::remove_dir_all` on the workspace
+/// directory.
+pub fn apply_prune_plan(plan: &[ClassifiedProjection], dry_run: bool) -> Result<PruneSummary> {
+    let mut summary = PruneSummary::default();
+    for item in plan {
+        match &item.action {
+            PruneAction::Skip { .. } => {
+                summary.skipped += 1;
+            }
+            PruneAction::Archive => {
+                if !dry_run {
+                    let current_json = item.workspace_dir.join("current.json");
+                    if let Ok(Some(mut projection)) =
+                        load_workspace_projection_from_path(&current_json)
+                    {
+                        projection.lifecycle_stage = WorkspaceLifecycleStage::Archived;
+                        projection.updated_at = Utc::now();
+                        save_workspace_projection_to_path(&current_json, &projection)?;
+                    }
+                }
+                summary.archived += 1;
+            }
+            PruneAction::Delete => {
+                if !dry_run {
+                    fs::remove_dir_all(&item.workspace_dir).map_err(|err| {
+                        GwtError::Other(format!(
+                            "failed to remove workspace dir {}: {}",
+                            item.workspace_dir.display(),
+                            err
+                        ))
+                    })?;
+                }
+                summary.deleted += 1;
+            }
+        }
+    }
+    Ok(summary)
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
@@ -3239,6 +3519,359 @@ mod tests {
         assert!(
             !events_path.exists(),
             "no work_events should be written for ineligible current projection",
+        );
+    }
+
+    fn make_stale_projection(updated_at: DateTime<Utc>) -> WorkspaceProjection {
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        projection.updated_at = updated_at;
+        projection
+    }
+
+    #[test]
+    fn stale_reason_returns_none_for_fresh_active_workspace() {
+        let now = Utc::now();
+        let projection = make_stale_projection(now);
+        let config = WorkspaceRetentionConfig::default();
+        assert_eq!(
+            workspace_projection_stale_reason(&projection, &config, now),
+            None,
+        );
+    }
+
+    #[test]
+    fn stale_reason_detects_missing_worktree() {
+        let now = Utc::now();
+        let mut projection = make_stale_projection(now);
+        projection.git_details = Some(GitDetails {
+            branch: Some("work/test".to_string()),
+            worktree_path: Some(PathBuf::from(
+                "/nonexistent/path/__stale_reason_should_not_exist_xyz__",
+            )),
+            base_branch: None,
+            pr_number: None,
+            pr_state: None,
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: now,
+        });
+        let config = WorkspaceRetentionConfig::default();
+        assert_eq!(
+            workspace_projection_stale_reason(&projection, &config, now),
+            Some(StaleReason::WorktreeMissing),
+        );
+    }
+
+    #[test]
+    fn stale_reason_detects_pr_merged_via_git_details() {
+        let now = Utc::now();
+        let mut projection = make_stale_projection(now);
+        projection.git_details = Some(GitDetails {
+            branch: Some("work/test".to_string()),
+            worktree_path: None,
+            base_branch: None,
+            pr_number: Some(123),
+            pr_state: Some("merged".to_string()),
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: now,
+        });
+        let config = WorkspaceRetentionConfig::default();
+        assert_eq!(
+            workspace_projection_stale_reason(&projection, &config, now),
+            Some(StaleReason::PrClosed),
+        );
+    }
+
+    #[test]
+    fn stale_reason_detects_pr_closed_via_linked_prs() {
+        let now = Utc::now();
+        let mut projection = make_stale_projection(now);
+        projection.linked_prs.push(WorkspacePrLink {
+            number: 456,
+            title: None,
+            url: None,
+            state: Some("Closed".to_string()),
+        });
+        let config = WorkspaceRetentionConfig::default();
+        assert_eq!(
+            workspace_projection_stale_reason(&projection, &config, now),
+            Some(StaleReason::PrClosed),
+        );
+    }
+
+    #[test]
+    fn stale_reason_detects_time_threshold() {
+        let now = Utc::now();
+        let projection = make_stale_projection(now - chrono::Duration::days(40));
+        let config = WorkspaceRetentionConfig::default();
+        assert_eq!(
+            workspace_projection_stale_reason(&projection, &config, now),
+            Some(StaleReason::TimeThreshold),
+        );
+    }
+
+    #[test]
+    fn stale_reason_returns_compound_when_multiple_conditions_hold() {
+        let now = Utc::now();
+        let mut projection = make_stale_projection(now - chrono::Duration::days(40));
+        projection.git_details = Some(GitDetails {
+            branch: Some("work/test".to_string()),
+            worktree_path: None,
+            base_branch: None,
+            pr_number: Some(789),
+            pr_state: Some("merged".to_string()),
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: now,
+        });
+        let config = WorkspaceRetentionConfig::default();
+        assert_eq!(
+            workspace_projection_stale_reason(&projection, &config, now),
+            Some(StaleReason::Compound),
+        );
+    }
+
+    #[test]
+    fn workspace_retention_config_default_uses_30_60_days() {
+        let config = WorkspaceRetentionConfig::default();
+        assert_eq!(config.archive_after_days, 30);
+        assert_eq!(config.delete_after_archive_days, 60);
+    }
+
+    #[test]
+    fn stale_reason_as_str_matches_snake_case_serde() {
+        assert_eq!(StaleReason::WorktreeMissing.as_str(), "worktree_missing");
+        assert_eq!(StaleReason::PrClosed.as_str(), "pr_closed");
+        assert_eq!(StaleReason::TimeThreshold.as_str(), "time_threshold");
+        assert_eq!(StaleReason::Compound.as_str(), "compound");
+    }
+
+    fn write_projection_at(workspace_dir: &Path, projection: &WorkspaceProjection) {
+        std::fs::create_dir_all(workspace_dir).expect("create workspace dir");
+        let current = workspace_dir.join("current.json");
+        save_workspace_projection_to_path(&current, projection).expect("save projection");
+    }
+
+    fn make_classify_projection(
+        id: &str,
+        project_root: &Path,
+        updated_at: DateTime<Utc>,
+        lifecycle: WorkspaceLifecycleStage,
+    ) -> WorkspaceProjection {
+        let mut projection = WorkspaceProjection::default_for_project(project_root);
+        projection.id = id.to_string();
+        projection.updated_at = updated_at;
+        projection.lifecycle_stage = lifecycle;
+        projection
+    }
+
+    #[test]
+    fn classify_workspace_projections_returns_empty_for_missing_scan_root() {
+        let scan_root = PathBuf::from("/nonexistent/projects/scan-root-xyz");
+        let now = Utc::now();
+        let result = classify_workspace_projections(
+            &scan_root,
+            &WorkspaceRetentionConfig::default(),
+            now,
+            |_| false,
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn classify_workspace_projections_classifies_stale_active_as_archive() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let scan_root = tmp.path().to_path_buf();
+        let project_dir = scan_root.join("abc123");
+        let workspace_dir = project_dir.join("workspace");
+        let now = Utc::now();
+        let projection = make_classify_projection(
+            "ws-archive-me",
+            &project_dir,
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+        write_projection_at(&workspace_dir, &projection);
+
+        let result = classify_workspace_projections(
+            &scan_root,
+            &WorkspaceRetentionConfig::default(),
+            now,
+            |_| false,
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].workspace_id, "ws-archive-me");
+        assert_eq!(result[0].action, PruneAction::Archive);
+        assert_eq!(result[0].stale_reason, Some(StaleReason::TimeThreshold));
+    }
+
+    #[test]
+    fn classify_workspace_projections_classifies_archived_beyond_threshold_as_delete() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let scan_root = tmp.path().to_path_buf();
+        let project_dir = scan_root.join("def456");
+        let workspace_dir = project_dir.join("workspace");
+        let now = Utc::now();
+        let projection = make_classify_projection(
+            "ws-delete-me",
+            &project_dir,
+            now - chrono::Duration::days(90),
+            WorkspaceLifecycleStage::Archived,
+        );
+        write_projection_at(&workspace_dir, &projection);
+
+        let result = classify_workspace_projections(
+            &scan_root,
+            &WorkspaceRetentionConfig::default(),
+            now,
+            |_| false,
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].action, PruneAction::Delete);
+    }
+
+    #[test]
+    fn classify_workspace_projections_skips_archived_too_soon() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let scan_root = tmp.path().to_path_buf();
+        let project_dir = scan_root.join("ghi789");
+        let workspace_dir = project_dir.join("workspace");
+        let now = Utc::now();
+        let projection = make_classify_projection(
+            "ws-keep-archived",
+            &project_dir,
+            now - chrono::Duration::days(10),
+            WorkspaceLifecycleStage::Archived,
+        );
+        write_projection_at(&workspace_dir, &projection);
+
+        let result = classify_workspace_projections(
+            &scan_root,
+            &WorkspaceRetentionConfig::default(),
+            now,
+            |_| false,
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].action,
+            PruneAction::Skip {
+                reason: PruneSkipReason::ArchivedTooSoon,
+            }
+        );
+    }
+
+    #[test]
+    fn classify_workspace_projections_skips_active_session() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let scan_root = tmp.path().to_path_buf();
+        let project_dir = scan_root.join("jkl012");
+        let workspace_dir = project_dir.join("workspace");
+        let now = Utc::now();
+        let projection = make_classify_projection(
+            "ws-active",
+            &project_dir,
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+        write_projection_at(&workspace_dir, &projection);
+
+        let result = classify_workspace_projections(
+            &scan_root,
+            &WorkspaceRetentionConfig::default(),
+            now,
+            |_| true, // every workspace has an active session
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].action,
+            PruneAction::Skip {
+                reason: PruneSkipReason::ActiveAgent,
+            }
+        );
+    }
+
+    #[test]
+    fn apply_prune_plan_dry_run_counts_without_filesystem_change() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let scan_root = tmp.path().to_path_buf();
+        let project_dir = scan_root.join("dry-run-test");
+        let workspace_dir = project_dir.join("workspace");
+        let now = Utc::now();
+        let projection = make_classify_projection(
+            "ws-dry",
+            &project_dir,
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+        write_projection_at(&workspace_dir, &projection);
+
+        let plan = classify_workspace_projections(
+            &scan_root,
+            &WorkspaceRetentionConfig::default(),
+            now,
+            |_| false,
+        );
+        let summary = apply_prune_plan(&plan, true).expect("dry run summary");
+        assert_eq!(summary.archived, 1);
+        assert_eq!(summary.deleted, 0);
+        assert_eq!(summary.skipped, 0);
+
+        let loaded = load_workspace_projection_from_path(&workspace_dir.join("current.json"))
+            .expect("load")
+            .expect("present");
+        assert_eq!(
+            loaded.lifecycle_stage,
+            WorkspaceLifecycleStage::Active,
+            "dry-run must not mutate lifecycle_stage",
+        );
+    }
+
+    #[test]
+    fn apply_prune_plan_archives_then_deletes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let scan_root = tmp.path().to_path_buf();
+
+        let now = Utc::now();
+        let archive_dir = scan_root.join("archive-target").join("workspace");
+        let archive_projection = make_classify_projection(
+            "ws-arch",
+            &scan_root.join("archive-target"),
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+        write_projection_at(&archive_dir, &archive_projection);
+
+        let delete_dir = scan_root.join("delete-target").join("workspace");
+        let delete_projection = make_classify_projection(
+            "ws-del",
+            &scan_root.join("delete-target"),
+            now - chrono::Duration::days(90),
+            WorkspaceLifecycleStage::Archived,
+        );
+        write_projection_at(&delete_dir, &delete_projection);
+
+        let plan = classify_workspace_projections(
+            &scan_root,
+            &WorkspaceRetentionConfig::default(),
+            now,
+            |_| false,
+        );
+        let summary = apply_prune_plan(&plan, false).expect("apply prune");
+        assert_eq!(summary.archived, 1);
+        assert_eq!(summary.deleted, 1);
+
+        let loaded = load_workspace_projection_from_path(&archive_dir.join("current.json"))
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.lifecycle_stage, WorkspaceLifecycleStage::Archived);
+
+        assert!(
+            !delete_dir.exists(),
+            "delete target workspace dir should have been removed",
         );
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2237,6 +2237,63 @@ impl AppRuntime {
             FrontendEvent::UpdateSystemSettings { language } => {
                 self.system_settings_update_events(client_id, language)
             }
+            FrontendEvent::WorkspaceProjectionPrune { dry_run, ids } => {
+                self.workspace_projection_prune_events(client_id, dry_run, ids)
+            }
+        }
+    }
+
+    /// SPEC-2359 US-41 (FR-153, FR-154, FR-155): handle
+    /// [`FrontendEvent::WorkspaceProjectionPrune`] by classifying every
+    /// projection under `~/.gwt/projects/`, applying or previewing the plan,
+    /// and replying with a count summary or an error.
+    ///
+    /// Note: `is_active_session` is `|_| false` here as a first-pass; a
+    /// follow-up commit will bridge the live-window registry so currently
+    /// running Agents block their owning Workspace from prune.
+    fn workspace_projection_prune_events(
+        &self,
+        client_id: ClientId,
+        dry_run: bool,
+        ids: Vec<String>,
+    ) -> Vec<OutboundEvent> {
+        use gwt_core::paths::gwt_projects_dir;
+        use gwt_core::workspace_projection::{
+            apply_prune_plan, classify_workspace_projections, WorkspaceRetentionConfig,
+        };
+
+        let scan_root = gwt_projects_dir();
+        let now = chrono::Utc::now();
+        let config = WorkspaceRetentionConfig::default();
+        let plan = classify_workspace_projections(&scan_root, &config, now, |_| false);
+        let filtered: Vec<_> = if ids.is_empty() {
+            plan
+        } else {
+            plan.into_iter()
+                .filter(|item| ids.iter().any(|id| id == &item.workspace_id))
+                .collect()
+        };
+
+        match apply_prune_plan(&filtered, dry_run) {
+            Ok(summary) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::WorkspaceProjectionPruneResult {
+                    mode: if dry_run {
+                        "dry_run".to_string()
+                    } else {
+                        "applied".to_string()
+                    },
+                    archived: summary.archived,
+                    deleted: summary.deleted,
+                    skipped: summary.skipped,
+                },
+            )],
+            Err(error) => vec![OutboundEvent::reply(
+                client_id,
+                BackendEvent::WorkspaceProjectionPruneError {
+                    message: error.to_string(),
+                },
+            )],
         }
     }
 

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -219,6 +219,13 @@ pub enum WorkspaceCommand {
         topic: Option<String>,
         boundary: Option<String>,
     },
+    /// SPEC-2359 US-41: `gwtd workspace projection-list [--stale] [--all]` —
+    /// list saved Workspace projections under `~/.gwt/projects/*/workspace/`
+    /// classified by [`gwt_core::workspace_projection::workspace_projection_stale_reason`].
+    ProjectionList { stale: bool, all: bool },
+    /// SPEC-2359 US-41: `gwtd workspace projection-prune [--dry-run] [--id <id>]...` —
+    /// archive / delete stale Workspace projections (FR-153, FR-154).
+    ProjectionPrune { dry_run: bool, ids: Vec<String> },
 }
 
 /// SPEC-1942 family enum for `gwtd issue ...` (includes `issue spec ...`).

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -1,10 +1,14 @@
-use chrono::Utc;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use gwt_core::paths::gwt_projects_dir;
 use gwt_core::workspace_projection::{
-    load_or_default_workspace_projection, load_or_synthesize_workspace_work_items,
-    record_workspace_work_event, save_workspace_projection,
-    update_workspace_projection_with_journal, WorkspaceAgentAffiliationStatus,
-    WorkspaceAgentSummary, WorkspaceExecutionContainerRef, WorkspaceProjection,
-    WorkspaceProjectionUpdate, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
+    apply_prune_plan, classify_workspace_projections, load_or_default_workspace_projection,
+    load_or_synthesize_workspace_work_items, record_workspace_work_event,
+    save_workspace_projection, update_workspace_projection_with_journal, ClassifiedProjection,
+    PruneAction, PruneSkipReason, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+    WorkspaceExecutionContainerRef, WorkspaceProjection, WorkspaceProjectionUpdate,
+    WorkspaceRetentionConfig, WorkspaceStatusCategory, WorkspaceWorkEvent, WorkspaceWorkEventKind,
     WorkspaceWorkItem,
 };
 use gwt_github::{ApiError, SpecOpsError};
@@ -19,8 +23,44 @@ pub fn parse(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
         "join" => parse_join(rest),
         "create" => parse_create(rest),
         "ensure" => parse_ensure(rest),
+        "projection-list" => parse_projection_list(rest),
+        "projection-prune" => parse_projection_prune(rest),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
     }
+}
+
+fn parse_projection_list(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut stale = false;
+    let mut all = false;
+    for arg in args {
+        match arg.as_str() {
+            "--stale" => stale = true,
+            "--all" => all = true,
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+    }
+    Ok(WorkspaceCommand::ProjectionList { stale, all })
+}
+
+fn parse_projection_prune(args: &[String]) -> Result<WorkspaceCommand, CliParseError> {
+    let mut dry_run = false;
+    let mut ids: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--dry-run" => {
+                dry_run = true;
+                i += 1;
+            }
+            "--id" => {
+                let value = parse_required_value(args, i, "--id")?;
+                ids.push(value);
+                i += 2;
+            }
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+    }
+    Ok(WorkspaceCommand::ProjectionPrune { dry_run, ids })
 }
 
 fn parse_required_value(
@@ -518,6 +558,145 @@ pub(super) fn run<E: CliEnv>(
             ));
             Ok(0)
         }
+        WorkspaceCommand::ProjectionList { stale, all } => {
+            let scan_root = gwt_projects_dir();
+            run_projection_list_with_scan_root(
+                &scan_root,
+                &WorkspaceRetentionConfig::default(),
+                Utc::now(),
+                stale,
+                all,
+                |_| false,
+                out,
+            )
+        }
+        WorkspaceCommand::ProjectionPrune { dry_run, ids } => {
+            let scan_root = gwt_projects_dir();
+            run_projection_prune_with_scan_root(
+                &scan_root,
+                &WorkspaceRetentionConfig::default(),
+                Utc::now(),
+                dry_run,
+                &ids,
+                |_| false,
+                out,
+            )
+        }
+    }
+}
+
+/// SPEC-2359 US-41 (FR-153): implement `gwtd workspace projection-list` over a
+/// caller-provided `scan_root` so the production path uses `gwt_projects_dir()`
+/// and tests can pass a tempdir. `is_active_session` bridges in the live-window
+/// registry from `app_runtime` (default `false` in CLI-only contexts).
+fn run_projection_list_with_scan_root<F>(
+    scan_root: &Path,
+    config: &WorkspaceRetentionConfig,
+    now: DateTime<Utc>,
+    stale: bool,
+    all: bool,
+    is_active_session: F,
+    out: &mut String,
+) -> Result<i32, SpecOpsError>
+where
+    F: Fn(&WorkspaceProjection) -> bool,
+{
+    let plan = classify_workspace_projections(scan_root, config, now, is_active_session);
+    let filtered = filter_projection_list(&plan, stale, all);
+    out.push_str(&format!(
+        "# workspace projection list (mode: {}, count: {})\n",
+        list_mode_label(stale, all),
+        filtered.len()
+    ));
+    for entry in filtered {
+        let reason = entry
+            .stale_reason
+            .map(|r| r.as_str().to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let action = format_prune_action(&entry.action);
+        out.push_str(&format!(
+            "{} | {} | {:?} | {} | {} | {}\n",
+            entry.workspace_id,
+            entry.project_root.display(),
+            entry.lifecycle_stage,
+            reason,
+            action,
+            entry.updated_at.format("%Y-%m-%dT%H:%M:%SZ"),
+        ));
+    }
+    Ok(0)
+}
+
+/// SPEC-2359 US-41 (FR-153, FR-154): implement `gwtd workspace projection-prune`
+/// over a caller-provided `scan_root`. `ids` lets the user scope the prune to
+/// specific workspace IDs; empty means "every classified entry".
+fn run_projection_prune_with_scan_root<F>(
+    scan_root: &Path,
+    config: &WorkspaceRetentionConfig,
+    now: DateTime<Utc>,
+    dry_run: bool,
+    ids: &[String],
+    is_active_session: F,
+    out: &mut String,
+) -> Result<i32, SpecOpsError>
+where
+    F: Fn(&WorkspaceProjection) -> bool,
+{
+    let plan = classify_workspace_projections(scan_root, config, now, is_active_session);
+    let filtered: Vec<ClassifiedProjection> = if ids.is_empty() {
+        plan
+    } else {
+        plan.into_iter()
+            .filter(|item| ids.iter().any(|id| id == &item.workspace_id))
+            .collect()
+    };
+    let summary = apply_prune_plan(&filtered, dry_run).map_err(core_error)?;
+    let mode = if dry_run { "DRY-RUN" } else { "APPLIED" };
+    out.push_str(&format!(
+        "{}: archive={} delete={} skip={}\n",
+        mode, summary.archived, summary.deleted, summary.skipped,
+    ));
+    Ok(0)
+}
+
+fn filter_projection_list(
+    plan: &[ClassifiedProjection],
+    stale: bool,
+    all: bool,
+) -> Vec<&ClassifiedProjection> {
+    if all {
+        plan.iter().collect()
+    } else if stale {
+        plan.iter()
+            .filter(|entry| {
+                !matches!(
+                    entry.action,
+                    PruneAction::Skip {
+                        reason: PruneSkipReason::NotStale,
+                    }
+                )
+            })
+            .collect()
+    } else {
+        plan.iter()
+            .filter(|entry| matches!(entry.action, PruneAction::Archive | PruneAction::Delete))
+            .collect()
+    }
+}
+
+fn list_mode_label(stale: bool, all: bool) -> &'static str {
+    match (stale, all) {
+        (_, true) => "all",
+        (true, _) => "stale-or-archived",
+        _ => "actionable",
+    }
+}
+
+fn format_prune_action(action: &PruneAction) -> String {
+    match action {
+        PruneAction::Skip { reason } => format!("skip:{:?}", reason),
+        PruneAction::Archive => "archive".to_string(),
+        PruneAction::Delete => "delete".to_string(),
     }
 }
 
@@ -1655,5 +1834,292 @@ mod tests {
             .expect("load workspace history")
             .expect("workspace history");
         assert_eq!(items.work_items.len(), 1);
+    }
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| v.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_workspace_projection_list_defaults_to_no_flags() {
+        let cmd = parse(&args(&["projection-list"])).expect("parse projection-list");
+        assert_eq!(
+            cmd,
+            WorkspaceCommand::ProjectionList {
+                stale: false,
+                all: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_workspace_projection_list_accepts_stale_and_all_flags() {
+        let cmd = parse(&args(&["projection-list", "--stale", "--all"]))
+            .expect("parse projection-list --stale --all");
+        assert_eq!(
+            cmd,
+            WorkspaceCommand::ProjectionList {
+                stale: true,
+                all: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_workspace_projection_prune_defaults_to_apply_mode() {
+        let cmd = parse(&args(&["projection-prune"])).expect("parse projection-prune");
+        assert_eq!(
+            cmd,
+            WorkspaceCommand::ProjectionPrune {
+                dry_run: false,
+                ids: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_workspace_projection_prune_accepts_dry_run() {
+        let cmd = parse(&args(&["projection-prune", "--dry-run"]))
+            .expect("parse projection-prune --dry-run");
+        assert_eq!(
+            cmd,
+            WorkspaceCommand::ProjectionPrune {
+                dry_run: true,
+                ids: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_workspace_projection_prune_accepts_repeated_ids() {
+        let cmd = parse(&args(&[
+            "projection-prune",
+            "--id",
+            "abc-123",
+            "--id",
+            "def-456",
+        ]))
+        .expect("parse projection-prune --id ... --id ...");
+        assert_eq!(
+            cmd,
+            WorkspaceCommand::ProjectionPrune {
+                dry_run: false,
+                ids: vec!["abc-123".to_string(), "def-456".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_workspace_projection_prune_rejects_unknown_flag() {
+        let err =
+            parse(&args(&["projection-prune", "--bogus"])).expect_err("unknown flag should fail");
+        assert!(matches!(err, CliParseError::UnknownSubcommand(_)));
+    }
+
+    use gwt_core::workspace_projection::{
+        save_workspace_projection_to_path, WorkspaceLifecycleStage,
+    };
+
+    fn seed_stale_workspace(
+        scan_root: &std::path::Path,
+        id: &str,
+        hash: &str,
+        updated_at: chrono::DateTime<chrono::Utc>,
+        lifecycle: WorkspaceLifecycleStage,
+    ) {
+        let project_dir = scan_root.join(hash);
+        let workspace_dir = project_dir.join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("create workspace dir");
+        let mut projection = WorkspaceProjection::default_for_project(&project_dir);
+        projection.id = id.to_string();
+        projection.updated_at = updated_at;
+        projection.lifecycle_stage = lifecycle;
+        save_workspace_projection_to_path(&workspace_dir.join("current.json"), &projection)
+            .expect("save");
+    }
+
+    #[test]
+    fn run_projection_list_with_scan_root_emits_actionable_only_by_default() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let now = Utc::now();
+        seed_stale_workspace(
+            tmp.path(),
+            "ws-stale",
+            "stale-hash",
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+        seed_stale_workspace(
+            tmp.path(),
+            "ws-fresh",
+            "fresh-hash",
+            now,
+            WorkspaceLifecycleStage::Active,
+        );
+
+        let mut out = String::new();
+        let code = run_projection_list_with_scan_root(
+            tmp.path(),
+            &WorkspaceRetentionConfig::default(),
+            now,
+            false,
+            false,
+            |_| false,
+            &mut out,
+        )
+        .expect("list");
+        assert_eq!(code, 0);
+        assert!(out.contains("ws-stale"), "stale workspace must be listed");
+        assert!(
+            !out.contains("ws-fresh"),
+            "fresh workspace must be filtered out in default (actionable) mode",
+        );
+        assert!(out.contains("mode: actionable"));
+    }
+
+    #[test]
+    fn run_projection_list_with_scan_root_includes_fresh_when_all_flag_set() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let now = Utc::now();
+        seed_stale_workspace(
+            tmp.path(),
+            "ws-fresh",
+            "fresh-hash",
+            now,
+            WorkspaceLifecycleStage::Active,
+        );
+
+        let mut out = String::new();
+        let code = run_projection_list_with_scan_root(
+            tmp.path(),
+            &WorkspaceRetentionConfig::default(),
+            now,
+            false,
+            true,
+            |_| false,
+            &mut out,
+        )
+        .expect("list");
+        assert_eq!(code, 0);
+        assert!(out.contains("ws-fresh"));
+        assert!(out.contains("mode: all"));
+    }
+
+    #[test]
+    fn run_projection_prune_with_scan_root_dry_run_reports_plan_without_changes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let now = Utc::now();
+        seed_stale_workspace(
+            tmp.path(),
+            "ws-archive-me",
+            "stale-hash",
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+
+        let mut out = String::new();
+        let code = run_projection_prune_with_scan_root(
+            tmp.path(),
+            &WorkspaceRetentionConfig::default(),
+            now,
+            true,
+            &[],
+            |_| false,
+            &mut out,
+        )
+        .expect("prune dry-run");
+        assert_eq!(code, 0);
+        assert!(out.contains("DRY-RUN: archive=1 delete=0 skip=0"));
+        // dry-run should not mutate lifecycle_stage
+        let projection_path = tmp.path().join("stale-hash/workspace/current.json");
+        let loaded =
+            gwt_core::workspace_projection::load_workspace_projection_from_path(&projection_path)
+                .expect("load")
+                .expect("present");
+        assert_eq!(loaded.lifecycle_stage, WorkspaceLifecycleStage::Active);
+    }
+
+    #[test]
+    fn run_projection_prune_with_scan_root_apply_persists_archive() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let now = Utc::now();
+        seed_stale_workspace(
+            tmp.path(),
+            "ws-archive-me",
+            "stale-hash",
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+
+        let mut out = String::new();
+        let code = run_projection_prune_with_scan_root(
+            tmp.path(),
+            &WorkspaceRetentionConfig::default(),
+            now,
+            false,
+            &[],
+            |_| false,
+            &mut out,
+        )
+        .expect("prune apply");
+        assert_eq!(code, 0);
+        assert!(out.contains("APPLIED: archive=1"));
+
+        let projection_path = tmp.path().join("stale-hash/workspace/current.json");
+        let loaded =
+            gwt_core::workspace_projection::load_workspace_projection_from_path(&projection_path)
+                .expect("load")
+                .expect("present");
+        assert_eq!(loaded.lifecycle_stage, WorkspaceLifecycleStage::Archived);
+    }
+
+    #[test]
+    fn run_projection_prune_with_scan_root_filters_by_id() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let now = Utc::now();
+        seed_stale_workspace(
+            tmp.path(),
+            "ws-keep",
+            "keep-hash",
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+        seed_stale_workspace(
+            tmp.path(),
+            "ws-take",
+            "take-hash",
+            now - chrono::Duration::days(40),
+            WorkspaceLifecycleStage::Active,
+        );
+
+        let mut out = String::new();
+        let _ = run_projection_prune_with_scan_root(
+            tmp.path(),
+            &WorkspaceRetentionConfig::default(),
+            now,
+            false,
+            &["ws-take".to_string()],
+            |_| false,
+            &mut out,
+        )
+        .expect("prune by id");
+        assert!(out.contains("APPLIED: archive=1"));
+
+        let keep = gwt_core::workspace_projection::load_workspace_projection_from_path(
+            &tmp.path().join("keep-hash/workspace/current.json"),
+        )
+        .expect("load keep")
+        .expect("present");
+        assert_eq!(
+            keep.lifecycle_stage,
+            WorkspaceLifecycleStage::Active,
+            "id filter must leave non-matching workspaces untouched",
+        );
+        let take = gwt_core::workspace_projection::load_workspace_projection_from_path(
+            &tmp.path().join("take-hash/workspace/current.json"),
+        )
+        .expect("load take")
+        .expect("present");
+        assert_eq!(take.lifecycle_stage, WorkspaceLifecycleStage::Archived);
     }
 }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -364,6 +364,17 @@ pub enum FrontendEvent {
     UpdateSystemSettings {
         language: String,
     },
+    /// SPEC-2359 US-41: classify Workspace projections under `~/.gwt/projects/`
+    /// and either preview (`dry_run = true`) or apply (`dry_run = false`) the
+    /// archive→delete transitions. `ids` limits the action to specific
+    /// `WorkspaceProjection::id` values; an empty list means "every classified
+    /// entry". Backend replies with [`BackendEvent::WorkspaceProjectionPruneResult`].
+    WorkspaceProjectionPrune {
+        #[serde(default)]
+        dry_run: bool,
+        #[serde(default)]
+        ids: Vec<String>,
+    },
 }
 
 fn default_board_history_limit() -> usize {
@@ -859,6 +870,22 @@ pub enum BackendEvent {
     /// human-readable; the frontend surfaces it as an inline status row in
     /// the System tab.
     SystemSettingsError {
+        message: String,
+    },
+    /// SPEC-2359 US-41: response to [`FrontendEvent::WorkspaceProjectionPrune`].
+    /// `mode` is `"dry_run"` or `"applied"`; counts reflect the plan executed
+    /// against `~/.gwt/projects/*/workspace/`.
+    WorkspaceProjectionPruneResult {
+        mode: String,
+        archived: usize,
+        deleted: usize,
+        skipped: usize,
+    },
+    /// SPEC-2359 US-41: error reply for
+    /// [`FrontendEvent::WorkspaceProjectionPrune`] when the backend cannot
+    /// classify or apply the plan (e.g. unreadable projection file, IO error
+    /// during delete).
+    WorkspaceProjectionPruneError {
         message: String,
     },
 }
@@ -1704,5 +1731,58 @@ mod tests {
                 && !production_source.contains("navigator.clipboard"),
             "expected frontend behavior details to stay out of protocol.rs",
         );
+    }
+
+    #[test]
+    fn frontend_event_workspace_projection_prune_round_trips() {
+        let payload = r#"{"kind":"workspace_projection_prune","dry_run":true,"ids":["w1","w2"]}"#;
+        let event: FrontendEvent =
+            serde_json::from_str(payload).expect("deserialize WorkspaceProjectionPrune");
+        match event {
+            FrontendEvent::WorkspaceProjectionPrune { dry_run, ids } => {
+                assert!(dry_run);
+                assert_eq!(ids, vec!["w1".to_string(), "w2".to_string()]);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn frontend_event_workspace_projection_prune_defaults() {
+        let payload = r#"{"kind":"workspace_projection_prune"}"#;
+        let event: FrontendEvent = serde_json::from_str(payload).expect("deserialize defaults");
+        match event {
+            FrontendEvent::WorkspaceProjectionPrune { dry_run, ids } => {
+                assert!(!dry_run);
+                assert!(ids.is_empty());
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn backend_event_workspace_projection_prune_result_serializes() {
+        let event = BackendEvent::WorkspaceProjectionPruneResult {
+            mode: "dry_run".to_string(),
+            archived: 3,
+            deleted: 1,
+            skipped: 5,
+        };
+        let value = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(value["kind"], "workspace_projection_prune_result");
+        assert_eq!(value["mode"], "dry_run");
+        assert_eq!(value["archived"], 3);
+        assert_eq!(value["deleted"], 1);
+        assert_eq!(value["skipped"], 5);
+    }
+
+    #[test]
+    fn backend_event_workspace_projection_prune_error_serializes() {
+        let event = BackendEvent::WorkspaceProjectionPruneError {
+            message: "scan failed: permission denied".to_string(),
+        };
+        let value = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(value["kind"], "workspace_projection_prune_error");
+        assert_eq!(value["message"], "scan failed: permission denied");
     }
 }


### PR DESCRIPTION
## Summary
- SPEC #2359 US-41 Phase 8a の実装。Workspace projection (`~/.gwt/projects/<hash>/workspace/`) の累積を整理する CLI と protocol を提供する。
- 2 段階 lifecycle: stale な `Active` projection を `Archived` に遷移し、`Archived` で `delete_after_archive_days` を超えたものは workspace ディレクトリごと物理削除。
- 既存 US-14 (Branch Cleanup) と分業: branch / worktree の削除は US-14、projection ファイルの retention は US-41。

## Test plan
- [x] cargo test -p gwt-core --lib (259 passed)
- [x] cargo test -p gwt --lib (609 passed)
- [x] cargo test -p gwt-core -p gwt --all-features (all green)
- [x] cargo clippy --all-targets --all-features -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] commitlint pass
- [ ] CI workflow GREEN (auto)

## New CLI surface
- `gwtd workspace projection-list [--stale] [--all]` — saved projection を classified table で表示。default は `Archive` / `Delete` 予定のみ、`--stale` で `ArchivedTooSoon` / `ActiveAgent` も含む、`--all` で全件。
- `gwtd workspace projection-prune [--dry-run] [--id <id>]...` — plan を適用 (または `--dry-run` で count のみ)。`--id` は repeatable で範囲を限定。

## New protocol surface
- `FrontendEvent::WorkspaceProjectionPrune { dry_run, ids }`
- `BackendEvent::WorkspaceProjectionPruneResult { mode, archived, deleted, skipped }`
- `BackendEvent::WorkspaceProjectionPruneError { message }`

## Out of scope (Phase 8b follow-up)
- GUI Drawer / OperatorShell "Prune Stale Projections…" button (frontend event は wired 済みなので、ボタン追加のみで動作)
- Live-window registry bridge for FR-155 (現状 `is_active_session = |_| false`; ActiveAgent skip は CLI で driver 側に依存)
- Integration test as separate file (現状は unit + handler tests でカバー済み)

## SPEC reference
https://github.com/akiojin/gwt/issues/2359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
