### PR TITLE
fix(gui): restore terminal focus transfer for xterm textarea

### DIFF
--- a/crates/gwt/web/__tests__/clone-modal-focus-guard.test.mjs
+++ b/crates/gwt/web/__tests__/clone-modal-focus-guard.test.mjs
@@ -72,6 +72,32 @@ test("returns true when document.activeElement is a TEXTAREA", () => {
   );
 });
 
+test("returns false when document.activeElement is xterm helper textarea", () => {
+  const document = makeDoc();
+  const textarea = document.createElement("textarea");
+  textarea.className = "xterm-helper-textarea";
+  document.body.appendChild(textarea);
+  Object.defineProperty(document, "activeElement", { value: textarea, configurable: true });
+  assert.equal(
+    shouldSkipTerminalFocusActivation({ doc: document, modalElements: [] }),
+    false,
+  );
+});
+
+test("modal open still suppresses focus when xterm helper textarea is active", () => {
+  const document = makeDoc();
+  const modal = document.createElement("div");
+  modal.classList.add("open");
+  const textarea = document.createElement("textarea");
+  textarea.className = "xterm-helper-textarea";
+  document.body.append(modal, textarea);
+  Object.defineProperty(document, "activeElement", { value: textarea, configurable: true });
+  assert.equal(
+    shouldSkipTerminalFocusActivation({ doc: document, modalElements: [modal] }),
+    true,
+  );
+});
+
 test("returns true when activeElement is contentEditable", () => {
   const document = makeDoc();
   const editable = document.createElement("div");

--- a/crates/gwt/web/clone-modal-focus-guard.js
+++ b/crates/gwt/web/clone-modal-focus-guard.js
@@ -17,6 +17,7 @@
 // blurred.
 
 const TEXT_INPUT_TAGS = new Set(["INPUT", "TEXTAREA"]);
+const XTERM_HELPER_TEXTAREA_CLASS = "xterm-helper-textarea";
 
 function modalOwnsFocus(modalElements) {
   if (!Array.isArray(modalElements)) {
@@ -39,6 +40,9 @@ function modalOwnsFocus(modalElements) {
 function textInputOwnsFocus(doc) {
   const active = doc && doc.activeElement;
   if (!active) {
+    return false;
+  }
+  if (active.classList?.contains?.(XTERM_HELPER_TEXTAREA_CLASS)) {
     return false;
   }
   if (TEXT_INPUT_TAGS.has(active.tagName)) {


### PR DESCRIPTION
## Summary

- Restore terminal input focus transfer after programmatic window switching by excluding the xterm helper textarea from normal text-input focus protection.
- Preserve modal focus protection so terminal focus is still suppressed while a modal is open.

## Changes

- `crates/gwt/web/clone-modal-focus-guard.js`: Add an xterm helper textarea class constant and return `false` for that internal textarea before the generic `TEXTAREA` guard.
- `crates/gwt/web/__tests__/clone-modal-focus-guard.test.mjs`: Add regression coverage for xterm helper textarea focus transfer and modal-open suppression.

## Testing

- [x] `node --test crates/gwt/web/__tests__/clone-modal-focus-guard.test.mjs crates/gwt/web/__tests__/clone-modal-focus-guard-wiring.test.mjs` — 14 tests passed.
- [x] `pnpm test:frontend-unit` — 431 tests passed.
- [x] `pnpm test:frontend-bundle` — completed successfully.
- [x] `cargo test -p gwt embedded_web --all-features` — embedded web tests passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — completed successfully.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — completed successfully.
- [x] `cargo fmt -- --check` — completed successfully.
- [x] `pnpm exec commitlint --from HEAD~1 --to HEAD` — completed successfully.
- [x] Pre-push hook — all checks passed with filtered line coverage 91.01%.

## Closing Issues

- None

## Related Issues / Links

- #2704
- #2008

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (N/A: internal focus behavior fix with no documentation surface change)
- [ ] Migration/backfill plan included (N/A: no schema or data change)
- [x] CHANGELOG impact considered (patch-level bug fix, no breaking change)

## Context

- The focus guard previously treated xterm.js internal `.xterm-helper-textarea` as a user text input, which suppressed `terminal.focus()` when Shift+Cmd+Arrow or other programmatic focus paths moved to another terminal window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal focus activation behavior when using xterm-based terminals.
  * Fixed focus handling to properly support terminal interaction while respecting modal window states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2707)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->