### PR TITLE
fix(codex): trust managed hooks by opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,8 +1493,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -1146,6 +1146,18 @@ mod tests {
             .args
             .windows(2)
             .any(|pair| pair[0] == "--enable" && pair[1] == "codex_hooks"));
+        assert!(!config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--disable" && pair[1] == "hooks"));
+        assert!(
+            !config
+                .args
+                .iter()
+                .any(|arg| arg.contains("bypass_hook_trust")),
+            "Codex launch must not bypass hook review globally: {:?}",
+            config.args
+        );
     }
 
     #[test]

--- a/crates/gwt-config/src/agent_config.rs
+++ b/crates/gwt-config/src/agent_config.rs
@@ -14,6 +14,8 @@ pub struct AgentConfig {
     pub agent_paths: HashMap<String, PathBuf>,
     /// Auto-install agent dependencies before launch.
     pub auto_install_deps: bool,
+    /// Explicit opt-in for pre-registering trust of gwt-generated Codex hooks.
+    pub codex_trust_managed_hooks: Option<bool>,
 }
 
 #[cfg(test)]
@@ -26,6 +28,7 @@ mod tests {
         assert!(c.default_agent.is_none());
         assert!(c.agent_paths.is_empty());
         assert!(!c.auto_install_deps);
+        assert_eq!(c.codex_trust_managed_hooks, None);
     }
 
     #[test]
@@ -38,11 +41,25 @@ mod tests {
             default_agent: Some("claude".to_string()),
             agent_paths: paths,
             auto_install_deps: true,
+            codex_trust_managed_hooks: Some(true),
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let loaded: AgentConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(loaded.default_agent, c.default_agent);
         assert_eq!(loaded.agent_paths.len(), 2);
         assert!(loaded.auto_install_deps);
+        assert_eq!(loaded.codex_trust_managed_hooks, Some(true));
+    }
+
+    #[test]
+    fn codex_trust_managed_hooks_is_explicit_opt_in() {
+        let default_config = AgentConfig::default();
+        assert_eq!(default_config.codex_trust_managed_hooks, None);
+
+        let disabled: AgentConfig = toml::from_str("codex_trust_managed_hooks = false").unwrap();
+        assert_eq!(disabled.codex_trust_managed_hooks, Some(false));
+
+        let enabled: AgentConfig = toml::from_str("codex_trust_managed_hooks = true").unwrap();
+        assert_eq!(enabled.codex_trust_managed_hooks, Some(true));
     }
 }

--- a/crates/gwt-skills/Cargo.toml
+++ b/crates/gwt-skills/Cargo.toml
@@ -16,6 +16,8 @@ include_dir.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+sha2.workspace = true
+toml.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/gwt-skills/src/codex_hook_trust.rs
+++ b/crates/gwt-skills/src/codex_hook_trust.rs
@@ -1,0 +1,431 @@
+//! Codex hook trust-state registration for gwt-managed project hooks.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::settings_local::{gwt_hook_bin_path, posix_shell_quote, write_text_atomically};
+
+const CODEX_HOOKS_PATH: &str = ".codex/hooks.json";
+const CODEX_DEFAULT_COMMAND_TIMEOUT_SECONDS: u64 = 600;
+const MANAGED_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "session_start"),
+    ("UserPromptSubmit", "user_prompt_submit"),
+    ("PreToolUse", "pre_tool_use"),
+    ("PostToolUse", "post_tool_use"),
+    ("Stop", "stop"),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexHookTrustEntry {
+    pub key: String,
+    pub trusted_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexHookTrustReport {
+    pub config_path: PathBuf,
+    pub trusted_entries: Vec<CodexHookTrustEntry>,
+}
+
+pub fn collect_codex_managed_hook_trust_entries(
+    worktree: &Path,
+) -> io::Result<Vec<CodexHookTrustEntry>> {
+    let hooks_path = worktree.join(CODEX_HOOKS_PATH);
+    if !hooks_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let key_source = fs::canonicalize(&hooks_path)?;
+    let content = fs::read_to_string(&hooks_path)?;
+    let root: Value = serde_json::from_str(&content).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Codex hooks JSON parse failed: {err}"),
+        )
+    })?;
+
+    let Some(hooks_by_event) = root.get("hooks").and_then(Value::as_object) else {
+        return Ok(Vec::new());
+    };
+
+    let mut entries = Vec::new();
+    for (event_json_name, event_snake_name) in MANAGED_EVENTS {
+        let Some(groups) = hooks_by_event
+            .get(*event_json_name)
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        let Some(group) = groups.first().and_then(Value::as_object) else {
+            continue;
+        };
+        let matcher = group
+            .get("matcher")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if matcher != "*" {
+            continue;
+        }
+        let Some(hook) = group
+            .get("hooks")
+            .and_then(Value::as_array)
+            .and_then(|hooks| hooks.first())
+            .and_then(Value::as_object)
+        else {
+            continue;
+        };
+        let Some(command) = hook.get("command").and_then(Value::as_str) else {
+            continue;
+        };
+        if hook.get("type").and_then(Value::as_str) != Some("command")
+            || !is_generated_gwt_event_command(command, event_json_name)
+        {
+            continue;
+        }
+
+        entries.push(CodexHookTrustEntry {
+            key: hook_key(&key_source, event_snake_name, 0, 0),
+            trusted_hash: command_hook_trusted_hash(event_snake_name, matcher, command),
+        });
+    }
+
+    Ok(entries)
+}
+
+pub fn register_codex_managed_hook_trust(
+    worktree: &Path,
+    config_path: &Path,
+) -> io::Result<CodexHookTrustReport> {
+    let trusted_entries = collect_codex_managed_hook_trust_entries(worktree)?;
+    if trusted_entries.is_empty() {
+        return Ok(CodexHookTrustReport {
+            config_path: config_path.to_path_buf(),
+            trusted_entries,
+        });
+    }
+
+    let mut root = read_codex_config(config_path)?;
+    let root_table = root.as_table_mut().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Codex config root must be a TOML table",
+        )
+    })?;
+    let hooks_table = ensure_child_table(root_table, "hooks")?;
+    let state_table = ensure_child_table(hooks_table, "state")?;
+
+    for entry in &trusted_entries {
+        let hook_state = ensure_child_table(state_table, &entry.key)?;
+        hook_state.insert(
+            "trusted_hash".to_string(),
+            toml::Value::String(entry.trusted_hash.clone()),
+        );
+    }
+
+    let rendered = toml::to_string_pretty(&root)
+        .map_err(|err| io::Error::other(format!("Codex config TOML serialize failed: {err}")))?;
+    write_text_atomically(config_path, &rendered)?;
+
+    Ok(CodexHookTrustReport {
+        config_path: config_path.to_path_buf(),
+        trusted_entries,
+    })
+}
+
+#[cfg(test)]
+fn command_hook_trusted_hash_for_test(
+    event_name_snake: &str,
+    matcher: &str,
+    command: &str,
+) -> String {
+    command_hook_trusted_hash(event_name_snake, matcher, command)
+}
+
+fn read_codex_config(path: &Path) -> io::Result<toml::Value> {
+    if !path.exists() {
+        return Ok(toml::Value::Table(toml::Table::new()));
+    }
+
+    let content = fs::read_to_string(path)?;
+    if content.trim().is_empty() {
+        return Ok(toml::Value::Table(toml::Table::new()));
+    }
+
+    toml::from_str::<toml::Value>(&content).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Codex config TOML parse failed: {err}"),
+        )
+    })
+}
+
+fn ensure_child_table<'a>(
+    table: &'a mut toml::Table,
+    key: &str,
+) -> io::Result<&'a mut toml::Table> {
+    if !table.contains_key(key) {
+        table.insert(key.to_string(), toml::Value::Table(toml::Table::new()));
+    }
+
+    table
+        .get_mut(key)
+        .and_then(toml::Value::as_table_mut)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Codex config key `{key}` must be a TOML table"),
+            )
+        })
+}
+
+fn hook_key(
+    key_source: &Path,
+    event_name: &str,
+    group_index: usize,
+    handler_index: usize,
+) -> String {
+    format!(
+        "{}:{event_name}:{group_index}:{handler_index}",
+        key_source.display()
+    )
+}
+
+fn command_hook_trusted_hash(event_name_snake: &str, matcher: &str, command: &str) -> String {
+    let mut identity = json!({
+        "event_name": event_name_snake,
+        "hooks": [
+            {
+                "async": false,
+                "command": command,
+                "timeout": CODEX_DEFAULT_COMMAND_TIMEOUT_SECONDS,
+                "type": "command"
+            }
+        ],
+        "matcher": matcher
+    });
+    sort_json_objects(&mut identity);
+    let bytes = serde_json::to_vec(&identity).expect("serialize Codex hook trust identity");
+    let digest = Sha256::digest(bytes);
+    format!("sha256:{digest:x}")
+}
+
+fn sort_json_objects(value: &mut Value) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                sort_json_objects(item);
+            }
+        }
+        Value::Object(map) => {
+            let mut sorted = std::mem::take(map).into_iter().collect::<Vec<_>>();
+            sorted.sort_by(|(left, _), (right, _)| left.cmp(right));
+            for (key, mut child) in sorted {
+                sort_json_objects(&mut child);
+                map.insert(key, child);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn is_generated_gwt_event_command(command: &str, event_json_name: &str) -> bool {
+    command == expected_generated_gwt_event_command(event_json_name)
+}
+
+fn expected_generated_gwt_event_command(event_json_name: &str) -> String {
+    let bin = gwt_hook_bin_path();
+    if cfg!(windows) {
+        let quoted = powershell_quote(&bin);
+        format!(
+            "powershell -NoProfile -Command \"& {{ & {quoted} hook event {event_json_name} }}\""
+        )
+    } else {
+        let quoted = posix_shell_quote(&bin);
+        format!("{quoted} hook event {event_json_name}")
+    }
+}
+
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::generate_codex_hooks;
+
+    #[test]
+    fn command_hook_hash_matches_codex_for_known_post_tool_use_fixture() {
+        let command = "'/Applications/GWT.app/Contents/MacOS/gwtd' hook event PostToolUse";
+
+        let trusted_hash = command_hook_trusted_hash_for_test("post_tool_use", "*", command);
+
+        assert_eq!(
+            trusted_hash,
+            "sha256:9c3ce103f03f0b27a28bc4a30883f7e98a80b5df566b4572fcbb2955ebf5ba62"
+        );
+    }
+
+    #[test]
+    fn generated_codex_hooks_produce_five_trust_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_codex_hooks(dir.path()).unwrap();
+        let hooks_path = fs::canonicalize(dir.path().join(".codex/hooks.json")).unwrap();
+
+        let entries = collect_codex_managed_hook_trust_entries(dir.path()).unwrap();
+
+        assert_eq!(
+            entries.len(),
+            5,
+            "expected one trust entry per managed event"
+        );
+        for event_name in [
+            "session_start",
+            "user_prompt_submit",
+            "pre_tool_use",
+            "post_tool_use",
+            "stop",
+        ] {
+            let expected_key = format!("{}:{event_name}:0:0", hooks_path.display());
+            let entry = entries
+                .iter()
+                .find(|entry| entry.key == expected_key)
+                .unwrap_or_else(|| panic!("missing trust key {expected_key}; got {entries:?}"));
+            assert!(
+                entry.trusted_hash.starts_with("sha256:"),
+                "trusted hash must use Codex sha256 prefix"
+            );
+        }
+    }
+
+    #[test]
+    fn registration_preserves_unrelated_config_and_skips_user_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_codex_hooks(dir.path()).unwrap();
+        let hooks_path = dir.path().join(".codex/hooks.json");
+        let hooks_content = fs::read_to_string(&hooks_path).unwrap();
+        let mut hooks_json: Value = serde_json::from_str(&hooks_content).unwrap();
+        hooks_json["hooks"]["PreToolUse"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "command": "echo user-hook",
+                        "type": "command"
+                    }
+                ]
+            }));
+        fs::write(
+            &hooks_path,
+            serde_json::to_string_pretty(&hooks_json).unwrap(),
+        )
+        .unwrap();
+
+        let config_path = dir.path().join("codex-config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[profiles.default]
+model = "gpt-5.2"
+
+[hooks.state."custom:pre_tool_use:0:0"]
+enabled = false
+"#,
+        )
+        .unwrap();
+
+        let report = register_codex_managed_hook_trust(dir.path(), &config_path).unwrap();
+
+        assert_eq!(report.trusted_entries.len(), 5);
+        let config = fs::read_to_string(&config_path).unwrap();
+        let parsed: toml::Value = toml::from_str(&config).unwrap();
+        assert_eq!(
+            parsed["profiles"]["default"]["model"].as_str(),
+            Some("gpt-5.2")
+        );
+        assert_eq!(
+            parsed["hooks"]["state"]["custom:pre_tool_use:0:0"]["enabled"].as_bool(),
+            Some(false)
+        );
+        assert!(
+            parsed["hooks"]["state"]["custom:pre_tool_use:0:0"]
+                .get("trusted_hash")
+                .is_none(),
+            "unrelated hook state must not receive a trusted hash"
+        );
+        let hooks_path = fs::canonicalize(&hooks_path).unwrap();
+        assert!(
+            parsed["hooks"]["state"]
+                .get(format!("{}:pre_tool_use:1:0", hooks_path.display()))
+                .is_none(),
+            "user hook entry must not be trusted"
+        );
+    }
+
+    #[test]
+    fn modified_gwt_command_is_not_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_codex_hooks(dir.path()).unwrap();
+        let hooks_path = dir.path().join(".codex/hooks.json");
+        let hooks_content = fs::read_to_string(&hooks_path).unwrap();
+        let mut hooks_json: Value = serde_json::from_str(&hooks_content).unwrap();
+        hooks_json["hooks"]["Stop"][0]["hooks"][0]["command"] =
+            Value::String("'gwtd' hook event Stop --unexpected".to_string());
+        fs::write(
+            &hooks_path,
+            serde_json::to_string_pretty(&hooks_json).unwrap(),
+        )
+        .unwrap();
+
+        let entries = collect_codex_managed_hook_trust_entries(dir.path()).unwrap();
+
+        assert_eq!(
+            entries.len(),
+            4,
+            "modified gwt command must be left for Codex /hooks review"
+        );
+        assert!(
+            entries.iter().all(|entry| !entry.key.contains(":stop:")),
+            "modified Stop hook must not be trusted; got {entries:?}"
+        );
+    }
+
+    #[test]
+    fn gwt_command_with_modified_binary_path_is_not_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_codex_hooks(dir.path()).unwrap();
+        let hooks_path = dir.path().join(".codex/hooks.json");
+        let hooks_content = fs::read_to_string(&hooks_path).unwrap();
+        let mut hooks_json: Value = serde_json::from_str(&hooks_content).unwrap();
+        hooks_json["hooks"]["Stop"][0]["hooks"][0]["command"] =
+            Value::String("'/tmp/gwtd' hook event Stop".to_string());
+        fs::write(
+            &hooks_path,
+            serde_json::to_string_pretty(&hooks_json).unwrap(),
+        )
+        .unwrap();
+
+        let entries = collect_codex_managed_hook_trust_entries(dir.path()).unwrap();
+
+        assert_eq!(
+            entries.len(),
+            4,
+            "path-modified gwt command must be left for Codex /hooks review"
+        );
+        assert!(
+            entries.iter().all(|entry| !entry.key.contains(":stop:")),
+            "path-modified Stop hook must not be trusted; got {entries:?}"
+        );
+    }
+}

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -1,6 +1,7 @@
 //! gwt-skills: Embedded skill bundling, distribution, and hooks management for gwt.
 
 pub mod assets;
+pub mod codex_hook_trust;
 pub mod coordination_guidance;
 pub mod distribute;
 pub mod git_exclude;
@@ -10,6 +11,10 @@ pub mod registry;
 pub mod settings_local;
 pub mod validate;
 
+pub use codex_hook_trust::{
+    collect_codex_managed_hook_trust_entries, register_codex_managed_hook_trust,
+    CodexHookTrustEntry, CodexHookTrustReport,
+};
 pub use coordination_guidance::{
     generate_coordination_guidance, generate_coordination_guidance_for_claude,
     generate_coordination_guidance_for_codex,

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -698,9 +698,13 @@ mod tests {
         let value: Value = serde_json::from_str(&content).unwrap();
         let stop_commands = commands_for_event(&value, "Stop");
         assert_eq!(
-            stop_commands,
-            vec!["'gwtd' hook event Stop"],
-            "Stop chain must collapse to the event dispatcher; got: {stop_commands:?}"
+            stop_commands.len(),
+            1,
+            "Stop chain must collapse to one event dispatcher; got: {stop_commands:?}"
+        );
+        assert!(
+            stop_commands[0].ends_with(" hook event Stop") && stop_commands[0].contains("gwtd"),
+            "Stop dispatcher must target gwtd via absolute or literal path; got: {stop_commands:?}"
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2234,9 +2234,10 @@ impl AppRuntime {
             FrontendEvent::SkipMigration { tab_id } => self.skip_migration_events(&tab_id),
             FrontendEvent::QuitMigration { tab_id } => self.quit_migration_events(&tab_id),
             FrontendEvent::GetSystemSettings => self.system_settings_get_events(client_id),
-            FrontendEvent::UpdateSystemSettings { language } => {
-                self.system_settings_update_events(client_id, language)
-            }
+            FrontendEvent::UpdateSystemSettings {
+                language,
+                codex_trust_managed_hooks,
+            } => self.system_settings_update_events(client_id, language, codex_trust_managed_hooks),
             FrontendEvent::WorkspaceProjectionPrune { dry_run, ids } => {
                 self.workspace_projection_prune_events(client_id, dry_run, ids)
             }
@@ -2329,6 +2330,7 @@ impl AppRuntime {
         &self,
         client_id: ClientId,
         language: String,
+        codex_trust_managed_hooks: Option<bool>,
     ) -> Vec<OutboundEvent> {
         let path = match gwt_config::Settings::global_config_path() {
             Some(p) => p,
@@ -2344,7 +2346,7 @@ impl AppRuntime {
         };
         vec![OutboundEvent::reply(
             client_id,
-            gwt::system_settings::update_event(&path, language),
+            gwt::system_settings::update_event(&path, language, codex_trust_managed_hooks),
         )]
     }
 
@@ -5035,6 +5037,22 @@ impl AppRuntime {
             .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
             refresh_managed_gwt_assets_for_agent(&worktree_path, &config.agent_id)
                 .map_err(|error| error.to_string())?;
+            if let Some(report) = maybe_register_codex_managed_hook_trust_for_launch(
+                &profile_config_path,
+                &worktree_path,
+                &config.agent_id,
+                config.runtime_target,
+            )? {
+                if !report.trusted_entries.is_empty() {
+                    proxy.send(UserEvent::LaunchProgress {
+                        window_id: window_id.clone(),
+                        message: format!(
+                            "Trusted {} gwt-managed Codex hooks.",
+                            report.trusted_entries.len()
+                        ),
+                    });
+                }
+            }
 
             if config.runtime_target == gwt_agent::LaunchRuntimeTarget::Host
                 && apply_host_package_runner_fallback(&mut config)
@@ -6172,6 +6190,48 @@ fn publish_runtime_hook_change(project_root: &Path, event: &gwt::RuntimeHookEven
 
 #[cfg(not(unix))]
 fn publish_runtime_hook_change(_project_root: &Path, _event: &gwt::RuntimeHookEvent) {}
+
+fn maybe_register_codex_managed_hook_trust_for_launch(
+    profile_config_path: &Path,
+    worktree_path: &Path,
+    agent_id: &gwt_agent::AgentId,
+    runtime_target: gwt_agent::LaunchRuntimeTarget,
+) -> Result<Option<gwt_skills::CodexHookTrustReport>, String> {
+    if agent_id != &gwt_agent::AgentId::Codex
+        || runtime_target != gwt_agent::LaunchRuntimeTarget::Host
+    {
+        return Ok(None);
+    }
+
+    let settings = if profile_config_path.exists() {
+        gwt_config::Settings::load_from_path(profile_config_path)
+            .map_err(|error| error.to_string())?
+    } else {
+        gwt_config::Settings::default()
+    };
+    if settings.agent.codex_trust_managed_hooks != Some(true) {
+        return Ok(None);
+    }
+
+    let codex_config_path =
+        codex_config_path_for_profile_config(profile_config_path).ok_or_else(|| {
+            format!(
+                "cannot derive Codex config path from gwt config path {}",
+                profile_config_path.display()
+            )
+        })?;
+    gwt_skills::register_codex_managed_hook_trust(worktree_path, &codex_config_path)
+        .map(Some)
+        .map_err(|error| error.to_string())
+}
+
+fn codex_config_path_for_profile_config(profile_config_path: &Path) -> Option<PathBuf> {
+    let gwt_config_dir = profile_config_path.parent()?;
+    if gwt_config_dir.file_name().and_then(|name| name.to_str()) != Some(".gwt") {
+        return None;
+    }
+    Some(gwt_config_dir.parent()?.join(".codex").join("config.toml"))
+}
 
 #[cfg(test)]
 mod tests {
@@ -13555,5 +13615,89 @@ exit 0
         let missing = logs_root.path().join("does-not-exist.log");
         let resolved = super::validate_update_log_path(missing.to_str().unwrap(), logs_root.path());
         assert!(resolved.is_none(), "missing files must be rejected");
+    }
+
+    #[test]
+    fn codex_hook_trust_launch_enabled_registers_host_codex_hooks() {
+        let home = tempdir().expect("home tempdir");
+        let profile_config_path = home.path().join(".gwt/config.toml");
+        let mut settings = Settings::default();
+        settings.agent.codex_trust_managed_hooks = Some(true);
+        settings.save(&profile_config_path).unwrap();
+
+        let worktree = tempdir().expect("worktree tempdir");
+        gwt_skills::generate_codex_hooks(worktree.path()).unwrap();
+
+        let report = super::maybe_register_codex_managed_hook_trust_for_launch(
+            &profile_config_path,
+            worktree.path(),
+            &gwt_agent::AgentId::Codex,
+            gwt_agent::LaunchRuntimeTarget::Host,
+        )
+        .unwrap()
+        .expect("enabled host Codex launch should register trust");
+
+        assert_eq!(report.trusted_entries.len(), 5);
+        let codex_config_path = home.path().join(".codex/config.toml");
+        let config = fs::read_to_string(&codex_config_path).unwrap();
+        assert!(
+            config.contains("trusted_hash"),
+            "Codex config should contain trusted hashes, got: {config}"
+        );
+        assert_eq!(report.config_path, codex_config_path);
+    }
+
+    #[test]
+    fn codex_hook_trust_launch_skips_without_explicit_host_codex_opt_in() {
+        let home = tempdir().expect("home tempdir");
+        let profile_config_path = home.path().join(".gwt/config.toml");
+        let worktree = tempdir().expect("worktree tempdir");
+        gwt_skills::generate_codex_hooks(worktree.path()).unwrap();
+
+        let unset = super::maybe_register_codex_managed_hook_trust_for_launch(
+            &profile_config_path,
+            worktree.path(),
+            &gwt_agent::AgentId::Codex,
+            gwt_agent::LaunchRuntimeTarget::Host,
+        )
+        .unwrap();
+        assert!(unset.is_none());
+
+        let mut settings = Settings::default();
+        settings.agent.codex_trust_managed_hooks = Some(false);
+        settings.save(&profile_config_path).unwrap();
+        let disabled = super::maybe_register_codex_managed_hook_trust_for_launch(
+            &profile_config_path,
+            worktree.path(),
+            &gwt_agent::AgentId::Codex,
+            gwt_agent::LaunchRuntimeTarget::Host,
+        )
+        .unwrap();
+        assert!(disabled.is_none());
+
+        settings.agent.codex_trust_managed_hooks = Some(true);
+        settings.save(&profile_config_path).unwrap();
+        let docker = super::maybe_register_codex_managed_hook_trust_for_launch(
+            &profile_config_path,
+            worktree.path(),
+            &gwt_agent::AgentId::Codex,
+            gwt_agent::LaunchRuntimeTarget::Docker,
+        )
+        .unwrap();
+        assert!(docker.is_none());
+
+        let claude = super::maybe_register_codex_managed_hook_trust_for_launch(
+            &profile_config_path,
+            worktree.path(),
+            &gwt_agent::AgentId::ClaudeCode,
+            gwt_agent::LaunchRuntimeTarget::Host,
+        )
+        .unwrap();
+        assert!(claude.is_none());
+
+        assert!(
+            !home.path().join(".codex/config.toml").exists(),
+            "skip paths must not create Codex config"
+        );
     }
 }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -363,6 +363,8 @@ pub enum FrontendEvent {
     /// [`BackendEvent::SystemSettingsError`] on failure.
     UpdateSystemSettings {
         language: String,
+        #[serde(default)]
+        codex_trust_managed_hooks: Option<bool>,
     },
     /// SPEC-2359 US-41: classify Workspace projections under `~/.gwt/projects/`
     /// and either preview (`dry_run = true`) or apply (`dry_run = false`) the
@@ -857,6 +859,8 @@ pub enum BackendEvent {
     /// Settings > System > Language select.
     SystemSettings {
         language: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        codex_trust_managed_hooks: Option<bool>,
     },
     /// SPEC-1933 US-4: confirmation that
     /// [`FrontendEvent::UpdateSystemSettings`] persisted successfully.
@@ -864,6 +868,8 @@ pub enum BackendEvent {
     /// optimistic UI with the authoritative config state.
     SystemSettingsUpdated {
         language: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        codex_trust_managed_hooks: Option<bool>,
     },
     /// SPEC-1933 US-4: error reply for [`FrontendEvent::GetSystemSettings`]
     /// or [`FrontendEvent::UpdateSystemSettings`]. `message` is

--- a/crates/gwt/src/system_settings.rs
+++ b/crates/gwt/src/system_settings.rs
@@ -34,6 +34,12 @@ pub enum SystemSettingsError {
 /// constant so the dispatch validator and (future) tests share it.
 pub const ALLOWED_LANGUAGES: &[&str] = &["auto", "en", "ja"];
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemSettingsSnapshot {
+    pub language: String,
+    pub codex_trust_managed_hooks: Option<bool>,
+}
+
 /// Validate that `value` is one of [`ALLOWED_LANGUAGES`] (case-insensitive,
 /// trimmed). Returns the canonical lowercase value on success.
 pub fn validate_language(value: &str) -> Result<String, SystemSettingsError> {
@@ -48,23 +54,38 @@ pub fn validate_language(value: &str) -> Result<String, SystemSettingsError> {
 /// Read the current global language from `path`. Returns `auto` when the
 /// config file does not exist (matching [`Settings::default`]).
 pub fn read_language(path: &Path) -> Result<String, SystemSettingsError> {
+    Ok(read_settings(path)?.language)
+}
+
+pub fn read_settings(path: &Path) -> Result<SystemSettingsSnapshot, SystemSettingsError> {
     let settings = if path.exists() {
         Settings::load_from_path(path)
             .map_err(|err| SystemSettingsError::Storage(err.to_string()))?
     } else {
         Settings::default()
     };
-    Ok(settings
-        .ai
-        .language
-        .clone()
-        .unwrap_or_else(|| "auto".to_string()))
+    Ok(SystemSettingsSnapshot {
+        language: settings
+            .ai
+            .language
+            .clone()
+            .unwrap_or_else(|| "auto".to_string()),
+        codex_trust_managed_hooks: settings.agent.codex_trust_managed_hooks,
+    })
 }
 
 /// Persist `language` into `path` under `[ai].language`. Returns the
 /// canonical value that was written so the dispatch layer can echo it
 /// back to the frontend.
 pub fn write_language(path: &Path, language: &str) -> Result<String, SystemSettingsError> {
+    Ok(write_settings(path, language, None)?.language)
+}
+
+pub fn write_settings(
+    path: &Path,
+    language: &str,
+    codex_trust_managed_hooks: Option<bool>,
+) -> Result<SystemSettingsSnapshot, SystemSettingsError> {
     let canonical = validate_language(language)?;
     let mut settings = if path.exists() {
         Settings::load_from_path(path)
@@ -73,16 +94,25 @@ pub fn write_language(path: &Path, language: &str) -> Result<String, SystemSetti
         Settings::default()
     };
     settings.ai.language = Some(canonical.clone());
+    if let Some(value) = codex_trust_managed_hooks {
+        settings.agent.codex_trust_managed_hooks = Some(value);
+    }
     settings
         .save(path)
         .map_err(|err| SystemSettingsError::Storage(err.to_string()))?;
-    Ok(canonical)
+    Ok(SystemSettingsSnapshot {
+        language: canonical,
+        codex_trust_managed_hooks: settings.agent.codex_trust_managed_hooks,
+    })
 }
 
 /// Build the `BackendEvent` reply for `FrontendEvent::GetSystemSettings`.
 pub fn get_event(path: &Path) -> BackendEvent {
-    match read_language(path) {
-        Ok(language) => BackendEvent::SystemSettings { language },
+    match read_settings(path) {
+        Ok(snapshot) => BackendEvent::SystemSettings {
+            language: snapshot.language,
+            codex_trust_managed_hooks: snapshot.codex_trust_managed_hooks,
+        },
         Err(err) => BackendEvent::SystemSettingsError {
             message: err.to_string(),
         },
@@ -90,10 +120,15 @@ pub fn get_event(path: &Path) -> BackendEvent {
 }
 
 /// Build the `BackendEvent` reply for `FrontendEvent::UpdateSystemSettings`.
-pub fn update_event(path: &Path, language: String) -> BackendEvent {
-    match write_language(path, &language) {
-        Ok(canonical) => BackendEvent::SystemSettingsUpdated {
-            language: canonical,
+pub fn update_event(
+    path: &Path,
+    language: String,
+    codex_trust_managed_hooks: Option<bool>,
+) -> BackendEvent {
+    match write_settings(path, &language, codex_trust_managed_hooks) {
+        Ok(snapshot) => BackendEvent::SystemSettingsUpdated {
+            language: snapshot.language,
+            codex_trust_managed_hooks: snapshot.codex_trust_managed_hooks,
         },
         Err(err) => BackendEvent::SystemSettingsError {
             message: err.to_string(),
@@ -168,12 +203,38 @@ mod tests {
     }
 
     #[test]
+    fn read_and_write_codex_hook_trust_opt_in() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+
+        let mut original = Settings::default();
+        original.agent.codex_trust_managed_hooks = Some(true);
+        original.save(&path).unwrap();
+
+        let snapshot = read_settings(&path).unwrap();
+        assert_eq!(snapshot.codex_trust_managed_hooks, Some(true));
+
+        let snapshot = write_settings(&path, "en", Some(false)).unwrap();
+        assert_eq!(snapshot.language, "en");
+        assert_eq!(snapshot.codex_trust_managed_hooks, Some(false));
+
+        let reloaded = Settings::load_from_path(&path).unwrap();
+        assert_eq!(reloaded.agent.codex_trust_managed_hooks, Some(false));
+    }
+
+    #[test]
     fn update_event_returns_updated_on_success() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("config.toml");
-        let event = update_event(&path, "ja".to_string());
+        let event = update_event(&path, "ja".to_string(), Some(true));
         match event {
-            BackendEvent::SystemSettingsUpdated { language } => assert_eq!(language, "ja"),
+            BackendEvent::SystemSettingsUpdated {
+                language,
+                codex_trust_managed_hooks,
+            } => {
+                assert_eq!(language, "ja");
+                assert_eq!(codex_trust_managed_hooks, Some(true));
+            }
             other => panic!("expected SystemSettingsUpdated, got {other:?}"),
         }
     }
@@ -182,7 +243,7 @@ mod tests {
     fn update_event_returns_error_for_invalid_language() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("config.toml");
-        let event = update_event(&path, "zh".to_string());
+        let event = update_event(&path, "zh".to_string(), None);
         match event {
             BackendEvent::SystemSettingsError { message } => {
                 assert!(message.contains("invalid language"));
@@ -198,7 +259,13 @@ mod tests {
         write_language(&path, "ja").unwrap();
         let event = get_event(&path);
         match event {
-            BackendEvent::SystemSettings { language } => assert_eq!(language, "ja"),
+            BackendEvent::SystemSettings {
+                language,
+                codex_trust_managed_hooks,
+            } => {
+                assert_eq!(language, "ja");
+                assert_eq!(codex_trust_managed_hooks, None);
+            }
             other => panic!("expected SystemSettings, got {other:?}"),
         }
     }

--- a/crates/gwt/web/__tests__/settings-system-tab.test.mjs
+++ b/crates/gwt/web/__tests__/settings-system-tab.test.mjs
@@ -29,6 +29,8 @@ test("components.css declares the settings tab and panel surfaces under :root[da
     ".settings-panel",
     ".settings-section",
     ".settings-select",
+    ".settings-checkbox-label",
+    ".settings-checkbox",
     ".settings-help",
     ".settings-status",
   ]) {
@@ -122,6 +124,19 @@ test("renderSystemPanel sends update_system_settings on select change", () => {
     appSource,
     /send\(\{\s*kind:\s*"update_system_settings",\s*language:\s*next\s*\}\)/,
     "expected select onChange to send update_system_settings",
+  );
+});
+
+test("renderSystemPanel exposes Codex managed hook trust opt-in", () => {
+  assert.match(
+    appSource,
+    /trustText\.textContent\s*=\s*"Trust gwt-managed Codex hooks"/,
+    "expected System tab Codex hook trust checkbox label",
+  );
+  assert.match(
+    appSource,
+    /send\(\{\s*kind:\s*"update_system_settings",\s*language:\s*systemSettingsState\.language\s*\|\|\s*"auto",\s*codex_trust_managed_hooks:\s*next,\s*\}\)/,
+    "expected checkbox onChange to send codex_trust_managed_hooks",
   );
 });
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -359,6 +359,8 @@
           }
           if (deferred.kind === "system_settings") {
             systemSettingsState.language = deferred.language || "auto";
+            systemSettingsState.codexTrustManagedHooks =
+              deferred.codex_trust_managed_hooks === true;
             systemSettingsState.loaded = true;
             if (
               !systemSettingsState.statusMessage
@@ -370,7 +372,9 @@
           } else if (deferred.kind === "system_settings_updated") {
             systemSettingsState.language = deferred.language
               || systemSettingsState.language;
-            systemSettingsState.statusMessage = `Saved language: ${deferred.language}.`;
+            systemSettingsState.codexTrustManagedHooks =
+              deferred.codex_trust_managed_hooks === true;
+            systemSettingsState.statusMessage = "Saved system settings.";
             systemSettingsState.statusKind = "success";
           } else if (deferred.kind === "system_settings_error") {
             systemSettingsState.statusMessage = deferred.message
@@ -7598,6 +7602,7 @@
       // (auto/en/ja); the backend `system_settings` reply seeds it.
       const systemSettingsState = {
         language: "auto",
+        codexTrustManagedHooks: false,
         loaded: false,
         statusMessage: "",
         statusKind: "",
@@ -7826,12 +7831,48 @@
           "Settings UI text and gwtd subcommands stay English.";
         section.appendChild(help);
 
+        const trustSection = createDiv("settings-section");
+        const trustLabel = document.createElement("label");
+        trustLabel.className = "settings-checkbox-label";
+        trustLabel.setAttribute("for", "settings-system-codex-hooks");
+
+        const trustCheckbox = document.createElement("input");
+        trustCheckbox.type = "checkbox";
+        trustCheckbox.className = "settings-checkbox";
+        trustCheckbox.id = "settings-system-codex-hooks";
+        trustCheckbox.checked = systemSettingsState.codexTrustManagedHooks === true;
+        trustCheckbox.addEventListener("change", (e) => {
+          const next = e.target.checked === true;
+          systemSettingsState.codexTrustManagedHooks = next;
+          systemSettingsState.statusMessage = "Saving…";
+          systemSettingsState.statusKind = "info";
+          renderSystemPanelStatus(panel);
+          send({
+            kind: "update_system_settings",
+            language: systemSettingsState.language || "auto",
+            codex_trust_managed_hooks: next,
+          });
+        });
+
+        const trustText = document.createElement("span");
+        trustText.textContent = "Trust gwt-managed Codex hooks";
+        trustLabel.appendChild(trustCheckbox);
+        trustLabel.appendChild(trustText);
+        trustSection.appendChild(trustLabel);
+
+        const trustHelp = document.createElement("p");
+        trustHelp.className = "settings-help";
+        trustHelp.textContent =
+          "Registers only generated gwt hook commands in Codex hook trust state.";
+        trustSection.appendChild(trustHelp);
+
         const status = document.createElement("p");
         status.className = "settings-status";
         status.dataset.role = "system-settings-status";
         section.appendChild(status);
 
         panel.appendChild(section);
+        panel.appendChild(trustSection);
         renderSystemPanelStatus(panel);
       }
 
@@ -9142,6 +9183,8 @@
               break;
             }
             systemSettingsState.language = event.language || "auto";
+            systemSettingsState.codexTrustManagedHooks =
+              event.codex_trust_managed_hooks === true;
             systemSettingsState.loaded = true;
             // Don't clobber an in-flight "Saving…" status; only seed when no
             // pending feedback is shown.
@@ -9162,7 +9205,9 @@
               break;
             }
             systemSettingsState.language = event.language || systemSettingsState.language;
-            systemSettingsState.statusMessage = `Saved language: ${event.language}.`;
+            systemSettingsState.codexTrustManagedHooks =
+              event.codex_trust_managed_hooks === true;
+            systemSettingsState.statusMessage = "Saved system settings.";
             systemSettingsState.statusKind = "success";
             renderSystemPanelInAllSettingsWindows();
             break;

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2996,6 +2996,28 @@ kbd.op-kbd {
   border-color: var(--color-state-active);
 }
 
+:root[data-theme] .settings-checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+:root[data-theme] .settings-checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-state-active);
+}
+
+:root[data-theme] .settings-checkbox:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 :root[data-theme] .settings-help {
   margin: 0;
   font-family: var(--font-body);


### PR DESCRIPTION
## Summary

- Adds an explicit opt-in that lets Host Codex launches trust only gwt-generated project hooks, removing the startup review warning without disabling hooks.
- Keeps broad bypasses out of the launch path, so user hooks and edited gwt hook commands still require Codex review.

## Changes

- `crates/gwt-skills`: adds Codex-compatible hook trust key/hash generation and TOML merge support for `~/.codex/config.toml`.
- `crates/gwt-config`, `crates/gwt/src/system_settings.rs`, `crates/gwt/src/protocol.rs`: adds `agent.codex_trust_managed_hooks` and wires it through System Settings.
- `crates/gwt/src/app_runtime/mod.rs`: registers trust state after managed Codex hooks are refreshed, only for explicit Host Codex opt-in.
- `crates/gwt-agent/src/launch.rs`: covers the guard that Codex launch args do not use `--disable hooks` or `bypass_hook_trust`.
- `crates/gwt/web`: adds the System Settings checkbox and frontend unit coverage.

## Testing

- [x] `cargo test -p gwt-skills codex_hook_trust -- --nocapture` — passed.
- [x] `cargo test -p gwt-config codex_trust_managed_hooks -- --nocapture` — passed.
- [x] `cargo test -p gwt codex_hook_trust_launch -- --nocapture` — passed.
- [x] `cargo test -p gwt-agent build_codex_does_not_enable_hooks_feature_flag_by_default -- --nocapture` — passed.
- [x] `cargo test -p gwt system_settings -- --nocapture` — passed.
- [x] `cargo test -p gwt-core -p gwt -p gwt-skills -p gwt-config -p gwt-agent --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-unit` — passed after installing frontend dependencies with `pnpm install --frozen-lockfile`.
- [x] `npm run lint:skills` — passed.
- [x] Pre-push CI-equivalent checks — passed, including 91.03% filtered line coverage against the 90.00% threshold.

## Closing Issues

- None

## Related Issues / Links

- #1935

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend unit/bundle tests)
- [x] Documentation updated (SPEC #1935 Phase 15 spec/plan/tasks)
- [x] Migration/backfill plan included (no schema or data migration; trust-state registration is explicit opt-in and launch-time only)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- Codex currently warns that five generated project hooks need review on startup. Passing `--disable hooks` would suppress the warning by disabling gwt hooks, and `bypass_hook_trust` would broadly bypass hook review. This PR instead records the exact generated gwt hook identities in Codex's trust state only after a user enables the new opt-in.

## Risk / Impact

- **Affected areas**: Codex launch preparation, generated hook trust-state registration, System Settings.
- **Rollback plan**: Revert this PR. Existing users are unaffected unless `agent.codex_trust_managed_hooks = true` is set.

## Screenshots

| Before | After |
|--------|-------|
| Existing System Settings without the opt-in checkbox. | System Settings includes `Trust gwt-managed Codex hooks`; covered by frontend unit tests. |

## Deployment

- Standard deploy. Users enable the option from System Settings or by setting `agent.codex_trust_managed_hooks = true` in `~/.gwt/config.toml`.
