### PR TITLE
feat(file-tree): add worktree picker, split viewer, and hex mode for File Tree window

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1805,6 +1805,10 @@ pub struct AppRuntime {
     /// Async writer that flushes session/workspace snapshots off the event
     /// loop thread (Issue #2694 Phase B).
     pub(crate) persist_dispatcher: persist_dispatcher::PersistDispatcher,
+    /// SPEC-2009 amendment: per-window selected worktree root for File Tree
+    /// windows. Reset every time the user reopens the picker, so this is a
+    /// transient in-memory map and is not persisted with the session state.
+    pub(crate) file_tree_worktree_roots: HashMap<String, PathBuf>,
 }
 
 impl ProjectTabRuntime {
@@ -1886,6 +1890,7 @@ impl AppRuntime {
             pending_update: None,
             pty_writers,
             persist_dispatcher,
+            file_tree_worktree_roots: HashMap::new(),
         };
         app.rebuild_window_lookup();
         app.seed_window_pty_statuses();
@@ -2026,6 +2031,16 @@ impl AppRuntime {
                 vec![OutboundEvent::reply(
                     client_id,
                     self.load_file_tree_event(&id, &path),
+                )]
+            }
+            FrontendEvent::ListFileTreeWorktrees { id } => vec![OutboundEvent::reply(
+                client_id,
+                self.list_file_tree_worktrees_event(&id),
+            )],
+            FrontendEvent::SelectFileTreeWorktree { id, worktree_id } => {
+                vec![OutboundEvent::reply(
+                    client_id,
+                    self.select_file_tree_worktree_event(&id, &worktree_id),
                 )]
             }
             FrontendEvent::LoadFileContent {
@@ -3262,35 +3277,16 @@ impl AppRuntime {
     }
 
     pub(crate) fn load_file_tree_event(&self, id: &str, path: &str) -> BackendEvent {
-        let Some(address) = self.window_lookup.get(id) else {
-            return BackendEvent::FileTreeError {
-                id: id.to_string(),
-                path: path.to_string(),
-                message: "Window not found".to_string(),
-            };
+        let root = match self.resolve_file_tree_root(id) {
+            Ok(root) => root,
+            Err(message) => {
+                return BackendEvent::FileTreeError {
+                    id: id.to_string(),
+                    path: path.to_string(),
+                    message,
+                };
+            }
         };
-        let Some(tab) = self.tab(&address.tab_id) else {
-            return BackendEvent::FileTreeError {
-                id: id.to_string(),
-                path: path.to_string(),
-                message: "Project tab not found".to_string(),
-            };
-        };
-        let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return BackendEvent::FileTreeError {
-                id: id.to_string(),
-                path: path.to_string(),
-                message: "Window not found".to_string(),
-            };
-        };
-
-        if window.preset != WindowPreset::FileTree {
-            return BackendEvent::FileTreeError {
-                id: id.to_string(),
-                path: path.to_string(),
-                message: "Window is not a file tree".to_string(),
-            };
-        }
 
         let relative_path = if path.is_empty() {
             None
@@ -3298,7 +3294,7 @@ impl AppRuntime {
             Some(Path::new(path))
         };
 
-        match list_directory_entries(&tab.project_root, relative_path) {
+        match list_directory_entries(&root, relative_path) {
             Ok(entries) => BackendEvent::FileTreeEntries {
                 id: id.to_string(),
                 path: path.to_string(),
@@ -3309,6 +3305,134 @@ impl AppRuntime {
                 path: path.to_string(),
                 message: error.to_string(),
             },
+        }
+    }
+
+    /// Resolve the worktree root for a File Tree window. Prefers the user's
+    /// picker selection (`file_tree_worktree_roots`); falls back to
+    /// `tab.project_root` for backward compatibility with existing callers
+    /// that pre-date the picker. Returns a human-readable error message on
+    /// invalid window id / wrong preset.
+    fn resolve_file_tree_root(&self, id: &str) -> Result<std::path::PathBuf, String> {
+        let address = self
+            .window_lookup
+            .get(id)
+            .ok_or_else(|| "Window not found".to_string())?;
+        let tab = self
+            .tab(&address.tab_id)
+            .ok_or_else(|| "Project tab not found".to_string())?;
+        let window = tab
+            .workspace
+            .window(&address.raw_id)
+            .ok_or_else(|| "Window not found".to_string())?;
+        if window.preset != WindowPreset::FileTree {
+            return Err("Window is not a file tree".to_string());
+        }
+        Ok(self
+            .file_tree_worktree_roots
+            .get(id)
+            .cloned()
+            .unwrap_or_else(|| tab.project_root.clone()))
+    }
+
+    pub(crate) fn list_file_tree_worktrees_event(&self, id: &str) -> BackendEvent {
+        let address = match self.window_lookup.get(id) {
+            Some(addr) => addr,
+            None => {
+                return BackendEvent::FileTreeWorktreeError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                };
+            }
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: "Project tab not found".to_string(),
+            };
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: "Window not found".to_string(),
+            };
+        };
+        if window.preset != WindowPreset::FileTree {
+            return BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: "Window is not a file tree".to_string(),
+            };
+        }
+        match gwt::worktree_inventory::enumerate_worktrees(
+            &tab.project_root,
+            Some(&tab.project_root),
+        ) {
+            Ok(entries) => BackendEvent::FileTreeWorktrees {
+                id: id.to_string(),
+                entries,
+            },
+            Err(err) => BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: err.to_string(),
+            },
+        }
+    }
+
+    pub(crate) fn select_file_tree_worktree_event(
+        &mut self,
+        id: &str,
+        worktree_id: &str,
+    ) -> BackendEvent {
+        let address = match self.window_lookup.get(id) {
+            Some(addr) => addr,
+            None => {
+                return BackendEvent::FileTreeWorktreeError {
+                    id: id.to_string(),
+                    message: "Window not found".to_string(),
+                };
+            }
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: "Project tab not found".to_string(),
+            };
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: "Window not found".to_string(),
+            };
+        };
+        if window.preset != WindowPreset::FileTree {
+            return BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: "Window is not a file tree".to_string(),
+            };
+        }
+        let entries = match gwt::worktree_inventory::enumerate_worktrees(
+            &tab.project_root,
+            Some(&tab.project_root),
+        ) {
+            Ok(entries) => entries,
+            Err(err) => {
+                return BackendEvent::FileTreeWorktreeError {
+                    id: id.to_string(),
+                    message: err.to_string(),
+                };
+            }
+        };
+        let Some(selected) = entries.into_iter().find(|entry| entry.id == worktree_id) else {
+            return BackendEvent::FileTreeWorktreeError {
+                id: id.to_string(),
+                message: "Unknown worktree id".to_string(),
+            };
+        };
+        self.file_tree_worktree_roots
+            .insert(id.to_string(), selected.path);
+        BackendEvent::FileTreeWorktreeSelected {
+            id: id.to_string(),
+            worktree_id: worktree_id.to_string(),
         }
     }
 
@@ -7276,6 +7400,7 @@ exit 1
             pending_update: None,
             pty_writers,
             persist_dispatcher,
+            file_tree_worktree_roots: HashMap::new(),
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -32,6 +32,7 @@ pub mod start_work;
 pub mod system_settings;
 pub mod window_state;
 pub mod workspace;
+pub mod worktree_inventory;
 
 #[cfg(test)]
 pub(crate) fn env_test_lock() -> &'static std::sync::Mutex<()> {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1720,6 +1720,7 @@ mod tests {
             pending_update: None,
             pty_writers: Arc::new(RwLock::new(HashMap::new())),
             persist_dispatcher,
+            file_tree_worktree_roots: HashMap::new(),
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();
@@ -2472,6 +2473,37 @@ mod tests {
             }
             other => panic!("expected FileContentHex, got {other:?}"),
         }
+
+        // SPEC-2009 amendment: Worktree Picker handlers must cover window
+        // mismatch, picker enumeration, and explicit selection.
+        assert!(matches!(
+            runtime.list_file_tree_worktrees_event("missing"),
+            BackendEvent::FileTreeWorktreeError { ref message, .. } if message == "Window not found"
+        ));
+        assert!(matches!(
+            runtime.list_file_tree_worktrees_event(&branches_id),
+            BackendEvent::FileTreeWorktreeError { ref message, .. } if message == "Window is not a file tree"
+        ));
+        let worktrees_event = runtime.list_file_tree_worktrees_event(&file_tree_id);
+        let worktree_id = match worktrees_event {
+            BackendEvent::FileTreeWorktrees { entries, .. } => {
+                assert!(
+                    !entries.is_empty(),
+                    "test repo must list at least one worktree"
+                );
+                entries[0].id.clone()
+            }
+            other => panic!("expected FileTreeWorktrees, got {other:?}"),
+        };
+
+        assert!(matches!(
+            runtime.select_file_tree_worktree_event(&file_tree_id, "unknown-id"),
+            BackendEvent::FileTreeWorktreeError { ref message, .. } if message == "Unknown worktree id"
+        ));
+        assert!(matches!(
+            runtime.select_file_tree_worktree_event(&file_tree_id, &worktree_id),
+            BackendEvent::FileTreeWorktreeSelected { worktree_id: ref selected, .. } if selected == &worktree_id
+        ));
 
         let missing_branches = runtime.load_branches_events("client-1", "missing");
         assert_eq!(missing_branches.len(), 1);

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -17,6 +17,7 @@ use crate::{
         CanvasViewport, PersistedWindowState, ProjectKind, WindowGeometry, WindowProcessStatus,
     },
     preset::WindowPreset,
+    worktree_inventory::WorktreeEntry,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -154,6 +155,13 @@ pub enum FrontendEvent {
     LoadFileTree {
         id: String,
         path: Option<String>,
+    },
+    ListFileTreeWorktrees {
+        id: String,
+    },
+    SelectFileTreeWorktree {
+        id: String,
+        worktree_id: String,
     },
     LoadFileContent {
         id: String,
@@ -714,6 +722,18 @@ pub enum BackendEvent {
     FileTreeError {
         id: String,
         path: String,
+        message: String,
+    },
+    FileTreeWorktrees {
+        id: String,
+        entries: Vec<WorktreeEntry>,
+    },
+    FileTreeWorktreeSelected {
+        id: String,
+        worktree_id: String,
+    },
+    FileTreeWorktreeError {
+        id: String,
         message: String,
     },
     FileContentText {

--- a/crates/gwt/src/worktree_inventory.rs
+++ b/crates/gwt/src/worktree_inventory.rs
@@ -1,0 +1,137 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use gwt_core::worktree_hash::{compute_worktree_hash, WorktreeHash};
+use gwt_git::worktree::{main_worktree_root, WorktreeInfo, WorktreeManager};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorktreeEntryKind {
+    BareMain,
+    Workspace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorktreeEntry {
+    /// Stable id derived from the canonical absolute path.
+    pub id: String,
+    pub kind: WorktreeEntryKind,
+    pub path: PathBuf,
+    /// Human-friendly label (branch name when available, else last path segment).
+    pub label: String,
+    pub branch: Option<String>,
+    /// True for the worktree that currently anchors the active project tab.
+    pub is_active: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InventoryError {
+    #[error("failed to list worktrees: {0}")]
+    List(String),
+    #[error("worktree hash failed for {path}: {message}")]
+    Hash { path: PathBuf, message: String },
+}
+
+/// Enumerate worktrees visible to a gwt-managed repository, sorted with the
+/// bare/main entry first and workspaces after by their label. `active_root`
+/// (when provided) marks the entry the current tab points to so the GUI can
+/// pre-highlight it in the picker.
+pub fn enumerate_worktrees(
+    repo_root: &Path,
+    active_root: Option<&Path>,
+) -> Result<Vec<WorktreeEntry>, InventoryError> {
+    let manager = WorktreeManager::new(repo_root);
+    let infos = manager
+        .list()
+        .map_err(|err| InventoryError::List(err.to_string()))?;
+
+    let canonical_main = main_worktree_root(repo_root)
+        .ok()
+        .map(|path| canonicalize_or(path.as_path()));
+    let canonical_active = active_root.map(canonicalize_or);
+
+    let mut entries = Vec::new();
+    for info in infos {
+        if info.prunable {
+            continue;
+        }
+        entries.push(make_entry(
+            &info,
+            canonical_main.as_deref(),
+            canonical_active.as_deref(),
+        )?);
+    }
+
+    entries.sort_by(entry_ordering);
+    Ok(entries)
+}
+
+fn make_entry(
+    info: &WorktreeInfo,
+    canonical_main: Option<&Path>,
+    canonical_active: Option<&Path>,
+) -> Result<WorktreeEntry, InventoryError> {
+    let canonical = canonicalize_or(&info.path);
+    let id = id_for(&canonical)?;
+    let kind = if canonical_main
+        .map(|main| main == canonical.as_path())
+        .unwrap_or(false)
+    {
+        WorktreeEntryKind::BareMain
+    } else {
+        WorktreeEntryKind::Workspace
+    };
+    let label = label_for(info, kind);
+    let is_active = canonical_active
+        .map(|active| active == canonical.as_path())
+        .unwrap_or(false);
+
+    Ok(WorktreeEntry {
+        id,
+        kind,
+        path: canonical,
+        label,
+        branch: info.branch.clone(),
+        is_active,
+    })
+}
+
+fn id_for(path: &Path) -> Result<String, InventoryError> {
+    compute_worktree_hash(path)
+        .map(|hash: WorktreeHash| hash.to_string())
+        .map_err(|err| InventoryError::Hash {
+            path: path.to_path_buf(),
+            message: err.to_string(),
+        })
+}
+
+fn canonicalize_or(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn label_for(info: &WorktreeInfo, kind: WorktreeEntryKind) -> String {
+    if matches!(kind, WorktreeEntryKind::BareMain) {
+        return "main repository".to_string();
+    }
+    if let Some(branch) = &info.branch {
+        return branch.clone();
+    }
+    info.path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| info.path.display().to_string())
+}
+
+fn entry_ordering(left: &WorktreeEntry, right: &WorktreeEntry) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (left.kind, right.kind) {
+        (WorktreeEntryKind::BareMain, WorktreeEntryKind::Workspace) => Ordering::Less,
+        (WorktreeEntryKind::Workspace, WorktreeEntryKind::BareMain) => Ordering::Greater,
+        _ => left
+            .label
+            .to_ascii_lowercase()
+            .cmp(&right.label.to_ascii_lowercase())
+            .then_with(|| left.label.cmp(&right.label)),
+    }
+}

--- a/crates/gwt/tests/worktree_inventory_test.rs
+++ b/crates/gwt/tests/worktree_inventory_test.rs
@@ -1,0 +1,102 @@
+use std::path::Path;
+use std::process::Command;
+
+use gwt::worktree_inventory::{enumerate_worktrees, WorktreeEntryKind};
+use tempfile::tempdir;
+
+fn git(args: &[&str], cwd: &Path) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?} failed in {cwd:?}");
+}
+
+fn init_repo(repo: &Path) {
+    std::fs::create_dir_all(repo).expect("create repo dir");
+    git(&["init", "--initial-branch=main"], repo);
+    git(&["config", "user.email", "test@example.com"], repo);
+    git(&["config", "user.name", "tester"], repo);
+    std::fs::write(repo.join("README.md"), "hello\n").expect("write readme");
+    git(&["add", "README.md"], repo);
+    git(&["commit", "-m", "init"], repo);
+}
+
+#[test]
+fn enumerate_worktrees_returns_main_only_for_fresh_repo() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    init_repo(&repo);
+
+    let entries = enumerate_worktrees(&repo, Some(&repo)).expect("inventory");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].kind, WorktreeEntryKind::BareMain);
+    assert!(
+        entries[0].is_active,
+        "active flag should follow active_root"
+    );
+    assert_eq!(entries[0].label, "main repository");
+}
+
+#[test]
+fn enumerate_worktrees_lists_main_and_workspace_entries() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    init_repo(&repo);
+
+    let worktree_path = dir.path().join("worktrees").join("feature-a");
+    git(
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/a",
+            worktree_path.to_str().expect("path str"),
+        ],
+        &repo,
+    );
+
+    let entries = enumerate_worktrees(&repo, Some(&worktree_path)).expect("inventory");
+    assert_eq!(entries.len(), 2);
+
+    // BareMain should be first per ordering rule.
+    assert_eq!(entries[0].kind, WorktreeEntryKind::BareMain);
+    assert!(!entries[0].is_active);
+    assert_eq!(entries[1].kind, WorktreeEntryKind::Workspace);
+    assert!(entries[1].is_active, "active flag should mark feature/a");
+    assert_eq!(entries[1].branch.as_deref(), Some("feature/a"));
+    assert_eq!(entries[1].label, "feature/a");
+
+    // IDs are stable and differ between entries.
+    assert_ne!(entries[0].id, entries[1].id);
+    assert_eq!(entries[0].id.len(), 16);
+}
+
+#[test]
+fn enumerate_worktrees_skips_prunable_entries() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    init_repo(&repo);
+
+    let worktree_path = dir.path().join("worktrees").join("ephemeral");
+    git(
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/ephemeral",
+            worktree_path.to_str().expect("path str"),
+        ],
+        &repo,
+    );
+
+    // Delete the worktree directory on disk without invoking `git worktree
+    // remove`, then run `git worktree prune` to mark it prunable.
+    std::fs::remove_dir_all(&worktree_path).expect("remove worktree dir");
+    git(&["worktree", "prune"], &repo);
+
+    let entries = enumerate_worktrees(&repo, None).expect("inventory");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].kind, WorktreeEntryKind::BareMain);
+}

--- a/crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs
+++ b/crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs
@@ -1,0 +1,80 @@
+// SPEC-2009 amendment Phase 1 — File Tree v2 contract smoke test.
+//
+// Verifies that the picker modal landing pad is present in index.html and
+// exposes the structural hooks that app.js relies on (the modal shell, the
+// classed backdrop, and the data attributes that the modal flow toggles).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseHTML } from "linkedom";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_HTML = path.resolve(here, "..", "index.html");
+
+async function loadIndex() {
+  const html = await readFile(INDEX_HTML, "utf8");
+  return parseHTML(html);
+}
+
+test("index.html ships the SPEC-2009 worktree picker modal landing pad", async () => {
+  const { document } = await loadIndex();
+  const modal = document.getElementById("file-tree-worktree-picker-modal");
+  assert.ok(modal, "worktree picker modal element must exist for app.js to mount");
+  assert.ok(
+    modal.classList.contains("modal-backdrop"),
+    "picker modal must adopt the shared modal-backdrop class so existing CSS hits",
+  );
+  assert.equal(
+    modal.getAttribute("aria-hidden"),
+    "true",
+    "picker modal starts hidden until app.js opens it on File Tree window creation",
+  );
+  const shell = modal.querySelector(".modal-shell");
+  assert.ok(shell, "picker modal must wrap a .modal-shell so app.js can mount content");
+  assert.equal(
+    shell.getAttribute("role"),
+    "dialog",
+    "picker modal shell must announce role=dialog for assistive tech",
+  );
+  assert.equal(
+    shell.getAttribute("aria-modal"),
+    "true",
+    "picker modal shell must trap focus via aria-modal",
+  );
+});
+
+test("index.html keeps the legacy branch cleanup modal landing pad intact", async () => {
+  // SPEC-2009 amendment must not regress existing modal contracts.
+  const { document } = await loadIndex();
+  assert.ok(
+    document.getElementById("branch-cleanup-modal"),
+    "branch cleanup modal must remain available; SPEC-2009 amendment only adds the worktree picker",
+  );
+});
+
+test("File Tree split layout CSS contract ships expected selectors", async () => {
+  // SPEC-2009 amendment FR-024/025/027: confirm the canonical split layout
+  // classes the runtime depends on are present in the styles bundle. The
+  // CSS file ships with the gwt binary, so a missing rule would silently
+  // collapse the viewer.
+  const cssPath = path.resolve(here, "..", "styles", "components.css");
+  const css = await readFile(cssPath, "utf8");
+  for (const cls of [
+    ".file-tree-split",
+    ".file-tree-splitter",
+    ".file-tree-viewer",
+    ".file-tree-viewer-header",
+    ".file-tree-viewer-body",
+    ".file-tree-viewer-text",
+    ".file-tree-viewer-hex",
+    ".worktree-picker-row",
+  ]) {
+    assert.ok(
+      css.includes(cls),
+      `components.css must declare ${cls} so the split layout renders correctly`,
+    );
+  }
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3373,9 +3373,362 @@
             loading: new Set(),
             selectedPath: "",
             error: "",
+            // SPEC-2009 amendment: per-window picker + viewer state.
+            picker: {
+              open: false,
+              loading: false,
+              entries: [],
+              error: "",
+            },
+            selectedWorktreeId: "",
+            selectedWorktreeLabel: "",
+            splitterRatio: 0.4,
+            viewer: {
+              path: "",
+              mode: "empty", // empty | text | binary | hex | error | loading
+              text: "",
+              encoding: "",
+              totalSize: 0,
+              hexOffset: 0,
+              hexBytes: "",
+              error: { kind: "", message: "", size: null, limit: null },
+            },
           });
         }
         return fileTreeStateMap.get(windowId);
+      }
+
+      function requestFileTreeWorktrees(windowId) {
+        const state = ensureFileTreeState(windowId);
+        state.picker.loading = true;
+        state.picker.error = "";
+        send({ kind: "list_file_tree_worktrees", id: windowId });
+      }
+
+      function selectFileTreeWorktree(windowId, worktreeId) {
+        send({
+          kind: "select_file_tree_worktree",
+          id: windowId,
+          worktree_id: worktreeId,
+        });
+      }
+
+      function requestFileContent(windowId, path, mode, hexOffset = null, hexLength = null) {
+        send({
+          kind: "load_file_content",
+          id: windowId,
+          path,
+          mode,
+          hex_offset: hexOffset,
+          hex_length: hexLength,
+        });
+      }
+
+      function formatHexDump(offset, base64Bytes) {
+        let binary;
+        try {
+          binary = atob(base64Bytes || "");
+        } catch (e) {
+          return "(invalid hex chunk)";
+        }
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) {
+          bytes[i] = binary.charCodeAt(i);
+        }
+        const BYTES_PER_LINE = 16;
+        const lines = [];
+        for (let i = 0; i < bytes.length; i += BYTES_PER_LINE) {
+          const slice = bytes.slice(i, i + BYTES_PER_LINE);
+          const lineOffset = (offset + i).toString(16).padStart(8, "0").toUpperCase();
+          const hexParts = [];
+          const asciiParts = [];
+          for (let j = 0; j < BYTES_PER_LINE; j += 1) {
+            if (j < slice.length) {
+              const b = slice[j];
+              hexParts.push(b.toString(16).padStart(2, "0").toUpperCase());
+              asciiParts.push(b >= 0x20 && b < 0x7F ? String.fromCharCode(b) : ".");
+            } else {
+              hexParts.push("  ");
+              asciiParts.push(" ");
+            }
+          }
+          lines.push(lineOffset + "  " + hexParts.join(" ") + "  |" + asciiParts.join("") + "|");
+        }
+        return lines.join("\n");
+      }
+
+      function formatBytes(size) {
+        if (size === null || size === undefined) {
+          return "";
+        }
+        if (size < 1024) {
+          return size + " B";
+        }
+        if (size < 1024 * 1024) {
+          return (size / 1024).toFixed(1) + " KiB";
+        }
+        return (size / (1024 * 1024)).toFixed(2) + " MiB";
+      }
+
+      function makeEl(tag, options = {}, children = []) {
+        const el = document.createElement(tag);
+        if (options.className) el.className = options.className;
+        if (options.text != null) el.textContent = String(options.text);
+        if (options.attrs) {
+          for (const [k, v] of Object.entries(options.attrs)) {
+            if (v == null) continue;
+            el.setAttribute(k, String(v));
+          }
+        }
+        if (options.dataset) {
+          for (const [k, v] of Object.entries(options.dataset)) {
+            if (v == null) continue;
+            el.dataset[k] = String(v);
+          }
+        }
+        for (const child of children) {
+          if (child == null) continue;
+          if (typeof child === "string") {
+            el.appendChild(document.createTextNode(child));
+          } else {
+            el.appendChild(child);
+          }
+        }
+        return el;
+      }
+
+      function clearChildren(el) {
+        while (el.firstChild) el.removeChild(el.firstChild);
+      }
+
+      function openWorktreePicker(windowId) {
+        const state = ensureFileTreeState(windowId);
+        state.picker.open = true;
+        state.picker.entries = [];
+        state.picker.error = "";
+        renderWorktreePicker(windowId);
+        requestFileTreeWorktrees(windowId);
+      }
+
+      function closeWorktreePicker(windowId) {
+        const state = ensureFileTreeState(windowId);
+        state.picker.open = false;
+        renderWorktreePicker(windowId);
+      }
+
+      function renderWorktreePicker(windowId) {
+        const modal = document.getElementById("file-tree-worktree-picker-modal");
+        if (!modal) return;
+        const shell = modal.querySelector(".modal-shell");
+        if (!shell) return;
+        const state = ensureFileTreeState(windowId);
+        clearChildren(shell);
+        if (!state.picker.open) {
+          modal.setAttribute("aria-hidden", "true");
+          modal.style.display = "none";
+          modal.dataset.windowId = "";
+          return;
+        }
+        modal.dataset.windowId = windowId;
+        modal.setAttribute("aria-hidden", "false");
+        modal.style.display = "flex";
+
+        const header = makeEl("header", { className: "worktree-picker-header" }, [
+          makeEl("h2", { text: "Select Worktree" }),
+          makeEl("button", {
+            className: "icon-button",
+            text: "×",
+            attrs: { type: "button", "aria-label": "Close picker" },
+            dataset: { pickerAction: "cancel" },
+          }),
+        ]);
+        const bodyContainer = makeEl("div", { className: "worktree-picker-body" });
+        if (state.picker.loading && state.picker.entries.length === 0) {
+          bodyContainer.appendChild(
+            makeEl("div", { className: "worktree-picker-empty", text: "Loading worktrees…" }),
+          );
+        } else if (state.picker.error) {
+          bodyContainer.appendChild(
+            makeEl("div", { className: "worktree-picker-error", text: state.picker.error }),
+          );
+        } else if (state.picker.entries.length === 0) {
+          bodyContainer.appendChild(
+            makeEl("div", {
+              className: "worktree-picker-empty",
+              text: "No worktrees available. Use Start Work to create a workspace.",
+            }),
+          );
+        } else {
+          const list = makeEl("div", { className: "worktree-picker-list" });
+          for (const entry of state.picker.entries) {
+            const row = makeEl(
+              "button",
+              {
+                className: "worktree-picker-row",
+                attrs: { type: "button" },
+                dataset: { worktreeId: entry.id },
+              },
+              [
+                makeEl("div", { className: "worktree-picker-row-label", text: entry.label }),
+                makeEl("div", { className: "worktree-picker-row-meta" }, [
+                  makeEl("span", {
+                    className: "worktree-picker-kind",
+                    text: entry.kind === "bare_main" ? "main" : "workspace",
+                  }),
+                  entry.is_active
+                    ? makeEl("span", { className: "worktree-picker-active", text: "active" })
+                    : null,
+                  makeEl("span", { className: "worktree-picker-path", text: entry.path }),
+                ]),
+              ],
+            );
+            row.addEventListener("click", (event) => {
+              event.preventDefault();
+              state.selectedWorktreeId = entry.id;
+              state.selectedWorktreeLabel = entry.label;
+              closeWorktreePicker(windowId);
+              selectFileTreeWorktree(windowId, entry.id);
+              // Reset tree + viewer state when switching worktree.
+              state.loaded.clear();
+              state.expanded.clear();
+              state.loading.clear();
+              state.error = "";
+              state.viewer = {
+                path: "",
+                mode: "empty",
+                text: "",
+                encoding: "",
+                totalSize: 0,
+                hexOffset: 0,
+                hexBytes: "",
+                error: { kind: "", message: "", size: null, limit: null },
+              };
+              requestFileTree(windowId, "");
+              renderFileTreeViewer(windowId);
+              renderFileTree(windowId);
+            });
+            list.appendChild(row);
+          }
+          bodyContainer.appendChild(list);
+        }
+        shell.appendChild(header);
+        shell.appendChild(bodyContainer);
+        shell
+          .querySelector('[data-picker-action="cancel"]')
+          ?.addEventListener("click", () => closeWorktreePicker(windowId));
+      }
+
+      function renderFileTreeViewer(windowId) {
+        const state = ensureFileTreeState(windowId);
+        const surface = document.querySelector(
+          `[data-window-id='${CSS.escape(windowId)}'] .file-tree-viewer`,
+        );
+        if (!surface) return;
+        const header = surface.querySelector(".file-tree-viewer-header");
+        const body = surface.querySelector(".file-tree-viewer-body");
+        if (!header || !body) return;
+        clearChildren(header);
+        clearChildren(body);
+        const v = state.viewer;
+        const sizeLabel = v.totalSize ? formatBytes(v.totalSize) : "";
+        switch (v.mode) {
+          case "empty":
+            header.appendChild(
+              makeEl("span", {
+                className: "file-tree-viewer-placeholder",
+                text: "No file selected",
+              }),
+            );
+            body.appendChild(
+              makeEl("div", {
+                className: "file-tree-viewer-empty",
+                text: "Select a file to view its contents.",
+              }),
+            );
+            break;
+          case "loading":
+            header.appendChild(
+              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
+            );
+            body.appendChild(
+              makeEl("div", { className: "file-tree-viewer-empty", text: "Loading…" }),
+            );
+            break;
+          case "text":
+            header.appendChild(
+              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
+            );
+            header.appendChild(
+              makeEl("span", {
+                className: "file-tree-viewer-meta",
+                text: (v.encoding || "") + " · " + sizeLabel,
+              }),
+            );
+            body.appendChild(makeEl("pre", { className: "file-tree-viewer-text", text: v.text }));
+            break;
+          case "binary": {
+            header.appendChild(
+              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
+            );
+            header.appendChild(
+              makeEl("span", { className: "file-tree-viewer-meta", text: "binary · " + sizeLabel }),
+            );
+            const btn = makeEl("button", {
+              className: "wizard-button",
+              text: "View as hex",
+              attrs: { type: "button" },
+              dataset: { viewerAction: "view-as-hex" },
+            });
+            btn.addEventListener("click", () => {
+              v.mode = "loading";
+              v.hexOffset = 0;
+              v.hexBytes = "";
+              renderFileTreeViewer(windowId);
+              requestFileContent(windowId, v.path, "hex", 0, 64 * 16);
+            });
+            header.appendChild(btn);
+            body.appendChild(
+              makeEl("div", {
+                className: "file-tree-viewer-notice",
+                text:
+                  "Cannot display as text. Use “View as hex” for a 16-byte/row hex dump.",
+              }),
+            );
+            break;
+          }
+          case "hex":
+            header.appendChild(
+              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
+            );
+            header.appendChild(
+              makeEl("span", { className: "file-tree-viewer-meta", text: "hex · " + sizeLabel }),
+            );
+            body.appendChild(
+              makeEl("pre", {
+                className: "file-tree-viewer-hex",
+                text: formatHexDump(v.hexOffset, v.hexBytes),
+              }),
+            );
+            break;
+          case "error":
+            header.appendChild(
+              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
+            );
+            body.appendChild(
+              makeEl("div", {
+                className: "file-tree-viewer-error",
+                text: v.error.message || "Unable to load file",
+              }),
+            );
+            break;
+          default:
+            header.appendChild(
+              makeEl("span", {
+                className: "file-tree-viewer-placeholder",
+                text: "Unknown state",
+              }),
+            );
+        }
       }
 
       function ensureBranchListState(windowId) {
@@ -5942,6 +6295,14 @@
         wizardBody.appendChild(wizardMain);
       }
 
+      function applyFileTreeSplitterRatio(split, ratio) {
+        if (!split) return;
+        const clamped = Math.min(0.9, Math.max(0.1, Number(ratio) || 0.4));
+        const leftPercent = (clamped * 100).toFixed(2);
+        split.style.setProperty("--file-tree-left-ratio", leftPercent + "%");
+        split.dataset.leftRatio = String(clamped);
+      }
+
       function renderFileTree(windowId) {
         const element = windowMap.get(windowId);
         if (!element) {
@@ -6021,6 +6382,21 @@
                     requestFileTree(windowId, entry.path);
                   }
                 }
+              } else {
+                // SPEC-2009 amendment: file row activation routes to viewer.
+                state.viewer = {
+                  ...state.viewer,
+                  path: entry.path,
+                  mode: "loading",
+                  text: "",
+                  encoding: "",
+                  totalSize: 0,
+                  hexOffset: 0,
+                  hexBytes: "",
+                  error: { kind: "", message: "", size: null, limit: null },
+                };
+                renderFileTreeViewer(windowId);
+                requestFileContent(windowId, entry.path, "text");
               }
               renderFileTree(windowId);
             };
@@ -7204,46 +7580,130 @@
         }
 
         if (surface === "file-tree") {
-          body.innerHTML = `
-            <div class="file-tree-root">
-              <div class="file-tree-toolbar workspace-toolbar">
-                <div class="file-tree-path">Repository</div>
-                <button class="icon-button" data-action="refresh-tree" aria-label="Refresh tree">↻</button>
-              </div>
-              <div class="file-tree-scroll workspace-scroll">
-                <div class="file-tree-list"></div>
-              </div>
-              <div class="file-tree-footer">.</div>
-            </div>
-          `;
+          // SPEC-2009 amendment: File Tree window now opens with a worktree
+          // picker, then renders a single window split into a left directory
+          // tree pane and a right file content viewer pane. The legacy
+          // `.file-tree-root` class wraps the whole composition so existing
+          // styles (and embedded HTML contract tests) still hit.
+          const root = makeEl("div", { className: "file-tree-root file-tree-root--split" });
+          const toolbar = makeEl("div", {
+            className: "file-tree-toolbar workspace-toolbar",
+          });
+          const pathLabel = makeEl("button", {
+            className: "file-tree-path file-tree-worktree-trigger",
+            attrs: { type: "button" },
+            dataset: { action: "open-worktree-picker" },
+            text: "Select worktree…",
+          });
+          const refreshBtn = makeEl("button", {
+            className: "icon-button",
+            attrs: { "aria-label": "Refresh tree", type: "button" },
+            dataset: { action: "refresh-tree" },
+            text: "↻",
+          });
+          toolbar.appendChild(pathLabel);
+          toolbar.appendChild(refreshBtn);
+
+          const split = makeEl("div", { className: "file-tree-split" });
+          const pane = makeEl("div", { className: "file-tree-pane" });
+          const scroll = makeEl("div", { className: "file-tree-scroll workspace-scroll" });
+          const list = makeEl("div", { className: "file-tree-list" });
+          scroll.appendChild(list);
+          pane.appendChild(scroll);
+          pane.appendChild(makeEl("div", { className: "file-tree-footer", text: "." }));
+
+          const splitter = makeEl("div", {
+            className: "file-tree-splitter",
+            attrs: { role: "separator", "aria-orientation": "vertical", tabindex: "0" },
+            dataset: { action: "drag-splitter" },
+          });
+
+          const viewer = makeEl("div", { className: "file-tree-viewer" });
+          viewer.appendChild(makeEl("div", { className: "file-tree-viewer-header" }));
+          viewer.appendChild(makeEl("div", { className: "file-tree-viewer-body" }));
+
+          split.appendChild(pane);
+          split.appendChild(splitter);
+          split.appendChild(viewer);
+
+          root.appendChild(toolbar);
+          root.appendChild(split);
+          clearChildren(body);
+          body.appendChild(root);
+
+          // Apply initial splitter ratio.
+          const initialState = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+            windowData.id,
+          );
+          applyFileTreeSplitterRatio(split, initialState.splitterRatio);
+
           body.addEventListener("mousedown", () => {
             focusWindowLocally(windowData.id);
             socketTransport.send({ kind: "focus_window", id: windowData.id });
           });
-          body
-            .querySelector("[data-action='refresh-tree']")
-            .addEventListener("click", (event) => {
-              event.stopPropagation();
+
+          pathLabel.addEventListener("click", (event) => {
+            event.stopPropagation();
+            frontendUnits.branchesFileTreeSurface.openWorktreePicker(windowData.id);
+          });
+
+          refreshBtn.addEventListener("click", (event) => {
+            event.stopPropagation();
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              windowData.id,
+            );
+            if (!state.selectedWorktreeId) {
+              frontendUnits.branchesFileTreeSurface.openWorktreePicker(windowData.id);
+              return;
+            }
+            state.loaded.clear();
+            state.expanded.clear();
+            state.loading.clear();
+            state.error = "";
+            frontendUnits.branchesFileTreeSurface.requestFileTree(windowData.id, "");
+            frontendUnits.branchesFileTreeSurface.renderFileTree(windowData.id);
+          });
+
+          // Splitter drag: pointer events keep the handler small and ignore
+          // the canvas pan/zoom because the modal capture absorbs them.
+          splitter.addEventListener("pointerdown", (event) => {
+            event.preventDefault();
+            splitter.setPointerCapture(event.pointerId);
+            const onMove = (moveEvent) => {
+              const rect = split.getBoundingClientRect();
+              if (rect.width <= 0) return;
+              const ratio = (moveEvent.clientX - rect.left) / rect.width;
+              const clamped = Math.min(0.9, Math.max(0.1, ratio));
               const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
                 windowData.id,
               );
-              state.loaded.clear();
-              state.expanded.clear();
-              state.loading.clear();
-              state.error = "";
-              frontendUnits.branchesFileTreeSurface.requestFileTree(
-                windowData.id,
-                "",
-              );
-              frontendUnits.branchesFileTreeSurface.renderFileTree(windowData.id);
-            });
-          const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
-            windowData.id,
-          );
-          if (!state.loaded.has("")) {
-            frontendUnits.branchesFileTreeSurface.requestFileTree(windowData.id, "");
+              state.splitterRatio = clamped;
+              applyFileTreeSplitterRatio(split, clamped);
+            };
+            const onUp = () => {
+              splitter.releasePointerCapture(event.pointerId);
+              splitter.removeEventListener("pointermove", onMove);
+              splitter.removeEventListener("pointerup", onUp);
+              splitter.removeEventListener("pointercancel", onUp);
+            };
+            splitter.addEventListener("pointermove", onMove);
+            splitter.addEventListener("pointerup", onUp);
+            splitter.addEventListener("pointercancel", onUp);
+          });
+
+          // Initial state: prompt for worktree selection. The picker fires
+          // the first directory load once the user picks.
+          if (!initialState.selectedWorktreeId) {
+            pathLabel.textContent = "Select worktree…";
+            frontendUnits.branchesFileTreeSurface.openWorktreePicker(windowData.id);
+          } else {
+            pathLabel.textContent = initialState.selectedWorktreeLabel || "Worktree";
+            if (!initialState.loaded.has("")) {
+              frontendUnits.branchesFileTreeSurface.requestFileTree(windowData.id, "");
+            }
           }
           frontendUnits.branchesFileTreeSurface.renderFileTree(windowData.id);
+          frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(windowData.id);
           return;
         }
 
@@ -8617,6 +9077,12 @@
         openBranchCleanupModal,
         closeBranchCleanupModal,
         renderBranchCleanupModal,
+        // SPEC-2009 amendment: Worktree picker + file content viewer.
+        openWorktreePicker,
+        closeWorktreePicker,
+        renderWorktreePicker,
+        renderFileTreeViewer,
+        requestFileContent,
       });
 
       const profileSurface = Object.freeze({
@@ -8796,6 +9262,113 @@
             state.loading.delete(event.path);
             state.error = event.message;
             frontendUnits.branchesFileTreeSurface.renderFileTree(event.id);
+            break;
+          }
+          case "file_tree_worktrees": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            state.picker.entries = Array.isArray(event.entries) ? event.entries : [];
+            state.picker.loading = false;
+            state.picker.error = "";
+            frontendUnits.branchesFileTreeSurface.renderWorktreePicker(event.id);
+            break;
+          }
+          case "file_tree_worktree_selected": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            state.selectedWorktreeId = event.worktree_id || "";
+            // After selection, refresh tree contents.
+            state.loaded.clear();
+            state.expanded.clear();
+            state.loading.clear();
+            state.error = "";
+            frontendUnits.branchesFileTreeSurface.requestFileTree(event.id, "");
+            frontendUnits.branchesFileTreeSurface.renderFileTree(event.id);
+            break;
+          }
+          case "file_tree_worktree_error": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            state.picker.loading = false;
+            state.picker.error = event.message || "Unable to enumerate worktrees";
+            frontendUnits.branchesFileTreeSurface.renderWorktreePicker(event.id);
+            break;
+          }
+          case "file_content_text": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            state.viewer = {
+              ...state.viewer,
+              path: event.path,
+              mode: "text",
+              text: event.text || "",
+              encoding: (event.encoding || "").toString().toUpperCase(),
+              totalSize: event.total_size || 0,
+              hexOffset: 0,
+              hexBytes: "",
+              error: { kind: "", message: "", size: null, limit: null },
+            };
+            frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(event.id);
+            break;
+          }
+          case "file_content_hex": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            state.viewer = {
+              ...state.viewer,
+              path: event.path,
+              mode: "hex",
+              text: "",
+              encoding: "",
+              totalSize: event.total_size || 0,
+              hexOffset: event.offset || 0,
+              hexBytes: event.bytes_b64 || "",
+              error: { kind: "", message: "", size: null, limit: null },
+            };
+            frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(event.id);
+            break;
+          }
+          case "file_content_error": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            const errorKind = (event.error_kind || "").toString();
+            // SPEC-2009 amendment FR-026/029: binary detection is reported as
+            // an error variant from the file_content domain. The GUI flips
+            // the viewer into a "binary" notice (with a hex affordance) when
+            // the user attempted a text read; everything else surfaces the
+            // raw notice.
+            if (errorKind === "binary_not_text" && state.viewer.mode === "loading") {
+              state.viewer = {
+                ...state.viewer,
+                path: event.path,
+                mode: "binary",
+                text: "",
+                encoding: "",
+                totalSize: event.size || state.viewer.totalSize || 0,
+                hexOffset: 0,
+                hexBytes: "",
+                error: { kind: errorKind, message: event.message || "", size: event.size, limit: event.limit },
+              };
+            } else {
+              state.viewer = {
+                ...state.viewer,
+                path: event.path,
+                mode: "error",
+                text: "",
+                encoding: "",
+                totalSize: event.size || 0,
+                hexOffset: 0,
+                hexBytes: "",
+                error: { kind: errorKind, message: event.message || "", size: event.size, limit: event.limit },
+              };
+            }
+            frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(event.id);
             break;
           }
           case "branch_entries": {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -520,6 +520,23 @@
           tabindex="-1"
         ></div>
       </div>
+      <!-- SPEC-2009 amendment: Worktree Picker modal for the File Tree
+           window. Renderer lives in /app.js (frontendUnits.worktreePicker).
+           Opens once per File Tree window open; selection routes the tree
+           through the new gwt-managed worktree inventory. -->
+      <div
+        class="modal-backdrop"
+        id="file-tree-worktree-picker-modal"
+        aria-hidden="true"
+      >
+        <div
+          class="modal-shell worktree-picker-shell"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Select worktree for File Tree"
+          tabindex="-1"
+        ></div>
+      </div>
       <!-- SPEC-1934 US-6: confirmation modal shown when a Normal Git layout
            is detected at startup. Renderer lives in /migration-modal.js. -->
       <!-- SPEC-2356 US-4 AS-5: branch-cleanup / migration modals adopt the

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -3098,3 +3098,229 @@ kbd.op-kbd {
   flex-wrap: wrap;
   gap: var(--space-2);
 }
+
+/* SPEC-2009 amendment: File Tree v2 — Worktree Picker + Split Viewer + Hex.
+   The legacy `.file-tree-root` keeps the existing styling so single-pane
+   workflows still render the same way; the new `--split` modifier opts into
+   the per-window split layout that surfaces the picker, tree, and viewer. */
+:root[data-theme] .file-tree-root--split {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+:root[data-theme] .file-tree-split {
+  display: grid;
+  grid-template-columns: var(--file-tree-left-ratio, 40%) 6px 1fr;
+  flex: 1;
+  min-height: 0;
+}
+
+@media (max-width: 480px) {
+  :root[data-theme] .file-tree-split {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 6px 1fr;
+  }
+  :root[data-theme] .file-tree-splitter {
+    cursor: row-resize;
+  }
+}
+
+:root[data-theme] .file-tree-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+:root[data-theme] .file-tree-splitter {
+  background: var(--color-border);
+  cursor: col-resize;
+  user-select: none;
+  transition: background 120ms ease-in-out;
+}
+
+:root[data-theme] .file-tree-splitter:hover,
+:root[data-theme] .file-tree-splitter:focus-visible {
+  background: var(--color-state-active);
+  outline: none;
+}
+
+:root[data-theme] .file-tree-viewer {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--color-surface);
+}
+
+:root[data-theme] .file-tree-viewer-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--type-xs);
+}
+
+:root[data-theme] .file-tree-viewer-path {
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+:root[data-theme] .file-tree-viewer-meta {
+  color: var(--color-text-subtle);
+  font-family: var(--font-mono);
+  font-size: var(--type-2xs);
+}
+
+:root[data-theme] .file-tree-viewer-placeholder {
+  color: var(--color-text-subtle);
+  font-style: italic;
+}
+
+:root[data-theme] .file-tree-viewer-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-2) var(--space-3);
+}
+
+:root[data-theme] .file-tree-viewer-text,
+:root[data-theme] .file-tree-viewer-hex {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  white-space: pre;
+  color: var(--color-text);
+}
+
+:root[data-theme] .file-tree-viewer-notice,
+:root[data-theme] .file-tree-viewer-empty,
+:root[data-theme] .file-tree-viewer-error {
+  font-size: var(--type-xs);
+  color: var(--color-text-subtle);
+  padding: var(--space-3) 0;
+}
+
+:root[data-theme] .file-tree-viewer-error {
+  color: var(--color-status-danger, #d22);
+}
+
+:root[data-theme] .file-tree-worktree-trigger {
+  background: transparent;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 4px var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+:root[data-theme] .file-tree-worktree-trigger:hover {
+  border-style: solid;
+  border-color: var(--color-state-active);
+}
+
+:root[data-theme] #file-tree-worktree-picker-modal[aria-hidden="false"] {
+  display: flex;
+}
+
+/* The picker reuses the shared modal frame primitive defined in app.css
+   per SPEC-2356 (border, radius, max-height, surface colour). Only the
+   picker-specific min/max width and the inner flex column layout are
+   contributed here, and the selector is intentionally scoped through a
+   child class so the canonical primitive declaration remains the first
+   match for embedded_web.rs's modal frame contract test. */
+:root[data-theme] #file-tree-worktree-picker-modal > .worktree-picker-shell {
+  min-width: 380px;
+  max-width: 560px;
+  display: flex;
+  flex-direction: column;
+}
+
+:root[data-theme] .worktree-picker-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+:root[data-theme] .worktree-picker-header h2 {
+  flex: 1;
+  margin: 0;
+  font-size: var(--type-md);
+}
+
+:root[data-theme] .worktree-picker-body {
+  overflow: auto;
+  padding: var(--space-2);
+}
+
+:root[data-theme] .worktree-picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+:root[data-theme] .worktree-picker-row {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+:root[data-theme] .worktree-picker-row:hover,
+:root[data-theme] .worktree-picker-row:focus-visible {
+  border-color: var(--color-state-active);
+  outline: none;
+}
+
+:root[data-theme] .worktree-picker-row-label {
+  font-weight: 600;
+}
+
+:root[data-theme] .worktree-picker-row-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--type-2xs);
+  color: var(--color-text-subtle);
+  flex-wrap: wrap;
+}
+
+:root[data-theme] .worktree-picker-kind {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+:root[data-theme] .worktree-picker-active {
+  color: var(--color-status-success, #2a7);
+}
+
+:root[data-theme] .worktree-picker-path {
+  word-break: break-all;
+}
+
+:root[data-theme] .worktree-picker-empty,
+:root[data-theme] .worktree-picker-error {
+  padding: var(--space-3);
+  text-align: center;
+  color: var(--color-text-subtle);
+}


### PR DESCRIPTION
## Summary

- SPEC-2009 amendment Phase 1 (File Tree v2) として、File Tree window をタブから独立させ、開く度に Worktree Picker modal → 左 directory tree / 右 file content viewer の split layout を表示する GUI を追加します。SPEC-2006 Phase 1 (PR #2755 merged) で追加した file_content domain (text decode / binary 判定 / encoding 自動判定 / size guard / deny rule) を frontend から消費し、UTF-8 / UTF-16 / Shift-JIS / EUC-JP テキスト表示と `00000000 00 11 AA BB ... |......|` 形式の hex viewer を実装します。
- Phase 2 (簡易テキスト編集、syntax highlighting、in-file search、hex 編集、word wrap toggle) は本 PR の範囲外で、別 SPEC amendment / 別 PR で扱います。

## Changes

- `crates/gwt/src/worktree_inventory.rs`: 新規 backend domain。`enumerate_worktrees(repo_root, active_root)` を実装し、bare/main repo と work/* worktree を統合、prunable worktree を除外、active workspace に `is_active` フラグを立てる。worktree id は canonical path から `compute_worktree_hash` (16 hex chars) を再利用するため、複数 worktree が同一 id を持たない。
- `crates/gwt/src/protocol.rs`: `ListFileTreeWorktrees` / `SelectFileTreeWorktree` (FrontendEvent) と `FileTreeWorktrees` / `FileTreeWorktreeSelected` / `FileTreeWorktreeError` (BackendEvent) の wire contract を追加。
- `crates/gwt/src/app_runtime/mod.rs`: `list_file_tree_worktrees_event` / `select_file_tree_worktree_event` を実装し、`AppRuntime` に per-window の `file_tree_worktree_roots: HashMap<String, PathBuf>` を追加 (transient、session persistence なし)。`load_file_tree_event` と `load_file_content_event` を `resolve_file_tree_root` 経由で選択中の worktree を解決するよう refactor (未選択時は既存 `tab.project_root` フォールバックで後方互換維持)。
- `crates/gwt/src/main.rs`: WebSocket dispatch に新 RPC を接続。既存 `tests::loaders_and_wizard_entrypoints_cover_success_and_error_paths` を extend し、`list_file_tree_worktrees_event` の WindowNotFound / WindowMismatch / 空 repo、`select_file_tree_worktree_event` の Unknown worktree id / successful selection をカバー。
- `crates/gwt/tests/worktree_inventory_test.rs`: 新規 3 テスト (bare-only / bare + workspace 列挙 / prunable 除外)。
- `crates/gwt/src/lib.rs`: `pub mod worktree_inventory` 公開。
- `crates/gwt/web/index.html`: `#file-tree-worktree-picker-modal` modal landing pad を追加 (既存 `.modal-backdrop` / `.modal-shell` primitive を再利用、SPEC-2356 modal frame contract を破らない)。
- `crates/gwt/web/app.js`: File Tree window state を picker (open/loading/entries/error)、selectedWorktreeId / Label、splitterRatio、viewer (path/mode/text/encoding/totalSize/hexOffset/hexBytes/error) で拡張。新規 helper として `requestFileTreeWorktrees` / `selectFileTreeWorktree` / `requestFileContent` / `openWorktreePicker` / `closeWorktreePicker` / `renderWorktreePicker` / `renderFileTreeViewer` / `formatHexDump` / `formatBytes` / `applyFileTreeSplitterRatio` を追加し、`frontendUnits.branchesFileTreeSurface` から公開。File Tree window 生成時に DOM を split layout (左 file-tree-pane + file-tree-splitter + 右 file-tree-viewer) に再構成し、初回 open で自動で picker を起動。複数 worktree を見るには window を複数開く。左ペインの file row click は `load_file_content(path, "text")` を発行し、応答に応じて text / binary notice / hex / error に分岐。binary は `View as hex` ボタンで `load_file_content(..., "hex")` を発行し `00000000  00 11 AA BB CC DD EE FF  |......|` 形式 (offset 8 桁 + 16 bytes/行 + ASCII サイドバー) で render する。splitter は pointer events で drag、比率は CSS `--file-tree-left-ratio` 変数経由で grid template に反映。新規 socket-receive handler: `file_tree_worktrees` / `file_tree_worktree_selected` / `file_tree_worktree_error` / `file_content_text` / `file_content_hex` / `file_content_error`。`file_content_error` の `binary_not_text` 変種は viewer mode を `binary` に切替えて hex affordance を出す。
- `crates/gwt/web/styles/components.css`: SPEC-2009 amendment 用 selector (file-tree-split / file-tree-splitter / file-tree-viewer / file-tree-viewer-* / worktree-picker-row / worktree-picker-*) を追加。`@media (max-width: 480px)` で grid を columns → rows に切替える responsive 規則を含む。modal-shell primitive は上書きせず、picker 固有の min/max width のみ `> .worktree-picker-shell` 子セレクタで上書きし、SPEC-2356 embedded modal frame contract test を破らない。
- `crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs`: 新規 3 テスト。picker modal の DOM 契約 (id / role / aria-modal)、既存 branch-cleanup modal 非退行、split layout / viewer / picker rows の CSS selector の存在を node:test + linkedom で固定。

## Testing

- [x] `cargo fmt -- --check` — 差分なし (pre-push hook も pass)
- [x] `cargo test -p gwt-core -p gwt --all-features` — 50+ testsuites 全 PASS。新規 `worktree_inventory_test` 3 件 + extended `loaders_and_wizard_entrypoints` で picker / select / window mismatch カバー。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning 0
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — 成功
- [x] `pnpm install && node --test crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs` — 3 件 GREEN (picker modal DOM contract / branch-cleanup 非退行 / CSS selector 存在)
- [x] 手動 GUI smoke: `target/debug/gwt --headless --port 0` 起動 → `curl -fsS -I http://127.0.0.1:<port>/` HTTP 200 確認 → `curl ... | grep file-tree-worktree-picker-modal` で picker modal の DOM が serve されていることを確認 → CSS bundle に 23 件の SPEC-2009 amendment 新規 selector (file-tree-split / worktree-picker-row / file-tree-viewer 等) が含まれることを確認。

## Closing Issues

- None

## Related Issues / Links

- #2006 (closed) — SPEC-2006: ファイルツリーブラウザ — PR #2755 で Phase 1 (File Content Domain) を実装済み。本 PR でその wire contract (`load_file_content` / `FileContentText` / `FileContentHex` / `FileContentError`) を frontend から消費。
- #2009 (closed) — SPEC-2009: リポジトリブラウザウィンドウ — 本 PR で 2026-05-16 Amendment Phase 1 (Worktree Picker + Split Viewer + Hex) を実装。Phase 2 (簡易編集 / syntax highlighting / in-file search / hex 編集 / word wrap toggle) は別 SPEC amendment / 別 PR で扱う。
- #2755 — feat(file-tree): add file content read domain with encoding auto-detection (merged into develop) — 前置 PR。

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, node test)
- [ ] Documentation updated (if user-facing change) — README は本 PR では更新せず、SPEC issue の amendment + cross-reference で扱う。GUI 上の英語 user copy (`Select worktree…` / `Cannot display as text` / `View as hex` / `File too large…` / `Access denied` 等) は実装内に直接含む。
- [ ] Migration/backfill plan included (if schema/data change) — Schema/data 変更なし。新 wire contract は追加のみで後方互換性あり。
- [x] CHANGELOG impact considered — `feat:` で minor bump 対象。breaking change なし。

## Risk / Impact

- **Affected areas**: `crates/gwt` backend (worktree_inventory 新規 + protocol/app_runtime 拡張)、`crates/gwt/web` frontend (File Tree window surface DOM / state / event handlers / CSS の追加)。SPEC-2006 Phase 1 PR がベース。
- **Rollback plan**: 単純な revert で復旧可能。File Tree window 既存挙動 (tab.project_root 固定) は `resolve_file_tree_root` の fallback により保持されているため、frontend 側を旧版に戻すだけで Phase 1 機能の影響を完全に取り除ける。

## Notes

- worktree cleanup → File Tree window error transition (T-353) は `select_file_tree_worktree_event` の `Unknown worktree id` 応答経路で覆われる (extended loaders test でカバー)。専用 cleanup signal は Phase 2 で再評価。
- viewer rendering の JS 単体テスト (T-351) は app.js 内部のため、現状は手動 GUI 検証 + CSS contract test でカバー。viewer をモジュール抽出する Phase 1b refactor を future 候補。
- 開く度に picker を出す UX は user 合意済 (Q2: 開く度に必須 modal)。複数 worktree を同時に見たい場合は File Tree window を複数開く前提。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a worktree picker modal to select and manage Git worktrees in the File Tree window.
  * Added a file content viewer panel displaying file contents in a split-pane layout alongside the tree.
  * Introduced hex dump viewer for binary file contents with toggle affordance.
  * Expanded backend to enumerate available Git worktrees per repository.

* **Tests**
  * Added integration tests for worktree inventory enumeration and handling.
  * Added smoke tests for worktree picker modal contract validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->