### PR TITLE
fix+feat: v9.38.0 Windows GUI rescue + headless browser auto-open

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -103,11 +103,16 @@ gwt
 オペレーターは出力された URL を任意のブラウザで開いて操作します。
 
 ```bash
-gwt serve                              # 127.0.0.1、ランダムポート、手動オープン
-gwt serve --port 8787 --open           # 固定ポート + システムブラウザ自動起動
-gwt serve --bind 0.0.0.0 --port 8787   # LAN (VPN 越し含む) へ公開
+gwt serve                              # 127.0.0.1、ランダムポート、ブラウザ自動起動
+gwt serve --no-open                    # 同じ動作だがブラウザ自動起動を抑制 (CI / スクリプト用)
+gwt serve --port 8787                  # 固定ポート + ブラウザ自動起動
+gwt serve --bind 0.0.0.0 --port 8787   # LAN (VPN 越し含む) へ公開 + ブラウザ自動起動
 gwt --headless --port 8787             # `gwt serve --port 8787` と同じ
 ```
+
+既定でシステムブラウザが自動起動します。CI / 自動化で server だけ立ち上げ
+たい場合は `--no-open` を指定してください。`--open` は既存スクリプト互換性
+維持のため no-op flag として残しています。
 
 信頼境界は **LAN のみ** (VPN-extended LAN を含む) です。`gwt serve` には
 TLS 終端、認証ゲート、レート制限は組み込まれていません。`--bind` で

--- a/README.md
+++ b/README.md
@@ -105,11 +105,16 @@ opening a native window. The embedded HTTP / WebSocket server stays up and
 the operator opens the printed URL in any browser instead.
 
 ```bash
-gwt serve                              # 127.0.0.1, random port, manual open
-gwt serve --port 8787 --open           # fixed port + system browser
-gwt serve --bind 0.0.0.0 --port 8787   # share with the LAN (VPN-extended)
+gwt serve                              # 127.0.0.1, random port, auto-open browser
+gwt serve --no-open                    # same, but suppress the browser launch (CI / scripts)
+gwt serve --port 8787                  # fixed port + auto-open browser
+gwt serve --bind 0.0.0.0 --port 8787   # share with the LAN (VPN-extended), auto-open browser
 gwt --headless --port 8787             # same as `gwt serve --port 8787`
 ```
+
+The system browser is opened automatically by default. Pass `--no-open` for
+CI / automation use cases that only need the server running. `--open` is kept
+as a no-op flag for backward compatibility with existing scripts.
 
 Trust boundary: **LAN only** (including VPN-extended LAN). `gwt serve` does
 not ship TLS termination, an authentication gate, or rate limiting. Anyone

--- a/crates/gwt/src/cli/serve.rs
+++ b/crates/gwt/src/cli/serve.rs
@@ -22,7 +22,11 @@ use std::net::{IpAddr, Ipv4Addr};
 ///   GUI behaviour at `crates/gwt/src/embedded_server.rs`). User-provided
 ///   values are kept verbatim.
 /// - `open`: whether to spawn the system default browser at the served URL
-///   after the server is up.
+///   after the server is up. SPEC-1942 2026-05-20 Amendment (FR-095): the
+///   default is `true`, matching the common headless user journey of "start
+///   server, then open browser." `--no-open` is the explicit opt-out for
+///   CI / automation; `--open` is preserved as a no-op for backward
+///   compatibility with existing scripts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServeArgs {
     pub bind: IpAddr,
@@ -35,7 +39,7 @@ impl Default for ServeArgs {
         Self {
             bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
             port: 0,
-            open: false,
+            open: true,
         }
     }
 }
@@ -117,7 +121,13 @@ pub fn parse(args: &[String]) -> Result<ServeArgs, ServeParseError> {
                     .map_err(|_| ServeParseError::InvalidPort(value.clone()))?;
             }
             "--open" => {
+                // SPEC-1942 2026-05-20 Amendment: `--open` is now the default
+                // and kept as a no-op flag for backward compatibility so
+                // existing CI scripts that pass it explicitly keep working.
                 out.open = true;
+            }
+            "--no-open" => {
+                out.open = false;
             }
             other => return Err(ServeParseError::UnknownFlag(other.to_string())),
         }
@@ -133,12 +143,52 @@ mod tests {
         parts.iter().map(|s| s.to_string()).collect()
     }
 
+    // SPEC-1942 2026-05-20 Amendment: `--open` is now the default, so bare
+    // `gwt serve` should set `open: true`.
     #[test]
-    fn parse_serve_defaults_bind_to_loopback_and_port_to_zero_and_open_false() {
+    fn parse_serve_defaults_bind_to_loopback_and_port_to_zero_and_open_true() {
         let parsed = parse(&argv(&["serve"])).expect("serve parses with defaults");
         assert_eq!(parsed.bind, IpAddr::V4(Ipv4Addr::LOCALHOST));
         assert_eq!(parsed.port, 0);
-        assert!(!parsed.open);
+        assert!(
+            parsed.open,
+            "SPEC-1942 2026-05-20 Amendment: --open is now the default"
+        );
+    }
+
+    #[test]
+    fn parse_serve_no_open_overrides_default() {
+        let parsed =
+            parse(&argv(&["serve", "--no-open"])).expect("serve accepts --no-open as opt-out");
+        assert!(
+            !parsed.open,
+            "--no-open must suppress the new default browser auto-open"
+        );
+    }
+
+    // Backward compatibility: scripts that already pass `--open` continue to
+    // work. The flag is now a no-op but parsing must still succeed.
+    #[test]
+    fn parse_serve_open_flag_is_still_accepted_as_noop() {
+        let parsed =
+            parse(&argv(&["serve", "--open"])).expect("explicit --open must still be accepted");
+        assert!(
+            parsed.open,
+            "--open is now redundant with the default, but must remain accepted"
+        );
+    }
+
+    // `--open` and `--no-open` together: rightmost flag wins (matches
+    // SPEC-1942 2026-05-20 Amendment scenario 3').
+    #[test]
+    fn parse_serve_last_open_flag_wins() {
+        let no_then_yes = parse(&argv(&["serve", "--no-open", "--open"]))
+            .expect("--no-open then --open should parse");
+        assert!(no_then_yes.open, "rightmost --open should win");
+
+        let yes_then_no = parse(&argv(&["serve", "--open", "--no-open"]))
+            .expect("--open then --no-open should parse");
+        assert!(!yes_then_no.open, "rightmost --no-open should win");
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -27,7 +27,7 @@ use gwt_terminal::{Pane, PaneStatus, PtyHandle};
 use tao::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy},
-    window::WindowBuilder,
+    window::{Window, WindowBuilder},
 };
 use tokio::runtime::Runtime;
 use uuid::Uuid;
@@ -1381,6 +1381,37 @@ mod tests {
         assert!(
             !runtime_mod_source.contains("RuntimeDaemonPublish"),
             "app_runtime/mod.rs should not regain daemon publish queue ownership"
+        );
+    }
+
+    // SPEC-1942 US-14 / 2026-05-20 Amendment Bug A: the GUI bootstrap must keep
+    // the `tao::Window` alive alongside the `wry::WebView` until `event_loop.run`
+    // terminates. On Windows the `tao::Window::Drop` impl calls
+    // `DestroyWindow(hwnd)`, which invalidates WebView2's parent HWND and
+    // leaves the process running an invisible window. Binding both into a
+    // tuple captured by the run-closure prevents that destruction.
+    #[test]
+    fn webview_surface_pairs_window_with_webview_for_event_loop_lifetime() {
+        let main_source = include_str!("main.rs");
+        // SPEC-1942 2026-05-20 Amendment Bug A: assemble the buggy pattern
+        // from substrings so the test's own assert message does not match
+        // the search and report a false positive.
+        let buggy_drop: String = ["let _ = ", "window", ";"].concat();
+        assert!(
+            main_source.contains("Option<(Window, wry::WebView)>"),
+            "webview_surface must hold the tao::Window alongside the wry::WebView so the OS window survives until event_loop.run terminates"
+        );
+        assert!(
+            main_source.contains("Some((window, webview))"),
+            "the GUI bootstrap must move the freshly built Window into webview_surface (do not drop it at the end of the inner block)"
+        );
+        assert!(
+            !main_source.contains(buggy_drop.as_str()),
+            "the bare `let _ = window` discards the Window at block end and on Windows triggers DestroyWindow before event_loop.run runs"
+        );
+        assert!(
+            main_source.contains("if let Some((_, webview)) = webview_surface.as_ref()"),
+            "ReloadWebView dispatch must destructure webview_surface as a (Window, WebView) tuple"
         );
     }
 
@@ -5978,11 +6009,18 @@ fn main() -> wry::Result<()> {
         app.active_project_root().map(Path::to_path_buf),
     );
 
-    // SPEC-1942 US-14: GUI path builds a wry/tao surface; headless path keeps
-    // the event_loop alive without any native window so the same closure can
-    // process UserEvent::Frontend / RuntimeHook / QuitApp messages from
-    // browser clients and signal handlers alike.
-    let webview_surface: Option<wry::WebView> = if serve_args.is_none() {
+    // SPEC-1942 US-14 / 2026-05-20 Amendment (Bug A): GUI path builds a wry/tao
+    // surface; headless path keeps the event_loop alive without any native
+    // window so the same closure can process UserEvent::Frontend / RuntimeHook
+    // / QuitApp messages from browser clients and signal handlers alike.
+    //
+    // The Window must live alongside the WebView until `event_loop.run`
+    // terminates: wry only borrows the Window (`&Window`) when attaching the
+    // WebView2 / WKWebView, and on Windows `tao::Window::Drop` calls
+    // `DestroyWindow(hwnd)` which invalidates the parent HWND that WebView2
+    // renders into. Binding the pair in a tuple keeps the Rust ownership of
+    // `Window` until the closure (and therefore the process) ends.
+    let webview_surface: Option<(Window, wry::WebView)> = if serve_args.is_none() {
         let window = WindowBuilder::new()
             .with_title(APP_NAME)
             .with_inner_size(tao::dpi::LogicalSize::new(1440.0, 920.0))
@@ -6009,12 +6047,7 @@ fn main() -> wry::Result<()> {
             let vbox = window.default_vbox().unwrap();
             builder.build_gtk(vbox)?
         };
-        // Keep the Window alive on the heap for the lifetime of the event
-        // loop. WebView holds the underlying NSWindow / HWND alive via the
-        // platform handle, but Box<Window> would still drop the Rust struct
-        // when this block ends — which is fine because the OS window stays.
-        let _ = window;
-        Some(webview)
+        Some((window, webview))
     } else {
         None
     };
@@ -6485,7 +6518,7 @@ fn main() -> wry::Result<()> {
                             // GUI builds, but guard against accidental
                             // dispatch when the headless path leaves the
                             // option as `None`.
-                            if let Some(webview) = webview_surface.as_ref() {
+                            if let Some((_, webview)) = webview_surface.as_ref() {
                                 if let Err(error) = webview.reload() {
                                     eprintln!("webview reload failed: {error}");
                                 }

--- a/crates/gwt/tests/serve_mode_test.rs
+++ b/crates/gwt/tests/serve_mode_test.rs
@@ -56,10 +56,14 @@ fn serve_mode_starts_server_without_opening_webview() {
     // GUI session on the same machine.
     let temp_cwd = tempfile::tempdir().expect("temp cwd");
 
+    // SPEC-1942 2026-05-20 Amendment: `gwt serve` now auto-opens the system
+    // browser by default. Pass `--no-open` so the regression test does not
+    // pop a browser window on the developer's machine.
     let mut child = Command::new(env!("CARGO_BIN_EXE_gwt"))
         .arg("serve")
         .arg("--port")
         .arg("0")
+        .arg("--no-open")
         .env("GWT_FORCE_NEW_INSTANCE", "1")
         .current_dir(temp_cwd.path())
         .stdin(Stdio::null())

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -43,11 +43,19 @@
   <Fragment>
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="GwtExecutableComponent">
-        <File Id="GwtExecutable" Source="!(bindpath.gwt)gwt.exe" KeyPath="yes" />
+        <!--
+          SPEC-1942 2026-05-20 Amendment Bug B: WiX v4 defaults the installed
+          File Name to the literal Source string when Name is omitted, so the
+          bindpath binder variable leaks into the on-disk file name (observed
+          in v9.37.0 as `!(bindpath.gwt)gwt.exe`). Pin the Name explicitly so
+          the installed file is always `gwt.exe` regardless of how bindpath
+          resolves at build time.
+        -->
+        <File Id="GwtExecutable" Source="!(bindpath.gwt)gwt.exe" Name="gwt.exe" KeyPath="yes" />
         <Environment Id="GwtUserPath" Name="PATH" Value="[INSTALLFOLDER]" Action="set" Part="last" />
       </Component>
       <Component Id="GwtdExecutableComponent">
-        <File Id="GwtdExecutable" Source="!(bindpath.gwt)gwtd.exe" KeyPath="yes" />
+        <File Id="GwtdExecutable" Source="!(bindpath.gwt)gwtd.exe" Name="gwtd.exe" KeyPath="yes" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
## Summary

v9.37.0 リリース後の Windows 実機検証で顕在化した 2 件のバグと、ヘッドレス起動の UX 改善 1 件をまとめて修正します。3 件は SPEC-1942 US-14 の文脈で関連しており、v9.38.0 minor release で同時にリリースします。

### 含まれる修正 (3 commits)

- **`fix(gui): keep tao::Window alive for the event_loop lifetime`** — Closes #2775
  SPEC-1942 US-14 の refactor で `Window` 変数のスコープが内側ブロックに縮退し、Windows で `tao::Window::Drop` が `DestroyWindow(hwnd)` を呼んでしまい WebView2 の親 HWND が破棄されていた regression を修正。`webview_surface` を `Option<(Window, WebView)>` に変えて `event_loop.run` 終了まで両方を生存させる。回帰防止 test を追加。

- **`fix(installer): pin gwt.exe / gwtd.exe Name in WiX manifest`** — Closes #2776
  WiX v4 で `<File>` の `Name` 属性省略時に Source の literal が File Name に使われる挙動のため、installed file 名が `!(bindpath.gwt)gwt.exe` になっていた問題を修正。`Name="gwt.exe"` / `Name="gwtd.exe"` を明示。

- **`feat(serve): open default browser unless --no-open is passed`** — Closes #2777
  `gwt serve` / `gwt --headless` を引数なしで実行した際の default 挙動として既定ブラウザを自動起動するよう変更。CI / 自動化用に `--no-open` opt-out flag を新設。`--open` は backward compat の no-op として残す。SPEC-1942 (#1942) FR-095 amendment 済み。

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test -p gwt --lib --bins` — 1062 GREEN (lib 680 / main 380 / gwtd 2)
- [x] `cargo test -p gwt --tests` — 全 integration test GREEN (`serve_mode_test` は `#[ignore]` のまま)
- [x] commitlint (`bunx commitlint --from HEAD~3 --to HEAD`) — exit 0
- [ ] **Windows 実機での確認 (PR review 後に user 検証):**
  - [ ] `gwt.exe` を Start Menu から起動 → WebView ウィンドウが表示される (Bug A 修正)
  - [ ] `%LOCALAPPDATA%\Programs\GWT\` の実体ファイル名が `gwt.exe` / `gwtd.exe` (Bug B 修正、新規インストール時のみ)
  - [ ] `gwt.exe serve` で既定ブラウザが自動で開く (Bug C 動作)
  - [ ] `gwt.exe serve --no-open` でブラウザが開かず URL のみ印字 (Bug C 動作)
- [ ] macOS 実機: `cargo run -p gwt --bin gwt` → WebView ウィンドウ表示 + Dock アイコン表示

## Release path

- Behavior change を含むため `feat:` が semver で minor を要求 → **v9.38.0** で release。
- 既存 Windows ユーザは v9.37.0 で WebView が表示されないため、可能な限り早く v9.38.0 公開を推奨。
- 既存 v9.37.0 install からの upgrade では旧 `!(bindpath.gwt)*.exe` が残る可能性があるため、release notes / README に手動削除手順を加える follow-up タスクあり。

## Owner SPEC

- **SPEC-1942** (#1942) 2026-05-20 Amendment: Bug A の lifetime fix + Bug C の FR-095 改訂 + 新規 SC-033 / SC-034
- **SPEC-1932**: Bug B (リリースフロー WiX manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
