### PR TITLE
fix(codex): harden managed hook trust registration

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 
 const DOCKER_GWTD_BIN_PATH: &str = "/usr/local/bin/gwtd";
-const DOCKER_CODEX_CONFIG_PATH: &str = "/root/.codex/config.toml";
 const DOCKER_HOST_GWT_BIN_NAME: &str = "gwt-linux";
 const DOCKER_HOST_GWTD_BIN_NAME: &str = "gwtd-linux";
 const DOCKER_GWT_OVERRIDE_HEADER: &str =
@@ -607,7 +606,13 @@ pub fn register_codex_managed_hook_trust_in_docker(
     docker_service: Option<&str>,
 ) -> Result<(), String> {
     let launch = resolve_docker_launch_plan(worktree, docker_service)?;
-    let args = docker_codex_hook_trust_registration_args(&launch.container_cwd);
+    let current_exe = std::env::current_exe().map_err(|err| format!("current_exe: {err}"))?;
+    let host_gwt_bin =
+        resolve_public_gwt_bin_with_lookup(&current_exe, |command| which::which(command).ok())
+            .into_os_string()
+            .into_string()
+            .map_err(|_| "host gwtd path is not valid UTF-8".to_string())?;
+    let args = docker_codex_hook_trust_registration_args(&launch.container_cwd, &host_gwt_bin);
     let output = gwt_docker::compose_service_exec_capture_with_files(
         &launch.compose_files,
         &launch.service,
@@ -634,16 +639,21 @@ pub fn register_codex_managed_hook_trust_in_docker(
     ))
 }
 
-fn docker_codex_hook_trust_registration_args(container_cwd: &str) -> Vec<String> {
-    vec![
-        DOCKER_GWTD_BIN_PATH.to_string(),
-        "hook".to_string(),
-        "register-codex-managed-hook-trust".to_string(),
-        "--project-root".to_string(),
-        container_cwd.to_string(),
-        "--codex-config".to_string(),
-        DOCKER_CODEX_CONFIG_PATH.to_string(),
-    ]
+fn docker_codex_hook_trust_registration_args(
+    container_cwd: &str,
+    host_gwt_bin_fallback: &str,
+) -> Vec<String> {
+    let script = format!(
+        "set -eu\ncodex_home=\"${{CODEX_HOME:-${{HOME:-/root}}/.codex}}\"\nGWT_HOOK_BIN={} exec {} hook register-codex-managed-hook-trust --project-root {} --codex-config \"$codex_home/config.toml\"",
+        shell_single_quote(host_gwt_bin_fallback),
+        shell_single_quote(DOCKER_GWTD_BIN_PATH),
+        shell_single_quote(container_cwd),
+    );
+    vec!["sh".to_string(), "-lc".to_string(), script]
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
 }
 
 fn finalize_docker_agent_launch_config(
@@ -1896,20 +1906,28 @@ mod tests {
     }
 
     #[test]
-    fn docker_codex_hook_trust_registration_invokes_container_local_gwtd() {
-        let args = docker_codex_hook_trust_registration_args("/workspace/app");
+    fn docker_codex_hook_trust_registration_uses_container_home_and_host_fallback() {
+        let args =
+            docker_codex_hook_trust_registration_args("/workspace/app", "/host/gwt/bin/gwtd");
 
-        assert_eq!(
-            args,
-            vec![
-                DOCKER_GWTD_BIN_PATH.to_string(),
-                "hook".to_string(),
-                "register-codex-managed-hook-trust".to_string(),
-                "--project-root".to_string(),
-                "/workspace/app".to_string(),
-                "--codex-config".to_string(),
-                "/root/.codex/config.toml".to_string(),
-            ]
+        assert_eq!(args[0], "sh");
+        assert_eq!(args[1], "-lc");
+        let script = &args[2];
+        assert!(
+            script.contains(r#"codex_home="${CODEX_HOME:-${HOME:-/root}/.codex}""#),
+            "script must derive Codex home from the active container user, got: {script}"
+        );
+        assert!(
+            script.contains(r#"--codex-config "$codex_home/config.toml""#),
+            "script must pass the derived Codex config path, got: {script}"
+        );
+        assert!(
+            script.contains("GWT_HOOK_BIN='/host/gwt/bin/gwtd' exec '/usr/local/bin/gwtd'"),
+            "script must invoke container-local gwtd while matching host-generated hooks, got: {script}"
+        );
+        assert!(
+            !script.contains("/root/.codex/config.toml"),
+            "script must not hard-code root's Codex config path, got: {script}"
         );
     }
 

--- a/crates/gwt-skills/src/codex_hook_trust.rs
+++ b/crates/gwt-skills/src/codex_hook_trust.rs
@@ -8,7 +8,9 @@ use std::{
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
-use crate::settings_local::{codex_event_hook_command, write_text_atomically};
+use crate::settings_local::{
+    codex_event_hook_command, codex_event_hook_command_with_bin, write_text_atomically,
+};
 
 const CODEX_HOOKS_PATH: &str = ".codex/hooks.json";
 const CODEX_DEFAULT_COMMAND_TIMEOUT_SECONDS: u64 = 600;
@@ -34,6 +36,13 @@ pub struct CodexHookTrustReport {
 
 pub fn collect_codex_managed_hook_trust_entries(
     worktree: &Path,
+) -> io::Result<Vec<CodexHookTrustEntry>> {
+    collect_codex_managed_hook_trust_entries_with_expected_bin(worktree, None)
+}
+
+fn collect_codex_managed_hook_trust_entries_with_expected_bin(
+    worktree: &Path,
+    expected_gwt_bin: Option<&str>,
 ) -> io::Result<Vec<CodexHookTrustEntry>> {
     let hooks_path = worktree.join(CODEX_HOOKS_PATH);
     if !hooks_path.exists() {
@@ -83,7 +92,7 @@ pub fn collect_codex_managed_hook_trust_entries(
             continue;
         };
         if hook.get("type").and_then(Value::as_str) != Some("command")
-            || !is_generated_gwt_event_command(command, event_json_name)
+            || !is_generated_gwt_event_command(command, event_json_name, expected_gwt_bin)
         {
             continue;
         }
@@ -250,57 +259,22 @@ fn sort_json_objects(value: &mut Value) {
     }
 }
 
-fn is_generated_gwt_event_command(command: &str, event_json_name: &str) -> bool {
-    command == expected_generated_gwt_event_command(event_json_name)
-        || is_portable_gwt_bin_path_event_command(command, event_json_name)
+fn is_generated_gwt_event_command(
+    command: &str,
+    event_json_name: &str,
+    expected_gwt_bin: Option<&str>,
+) -> bool {
+    command == expected_generated_gwt_event_command(event_json_name, expected_gwt_bin)
 }
 
-fn expected_generated_gwt_event_command(event_json_name: &str) -> String {
-    codex_event_hook_command(event_json_name)
-}
-
-fn is_portable_gwt_bin_path_event_command(command: &str, event_json_name: &str) -> bool {
-    is_posix_portable_gwt_bin_path_event_command(command, event_json_name)
-        || is_powershell_portable_gwt_bin_path_event_command(command, event_json_name)
-}
-
-fn is_posix_portable_gwt_bin_path_event_command(command: &str, event_json_name: &str) -> bool {
-    let prefix = "gwt_bin=\"${GWT_BIN_PATH:-";
-    let suffix = format!("}}\"; \"$gwt_bin\" hook event {event_json_name}");
-    let Some(fallback) = command
-        .strip_prefix(prefix)
-        .and_then(|rest| rest.strip_suffix(&suffix))
-    else {
-        return false;
-    };
-    fallback_path_looks_like_gwtd(fallback)
-}
-
-fn is_powershell_portable_gwt_bin_path_event_command(command: &str, event_json_name: &str) -> bool {
-    let prefix = "powershell -NoProfile -Command \"& { $gwtBin = if ($env:GWT_BIN_PATH) { $env:GWT_BIN_PATH } else { ";
-    let suffix = format!(" }}; & $gwtBin hook event {event_json_name} }}\"");
-    let Some(fallback) = command
-        .strip_prefix(prefix)
-        .and_then(|rest| rest.strip_suffix(&suffix))
-    else {
-        return false;
-    };
-    let Some(unquoted) = fallback
-        .strip_prefix('\'')
-        .and_then(|value| value.strip_suffix('\''))
-    else {
-        return false;
-    };
-    fallback_path_looks_like_gwtd(unquoted)
-}
-
-fn fallback_path_looks_like_gwtd(fallback: &str) -> bool {
-    let normalized = fallback.replace("\\\"", "\"").replace("\\\\", "\\");
-    normalized == "gwtd"
-        || normalized == "gwtd.exe"
-        || normalized.ends_with("/gwtd")
-        || normalized.ends_with("\\gwtd")
-        || normalized.ends_with("\\gwtd.exe")
+fn expected_generated_gwt_event_command(
+    event_json_name: &str,
+    expected_gwt_bin: Option<&str>,
+) -> String {
+    expected_gwt_bin.map_or_else(
+        || codex_event_hook_command(event_json_name),
+        |bin| codex_event_hook_command_with_bin(bin, event_json_name),
+    )
 }
 
 #[cfg(test)]
@@ -310,7 +284,7 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::*;
-    use crate::{generate_codex_hooks, settings_local::codex_event_hook_command_with_bin};
+    use crate::generate_codex_hooks;
 
     #[test]
     fn command_hook_hash_matches_codex_for_known_post_tool_use_fixture() {
@@ -374,10 +348,11 @@ mod tests {
     }
 
     #[test]
-    fn portable_generated_hooks_are_trusted_across_host_and_container_fallback_paths() {
+    fn portable_generated_hooks_are_trusted_for_explicit_expected_fallback_path() {
         let dir = tempfile::tempdir().unwrap();
         let codex_dir = dir.path().join(".codex");
         fs::create_dir_all(&codex_dir).unwrap();
+        let expected_fallback = "/host/gwt/bin/gwtd";
         let mut hooks = serde_json::Map::new();
         for event in [
             "SessionStart",
@@ -393,7 +368,7 @@ mod tests {
                         "matcher": "*",
                         "hooks": [
                             {
-                                "command": codex_event_hook_command_with_bin("/host/gwt/bin/gwtd", event),
+                                "command": codex_event_hook_command_with_bin(expected_fallback, event),
                                 "type": "command"
                             }
                         ]
@@ -407,12 +382,45 @@ mod tests {
         )
         .unwrap();
 
-        let entries = collect_codex_managed_hook_trust_entries(dir.path()).unwrap();
+        let entries = collect_codex_managed_hook_trust_entries_with_expected_bin(
+            dir.path(),
+            Some(expected_fallback),
+        )
+        .unwrap();
 
         assert_eq!(
             entries.len(),
             5,
-            "container-local registration must accept host-generated GWT_BIN_PATH-first commands"
+            "container-local registration must accept the exact host-generated fallback path"
+        );
+    }
+
+    #[test]
+    fn portable_generated_hook_with_unexpected_fallback_is_not_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_codex_hooks(dir.path()).unwrap();
+        let hooks_path = dir.path().join(".codex/hooks.json");
+        let hooks_content = fs::read_to_string(&hooks_path).unwrap();
+        let mut hooks_json: Value = serde_json::from_str(&hooks_content).unwrap();
+        hooks_json["hooks"]["Stop"][0]["hooks"][0]["command"] = Value::String(
+            codex_event_hook_command_with_bin("/tmp/attacker/gwtd", "Stop"),
+        );
+        fs::write(
+            &hooks_path,
+            serde_json::to_string_pretty(&hooks_json).unwrap(),
+        )
+        .unwrap();
+
+        let entries = collect_codex_managed_hook_trust_entries(dir.path()).unwrap();
+
+        assert_eq!(
+            entries.len(),
+            4,
+            "unexpected portable fallback path must be left for Codex /hooks review"
+        );
+        assert!(
+            entries.iter().all(|entry| !entry.key.contains(":stop:")),
+            "unexpected fallback Stop hook must not be trusted; got {entries:?}"
         );
     }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,34 @@
 # Lessons Learned
 
+## 2026-05-15 — Hook trust recognizers must not accept shape-only gwtd paths
+
+### 事象
+
+PR #2733 の Codex review で、Codex hook trust 登録が Docker 内では
+`/root/.codex/config.toml` 固定になっており、非 root devcontainer の Codex
+設定を更新できないことを指摘された。同時に portable hook command の fallback
+判定が `.../gwtd` で終わる任意パスを trust 対象にしていたため、
+`/tmp/attacker/gwtd` のようなパスでも review signal を消せる状態だった。
+
+### 原因
+
+Docker registration と hook trust recognizer の責務が混ざり、container 内で
+実行する `gwtd` と、host で生成された hook command の fallback path を同一視
+していた。さらに recognizer が「gwt が生成した正確な command」ではなく
+「gwtd らしい suffix」を見ていたため、攻撃者が制御できる fallback path まで
+許容していた。
+
+### 再発防止策
+
+1. trust / approval / allowlist 系の matcher は、suffix や shape ではなく
+   生成器が出す exact command か、明示的に渡された exact fallback のみを
+   許可する。
+2. Docker 内で host-generated hook を登録する場合は、実行バイナリ
+   (`/usr/local/bin/gwtd`) と trust 対象 fallback (`GWT_HOOK_BIN`) を分離する。
+3. container 内の user config path は `/root` 固定にせず、
+   `${CODEX_HOME:-${HOME:-/root}/.codex}/config.toml` のように active user から
+   導出する。
+
 ## 2026-05-15 — Codex hook trust hashing must mirror event matcher semantics
 
 ### 事象


### PR DESCRIPTION
## Summary

- Harden Codex managed hook trust registration after PR #2733 review feedback.
- Docker registration now resolves Codex config from the active container user instead of assuming root.
- Managed hook trust now accepts only exact generated fallback paths, leaving unexpected fallback binaries for Codex review.

## Changes

- `crates/gwt-agent/src/prepare.rs`: run container-local `gwtd` through a shell wrapper that derives `${CODEX_HOME:-${HOME:-/root}/.codex}/config.toml` and passes the host-generated hook fallback through `GWT_HOOK_BIN`.
- `crates/gwt-skills/src/codex_hook_trust.rs`: remove suffix-based portable fallback trust and restrict collection to exact generated commands or an explicit expected fallback.
- `tasks/lessons.md`: record the review lesson for exact hook trust matching and container user config paths.

## Testing

- [x] `cargo test -p gwt-agent docker_codex_hook_trust_registration_uses_container_home_and_host_fallback -- --nocapture` — passed
- [x] `cargo test -p gwt-skills codex_hook_trust -- --nocapture` — passed
- [x] `cargo test -p gwt --test gwtd_cli_test gwtd_hook_register_codex_managed_hook_trust_writes_requested_config --all-features -- --nocapture` — passed
- [x] `cargo test -p gwt --lib --all-features` — passed on retry after an initial unrelated parallel Board/Workspace lock-poison failure
- [x] `cargo test -p gwt-core -p gwt -p gwt-skills -p gwt-agent --all-features -- --test-threads=1` — passed
- [x] `cargo fmt -- --check` — passed
- [x] `bunx markdownlint-cli2 AGENTS.md tasks/lessons.md` — passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed

## Closing Issues

- None

## Related Issues / Links

- #2733
- https://github.com/akiojin/gwt/pull/2733#discussion_r

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This is a follow-up to unresolved Codex review threads on already-merged PR #2733.

## Risk / Impact

- **Affected areas**: Codex managed hook trust registration, especially Docker/devcontainer launches.
- **Rollback plan**: Revert this PR to restore the previous trust registration behavior.
