### PR TITLE
fix(workspace): set agent identity from user prompts

### DIFF
--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -9,7 +9,7 @@ use std::{path::Path, time::Instant};
 
 use super::{
     board_reminder, diagnostics, skill_build_spec_stop_check, skill_discussion_stop_check,
-    skill_plan_spec_stop_check, workflow_policy, HookError, HookOutput,
+    skill_plan_spec_stop_check, workflow_policy, workspace_identity, HookError, HookOutput,
 };
 
 pub fn handle_with_input(
@@ -50,9 +50,15 @@ fn handle_user_prompt_submit(event: &str, input: &str) -> Result<HookOutput, Hoo
     run_step(event, "forward", || {
         crate::daemon_runtime::handle_forward(input)
     })?;
-    run_step(event, "board-reminder", || {
+    let identity = run_step(event, "workspace-identity", || {
+        workspace_identity::handle_user_prompt_submit(input)
+    })?;
+    let reminder = run_step(event, "board-reminder", || {
         board_reminder::handle_with_input(event, input)
-    })
+    })?;
+    Ok(workspace_identity::append_identity_context(
+        reminder, identity,
+    ))
 }
 
 fn handle_pre_tool_use(event: &str, input: &str) -> Result<HookOutput, HookError> {

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -30,6 +30,7 @@ pub mod skill_build_spec_stop_check;
 pub mod skill_discussion_stop_check;
 pub mod skill_plan_spec_stop_check;
 pub mod workflow_policy;
+mod workspace_identity;
 pub mod worktree;
 
 use std::io::{self, Read};

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -112,7 +112,7 @@ pub fn evaluate_with_context(
 
 pub fn evaluate(event: &HookEvent, worktree_root: &Path) -> Result<HookOutput, HookError> {
     let context = resolve_workflow_context(worktree_root)
-        .with_title_summary_missing(current_agent_title_summary_missing(worktree_root)?);
+        .with_title_summary_missing(current_agent_workspace_identity_missing(worktree_root)?);
     evaluate_with_context(event, worktree_root, &context)
 }
 
@@ -181,7 +181,7 @@ fn load_session_from_env() -> Option<Session> {
     Session::load_and_migrate(&session_path).ok()
 }
 
-fn current_agent_title_summary_missing(worktree_root: &Path) -> Result<bool, HookError> {
+fn current_agent_workspace_identity_missing(worktree_root: &Path) -> Result<bool, HookError> {
     let Some(session) = load_session_from_env() else {
         return Ok(false);
     };
@@ -203,12 +203,19 @@ fn current_agent_title_summary_missing(worktree_root: &Path) -> Result<bool, Hoo
     if agent.is_unassigned() {
         return Ok(false);
     }
-    Ok(agent
+    let title_summary_missing = agent
         .title_summary
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .is_none())
+        .is_none();
+    let current_focus_missing = agent
+        .current_focus
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_none();
+    Ok(title_summary_missing || current_focus_missing)
 }
 
 fn evaluate_title_summary_guard(
@@ -219,14 +226,14 @@ fn evaluate_title_summary_guard(
         return Ok(HookOutput::Silent);
     }
 
-    if is_title_summary_update_event(event) || is_read_only_exploration_event(event) {
+    if is_workspace_identity_update_event(event) {
         return Ok(HookOutput::Silent);
     }
 
-    if is_title_sensitive_tool(event) {
+    if is_title_sensitive_tool(event) || is_read_only_exploration_event(event) {
         return Ok(HookOutput::pre_tool_use_permission(
-            "Agent title-summary is required before work starts",
-            "Set a short work name before implementation or verification commands. The title-summary must describe what the work is, not a status/result.\n\n\
+            "Agent Workspace identity is required before work starts",
+            "Set both a short work name and current focus before exploration, implementation, or verification commands. This is required so Workspace can show which window is doing what.\n\n\
 Required command shape:\n\
   gwtd workspace update --agent-session \"$GWT_SESSION_ID\" --current-focus '<current work focus>' --title-summary '<short work title>'\n\n\
 Good example: --title-summary 'Agent title improvement'\n\
@@ -246,7 +253,7 @@ fn is_title_sensitive_tool(event: &HookEvent) -> bool {
     }
 }
 
-fn is_title_summary_update_event(event: &HookEvent) -> bool {
+fn is_workspace_identity_update_event(event: &HookEvent) -> bool {
     if event.tool_name.as_deref() != Some("Bash") {
         return false;
     }
@@ -257,10 +264,10 @@ fn is_title_summary_update_event(event: &HookEvent) -> bool {
     !segments.is_empty()
         && segments
             .iter()
-            .all(|segment| is_title_summary_update_segment(segment))
+            .all(|segment| is_workspace_identity_update_segment(segment))
 }
 
-fn is_title_summary_update_segment(segment: &str) -> bool {
+fn is_workspace_identity_update_segment(segment: &str) -> bool {
     let tokens = segment_tokens(segment);
     let Some(command_name) = tokens.first().map(|token| normalize_command_name(token)) else {
         return false;
@@ -270,12 +277,15 @@ fn is_title_summary_update_segment(segment: &str) -> bool {
     }
     match tokens.as_slice() {
         [_, "workspace", "update", rest @ ..] => {
-            rest.contains(&"--agent-session") && rest.contains(&"--title-summary")
+            rest.contains(&"--agent-session")
+                && rest.contains(&"--title-summary")
+                && rest.contains(&"--current-focus")
         }
         [_, "workspace", "ensure", rest @ ..] => {
-            rest.contains(&"--agent-session") && rest.contains(&"--title-summary")
+            rest.contains(&"--agent-session")
+                && rest.contains(&"--title-summary")
+                && rest.contains(&"--current-focus")
         }
-        [_, "board", "post", rest @ ..] => rest.contains(&"--title-summary"),
         _ => false,
     }
 }
@@ -748,7 +758,7 @@ Coverage requirements.
         assert!(detail.contains("--title-summary"));
         assert!(detail.contains("--agent-session"));
         assert!(detail.contains("work name"), "{detail}");
-        assert!(detail.contains("not a status"), "{detail}");
+        assert!(detail.contains("which window is doing what"), "{detail}");
     }
 
     #[test]
@@ -822,7 +832,7 @@ Coverage requirements.
     }
 
     #[test]
-    fn title_summary_guard_allows_read_only_exploration() {
+    fn title_summary_guard_blocks_read_only_exploration_before_identity_is_set() {
         let event = HookEvent {
             tool_name: Some("Bash".to_string()),
             tool_input: Some(serde_json::json!({
@@ -832,14 +842,14 @@ Coverage requirements.
             cwd: None,
         };
 
-        assert_eq!(
+        assert!(matches!(
             evaluate_title_summary_guard(&event, true).expect("guard output"),
-            HookOutput::Silent
-        );
+            HookOutput::PreToolUsePermission { .. }
+        ));
     }
 
     #[test]
-    fn title_summary_guard_allows_read_only_git_config() {
+    fn title_summary_guard_blocks_read_only_git_config_before_identity_is_set() {
         let event = HookEvent {
             tool_name: Some("Bash".to_string()),
             tool_input: Some(serde_json::json!({
@@ -849,14 +859,14 @@ Coverage requirements.
             cwd: None,
         };
 
-        assert_eq!(
+        assert!(matches!(
             evaluate_title_summary_guard(&event, true).expect("guard output"),
-            HookOutput::Silent
-        );
+            HookOutput::PreToolUsePermission { .. }
+        ));
     }
 
     #[test]
-    fn title_summary_guard_allows_read_only_git_remote() {
+    fn title_summary_guard_blocks_read_only_git_remote_before_identity_is_set() {
         let event = HookEvent {
             tool_name: Some("Bash".to_string()),
             tool_input: Some(serde_json::json!({
@@ -866,14 +876,14 @@ Coverage requirements.
             cwd: None,
         };
 
-        assert_eq!(
+        assert!(matches!(
             evaluate_title_summary_guard(&event, true).expect("guard output"),
-            HookOutput::Silent
-        );
+            HookOutput::PreToolUsePermission { .. }
+        ));
     }
 
     #[test]
-    fn title_summary_guard_allows_read_only_git_branch_queries() {
+    fn title_summary_guard_blocks_read_only_git_branch_queries_before_identity_is_set() {
         for command in [
             "git branch --contains HEAD",
             "git branch --points-at HEAD",
@@ -900,9 +910,11 @@ Coverage requirements.
                 cwd: None,
             };
 
-            assert_eq!(
-                evaluate_title_summary_guard(&event, true).expect("guard output"),
-                HookOutput::Silent,
+            assert!(
+                matches!(
+                    evaluate_title_summary_guard(&event, true).expect("guard output"),
+                    HookOutput::PreToolUsePermission { .. }
+                ),
                 "{command}"
             );
         }

--- a/crates/gwt/src/cli/hook/workspace_identity.rs
+++ b/crates/gwt/src/cli/hook/workspace_identity.rs
@@ -1,0 +1,575 @@
+use std::{fs, path::Path};
+
+use gwt_agent::{Session, GWT_SESSION_ID_ENV};
+use gwt_core::workspace_projection::{
+    load_workspace_projection, update_workspace_projection_with_journal, WorkspaceProjectionUpdate,
+};
+
+use super::{HookError, HookOutput, IntentBoundaryEvent};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspacePromptIdentity {
+    pub title_summary: String,
+    pub current_focus: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceIdentityHookResult {
+    pub updated: bool,
+    pub identity: Option<WorkspacePromptIdentity>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MissingIdentity {
+    title_summary: bool,
+    current_focus: bool,
+}
+
+impl MissingIdentity {
+    fn complete(self) -> bool {
+        !self.title_summary && !self.current_focus
+    }
+}
+
+pub(crate) fn handle_user_prompt_submit(
+    input: &str,
+) -> Result<WorkspaceIdentityHookResult, HookError> {
+    let Some(session) = current_session_from_env()? else {
+        return Ok(WorkspaceIdentityHookResult {
+            updated: false,
+            identity: None,
+        });
+    };
+    let Some(missing) = missing_identity_for_session(&session)? else {
+        return Ok(WorkspaceIdentityHookResult {
+            updated: false,
+            identity: None,
+        });
+    };
+    if missing.complete() {
+        return Ok(WorkspaceIdentityHookResult {
+            updated: false,
+            identity: None,
+        });
+    }
+
+    let Some(prompt) = prompt_from_hook_input(input) else {
+        return Ok(WorkspaceIdentityHookResult {
+            updated: false,
+            identity: None,
+        });
+    };
+    let Some(identity) = derive_identity_from_prompt(&prompt) else {
+        return Ok(WorkspaceIdentityHookResult {
+            updated: false,
+            identity: None,
+        });
+    };
+
+    let title_summary = missing
+        .title_summary
+        .then(|| identity.title_summary.clone());
+    let current_focus = missing
+        .current_focus
+        .then(|| identity.current_focus.clone());
+    if title_summary.is_none() && current_focus.is_none() {
+        return Ok(WorkspaceIdentityHookResult {
+            updated: false,
+            identity: Some(identity),
+        });
+    }
+
+    update_workspace_projection_with_journal(
+        &session.worktree_path,
+        WorkspaceProjectionUpdate {
+            title: None,
+            status_category: None,
+            status_text: None,
+            owner: None,
+            next_action: None,
+            summary: None,
+            agent_session_id: Some(session.id.clone()),
+            agent_current_focus: current_focus,
+            agent_title_summary: title_summary,
+        },
+    )?;
+    crate::cli::workspace::publish_workspace_change(&session.worktree_path);
+
+    Ok(WorkspaceIdentityHookResult {
+        updated: true,
+        identity: Some(identity),
+    })
+}
+
+pub(crate) fn append_identity_context(
+    output: HookOutput,
+    result: WorkspaceIdentityHookResult,
+) -> HookOutput {
+    if !result.updated {
+        return output;
+    };
+    let Some(identity) = result.identity else {
+        return output;
+    };
+    let text = format!(
+        "# Workspace Identity Updated\n\nUserPromptSubmit has set this Agent window / Workspace identity from the prompt.\n\n- title-summary: `{}`\n- current-focus: {}\n\nIf this identity is inaccurate, correct it before continuing with `gwtd workspace update --agent-session \"$GWT_SESSION_ID\" --current-focus '<focus>' --title-summary '<short work name>'`.",
+        identity.title_summary, identity.current_focus
+    );
+    append_user_prompt_context(output, text)
+}
+
+fn append_user_prompt_context(output: HookOutput, text: String) -> HookOutput {
+    match output {
+        HookOutput::HookSpecificAdditionalContext {
+            event: IntentBoundaryEvent::UserPromptSubmit,
+            text: existing,
+        } => HookOutput::hook_specific_additional_context(
+            IntentBoundaryEvent::UserPromptSubmit,
+            format!("{text}\n\n{existing}"),
+        ),
+        HookOutput::Silent => HookOutput::hook_specific_additional_context(
+            IntentBoundaryEvent::UserPromptSubmit,
+            text,
+        ),
+        other => other,
+    }
+}
+
+fn current_session_from_env() -> Result<Option<Session>, HookError> {
+    let Some(session_id) = std::env::var_os(GWT_SESSION_ID_ENV) else {
+        return Ok(None);
+    };
+    let session_id = session_id.to_string_lossy();
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Ok(None);
+    }
+    let path = gwt_core::paths::gwt_sessions_dir().join(format!("{session_id}.toml"));
+    if !path.exists() {
+        return Ok(None);
+    }
+    Session::load_and_migrate(&path)
+        .map(Some)
+        .map_err(HookError::Io)
+}
+
+fn missing_identity_for_session(session: &Session) -> Result<Option<MissingIdentity>, HookError> {
+    let Some(projection) = load_workspace_projection(&session.worktree_path)? else {
+        return Ok(None);
+    };
+    let Some(agent) = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session.id)
+    else {
+        return Ok(None);
+    };
+    if agent.is_unassigned() {
+        return Ok(None);
+    }
+    Ok(Some(MissingIdentity {
+        title_summary: agent
+            .title_summary
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none(),
+        current_focus: agent
+            .current_focus
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none(),
+    }))
+}
+
+pub(crate) fn derive_identity_from_prompt(prompt: &str) -> Option<WorkspacePromptIdentity> {
+    let focus = sanitize_prompt_focus(prompt)?;
+    let title_summary = derive_title_summary(&focus)?;
+    if super::super::validate_title_summary_work_name("--title-summary", &title_summary).is_err() {
+        return None;
+    }
+    Some(WorkspacePromptIdentity {
+        title_summary,
+        current_focus: truncate_chars(&focus, 160),
+    })
+}
+
+fn derive_title_summary(focus: &str) -> Option<String> {
+    let lower = focus.to_ascii_lowercase();
+    if lower.contains("workspace")
+        && (focus.contains("ウィンドウ")
+            || lower.contains("window")
+            || focus.contains("何をしている")
+            || focus.contains("把握"))
+        && (lower.contains("ux") || focus.contains("識別") || focus.contains("把握"))
+    {
+        return Some("Workspace識別UX不具合".to_string());
+    }
+    if (focus.contains("エージェントウィンドウ") || lower.contains("agent window"))
+        && (focus.contains("更新") || focus.contains("タイトル") || lower.contains("title"))
+        && (focus.contains("不具合")
+            || focus.contains("されません")
+            || focus.contains("直っていません")
+            || lower.contains("bug"))
+    {
+        return Some("エージェントウィンドウ更新不具合".to_string());
+    }
+
+    let first = focus
+        .split(['\n', '。', '.', '？', '?', '！', '!'])
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    let first = trim_request_suffixes(first);
+    let title = truncate_chars(&first, 30);
+    (!title.trim().is_empty()).then_some(title)
+}
+
+fn sanitize_prompt_focus(prompt: &str) -> Option<String> {
+    let without_blocks = strip_fenced_blocks(prompt);
+    let mut lines = Vec::new();
+    for raw in without_blocks.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('<') || line.starts_with("# ") {
+            continue;
+        }
+        let line = line
+            .strip_prefix("$gwt-discussion")
+            .or_else(|| line.strip_prefix("$gwt-build-spec"))
+            .or_else(|| line.strip_prefix("$gwt-fix-issue"))
+            .unwrap_or(line)
+            .trim();
+        if !line.is_empty() {
+            lines.push(line);
+        }
+    }
+    let joined = lines.join(" ");
+    let normalized = joined.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn strip_fenced_blocks(value: &str) -> String {
+    let mut out = String::new();
+    let mut in_fence = false;
+    for line in value.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if !in_fence {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn trim_request_suffixes(value: &str) -> String {
+    let suffixes = [
+        "ちゃんと考えて対応してください",
+        "対応してください",
+        "修正してください",
+        "実装してください",
+        "調査してください",
+        "お願いします",
+        "してください",
+    ];
+    let mut out = value.trim().to_string();
+    for suffix in suffixes {
+        if out.ends_with(suffix) {
+            out.truncate(out.len() - suffix.len());
+            break;
+        }
+    }
+    out.trim_matches(|ch: char| ch.is_whitespace() || matches!(ch, '。' | '.' | '、' | ','))
+        .to_string()
+}
+
+fn truncate_chars(value: &str, max: usize) -> String {
+    let value = value.trim();
+    if value.chars().count() <= max {
+        return value.to_string();
+    }
+    value.chars().take(max).collect::<String>()
+}
+
+fn prompt_from_hook_input(input: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(input).ok()?;
+    string_at_any(
+        &value,
+        &[
+            &["prompt"],
+            &["user_prompt"],
+            &["userPrompt"],
+            &["message"],
+            &["message", "content"],
+            &["message", "text"],
+            &["input"],
+            &["input", "content"],
+            &["input", "text"],
+        ],
+    )
+    .or_else(|| latest_message_content(&value))
+    .or_else(|| {
+        string_at_any(&value, &[&["transcript_path"], &["transcriptPath"]])
+            .and_then(|path| prompt_from_transcript_path(Path::new(&path)))
+    })
+}
+
+fn latest_message_content(value: &serde_json::Value) -> Option<String> {
+    let messages = value.get("messages")?.as_array()?;
+    messages.iter().rev().find_map(|message| {
+        let role = message.get("role").and_then(serde_json::Value::as_str);
+        if role.is_some_and(|role| role != "user") {
+            return None;
+        }
+        value_to_text(message.get("content")?)
+    })
+}
+
+fn prompt_from_transcript_path(path: &Path) -> Option<String> {
+    let text = fs::read_to_string(path).ok()?;
+    text.lines().rev().find_map(|line| {
+        let value: serde_json::Value = serde_json::from_str(line).ok()?;
+        string_at_any(&value, &[&["lastPrompt"], &["last_prompt"]])
+            .or_else(|| {
+                let ty = value.get("type").and_then(serde_json::Value::as_str);
+                if ty.is_some_and(|ty| ty != "user") {
+                    return None;
+                }
+                value
+                    .get("message")
+                    .and_then(|message| value_to_text(message.get("content")?))
+            })
+            .or_else(|| string_at_any(&value, &[&["text"]]))
+    })
+}
+
+fn string_at_any(value: &serde_json::Value, paths: &[&[&str]]) -> Option<String> {
+    paths.iter().find_map(|path| {
+        let mut current = value;
+        for key in *path {
+            current = current.get(*key)?;
+        }
+        current
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn value_to_text(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => Some(text.trim().to_string()),
+        serde_json::Value::Array(items) => {
+            let parts = items
+                .iter()
+                .filter_map(|item| {
+                    item.as_str()
+                        .map(str::to_string)
+                        .or_else(|| string_at_any(item, &[&["text"], &["content"]]))
+                })
+                .map(|part| part.trim().to_string())
+                .filter(|part| !part.is_empty())
+                .collect::<Vec<_>>();
+            (!parts.is_empty()).then(|| parts.join("\n"))
+        }
+        serde_json::Value::Object(_) => string_at_any(value, &[&["text"], &["content"]]),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use gwt_agent::{AgentId, Session, GWT_SESSION_ID_ENV};
+    use gwt_core::workspace_projection::{
+        load_workspace_projection, save_workspace_projection, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
+    };
+
+    use crate::cli::test_support::ScopedEnvVar;
+
+    use super::*;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn assigned_agent(session_id: &str, repo: &std::path::Path) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            title_summary: None,
+            worktree_path: Some(repo.to_path_buf()),
+            branch: Some("work/identity".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn derive_identity_from_prompt_identifies_workspace_window_ux() {
+        let prompt = "$gwt-discussion 単なるタイトル更新と思っているかもしれませんが、現在のWorkspace運用の場合、どのウィンドウで何をしているのか？を把握できないとUX的には最悪です。";
+
+        let identity = derive_identity_from_prompt(prompt).expect("identity");
+
+        assert_eq!(identity.title_summary, "Workspace識別UX不具合");
+        assert!(
+            identity
+                .current_focus
+                .contains("どのウィンドウで何をしているのか"),
+            "{}",
+            identity.current_focus
+        );
+    }
+
+    #[test]
+    fn user_prompt_submit_persists_missing_workspace_identity() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        std::fs::create_dir_all(&home).expect("home");
+
+        let _home = ScopedEnvVar::set("HOME", &home);
+        let session = Session::new(&repo, "work/identity", AgentId::Codex);
+        session
+            .save(&gwt_core::paths::gwt_sessions_dir())
+            .expect("session");
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(assigned_agent(&session.id, &repo));
+        save_workspace_projection(&repo, &projection).expect("projection");
+
+        let payload = serde_json::json!({
+            "session_id": "codex-provider-session",
+            "prompt": "$gwt-discussion エージェントウィンドウの更新がいまだにされません。今回の場合であれば「エージェントウィンドウの更新不具合」などが表示されるべきです。"
+        });
+
+        let result = handle_user_prompt_submit(&payload.to_string()).expect("identity update");
+
+        assert!(result.updated, "{result:?}");
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent");
+        assert_eq!(
+            agent.title_summary.as_deref(),
+            Some("エージェントウィンドウ更新不具合")
+        );
+        assert!(
+            agent
+                .current_focus
+                .as_deref()
+                .is_some_and(|focus| focus.contains("エージェントウィンドウの更新")),
+            "{:?}",
+            agent.current_focus
+        );
+    }
+
+    #[test]
+    fn user_prompt_submit_does_not_overwrite_existing_identity() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        std::fs::create_dir_all(&home).expect("home");
+
+        let _home = ScopedEnvVar::set("HOME", &home);
+        let session = Session::new(&repo, "work/identity", AgentId::Codex);
+        session
+            .save(&gwt_core::paths::gwt_sessions_dir())
+            .expect("session");
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+
+        let mut agent = assigned_agent(&session.id, &repo);
+        agent.title_summary = Some("明示タイトル".to_string());
+        agent.current_focus = Some("明示 focus".to_string());
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(agent);
+        save_workspace_projection(&repo, &projection).expect("projection");
+
+        let payload = serde_json::json!({
+            "session_id": "codex-provider-session",
+            "prompt": "エージェントウィンドウの更新がされません。"
+        });
+
+        let result = handle_user_prompt_submit(&payload.to_string()).expect("identity update");
+
+        assert!(!result.updated, "{result:?}");
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent");
+        assert_eq!(agent.title_summary.as_deref(), Some("明示タイトル"));
+        assert_eq!(agent.current_focus.as_deref(), Some("明示 focus"));
+    }
+
+    #[test]
+    fn user_prompt_submit_uses_transcript_path_when_prompt_field_is_absent() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        std::fs::create_dir_all(&home).expect("home");
+
+        let transcript = temp.path().join("transcript.jsonl");
+        std::fs::write(
+            &transcript,
+            r#"{"type":"last-prompt","lastPrompt":"単なるタイトル更新と思っているかもしれませんが、現在のWorkspace運用の場合、どのウィンドウで何をしているのか？を把握できないとUX的には最悪です。"}"#,
+        )
+        .expect("transcript");
+
+        let _home = ScopedEnvVar::set("HOME", &home);
+        let session = Session::new(&repo, "work/identity", AgentId::Codex);
+        session
+            .save(&gwt_core::paths::gwt_sessions_dir())
+            .expect("session");
+        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
+
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push(assigned_agent(&session.id, &repo));
+        save_workspace_projection(&repo, &projection).expect("projection");
+
+        let payload = serde_json::json!({
+            "session_id": "codex-provider-session",
+            "transcript_path": transcript
+        });
+
+        let result = handle_user_prompt_submit(&payload.to_string()).expect("identity update");
+
+        assert!(result.updated, "{result:?}");
+        let saved = load_workspace_projection(&repo)
+            .expect("load projection")
+            .expect("projection");
+        let agent = saved
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent");
+        assert_eq!(
+            agent.title_summary.as_deref(),
+            Some("Workspace識別UX不具合")
+        );
+    }
+}

--- a/crates/gwt/src/cli/hook/workspace_identity.rs
+++ b/crates/gwt/src/cli/hook/workspace_identity.rs
@@ -40,7 +40,14 @@ pub(crate) fn handle_user_prompt_submit(
             identity: None,
         });
     };
-    let Some(missing) = missing_identity_for_session(&session)? else {
+    handle_user_prompt_submit_for_session(input, &session)
+}
+
+fn handle_user_prompt_submit_for_session(
+    input: &str,
+    session: &Session,
+) -> Result<WorkspaceIdentityHookResult, HookError> {
+    let Some(missing) = missing_identity_for_session(session)? else {
         return Ok(WorkspaceIdentityHookResult {
             updated: false,
             identity: None,
@@ -66,33 +73,15 @@ pub(crate) fn handle_user_prompt_submit(
         });
     };
 
-    let title_summary = missing
-        .title_summary
-        .then(|| identity.title_summary.clone());
-    let current_focus = missing
-        .current_focus
-        .then(|| identity.current_focus.clone());
-    if title_summary.is_none() && current_focus.is_none() {
+    let Some(update) = workspace_projection_update_for_identity(&session.id, missing, &identity)
+    else {
         return Ok(WorkspaceIdentityHookResult {
             updated: false,
             identity: Some(identity),
         });
-    }
+    };
 
-    update_workspace_projection_with_journal(
-        &session.worktree_path,
-        WorkspaceProjectionUpdate {
-            title: None,
-            status_category: None,
-            status_text: None,
-            owner: None,
-            next_action: None,
-            summary: None,
-            agent_session_id: Some(session.id.clone()),
-            agent_current_focus: current_focus,
-            agent_title_summary: title_summary,
-        },
-    )?;
+    update_workspace_projection_with_journal(&session.worktree_path, update)?;
     crate::cli::workspace::publish_workspace_change(&session.worktree_path);
 
     Ok(WorkspaceIdentityHookResult {
@@ -167,7 +156,13 @@ fn missing_identity_for_session(session: &Session) -> Result<Option<MissingIdent
     if agent.is_unassigned() {
         return Ok(None);
     }
-    Ok(Some(MissingIdentity {
+    Ok(Some(missing_identity_for_agent(agent)))
+}
+
+fn missing_identity_for_agent(
+    agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
+) -> MissingIdentity {
+    MissingIdentity {
         title_summary: agent
             .title_summary
             .as_deref()
@@ -180,7 +175,34 @@ fn missing_identity_for_session(session: &Session) -> Result<Option<MissingIdent
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .is_none(),
-    }))
+    }
+}
+
+fn workspace_projection_update_for_identity(
+    session_id: &str,
+    missing: MissingIdentity,
+    identity: &WorkspacePromptIdentity,
+) -> Option<WorkspaceProjectionUpdate> {
+    let title_summary = missing
+        .title_summary
+        .then(|| identity.title_summary.clone());
+    let current_focus = missing
+        .current_focus
+        .then(|| identity.current_focus.clone());
+    if title_summary.is_none() && current_focus.is_none() {
+        return None;
+    }
+    Some(WorkspaceProjectionUpdate {
+        title: None,
+        status_category: None,
+        status_text: None,
+        owner: None,
+        next_action: None,
+        summary: None,
+        agent_session_id: Some(session_id.to_string()),
+        agent_current_focus: current_focus,
+        agent_title_summary: title_summary,
+    })
 }
 
 pub(crate) fn derive_identity_from_prompt(prompt: &str) -> Option<WorkspacePromptIdentity> {
@@ -331,18 +353,30 @@ fn prompt_from_transcript_path(path: &Path) -> Option<String> {
     let text = fs::read_to_string(path).ok()?;
     text.lines().rev().find_map(|line| {
         let value: serde_json::Value = serde_json::from_str(line).ok()?;
-        string_at_any(&value, &[&["lastPrompt"], &["last_prompt"]])
-            .or_else(|| {
-                let ty = value.get("type").and_then(serde_json::Value::as_str);
-                if ty.is_some_and(|ty| ty != "user") {
-                    return None;
-                }
-                value
-                    .get("message")
-                    .and_then(|message| value_to_text(message.get("content")?))
-            })
+        if let Some(prompt) = string_at_any(&value, &[&["lastPrompt"], &["last_prompt"]]) {
+            return Some(prompt);
+        }
+        if !is_transcript_user_record(&value) {
+            return None;
+        }
+        value
+            .get("message")
+            .and_then(|message| value_to_text(message.get("content")?))
             .or_else(|| string_at_any(&value, &[&["text"]]))
     })
+}
+
+fn is_transcript_user_record(value: &serde_json::Value) -> bool {
+    string_at_any(
+        value,
+        &[
+            &["type"],
+            &["role"],
+            &["message", "role"],
+            &["event", "role"],
+        ],
+    )
+    .is_some_and(|role| role.eq_ignore_ascii_case("user"))
 }
 
 fn string_at_any(value: &serde_json::Value, paths: &[&[&str]]) -> Option<String> {
@@ -383,17 +417,11 @@ fn value_to_text(value: &serde_json::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use gwt_agent::{AgentId, Session, GWT_SESSION_ID_ENV};
     use gwt_core::workspace_projection::{
-        load_workspace_projection, save_workspace_projection, WorkspaceAgentAffiliationStatus,
-        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
+        WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceStatusCategory,
     };
 
-    use crate::cli::test_support::ScopedEnvVar;
-
     use super::*;
-
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn assigned_agent(session_id: &str, repo: &std::path::Path) -> WorkspaceAgentSummary {
         WorkspaceAgentSummary {
@@ -432,107 +460,64 @@ mod tests {
     }
 
     #[test]
-    fn user_prompt_submit_persists_missing_workspace_identity() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
+    fn user_prompt_submit_builds_update_for_missing_workspace_identity() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let home = temp.path().join("home");
         let repo = temp.path().join("repo");
-        std::fs::create_dir_all(&repo).expect("repo");
-        std::fs::create_dir_all(&home).expect("home");
-
-        let _home = ScopedEnvVar::set("HOME", &home);
-        let session = Session::new(&repo, "work/identity", AgentId::Codex);
-        session
-            .save(&gwt_core::paths::gwt_sessions_dir())
-            .expect("session");
-        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
-
-        let mut projection = WorkspaceProjection::default_for_project(&repo);
-        projection.agents.push(assigned_agent(&session.id, &repo));
-        save_workspace_projection(&repo, &projection).expect("projection");
+        let agent = assigned_agent("session-1", &repo);
 
         let payload = serde_json::json!({
             "session_id": "codex-provider-session",
             "prompt": "$gwt-discussion エージェントウィンドウの更新がいまだにされません。今回の場合であれば「エージェントウィンドウの更新不具合」などが表示されるべきです。"
         });
 
-        let result = handle_user_prompt_submit(&payload.to_string()).expect("identity update");
+        let prompt = prompt_from_hook_input(&payload.to_string()).expect("prompt");
+        let identity = derive_identity_from_prompt(&prompt).expect("identity");
+        let update = workspace_projection_update_for_identity(
+            "session-1",
+            missing_identity_for_agent(&agent),
+            &identity,
+        )
+        .expect("projection update");
 
-        assert!(result.updated, "{result:?}");
-        let saved = load_workspace_projection(&repo)
-            .expect("load projection")
-            .expect("projection");
-        let agent = saved
-            .agents
-            .iter()
-            .find(|agent| agent.session_id == session.id)
-            .expect("agent");
+        assert_eq!(update.agent_session_id.as_deref(), Some("session-1"));
         assert_eq!(
-            agent.title_summary.as_deref(),
+            update.agent_title_summary.as_deref(),
             Some("エージェントウィンドウ更新不具合")
         );
         assert!(
-            agent
-                .current_focus
+            update
+                .agent_current_focus
                 .as_deref()
                 .is_some_and(|focus| focus.contains("エージェントウィンドウの更新")),
             "{:?}",
-            agent.current_focus
+            update.agent_current_focus
         );
     }
 
     #[test]
     fn user_prompt_submit_does_not_overwrite_existing_identity() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
         let temp = tempfile::tempdir().expect("tempdir");
-        let home = temp.path().join("home");
         let repo = temp.path().join("repo");
-        std::fs::create_dir_all(&repo).expect("repo");
-        std::fs::create_dir_all(&home).expect("home");
 
-        let _home = ScopedEnvVar::set("HOME", &home);
-        let session = Session::new(&repo, "work/identity", AgentId::Codex);
-        session
-            .save(&gwt_core::paths::gwt_sessions_dir())
-            .expect("session");
-        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
-
-        let mut agent = assigned_agent(&session.id, &repo);
+        let mut agent = assigned_agent("session-1", &repo);
         agent.title_summary = Some("明示タイトル".to_string());
         agent.current_focus = Some("明示 focus".to_string());
-        let mut projection = WorkspaceProjection::default_for_project(&repo);
-        projection.agents.push(agent);
-        save_workspace_projection(&repo, &projection).expect("projection");
 
-        let payload = serde_json::json!({
-            "session_id": "codex-provider-session",
-            "prompt": "エージェントウィンドウの更新がされません。"
-        });
+        let missing = missing_identity_for_agent(&agent);
 
-        let result = handle_user_prompt_submit(&payload.to_string()).expect("identity update");
-
-        assert!(!result.updated, "{result:?}");
-        let saved = load_workspace_projection(&repo)
-            .expect("load projection")
-            .expect("projection");
-        let agent = saved
-            .agents
-            .iter()
-            .find(|agent| agent.session_id == session.id)
-            .expect("agent");
-        assert_eq!(agent.title_summary.as_deref(), Some("明示タイトル"));
-        assert_eq!(agent.current_focus.as_deref(), Some("明示 focus"));
+        assert!(missing.complete(), "{missing:?}");
+        let identity = WorkspacePromptIdentity {
+            title_summary: "エージェントウィンドウ更新不具合".to_string(),
+            current_focus: "エージェントウィンドウの更新がされません".to_string(),
+        };
+        assert!(
+            workspace_projection_update_for_identity("session-1", missing, &identity).is_none()
+        );
     }
 
     #[test]
     fn user_prompt_submit_uses_transcript_path_when_prompt_field_is_absent() {
-        let _guard = ENV_LOCK.lock().expect("env lock");
         let temp = tempfile::tempdir().expect("tempdir");
-        let home = temp.path().join("home");
-        let repo = temp.path().join("repo");
-        std::fs::create_dir_all(&repo).expect("repo");
-        std::fs::create_dir_all(&home).expect("home");
-
         let transcript = temp.path().join("transcript.jsonl");
         std::fs::write(
             &transcript,
@@ -540,36 +525,35 @@ mod tests {
         )
         .expect("transcript");
 
-        let _home = ScopedEnvVar::set("HOME", &home);
-        let session = Session::new(&repo, "work/identity", AgentId::Codex);
-        session
-            .save(&gwt_core::paths::gwt_sessions_dir())
-            .expect("session");
-        let _session_env = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session.id);
-
-        let mut projection = WorkspaceProjection::default_for_project(&repo);
-        projection.agents.push(assigned_agent(&session.id, &repo));
-        save_workspace_projection(&repo, &projection).expect("projection");
-
         let payload = serde_json::json!({
             "session_id": "codex-provider-session",
             "transcript_path": transcript
         });
 
-        let result = handle_user_prompt_submit(&payload.to_string()).expect("identity update");
+        let prompt = prompt_from_hook_input(&payload.to_string()).expect("prompt");
+        let identity = derive_identity_from_prompt(&prompt).expect("identity");
 
-        assert!(result.updated, "{result:?}");
-        let saved = load_workspace_projection(&repo)
-            .expect("load projection")
-            .expect("projection");
-        let agent = saved
-            .agents
-            .iter()
-            .find(|agent| agent.session_id == session.id)
-            .expect("agent");
-        assert_eq!(
-            agent.title_summary.as_deref(),
-            Some("Workspace識別UX不具合")
-        );
+        assert_eq!(identity.title_summary, "Workspace識別UX不具合");
+    }
+
+    #[test]
+    fn transcript_path_ignores_non_user_text_records() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let transcript = temp.path().join("transcript.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"user","text":"エージェントウィンドウの更新がいまだにされません。"}"#,
+                "\n",
+                r#"{"type":"assistant","text":"実装方針を説明します。"}"#,
+                "\n"
+            ),
+        )
+        .expect("transcript");
+
+        let prompt = prompt_from_transcript_path(&transcript).expect("prompt");
+
+        assert!(prompt.contains("エージェントウィンドウの更新"), "{prompt}");
+        assert!(!prompt.contains("実装方針"), "{prompt}");
     }
 }

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -1038,7 +1038,7 @@ fn workspace_tokens(value: &str) -> std::collections::BTreeSet<String> {
 }
 
 #[cfg(unix)]
-fn publish_workspace_change(project_root: &std::path::Path) {
+pub(crate) fn publish_workspace_change(project_root: &std::path::Path) {
     let result = crate::daemon_publisher::publish_event(
         project_root,
         "workspace",
@@ -1054,7 +1054,7 @@ fn publish_workspace_change(project_root: &std::path::Path) {
 }
 
 #[cfg(not(unix))]
-fn publish_workspace_change(_project_root: &std::path::Path) {}
+pub(crate) fn publish_workspace_change(_project_root: &std::path::Path) {}
 
 fn parse_status_category(value: &str) -> Result<WorkspaceStatusCategory, String> {
     match value {


### PR DESCRIPTION
## Summary

- UserPromptSubmit now derives a provisional Workspace identity from the first prompt and persists missing agent `title_summary` / `current_focus` immediately.
- The workflow guard now blocks exploration as well as implementation when an assigned agent window lacks Workspace identity, while still allowing a proper repair command.

## Changes

- `crates/gwt/src/cli/hook/workspace_identity.rs`: Adds prompt parsing, transcript fallback, title/focus derivation, projection journal update, Workspace change publish, and focused tests.
- `crates/gwt/src/cli/hook/event_dispatcher.rs`: Runs the Workspace identity hook before the Board reminder and injects correction guidance into UserPromptSubmit context.
- `crates/gwt/src/cli/hook/workflow_policy.rs`: Requires both `title_summary` and `current_focus`, blocks read-only exploration before identity is set, and restricts repair commands to Workspace update/ensure with both fields.
- `crates/gwt/src/cli/workspace.rs`: Exposes the Workspace publish helper for hook-side projection updates.

## Testing

- [x] `cargo test -p gwt cli::hook::workspace_identity -- --nocapture` — passed.
- [x] `cargo test -p gwt cli::hook::workflow_policy::tests::title_summary_guard -- --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` and `git diff --cached --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2359 sections updated)
- [x] Migration/backfill plan not needed (no schema or stored data migration)
- [x] CHANGELOG impact considered (patch fix)

## Context

- This fixes the Workspace UX failure where agent windows often remained at the default identity even though the initial user prompt already described the work clearly.

## Risk / Impact

- **Affected areas**: UserPromptSubmit hooks, Workspace projection updates, and workflow-policy pre-tool guard behavior.
- **Rollback plan**: Revert this commit to restore the previous title guard and remove prompt-derived Workspace identity updates.
