### PR TITLE
feat(launch-wizard): split runtime resolution

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -408,6 +408,10 @@ impl LaunchWizardMemoryCache {
         )
     }
 
+    fn agent_preferences(&self) -> gwt::LaunchWizardPreviousProfiles {
+        gwt::launch_wizard::previous_launch_profiles_from_sessions(&self.sessions)
+    }
+
     fn previous_profiles(&self, repo_path: &Path) -> gwt::LaunchWizardPreviousProfiles {
         gwt::launch_wizard::previous_launch_profiles_for_repo_from_sessions(
             repo_path,
@@ -7875,7 +7879,7 @@ exit 0
     }
 
     #[test]
-    fn app_runtime_open_launch_wizard_uses_branch_worktree_for_docker_context() {
+    fn app_runtime_open_launch_wizard_does_not_probe_branch_worktree_for_docker_context() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo");
@@ -7919,19 +7923,127 @@ exit 0
             .expect("open launch wizard");
 
         let wizard = &runtime.launch_wizard.as_ref().expect("wizard").wizard;
+        assert!(wizard.context.worktree_path.is_none());
+        assert!(same_worktree_path(&wizard.context.quick_start_root, &repo));
+        let view = wizard.view();
+        assert!(!view.runtime_context_resolved);
+        assert!(!view.show_runtime_target);
+        assert!(view.selected_docker_service.is_none());
+    }
+
+    #[test]
+    fn app_runtime_launch_wizard_continue_resolves_runtime_context_from_worktree() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        run_git(&repo, &["init", "-q", "-b", "develop"]);
+        run_git(&repo, &["config", "user.name", "Codex"]);
+        run_git(&repo, &["config", "user.email", "codex@example.com"]);
+        fs::write(repo.join("README.md"), "repo\n").expect("readme");
+        fs::write(
+            repo.join("docker-compose.yml"),
+            "services:\n  app:\n    image: alpine:3.20\n",
+        )
+        .expect("compose");
+        run_git(&repo, &["add", "README.md", "docker-compose.yml"]);
+        run_git(&repo, &["commit", "-qm", "init"]);
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_launch_wizard_for_branch("tab-1", &repo, "develop", None, None)
+            .expect("open launch wizard");
+        assert!(
+            !runtime
+                .launch_wizard
+                .as_ref()
+                .expect("wizard")
+                .wizard
+                .view()
+                .runtime_context_resolved
+        );
+
+        let events = runtime.handle_launch_wizard_action(LaunchWizardAction::Submit, None);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0].event,
+            BackendEvent::LaunchWizardState { wizard: Some(_) }
+        ));
+        let wizard = &runtime.launch_wizard.as_ref().expect("wizard").wizard;
         assert!(wizard
             .context
             .worktree_path
             .as_ref()
-            .is_some_and(|path| same_worktree_path(path, &branch_worktree)));
-        assert!(same_worktree_path(
-            &wizard.context.quick_start_root,
-            &branch_worktree
-        ));
+            .is_some_and(|path| same_worktree_path(path, &repo)));
         let view = wizard.view();
+        assert!(view.runtime_context_resolved);
         assert!(view.show_runtime_target);
         assert_eq!(view.selected_runtime_target, "docker");
         assert_eq!(view.selected_docker_service.as_deref(), Some("app"));
+    }
+
+    #[test]
+    fn app_runtime_launch_wizard_continue_falls_back_to_host_without_resolved_docker_context() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        run_git(&repo, &["init", "-q", "-b", "develop"]);
+        run_git(&repo, &["config", "user.name", "Codex"]);
+        run_git(&repo, &["config", "user.email", "codex@example.com"]);
+        fs::write(repo.join("README.md"), "repo\n").expect("readme");
+        run_git(&repo, &["add", "README.md"]);
+        run_git(&repo, &["commit", "-qm", "init"]);
+
+        let sessions_dir = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+        let mut session = gwt_agent::Session::new(&repo, "develop", gwt_agent::AgentId::Codex);
+        session.runtime_target = gwt_agent::LaunchRuntimeTarget::Docker;
+        session.docker_service = Some("app".to_string());
+        session.docker_lifecycle_intent = gwt_agent::DockerLifecycleIntent::Restart;
+        session.save(&sessions_dir).expect("save session");
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_launch_wizard_for_branch("tab-1", &repo, "develop", None, None)
+            .expect("open launch wizard");
+        let phase_one = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .view();
+        assert!(!phase_one.runtime_context_resolved);
+        assert_eq!(phase_one.selected_runtime_target, "host");
+        assert!(!phase_one.show_runtime_target);
+
+        let events = runtime.handle_launch_wizard_action(LaunchWizardAction::Submit, None);
+        assert_eq!(events.len(), 1);
+
+        let view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .view();
+        assert!(view.runtime_context_resolved);
+        assert_eq!(view.selected_runtime_target, "host");
+        assert!(!view.show_runtime_target);
+        assert!(view.selected_docker_service.is_none());
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -61,9 +61,9 @@ fn start_work_open_error(client_id: &str, message: impl Into<String>) -> Vec<Out
 }
 
 use super::{
-    branch_worktree_path, branch_worktree_path_for, build_shell_process_launch, combined_window_id,
-    detect_wizard_docker_context_and_status, knowledge_error_event, knowledge_kind_for_preset,
-    list_branch_entries_with_active_sessions, normalize_branch_name, preferred_issue_launch_branch,
+    build_shell_process_launch, combined_window_id, detect_wizard_docker_context_and_status,
+    knowledge_error_event, knowledge_kind_for_preset, list_branch_entries_with_active_sessions,
+    normalize_branch_name, preferred_issue_launch_branch, resolve_launch_worktree,
     resolve_shell_launch_worktree, synthetic_branch_entry, workspace_projection_for_current_resume,
     workspace_resume_branch_exists, workspace_resume_branch_from_journal_project_root,
     workspace_resume_context_from_journal, workspace_resume_context_from_projection,
@@ -166,46 +166,35 @@ impl AppRuntime {
     ) -> Result<(), String> {
         let normalized_branch_name = normalize_branch_name(branch_name);
         let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
-        // SPEC-2014 FR-PERF-003: reuse the project tab's cached
-        // `main_worktree_root` resolution so the Launch Wizard cold-open path
-        // avoids another `git rev-parse --git-common-dir` spawn on Windows.
-        let main_repo_path = self.tab(tab_id).map(|tab| tab.main_worktree_root());
-        let worktree_path = main_repo_path.as_deref().map_or_else(
-            || branch_worktree_path(project_root, &normalized_branch_name),
-            |main_root| branch_worktree_path_for(main_root, &normalized_branch_name),
-        );
-        let quick_start_root = worktree_path
-            .clone()
-            .unwrap_or_else(|| project_root.to_path_buf());
-        let quick_start_entries = self
-            .launch_wizard_cache
-            .quick_start_entries(&quick_start_root, &normalized_branch_name);
-        let previous_profiles = self
-            .launch_wizard_cache
-            .previous_profiles(&quick_start_root);
+        let worktree_path = None;
+        let quick_start_root = project_root.to_path_buf();
+        let quick_start_entries = Vec::new();
+        let previous_profiles = self.launch_wizard_cache.agent_preferences();
         let agent_options = self.launch_wizard_cache.agent_options();
-        let (docker_context, docker_service_status) =
-            detect_wizard_docker_context_and_status(&quick_start_root);
+        let docker_context = None;
+        let docker_service_status = gwt_docker::ComposeServiceStatus::NotFound;
         let wizard_id = Uuid::new_v4().to_string();
+        let mut wizard = LaunchWizardState::open_with_previous_profiles(
+            LaunchWizardContext {
+                selected_branch: synthetic_branch_entry(branch_name),
+                normalized_branch_name,
+                worktree_path,
+                quick_start_root,
+                live_sessions,
+                docker_context,
+                docker_service_status,
+                linked_issue_number,
+                linked_issue_kind,
+            },
+            agent_options,
+            quick_start_entries,
+            previous_profiles,
+        );
+        wizard.mark_runtime_context_unresolved();
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
             wizard_id,
-            wizard: LaunchWizardState::open_with_previous_profiles(
-                LaunchWizardContext {
-                    selected_branch: synthetic_branch_entry(branch_name),
-                    normalized_branch_name,
-                    worktree_path,
-                    quick_start_root,
-                    live_sessions,
-                    docker_context,
-                    docker_service_status,
-                    linked_issue_number,
-                    linked_issue_kind,
-                },
-                agent_options,
-                quick_start_entries,
-                previous_profiles,
-            ),
+            wizard,
             workspace_resume_context,
         });
 
@@ -418,38 +407,36 @@ impl AppRuntime {
             gwt::start_work::reserve_start_work_branch_name_for_project(project_root, Utc::now())
                 .map_err(|error| error.to_string())?;
         let quick_start_root = project_root.to_path_buf();
-        let quick_start_entries = self
-            .launch_wizard_cache
-            .quick_start_entries(&quick_start_root, &work_branch);
-        let previous_profiles = self
-            .launch_wizard_cache
-            .previous_profiles(&quick_start_root);
+        let quick_start_entries = Vec::new();
+        let previous_profiles = self.launch_wizard_cache.agent_preferences();
         let agent_options = self.launch_wizard_cache.agent_options();
-        let (docker_context, docker_service_status) =
-            detect_wizard_docker_context_and_status(&quick_start_root);
+        let docker_context = None;
+        let docker_service_status = gwt_docker::ComposeServiceStatus::NotFound;
         let wizard_id = Uuid::new_v4().to_string();
+        let mut wizard = LaunchWizardState::open_start_work_with_previous_profiles(
+            LaunchWizardContext {
+                selected_branch: synthetic_branch_entry(&base_branch),
+                normalized_branch_name: work_branch,
+                worktree_path: None,
+                quick_start_root,
+                live_sessions: Vec::new(),
+                docker_context,
+                docker_service_status,
+                linked_issue_number: workspace_resume_context.as_ref().and_then(|context| {
+                    workspace_resume_owner_issue_number(context.owner.as_deref())
+                }),
+                linked_issue_kind: None,
+            },
+            base_branch,
+            agent_options,
+            quick_start_entries,
+            previous_profiles,
+        );
+        wizard.mark_runtime_context_unresolved();
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
             wizard_id,
-            wizard: LaunchWizardState::open_start_work_with_previous_profiles(
-                LaunchWizardContext {
-                    selected_branch: synthetic_branch_entry(&base_branch),
-                    normalized_branch_name: work_branch,
-                    worktree_path: None,
-                    quick_start_root,
-                    live_sessions: Vec::new(),
-                    docker_context,
-                    docker_service_status,
-                    linked_issue_number: workspace_resume_context.as_ref().and_then(|context| {
-                        workspace_resume_owner_issue_number(context.owner.as_deref())
-                    }),
-                    linked_issue_kind: None,
-                },
-                base_branch,
-                agent_options,
-                quick_start_entries,
-                previous_profiles,
-            ),
+            wizard,
             workspace_resume_context,
         });
 
@@ -658,6 +645,26 @@ impl AppRuntime {
                     self.launch_wizard_state_broadcast(None),
                 ]
             }
+            Some(LaunchWizardCompletion::ResolveRuntime(config)) => {
+                match self.resolve_launch_wizard_runtime_context(&mut session, *config) {
+                    Ok(()) => {
+                        self.launch_wizard = Some(session);
+                        vec![self.launch_wizard_state_outbound()]
+                    }
+                    Err(error) => {
+                        Self::log_launch_wizard_error(
+                            &session,
+                            "resolve_runtime",
+                            action_label,
+                            requested_agent_id.as_deref(),
+                            &error,
+                        );
+                        session.wizard.error = Some(error);
+                        self.launch_wizard = Some(session);
+                        vec![self.launch_wizard_state_outbound()]
+                    }
+                }
+            }
             Some(LaunchWizardCompletion::Launch(config)) => {
                 let Some(bounds) = bounds else {
                     let error = "Viewport bounds are required to launch a window".to_string();
@@ -726,6 +733,54 @@ impl AppRuntime {
                 vec![self.launch_wizard_state_outbound()]
             }
         }
+    }
+
+    fn resolve_launch_wizard_runtime_context(
+        &mut self,
+        session: &mut LaunchWizardSession,
+        mut config: LaunchWizardLaunchRequest,
+    ) -> Result<(), String> {
+        let project_root = self
+            .tab(&session.tab_id)
+            .map(|tab| tab.project_root.clone())
+            .ok_or_else(|| "Project tab not found".to_string())?;
+
+        let worktree_path = match &mut config {
+            LaunchWizardLaunchRequest::Agent(config) => {
+                resolve_launch_worktree(&project_root, config)?;
+                config
+                    .working_dir
+                    .clone()
+                    .unwrap_or_else(|| project_root.clone())
+            }
+            LaunchWizardLaunchRequest::Shell(config) => {
+                resolve_shell_launch_worktree(&project_root, config)?;
+                config
+                    .working_dir
+                    .clone()
+                    .unwrap_or_else(|| project_root.clone())
+            }
+        };
+        let branch_name = session.wizard.branch_name.clone();
+        let quick_start_entries = self
+            .launch_wizard_cache
+            .quick_start_entries(&worktree_path, &branch_name);
+        let previous_profiles = self.launch_wizard_cache.previous_profiles(&worktree_path);
+        let agent_options = self.launch_wizard_cache.agent_options();
+        let (docker_context, docker_service_status) =
+            detect_wizard_docker_context_and_status(&worktree_path);
+        session.wizard.apply_runtime_context(LaunchWizardHydration {
+            selected_branch: None,
+            normalized_branch_name: branch_name,
+            worktree_path: Some(worktree_path.clone()),
+            quick_start_root: worktree_path,
+            docker_context,
+            docker_service_status,
+            agent_options,
+            quick_start_entries,
+            previous_profiles: Some(previous_profiles),
+        });
+        Ok(())
     }
 
     pub(crate) fn spawn_wizard_shell_window(

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -120,6 +120,7 @@ pub struct LaunchWizardView {
     pub selected_branch_name: String,
     pub linked_issue_number: Option<u64>,
     pub is_hydrating: bool,
+    pub runtime_context_resolved: bool,
     pub hydration_error: Option<String>,
     pub quick_start_entries: Vec<LaunchWizardQuickStartView>,
     pub live_sessions: Vec<LaunchWizardLiveSessionView>,
@@ -537,6 +538,7 @@ pub enum LaunchWizardLaunchRequest {
 #[derive(Debug, Clone)]
 pub enum LaunchWizardCompletion {
     Launch(Box<LaunchWizardLaunchRequest>),
+    ResolveRuntime(Box<LaunchWizardLaunchRequest>),
     FocusWindow { window_id: String },
     Cancelled,
 }
@@ -640,6 +642,7 @@ pub struct LaunchWizardState {
     pub completion: Option<LaunchWizardCompletion>,
     pub error: Option<String>,
     pub is_hydrating: bool,
+    pub runtime_context_resolved: bool,
     pub hydration_error: Option<String>,
     pub linked_issue_number: Option<u64>,
 }
@@ -713,6 +716,7 @@ impl LaunchWizardState {
             completion: None,
             error: None,
             is_hydrating,
+            runtime_context_resolved: true,
             hydration_error: None,
             linked_issue_number: context.linked_issue_number,
         };
@@ -844,6 +848,7 @@ impl LaunchWizardState {
             selected_branch_name: self.context.selected_branch.name.clone(),
             linked_issue_number: self.linked_issue_number,
             is_hydrating: self.is_hydrating,
+            runtime_context_resolved: self.runtime_context_resolved,
             hydration_error: self.hydration_error.clone(),
             quick_start_entries: self.quick_start_entries_view(),
             live_sessions: self.live_sessions_view(),
@@ -880,11 +885,14 @@ impl LaunchWizardState {
             skip_permissions: self.skip_permissions,
             show_agent_settings: self.launch_target_is_agent(),
             show_reasoning: self.launch_target_is_agent() && self.agent_uses_reasoning_step(),
-            show_runtime_target: self.has_docker_workflow(),
-            show_windows_shell: self.show_windows_shell_selection(),
+            show_runtime_target: self.runtime_context_resolved && self.has_docker_workflow(),
+            show_windows_shell: self.runtime_context_resolved
+                && self.show_windows_shell_selection(),
             show_docker_service: self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker
+                && self.runtime_context_resolved
                 && self.docker_service_prompt_required(),
-            show_docker_lifecycle: self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker,
+            show_docker_lifecycle: self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker
+                && self.runtime_context_resolved,
             show_version: self.launch_target_is_agent()
                 && agent_has_npm_package(self.effective_agent_id()),
             show_execution_mode: self.launch_target_is_agent(),
@@ -921,6 +929,7 @@ impl LaunchWizardState {
         Self::hydrate_live_window_ids(&self.context, &mut quick_start_entries);
         self.quick_start_entries = quick_start_entries;
         self.is_hydrating = false;
+        self.runtime_context_resolved = true;
         self.hydration_error = None;
         self.branch_name = if self.is_new_branch {
             self.branch_name.clone()
@@ -948,6 +957,25 @@ impl LaunchWizardState {
         self.selected = self
             .selected
             .min(self.current_options().len().saturating_sub(1));
+    }
+
+    pub fn mark_runtime_context_unresolved(&mut self) {
+        self.runtime_context_resolved = false;
+        self.context.worktree_path = None;
+        self.context.docker_context = None;
+        self.context.docker_service_status = gwt_docker::ComposeServiceStatus::NotFound;
+        self.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
+        self.docker_service = None;
+        self.docker_lifecycle_intent =
+            default_docker_lifecycle_intent(self.context.docker_service_status);
+        self.sync_docker_lifecycle_default();
+    }
+
+    pub fn apply_runtime_context(&mut self, hydration: LaunchWizardHydration) {
+        self.apply_hydration(hydration);
+        self.is_new_branch = false;
+        self.base_branch_name = None;
+        self.runtime_context_resolved = true;
     }
 
     pub fn set_hydration_error(&mut self, error: String) {
@@ -1199,7 +1227,11 @@ impl LaunchWizardState {
 
         match self.build_launch_request() {
             Ok(config) => {
-                self.completion = Some(LaunchWizardCompletion::Launch(Box::new(config)));
+                self.completion = Some(if self.runtime_context_resolved {
+                    LaunchWizardCompletion::Launch(Box::new(config))
+                } else {
+                    LaunchWizardCompletion::ResolveRuntime(Box::new(config))
+                });
             }
             Err(error) => {
                 self.error = Some(error);
@@ -1331,7 +1363,11 @@ impl LaunchWizardState {
 
         match self.build_launch_request() {
             Ok(config) => {
-                self.completion = Some(LaunchWizardCompletion::Launch(Box::new(config)));
+                self.completion = Some(if self.runtime_context_resolved {
+                    LaunchWizardCompletion::Launch(Box::new(config))
+                } else {
+                    LaunchWizardCompletion::ResolveRuntime(Box::new(config))
+                });
             }
             Err(error) => {
                 self.error = Some(error);
@@ -2933,7 +2969,7 @@ impl<'a> LaunchWizardFlow<'a> {
     }
 
     fn next_after_host_runtime(&self) -> Option<LaunchWizardStep> {
-        if self.state.show_windows_shell_selection() {
+        if self.state.runtime_context_resolved && self.state.show_windows_shell_selection() {
             Some(LaunchWizardStep::WindowsShell)
         } else {
             self.next_after_windows_shell()
@@ -2983,7 +3019,7 @@ impl<'a> LaunchWizardFlow<'a> {
     fn previous_before_version_select(&self) -> Option<LaunchWizardStep> {
         if self.state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
             Some(LaunchWizardStep::DockerLifecycle)
-        } else if self.state.show_windows_shell_selection() {
+        } else if self.state.runtime_context_resolved && self.state.show_windows_shell_selection() {
             Some(LaunchWizardStep::WindowsShell)
         } else if self.state.has_docker_workflow() {
             Some(LaunchWizardStep::RuntimeTarget)
@@ -2995,7 +3031,7 @@ impl<'a> LaunchWizardFlow<'a> {
     fn previous_before_execution_mode(&self) -> Option<LaunchWizardStep> {
         if self.state.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
             Some(LaunchWizardStep::DockerLifecycle)
-        } else if self.state.show_windows_shell_selection() {
+        } else if self.state.runtime_context_resolved && self.state.show_windows_shell_selection() {
             Some(LaunchWizardStep::WindowsShell)
         } else if agent_has_npm_package(self.state.effective_agent_id()) {
             Some(LaunchWizardStep::VersionSelect)
@@ -5770,6 +5806,57 @@ mod tests {
         assert_eq!(view.selected_agent_id, "claude");
         assert_eq!(view.agent_options.len(), 2);
         assert_eq!(view.selected_runtime_target, "docker");
+    }
+
+    #[test]
+    fn phase_one_hides_runtime_until_worktree_is_resolved() {
+        let mut ctx = context(branch("feature/current"), "feature/current");
+        ctx.docker_context = Some(DockerWizardContext {
+            services: vec!["app".to_string()],
+            suggested_service: Some("app".to_string()),
+        });
+        ctx.docker_service_status = gwt_docker::ComposeServiceStatus::Running;
+        let mut state = LaunchWizardState::open_with_previous_profiles(
+            ctx,
+            sample_agent_options(),
+            Vec::new(),
+            Default::default(),
+        );
+        state.mark_runtime_context_unresolved();
+
+        let view = state.view();
+        assert!(!view.runtime_context_resolved);
+        assert!(!view.show_runtime_target);
+        assert!(!view.show_docker_service);
+        assert!(!view.show_docker_lifecycle);
+
+        state.apply(LaunchWizardAction::Submit);
+        assert!(matches!(
+            state.completion,
+            Some(LaunchWizardCompletion::ResolveRuntime(_))
+        ));
+
+        state.completion = None;
+        state.apply_runtime_context(LaunchWizardHydration {
+            selected_branch: None,
+            normalized_branch_name: "feature/current".to_string(),
+            worktree_path: Some(PathBuf::from("/tmp/repo-feature-current")),
+            quick_start_root: PathBuf::from("/tmp/repo-feature-current"),
+            docker_context: Some(DockerWizardContext {
+                services: vec!["app".to_string()],
+                suggested_service: Some("app".to_string()),
+            }),
+            docker_service_status: gwt_docker::ComposeServiceStatus::Running,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: Some(Default::default()),
+        });
+
+        let view = state.view();
+        assert!(view.runtime_context_resolved);
+        assert!(view.show_runtime_target);
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("app"));
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -86,15 +86,14 @@ pub(crate) use launch_runtime::{
     resolve_launch_worktree_request,
 };
 pub(crate) use runtime_support::{
-    app_state_view_from_parts, attach_parent_console_for_cli, branch_worktree_path,
-    branch_worktree_path_for, close_window_from_workspace, combined_window_id, current_git_branch,
-    dedupe_recent_projects, fallback_project_target, first_available_worktree_path,
-    front_door_route, geometry_to_pty_size, knowledge_kind_for_preset, local_branch_exists,
-    normalize_active_tab_id, normalize_branch_name, origin_remote_ref,
-    prune_missing_recent_projects, resolve_launch_spec_with_fallback, resolve_project_target,
-    run_cli, same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
-    synthetic_branch_entry, usable_worktree_path_for_branch, workspace_view_for_tab,
-    worktrees_have_stale_branch_entry,
+    app_state_view_from_parts, attach_parent_console_for_cli, close_window_from_workspace,
+    combined_window_id, current_git_branch, dedupe_recent_projects, fallback_project_target,
+    first_available_worktree_path, front_door_route, geometry_to_pty_size,
+    knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
+    origin_remote_ref, prune_missing_recent_projects, resolve_launch_spec_with_fallback,
+    resolve_project_target, run_cli, same_worktree_path, should_auto_close_agent_window,
+    should_auto_start_restored_window, synthetic_branch_entry, usable_worktree_path_for_branch,
+    workspace_view_for_tab, worktrees_have_stale_branch_entry,
 };
 #[cfg(test)]
 pub(crate) use runtime_support::{

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -227,6 +227,7 @@ pub fn knowledge_kind_for_preset(preset: WindowPreset) -> Option<KnowledgeKind> 
 /// extra spawn was pure overhead on Windows (one `CreateProcess` +
 /// Defender scan per Launch Wizard open). The current implementation skips
 /// `current_git_branch` entirely and relies on the worktree list.
+#[cfg(test)]
 pub fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
     let main_repo_path = gwt_git::worktree::main_worktree_root(repo_path).ok()?;
     branch_worktree_path_for(&main_repo_path, branch_name)
@@ -239,6 +240,7 @@ pub fn branch_worktree_path(repo_path: &Path, branch_name: &str) -> Option<PathB
 /// `git rev-parse --git-common-dir` resolution that `branch_worktree_path`
 /// would otherwise perform halves the cold-open git spawn count for branch
 /// resolution.
+#[cfg(test)]
 pub fn branch_worktree_path_for(main_repo_path: &Path, branch_name: &str) -> Option<PathBuf> {
     let manager = gwt_git::WorktreeManager::new(main_repo_path);
     let mut worktrees = manager.list().ok()?;

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1355,6 +1355,14 @@ test("Launch wizard separates launch settings from runtime controls", () => {
   }
 });
 
+test("Launch wizard submit button uses Continue before runtime context is resolved", () => {
+  assert.match(
+    appSource,
+    /launchWizard\.runtime_context_resolved === false\s*\?\s*"Continue"\s*:/,
+    "expected unresolved Launch Agent runtime context to use Continue instead of Launch",
+  );
+});
+
 test("Selected list rows mark active item with aria-current", () => {
   // Same pattern as project tabs (PR #2455): list-style buttons with a
   // selected state need aria-current to announce which row is active.

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -5334,9 +5334,11 @@
           }`;
         wizardSubmitButton.textContent = launchWizard.is_hydrating
           ? "Loading..."
-          : launchWizard.branch_mode === "create_new"
-            ? "Create and launch"
-            : "Launch";
+          : launchWizard.runtime_context_resolved === false
+            ? "Continue"
+            : launchWizard.branch_mode === "create_new"
+              ? "Create and launch"
+              : "Launch";
         wizardSubmitButton.disabled = Boolean(launchWizard.is_hydrating);
 
         if (launchWizard.error || launchWizard.hydration_error) {


### PR DESCRIPTION
## Summary

- Splits Launch Agent into a two-phase wizard so opening the modal does not resolve worktrees or inspect Docker/Compose configuration.
- Defers Docker/runtime defaults until the user continues and the target worktree has been resolved, so Docker settings come only from the actual launch directory.
- Keeps global agent preferences available on Phase 1 while repo-local QuickStart/runtime history loads only after Phase 2 context resolution.

## Changes

- `crates/gwt/src/launch_wizard.rs`: adds unresolved runtime context state, a `ResolveRuntime` completion, and gates runtime/Docker/Windows-shell steps until context is resolved.
- `crates/gwt/src/app_runtime/wizard.rs`: removes worktree/Docker probing from the open path and resolves runtime context on Continue using the launch target worktree.
- `crates/gwt/src/app_runtime/mod.rs`: adds memory-cache support for agent-only preferences and covers the two-phase AppRuntime flow.
- `crates/gwt/web/app.js`: changes the Phase 1 primary action label to `Continue` and keeps runtime controls hidden until the backend marks context resolved.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds frontend source coverage for the Phase 1 Continue label.
- `crates/gwt/src/runtime_support.rs` and `crates/gwt/src/main.rs`: keep branch-worktree helpers test-scoped after removing them from the production open path.

## Testing

- [x] `cargo test -p gwt --lib phase_one_hides_runtime_until_worktree_is_resolved -- --nocapture` — passed.
- [x] `cargo test -p gwt --bin gwt app_runtime_open_launch_wizard -- --nocapture` — passed.
- [x] `cargo test -p gwt --bin gwt app_runtime_launch_wizard_continue -- --nocapture` — passed.
- [x] `cargo test -p gwt --lib launch_wizard::tests -- --nocapture` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-unit` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json -- --test-threads=1` — passed.
- [x] `node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90` — passed with filtered line coverage 91.07% locally; pre-push hook passed at 91.06%.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git push` — passed; pre-push CI-equivalent checks and coverage passed.

## Closing Issues

None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend tests)
- [ ] Documentation updated (if user-facing change) — Not updated: the behavior is tracked in SPEC #2014 and README usage docs do not describe Launch Wizard runtime internals.
- [x] Migration/backfill plan included (if schema/data change) — Not required: no schema or persisted-data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit) — Feature change, no breaking API.

## Context

- Launch Agent cold-open was still doing worktree and Docker/Compose discovery before the user had committed to a launch directory. That was both slow, especially on Windows, and conceptually wrong because Docker files may exist on one branch/worktree and not another.

## Risk / Impact

- **Affected areas**: Launch Agent modal open/submit flow, Launch Wizard runtime controls, repo-local QuickStart/runtime history restoration.
- **Rollback plan**: Revert this PR to restore the previous single-phase open-time runtime detection path.

## Screenshots

Not attached: this change gates existing runtime controls and changes the Phase 1 primary button label to `Continue`; behavior is covered by frontend source tests and backend state tests.
