### PR TITLE
fix(launch): remove duplicate wizard close button

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2366,8 +2366,8 @@ mod tests {
             r#"function sendWizardAction\(action\)\s*\{\s*send\(\{\s*kind:\s*"launch_wizard_action",\s*action,\s*bounds:\s*visibleBounds\(\),\s*\}\);\s*\}"#,
         )
         .expect("valid regex");
-        let close_controls = regex::Regex::new(
-            r#"wizardCloseButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\);\s*wizardCancelButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\);"#,
+        let footer_close_control = regex::Regex::new(
+            r#"wizardCancelButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\);"#,
         )
         .expect("valid regex");
         let submit_button = regex::Regex::new(
@@ -2389,8 +2389,12 @@ mod tests {
             "expected wizard actions to be normalized through launch_wizard_action and always attach visible bounds",
         );
         assert!(
-            close_controls.is_match(html),
-            "expected both close controls to share the wizard close helper",
+            !html.contains(r#"id="wizard-close-button""#) && !html.contains("wizardCloseButton"),
+            "expected Launch Wizard to avoid a duplicate header Close control",
+        );
+        assert!(
+            footer_close_control.is_match(html),
+            "expected footer dismiss control to own the wizard close helper",
         );
         assert!(
             html.contains("function closeLaunchWizardFromChrome()")

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1243,6 +1243,28 @@ test("Launch wizard open errors render in wizard modal and close locally", () =>
   );
 });
 
+test("Launch wizard uses one visible dismiss control in the footer", () => {
+  assert.equal(
+    document.getElementById("wizard-close-button"),
+    null,
+    "Launch wizard header must not render a second Close button",
+  );
+  assert.ok(
+    document.getElementById("wizard-cancel-button"),
+    "Launch wizard footer dismiss button must remain available",
+  );
+  assert.equal(
+    appSource.includes("wizardCloseButton"),
+    false,
+    "Launch wizard should not keep dead wiring for a removed header close button",
+  );
+  assert.match(
+    appSource,
+    /wizardCancelButton\.addEventListener\("click",\s*closeLaunchWizardFromChrome\)/,
+    "expected the footer dismiss button to own the close helper",
+  );
+});
+
 test("File tree rows are keyboard-navigable (tabindex + role + keydown)", () => {
   // <div>-based rows can't be Tab'd to or activated with the keyboard
   // unless explicitly opted in. Add tabindex, role="button", and a

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -139,7 +139,6 @@
       const wizardSummary = document.getElementById("wizard-summary");
       const wizardBody = document.getElementById("wizard-body");
       const wizardError = document.getElementById("wizard-error");
-      const wizardCloseButton = document.getElementById("wizard-close-button");
       const wizardCancelButton = document.getElementById("wizard-cancel-button");
       const wizardSubmitButton = document.getElementById("wizard-submit-button");
       const cloneProjectModal = document.getElementById("clone-project-modal");
@@ -9930,7 +9929,6 @@
           closeModal();
         }
       });
-      wizardCloseButton.addEventListener("click", closeLaunchWizardFromChrome);
       wizardCancelButton.addEventListener("click", closeLaunchWizardFromChrome);
       wizardSubmitButton.addEventListener("click", () => {
         if (launchWizardOpenError) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -482,7 +482,6 @@
               <h2 class="wizard-title" id="wizard-title">Launch Agent</h2>
               <div class="wizard-meta" id="wizard-meta"></div>
             </div>
-            <button class="wizard-button" id="wizard-close-button">Close</button>
           </div>
           <div class="wizard-error" id="wizard-error" role="alert" hidden></div>
           <div class="wizard-summary" id="wizard-summary"></div>


### PR DESCRIPTION
## Summary

- Launch Wizard now has one visible dismiss control so the header and footer no longer expose duplicate close actions.
- Footer `Cancel`, Esc, and backdrop dismiss continue to use the existing close path.

## Changes

- `crates/gwt/web/index.html`: removed the duplicate header `Close` button from the Launch Wizard chrome.
- `crates/gwt/web/app.js`: removed the obsolete header close-button lookup and listener while keeping footer cancel wiring.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: added frontend structure coverage for the single dismiss control.
- `crates/gwt/src/embedded_web.rs`: updated the embedded web contract test to reject duplicate header close wiring.

## Testing

- [x] `cargo test -p gwt embedded_web_launch_wizard_actions_flow_through_named_transport -- --nocapture` - failed before implementation on the duplicate header close control, then passed after the fix.
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` - passed.
- [x] `npm run test:frontend-bundle` - passed.
- [x] `pnpm test:frontend-unit` - passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `git diff --check` - passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.
- [x] `git push` - passed; pre-push CI-equivalent checks and coverage passed with filtered line coverage 90.52%.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not needed: user-facing behavior simplified without docs changes)
- [x] Migration/backfill plan included (not needed: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level fix; no breaking change)

## Context

- The Launch Wizard previously exposed `Close` in the header and `Cancel` in the footer with equivalent dismiss behavior, which made the action surface unnecessarily ambiguous.

## Risk / Impact

- **Affected areas**: Launch Wizard chrome and its frontend close wiring.
- **Rollback plan**: Revert commit `c4a7cb3c1`.

## Screenshots

- Not attached; the visual change is removal of the header `Close` button and is covered by frontend and embedded web contract tests.
