### PR TITLE
perf(index): reduce startup index work

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2117,6 +2117,9 @@ impl AppRuntime {
                 scope,
                 worktree_hash,
             } => self.rebuild_index_cell_events(project_root, scope, worktree_hash),
+            FrontendEvent::RefreshIndexStatus { project_root } => {
+                self.refresh_index_status_events(project_root)
+            }
             FrontendEvent::PostBoardEntry {
                 id,
                 entry_kind,
@@ -4175,6 +4178,17 @@ impl AppRuntime {
             scope,
             worktree_hash,
         );
+        Vec::new()
+    }
+
+    /// Settings.Index requests the full all-worktree health table on demand.
+    /// The startup path stays current-worktree only to avoid UI-visible CPU
+    /// spikes on repositories with many active worktrees.
+    pub(crate) fn refresh_index_status_events(&self, project_root: String) -> Vec<OutboundEvent> {
+        let project_root = std::path::PathBuf::from(project_root);
+        let service =
+            crate::project_index_bootstrap::ProjectIndexBootstrapService::global().clone();
+        let _request = service.spawn_full_status_refresh(self.proxy.clone(), project_root);
         Vec::new()
     }
 }

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -444,14 +444,42 @@ pub fn aggregate_project_index_status_for_path(project_root: &Path) -> ProjectIn
     if let Some(fixture) = load_test_fixture_status() {
         return fixture;
     }
-    match aggregate_project_index_status_for_path_inner(project_root) {
+    match aggregate_project_index_status_for_path_inner(
+        project_root,
+        StatusProbeScope::AllWorktrees,
+    ) {
         Ok(status) => status,
         Err(error) => ProjectIndexStatusView::new(ProjectIndexStatusState::Error, error),
     }
 }
 
+/// Probe only the current worktree. This is the startup path: it gives the
+/// project tab and auto-repair orchestrator enough health data without
+/// spawning one Python status process for every inactive worktree.
+pub fn aggregate_current_worktree_index_status_for_path(
+    project_root: &Path,
+) -> ProjectIndexStatusView {
+    if let Some(fixture) = load_test_fixture_status() {
+        return fixture;
+    }
+    match aggregate_project_index_status_for_path_inner(
+        project_root,
+        StatusProbeScope::CurrentWorktree,
+    ) {
+        Ok(status) => status,
+        Err(error) => ProjectIndexStatusView::new(ProjectIndexStatusState::Error, error),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StatusProbeScope {
+    AllWorktrees,
+    CurrentWorktree,
+}
+
 fn aggregate_project_index_status_for_path_inner(
     project_root: &Path,
+    probe_scope: StatusProbeScope,
 ) -> Result<ProjectIndexStatusView, String> {
     let Some(repo_root) = resolve_git_worktree_root(project_root) else {
         return Ok(ProjectIndexStatusView::new(
@@ -475,7 +503,13 @@ fn aggregate_project_index_status_for_path_inner(
         "project index runtime ensured for aggregated status"
     );
 
-    let inputs = list_worktree_probe_inputs(&repo_root)?;
+    let inputs = match probe_scope {
+        StatusProbeScope::AllWorktrees => list_worktree_probe_inputs(&repo_root)?,
+        StatusProbeScope::CurrentWorktree => {
+            let inputs = list_worktree_probe_inputs(&repo_root)?;
+            collect_current_worktree_probe_inputs(inputs, &repo_root)
+        }
+    };
     let mut probes: Vec<WorktreeProbeOutcome> = Vec::with_capacity(inputs.len());
     for input in inputs {
         let payload = probe_worktree_status(&repo_root, &repo_hash, &input.worktree_hash);
@@ -489,6 +523,17 @@ fn aggregate_project_index_status_for_path_inner(
         report.runner_hash.as_str(),
         &probes,
     ))
+}
+
+fn collect_current_worktree_probe_inputs(
+    inputs: Vec<WorktreeProbeInput>,
+    current_worktree_root: &Path,
+) -> Vec<WorktreeProbeInput> {
+    let current = canonicalize_path(current_worktree_root.to_path_buf());
+    inputs
+        .into_iter()
+        .filter(|input| canonicalize_path(input.path.clone()) == current)
+        .collect()
 }
 
 /// Enumerate worktrees under `repo_root` via `git worktree list --porcelain`.
@@ -788,6 +833,45 @@ pub fn collect_unhealthy_rebuild_targets(scopes: &ProjectIndexScopes) -> Vec<Reb
     targets
 }
 
+/// Collect startup auto-repair targets for the currently opened worktree.
+///
+/// Repo-shared scopes (`issues`, `specs`) are still eligible, but per-worktree
+/// file scopes are limited to `project_root`. Inactive worktrees remain
+/// visible in the aggregated health table and can be repaired explicitly from
+/// Settings.Index.
+pub fn collect_unhealthy_rebuild_targets_for_project_root(
+    scopes: &ProjectIndexScopes,
+    project_root: &Path,
+) -> Vec<RebuildTarget> {
+    let current_hash = compute_worktree_hash(project_root).ok();
+    collect_unhealthy_rebuild_targets_for_worktree_hash(
+        scopes,
+        current_hash.as_ref().map(|hash| hash.as_str()),
+    )
+}
+
+fn collect_unhealthy_rebuild_targets_for_worktree_hash(
+    scopes: &ProjectIndexScopes,
+    current_worktree_hash: Option<&str>,
+) -> Vec<RebuildTarget> {
+    let mut targets = Vec::new();
+    if matches!(&scopes.issues, Some(view) if !view.healthy) {
+        targets.push((IndexRebuildScope::Issues, None));
+    }
+    if matches!(&scopes.specs, Some(view) if !view.healthy) {
+        targets.push((IndexRebuildScope::Specs, None));
+    }
+    if let Some(current_hash) = current_worktree_hash {
+        if matches!(scopes.files.get(current_hash), Some(view) if !view.healthy) {
+            targets.push((IndexRebuildScope::Files, Some(current_hash.to_string())));
+        }
+        if matches!(scopes.files_docs.get(current_hash), Some(view) if !view.healthy) {
+            targets.push((IndexRebuildScope::FilesDocs, Some(current_hash.to_string())));
+        }
+    }
+    targets
+}
+
 /// Auto-repair every unhealthy scope reported in `initial_status` by
 /// rebuilding them serially in a background thread.
 ///
@@ -818,6 +902,34 @@ where
         return None;
     }
     let targets = collect_unhealthy_rebuild_targets(&initial_status.scopes);
+    auto_repair_unhealthy_targets(
+        project_root,
+        initial_status,
+        targets,
+        spawner,
+        final_status_provider,
+        event_sink,
+    )
+}
+
+/// Auto-repair a preselected list of unhealthy targets while preserving the
+/// full initial status payload in progress events.
+pub fn auto_repair_unhealthy_targets<S, F, P>(
+    project_root: PathBuf,
+    initial_status: &ProjectIndexStatusView,
+    targets: Vec<RebuildTarget>,
+    spawner: S,
+    final_status_provider: P,
+    event_sink: F,
+) -> Option<std::thread::JoinHandle<()>>
+where
+    S: IndexRebuildSpawner,
+    F: Fn(ProjectIndexStatusView) + Send + 'static,
+    P: FnOnce(&Path) -> ProjectIndexStatusView + Send + 'static,
+{
+    if initial_status.state != ProjectIndexStatusState::RepairRequired {
+        return None;
+    }
     if targets.is_empty() {
         return None;
     }
@@ -1448,6 +1560,30 @@ detached
     }
 
     #[test]
+    fn current_worktree_probe_inputs_exclude_inactive_worktrees() {
+        let current = tempfile::tempdir().expect("current worktree");
+        let inactive = tempfile::tempdir().expect("inactive worktree");
+        let inputs = vec![
+            WorktreeProbeInput {
+                worktree_hash: "current-hash".to_string(),
+                branch: "develop".to_string(),
+                path: current.path().to_path_buf(),
+            },
+            WorktreeProbeInput {
+                worktree_hash: "inactive-hash".to_string(),
+                branch: "feature/inactive".to_string(),
+                path: inactive.path().to_path_buf(),
+            },
+        ];
+
+        let filtered = collect_current_worktree_probe_inputs(inputs, current.path());
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].worktree_hash, "current-hash");
+        assert_eq!(filtered[0].branch, "develop");
+    }
+
+    #[test]
     fn aggregate_uses_test_fixture_when_env_var_set() {
         // SPEC-1939 T-IDX-109/110 follow-up scaffolding: when
         // GWT_INDEX_TEST_FIXTURE is set, the aggregator returns the parsed
@@ -1684,6 +1820,52 @@ detached
             scopes,
             worktrees: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn startup_auto_repair_targets_only_current_worktree_file_scopes() {
+        let current = tempfile::tempdir().expect("current worktree");
+        let inactive = tempfile::tempdir().expect("inactive worktree");
+        let current_hash = compute_worktree_hash(current.path())
+            .expect("current hash")
+            .to_string();
+        let inactive_hash = compute_worktree_hash(inactive.path())
+            .expect("inactive hash")
+            .to_string();
+
+        let mut scopes = ProjectIndexScopes {
+            issues: Some(ScopeHealthView::unhealthy("missing")),
+            specs: Some(ScopeHealthView::unhealthy("count_mismatch")),
+            ..Default::default()
+        };
+        scopes.files.insert(
+            current_hash.clone(),
+            ScopeHealthView::unhealthy("manifest_missing"),
+        );
+        scopes.files_docs.insert(
+            current_hash.clone(),
+            ScopeHealthView::unhealthy("collection_missing"),
+        );
+        scopes.files.insert(
+            inactive_hash.clone(),
+            ScopeHealthView::unhealthy("manifest_missing"),
+        );
+        scopes.files_docs.insert(
+            inactive_hash,
+            ScopeHealthView::unhealthy("collection_missing"),
+        );
+
+        let targets = collect_unhealthy_rebuild_targets_for_project_root(&scopes, current.path());
+
+        assert_eq!(
+            targets,
+            vec![
+                (IndexRebuildScope::Issues, None),
+                (IndexRebuildScope::Specs, None),
+                (IndexRebuildScope::Files, Some(current_hash.clone())),
+                (IndexRebuildScope::FilesDocs, Some(current_hash)),
+            ]
+        );
     }
 
     #[test]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -53,12 +53,14 @@ pub use daemon_runtime::{HookForwardTarget, RuntimeHookEvent, RuntimeHookEventKi
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
 pub use gwt_agent::{ClaudeCodeOpenaiCompatInput, PresetDefinition, PresetId};
 pub use index_worker::{
-    aggregate_project_index_status_for_path, auto_repair_unhealthy_scopes,
-    build_aggregated_status_view, collect_unhealthy_rebuild_targets, default_rebuild_runner,
-    global_aggregated_status_cache, list_worktree_probe_inputs, parse_scope_health,
-    AggregatedStatusCache, IndexRebuildRunnerFn, IndexRebuildScope, IndexRebuildSpawner,
-    ProjectIndexScopes, ProjectIndexStatusState, ProjectIndexStatusView, RebuildProgress,
-    RebuildTarget, ScopeHealthView, WorktreeMeta, WorktreeProbeInput, WorktreeProbeOutcome,
+    aggregate_current_worktree_index_status_for_path, aggregate_project_index_status_for_path,
+    auto_repair_unhealthy_scopes, auto_repair_unhealthy_targets, build_aggregated_status_view,
+    collect_unhealthy_rebuild_targets, collect_unhealthy_rebuild_targets_for_project_root,
+    default_rebuild_runner, global_aggregated_status_cache, list_worktree_probe_inputs,
+    parse_scope_health, AggregatedStatusCache, IndexRebuildRunnerFn, IndexRebuildScope,
+    IndexRebuildSpawner, ProjectIndexScopes, ProjectIndexStatusState, ProjectIndexStatusView,
+    RebuildProgress, RebuildTarget, ScopeHealthView, WorktreeMeta, WorktreeProbeInput,
+    WorktreeProbeOutcome,
 };
 pub use knowledge_bridge::{
     load_knowledge_bridge, refresh_knowledge_bridge_cache, search_knowledge_bridge,

--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -61,6 +61,19 @@ impl ProjectIndexBootstrapService {
             proxy,
             project_root,
             gwt::index_worker::bootstrap_project_index_for_path,
+            current_worktree_status_probe,
+        )
+    }
+
+    pub(crate) fn spawn_full_status_refresh(
+        &self,
+        proxy: AppEventProxy,
+        project_root: PathBuf,
+    ) -> ProjectIndexBootstrapRequest {
+        self.spawn_with(
+            proxy,
+            project_root,
+            gwt::index_worker::bootstrap_project_index_for_path,
             cached_aggregate_status_probe,
         )
     }
@@ -434,16 +447,30 @@ pub(crate) fn trigger_auto_repair_for_project(
     };
     let final_status_provider = |path: &Path| -> gwt::ProjectIndexStatusView {
         gwt::global_aggregated_status_cache().invalidate(path);
-        gwt::aggregate_project_index_status_for_path(path)
+        gwt::aggregate_current_worktree_index_status_for_path(path)
     };
+    let targets = gwt::collect_unhealthy_rebuild_targets_for_project_root(
+        &initial_status.scopes,
+        &project_root,
+    );
+    if targets.is_empty() {
+        tracing::info!(
+            target: "gwt::index",
+            worktree = %project_root_label,
+            "skipping startup auto-rebuild because only inactive worktree scopes require repair"
+        );
+        return None;
+    }
     tracing::info!(
         target: "gwt::index",
         worktree = %project_root_label,
+        target_count = targets.len(),
         "kicking auto-rebuild orchestrator after repair_required status"
     );
-    gwt::auto_repair_unhealthy_scopes(
+    gwt::auto_repair_unhealthy_targets(
         project_root,
         initial_status,
+        targets,
         ServiceBackedRebuildSpawner::with_default_runner(service),
         final_status_provider,
         event_sink,
@@ -470,6 +497,10 @@ fn normalize_project_root(project_root: &Path) -> PathBuf {
 fn cached_aggregate_status_probe(project_root: &Path) -> gwt::ProjectIndexStatusView {
     gwt::global_aggregated_status_cache()
         .get_or_compute(project_root, gwt::aggregate_project_index_status_for_path)
+}
+
+fn current_worktree_status_probe(project_root: &Path) -> gwt::ProjectIndexStatusView {
+    gwt::aggregate_current_worktree_index_status_for_path(project_root)
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -212,6 +212,12 @@ pub enum FrontendEvent {
         #[serde(default)]
         worktree_hash: Option<String>,
     },
+    /// Request the full Project Index health table. Startup only probes the
+    /// current worktree; Settings.Index asks for the expensive all-worktree
+    /// view on demand.
+    RefreshIndexStatus {
+        project_root: String,
+    },
     PostBoardEntry {
         id: String,
         entry_kind: BoardEntryKind,
@@ -1291,6 +1297,21 @@ mod tests {
             matches!(event, FrontendEvent::OpenStartWork),
             "Start Work must be a global command, not a Branches window event"
         );
+    }
+
+    #[test]
+    fn frontend_event_accepts_project_index_full_refresh_request() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "refresh_index_status",
+            "project_root": "/repo/worktree"
+        }))
+        .expect("deserialize refresh_index_status");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::RefreshIndexStatus { project_root }
+                if project_root == "/repo/worktree"
+        ));
     }
 
     #[test]

--- a/crates/gwt/web/__tests__/index-status-controller.test.mjs
+++ b/crates/gwt/web/__tests__/index-status-controller.test.mjs
@@ -146,3 +146,19 @@ test("app.js still wires the per-tab dot aggregator", () => {
     "app.js must not retain references to the removed badge element",
   );
 });
+
+test("Settings.Index requests full index status only when the Index tab opens", () => {
+  assert.ok(
+    appSource.includes("function requestFullIndexStatusRefresh()"),
+    "expected a dedicated Settings.Index full refresh request helper",
+  );
+  assert.ok(
+    appSource.includes('send({ kind: "refresh_index_status", project_root: activeProjectRoot })'),
+    "Settings.Index must request the expensive all-worktree status on demand",
+  );
+  assert.ok(
+    appSource.includes('if (target === "index")') &&
+      appSource.includes("requestFullIndexStatusRefresh();"),
+    "switching to the Index tab must trigger the full status refresh",
+  );
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7877,6 +7877,12 @@
         }
       }
 
+      function requestFullIndexStatusRefresh() {
+        const activeProjectRoot = activeProjectTab()?.project_root || "";
+        if (!activeProjectRoot) return;
+        send({ kind: "refresh_index_status", project_root: activeProjectRoot });
+      }
+
       document.addEventListener("settings:open", (event) => {
         const target = event?.detail?.target || "system";
         const existingBody = Array.from(settingsWindowBodies).find(
@@ -7915,6 +7921,9 @@
             panel.dataset.settingsPanel !== target,
           );
         });
+        if (target === "index") {
+          requestFullIndexStatusRefresh();
+        }
       }
 
       function renderSystemPanel(panel) {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5440,3 +5440,25 @@ CPU% ではなく main-thread blocking として体感遅延になった。
 ### 関連 PR / Issue
 
 - Issue #2725
+
+## Project Index は起動時 visibility と repair scheduling を分離する
+
+### 事象
+
+GUI 起動直後に Project Index が全 active worktree の status probe と auto-repair を走らせ、
+worktree が多いリポジトリでは 15 秒以上 Python/Chroma プロセスが連続起動して UI がカクついた。
+
+### 原因
+
+Project tab の dot 表示、Settings.Index の全 worktree health 表示、startup auto-repair の
+3 つが同じ aggregated status 経路を共有していた。起動時に必要なのは現在の worktree と
+repo-shared scopes だけなのに、Settings.Index 向けの全 worktree 可視性まで毎回読んでいた。
+
+### 再発防止策
+
+1. 起動時 status probe は current worktree 限定にする。全 worktree の health table は
+   Settings.Index を開いた時だけオンデマンドで取得する。
+2. Startup auto-repair は repo-shared scopes と current worktree の file scopes だけを対象にし、
+   inactive worktree の repair は Settings.Index の明示操作に任せる。
+3. 性能修正では `sample` と子プロセス監視で、起動 smoke 中に `index-files` や全 worktree
+   `--action status` が勝手に並ばないことを確認する。


### PR DESCRIPTION
## Summary

- Reduce GUI startup Project Index work so the app probes and repairs only the current worktree by default.
- Keep the full Settings.Index health table available on demand, instead of computing all active worktrees during startup.

## Changes

- `crates/gwt/src/index_worker.rs`: add current-worktree status probing and startup auto-repair target filtering.
- `crates/gwt/src/project_index_bootstrap.rs`: use current-only startup status while preserving a full refresh helper for Settings.Index.
- `crates/gwt/src/protocol.rs` and `crates/gwt/src/app_runtime/mod.rs`: add and handle the `refresh_index_status` frontend event.
- `crates/gwt/web/app.js`: request the full index table only when Settings.Index opens.
- `crates/gwt/web/__tests__/index-status-controller.test.mjs`: cover the on-demand Settings.Index refresh contract.
- `tasks/lessons.md`: record the startup visibility versus repair scheduling lesson.

## Testing

- [x] `cargo test -p gwt startup_auto_repair_targets_only_current_worktree_file_scopes -- --nocapture` — passed.
- [x] `cargo test -p gwt current_worktree_probe_inputs_exclude_inactive_worktrees -- --nocapture` — passed.
- [x] `cargo test -p gwt frontend_event_accepts_project_index_full_refresh_request -- --nocapture` — passed.
- [x] `node --test crates/gwt/web/__tests__/index-status-controller.test.mjs crates/gwt/web/__tests__/index-settings-panel.test.mjs` — passed.
- [x] `node --check crates/gwt/web/app.js` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:64847/ npm run test:visual -- crates/gwt/playwright/tests/chrome.spec.ts crates/gwt/playwright/tests/theme-toggle.spec.ts crates/gwt/playwright/tests/reduced-motion.spec.ts` — passed, 16 tests.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-unit` — passed, 463 tests.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md --ignore tasks/todo.md` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] Pre-push coverage hook — passed, filtered line coverage 90.47%.

## Closing Issues

None

## Related Issues / Links

- #1939

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (`tasks/lessons.md` and SPEC #1939 sections)
- [x] Migration/backfill plan not needed; no schema or data migration
- [x] CHANGELOG impact considered; `perf(index)` is patch-level

## Context

- Startup profiling showed the GUI running Project Index status across all active worktrees after frontend reload, with live logs showing a roughly 19.5 second all-worktree status refresh before this change.
- After this patch, the same startup path probes only the current worktree, completed in roughly 1.6 seconds in the live smoke, and child-process inspection showed no inactive-worktree `index-files` jobs during the smoke window.

## Risk / Impact

- **Affected areas**: GUI startup Project Index status, Settings.Index refresh, startup auto-repair scheduling.
- **Rollback plan**: Revert this PR; no persisted data or migration state is changed.
