### PR TITLE
chore(release): v9.35.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,21 @@ jobs:
         continue-on-error: true
       - name: Check Windows compilation
         run: cargo check -p gwt-core -p gwt
+
+  check-macos:
+    name: Check (macOS)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+      - name: Reset broken pre-installed Rust on macOS runners
+        shell: bash
+        run: |
+          set -e
+          rm -rf "$HOME/.cargo" "$HOME/.rustup" || true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: check-macos
+        continue-on-error: true
+      - name: Check macOS compilation
+        run: cargo check -p gwt-core -p gwt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           set -e
           rm -rf "$HOME/.cargo" "$HOME/.rustup" || true
+          mkdir -p "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,8 @@ jobs:
         run: |
           set -e
           rm -rf "$HOME/.cargo" "$HOME/.rustup" || true
-          mkdir -p "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain none --no-modify-path
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,15 @@ jobs:
         run: |
           set -e
           rm -rf "$HOME/.cargo" "$HOME/.rustup" || true
-          # dtolnay's rust-toolchain action only appends $CARGO_HOME/bin to
-          # PATH when it has to install rustup itself. The macos-14 image ships
-          # an extra rustup binary outside ~/.cargo/bin so the action skips the
-          # PATH update, leaving the freshly created rustc/cargo proxies
-          # invisible after the wipe. Re-add the path here to bridge that gap.
-          mkdir -p "$HOME/.cargo/bin"
+          # The macos-14 image ships a stray rustup binary outside
+          # ~/.cargo/bin, so dtolnay's `command -v rustup` keeps finding it
+          # and skips both its install and the $CARGO_HOME/bin PATH update.
+          # That leaves no rustc/cargo proxy under ~/.cargo/bin and aborts
+          # later steps with "rustc: command not found". Run rustup-init
+          # ourselves so the proxies live under ~/.cargo/bin, then prepend
+          # that directory so dtolnay picks our rustup over the stray one.
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain none --no-modify-path
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -271,12 +274,15 @@ jobs:
         run: |
           set -e
           rm -rf "$HOME/.cargo" "$HOME/.rustup" || true
-          # dtolnay's rust-toolchain action only appends $CARGO_HOME/bin to
-          # PATH when it has to install rustup itself. The macos-14 image ships
-          # an extra rustup binary outside ~/.cargo/bin so the action skips the
-          # PATH update, leaving the freshly created rustc/cargo proxies
-          # invisible after the wipe. Re-add the path here to bridge that gap.
-          mkdir -p "$HOME/.cargo/bin"
+          # The macos-14 image ships a stray rustup binary outside
+          # ~/.cargo/bin, so dtolnay's `command -v rustup` keeps finding it
+          # and skips both its install and the $CARGO_HOME/bin PATH update.
+          # That leaves no rustc/cargo proxy under ~/.cargo/bin and aborts
+          # later steps with "rustc: command not found". Run rustup-init
+          # ourselves so the proxies live under ~/.cargo/bin, then prepend
+          # that directory so dtolnay picks our rustup over the stray one.
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain none --no-modify-path
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,13 @@ jobs:
         run: |
           set -e
           rm -rf "$HOME/.cargo" "$HOME/.rustup" || true
+          # dtolnay's rust-toolchain action only appends $CARGO_HOME/bin to
+          # PATH when it has to install rustup itself. The macos-14 image ships
+          # an extra rustup binary outside ~/.cargo/bin so the action skips the
+          # PATH update, leaving the freshly created rustc/cargo proxies
+          # invisible after the wipe. Re-add the path here to bridge that gap.
+          mkdir -p "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -264,6 +271,13 @@ jobs:
         run: |
           set -e
           rm -rf "$HOME/.cargo" "$HOME/.rustup" || true
+          # dtolnay's rust-toolchain action only appends $CARGO_HOME/bin to
+          # PATH when it has to install rustup itself. The macos-14 image ships
+          # an extra rustup binary outside ~/.cargo/bin so the action skips the
+          # PATH update, leaving the freshly created rustc/cargo proxies
+          # invisible after the wipe. Re-add the path here to bridge that gap.
+          mkdir -p "$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.35.4] - 2026-05-15
+
+### Bug Fixes
+
+- **ci:** Wipe broken pre-installed rust on macos runners before toolchain install by @akiojin
+- **launch:** Remove duplicate wizard close button by @akiojin
+- **ci:** Expose rebuilt cargo bin dir on macOS PATH after wipe
+
+### Ci
+
+- Add pre-merge cargo check on macOS
+
 ## [9.35.3] - 2026-05-15
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "ammonia",
  "axum",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "chrono",
  "dunce",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "reqwest",
  "serde",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "dirs",
  "serde",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "chrono",
  "fs2",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "libc",
  "nix 0.31.2",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.35.3"
+version = "9.35.4"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.35.3"
+version = "9.35.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.35.3",
+  "version": "9.35.4",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v9.35.4 パッチリリース。v9.35.3 の release pipeline 失敗（`rustc: command not found`）の修正と、PR 段階で macOS コンパイル check を走らせる新ジョブを含みます。コードの動作変更はありません。

## Changes

### Bug Fixes
- (ci) macOS runner で `~/.cargo` `~/.rustup` を wipe した後、dtolnay が新規作成する `$CARGO_HOME/bin` を `GITHUB_PATH` に明示追加
- (ci) PR 段階で `Check (macOS)` job を走らせ、main の Required Checks にも追加

## Background

v9.35.3 では事前 wipe で broken Rust state を解消しましたが、dtolnay/rust-toolchain は別の rustup（macos-14 イメージ内の余剰バイナリ）を見つけたため `$CARGO_HOME/bin` を PATH に追加しないまま完了し、新規生成された rustc/cargo proxy が PATH に乗らず後続 step が `rustc: command not found` で abort していました。

## Version

v9.35.4

## Closing Issues

None

## Related Issues / Links

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
