### PR TITLE
fix(workspace): SessionStart hook で projection.agents に session を登録する

### DIFF
--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -35,6 +35,15 @@ fn handle_session_start(event: &str, input: &str) -> Result<HookOutput, HookErro
     run_step(event, "forward", || {
         crate::daemon_runtime::handle_forward(input)
     })?;
+    // SPEC-2359: register the running session into `projection.agents[]`
+    // before any further coordination CLI runs so `gwtd workspace update
+    // --title-summary` is not silently dropped. Fail-open: registration
+    // errors must not abort the agent boot.
+    run_value(event, "workspace-registration", || {
+        if let Err(error) = workspace_identity::handle_session_start() {
+            tracing::warn!(?error, "workspace-registration hook step failed");
+        }
+    });
     run_step(event, "coordination-event", || {
         crate::daemon_runtime::handle_coordination_event(event, input)
     })?;

--- a/crates/gwt/src/cli/hook/workspace_identity.rs
+++ b/crates/gwt/src/cli/hook/workspace_identity.rs
@@ -1,8 +1,11 @@
 use std::{fs, path::Path};
 
+use chrono::{DateTime, Utc};
 use gwt_agent::{Session, GWT_SESSION_ID_ENV};
 use gwt_core::workspace_projection::{
-    load_workspace_projection, update_workspace_projection_with_journal, WorkspaceProjectionUpdate,
+    load_or_default_workspace_projection, load_workspace_projection, save_workspace_projection,
+    update_workspace_projection_with_journal, WorkspaceAgentAffiliationStatus,
+    WorkspaceAgentSummary, WorkspaceProjection, WorkspaceProjectionUpdate, WorkspaceStatusCategory,
 };
 
 use super::{HookError, HookOutput, IntentBoundaryEvent};
@@ -28,6 +31,75 @@ struct MissingIdentity {
 impl MissingIdentity {
     fn complete(self) -> bool {
         !self.title_summary && !self.current_focus
+    }
+}
+
+/// SessionStart hook: ensure the running agent session is present in the
+/// Workspace projection's `agents[]` before any further coordination CLI
+/// runs. Without this, `gwtd workspace update --agent-session ... --title-summary ...`
+/// silently no-ops because `apply_update`'s session matcher finds nothing
+/// to update (only a journal entry is written, and no `WorkspaceState`
+/// broadcast fires).
+///
+/// Registration is idempotent: if the launch flow has already registered
+/// the session (with `Assigned` affiliation, a workspace_id, etc.) we
+/// leave that record untouched so the richer launch-time state survives.
+pub(crate) fn handle_session_start() -> Result<(), HookError> {
+    let Some(session) = current_session_from_env()? else {
+        return Ok(());
+    };
+    let mut projection = load_or_default_workspace_projection(&session.worktree_path)?;
+    projection.project_root = session.worktree_path.clone();
+    let registered = register_session_in_projection(&mut projection, &session, Utc::now());
+    if registered {
+        save_workspace_projection(&session.worktree_path, &projection)?;
+        crate::cli::workspace::publish_workspace_change(&session.worktree_path);
+    }
+    Ok(())
+}
+
+/// Insert a stub `WorkspaceAgentSummary` for `session` if no agent with
+/// the same `session_id` is present. Returns `true` when a new record
+/// was inserted. Existing records are preserved as-is.
+pub(crate) fn register_session_in_projection(
+    projection: &mut WorkspaceProjection,
+    session: &Session,
+    now: DateTime<Utc>,
+) -> bool {
+    if projection
+        .agents
+        .iter()
+        .any(|agent| agent.session_id == session.id)
+    {
+        return false;
+    }
+    projection
+        .agents
+        .push(workspace_agent_summary_from_session(session, now));
+    projection.updated_at = now;
+    true
+}
+
+fn workspace_agent_summary_from_session(
+    session: &Session,
+    now: DateTime<Utc>,
+) -> WorkspaceAgentSummary {
+    WorkspaceAgentSummary {
+        session_id: session.id.clone(),
+        window_id: None,
+        agent_id: session.agent_id.command().to_string(),
+        display_name: session.display_name.clone(),
+        status_category: WorkspaceStatusCategory::Active,
+        current_focus: None,
+        title_summary: None,
+        worktree_path: Some(session.worktree_path.clone()),
+        branch: Some(session.branch.clone()),
+        last_board_entry_id: None,
+        last_board_entry_kind: None,
+        coordination_scope: None,
+        affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+        workspace_id: None,
+        updated_at: now,
     }
 }
 
@@ -417,11 +489,110 @@ fn value_to_text(value: &serde_json::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
+    use gwt_agent::{AgentId, Session};
     use gwt_core::workspace_projection::{
-        WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceStatusCategory,
+        WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceProjection,
+        WorkspaceStatusCategory,
     };
 
     use super::*;
+
+    fn projection_for(repo: &std::path::Path) -> WorkspaceProjection {
+        let now = Utc::now();
+        WorkspaceProjection {
+            id: "ws-test".to_string(),
+            project_root: repo.to_path_buf(),
+            title: String::new(),
+            status_category: WorkspaceStatusCategory::Unknown,
+            status_text: String::new(),
+            summary: None,
+            owner: None,
+            next_action: None,
+            agents: Vec::new(),
+            git_details: None,
+            board_refs: Vec::new(),
+            updated_at: now,
+            created_at: now,
+            creator: None,
+            lifecycle_stage: Default::default(),
+            blocked_reason: None,
+            linked_issues: Vec::new(),
+            linked_prs: Vec::new(),
+            tags: Vec::new(),
+            progress_pct: None,
+        }
+    }
+
+    fn fresh_session(repo: &std::path::Path) -> Session {
+        Session::new(repo.to_path_buf(), "work/test-session", AgentId::Codex)
+    }
+
+    #[test]
+    fn register_session_inserts_unassigned_agent_when_absent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let mut projection = projection_for(&repo);
+        let session = fresh_session(&repo);
+        let now = Utc::now();
+
+        let inserted = register_session_in_projection(&mut projection, &session, now);
+
+        assert!(inserted, "first registration should insert");
+        assert_eq!(projection.agents.len(), 1);
+        let agent = &projection.agents[0];
+        assert_eq!(agent.session_id, session.id);
+        assert_eq!(agent.agent_id, "codex");
+        assert!(agent.is_unassigned());
+        assert_eq!(agent.worktree_path.as_deref(), Some(repo.as_path()));
+        assert_eq!(agent.branch.as_deref(), Some("work/test-session"));
+        assert_eq!(agent.title_summary, None);
+        assert_eq!(agent.window_id, None);
+        assert_eq!(projection.updated_at, now);
+    }
+
+    #[test]
+    fn register_session_is_idempotent_for_same_session() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let mut projection = projection_for(&repo);
+        let session = fresh_session(&repo);
+
+        assert!(register_session_in_projection(
+            &mut projection,
+            &session,
+            Utc::now()
+        ));
+        let second = register_session_in_projection(&mut projection, &session, Utc::now());
+
+        assert!(!second, "second registration should not re-insert");
+        assert_eq!(projection.agents.len(), 1);
+    }
+
+    #[test]
+    fn register_session_preserves_existing_agent_fields() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let mut projection = projection_for(&repo);
+        let session = fresh_session(&repo);
+
+        let mut existing = assigned_agent(&session.id, &repo);
+        existing.title_summary = Some("preserved title".to_string());
+        existing.current_focus = Some("preserved focus".to_string());
+        existing.workspace_id = Some("ws-1".to_string());
+        existing.window_id = Some("win-7".to_string());
+        projection.agents.push(existing);
+
+        let inserted = register_session_in_projection(&mut projection, &session, Utc::now());
+
+        assert!(!inserted);
+        assert_eq!(projection.agents.len(), 1);
+        let agent = &projection.agents[0];
+        assert_eq!(agent.title_summary.as_deref(), Some("preserved title"));
+        assert_eq!(agent.current_focus.as_deref(), Some("preserved focus"));
+        assert_eq!(agent.workspace_id.as_deref(), Some("ws-1"));
+        assert_eq!(agent.window_id.as_deref(), Some("win-7"));
+        assert!(agent.is_assigned());
+    }
 
     fn assigned_agent(session_id: &str, repo: &std::path::Path) -> WorkspaceAgentSummary {
         WorkspaceAgentSummary {

--- a/crates/gwt/tests/workspace_identity_session_start_test.rs
+++ b/crates/gwt/tests/workspace_identity_session_start_test.rs
@@ -1,0 +1,164 @@
+//! SPEC-2359: SessionStart hook must register the running agent session
+//! into `projection.agents[]` so that `gwtd workspace update --title-summary`
+//! reaches the matching agent record instead of being silently dropped at
+//! the `apply_update` matcher in `gwt_core::workspace_projection`.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
+
+use gwt::cli::hook::event_dispatcher;
+use gwt_agent::{session::GWT_SESSION_ID_ENV, AgentId, Session};
+use gwt_core::{
+    paths::gwt_sessions_dir,
+    workspace_projection::{
+        load_workspace_projection, update_workspace_projection_with_journal,
+        WorkspaceProjectionUpdate,
+    },
+};
+use tempfile::TempDir;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct EnvGuard {
+    _guard: std::sync::MutexGuard<'static, ()>,
+    previous_home: Option<std::ffi::OsString>,
+    previous_session_id: Option<std::ffi::OsString>,
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous_home.take() {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match self.previous_session_id.take() {
+            Some(value) => std::env::set_var(GWT_SESSION_ID_ENV, value),
+            None => std::env::remove_var(GWT_SESSION_ID_ENV),
+        }
+    }
+}
+
+fn with_temp_env(home: &Path, session_id: &str) -> EnvGuard {
+    let guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let previous_home = std::env::var_os("HOME");
+    let previous_session_id = std::env::var_os(GWT_SESSION_ID_ENV);
+    std::env::set_var("HOME", home);
+    std::env::set_var(GWT_SESSION_ID_ENV, session_id);
+    EnvGuard {
+        _guard: guard,
+        previous_home,
+        previous_session_id,
+    }
+}
+
+fn init_repo(home: &TempDir) -> PathBuf {
+    let repo_path = home.path().join("repo");
+    std::fs::create_dir_all(&repo_path).expect("create repo dir");
+    assert!(std::process::Command::new("git")
+        .arg("init")
+        .arg(&repo_path)
+        .status()
+        .expect("git init")
+        .success());
+    assert!(std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_path)
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/gwt-session-start.git",
+        ])
+        .status()
+        .expect("git remote add")
+        .success());
+    repo_path
+}
+
+fn save_session(repo_path: &Path) -> String {
+    let mut session = Session::new(repo_path, "work/session-start-test", AgentId::Codex);
+    session.id = "session-start-fixture".to_string();
+    session.save(&gwt_sessions_dir()).expect("save session");
+    session.id
+}
+
+#[test]
+fn session_start_hook_registers_agent_so_workspace_update_persists_title_summary() {
+    let home = tempfile::tempdir().expect("temp home");
+    let _env = with_temp_env(home.path(), "session-start-fixture");
+    let repo_path = init_repo(&home);
+    let session_id = save_session(&repo_path);
+
+    let output = event_dispatcher::handle_with_input("SessionStart", "{}", &repo_path, None)
+        .expect("SessionStart dispatch should succeed");
+    drop(output);
+
+    let projection = load_workspace_projection(&repo_path)
+        .expect("load projection")
+        .expect("projection should exist after SessionStart");
+    let agent = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+        .expect("SessionStart must register the running session");
+    assert!(agent.is_unassigned());
+    assert_eq!(agent.agent_id, "codex");
+    assert_eq!(agent.title_summary, None);
+
+    let update = WorkspaceProjectionUpdate {
+        title: None,
+        status_category: None,
+        status_text: None,
+        owner: None,
+        next_action: None,
+        summary: None,
+        agent_session_id: Some(session_id.clone()),
+        agent_current_focus: None,
+        agent_title_summary: Some("verify session start fixes".to_string()),
+    };
+    update_workspace_projection_with_journal(&repo_path, update).expect("workspace update");
+
+    let projection = load_workspace_projection(&repo_path)
+        .expect("reload projection")
+        .expect("projection should exist after update");
+    let agent = projection
+        .agents
+        .iter()
+        .find(|agent| agent.session_id == session_id)
+        .expect("agent must remain after update");
+    assert_eq!(
+        agent.title_summary.as_deref(),
+        Some("verify session start fixes"),
+        "title_summary must reach the registered agent record"
+    );
+}
+
+#[test]
+fn session_start_hook_is_idempotent_across_repeated_invocations() {
+    let home = tempfile::tempdir().expect("temp home");
+    let _env = with_temp_env(home.path(), "session-start-fixture");
+    let repo_path = init_repo(&home);
+    let session_id = save_session(&repo_path);
+
+    for _ in 0..3 {
+        event_dispatcher::handle_with_input("SessionStart", "{}", &repo_path, None)
+            .expect("SessionStart dispatch should succeed");
+    }
+
+    let projection = load_workspace_projection(&repo_path)
+        .expect("load projection")
+        .expect("projection should exist after SessionStart");
+    let matches = projection
+        .agents
+        .iter()
+        .filter(|agent| agent.session_id == session_id)
+        .count();
+    assert_eq!(matches, 1, "SessionStart hook must not duplicate agents");
+}


### PR DESCRIPTION
## Summary

- `gwtd workspace update --agent-session "$GWT_SESSION_ID" --title-summary X` が agent window タイトルを変えない無音バグを修正する
- **Phase U-3 (registration)**: SessionStart hook で `projection.agents[]` に session を upsert する `workspace-registration` step を追加 (canonical registration ポイント)
- **Phase U-4 (resolution)**: `resolve_title_sync_window_id` に worktree-only fallback を追加し、SessionStart 登録 record (`window_id = None`) でも同 worktree のユニークな同種 active session 経由で pane を解決可能にした
- 既存 Launch flow による登録は idempotent に保持

## Context

### 元のバグ

`WorkspaceProjection::apply_update` (crates/gwt-core/src/workspace_projection.rs:529-552) は `update.agent_session_id` を `projection.agents[]` から探して title_summary を更新するが、該当 session が未登録だと無音 no-op になり journal だけ残る。CLI は `workspace updated` を返すため呼び出し側はサイレント失敗に気付けない。

これまで `projection.agents[]` への登録は gwt の Launch flow (`save_unassigned_workspace_launch_projection`) のみが担っていた。GUI 再起動後や Launch flow を経由しない agent では projection.agents が空のまま残り、AGENTS.md / coordination skill が正規経路として案内している `gwtd workspace update --title-summary` が事実上無効になっていた。

### 解決策

Claude Code / Codex のどちらも SessionStart hook で `GWT_SESSION_ID` 付きで起動と同時に呼び出されるため、ここを正規の registration ポイントにする (Phase U-3)。

加えて、SessionStart hook が登録する record は `window_id = None` のため `resolve_title_sync_window_id` の既存 Phase U-3 fallback (projection.window_id 必須) を通らず GUI 描画が更新されない。Phase U-4 として、`active_agent_sessions` に worktree + agent_id が一致する session がちょうど 1 件存在するときに限ってその window にフォールバック解決する経路を追加 (曖昧性回避のため複数一致や agent_id 不一致は意図的に None)。

## Changes

### Phase U-3: registration
- `crates/gwt/src/cli/hook/workspace_identity.rs`
  - `handle_session_start()`, `register_session_in_projection`, `workspace_agent_summary_from_session` を追加
  - 同じ `session_id` の agent が既にあれば触らず、無いときだけ Unassigned 状態の `WorkspaceAgentSummary` を push
- `crates/gwt/src/cli/hook/event_dispatcher.rs`
  - `handle_session_start` の冒頭に `workspace-registration` ステップを追加 (fail-open: 失敗は `tracing::warn!` のみで agent boot を止めない)
- `crates/gwt/tests/workspace_identity_session_start_test.rs` 新規追加 (registers + idempotent E2E)

### Phase U-4: resolution
- `crates/gwt/src/app_runtime/mod.rs::resolve_title_sync_window_id`
  - `window_id` 不在でも `worktree_path` 一致 + active_agent_sessions に同 worktree + 同 agent_id の唯一の session があれば、その window を返す
- 同 module の test 内に 3 新規テスト追加
  - `sync_agent_window_titles_falls_back_to_worktree_when_session_id_not_active`
  - `sync_agent_window_titles_worktree_fallback_refuses_when_agent_id_mismatches`
  - `sync_agent_window_titles_worktree_fallback_refuses_when_multiple_sessions_match`

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features` 全 pass (Phase U-3 unit/E2E + Phase U-4 unit 計 6 件追加、既存 testsuite に regression なし)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` クリーン
- [x] `cargo build -p gwt --bin gwt --bin gwtd` ok
- [x] `bunx commitlint` exit=0 (両コミット)
- [x] CLI/data layer: SessionStart hook 発火 → `current.json` の `agents[]` が `0 → 1` → `gwtd workspace update --title-summary 'X'` で `agents[0].title_summary = 'X'` が persist することを実環境で確認
- [ ] **GUI 表示確認 (要 GUI 再起動)**: target/debug/gwt または `/Applications/GWT.app` を新ビルドへ更新 → GUI 再起動 → 新規 Agent 起動後に `gwtd workspace update --agent-session "$GWT_SESSION_ID" --title-summary 'verify'` でタブタイトルが即時 `verify` へ変わることを目視確認

## Risk / Impact

- SessionStart hook の処理を 1 ステップ増やす (fail-open のため失敗時も既存挙動を維持)
- `resolve_title_sync_window_id` の新フォールバック経路は厳格な条件 (worktree + agent_id がちょうど 1 件) でのみ発火するため、既存の解決結果は変えない
- Launch flow による Assigned 登録は上書きされないため、richer な launch-time state は保持される

## Closing Issues

None.

## Related

- SPEC-2359: Workspace / Start Work — ブランチレス作業開始・現在作業 Projection
- Phase U-2: `BackendEvent::WorkspaceState` broadcast (この PR の上に積み上がる)

## Checklist

- [x] Conventional Commits 形式のコミットメッセージ
- [x] 単体テスト追加 (Phase U-3 + Phase U-4)
- [x] 結合テスト追加 (Phase U-3 E2E)
- [x] 全テスト pass
- [x] clippy / fmt クリーン
- [x] CLI/data layer 実環境確認
- [ ] GUI 表示確認 (要 GUI 再起動)
