### PR TITLE
fix(workspace): persist Completed column items across startup

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -1231,10 +1231,11 @@ pub fn retroactive_auto_done_scan_paths(
 }
 
 /// SPEC-2359 US-37: Schema version recorded in `work_items.migration.json`.
-/// Bumping this value forces the [`rebuild_work_items_from_events_*`]
-/// migration to re-run on existing data. Version 1 corresponds to the
-/// terminal-Done apply_event fix; prior projections may show stale
-/// non-Done status_category for items whose latest event regressed Done.
+/// Bumping this value forces [`rebuild_work_items_from_events_paths`] and
+/// [`rebuild_work_items_from_events_for_repo`] to re-run on existing data.
+/// Version 1 corresponds to the terminal-Done apply_event fix; prior
+/// projections may show stale non-Done status_category for items whose
+/// latest event regressed Done.
 pub const WORKSPACE_WORK_ITEMS_REBUILD_VERSION: u32 = 1;
 
 /// SPEC-2359 US-37: Outcome of the work_items.json rebuild migration.

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -856,9 +856,21 @@ impl WorkspaceWorkItemsProjection {
         if let Some(owner) = non_empty_clone(event.owner.as_deref()) {
             item.owner = Some(owner);
         }
-        item.status_category = workspace_work_event_status(&event);
+        // SPEC-2359 US-37: Done is a terminal state. Heartbeat update events
+        // (kind=Update with status_category=None) emitted after a Done event
+        // must not regress the WorkItem to Active/Idle. Only events that
+        // carry an explicit `status_category` may transition out of Done.
+        let new_status = workspace_work_event_status(&event);
+        let preserve_done = item.status_category == WorkspaceStatusCategory::Done
+            && event.status_category.is_none();
+        if !preserve_done {
+            item.status_category = new_status;
+        }
         if item.status_category == WorkspaceStatusCategory::Done {
-            item.completed_at = Some(event.updated_at);
+            // Preserve the first Done timestamp so idempotent Done re-applies
+            // (e.g. retroactive_auto_done_scan rerun) keep the original
+            // completion time.
+            item.completed_at = item.completed_at.or(Some(event.updated_at));
         } else {
             item.completed_at = None;
         }
@@ -1216,6 +1228,112 @@ pub fn retroactive_auto_done_scan_paths(
     }
 
     Ok(emitted)
+}
+
+/// SPEC-2359 US-37: Schema version recorded in `work_items.migration.json`.
+/// Bumping this value forces the [`rebuild_work_items_from_events_*`]
+/// migration to re-run on existing data. Version 1 corresponds to the
+/// terminal-Done apply_event fix; prior projections may show stale
+/// non-Done status_category for items whose latest event regressed Done.
+pub const WORKSPACE_WORK_ITEMS_REBUILD_VERSION: u32 = 1;
+
+/// SPEC-2359 US-37: Outcome of the work_items.json rebuild migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceWorkItemsRebuildOutcome {
+    /// `work_events.jsonl` does not exist. Nothing to rebuild.
+    Missing,
+    /// Marker already records the current rebuild version. Skip silently.
+    AlreadyMigrated,
+    /// Rebuilt `work_items.json` from the event log and wrote the marker.
+    Applied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct WorkspaceWorkItemsRebuildMarker {
+    version: u32,
+    #[serde(default)]
+    migrated_at: Option<DateTime<Utc>>,
+}
+
+/// SPEC-2359 US-37: Rebuild `work_items.json` by replaying every event in
+/// `work_events.jsonl` through the (fixed) apply_event semantics. This
+/// recovers historical Done state that the legacy apply_event regressed
+/// when subsequent heartbeat update events arrived after the Done event.
+/// The rebuild is idempotent across daemon restarts: a marker file records
+/// the current schema version.
+pub fn rebuild_work_items_from_events_paths(
+    work_items_path: &Path,
+    events_path: &Path,
+    marker_path: &Path,
+) -> Result<WorkspaceWorkItemsRebuildOutcome> {
+    if rebuild_marker_at_or_above(marker_path, WORKSPACE_WORK_ITEMS_REBUILD_VERSION)? {
+        return Ok(WorkspaceWorkItemsRebuildOutcome::AlreadyMigrated);
+    }
+    if !events_path.exists() {
+        return Ok(WorkspaceWorkItemsRebuildOutcome::Missing);
+    }
+    let content = fs::read_to_string(events_path)?;
+    let mut events: Vec<WorkspaceWorkEvent> = content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<WorkspaceWorkEvent>(line)
+                .map_err(|err| GwtError::Other(format!("workspace work event json: {err}")))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    events.sort_by_key(|event| event.updated_at);
+    let initial_updated_at = events
+        .first()
+        .map(|event| event.updated_at)
+        .unwrap_or_else(chrono::Utc::now);
+    let mut projection = WorkspaceWorkItemsProjection::empty(initial_updated_at);
+    for event in events {
+        projection.apply_event(event);
+    }
+    projection.updated_at = chrono::Utc::now();
+    save_workspace_work_items_projection_to_path(work_items_path, &projection)?;
+    write_rebuild_marker(marker_path)?;
+    Ok(WorkspaceWorkItemsRebuildOutcome::Applied)
+}
+
+/// SPEC-2359 US-37: Convenience wrapper for the daemon bootstrap hook.
+/// Resolves the project-scoped paths and invokes
+/// [`rebuild_work_items_from_events_paths`].
+pub fn rebuild_work_items_from_events_for_repo(
+    repo_path: &Path,
+) -> Result<WorkspaceWorkItemsRebuildOutcome> {
+    let work_items_path = gwt_workspace_work_items_path_for_repo_path(repo_path);
+    let events_path = gwt_workspace_work_events_path_for_repo_path(repo_path);
+    let marker_path = work_items_path
+        .parent()
+        .map(|dir| dir.join("work_items.migration.json"))
+        .unwrap_or_else(|| PathBuf::from("work_items.migration.json"));
+    rebuild_work_items_from_events_paths(&work_items_path, &events_path, &marker_path)
+}
+
+fn rebuild_marker_at_or_above(path: &Path, required: u32) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let body = fs::read_to_string(path)?;
+    Ok(
+        serde_json::from_str::<WorkspaceWorkItemsRebuildMarker>(&body)
+            .map(|marker| marker.version >= required)
+            .unwrap_or(false),
+    )
+}
+
+fn write_rebuild_marker(path: &Path) -> Result<()> {
+    let marker = WorkspaceWorkItemsRebuildMarker {
+        version: WORKSPACE_WORK_ITEMS_REBUILD_VERSION,
+        migrated_at: Some(chrono::Utc::now()),
+    };
+    let body = serde_json::to_vec_pretty(&marker)
+        .map_err(|error| GwtError::Other(format!("work items migration marker: {error}")))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    write_atomic(path, &body)
 }
 
 /// SPEC-2359 US-37 / FR-119: Convenience wrapper resolving the project-scoped
@@ -3873,5 +3991,136 @@ mod tests {
             !delete_dir.exists(),
             "delete target workspace dir should have been removed",
         );
+    }
+
+    #[test]
+    fn apply_event_preserves_done_against_subsequent_heartbeat() {
+        let work_item_id = "test-item-preserve";
+        let t1 = Utc.with_ymd_and_hms(2026, 5, 14, 10, 0, 0).unwrap();
+        let t2 = Utc.with_ymd_and_hms(2026, 5, 14, 11, 0, 0).unwrap();
+
+        let mut projection = WorkspaceWorkItemsProjection::empty(t1);
+
+        let mut done_event =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Done, work_item_id, t1);
+        done_event.status_category = Some(WorkspaceStatusCategory::Done);
+        done_event.title = Some("Test work item".to_string());
+        projection.apply_event(done_event);
+
+        let item_after_done = projection
+            .work_items
+            .iter()
+            .find(|it| it.id == work_item_id)
+            .expect("done event must create work item");
+        assert_eq!(
+            item_after_done.status_category,
+            WorkspaceStatusCategory::Done
+        );
+        assert_eq!(item_after_done.completed_at, Some(t1));
+
+        let update_event =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Update, work_item_id, t2);
+        assert!(
+            update_event.status_category.is_none(),
+            "heartbeat update event has no explicit status_category"
+        );
+        projection.apply_event(update_event);
+
+        let item_after_update = projection
+            .work_items
+            .iter()
+            .find(|it| it.id == work_item_id)
+            .expect("item still exists");
+        assert_eq!(
+            item_after_update.status_category,
+            WorkspaceStatusCategory::Done,
+            "SPEC-2359 US-37: Done is a terminal state; heartbeat update with status_category=None must not regress it"
+        );
+        assert_eq!(
+            item_after_update.completed_at,
+            Some(t1),
+            "initial Done timestamp must be preserved across subsequent update events"
+        );
+    }
+
+    #[test]
+    fn rebuild_work_items_from_events_recovers_done_after_subsequent_update() {
+        // SPEC-2359 US-37: Existing work_items.json files written with the
+        // legacy apply_event semantics may show status=active even though
+        // work_events.jsonl contains a Done event. Replaying events through
+        // the fixed apply_event must restore the Done terminal state.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let events_path = temp.path().join("work_events.jsonl");
+        let work_items_path = temp.path().join("work_items.json");
+        let marker_path = temp.path().join("work_items.migration.json");
+
+        let work_item_id = "wi-recovered";
+        let t1 = Utc.with_ymd_and_hms(2026, 5, 10, 10, 0, 0).unwrap();
+        let t2 = Utc.with_ymd_and_hms(2026, 5, 10, 11, 0, 0).unwrap();
+        let mut done_event =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Done, work_item_id, t1);
+        done_event.status_category = Some(WorkspaceStatusCategory::Done);
+        done_event.title = Some("Recovered work".to_string());
+        append_workspace_work_event_to_path(&events_path, &done_event).expect("append done");
+        let update_event =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Update, work_item_id, t2);
+        append_workspace_work_event_to_path(&events_path, &update_event).expect("append update");
+
+        let outcome =
+            rebuild_work_items_from_events_paths(&work_items_path, &events_path, &marker_path)
+                .expect("rebuild");
+        assert_eq!(outcome, WorkspaceWorkItemsRebuildOutcome::Applied);
+
+        let projection = load_workspace_work_items_from_path(&work_items_path)
+            .expect("load")
+            .expect("present");
+        let item = projection
+            .work_items
+            .iter()
+            .find(|it| it.id == work_item_id)
+            .expect("recovered item exists");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(item.completed_at, Some(t1));
+
+        // Re-running is idempotent (marker prevents rebuild).
+        let outcome_again =
+            rebuild_work_items_from_events_paths(&work_items_path, &events_path, &marker_path)
+                .expect("rebuild idempotent");
+        assert_eq!(
+            outcome_again,
+            WorkspaceWorkItemsRebuildOutcome::AlreadyMigrated
+        );
+    }
+
+    #[test]
+    fn apply_event_idempotent_done_keeps_first_timestamp() {
+        let work_item_id = "test-item-idempotent";
+        let t1 = Utc.with_ymd_and_hms(2026, 5, 14, 10, 0, 0).unwrap();
+        let t2 = Utc.with_ymd_and_hms(2026, 5, 14, 12, 0, 0).unwrap();
+
+        let mut projection = WorkspaceWorkItemsProjection::empty(t1);
+
+        let mut first_done =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Done, work_item_id, t1);
+        first_done.status_category = Some(WorkspaceStatusCategory::Done);
+        projection.apply_event(first_done);
+
+        let mut second_done =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Done, work_item_id, t2);
+        second_done.status_category = Some(WorkspaceStatusCategory::Done);
+        projection.apply_event(second_done);
+
+        let item = projection
+            .work_items
+            .iter()
+            .find(|it| it.id == work_item_id)
+            .expect("item exists after idempotent done");
+        assert_eq!(item.status_category, WorkspaceStatusCategory::Done);
+        assert_eq!(
+            item.completed_at,
+            Some(t1),
+            "first Done timestamp must be preserved on idempotent Done re-apply"
+        );
+        assert_eq!(item.updated_at, t2, "updated_at should still advance");
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -778,7 +778,7 @@ fn workspace_journal_entry_view_from_entry(
     }
 }
 
-fn workspace_work_item_view_from_item(
+pub(crate) fn workspace_work_item_view_from_item(
     item: &gwt_core::workspace_projection::WorkspaceWorkItem,
 ) -> gwt::WorkspaceHistoryView {
     gwt::WorkspaceHistoryView {
@@ -1921,6 +1921,15 @@ impl AppRuntime {
             // Errors are silently dropped (`let _ = ...`) so a corrupt or
             // unreadable Workspace cannot block daemon startup.
             let _ = gwt_core::workspace_projection_migration::migrate_workspace_projection_for_repo(
+                &tab.project_root,
+            );
+            // SPEC-2359 US-37: One-shot rebuild of work_items.json from the
+            // event log. Recovers legacy installations whose work_items.json
+            // shows status=active/idle for items that already have a Done
+            // event in work_events.jsonl (caused by the old apply_event
+            // semantics that regressed Done on subsequent update events).
+            // Idempotent via `work_items.migration.json` marker.
+            let _ = gwt_core::workspace_projection::rebuild_work_items_from_events_for_repo(
                 &tab.project_root,
             );
         }
@@ -13555,5 +13564,71 @@ exit 0
         let missing = logs_root.path().join("does-not-exist.log");
         let resolved = super::validate_update_log_path(missing.to_str().unwrap(), logs_root.path());
         assert!(resolved.is_none(), "missing files must be rejected");
+    }
+
+    #[test]
+    fn workspace_view_for_tab_includes_done_work_items_from_disk() {
+        // SPEC-2359 US-37: workspace_state broadcast must carry work_items so
+        // the Workspace Overview Completed column renders without depending on
+        // the limited-trigger active_work_projection broadcast.
+        let _env_guard = env_test_lock().lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+
+        use chrono::TimeZone as _;
+        let completed_at = chrono::Utc.with_ymd_and_hms(2026, 5, 14, 10, 0, 0).unwrap();
+        let work_item = gwt_core::workspace_projection::WorkspaceWorkItem {
+            id: "work-item-done".to_string(),
+            title: "Test Done Item".to_string(),
+            intent: None,
+            summary: None,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Done,
+            owner: None,
+            created_at: completed_at,
+            updated_at: completed_at,
+            completed_at: Some(completed_at),
+            agents: Vec::new(),
+            execution_containers: Vec::new(),
+            board_refs: Vec::new(),
+            related_work_item_ids: Vec::new(),
+            events: Vec::new(),
+        };
+        let projection = gwt_core::workspace_projection::WorkspaceWorkItemsProjection {
+            updated_at: completed_at,
+            work_items: vec![work_item],
+        };
+        let work_items_path = gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(&repo);
+        fs::create_dir_all(work_items_path.parent().expect("parent dir"))
+            .expect("create workspace dir");
+        gwt_core::workspace_projection::save_workspace_work_items_projection_to_path(
+            &work_items_path,
+            &projection,
+        )
+        .expect("save work items projection");
+
+        let tab = ProjectTabRuntime {
+            id: "tab-1".to_string(),
+            title: "Repo".to_string(),
+            project_root: repo.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(empty_workspace_state()),
+            migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
+        };
+
+        let view = crate::runtime_support::workspace_view_for_tab(&tab);
+        assert!(
+            view.work_items
+                .iter()
+                .any(|item| item.id == "work-item-done" && item.status_category == "done"),
+            "WorkspaceView.work_items must include the Done work item persisted on disk so workspace_state broadcast renders the Completed column on startup; got {:?}",
+            view.work_items
+                .iter()
+                .map(|i| (i.id.clone(), i.status_category.clone()))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1571,8 +1571,13 @@ mod tests {
     #[test]
     fn embedded_web_workspace_state_renders_active_workspace_through_app_state_helper() {
         let html = frontend_bundle_source();
+        // SPEC-2359 US-37: workspace_state case wraps in a block to
+        // populate the Workspace Overview Completed column from
+        // event.workspace.tabs[active].workspace.work_items before
+        // breaking. Tolerate the optional `{` and additional code
+        // between renderAppState and break.
         let workspace_state_flow = regex::Regex::new(
-            r#"case\s*"workspace_state":\s*projectError\s*=\s*"";\s*(?:renderAppState|frontendUnits\.projectWorkspaceShell\.renderAppState)\(event\.workspace\);\s*break;"#,
+            r#"case\s*"workspace_state":\s*\{?\s*projectError\s*=\s*"";\s*(?:renderAppState|frontendUnits\.projectWorkspaceShell\.renderAppState)\(event\.workspace\);[\s\S]*?\bbreak;"#,
         )
         .expect("valid regex");
 
@@ -2460,8 +2465,13 @@ mod tests {
     #[test]
     fn embedded_web_frontend_units_receive_and_bootstrap_through_named_surfaces() {
         let html = frontend_bundle_source();
+        // SPEC-2359 US-37: workspace_state case wraps in a block to
+        // populate the Workspace Overview Completed column from
+        // event.workspace.tabs[active].workspace.work_items. Tolerate
+        // the optional `{` and additional code between renderAppState
+        // and break.
         let workspace_event = regex::Regex::new(
-            r#"case\s*"workspace_state":\s*projectError\s*=\s*"";\s*frontendUnits\.projectWorkspaceShell\.renderAppState\(event\.workspace\);\s*break;"#,
+            r#"case\s*"workspace_state":\s*\{?\s*projectError\s*=\s*"";\s*frontendUnits\.projectWorkspaceShell\.renderAppState\(event\.workspace\);[\s\S]*?\bbreak;"#,
         )
         .expect("valid regex");
         let terminal_event = regex::Regex::new(

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -385,6 +385,13 @@ fn default_board_history_limit() -> usize {
 pub struct WorkspaceView {
     pub viewport: CanvasViewport,
     pub windows: Vec<PersistedWindowState>,
+    // SPEC-2359 US-37: Workspace Overview Completed カラムは
+    // active_work_projection broadcast に依存していたが、その broadcast
+    // は限定された trigger でしか走らないため起動直後に表示されない
+    // 問題があった。workspace_state は frequently broadcast されるので、
+    // 同 event に work_items を載せて broadcast invariant を 1 本化する。
+    #[serde(default)]
+    pub work_items: Vec<WorkspaceHistoryView>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::app_runtime::workspace_work_item_view_from_item;
 
 pub fn combined_window_id(tab_id: &str, raw_id: &str) -> String {
     format!("{tab_id}::{raw_id}")
@@ -41,6 +42,20 @@ pub fn current_app_version() -> &'static str {
 }
 
 pub fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
+    // SPEC-2359 US-37: workspace_state broadcast に work_items を含めて
+    // Workspace Overview Completed カラムを populate する。読み込み失敗は
+    // 既存の WorkspaceView semantics (welcome/empty) を壊さないよう空 Vec
+    // に縮退する。
+    let work_items =
+        gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(&tab.project_root)
+            .map(|projection| {
+                projection
+                    .work_items
+                    .iter()
+                    .map(workspace_work_item_view_from_item)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
     gwt::WorkspaceView {
         viewport: tab.workspace.persisted().viewport.clone(),
         windows: tab
@@ -54,6 +69,7 @@ pub fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
                 window
             })
             .collect(),
+        work_items,
     }
 }
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -8464,10 +8464,42 @@
 
       function receive(event) {
         switch (event.kind) {
-          case "workspace_state":
+          case "workspace_state": {
             projectError = "";
             frontendUnits.projectWorkspaceShell.renderAppState(event.workspace);
+            // SPEC-2359 US-37: populate the Workspace Overview Completed
+            // column directly from workspace_state because the
+            // active_work_projection broadcast only fires on tab switch,
+            // user event, title sync, and window ops. Without this, the
+            // Completed column stays empty on startup until the user
+            // happens to switch tabs.
+            const activeTabId = event.workspace && event.workspace.active_tab_id;
+            const activeTab = Array.isArray(event.workspace && event.workspace.tabs)
+              ? event.workspace.tabs.find((tab) => tab.id === activeTabId)
+              : null;
+            const tabWorkItems = activeTab && activeTab.workspace && Array.isArray(activeTab.workspace.work_items)
+              ? activeTab.workspace.work_items
+              : [];
+            if (tabWorkItems.length > 0) {
+              if (!activeWorkProjection) {
+                activeWorkProjection = {
+                  id: activeTabId || "active-tab",
+                  title: (activeTab && activeTab.title) || "Workspace",
+                  workspaces: tabWorkItems,
+                };
+              } else if (
+                !Array.isArray(activeWorkProjection.workspaces) ||
+                activeWorkProjection.workspaces.length === 0
+              ) {
+                activeWorkProjection = {
+                  ...activeWorkProjection,
+                  workspaces: tabWorkItems,
+                };
+              }
+              workspaceKanbanSurface.renderWindows();
+            }
             break;
+          }
           case "workspace_projection_prune_result": {
             // SPEC-2359 US-41 Phase 8b: minimal feedback for projection prune.
             // A richer Drawer surface lands in a follow-up; for now an alert


### PR DESCRIPTION
## Summary

- Workspace Overview Completed カラムが起動直後から永久に空になる問題を 3 層 fix で根本修正
- 実 file 検証で真因 (`apply_event` の Done terminal state 欠如) を特定し、過去 PR #2670/#2673 が emit 層のみ修正していた盲点を埋める
- 既存 corrupted state も work_events.jsonl 由来の migration で自動復旧

## Changes

- `crates/gwt-core/src/workspace_projection.rs`: `apply_event` を Done terminal state preserve に変更 (`preserve_done` 不変条件 + `completed_at` の `or()` preserve)、および `rebuild_work_items_from_events_*` migration を追加
- `crates/gwt/src/app_runtime/mod.rs`: bootstrap で migration を呼び出し、`workspace_work_item_view_from_item` を `pub(crate)` 化、新規 integration test を追加
- `crates/gwt/src/protocol.rs`: `WorkspaceView` に `#[serde(default)] work_items: Vec<WorkspaceHistoryView>` を追加
- `crates/gwt/src/runtime_support.rs`: `workspace_view_for_tab` で `load_or_synthesize_workspace_work_items` から `work_items` を populate
- `crates/gwt/web/app.js`: `workspace_state` handler を block 化、active tab の `work_items` を kanban に伝播
- `crates/gwt/src/embedded_web.rs`: `workspace_state` regex を case-block syntax に対応

## Testing

- [x] `cargo test -p gwt-core --lib` — 262 passed (新規 3 件含む)
- [x] `cargo test -p gwt --bin gwt` — 342 passed (新規 1 件含む)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: gwt 起動 → Workspace Overview の Completed カラムに過去の Done items が起動直後 (tab 切替なし) で表示されること

## Closing Issues

- None

## Related Issues / Links

- #2359 (SPEC-2359 US-37 — Workspace auto-done on completion signals)
- Builds on PR #2670, #2673 (Done event emission)

## Checklist

- [x] Tests added/updated (apply_event Done preservation × 2, work_items migration × 1, workspace_view integration × 1)
- [x] Lint/format passed
- [x] Documentation updated — N/A: コード内コメントで SPEC-2359 US-37 を引用
- [x] Migration/backfill plan included — `rebuild_work_items_from_events_for_repo` を bootstrap で idempotent 呼び出し、`work_items.migration.json` marker で再走防止
- [x] CHANGELOG impact considered — `fix(workspace):` Conventional Commits で patch bump 想定。`WorkspaceView` の schema 拡張は `#[serde(default)]` で backward-compatible

## Context

- 過去 PR #2670 / #2673 が Done event を emit する層のみ修正していたが、emit された event を「Done として保持」する apply 層と、それを UI に届ける broadcast 層が壊れていた
- 実 file (`~/.gwt/projects/.../workspace/work_events.jsonl`) では Done event が 10 件正しく emit されていたが、`work_items.json` の status=done は 0 件 (後続 update event で上書きされていた)
- systematic-debugging Phase 4.5 の "3+ fixes failed = architectural problem" に該当。表面 fix ではなく invariant の建立が必要だった

## Risk / Impact

- **Affected areas**: Workspace Overview Completed column、`workspace_state` broadcast payload schema、bootstrap migration
- **Rollback plan**: revert commit でロールバック可能。Migration marker (`work_items.migration.json`) が残るので、再 land 時は marker を削除して再走させる必要あり
