### PR TITLE
fix(workspace): surface Resume failures with LaunchWizardOpenError

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2207,7 +2207,7 @@ impl AppRuntime {
             }
             FrontendEvent::OpenStartWork => self.open_start_work(&client_id),
             FrontendEvent::ResumeWorkspace { source, journal_id } => {
-                self.resume_workspace_events(source, journal_id)
+                self.resume_workspace_events(&client_id, source, journal_id)
             }
             FrontendEvent::OpenLaunchWizard {
                 id,
@@ -8798,6 +8798,77 @@ exit 1
             events.first().map(|event| &event.event),
             Some(BackendEvent::LaunchWizardOpenError { title, message })
                 if title == "Launch Agent" && message == "Window not found"
+        ));
+    }
+
+    #[test]
+    fn app_runtime_resume_workspace_failure_surfaces_launch_wizard_open_error() {
+        // SPEC-2359 / Issue #2757: Resume クリックで `resume_workspace_events`
+        // が早期 return / Start Work fallback 失敗を起こした場合、frontend で
+        // 可視な `LaunchWizardOpenError` を return しなければならない。
+        // 旧経路は `ProjectOpenError` を broadcast していたが、project 開放中は
+        // `renderProjectPicker` が hidden なので silent failure になっていた。
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo,
+            ProjectKind::Git,
+            &[WindowPreset::Board],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::ResumeWorkspace {
+                source: gwt::WorkspaceResumeSource::Current,
+                journal_id: None,
+            },
+        );
+
+        assert!(runtime.launch_wizard.is_none());
+        assert!(
+            matches!(
+                events.first().map(|event| &event.target),
+                Some(DispatchTarget::Client(client_id)) if client_id == "client-1"
+            ),
+            "Resume failure must be replied to the originating client, not broadcast as ProjectOpenError"
+        );
+        assert!(
+            matches!(
+                events.first().map(|event| &event.event),
+                Some(BackendEvent::LaunchWizardOpenError { title, message })
+                    if title == "Resume Workspace" && !message.is_empty()
+            ),
+            "Resume failure must surface as LaunchWizardOpenError so Workspace Overview can render a visible overlay"
+        );
+    }
+
+    #[test]
+    fn app_runtime_resume_workspace_without_active_tab_returns_launch_wizard_open_error() {
+        // Same contract for the `Open a project before resuming work` early return.
+        let temp = tempdir().expect("tempdir");
+        let mut runtime = sample_runtime(temp.path(), Vec::new(), None);
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::ResumeWorkspace {
+                source: gwt::WorkspaceResumeSource::Current,
+                journal_id: None,
+            },
+        );
+
+        assert!(matches!(
+            events.first().map(|event| &event.target),
+            Some(DispatchTarget::Client(client_id)) if client_id == "client-1"
+        ));
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::LaunchWizardOpenError { title, message })
+                if title == "Resume Workspace"
+                    && message == "Open a project before resuming work"
         ));
     }
 

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -273,13 +273,21 @@ impl AppRuntime {
 
     pub(crate) fn resume_workspace_events(
         &mut self,
+        client_id: &str,
         source: gwt::WorkspaceResumeSource,
         journal_id: Option<String>,
     ) -> Vec<OutboundEvent> {
+        // SPEC-2359 / Issue #2757: Resume click failures must surface through
+        // `LaunchWizardOpenError` (a client-scoped reply) instead of the
+        // legacy `ProjectOpenError` broadcast, which the frontend renders only
+        // on the project picker overlay and is therefore invisible while a
+        // project tab is already open.
         let error_event = |message: &str| {
-            vec![OutboundEvent::broadcast(BackendEvent::ProjectOpenError {
-                message: message.to_string(),
-            })]
+            vec![launch_wizard_open_error(
+                client_id,
+                "Resume Workspace",
+                message,
+            )]
         };
 
         let Some(tab_id) = self.active_tab_id.clone() else {


### PR DESCRIPTION
## Summary

- Workspace Overview の `Resume` ボタンを押した際の早期 return や Start Work
  fallback 失敗が、frontend で hidden な `project_open_error` パスに流れ込み
  silent failure になっていた問題を修正します (Issue #2757、SPEC-2359 US-44)
- `resume_workspace_events` に `client_id` を伝達し、内部 `error_event` を
  既存の `launch_wizard_open_error(client_id, "Resume Workspace", message)` に
  置換することで、他の Launch Wizard 入口と同じ error overlay 経路で常に可視
  化します
- RED→GREEN test 2 件 (`..._failure_surfaces_launch_wizard_open_error`、
  `..._without_active_tab_returns_launch_wizard_open_error`) を追加。既存 4 件
  の `app_runtime_resume_workspace_*` success-path test も維持して GREEN

## Why

Issue #2757 で「Workspace Resume を押しても何も起きない」という症状が報告され
ました。原因は `resume_workspace_events` (`crates/gwt/src/app_runtime/wizard.rs:274`)
が `BackendEvent::ProjectOpenError` を broadcast していたことで、frontend
(`crates/gwt/web/app.js:9793`) は `case "project_open_error":` で
`renderProjectPicker()` を呼びますが、project tab を開いている間は picker
overlay が hidden です。

一方、他の Launch Wizard 入口 (`OpenStartWork` / `OpenLaunchWizard` /
`OpenActiveWorkLaunchWizard`) は失敗時に `LaunchWizardOpenError`
(`title` + `message`) を `OutboundEvent::reply` で返し、frontend の
`launch_wizard_open_error` handler が error overlay を描画します。Resume だけ
が event type を取り違えていました。

## Test plan

- [x] `cargo test -p gwt app_runtime_resume_workspace` (新規 2 件 + 既存 4 件 = 6 件 GREEN)
- [x] `cargo test -p gwt-core -p gwt --all-features` (全 test GREEN)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build -p gwt --bin gwt --bin gwtd`
- [x] `pnpm test:frontend-unit` (472 tests GREEN)
- 手動確認 (user 担当): Workspace Overview の Current/Journal card で `Resume`
  を押し、想定エラー条件（projection 空、Git でない project tab、migration
  pending など）で `Resume Workspace` の error overlay が visible に表示される
  ことを確認

## Related

- Closes #2757 (fix(workspace): Resume button has no visible effect on Workspace Overview cards)
- SPEC #2359 — 2026-05-18 Update / US-44 / FR-168..170 / SC-066/067 を追記
- 過去 fix: `154d1b567`、`8f3fcae16`、`85e0e9f35`、`28c8269b2`

## Notes

- 本 PR は **silent failure を可視化する最小スコープ**。SPEC-2359 US-42
  (conversation re-attach with `agent_sessions` / `--resume <session_id>`) は
  PROPOSED のまま別 PR で扱います。
- ユーザー側で「Resume クリック → 何が表示されるか」を本 PR landing 後に確認
  でき、もし表示メッセージから別の root cause が判明した場合は US-42 実装か
  別 regression fix に route できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for workspace resumption—when resuming a workspace fails, error messages are now correctly displayed to the user in the launch wizard dialog instead of being misrouted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->