### PR TITLE
fix(git): include git config rewrites in repo hash

### DIFF
--- a/crates/gwt-core/src/repo_hash.rs
+++ b/crates/gwt-core/src/repo_hash.rs
@@ -6,6 +6,7 @@
 //! resolves to the same `RepoHash`.
 
 use std::{
+    collections::HashSet,
     fmt, fs,
     path::{Path, PathBuf},
 };
@@ -123,10 +124,16 @@ pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
 fn origin_url_from_git_config(repo_root: &Path) -> Option<String> {
     let git_dir = resolve_git_dir(repo_root)?;
     let common_dir = resolve_common_git_dir(&git_dir);
-    let config = fs::read_to_string(common_dir.join("config")).ok()?;
-    let url = parse_origin_url_from_git_config(&config)?;
-    let mut rewrite_configs = read_user_git_config_contents();
-    rewrite_configs.push(config);
+    let local_configs = read_git_config_chain(
+        &common_dir.join("config"),
+        repo_root,
+        &git_dir,
+        &mut HashSet::new(),
+        0,
+    );
+    let url = parse_origin_url_from_git_configs(&local_configs)?;
+    let mut rewrite_configs = read_user_git_config_contents(repo_root, &git_dir);
+    rewrite_configs.extend(local_configs);
     Some(apply_url_instead_of_rewrite(
         &url,
         &url_rewrite_rules_from_configs(&rewrite_configs),
@@ -178,6 +185,173 @@ fn resolve_common_git_dir(git_dir: &Path) -> PathBuf {
     } else {
         git_dir.join(common_dir)
     }
+}
+
+fn read_git_config_chain(
+    path: &Path,
+    repo_root: &Path,
+    git_dir: &Path,
+    visited: &mut HashSet<PathBuf>,
+    depth: usize,
+) -> Vec<String> {
+    if depth > 8 {
+        return Vec::new();
+    }
+    let key = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(key) {
+        return Vec::new();
+    }
+    let Ok(config) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut configs = Vec::new();
+    let mut current_config = String::new();
+    let mut include_enabled = false;
+    for raw_line in config.lines() {
+        let line = raw_line.trim();
+        let mut include_path = None;
+        if !line.is_empty() && !line.starts_with('#') && !line.starts_with(';') {
+            if let Some(section) = line
+                .strip_prefix('[')
+                .and_then(|value| value.strip_suffix(']'))
+            {
+                include_enabled = include_section_enabled(section.trim(), repo_root, git_dir);
+            } else if include_enabled {
+                if let Some((key, value)) = line.split_once('=') {
+                    if key.trim().eq_ignore_ascii_case("path") {
+                        let path = clean_git_config_value(value);
+                        if !path.is_empty() {
+                            include_path = Some(resolve_git_config_include_path(path, config_dir));
+                        }
+                    }
+                }
+            }
+        }
+        current_config.push_str(raw_line);
+        current_config.push('\n');
+        if let Some(include_path) = include_path {
+            if !current_config.trim().is_empty() {
+                configs.push(std::mem::take(&mut current_config));
+            }
+            configs.extend(read_git_config_chain(
+                &include_path,
+                repo_root,
+                git_dir,
+                visited,
+                depth + 1,
+            ));
+        }
+    }
+    if !current_config.trim().is_empty() {
+        configs.push(current_config);
+    }
+    configs
+}
+
+fn include_section_enabled(section: &str, repo_root: &Path, git_dir: &Path) -> bool {
+    section.eq_ignore_ascii_case("include")
+        || include_if_condition_from_section(section)
+            .map(|condition| include_if_condition_matches(&condition, repo_root, git_dir))
+            .unwrap_or(false)
+}
+
+fn include_if_condition_from_section(section: &str) -> Option<String> {
+    if section.len() >= 9 && section[..9].eq_ignore_ascii_case("includeif") {
+        let rest = section[9..].trim_start();
+        if let Some(value) = rest.strip_prefix('.') {
+            let value = value.trim();
+            return (!value.is_empty()).then(|| value.to_string());
+        }
+        let value = rest.trim();
+        if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
+            return Some(value[1..value.len() - 1].to_string());
+        }
+    }
+    None
+}
+
+fn include_if_condition_matches(condition: &str, _repo_root: &Path, git_dir: &Path) -> bool {
+    if let Some(pattern) = condition.strip_prefix("gitdir/i:") {
+        return gitdir_pattern_matches(pattern, git_dir, true);
+    }
+    if let Some(pattern) = condition.strip_prefix("gitdir:") {
+        return gitdir_pattern_matches(pattern, git_dir, false);
+    }
+    false
+}
+
+fn gitdir_pattern_matches(pattern: &str, git_dir: &Path, case_insensitive: bool) -> bool {
+    let pattern = normalize_git_config_pattern(pattern);
+    let mut candidate = normalize_path_for_config_match(git_dir);
+    if !candidate.ends_with('/') {
+        candidate.push('/');
+    }
+    let mut pattern = pattern.replace('\\', "/");
+    if !pattern.ends_with('/') && !pattern.contains('*') && !pattern.contains('?') {
+        pattern.push('/');
+    }
+    if case_insensitive {
+        wildcard_match(&pattern.to_lowercase(), &candidate.to_lowercase())
+    } else {
+        wildcard_match(&pattern, &candidate)
+    }
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    fn matches(pattern: &[u8], value: &[u8]) -> bool {
+        match pattern {
+            [] => value.is_empty(),
+            [b'*', rest @ ..] => {
+                matches(rest, value) || (!value.is_empty() && matches(pattern, &value[1..]))
+            }
+            [b'?', rest @ ..] => !value.is_empty() && matches(rest, &value[1..]),
+            [head, rest @ ..] => value.first() == Some(head) && matches(rest, &value[1..]),
+        }
+    }
+    matches(pattern.as_bytes(), value.as_bytes())
+}
+
+fn resolve_git_config_include_path(path: &str, config_dir: &Path) -> PathBuf {
+    let path = expand_home_path(path);
+    if path.is_absolute() {
+        path
+    } else {
+        config_dir.join(path)
+    }
+}
+
+fn normalize_git_config_pattern(pattern: &str) -> String {
+    let expanded = expand_home_path(pattern);
+    if pattern.contains('*') || pattern.contains('?') {
+        normalize_path_string(&expanded)
+    } else {
+        normalize_path_for_config_match(&expanded)
+    }
+}
+
+fn normalize_path_for_config_match(path: &Path) -> String {
+    normalize_path_string(&dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
+}
+
+fn normalize_path_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn expand_home_path(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home_dir_from_env() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+fn parse_origin_url_from_git_configs(configs: &[String]) -> Option<String> {
+    configs
+        .iter()
+        .filter_map(|config| parse_origin_url_from_git_config(config))
+        .next_back()
 }
 
 fn parse_origin_url_from_git_config(config: &str) -> Option<String> {
@@ -283,10 +457,11 @@ fn apply_url_instead_of_rewrite(url: &str, rules: &[UrlRewriteRule]) -> String {
     format!("{}{}", rule.base, &url[rule.instead_of.len()..])
 }
 
-fn read_user_git_config_contents() -> Vec<String> {
+fn read_user_git_config_contents(repo_root: &Path, git_dir: &Path) -> Vec<String> {
+    let mut visited = HashSet::new();
     user_git_config_paths()
         .into_iter()
-        .filter_map(|path| fs::read_to_string(path).ok())
+        .flat_map(|path| read_git_config_chain(&path, repo_root, git_dir, &mut visited, 0))
         .collect()
 }
 
@@ -463,6 +638,113 @@ mod tests {
         assert_eq!(
             actual.as_str(),
             compute_repo_hash("git@github.com:example/rewrite.git").as_str()
+        );
+    }
+
+    #[test]
+    fn detect_repo_hash_applies_url_rewrite_from_included_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        fs::write(repo.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        fs::write(
+            repo.join(".git/config"),
+            r#"
+[include]
+    path = rewrites.inc
+[remote "origin"]
+    url = gh:example/included.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#,
+        )
+        .unwrap();
+        fs::write(
+            repo.join(".git/rewrites.inc"),
+            r#"
+[url "git@github.com:"]
+    insteadOf = gh:
+"#,
+        )
+        .unwrap();
+
+        let actual = detect_repo_hash(&repo).expect("repo hash");
+
+        assert_eq!(
+            actual.as_str(),
+            compute_repo_hash("git@github.com:example/included.git").as_str()
+        );
+    }
+
+    #[test]
+    fn detect_repo_hash_preserves_include_insertion_order_for_origin_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        fs::write(repo.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        fs::write(
+            repo.join(".git/config"),
+            r#"
+[include]
+    path = included-origin.inc
+[remote "origin"]
+    url = https://github.com/example/local.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#,
+        )
+        .unwrap();
+        fs::write(
+            repo.join(".git/included-origin.inc"),
+            r#"
+[remote "origin"]
+    url = https://github.com/example/included.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#,
+        )
+        .unwrap();
+
+        let actual = detect_repo_hash(&repo).expect("repo hash");
+
+        assert_eq!(
+            actual.as_str(),
+            compute_repo_hash("https://github.com/example/local.git").as_str()
+        );
+    }
+
+    #[test]
+    fn detect_repo_hash_applies_url_rewrite_from_matching_include_if_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let git_dir = repo.join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        let git_dir_pattern = format!("{}/", git_dir.display());
+        fs::write(
+            git_dir.join("config"),
+            format!(
+                r#"
+[includeIf "gitdir:{git_dir_pattern}"]
+    path = conditional.inc
+[remote "origin"]
+    url = gh:example/conditional.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+"#
+            ),
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("conditional.inc"),
+            r#"
+[url "git@github.com:"]
+    insteadOf = gh:
+"#,
+        )
+        .unwrap();
+
+        let actual = detect_repo_hash(&repo).expect("repo hash");
+
+        assert_eq!(
+            actual.as_str(),
+            compute_repo_hash("git@github.com:example/conditional.git").as_str()
         );
     }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,33 @@
 # Lessons Learned
 
+## 2026-05-15 — Git config emulation must preserve include insertion order
+
+### 事象
+
+PR #2727 の review thread で、`repo_hash` が `url.*.insteadOf` を top-level
+Git config からしか読まず、`[include]` / `[includeIf]` 先の rewrite 設定を
+無視する問題を指摘された。追修正の初期実装では include 先を親 config の
+末尾へ単純追加していたため、include 先が `remote.origin.url` も定義する
+場合に、include 行より後ろのローカル設定が勝つという Git の順序とずれた。
+
+### 原因
+
+Git config の include は「親ファイルを読み終えた後に追加する」処理ではなく、
+`path = ...` 行の位置に include 先の内容を挿入する処理である。プロセス起動
+を避けるために Git config を自前解決する場合、ファイル単位の `Vec<String>`
+へ単純 append すると、同じ key が親子 config の両方にあるケースで上書き順序
+が変わる。
+
+### 再発防止策
+
+1. `git config` / `git remote get-url` 相当の処理を自前実装する場合は、
+   include / includeIf / user config / local config の順序をテストで固定して
+   から実装する。
+2. `[include]` は include 行の位置で展開し、loop guard と最大深さを持たせる。
+   「親を全部読んでから include を末尾追加する」形にしない。
+3. review 指摘への follow-up では、指摘された直接ケースだけでなく、隣接する
+   Git config precedence の回帰テストを 1 件追加してから GREEN にする。
+
 ## 2026-05-12 — Workspace coordination must not become a global tool lock
 
 ### 事象


### PR DESCRIPTION
## Summary

- Expands Git config include and includeIf chains before applying url.insteadOf rules so repo hashes match Git's effective remote URL behavior.
- Preserves include insertion order to avoid letting included files override later local config entries.
- Records the Git config emulation lesson to prevent future process-free parity regressions.

## Changes

- `crates/gwt-core/src/repo_hash.rs`: reads local and user Git config chains with include/includeIf expansion, loop protection, and gitdir matching before parsing origin URL rewrite rules.
- `crates/gwt-core/src/repo_hash.rs`: adds regression tests for included rewrite rules, matching includeIf rewrite rules, and include insertion-order precedence.
- `tasks/lessons.md`: documents the Git config include ordering pitfall found while addressing the PR #2727 review thread.

## Testing

- [x] `cargo test -p gwt-core repo_hash::tests::detect_repo_hash_applies_url_rewrite_from_included_config --all-features` — failed before include expansion, passed after the fix.
- [x] `cargo test -p gwt-core repo_hash::tests::detect_repo_hash_applies_url_rewrite_from_matching_include_if_config --all-features` — failed before includeIf expansion, passed after the fix.
- [x] `cargo test -p gwt-core repo_hash::tests::detect_repo_hash_preserves_include_insertion_order_for_origin_url --all-features` — failed before insertion-order expansion, passed after the fix.
- [x] `cargo test -p gwt-core repo_hash::tests::detect_repo_hash --all-features` — passed.
- [x] `cargo fmt` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx --bun markdownlint-cli tasks/lessons.md --config .markdownlint.json` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #2725
- #2726
- #2727

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- PR #2727 removed the immediate url.insteadOf parity gap after replacing hot-path Git process calls, but a review thread correctly noted that included Git config files were still ignored.

## Risk / Impact

- **Affected areas**: repo hash detection for repositories that rely on Git config includes or conditional includes for remote URL rewrites.
- **Rollback plan**: revert this PR; repo hash detection falls back to the previous top-level config behavior.
