### PR TITLE
fix: require evidence gate before discussion resolve

### DIFF
--- a/.claude/commands/gwt-discussion.md
+++ b/.claude/commands/gwt-discussion.md
@@ -22,7 +22,7 @@ mid-implementation investigation.
 3. Investigate code, map dependencies, then present findings before proposing a path.
 4. Discuss one question at a time with selection UI first. In Codex, use `request_user_input` when that UI is available.
 5. After each answer, update `Discussion TODO`, `Coverage Checks`, and `Exit Blockers`, then re-rank unresolved high-impact unknowns and ask the next highest-impact question before exiting.
-6. Do not leave Plan Mode until `Action Delta` and `Action Bundle` are ready and the depth gate is satisfied or intentionally deferred.
+6. Do not leave Plan Mode until `Action Delta` and `Action Bundle` are ready, the depth gate is satisfied or intentionally deferred, and `Evidence Gate: complete` is backed by implementation proof, SPEC/Issue proof, gap-check proof, official docs proof when applicable, and external research proof when needed.
 7. If managed hooks surface an unfinished discussion prompt, use `.gwt/discussion.md` as the source of truth and choose `Resume discussion`, `Park proposal`, or `Dismiss for now`.
 
 ## Examples

--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -52,6 +52,10 @@ Keep these artifacts throughout the discussion:
 questions, dependency checks, deferred decisions, coverage gaps, exit blockers,
 and the next question to ask.
 
+Evidence is part of the discussion state, not a later implementation detail.
+Do not mark a proposal `[chosen]` until its evidence fields prove the outcome
+without relying on speculation, guesses, or vibes.
+
 Mirror structure for `.gwt/discussion.md`:
 
 ```markdown
@@ -65,6 +69,12 @@ Mirror structure for `.gwt/discussion.md`:
 - Coverage Checks:
 - Exit Blockers:
 - Next Question:
+- Implementation Proof:
+- SPEC/Issue Proof:
+- Gap Check Proof:
+- Official Docs Proof:
+- External Research Proof:
+- Evidence Gate:
 - Promotable Changes:
 ```
 
@@ -90,15 +100,16 @@ high-impact unknown behind it has been resolved.
 SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
 which inspects `.gwt/discussion.md` and blocks Stop (with
 `{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
-with a non-empty `Next Question:`. To let Stop succeed, mark each proposal
-explicitly using the exit CLI:
+with a non-empty `Next Question:`, unresolved `Exit Blockers:`, incomplete
+proof fields, or an `Evidence Gate:` that is not `complete`. To let Stop
+succeed, mark each proposal explicitly using the exit CLI:
 
-- `gwtd discuss resolve --proposal "Proposal A"` — active → chosen
+- `gwtd discuss resolve --proposal "Proposal A"` — active → chosen only after
+  `Evidence Gate: complete`
 - `gwtd discuss park --proposal "Proposal A"` — active → parked (resume later)
 - `gwtd discuss reject --proposal "Proposal A"` — active → rejected
-- `gwtd discuss clear-next-question --proposal "Proposal A"` — keep the
-  proposal active but pause Stop-block (exceptional; only when waiting on a
-  user answer the skill truly cannot resolve alone)
+- `gwtd discuss clear-next-question --proposal "Proposal A"` — clear only the
+  question line. It does not bypass incomplete evidence.
 
 When the `Action Bundle` is produced, call the matching exit command for each
 proposal before stopping. Claude Code's built-in `stop_hook_active` flag keeps
@@ -162,6 +173,11 @@ Do not ask the user anything until you have investigated.
 - Read the files or artifacts that would change
 - If possible, run the code or command to observe actual behavior
 - Compare code, SPEC, plan, and issue state when they disagree
+- Check official documentation for external APIs, runtimes, operating systems,
+  CLIs, libraries, hooks, or platform behavior that cannot be proven locally
+- Use web research when repo-local evidence and official documentation are not
+  enough. For fast-moving operational facts, use X search when available, and
+  record the source account, URL, timestamp, and whether it is first-party
 
 For every potential change surface, map:
 
@@ -234,6 +250,33 @@ independent comparison work and do not let it replace the main discussion flow.
 
 Do not end the discussion after a single answer when unresolved high-impact
 unknowns still exist.
+
+## Evidence Gate
+
+Before producing the final Action Delta / Action Bundle, complete the proof
+fields for every `[active]` proposal that will become `[chosen]`.
+
+- `Implementation Proof`: name the implementation files, logs, commands, or
+  tests inspected or run. If no implementation exists, say what proves that.
+- `SPEC/Issue Proof`: name the owner SPEC / plan / tasks / Issue sections read,
+  including any missing or stale items found.
+- `Gap Check Proof`: explicitly cover scope, ownership/integration,
+  failure/edge cases, migration/compatibility, and verification/success signal.
+- `Official Docs Proof`: cite official documentation checked for external API,
+  runtime, OS, CLI, library, or hook behavior. Use `not-applicable: <reason>`
+  only for purely local behavior.
+- `External Research Proof`: cite non-official research, issue trackers, web
+  search, or X search when needed. Use `not-applicable: <reason>` only when
+  official docs and local evidence fully settle the question.
+- `Evidence Gate`: set to `complete` only when the proposal has no unresolved
+  `Exit Blockers:` and all proof fields above are non-empty or explicitly
+  `not-applicable: <reason>`.
+
+Official documentation is the preferred external evidence. X search and
+X API Search Posts official docs are valid discovery paths for fast-moving
+facts, but X posts alone are not sufficient for irreversible conclusions unless
+they are first-party posts with URL and timestamp, or are corroborated by
+official docs or another primary source.
 
 ### Phase 4: Design and artifact updates
 

--- a/.codex/skills/gwt-discussion/SKILL.md
+++ b/.codex/skills/gwt-discussion/SKILL.md
@@ -52,6 +52,10 @@ Keep these artifacts throughout the discussion:
 questions, dependency checks, deferred decisions, coverage gaps, exit blockers,
 and the next question to ask.
 
+Evidence is part of the discussion state, not a later implementation detail.
+Do not mark a proposal `[chosen]` until its evidence fields prove the outcome
+without relying on speculation, guesses, or vibes.
+
 Mirror structure for `.gwt/discussion.md`:
 
 ```markdown
@@ -65,6 +69,12 @@ Mirror structure for `.gwt/discussion.md`:
 - Coverage Checks:
 - Exit Blockers:
 - Next Question:
+- Implementation Proof:
+- SPEC/Issue Proof:
+- Gap Check Proof:
+- Official Docs Proof:
+- External Research Proof:
+- Evidence Gate:
 - Promotable Changes:
 ```
 
@@ -90,15 +100,16 @@ high-impact unknown behind it has been resolved.
 SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
 which inspects `.gwt/discussion.md` and blocks Stop (with
 `{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
-with a non-empty `Next Question:`. To let Stop succeed, mark each proposal
-explicitly using the exit CLI:
+with a non-empty `Next Question:`, unresolved `Exit Blockers:`, incomplete
+proof fields, or an `Evidence Gate:` that is not `complete`. To let Stop
+succeed, mark each proposal explicitly using the exit CLI:
 
-- `gwtd discuss resolve --proposal "Proposal A"` — active → chosen
+- `gwtd discuss resolve --proposal "Proposal A"` — active → chosen only after
+  `Evidence Gate: complete`
 - `gwtd discuss park --proposal "Proposal A"` — active → parked (resume later)
 - `gwtd discuss reject --proposal "Proposal A"` — active → rejected
-- `gwtd discuss clear-next-question --proposal "Proposal A"` — keep the
-  proposal active but pause Stop-block (exceptional; only when waiting on a
-  user answer the skill truly cannot resolve alone)
+- `gwtd discuss clear-next-question --proposal "Proposal A"` — clear only the
+  question line. It does not bypass incomplete evidence.
 
 When the `Action Bundle` is produced, call the matching exit command for each
 proposal before stopping. Codex's `stop_hook_active` flag (shared with Claude
@@ -180,6 +191,11 @@ Do not ask the user anything until you have investigated.
 - Read the files or artifacts that would change
 - If possible, run the code or command to observe actual behavior
 - Compare code, SPEC, plan, and issue state when they disagree
+- Check official documentation for external APIs, runtimes, operating systems,
+  CLIs, libraries, hooks, or platform behavior that cannot be proven locally
+- Use web research when repo-local evidence and official documentation are not
+  enough. For fast-moving operational facts, use X search when available, and
+  record the source account, URL, timestamp, and whether it is first-party
 
 For every potential change surface, map:
 
@@ -252,6 +268,33 @@ independent comparison work and do not let it replace the main discussion flow.
 
 Do not end the discussion after a single answer when unresolved high-impact
 unknowns still exist.
+
+## Evidence Gate
+
+Before producing the final Action Delta / Action Bundle, complete the proof
+fields for every `[active]` proposal that will become `[chosen]`.
+
+- `Implementation Proof`: name the implementation files, logs, commands, or
+  tests inspected or run. If no implementation exists, say what proves that.
+- `SPEC/Issue Proof`: name the owner SPEC / plan / tasks / Issue sections read,
+  including any missing or stale items found.
+- `Gap Check Proof`: explicitly cover scope, ownership/integration,
+  failure/edge cases, migration/compatibility, and verification/success signal.
+- `Official Docs Proof`: cite official documentation checked for external API,
+  runtime, OS, CLI, library, or hook behavior. Use `not-applicable: <reason>`
+  only for purely local behavior.
+- `External Research Proof`: cite non-official research, issue trackers, web
+  search, or X search when needed. Use `not-applicable: <reason>` only when
+  official docs and local evidence fully settle the question.
+- `Evidence Gate`: set to `complete` only when the proposal has no unresolved
+  `Exit Blockers:` and all proof fields above are non-empty or explicitly
+  `not-applicable: <reason>`.
+
+Official documentation is the preferred external evidence. X search and
+X API Search Posts official docs are valid discovery paths for fast-moving
+facts, but X posts alone are not sufficient for irreversible conclusions unless
+they are first-party posts with URL and timestamp, or are corroborated by
+official docs or another primary source.
 
 ### Phase 4: Design and artifact updates
 

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -811,6 +811,22 @@ mod tests {
                 "expected discussion skill to define a depth gate with coverage and exit blocker tracking in {relative}"
             );
             assert!(
+                discussion_skill.contains("## Evidence Gate")
+                    && discussion_skill.contains("Implementation Proof")
+                    && discussion_skill.contains("SPEC/Issue Proof")
+                    && discussion_skill.contains("Gap Check Proof")
+                    && discussion_skill.contains("Official Docs Proof")
+                    && discussion_skill.contains("External Research Proof")
+                    && discussion_skill.contains("Evidence Gate: complete"),
+                "expected discussion skill to require evidence proof fields in {relative}"
+            );
+            assert!(
+                discussion_skill.contains("official documentation")
+                    && discussion_skill.contains("X search")
+                    && discussion_skill.contains("X API Search Posts"),
+                "expected discussion skill to require official docs and X research policy in {relative}"
+            );
+            assert!(
                 discussion_skill.contains("scope boundary")
                     && discussion_skill.contains("ownership / integration")
                     && discussion_skill.contains("failure / edge case")

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -691,16 +691,20 @@ mod tests {
     }
 
     #[test]
-    fn managed_stop_chain_includes_three_skill_check_handlers_after_board_reminder() {
+    fn managed_stop_chain_collapses_to_event_dispatcher() {
         let dir = tempfile::tempdir().unwrap();
         generate_settings_local(dir.path()).unwrap();
         let content = fs::read_to_string(dir.path().join(".claude/settings.local.json")).unwrap();
         let value: Value = serde_json::from_str(&content).unwrap();
         let stop_commands = commands_for_event(&value, "Stop");
         assert_eq!(
-            stop_commands,
-            vec!["'gwtd' hook event Stop"],
+            stop_commands.len(),
+            1,
             "Stop chain must collapse to the event dispatcher; got: {stop_commands:?}"
+        );
+        assert!(
+            stop_commands[0].contains(" hook event Stop"),
+            "Stop chain must dispatch through the event dispatcher; got: {stop_commands:?}"
         );
     }
 

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -276,7 +276,7 @@ fn format_discuss_help() -> String {
         "Usage: gwtd discuss <action> --proposal <label>",
         "",
         "Actions:",
-        "  resolve --proposal <label>              Mark a proposal chosen",
+        "  resolve --proposal <label>              Mark a proposal chosen after Evidence Gate",
         "  park --proposal <label>                 Mark a proposal parked",
         "  reject --proposal <label>               Mark a proposal rejected",
         "  clear-next-question --proposal <label>  Clear the open question (Stop unblock)",

--- a/crates/gwt/src/cli/discuss.rs
+++ b/crates/gwt/src/cli/discuss.rs
@@ -12,7 +12,9 @@
 use gwt_github::SpecOpsError;
 
 use crate::cli::{CliEnv, DiscussAction};
-use crate::discussion_resume::{clear_proposal_next_question, set_proposal_status_by_label};
+use crate::discussion_resume::{
+    clear_proposal_next_question, proposal_evidence_blocker_by_label, set_proposal_status_by_label,
+};
 
 pub(super) fn run<E: CliEnv>(
     env: &mut E,
@@ -21,7 +23,21 @@ pub(super) fn run<E: CliEnv>(
 ) -> Result<i32, SpecOpsError> {
     let worktree = env.repo_path().to_path_buf();
     match action {
-        DiscussAction::Resolve { proposal } => apply_status(&worktree, &proposal, "chosen", out),
+        DiscussAction::Resolve { proposal } => {
+            match proposal_evidence_blocker_by_label(&worktree, &proposal) {
+                Ok(Some(reason)) => {
+                    out.push_str(&format!(
+                        "discuss: cannot resolve {proposal}; Evidence Gate incomplete: {reason}\n"
+                    ));
+                    Ok(2)
+                }
+                Ok(None) => apply_status(&worktree, &proposal, "chosen", out),
+                Err(err) => {
+                    out.push_str(&format!("discuss: evidence gate check failed: {err}\n"));
+                    Ok(1)
+                }
+            }
+        }
         DiscussAction::Park { proposal } => apply_status(&worktree, &proposal, "parked", out),
         DiscussAction::Reject { proposal } => apply_status(&worktree, &proposal, "rejected", out),
         DiscussAction::ClearNextQuestion { proposal } => {

--- a/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use super::{envelope::stop_hook_active_from, HookError, HookOutput};
-use crate::discussion_resume::load_pending_resume;
+use crate::discussion_resume::discussion_stop_blocker;
 
 pub fn handle() -> Result<HookOutput, HookError> {
     let mut input = String::new();
@@ -32,7 +32,7 @@ pub fn handle_with_input(worktree: &Path, input: &str) -> HookOutput {
     if stop_hook_active_from(input) {
         return HookOutput::Silent;
     }
-    let Ok(Some(pending)) = load_pending_resume(worktree) else {
+    let Ok(Some(pending)) = discussion_stop_blocker(worktree) else {
         return HookOutput::Silent;
     };
     let Some(question) = pending
@@ -46,7 +46,7 @@ pub fn handle_with_input(worktree: &Path, input: &str) -> HookOutput {
 
     HookOutput::stop_block(format!(
         "Discussion is still [active] on proposal \"{title}\".\n\
-         Next question: {question}\n\
+         Next question or evidence blocker: {question}\n\
          Continue the gwt-discussion workflow (investigate → ask the user → update Discussion TODO), \
          or call `gwtd discuss resolve|park|reject --proposal \"{label}\"` to exit the discussion explicitly.",
         title = pending.proposal_title,
@@ -69,7 +69,27 @@ mod tests {
     const ACTIVE_WITHOUT_QUESTION: &str = "## Discussion TODO\n\n\
 ### Proposal A - Hook-driven resume [active]\n\
 - Summary: Keep unfinished discussion state in the local artifact.\n\
+- Implementation Proof: crates/gwt/src/discussion_resume.rs inspected.\n\
+- SPEC/Issue Proof: SPEC-1935 checked.\n\
+- Gap Check Proof: scope/integration/failure/migration/verification checked.\n\
+- Official Docs Proof: Claude Code hooks docs checked.\n\
+- External Research Proof: not-applicable: local-only behavior.\n\
+- Exit Blockers: none\n\
 - Next Question:\n\
+- Evidence Gate: complete\n\
+";
+
+    const ACTIVE_WITH_EXIT_BLOCKER_WITHOUT_QUESTION: &str = "## Discussion TODO\n\n\
+### Proposal A - Evidence gate [active]\n\
+- Summary: Implementation is not proven yet.\n\
+- Implementation Proof: TODO\n\
+- SPEC/Issue Proof: SPEC-1935 checked.\n\
+- Gap Check Proof: scope/integration/failure/migration/verification checked.\n\
+- Official Docs Proof: Claude Code hooks docs checked.\n\
+- External Research Proof: not-applicable: local-only behavior.\n\
+- Exit Blockers: implementation proof is missing\n\
+- Next Question:\n\
+- Evidence Gate: open\n\
 ";
 
     const ALL_RESOLVED: &str = "## Discussion TODO\n\n\
@@ -157,6 +177,20 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write_discussion(dir.path(), ACTIVE_WITHOUT_QUESTION);
         assert_eq!(handle_with_input(dir.path(), "{}"), HookOutput::Silent);
+    }
+
+    #[test]
+    fn blocks_when_evidence_gate_is_incomplete_without_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ACTIVE_WITH_EXIT_BLOCKER_WITHOUT_QUESTION);
+        assert_stop_block(
+            handle_with_input(dir.path(), "{}"),
+            &[
+                "Evidence gate",
+                "Exit Blockers remain unresolved",
+                "Next question or evidence blocker",
+            ],
+        );
     }
 
     #[test]

--- a/crates/gwt/src/discussion_resume.rs
+++ b/crates/gwt/src/discussion_resume.rs
@@ -190,6 +190,7 @@ pub struct ParsedProposal {
     pub(crate) title: String,
     pub(crate) status: ProposalStatus,
     pub(crate) next_question: Option<String>,
+    pub(crate) fields: Vec<(String, Option<String>)>,
 }
 
 pub fn parse_proposals(content: &str) -> Vec<ParsedProposal> {
@@ -201,6 +202,9 @@ pub fn parse_proposals(content: &str) -> Vec<ParsedProposal> {
             if let Some(current) = proposals.last_mut() {
                 if let Some(question) = parse_field_value(trimmed, "Next Question") {
                     current.next_question = question;
+                }
+                if let Some((field, value)) = parse_any_field_value(trimmed) {
+                    current.fields.push((field, value));
                 }
             }
             continue;
@@ -223,6 +227,7 @@ pub fn parse_proposals(content: &str) -> Vec<ParsedProposal> {
             title: title.trim().to_string(),
             status: parse_status(status),
             next_question: None,
+            fields: Vec::new(),
         });
     }
 
@@ -250,6 +255,51 @@ fn parse_field_value(line: &str, field: &str) -> Option<Option<String>> {
     }
 }
 
+fn parse_any_field_value(line: &str) -> Option<(String, Option<String>)> {
+    let remainder = line.strip_prefix("- ")?;
+    let (field, value) = remainder.split_once(':')?;
+    let field = field.trim();
+    if field.is_empty() {
+        return None;
+    }
+    let value = value.trim();
+    Some((
+        field.to_string(),
+        if value.is_empty() {
+            None
+        } else {
+            Some(value.to_string())
+        },
+    ))
+}
+
+pub fn proposal_evidence_blocker_by_label(
+    worktree: &Path,
+    label: &str,
+) -> io::Result<Option<String>> {
+    let discussion_path = worktree.join(DISCUSSION_RELATIVE_PATH);
+    if !discussion_path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&discussion_path)?;
+    let proposals = parse_proposals(&content);
+    Ok(proposals
+        .iter()
+        .find(|p| p.status == ProposalStatus::Active && p.label.eq_ignore_ascii_case(label))
+        .and_then(evidence_gate_blocker))
+}
+
+pub fn discussion_stop_blocker(worktree: &Path) -> io::Result<Option<PendingDiscussionResume>> {
+    let discussion_path = worktree.join(DISCUSSION_RELATIVE_PATH);
+    if !discussion_path.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(discussion_path)?;
+    let proposals = parse_proposals(&content);
+    Ok(select_pending_discussion_blocker(&proposals))
+}
+
 fn select_pending_resume(proposals: &[ParsedProposal]) -> Option<PendingDiscussionResume> {
     proposals
         .iter()
@@ -266,6 +316,100 @@ fn select_pending_resume(proposals: &[ParsedProposal]) -> Option<PendingDiscussi
             proposal_title: proposal.title.clone(),
             next_question: proposal.next_question.clone(),
         })
+}
+
+fn select_pending_discussion_blocker(
+    proposals: &[ParsedProposal],
+) -> Option<PendingDiscussionResume> {
+    proposals
+        .iter()
+        .find(|proposal| {
+            proposal.status == ProposalStatus::Active && proposal.next_question.is_some()
+        })
+        .map(|proposal| PendingDiscussionResume {
+            proposal_label: proposal.label.clone(),
+            proposal_title: proposal.title.clone(),
+            next_question: proposal.next_question.clone(),
+        })
+        .or_else(|| {
+            proposals
+                .iter()
+                .filter(|proposal| proposal.status == ProposalStatus::Active)
+                .find_map(|proposal| {
+                    evidence_gate_blocker(proposal).map(|reason| PendingDiscussionResume {
+                        proposal_label: proposal.label.clone(),
+                        proposal_title: proposal.title.clone(),
+                        next_question: Some(reason),
+                    })
+                })
+        })
+}
+
+fn evidence_gate_blocker(proposal: &ParsedProposal) -> Option<String> {
+    let exit_blockers = field_value(proposal, "Exit Blockers");
+    if is_blocking_value(exit_blockers.as_deref()) {
+        return Some(format!(
+            "Exit Blockers remain unresolved: {}",
+            exit_blockers.unwrap_or_default()
+        ));
+    }
+
+    let required_fields = [
+        "Implementation Proof",
+        "SPEC/Issue Proof",
+        "Gap Check Proof",
+        "Official Docs Proof",
+        "External Research Proof",
+    ];
+    for field in required_fields {
+        let value = field_value(proposal, field);
+        if !is_acceptable_proof(value.as_deref()) {
+            return Some(format!("{field} is missing or incomplete"));
+        }
+    }
+
+    match field_value(proposal, "Evidence Gate") {
+        Some(value) if value.eq_ignore_ascii_case("complete") => None,
+        Some(value) => Some(format!("Evidence Gate is not complete: {value}")),
+        None => Some("Evidence Gate is missing".to_string()),
+    }
+}
+
+fn field_value(proposal: &ParsedProposal, field: &str) -> Option<String> {
+    proposal
+        .fields
+        .iter()
+        .rev()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(field))
+        .and_then(|(_, value)| value.clone())
+}
+
+fn is_acceptable_proof(value: Option<&str>) -> bool {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    let lower = value.to_ascii_lowercase();
+    if let Some(reason) = lower.strip_prefix("not-applicable:") {
+        return !reason.trim().is_empty();
+    }
+    !is_placeholder_value(value)
+}
+
+fn is_blocking_value(value: Option<&str>) -> bool {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    !matches!(
+        value.to_ascii_lowercase().as_str(),
+        "none" | "resolved" | "complete" | "closed" | "n/a" | "not-applicable"
+    )
+}
+
+fn is_placeholder_value(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "tbd" | "todo" | "unknown" | "unverified" | "none" | "n/a" | "not-applicable"
+    )
 }
 
 #[cfg(test)]
@@ -487,6 +631,10 @@ mod tests {
             parse_field_value("- Next Question:", "Next Question"),
             Some(None)
         );
+        assert_eq!(
+            parse_any_field_value("- Evidence Gate: complete"),
+            Some(("Evidence Gate".to_string(), Some("complete".to_string())))
+        );
 
         let pending = select_pending_resume(&proposals).expect("pending proposal");
         assert_eq!(pending.proposal_label, "Proposal C");
@@ -494,5 +642,114 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(load_pending_resume(dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn discussion_stop_blocker_reports_exit_blockers_without_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Evidence gap [active]\n\
+             - Summary: Root cause is still hypothetical.\n\
+             - Implementation Proof: crates/gwt/src/foo.rs inspected\n\
+             - SPEC/Issue Proof: SPEC-1935 checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable: local-only behavior\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: root cause has no reproducer yet\n\
+             - Next Question:\n\
+             - Evidence Gate: open\n",
+        )
+        .unwrap();
+
+        let pending = discussion_stop_blocker(dir.path())
+            .unwrap()
+            .expect("exit blocker should keep discussion active");
+        assert_eq!(pending.proposal_label, "Proposal A");
+        assert!(pending
+            .next_question
+            .as_deref()
+            .unwrap_or("")
+            .contains("Exit Blockers remain unresolved"));
+    }
+
+    #[test]
+    fn discussion_stop_blocker_is_silent_when_evidence_gate_is_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Evidence complete [active]\n\
+             - Summary: Evidence is complete.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected and focused tests run\n\
+             - SPEC/Issue Proof: SPEC-1935 spec/plan/tasks checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: Claude Code hooks docs checked\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        assert_eq!(discussion_stop_blocker(dir.path()).unwrap(), None);
+        assert_eq!(
+            proposal_evidence_blocker_by_label(dir.path(), "Proposal A").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn proposal_evidence_blocker_reports_missing_proofs() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Missing proof [active]\n\
+             - Summary: Missing proof.\n\
+             - Exit Blockers: none\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        let blocker = proposal_evidence_blocker_by_label(dir.path(), "Proposal A")
+            .unwrap()
+            .expect("missing proof should block resolve");
+        assert!(blocker.contains("Implementation Proof"));
+    }
+
+    #[test]
+    fn proposal_evidence_blocker_rejects_not_applicable_without_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Empty not applicable [active]\n\
+             - Summary: Missing proof reason.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+             - SPEC/Issue Proof: SPEC-1935 checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable:\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        let blocker = proposal_evidence_blocker_by_label(dir.path(), "Proposal A")
+            .unwrap()
+            .expect("empty not-applicable reason should block resolve");
+        assert!(blocker.contains("Official Docs Proof"));
     }
 }

--- a/crates/gwt/tests/skill_exit_cli_test.rs
+++ b/crates/gwt/tests/skill_exit_cli_test.rs
@@ -34,7 +34,14 @@ fn discuss_resolve_flips_active_proposal_to_chosen() {
     std::fs::write(
         &discussion_path,
         "### Proposal A - Hook-driven resume [active]\n\
-         - Next Question: Should we block on Stop?\n",
+         - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+         - SPEC/Issue Proof: SPEC-1935 checked\n\
+         - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+         - Official Docs Proof: Claude Code hooks docs checked\n\
+         - External Research Proof: not-applicable: local-only behavior\n\
+         - Exit Blockers: none\n\
+         - Next Question: Should we block on Stop?\n\
+         - Evidence Gate: complete\n",
     )
     .unwrap();
 
@@ -46,6 +53,31 @@ fn discuss_resolve_flips_active_proposal_to_chosen() {
     let updated = std::fs::read_to_string(&discussion_path).unwrap();
     assert!(updated.contains("[chosen]"));
     assert!(!updated.contains("[active]"));
+}
+
+#[test]
+fn discuss_resolve_rejects_incomplete_evidence_gate() {
+    let (mut env, dir) = new_env();
+    let discussion_path = dir.path().join(".gwt/discussion.md");
+    std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &discussion_path,
+        "### Proposal A - Evidence gap [active]\n\
+         - Summary: Missing proof.\n\
+         - Exit Blockers: none\n\
+         - Next Question:\n\
+         - Evidence Gate: complete\n",
+    )
+    .unwrap();
+
+    let code = dispatch(
+        &mut env,
+        &argv(&["gwt", "discuss", "resolve", "--proposal", "Proposal A"]),
+    );
+    assert_eq!(code, 2);
+    let updated = std::fs::read_to_string(&discussion_path).unwrap();
+    assert!(updated.contains("[active]"));
+    assert!(!updated.contains("[chosen]"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Require gwt-discussion proposals to complete an Evidence Gate before `gwtd discuss resolve` can mark them chosen.
- Keep Stop hooks blocking when discussion evidence or exit blockers remain unresolved, even if `Next Question:` is empty.
- Update Claude and Codex gwt-discussion guidance so investigations record implementation, SPEC/Issue, gap-check, official-docs, and external-research proof.

## Changes

- `crates/gwt/src/discussion_resume.rs`: parses proposal proof fields and evaluates Evidence Gate blockers, including reason-required `not-applicable:` entries.
- `crates/gwt/src/cli/discuss.rs`: rejects `resolve` with exit code 2 when required proof fields or `Evidence Gate: complete` are missing.
- `crates/gwt/src/cli/hook/skill_discussion_stop_check.rs`: surfaces evidence and exit-blocker reasons through the StopBlock response.
- `.claude/skills/gwt-discussion/SKILL.md` and `.codex/skills/gwt-discussion/SKILL.md`: document the Evidence Gate, official-docs preference, and X/X API research policy.
- `crates/gwt-skills/src/lib.rs`: adds asset regression coverage for the new discussion evidence contract.
- `crates/gwt-skills/src/settings_local.rs`: makes the Stop dispatcher assertion match the absolute-or-literal `gwtd` path contract exposed by full gwt-skills testing.

## Testing

- [x] `cargo test -p gwt discussion_resume -- --nocapture` — 14 discussion resume tests passed.
- [x] `cargo test -p gwt skill_discussion_stop_check -- --nocapture` — 8 stop-check tests passed.
- [x] `cargo test -p gwt --test skill_exit_cli_test -- --nocapture` — 15 CLI lifecycle tests passed.
- [x] `cargo test -p gwt-skills local_github_issue_workflows_use_canonical_gwt_surfaces -- --nocapture` — asset contract test passed.
- [x] `cargo test -p gwt-skills --all-features` — 139 gwt-skills tests passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — full relevant Rust tests passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — completed with no warnings.
- [x] `cargo fmt -- --check` and `git diff --check` — formatting and whitespace checks passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — both binaries built successfully.
- [x] `npm run lint:skills` and `bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md --ignore tasks/todo.md` — skill frontmatter and Markdown lint passed.
- [x] Manual `target/debug/gwtd` smoke — incomplete Evidence Gate blocks Stop and resolve; complete gate resolves to `[chosen]`.
- [x] `bunx commitlint --from origin/develop --to HEAD` — commit messages passed.

## Closing Issues

None

## Related Issues / Links

- #1935
- https://docs.claude.com/en/docs/claude-code/hooks
- https://help.x.com/en/using-x/x-search
- https://docs.x.com/x-api/posts/search/introduction

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (gwt-discussion skill and command guidance)
- [x] Migration/backfill plan included (N/A: discussion artifact format remains additive and optional for non-resolve exits)
- [x] CHANGELOG impact considered (patch-level behavior hardening, no breaking API change)

## Context

- SPEC-1935 Phase 14 requires gwt-discussion to avoid ending with speculation or unproven assumptions.
- The previous Stop check only enforced non-empty `Next Question:`, which allowed discussions to clear the question while leaving evidence incomplete.

## Risk / Impact

- **Affected areas**: gwt-discussion Stop hook behavior, `gwtd discuss resolve`, Claude/Codex discussion skill guidance.
- **Rollback plan**: Revert this PR to restore the previous question-only discussion exit behavior.
