### PR TITLE
fix(index): keep full status retry until bootstrap completes

### DIFF
--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -18,7 +18,6 @@ pub enum ProjectIndexBootstrapRequest {
 }
 
 const FULL_STATUS_RETRY_DELAY: Duration = Duration::from_millis(100);
-const FULL_STATUS_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 
 type BootstrapFn = dyn Fn(&Path) -> Result<(), String> + Send + Sync + 'static;
 type StatusProbeFn = dyn Fn(&Path) -> gwt::ProjectIndexStatusView + Send + Sync + 'static;
@@ -87,7 +86,6 @@ impl ProjectIndexBootstrapService {
             Arc::new(gwt::index_worker::bootstrap_project_index_for_path),
             Arc::new(cached_aggregate_status_probe),
             FULL_STATUS_RETRY_DELAY,
-            FULL_STATUS_RETRY_TIMEOUT,
         )
     }
 
@@ -98,7 +96,6 @@ impl ProjectIndexBootstrapService {
         bootstrap: Arc<BootstrapFn>,
         status_probe: Arc<StatusProbeFn>,
         retry_delay: Duration,
-        retry_timeout: Duration,
     ) -> ProjectIndexBootstrapRequest {
         let request = self.spawn_full_status_refresh_once_with(
             proxy.clone(),
@@ -115,7 +112,6 @@ impl ProjectIndexBootstrapService {
             bootstrap,
             status_probe,
             retry_delay,
-            retry_timeout,
         )
     }
 
@@ -141,7 +137,6 @@ impl ProjectIndexBootstrapService {
         bootstrap: Arc<BootstrapFn>,
         status_probe: Arc<StatusProbeFn>,
         retry_delay: Duration,
-        retry_timeout: Duration,
     ) -> ProjectIndexBootstrapRequest {
         let project_key = normalize_project_root(&project_root);
         let project_root_label = project_key.display().to_string();
@@ -169,15 +164,6 @@ impl ProjectIndexBootstrapService {
                 };
                 let started = Instant::now();
                 loop {
-                    if started.elapsed() >= retry_timeout {
-                        tracing::warn!(
-                            target: "gwt::index",
-                            worktree = %project_root_label,
-                            elapsed_ms = started.elapsed().as_millis() as u64,
-                            "timed out waiting to retry project index full status refresh"
-                        );
-                        return;
-                    }
                     thread::sleep(retry_delay);
                     match service_for_thread.spawn_full_status_refresh_once_with(
                         proxy.clone(),
@@ -806,7 +792,6 @@ mod tests {
                 gwt::ProjectIndexStatusView::new(gwt::ProjectIndexStatusState::Ready, "full table")
             }),
             Duration::from_millis(5),
-            Duration::from_secs(2),
         );
         assert_eq!(full, super::ProjectIndexBootstrapRequest::AlreadyRunning);
         assert!(

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5465,4 +5465,5 @@ repo-shared scopes だけなのに、Settings.Index 向けの全 worktree 可視
 4. 起動時 probe とオンデマンド full refresh を分離する場合、in-flight coalescing は
    「要求を捨てる」のではなく「必要な重い可視性を後続で流す」契約にする。Settings.Index
    のようにユーザーが明示的に開いた full table は、startup current-only probe と衝突しても
-   後続 retry で最後に full status を配信する。
+   後続 retry で最後に full status を配信する。この retry は固定短時間 timeout で捨てず、
+   bootstrap が長引く初回 runtime 準備や大規模 repo でも要求を保持する。


### PR DESCRIPTION
## Summary

- Follow-up to PR #2737 review: keep queued Settings.Index full status refresh retries alive until the startup bootstrap finishes.
- Remove the fixed 15 second retry timeout so long startup bootstraps cannot silently drop the user's full-refresh request.
- Record the retry-timeout lesson and update SPEC #1939 task evidence.

## Verification

- `cargo fmt -- --check`
- `cargo test -p gwt project_index_bootstrap -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `bunx --bun markdownlint-cli tasks/lessons.md tasks/spec-1939-perf/tasks.md --config .markdownlint.json`
- `bunx commitlint --from HEAD~1 --to HEAD`
- pre-push checks passed, including filtered line coverage 90.47%
