### PR TITLE
fix(start-work): ensure remote develop base

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -22,12 +22,7 @@ const DOCKER_GWT_OVERRIDE_HEADER: &str =
     "# Auto-generated docker-compose override for gwt bundle mounting";
 const DOCKER_GWT_OVERRIDE_FILE_NAME: &str = "docker-compose.gwt.override.yml";
 const DOCKER_USER_OVERRIDE_FILE_NAME: &str = "docker-compose.override.yml";
-const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 4] = [
-    "origin/develop",
-    "origin/HEAD",
-    "origin/main",
-    "origin/master",
-];
+const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 1] = ["origin/develop"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreparedProcessLaunch {
@@ -327,9 +322,17 @@ pub fn resolve_launch_worktree_request(
     let mut remote_base_ref = origin_remote_ref(&base_branch);
     let remote_branch_ref = origin_remote_ref(&branch_name);
 
-    manager
-        .fetch_origin()
-        .map_err(|err| format!("failed to fetch origin: {err}"))?;
+    if is_start_work_branch_name(&branch_name) {
+        manager
+            .prepare_start_work_remote_develop()
+            .map_err(|err| format!("failed to prepare origin/develop for Start Work: {err}"))?;
+        base_branch = "origin/develop".to_string();
+        remote_base_ref = origin_remote_ref(&base_branch);
+    } else {
+        manager
+            .fetch_origin()
+            .map_err(|err| format!("failed to fetch origin: {err}"))?;
+    }
 
     if !manager
         .remote_branch_exists(&remote_base_ref)

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -131,8 +131,6 @@ pub struct GitHubProjectCloneTarget {
 pub struct GitHubProjectCloneOutcome {
     pub workspace_home: PathBuf,
     pub bare_repo_path: PathBuf,
-    pub initial_worktree_path: PathBuf,
-    pub initial_branch: String,
 }
 
 /// Derive the gwt Workspace Home and nested bare repo path from a repository
@@ -199,7 +197,6 @@ fn repository_name_from_url(url: &str) -> Result<String> {
 /// ```text
 /// <parent>/<repo>/
 /// ├── <repo>.git/
-/// ├── <initial-branch>/
 /// └── .gwt/project.toml
 /// ```
 pub fn clone_project_as_nested_bare(
@@ -257,27 +254,15 @@ fn clone_project_as_nested_bare_inner(
         )));
     }
 
-    install_develop_protection(&target.bare_repo_path)?;
+    crate::worktree::WorktreeManager::new(&target.bare_repo_path)
+        .prepare_start_work_remote_develop()
+        .map_err(|error| {
+            GwtError::Git(format!(
+                "failed to prepare origin/develop for Start Work: {error}"
+            ))
+        })?;
 
-    let initial_branch = preferred_initial_branch(&target.bare_repo_path)?;
-    let initial_worktree_path = target.workspace_home.join(&initial_branch);
-    let worktree_path = initial_worktree_path.to_str().ok_or_else(|| {
-        GwtError::Git(format!(
-            "invalid worktree path: {}",
-            initial_worktree_path.display()
-        ))
-    })?;
-    let worktree_output = gwt_core::process::hidden_command("git")
-        .args(["worktree", "add", worktree_path, &initial_branch])
-        .current_dir(&target.bare_repo_path)
-        .output()
-        .map_err(|error| GwtError::Git(format!("git worktree add: {error}")))?;
-    if !worktree_output.status.success() {
-        return Err(GwtError::Git(format!(
-            "failed to create initial worktree for branch '{initial_branch}': {}",
-            git_stderr(&worktree_output)
-        )));
-    }
+    install_develop_protection(&target.bare_repo_path)?;
 
     BareProjectConfig {
         bare_repo_name: format!("{}.git", target.repo_name),
@@ -290,39 +275,7 @@ fn clone_project_as_nested_bare_inner(
     Ok(GitHubProjectCloneOutcome {
         workspace_home: target.workspace_home.clone(),
         bare_repo_path: target.bare_repo_path.clone(),
-        initial_worktree_path,
-        initial_branch,
     })
-}
-
-fn preferred_initial_branch(bare_repo_path: &Path) -> Result<String> {
-    let develop = gwt_core::process::hidden_command("git")
-        .args(["show-ref", "--verify", "--quiet", "refs/heads/develop"])
-        .current_dir(bare_repo_path)
-        .status()
-        .map_err(|error| GwtError::Git(format!("git show-ref develop: {error}")))?;
-    if develop.success() {
-        return Ok("develop".to_string());
-    }
-
-    let output = gwt_core::process::hidden_command("git")
-        .args(["symbolic-ref", "--quiet", "--short", "HEAD"])
-        .current_dir(bare_repo_path)
-        .output()
-        .map_err(|error| GwtError::Git(format!("git symbolic-ref HEAD: {error}")))?;
-    if !output.status.success() {
-        return Err(GwtError::Git(format!(
-            "failed to determine remote default branch: {}",
-            git_stderr(&output)
-        )));
-    }
-    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if branch.is_empty() {
-        return Err(GwtError::Git(
-            "failed to determine remote default branch".to_string(),
-        ));
-    }
-    Ok(branch)
 }
 
 fn git_stderr(output: &std::process::Output) -> String {

--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -80,6 +80,102 @@ impl WorktreeManager {
         Ok(())
     }
 
+    /// Prepare `origin/develop` as the canonical Start Work base.
+    ///
+    /// Fresh bare clones can lack both `remote.origin.fetch` and
+    /// `refs/remotes/origin/*`. Normalize the refspec first, prune stale
+    /// tracking refs, and create remote `develop` from the remote default
+    /// branch when it is missing.
+    pub fn prepare_start_work_remote_develop(&self) -> Result<()> {
+        crate::migration::normalize_fetch_refspec(&self.repo_path)?;
+        self.fetch_origin()?;
+        if self.remote_branch_exists("origin/develop")? {
+            return Ok(());
+        }
+
+        let default_branch = self.remote_default_branch()?;
+        let default_remote_ref = format!("origin/{default_branch}");
+        self.fetch_remote_branch_tracking_ref(&default_branch)?;
+        if !self.remote_branch_exists(&default_remote_ref)? {
+            return Err(GwtError::Git(format!(
+                "remote default branch is not available locally after fetch: {default_remote_ref}"
+            )));
+        }
+
+        self.create_remote_branch_from_base(&default_remote_ref, "develop")?;
+        if !self.remote_branch_exists("origin/develop")? {
+            return Err(GwtError::Git(
+                "failed to create and fetch origin/develop".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn remote_default_branch(&self) -> Result<String> {
+        let output = gwt_core::process::hidden_command("git")
+            .args(["ls-remote", "--symref", "origin", "HEAD"])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| GwtError::Git(format!("ls-remote origin HEAD: {e}")))?;
+
+        if output.status.success() {
+            if let Some(branch) = parse_ls_remote_head_symref(&output.stdout) {
+                return Ok(branch);
+            }
+        }
+
+        let local_head = gwt_core::process::hidden_command("git")
+            .args([
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "refs/remotes/origin/HEAD",
+            ])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| GwtError::Git(format!("symbolic-ref origin/HEAD: {e}")))?;
+        if local_head.status.success() {
+            let branch = String::from_utf8_lossy(&local_head.stdout)
+                .trim()
+                .strip_prefix("origin/")
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    String::from_utf8_lossy(&local_head.stdout)
+                        .trim()
+                        .to_string()
+                });
+            if !branch.is_empty() {
+                return Ok(branch);
+            }
+        }
+
+        Err(GwtError::Git(format!(
+            "failed to resolve remote default branch: {}",
+            command_stderr(&output)
+        )))
+    }
+
+    fn fetch_remote_branch_tracking_ref(&self, branch: &str) -> Result<()> {
+        if branch.trim().is_empty() {
+            return Err(GwtError::Git("remote branch name is empty".to_string()));
+        }
+        let refspec = format!("refs/heads/{branch}:refs/remotes/origin/{branch}");
+        let output = gwt_core::process::hidden_command("git")
+            .args(["fetch", "origin", "--prune", &refspec])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| GwtError::Git(format!("fetch origin {refspec}: {e}")))?;
+
+        if !output.status.success() {
+            return Err(GwtError::Git(format!(
+                "fetch origin {refspec}: {}",
+                command_stderr(&output)
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Return whether a remote-tracking branch exists.
     ///
     /// Accepts `origin/<name>` or `refs/remotes/origin/<name>`.
@@ -152,6 +248,9 @@ impl WorktreeManager {
     /// Create `origin/<new_branch>` from a remote base reference.
     ///
     /// `base_remote_ref` must be `origin/<name>` or `refs/remotes/origin/<name>`.
+    /// After a successful push, the corresponding remote-tracking ref is
+    /// fetched explicitly so single-branch or freshly-normalized clones can
+    /// materialize the branch immediately.
     pub fn create_remote_branch_from_base(
         &self,
         base_remote_ref: &str,
@@ -170,6 +269,7 @@ impl WorktreeManager {
             return Err(GwtError::Git(stderr));
         }
 
+        self.fetch_remote_branch_tracking_ref(new_branch)?;
         Ok(())
     }
 
@@ -463,6 +563,28 @@ fn join_pipe_reader(
 fn join_pipe_reader_lossy(reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>) {
     if let Some(reader) = reader {
         let _ = reader.join();
+    }
+}
+
+fn parse_ls_remote_head_symref(stdout: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(stdout).lines().find_map(|line| {
+        let (symref, target) = line.split_once('\t')?;
+        if target != "HEAD" {
+            return None;
+        }
+        symref
+            .strip_prefix("ref: refs/heads/")
+            .filter(|branch| !branch.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn command_stderr(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        "git command failed without stderr".to_string()
+    } else {
+        stderr
     }
 }
 

--- a/crates/gwt-git/tests/github_project_clone_test.rs
+++ b/crates/gwt-git/tests/github_project_clone_test.rs
@@ -18,6 +18,37 @@ fn git(args: &[&str], cwd: &Path) {
     );
 }
 
+fn git_output(args: &[&str], cwd: &Path) -> String {
+    let output = gwt_core::process::hidden_command("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("git {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn install_reject_develop_hook(remote: &Path) {
+    let hook = remote.join("hooks").join("pre-receive");
+    std::fs::write(
+        &hook,
+        "#!/bin/sh\nwhile read _old _new ref; do\n  if [ \"$ref\" = \"refs/heads/develop\" ]; then\n    echo 'develop rejected by test hook' >&2\n    exit 1\n  fi\ndone\nexit 0\n",
+    )
+    .expect("write pre-receive hook");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod pre-receive hook");
+    }
+}
+
 fn remote_repo(default_branch: &str, include_develop: bool) -> (TempDir, PathBuf) {
     let temp = tempfile::tempdir().expect("remote tempdir");
     let source = temp.path().join("source");
@@ -49,7 +80,7 @@ fn remote_repo(default_branch: &str, include_develop: bool) -> (TempDir, PathBuf
 }
 
 #[test]
-fn clone_project_as_nested_bare_creates_develop_worktree_and_project_config() {
+fn clone_project_as_nested_bare_creates_workspace_home_without_default_worktree() {
     let (_remote_temp, remote) = remote_repo("main", true);
     let parent = tempfile::tempdir().expect("parent tempdir");
 
@@ -61,19 +92,37 @@ fn clone_project_as_nested_bare_creates_develop_worktree_and_project_config() {
         outcome.bare_repo_path,
         outcome.workspace_home.join("sample.git")
     );
-    assert_eq!(outcome.initial_branch, "develop");
-    assert_eq!(
-        outcome.initial_worktree_path,
-        outcome.workspace_home.join("develop")
-    );
     assert!(outcome.bare_repo_path.join("HEAD").is_file());
-    assert!(outcome.initial_worktree_path.join(".git").is_file());
+    assert!(
+        !outcome.workspace_home.join("develop").exists(),
+        "Clone Project must not create a local develop worktree"
+    );
+    assert!(
+        !outcome.workspace_home.join("main").exists(),
+        "Clone Project must not create a local main worktree"
+    );
     assert!(matches!(
         detect_repo_type(&outcome.workspace_home),
         RepoType::Bare {
-            develop_worktree: Some(path)
-        } if path == outcome.initial_worktree_path
+            develop_worktree: None
+        }
     ));
+    assert_eq!(
+        git_output(
+            &["config", "--get", "remote.origin.fetch"],
+            &outcome.bare_repo_path
+        ),
+        "+refs/heads/*:refs/remotes/origin/*"
+    );
+    assert_eq!(
+        git_output(
+            &["show-ref", "--verify", "refs/remotes/origin/develop"],
+            &outcome.bare_repo_path
+        )
+        .split_whitespace()
+        .last(),
+        Some("refs/remotes/origin/develop")
+    );
 
     let config = BareProjectConfig::load(&outcome.workspace_home)
         .expect("load project config")
@@ -84,19 +133,62 @@ fn clone_project_as_nested_bare_creates_develop_worktree_and_project_config() {
 }
 
 #[test]
-fn clone_project_as_nested_bare_falls_back_to_default_branch_without_develop() {
+fn clone_project_as_nested_bare_creates_remote_develop_without_local_default_worktree() {
     let (_remote_temp, remote) = remote_repo("main", false);
     let parent = tempfile::tempdir().expect("parent tempdir");
 
     let outcome = clone_project_as_nested_bare(remote.to_str().unwrap(), parent.path())
         .expect("clone project");
 
-    assert_eq!(outcome.initial_branch, "main");
-    assert_eq!(
-        outcome.initial_worktree_path,
-        outcome.workspace_home.join("main")
+    assert!(
+        !outcome.workspace_home.join("main").exists(),
+        "Clone Project must not create a local main worktree"
     );
-    assert!(outcome.initial_worktree_path.join(".git").is_file());
+    assert!(
+        !outcome.workspace_home.join("develop").exists(),
+        "Clone Project must not create a local develop worktree"
+    );
+    assert_eq!(
+        git_output(&["show-ref", "--verify", "refs/heads/develop"], &remote)
+            .split_whitespace()
+            .last(),
+        Some("refs/heads/develop"),
+        "remote develop must be created from the remote default branch"
+    );
+    assert_eq!(
+        git_output(
+            &["show-ref", "--verify", "refs/remotes/origin/develop"],
+            &outcome.bare_repo_path
+        )
+        .split_whitespace()
+        .last(),
+        Some("refs/remotes/origin/develop")
+    );
+}
+
+#[test]
+fn clone_project_as_nested_bare_cleans_up_when_remote_develop_creation_fails() {
+    let (_remote_temp, remote) = remote_repo("main", false);
+    install_reject_develop_hook(&remote);
+    let parent = tempfile::tempdir().expect("parent tempdir");
+    let workspace_home = parent.path().join("sample");
+
+    let error = clone_project_as_nested_bare(remote.to_str().unwrap(), parent.path())
+        .expect_err("remote develop creation must fail");
+
+    assert!(
+        error.to_string().contains("origin/develop")
+            || error.to_string().contains("develop rejected by test hook"),
+        "error should explain the failed develop preparation: {error}"
+    );
+    assert!(
+        !workspace_home.exists(),
+        "failed Clone Project must clean up the partial Workspace Home"
+    );
+    assert!(
+        git_output(&["for-each-ref", "refs/heads/work"], &remote).is_empty(),
+        "failed develop preparation must not create remote work branches"
+    );
 }
 
 #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2835,7 +2835,6 @@ impl AppRuntime {
             match gwt_git::clone_project_as_nested_bare(&url, &parent) {
                 Ok(outcome) => proxy.send(UserEvent::CloneProjectDone {
                     workspace_home: outcome.workspace_home,
-                    initial_worktree_path: outcome.initial_worktree_path,
                 }),
                 Err(error) => proxy.send(UserEvent::CloneProjectError {
                     message: error.to_string(),
@@ -2877,17 +2876,15 @@ impl AppRuntime {
     pub(crate) fn handle_clone_project_done(
         &mut self,
         workspace_home: &Path,
-        initial_worktree_path: &Path,
     ) -> Vec<OutboundEvent> {
-        match self.open_project_path(initial_worktree_path.to_path_buf()) {
+        match self.open_project_path(workspace_home.to_path_buf()) {
             Ok(wizard_closed) => {
-                self.remember_recent_clone_workspace_home(workspace_home, initial_worktree_path);
+                self.remember_recent_clone_workspace_home(workspace_home);
                 let _ = self.persist();
                 let mut events = vec![
                     self.workspace_state_broadcast(),
                     OutboundEvent::broadcast(BackendEvent::CloneProjectDone {
                         workspace_home: workspace_home.display().to_string(),
-                        initial_worktree_path: initial_worktree_path.display().to_string(),
                     }),
                 ];
                 if let Some(event) = self.active_work_projection_broadcast_on_tab_change() {
@@ -2904,17 +2901,11 @@ impl AppRuntime {
         }
     }
 
-    fn remember_recent_clone_workspace_home(
-        &mut self,
-        workspace_home: &Path,
-        initial_worktree_path: &Path,
-    ) {
+    fn remember_recent_clone_workspace_home(&mut self, workspace_home: &Path) {
         let canonical_home =
             dunce::canonicalize(workspace_home).unwrap_or_else(|_| workspace_home.to_path_buf());
-        self.recent_projects.retain(|entry| {
-            !same_worktree_path(&entry.path, &canonical_home)
-                && !same_worktree_path(&entry.path, initial_worktree_path)
-        });
+        self.recent_projects
+            .retain(|entry| !same_worktree_path(&entry.path, &canonical_home));
         self.recent_projects.insert(
             0,
             gwt::RecentProjectEntry {
@@ -8024,20 +8015,19 @@ exit 0
     }
 
     #[test]
-    fn app_runtime_open_start_work_uses_active_project_without_creating_git_environment() {
+    fn app_runtime_open_start_work_ensures_remote_develop_without_creating_work_branch() {
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
         let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
         let repo = temp.path().join("repo");
-        fs::create_dir_all(&repo).expect("create repo");
-        run_git(&repo, &["init", "-q", "-b", "main"]);
-        run_git(&repo, &["config", "user.name", "Codex"]);
-        run_git(&repo, &["config", "user.email", "codex@example.com"]);
-        fs::write(repo.join("README.md"), "repo\n").expect("readme");
-        run_git(&repo, &["add", "README.md"]);
-        run_git(&repo, &["commit", "-qm", "init"]);
-        run_git(&repo, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        let origin = init_git_clone_with_origin(&repo);
+        run_git(&repo, &["checkout", "-qb", "main"]);
+        run_git(&repo, &["push", "origin", "main"]);
+        run_git(&origin, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        run_git(&repo, &["checkout", "develop"]);
+        run_git(&repo, &["remote", "set-head", "origin", "-a"]);
+        run_git(&origin, &["branch", "-D", "develop"]);
 
         let tab = sample_project_tab(
             "tab-1",
@@ -8064,8 +8054,23 @@ exit 0
         assert_eq!(view.mode, gwt::LaunchWizardMode::StartWork);
         assert_eq!(view.title, "Start Work");
         assert!(!view.show_branch_controls);
-        assert_eq!(view.selected_branch_name, "origin/main");
+        assert_eq!(view.selected_branch_name, "origin/develop");
         assert!(view.branch_name.starts_with("work/"));
+
+        let develop = gwt_core::process::hidden_command("git")
+            .args([
+                "show-ref",
+                "--verify",
+                "--quiet",
+                "refs/remotes/origin/develop",
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("check origin/develop");
+        assert!(
+            develop.success(),
+            "opening Start Work should restore origin/develop from the remote default branch"
+        );
 
         let refs = gwt_core::process::hidden_command("git")
             .args([
@@ -13292,20 +13297,28 @@ exit 0
     }
 
     #[test]
-    fn clone_project_done_opens_initial_worktree_and_broadcasts_done() {
+    fn clone_project_done_opens_workspace_home_and_broadcasts_done() {
         let temp = tempdir().expect("tempdir");
         let workspace_home = temp.path().join("sample");
-        let worktree = workspace_home.join("develop");
-        fs::create_dir_all(&worktree).expect("worktree dir");
-        init_repo(&worktree);
+        let bare_repo = workspace_home.join("sample.git");
+        fs::create_dir_all(&workspace_home).expect("workspace home");
+        let output = gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_repo.to_str().expect("bare path")])
+            .output()
+            .expect("git init --bare");
+        assert!(
+            output.status.success(),
+            "git init --bare failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
         let mut runtime = sample_runtime(temp.path(), Vec::new(), None);
 
-        let events = runtime.handle_clone_project_done(&workspace_home, &worktree);
+        let events = runtime.handle_clone_project_done(&workspace_home);
 
         assert_eq!(runtime.tabs.len(), 1);
         assert_eq!(
             runtime.tabs[0].project_root,
-            dunce::canonicalize(&worktree).unwrap()
+            dunce::canonicalize(&workspace_home).unwrap()
         );
         assert_eq!(runtime.recent_projects.len(), 1);
         assert_eq!(
@@ -13318,10 +13331,8 @@ exit 0
                 target: DispatchTarget::Broadcast,
                 event: BackendEvent::CloneProjectDone {
                     workspace_home: emitted_workspace_home,
-                    initial_worktree_path,
                 },
             } if emitted_workspace_home == &workspace_home.display().to_string()
-                && initial_worktree_path == &worktree.display().to_string()
         )));
         assert!(events.iter().any(|event| matches!(
             event,

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -75,9 +75,18 @@ pub fn resolve_launch_worktree_request(
     let has_local_branch = local_branch_exists(&main_repo_path, &branch_name)?;
 
     if !has_local_branch {
-        manager
-            .fetch_origin()
-            .map_err(|err| format!("failed to fetch origin: {err}"))?;
+        if is_start_work_branch_name(&branch_name) {
+            manager
+                .prepare_start_work_remote_develop()
+                .map_err(|err| format!("failed to prepare origin/develop for Start Work: {err}"))?;
+            effective_base_branch = "origin/develop".to_string();
+            remote_base_ref = origin_remote_ref(&effective_base_branch);
+            *base_branch = Some(effective_base_branch.clone());
+        } else {
+            manager
+                .fetch_origin()
+                .map_err(|err| format!("failed to fetch origin: {err}"))?;
+        }
 
         if !manager
             .remote_branch_exists(&remote_base_ref)
@@ -146,6 +155,12 @@ pub fn resolve_launch_worktree_request(
         worktree_path.display().to_string(),
     );
     Ok(())
+}
+
+fn is_start_work_branch_name(branch_name: &str) -> bool {
+    branch_name
+        .strip_prefix("work/")
+        .is_some_and(|name| !name.is_empty())
 }
 
 pub fn resolve_launch_worktree(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -679,7 +679,6 @@ enum UserEvent {
     },
     CloneProjectDone {
         workspace_home: PathBuf,
-        initial_worktree_path: PathBuf,
     },
     CloneProjectError {
         message: String,
@@ -4541,7 +4540,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_launch_worktree_refalls_back_when_start_work_develop_ref_is_stale() {
+    fn resolve_launch_worktree_recreates_remote_develop_when_start_work_ref_is_stale() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
         let origin = init_git_clone_with_origin(&repo);
@@ -4593,11 +4592,25 @@ mod tests {
             &mut working_dir,
             &mut env_vars,
         )
-        .expect("stale Start Work base should refallback after fetch");
+        .expect("stale Start Work base should recreate origin/develop after fetch");
 
         let worktree = working_dir.expect("materialized worktree");
-        assert_eq!(base_branch.as_deref(), Some("origin/HEAD"));
+        assert_eq!(base_branch.as_deref(), Some("origin/develop"));
         assert!(worktree.exists());
+        let restored_develop = gwt_core::process::hidden_command("git")
+            .args([
+                "show-ref",
+                "--verify",
+                "--quiet",
+                "refs/remotes/origin/develop",
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("check restored origin/develop");
+        assert!(
+            restored_develop.success(),
+            "origin/develop tracking ref must be restored"
+        );
         assert!(env_vars
             .get("GWT_PROJECT_ROOT")
             .is_some_and(|value| super::same_worktree_path(Path::new(value), &worktree)));
@@ -5667,11 +5680,8 @@ fn main() -> wry::Result<()> {
                     BackendEvent::CloneProjectProgress { message },
                 )]);
             }
-            Event::UserEvent(UserEvent::CloneProjectDone {
-                workspace_home,
-                initial_worktree_path,
-            }) => {
-                let events = app.handle_clone_project_done(&workspace_home, &initial_worktree_path);
+            Event::UserEvent(UserEvent::CloneProjectDone { workspace_home }) => {
+                let events = app.handle_clone_project_done(&workspace_home);
                 board_projection_watchers.sync(&app, proxy.clone());
                 #[cfg(unix)]
                 board_daemon_subscribers.sync(&app, proxy.clone());

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -725,7 +725,6 @@ pub enum BackendEvent {
     },
     CloneProjectDone {
         workspace_home: String,
-        initial_worktree_path: String,
     },
     CloneProjectError {
         message: String,

--- a/crates/gwt/src/start_work.rs
+++ b/crates/gwt/src/start_work.rs
@@ -6,12 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 4] = [
-    "origin/develop",
-    START_WORK_REMOTE_HEAD_REF,
-    "origin/main",
-    "origin/master",
-];
+pub const START_WORK_BASE_BRANCH_CANDIDATES: [&str; 1] = ["origin/develop"];
 pub const START_WORK_REMOTE_HEAD_REF: &str = "origin/HEAD";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StartWorkError {
@@ -23,9 +18,7 @@ pub enum StartWorkError {
 impl std::fmt::Display for StartWorkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::MissingBaseBranch => f.write_str(
-                "No default base branch found (origin/develop, origin/HEAD, origin/main, origin/master)",
-            ),
+            Self::MissingBaseBranch => f.write_str("No default base branch found (origin/develop)"),
             Self::ReservationIo(error) => {
                 write!(f, "Failed to reserve Start Work branch name: {error}")
             }
@@ -104,6 +97,9 @@ pub fn resolve_start_work_base_branch(repo_path: &Path) -> Result<String, StartW
 /// from [`gwt_git::worktree::main_worktree_root`] or a tab-level cache
 /// (FR-PERF-003).
 pub fn resolve_start_work_base_branch_in(git_root: &Path) -> Result<String, StartWorkError> {
+    gwt_git::WorktreeManager::new(git_root)
+        .prepare_start_work_remote_develop()
+        .map_err(|error| StartWorkError::Lookup(error.to_string()))?;
     resolve_start_work_base_branch_with(|candidates| lookup_short_refs(git_root, candidates))
 }
 
@@ -252,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn start_work_base_branch_prefers_develop_before_remote_head() {
+    fn start_work_base_branch_uses_develop() {
         let existing = HashSet::from([
             "origin/HEAD".to_string(),
             "origin/develop".to_string(),
@@ -265,26 +261,25 @@ mod tests {
     }
 
     #[test]
-    fn start_work_base_branch_uses_remote_head_when_develop_is_missing() {
+    fn start_work_base_branch_reports_missing_when_develop_is_missing() {
         let existing = HashSet::from(["origin/HEAD".to_string(), "origin/main".to_string()]);
-        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
-            .expect("resolve base branch");
+        let error = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect_err("missing base");
 
-        assert_eq!(resolved, "origin/HEAD");
+        assert_eq!(error, StartWorkError::MissingBaseBranch);
     }
 
     #[test]
-    fn start_work_base_branch_refalls_back_after_selected_develop_is_pruned() {
+    fn start_work_base_branch_does_not_refallback_after_selected_develop_is_pruned() {
         let existing = HashSet::from(["origin/HEAD".to_string(), "origin/main".to_string()]);
         let resolved = refallback_start_work_base_branch_with(
             "work/20260507-0734",
             "origin/develop",
             |candidate| Ok::<_, std::convert::Infallible>(existing.contains(candidate)),
         )
-        .expect("refallback")
-        .expect("fallback base");
+        .expect("refallback");
 
-        assert_eq!(resolved, "origin/HEAD");
+        assert!(resolved.is_none());
     }
 
     #[test]
@@ -300,12 +295,12 @@ mod tests {
     }
 
     #[test]
-    fn start_work_base_branch_falls_back_to_develop_main_master_order() {
+    fn start_work_base_branch_ignores_main_and_master() {
         let existing = HashSet::from(["origin/main".to_string(), "origin/master".to_string()]);
-        let resolved = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
-            .expect("resolve base branch");
+        let error = resolve_start_work_base_branch_with(|_| Ok(ok_existing(&existing)))
+            .expect_err("missing base");
 
-        assert_eq!(resolved, "origin/main");
+        assert_eq!(error, StartWorkError::MissingBaseBranch);
     }
 
     #[test]
@@ -356,10 +351,6 @@ mod tests {
 
     #[test]
     fn start_work_remote_tracking_ref_does_not_double_origin_prefix() {
-        assert_eq!(
-            remote_tracking_ref("origin/HEAD"),
-            "refs/remotes/origin/HEAD"
-        );
         assert_eq!(
             remote_tracking_ref("origin/develop"),
             "refs/remotes/origin/develop"

--- a/crates/gwt/tests/start_work_test.rs
+++ b/crates/gwt/tests/start_work_test.rs
@@ -1,4 +1,7 @@
-use std::{path::Path, process::Command};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use chrono::{TimeZone, Utc};
 use tempfile::tempdir;
@@ -20,6 +23,31 @@ fn git_output(repo: &Path, args: &[&str]) -> String {
         .expect("git command");
     assert!(output.status.success(), "git {:?} failed", args);
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn git_ref_exists(repo: &Path, refname: &str) -> bool {
+    let status = Command::new("git")
+        .args(["show-ref", "--verify", "--quiet", refname])
+        .current_dir(repo)
+        .status()
+        .expect("git show-ref");
+    status.success()
+}
+
+fn install_reject_develop_hook(remote: &Path) {
+    let hook = remote.join("hooks").join("pre-receive");
+    std::fs::write(
+        &hook,
+        "#!/bin/sh\nwhile read _old _new ref; do\n  if [ \"$ref\" = \"refs/heads/develop\" ]; then\n    echo 'develop rejected by test hook' >&2\n    exit 1\n  fi\ndone\nexit 0\n",
+    )
+    .expect("write pre-receive hook");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod pre-receive hook");
+    }
 }
 
 fn init_git_clone_with_origin(repo: &Path) {
@@ -66,6 +94,45 @@ fn init_git_clone_with_origin(repo: &Path) {
 fn delete_origin_branch(repo: &Path, branch: &str) {
     let origin = repo.parent().expect("repo parent").join("origin.git");
     run_git(&origin, &["branch", "-D", branch]);
+}
+
+fn init_main_only_bare_workspace_home(workspace_home: &Path) -> (PathBuf, PathBuf) {
+    let root = workspace_home.parent().expect("workspace parent");
+    let seed = root.join("main-only-seed");
+    let origin = root.join("main-only-origin.git");
+    let bare_repo = workspace_home.join("sample.git");
+
+    std::fs::create_dir_all(&seed).expect("create seed");
+    run_git(root, &["init", "-q", "-b", "main", "main-only-seed"]);
+    run_git(&seed, &["config", "user.name", "Codex Test"]);
+    run_git(&seed, &["config", "user.email", "codex@example.com"]);
+    std::fs::write(seed.join("main-only.txt"), "main\n").expect("write main marker");
+    run_git(&seed, &["add", "main-only.txt"]);
+    run_git(&seed, &["commit", "-qm", "init"]);
+
+    let status = Command::new("git")
+        .args(["clone", "--bare"])
+        .arg(&seed)
+        .arg(&origin)
+        .status()
+        .expect("git clone --bare origin");
+    assert!(status.success(), "git clone --bare origin failed");
+
+    std::fs::create_dir_all(workspace_home).expect("create workspace home");
+    let status = Command::new("git")
+        .args(["clone", "--bare"])
+        .arg(&origin)
+        .arg(&bare_repo)
+        .status()
+        .expect("git clone --bare workspace");
+    assert!(status.success(), "git clone --bare workspace failed");
+
+    let _ = Command::new("git")
+        .args(["config", "--unset-all", "remote.origin.fetch"])
+        .current_dir(&bare_repo)
+        .status();
+
+    (bare_repo, origin)
 }
 
 #[test]
@@ -123,7 +190,7 @@ fn start_work_launch_confirmation_materializes_reserved_work_branch_and_worktree
 }
 
 #[test]
-fn start_work_launch_confirmation_falls_back_when_develop_tracking_ref_is_stale() {
+fn start_work_launch_confirmation_recreates_remote_develop_when_tracking_ref_is_stale() {
     let temp = tempdir().expect("tempdir");
     let repo = temp.path().join("repo");
     init_git_clone_with_origin(&repo);
@@ -147,10 +214,124 @@ fn start_work_launch_confirmation_falls_back_when_develop_tracking_ref_is_stale(
     );
     assert!(
         worktree.join("main-only.txt").is_file(),
-        "stale origin/develop should fall back to origin/HEAD"
+        "stale origin/develop should be recreated from the remote default branch"
     );
     assert!(
         !worktree.join("develop-only.txt").exists(),
         "deleted upstream develop must not be used as the Start Work base"
+    );
+    assert!(
+        !git_output(
+            &repo,
+            &["show-ref", "--verify", "refs/remotes/origin/develop"]
+        )
+        .is_empty(),
+        "origin/develop tracking ref must be restored"
+    );
+}
+
+#[test]
+fn start_work_resolves_main_only_bare_workspace_home_by_creating_remote_develop() {
+    let temp = tempdir().expect("tempdir");
+    let workspace_home = temp.path().join("sample");
+    let (bare_repo, origin) = init_main_only_bare_workspace_home(&workspace_home);
+
+    let base_branch = gwt::start_work::resolve_start_work_base_branch(&workspace_home)
+        .expect("start work base branch");
+
+    assert_eq!(base_branch, "origin/develop");
+    assert!(
+        !workspace_home.join("main").exists(),
+        "Start Work base resolution must not create a local main worktree"
+    );
+    assert!(
+        !workspace_home.join("develop").exists(),
+        "Start Work base resolution must not create a local develop worktree"
+    );
+    assert_eq!(
+        git_output(&origin, &["show-ref", "--verify", "refs/heads/develop"])
+            .split_whitespace()
+            .last(),
+        Some("refs/heads/develop"),
+        "remote develop must be created from the remote default branch"
+    );
+    assert_eq!(
+        git_output(
+            &bare_repo,
+            &["show-ref", "--verify", "refs/remotes/origin/develop"]
+        )
+        .split_whitespace()
+        .last(),
+        Some("refs/remotes/origin/develop"),
+        "local origin/develop tracking ref must be fetched"
+    );
+
+    let reserved_branch = "work/main-only";
+    let mut config = gwt_agent::AgentLaunchBuilder::new(gwt_agent::AgentId::Codex)
+        .branch(reserved_branch)
+        .base_branch(&base_branch)
+        .build();
+
+    gwt_agent::resolve_launch_worktree(&workspace_home, &mut config)
+        .expect("materialize launch worktree");
+
+    let worktree = config.working_dir.expect("materialized worktree");
+    assert_eq!(
+        git_output(&worktree, &["branch", "--show-current"]),
+        reserved_branch
+    );
+    assert!(
+        worktree.join("main-only.txt").is_file(),
+        "Start Work branch should be created from the newly-created origin/develop"
+    );
+    assert_eq!(
+        git_output(
+            &origin,
+            &["show-ref", "--verify", "refs/heads/work/main-only"]
+        )
+        .split_whitespace()
+        .last(),
+        Some("refs/heads/work/main-only"),
+        "remote work branch must be pushed from origin/develop"
+    );
+}
+
+#[test]
+fn start_work_launch_fails_without_work_branch_when_remote_develop_creation_fails() {
+    let temp = tempdir().expect("tempdir");
+    let workspace_home = temp.path().join("sample");
+    let (bare_repo, origin) = init_main_only_bare_workspace_home(&workspace_home);
+    install_reject_develop_hook(&origin);
+    let reserved_branch = "work/rejected-develop";
+    let mut config = gwt_agent::AgentLaunchBuilder::new(gwt_agent::AgentId::Codex)
+        .branch(reserved_branch)
+        .base_branch("origin/develop")
+        .build();
+
+    let error = gwt_agent::resolve_launch_worktree(&workspace_home, &mut config)
+        .expect_err("remote develop creation must fail");
+
+    assert!(
+        error.contains("origin/develop") || error.contains("develop rejected by test hook"),
+        "error should explain the failed develop preparation: {error}"
+    );
+    assert!(
+        config.working_dir.is_none(),
+        "failed launch materialization must not assign a worktree"
+    );
+    assert!(
+        !workspace_home
+            .join("work")
+            .join("rejected-develop")
+            .exists(),
+        "failed launch materialization must not leave a local worktree"
+    );
+    assert!(
+        !git_ref_exists(&origin, "refs/heads/work/rejected-develop"),
+        "failed develop preparation must not create a remote work branch"
+    );
+    assert!(
+        !git_ref_exists(&bare_repo, "refs/remotes/origin/work/rejected-develop"),
+        "failed develop preparation must not fetch a remote work tracking ref"
     );
 }


### PR DESCRIPTION
## Summary

- Clone Project now creates a branchless Workspace Home while preparing `origin/develop` for future Start Work sessions.
- Start Work, Launch materialization, and Agent Prepare now share one remote `develop` self-heal path so main-only GitHub repos no longer fail with a missing base branch.

## Changes

- `crates/gwt-git/src/worktree.rs`: added shared preparation for `origin/develop`, including refspec normalization, fetch/prune, remote default branch lookup, and remote `develop` creation.
- `crates/gwt-git/src/repository.rs`: stopped creating local `main` or `develop` worktrees during Clone Project and prepared the remote Start Work base instead.
- `crates/gwt/src/start_work.rs`, `crates/gwt/src/launch_runtime.rs`, `crates/gwt-agent/src/prepare.rs`: made `origin/develop` the single Start Work base and reused the shared preparation path before materialization.
- `crates/gwt/src/app_runtime/mod.rs`, `crates/gwt/src/main.rs`, `crates/gwt/src/protocol.rs`: changed Clone Project completion to open Workspace Home and removed `initial_worktree_path` from the done event.
- `crates/gwt-git/tests/github_project_clone_test.rs`, `crates/gwt/tests/start_work_test.rs`: added regression coverage for branchless clone, main-only remotes, stale/missing `origin/develop`, and develop-creation failure cleanup.

## Testing

- [x] `cargo test -p gwt-git clone_project_as_nested_bare --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt --test start_work_test -- --nocapture` - passed.
- [x] `cargo test -p gwt clone_project_done_opens_workspace_home_and_broadcasts_done --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt start_work_base_branch --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt resolve_launch_worktree_recreates_remote_develop_when_start_work_ref_is_stale --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt resolve_launch_worktree_helpers_cover_short_circuits_existing_and_remote_creation --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt-git -p gwt-agent -p gwt-core -p gwt --all-features -- --test-threads=1` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed.
- [x] `git diff --check` - passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.

## Closing Issues

- Closes #2696

## Related Issues / Links

- #1934
- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated or not needed: SPEC-1934 and SPEC-2359 tasks were updated; README copy did not change.
- [x] Migration/backfill plan included or not needed: no schema or data migration.
- [x] CHANGELOG impact considered: patch-level bug fix.

## Context

- The failing path came from a freshly cloned GitHub project whose remote only had `main`, leaving Start Work without `origin/develop` and without normalized remote-tracking refs.
- The intended workflow is branchless Clone Project followed by Start Work materialization from a remote-created `develop` base.

## Risk / Impact

- **Affected areas**: GitHub Clone Project, Start Work base resolution, Launch materialization, and Agent Prepare.
- **Rollback plan**: Revert `38bbfad73` if remote `develop` preparation causes unexpected clone or launch failures.
