### PR TITLE
fix(gui): hide setup forms during runtime confirmation

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2472,6 +2472,32 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_launch_wizard_runtime_confirmation_summary_contract() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("const isRuntimeConfirmation = Boolean(")
+                && html.contains("launchWizard.runtime_context_resolved")
+                && html.contains("launchWizard.show_runtime_confirmation"),
+            "expected Launch Wizard to derive a dedicated Runtime confirmation state",
+        );
+        assert!(
+            html.contains("const showSetupForms = showManualSetup && !isRuntimeConfirmation;"),
+            "expected setup form rendering to be disabled during Runtime confirmation",
+        );
+        assert!(
+            html.contains("renderWizardSummary();")
+                && html.contains("if (!isRuntimeConfirmation"),
+            "expected Runtime confirmation to keep the read-only summary while hiding selection/setup rows",
+        );
+        assert!(
+            html.contains("showSetupForms && launchWizard.show_branch_controls !== false")
+                && html.contains("showSetupForms && launchWizard.show_agent_settings"),
+            "expected branch and linked issue controls to be gated to setup forms",
+        );
+    }
+
+    #[test]
     fn embedded_web_shared_bundle_keeps_user_facing_copy_english_only() {
         let html = frontend_bundle_source();
         let japanese_scripts = regex::Regex::new(r"[ぁ-んァ-ン一-龯]").expect("valid regex");

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1404,6 +1404,49 @@ test("Launch wizard separates launch settings from runtime controls", () => {
   }
 });
 
+test("Launch wizard runtime confirmation shows summary without setup forms", () => {
+  assert.match(
+    appSource,
+    /const isRuntimeConfirmation = Boolean\(\s*launchWizard\.runtime_context_resolved\s*&&\s*launchWizard\.show_runtime_confirmation\s*\);/,
+    "expected renderer to derive a dedicated Runtime confirmation state",
+  );
+  assert.match(
+    appSource,
+    /const showSetupForms = showManualSetup && !isRuntimeConfirmation;/,
+    "expected manual setup forms to be suppressed during Runtime confirmation",
+  );
+  assert.match(
+    appSource,
+    /renderWizardSummary\(\);[\s\S]*?const isRuntimeConfirmation = Boolean/,
+    "expected read-only launch summary to remain visible before Runtime-only body rendering",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(\s*!isRuntimeConfirmation\s*&&\s*\(\s*\(launchWizard\.quick_start_entries \|\| \[\]\)\.length > 0/,
+    "expected Quick Start selection rows to be hidden during Runtime confirmation",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(\s*showSetupForms\s*&&\s*launchWizard\.show_branch_controls !== false\s*\)/,
+    "expected Branch controls to be part of setup forms only",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(\s*showSetupForms\s*\)\s*\{[\s\S]*?createLaunchSection\(\s*"Launch"/,
+    "expected Launch controls to be part of setup forms only",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(\s*showSetupForms\s*&&[\s\S]*?launchWizard\.show_codex_fast_mode[\s\S]*?\)\s*\{[\s\S]*?createLaunchSection\(\s*"Launch settings"/,
+    "expected Launch settings controls to be part of setup forms only",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(\s*showSetupForms\s*&&\s*launchWizard\.show_agent_settings\s*\)/,
+    "expected Linked issue controls to be part of setup forms only",
+  );
+});
+
 test("Launch wizard submit button uses Continue before runtime context is resolved", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -5429,6 +5429,11 @@
         }
 
         renderWizardSummary();
+        const isRuntimeConfirmation = Boolean(
+          launchWizard.runtime_context_resolved
+          && launchWizard.show_runtime_confirmation
+        );
+        const showSetupForms = showManualSetup && !isRuntimeConfirmation;
         wizardBody.innerHTML = "";
         const wizardMain = createNode("div", "wizard-main");
         wizardMain.appendChild(renderWizardProgressRail());
@@ -5456,10 +5461,10 @@
           );
         }
 
-        if (
+        if (!isRuntimeConfirmation && (
           (launchWizard.quick_start_entries || []).length > 0 ||
           (launchWizard.live_sessions || []).length > 0
-        ) {
+        )) {
           const section = createLaunchSection(
             "Quick start",
             "Reuse a recent launch profile or jump to a running window.",
@@ -5571,7 +5576,7 @@
           panel.appendChild(section);
         }
 
-        if (launchWizard.show_branch_controls !== false) {
+        if (showSetupForms && launchWizard.show_branch_controls !== false) {
           const section = createLaunchSection(
             "Branch",
             "Choose the selected branch or create a new branch from it.",
@@ -5661,7 +5666,7 @@
           panel.appendChild(section);
         }
 
-        if (showManualSetup) {
+        if (showSetupForms) {
           const section = createLaunchSection(
             "Launch",
             "Choose what to launch on the selected branch.",
@@ -5758,7 +5763,7 @@
         }
 
         if (
-          showManualSetup &&
+          showSetupForms &&
           (
             launchWizard.show_version ||
             launchWizard.show_skip_permissions ||
@@ -5813,7 +5818,7 @@
           panel.appendChild(section);
         }
 
-        if (showManualSetup && launchWizard.show_agent_settings) {
+        if (showSetupForms && launchWizard.show_agent_settings) {
           const section = createLaunchSection(
             "Linked issue",
             "Optional: Link an issue to this launch session.",
@@ -5855,7 +5860,7 @@
             (launchWizard.docker_lifecycle_options || []).length > 0);
         if (
           launchWizard.show_runtime_confirmation &&
-          (hasRuntimeControls || !showManualSetup)
+          (hasRuntimeControls || isRuntimeConfirmation || !showManualSetup)
         ) {
           const section = createLaunchSection(
             "Runtime",


### PR DESCRIPTION
## Summary

- Hide Settings-side setup forms during Runtime confirmation so the Launch Wizard split has a distinct Runtime-only edit step.
- Keep the selected agent/model/version/permission/fast-mode choices visible through the existing read-only wizard summary.

## Changes

- `crates/gwt/web/app.js`: Derives a Runtime confirmation state and gates Quick Start, Branch, Launch, Launch settings, and Linked issue controls behind setup-form rendering.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: Adds a frontend structure contract for Runtime confirmation summary-only setup rendering.
- `crates/gwt/src/embedded_web.rs`: Adds an embedded bundle contract test for the same Runtime confirmation rendering boundary.

## Testing

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — passed after RED failure before implementation.
- [x] `cargo test -p gwt embedded_web_launch_wizard_runtime_confirmation_summary_contract -- --nocapture` — passed after RED failure before implementation.
- [x] `pnpm test:frontend-unit` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json -- --test-threads=1` — passed.
- [x] `node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90` — passed with filtered line coverage 90.51%.
- [x] `bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md --ignore tasks/todo.md` — passed.
- [x] `pnpm lint:skills` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git push` — passed; pre-push hook reran CI-equivalent checks and coverage successfully.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not needed: no user-facing docs change)
- [x] Migration/backfill plan included (not needed: no schema/data change)
- [x] CHANGELOG impact considered (patch fix, no breaking change)

## Context

- The Launch Wizard was split into Settings and Runtime phases, but Runtime confirmation still rendered the same setup controls as Settings. This made the split functionally redundant.

## Risk / Impact

- **Affected areas**: Launch Wizard frontend rendering only.
- **Rollback plan**: Revert the single commit to restore the previous rendering behavior.
