### PR TITLE
fix(launch-wizard): preserve user-selected agent across hydration

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1038,10 +1038,13 @@ impl LaunchWizardState {
             self.docker_lifecycle_intent = resolved_lifecycle;
         }
         self.sync_selected_agent_options();
-        // Agent preference の再適用は previous_profiles が refresh されたときのみ。
-        // 現 wizard 内で user が編集した draft (model / reasoning など) を上書きしない。
+        // SPEC-2014 FR-054 / FR-056 (2026-05-15 Wizard Hydration Preserves User-Selected Agent):
+        // hydration では preferred_agent_id で agent identity を上書きせず、
+        // 現在選択 agent の per-agent draft / previous profile だけ refresh する。
+        // preferred agent identity の適用は constructor (apply_preferred_agent_profile)
+        // と set_agent_id 経由の明示的 agent 切替に限定する。
         if refreshed_previous_profiles && self.launch_path != LaunchWizardLaunchPath::QuickStart {
-            self.apply_preferred_agent_profile();
+            self.restore_agent_draft_or_defaults();
         }
         self.sync_docker_lifecycle_default();
         self.selected = self
@@ -1588,6 +1591,12 @@ impl LaunchWizardState {
         self.sync_docker_lifecycle_default();
     }
 
+    /// Apply the locally-preferred agent identity (and matching per-agent
+    /// draft) to the wizard. Constructor-only entry point for SPEC-2014
+    /// FR-024 / FR-026 (Local User Agent Preferences). MUST NOT be called from
+    /// `apply_hydration` or other mid-wizard refresh paths because it
+    /// overwrites `self.agent_id`, which would discard the user's explicit
+    /// Settings-step selection (SPEC-2014 FR-054).
     fn apply_preferred_agent_profile(&mut self) -> bool {
         if let Some(agent_id) = self
             .previous_profiles
@@ -5172,6 +5181,101 @@ mod tests {
         assert_eq!(view.selected_execution_mode, "continue");
         assert!(view.skip_permissions);
         assert!(view.codex_fast_mode);
+    }
+
+    #[test]
+    fn apply_runtime_context_preserves_user_selected_agent_after_settings_step() {
+        // SPEC-2014 FR-054 / FR-056 (2026-05-15 Wizard Hydration Preserves
+        // User-Selected Agent): Settings step で user が agent を切り替えた後、
+        // Runtime confirmation 経路 (apply_runtime_context) が previous_profiles を
+        // refresh しても user 選択 agent_id を上書きしてはならない。
+        let codex_session = sample_session_record(
+            "feature/old",
+            Path::new("/tmp/old-repo"),
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        let previous_profiles =
+            previous_launch_profiles_from_sessions(std::slice::from_ref(&codex_session));
+        let mut state = LaunchWizardState::open_with_previous_profiles(
+            context(branch("feature/current"), "feature/current"),
+            sample_agent_options(),
+            Vec::new(),
+            previous_profiles.clone(),
+        );
+        assert_eq!(state.view().selected_agent_id, "codex");
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        assert_eq!(state.view().selected_agent_id, "claude");
+
+        state.apply_runtime_context(LaunchWizardHydration {
+            selected_branch: Some(branch("feature/current")),
+            normalized_branch_name: "feature/current".to_string(),
+            worktree_path: Some(PathBuf::from("/tmp/current-repo")),
+            quick_start_root: PathBuf::from("/tmp/current-repo"),
+            docker_context: None,
+            docker_service_status: gwt_docker::ComposeServiceStatus::Unknown,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: Some(previous_profiles),
+        });
+
+        let view = state.view();
+        assert_eq!(view.selected_agent_id, "claude");
+        let config = state
+            .build_launch_config()
+            .expect("launch config builds for user-selected agent");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
+    }
+
+    #[test]
+    fn custom_agent_cache_refresh_preserves_user_selected_agent() {
+        // SPEC-2014 FR-054 / FR-056 (2026-05-15 Wizard Hydration Preserves
+        // User-Selected Agent): mid-wizard custom agent cache refresh (FR-018) でも
+        // user 選択 agent_id は preferred_agent_id で上書きされてはならない。
+        let codex_session = sample_session_record(
+            "feature/old",
+            Path::new("/tmp/old-repo"),
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 10, 9, 0, 0).unwrap(),
+            None,
+        );
+        let previous_profiles =
+            previous_launch_profiles_from_sessions(std::slice::from_ref(&codex_session));
+        let mut state = LaunchWizardState::open_with_previous_profiles(
+            context(branch("feature/current"), "feature/current"),
+            sample_agent_options(),
+            Vec::new(),
+            previous_profiles.clone(),
+        );
+        assert_eq!(state.view().selected_agent_id, "codex");
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        assert_eq!(state.view().selected_agent_id, "claude");
+
+        state.apply_hydration(LaunchWizardHydration {
+            selected_branch: None,
+            normalized_branch_name: "feature/current".to_string(),
+            worktree_path: Some(PathBuf::from("/tmp/current-repo")),
+            quick_start_root: PathBuf::from("/tmp/current-repo"),
+            docker_context: None,
+            docker_service_status: gwt_docker::ComposeServiceStatus::Unknown,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: Some(previous_profiles),
+        });
+
+        let view = state.view();
+        assert_eq!(view.selected_agent_id, "claude");
+        let config = state
+            .build_launch_config()
+            .expect("launch config builds for user-selected agent");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wizard の Settings step で選んだ agent が Runtime confirmation 後に前回 Launch agent (preferred agent) で上書きされる regression を解消
- `LaunchWizardState::apply_hydration` から agent identity 上書きを除き、現在選択 agent の per-agent draft / previous profile だけを refresh する設計へ補正
- SPEC-2014 に新 phase `2026-05-15 Wizard Hydration Preserves User-Selected Agent` を追加し、US-24 / FR-054..FR-056 / SC-029..SC-030 を spec / plan / tasks に反映

## Changes

- `crates/gwt/src/launch_wizard.rs`: `apply_hydration` 内の `apply_preferred_agent_profile()` 呼び出しを `restore_agent_draft_or_defaults()` に置換 (line 1043-1049 周辺)。`apply_preferred_agent_profile` 自体は constructor 経由 (line 781) と `set_agent_id` 経由の明示的切替で利用するため残し、関数 doc コメントに constructor-only と明示
- `crates/gwt/src/launch_wizard.rs` (`mod tests`): RED test を 2 件追加
  - `apply_runtime_context_preserves_user_selected_agent_after_settings_step` — Runtime confirmation 経路で user の agent_id 選択が保持されることを固定
  - `custom_agent_cache_refresh_preserves_user_selected_agent` — custom agent cache refresh 経路で同じ性質を固定
- SPEC-2014 (Issue #2014): `spec` / `plan` / `tasks` に `## 2026-05-15 Wizard Hydration Preserves User-Selected Agent` phase を追加 (US-24 / FR-054..FR-056 / SC-029..SC-030 / T85..T88)

## Testing

- [x] `cargo test -p gwt --lib launch_wizard::tests::apply_runtime_context_preserves_user_selected_agent_after_settings_step --nocapture` — fix 前 FAILED (`left: "codex" right: "claude"`) → fix 後 PASSED
- [x] `cargo test -p gwt --lib launch_wizard::tests::custom_agent_cache_refresh_preserves_user_selected_agent --nocapture` — fix 前 FAILED → fix 後 PASSED
- [x] `cargo test -p gwt --lib launch_wizard::tests::hydration_refresh_preserves_open_wizard_agent_settings_without_reapplying_preferences --nocapture` — GREEN を維持
- [x] `cargo test -p gwt --lib launch_wizard::tests` — 75 passed / 0 failed
- [x] `cargo test -p gwt-core -p gwt --all-features` — 全 suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning なし
- [x] `cargo fmt -- --check` — diff なし
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — success
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — exit 0

### Manual Verification (推奨)

1. `cargo run -p gwt --bin gwt` で gwt 起動
2. Branches 画面で branch を選択 → `Launch Agent`
3. Settings step で agent を前回と異なる agent (例: 前回 Codex なら Claude Code) に切り替え
4. `Continue` で Runtime confirmation step に進む
5. **期待**: agent indicator / summary が手順 3 で選んだ agent を維持し、Launch 時に同 agent の PTY が起動する
6. `Start Work` 経由でも同手順で再現確認

## Closing Issues

- None

## Related Issues / Links

- #2014 (SPEC-2014: Launch Wizard) — `2026-05-15 Wizard Hydration Preserves User-Selected Agent` phase 追加
- 並行作業: `work/20260515-1015-2` PR #2740 (Runtime confirmation progress rail) — seam が異なり衝突なし、Board に claim 済み

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — SPEC-2014 spec/plan/tasks 更新
- [ ] Migration/backfill plan included (if schema/data change) — schema/data 変更なし
- [x] CHANGELOG impact considered (breaking change flagged in commit) — `fix:` patch 扱い、breaking change なし

## Context

- 直近の SPEC-2014 追加項目 `2026-05-11 Local User Agent Preferences` と `2026-05-12 Host/Docker Per-Repo Persistence` で hydration 経路の `previous_profiles` refresh が強化された際、`apply_preferred_agent_profile()` が agent_id まで上書きしていた点が見落とされた regression
- SPEC-2014 plan の `LaunchWizardState の初期化と agent 切替時の fallback を、open Wizard draft -> local user agent preference -> agent defaults の順にする` 規定 (2026-05-11 Local User Agent Preferences) と実装の乖離を解消する

## Risk / Impact

- **Affected areas**: Launch Wizard hydration 経路 (Runtime confirmation / custom agent cache refresh / runtime hydration の 3 経路)
- **Rollback plan**: `apply_hydration` 内の 1 行 (`restore_agent_draft_or_defaults` → `apply_preferred_agent_profile`) を戻すだけで挙動が元に戻る。SPEC-2014 phase 追加は revert 不要 (記録として保持可)
