### PR TITLE
fix(docker): avoid quick timeout for compose exec capture

### DIFF
--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -100,6 +100,16 @@ fn docker_compose_up_timeout() -> Duration {
         .unwrap_or_else(|| Duration::from_millis(DEFAULT_TIMEOUT_MS))
 }
 
+fn docker_compose_exec_timeout() -> Duration {
+    const DEFAULT_TIMEOUT_MS: u64 = 120_000;
+    std::env::var("GWT_DOCKER_COMPOSE_EXEC_TIMEOUT_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| Duration::from_millis(DEFAULT_TIMEOUT_MS))
+}
+
 fn run_docker_with_timeout(args: &[&str], action: &str) -> Result<Output> {
     run_docker_with_timeout_in_dir(args, action, None)
 }
@@ -636,10 +646,11 @@ pub fn compose_service_exec_capture_with_files(
     docker_args.extend(args.iter().cloned());
     let arg_refs = docker_args.iter().map(String::as_str).collect::<Vec<_>>();
 
-    run_docker_with_timeout_in_dir(
+    run_docker_with_timeout_in_dir_and_timeout(
         &arg_refs,
         "docker compose exec",
         Some(compose_parent_dir_for_files(compose_files)),
+        docker_compose_exec_timeout(),
     )
 }
 
@@ -1445,6 +1456,39 @@ mod tests {
                     compose_path.display()
                 )
             );
+        });
+    }
+
+    #[test]
+    fn compose_service_exec_capture_uses_longer_timeout_than_default_docker_commands() {
+        let compose_dir = tempfile::tempdir().expect("temp compose dir");
+        let compose_path = compose_dir.path().join("docker-compose.yml");
+        fs::write(
+            &compose_path,
+            "services:\n  app:\n    image: nginx:latest\n",
+        )
+        .expect("compose");
+        let script = "#!/bin/sh\nif [ \"$1\" = \"compose\" ] && [ \"$4\" = \"exec\" ]; then\n  sleep 0.1\n  printf 'ok\\n'\n  exit 0\nfi\nexit 0\n";
+
+        with_fake_docker(script, |_| {
+            let previous_timeout = std::env::var_os("GWT_DOCKER_TIMEOUT_MS");
+            let previous_exec_timeout = std::env::var_os("GWT_DOCKER_COMPOSE_EXEC_TIMEOUT_MS");
+            std::env::set_var("GWT_DOCKER_TIMEOUT_MS", "50");
+            std::env::set_var("GWT_DOCKER_COMPOSE_EXEC_TIMEOUT_MS", "500");
+
+            let result =
+                compose_service_exec_capture(&compose_path, "app", None, &["true".to_string()]);
+
+            match previous_timeout {
+                Some(value) => std::env::set_var("GWT_DOCKER_TIMEOUT_MS", value),
+                None => std::env::remove_var("GWT_DOCKER_TIMEOUT_MS"),
+            }
+            match previous_exec_timeout {
+                Some(value) => std::env::set_var("GWT_DOCKER_COMPOSE_EXEC_TIMEOUT_MS", value),
+                None => std::env::remove_var("GWT_DOCKER_COMPOSE_EXEC_TIMEOUT_MS"),
+            }
+
+            result.expect("compose exec capture should use compose-exec timeout");
         });
     }
 


### PR DESCRIPTION
## Summary

- Prevent Docker runtime launch preflight from failing `docker compose exec -T` capture after the quick 5 second probe timeout.
- Keep short Docker probes on the existing quick timeout while giving package runner probes, root user checks, and container-local setup a dedicated Compose exec timeout.

## Changes

- `crates/gwt-docker/src/container.rs`: add `GWT_DOCKER_COMPOSE_EXEC_TIMEOUT_MS` with a 120 second default and use it for `compose_service_exec_capture_with_files`.
- `crates/gwt-docker/src/container.rs`: add a regression test proving `compose_service_exec_capture` is not capped by `GWT_DOCKER_TIMEOUT_MS`.

## Testing

- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt-docker --all-features` — passed; 65 unit tests, 1 integration test, and doc tests completed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.

## Closing Issues

None

## Related Issues / Links

- #1936

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC-1936 was updated; no README change required)
- [x] Migration/backfill plan included (not applicable: no schema or data change)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Docker operations now feature configurable timeout settings, defaulting to 120 seconds. Users can adjust execution duration through environment configuration to suit their deployment workflows.

* **Tests**
  * Added regression test to validate Docker timeout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->