### PR TITLE
chore(release): v9.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.38.0] - 2026-05-19
+
+### Bug Fixes
+
+- **gui:** Keep tao::Window alive for the event_loop lifetime
+- **installer:** Pin gwt.exe / gwtd.exe Name in WiX manifest
+
+### Features
+
+- **serve:** Open default browser unless --no-open is passed
+
+### Refactor
+
+- **repo:** Retract develop worktree auto-select for bare layout
+
 ## [9.37.0] - 2026-05-19
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "ammonia",
  "axum",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "libc",
  "nix 0.31.3",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.37.0"
+version = "9.38.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.37.0"
+version = "9.38.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/README.ja.md
+++ b/README.ja.md
@@ -103,11 +103,16 @@ gwt
 オペレーターは出力された URL を任意のブラウザで開いて操作します。
 
 ```bash
-gwt serve                              # 127.0.0.1、ランダムポート、手動オープン
-gwt serve --port 8787 --open           # 固定ポート + システムブラウザ自動起動
-gwt serve --bind 0.0.0.0 --port 8787   # LAN (VPN 越し含む) へ公開
+gwt serve                              # 127.0.0.1、ランダムポート、ブラウザ自動起動
+gwt serve --no-open                    # 同じ動作だがブラウザ自動起動を抑制 (CI / スクリプト用)
+gwt serve --port 8787                  # 固定ポート + ブラウザ自動起動
+gwt serve --bind 0.0.0.0 --port 8787   # LAN (VPN 越し含む) へ公開 + ブラウザ自動起動
 gwt --headless --port 8787             # `gwt serve --port 8787` と同じ
 ```
+
+既定でシステムブラウザが自動起動します。CI / 自動化で server だけ立ち上げ
+たい場合は `--no-open` を指定してください。`--open` は既存スクリプト互換性
+維持のため no-op flag として残しています。
 
 信頼境界は **LAN のみ** (VPN-extended LAN を含む) です。`gwt serve` には
 TLS 終端、認証ゲート、レート制限は組み込まれていません。`--bind` で

--- a/README.md
+++ b/README.md
@@ -105,11 +105,16 @@ opening a native window. The embedded HTTP / WebSocket server stays up and
 the operator opens the printed URL in any browser instead.
 
 ```bash
-gwt serve                              # 127.0.0.1, random port, manual open
-gwt serve --port 8787 --open           # fixed port + system browser
-gwt serve --bind 0.0.0.0 --port 8787   # share with the LAN (VPN-extended)
+gwt serve                              # 127.0.0.1, random port, auto-open browser
+gwt serve --no-open                    # same, but suppress the browser launch (CI / scripts)
+gwt serve --port 8787                  # fixed port + auto-open browser
+gwt serve --bind 0.0.0.0 --port 8787   # share with the LAN (VPN-extended), auto-open browser
 gwt --headless --port 8787             # same as `gwt serve --port 8787`
 ```
+
+The system browser is opened automatically by default. Pass `--no-open` for
+CI / automation use cases that only need the server running. `--open` is kept
+as a no-op flag for backward compatibility with existing scripts.
 
 Trust boundary: **LAN only** (including VPN-extended LAN). `gwt serve` does
 not ship TLS termination, an authentication gate, or rate limiting. Anyone

--- a/crates/gwt-git/src/repository.rs
+++ b/crates/gwt-git/src/repository.rs
@@ -46,9 +46,8 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
     }
     // Check if path itself is a bare repo (has HEAD + objects + refs)
     if path.join("HEAD").exists() && path.join("objects").exists() && path.join("refs").exists() {
-        let develop = find_develop_worktree(path.parent().unwrap_or(path));
         return RepoType::Bare {
-            develop_worktree: develop,
+            develop_worktree: None,
         };
     }
     // Check child directories for bare repos, worktrees, or normal repos
@@ -76,9 +75,12 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
             }
         }
         if found_bare {
-            let develop = find_develop_worktree(path);
+            // SPEC-1934 2026-05-20 Update FR-050: child scan で bare layout を
+            // 検出した場合、`develop` / `main` 等の worktree を auto-select しない。
+            // 呼び出し側 (`resolve_project_target`) が workspace home を返し、
+            // 実際の worktree 選択は Workspace Overview に委ねる。
             return RepoType::Bare {
-                develop_worktree: develop,
+                develop_worktree: None,
             };
         }
     }
@@ -96,6 +98,9 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
             };
         }
         if dot_git.is_file() {
+            // Subdir inside a linked worktree: resolve to the worktree root so
+            // a path like `<worktree>/src/foo` opens the worktree, not the
+            // workspace home (preserves SC-035 direct-pick semantics).
             return RepoType::Bare {
                 develop_worktree: Some(parent.to_path_buf()),
             };
@@ -104,31 +109,13 @@ pub fn detect_repo_type(path: &Path) -> RepoType {
             && parent.join("objects").exists()
             && parent.join("refs").exists()
         {
-            let develop = find_develop_worktree(parent.parent().unwrap_or(parent));
             return RepoType::Bare {
-                develop_worktree: develop,
+                develop_worktree: None,
             };
         }
         current = parent.to_path_buf();
     }
     RepoType::NonRepo
-}
-
-/// Find a develop worktree in the given directory.
-/// Looks for a child directory named "develop" that has a .git worktree marker.
-fn find_develop_worktree(parent: &Path) -> Option<PathBuf> {
-    let develop = parent.join("develop");
-    if develop.is_dir() && develop.join(".git").exists() {
-        return Some(develop);
-    }
-    let mut worktrees = fs::read_dir(parent)
-        .ok()?
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir() && path.join(".git").is_file())
-        .collect::<Vec<_>>();
-    worktrees.sort();
-    worktrees.into_iter().next()
 }
 
 /// Derived filesystem target for creating a gwt project from a GitHub repo URL.
@@ -685,26 +672,37 @@ mod tests {
     }
 
     #[test]
-    fn detect_repo_type_prefers_any_child_worktree_when_develop_is_absent() {
+    fn detect_repo_type_returns_bare_with_none_for_child_scan() {
+        // SPEC-1934 2026-05-20 Update (FR-050): child scan で bare layout を
+        // 検出した場合、`develop` / `main` / 任意の worktree を auto-select する
+        // ロジックは撤回される。`Bare { develop_worktree: None }` を返し、
+        // routing 先は呼び出し側 (`resolve_project_target`) に委ねる。
         let tmp = tempfile::tempdir().unwrap();
         let bare_dir = tmp.path().join("repo.git");
         let main_worktree = tmp.path().join("main");
+        let develop_worktree = tmp.path().join("develop");
         gwt_core::process::hidden_command("git")
             .args(["init", "--bare", bare_dir.to_str().unwrap()])
             .output()
             .unwrap();
-        std::fs::create_dir_all(&main_worktree).unwrap();
-        std::fs::write(
-            main_worktree.join(".git"),
-            "gitdir: ../repo.git/worktrees/main\n",
-        )
-        .unwrap();
+        for wt in [&main_worktree, &develop_worktree] {
+            std::fs::create_dir_all(wt).unwrap();
+            std::fs::write(
+                wt.join(".git"),
+                format!(
+                    "gitdir: ../repo.git/worktrees/{}\n",
+                    wt.file_name().unwrap().to_string_lossy()
+                ),
+            )
+            .unwrap();
+        }
 
         assert_eq!(
             detect_repo_type(tmp.path()),
             RepoType::Bare {
-                develop_worktree: Some(main_worktree)
-            }
+                develop_worktree: None
+            },
+            "child scan must not auto-select develop or main worktrees (SPEC-1934 FR-050)"
         );
     }
 

--- a/crates/gwt/src/cli/serve.rs
+++ b/crates/gwt/src/cli/serve.rs
@@ -22,7 +22,11 @@ use std::net::{IpAddr, Ipv4Addr};
 ///   GUI behaviour at `crates/gwt/src/embedded_server.rs`). User-provided
 ///   values are kept verbatim.
 /// - `open`: whether to spawn the system default browser at the served URL
-///   after the server is up.
+///   after the server is up. SPEC-1942 2026-05-20 Amendment (FR-095): the
+///   default is `true`, matching the common headless user journey of "start
+///   server, then open browser." `--no-open` is the explicit opt-out for
+///   CI / automation; `--open` is preserved as a no-op for backward
+///   compatibility with existing scripts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServeArgs {
     pub bind: IpAddr,
@@ -35,7 +39,7 @@ impl Default for ServeArgs {
         Self {
             bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
             port: 0,
-            open: false,
+            open: true,
         }
     }
 }
@@ -117,7 +121,13 @@ pub fn parse(args: &[String]) -> Result<ServeArgs, ServeParseError> {
                     .map_err(|_| ServeParseError::InvalidPort(value.clone()))?;
             }
             "--open" => {
+                // SPEC-1942 2026-05-20 Amendment: `--open` is now the default
+                // and kept as a no-op flag for backward compatibility so
+                // existing CI scripts that pass it explicitly keep working.
                 out.open = true;
+            }
+            "--no-open" => {
+                out.open = false;
             }
             other => return Err(ServeParseError::UnknownFlag(other.to_string())),
         }
@@ -133,12 +143,52 @@ mod tests {
         parts.iter().map(|s| s.to_string()).collect()
     }
 
+    // SPEC-1942 2026-05-20 Amendment: `--open` is now the default, so bare
+    // `gwt serve` should set `open: true`.
     #[test]
-    fn parse_serve_defaults_bind_to_loopback_and_port_to_zero_and_open_false() {
+    fn parse_serve_defaults_bind_to_loopback_and_port_to_zero_and_open_true() {
         let parsed = parse(&argv(&["serve"])).expect("serve parses with defaults");
         assert_eq!(parsed.bind, IpAddr::V4(Ipv4Addr::LOCALHOST));
         assert_eq!(parsed.port, 0);
-        assert!(!parsed.open);
+        assert!(
+            parsed.open,
+            "SPEC-1942 2026-05-20 Amendment: --open is now the default"
+        );
+    }
+
+    #[test]
+    fn parse_serve_no_open_overrides_default() {
+        let parsed =
+            parse(&argv(&["serve", "--no-open"])).expect("serve accepts --no-open as opt-out");
+        assert!(
+            !parsed.open,
+            "--no-open must suppress the new default browser auto-open"
+        );
+    }
+
+    // Backward compatibility: scripts that already pass `--open` continue to
+    // work. The flag is now a no-op but parsing must still succeed.
+    #[test]
+    fn parse_serve_open_flag_is_still_accepted_as_noop() {
+        let parsed =
+            parse(&argv(&["serve", "--open"])).expect("explicit --open must still be accepted");
+        assert!(
+            parsed.open,
+            "--open is now redundant with the default, but must remain accepted"
+        );
+    }
+
+    // `--open` and `--no-open` together: rightmost flag wins (matches
+    // SPEC-1942 2026-05-20 Amendment scenario 3').
+    #[test]
+    fn parse_serve_last_open_flag_wins() {
+        let no_then_yes = parse(&argv(&["serve", "--no-open", "--open"]))
+            .expect("--no-open then --open should parse");
+        assert!(no_then_yes.open, "rightmost --open should win");
+
+        let yes_then_no = parse(&argv(&["serve", "--open", "--no-open"]))
+            .expect("--open then --no-open should parse");
+        assert!(!yes_then_no.open, "rightmost --no-open should win");
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -27,7 +27,7 @@ use gwt_terminal::{Pane, PaneStatus, PtyHandle};
 use tao::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy},
-    window::WindowBuilder,
+    window::{Window, WindowBuilder},
 };
 use tokio::runtime::Runtime;
 use uuid::Uuid;
@@ -1381,6 +1381,37 @@ mod tests {
         assert!(
             !runtime_mod_source.contains("RuntimeDaemonPublish"),
             "app_runtime/mod.rs should not regain daemon publish queue ownership"
+        );
+    }
+
+    // SPEC-1942 US-14 / 2026-05-20 Amendment Bug A: the GUI bootstrap must keep
+    // the `tao::Window` alive alongside the `wry::WebView` until `event_loop.run`
+    // terminates. On Windows the `tao::Window::Drop` impl calls
+    // `DestroyWindow(hwnd)`, which invalidates WebView2's parent HWND and
+    // leaves the process running an invisible window. Binding both into a
+    // tuple captured by the run-closure prevents that destruction.
+    #[test]
+    fn webview_surface_pairs_window_with_webview_for_event_loop_lifetime() {
+        let main_source = include_str!("main.rs");
+        // SPEC-1942 2026-05-20 Amendment Bug A: assemble the buggy pattern
+        // from substrings so the test's own assert message does not match
+        // the search and report a false positive.
+        let buggy_drop: String = ["let _ = ", "window", ";"].concat();
+        assert!(
+            main_source.contains("Option<(Window, wry::WebView)>"),
+            "webview_surface must hold the tao::Window alongside the wry::WebView so the OS window survives until event_loop.run terminates"
+        );
+        assert!(
+            main_source.contains("Some((window, webview))"),
+            "the GUI bootstrap must move the freshly built Window into webview_surface (do not drop it at the end of the inner block)"
+        );
+        assert!(
+            !main_source.contains(buggy_drop.as_str()),
+            "the bare `let _ = window` discards the Window at block end and on Windows triggers DestroyWindow before event_loop.run runs"
+        );
+        assert!(
+            main_source.contains("if let Some((_, webview)) = webview_surface.as_ref()"),
+            "ReloadWebView dispatch must destructure webview_surface as a (Window, WebView) tuple"
         );
     }
 
@@ -5978,11 +6009,18 @@ fn main() -> wry::Result<()> {
         app.active_project_root().map(Path::to_path_buf),
     );
 
-    // SPEC-1942 US-14: GUI path builds a wry/tao surface; headless path keeps
-    // the event_loop alive without any native window so the same closure can
-    // process UserEvent::Frontend / RuntimeHook / QuitApp messages from
-    // browser clients and signal handlers alike.
-    let webview_surface: Option<wry::WebView> = if serve_args.is_none() {
+    // SPEC-1942 US-14 / 2026-05-20 Amendment (Bug A): GUI path builds a wry/tao
+    // surface; headless path keeps the event_loop alive without any native
+    // window so the same closure can process UserEvent::Frontend / RuntimeHook
+    // / QuitApp messages from browser clients and signal handlers alike.
+    //
+    // The Window must live alongside the WebView until `event_loop.run`
+    // terminates: wry only borrows the Window (`&Window`) when attaching the
+    // WebView2 / WKWebView, and on Windows `tao::Window::Drop` calls
+    // `DestroyWindow(hwnd)` which invalidates the parent HWND that WebView2
+    // renders into. Binding the pair in a tuple keeps the Rust ownership of
+    // `Window` until the closure (and therefore the process) ends.
+    let webview_surface: Option<(Window, wry::WebView)> = if serve_args.is_none() {
         let window = WindowBuilder::new()
             .with_title(APP_NAME)
             .with_inner_size(tao::dpi::LogicalSize::new(1440.0, 920.0))
@@ -6009,12 +6047,7 @@ fn main() -> wry::Result<()> {
             let vbox = window.default_vbox().unwrap();
             builder.build_gtk(vbox)?
         };
-        // Keep the Window alive on the heap for the lifetime of the event
-        // loop. WebView holds the underlying NSWindow / HWND alive via the
-        // platform handle, but Box<Window> would still drop the Rust struct
-        // when this block ends — which is fine because the OS window stays.
-        let _ = window;
-        Some(webview)
+        Some((window, webview))
     } else {
         None
     };
@@ -6485,7 +6518,7 @@ fn main() -> wry::Result<()> {
                             // GUI builds, but guard against accidental
                             // dispatch when the headless path leaves the
                             // option as `None`.
-                            if let Some(webview) = webview_surface.as_ref() {
+                            if let Some((_, webview)) = webview_surface.as_ref() {
                                 if let Err(error) = webview.reload() {
                                     eprintln!("webview reload failed: {error}");
                                 }

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -888,6 +888,122 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
+    // SPEC-1934 2026-05-20 Update: Open Project Auto-Select Retraction
+    // US-7 / US-8 / FR-050 / FR-052 / SC-034..SC-037
+    // -------------------------------------------------------------------
+
+    fn make_worktree_marker(parent: &std::path::Path, name: &str) -> std::path::PathBuf {
+        let worktree = parent.join(name);
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: ../repo.git/worktrees/{name}\n"),
+        )
+        .unwrap();
+        std::fs::create_dir_all(parent.join("repo.git").join("worktrees").join(name)).unwrap();
+        worktree
+    }
+
+    #[test]
+    fn resolve_project_target_opens_workspace_home_for_bare_with_develop_worktree() {
+        // SC-034: workspace_home (= parent dir) を Open Project で選んだとき、
+        // `develop` worktree が存在しても auto-select せず、workspace_home を
+        // project_root として返す。これにより Workspace Overview が hub になる。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+        let _develop = make_worktree_marker(tmp.path(), "develop");
+
+        let target = super::resolve_project_target(tmp.path()).expect("bare workspace home target");
+
+        assert_eq!(target.kind, gwt::ProjectKind::Git);
+        assert!(!target.needs_migration);
+        assert_eq!(
+            target.project_root,
+            dunce::canonicalize(tmp.path()).unwrap(),
+            "Open Project on workspace home must not redirect to develop worktree (SC-034)"
+        );
+    }
+
+    #[test]
+    fn resolve_project_target_respects_direct_worktree_pick_under_bare() {
+        // SC-035: user が worktree dir を直接 Open Project で指定した場合は、
+        // workspace_home に rebasing せずその worktree を開く。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+        let develop = make_worktree_marker(tmp.path(), "develop");
+
+        let target = super::resolve_project_target(&develop).expect("direct worktree target");
+
+        assert_eq!(target.kind, gwt::ProjectKind::Git);
+        assert!(!target.needs_migration);
+        assert_eq!(
+            target.project_root,
+            dunce::canonicalize(&develop).unwrap(),
+            "Direct worktree pick must be honored, not rebased to workspace home (SC-035)"
+        );
+    }
+
+    #[test]
+    fn resolve_project_target_handles_bare_without_any_worktree() {
+        // SC-036: bare のみで worktree 0 件 (Clone Project 直後の状態) でも
+        // workspace_home を Git project として返す。empty state は Workspace
+        // Overview 側で描画する。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+
+        let target = super::resolve_project_target(tmp.path()).expect("bare-only target");
+
+        assert_eq!(target.kind, gwt::ProjectKind::Git);
+        assert!(!target.needs_migration);
+        assert_eq!(
+            target.project_root,
+            dunce::canonicalize(tmp.path()).unwrap(),
+            "Bare-only workspace home must open Workspace Overview (SC-036)"
+        );
+    }
+
+    #[test]
+    fn resolve_project_target_does_not_recreate_after_worktree_remove() {
+        // SC-037: develop worktree が削除された状態でも auto-repair / auto-create
+        // しない。bare layout のまま workspace_home を返す。
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bare_dir = tmp.path().join("repo.git");
+        gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_dir.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+
+        let before = super::resolve_project_target(tmp.path()).expect("first resolve");
+        assert_eq!(
+            before.project_root,
+            dunce::canonicalize(tmp.path()).unwrap()
+        );
+        assert!(
+            !tmp.path().join("develop").exists(),
+            "resolve must not create develop worktree side-effects (SC-037)"
+        );
+
+        let after = super::resolve_project_target(tmp.path()).expect("second resolve");
+        assert_eq!(after.project_root, before.project_root);
+        assert!(
+            !tmp.path().join("develop").exists(),
+            "repeated resolve must remain idempotent and side-effect free"
+        );
+    }
+
+    // -------------------------------------------------------------------
     // Issue #2054: gwt pr remote resolution must tolerate non-GitHub
     // `origin` and explicit env overrides.
     // -------------------------------------------------------------------

--- a/crates/gwt/tests/serve_mode_test.rs
+++ b/crates/gwt/tests/serve_mode_test.rs
@@ -56,10 +56,14 @@ fn serve_mode_starts_server_without_opening_webview() {
     // GUI session on the same machine.
     let temp_cwd = tempfile::tempdir().expect("temp cwd");
 
+    // SPEC-1942 2026-05-20 Amendment: `gwt serve` now auto-opens the system
+    // browser by default. Pass `--no-open` so the regression test does not
+    // pop a browser window on the developer's machine.
     let mut child = Command::new(env!("CARGO_BIN_EXE_gwt"))
         .arg("serve")
         .arg("--port")
         .arg("0")
+        .arg("--no-open")
         .env("GWT_FORCE_NEW_INSTANCE", "1")
         .current_dir(temp_cwd.path())
         .stdin(Stdio::null())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.37.0",
+  "version": "9.38.0",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -43,11 +43,19 @@
   <Fragment>
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="GwtExecutableComponent">
-        <File Id="GwtExecutable" Source="!(bindpath.gwt)gwt.exe" KeyPath="yes" />
+        <!--
+          SPEC-1942 2026-05-20 Amendment Bug B: WiX v4 defaults the installed
+          File Name to the literal Source string when Name is omitted, so the
+          bindpath binder variable leaks into the on-disk file name (observed
+          in v9.37.0 as `!(bindpath.gwt)gwt.exe`). Pin the Name explicitly so
+          the installed file is always `gwt.exe` regardless of how bindpath
+          resolves at build time.
+        -->
+        <File Id="GwtExecutable" Source="!(bindpath.gwt)gwt.exe" Name="gwt.exe" KeyPath="yes" />
         <Environment Id="GwtUserPath" Name="PATH" Value="[INSTALLFOLDER]" Action="set" Part="last" />
       </Component>
       <Component Id="GwtdExecutableComponent">
-        <File Id="GwtdExecutable" Source="!(bindpath.gwt)gwtd.exe" KeyPath="yes" />
+        <File Id="GwtdExecutable" Source="!(bindpath.gwt)gwtd.exe" Name="gwtd.exe" KeyPath="yes" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
## Summary

v9.38.0 (MINOR release) — Windows GUI WebView lifetime regression と WiX MSI の bindpath 未展開を patch しつつ、`gwt serve` のデフォルト挙動をブラウザ自動起動側へ反転して headless 起動の摩擦を取り除くリリース。

## Changes

### Features
- **serve:** `--open` をデフォルト挙動にし、`--no-open` でオプトアウト可能に反転 (SPEC-1942 2026-05-20 Amendment, Issue #2777)

### Bug Fixes
- **gui:** `tao::Window` を `event_loop` のライフタイムにわたって保持し、Windows での WebView 非表示 regression を解消 (Issue #2775)
- **installer:** WiX manifest で `gwt.exe` / `gwtd.exe` の `Name` を固定し、v9.37.0 で発生した bindpath 未展開での MSI ビルド失敗を修正 (Issue #2776)

### Refactor
- **repo:** Bare layout における `develop` worktree auto-select を取り下げ、ユーザーの worktree 選択挙動を維持 (PR #2774)

## Version

`v9.37.0` → `v9.38.0` (MINOR bump)

判定根拠: 上記 `feat(serve)` が含まれるため MINOR。BREAKING CHANGE は無し。

## Closing Issues

Closes #2775
Closes #2776
Closes #2777

## Related Issues / Links

- #1934 (SPEC-1921: External Agent vs Backend Override 概念分離) — gwt-spec Issue のためリリースで auto-close しない方針。`release_issue_refs.py` 判定により reference-only として扱う。

## Test plan

- [x] develop で `cargo test -p gwt-core` 212 件 GREEN (pre-commit hook 経由)
- [x] develop で `cargo llvm-cov` 90.27% coverage (90% threshold 維持)、`cargo clippy --all-targets --all-features -- -D warnings` clean、`cargo fmt --check` clean (pre-push hook 経由)
- [x] `pnpm lint:skills` で 31 SKILL.md frontmatter 検証 pass
- [ ] CI required status checks (10 件) all green
- [ ] Windows 実機での `gwt` GUI 起動と WebView 表示確認 (Bug A regression 再発防止)
- [ ] Windows 実機での MSI installer 経由インストール確認 (Bug B regression 再発防止)
- [ ] macOS / Linux で `gwt serve` をオプション無し起動して既定ブラウザが立ち上がること、`gwt serve --no-open` で起動しないことを確認 (Bug C 反転挙動)

## マージ後の自動処理

PR が main にマージされると `.github/workflows/release.yml` が:

1. Git tag `v9.38.0` を作成
2. GitHub Release を作成
3. クロスコンパイル済みバイナリを各 platform 向けにアップロード
4. npm へ `@akiojin/gwt@9.38.0` を publish
