### PR TITLE
fix(launch-wizard): execution mode resume launches per-agent session picker

### DIFF
--- a/crates/gwt-agent/src/custom.rs
+++ b/crates/gwt-agent/src/custom.rs
@@ -43,6 +43,13 @@ pub struct CustomCodingAgent {
     pub skip_permissions_args: Vec<String>,
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Opt-in flag for Launch Wizard Execution Mode `Resume` visibility.
+    ///
+    /// `mode_args.resume` 単独で interactive picker を起動できる custom agent
+    /// だけが `true` を設定する。default は `false` で、Launch Wizard は
+    /// Resume option を除外する。SPEC-2014 2026-05-18 amendment FR-C / FR-D.
+    #[serde(default)]
+    pub supports_resume_picker: bool,
 }
 
 impl CustomCodingAgent {
@@ -87,6 +94,7 @@ mod tests {
             }),
             skip_permissions_args: vec!["--yolo".to_string()],
             env: HashMap::from([("KEY".to_string(), "VALUE".to_string())]),
+            supports_resume_picker: false,
         }
     }
 
@@ -208,6 +216,32 @@ mod tests {
             decoded.env.get("ANTHROPIC_DEFAULT_OPUS_MODEL").unwrap(),
             "openai/gpt-oss-20b"
         );
+    }
+
+    #[test]
+    fn supports_resume_picker_defaults_to_false_in_toml() {
+        // SPEC-2014 2026-05-18 amendment FR-C: custom agent の picker capability
+        // は opt-in。既存の TOML から flag を省略しても default false で読める。
+        let toml_text = r#"
+id = "legacy-agent"
+display_name = "Legacy"
+type = "command"
+command = "legacy-cli"
+"#;
+        let decoded: CustomCodingAgent =
+            toml::from_str(toml_text).expect("legacy TOML deserializes");
+        assert!(!decoded.supports_resume_picker);
+
+        let toml_with_flag = r#"
+id = "picker-agent"
+display_name = "Picker Agent"
+type = "command"
+command = "picker-cli"
+supports_resume_picker = true
+"#;
+        let decoded: CustomCodingAgent =
+            toml::from_str(toml_with_flag).expect("opt-in TOML deserializes");
+        assert!(decoded.supports_resume_picker);
     }
 
     #[test]

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -630,6 +630,10 @@ impl AgentLaunchBuilder {
         );
 
         args.extend(canonical_launch_args(&AgentId::Codex));
+        // SPEC-2014 2026-05-18 amendment FR-B:
+        // - Continue        → `codex resume --last`  (resume the most recent session)
+        // - Resume + id     → `codex resume <id>`    (Quick Start: replay specific session)
+        // - Resume (no id)  → `codex resume`         (Execution Mode picker; do NOT add `--last`)
         match self.session_mode {
             SessionMode::Continue => {
                 args.push("resume".to_string());
@@ -639,8 +643,6 @@ impl AgentLaunchBuilder {
                 args.push("resume".to_string());
                 if let Some(ref id) = self.resume_session_id {
                     args.push(id.clone());
-                } else {
-                    args.push("--last".to_string());
                 }
             }
             SessionMode::Normal => {}
@@ -1047,15 +1049,29 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_resume_without_id_uses_last_session() {
+    fn build_codex_resume_without_id_opens_picker() {
+        // SPEC-2014 2026-05-18 amendment FR-B / SC-A:
+        // Codex Execution Mode Resume (no session id) must produce a bare
+        // `codex resume` so the interactive picker opens. `--last` is reserved
+        // for Continue mode only.
         let config = AgentLaunchBuilder::new(AgentId::Codex)
             .session_mode(SessionMode::Resume)
             .build();
 
-        assert!(config
+        let resume_index = config
             .args
-            .windows(2)
-            .any(|pair| pair[0] == "resume" && pair[1] == "--last"));
+            .iter()
+            .position(|arg| arg == "resume")
+            .expect("codex args must contain the `resume` subcommand");
+        assert_ne!(
+            config.args.get(resume_index + 1).map(String::as_str),
+            Some("--last"),
+            "Execution Mode Resume must not append --last; that is Continue's role"
+        );
+        assert!(
+            !config.args.contains(&"--last".to_string()),
+            "no --last anywhere when SessionMode::Resume has no resume_session_id"
+        );
     }
 
     #[test]
@@ -1604,6 +1620,7 @@ mod tests {
                 "ANTHROPIC_BASE_URL".to_string(),
                 "http://proxy.local:32768".to_string(),
             )]),
+            supports_resume_picker: false,
         };
 
         let config = AgentLaunchBuilder::new(AgentId::Custom("proxy-agent".into()))

--- a/crates/gwt-agent/src/presets.rs
+++ b/crates/gwt-agent/src/presets.rs
@@ -271,6 +271,7 @@ pub fn claude_code_openai_compat_preset(
         mode_args: None,
         skip_permissions_args: vec!["--dangerously-skip-permissions".to_string()],
         env,
+        supports_resume_picker: false,
     }
 }
 

--- a/crates/gwt-agent/src/store.rs
+++ b/crates/gwt-agent/src/store.rs
@@ -75,6 +75,13 @@ struct CustomAgentToml {
     mode_args: Option<ModeArgs>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     env: HashMap<String, String>,
+    #[serde(
+        default,
+        rename = "supportsResumePicker",
+        alias = "supports_resume_picker",
+        skip_serializing_if = "std::ops::Not::not"
+    )]
+    supports_resume_picker: bool,
 }
 
 impl CustomAgentToml {
@@ -92,6 +99,7 @@ impl CustomAgentToml {
             skip_permissions_args: self.skip_permissions_args,
             mode_args: self.mode_args,
             env: self.env,
+            supports_resume_picker: self.supports_resume_picker,
         };
 
         agent.validate().then_some(agent)
@@ -109,6 +117,7 @@ impl From<&CustomCodingAgent> for CustomAgentToml {
             skip_permissions_args: agent.skip_permissions_args.clone(),
             mode_args: agent.mode_args.clone(),
             env: agent.env.clone(),
+            supports_resume_picker: agent.supports_resume_picker,
         }
     }
 }
@@ -430,6 +439,7 @@ default = { id = "default", label = "Default", arg = "" }
             mode_args: None,
             skip_permissions_args: vec![],
             env: HashMap::new(),
+            supports_resume_picker: false,
         });
         let a2 = StoredCustomAgent::new(CustomCodingAgent {
             id: "dup".to_string(),
@@ -440,6 +450,7 @@ default = { id = "default", label = "Default", arg = "" }
             mode_args: None,
             skip_permissions_args: vec![],
             env: HashMap::new(),
+            supports_resume_picker: false,
         });
         let err = save_stored_custom_agents_to_path(&path, &[a1, a2]).unwrap_err();
         assert!(err.contains("duplicate"));
@@ -458,6 +469,7 @@ default = { id = "default", label = "Default", arg = "" }
             mode_args: None,
             skip_permissions_args: vec![],
             env: HashMap::new(),
+            supports_resume_picker: false,
         });
         let err = save_stored_custom_agents_to_path(&path, &[entry]).unwrap_err();
         assert!(err.contains("invalid"));
@@ -532,6 +544,7 @@ default = { id = "default", label = "Default", arg = "" }
             mode_args: None,
             skip_permissions_args: vec!["--yolo".to_string()],
             env: HashMap::from([("FOO".to_string(), "BAR".to_string())]),
+            supports_resume_picker: false,
         });
         save_stored_custom_agents_to_path(&config_path, &[entry]).expect("save");
 

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -55,6 +55,16 @@ impl AgentId {
             .iter()
             .find(|descriptor| descriptor.id == *self)
     }
+
+    /// Whether this agent's CLI exposes an interactive session picker when its
+    /// resume command is invoked without a session id (e.g. `claude --resume`
+    /// shows the picker, `codex resume` shows the picker). Used by the Launch
+    /// Wizard to gate the Execution Mode `Resume` option.
+    ///
+    /// SPEC-2014 2026-05-18 amendment FR-C.
+    pub fn supports_resume_picker(&self) -> bool {
+        matches!(self, Self::ClaudeCode | Self::Codex)
+    }
 }
 
 impl std::fmt::Display for AgentId {
@@ -412,6 +422,27 @@ mod tests {
     #[test]
     fn session_mode_default_is_normal() {
         assert_eq!(SessionMode::default(), SessionMode::Normal);
+    }
+
+    #[test]
+    fn supports_resume_picker_only_for_picker_capable_builtins() {
+        // SPEC-2014 2026-05-18 amendment FR-C: Claude Code と Codex のみ
+        // interactive picker (`claude --resume` / `codex resume`) を持つ。
+        assert!(AgentId::ClaudeCode.supports_resume_picker());
+        assert!(AgentId::Codex.supports_resume_picker());
+        for non_picker in [
+            AgentId::Gemini,
+            AgentId::OpenCode,
+            AgentId::OpenClaw,
+            AgentId::Hermes,
+            AgentId::Copilot,
+            AgentId::Custom("aider".into()),
+        ] {
+            assert!(
+                !non_picker.supports_resume_picker(),
+                "{non_picker:?} should not advertise picker support"
+            );
+        }
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -942,7 +942,9 @@ impl LaunchWizardState {
                 .to_string(),
             version_options: self.version_options_view(),
             selected_version: self.version.clone(),
-            execution_mode_options: execution_mode_options_view(),
+            execution_mode_options: execution_mode_options_view(
+                self.current_agent_supports_resume_picker(),
+            ),
             selected_execution_mode: self.mode.clone(),
             skip_permissions: self.skip_permissions,
             show_agent_settings: show_manual_setup && self.launch_target_is_agent(),
@@ -1269,12 +1271,22 @@ impl LaunchWizardState {
             builder = builder.docker_service(docker_service.to_string());
         }
         builder = builder.docker_lifecycle_intent(self.docker_lifecycle_intent);
+        // SPEC-2014 2026-05-18 amendment FR-A:
+        // Execution Mode `"resume"` always maps to `SessionMode::Resume`.
+        // - Quick Start Resume (with id)       → SessionMode::Resume + id
+        // - Execution Mode Resume (no id)      → SessionMode::Resume (agent picker)
+        // The earlier silent downgrade to Continue when id was absent has been
+        // removed; UI option filtering and `normalize_execution_mode` already
+        // prevent this state for picker-unsupported agents.
         builder = match self.mode.as_str() {
             "continue" => builder.session_mode(gwt_agent::SessionMode::Continue),
-            "resume" if self.resume_session_id.is_some() => builder
-                .session_mode(gwt_agent::SessionMode::Resume)
-                .resume_session_id(self.resume_session_id.clone().expect("resume session id")),
-            "resume" => builder.session_mode(gwt_agent::SessionMode::Continue),
+            "resume" => {
+                let mut b = builder.session_mode(gwt_agent::SessionMode::Resume);
+                if let Some(id) = self.resume_session_id.clone() {
+                    b = b.resume_session_id(id);
+                }
+                b
+            }
             _ => builder.session_mode(gwt_agent::SessionMode::Normal),
         };
 
@@ -1450,7 +1462,8 @@ impl LaunchWizardState {
                 }
             }
             LaunchWizardStep::ExecutionMode => {
-                if let Some(option) = EXECUTION_MODE_OPTIONS.get(self.selected) {
+                let options = self.execution_mode_step_options();
+                if let Some(option) = options.get(self.selected) {
                     self.mode = option.value.to_string();
                 }
             }
@@ -2314,6 +2327,31 @@ impl LaunchWizardState {
         self.launch_target_is_agent() && self.effective_agent_id() == "codex"
     }
 
+    /// SPEC-2014 2026-05-18 amendment FR-D: filtered Execution Mode option
+    /// list seen by both the wizard-step path (`current_options`) and the
+    /// default-selection helper. Mirrors the LaunchWizardView's
+    /// `execution_mode_options`.
+    fn execution_mode_step_options(&self) -> Vec<LaunchWizardOptionView> {
+        execution_mode_options_view(self.current_agent_supports_resume_picker())
+    }
+
+    /// SPEC-2014 2026-05-18 amendment FR-C / FR-D:
+    /// Whether the current Launch target agent supports an interactive resume
+    /// picker. Used by Execution Mode option filtering and `Resume → Continue`
+    /// downgrade in [`Self::normalize_execution_mode`].
+    fn current_agent_supports_resume_picker(&self) -> bool {
+        if !self.launch_target_is_agent() {
+            return false;
+        }
+        if let Some(custom) = self
+            .selected_agent()
+            .and_then(|agent| agent.custom_agent.as_ref())
+        {
+            return custom.supports_resume_picker;
+        }
+        agent_id_from_key(self.effective_agent_id()).supports_resume_picker()
+    }
+
     fn agent_has_models(&self) -> bool {
         self.launch_target_is_agent()
             && matches!(self.effective_agent_id(), "claude" | "codex" | "gemini")
@@ -2492,13 +2530,25 @@ impl LaunchWizardState {
     }
 
     fn normalize_execution_mode(&mut self) {
+        // Unknown mode strings always fall back to Normal.
         if !EXECUTION_MODE_OPTIONS
             .iter()
             .any(|option| option.value == self.mode)
         {
             self.mode = "normal".to_string();
             self.resume_session_id = None;
-        } else if self.mode != "resume" {
+            return;
+        }
+        // SPEC-2014 2026-05-18 amendment FR-E:
+        // Downgrade Resume → Continue when the current agent does not support
+        // an interactive picker (e.g. Gemini / OpenCode / OpenClaw / Hermes /
+        // Copilot / custom agents without opt-in capability).
+        if self.mode == "resume" && !self.current_agent_supports_resume_picker() {
+            self.mode = "continue".to_string();
+            self.resume_session_id = None;
+            return;
+        }
+        if self.mode != "resume" {
             self.resume_session_id = None;
         }
     }
@@ -2750,15 +2800,9 @@ impl LaunchWizardState {
                     color: None,
                 })
                 .collect(),
-            LaunchWizardStep::ExecutionMode => EXECUTION_MODE_OPTIONS
-                .iter()
-                .map(|option| LaunchWizardOptionView {
-                    value: option.value.to_string(),
-                    label: option.label.to_string(),
-                    description: Some(option.description.to_string()),
-                    color: None,
-                })
-                .collect(),
+            LaunchWizardStep::ExecutionMode => {
+                execution_mode_options_view(self.current_agent_supports_resume_picker())
+            }
             LaunchWizardStep::SkipPermissions => YES_NO_OPTIONS
                 .iter()
                 .map(|option| LaunchWizardOptionView {
@@ -3030,7 +3074,7 @@ const EXECUTION_MODE_OPTIONS: [ExecutionModeOption; 3] = [
     },
     ExecutionModeOption {
         label: "Resume",
-        description: "Resume the selected session metadata",
+        description: "Open the agent's session picker",
         value: "resume",
     },
 ];
@@ -3447,7 +3491,8 @@ fn step_default_selection(step: LaunchWizardStep, state: &LaunchWizardState) -> 
             .iter()
             .position(|option| option.value == state.version)
             .unwrap_or(0),
-        LaunchWizardStep::ExecutionMode => EXECUTION_MODE_OPTIONS
+        LaunchWizardStep::ExecutionMode => state
+            .execution_mode_step_options()
             .iter()
             .position(|option| option.value == state.mode)
             .unwrap_or(0),
@@ -3616,9 +3661,10 @@ where
     gwt_agent::WindowsShellKind::CommandPrompt
 }
 
-fn execution_mode_options_view() -> Vec<LaunchWizardOptionView> {
+fn execution_mode_options_view(supports_resume_picker: bool) -> Vec<LaunchWizardOptionView> {
     EXECUTION_MODE_OPTIONS
         .iter()
+        .filter(|option| supports_resume_picker || option.value != "resume")
         .map(|option| LaunchWizardOptionView {
             value: option.value.to_string(),
             label: option.label.to_string(),
@@ -3631,7 +3677,8 @@ fn execution_mode_options_view() -> Vec<LaunchWizardOptionView> {
 fn execution_mode_value_from_session_mode(mode: gwt_agent::SessionMode) -> &'static str {
     match mode {
         gwt_agent::SessionMode::Normal => "normal",
-        gwt_agent::SessionMode::Continue | gwt_agent::SessionMode::Resume => "continue",
+        gwt_agent::SessionMode::Continue => "continue",
+        gwt_agent::SessionMode::Resume => "resume",
     }
 }
 
@@ -3805,6 +3852,7 @@ mod tests {
             }),
             skip_permissions_args: vec!["--unsafe".to_string()],
             env: HashMap::from([("API_KEY".to_string(), "secret".to_string())]),
+            supports_resume_picker: false,
         }
     }
 
@@ -4470,6 +4518,129 @@ mod tests {
         assert_eq!(config.docker_service.as_deref(), Some("gwt"));
         assert!(config.skip_permissions);
         assert!(config.codex_fast_mode);
+    }
+
+    // SPEC-2014 2026-05-18 amendment FR-A / SC-A / SC-B:
+    // Execution Mode `Resume` without a resume_session_id (i.e. the picker
+    // path) must reach the agent CLI as SessionMode::Resume without an id.
+    // The earlier silent downgrade to SessionMode::Continue is removed.
+    #[test]
+    fn build_launch_config_resume_without_id_keeps_session_mode_resume_for_codex() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.agent_id = "codex".to_string();
+        state.mode = "resume".to_string();
+        state.resume_session_id = None;
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.session_mode, gwt_agent::SessionMode::Resume);
+        assert!(config.resume_session_id.is_none());
+        // Codex builder must produce `codex resume` (picker) — no `--last`.
+        assert!(!config.args.contains(&"--last".to_string()));
+        assert!(config.args.iter().any(|arg| arg == "resume"));
+    }
+
+    #[test]
+    fn build_launch_config_resume_without_id_keeps_session_mode_resume_for_claude() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.agent_id = "claude".to_string();
+        state.mode = "resume".to_string();
+        state.resume_session_id = None;
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.session_mode, gwt_agent::SessionMode::Resume);
+        assert!(config.resume_session_id.is_none());
+        // Claude builder pushes `--resume` (no id) which opens its picker.
+        assert!(config.args.contains(&"--resume".to_string()));
+        assert!(!config.args.iter().any(|arg| arg == "--continue"));
+    }
+
+    // SPEC-2014 2026-05-18 amendment FR-D / SC-C:
+    // execution_mode_options_view filters `resume` for picker-unsupported
+    // agents. The Launch Wizard view must match.
+    #[test]
+    fn execution_mode_options_omit_resume_for_picker_unsupported_agent() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.agent_id = "gemini".to_string();
+
+        let view = state.view();
+        assert!(
+            view.execution_mode_options
+                .iter()
+                .all(|option| option.value != "resume"),
+            "Gemini must not advertise the picker option: {:?}",
+            view.execution_mode_options
+        );
+
+        state.agent_id = "claude".to_string();
+        let view = state.view();
+        assert!(view
+            .execution_mode_options
+            .iter()
+            .any(|option| option.value == "resume"));
+
+        state.agent_id = "codex".to_string();
+        let view = state.view();
+        assert!(view
+            .execution_mode_options
+            .iter()
+            .any(|option| option.value == "resume"));
+    }
+
+    // SPEC-2014 2026-05-18 amendment FR-E / SC-D:
+    // Switching to a picker-unsupported agent while Resume is selected must
+    // downgrade to Continue and clear any stale resume_session_id.
+    #[test]
+    fn normalize_execution_mode_downgrades_resume_when_switching_to_gemini() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.agent_id = "claude".to_string();
+        state.mode = "resume".to_string();
+        state.resume_session_id = Some("stale-id".to_string());
+
+        // Sanity: Claude keeps Resume.
+        state.normalize_execution_mode();
+        assert_eq!(state.mode, "resume");
+
+        // Switch to Gemini → Resume downgrades to Continue.
+        state.agent_id = "gemini".to_string();
+        state.normalize_execution_mode();
+        assert_eq!(state.mode, "continue");
+        assert!(state.resume_session_id.is_none());
+    }
+
+    // SPEC-2014 2026-05-18 amendment FR-F / SC-E:
+    // execution_mode_value_from_session_mode roundtrips Resume → "resume"
+    // instead of collapsing to "continue", so previous-profile Resume can be
+    // restored as picker mode (id intentionally cleared on restore).
+    #[test]
+    fn execution_mode_value_from_session_mode_round_trips_resume() {
+        assert_eq!(
+            execution_mode_value_from_session_mode(gwt_agent::SessionMode::Normal),
+            "normal"
+        );
+        assert_eq!(
+            execution_mode_value_from_session_mode(gwt_agent::SessionMode::Continue),
+            "continue"
+        );
+        assert_eq!(
+            execution_mode_value_from_session_mode(gwt_agent::SessionMode::Resume),
+            "resume"
+        );
     }
 
     #[test]
@@ -6062,13 +6233,26 @@ mod tests {
             .iter()
             .any(|option| option.value == "docker"));
 
-        let execution_modes = execution_mode_options_view();
+        let execution_modes = execution_mode_options_view(true);
         assert!(execution_modes
             .iter()
             .any(|option| option.value == "normal"));
         assert!(execution_modes
             .iter()
             .any(|option| option.value == "resume"));
+
+        // SPEC-2014 2026-05-18 amendment FR-D / SC-C:
+        // picker 非対応 capability では "resume" option を除外する。
+        let modes_without_picker = execution_mode_options_view(false);
+        assert!(modes_without_picker
+            .iter()
+            .all(|option| option.value != "resume"));
+        assert!(modes_without_picker
+            .iter()
+            .any(|option| option.value == "normal"));
+        assert!(modes_without_picker
+            .iter()
+            .any(|option| option.value == "continue"));
 
         assert!(current_model_options("claude").contains(&"sonnet"));
         assert_eq!(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1817,6 +1817,7 @@ mod tests {
                     mode_args: None,
                     skip_permissions_args: Vec::new(),
                     env: HashMap::new(),
+                    supports_resume_picker: false,
                 }),
             },
         ]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,42 @@
 # Lessons Learned
 
+## 2026-05-18 — Launch Agent Execution Mode の Resume を silent downgrade させない
+
+### 事象
+
+ユーザー報告で「Launch Agent の Execution Mode が機能しない」が判明。Execution Mode で
+`Resume` を選んでも実際は `claude --continue` / `codex resume --last` 相当の Continue
+動作になり、agent の interactive session picker が開かなかった。
+
+### 原因
+
+1. `crates/gwt/src/launch_wizard.rs:1277` で `mode == "resume"` かつ
+   `resume_session_id is None` の場合に **silently `SessionMode::Continue` に
+   downgrade** されていた。Quick Start 経由でないと resume_session_id がセット
+   されないため、通常フォームの Resume は Continue 扱いになっていた。
+2. `crates/gwt-agent/src/launch.rs:638-645` で Codex builder は
+   `SessionMode::Resume` + `resume_session_id is None` のとき常に `--last` を
+   付与しており、仮に (1) を直しても `codex resume` ではなく `codex resume --last`
+   になり picker mode が成立しなかった。
+3. `execution_mode_value_from_session_mode` (launch_wizard.rs:3631) が
+   `SessionMode::Resume` を `"continue"` に collapse しており、前回 profile から
+   Resume を復元できなかった。
+
+### 再発防止策
+
+1. 「ユーザー UI 上の選択肢」と「agent CLI に渡す引数」を 1:1 で対応させる。
+   UI が `Resume` と表示している以上、内部で `Continue` に黙って差し替えてはいけない。
+   downgrade が必要な状況 (capability 不在 等) は明示的に UI から option を除外する。
+2. CLI 引数を組み立てる builder では、`SessionMode::Resume` + `resume_session_id`
+   の有無で picker mode と id 指定 mode を **別物として扱う**。デフォルトで
+   `--last` のような便宜 flag を勝手に足さない。
+3. `SessionMode` <-> 表示文字列の変換 helper は片方向 collapse を避け、
+   ラウンドトリップ可能にする (`Resume → "resume"`, `Continue → "continue"`,
+   `Normal → "normal"`)。
+4. 新しい Execution Mode option を追加するときは、agent 側の capability
+   (`AgentId::supports_resume_picker()` 等) を view 構築に渡し、対応していない
+   agent では option を除外する設計にする。
+
 ## 2026-05-15 — Exact hook trust must include generator resolution and shell format
 
 ### 事象


### PR DESCRIPTION
## Summary

- Launch Agent の Execution Mode `Resume` が、Quick Start とは違って各 agent の interactive picker を起動する正しい挙動になりました。
- 既存の 3 つの意図を分離: Continue = 直近 session 継続 / Quick Start Resume = session id 指定 / Execution Mode Resume = picker。
- Picker 非対応 agent (Gemini / OpenCode / OpenClaw / Hermes / Copilot / 未 opt-in custom agent) では Execution Mode の Resume option を UI から除外。
- SPEC-2014 (Launch Wizard) 2026-05-18 amendment (US-16/17, FR-A..G, SC-A..E) の実装。

## 根本原因

1. `crates/gwt/src/launch_wizard.rs:1277` が `mode == "resume"` && `resume_session_id is None` を silently `SessionMode::Continue` に downgrade。
2. `crates/gwt-agent/src/launch.rs` の Codex builder が `SessionMode::Resume` + no id のとき `--last` を強制付与し picker を阻害。
3. `execution_mode_value_from_session_mode` が `Resume → "continue"` に collapse し、前回 profile から Resume を復元できない。

## 主要変更

- `AgentId::supports_resume_picker()` を新設 (ClaudeCode / Codex のみ true)。
- `CustomCodingAgent.supports_resume_picker: bool` (serde default false) を追加。Store schema は `supportsResumePicker` / `supports_resume_picker` alias で読み書き。
- `launch_wizard`: silent downgrade を撤廃、view と wizard-step の execution mode option を picker capability で filter、`normalize_execution_mode` で picker 非対応 agent 切替時に `resume → continue` 自動丸め、`execution_mode_value_from_session_mode` を Resume → "resume" round-trip、UI description を "Open the agent's session picker" に変更。
- Codex builder: `SessionMode::Resume` + no id 経路から `--last` を撤廃 → `codex resume` の picker mode が成立。

## 追加テスト (RED → GREEN)

- `supports_resume_picker_only_for_picker_capable_builtins` (gwt-agent)
- `supports_resume_picker_defaults_to_false_in_toml` (gwt-agent)
- `build_codex_resume_without_id_opens_picker` (gwt-agent, 旧 `--last` assertion を picker 仕様に反転)
- `build_launch_config_resume_without_id_keeps_session_mode_resume_for_codex` (gwt)
- `build_launch_config_resume_without_id_keeps_session_mode_resume_for_claude` (gwt)
- `execution_mode_options_omit_resume_for_picker_unsupported_agent` (gwt)
- `normalize_execution_mode_downgrades_resume_when_switching_to_gemini` (gwt)
- `execution_mode_value_from_session_mode_round_trips_resume` (gwt)

## 公式仕様の根拠

- Claude Code CLI docs: `--continue` = load most recent / `--resume` = id or interactive picker。
- Codex `codex-rs/tui/src/cli.rs`: `resume_picker` / `resume_last` / `resume_session_id` の 3 内部 flag を分離。`codex resume` (no args) で picker mode。

## Test plan

- [x] `cargo test -p gwt-core -p gwt -p gwt-agent --all-features` (GREEN)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (gwt / gwt-core / gwt-agent, clean)
- [x] `cargo fmt -- --check` (clean)
- [x] `cargo build -p gwt --bin gwt --bin gwtd` (success)
- [x] `pnpm test:frontend-unit` (472/472)
- [x] `pnpm test:frontend-bundle` (clean)
- [x] husky pre-push (cargo-llvm-cov coverage 90.57%, threshold 90% 達成、skills frontmatter 28/28)
- [ ] 実機 GUI smoke (Launch Agent → Execution Mode Resume を Claude/Codex/Gemini で操作)

## 参照

- SPEC-2014 #2014 (Launch Wizard) — 2026-05-18 amendment (`gwtd issue spec 2014 --section spec`)
- Discussion plan: `/Users/akiojin/.claude/plans/launch-agent-execution-mode-continue-res-tingly-meadow.md`
- `tasks/lessons.md` に再発防止策を 4 点追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
