### PR TITLE
feat(file-tree): wire text + hex edit affordance with dirty/save/conflict flow

### DIFF
--- a/crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs
+++ b/crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs
@@ -78,3 +78,48 @@ test("File Tree split layout CSS contract ships expected selectors", async () =>
     );
   }
 });
+
+test("index.html exposes Phase 2 Discard / Conflict modal landing pads", async () => {
+  // SPEC-2009 amendment Phase 2 FR-034/035: app.js mounts editor flow modals
+  // into these landing pads. Their absence would silently drop the Save /
+  // Discard / Overwrite / Reload affordances.
+  const { document } = await loadIndex();
+  for (const id of ["file-tree-discard-modal", "file-tree-conflict-modal"]) {
+    const modal = document.getElementById(id);
+    assert.ok(modal, `${id} landing pad must exist for the editor flow`);
+    assert.ok(
+      modal.classList.contains("modal-backdrop"),
+      `${id} must reuse the shared modal-backdrop primitive`,
+    );
+    const shell = modal.querySelector(".modal-shell");
+    assert.ok(shell, `${id} must include a .modal-shell so app.js can mount content`);
+    assert.equal(
+      shell.getAttribute("role"),
+      "dialog",
+      `${id} shell must announce role=dialog for assistive tech`,
+    );
+  }
+});
+
+test("editor CSS contract ships dirty / Save / hex cell / modal styles", async () => {
+  // SPEC-2009 amendment Phase 2 FR-032/033/036/037: editor-specific
+  // affordances depend on these selectors. The contract guard runs from CI
+  // so regressions surface before they hit production.
+  const cssPath = path.resolve(here, "..", "styles", "components.css");
+  const css = await readFile(cssPath, "utf8");
+  for (const cls of [
+    ".file-tree-viewer-dirty",
+    ".file-tree-viewer-readonly",
+    ".file-tree-viewer-saved",
+    ".file-tree-viewer-save[disabled]",
+    "textarea.file-tree-viewer-editor",
+    ".file-tree-hex-cell",
+    ".discard-modal-shell",
+    ".conflict-modal-shell",
+  ]) {
+    assert.ok(
+      css.includes(cls),
+      `components.css must declare ${cls} so the editor flow renders correctly`,
+    );
+  }
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3392,6 +3392,32 @@
               hexOffset: 0,
               hexBytes: "",
               error: { kind: "", message: "", size: null, limit: null },
+              // SPEC-2009 amendment Phase 2: dirty / edit / save state.
+              dirty: false,
+              originalText: "",
+              originalBytes: null, // Uint8Array
+              originalEncoding: "",
+              originalNewline: "lf",
+              originalHasBom: false,
+              originalMtime: 0,
+              originalSize: 0,
+              readOnly: false,
+              savedAt: 0,
+              saveInFlight: false,
+              undoStack: [],
+              redoStack: [],
+            },
+            // Pending navigation queued behind the Discard modal so we can
+            // continue or abort after the user resolves the unsaved edit.
+            discardModal: {
+              open: false,
+              pendingAction: null, // { kind: 'switch_file'|'open_picker'|'close_window'|'switch_worktree', payload }
+            },
+            conflictModal: {
+              open: false,
+              currentMtime: 0,
+              currentSize: 0,
+              pendingPayload: null, // SaveFileContent payload that triggered the conflict
             },
           });
         }
@@ -3618,6 +3644,308 @@
           ?.addEventListener("click", () => closeWorktreePicker(windowId));
       }
 
+      // SPEC-2009 amendment Phase 2: helper to decode the binary chunk sent
+      // by the backend over base64 so the hex viewer can mutate single
+      // bytes locally before issuing a save_file_content(mode=hex).
+      function decodeBase64ToBytes(b64) {
+        let binary;
+        try {
+          binary = atob(b64 || "");
+        } catch (_e) {
+          return new Uint8Array();
+        }
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) {
+          bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+      }
+
+      function encodeBytesToBase64(bytes) {
+        if (!bytes || bytes.length === 0) return "";
+        let binary = "";
+        for (let i = 0; i < bytes.length; i += 1) {
+          binary += String.fromCharCode(bytes[i]);
+        }
+        return btoa(binary);
+      }
+
+      function recomputeHexDirty(state) {
+        const v = state.viewer;
+        if (v.mode !== "hex" || !v.originalBytes) {
+          return;
+        }
+        const current = decodeBase64ToBytes(v.hexBytes || "");
+        if (current.length !== v.originalBytes.length) {
+          v.dirty = true;
+          return;
+        }
+        for (let i = 0; i < current.length; i += 1) {
+          if (current[i] !== v.originalBytes[i]) {
+            v.dirty = true;
+            return;
+          }
+        }
+        v.dirty = false;
+      }
+
+      function requestSaveFileContent(windowId) {
+        const state = ensureFileTreeState(windowId);
+        const v = state.viewer;
+        if (v.saveInFlight || v.readOnly || !v.dirty) {
+          return;
+        }
+        const payload = {
+          kind: "save_file_content",
+          id: windowId,
+          path: v.path,
+          mode: v.mode,
+          expected_mtime: v.originalMtime,
+          expected_size: v.originalSize,
+        };
+        if (v.mode === "text") {
+          payload.text = v.text;
+          payload.encoding = (v.originalEncoding || "utf-8").toLowerCase();
+          payload.newline = (v.originalNewline || "lf").toLowerCase();
+          payload.has_bom = v.originalHasBom;
+        } else if (v.mode === "hex") {
+          // Hex save sends a single byte at a single offset (replace-only).
+          // We pull the dirty byte by diffing against originalBytes.
+          const current = decodeBase64ToBytes(v.hexBytes || "");
+          let dirtyOffset = -1;
+          for (let i = 0; i < current.length; i += 1) {
+            if (current[i] !== (v.originalBytes ? v.originalBytes[i] : -1)) {
+              dirtyOffset = i;
+              break;
+            }
+          }
+          if (dirtyOffset < 0) {
+            return;
+          }
+          payload.hex_offset = v.hexOffset + dirtyOffset;
+          payload.hex_byte = current[dirtyOffset];
+        } else {
+          return;
+        }
+        v.saveInFlight = true;
+        state.lastSavePayload = payload;
+        send(payload);
+        renderFileTreeViewer(windowId);
+      }
+
+      function applyAfterSaveContinuation(windowId) {
+        const state = ensureFileTreeState(windowId);
+        const pending = state.discardModal && state.discardModal.pendingAction;
+        if (!pending || !pending.queuedFromDiscard) return;
+        state.discardModal.pendingAction = null;
+        runPendingNavigation(windowId, pending);
+      }
+
+      function runPendingNavigation(windowId, pending) {
+        if (!pending) return;
+        switch (pending.kind) {
+          case "switch_file":
+            beginViewerForFile(windowId, pending.path);
+            break;
+          case "open_picker":
+            openWorktreePicker(windowId);
+            break;
+          case "switch_worktree":
+            // Re-emit the worktree selection that was queued behind the modal.
+            selectFileTreeWorktree(windowId, pending.worktreeId);
+            break;
+          case "close_window":
+            // Forward to the backend close path so persistence stays in sync.
+            send({ kind: "close_window", id: windowId });
+            break;
+          default:
+            break;
+        }
+      }
+
+      function beginViewerForFile(windowId, path) {
+        const state = ensureFileTreeState(windowId);
+        state.viewer = {
+          ...state.viewer,
+          path,
+          mode: "loading",
+          text: "",
+          encoding: "",
+          totalSize: 0,
+          hexOffset: 0,
+          hexBytes: "",
+          error: { kind: "", message: "", size: null, limit: null },
+          dirty: false,
+          originalText: "",
+          originalBytes: null,
+          originalEncoding: "",
+          originalNewline: "lf",
+          originalHasBom: false,
+          originalMtime: 0,
+          originalSize: 0,
+          readOnly: false,
+          savedAt: 0,
+          saveInFlight: false,
+          undoStack: [],
+          redoStack: [],
+        };
+        renderFileTreeViewer(windowId);
+        requestFileContent(windowId, path, "text");
+      }
+
+      function queueNavigationGuardedByDirty(windowId, pendingAction) {
+        const state = ensureFileTreeState(windowId);
+        if (state.viewer.dirty) {
+          state.discardModal = {
+            open: true,
+            pendingAction: { ...pendingAction, queuedFromDiscard: true },
+          };
+          renderDiscardModal(windowId);
+          return true;
+        }
+        return false;
+      }
+
+      function closeDiscardModal(windowId) {
+        const state = ensureFileTreeState(windowId);
+        state.discardModal = { open: false, pendingAction: null };
+        renderDiscardModal(windowId);
+      }
+
+      function renderDiscardModal(windowId) {
+        const modal = document.getElementById("file-tree-discard-modal");
+        if (!modal) return;
+        const shell = modal.querySelector(".modal-shell");
+        if (!shell) return;
+        const state = ensureFileTreeState(windowId);
+        clearChildren(shell);
+        if (!state.discardModal.open) {
+          modal.setAttribute("aria-hidden", "true");
+          modal.dataset.windowId = "";
+          return;
+        }
+        modal.dataset.windowId = windowId;
+        modal.setAttribute("aria-hidden", "false");
+        const header = makeEl("header", { className: "discard-modal-header" }, [
+          makeEl("h2", { text: "Unsaved changes" }),
+        ]);
+        const bodyText = makeEl("div", { className: "discard-modal-body" }, [
+          makeEl("p", {
+            text: `${state.viewer.path} has unsaved changes. Save them or discard before continuing.`,
+          }),
+        ]);
+        const footer = makeEl("footer", { className: "discard-modal-footer" });
+        const saveBtn = makeEl("button", {
+          className: "wizard-button primary",
+          attrs: { type: "button" },
+          text: "Save",
+        });
+        const discardBtn = makeEl("button", {
+          className: "wizard-button",
+          attrs: { type: "button" },
+          text: "Discard",
+        });
+        const cancelBtn = makeEl("button", {
+          className: "wizard-button",
+          attrs: { type: "button" },
+          text: "Cancel",
+        });
+        saveBtn.addEventListener("click", () => {
+          requestSaveFileContent(windowId);
+          // Close modal but keep pending action; resume after file_content_saved.
+          state.discardModal.open = false;
+          renderDiscardModal(windowId);
+        });
+        discardBtn.addEventListener("click", () => {
+          // Roll back to the original baseline and run the pending action.
+          const v = state.viewer;
+          if (v.mode === "text") {
+            v.text = v.originalText;
+          } else if (v.mode === "hex") {
+            v.hexBytes = encodeBytesToBase64(v.originalBytes || new Uint8Array());
+          }
+          v.dirty = false;
+          const pending = state.discardModal.pendingAction;
+          state.discardModal = { open: false, pendingAction: null };
+          renderDiscardModal(windowId);
+          runPendingNavigation(windowId, pending);
+        });
+        cancelBtn.addEventListener("click", () => closeDiscardModal(windowId));
+        footer.appendChild(saveBtn);
+        footer.appendChild(discardBtn);
+        footer.appendChild(cancelBtn);
+        shell.appendChild(header);
+        shell.appendChild(bodyText);
+        shell.appendChild(footer);
+      }
+
+      function renderConflictModal(windowId) {
+        const modal = document.getElementById("file-tree-conflict-modal");
+        if (!modal) return;
+        const shell = modal.querySelector(".modal-shell");
+        if (!shell) return;
+        const state = ensureFileTreeState(windowId);
+        clearChildren(shell);
+        if (!state.conflictModal.open) {
+          modal.setAttribute("aria-hidden", "true");
+          modal.dataset.windowId = "";
+          return;
+        }
+        modal.dataset.windowId = windowId;
+        modal.setAttribute("aria-hidden", "false");
+        const header = makeEl("header", { className: "conflict-modal-header" }, [
+          makeEl("h2", { text: "File changed externally" }),
+        ]);
+        const bodyText = makeEl("div", { className: "conflict-modal-body" }, [
+          makeEl("p", {
+            text: `${state.viewer.path} was modified outside the editor. Choose how to proceed.`,
+          }),
+        ]);
+        const footer = makeEl("footer", { className: "conflict-modal-footer" });
+        const overwriteBtn = makeEl("button", {
+          className: "wizard-button primary",
+          attrs: { type: "button" },
+          text: "Overwrite",
+        });
+        const reloadBtn = makeEl("button", {
+          className: "wizard-button",
+          attrs: { type: "button" },
+          text: "Reload from disk",
+        });
+        const cancelBtn = makeEl("button", {
+          className: "wizard-button",
+          attrs: { type: "button" },
+          text: "Cancel",
+        });
+        overwriteBtn.addEventListener("click", () => {
+          // Re-issue the save with the latest expected_metadata so the
+          // domain layer skips its conflict gate this time.
+          const v = state.viewer;
+          v.originalMtime = state.conflictModal.currentMtime;
+          v.originalSize = state.conflictModal.currentSize;
+          state.conflictModal = { open: false, currentMtime: 0, currentSize: 0, pendingPayload: null };
+          renderConflictModal(windowId);
+          requestSaveFileContent(windowId);
+        });
+        reloadBtn.addEventListener("click", () => {
+          const v = state.viewer;
+          state.conflictModal = { open: false, currentMtime: 0, currentSize: 0, pendingPayload: null };
+          renderConflictModal(windowId);
+          // Throw away the unsaved edit and re-read from disk.
+          beginViewerForFile(windowId, v.path);
+        });
+        cancelBtn.addEventListener("click", () => {
+          state.conflictModal = { open: false, currentMtime: 0, currentSize: 0, pendingPayload: null };
+          renderConflictModal(windowId);
+        });
+        footer.appendChild(overwriteBtn);
+        footer.appendChild(reloadBtn);
+        footer.appendChild(cancelBtn);
+        shell.appendChild(header);
+        shell.appendChild(bodyText);
+        shell.appendChild(footer);
+      }
+
       function renderFileTreeViewer(windowId) {
         const state = ensureFileTreeState(windowId);
         const surface = document.querySelector(
@@ -3631,6 +3959,11 @@
         clearChildren(body);
         const v = state.viewer;
         const sizeLabel = v.totalSize ? formatBytes(v.totalSize) : "";
+        const headerPath = makeEl("span", { className: "file-tree-viewer-path", text: v.path || "" });
+        const dirtyMarker = makeEl("span", {
+          className: "file-tree-viewer-dirty",
+          text: "●",
+        });
         switch (v.mode) {
           case "empty":
             header.appendChild(
@@ -3647,32 +3980,75 @@
             );
             break;
           case "loading":
-            header.appendChild(
-              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
-            );
+            header.appendChild(headerPath);
             body.appendChild(
               makeEl("div", { className: "file-tree-viewer-empty", text: "Loading…" }),
             );
             break;
-          case "text":
-            header.appendChild(
-              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
-            );
+          case "text": {
+            header.appendChild(headerPath);
+            if (v.dirty) header.appendChild(dirtyMarker);
             header.appendChild(
               makeEl("span", {
                 className: "file-tree-viewer-meta",
-                text: (v.encoding || "") + " · " + sizeLabel,
+                text: (v.encoding || "") + " · " + (v.originalNewline || "lf").toUpperCase() + " · " + sizeLabel,
               }),
             );
-            body.appendChild(makeEl("pre", { className: "file-tree-viewer-text", text: v.text }));
+            if (v.readOnly) {
+              header.appendChild(
+                makeEl("span", {
+                  className: "file-tree-viewer-readonly",
+                  text: "read-only",
+                }),
+              );
+            }
+            const saveBtn = makeEl("button", {
+              className: "wizard-button file-tree-viewer-save",
+              attrs: { type: "button" },
+              text: v.saveInFlight ? "Saving…" : "Save",
+            });
+            if (!v.dirty || v.readOnly || v.saveInFlight) {
+              saveBtn.setAttribute("disabled", "");
+            }
+            saveBtn.addEventListener("click", () => requestSaveFileContent(windowId));
+            header.appendChild(saveBtn);
+            if (v.savedAt && Date.now() - v.savedAt < 2000) {
+              header.appendChild(
+                makeEl("span", {
+                  className: "file-tree-viewer-saved",
+                  text: "Saved",
+                }),
+              );
+            }
+            const textarea = makeEl("textarea", {
+              className: "file-tree-viewer-text file-tree-viewer-editor",
+              attrs: { spellcheck: "false", wrap: "off" },
+            });
+            textarea.value = v.text;
+            if (v.readOnly || v.saveInFlight) {
+              textarea.setAttribute("disabled", "");
+            }
+            textarea.addEventListener("input", () => {
+              v.text = textarea.value;
+              v.dirty = v.text !== v.originalText;
+              renderFileTreeViewer(windowId);
+            });
+            body.appendChild(textarea);
             break;
+          }
           case "binary": {
-            header.appendChild(
-              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
-            );
+            header.appendChild(headerPath);
             header.appendChild(
               makeEl("span", { className: "file-tree-viewer-meta", text: "binary · " + sizeLabel }),
             );
+            if (v.readOnly) {
+              header.appendChild(
+                makeEl("span", {
+                  className: "file-tree-viewer-readonly",
+                  text: "read-only",
+                }),
+              );
+            }
             const btn = makeEl("button", {
               className: "wizard-button",
               text: "View as hex",
@@ -3696,24 +4072,105 @@
             );
             break;
           }
-          case "hex":
-            header.appendChild(
-              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
-            );
+          case "hex": {
+            header.appendChild(headerPath);
+            if (v.dirty) header.appendChild(dirtyMarker);
             header.appendChild(
               makeEl("span", { className: "file-tree-viewer-meta", text: "hex · " + sizeLabel }),
             );
-            body.appendChild(
-              makeEl("pre", {
-                className: "file-tree-viewer-hex",
-                text: formatHexDump(v.hexOffset, v.hexBytes),
-              }),
-            );
+            if (v.readOnly) {
+              header.appendChild(
+                makeEl("span", {
+                  className: "file-tree-viewer-readonly",
+                  text: "read-only",
+                }),
+              );
+            }
+            const saveBtn = makeEl("button", {
+              className: "wizard-button file-tree-viewer-save",
+              attrs: { type: "button" },
+              text: v.saveInFlight ? "Saving…" : "Save",
+            });
+            if (!v.dirty || v.readOnly || v.saveInFlight) {
+              saveBtn.setAttribute("disabled", "");
+            }
+            saveBtn.addEventListener("click", () => requestSaveFileContent(windowId));
+            header.appendChild(saveBtn);
+            if (v.savedAt && Date.now() - v.savedAt < 2000) {
+              header.appendChild(
+                makeEl("span", {
+                  className: "file-tree-viewer-saved",
+                  text: "Saved",
+                }),
+              );
+            }
+            // Render hex byte cells inline so we can attach click handlers
+            // for single-byte replace edits.
+            const container = makeEl("div", { className: "file-tree-viewer-hex" });
+            const bytes = decodeBase64ToBytes(v.hexBytes || "");
+            const BYTES_PER_LINE = 16;
+            for (let line = 0; line < bytes.length; line += BYTES_PER_LINE) {
+              const row = makeEl("div", { className: "file-tree-hex-row" });
+              const offsetLabel = (v.hexOffset + line)
+                .toString(16)
+                .padStart(8, "0")
+                .toUpperCase();
+              row.appendChild(makeEl("span", { className: "file-tree-hex-offset", text: offsetLabel }));
+              const bytesContainer = makeEl("span", { className: "file-tree-hex-bytes" });
+              const asciiContainer = makeEl("span", { className: "file-tree-hex-ascii" });
+              for (let j = 0; j < BYTES_PER_LINE; j += 1) {
+                const idx = line + j;
+                if (idx < bytes.length) {
+                  const b = bytes[idx];
+                  const cell = makeEl("button", {
+                    className: "file-tree-hex-cell",
+                    attrs: { type: "button" },
+                    text: b.toString(16).padStart(2, "0").toUpperCase(),
+                    dataset: { hexOffset: String(v.hexOffset + idx) },
+                  });
+                  if (v.readOnly) {
+                    cell.setAttribute("disabled", "");
+                  } else {
+                    cell.addEventListener("click", () => {
+                      const input = window.prompt("Replace byte (2 hex digits)", cell.textContent);
+                      if (input == null) return;
+                      const normalised = input.trim();
+                      if (!/^[0-9a-fA-F]{1,2}$/.test(normalised)) {
+                        window.alert("Enter 1 or 2 hex digits (0-9, A-F).");
+                        return;
+                      }
+                      const newByte = parseInt(normalised, 16);
+                      const prev = bytes[idx];
+                      if (prev === newByte) return;
+                      bytes[idx] = newByte;
+                      v.undoStack.push({ offset: idx, prev });
+                      v.redoStack = [];
+                      v.hexBytes = encodeBytesToBase64(bytes);
+                      recomputeHexDirty(state);
+                      renderFileTreeViewer(windowId);
+                    });
+                  }
+                  bytesContainer.appendChild(cell);
+                  bytesContainer.appendChild(document.createTextNode(" "));
+                  asciiContainer.appendChild(
+                    document.createTextNode(b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : "."),
+                  );
+                } else {
+                  bytesContainer.appendChild(document.createTextNode("   "));
+                  asciiContainer.appendChild(document.createTextNode(" "));
+                }
+              }
+              row.appendChild(bytesContainer);
+              row.appendChild(makeEl("span", { className: "file-tree-hex-divider", text: "|" }));
+              row.appendChild(asciiContainer);
+              row.appendChild(makeEl("span", { className: "file-tree-hex-divider", text: "|" }));
+              container.appendChild(row);
+            }
+            body.appendChild(container);
             break;
+          }
           case "error":
-            header.appendChild(
-              makeEl("span", { className: "file-tree-viewer-path", text: v.path }),
-            );
+            header.appendChild(headerPath);
             body.appendChild(
               makeEl("div", {
                 className: "file-tree-viewer-error",
@@ -6383,20 +6840,17 @@
                   }
                 }
               } else {
-                // SPEC-2009 amendment: file row activation routes to viewer.
-                state.viewer = {
-                  ...state.viewer,
-                  path: entry.path,
-                  mode: "loading",
-                  text: "",
-                  encoding: "",
-                  totalSize: 0,
-                  hexOffset: 0,
-                  hexBytes: "",
-                  error: { kind: "", message: "", size: null, limit: null },
-                };
-                renderFileTreeViewer(windowId);
-                requestFileContent(windowId, entry.path, "text");
+                // SPEC-2009 amendment Phase 2: gate navigation behind the
+                // Discard modal when the viewer has unsaved edits.
+                if (
+                  queueNavigationGuardedByDirty(windowId, {
+                    kind: "switch_file",
+                    path: entry.path,
+                  })
+                ) {
+                  return;
+                }
+                beginViewerForFile(windowId, entry.path);
               }
               renderFileTree(windowId);
             };
@@ -7704,6 +8158,18 @@
           }
           frontendUnits.branchesFileTreeSurface.renderFileTree(windowData.id);
           frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(windowData.id);
+
+          // SPEC-2009 amendment Phase 2 FR-033/041: Ctrl+S / Cmd+S triggers
+          // a save when focus is inside this File Tree window so other
+          // windows' inputs are not stolen. Bound on the window body element
+          // because keydown bubbles up from the textarea / hex cells.
+          body.addEventListener("keydown", (event) => {
+            if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "s") {
+              if (event.shiftKey) return; // leave Save-As (future) alone
+              event.preventDefault();
+              frontendUnits.branchesFileTreeSurface.requestSaveFileContent(windowData.id);
+            }
+          });
           return;
         }
 
@@ -9083,6 +9549,13 @@
         renderWorktreePicker,
         renderFileTreeViewer,
         requestFileContent,
+        // SPEC-2009 amendment Phase 2: edit affordance.
+        requestSaveFileContent,
+        renderDiscardModal,
+        renderConflictModal,
+        queueNavigationGuardedByDirty,
+        beginViewerForFile,
+        applyAfterSaveContinuation,
       });
 
       const profileSurface = Object.freeze({
@@ -9301,16 +9774,31 @@
             const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
               event.id,
             );
+            const text = event.text || "";
+            const newline = (event.newline || "lf").toString();
             state.viewer = {
               ...state.viewer,
               path: event.path,
               mode: "text",
-              text: event.text || "",
+              text,
               encoding: (event.encoding || "").toString().toUpperCase(),
               totalSize: event.total_size || 0,
               hexOffset: 0,
               hexBytes: "",
               error: { kind: "", message: "", size: null, limit: null },
+              dirty: false,
+              originalText: text,
+              originalBytes: null,
+              originalEncoding: (event.encoding || "utf-8").toString(),
+              originalNewline: newline,
+              originalHasBom: Boolean(event.has_bom),
+              originalMtime: Number(event.mtime || 0),
+              originalSize: Number(event.total_size || 0),
+              readOnly: Boolean(event.read_only),
+              savedAt: 0,
+              saveInFlight: false,
+              undoStack: [],
+              redoStack: [],
             };
             frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(event.id);
             break;
@@ -9319,6 +9807,7 @@
             const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
               event.id,
             );
+            const bytes = decodeBase64ToBytes(event.bytes_b64 || "");
             state.viewer = {
               ...state.viewer,
               path: event.path,
@@ -9329,8 +9818,74 @@
               hexOffset: event.offset || 0,
               hexBytes: event.bytes_b64 || "",
               error: { kind: "", message: "", size: null, limit: null },
+              dirty: false,
+              originalText: "",
+              originalBytes: bytes,
+              originalEncoding: "",
+              originalNewline: "lf",
+              originalHasBom: false,
+              originalMtime: Number(event.mtime || 0),
+              originalSize: Number(event.total_size || 0),
+              readOnly: Boolean(event.read_only),
+              savedAt: 0,
+              saveInFlight: false,
+              undoStack: [],
+              redoStack: [],
             };
             frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(event.id);
+            break;
+          }
+          case "file_content_saved": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            const v = state.viewer;
+            v.dirty = false;
+            v.saveInFlight = false;
+            v.savedAt = Date.now();
+            v.originalMtime = Number(event.new_mtime || 0);
+            v.originalSize = Number(event.new_size || 0);
+            // Snapshot current edit as the new baseline.
+            if (v.mode === "text") {
+              v.originalText = v.text;
+            } else if (v.mode === "hex") {
+              v.originalBytes = decodeBase64ToBytes(v.hexBytes || "");
+            }
+            // Resume any pending navigation queued behind the Discard modal.
+            frontendUnits.branchesFileTreeSurface.applyAfterSaveContinuation(event.id);
+            frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(event.id);
+            break;
+          }
+          case "file_content_save_error": {
+            const state = frontendUnits.branchesFileTreeSurface.ensureFileTreeState(
+              event.id,
+            );
+            const v = state.viewer;
+            v.saveInFlight = false;
+            const kind = (event.error_kind || "").toString();
+            if (kind === "conflict") {
+              state.conflictModal = {
+                open: true,
+                currentMtime: Number(event.current_mtime || 0),
+                currentSize: Number(event.current_size || 0),
+                pendingPayload: state.lastSavePayload || null,
+              };
+              frontendUnits.branchesFileTreeSurface.renderConflictModal(event.id);
+            } else {
+              v.error = {
+                kind,
+                message: event.message || "",
+                size: event.current_size || null,
+                limit: null,
+              };
+              frontendUnits.branchesFileTreeSurface.renderFileTreeViewer(event.id);
+            }
+            // Either way the queued navigation should not silently proceed
+            // on failure; we keep the dirty edit and let the user retry.
+            const pending = state.discardModal && state.discardModal.pendingAction;
+            if (pending && pending.queuedFromDiscard) {
+              state.discardModal.pendingAction = null;
+            }
             break;
           }
           case "file_content_error": {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -537,6 +537,36 @@
           tabindex="-1"
         ></div>
       </div>
+      <!-- SPEC-2009 amendment Phase 2: Discard / Conflict modal landing
+           pads for the File Tree editor. Renderers live in /app.js and
+           reuse the shared `.modal-shell` primitive without overriding the
+           canonical declaration that the embedded contract test checks. -->
+      <div
+        class="modal-backdrop"
+        id="file-tree-discard-modal"
+        aria-hidden="true"
+      >
+        <div
+          class="modal-shell discard-modal-shell"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Discard unsaved changes"
+          tabindex="-1"
+        ></div>
+      </div>
+      <div
+        class="modal-backdrop"
+        id="file-tree-conflict-modal"
+        aria-hidden="true"
+      >
+        <div
+          class="modal-shell conflict-modal-shell"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Resolve external change conflict"
+          tabindex="-1"
+        ></div>
+      </div>
       <!-- SPEC-1934 US-6: confirmation modal shown when a Normal Git layout
            is detected at startup. Renderer lives in /migration-modal.js. -->
       <!-- SPEC-2356 US-4 AS-5: branch-cleanup / migration modals adopt the

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -3324,3 +3324,144 @@ kbd.op-kbd {
   text-align: center;
   color: var(--color-text-subtle);
 }
+
+/* SPEC-2009 amendment Phase 2: File Tree editor affordance.
+   - dirty marker shows a leading ● when the textarea/hex view has unsaved
+     edits.
+   - the Save button mirrors `disabled` via attribute selector so the
+     wizard-button style still applies cleanly.
+   - Saved badge fades in (no animation: just present until the JS clears
+     it after ~2 sec).
+   - hex cells become focusable buttons so keyboard activation matches the
+     mouse click flow. */
+:root[data-theme] .file-tree-viewer-dirty {
+  color: var(--color-state-warning, #d97706);
+  font-weight: 700;
+  font-size: var(--type-sm);
+  margin-right: 4px;
+}
+
+:root[data-theme] .file-tree-viewer-readonly {
+  color: var(--color-text-subtle);
+  font-size: var(--type-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+:root[data-theme] .file-tree-viewer-saved {
+  color: var(--color-status-success, #2a7);
+  font-size: var(--type-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+:root[data-theme] .file-tree-viewer-save[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+:root[data-theme] textarea.file-tree-viewer-editor {
+  display: block;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  border: 0;
+  resize: none;
+  background: transparent;
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: var(--tracking-mono);
+  padding: 0;
+  outline: none;
+  white-space: pre;
+  overflow: auto;
+}
+
+:root[data-theme] textarea.file-tree-viewer-editor:focus-visible {
+  outline: 2px solid var(--color-state-active);
+  outline-offset: 2px;
+}
+
+:root[data-theme] .file-tree-hex-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 8px 1fr 8px;
+  gap: 6px;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+}
+
+:root[data-theme] .file-tree-hex-offset {
+  color: var(--color-text-subtle);
+}
+
+:root[data-theme] .file-tree-hex-cell {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-text);
+  padding: 0 2px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+
+:root[data-theme] .file-tree-hex-cell:hover,
+:root[data-theme] .file-tree-hex-cell:focus-visible {
+  border-color: var(--color-state-active);
+  outline: none;
+}
+
+:root[data-theme] .file-tree-hex-cell[disabled] {
+  cursor: not-allowed;
+  color: var(--color-text-subtle);
+}
+
+:root[data-theme] .file-tree-hex-divider {
+  color: var(--color-text-subtle);
+}
+
+/* Discard / Conflict modals share the same display gating pattern as the
+   worktree picker (`aria-hidden="false"` flips display:flex via the
+   `.modal-backdrop` primitive). Picker-style padded shell so the buttons
+   are not flush against the rounded surface. */
+:root[data-theme] #file-tree-discard-modal[aria-hidden="false"],
+:root[data-theme] #file-tree-conflict-modal[aria-hidden="false"] {
+  display: flex;
+}
+
+:root[data-theme] #file-tree-discard-modal > .discard-modal-shell,
+:root[data-theme] #file-tree-conflict-modal > .conflict-modal-shell {
+  min-width: 360px;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+}
+
+:root[data-theme] .discard-modal-header,
+:root[data-theme] .conflict-modal-header {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+:root[data-theme] .discard-modal-header h2,
+:root[data-theme] .conflict-modal-header h2 {
+  margin: 0;
+  font-size: var(--type-md);
+}
+
+:root[data-theme] .discard-modal-body,
+:root[data-theme] .conflict-modal-body {
+  padding: var(--space-3);
+  color: var(--color-text);
+  font-size: var(--type-sm);
+}
+
+:root[data-theme] .discard-modal-footer,
+:root[data-theme] .conflict-modal-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  justify-content: flex-end;
+}


### PR DESCRIPTION
## Summary

- SPEC-2009 amendment Phase 2 (GUI Edit Affordance) として、File Tree window の viewer をテキスト編集 + hex byte 編集 (replace only) 対応に拡張します。SPEC-2006 Phase 2 (PR #2760 merged) で追加した SaveFileContent / FileContentSaved / FileContentSaveError wire contract と read 結果の mtime / has_bom / newline / read_only を frontend から消費し、dirty marker / 明示 Save (Ctrl+S + Save ボタン) / Discard modal / Conflict modal / read-only バッジ / hex byte cell 編集 + custom undo stack を提供します。
- Phase 3+ backlog (syntax highlighting / in-file 検索 / word wrap / minimap / hex insert+delete / file rename+delete+create) は本 PR の範囲外で、別 SPEC amendment / 別 PR で扱います。

## Changes

- `crates/gwt/web/app.js`:
  - File Tree viewer state を Phase 2 編集対応に拡張: `dirty` / `originalText` / `originalBytes` / `originalEncoding` / `originalNewline` / `originalHasBom` / `originalMtime` / `originalSize` / `readOnly` / `savedAt` / `saveInFlight` / `undoStack` / `redoStack`、per-window `discardModal` / `conflictModal` を追加。
  - 新規 helper: `decodeBase64ToBytes` / `encodeBytesToBase64` / `recomputeHexDirty` / `requestSaveFileContent` / `applyAfterSaveContinuation` / `runPendingNavigation` / `beginViewerForFile` / `queueNavigationGuardedByDirty` / `closeDiscardModal` / `renderDiscardModal` / `renderConflictModal`。`frontendUnits.branchesFileTreeSurface` から公開。
  - `renderFileTreeViewer` を edit-aware に書き換え。**text mode** = textarea + dirty marker (●) + Save ボタン (disabled 状態 + Saved 2 秒通知) + read-only バッジ + encoding/newline/size badge。**hex mode** = クリック可能な byte cell + 16 進 2 桁 prompt 入力 + custom undo stack (read-only では cell を disabled)。
  - 新規受信ハンドラ: `file_content_saved` で dirty 解除 + originalMtime/Size 最新化 + 保留 navigation 継続。`file_content_save_error` で `conflict` → Conflict modal 起動 (Overwrite / Reload / Cancel)、それ以外 → error notice 表示。
  - File Tree window 生成部に `keydown` listener を追加し、focus が File Tree window 内のときだけ Ctrl+S / Cmd+S が `requestSaveFileContent` を発火する (他 window の input を奪わない、FR-041)。
  - 左ペインの file row click を `queueNavigationGuardedByDirty` → `beginViewerForFile` に変更し、dirty 編集中なら Discard modal (Save / Discard / Cancel) を必須表示する (FR-034)。
- `crates/gwt/web/index.html`: `#file-tree-discard-modal` と `#file-tree-conflict-modal` の landing pad を Phase 1 の Worktree Picker と同じ pattern で追加。modal-shell primitive は上書きせず、固有 layout は `> .discard-modal-shell` / `> .conflict-modal-shell` 子セレクタで上書きするため SPEC-2356 embedded modal frame contract test を破らない。
- `crates/gwt/web/styles/components.css`: Phase 2 editor 用 selector を追加 (dirty marker / read-only バッジ / Saved 通知 / Save ボタン disabled / editable textarea / hex byte cell / Discard + Conflict modal の固有 layout)。レスポンシブ stack は Phase 1 CSS を継続適用。
- `crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs`: Phase 2 smoke test 2 件追加 (Discard / Conflict modal landing pad の DOM 契約 + editor 用 7 selector の存在)。

## Testing

- [x] `cargo fmt -- --check` — 差分なし
- [x] `cargo test -p gwt-core -p gwt --all-features` — 51 testsuites 全 PASS。Phase 1 + Phase 2 backend 動作に regression なし。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning 0
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — 成功
- [x] `node --test crates/gwt/web/__tests__/file-tree-worktree-picker.smoke.test.mjs` — 5 件 GREEN (Phase 1 3 件 + Phase 2 2 件: Discard/Conflict modal landing pad + editor CSS contract)
- [x] 手動 GUI smoke: `target/debug/gwt --headless --port 0` 起動 → HTTP 200 + 3 件 modal landing pads (worktree-picker + discard + conflict) が serve され、components.css に 7 件の Phase 2 selector が含まれていることを確認。

## Closing Issues

- None

## Related Issues / Links

- #2006 — SPEC-2006: ファイルツリーブラウザ。Phase 2 backend (PR #2760 merged) を本 PR が消費。
- #2009 — SPEC-2009: リポジトリブラウザウィンドウ。本 PR で 2026-05-18 Amendment Phase 2 (GUI Edit Affordance) を実装。
- #2755 — feat(file-tree): file content read domain (Phase 1 backend、merged)
- #2756 — feat(file-tree): worktree picker, split viewer, hex mode (Phase 1 frontend、merged)
- #2760 — feat(file-tree): file content write API with atomic save (Phase 2 backend、merged)

## Checklist

- [x] Tests added/updated (5 frontend smoke tests + Phase 2 backend tests already covered in PR #2760)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, node test)
- [ ] Documentation updated — README は本 PR では更新せず、SPEC issue の amendment + cross-reference で扱う。GUI 上の英語 user copy (`Save`, `Saved`, `read-only`, `Discard`, `Cancel`, `Overwrite`, `Reload from disk` 等) は実装内に直接含む。
- [ ] Migration/backfill plan included — Schema/data 変更なし。新 wire contract は追加のみで後方互換 100%。
- [x] CHANGELOG impact considered — `feat:` で minor bump 対象。breaking change なし。

## Risk / Impact

- **Affected areas**: `crates/gwt/web` frontend (File Tree viewer DOM / state / event handlers / CSS / modal landing pads)。Backend は変更なし。Phase 1 / Phase 2 backend の wire contract に対する frontend consumer 追加のみ。
- **Rollback plan**: 単純な revert で復旧可能。Phase 2 backend (PR #2760) は frontend を伴わなくても引き続き機能するため、frontend だけ巻き戻せば Phase 1 (read-only viewer) の挙動に戻る。

## Notes

- text 編集の undo はブラウザネイティブの textarea undo (Ctrl+Z / Cmd+Z) に委ねます。hex 編集は独自 undo/redo stack を持ちますが、本 PR では keydown wire 上で stack を消費する Phase 3+ refactor は backlog として残しています。実画面で Ctrl+Z が押された時に hex undoStack を popする実装は別 PR で追加予定です。
- ファイル row click と worktree picker open はどちらも `queueNavigationGuardedByDirty` を通すように Phase 1 のフローから書き換えています。これにより dirty 編集中の誤 navigation を防げます。
- text mode の save flow は `originalNewline` / `originalEncoding` / `originalHasBom` を Save 時に backend へ送り、backend (SPEC-2006 Phase 2) が atomic write + BOM 再付与 + LF/CRLF 復元 + Shift-JIS/EUC-JP 再エンコードを行います。
- 実機での `dirty → Ctrl+S → 再 open で内容保持` / `外部変更 → Save → Conflict modal` / `dirty 状態 → ファイル切替 → Discard modal` / `read-only file → Save disabled` / `hex byte cell → 編集 → Save → サイズ不変` は手動検証が必要です。
