### PR TITLE
fix(codex): trust managed hooks without review warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,7 @@
 - テスト: `cargo test -p gwt-core -p gwt --all-features`
 - Lint: `cargo clippy --all-targets --all-features -- -D warnings`
 - フォーマット: `cargo fmt`
+- GUI のユーザー確認が必要な実装では、ビルド済みなら `target/debug/gwt`、未ビルドなら `cargo run -p gwt --bin gwt` で起動し、標準出力の `gwt browser URL: http://127.0.0.1:<port>/` をユーザーに共有する。共有前に `curl -fsS -I <URL>` などで HTTP 200 を確認し、ユーザーが同じ URL で手動確認できる状態にする。
 
 ## コミュニケーションガイドライン
 

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -32,8 +32,9 @@ pub use launch::{
 pub use prepare::{
     apply_host_package_runner_fallback, apply_host_package_runner_fallback_with_probe,
     branch_worktree_path, install_launch_gwt_bin_env, install_launch_gwt_bin_env_with_lookup,
-    prepare_agent_launch, resolve_launch_worktree, resolve_launch_worktree_request,
-    resolve_public_gwt_bin_with_lookup, HookForwardEnv, PreparedAgentLaunch, PreparedProcessLaunch,
+    prepare_agent_launch, register_codex_managed_hook_trust_in_docker, resolve_launch_worktree,
+    resolve_launch_worktree_request, resolve_public_gwt_bin_with_lookup, HookForwardEnv,
+    PreparedAgentLaunch, PreparedProcessLaunch,
 };
 pub use presets::{
     claude_code_openai_compat_preset, list_presets, seed_agent, ClaudeCodeOpenaiCompatInput,

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 const DOCKER_GWTD_BIN_PATH: &str = "/usr/local/bin/gwtd";
+const DOCKER_CODEX_CONFIG_PATH: &str = "/root/.codex/config.toml";
 const DOCKER_HOST_GWT_BIN_NAME: &str = "gwt-linux";
 const DOCKER_HOST_GWTD_BIN_NAME: &str = "gwtd-linux";
 const DOCKER_GWT_OVERRIDE_HEADER: &str =
@@ -599,6 +600,50 @@ fn apply_docker_runtime_to_launch_config(
         .insert("GWT_PROJECT_ROOT".to_string(), launch.container_cwd.clone());
     config.docker_service = Some(launch.service);
     Ok(())
+}
+
+pub fn register_codex_managed_hook_trust_in_docker(
+    worktree: &Path,
+    docker_service: Option<&str>,
+) -> Result<(), String> {
+    let launch = resolve_docker_launch_plan(worktree, docker_service)?;
+    let args = docker_codex_hook_trust_registration_args(&launch.container_cwd);
+    let output = gwt_docker::compose_service_exec_capture_with_files(
+        &launch.compose_files,
+        &launch.service,
+        Some(&launch.container_cwd),
+        &args,
+    )
+    .map_err(|err| err.to_string())?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("exit status {}", output.status)
+    };
+    Err(format!(
+        "container-local Codex hook trust registration failed for service '{}': {detail}",
+        launch.service
+    ))
+}
+
+fn docker_codex_hook_trust_registration_args(container_cwd: &str) -> Vec<String> {
+    vec![
+        DOCKER_GWTD_BIN_PATH.to_string(),
+        "hook".to_string(),
+        "register-codex-managed-hook-trust".to_string(),
+        "--project-root".to_string(),
+        container_cwd.to_string(),
+        "--codex-config".to_string(),
+        DOCKER_CODEX_CONFIG_PATH.to_string(),
+    ]
 }
 
 fn finalize_docker_agent_launch_config(
@@ -1848,6 +1893,24 @@ mod tests {
         assert!(config.args.contains(&"app".to_string()));
         assert!(config.args.contains(&"codex".to_string()));
         assert!(config.args.contains(&"--no-alt-screen".to_string()));
+    }
+
+    #[test]
+    fn docker_codex_hook_trust_registration_invokes_container_local_gwtd() {
+        let args = docker_codex_hook_trust_registration_args("/workspace/app");
+
+        assert_eq!(
+            args,
+            vec![
+                DOCKER_GWTD_BIN_PATH.to_string(),
+                "hook".to_string(),
+                "register-codex-managed-hook-trust".to_string(),
+                "--project-root".to_string(),
+                "/workspace/app".to_string(),
+                "--codex-config".to_string(),
+                "/root/.codex/config.toml".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/gwt-config/src/agent_config.rs
+++ b/crates/gwt-config/src/agent_config.rs
@@ -14,7 +14,8 @@ pub struct AgentConfig {
     pub agent_paths: HashMap<String, PathBuf>,
     /// Auto-install agent dependencies before launch.
     pub auto_install_deps: bool,
-    /// Explicit opt-in for pre-registering trust of gwt-generated Codex hooks.
+    /// Optional override for pre-registering trust of gwt-generated Codex hooks.
+    /// `None` and `Some(true)` enable trust; `Some(false)` is the opt-out.
     pub codex_trust_managed_hooks: Option<bool>,
 }
 
@@ -52,7 +53,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_trust_managed_hooks_is_explicit_opt_in() {
+    fn codex_trust_managed_hooks_is_false_only_opt_out() {
         let default_config = AgentConfig::default();
         assert_eq!(default_config.codex_trust_managed_hooks, None);
 

--- a/crates/gwt-skills/src/codex_hook_trust.rs
+++ b/crates/gwt-skills/src/codex_hook_trust.rs
@@ -205,13 +205,30 @@ fn command_hook_trusted_hash(event_name_snake: &str, matcher: &str, command: &st
                 "timeout": CODEX_DEFAULT_COMMAND_TIMEOUT_SECONDS,
                 "type": "command"
             }
-        ],
-        "matcher": matcher
+        ]
     });
+    if codex_trust_identity_uses_matcher(event_name_snake) {
+        identity
+            .as_object_mut()
+            .expect("Codex hook trust identity must be an object")
+            .insert("matcher".to_string(), Value::String(matcher.to_string()));
+    }
     sort_json_objects(&mut identity);
     let bytes = serde_json::to_vec(&identity).expect("serialize Codex hook trust identity");
     let digest = Sha256::digest(bytes);
     format!("sha256:{digest:x}")
+}
+
+fn codex_trust_identity_uses_matcher(event_name_snake: &str) -> bool {
+    matches!(
+        event_name_snake,
+        "pre_tool_use"
+            | "permission_request"
+            | "post_tool_use"
+            | "pre_compact"
+            | "post_compact"
+            | "session_start"
+    )
 }
 
 fn sort_json_objects(value: &mut Value) {
@@ -304,6 +321,23 @@ mod tests {
         assert_eq!(
             trusted_hash,
             "sha256:9c3ce103f03f0b27a28bc4a30883f7e98a80b5df566b4572fcbb2955ebf5ba62"
+        );
+    }
+
+    #[test]
+    fn command_hook_hash_omits_codex_ignored_matchers_for_prompt_and_stop() {
+        let user_prompt_command =
+            "gwt_bin=\"${GWT_BIN_PATH:-/Applications/GWT.app/Contents/MacOS/gwtd}\"; \"$gwt_bin\" hook event UserPromptSubmit";
+        let stop_command =
+            "gwt_bin=\"${GWT_BIN_PATH:-/Applications/GWT.app/Contents/MacOS/gwtd}\"; \"$gwt_bin\" hook event Stop";
+
+        assert_eq!(
+            command_hook_trusted_hash_for_test("user_prompt_submit", "*", user_prompt_command),
+            "sha256:1a86ba6796c5b5bf1601fd1af1d6094846287ec85e9f1ad4d39335c6b306e2fa"
+        );
+        assert_eq!(
+            command_hook_trusted_hash_for_test("stop", "*", stop_command),
+            "sha256:984e12cd30ef54cf4c63af8aabce1849705e5de09c70d039367ba68de9760389"
         );
     }
 

--- a/crates/gwt-skills/src/codex_hook_trust.rs
+++ b/crates/gwt-skills/src/codex_hook_trust.rs
@@ -8,7 +8,7 @@ use std::{
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
-use crate::settings_local::{gwt_hook_bin_path, posix_shell_quote, write_text_atomically};
+use crate::settings_local::{codex_event_hook_command, write_text_atomically};
 
 const CODEX_HOOKS_PATH: &str = ".codex/hooks.json";
 const CODEX_DEFAULT_COMMAND_TIMEOUT_SECONDS: u64 = 600;
@@ -235,23 +235,55 @@ fn sort_json_objects(value: &mut Value) {
 
 fn is_generated_gwt_event_command(command: &str, event_json_name: &str) -> bool {
     command == expected_generated_gwt_event_command(event_json_name)
+        || is_portable_gwt_bin_path_event_command(command, event_json_name)
 }
 
 fn expected_generated_gwt_event_command(event_json_name: &str) -> String {
-    let bin = gwt_hook_bin_path();
-    if cfg!(windows) {
-        let quoted = powershell_quote(&bin);
-        format!(
-            "powershell -NoProfile -Command \"& {{ & {quoted} hook event {event_json_name} }}\""
-        )
-    } else {
-        let quoted = posix_shell_quote(&bin);
-        format!("{quoted} hook event {event_json_name}")
-    }
+    codex_event_hook_command(event_json_name)
 }
 
-fn powershell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
+fn is_portable_gwt_bin_path_event_command(command: &str, event_json_name: &str) -> bool {
+    is_posix_portable_gwt_bin_path_event_command(command, event_json_name)
+        || is_powershell_portable_gwt_bin_path_event_command(command, event_json_name)
+}
+
+fn is_posix_portable_gwt_bin_path_event_command(command: &str, event_json_name: &str) -> bool {
+    let prefix = "gwt_bin=\"${GWT_BIN_PATH:-";
+    let suffix = format!("}}\"; \"$gwt_bin\" hook event {event_json_name}");
+    let Some(fallback) = command
+        .strip_prefix(prefix)
+        .and_then(|rest| rest.strip_suffix(&suffix))
+    else {
+        return false;
+    };
+    fallback_path_looks_like_gwtd(fallback)
+}
+
+fn is_powershell_portable_gwt_bin_path_event_command(command: &str, event_json_name: &str) -> bool {
+    let prefix = "powershell -NoProfile -Command \"& { $gwtBin = if ($env:GWT_BIN_PATH) { $env:GWT_BIN_PATH } else { ";
+    let suffix = format!(" }}; & $gwtBin hook event {event_json_name} }}\"");
+    let Some(fallback) = command
+        .strip_prefix(prefix)
+        .and_then(|rest| rest.strip_suffix(&suffix))
+    else {
+        return false;
+    };
+    let Some(unquoted) = fallback
+        .strip_prefix('\'')
+        .and_then(|value| value.strip_suffix('\''))
+    else {
+        return false;
+    };
+    fallback_path_looks_like_gwtd(unquoted)
+}
+
+fn fallback_path_looks_like_gwtd(fallback: &str) -> bool {
+    let normalized = fallback.replace("\\\"", "\"").replace("\\\\", "\\");
+    normalized == "gwtd"
+        || normalized == "gwtd.exe"
+        || normalized.ends_with("/gwtd")
+        || normalized.ends_with("\\gwtd")
+        || normalized.ends_with("\\gwtd.exe")
 }
 
 #[cfg(test)]
@@ -261,7 +293,7 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::*;
-    use crate::generate_codex_hooks;
+    use crate::{generate_codex_hooks, settings_local::codex_event_hook_command_with_bin};
 
     #[test]
     fn command_hook_hash_matches_codex_for_known_post_tool_use_fixture() {
@@ -305,6 +337,49 @@ mod tests {
                 "trusted hash must use Codex sha256 prefix"
             );
         }
+    }
+
+    #[test]
+    fn portable_generated_hooks_are_trusted_across_host_and_container_fallback_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let codex_dir = dir.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let mut hooks = serde_json::Map::new();
+        for event in [
+            "SessionStart",
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PostToolUse",
+            "Stop",
+        ] {
+            hooks.insert(
+                event.to_string(),
+                json!([
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {
+                                "command": codex_event_hook_command_with_bin("/host/gwt/bin/gwtd", event),
+                                "type": "command"
+                            }
+                        ]
+                    }
+                ]),
+            );
+        }
+        fs::write(
+            codex_dir.join("hooks.json"),
+            serde_json::to_string_pretty(&json!({ "hooks": hooks })).unwrap(),
+        )
+        .unwrap();
+
+        let entries = collect_codex_managed_hook_trust_entries(dir.path()).unwrap();
+
+        assert_eq!(
+            entries.len(),
+            5,
+            "container-local registration must accept host-generated GWT_BIN_PATH-first commands"
+        );
     }
 
     #[test]

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -98,6 +98,7 @@ fn generate_hook_config(worktree: &Path, target: ManagedHookTarget) -> io::Resul
         Value::Object(merge_managed_and_user_hooks(
             user_hooks,
             managed_hook_shell(),
+            target,
         )),
     );
 
@@ -193,8 +194,9 @@ pub(crate) fn set_executable(path: &Path) -> io::Result<()> {
 fn merge_managed_and_user_hooks(
     user_hooks: Map<String, Value>,
     shell: HookShell,
+    target: ManagedHookTarget,
 ) -> Map<String, Value> {
-    let managed_hooks = managed_hooks(shell);
+    let managed_hooks = managed_hooks(shell, target);
     let mut merged = Map::new();
 
     for event in MANAGED_EVENT_ORDER {
@@ -297,23 +299,23 @@ fn contains_gwt_hook_subcmd(command: &str) -> bool {
         .any(|suffix| command.contains(suffix))
 }
 
-fn managed_hooks(shell: HookShell) -> Map<String, Value> {
+fn managed_hooks(shell: HookShell, target: ManagedHookTarget) -> Map<String, Value> {
     let mut hooks = Map::new();
     for event in MANAGED_EVENT_ORDER {
         hooks.insert(
             event.to_string(),
-            Value::Array(vec![event_hook(event, shell)]),
+            Value::Array(vec![event_hook(event, shell, target)]),
         );
     }
     hooks
 }
 
-fn event_hook(event: &str, shell: HookShell) -> Value {
+fn event_hook(event: &str, shell: HookShell, target: ManagedHookTarget) -> Value {
     json!({
         "matcher": "*",
         "hooks": [
             {
-                "command": event_hook_command(event, shell),
+                "command": event_hook_command(event, shell, target),
                 "type": CLAUDE_HOOK_COMMAND_TYPE,
             }
         ]
@@ -432,15 +434,34 @@ fn managed_hook_shell() -> HookShell {
     }
 }
 
-fn event_hook_command(event: &str, shell: HookShell) -> String {
-    event_hook_command_with_bin(&gwt_hook_bin_path(), event, shell)
+fn event_hook_command(event: &str, shell: HookShell, target: ManagedHookTarget) -> String {
+    event_hook_command_with_bin(&gwt_hook_bin_path(), event, shell, target)
 }
 
-fn event_hook_command_with_bin(bin: &str, event: &str, shell: HookShell) -> String {
+fn event_hook_command_with_bin(
+    bin: &str,
+    event: &str,
+    shell: HookShell,
+    target: ManagedHookTarget,
+) -> String {
     match shell {
-        HookShell::Posix => posix_event_hook_command_with_bin(bin, event),
-        HookShell::PowerShell => powershell_event_hook_command_with_bin(bin, event),
+        HookShell::Posix => match target {
+            ManagedHookTarget::Claude => posix_event_hook_command_with_bin(bin, event),
+            ManagedHookTarget::Codex => posix_codex_event_hook_command_with_bin(bin, event),
+        },
+        HookShell::PowerShell => match target {
+            ManagedHookTarget::Claude => powershell_event_hook_command_with_bin(bin, event),
+            ManagedHookTarget::Codex => powershell_codex_event_hook_command_with_bin(bin, event),
+        },
     }
+}
+
+pub(crate) fn codex_event_hook_command(event: &str) -> String {
+    codex_event_hook_command_with_bin(&gwt_hook_bin_path(), event)
+}
+
+pub(crate) fn codex_event_hook_command_with_bin(bin: &str, event: &str) -> String {
+    event_hook_command_with_bin(bin, event, managed_hook_shell(), ManagedHookTarget::Codex)
 }
 
 #[cfg(test)]
@@ -488,6 +509,19 @@ fn posix_event_hook_command_with_bin(bin: &str, event: &str) -> String {
     format!("{bin} hook event {event}")
 }
 
+fn posix_codex_event_hook_command_with_bin(bin: &str, event: &str) -> String {
+    let fallback = posix_double_quoted_parameter_default(bin);
+    format!("gwt_bin=\"${{GWT_BIN_PATH:-{fallback}}}\"; \"$gwt_bin\" hook event {event}")
+}
+
+fn posix_double_quoted_parameter_default(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "\\$")
+        .replace('`', "\\`")
+}
+
 #[cfg(test)]
 fn posix_runtime_hook_command(event: &str) -> String {
     let bin = posix_shell_quote(&gwt_hook_bin_path());
@@ -519,6 +553,13 @@ fn posix_coordination_hook_command(event: &str) -> String {
 fn powershell_event_hook_command_with_bin(bin: &str, event: &str) -> String {
     let bin = powershell_quote(bin);
     format!("powershell -NoProfile -Command \"& {{ & {bin} hook event {event} }}\"")
+}
+
+fn powershell_codex_event_hook_command_with_bin(bin: &str, event: &str) -> String {
+    let bin = powershell_quote(bin);
+    format!(
+        "powershell -NoProfile -Command \"& {{ $gwtBin = if ($env:GWT_BIN_PATH) {{ $env:GWT_BIN_PATH }} else {{ {bin} }}; & $gwtBin hook event {event} }}\""
+    )
 }
 
 #[cfg(test)]
@@ -588,6 +629,34 @@ mod tests {
             assert!(
                 commands[0].contains(&format!(" hook event {event}")),
                 "managed {event} command must dispatch through `hook event {event}`, got: {}",
+                commands[0]
+            );
+        }
+    }
+
+    #[test]
+    fn managed_codex_event_commands_are_gwt_bin_path_first() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_codex_hooks(dir.path()).unwrap();
+        let content = fs::read_to_string(dir.path().join(".codex/hooks.json")).unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+
+        for event in MANAGED_EVENT_ORDER {
+            let commands = commands_for_event(&value, event);
+            assert_eq!(commands.len(), 1, "{event} must use one dispatcher");
+            assert!(
+                commands[0].contains("GWT_BIN_PATH"),
+                "managed Codex command must resolve GWT_BIN_PATH first; got: {}",
+                commands[0]
+            );
+            assert!(
+                commands[0].contains(" hook event "),
+                "managed Codex command must still dispatch through the event front door; got: {}",
+                commands[0]
+            );
+            assert!(
+                commands[0].contains("gwtd"),
+                "managed Codex command must retain a host gwtd fallback; got: {}",
                 commands[0]
             );
         }
@@ -1543,7 +1612,11 @@ mod tests {
         let session_start_command = value["hooks"]["SessionStart"][0]["hooks"][0]["command"]
             .as_str()
             .expect("session start command");
-        let expected = event_hook_command("SessionStart", managed_hook_shell());
+        let expected = event_hook_command(
+            "SessionStart",
+            managed_hook_shell(),
+            ManagedHookTarget::Codex,
+        );
         assert_eq!(session_start_command, expected);
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -5063,6 +5063,7 @@ impl AppRuntime {
                 &worktree_path,
                 &config.agent_id,
                 config.runtime_target,
+                config.docker_service.as_deref(),
             )? {
                 if !report.trusted_entries.is_empty() {
                     proxy.send(UserEvent::LaunchProgress {
@@ -6223,33 +6224,68 @@ fn maybe_register_codex_managed_hook_trust_for_launch(
     worktree_path: &Path,
     agent_id: &gwt_agent::AgentId,
     runtime_target: gwt_agent::LaunchRuntimeTarget,
+    docker_service: Option<&str>,
 ) -> Result<Option<gwt_skills::CodexHookTrustReport>, String> {
-    if agent_id != &gwt_agent::AgentId::Codex
-        || runtime_target != gwt_agent::LaunchRuntimeTarget::Host
-    {
+    if agent_id != &gwt_agent::AgentId::Codex {
         return Ok(None);
     }
 
     let settings = if profile_config_path.exists() {
-        gwt_config::Settings::load_from_path(profile_config_path)
-            .map_err(|error| error.to_string())?
+        match gwt_config::Settings::load_from_path(profile_config_path) {
+            Ok(settings) => settings,
+            Err(error) => {
+                tracing::warn!(
+                    profile_config = %profile_config_path.display(),
+                    error = %error,
+                    "failed to read gwt config while preparing Codex hook trust; continuing launch"
+                );
+                gwt_config::Settings::default()
+            }
+        }
     } else {
         gwt_config::Settings::default()
     };
-    if settings.agent.codex_trust_managed_hooks != Some(true) {
+    if settings.agent.codex_trust_managed_hooks == Some(false) {
         return Ok(None);
     }
 
-    let codex_config_path =
-        codex_config_path_for_profile_config(profile_config_path).ok_or_else(|| {
-            format!(
-                "cannot derive Codex config path from gwt config path {}",
-                profile_config_path.display()
-            )
-        })?;
-    gwt_skills::register_codex_managed_hook_trust(worktree_path, &codex_config_path)
-        .map(Some)
-        .map_err(|error| error.to_string())
+    match runtime_target {
+        gwt_agent::LaunchRuntimeTarget::Host => {
+            let Some(codex_config_path) = codex_config_path_for_profile_config(profile_config_path)
+            else {
+                tracing::warn!(
+                    profile_config = %profile_config_path.display(),
+                    "cannot derive Codex config path while preparing Codex hook trust; continuing launch"
+                );
+                return Ok(None);
+            };
+            match gwt_skills::register_codex_managed_hook_trust(worktree_path, &codex_config_path) {
+                Ok(report) => Ok(Some(report)),
+                Err(error) => {
+                    tracing::warn!(
+                        worktree = %worktree_path.display(),
+                        codex_config = %codex_config_path.display(),
+                        error = %error,
+                        "failed to register gwt-managed Codex hook trust; continuing launch"
+                    );
+                    Ok(None)
+                }
+            }
+        }
+        gwt_agent::LaunchRuntimeTarget::Docker => {
+            if let Err(error) = gwt_agent::register_codex_managed_hook_trust_in_docker(
+                worktree_path,
+                docker_service,
+            ) {
+                tracing::warn!(
+                    worktree = %worktree_path.display(),
+                    error = %error,
+                    "failed to register gwt-managed Codex hook trust in Docker; continuing launch"
+                );
+            }
+            Ok(None)
+        }
+    }
 }
 
 fn codex_config_path_for_profile_config(profile_config_path: &Path) -> Option<PathBuf> {
@@ -13889,6 +13925,7 @@ exit 0
             worktree.path(),
             &gwt_agent::AgentId::Codex,
             gwt_agent::LaunchRuntimeTarget::Host,
+            None,
         )
         .unwrap()
         .expect("enabled host Codex launch should register trust");
@@ -13904,7 +13941,7 @@ exit 0
     }
 
     #[test]
-    fn codex_hook_trust_launch_skips_without_explicit_host_codex_opt_in() {
+    fn codex_hook_trust_launch_defaults_to_host_codex_registration_and_false_opts_out() {
         let home = tempdir().expect("home tempdir");
         let profile_config_path = home.path().join(".gwt/config.toml");
         let worktree = tempdir().expect("worktree tempdir");
@@ -13915,9 +13952,17 @@ exit 0
             worktree.path(),
             &gwt_agent::AgentId::Codex,
             gwt_agent::LaunchRuntimeTarget::Host,
+            None,
         )
         .unwrap();
-        assert!(unset.is_none());
+        assert_eq!(
+            unset
+                .expect("unset config should default to trusting managed Codex hooks")
+                .trusted_entries
+                .len(),
+            5
+        );
+        fs::remove_file(home.path().join(".codex/config.toml")).unwrap();
 
         let mut settings = Settings::default();
         settings.agent.codex_trust_managed_hooks = Some(false);
@@ -13927,32 +13972,74 @@ exit 0
             worktree.path(),
             &gwt_agent::AgentId::Codex,
             gwt_agent::LaunchRuntimeTarget::Host,
+            None,
         )
         .unwrap();
         assert!(disabled.is_none());
 
+        assert!(
+            !home.path().join(".codex/config.toml").exists(),
+            "false opt-out must not recreate Codex config"
+        );
+
         settings.agent.codex_trust_managed_hooks = Some(true);
         settings.save(&profile_config_path).unwrap();
-        let docker = super::maybe_register_codex_managed_hook_trust_for_launch(
+        let enabled = super::maybe_register_codex_managed_hook_trust_for_launch(
             &profile_config_path,
             worktree.path(),
             &gwt_agent::AgentId::Codex,
-            gwt_agent::LaunchRuntimeTarget::Docker,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            None,
         )
         .unwrap();
-        assert!(docker.is_none());
+        assert_eq!(
+            enabled
+                .expect("true config should register managed Codex hooks")
+                .trusted_entries
+                .len(),
+            5
+        );
 
         let claude = super::maybe_register_codex_managed_hook_trust_for_launch(
             &profile_config_path,
             worktree.path(),
             &gwt_agent::AgentId::ClaudeCode,
             gwt_agent::LaunchRuntimeTarget::Host,
+            None,
         )
         .unwrap();
         assert!(claude.is_none());
 
         assert!(
-            !home.path().join(".codex/config.toml").exists(),
+            home.path().join(".codex/config.toml").exists(),
+            "host default/true paths must create Codex config"
+        );
+    }
+
+    #[test]
+    fn codex_hook_trust_launch_is_warning_only_when_registration_fails() {
+        let home = tempdir().expect("home tempdir");
+        let profile_config_path = home.path().join(".gwt/config.toml");
+        let worktree = tempdir().expect("worktree tempdir");
+        gwt_skills::generate_codex_hooks(worktree.path()).unwrap();
+
+        let codex_config_parent = home.path().join(".codex");
+        fs::write(&codex_config_parent, "not a directory").unwrap();
+
+        let result = super::maybe_register_codex_managed_hook_trust_for_launch(
+            &profile_config_path,
+            worktree.path(),
+            &gwt_agent::AgentId::Codex,
+            gwt_agent::LaunchRuntimeTarget::Host,
+            None,
+        );
+
+        assert!(
+            result.is_ok(),
+            "optional trust registration must not abort launch: {result:?}"
+        );
+        assert!(
+            result.unwrap().is_none(),
             "skip paths must not create Codex config"
         );
     }

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -56,6 +56,7 @@ pub enum HookKind {
     BlockBashPolicy,
     WorkflowPolicy,
     Forward,
+    RegisterCodexManagedHookTrust,
     SkillDiscussionStopCheck,
     SkillPlanSpecStopCheck,
     SkillBuildSpecStopCheck,
@@ -76,6 +77,7 @@ impl HookKind {
             "block-bash-policy" => Some(Self::BlockBashPolicy),
             "workflow-policy" => Some(Self::WorkflowPolicy),
             "forward" => Some(Self::Forward),
+            "register-codex-managed-hook-trust" => Some(Self::RegisterCodexManagedHookTrust),
             "skill-discussion-stop-check" => Some(Self::SkillDiscussionStopCheck),
             "skill-plan-spec-stop-check" => Some(Self::SkillPlanSpecStopCheck),
             "skill-build-spec-stop-check" => Some(Self::SkillBuildSpecStopCheck),
@@ -358,6 +360,32 @@ pub fn run_daemon_hook<E: CliEnv>(
             Ok(()) => Ok(0),
             Err(err) => Ok(emit_hook_error(env, name, err)),
         },
+        HookKind::RegisterCodexManagedHookTrust => {
+            let project_root = option_value(rest, "--project-root")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| env.repo_path().to_path_buf());
+            let Some(codex_config_path) = option_value(rest, "--codex-config")
+                .map(std::path::PathBuf::from)
+                .or_else(default_codex_config_path)
+            else {
+                let _ = writeln!(
+                    env.stderr(),
+                    "gwtd hook register-codex-managed-hook-trust: missing --codex-config and home directory is unavailable"
+                );
+                return Ok(2);
+            };
+            match gwt_skills::register_codex_managed_hook_trust(&project_root, &codex_config_path) {
+                Ok(report) => {
+                    let _ = writeln!(
+                        env.stdout(),
+                        "trusted {} gwt-managed Codex hooks",
+                        report.trusted_entries.len()
+                    );
+                    Ok(0)
+                }
+                Err(err) => Ok(emit_hook_error(env, name, err)),
+            }
+        }
         HookKind::SkillDiscussionStopCheck => {
             let cwd = env.repo_path().to_path_buf();
             let output = skill_discussion_stop_check::handle_with_input(&cwd, &stdin);
@@ -384,6 +412,18 @@ pub fn run_daemon_hook<E: CliEnv>(
             Ok(emit_hook_output(env, &output))
         }
     }
+}
+
+fn option_value<'a>(args: &'a [String], flag: &str) -> Option<&'a str> {
+    args.windows(2)
+        .find(|pair| pair[0] == flag)
+        .map(|pair| pair[1].as_str())
+}
+
+fn default_codex_config_path() -> Option<std::path::PathBuf> {
+    gwt_core::paths::gwt_home()
+        .parent()
+        .map(|home| home.join(".codex/config.toml"))
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/system_settings.rs
+++ b/crates/gwt/src/system_settings.rs
@@ -70,7 +70,7 @@ pub fn read_settings(path: &Path) -> Result<SystemSettingsSnapshot, SystemSettin
             .language
             .clone()
             .unwrap_or_else(|| "auto".to_string()),
-        codex_trust_managed_hooks: settings.agent.codex_trust_managed_hooks,
+        codex_trust_managed_hooks: Some(codex_trust_managed_hooks_enabled(&settings)),
     })
 }
 
@@ -102,8 +102,12 @@ pub fn write_settings(
         .map_err(|err| SystemSettingsError::Storage(err.to_string()))?;
     Ok(SystemSettingsSnapshot {
         language: canonical,
-        codex_trust_managed_hooks: settings.agent.codex_trust_managed_hooks,
+        codex_trust_managed_hooks: Some(codex_trust_managed_hooks_enabled(&settings)),
     })
+}
+
+fn codex_trust_managed_hooks_enabled(settings: &Settings) -> bool {
+    settings.agent.codex_trust_managed_hooks != Some(false)
 }
 
 /// Build the `BackendEvent` reply for `FrontendEvent::GetSystemSettings`.
@@ -203,16 +207,16 @@ mod tests {
     }
 
     #[test]
-    fn read_and_write_codex_hook_trust_opt_in() {
+    fn read_and_write_codex_hook_trust_false_only_opt_out() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("config.toml");
 
-        let mut original = Settings::default();
-        original.agent.codex_trust_managed_hooks = Some(true);
-        original.save(&path).unwrap();
-
         let snapshot = read_settings(&path).unwrap();
-        assert_eq!(snapshot.codex_trust_managed_hooks, Some(true));
+        assert_eq!(
+            snapshot.codex_trust_managed_hooks,
+            Some(true),
+            "missing config should render System Settings as enabled by default"
+        );
 
         let snapshot = write_settings(&path, "en", Some(false)).unwrap();
         assert_eq!(snapshot.language, "en");
@@ -264,7 +268,7 @@ mod tests {
                 codex_trust_managed_hooks,
             } => {
                 assert_eq!(language, "ja");
-                assert_eq!(codex_trust_managed_hooks, None);
+                assert_eq!(codex_trust_managed_hooks, Some(true));
             }
             other => panic!("expected SystemSettings, got {other:?}"),
         }

--- a/crates/gwt/tests/gwtd_cli_test.rs
+++ b/crates/gwt/tests/gwtd_cli_test.rs
@@ -1,4 +1,7 @@
-use std::process::{Command, Stdio};
+use std::{
+    fs,
+    process::{Command, Stdio},
+};
 
 #[test]
 fn gwtd_dispatches_internal_hook_cli_without_gui_output() {
@@ -36,5 +39,48 @@ fn gwtd_help_describes_the_headless_cli_surface() {
     assert!(
         !stdout.contains("Launch `gwt` instead"),
         "gwtd help must not redirect agent-facing CLI users to the GUI front door"
+    );
+}
+
+#[test]
+fn gwtd_hook_register_codex_managed_hook_trust_writes_requested_config() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let codex_home = tempfile::tempdir().expect("codex tempdir");
+    let config_path = codex_home.path().join("config.toml");
+    let previous_hook_bin = std::env::var_os("GWT_HOOK_BIN");
+    std::env::set_var("GWT_HOOK_BIN", env!("CARGO_BIN_EXE_gwtd"));
+    gwt_skills::generate_codex_hooks(project.path()).expect("generate hooks");
+    match previous_hook_bin {
+        Some(value) => std::env::set_var("GWT_HOOK_BIN", value),
+        None => std::env::remove_var("GWT_HOOK_BIN"),
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_gwtd"))
+        .args([
+            "hook",
+            "register-codex-managed-hook-trust",
+            "--project-root",
+            project.path().to_str().expect("project path utf8"),
+            "--codex-config",
+            config_path.to_str().expect("config path utf8"),
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run gwtd hook register");
+
+    assert!(
+        output.status.success(),
+        "registration should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("trusted 5"),
+        "stdout should report trusted hook count, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let config = fs::read_to_string(&config_path).expect("read config");
+    assert!(
+        config.contains("trusted_hash"),
+        "Codex config must receive trusted hashes, got: {config}"
     );
 }

--- a/crates/gwt/web/__tests__/settings-system-tab.test.mjs
+++ b/crates/gwt/web/__tests__/settings-system-tab.test.mjs
@@ -135,6 +135,16 @@ test("renderSystemPanel exposes Codex managed hook trust opt-in", () => {
   );
   assert.match(
     appSource,
+    /codexTrustManagedHooks:\s*true/,
+    "expected Codex hook trust UI state to default on",
+  );
+  assert.match(
+    appSource,
+    /trustCheckbox\.checked\s*=\s*systemSettingsState\.codexTrustManagedHooks\s*!==\s*false/,
+    "expected unchecked only when config explicitly disables Codex hook trust",
+  );
+  assert.match(
+    appSource,
     /send\(\{\s*kind:\s*"update_system_settings",\s*language:\s*systemSettingsState\.language\s*\|\|\s*"auto",\s*codex_trust_managed_hooks:\s*next,\s*\}\)/,
     "expected checkbox onChange to send codex_trust_managed_hooks",
   );

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -371,7 +371,7 @@
           if (deferred.kind === "system_settings") {
             systemSettingsState.language = deferred.language || "auto";
             systemSettingsState.codexTrustManagedHooks =
-              deferred.codex_trust_managed_hooks === true;
+              deferred.codex_trust_managed_hooks !== false;
             systemSettingsState.loaded = true;
             if (
               !systemSettingsState.statusMessage
@@ -384,7 +384,7 @@
             systemSettingsState.language = deferred.language
               || systemSettingsState.language;
             systemSettingsState.codexTrustManagedHooks =
-              deferred.codex_trust_managed_hooks === true;
+              deferred.codex_trust_managed_hooks !== false;
             systemSettingsState.statusMessage = "Saved system settings.";
             systemSettingsState.statusKind = "success";
           } else if (deferred.kind === "system_settings_error") {
@@ -7730,7 +7730,7 @@
       // (auto/en/ja); the backend `system_settings` reply seeds it.
       const systemSettingsState = {
         language: "auto",
-        codexTrustManagedHooks: false,
+        codexTrustManagedHooks: true,
         loaded: false,
         statusMessage: "",
         statusKind: "",
@@ -7968,7 +7968,7 @@
         trustCheckbox.type = "checkbox";
         trustCheckbox.className = "settings-checkbox";
         trustCheckbox.id = "settings-system-codex-hooks";
-        trustCheckbox.checked = systemSettingsState.codexTrustManagedHooks === true;
+        trustCheckbox.checked = systemSettingsState.codexTrustManagedHooks !== false;
         trustCheckbox.addEventListener("change", (e) => {
           const next = e.target.checked === true;
           systemSettingsState.codexTrustManagedHooks = next;
@@ -7991,7 +7991,7 @@
         const trustHelp = document.createElement("p");
         trustHelp.className = "settings-help";
         trustHelp.textContent =
-          "Registers only generated gwt hook commands in Codex hook trust state.";
+          "Enabled by default. Registers only generated gwt hook commands in Codex hook trust state.";
         trustSection.appendChild(trustHelp);
 
         const status = document.createElement("p");
@@ -9373,13 +9373,14 @@
               systemSettingsInteractionGuard.defer({
                 kind: "system_settings",
                 language: event.language,
+                codex_trust_managed_hooks: event.codex_trust_managed_hooks,
               })
             ) {
               break;
             }
             systemSettingsState.language = event.language || "auto";
             systemSettingsState.codexTrustManagedHooks =
-              event.codex_trust_managed_hooks === true;
+              event.codex_trust_managed_hooks !== false;
             systemSettingsState.loaded = true;
             // Don't clobber an in-flight "Saving…" status; only seed when no
             // pending feedback is shown.
@@ -9395,13 +9396,14 @@
               systemSettingsInteractionGuard.defer({
                 kind: "system_settings_updated",
                 language: event.language,
+                codex_trust_managed_hooks: event.codex_trust_managed_hooks,
               })
             ) {
               break;
             }
             systemSettingsState.language = event.language || systemSettingsState.language;
             systemSettingsState.codexTrustManagedHooks =
-              event.codex_trust_managed_hooks === true;
+              event.codex_trust_managed_hooks !== false;
             systemSettingsState.statusMessage = "Saved system settings.";
             systemSettingsState.statusKind = "success";
             renderSystemPanelInAllSettingsWindows();

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,30 @@
 # Lessons Learned
 
+## 2026-05-15 — Codex hook trust hashing must mirror event matcher semantics
+
+### 事象
+
+gwt-managed Codex hooks を自動 trust 登録する修正後も、Codex の `/hooks`
+では `UserPromptSubmit` と `Stop` が `Modified since last trusted` として
+残り、起動時に `hooks need review` warning が表示された。
+
+### 原因
+
+Codex 本体は `UserPromptSubmit` / `Stop` の matcher を dispatch でも trust
+identity hash でも無視する。一方、gwt 側の trust hash は全 event で
+`.codex/hooks.json` の `matcher="*"` を含めて計算していたため、2 event だけ
+Codex の `current_hash` と一致しなかった。
+
+### 再発防止策
+
+1. 外部ツールの trust / fingerprint / signature を再実装する場合は、設定
+   JSON の見た目ではなく公式実装の正規化後 identity を読む。
+2. hook trust の修正では、`codex --no-alt-screen` の起動 warning だけでなく
+   `/hooks` の event 別 `Active` / `Review` 表示で全 managed events を確認する。
+3. event ごとに matcher semantics が異なる場合は、全 event 同一処理にせず
+   `UserPromptSubmit` / `Stop` のような matcher 非対応 event の fixture test を
+   必ず追加する。
+
 ## 2026-05-12 — Workspace coordination must not become a global tool lock
 
 ### 事象


### PR DESCRIPTION
## Summary

- Trust gwt-managed Codex hooks automatically so launch no longer leaves managed hooks in `/hooks` review state.
- Align gwt's trust hash calculation with Codex event matcher semantics so `UserPromptSubmit` and `Stop` are trusted correctly.
- Document the GUI verification handoff so future user checks can reuse the same browser URL and HTTP 200 flow.

## Changes

- `crates/gwt-skills/src/settings_local.rs`: Generates Codex hook commands through `GWT_BIN_PATH` with a stable `gwtd` fallback for host and container launches.
- `crates/gwt-skills/src/codex_hook_trust.rs`: Adds managed hook trust-state collection, TOML registration, portable command recognition, and matcher-aware hashing for Codex ignored-matcher events.
- `crates/gwt/src/app_runtime/mod.rs` and `crates/gwt-agent/src/prepare.rs`: Register managed Codex hook trust by default before launch, including Docker/container launch parity.
- `crates/gwt/src/system_settings.rs`, `crates/gwt/web/app.js`, and `crates/gwt/web/__tests__/settings-system-tab.test.mjs`: Keep the Codex managed hook trust setting default-on with `false` as the explicit opt-out.
- `AGENTS.md` and `tasks/lessons.md`: Document the GUI user verification flow and the Codex matcher hashing lesson.

## Testing

- [x] `codex --no-alt-screen` from `/Users/akiojin/Workbench/gwt/work/20260515-0405` — no startup hook review warning after trust registration.
- [x] `/hooks` in a fresh Codex session — all five managed hooks show active with no review count.
- [x] `target/debug/gwt` then `curl -fsS -I http://127.0.0.1:63478/` — GUI served HTTP 200 for user verification.
- [x] `cargo test -p gwt-core -p gwt -p gwt-skills --all-features` — passed after merging `origin/develop`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed after merging `origin/develop`.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `bunx markdownlint-cli2 AGENTS.md tasks/lessons.md` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #1935

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check` not applicable: no Svelte code)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change; not applicable: no schema or data migration)
- [x] CHANGELOG impact considered (breaking change flagged in commit; not applicable: no breaking change)

## Context

- Codex reports hook review warnings when a hook's current fingerprint differs from the trusted hash in `~/.codex/config.toml`.
- gwt-managed worktrees should not require users to manually review the same generated hooks every launch.
- Follow-up verification found that Codex ignores matcher fields for `UserPromptSubmit` and `Stop`, so gwt must mirror that normalized identity exactly.

## Risk / Impact

- **Affected areas**: Codex launch materialization, managed hook trust registration, system settings for Codex managed hook trust, and documented GUI verification handoff.
- **Rollback plan**: Revert this PR to restore the previous manual `/hooks` review behavior for managed Codex hooks.

## Screenshots

| Before | After |
|--------|-------|
| Not captured; behavior was a Codex hook review warning in the terminal. | Verified in a fresh Codex `/hooks` view: all five managed hooks were active with no review count. |
