### PR TITLE
fix(gui): keep Runtime active during confirmation

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2123,6 +2123,7 @@ impl LaunchWizardState {
             LaunchWizardLaunchPath::ManualSetup => "Setup",
             LaunchWizardLaunchPath::FocusSession => "Focus",
         };
+        let runtime_confirmation_active = self.show_runtime_confirmation();
         let setup_state = if self.launch_path == LaunchWizardLaunchPath::ManualSetup {
             if self.runtime_context_resolved || self.runtime_resolution_pending {
                 "done"
@@ -2132,15 +2133,15 @@ impl LaunchWizardState {
         } else {
             "done"
         };
-        let runtime_state = if self.runtime_resolution_pending {
+        let runtime_state = if self.runtime_resolution_pending || runtime_confirmation_active {
             "active"
         } else if self.runtime_context_resolved {
             "done"
         } else {
             "pending"
         };
-        let start_state = if self.runtime_context_resolved
-            || self.launch_path == LaunchWizardLaunchPath::FocusSession
+        let start_state = if self.launch_path == LaunchWizardLaunchPath::FocusSession
+            || (self.runtime_context_resolved && !runtime_confirmation_active)
         {
             "active"
         } else {
@@ -6189,6 +6190,18 @@ mod tests {
         assert!(view.show_runtime_target);
         assert_eq!(view.selected_runtime_target, "docker");
         assert_eq!(view.selected_docker_service.as_deref(), Some("app"));
+        assert!(
+            view.progress_steps
+                .iter()
+                .any(|step| step.key == "runtime" && step.state == "active"),
+            "Runtime confirmation must keep the Runtime rail step active",
+        );
+        assert!(
+            view.progress_steps
+                .iter()
+                .any(|step| step.key == "start" && step.state == "pending"),
+            "Start must stay pending while Runtime choices are still visible",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep the Start Work Launch Wizard progress rail aligned with the visible Runtime confirmation step.
- Prevent the progress rail from advancing to Start while Runtime target controls are still editable.

## Changes

- `crates/gwt/src/launch_wizard.rs`: Treat active Runtime confirmation as `Runtime=active` and `Start=pending` in `progress_steps_view`.
- `crates/gwt/src/launch_wizard.rs`: Add regression assertions for the two-phase Runtime confirmation progress state.

## Testing

- [x] `cargo test -p gwt --lib phase_one_hides_runtime_until_worktree_is_resolved -- --nocapture` - passed.
- [x] `cargo test -p gwt --lib launch_wizard::tests:: -- --nocapture` - passed.
- [x] `node /tmp/gwt-runtime-progress-e2e/start-work-runtime-progress.mjs http://127.0.0.1:57519/` - passed against a live `./target/debug/gwt` server after clicking Start Work, changing Agent, and clicking Continue.
- [x] `node /tmp/gwt-runtime-progress-e2e/start-work-runtime-progress.mjs http://127.0.0.1:59218/` - passed again after merging `origin/develop` and rebuilding the current HEAD server.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `git diff --check` - passed.
- [x] `npm run test:frontend-bundle` - passed.
- [x] `npm run test:frontend-unit` - passed.
- [x] `git push` pre-push checks - passed with filtered line coverage 90.58%.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not applicable: no README/user-doc change)
- [x] Migration/backfill plan included (not applicable: no schema/data change)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Risk / Impact

- **Affected areas**: Launch Wizard progress rail state for Start Work and Launch Agent Runtime confirmation.
- **Rollback plan**: Revert this PR to restore the previous progress-state behavior.
