### PR TITLE
feat(workspace): add Workspace projection retention GUI + FR-155 bridge (US-41 Phase 8b)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2265,7 +2265,16 @@ impl AppRuntime {
         let scan_root = gwt_projects_dir();
         let now = chrono::Utc::now();
         let config = WorkspaceRetentionConfig::default();
-        let plan = classify_workspace_projections(&scan_root, &config, now, |_| false);
+        let live_session_ids: std::collections::HashSet<String> =
+            self.active_agent_sessions.keys().cloned().collect();
+        let is_active_session =
+            |projection: &gwt_core::workspace_projection::WorkspaceProjection| {
+                projection
+                    .agents
+                    .iter()
+                    .any(|agent| live_session_ids.contains(&agent.session_id))
+            };
+        let plan = classify_workspace_projections(&scan_root, &config, now, is_active_session);
         let filtered: Vec<_> = if ids.is_empty() {
             plan
         } else {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -460,6 +460,42 @@
         pendingMessages.push(message);
       }
 
+      // SPEC-2359 US-41 Phase 8b: surface Workspace projection prune through
+      // the Command Palette. The dry-run entry previews the plan; the apply
+      // entry confirms before mutating projection files on disk.
+      if (window.__operatorShell?.palette) {
+        window.__operatorShell.palette.register({
+          id: "workspace-projection-prune-dry-run",
+          label: "Workspace: Prune Stale Projections (dry-run)",
+          group: "Workspace",
+          handler: () => {
+            send({
+              kind: "workspace_projection_prune",
+              dry_run: true,
+              ids: [],
+            });
+          },
+        });
+        window.__operatorShell.palette.register({
+          id: "workspace-projection-prune-apply",
+          label: "Workspace: Prune Stale Projections (apply)",
+          group: "Workspace",
+          handler: () => {
+            if (
+              window.confirm(
+                "Apply Workspace projection prune now? Archived entries past their grace period will be physically removed.",
+              )
+            ) {
+              send({
+                kind: "workspace_projection_prune",
+                dry_run: false,
+                ids: [],
+              });
+            }
+          },
+        });
+      }
+
       const updateCtaController = createUpdateCtaController({
         document,
         send,
@@ -8321,6 +8357,25 @@
           case "workspace_state":
             projectError = "";
             frontendUnits.projectWorkspaceShell.renderAppState(event.workspace);
+            break;
+          case "workspace_projection_prune_result": {
+            // SPEC-2359 US-41 Phase 8b: minimal feedback for projection prune.
+            // A richer Drawer surface lands in a follow-up; for now an alert
+            // keeps the loop closed so users see the count summary.
+            const modeLabel =
+              event.mode === "dry_run" ? "dry-run" : "applied";
+            window.alert(
+              `Workspace Projection Prune (${modeLabel})\n` +
+                `  archived: ${event.archived}\n` +
+                `  deleted: ${event.deleted}\n` +
+                `  skipped: ${event.skipped}`,
+            );
+            break;
+          }
+          case "workspace_projection_prune_error":
+            window.alert(
+              `Workspace Projection Prune error: ${event.message}`,
+            );
             break;
           case "active_work_projection":
             activeWorkProjection = event.projection || null;


### PR DESCRIPTION
## Summary
- SPEC #2359 US-41 Phase 8b の実装。Phase 8a (PR #2701) で構築した CLI + protocol の上に、live-window registry bridge (FR-155) と Command Palette UI (FR-156 部分) を追加。
- `workspace_projection_prune_events` ハンドラが `self.active_agent_sessions` の HashMap キーを集めて `is_active_session` closure を組み立て、生きている Agent を抱えた Workspace を archive 対象から除外する。
- Command Palette に `Workspace: Prune Stale Projections (dry-run)` と `Workspace: Prune Stale Projections (apply)` を登録。apply は window.confirm を経由してから dispatch する。
- BackendEvent (`workspace_projection_prune_result` / `workspace_projection_prune_error`) の結果は alert で表示する暫定 UX。Drawer ベースのリッチ表示は別 PR で対応。

## Test plan
- [x] cargo test -p gwt-core -p gwt --all-features (all green)
- [x] cargo clippy --all-targets --all-features -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] npm run test:frontend-bundle (clean)
- [x] npm run test:frontend-smoke (17/17)
- [x] npm run test:frontend-unit (370/370)
- [x] husky pre-push (clippy / fmt / coverage 91.01% / markdownlint / skills) all pass
- [x] commitlint pass
- [ ] CI workflow GREEN (auto)

## Out of scope (follow-up)
- Drawer ベースの dry-run 結果表示 + apply 確認 UI (alert を置換)
- Phase 9 (US-42 Workspace Resume re-attaches agent conversation) は別 PR で対応

## SPEC reference
https://github.com/akiojin/gwt/issues/2359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
