### PR TITLE
fix(runtime): harden runtime event delivery follow-up

### DIFF
--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -491,10 +491,7 @@ mod tests {
         let queue = Mutex::new(None);
 
         assert!(runtime_daemon_publish_sender_from(&queue, |_receiver| {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "spawn failed",
-            ))
+            Err(std::io::Error::other("spawn failed"))
         })
         .is_none());
         assert!(queue.lock().expect("queue").is_none());

--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 use std::sync::mpsc as std_mpsc;
+#[cfg(unix)]
+use std::sync::Mutex;
 
 use super::{
     close_window_from_workspace, should_auto_close_agent_window, AppRuntime, BackendEvent,
@@ -80,6 +82,7 @@ impl AppRuntime {
     ) -> Vec<OutboundEvent> {
         let Some(_address) = self.window_lookup.get(&id).cloned() else {
             self.remove_window_state_tracking(&id);
+            self.mark_agent_session_stopped(&id);
             self.deregister_pty_writer(&id);
             self.runtimes.remove(&id);
             self.window_details.remove(&id);
@@ -247,26 +250,44 @@ enum RuntimeDaemonPublishEnqueueError {
 
 #[cfg(unix)]
 static RUNTIME_DAEMON_PUBLISH_QUEUE: std::sync::OnceLock<
-    Option<std_mpsc::SyncSender<RuntimeDaemonPublish>>,
+    Mutex<Option<std_mpsc::SyncSender<RuntimeDaemonPublish>>>,
 > = std::sync::OnceLock::new();
 
 #[cfg(unix)]
-fn runtime_daemon_publish_sender() -> Option<&'static std_mpsc::SyncSender<RuntimeDaemonPublish>> {
-    RUNTIME_DAEMON_PUBLISH_QUEUE
-        .get_or_init(|| {
-            let (sender, receiver) = std_mpsc::sync_channel(RUNTIME_DAEMON_PUBLISH_QUEUE_CAPACITY);
-            match std::thread::Builder::new()
-                .name("gwt-runtime-daemon-publish-worker".to_string())
-                .spawn(move || run_runtime_daemon_publish_worker(receiver))
-            {
-                Ok(_handle) => Some(sender),
-                Err(err) => {
-                    tracing::debug!(error = %err, "runtime daemon publish worker spawn failed");
-                    None
-                }
-            }
-        })
-        .as_ref()
+fn runtime_daemon_publish_sender() -> Option<std_mpsc::SyncSender<RuntimeDaemonPublish>> {
+    let queue = RUNTIME_DAEMON_PUBLISH_QUEUE.get_or_init(|| Mutex::new(None));
+    runtime_daemon_publish_sender_from(queue, |receiver| {
+        std::thread::Builder::new()
+            .name("gwt-runtime-daemon-publish-worker".to_string())
+            .spawn(move || run_runtime_daemon_publish_worker(receiver))
+            .map(|_handle| ())
+    })
+}
+
+#[cfg(unix)]
+fn runtime_daemon_publish_sender_from(
+    queue: &Mutex<Option<std_mpsc::SyncSender<RuntimeDaemonPublish>>>,
+    spawn_worker: impl FnOnce(std_mpsc::Receiver<RuntimeDaemonPublish>) -> std::io::Result<()>,
+) -> Option<std_mpsc::SyncSender<RuntimeDaemonPublish>> {
+    let Ok(mut queue) = queue.lock() else {
+        tracing::debug!("runtime daemon publish queue lock poisoned");
+        return None;
+    };
+    if let Some(sender) = queue.as_ref() {
+        return Some(sender.clone());
+    }
+
+    let (sender, receiver) = std_mpsc::sync_channel(RUNTIME_DAEMON_PUBLISH_QUEUE_CAPACITY);
+    match spawn_worker(receiver) {
+        Ok(()) => {
+            *queue = Some(sender.clone());
+            Some(sender)
+        }
+        Err(err) => {
+            tracing::debug!(error = %err, "runtime daemon publish worker spawn failed");
+            None
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -292,7 +313,7 @@ fn enqueue_runtime_daemon_publish(publish: RuntimeDaemonPublish) {
     let Some(sender) = runtime_daemon_publish_sender() else {
         return;
     };
-    if let Err(err) = try_enqueue_runtime_daemon_publish(sender, publish) {
+    if let Err(err) = try_enqueue_runtime_daemon_publish(&sender, publish) {
         tracing::debug!(
             ?err,
             "runtime daemon publish queue rejected event (non-fatal)"
@@ -425,11 +446,12 @@ mod tests {
     use std::path::PathBuf;
 
     #[cfg(unix)]
-    use std::sync::mpsc;
+    use std::sync::{mpsc, Mutex};
 
     #[cfg(unix)]
     use super::{
-        try_enqueue_runtime_daemon_publish, RuntimeDaemonPublish, RuntimeDaemonPublishEnqueueError,
+        runtime_daemon_publish_sender_from, try_enqueue_runtime_daemon_publish,
+        RuntimeDaemonPublish, RuntimeDaemonPublishEnqueueError,
     };
     #[cfg(unix)]
     use crate::WindowProcessStatus;
@@ -461,5 +483,28 @@ mod tests {
             ),
             Err(RuntimeDaemonPublishEnqueueError::Full)
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_daemon_publish_sender_retries_after_spawn_failure() {
+        let queue = Mutex::new(None);
+
+        assert!(runtime_daemon_publish_sender_from(&queue, |_receiver| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "spawn failed",
+            ))
+        })
+        .is_none());
+        assert!(queue.lock().expect("queue").is_none());
+
+        assert!(runtime_daemon_publish_sender_from(&queue, |_receiver| Ok(())).is_some());
+        assert!(queue.lock().expect("queue").is_some());
+
+        assert!(runtime_daemon_publish_sender_from(&queue, |_receiver| {
+            panic!("sender should be reused without spawning a second worker")
+        })
+        .is_some());
     }
 }

--- a/crates/gwt/src/cli/env/tests.rs
+++ b/crates/gwt/src/cli/env/tests.rs
@@ -210,6 +210,7 @@ fn default_cli_env_construction_does_not_touch_issue_client_factory() {
 
 #[test]
 fn new_for_hooks_keeps_detached_cache_root() {
+    let _env_lock = crate::env_test_lock().lock().expect("env lock");
     let env = DefaultCliEnv::new_for_hooks();
 
     assert_eq!(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1338,8 +1338,24 @@ mod tests {
             "app_runtime/mod.rs should not regain runtime output handling"
         );
         assert!(
+            !runtime_mod_source.contains("fn handle_runtime_status"),
+            "app_runtime/mod.rs should not regain runtime status handling"
+        );
+        assert!(
+            !runtime_mod_source.contains("fn handle_runtime_hook_event"),
+            "app_runtime/mod.rs should not regain runtime hook handling"
+        );
+        assert!(
+            !runtime_mod_source.contains("fn handle_daemon_runtime_"),
+            "app_runtime/mod.rs should not regain daemon runtime event handlers"
+        );
+        assert!(
             !runtime_mod_source.contains("enum RuntimeDaemonPublish"),
             "app_runtime/mod.rs should not regain the daemon publish queue"
+        );
+        assert!(
+            !runtime_mod_source.contains("RuntimeDaemonPublish"),
+            "app_runtime/mod.rs should not regain daemon publish queue ownership"
         );
     }
 
@@ -3021,6 +3037,36 @@ mod tests {
             BackendEvent::TerminalStatus { ref detail, .. }
                 if detail.as_deref() == Some("Window not found")
         ));
+    }
+
+    #[test]
+    fn runtime_status_missing_window_cleans_active_agent_session() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo,
+            ProjectKind::NonRepo,
+            &[WindowPreset::Claude],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let stale_id = "tab-1::stale-agent".to_string();
+        runtime.active_agent_sessions.insert(
+            stale_id.clone(),
+            sample_active_agent_session("tab-1", &stale_id),
+        );
+        runtime
+            .window_details
+            .insert(stale_id.clone(), "stale detail".to_string());
+
+        let events =
+            runtime.handle_runtime_status(stale_id.clone(), WindowProcessStatus::Exited, None);
+
+        assert!(events.is_empty());
+        assert!(!runtime.active_agent_sessions.contains_key(&stale_id));
+        assert!(!runtime.window_details.contains_key(&stale_id));
     }
 
     #[test]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1269,8 +1269,8 @@ pub const BACKEND_EVENT_POLICIES: &[BackendEventPolicy] = &[
     ),
     BackendEventPolicy::new(
         "file_content_saved",
-        BackendEventDeliveryClass::EphemeralStatus,
-        BackendEventBackpressurePolicy::BestEffort,
+        BackendEventDeliveryClass::Snapshot,
+        BackendEventBackpressurePolicy::ClientScopedSnapshot,
     ),
     BackendEventPolicy::new(
         "file_content_save_error",
@@ -1673,7 +1673,7 @@ mod tests {
     use super::{
         backend_event_policy, BackendEvent, BackendEventBackpressurePolicy,
         BackendEventDeliveryClass, BranchEntriesPhase, FrontendEvent, ProfileEntryView,
-        ProfileEnvEntryView, ProfileSnapshotView, UiTracePayload,
+        ProfileEnvEntryView, ProfileSnapshotView, UiTracePayload, BACKEND_EVENT_POLICIES,
     };
 
     #[test]
@@ -1870,40 +1870,29 @@ mod tests {
             runtime_hook_event.backpressure,
             BackendEventBackpressurePolicy::BestEffort
         );
+
+        let file_content_saved =
+            backend_event_policy("file_content_saved").expect("file_content_saved policy");
+        assert_eq!(
+            file_content_saved.delivery,
+            BackendEventDeliveryClass::Snapshot
+        );
+        assert_eq!(
+            file_content_saved.backpressure,
+            BackendEventBackpressurePolicy::ClientScopedSnapshot
+        );
     }
 
     #[test]
     fn frontend_coalescing_contract_matches_backend_latest_wins_policy() {
         let frontend_dispatcher = include_str!("../web/socket-receive-dispatcher.js");
 
-        for kind in [
-            "workspace_state",
-            "active_work_projection",
-            "window_list",
-            "project_index_status",
-            "launch_wizard_state",
-            "update_state",
-        ] {
-            let policy = backend_event_policy(kind).expect("backend event policy");
-            assert!(
+        for policy in BACKEND_EVENT_POLICIES {
+            assert_eq!(
+                frontend_dispatcher.contains(&format!("\"{}\"", policy.kind)),
                 policy.coalesces_on_frontend(),
-                "{kind} should be latest-wins in backend policy"
-            );
-            assert!(
-                frontend_dispatcher.contains(&format!("\"{kind}\"")),
-                "{kind} should be listed in DEFAULT_COALESCE_KINDS"
-            );
-        }
-
-        for kind in ["terminal_output", "terminal_snapshot", "runtime_hook_event"] {
-            let policy = backend_event_policy(kind).expect("backend event policy");
-            assert!(
-                !policy.coalesces_on_frontend(),
-                "{kind} must preserve delivery semantics on the frontend"
-            );
-            assert!(
-                !frontend_dispatcher.contains(&format!("\"{kind}\"")),
-                "{kind} must not be listed in DEFAULT_COALESCE_KINDS"
+                "{} backend policy disagrees with DEFAULT_COALESCE_KINDS",
+                policy.kind
             );
         }
 


### PR DESCRIPTION
## Summary

- Fixes the valid CodeRabbit follow-up findings from merged PR #2765 around runtime event cleanup, daemon publish initialization, and file save delivery policy.
- Keeps daemon IPC wire schema and frontend event names unchanged while tightening tests that guard runtime-event ownership and frontend/backend policy drift.

## Changes

- `crates/gwt/src/app_runtime/runtime_events.rs`: clear active agent session state when status cleanup sees a missing window, and make the Unix daemon publish queue retryable after worker spawn failure.
- `crates/gwt/src/protocol.rs`: classify `file_content_saved` as a reliable snapshot event and make the frontend coalescing contract test iterate all backend policies.
- `crates/gwt/src/main.rs`: strengthen runtime event ownership guards and add regression coverage for stale active sessions on missing-window status cleanup.
- `crates/gwt/src/cli/env/tests.rs`: add the shared env test lock to a cache-root test exposed as order-sensitive by full local verification.

## Testing

- [x] `cargo test -p gwt --lib backend_event_policy_classifies_high_risk_delivery_contract` — passed.
- [x] `cargo test -p gwt --lib frontend_coalescing_contract_matches_backend_latest_wins_policy` — passed.
- [x] `cargo test -p gwt --bin gwt runtime_status_missing_window_cleans_active_agent_session` — passed.
- [x] `cargo test -p gwt --bin gwt runtime_event_handlers_are_owned_by_runtime_events_module` — passed.
- [x] `cargo test -p gwt --bin gwt runtime_status_helpers_cover_sessions_auto_close_and_launch_errors` — passed.
- [x] `cargo test -p gwt runtime_daemon_events` — passed.
- [x] `node --test crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt --lib --all-features` — passed after adding the env test lock.
- [x] `cargo test -p gwt-core --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.
- [ ] `cargo test -p gwt --all-features` — attempted; stopped after existing app_runtime workspace/title-sync tests stayed active for several minutes. Focused changed tests and `gwt --lib --all-features` passed; `Clippy & Rustfmt` Linux CI failure from the first push was fixed in a second commit.

## Closing Issues

None

## Related Issues / Links

- #2765
- #2077
- #2012

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-2077 tasks T-233/T-235 updated; no user-facing docs)
- [x] Migration/backfill plan included (no schema/data migration)
- [x] CHANGELOG impact considered (patch-level `fix:`)

## Context

- PR #2765 merged before CodeRabbit's actionable comments were resolved, so this PR carries the review follow-up as a separate patch.

## Risk / Impact

- **Affected areas**: runtime status cleanup, Unix daemon runtime event publish queue, backend event delivery policy metadata, and tests.
- **Rollback plan**: revert this PR; no migration or wire-format rollback is required.

