### PR TITLE
fix(codex): align hook trust command matching

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -559,6 +559,18 @@ pub fn resolve_public_gwt_bin_with_lookup(
     current_exe.to_path_buf()
 }
 
+fn resolve_generated_hook_gwt_bin_with_lookup(
+    current_exe: &Path,
+    lookup: impl FnOnce(&str) -> Option<PathBuf>,
+) -> PathBuf {
+    if is_named_gwt_binary(current_exe) && !is_bunx_temp_executable(current_exe) {
+        if let Some(candidate) = sibling_gwtd_binary(current_exe) {
+            return candidate;
+        }
+    }
+    resolve_public_gwt_bin_with_lookup(current_exe, lookup)
+}
+
 fn sibling_gwtd_binary(path: &Path) -> Option<PathBuf> {
     if !is_named_gwt_binary(path) {
         return None;
@@ -607,11 +619,12 @@ pub fn register_codex_managed_hook_trust_in_docker(
 ) -> Result<(), String> {
     let launch = resolve_docker_launch_plan(worktree, docker_service)?;
     let current_exe = std::env::current_exe().map_err(|err| format!("current_exe: {err}"))?;
-    let host_gwt_bin =
-        resolve_public_gwt_bin_with_lookup(&current_exe, |command| which::which(command).ok())
-            .into_os_string()
-            .into_string()
-            .map_err(|_| "host gwtd path is not valid UTF-8".to_string())?;
+    let host_gwt_bin = resolve_generated_hook_gwt_bin_with_lookup(&current_exe, |command| {
+        which::which(command).ok()
+    })
+    .into_os_string()
+    .into_string()
+    .map_err(|_| "host gwtd path is not valid UTF-8".to_string())?;
     let args = docker_codex_hook_trust_registration_args(&launch.container_cwd, &host_gwt_bin);
     let output = gwt_docker::compose_service_exec_capture_with_files(
         &launch.compose_files,
@@ -1928,6 +1941,20 @@ mod tests {
         assert!(
             !script.contains("/root/.codex/config.toml"),
             "script must not hard-code root's Codex config path, got: {script}"
+        );
+    }
+
+    #[test]
+    fn docker_codex_hook_trust_fallback_matches_gui_hook_generator_sibling() {
+        let fallback = resolve_generated_hook_gwt_bin_with_lookup(
+            Path::new("/Applications/GWT.app/Contents/MacOS/gwt"),
+            |_| Some(PathBuf::from("/usr/local/bin/gwtd")),
+        );
+
+        assert_eq!(
+            fallback,
+            PathBuf::from("/Applications/GWT.app/Contents/MacOS/gwtd"),
+            "Docker trust fallback must match settings_local::gwt_hook_bin_path for GUI launches"
         );
     }
 

--- a/crates/gwt-skills/src/codex_hook_trust.rs
+++ b/crates/gwt-skills/src/codex_hook_trust.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use crate::settings_local::{
-    codex_event_hook_command, codex_event_hook_command_with_bin, write_text_atomically,
+    codex_event_hook_commands, codex_event_hook_commands_with_bin, write_text_atomically,
 };
 
 const CODEX_HOOKS_PATH: &str = ".codex/hooks.json";
@@ -264,16 +264,18 @@ fn is_generated_gwt_event_command(
     event_json_name: &str,
     expected_gwt_bin: Option<&str>,
 ) -> bool {
-    command == expected_generated_gwt_event_command(event_json_name, expected_gwt_bin)
+    expected_generated_gwt_event_commands(event_json_name, expected_gwt_bin)
+        .iter()
+        .any(|expected| expected == command)
 }
 
-fn expected_generated_gwt_event_command(
+fn expected_generated_gwt_event_commands(
     event_json_name: &str,
     expected_gwt_bin: Option<&str>,
-) -> String {
+) -> Vec<String> {
     expected_gwt_bin.map_or_else(
-        || codex_event_hook_command(event_json_name),
-        |bin| codex_event_hook_command_with_bin(bin, event_json_name),
+        || codex_event_hook_commands(event_json_name),
+        |bin| codex_event_hook_commands_with_bin(bin, event_json_name),
     )
 }
 
@@ -284,7 +286,7 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::*;
-    use crate::generate_codex_hooks;
+    use crate::{generate_codex_hooks, settings_local::codex_event_hook_commands_with_bin};
 
     #[test]
     fn command_hook_hash_matches_codex_for_known_post_tool_use_fixture() {
@@ -368,7 +370,10 @@ mod tests {
                         "matcher": "*",
                         "hooks": [
                             {
-                                "command": codex_event_hook_command_with_bin(expected_fallback, event),
+                                "command": codex_event_hook_commands_with_bin(expected_fallback, event)
+                                    .into_iter()
+                                    .next()
+                                    .unwrap(),
                                 "type": "command"
                             }
                         ]
@@ -396,6 +401,49 @@ mod tests {
     }
 
     #[test]
+    fn powershell_generated_hook_with_expected_fallback_is_trusted_on_posix_registration() {
+        let dir = tempfile::tempdir().unwrap();
+        let codex_dir = dir.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let expected_fallback = "C:/Program Files/GWT/gwtd.exe";
+        let powershell_stop_command = format!(
+            "powershell -NoProfile -Command \"& {{ $gwtBin = if ($env:GWT_BIN_PATH) {{ $env:GWT_BIN_PATH }} else {{ '{expected_fallback}' }}; & $gwtBin hook event Stop }}\""
+        );
+        fs::write(
+            codex_dir.join("hooks.json"),
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "Stop": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "command": powershell_stop_command,
+                                    "type": "command"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let entries = collect_codex_managed_hook_trust_entries_with_expected_bin(
+            dir.path(),
+            Some(expected_fallback),
+        )
+        .unwrap();
+
+        assert_eq!(
+            entries.len(),
+            1,
+            "Linux container registration must trust exact PowerShell-generated Codex hooks"
+        );
+    }
+
+    #[test]
     fn portable_generated_hook_with_unexpected_fallback_is_not_trusted() {
         let dir = tempfile::tempdir().unwrap();
         generate_codex_hooks(dir.path()).unwrap();
@@ -403,7 +451,10 @@ mod tests {
         let hooks_content = fs::read_to_string(&hooks_path).unwrap();
         let mut hooks_json: Value = serde_json::from_str(&hooks_content).unwrap();
         hooks_json["hooks"]["Stop"][0]["hooks"][0]["command"] = Value::String(
-            codex_event_hook_command_with_bin("/tmp/attacker/gwtd", "Stop"),
+            codex_event_hook_commands_with_bin("/tmp/attacker/gwtd", "Stop")
+                .into_iter()
+                .next()
+                .unwrap(),
         );
         fs::write(
             &hooks_path,

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -456,12 +456,15 @@ fn event_hook_command_with_bin(
     }
 }
 
-pub(crate) fn codex_event_hook_command(event: &str) -> String {
-    codex_event_hook_command_with_bin(&gwt_hook_bin_path(), event)
+pub(crate) fn codex_event_hook_commands(event: &str) -> Vec<String> {
+    codex_event_hook_commands_with_bin(&gwt_hook_bin_path(), event)
 }
 
-pub(crate) fn codex_event_hook_command_with_bin(bin: &str, event: &str) -> String {
-    event_hook_command_with_bin(bin, event, managed_hook_shell(), ManagedHookTarget::Codex)
+pub(crate) fn codex_event_hook_commands_with_bin(bin: &str, event: &str) -> Vec<String> {
+    vec![
+        posix_codex_event_hook_command_with_bin(bin, event),
+        powershell_codex_event_hook_command_with_bin(bin, event),
+    ]
 }
 
 #[cfg(test)]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,32 @@
 # Lessons Learned
 
+## 2026-05-15 — Exact hook trust must include generator resolution and shell format
+
+### 事象
+
+PR #2735 の follow-up review で、Docker trust registration が `GWT_HOOK_BIN`
+fallback を独自解決しており、hook 生成時の binary path resolution とずれる
+可能性を指摘された。また exact command match を現在 runtime の shell 形式
+だけに絞ったため、PowerShell 形式で生成済みの Codex hooks を Linux Docker
+内の registration が trust できない互換性リスクも残っていた。
+
+### 原因
+
+「suffix ではなく exact command を trust する」という安全側の修正で、
+exact command の入力元を current runtime だけに寄せすぎた。hook trust は
+実行環境の shell 形式ではなく、既に生成済みの `.codex/hooks.json` に書かれた
+正規 command と一致するかを見る必要がある。
+
+### 再発防止策
+
+1. hook trust の exact match を変更する場合は、binary fallback resolution と
+   shell command format の両方を generator とそろえる。
+2. Docker / container registration は、host-generated command を検証するための
+   fallback path と、container 内で実行する `gwtd` path を別々にテストする。
+3. POSIX / PowerShell のように生成 shell が複数ある managed command では、
+   「現在 OS の command」だけでなく「生成器が出し得る exact command 群」を
+   trust 判定の対象にする。
+
 ## 2026-05-15 — Hook trust recognizers must not accept shape-only gwtd paths
 
 ### 事象


### PR DESCRIPTION
## Summary

Follow-up to PR #2735. This tightens Codex managed hook trust registration after review found two exact-match edge cases.

## Changes

- Align Docker trust fallback resolution with the hook generator for GUI launches, so `GWT_HOOK_BIN` matches the sibling `gwtd` path that generated `.codex/hooks.json`.
- Trust exact managed Codex event commands from both POSIX and PowerShell generator formats for the expected fallback binary.
- Add regression coverage for GUI sibling fallback resolution and PowerShell-generated hooks registered from POSIX/Linux Docker.
- Record the review lesson in `tasks/lessons.md`.

## Testing

- `cargo test -p gwt-agent docker_codex_hook_trust -- --nocapture`
- `cargo test -p gwt-skills codex_hook_trust -- --nocapture`
- `cargo test -p gwt-skills -p gwt-agent --all-features`
- `cargo fmt -- --check`
- `bunx markdownlint-cli2 AGENTS.md tasks/lessons.md`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt --bin gwt --bin gwtd`
- `git diff --check`
- `bunx commitlint --from origin/develop --to HEAD`

## Closing Issues

None

## Related Issues

None

## Checklist

- [x] Tests and lint pass locally
- [x] Review comments from PR #2735 addressed
- [x] No unresolved TODOs added
