### PR TITLE
chore(release): v9.35.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
       - name: Build gwt bundle binaries
-        run: cargo build --release -p gwt --target ${{ matrix.target }} --bin gwt --bin gwtd
+        run: rustup run stable cargo build --release -p gwt --target ${{ matrix.target }} --bin gwt --bin gwtd
       - name: Prepare macOS signing keychain
         if: runner.os == 'macOS'
         shell: bash
@@ -234,7 +234,7 @@ jobs:
         run: |
           dotnet tool install --global wix --version 6.0.2
       - name: Build gwt bundle binaries
-        run: cargo build --release -p gwt --target x86_64-pc-windows-msvc --bin gwt --bin gwtd
+        run: rustup run stable cargo build --release -p gwt --target x86_64-pc-windows-msvc --bin gwt --bin gwtd
       - name: Build MSI
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
@@ -261,9 +261,9 @@ jobs:
           key: gwt-dmg
         continue-on-error: true
       - name: Build gwt bundle binaries for aarch64
-        run: cargo build --release -p gwt --target aarch64-apple-darwin --bin gwt --bin gwtd
+        run: rustup run stable cargo build --release -p gwt --target aarch64-apple-darwin --bin gwt --bin gwtd
       - name: Build gwt bundle binaries for x86_64
-        run: cargo build --release -p gwt --target x86_64-apple-darwin --bin gwt --bin gwtd
+        run: rustup run stable cargo build --release -p gwt --target x86_64-apple-darwin --bin gwt --bin gwtd
       - name: Create universal binaries
         run: |
           mkdir -p dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.35.2] - 2026-05-15
+
+### Bug Fixes
+
+- **ci:** Bypass broken cargo proxy on macos runner image via rustup run
+
 ## [9.35.1] - 2026-05-15
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "ammonia",
  "axum",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "chrono",
  "dunce",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "dirs",
  "serde",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.35.1"
+version = "9.35.2"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.35.1"
+version = "9.35.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.35.1",
+  "version": "9.35.2",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.35.2 パッチリリース。v9.35.1 のリリース pipeline を破壊した GitHub Actions runner image regression を回避する CI 修正のみを含みます。コードの動作変更はありません。

## Changes

### Bug Fixes
- (ci) `cargo build` を `rustup run stable cargo build` に切り替えて、macos-14-arm64 runner image 20260512.0058.1 で `/Users/runner/.cargo/bin/cargo` が `rustup-init` 化している不具合を回避

## Background

v9.35.1 の release.yml は新しい runner image で `error: unexpected argument 'build' found / Usage: rustup-init[EXE] [OPTIONS]` で即時失敗していました。`rustup` と `rustc` の proxy は無事だったため、cargo を rustup 経由で起動することでこの破損 PATH 経路を bypass します。

## Version

v9.35.2

## Closing Issues

None

## Related Issues / Links

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI build reliability issue on macOS by addressing Cargo proxy configuration in the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2720)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->