### PR TITLE
fix(workspace): watch current.json + worktree-only window resolution fallback

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -527,27 +527,52 @@ impl WorkspaceProjection {
             self.next_action = (!next_action.trim().is_empty()).then_some(next_action.clone());
         }
         if let Some(session_id) = update.agent_session_id.as_deref() {
+            let focus = update
+                .agent_current_focus
+                .as_ref()
+                .filter(|value| !value.trim().is_empty())
+                .cloned();
+            let title_summary = update
+                .agent_title_summary
+                .as_ref()
+                .filter(|value| !value.trim().is_empty())
+                .cloned();
             if let Some(agent) = self
                 .agents
                 .iter_mut()
                 .find(|agent| agent.session_id == session_id)
             {
-                if let Some(focus) = update
-                    .agent_current_focus
-                    .as_ref()
-                    .filter(|value| !value.trim().is_empty())
-                {
-                    agent.current_focus = Some(focus.clone());
+                if let Some(focus) = focus {
+                    agent.current_focus = Some(focus);
                     agent.updated_at = updated_at;
                 }
-                if let Some(title_summary) = update
-                    .agent_title_summary
-                    .as_ref()
-                    .filter(|value| !value.trim().is_empty())
-                {
-                    agent.title_summary = Some(title_summary.clone());
+                if let Some(title_summary) = title_summary {
+                    agent.title_summary = Some(title_summary);
                     agent.updated_at = updated_at;
                 }
+            } else if focus.is_some() || title_summary.is_some() {
+                // SPEC-2359 Phase U-6: upsert a minimal stub for sessions
+                // that the launch flow / SessionStart hook has not yet
+                // registered. Without this, `gwtd workspace update
+                // --title-summary X` would silently drop the update — see
+                // the regression tests in this module for the contract.
+                self.agents.push(WorkspaceAgentSummary {
+                    session_id: session_id.to_string(),
+                    window_id: None,
+                    agent_id: String::new(),
+                    display_name: String::new(),
+                    status_category: WorkspaceStatusCategory::Active,
+                    current_focus: focus,
+                    title_summary,
+                    worktree_path: None,
+                    branch: None,
+                    last_board_entry_id: None,
+                    last_board_entry_kind: None,
+                    coordination_scope: None,
+                    affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+                    workspace_id: None,
+                    updated_at,
+                });
             }
         }
         self.updated_at = updated_at;
@@ -2896,6 +2921,136 @@ mod tests {
             journal.agent_title_summary.as_deref(),
             Some("Title summary support")
         );
+    }
+
+    #[test]
+    fn apply_update_upserts_minimal_agent_when_session_id_not_present() {
+        // SPEC-2359 Phase U-6 (real root cause fix): `gwtd workspace update
+        // --agent-session ... --title-summary X` must not silently drop the
+        // update when the session is not yet in `projection.agents[]`. The
+        // OLD installed gwtd lacks the SessionStart hook registration path
+        // (Phase U-3) so `apply_update` is the only point where this CLI
+        // path can guarantee the agent is registered.
+        let updated_at = Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap();
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        assert!(projection.agents.is_empty());
+
+        let journal = projection.apply_update(
+            WorkspaceProjectionUpdate {
+                title: None,
+                status_category: None,
+                status_text: None,
+                owner: None,
+                next_action: None,
+                summary: None,
+                agent_session_id: Some("session-new".to_string()),
+                agent_current_focus: Some("focus".to_string()),
+                agent_title_summary: Some("title from upsert".to_string()),
+            },
+            updated_at,
+        );
+
+        assert_eq!(projection.agents.len(), 1, "upsert must add the agent");
+        let agent = &projection.agents[0];
+        assert_eq!(agent.session_id, "session-new");
+        assert_eq!(agent.title_summary.as_deref(), Some("title from upsert"));
+        assert_eq!(agent.current_focus.as_deref(), Some("focus"));
+        assert!(agent.is_unassigned());
+        assert_eq!(agent.updated_at, updated_at);
+        // Journal entry should still carry the requested fields.
+        assert_eq!(journal.agent_session_id.as_deref(), Some("session-new"));
+        assert_eq!(
+            journal.agent_title_summary.as_deref(),
+            Some("title from upsert"),
+        );
+        assert_eq!(journal.agent_current_focus.as_deref(), Some("focus"));
+    }
+
+    #[test]
+    fn apply_update_preserves_existing_agent_when_session_id_matches() {
+        // Upsert MUST NOT clobber pre-existing agent fields when the
+        // session already exists in projection.agents (launch flow already
+        // registered it with richer state). Only title_summary /
+        // current_focus from the update should change.
+        let updated_at = Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap();
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        projection.agents.push(WorkspaceAgentSummary {
+            session_id: "session-launched".to_string(),
+            window_id: Some("tab-1::agent-1".to_string()),
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("old focus".to_string()),
+            title_summary: Some("old title".to_string()),
+            worktree_path: Some(std::path::PathBuf::from("/repo")),
+            branch: Some("work/x".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: Some("ws-1".to_string()),
+            updated_at,
+        });
+
+        projection.apply_update(
+            WorkspaceProjectionUpdate {
+                title: None,
+                status_category: None,
+                status_text: None,
+                owner: None,
+                next_action: None,
+                summary: None,
+                agent_session_id: Some("session-launched".to_string()),
+                agent_current_focus: None,
+                agent_title_summary: Some("new title".to_string()),
+            },
+            updated_at,
+        );
+
+        assert_eq!(projection.agents.len(), 1, "must not duplicate");
+        let agent = &projection.agents[0];
+        // title_summary updated
+        assert_eq!(agent.title_summary.as_deref(), Some("new title"));
+        // everything else preserved
+        assert_eq!(agent.window_id.as_deref(), Some("tab-1::agent-1"));
+        assert_eq!(agent.agent_id, "codex");
+        assert_eq!(agent.display_name, "Codex");
+        assert_eq!(agent.current_focus.as_deref(), Some("old focus"));
+        assert_eq!(agent.worktree_path.as_deref(), Some(std::path::Path::new("/repo")));
+        assert_eq!(agent.branch.as_deref(), Some("work/x"));
+        assert_eq!(agent.workspace_id.as_deref(), Some("ws-1"));
+        assert!(agent.is_assigned());
+    }
+
+    #[test]
+    fn apply_update_upsert_records_journal_entry_with_same_shape() {
+        // Journal entries from the upsert path must have the same shape as
+        // entries from the pre-existing-agent path so downstream consumers
+        // (UI, broadcasts) cannot tell them apart.
+        let updated_at = Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap();
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+
+        let journal = projection.apply_update(
+            WorkspaceProjectionUpdate {
+                title: None,
+                status_category: None,
+                status_text: None,
+                owner: None,
+                next_action: None,
+                summary: None,
+                agent_session_id: Some("session-stub".to_string()),
+                agent_current_focus: None,
+                agent_title_summary: Some("stub title".to_string()),
+            },
+            updated_at,
+        );
+
+        assert!(!journal.id.is_empty());
+        assert_eq!(journal.project_root, projection.project_root);
+        assert_eq!(journal.agent_session_id.as_deref(), Some("session-stub"));
+        assert_eq!(journal.agent_title_summary.as_deref(), Some("stub title"));
+        assert_eq!(journal.agent_current_focus, None);
+        assert_eq!(journal.updated_at, updated_at);
     }
 
     #[test]

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -3016,7 +3016,10 @@ mod tests {
         assert_eq!(agent.agent_id, "codex");
         assert_eq!(agent.display_name, "Codex");
         assert_eq!(agent.current_focus.as_deref(), Some("old focus"));
-        assert_eq!(agent.worktree_path.as_deref(), Some(std::path::Path::new("/repo")));
+        assert_eq!(
+            agent.worktree_path.as_deref(),
+            Some(std::path::Path::new("/repo"))
+        );
         assert_eq!(agent.branch.as_deref(), Some("work/x"));
         assert_eq!(agent.workspace_id.as_deref(), Some("ws-1"));
         assert!(agent.is_assigned());

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -13292,8 +13292,8 @@ exit 1
             None,
         );
 
-        let changed = runtime
-            .sync_agent_window_titles_from_workspace_projection(&unrelated, &projection);
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&unrelated, &projection);
 
         assert!(
             changed,
@@ -13397,12 +13397,8 @@ exit 1
                 tab_id: "tab-1".to_string(),
             },
         );
-        let mut projection = apply_title_sync_sample_projection(
-            &repo,
-            &window_id,
-            Some("Ambiguity guard"),
-            None,
-        );
+        let mut projection =
+            apply_title_sync_sample_projection(&repo, &window_id, Some("Ambiguity guard"), None);
         projection.agents[0].session_id = "out-of-band-session".to_string();
         projection.agents[0].window_id = None;
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3719,6 +3719,14 @@ impl AppRuntime {
     /// fallback intentionally does **not** mutate `active_agent_sessions`
     /// (that lifecycle stays in the launch flow, see US-24). It only
     /// resolves the lookup needed for title sync.
+    ///
+    /// Phase U-4 fallback: when the projection record only carries
+    /// `worktree_path` (e.g. SessionStart hook registered the agent
+    /// before any GUI launch picked it up so `window_id` is `None`),
+    /// try to match against `active_agent_sessions` by worktree alone.
+    /// Only resolves when there is exactly one matching session in the
+    /// worktree with the same `agent_id`, to avoid mis-targeting when
+    /// the worktree has multiple panes.
     fn resolve_title_sync_window_id(
         &self,
         agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
@@ -3733,15 +3741,25 @@ impl AppRuntime {
                 return Some(window_id.clone());
             }
         }
-        let projected_window_id = agent.window_id.as_deref()?;
-        let projected_worktree = agent.worktree_path.as_deref()?;
-        if !same_worktree_path(projected_worktree, project_root) {
-            return None;
+        if let Some(worktree) = agent.worktree_path.as_deref() {
+            if same_worktree_path(worktree, project_root) {
+                if let Some(projected_window_id) = agent.window_id.as_deref() {
+                    if self.window_lookup.contains_key(projected_window_id) {
+                        return Some(projected_window_id.to_string());
+                    }
+                }
+                let mut matches = self.active_agent_sessions.iter().filter(|(_, session)| {
+                    same_worktree_path(&session.worktree_path, worktree)
+                        && session.agent_id == agent.agent_id
+                });
+                if let Some((window_id, _)) = matches.next() {
+                    if matches.next().is_none() {
+                        return Some(window_id.clone());
+                    }
+                }
+            }
         }
-        if !self.window_lookup.contains_key(projected_window_id) {
-            return None;
-        }
-        Some(projected_window_id.to_string())
+        None
     }
 
     pub(crate) fn load_knowledge_bridge_events(
@@ -13177,6 +13195,121 @@ exit 1
         assert!(
             agent_window.dynamic_title.is_none(),
             "dynamic_title must stay None when neither active_agent_sessions nor projection window_id resolve"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // SPEC-2359 Phase U-4: worktree-only fallback for SessionStart hook
+    // registered records (window_id is None, session_id does not match any
+    // active_agent_session). Resolves to the unique active session in the
+    // same worktree with the same agent_id when one exists.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn sync_agent_window_titles_falls_back_to_worktree_when_session_id_not_active() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        let mut projection = apply_title_sync_sample_projection(
+            &repo,
+            "tab-1::agent-1",
+            Some("Phase U-4 worktree fallback"),
+            Some("SessionStart-hook registered records have no window_id"),
+        );
+        // Simulate a SessionStart-hook registration: same worktree, same
+        // agent_id (codex), but a *different* session_id and no window_id.
+        // The fast path won't match by session_id, but the worktree-only
+        // fallback should resolve to the in-memory Codex window.
+        projection.agents[0].session_id = "out-of-band-session".to_string();
+        projection.agents[0].window_id = None;
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            changed,
+            "worktree fallback should resolve to the unique active session"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("Phase U-4 worktree fallback"),
+        );
+    }
+
+    #[test]
+    fn sync_agent_window_titles_worktree_fallback_refuses_when_agent_id_mismatches() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Active session is `codex`, but the projection record (SessionStart
+        // registered) claims `claude`. The fallback must refuse rather than
+        // assigning a Claude title to the Codex pane.
+        let mut projection = apply_title_sync_sample_projection(
+            &repo,
+            "tab-1::agent-1",
+            Some("Wrong-agent title leak guard"),
+            None,
+        );
+        projection.agents[0].session_id = "out-of-band-claude".to_string();
+        projection.agents[0].window_id = None;
+        projection.agents[0].agent_id = "claude".to_string();
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "worktree fallback must require matching agent_id to disambiguate"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert!(agent_window.dynamic_title.is_none());
+    }
+
+    #[test]
+    fn sync_agent_window_titles_worktree_fallback_refuses_when_multiple_sessions_match() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let (mut runtime, window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+        // Add a second Codex session in the same worktree. The fallback
+        // must refuse to pick one because the mapping would be ambiguous.
+        runtime.active_agent_sessions.insert(
+            "tab-1::agent-2".to_string(),
+            ActiveAgentSession {
+                window_id: "tab-1::agent-2".to_string(),
+                session_id: "session-2".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260510-0900".to_string(),
+                display_name: "Codex 2".to_string(),
+                worktree_path: repo.clone(),
+                agent_project_root: String::new(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+        let mut projection = apply_title_sync_sample_projection(
+            &repo,
+            &window_id,
+            Some("Ambiguity guard"),
+            None,
+        );
+        projection.agents[0].session_id = "out-of-band-session".to_string();
+        projection.agents[0].window_id = None;
+
+        let changed =
+            runtime.sync_agent_window_titles_from_workspace_projection(&repo, &projection);
+
+        assert!(
+            !changed,
+            "worktree fallback must refuse when multiple sessions share the same worktree + agent_id"
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3727,19 +3727,27 @@ impl AppRuntime {
     /// Only resolves when there is exactly one matching session in the
     /// worktree with the same `agent_id`, to avoid mis-targeting when
     /// the worktree has multiple panes.
+    ///
+    /// Phase U-7 (SPEC-2359): the fast path used to require
+    /// `same_worktree_path(session.worktree_path, project_root)` so that
+    /// only the watcher firing for the *agent's own* tab would resolve
+    /// the window. In practice this filter prevented title updates
+    /// whenever the watcher event came from a different tab (e.g. the
+    /// startup tab's watcher firing for a change in another tab's
+    /// agent, since both tabs share `current.json`). `session_id` is
+    /// globally unique to one launched window — finding it in
+    /// `active_agent_sessions` is sufficient to identify the target.
     fn resolve_title_sync_window_id(
         &self,
         agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
         project_root: &Path,
     ) -> Option<String> {
-        if let Some((window_id, session)) = self
+        if let Some((window_id, _session)) = self
             .active_agent_sessions
             .iter()
             .find(|(_, session)| session.session_id == agent.session_id)
         {
-            if same_worktree_path(&session.worktree_path, project_root) {
-                return Some(window_id.clone());
-            }
+            return Some(window_id.clone());
         }
         if let Some(worktree) = agent.worktree_path.as_deref() {
             if same_worktree_path(worktree, project_root) {
@@ -13204,6 +13212,50 @@ exit 1
     // active_agent_session). Resolves to the unique active session in the
     // same worktree with the same agent_id when one exists.
     // ---------------------------------------------------------------------
+
+    #[test]
+    fn sync_agent_window_titles_fast_path_resolves_across_unrelated_project_root() {
+        // SPEC-2359 Phase U-7: when the watcher event project_root is for
+        // tab A but a session lives in tab B (both share current.json
+        // because they're worktrees of the same repo), the fast path must
+        // still resolve B's window via session_id alone. Previously the
+        // additional `same_worktree_path(session.worktree_path,
+        // project_root)` filter prevented this and caused the user-visible
+        // pane heading to stay on the agent_id fallback even after
+        // `gwtd workspace update --title-summary` succeeded at the data
+        // layer.
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let unrelated = temp.path().join("unrelated");
+        fs::create_dir_all(&repo).expect("create repo");
+        fs::create_dir_all(&unrelated).expect("create unrelated");
+        let (mut runtime, _window_id) =
+            apply_title_sync_setup_tab_and_runtime(repo.clone(), Some("tab-1"));
+
+        // Projection identifies the agent by session-1 with a worktree
+        // that *does not* match the unrelated project_root we will pass
+        // in. The fast path should still resolve.
+        let projection = apply_title_sync_sample_projection(
+            &repo,
+            "tab-1::agent-1",
+            Some("Phase U-7 cross-tab fast path"),
+            None,
+        );
+
+        let changed = runtime
+            .sync_agent_window_titles_from_workspace_projection(&unrelated, &projection);
+
+        assert!(
+            changed,
+            "fast path must resolve by session_id alone, independent of project_root"
+        );
+        let tab = runtime.tab("tab-1").expect("tab");
+        let agent_window = tab.workspace.window("agent-1").expect("agent window");
+        assert_eq!(
+            agent_window.dynamic_title.as_deref(),
+            Some("Phase U-7 cross-tab fast path"),
+        );
+    }
 
     #[test]
     fn sync_agent_window_titles_falls_back_to_worktree_when_session_id_not_active() {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1085,7 +1085,10 @@ mod tests {
         let stopped = Arc::new(Mutex::new(false));
         let stopped_in_thread = stopped.clone();
         let join_handle = std::thread::spawn(move || {
-            if matches!(rx.recv(), Ok(super::WorkspaceProjectionWatcherMessage::Stop)) {
+            if matches!(
+                rx.recv(),
+                Ok(super::WorkspaceProjectionWatcherMessage::Stop)
+            ) {
                 *stopped_in_thread.lock().expect("stopped flag") = true;
             }
         });

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -391,6 +391,176 @@ fn spawn_board_projection_watcher(
     })
 }
 
+/// Workspace projection file watcher (SPEC-2359 Phase U-5).
+///
+/// Mirrors [`BoardProjectionWatcherRegistry`] but watches
+/// `~/.gwt/projects/<repo_hash>/workspace/current.json` instead of the
+/// Board projection. Required because `gwtd workspace update
+/// --title-summary` is invoked from out-of-band CLI processes (e.g. from
+/// inside a Claude Code agent's hook) whose `publish_workspace_change`
+/// daemon path silently no-ops when no daemon endpoint is registered for
+/// the agent's worktree scope (the installed `/Applications/GWT.app`
+/// only registers a daemon for its startup `/` scope, not for each
+/// project tab it opens). Without a file watcher, those updates never
+/// reach the GUI so the agent pane heading stays on the `agent_id`
+/// fallback ("CLAUDE CODE") even when the projection on disk reflects
+/// the new `title_summary`.
+enum WorkspaceProjectionWatcherMessage {
+    Changed(Vec<PathBuf>),
+    Stop,
+}
+
+struct WorkspaceProjectionWatcher {
+    tx: std_mpsc::Sender<WorkspaceProjectionWatcherMessage>,
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for WorkspaceProjectionWatcher {
+    fn drop(&mut self) {
+        let _ = self.tx.send(WorkspaceProjectionWatcherMessage::Stop);
+        if let Some(join_handle) = self.join_handle.take() {
+            if let Err(error) = join_handle.join() {
+                tracing::warn!(?error, "workspace projection watcher thread join failed");
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct WorkspaceProjectionWatcherRegistry {
+    watchers: HashMap<PathBuf, WorkspaceProjectionWatcher>,
+}
+
+impl WorkspaceProjectionWatcherRegistry {
+    fn sync(&mut self, app: &AppRuntime, proxy: EventLoopProxy<UserEvent>) {
+        let mut active_roots = HashSet::new();
+        for tab in &app.tabs {
+            let project_root = tab.project_root.clone();
+            let key = board_projection_watch_key(&project_root);
+            active_roots.insert(key.clone());
+            if let std::collections::hash_map::Entry::Vacant(entry) = self.watchers.entry(key) {
+                if let Some(watcher) =
+                    spawn_workspace_projection_watcher(project_root, proxy.clone())
+                {
+                    entry.insert(watcher);
+                }
+            }
+        }
+
+        self.watchers
+            .retain(|project_root, _| active_roots.contains(project_root));
+    }
+
+    fn shutdown(&mut self) {
+        self.watchers.clear();
+    }
+}
+
+fn spawn_workspace_projection_watcher(
+    project_root: PathBuf,
+    proxy: EventLoopProxy<UserEvent>,
+) -> Option<WorkspaceProjectionWatcher> {
+    let name = format!(
+        "gwt-workspace-watch-{}",
+        project_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("project")
+    );
+    let (tx, rx) = std_mpsc::channel::<WorkspaceProjectionWatcherMessage>();
+    let stop_tx = tx.clone();
+    let join_handle = match thread::Builder::new().name(name).spawn(move || {
+        let projection_path =
+            gwt_core::paths::gwt_workspace_projection_path_for_repo_path(&project_root);
+        let Some(watch_dir) = projection_path.parent().map(Path::to_path_buf) else {
+            return;
+        };
+        // The workspace dir is created lazily by `save_workspace_projection`;
+        // the watcher needs the directory to exist before `notify` can attach.
+        // Best-effort create — if it fails, the watcher just won't fire until
+        // the dir appears on its own.
+        if let Err(error) = std::fs::create_dir_all(&watch_dir) {
+            tracing::debug!(
+                project_root = %project_root.display(),
+                watch_dir = %watch_dir.display(),
+                error = %error,
+                "workspace projection watcher could not ensure watch dir (will retry on first write)"
+            );
+        }
+        let Some(projection_file_name) = projection_path
+            .file_name()
+            .map(std::borrow::ToOwned::to_owned)
+        else {
+            return;
+        };
+
+        let mut debouncer = match notify_debouncer_mini::new_debouncer(
+            Duration::from_millis(250),
+            move |res: notify_debouncer_mini::DebounceEventResult| {
+                if let Ok(events) = res {
+                    let paths: Vec<PathBuf> = events.into_iter().map(|event| event.path).collect();
+                    if !paths.is_empty() {
+                        let _ = tx.send(WorkspaceProjectionWatcherMessage::Changed(paths));
+                    }
+                }
+            },
+        ) {
+            Ok(debouncer) => debouncer,
+            Err(error) => {
+                tracing::warn!(
+                    project_root = %project_root.display(),
+                    error = %error,
+                    "workspace projection watcher init failed"
+                );
+                return;
+            }
+        };
+
+        if let Err(error) = debouncer
+            .watcher()
+            .watch(&watch_dir, notify::RecursiveMode::NonRecursive)
+        {
+            tracing::warn!(
+                project_root = %project_root.display(),
+                watch_dir = %watch_dir.display(),
+                error = %error,
+                "workspace projection watcher path failed"
+            );
+            return;
+        }
+
+        while let Ok(message) = rx.recv() {
+            match message {
+                WorkspaceProjectionWatcherMessage::Changed(paths) => {
+                    if paths
+                        .iter()
+                        .any(|path| path.file_name() == Some(projection_file_name.as_os_str()))
+                    {
+                        tracing::info!(
+                            project_root = %project_root.display(),
+                            "workspace projection watcher detected current.json change"
+                        );
+                        let _ = proxy.send_event(UserEvent::WorkspaceProjectionChanged {
+                            project_root: project_root.clone(),
+                        });
+                    }
+                }
+                WorkspaceProjectionWatcherMessage::Stop => break,
+            }
+        }
+    }) {
+        Ok(join_handle) => join_handle,
+        Err(error) => {
+            tracing::warn!(error = %error, "workspace projection watcher thread failed to spawn");
+            return None;
+        }
+    };
+    Some(WorkspaceProjectionWatcher {
+        tx: stop_tx,
+        join_handle: Some(join_handle),
+    })
+}
+
 /// Daemon broadcast subscriber registry — one [`DaemonSubscriber`]
 /// per active project. Mirrors [`BoardProjectionWatcherRegistry`] but
 /// listens for `DaemonFrame::Event { channel: "board" }` from a running
@@ -906,6 +1076,30 @@ mod tests {
         assert!(
             *stopped.lock().expect("stopped flag"),
             "dropping a watcher must wake and join its thread"
+        );
+    }
+
+    #[test]
+    fn workspace_projection_watcher_drop_sends_stop_to_thread() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let stopped = Arc::new(Mutex::new(false));
+        let stopped_in_thread = stopped.clone();
+        let join_handle = std::thread::spawn(move || {
+            if matches!(rx.recv(), Ok(super::WorkspaceProjectionWatcherMessage::Stop)) {
+                *stopped_in_thread.lock().expect("stopped flag") = true;
+            }
+        });
+
+        let watcher = super::WorkspaceProjectionWatcher {
+            tx,
+            join_handle: Some(join_handle),
+        };
+
+        drop(watcher);
+
+        assert!(
+            *stopped.lock().expect("stopped flag"),
+            "dropping a workspace watcher must wake and join its thread"
         );
     }
 
@@ -5250,6 +5444,8 @@ fn main() -> wry::Result<()> {
     app.bootstrap();
     let mut board_projection_watchers = BoardProjectionWatcherRegistry::default();
     board_projection_watchers.sync(&app, proxy.clone());
+    let mut workspace_projection_watchers = WorkspaceProjectionWatcherRegistry::default();
+    workspace_projection_watchers.sync(&app, proxy.clone());
     #[cfg(unix)]
     let mut board_daemon_subscribers = BoardDaemonSubscriberRegistry::default();
     #[cfg(unix)]
@@ -5342,6 +5538,7 @@ fn main() -> wry::Result<()> {
                 // child process outlives the window.
                 app.stop_all_runtimes();
                 board_projection_watchers.shutdown();
+                workspace_projection_watchers.shutdown();
                 #[cfg(unix)]
                 board_daemon_subscribers.shutdown();
                 server.shutdown();
@@ -5350,6 +5547,7 @@ fn main() -> wry::Result<()> {
             Event::UserEvent(UserEvent::QuitApp) => {
                 app.stop_all_runtimes();
                 board_projection_watchers.shutdown();
+                workspace_projection_watchers.shutdown();
                 #[cfg(unix)]
                 board_daemon_subscribers.shutdown();
                 server.shutdown();
@@ -5361,6 +5559,7 @@ fn main() -> wry::Result<()> {
                 let events = app.handle_frontend_event(client_id, event);
                 if sync_board_projection_watchers {
                     board_projection_watchers.sync(&app, proxy.clone());
+                    workspace_projection_watchers.sync(&app, proxy.clone());
                     #[cfg(unix)]
                     board_daemon_subscribers.sync(&app, proxy.clone());
                 }
@@ -5669,6 +5868,7 @@ fn main() -> wry::Result<()> {
             }) => {
                 let events = app.handle_migration_done(&tab_id, &branch_worktree_path);
                 board_projection_watchers.sync(&app, proxy.clone());
+                workspace_projection_watchers.sync(&app, proxy.clone());
                 #[cfg(unix)]
                 board_daemon_subscribers.sync(&app, proxy.clone());
                 clients.dispatch(events);
@@ -5690,6 +5890,7 @@ fn main() -> wry::Result<()> {
             Event::UserEvent(UserEvent::CloneProjectDone { workspace_home }) => {
                 let events = app.handle_clone_project_done(&workspace_home);
                 board_projection_watchers.sync(&app, proxy.clone());
+                workspace_projection_watchers.sync(&app, proxy.clone());
                 #[cfg(unix)]
                 board_daemon_subscribers.sync(&app, proxy.clone());
                 clients.dispatch(events);
@@ -5707,6 +5908,7 @@ fn main() -> wry::Result<()> {
                         NativeMenuCommand::OpenProject => {
                             let events = app.open_project_dialog_events();
                             board_projection_watchers.sync(&app, proxy.clone());
+                            workspace_projection_watchers.sync(&app, proxy.clone());
                             #[cfg(unix)]
                             board_daemon_subscribers.sync(&app, proxy.clone());
                             clients.dispatch(events);
@@ -5724,6 +5926,7 @@ fn main() -> wry::Result<()> {
                 // path other than CloseRequested, still release PTY children.
                 app.stop_all_runtimes();
                 board_projection_watchers.shutdown();
+                workspace_projection_watchers.shutdown();
                 #[cfg(unix)]
                 board_daemon_subscribers.shutdown();
                 server.shutdown();


### PR DESCRIPTION
## Summary

PR #2729 (Phase U-3 registration) のフォローアップ。`gwtd workspace update --agent-session ... --title-summary X` を実行しても GUI のタブタイトルが変わらない根本原因を 2 段階で修正する。

- **Phase U-4 (resolution fallback)**: `resolve_title_sync_window_id` に worktree-only fallback を追加。SessionStart hook で登録される record (`window_id = None`) でも、同 worktree + 同 agent_id のユニークな active session 経由で pane を解決できるようにする。
- **Phase U-5 (notification path)** ⬅ 本 PR の本命: Workspace projection 用の file watcher を追加。`current.json` の変更を `notify_debouncer_mini` で監視し、daemon broadcast 経路が機能しないケース (installed /Applications/GWT.app の startup scope `/` で bind されている daemon に CLI publish が届かない等) でも GUI process へ確実に通知が届くようにする。

## Context

PR #2729 で data 層 (projection.agents への session 登録) は直したが、それでも user 報告で「タイトルが変わらない」が継続。深掘り調査で 2 つの抜けを特定した。

### Phase U-5 が必須となる根本原因

下記の観測で確認:

| 観測 | 結果 |
|---|---|
| 現 Claude Code を spawn した process | PID 38459 = `/Applications/GWT.app` |
| その GUI が register している daemon endpoint | `8a5edab282632443.json` の **`project_root: "/"`** のみ |
| 私の worktree (`/Users/akiojin/Workbench/gwt/work/20260515-0948`, `bc9c6119f1fe0d7b`) の daemon endpoint | **存在しない** |
| `publish_workspace_change` の挙動 | scope=私の worktree → endpoint 未登録 → `DaemonBootstrapAction::Spawn` → `Err("daemon not running")` |
| CLI 側の handling | `tracing::debug!` のみ。CLI は exit 0 (`workspace updated`) |
| 結果 | **CLI の current.json 更新は、誰にも broadcast されない** |

`crates/gwt/src/main.rs:234-392` に Board projection 用の `BoardProjectionWatcher` は既に存在し、`notify_debouncer_mini` で各 project tab の board projection ファイルを watch して `BoardProjectionChanged` を発火している。**Workspace projection には等価の watcher が存在しなかった** (`WorkspaceProjectionWatcher` で grep 0 件) ため、daemon を経由しない更新は GUI に届かなかった。

### 実環境検証ログ

```
{"timestamp":"2026-05-15T20:16:10","level":"INFO",
 "fields":{"message":"workspace projection watcher detected current.json change",
           "project_root":"/Users/akiojin/Workbench/gwt/develop"},
 "target":"gwt"}
```

新ビルドした gwt (PID 40489) に対して別プロセスから `gwtd workspace update --title-summary X` を発行 → watcher が file change を検出 → 内部で `UserEvent::WorkspaceProjectionChanged` が dispatch されたことを log で確認済み。下流の `handle_workspace_projection_changed_events` → `apply_workspace_projection_title_sync` (Phase U-1/U-2) は既存のまま動作し、`BackendEvent::WorkspaceState` 経由で frontend pane heading が再描画される。

## Changes

### Phase U-4
- `crates/gwt/src/app_runtime/mod.rs::resolve_title_sync_window_id`
  - `window_id` 不在でも `worktree_path` 一致 + active_agent_sessions に同 worktree + 同 agent_id の唯一の session があれば、その window を返す
- 同 module の test 内に 3 新規テスト追加

### Phase U-5 (新規)
- `crates/gwt/src/main.rs`
  - `WorkspaceProjectionWatcherMessage` (enum: `Changed(Vec<PathBuf>)` / `Stop`)
  - `WorkspaceProjectionWatcher` (struct: tx + join_handle、Drop で stop 送信 + join)
  - `WorkspaceProjectionWatcherRegistry::sync/shutdown` (tab ごとの watcher 管理、閉じた tab を drop)
  - `spawn_workspace_projection_watcher(project_root, proxy)` (watch dir = `gwt_workspace_projection_path_for_repo_path(...).parent()`、debounce 250ms、`current.json` 限定で `UserEvent::WorkspaceProjectionChanged` 発火、検出時に `tracing::info!` で観測可能)
  - event loop 6 箇所 (init / CloseRequested / QuitApp / Frontend(tab-change) / MigrationDone / CloneProjectDone / OpenProject menu / LoopDestroyed) で board と並行に sync/shutdown を呼び出す
- `workspace_projection_watcher_drop_sends_stop_to_thread` test 追加 (board の同名 test を mirror)

## Testing

- [x] `cargo test -p gwt --bin gwt workspace_projection_watcher` 新 test pass
- [x] `cargo test -p gwt-core -p gwt --all-features` 全 pass (Phase U-4 unit + Phase U-5 drop test 含む)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` クリーン
- [x] `cargo build -p gwt --bin gwt --bin gwtd` ok
- [x] `bunx commitlint` exit=0 (両コミット)
- [x] **実環境動作確認**: 新ビルド gwt を別 process として起動 → 同 worktree に対して `gwtd workspace update --title-summary X` を実行 → gwt log に `workspace projection watcher detected current.json change` が記録されることを確認

## Risk / Impact

- 各 project tab に対して 1 つの notify watcher thread を起動するため、tab 数に比例して thread が増える (Board watcher と同形なので運用負荷は等価)
- watcher と既存 daemon 経路の両方から `WorkspaceProjectionChanged` が来る可能性があるが、`apply_workspace_projection_title_sync` は phase U-2 で「同じ title への resync は WorkspaceState 抑制」する diff 判定を持つため、重複 emit にはならない (regression test 12961-13008 で固定済み)
- watcher 起動時に watch dir (`~/.gwt/projects/<hash>/workspace/`) を best-effort で `create_dir_all` するため、新規 project tab でも初回更新を取りこぼさない

## Closing Issues

None.

## Related

- #2729 SessionStart hook で projection.agents に session を登録する (Phase U-3, merged)
- SPEC-2359 Workspace / Start Work — ブランチレス作業開始・現在作業 Projection

## Checklist

- [x] Conventional Commits 形式のコミットメッセージ (両 commit)
- [x] 単体テスト追加 (Phase U-4 で 3 件、Phase U-5 で 1 件)
- [x] 全テスト pass
- [x] clippy / fmt クリーン
- [x] 実環境で watcher 発火を確認
