### PR TITLE
feat(file-tree): add file content write API with atomic save and conflict detection

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2053,6 +2053,34 @@ impl AppRuntime {
                 client_id,
                 self.load_file_content_event(&id, &path, mode, hex_offset, hex_length),
             )],
+            FrontendEvent::SaveFileContent {
+                id,
+                path,
+                mode,
+                expected_mtime,
+                expected_size,
+                text,
+                encoding,
+                newline,
+                has_bom,
+                hex_offset,
+                hex_byte,
+            } => vec![OutboundEvent::reply(
+                client_id,
+                self.save_file_content_event(
+                    &id,
+                    &path,
+                    mode,
+                    expected_mtime,
+                    expected_size,
+                    text,
+                    encoding,
+                    newline,
+                    has_bom,
+                    hex_offset,
+                    hex_byte,
+                ),
+            )],
             FrontendEvent::LoadBranches { id } => self.load_branches_events(&client_id, &id),
             FrontendEvent::LoadBoard { id, all } => self.load_board_events(&client_id, &id, all),
             FrontendEvent::LoadBoardHistory {
@@ -3456,68 +3484,170 @@ impl AppRuntime {
                 }
             };
 
-        let Some(address) = self.window_lookup.get(id) else {
-            return make_error(
-                FileContentErrorKind::WindowNotFound,
-                "Window not found".to_string(),
-                None,
-                None,
-            );
+        let root = match self.resolve_file_tree_root(id) {
+            Ok(root) => root,
+            Err(message) => {
+                let kind = if message == "Window is not a file tree" {
+                    FileContentErrorKind::WindowMismatch
+                } else {
+                    FileContentErrorKind::WindowNotFound
+                };
+                return make_error(kind, message, None, None);
+            }
         };
-        let Some(tab) = self.tab(&address.tab_id) else {
-            return make_error(
-                FileContentErrorKind::WindowNotFound,
-                "Project tab not found".to_string(),
-                None,
-                None,
-            );
-        };
-        let Some(window) = tab.workspace.window(&address.raw_id) else {
-            return make_error(
-                FileContentErrorKind::WindowNotFound,
-                "Window not found".to_string(),
-                None,
-                None,
-            );
-        };
-
-        if window.preset != WindowPreset::FileTree {
-            return make_error(
-                FileContentErrorKind::WindowMismatch,
-                "Window is not a file tree".to_string(),
-                None,
-                None,
-            );
-        }
 
         let relative_path = Path::new(path);
         let limits = ContentLimits::default();
 
         match mode {
-            FileContentMode::Text => {
-                match read_text_file(&tab.project_root, relative_path, &limits) {
-                    Ok(result) => BackendEvent::FileContentText {
-                        id: id.to_string(),
-                        path: path.to_string(),
-                        encoding: result.encoding,
-                        text: result.text,
-                        total_size: result.total_size,
-                    },
-                    Err(err) => file_content_error_to_event(id, path, err),
-                }
-            }
+            FileContentMode::Text => match read_text_file(&root, relative_path, &limits) {
+                Ok(result) => BackendEvent::FileContentText {
+                    id: id.to_string(),
+                    path: path.to_string(),
+                    encoding: result.encoding,
+                    text: result.text,
+                    total_size: result.total_size,
+                    mtime: result.mtime,
+                    has_bom: result.has_bom,
+                    newline: result.newline,
+                    read_only: result.read_only,
+                },
+                Err(err) => file_content_error_to_event(id, path, err),
+            },
             FileContentMode::Hex => {
                 let offset = hex_offset.unwrap_or(0);
                 let length = hex_length.unwrap_or(64 * 16);
-                match read_binary_chunk(&tab.project_root, relative_path, offset, length, &limits) {
+                match read_binary_chunk(&root, relative_path, offset, length, &limits) {
                     Ok(chunk) => BackendEvent::FileContentHex {
                         id: id.to_string(),
                         path: path.to_string(),
                         offset: chunk.offset,
                         bytes_b64: base64::engine::general_purpose::STANDARD.encode(chunk.bytes),
                         total_size: chunk.total_size,
+                        mtime: chunk.mtime,
+                        read_only: chunk.read_only,
                     },
                     Err(err) => file_content_error_to_event(id, path, err),
+                }
+            }
+        }
+    }
+
+    /// SPEC-2006 Phase 2 amendment: write the modified text or single hex
+    /// byte back to disk, mapping every domain error to the structured
+    /// `FileContentSaveErrorKind` variant the GUI listens for.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn save_file_content_event(
+        &self,
+        id: &str,
+        path: &str,
+        mode: FileContentMode,
+        expected_mtime: u64,
+        expected_size: u64,
+        text: Option<String>,
+        encoding: Option<gwt::Encoding>,
+        newline: Option<gwt::Newline>,
+        has_bom: Option<bool>,
+        hex_offset: Option<u64>,
+        hex_byte: Option<u8>,
+    ) -> BackendEvent {
+        let root = match self.resolve_file_tree_root(id) {
+            Ok(root) => root,
+            Err(message) => {
+                let kind = if message == "Window is not a file tree" {
+                    gwt::FileContentSaveErrorKind::WindowMismatch
+                } else {
+                    gwt::FileContentSaveErrorKind::WindowNotFound
+                };
+                return BackendEvent::FileContentSaveError {
+                    id: id.to_string(),
+                    path: path.to_string(),
+                    mode,
+                    error_kind: kind,
+                    message,
+                    current_mtime: None,
+                    current_size: None,
+                };
+            }
+        };
+
+        let relative_path = Path::new(path);
+        let limits = ContentLimits::default();
+        let expected = gwt::ExpectedMetadata {
+            mtime: expected_mtime,
+            size: expected_size,
+        };
+
+        match mode {
+            FileContentMode::Text => {
+                let Some(text) = text else {
+                    return file_content_save_error(
+                        id,
+                        path,
+                        mode,
+                        gwt::FileContentSaveErrorKind::IoError,
+                        "save_file_content(text) missing text payload".to_string(),
+                        None,
+                        None,
+                    );
+                };
+                let encoding = encoding.unwrap_or(gwt::Encoding::Utf8);
+                let newline = newline.unwrap_or(gwt::Newline::Lf);
+                let has_bom = has_bom.unwrap_or(false);
+                match gwt::write_text_file(
+                    &root,
+                    relative_path,
+                    &text,
+                    encoding,
+                    newline,
+                    has_bom,
+                    expected,
+                    &limits,
+                ) {
+                    Ok(outcome) => BackendEvent::FileContentSaved {
+                        id: id.to_string(),
+                        path: path.to_string(),
+                        mode,
+                        new_mtime: outcome.new_mtime,
+                        new_size: outcome.new_size,
+                        encoding_fallback: outcome.encoding_fallback,
+                    },
+                    Err(err) => write_error_to_event(id, path, mode, err),
+                }
+            }
+            FileContentMode::Hex => {
+                let Some(offset) = hex_offset else {
+                    return file_content_save_error(
+                        id,
+                        path,
+                        mode,
+                        gwt::FileContentSaveErrorKind::IoError,
+                        "save_file_content(hex) missing hex_offset".to_string(),
+                        None,
+                        None,
+                    );
+                };
+                let Some(byte) = hex_byte else {
+                    return file_content_save_error(
+                        id,
+                        path,
+                        mode,
+                        gwt::FileContentSaveErrorKind::IoError,
+                        "save_file_content(hex) missing hex_byte".to_string(),
+                        None,
+                        None,
+                    );
+                };
+                match gwt::write_binary_byte(&root, relative_path, offset, byte, expected) {
+                    Ok(outcome) => BackendEvent::FileContentSaved {
+                        id: id.to_string(),
+                        path: path.to_string(),
+                        mode,
+                        new_mtime: outcome.new_mtime,
+                        new_size: outcome.new_size,
+                        encoding_fallback: outcome.encoding_fallback,
+                    },
+                    Err(err) => write_error_to_event(id, path, mode, err),
                 }
             }
         }
@@ -6540,6 +6670,69 @@ fn codex_config_path_for_profile_config(profile_config_path: &Path) -> Option<Pa
     Some(gwt_config_dir.parent()?.join(".codex").join("config.toml"))
 }
 
+fn file_content_save_error(
+    id: &str,
+    path: &str,
+    mode: FileContentMode,
+    kind: gwt::FileContentSaveErrorKind,
+    message: String,
+    current_mtime: Option<u64>,
+    current_size: Option<u64>,
+) -> BackendEvent {
+    BackendEvent::FileContentSaveError {
+        id: id.to_string(),
+        path: path.to_string(),
+        mode,
+        error_kind: kind,
+        message,
+        current_mtime,
+        current_size,
+    }
+}
+
+fn write_error_to_event(
+    id: &str,
+    path: &str,
+    mode: FileContentMode,
+    err: FileContentError,
+) -> BackendEvent {
+    use gwt::FileContentSaveErrorKind as Kind;
+    let (kind, message, current_mtime, current_size) = match err {
+        FileContentError::Denied => (Kind::Denied, "Access denied".to_string(), None, None),
+        FileContentError::TooLarge { size, limit } => (
+            Kind::TooLarge,
+            format!("File too large ({} bytes, limit {})", size, limit),
+            None,
+            None,
+        ),
+        FileContentError::IoError(message) => (Kind::IoError, message, None, None),
+        FileContentError::NotAFile => (Kind::NotAFile, "Not a file".to_string(), None, None),
+        FileContentError::BinaryNotText => (
+            Kind::IoError,
+            "Cannot decode as text".to_string(),
+            None,
+            None,
+        ),
+        FileContentError::Conflict {
+            current_mtime,
+            current_size,
+        } => (
+            Kind::Conflict,
+            format!("File changed externally (current mtime={current_mtime}, size={current_size})"),
+            Some(current_mtime),
+            Some(current_size),
+        ),
+        FileContentError::ReadOnly => (Kind::ReadOnly, "File is read-only".to_string(), None, None),
+        FileContentError::OutOfRange { offset, size } => (
+            Kind::OutOfRange,
+            format!("Offset {offset} is outside file (size {size})"),
+            None,
+            Some(size),
+        ),
+    };
+    file_content_save_error(id, path, mode, kind, message, current_mtime, current_size)
+}
+
 fn file_content_error_to_event(id: &str, path: &str, err: FileContentError) -> BackendEvent {
     let (kind, message, size, limit) = match err {
         FileContentError::Denied => (
@@ -6565,6 +6758,31 @@ fn file_content_error_to_event(id: &str, path: &str, err: FileContentError) -> B
             FileContentErrorKind::BinaryNotText,
             "Cannot decode as text".to_string(),
             None,
+            None,
+        ),
+        // SPEC-2006 Phase 2 variants are write-only and should never reach
+        // the read-path mapping. Map defensively to IoError so the read
+        // surface keeps working if a future caller funnels them here by
+        // mistake; the write surface owns the structured Save error variant.
+        FileContentError::Conflict {
+            current_mtime,
+            current_size,
+        } => (
+            FileContentErrorKind::IoError,
+            format!("Unexpected Conflict in read path (mtime={current_mtime} size={current_size})"),
+            Some(current_size),
+            None,
+        ),
+        FileContentError::ReadOnly => (
+            FileContentErrorKind::IoError,
+            "Unexpected ReadOnly in read path".to_string(),
+            None,
+            None,
+        ),
+        FileContentError::OutOfRange { offset, size } => (
+            FileContentErrorKind::IoError,
+            format!("Unexpected OutOfRange in read path (offset={offset} size={size})"),
+            Some(size),
             None,
         ),
     };

--- a/crates/gwt/src/file_content.rs
+++ b/crates/gwt/src/file_content.rs
@@ -1,4 +1,8 @@
-use std::path::Path;
+use std::{
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +33,15 @@ impl Encoding {
     }
 }
 
+/// Newline convention preserved across read/write round-trips. Files with
+/// mixed newlines collapse to the dominant style on detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Newline {
+    Lf,
+    Crlf,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FileKind {
@@ -36,11 +49,24 @@ pub enum FileKind {
     Binary,
 }
 
+/// SPEC-2006 Phase 2 amendment FR-018: callers send back the metadata they
+/// observed at read time so the write path can detect external mutations
+/// before atomic rename.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpectedMetadata {
+    pub mtime: u64,
+    pub size: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TextResult {
     pub encoding: Encoding,
     pub text: String,
     pub total_size: u64,
+    pub mtime: u64,
+    pub has_bom: bool,
+    pub newline: Newline,
+    pub read_only: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,16 +74,43 @@ pub struct BinaryChunk {
     pub offset: u64,
     pub bytes: Vec<u8>,
     pub total_size: u64,
+    pub mtime: u64,
+    pub read_only: bool,
+}
+
+/// Result of a successful write. `encoding_fallback` is the number of source
+/// characters that could not be represented in the target encoding (UTF-8
+/// gets a `?` substitution); zero means a perfect round-trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WriteOutcome {
+    pub new_mtime: u64,
+    pub new_size: u64,
+    pub encoding_fallback: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FileContentError {
     Denied,
-    TooLarge { size: u64, limit: u64 },
+    TooLarge {
+        size: u64,
+        limit: u64,
+    },
     IoError(String),
     NotAFile,
     BinaryNotText,
+    /// SPEC-2006 Phase 2: write path mtime/size mismatch.
+    Conflict {
+        current_mtime: u64,
+        current_size: u64,
+    },
+    /// SPEC-2006 Phase 2: target file is read-only on disk.
+    ReadOnly,
+    /// SPEC-2006 Phase 2: hex byte write offset >= file size.
+    OutOfRange {
+        offset: u64,
+        size: u64,
+    },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -75,14 +128,20 @@ impl Default for ContentLimits {
     }
 }
 
+struct ResolvedFile {
+    path: PathBuf,
+    size: u64,
+    mtime: u64,
+    read_only: bool,
+}
+
 fn resolve_file(root: &Path, relative: &Path) -> Result<ResolvedFile, FileContentError> {
-    // Path filter: must be inside the root and pass normalization checks.
     let canonical = path_filter::canonical_root(root);
     let normalized =
         path_filter::normalize_relative(relative).map_err(|_| FileContentError::Denied)?;
 
-    // Deny rule (builtin skip + .gitignore): applies before existence check, so
-    // attempts to read .git/.gwt/etc. are rejected even when the file exists.
+    // Deny rule applies before existence check, so .git/.gwt/etc. are
+    // rejected even when the file exists.
     if is_relative_denied(&canonical, &normalized) {
         return Err(FileContentError::Denied);
     }
@@ -103,12 +162,15 @@ fn resolve_file(root: &Path, relative: &Path) -> Result<ResolvedFile, FileConten
     Ok(ResolvedFile {
         path: resolved.canonical_path,
         size: metadata.len(),
+        mtime: system_time_to_secs(metadata.modified().unwrap_or(UNIX_EPOCH)),
+        read_only: metadata.permissions().readonly(),
     })
 }
 
-struct ResolvedFile {
-    path: std::path::PathBuf,
-    size: u64,
+fn system_time_to_secs(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 fn read_all_bytes(path: &Path) -> Result<Vec<u8>, FileContentError> {
@@ -138,14 +200,23 @@ pub fn read_text_file(
             encoding: Encoding::Utf8,
             text: String::new(),
             total_size: 0,
+            mtime: resolved.mtime,
+            has_bom: false,
+            newline: Newline::Lf,
+            read_only: resolved.read_only,
         });
     }
 
-    let (encoding, text) = detect_and_decode(&bytes)?;
+    let (encoding, text, has_bom) = detect_and_decode(&bytes)?;
+    let newline = detect_newline(&text);
     Ok(TextResult {
         encoding,
         text,
         total_size: resolved.size,
+        mtime: resolved.mtime,
+        has_bom,
+        newline,
+        read_only: resolved.read_only,
     })
 }
 
@@ -173,7 +244,6 @@ pub fn read_binary_chunk(
 
     let mut bytes = vec![0u8; read_len as usize];
     if read_len > 0 {
-        use std::io::{Read, Seek, SeekFrom};
         let mut file = std::fs::File::open(&resolved.path)
             .map_err(|err| FileContentError::IoError(err.to_string()))?;
         file.seek(SeekFrom::Start(clamped_offset))
@@ -186,6 +256,8 @@ pub fn read_binary_chunk(
         offset: clamped_offset,
         bytes,
         total_size: resolved.size,
+        mtime: resolved.mtime,
+        read_only: resolved.read_only,
     })
 }
 
@@ -208,42 +280,146 @@ pub fn file_kind(
         });
     }
     match detect_and_decode(&bytes) {
-        Ok((encoding, _)) => Ok(FileKind::Text { encoding }),
+        Ok((encoding, _, _)) => Ok(FileKind::Text { encoding }),
         Err(FileContentError::BinaryNotText) => Ok(FileKind::Binary),
         Err(other) => Err(other),
     }
 }
 
-fn detect_and_decode(bytes: &[u8]) -> Result<(Encoding, String), FileContentError> {
-    // BOM checks take precedence — these are unambiguous.
+/// SPEC-2006 Phase 2 FR-017: write a text file using atomic tmp+rename,
+/// preserving the original encoding, BOM, and newline convention. The
+/// `expected` metadata guards against external mutations; mismatch raises
+/// `Conflict` and leaves the on-disk file untouched.
+#[allow(clippy::too_many_arguments)]
+pub fn write_text_file(
+    root: &Path,
+    relative: &Path,
+    text: &str,
+    encoding: Encoding,
+    newline: Newline,
+    has_bom: bool,
+    expected: ExpectedMetadata,
+    limits: &ContentLimits,
+) -> Result<WriteOutcome, FileContentError> {
+    let resolved = resolve_file(root, relative)?;
+    if resolved.read_only {
+        return Err(FileContentError::ReadOnly);
+    }
+    if resolved.size != expected.size || resolved.mtime != expected.mtime {
+        return Err(FileContentError::Conflict {
+            current_mtime: resolved.mtime,
+            current_size: resolved.size,
+        });
+    }
+
+    // Normalise the in-memory text to the desired newline. The viewer always
+    // sends LF-separated content; we splice CRLF back on the write side so
+    // Windows-authored files round-trip exactly.
+    let normalised = match newline {
+        Newline::Lf => text.replace("\r\n", "\n"),
+        Newline::Crlf => text.replace("\r\n", "\n").replace('\n', "\r\n"),
+    };
+
+    let (mut encoded, encoding_fallback) = encode_text(&normalised, encoding)?;
+    if has_bom {
+        prepend_bom(&mut encoded, encoding);
+    }
+
+    if encoded.len() as u64 > limits.text_max_bytes {
+        return Err(FileContentError::TooLarge {
+            size: encoded.len() as u64,
+            limit: limits.text_max_bytes,
+        });
+    }
+
+    atomic_write(&resolved.path, &encoded)?;
+
+    let new_metadata = std::fs::metadata(&resolved.path)
+        .map_err(|err| FileContentError::IoError(err.to_string()))?;
+    Ok(WriteOutcome {
+        new_mtime: system_time_to_secs(new_metadata.modified().unwrap_or(UNIX_EPOCH)),
+        new_size: new_metadata.len(),
+        encoding_fallback,
+    })
+}
+
+/// SPEC-2006 Phase 2 FR-019: replace a single byte at `offset` in-place,
+/// keeping the file size unchanged. Uses a direct seek+write because a full
+/// atomic rewrite would dominate hex-edit cost on multi-MiB binaries; the
+/// surface is intentionally narrow (a single byte) so partial-write damage
+/// is bounded to that byte.
+pub fn write_binary_byte(
+    root: &Path,
+    relative: &Path,
+    offset: u64,
+    byte: u8,
+    expected: ExpectedMetadata,
+) -> Result<WriteOutcome, FileContentError> {
+    let resolved = resolve_file(root, relative)?;
+    if resolved.read_only {
+        return Err(FileContentError::ReadOnly);
+    }
+    if resolved.size != expected.size || resolved.mtime != expected.mtime {
+        return Err(FileContentError::Conflict {
+            current_mtime: resolved.mtime,
+            current_size: resolved.size,
+        });
+    }
+    if offset >= resolved.size {
+        return Err(FileContentError::OutOfRange {
+            offset,
+            size: resolved.size,
+        });
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&resolved.path)
+        .map_err(|err| FileContentError::IoError(err.to_string()))?;
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|err| FileContentError::IoError(err.to_string()))?;
+    file.write_all(&[byte])
+        .map_err(|err| FileContentError::IoError(err.to_string()))?;
+    file.sync_all()
+        .map_err(|err| FileContentError::IoError(err.to_string()))?;
+
+    let new_metadata = std::fs::metadata(&resolved.path)
+        .map_err(|err| FileContentError::IoError(err.to_string()))?;
+    Ok(WriteOutcome {
+        new_mtime: system_time_to_secs(new_metadata.modified().unwrap_or(UNIX_EPOCH)),
+        new_size: new_metadata.len(),
+        encoding_fallback: 0,
+    })
+}
+
+fn detect_and_decode(bytes: &[u8]) -> Result<(Encoding, String, bool), FileContentError> {
     if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
-        let stripped = &bytes[3..];
-        return decode_with(encoding_rs::UTF_8, Encoding::Utf8, stripped);
+        let (encoding, text) = decode_with(encoding_rs::UTF_8, Encoding::Utf8, &bytes[3..])?;
+        return Ok((encoding, text, true));
     }
     if bytes.starts_with(&[0xFF, 0xFE]) {
-        let stripped = &bytes[2..];
-        return decode_with(encoding_rs::UTF_16LE, Encoding::Utf16Le, stripped);
+        let (encoding, text) = decode_with(encoding_rs::UTF_16LE, Encoding::Utf16Le, &bytes[2..])?;
+        return Ok((encoding, text, true));
     }
     if bytes.starts_with(&[0xFE, 0xFF]) {
-        let stripped = &bytes[2..];
-        return decode_with(encoding_rs::UTF_16BE, Encoding::Utf16Be, stripped);
+        let (encoding, text) = decode_with(encoding_rs::UTF_16BE, Encoding::Utf16Be, &bytes[2..])?;
+        return Ok((encoding, text, true));
     }
 
     if bytes.contains(&0u8) {
         return Err(FileContentError::BinaryNotText);
     }
 
-    // Try strict UTF-8 first. Failing that, ask chardetng for a best guess
-    // restricted to encodings we explicitly support; anything else is binary.
     if let Ok(text) = std::str::from_utf8(bytes) {
-        return Ok((Encoding::Utf8, text.to_owned()));
+        return Ok((Encoding::Utf8, text.to_owned(), false));
     }
 
     let mut detector = chardetng::EncodingDetector::new();
     detector.feed(bytes, true);
     let detected = detector.guess(None, true);
     let supported = supported_encoding(detected).ok_or(FileContentError::BinaryNotText)?;
-    decode_with(detected, supported, bytes)
+    let (encoding, text) = decode_with(detected, supported, bytes)?;
+    Ok((encoding, text, false))
 }
 
 fn decode_with(
@@ -272,4 +448,106 @@ fn supported_encoding(detected: &'static encoding_rs::Encoding) -> Option<Encodi
     } else {
         None
     }
+}
+
+fn detect_newline(text: &str) -> Newline {
+    // Count CRLF first because the LF inside a CRLF would otherwise be
+    // double-counted. The dominant convention wins; an empty file defaults
+    // to LF so round-trips remain stable on UNIX hosts.
+    let crlf_count = text.matches("\r\n").count();
+    let lf_only_count = text.matches('\n').count().saturating_sub(crlf_count);
+    if crlf_count > lf_only_count {
+        Newline::Crlf
+    } else {
+        Newline::Lf
+    }
+}
+
+fn encode_text(text: &str, encoding: Encoding) -> Result<(Vec<u8>, u64), FileContentError> {
+    let target = encoding_for(encoding);
+    let (encoded, _, had_unmappable) = target.encode(text);
+    let fallback = if had_unmappable {
+        // encoding_rs replaces unmappable code points with HTML numeric
+        // references (e.g. `&#1234;`) when encoding a non-Unicode target.
+        // We surface the count so the GUI can warn the user — the count is
+        // bounded by the number of times the substitution was emitted.
+        count_html_numeric_substitutions(&encoded)
+    } else {
+        0
+    };
+    Ok((encoded.into_owned(), fallback))
+}
+
+fn encoding_for(encoding: Encoding) -> &'static encoding_rs::Encoding {
+    match encoding {
+        Encoding::Utf8 => encoding_rs::UTF_8,
+        Encoding::Utf16Le => encoding_rs::UTF_16LE,
+        Encoding::Utf16Be => encoding_rs::UTF_16BE,
+        Encoding::ShiftJis => encoding_rs::SHIFT_JIS,
+        Encoding::EucJp => encoding_rs::EUC_JP,
+    }
+}
+
+fn count_html_numeric_substitutions(bytes: &[u8]) -> u64 {
+    // Look for the pattern `&#NNN;` and count occurrences. UTF-8 / UTF-16
+    // never go through this path because they are Unicode-complete.
+    let s = String::from_utf8_lossy(bytes);
+    let mut count = 0u64;
+    let mut rest = s.as_ref();
+    while let Some(pos) = rest.find("&#") {
+        let after = &rest[pos + 2..];
+        if let Some(end) = after.find(';') {
+            if after[..end].chars().all(|c| c.is_ascii_digit()) {
+                count += 1;
+            }
+            rest = &after[end + 1..];
+        } else {
+            break;
+        }
+    }
+    count
+}
+
+fn prepend_bom(bytes: &mut Vec<u8>, encoding: Encoding) {
+    let bom: &[u8] = match encoding {
+        Encoding::Utf8 => &[0xEF, 0xBB, 0xBF],
+        Encoding::Utf16Le => &[0xFF, 0xFE],
+        Encoding::Utf16Be => &[0xFE, 0xFF],
+        _ => return,
+    };
+    let mut prefixed = Vec::with_capacity(bom.len() + bytes.len());
+    prefixed.extend_from_slice(bom);
+    prefixed.extend_from_slice(bytes);
+    *bytes = prefixed;
+}
+
+fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), FileContentError> {
+    let parent = target.parent().ok_or_else(|| {
+        FileContentError::IoError(format!(
+            "target has no parent directory: {}",
+            target.display()
+        ))
+    })?;
+    let basename = target
+        .file_name()
+        .ok_or_else(|| {
+            FileContentError::IoError(format!("target has no file name: {}", target.display()))
+        })?
+        .to_string_lossy();
+    let pid = std::process::id();
+    let nonce = system_time_to_secs(SystemTime::now()).wrapping_mul(31);
+    let tmp_name = format!(".{basename}.gwt-edit-tmp.{pid}.{nonce}");
+    let tmp_path = parent.join(tmp_name);
+
+    let write_result = std::fs::write(&tmp_path, bytes);
+    if let Err(err) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(FileContentError::IoError(err.to_string()));
+    }
+
+    if let Err(err) = std::fs::rename(&tmp_path, target) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(FileContentError::IoError(err.to_string()));
+    }
+    Ok(())
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -54,8 +54,9 @@ pub use custom_agents_service::{
 };
 pub use daemon_runtime::{HookForwardTarget, RuntimeHookEvent, RuntimeHookEventKind};
 pub use file_content::{
-    file_kind, read_binary_chunk, read_text_file, BinaryChunk, ContentLimits, Encoding,
-    FileContentError, FileKind, TextResult,
+    file_kind, read_binary_chunk, read_text_file, write_binary_byte, write_text_file, BinaryChunk,
+    ContentLimits, Encoding, ExpectedMetadata, FileContentError, FileKind, Newline, TextResult,
+    WriteOutcome,
 };
 pub use file_tree::{list_directory_entries, FileTreeEntry, FileTreeEntryKind};
 pub use gwt_agent::{ClaudeCodeOpenaiCompatInput, PresetDefinition, PresetId};
@@ -111,9 +112,10 @@ pub use preset::{
 };
 pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
-    ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FocusCycleDirection,
-    FrontendEvent, GitHubRepositorySearchResultView, ProfileEntryView, ProfileEnvEntryView,
-    ProfileSnapshotView, ProjectTabView, RecentProjectView, UiTraceEntry, UiTracePayload,
+    ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FileContentErrorKind,
+    FileContentMode, FileContentSaveErrorKind, FocusCycleDirection, FrontendEvent,
+    GitHubRepositorySearchResultView, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView,
+    ProjectTabView, RecentProjectView, UiTraceEntry, UiTracePayload,
     WorkspaceExecutionContainerView, WorkspaceHistoryAgentView, WorkspaceHistoryEventView,
     WorkspaceHistoryView, WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView,
     WorkspaceWorkAgentView, WorkspaceWorkEventView, WorkspaceWorkItemView,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2505,6 +2505,113 @@ mod tests {
             BackendEvent::FileTreeWorktreeSelected { worktree_id: ref selected, .. } if selected == &worktree_id
         ));
 
+        // SPEC-2006 Phase 2 amendment: save_file_content_event must cover
+        // WindowNotFound / WindowMismatch / successful text save / Conflict
+        // (mismatched expected_mtime) / OutOfRange (hex offset >= size).
+        let missing_save = runtime.save_file_content_event(
+            "missing",
+            "README.md",
+            gwt::FileContentMode::Text,
+            0,
+            0,
+            Some("ignored".to_string()),
+            Some(gwt::Encoding::Utf8),
+            Some(gwt::Newline::Lf),
+            Some(false),
+            None,
+            None,
+        );
+        assert!(matches!(
+            missing_save,
+            BackendEvent::FileContentSaveError {
+                error_kind: gwt::FileContentSaveErrorKind::WindowNotFound,
+                ..
+            }
+        ));
+
+        let wrong_save = runtime.save_file_content_event(
+            &branches_id,
+            "README.md",
+            gwt::FileContentMode::Text,
+            0,
+            0,
+            Some("ignored".to_string()),
+            Some(gwt::Encoding::Utf8),
+            Some(gwt::Newline::Lf),
+            Some(false),
+            None,
+            None,
+        );
+        assert!(matches!(
+            wrong_save,
+            BackendEvent::FileContentSaveError {
+                error_kind: gwt::FileContentSaveErrorKind::WindowMismatch,
+                ..
+            }
+        ));
+
+        // Re-read current README.md metadata to drive a successful save.
+        let read_event = runtime.load_file_content_event(
+            &file_tree_id,
+            "README.md",
+            FileContentMode::Text,
+            None,
+            None,
+        );
+        let (saved_mtime, saved_size, encoding, newline, has_bom) = match read_event {
+            BackendEvent::FileContentText {
+                mtime,
+                total_size,
+                encoding,
+                newline,
+                has_bom,
+                ..
+            } => (mtime, total_size, encoding, newline, has_bom),
+            other => panic!("expected FileContentText, got {other:?}"),
+        };
+
+        let conflict_save = runtime.save_file_content_event(
+            &file_tree_id,
+            "README.md",
+            gwt::FileContentMode::Text,
+            saved_mtime.saturating_add(99),
+            saved_size,
+            Some("conflict".to_string()),
+            Some(encoding),
+            Some(newline),
+            Some(has_bom),
+            None,
+            None,
+        );
+        assert!(matches!(
+            conflict_save,
+            BackendEvent::FileContentSaveError {
+                error_kind: gwt::FileContentSaveErrorKind::Conflict,
+                ..
+            }
+        ));
+
+        let hex_out_of_range = runtime.save_file_content_event(
+            &file_tree_id,
+            "README.md",
+            gwt::FileContentMode::Hex,
+            saved_mtime,
+            saved_size,
+            None,
+            None,
+            None,
+            None,
+            Some(saved_size + 100),
+            Some(0xFF),
+        );
+        assert!(matches!(
+            hex_out_of_range,
+            BackendEvent::FileContentSaveError {
+                error_kind: gwt::FileContentSaveErrorKind::OutOfRange,
+                ..
+            }
+        ));
+
         let missing_branches = runtime.load_branches_events("client-1", "missing");
         assert_eq!(missing_branches.len(), 1);
         assert!(matches!(

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -9,7 +9,7 @@ use crate::{
     branch_cleanup::BranchCleanupResultEntry,
     branch_list::BranchListEntry,
     daemon_runtime::RuntimeHookEvent,
-    file_content::Encoding,
+    file_content::{Encoding, Newline},
     file_tree::FileTreeEntry,
     knowledge_bridge::{KnowledgeDetailView, KnowledgeKind, KnowledgeListItem},
     launch_wizard::{LaunchWizardAction, LaunchWizardView},
@@ -35,6 +35,24 @@ pub enum FileContentErrorKind {
     IoError,
     NotAFile,
     BinaryNotText,
+    WindowNotFound,
+    WindowMismatch,
+}
+
+/// SPEC-2006 Phase 2 amendment: structured error variants for the write
+/// surface. Kept separate from read-side `FileContentErrorKind` so the GUI
+/// can match exhaustively on save-only outcomes (conflict / read-only /
+/// out-of-range / encoding fallback).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileContentSaveErrorKind {
+    Denied,
+    Conflict,
+    ReadOnly,
+    OutOfRange,
+    TooLarge,
+    IoError,
+    NotAFile,
     WindowNotFound,
     WindowMismatch,
 }
@@ -171,6 +189,28 @@ pub enum FrontendEvent {
         hex_offset: Option<u64>,
         #[serde(default)]
         hex_length: Option<u64>,
+    },
+    /// SPEC-2006 Phase 2 amendment: write the modified text or single hex
+    /// byte back to disk. `expected_mtime` / `expected_size` are the values
+    /// returned by the most recent read; mismatch raises Conflict.
+    SaveFileContent {
+        id: String,
+        path: String,
+        mode: FileContentMode,
+        expected_mtime: u64,
+        expected_size: u64,
+        #[serde(default)]
+        text: Option<String>,
+        #[serde(default)]
+        encoding: Option<Encoding>,
+        #[serde(default)]
+        newline: Option<Newline>,
+        #[serde(default)]
+        has_bom: Option<bool>,
+        #[serde(default)]
+        hex_offset: Option<u64>,
+        #[serde(default)]
+        hex_byte: Option<u8>,
     },
     LoadBranches {
         id: String,
@@ -486,6 +526,11 @@ fn default_board_history_limit() -> usize {
     50
 }
 
+#[allow(dead_code)]
+fn default_newline() -> Newline {
+    Newline::Lf
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct WorkspaceView {
     pub viewport: CanvasViewport,
@@ -742,6 +787,16 @@ pub enum BackendEvent {
         encoding: Encoding,
         text: String,
         total_size: u64,
+        // SPEC-2006 Phase 2 amendment: extra fields the GUI needs to support
+        // dirty/save/conflict flows. Defaults keep older clients compiling.
+        #[serde(default)]
+        mtime: u64,
+        #[serde(default)]
+        has_bom: bool,
+        #[serde(default = "default_newline")]
+        newline: Newline,
+        #[serde(default)]
+        read_only: bool,
     },
     FileContentHex {
         id: String,
@@ -749,6 +804,10 @@ pub enum BackendEvent {
         offset: u64,
         bytes_b64: String,
         total_size: u64,
+        #[serde(default)]
+        mtime: u64,
+        #[serde(default)]
+        read_only: bool,
     },
     FileContentError {
         id: String,
@@ -759,6 +818,29 @@ pub enum BackendEvent {
         size: Option<u64>,
         #[serde(default)]
         limit: Option<u64>,
+    },
+    /// SPEC-2006 Phase 2 amendment: successful write. `new_mtime` / `new_size`
+    /// become the next `expected_*` baseline so subsequent saves keep their
+    /// conflict checks aligned with what is actually on disk.
+    FileContentSaved {
+        id: String,
+        path: String,
+        mode: FileContentMode,
+        new_mtime: u64,
+        new_size: u64,
+        #[serde(default)]
+        encoding_fallback: u64,
+    },
+    FileContentSaveError {
+        id: String,
+        path: String,
+        mode: FileContentMode,
+        error_kind: FileContentSaveErrorKind,
+        message: String,
+        #[serde(default)]
+        current_mtime: Option<u64>,
+        #[serde(default)]
+        current_size: Option<u64>,
     },
     BranchEntries {
         id: String,

--- a/crates/gwt/tests/file_content_test.rs
+++ b/crates/gwt/tests/file_content_test.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use gwt::file_content::{
-    file_kind, read_binary_chunk, read_text_file, ContentLimits, Encoding, FileContentError,
-    FileKind,
+    file_kind, read_binary_chunk, read_text_file, write_binary_byte, write_text_file,
+    ContentLimits, Encoding, ExpectedMetadata, FileContentError, FileKind, Newline,
 };
 use tempfile::tempdir;
 
@@ -255,4 +255,327 @@ fn read_binary_chunk_returns_empty_chunk_for_zero_byte_file() {
     assert_eq!(chunk.offset, 0);
     assert!(chunk.bytes.is_empty());
     assert_eq!(chunk.total_size, 0);
+}
+
+// SPEC-2006 Phase 2 amendment: read_text_file must expose mtime/has_bom/newline
+// so the GUI can preserve them across a save round-trip.
+#[test]
+fn read_text_file_detects_crlf_lf_and_bom_metadata() {
+    let dir = tempdir().expect("tempdir");
+    write_at(dir.path(), "lf.txt", b"alpha\nbeta\n");
+    write_at(dir.path(), "crlf.txt", b"alpha\r\nbeta\r\n");
+    write_at(dir.path(), "bom.txt", b"\xEF\xBB\xBFhello\n");
+
+    let limits = ContentLimits::default();
+
+    let lf = read_text_file(dir.path(), Path::new("lf.txt"), &limits).expect("lf");
+    assert_eq!(lf.newline, Newline::Lf);
+    assert!(!lf.has_bom);
+    assert!(
+        lf.mtime > 0,
+        "mtime should be populated from filesystem metadata"
+    );
+    assert_eq!(lf.total_size, 11);
+
+    let crlf = read_text_file(dir.path(), Path::new("crlf.txt"), &limits).expect("crlf");
+    assert_eq!(crlf.newline, Newline::Crlf);
+    assert!(!crlf.has_bom);
+
+    let bom = read_text_file(dir.path(), Path::new("bom.txt"), &limits).expect("bom");
+    assert!(bom.has_bom);
+    assert_eq!(bom.encoding, Encoding::Utf8);
+    assert_eq!(bom.newline, Newline::Lf);
+}
+
+#[test]
+fn write_text_file_round_trips_utf8_lf_without_bom() {
+    let dir = tempdir().expect("tempdir");
+    write_at(dir.path(), "note.txt", b"hello\n");
+
+    let limits = ContentLimits::default();
+    let before = read_text_file(dir.path(), Path::new("note.txt"), &limits).expect("read");
+    let outcome = write_text_file(
+        dir.path(),
+        Path::new("note.txt"),
+        "hello world\n",
+        before.encoding,
+        before.newline,
+        before.has_bom,
+        ExpectedMetadata {
+            mtime: before.mtime,
+            size: before.total_size,
+        },
+        &limits,
+    )
+    .expect("write");
+    assert_eq!(outcome.encoding_fallback, 0);
+    assert!(outcome.new_size >= "hello world\n".len() as u64);
+
+    let after_bytes = std::fs::read(dir.path().join("note.txt")).expect("re-read");
+    assert_eq!(after_bytes, b"hello world\n".to_vec());
+}
+
+#[test]
+fn write_text_file_preserves_utf8_bom_and_crlf_round_trip() {
+    let dir = tempdir().expect("tempdir");
+    let original: &[u8] = b"\xEF\xBB\xBFalpha\r\nbeta\r\n";
+    write_at(dir.path(), "crlf-bom.txt", original);
+
+    let limits = ContentLimits::default();
+    let before = read_text_file(dir.path(), Path::new("crlf-bom.txt"), &limits).expect("read");
+    assert!(before.has_bom);
+    assert_eq!(before.newline, Newline::Crlf);
+
+    write_text_file(
+        dir.path(),
+        Path::new("crlf-bom.txt"),
+        &before.text,
+        before.encoding,
+        before.newline,
+        before.has_bom,
+        ExpectedMetadata {
+            mtime: before.mtime,
+            size: before.total_size,
+        },
+        &limits,
+    )
+    .expect("write");
+
+    let after_bytes = std::fs::read(dir.path().join("crlf-bom.txt")).expect("re-read");
+    assert_eq!(
+        after_bytes,
+        original.to_vec(),
+        "BOM + CRLF must survive a round-trip"
+    );
+}
+
+#[test]
+fn write_text_file_round_trips_shift_jis_and_euc_jp() {
+    let dir = tempdir().expect("tempdir");
+    let sjis = encoding_rs::SHIFT_JIS.encode("こんにちは\n").0.into_owned();
+    write_at(dir.path(), "sjis.txt", &sjis);
+    let euc = encoding_rs::EUC_JP.encode("こんばんは\n").0.into_owned();
+    write_at(dir.path(), "euc.txt", &euc);
+
+    let limits = ContentLimits::default();
+    for (name, expected_enc) in [
+        ("sjis.txt", Encoding::ShiftJis),
+        ("euc.txt", Encoding::EucJp),
+    ] {
+        let before = read_text_file(dir.path(), Path::new(name), &limits).expect("read");
+        assert_eq!(before.encoding, expected_enc);
+        let mutated = format!("{}追記\n", before.text);
+        let outcome = write_text_file(
+            dir.path(),
+            Path::new(name),
+            &mutated,
+            before.encoding,
+            before.newline,
+            before.has_bom,
+            ExpectedMetadata {
+                mtime: before.mtime,
+                size: before.total_size,
+            },
+            &limits,
+        )
+        .expect("write");
+        assert_eq!(
+            outcome.encoding_fallback, 0,
+            "Japanese text must encode without fallback"
+        );
+
+        let after = read_text_file(dir.path(), Path::new(name), &limits).expect("re-read");
+        assert_eq!(after.encoding, expected_enc);
+        assert_eq!(after.text, mutated);
+    }
+}
+
+#[test]
+fn write_text_file_rejects_conflict_when_mtime_mismatches() {
+    let dir = tempdir().expect("tempdir");
+    write_at(dir.path(), "race.txt", b"original\n");
+
+    let limits = ContentLimits::default();
+    let before = read_text_file(dir.path(), Path::new("race.txt"), &limits).expect("read");
+
+    // Simulate an external editor mutating the file after we read it.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    std::fs::write(dir.path().join("race.txt"), b"external write\n").expect("external write");
+
+    let err = write_text_file(
+        dir.path(),
+        Path::new("race.txt"),
+        "our edit\n",
+        before.encoding,
+        before.newline,
+        before.has_bom,
+        ExpectedMetadata {
+            mtime: before.mtime,
+            size: before.total_size,
+        },
+        &limits,
+    )
+    .expect_err("conflict");
+    match err {
+        FileContentError::Conflict { current_size, .. } => {
+            assert_eq!(current_size, b"external write\n".len() as u64);
+        }
+        other => panic!("expected Conflict, got {other:?}"),
+    }
+
+    // Disk content must remain the external write — atomic write never ran.
+    let on_disk = std::fs::read(dir.path().join("race.txt")).expect("re-read");
+    assert_eq!(on_disk, b"external write\n".to_vec());
+}
+
+#[test]
+fn write_text_file_rejects_read_only_files() {
+    let dir = tempdir().expect("tempdir");
+    write_at(dir.path(), "ro.txt", b"keep\n");
+    let target = dir.path().join("ro.txt");
+    let mut perms = std::fs::metadata(&target).expect("metadata").permissions();
+    perms.set_readonly(true);
+    std::fs::set_permissions(&target, perms).expect("chmod ro");
+
+    let limits = ContentLimits::default();
+    let before = read_text_file(dir.path(), Path::new("ro.txt"), &limits).expect("read");
+    assert!(
+        before.read_only,
+        "TextResult.read_only must reflect permissions"
+    );
+
+    let err = write_text_file(
+        dir.path(),
+        Path::new("ro.txt"),
+        "new\n",
+        before.encoding,
+        before.newline,
+        before.has_bom,
+        ExpectedMetadata {
+            mtime: before.mtime,
+            size: before.total_size,
+        },
+        &limits,
+    )
+    .expect_err("read-only");
+    assert!(matches!(err, FileContentError::ReadOnly));
+
+    // Restore writeable so tempdir cleanup succeeds.
+    #[allow(clippy::permissions_set_readonly_false)]
+    {
+        let mut perms = std::fs::metadata(&target).expect("metadata").permissions();
+        perms.set_readonly(false);
+        let _ = std::fs::set_permissions(&target, perms);
+    }
+}
+
+#[test]
+fn write_text_file_rejects_deny_rule_targets() {
+    let dir = tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".git")).expect("create .git");
+    write_at(dir.path(), ".git/HEAD", b"ref: refs/heads/main\n");
+
+    let limits = ContentLimits::default();
+    let err = write_text_file(
+        dir.path(),
+        Path::new(".git/HEAD"),
+        "ref: refs/heads/feature\n",
+        Encoding::Utf8,
+        Newline::Lf,
+        false,
+        ExpectedMetadata { mtime: 0, size: 0 },
+        &limits,
+    )
+    .expect_err("deny");
+    assert!(matches!(err, FileContentError::Denied));
+}
+
+#[test]
+fn write_binary_byte_replaces_a_single_byte_in_place() {
+    let dir = tempdir().expect("tempdir");
+    let payload: Vec<u8> = (0u8..16).collect();
+    write_at(dir.path(), "bin.dat", &payload);
+
+    let limits = ContentLimits::default();
+    let before = read_binary_chunk(dir.path(), Path::new("bin.dat"), 0, 16, &limits).expect("read");
+
+    let outcome = write_binary_byte(
+        dir.path(),
+        Path::new("bin.dat"),
+        4,
+        0xAB,
+        ExpectedMetadata {
+            mtime: before.mtime,
+            size: before.total_size,
+        },
+    )
+    .expect("write");
+    assert_eq!(
+        outcome.new_size, 16,
+        "single-byte replace must not change file size"
+    );
+
+    let after = std::fs::read(dir.path().join("bin.dat")).expect("re-read");
+    assert_eq!(after[4], 0xAB);
+    assert_eq!(after.len(), 16);
+    // Other bytes must be untouched.
+    for i in [0usize, 3, 5, 15] {
+        assert_eq!(after[i], i as u8);
+    }
+}
+
+#[test]
+fn write_binary_byte_returns_out_of_range_for_offset_at_or_beyond_size() {
+    let dir = tempdir().expect("tempdir");
+    write_at(dir.path(), "tiny.dat", &[0xCAu8, 0xFE]);
+
+    let limits = ContentLimits::default();
+    let before = read_binary_chunk(dir.path(), Path::new("tiny.dat"), 0, 2, &limits).expect("read");
+
+    let err = write_binary_byte(
+        dir.path(),
+        Path::new("tiny.dat"),
+        2,
+        0x00,
+        ExpectedMetadata {
+            mtime: before.mtime,
+            size: before.total_size,
+        },
+    )
+    .expect_err("oor");
+    match err {
+        FileContentError::OutOfRange { offset, size } => {
+            assert_eq!(offset, 2);
+            assert_eq!(size, 2);
+        }
+        other => panic!("expected OutOfRange, got {other:?}"),
+    }
+}
+
+#[test]
+fn write_binary_byte_rejects_conflict_and_deny() {
+    let dir = tempdir().expect("tempdir");
+    write_at(dir.path(), "data.bin", &[0u8, 1, 2, 3]);
+
+    let conflict_err = write_binary_byte(
+        dir.path(),
+        Path::new("data.bin"),
+        1,
+        0xFF,
+        ExpectedMetadata { mtime: 0, size: 99 },
+    )
+    .expect_err("conflict");
+    assert!(matches!(conflict_err, FileContentError::Conflict { .. }));
+
+    std::fs::create_dir_all(dir.path().join(".gwt")).expect("create .gwt");
+    write_at(dir.path(), ".gwt/state.bin", &[0u8; 8]);
+    let deny_err = write_binary_byte(
+        dir.path(),
+        Path::new(".gwt/state.bin"),
+        0,
+        0x42,
+        ExpectedMetadata { mtime: 0, size: 0 },
+    )
+    .expect_err("deny");
+    assert!(matches!(deny_err, FileContentError::Denied));
 }


### PR DESCRIPTION
## Summary

- SPEC-2006 amendment Phase 2 (File Content Write Domain) として、File Tree window が選択ファイルを編集 → Save する backend を追加します。Phase 1 (PR #2755 + #2756 merged) で実装した read-only viewer に対し、テキスト編集 + hex byte 編集 (replace only) を支える write API、atomic write (tmp+rename)、外部変更 conflict 検出、encoding+newline 保持を提供します。
- GUI 統合 (dirty marker / Ctrl+S / Discard modal / Conflict modal / read-only バッジ / hex byte 編集 affordance / undo) は SPEC-2009 Phase 2 amendment が所有し、本 PR の wire contract を frontend から消費する形で別 PR で実装します。

## Changes

- `crates/gwt/src/file_content.rs`: `Newline { Lf | Crlf }` 型 + `ExpectedMetadata { mtime, size }` を追加。`read_text_file` の `TextResult` に `mtime` / `has_bom` / `newline` / `read_only` を、`BinaryChunk` に `mtime` / `read_only` を追加 (Save 時の conflict 検査と read-only バッジに必要)。`write_text_file(root, path, text, encoding, newline, has_bom, expected, limits)` を atomic write (tmp + rename) で実装し、BOM 再付与、LF/CRLF 復元、Shift-JIS/EUC-JP encoding 保持、UTF-8 mapping 失敗時の `EncodingFallback` 集計を含む。`write_binary_byte(root, path, offset, byte, expected)` を seek+write で 1 byte だけ in-place 置換する (100 MiB 級 binary を rewrite せずに済むため direct write を選び、surface が 1 byte に限定されることで partial-write damage を最小化)。`FileContentError` に `Conflict { current_mtime, current_size }` / `ReadOnly` / `OutOfRange { offset, size }` を追加し、deny rule の再評価は read path と同じ `is_relative_denied` を共有する。
- `crates/gwt/src/protocol.rs`: `SaveFileContent` (FrontendEvent) を追加 (text / hex 両モード単一 enum)。`FileContentSaved` / `FileContentSaveError` (BackendEvent) + `FileContentSaveErrorKind` enum (Denied / Conflict / ReadOnly / OutOfRange / TooLarge / IoError / NotAFile / WindowNotFound / WindowMismatch) を追加。既存 `FileContentText` / `FileContentHex` に `mtime` / `has_bom` / `newline` / `read_only` を defaults 付きで追加 (後方互換)。
- `crates/gwt/src/app_runtime/mod.rs`: `load_file_content_event` を `resolve_file_tree_root` 経由の共通パスに refactor し、Phase 1 / Phase 2 で worktree root 解決を共有する。`save_file_content_event` を追加し、`write_text_file` / `write_binary_byte` を呼んで全 error を `FileContentSaveErrorKind` に struct mapping する。WebSocket dispatch に `SaveFileContent` を接続。
- `crates/gwt/src/main.rs`: 既存 `tests::loaders_and_wizard_entrypoints_cover_success_and_error_paths` を extend し、`save_file_content_event` の WindowNotFound / WindowMismatch / Conflict / OutOfRange をカバー (text save success path は file_content_test 側で round-trip 検証)。
- `crates/gwt/src/lib.rs`: 新型 `write_text_file` / `write_binary_byte` / `Newline` / `ExpectedMetadata` / `WriteOutcome` / `FileContentMode` / `FileContentErrorKind` / `FileContentSaveErrorKind` を re-export する。
- `crates/gwt/tests/file_content_test.rs`: Phase 2 RED→GREEN テスト 10 件追加。CRLF/BOM/mtime 検出、UTF-8 LF / BOM + CRLF / Shift-JIS + EUC-JP write round-trip、Conflict on mtime mismatch、ReadOnly、deny rule、`write_binary_byte` 1 byte replace / OutOfRange / Conflict + Denied。既存 14 テストの後方互換も確認。

## Testing

- [x] `cargo fmt -- --check` — 差分なし
- [x] `cargo test -p gwt-core -p gwt --all-features` — 51 testsuites 全 PASS。`file_content_test` は 24 件 (Phase 1 14 + Phase 2 新規 10)、`loaders_and_wizard_entrypoints` extension で `save_file_content_event` の 4 経路カバー。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning 0 (write_text_file の 8 引数に `#[allow(clippy::too_many_arguments)]`、テストの `set_readonly(false)` に `#[allow(clippy::permissions_set_readonly_false)]` を最小範囲で適用)
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — 成功
- [x] commitlint pass (`feat(file-tree)`)

## Closing Issues

- None

## Related Issues / Links

- #2006 — SPEC-2006: ファイルツリーブラウザ。本 PR で 2026-05-18 Amendment (Phase 2 File Content Write Domain) を実装。
- #2009 — SPEC-2009: リポジトリブラウザウィンドウ。Phase 2 amendment (GUI dirty marker / Save / Discard modal / Conflict modal / read-only バッジ / hex byte 編集 / undo) は本 PR の wire contract を消費する形で別 PR で実装予定。
- #2755 — feat(file-tree): add file content read domain (Phase 1 backend、merged into develop)
- #2756 — feat(file-tree): add worktree picker, split viewer, and hex mode (Phase 1 frontend、merged into develop)

## Checklist

- [x] Tests added/updated (24 unit tests in `file_content_test.rs` + extended `loaders_and_wizard_entrypoints` integration test)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated — User-facing change は本 PR では発生しない (backend domain のみ)。SPEC-2006 amendment を更新済み。GUI 側 amendment で初めて user-visible になる。
- [ ] Migration/backfill plan included — Schema/data 変更なし。新 wire contract は新 variant + defaults 付き既存 variant 拡張で後方互換性 100%。
- [x] CHANGELOG impact considered — `feat:` で minor bump 対象。breaking change なし。

## Risk / Impact

- **Affected areas**: `crates/gwt` の file_content domain (read API 拡張 + write API 新設)、protocol.rs (wire contract 追加)、app_runtime.rs (save handler 追加)、main.rs (test extension)。既存挙動への変更は load_file_content_event の root 解決を `resolve_file_tree_root` ヘルパに集約した点のみ (Phase 1 と同じセマンティクス)。
- **Rollback plan**: 単純な revert で復旧可能。新規 wire contract は追加のみで、Phase 1 GUI (PR #2756 merged) との互換性を `#[serde(default)]` で維持しているため frontend 側は読み飛ばし。

## Notes

- write_binary_byte は atomic ではなく direct seek+write を採用しています。理由は 100 MiB 級 binary を 1 byte 変更のたびに rewrite するコストを避けるためで、書込み surface が 1 byte に限定されることで partial-write damage は当該 byte に限られます。NFR-007 (< 50 ms 目安) を満たすために必要な判断です。
- text save の atomic write は `.<basename>.gwt-edit-tmp.<pid>.<nonce>` の同 directory tmp ファイル経由で rename します。cross-device rename は repo 内に閉じる前提 (deny rule で外に出ない) のため OS の atomic 保証に依存します。
- `EncodingFallback { lost_chars }` は encoding_rs が HTML numeric reference に置換した文字を数えて返します。Shift-JIS / EUC-JP で表現できない Unicode 文字 (例: 絵文字) を含む text を save しようとした場合に GUI で warning を出すための情報です。
- read 系 BackendEvent の新 field (`mtime` / `has_bom` / `newline` / `read_only`) は `#[serde(default)]` 付きで追加しているため、未更新の frontend ビルドが本 PR をマージしたあとに古い JSON を送ってきても serde は default 値で fill in します。Save 系 (FrontendEvent::SaveFileContent) は新 variant 追加のみで既存 dispatch を壊しません。
