### PR TITLE
fix(gui): remove git spawns from active work hot path

### DIFF
--- a/crates/gwt-core/src/repo_hash.rs
+++ b/crates/gwt-core/src/repo_hash.rs
@@ -5,11 +5,12 @@
 //! upstream repository (HTTPS clone, SSH clone, second worktree) always
 //! resolves to the same `RepoHash`.
 
-use std::{fmt, path::Path};
+use std::{
+    fmt, fs,
+    path::{Path, PathBuf},
+};
 
 use sha2::{Digest, Sha256};
-
-use crate::process::scrub_git_env;
 
 const HASH_HEX_LEN: usize = 16;
 
@@ -112,24 +113,122 @@ pub fn compute_path_hash(path: &Path) -> RepoHash {
 
 /// Detect a `RepoHash` from the `origin` remote configured for `repo_root`.
 pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
-    let mut cmd = crate::process::hidden_command("git");
-    cmd.args(["remote", "get-url", "origin"])
-        .current_dir(repo_root);
-    scrub_git_env(&mut cmd);
-    let output = cmd.output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let url = origin_url_from_git_config(repo_root)?;
     if url.is_empty() {
         return None;
     }
     Some(compute_repo_hash(&url))
 }
 
+fn origin_url_from_git_config(repo_root: &Path) -> Option<String> {
+    let git_dir = resolve_git_dir(repo_root)?;
+    let common_dir = resolve_common_git_dir(&git_dir);
+    let config = fs::read_to_string(common_dir.join("config")).ok()?;
+    parse_origin_url_from_git_config(&config)
+}
+
+fn resolve_git_dir(repo_root: &Path) -> Option<PathBuf> {
+    let dot_git = repo_root.join(".git");
+    if dot_git.is_dir() {
+        return Some(dot_git);
+    }
+    if dot_git.is_file() {
+        return resolve_gitdir_file(&dot_git);
+    }
+    if repo_root.join("config").is_file() {
+        return Some(repo_root.to_path_buf());
+    }
+    None
+}
+
+fn resolve_gitdir_file(dot_git: &Path) -> Option<PathBuf> {
+    let contents = fs::read_to_string(dot_git).ok()?;
+    let raw = contents
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("gitdir:"))?
+        .trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let git_dir = PathBuf::from(raw);
+    if git_dir.is_absolute() {
+        Some(git_dir)
+    } else {
+        Some(dot_git.parent()?.join(git_dir))
+    }
+}
+
+fn resolve_common_git_dir(git_dir: &Path) -> PathBuf {
+    let Ok(contents) = fs::read_to_string(git_dir.join("commondir")) else {
+        return git_dir.to_path_buf();
+    };
+    let raw = contents.lines().next().unwrap_or_default().trim();
+    if raw.is_empty() {
+        return git_dir.to_path_buf();
+    }
+    let common_dir = PathBuf::from(raw);
+    if common_dir.is_absolute() {
+        common_dir
+    } else {
+        git_dir.join(common_dir)
+    }
+}
+
+fn parse_origin_url_from_git_config(config: &str) -> Option<String> {
+    let mut in_origin_remote = false;
+    for raw_line in config.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if let Some(section) = line
+            .strip_prefix('[')
+            .and_then(|value| value.strip_suffix(']'))
+        {
+            in_origin_remote = is_origin_remote_section(section.trim());
+            continue;
+        }
+        if !in_origin_remote {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim().eq_ignore_ascii_case("url") {
+            let url = clean_git_config_value(value);
+            if !url.is_empty() {
+                return Some(url.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn is_origin_remote_section(section: &str) -> bool {
+    section.eq_ignore_ascii_case(r#"remote "origin""#)
+        || section.eq_ignore_ascii_case("remote.origin")
+}
+
+fn clean_git_config_value(value: &str) -> &str {
+    let trimmed = value.trim();
+    let trimmed = trimmed
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(trimmed);
+    let mut end = trimmed.len();
+    for marker in [" #", "\t#", " ;", "\t;"] {
+        if let Some(index) = trimmed.find(marker) {
+            end = end.min(index);
+        }
+    }
+    trimmed[..end].trim()
+}
+
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{fs, path::Path};
+
+    use crate::process::scrub_git_env;
 
     use super::*;
 
@@ -186,6 +285,31 @@ mod tests {
         assert_eq!(
             actual.as_str(),
             compute_repo_hash("https://github.com/example/project.git").as_str()
+        );
+    }
+
+    #[test]
+    fn detect_repo_hash_reads_origin_remote_from_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        fs::write(
+            repo.join(".git/config"),
+            r#"
+[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = https://github.com/example/config-only.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#,
+        )
+        .unwrap();
+
+        let actual = detect_repo_hash(&repo).expect("repo hash");
+
+        assert_eq!(
+            actual.as_str(),
+            compute_repo_hash("https://github.com/example/config-only.git").as_str()
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1325,26 +1325,12 @@ fn workspace_projection_for_current_resume(
 }
 
 fn workspace_cleanup_candidate_for_projection(
-    project_root: &Path,
     projection: &gwt_core::workspace_projection::WorkspaceProjection,
     sessions: &[&ActiveAgentSession],
 ) -> Option<gwt::ActiveWorkCleanupCandidateView> {
     let branch = projection.git_details.as_ref()?.branch.as_deref()?;
     let branch_has_live_agent = sessions.iter().any(|session| session.branch_name == branch);
-    let mut candidate = projection.cleanup_candidate(branch_has_live_agent)?;
-    if let Ok(entries) = list_branch_entries_with_active_sessions(
-        project_root,
-        &sessions
-            .iter()
-            .map(|session| session.branch_name.clone())
-            .collect::<std::collections::HashSet<_>>(),
-    ) {
-        candidate.remote_delete_available = entries
-            .iter()
-            .find(|entry| entry.name == candidate.branch)
-            .and_then(|entry| entry.cleanup.upstream.as_ref())
-            .is_some();
-    }
+    let candidate = projection.cleanup_candidate(branch_has_live_agent)?;
     Some(active_work_cleanup_candidate_view_from_candidate(candidate))
 }
 
@@ -2696,11 +2682,8 @@ impl AppRuntime {
         {
             let mut projection = projection;
             let had_saved_agents = !projection.agents.is_empty();
-            let cleanup_candidate = workspace_cleanup_candidate_for_projection(
-                &tab.project_root,
-                &projection,
-                &sessions,
-            );
+            let cleanup_candidate =
+                workspace_cleanup_candidate_for_projection(&projection, &sessions);
             merge_active_sessions_into_projection(
                 &mut projection,
                 sessions.iter().copied(),
@@ -6610,14 +6593,51 @@ exit 0
         }
     }
 
-    fn prepend_fake_gh_to_path(fake_gh: &Path) -> ScopedEnvVar {
-        let parent = fake_gh.parent().expect("fake gh parent");
+    fn write_fake_git_recorder(temp_root: &Path) -> PathBuf {
+        #[cfg(windows)]
+        {
+            let fake_git = temp_root.join("git.cmd");
+            fs::write(
+                &fake_git,
+                "@echo off\r\n\
+if not \"%GWT_FAKE_GIT_LOG%\"==\"\" echo %*>>\"%GWT_FAKE_GIT_LOG%\"\r\n\
+exit /b 1\r\n",
+            )
+            .expect("write fake git");
+            fake_git
+        }
+        #[cfg(not(windows))]
+        {
+            let fake_git = temp_root.join("git");
+            fs::write(
+                &fake_git,
+                r#"#!/bin/sh
+if [ -n "$GWT_FAKE_GIT_LOG" ]; then
+  printf '%s\n' "$*" >> "$GWT_FAKE_GIT_LOG"
+fi
+exit 1
+"#,
+            )
+            .expect("write fake git");
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&fake_git, fs::Permissions::from_mode(0o755))
+                .expect("chmod fake git");
+            fake_git
+        }
+    }
+
+    fn prepend_tool_parent_to_path(tool: &Path) -> ScopedEnvVar {
+        let parent = tool.parent().expect("tool parent");
         let mut paths = vec![parent.to_path_buf()];
         if let Some(existing) = std::env::var_os("PATH") {
             paths.extend(std::env::split_paths(&existing));
         }
         let joined = std::env::join_paths(paths).expect("join PATH");
         ScopedEnvVar::set("PATH", joined)
+    }
+
+    fn prepend_fake_gh_to_path(fake_gh: &Path) -> ScopedEnvVar {
+        prepend_tool_parent_to_path(fake_gh)
     }
 
     fn canvas_bounds() -> WindowGeometry {
@@ -9559,6 +9579,53 @@ exit 0
         assert_eq!(candidate.branch, "work/20260507-0200");
         assert_eq!(candidate.reason, "workspace_done");
         assert!(!candidate.default_delete_remote);
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_does_not_spawn_git_for_cleanup_candidate() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let fake_bin = temp.path().join("fake-bin");
+        fs::create_dir_all(&fake_bin).expect("create fake bin");
+        let fake_git = write_fake_git_recorder(&fake_bin);
+        let git_log = temp.path().join("git-invocations.log");
+        let _path = prepend_tool_parent_to_path(&fake_git);
+        let _git_log = ScopedEnvVar::set("GWT_FAKE_GIT_LOG", &git_log);
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Done;
+        projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
+            branch: Some("work/20260507-0200".to_string()),
+            worktree_path: Some(repo.join("work/20260507-0200")),
+            base_branch: Some("origin/main".to_string()),
+            pr_number: Some(2525),
+            pr_state: None,
+            pr_url: None,
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: chrono::Utc::now(),
+        });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let view = runtime
+            .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
+            .expect("projection view");
+
+        assert!(view.cleanup_candidate.is_some());
+        let invocations = fs::read_to_string(&git_log).unwrap_or_default();
+        assert!(
+            invocations.trim().is_empty(),
+            "active-work projection must not spawn git on the GUI hot path; invocations:\n{invocations}"
+        );
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5385,3 +5385,30 @@ race も存在した。
 - PR #2693 (Phase 26.B / 26.A / 26.C-1 一括)
 - SPEC-2008 (Phase 26 spec/plan/tasks に FR-056〜FR-059、T-199〜T-220、SC-035〜SC-038)
 - closed regressions: #2096 / #2091 / #2513 / #2668 / SPEC-2014 Phase C1
+
+## GUI hot path の同期プロセス起動は CPU% だけでは見落とす
+
+### 事象
+
+macOS/Windows GUI が全体的に重く、キー入力・ウィンドウ操作・Launch Agent 起動が遅い。
+CPU 使用率は高く見えない一方、macOS `sample` では GUI main thread が `poll` / `posix_spawnp`
+配下で時間を使っていた。
+
+### 原因
+
+UI の Active Work / Workspace 投影 hot path で、repo hash 解決のたびに `git remote get-url origin`
+を同期起動し、さらに Workspace cleanup candidate の remote delete 可否判定で branch inventory
+hydration を同期実行していた。Board/Workspace daemon update や frontend ready で繰り返されるため、
+CPU% ではなく main-thread blocking として体感遅延になった。
+
+### 再発防止策
+
+1. GUI hot path では `git` / `gh` / `docker` などの外部プロセスを同期起動しない。必要なら
+   config/file cache を読むか、blocking task に逃がす。
+2. 性能回帰テストは fake executable を `PATH` 先頭に置いて呼び出しログを検査し、対象処理が
+   外部プロセスを起動していないことを pin する。
+3. CPU% が低い重さは `sample` / profiler で main-thread blocking と process spawn を確認する。
+
+### 関連 PR / Issue
+
+- Issue #2725


### PR DESCRIPTION
## Summary

- Removes synchronous Git process launches from GUI hot paths that made key input, window movement, and Launch Agent startup feel heavy.
- Keeps Active Work cleanup available while deferring remote-branch availability probing away from the projection path.
- Adds a regression test that fails if Active Work projection spawns `git`.

## Changes

- `crates/gwt-core/src/repo_hash.rs`: resolves the origin remote by reading `.git/config`, including linked-worktree `commondir`, instead of running `git remote get-url origin`.
- `crates/gwt/src/app_runtime/mod.rs`: removes branch inventory hydration from Active Work cleanup candidate generation and adds a fake-`git` regression test for the projection hot path.
- `tasks/lessons.md`: records the profiler finding and prevention pattern for future GUI hot-path performance work.

## Testing

- [x] `cargo fmt` — completed successfully.
- [x] `cargo test -p gwt app_runtime_active_work_projection_does_not_spawn_git_for_cleanup_candidate --all-features` — passed after first confirming the test failed before the fix.
- [x] `cargo test -p gwt-core repo_hash::tests::detect_repo_hash --all-features` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx --bun markdownlint-cli tasks/lessons.md --config .markdownlint.json` — passed.

## Closing Issues

- Closes #2725

## Related Issues / Links

- #2694
- #2698

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (internal lessons entry added; no user-facing docs changed)
- [ ] Migration/backfill plan included (not applicable: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- A macOS `sample` of the installed GUI while idle showed the main thread repeatedly under `poll` / `posix_spawnp`.
- The remaining synchronous calls came from project-scoped path lookup and Active Work cleanup candidate generation, both of which are triggered by frontend ready and Board/Workspace updates.

## Risk / Impact

- **Affected areas**: repo hash detection, Active Work projection, Workspace cleanup modal remote-delete availability.
- **Rollback plan**: revert this PR; local Workspace cleanup remains available, while remote deletion can still be handled by branch cleanup flows that already load branch inventory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved GUI responsiveness by eliminating blocking external process calls during workspace operations.
  * Enhanced repository detection efficiency through optimized configuration reading.

* **Documentation**
  * Added best practices guide for avoiding synchronous external process calls in performance-critical application paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2726)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->