### PR TITLE
fix(gui): align resize final size with pointerup

### DIFF
--- a/crates/gwt/playwright/tests/agent-resize.spec.ts
+++ b/crates/gwt/playwright/tests/agent-resize.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+test.describe("Agent window resize tracking", () => {
+  test.use({
+    deviceScaleFactor: 1,
+    viewport: { width: 1440, height: 900 },
+  });
+
+  test("pointerup coordinates decide the final resize geometry", async ({ page }) => {
+    await installEmbeddedRoutes(page);
+    await installAgentWindowBackend(page);
+    await page.goto(APP_URL);
+
+    const windowFrame = page.locator(".workspace-window[data-id='agent-1']");
+    const resizeHandle = windowFrame.locator(".resize-handle");
+    await expect(windowFrame).toBeVisible();
+    await expect(resizeHandle).toBeVisible();
+
+    const box = await windowFrame.boundingBox();
+    expect(box).not.toBeNull();
+    const startX = Math.round(box!.x + box!.width - 3);
+    const startY = Math.round(box!.y + box!.height - 3);
+
+    await resizeHandle.dispatchEvent("pointerdown", {
+      pointerId: 23,
+      pointerType: "mouse",
+      button: 0,
+      buttons: 1,
+      clientX: startX,
+      clientY: startY,
+    });
+    await page.evaluate(
+      ({ x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            pointerId: 23,
+            pointerType: "mouse",
+            buttons: 1,
+            clientX: x,
+            clientY: y,
+            bubbles: true,
+          }),
+        );
+      },
+      { x: startX + 20, y: startY + 20 },
+    );
+    await page.evaluate(
+      ({ x, y }) => {
+        window.dispatchEvent(
+          new PointerEvent("pointerup", {
+            pointerId: 23,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 0,
+            clientX: x,
+            clientY: y,
+            bubbles: true,
+          }),
+        );
+      },
+      { x: startX + 120, y: startY + 80 },
+    );
+
+    await expect
+      .poll(() => windowFrame.evaluate((element) => ({
+        width: element.style.width,
+        height: element.style.height,
+      })))
+      .toEqual({ width: "640px", height: "380px" });
+  });
+});
+
+async function installAgentWindowBackend(page) {
+  await page.addInitScript(() => {
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "playwright",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Resize Fixture",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [
+                {
+                  id: "agent-1",
+                  title: "Agent",
+                  preset: "agent",
+                  geometry: { x: 140, y: 100, width: 520, height: 300 },
+                  geometry_revision: 0,
+                  z_index: 1,
+                  status: "running",
+                  minimized: false,
+                  maximized: false,
+                  pre_maximize_geometry: null,
+                  persist: true,
+                  purpose_title: null,
+                  dynamic_title: null,
+                  dynamic_title_detail: null,
+                  agent_id: "agent-1",
+                  agent_color: null,
+                  tab_group_id: null,
+                  tab_group_active: false,
+                },
+              ],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        this.recordedSends = [];
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.emit(workspaceState);
+        }, 0);
+      }
+
+      send(data) {
+        this.recordedSends.push(JSON.parse(data));
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -835,11 +835,11 @@ mod tests {
         // up resizeState immediately via forceResetResizeState.
         let html = frontend_bundle_source();
         let pointerup_fallback = regex::Regex::new(
-            r#"(?s)window\.addEventListener\("pointerup", \(event\) => \{[\s\S]*?if \(resizeState\) \{[\s\S]*?if \(resizeState\.pointerId === event\.pointerId\) \{[\s\S]*?finishWindowResize\(event\.pointerId\);[\s\S]*?\} else \{[\s\S]*?forceResetResizeState\("window pointerup pointerId mismatch"\);"#,
+            r#"(?s)window\.addEventListener\("pointerup", \(event\) => \{[\s\S]*?if \(resizeState\) \{[\s\S]*?if \(resizeState\.pointerId === event\.pointerId\) \{[\s\S]*?finishWindowResize\(event\.pointerId,\s*event\);[\s\S]*?\} else \{[\s\S]*?forceResetResizeState\("window pointerup pointerId mismatch"\);"#,
         )
         .expect("valid regex");
         let pointercancel_fallback = regex::Regex::new(
-            r#"(?s)window\.addEventListener\("pointercancel", \(event\) => \{[\s\S]*?if \(resizeState && resizeState\.pointerId !== event\.pointerId\) \{[\s\S]*?forceResetResizeState\("window pointercancel pointerId mismatch"\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?finishWindowResize\(event\.pointerId\);"#,
+            r#"(?s)window\.addEventListener\("pointercancel", \(event\) => \{[\s\S]*?if \(resizeState && resizeState\.pointerId !== event\.pointerId\) \{[\s\S]*?forceResetResizeState\("window pointercancel pointerId mismatch"\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?finishWindowResize\(event\.pointerId,\s*event\);"#,
         )
         .expect("valid regex");
 
@@ -861,7 +861,7 @@ mod tests {
         )
         .expect("valid regex");
         let resize_finalizer = regex::Regex::new(
-            r"function finishWindowResize\(pointerId\) \{(?s:.*?)cancelTerminalResizeFit\(\);(?s:.*?)fitTerminal\(resizeState\.id,\s*false\);(?s:.*?)sendGeometry\((?s:.*?)runtime\?\.terminal\.focus\(\);(?s:.*?)resizeState = null;",
+            r"function finishWindowResize\(pointerId,\s*event = null\) \{(?s:.*?)syncResizeStatePointerEvent\(resizeState,\s*event\);(?s:.*?)cancelTerminalResizeFit\(\);(?s:.*?)fitTerminal\(resizeState\.id,\s*false\);(?s:.*?)sendGeometry\((?s:.*?)runtime\?\.terminal\.focus\(\);(?s:.*?)resizeState = null;",
         )
         .expect("valid regex");
 
@@ -885,22 +885,22 @@ mod tests {
         let html = frontend_bundle_source();
 
         assert!(
-            html.contains("function finishWindowResize(pointerId)"),
+            html.contains("function finishWindowResize(pointerId, event = null)"),
             "expected all floating window resize completion paths to share one finalizer",
         );
         assert!(
-            html.contains("finishWindowResize(event.pointerId);"),
-            "expected pointerup resize path to use the shared finalizer",
+            html.contains("finishWindowResize(event.pointerId, event);"),
+            "expected pointerup resize path to use the shared finalizer with release coordinates",
         );
         assert!(
             html.contains("window.addEventListener(\"pointercancel\", (event) => {")
-                && html.contains("finishWindowResize(event.pointerId);"),
-            "expected pointercancel to finalize resize state",
+                && html.contains("finishWindowResize(event.pointerId, event);"),
+            "expected pointercancel to finalize resize state with release coordinates",
         );
         assert!(
             html.contains("resizeHandle.addEventListener(\"lostpointercapture\", (event) => {")
-                && html.contains("finishWindowResize(event.pointerId);"),
-            "expected lost pointer capture to finalize resize state",
+                && html.contains("finishWindowResize(event.pointerId, event);"),
+            "expected lost pointer capture to finalize resize state with release coordinates",
         );
         assert!(
             html.contains("if (!terminalMap.has(windowId)) {\n          return;\n        }"),

--- a/crates/gwt/web/__tests__/window-geometry-sync.test.mjs
+++ b/crates/gwt/web/__tests__/window-geometry-sync.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import * as geometrySync from "../window-geometry-sync.js";
 import {
   beginLocalGeometryEdit,
   clearLocalGeometryEdit,
@@ -95,4 +96,38 @@ test("clearLocalGeometryEdit removes the stale workspace geometry guard", () => 
     shouldApplyWorkspaceGeometry(state, { id: "w-1", geometryRevision: 2 }),
     true,
   );
+});
+
+test("resize release geometry uses the pointer-end event coordinates", () => {
+  assert.equal(typeof geometrySync.syncResizeStatePointerEvent, "function");
+  assert.equal(typeof geometrySync.resizeGeometryFromPointerState, "function");
+
+  const resizeState = {
+    startX: 100,
+    startY: 50,
+    latestClientX: 126,
+    latestClientY: 66,
+    width: 500,
+    height: 300,
+  };
+
+  const synced = geometrySync.syncResizeStatePointerEvent(resizeState, {
+    clientX: 190,
+    clientY: 130,
+  });
+  const geometry = geometrySync.resizeGeometryFromPointerState(resizeState, {
+    zoom: 2,
+    minWidth: 420,
+    minHeight: 260,
+  });
+
+  assert.equal(synced, true);
+  assert.equal(resizeState.latestClientX, 190);
+  assert.equal(resizeState.latestClientY, 130);
+  assert.deepEqual(geometry, {
+    clientX: 190,
+    clientY: 130,
+    width: 545,
+    height: 340,
+  });
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -47,7 +47,9 @@
         commitLocalGeometryEdit,
         createGeometrySyncState,
         localGeometryBaseRevision,
+        resizeGeometryFromPointerState,
         shouldApplyWorkspaceGeometry,
+        syncResizeStatePointerEvent,
         workspaceGeometryRevision,
       } from "/window-geometry-sync.js";
       import { createSocketReceiveDispatcher } from "/socket-receive-dispatcher.js";
@@ -1852,16 +1854,17 @@
         resizeState.fitFrame = null;
       }
 
-      function finishWindowResize(pointerId) {
+      function finishWindowResize(pointerId, event = null) {
         if (!resizeState || resizeState.pointerId !== pointerId) {
           return;
         }
         const runtime = terminalMap.get(resizeState.id);
+        syncResizeStatePointerEvent(resizeState, event);
         cancelTerminalResizeFit();
         cancelResizePointermoveApply();
         cancelResizeStalenessGuard();
         // Flush the last pointer coordinates to the DOM so the final geometry
-        // matches the latest pointermove. fitTerminal + sendGeometry below
+        // matches the latest pointer event. fitTerminal + sendGeometry below
         // observe the up-to-date `element.style.width/height`.
         applyResizePointermove(resizeState);
         fitTerminal(resizeState.id, false);
@@ -1929,23 +1932,16 @@
         if (!element) {
           return;
         }
-        const x = state.latestClientX ?? state.startX;
-        const y = state.latestClientY ?? state.startY;
-        const width = clamp(
-          state.width + (x - state.startX) / viewport.zoom,
-          420,
-        );
-        const height = clamp(
-          state.height + (y - state.startY) / viewport.zoom,
-          260,
-        );
+        const { clientX, clientY, width, height } = resizeGeometryFromPointerState(state, {
+          zoom: viewport.zoom,
+        });
         element.style.width = `${width}px`;
         element.style.height = `${height}px`;
         traceUi(UI_TRACE_EVENT.resizePointermoveApply, {
           window_id: state.id,
           pointer_id: state.pointerId,
-          client_x: x,
-          client_y: y,
+          client_x: clientX,
+          client_y: clientY,
           width,
           height,
         });
@@ -8394,7 +8390,7 @@
               accepted: true,
               window_id: windowData.id,
             });
-            finishWindowResize(event.pointerId);
+            finishWindowResize(event.pointerId, event);
           });
         }
 
@@ -9662,7 +9658,7 @@
               accepted: true,
               window_id: resizeState.id,
             });
-            finishWindowResize(event.pointerId);
+            finishWindowResize(event.pointerId, event);
           } else {
             // SPEC-2008 Phase 26.C / FR-059 — Windows WebView2 sometimes
             // emits a `pointerup` whose pointerId does not match the one
@@ -9748,7 +9744,7 @@
             window_id: resizeState.id,
           });
         }
-        finishWindowResize(event.pointerId);
+        finishWindowResize(event.pointerId, event);
       });
 
       canvas.addEventListener("contextmenu", (event) => {

--- a/crates/gwt/web/window-geometry-sync.js
+++ b/crates/gwt/web/window-geometry-sync.js
@@ -5,6 +5,14 @@ function normalizeRevision(value) {
   return Math.trunc(value);
 }
 
+function finiteNumber(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function positiveFiniteNumber(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
 export function createGeometrySyncState() {
   return {
     localEdits: new Map(),
@@ -85,4 +93,38 @@ export function localGeometryBaseRevision(state, id, windowData) {
     workspaceRevision,
     normalizeRevision(localEdit.optimisticRevision),
   );
+}
+
+export function syncResizeStatePointerEvent(state, event) {
+  if (!state || !event) {
+    return false;
+  }
+  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+    return false;
+  }
+  state.latestClientX = event.clientX;
+  state.latestClientY = event.clientY;
+  return true;
+}
+
+export function resizeGeometryFromPointerState(
+  state,
+  { zoom = 1, minWidth = 420, minHeight = 260 } = {},
+) {
+  const normalizedZoom = positiveFiniteNumber(zoom, 1);
+  const minimumWidth = positiveFiniteNumber(minWidth, 420);
+  const minimumHeight = positiveFiniteNumber(minHeight, 260);
+  const startX = finiteNumber(state?.startX);
+  const startY = finiteNumber(state?.startY);
+  const clientX = finiteNumber(state?.latestClientX, startX);
+  const clientY = finiteNumber(state?.latestClientY, startY);
+  const baseWidth = finiteNumber(state?.width, minimumWidth);
+  const baseHeight = finiteNumber(state?.height, minimumHeight);
+
+  return {
+    clientX,
+    clientY,
+    width: Math.max(minimumWidth, baseWidth + (clientX - startX) / normalizedZoom),
+    height: Math.max(minimumHeight, baseHeight + (clientY - startY) / normalizedZoom),
+  };
 }


### PR DESCRIPTION
## Summary

- Fixes Agent/floating terminal resize finalization so the release event coordinates decide the final window size.
- Keeps pointermove DOM writes coalesced for performance while preventing stale `latestClientX/latestClientY` from being committed.
- Adds browser regression coverage for the case where `pointerup` arrives at a newer coordinate than the last applied pointermove.

## Changes

- `crates/gwt/web/app.js`: passes pointer end events into the resize finalizer and flushes geometry after syncing those coordinates.
- `crates/gwt/web/window-geometry-sync.js`: adds shared resize-state coordinate sync and geometry calculation helpers.
- `crates/gwt/web/__tests__/window-geometry-sync.test.mjs`: covers pointer-end coordinate sync before final geometry calculation.
- `crates/gwt/playwright/tests/agent-resize.spec.ts`: adds an embedded-browser regression that dispatches a final `pointerup` without a matching final `pointermove`.
- `crates/gwt/src/embedded_web.rs`: updates embedded bundle contracts for the new event-aware resize finalizer.

## Testing

- [x] `node --test crates/gwt/web/__tests__/window-geometry-sync.test.mjs` — passed after first observing RED before implementation.
- [x] `npm run test:visual -- crates/gwt/playwright/tests/agent-resize.spec.ts` — passed.
- [x] `npm run test:frontend-bundle` — passed.
- [x] `npm run test:frontend-unit` — passed.
- [x] `cargo test -p gwt embedded_web_ --all-features` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.
- [x] `git diff --cached --check` — passed before commit.
- [x] `git push origin HEAD:work/20260515-0406` — pre-push checks passed, including coverage threshold 90.47% >= 90.00%.
- [x] `GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:62090/ npm run test:visual -- crates/gwt/playwright/tests/chrome.spec.ts crates/gwt/playwright/tests/theme-toggle.spec.ts crates/gwt/playwright/tests/reduced-motion.spec.ts` — passed against the live local server.

## Closing Issues

- Closes #2741

## Related Issues / Links

- SPEC-2008
- #2513

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo fmt`, `cargo clippy`)
- [x] Documentation not required; this is a behavioral bugfix with no user-facing docs or commands.
- [x] Migration/backfill not required; no schema or persisted data format changes.
- [x] CHANGELOG impact considered; conventional `fix:` commit marks patch-level impact.

## Context

- `SS.mov` showed the resize preview and final Agent window size lagging behind the cursor after the broader UI performance fix.
- The root cause is the existing rAF pointermove coalescing path: it improves resize performance, but `finishWindowResize(pointerId)` previously flushed whatever coordinates were last stored by pointermove, not the current pointer end event.

## Risk / Impact

- **Affected areas**: Floating workspace window resize for Agent/Shell/Claude/Codex terminal windows and other resizable workspace windows.
- **Rollback plan**: Revert commit `79297fe90` if resize finalization regresses.
