### PR TITLE
fix(migration): ignore linked worktree markers

### DIFF
--- a/crates/gwt-core/src/migration/validator.rs
+++ b/crates/gwt-core/src/migration/validator.rs
@@ -15,6 +15,7 @@ use crate::process::hidden_command;
 
 #[derive(Debug)]
 pub enum ValidationError {
+    NotNormalGitDirectory(PathBuf),
     InsufficientDiskSpace { required: u64, available: u64 },
     LockedWorktrees(Vec<PathBuf>),
     WritePermissionDenied(PathBuf),
@@ -24,6 +25,11 @@ pub enum ValidationError {
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::NotNormalGitDirectory(path) => write!(
+                f,
+                "not a normal Git repository with a .git directory: {}",
+                path.display()
+            ),
             Self::InsufficientDiskSpace {
                 required,
                 available,
@@ -153,9 +159,23 @@ pub fn check_write_permission(project_root: &Path) -> Result<(), ValidationError
     }
 }
 
+/// Confirm the migration root is a Normal Git repository with a real `.git/`
+/// directory. Linked worktrees use a `.git` marker file and are already part of
+/// a bare/worktree layout, so migrating them as Normal Git would be destructive.
+pub fn check_normal_git_directory(project_root: &Path) -> Result<(), ValidationError> {
+    if project_root.join(".git").is_dir() {
+        Ok(())
+    } else {
+        Err(ValidationError::NotNormalGitDirectory(
+            project_root.to_path_buf(),
+        ))
+    }
+}
+
 /// Run all pre-flight checks against `project_root`. Short-circuits on the
 /// first failure.
 pub fn validate(project_root: &Path) -> Result<(), ValidationError> {
+    check_normal_git_directory(project_root)?;
     check_write_permission(project_root)?;
     check_disk_space(project_root)?;
     check_locked_worktrees(project_root)?;

--- a/crates/gwt-core/tests/migration_workflow_test.rs
+++ b/crates/gwt-core/tests/migration_workflow_test.rs
@@ -201,6 +201,25 @@ fn t026_validate_aggregates_all_checks_for_clean_normal_repo() {
 }
 
 #[test]
+fn t026_validate_rejects_git_file_worktree_marker_before_backup() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".git"),
+        "gitdir: ../repo.git/worktrees/feature\n",
+    )
+    .unwrap();
+
+    let err = validator::validate(tmp.path())
+        .expect_err("linked worktree markers must not be valid Normal Git migration roots");
+
+    assert!(
+        err.to_string()
+            .contains("not a normal Git repository with a .git directory"),
+        "unexpected validation error: {err}"
+    );
+}
+
+#[test]
 fn t030_backup_create_copies_tree_into_backup_dir() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("a.txt"), "alpha").unwrap();

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -30,11 +30,18 @@ pub enum RepoType {
 /// Checks the path itself and walks parent directories to find a git repo.
 /// Distinguishes between normal repos, bare repos, and non-repo directories.
 pub fn detect_repo_type(path: &Path) -> RepoType {
-    // Check if path itself has .git (normal repo or worktree)
-    if path.join(".git").exists() {
+    // Check if path itself has `.git/` (Normal repo) or a `.git` marker file
+    // (linked worktree).
+    let dot_git = path.join(".git");
+    if dot_git.is_dir() {
         return RepoType::Normal {
             path: path.to_path_buf(),
             needs_migration: true,
+        };
+    }
+    if dot_git.is_file() {
+        return RepoType::Bare {
+            develop_worktree: Some(path.to_path_buf()),
         };
     }
     // Check if path itself is a bare repo (has HEAD + objects + refs)
@@ -81,10 +88,16 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
         if parent == current {
             break;
         }
-        if parent.join(".git").exists() {
+        let dot_git = parent.join(".git");
+        if dot_git.is_dir() {
             return RepoType::Normal {
                 path: parent.to_path_buf(),
                 needs_migration: true,
+            };
+        }
+        if dot_git.is_file() {
+            return RepoType::Bare {
+                develop_worktree: Some(parent.to_path_buf()),
             };
         }
         if parent.join("HEAD").exists()
@@ -587,6 +600,28 @@ mod tests {
     }
 
     #[test]
+    fn detect_repo_type_treats_git_file_marker_as_worktree_not_normal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare_dir = tmp.path().join("repo.git");
+        let worktree = tmp.path().join("feature");
+        std::fs::create_dir_all(bare_dir.join("worktrees").join("feature")).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: ../repo.git/worktrees/feature\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            detect_repo_type(&worktree),
+            RepoType::Bare {
+                develop_worktree: Some(worktree)
+            },
+            "linked worktree markers are already gwt-compatible worktrees and must not request Normal migration"
+        );
+    }
+
+    #[test]
     fn detect_repo_type_returns_bare_for_bare_repo() {
         let tmp = tempfile::tempdir().unwrap();
         gwt_core::process::hidden_command("git")
@@ -609,6 +644,29 @@ mod tests {
         let subdir = tmp.path().join("a").join("b");
         std::fs::create_dir_all(&subdir).unwrap();
         assert!(matches!(detect_repo_type(&subdir), RepoType::Normal { .. }));
+    }
+
+    #[test]
+    fn detect_repo_type_walks_parents_to_find_worktree_marker_without_migration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare_dir = tmp.path().join("repo.git");
+        let worktree = tmp.path().join("feature");
+        let nested = worktree.join("src").join("bin");
+        std::fs::create_dir_all(bare_dir.join("worktrees").join("feature")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: ../repo.git/worktrees/feature\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            detect_repo_type(&nested),
+            RepoType::Bare {
+                develop_worktree: Some(worktree)
+            },
+            "opening a subdirectory inside a linked worktree must resolve the worktree without migration"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -753,6 +753,29 @@ mod tests {
     }
 
     #[test]
+    fn resolve_project_target_does_not_request_migration_for_worktree_marker() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare = tmp.path().join("repo.git");
+        let worktree = tmp.path().join("feature");
+        std::fs::create_dir_all(bare.join("worktrees").join("feature")).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: ../repo.git/worktrees/feature\n",
+        )
+        .unwrap();
+
+        let target = super::resolve_project_target(&worktree).expect("worktree target");
+
+        assert_eq!(target.kind, gwt::ProjectKind::Git);
+        assert_eq!(target.project_root, dunce::canonicalize(&worktree).unwrap());
+        assert!(
+            !target.needs_migration,
+            "linked worktree markers must not be treated as Normal Git migration targets"
+        );
+    }
+
+    #[test]
     fn fallback_project_target_does_not_set_needs_migration() {
         let target =
             super::fallback_project_target(std::path::PathBuf::from("/tmp/_does_not_exist"));

--- a/crates/gwt/tests/migration_e2e_test.rs
+++ b/crates/gwt/tests/migration_e2e_test.rs
@@ -352,6 +352,39 @@ fn t103_e2e_locked_worktree_blocks_migration_with_no_changes() {
 }
 
 #[test]
+fn t103_git_file_worktree_marker_aborts_before_backup() {
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(
+        project.path().join(".git"),
+        "gitdir: ../repo.git/worktrees/feature\n",
+    )
+    .unwrap();
+    std::fs::write(project.path().join("README.md"), "# sample\n").unwrap();
+
+    let result = execute_migration(
+        project.path(),
+        MigrationOptions::default(),
+        |_phase, _pct| {},
+    );
+
+    let err = result.expect_err("linked worktree marker must not be migrated as Normal Git");
+    assert_eq!(err.phase, MigrationPhase::Validate);
+    assert_eq!(err.recovery, RecoveryState::Untouched);
+    assert!(
+        err.message
+            .contains("not a normal Git repository with a .git directory"),
+        "unexpected migration error: {err}"
+    );
+    assert!(
+        !project
+            .path()
+            .join(gwt_core::migration::backup::BACKUP_DIR_NAME)
+            .exists(),
+        "validation must fail before creating .gwt-migration-backup"
+    );
+}
+
+#[test]
 fn t104_e2e_failure_injected_during_bareify_rolls_back_to_original_layout() {
     // SPEC-1934 US-6.6: when a phase after Backup fails, rollback must
     // restore the original Normal Git layout. We provoke the failure by


### PR DESCRIPTION
## Summary

- Prevent linked worktree `.git` marker files from being classified as Normal Git repositories that need migration.
- Add a migration preflight guard so direct migration calls fail before creating `.gwt-migration-backup/` on linked worktree roots.

## Changes

- `crates/gwt-git/src/repository.rs`: Treat only `.git/` directories as Normal Git migration candidates and resolve `.git` marker files as linked worktrees.
- `crates/gwt-core/src/migration/validator.rs`: Add Normal Git directory validation before backup, disk, permission, and locked-worktree checks.
- `crates/gwt/src/runtime_support.rs`: Cover project target resolution for linked worktree marker roots.
- `crates/gwt-core/tests/migration_workflow_test.rs`: Cover validator rejection for `.git` marker roots.
- `crates/gwt/tests/migration_e2e_test.rs`: Cover direct migration abort before `.gwt-migration-backup/` creation.

## Testing

- [x] `cargo test -p gwt-git detect_repo_type --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt resolve_project_target --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt-core t026_validate_rejects_git_file_worktree_marker_before_backup --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt --test migration_e2e_test t103_git_file_worktree_marker_aborts_before_backup --all-features -- --nocapture` - passed.
- [x] `cargo test -p gwt-core -p gwt-git -p gwt --all-features` - passed on rerun.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed.
- [x] `git diff --check` - passed.

## Closing Issues

None

## Related Issues / Links

- #1934

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-1934 `spec` and `tasks` sections updated)
- [x] Migration/backfill plan included (guard prevents backup creation for linked worktree marker roots)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- Opening a valid gwt linked worktree such as `/Users/akiojin/Workbench/gwt/work/20260515-0405` could previously trigger the Normal Git migration recovery path because `.git` marker files were treated the same as `.git/` directories.

## Risk / Impact

- **Affected areas**: repository type detection and migration preflight validation.
- **Rollback plan**: Revert this PR; no data/schema migration is introduced.

## Notes

- The first broad test run hit a transient `watcher_debounce::batch_size_limit_splits_burst` timing failure unrelated to this diff. The failing test passed in isolation, the test file passed, and the full command passed on rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Migration now validates that the project root is a normal Git repository with a `.git` directory, preventing migration of linked worktrees and providing clear error messages before any changes occur.

* **Tests**
  * Added comprehensive tests across workflow, integration, and end-to-end scenarios to verify validation of Git repository structure and early rejection of incompatible setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2730)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->