### PR TITLE
fix(gui): preserve terminal mouse wheel reporting

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1852,6 +1852,7 @@ mod tests {
             "/operator-shell.js",
             "/focus-trap.js",
             "/terminal-context-menu.js",
+            "/terminal-wheel-scroll.js",
             "/custom-agent-env-editor.js",
         ] {
             assert!(

--- a/crates/gwt/web/__tests__/terminal-wheel-scroll.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-wheel-scroll.test.mjs
@@ -9,6 +9,7 @@ import test from "node:test";
 
 import {
   createTerminalWheelScrollController,
+  isTerminalMouseTrackingActive,
   wheelDeltaToScrollLines,
 } from "../terminal-wheel-scroll.js";
 
@@ -21,6 +22,21 @@ test("Windows terminal plain wheel scrolls xterm scrollback and stops bubbling",
   assert.equal(event.defaultPrevented, true);
   assert.deepEqual(fixture.scrollCalls, [3]);
   assert.equal(fixture.bubbledWheelCount, 0);
+  fixture.dispose();
+});
+
+test("Windows terminal mouse tracking lets xterm receive plain wheel events", () => {
+  const fixture = mountFixture({
+    isWindowsHost: () => true,
+    terminalOptions: { modes: { mouseTrackingMode: "any" } },
+  });
+  const event = wheelEvent(fixture.window, { deltaY: 96 });
+
+  fixture.terminalRoot.dispatchEvent(event);
+
+  assert.equal(event.defaultPrevented, false);
+  assert.deepEqual(fixture.scrollCalls, []);
+  assert.equal(fixture.bubbledWheelCount, 1);
   fixture.dispose();
 });
 
@@ -71,7 +87,13 @@ test("wheelDeltaToScrollLines handles pixel, line, and page units", () => {
   assert.equal(wheelDeltaToScrollLines({ deltaY: 0, deltaMode: 0 }), 0);
 });
 
-function mountFixture({ isWindowsHost }) {
+test("isTerminalMouseTrackingActive reads xterm public mouse tracking mode", () => {
+  assert.equal(isTerminalMouseTrackingActive({ modes: { mouseTrackingMode: "none" } }), false);
+  assert.equal(isTerminalMouseTrackingActive({ modes: { mouseTrackingMode: "vt200" } }), true);
+  assert.equal(isTerminalMouseTrackingActive({}), false);
+});
+
+function mountFixture({ isWindowsHost, terminalOptions = {} }) {
   const terminalRoot = new FakeTerminalRoot();
   const scrollCalls = [];
   let bubbledWheelCount = 0;
@@ -83,6 +105,7 @@ function mountFixture({ isWindowsHost }) {
     terminalRoot,
     terminal: {
       scrollLines: (lines) => scrollCalls.push(lines),
+      ...terminalOptions,
     },
     window: { navigator: { platform: "Win32" } },
     isWindowsHost,

--- a/crates/gwt/web/terminal-wheel-scroll.js
+++ b/crates/gwt/web/terminal-wheel-scroll.js
@@ -38,6 +38,11 @@ export function shouldOverrideTerminalWheel(event, { window, isWindowsHost: host
   return check();
 }
 
+export function isTerminalMouseTrackingActive(terminal) {
+  const mouseTrackingMode = terminal?.modes?.mouseTrackingMode;
+  return typeof mouseTrackingMode === "string" && mouseTrackingMode !== "none";
+}
+
 export function createTerminalWheelScrollController({
   terminalRoot,
   terminal,
@@ -58,7 +63,8 @@ export function createTerminalWheelScrollController({
       !shouldOverrideTerminalWheel(event, {
         window,
         isWindowsHost: hostCheck,
-      })
+      }) ||
+      isTerminalMouseTrackingActive(terminal)
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

- Preserve xterm mouse-wheel reporting for terminal applications that enable mouse tracking.
- Add contract coverage for the `/terminal-wheel-scroll.js` root module registration.

## Changes

- `crates/gwt/web/terminal-wheel-scroll.js`: skips the Windows scrollback override when `terminal.modes.mouseTrackingMode` is active so xterm can deliver wheel events to the running TUI.
- `crates/gwt/web/__tests__/terminal-wheel-scroll.test.mjs`: covers mouse-tracking bypass behavior and the public xterm mode reader.
- `crates/gwt/src/embedded_web.rs`: includes `/terminal-wheel-scroll.js` in the root JS module registry contract list.

## Testing

- [x] `node --test crates/gwt/web/__tests__/terminal-wheel-scroll.test.mjs` — 7 tests passed.
- [x] `npm run test:frontend-bundle` — all checked frontend modules parsed successfully.
- [x] `cargo test -p gwt embedded_web::tests::embedded_web_root_js_module_registry_covers_app_imports --all-features -- --exact` — registry contract test passed.
- [x] `cargo fmt -- --check` — formatting passed.
- [x] `git diff --check` — whitespace check passed.
- [x] `git push -u origin work/20260518-0827` — pre-push CI-equivalent checks passed, including filtered line coverage 90.44% against the 90.00% threshold.

## Closing Issues

None

## Related Issues / Links

- #2768

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (N/A: internal terminal event handling only)
- [ ] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level bug fix, no breaking change)

## Context

- This follows up on automated review feedback from #2768. The original Windows wheel override fixed scrollback but could also intercept wheel input before xterm delivered it to TUIs using mouse tracking.

## Risk / Impact

- **Affected areas**: Windows terminal wheel handling when TUI mouse tracking is active.
- **Rollback plan**: Revert this PR if Windows terminal scrollback or TUI mouse-wheel behavior regresses.
