### PR TITLE
refactor(repo): retract develop worktree auto-select for bare layout

### DIFF
--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -46,9 +46,8 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
     }
     // Check if path itself is a bare repo (has HEAD + objects + refs)
     if path.join("HEAD").exists() && path.join("objects").exists() && path.join("refs").exists() {
-        let develop = find_develop_worktree(path.parent().unwrap_or(path));
         return RepoType::Bare {
-            develop_worktree: develop,
+            develop_worktree: None,
         };
     }
     // Check child directories for bare repos, worktrees, or normal repos
@@ -76,9 +75,12 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
             }
         }
         if found_bare {
-            let develop = find_develop_worktree(path);
+            // SPEC-1934 2026-05-20 Update FR-050: child scan で bare layout を
+            // 検出した場合、`develop` / `main` 等の worktree を auto-select しない。
+            // 呼び出し側 (`resolve_project_target`) が workspace home を返し、
+            // 実際の worktree 選択は Workspace Overview に委ねる。
             return RepoType::Bare {
-                develop_worktree: develop,
+                develop_worktree: None,
             };
         }
     }
@@ -96,6 +98,9 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
             };
         }
         if dot_git.is_file() {
+            // Subdir inside a linked worktree: resolve to the worktree root so
+            // a path like `<worktree>/src/foo` opens the worktree, not the
+            // workspace home (preserves SC-035 direct-pick semantics).
             return RepoType::Bare {
                 develop_worktree: Some(parent.to_path_buf()),
             };
@@ -104,31 +109,13 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
             && parent.join("objects").exists()
             && parent.join("refs").exists()
         {
-            let develop = find_develop_worktree(parent.parent().unwrap_or(parent));
             return RepoType::Bare {
-                develop_worktree: develop,
+                develop_worktree: None,
             };
         }
         current = parent.to_path_buf();
     }
     RepoType::NonRepo
-}
-
-/// Find a develop worktree in the given directory.
-/// Looks for a child directory named "develop" that has a .git worktree marker.
-fn find_develop_worktree(parent: &Path) -> Option<PathBuf> {
-    let develop = parent.join("develop");
-    if develop.is_dir() && develop.join(".git").exists() {
-        return Some(develop);
-    }
-    let mut worktrees = fs::read_dir(parent)
-        .ok()?
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir() && path.join(".git").is_file())
-        .collect::<Vec<_>>();
-    worktrees.sort();
-    worktrees.into_iter().next()
 }
 
 /// Derived filesystem target for creating a gwt project from a GitHub repo URL.
@@ -685,26 +672,37 @@ mod tests {
     }
 
     #[test]
-    fn detect_repo_type_prefers_any_child_worktree_when_develop_is_absent() {
+    fn detect_repo_type_returns_bare_with_none_for_child_scan() {
+        // SPEC-1934 2026-05-20 Update (FR-050): child scan で bare layout を
+        // 検出した場合、`develop` / `main` / 任意の worktree を auto-select する
+        // ロジックは撤回される。`Bare { develop_worktree: None }` を返し、
+        // routing 先は呼び出し側 (`resolve_project_target`) に委ねる。
         let tmp = tempfile::tempdir().unwrap();
         let bare_dir = tmp.path().join("repo.git");
         let main_worktree = tmp.path().join("main");
+        let develop_worktree = tmp.path().join("develop");
         gwt_core::process::hidden_command("git")
             .args(["init", "--bare", bare_dir.to_str().unwrap()])
             .output()
             .unwrap();
-        std::fs::create_dir_all(&main_worktree).unwrap();
-        std::fs::write(
-            main_worktree.join(".git"),
-            "gitdir: ../repo.git/worktrees/main\n",
-        )
-        .unwrap();
+        for wt in [&main_worktree, &develop_worktree] {
+            std::fs::create_dir_all(wt).unwrap();
+            std::fs::write(
+                wt.join(".git"),
+                format!(
+                    "gitdir: ../repo.git/worktrees/{}\n",
+                    wt.file_name().unwrap().to_string_lossy()
+                ),
+            )
+            .unwrap();
+        }
 
         assert_eq!(
             detect_repo_type(tmp.path()),
             RepoType::Bare {
-                develop_worktree: Some(main_worktree)
-            }
+                develop_worktree: None
+            },
+            "child scan must not auto-select develop or main worktrees (SPEC-1934 FR-050)"
         );
     }
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -888,6 +888,122 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
+    // SPEC-1934 2026-05-20 Update: Open Project Auto-Select Retraction
+    // US-7 / US-8 / FR-050 / FR-052 / SC-034..SC-037
+    // -------------------------------------------------------------------
+
+    fn make_worktree_marker(parent: &std::path::Path, name: &str) -> std::path::PathBuf {
+        let worktree = parent.join(name);
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: ../repo.git/worktrees/{name}\n"),
+        )
+        .unwrap();
+        std::fs::create_dir_all(parent.join("repo.git").join("worktrees").join(name)).unwrap();
+        worktree
+    }
+
+    #[test]
+    fn resolve_project_target_opens_workspace_home_for_bare_with_develop_worktree() {
+        // SC-034: workspace_home (= parent dir) を Open Project で選んだとき、
+        // `develop` worktree が存在しても auto-select せず、workspace_home を
+        // project_root として返す。これにより Workspace Overview が hub になる。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+        let _develop = make_worktree_marker(tmp.path(), "develop");
+
+        let target = super::resolve_project_target(tmp.path()).expect("bare workspace home target");
+
+        assert_eq!(target.kind, gwt::ProjectKind::Git);
+        assert!(!target.needs_migration);
+        assert_eq!(
+            target.project_root,
+            dunce::canonicalize(tmp.path()).unwrap(),
+            "Open Project on workspace home must not redirect to develop worktree (SC-034)"
+        );
+    }
+
+    #[test]
+    fn resolve_project_target_respects_direct_worktree_pick_under_bare() {
+        // SC-035: user が worktree dir を直接 Open Project で指定した場合は、
+        // workspace_home に rebasing せずその worktree を開く。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+        let develop = make_worktree_marker(tmp.path(), "develop");
+
+        let target = super::resolve_project_target(&develop).expect("direct worktree target");
+
+        assert_eq!(target.kind, gwt::ProjectKind::Git);
+        assert!(!target.needs_migration);
+        assert_eq!(
+            target.project_root,
+            dunce::canonicalize(&develop).unwrap(),
+            "Direct worktree pick must be honored, not rebased to workspace home (SC-035)"
+        );
+    }
+
+    #[test]
+    fn resolve_project_target_handles_bare_without_any_worktree() {
+        // SC-036: bare のみで worktree 0 件 (Clone Project 直後の状態) でも
+        // workspace_home を Git project として返す。empty state は Workspace
+        // Overview 側で描画する。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+
+        let target = super::resolve_project_target(tmp.path()).expect("bare-only target");
+
+        assert_eq!(target.kind, gwt::ProjectKind::Git);
+        assert!(!target.needs_migration);
+        assert_eq!(
+            target.project_root,
+            dunce::canonicalize(tmp.path()).unwrap(),
+            "Bare-only workspace home must open Workspace Overview (SC-036)"
+        );
+    }
+
+    #[test]
+    fn resolve_project_target_does_not_recreate_after_worktree_remove() {
+        // SC-037: develop worktree が削除された状態でも auto-repair / auto-create
+        // しない。bare layout のまま workspace_home を返す。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+
+        let before = super::resolve_project_target(tmp.path()).expect("first resolve");
+        assert_eq!(
+            before.project_root,
+            dunce::canonicalize(tmp.path()).unwrap()
+        );
+        assert!(
+            !tmp.path().join("develop").exists(),
+            "resolve must not create develop worktree side-effects (SC-037)"
+        );
+
+        let after = super::resolve_project_target(tmp.path()).expect("second resolve");
+        assert_eq!(after.project_root, before.project_root);
+        assert!(
+            !tmp.path().join("develop").exists(),
+            "repeated resolve must remain idempotent and side-effect free"
+        );
+    }
+
+    // -------------------------------------------------------------------
     // Issue #2054: gwt pr remote resolution must tolerate non-GitHub
     // `origin` and explicit env overrides.
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Open Project で workspace home (= bare repo の親 dir) を選んだ際に `develop/` worktree を auto-select する挙動 (commit `baa5ee0e6` 2026-04-03) を撤回し、workspace home を Git project として返して Workspace Overview (SPEC-2359) を hub にする。
- これは SPEC-1934 の 2026-05-15 Update (FR-049 / SC-032「Clone Project は local develop worktree を作らない」) を Open Project 側に展開する整合性修正であり、user の workspace モデル (bare repo は base ref host、ローカル main/master/develop worktree は不要・削除自由) と Open Project routing を整合させる。

## Context

- 観測: `~/Workbench/gwt/` を Open Project で選ぶと `~/Workbench/gwt/develop/` worktree が auto-select される
- 経路: `crates/gwt-git/src/repository.rs:119-132` `find_develop_worktree()` (commit `baa5ee0e6`) → `crates/gwt/src/runtime_support.rs:224-230` で `RepoType::Bare { develop_worktree: Some(_) }` を `project_root = worktree` に解決
- 不整合: SPEC-1934 2026-05-15 Update で Clone Project は local develop worktree を作らない仕様 (FR-049 / SC-032) になったが、Open Project の解決パスにはこの前提が反映されていなかった
- 判断: gwt-discussion で「ローカル main/master/develop worktree は作っても良いが auto-select は撤回する」「Open Project では Workspace Overview を hub として開く」「SPEC-1934 を reopen して改訂」を確定

## Changes

- `crates/gwt-git/src/repository.rs`:
  - `find_develop_worktree()` 関数を削除 (FR-050)
  - `detect_repo_type()` の child scan / `path` 自身が bare repo / parent walk で bare 自身検出の 3 経路で `develop_worktree: None` を返すよう変更
  - `.git` marker file 検出経路 (直接指定 / subdir 指定) は `develop_worktree: Some(worktree_root)` を維持し SC-035 (直接指定の尊重) を保つ
  - 既存テスト `detect_repo_type_prefers_any_child_worktree_when_develop_is_absent` を `detect_repo_type_returns_bare_with_none_for_child_scan` に書き換え
- `crates/gwt/src/runtime_support.rs`:
  - `resolve_project_target_opens_workspace_home_for_bare_with_develop_worktree` (SC-034) を追加
  - `resolve_project_target_respects_direct_worktree_pick_under_bare` (SC-035) を追加
  - `resolve_project_target_handles_bare_without_any_worktree` (SC-036) を追加
  - `resolve_project_target_does_not_recreate_after_worktree_remove` (SC-037) を追加
  - 既存の Bare+Some / Bare+None 分岐は維持 (候補 B 採用、セマンティクス再定義により touch 不要)

## Testing

- [x] `cargo test -p gwt-core -p gwt-git -p gwt --all-features` PASS (gwt: 677 lib + 383 bin + integration / gwt-core: 271 / gwt-git: 126)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual verify: `cargo run -p gwt --bin gwt` 起動後、`~/Workbench/gwt/` を Open Project で選択 → Workspace Overview が表示され、`~/Workbench/gwt/develop/` への redirect が発生しないことを目視確認 (frontend は touch していないので reviewer 側で 1 回確認推奨)

## Closing Issues

- Closes #1934

## Related Issues / Links

- SPEC-2359 (OPEN, Workspace / Start Work) — bare 検出時の routing 先 Workspace Overview を所有
- commit `baa5ee0e6` (2026-04-03 `feat: auto-select develop worktree for bare repo workspace`) — semantic revert 対象

## Checklist

- [x] Tests added/updated (4 つの受け入れシナリオ test を `runtime_support.rs` に追加、既存 `detect_repo_type` test を新仕様で書き換え)
- [x] Lint/format passed (`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`)
- [x] Documentation updated — SPEC-1934 の spec / plan / tasks に Amendment 2026-05-20 セクションを追加済み
- [ ] Migration/backfill plan included — 不要 (型シグネチャ維持、データ migration なし)
- [x] CHANGELOG impact considered — `refactor:` タイプで patch 相当。breaking 相当の動作変化なし (auto-select 撤回は内部 routing のみで public API シグネチャ不変)

## Risk / Impact

- **Affected areas**: Open Project の解決パス (`resolve_project_target`)、`detect_repo_type` の戻り値セマンティクス
- **Behavior change**:
  - workspace home を Open Project で選んだ際 develop worktree に自動 redirect されなくなる (Workspace Overview にとどまる)
  - 既存の develop worktree は **削除されない**。auto-select されないだけ
  - `~/Workbench/<project>/develop/` を直接 Open Project で選択した場合は引き続き develop worktree が開かれる
- **Rollback plan**: 本 commit (`66649e04f`) を revert すれば旧挙動 (auto-select) に戻る。後方互換性は SPEC-1934 2026-05-15 Update (FR-049) との整合を取った前提なので、revert 時は SPEC との不整合が再発する点に注意

## Notes

- 当初 SPEC plan で推奨した「`RepoType::Bare` を unit variant 化 (候補 A)」は実装段階で撤回。理由: `.git` marker file 直接指定 / subdir 指定の worktree 解決が壊れる。代わりに「field 維持、child scan のみ `develop_worktree: None`」(候補 B) を採用し、`develop_worktree: Some(_)` のセマンティクスを「auto-selected develop」から「marker 上で解決した worktree root」に再定義した。SPEC-1934 tasks セクションの T-301 / T-303 / T-306 に決定を反映済み。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bare repositories no longer automatically select a develop or main worktree when detected. This prevents unintended workspace redirection in bare repository layouts.

* **Tests**
  * Enhanced test coverage for bare repository and worktree resolution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->